### PR TITLE
fix: ensure nemoclaw CLI is on PATH after nvm-based install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,13 @@ install_or_upgrade_ollama() {
 # 3. NemoClaw
 # ---------------------------------------------------------------------------
 install_nemoclaw() {
+  # Ensure npm global bin is on PATH (nvm installs to a non-standard location)
+  local npm_bin
+  npm_bin="$(npm config get prefix)/bin"
+  if ! echo "$PATH" | tr ':' '\n' | grep -qx "$npm_bin"; then
+    export PATH="$npm_bin:$PATH"
+  fi
+
   if [[ -f "./package.json" ]] && grep -q '"name": "nemoclaw"' ./package.json 2>/dev/null; then
     info "NemoClaw package.json found in current directory — installing from source…"
     npm install && npm link
@@ -127,6 +134,19 @@ install_nemoclaw() {
     info "Installing NemoClaw from npm…"
     npm install -g nemoclaw
   fi
+
+  # Persist npm global bin for future shells
+  local profile="$HOME/.bashrc"
+  [ -f "$HOME/.zshrc" ] && profile="$HOME/.zshrc"
+  if ! grep -q 'npm config get prefix' "$profile" 2>/dev/null; then
+    echo 'export PATH="$(npm config get prefix)/bin:$PATH"' >> "$profile"
+    info "Added npm global bin to $profile"
+  fi
+
+  if ! command_exists nemoclaw; then
+    error "nemoclaw not found in PATH after install. Try: source ~/.bashrc && nemoclaw --help"
+  fi
+  info "nemoclaw is ready: $(nemoclaw --version 2>/dev/null || echo 'installed')"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- After `install.sh` installs Node.js via nvm, `npm link` / `npm install -g` puts the `nemoclaw` binary in nvm's non-standard bin directory which isn't on PATH
- Users see `nemoclaw: command not found` after a successful install
- This fix adds the npm global bin dir to PATH immediately during install, persists it to `.bashrc`/`.zshrc`, and verifies `nemoclaw` is callable before continuing to onboard

## Test plan

- [ ] Run `install.sh` on a clean Ubuntu 22.04 container with no Node.js
- [ ] Verify `nemoclaw` is callable immediately after install completes
- [ ] Open a new shell and verify `nemoclaw` is still callable

🤖 Generated with [Claude Code](https://claude.com/claude-code)