### PR TITLE
docs: replace deprecated nemoclaw setup with onboard, add missing com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Run these on the host to set up, connect to, and manage sandboxes.
 | `nemoclaw onboard`                  | Interactive setup wizard: gateway, providers, sandbox. |
 | `nemoclaw deploy <instance>`         | Deploy to a remote GPU instance through Brev.          |
 | `nemoclaw <name> connect`            | Open an interactive shell inside the sandbox.          |
-| `nemoclaw term`                      | Launch the OpenShell TUI for monitoring and approvals. |
+| `openshell term`                     | Launch the OpenShell TUI for monitoring and approvals. |
 | `nemoclaw start` / `stop` / `status` | Manage auxiliary services (Telegram bridge, tunnel).   |
 
 ### Plugin commands (`openclaw nemoclaw`)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Run these on the host to set up, connect to, and manage sandboxes.
 
 | Command                              | Description                                            |
 |--------------------------------------|--------------------------------------------------------|
-| `nemoclaw setup`                     | Full host-side setup: gateway, providers, sandbox.     |
+| `nemoclaw onboard`                  | Interactive setup wizard: gateway, providers, sandbox. |
 | `nemoclaw deploy <instance>`         | Deploy to a remote GPU instance through Brev.          |
 | `nemoclaw <name> connect`            | Open an interactive shell inside the sandbox.          |
 | `nemoclaw term`                      | Launch the OpenShell TUI for monitoring and approvals. |

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -57,10 +57,10 @@ $ nemoclaw deploy <instance-name>
 
 ## Monitor the Remote Sandbox
 
-Open the OpenShell TUI on the remote instance to monitor activity and approve network requests:
+SSH to the instance and run the OpenShell TUI to monitor activity and approve network requests:
 
 ```console
-$ nemoclaw term <instance-name>
+$ ssh <instance-name> 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell term'
 ```
 
 ## Verify Inference

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -43,18 +43,17 @@ The deploy script performs the following steps on the VM:
 
 1. Installs Docker and the NVIDIA Container Toolkit if a GPU is present.
 2. Installs the OpenShell CLI.
-3. Runs `nemoclaw setup` to create the gateway, register providers, and launch the sandbox.
+3. Runs the host setup script to create the gateway, register providers, and launch the sandbox.
 4. Starts auxiliary services, such as the Telegram bridge and cloudflared tunnel.
 
 ## Connect to the Remote Sandbox
 
-After deployment finishes, connect to the sandbox on the remote instance:
+After deployment finishes, the deploy command opens an interactive shell inside the remote sandbox.
+To reconnect after closing the session, run the deploy command again:
 
 ```console
 $ nemoclaw deploy <instance-name>
 ```
-
-This opens an interactive shell inside the remote sandbox.
 
 ## Monitor the Remote Sandbox
 

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -43,7 +43,7 @@ The deploy script performs the following steps on the VM:
 
 1. Installs Docker and the NVIDIA Container Toolkit if a GPU is present.
 2. Installs the OpenShell CLI.
-3. Runs the host setup script to create the gateway, register providers, and launch the sandbox.
+3. Runs the nemoclaw setup to create the gateway, register providers, and launch the sandbox.
 4. Starts auxiliary services, such as the Telegram bridge and cloudflared tunnel.
 
 ## Connect to the Remote Sandbox

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -37,7 +37,7 @@ $ openshell inference set --provider nvidia-nim --model nvidia/nemotron-3-super-
 ```
 
 This profile requires the `NVIDIA_API_KEY` environment variable.
-The `nemoclaw setup` command stores this key in `~/.nemoclaw/credentials.json` on first run.
+The `nemoclaw onboard` command stores this key in `~/.nemoclaw/credentials.json` on first run.
 
 ## Switch to Local vLLM
 

--- a/docs/monitoring/monitor-sandbox-activity.md
+++ b/docs/monitoring/monitor-sandbox-activity.md
@@ -81,11 +81,7 @@ Open the OpenShell terminal UI for a live view of sandbox network activity and e
 $ openshell term
 ```
 
-For a remote sandbox:
-
-```console
-$ nemoclaw term <instance-name>
-```
+For a remote sandbox, SSH to the instance and run `openshell term` there.
 
 The TUI shows the following information:
 

--- a/docs/monitoring/monitor-sandbox-activity.md
+++ b/docs/monitoring/monitor-sandbox-activity.md
@@ -117,7 +117,7 @@ The following table lists common problems and their resolution steps:
 
 | Symptom | Resolution |
 |---|---|
-| Sandbox shows as stopped | Run `nemoclaw setup` to recreate the sandbox. |
+| Sandbox shows as stopped | Run `nemoclaw onboard` to recreate the sandbox. |
 | Inference requests time out | Verify the provider endpoint is reachable. Check `openclaw nemoclaw status` for the active endpoint. |
 | Agent cannot reach an external host | Open the TUI with `openshell term` and approve the blocked request, or add the endpoint to the policy. |
 | Blueprint run failed | Run `openclaw nemoclaw logs --run-id <id>` to view the error output for the failed run. |

--- a/docs/network-policy/approve-network-requests.md
+++ b/docs/network-policy/approve-network-requests.md
@@ -39,7 +39,7 @@ $ openshell term
 For a remote sandbox, pass the instance name:
 
 ```console
-$ nemoclaw term my-gpu-box
+$ ssh my-gpu-box 'cd /home/ubuntu/nemoclaw && . .env && openshell term'
 ```
 
 The TUI displays the sandbox state, active inference provider, and a live feed of network activity.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -30,7 +30,7 @@ NemoClaw supports both static policy changes that persist across restarts and dy
 
 ## Static Changes
 
-Static changes modify the baseline policy file and take effect after the next setup.
+Static changes modify the baseline policy file and take effect after the next sandbox creation.
 
 ### Edit the Policy File
 
@@ -47,15 +47,15 @@ Each entry in the `network` section defines an endpoint group with the following
 `rules`
 : HTTP methods and paths that are permitted.
 
-### Re-Run Setup
+### Re-Run Onboard
 
-Apply the updated policy by re-running setup:
+Apply the updated policy by re-running the onboard wizard:
 
 ```console
-$ nemoclaw setup
+$ nemoclaw onboard
 ```
 
-Setup picks up the modified policy file and applies it to the sandbox.
+The wizard picks up the modified policy file and applies it to the sandbox.
 
 ### Verify the Policy
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -43,6 +43,15 @@ $ openclaw nemoclaw launch [--force] [--profile <profile>]
 `--profile <profile>`
 : Blueprint profile to use. Default: `default`.
 
+### `nemoclaw <name> connect`
+
+Open an interactive shell inside the OpenClaw sandbox.
+Use this after launch to connect and chat with the agent through the TUI or CLI.
+
+```console
+$ nemoclaw my-assistant connect
+```
+
 ### `openclaw nemoclaw status`
 
 Display sandbox health, blueprint run state, and inference configuration.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -163,14 +163,16 @@ List available policy presets and show which ones are applied to the sandbox.
 $ nemoclaw my-assistant policy-list
 ```
 
-### `nemoclaw term`
+### `openshell term`
 
 Open the OpenShell TUI to monitor sandbox activity and approve network egress requests.
+Run this on the host where the sandbox is running.
 
 ```console
-$ nemoclaw term                  # local
-$ nemoclaw term my-gpu-box       # remote Brev instance
+$ openshell term
 ```
+
+For a remote Brev instance, SSH to the instance and run `openshell term` there, or use a port-forward to the gateway.
 
 ### `nemoclaw start`
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -43,14 +43,6 @@ $ openclaw nemoclaw launch [--force] [--profile <profile>]
 `--profile <profile>`
 : Blueprint profile to use. Default: `default`.
 
-### `nemoclaw <name> connect`
-
-Open an interactive shell inside the OpenClaw sandbox.
-
-```console
-$ nemoclaw my-assistant connect
-```
-
 ### `openclaw nemoclaw status`
 
 Display sandbox health, blueprint run state, and inference configuration.
@@ -87,24 +79,34 @@ The `/nemoclaw` slash command is available inside the OpenClaw chat interface fo
 |---|---|
 | `/nemoclaw status` | Show sandbox and inference state |
 
-## Standalone Wrapper Commands
+## Standalone Host Commands
 
 The `nemoclaw` binary handles host-side operations that run outside the OpenClaw plugin context.
 
-### `nemoclaw setup`
+### `nemoclaw onboard`
 
-Run the full host-side setup: start an OpenShell gateway, register inference providers, build the sandbox image, and create the sandbox.
+Run the interactive setup wizard.
+The wizard creates an OpenShell gateway, registers inference providers, builds the sandbox image, and creates the sandbox.
+Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw setup
+$ nemoclaw onboard
 ```
 
 The first run prompts for your NVIDIA API key and saves it to `~/.nemoclaw/credentials.json`.
 
+### `nemoclaw list`
+
+List all registered sandboxes with their model, provider, and policy presets.
+
+```console
+$ nemoclaw list
+```
+
 ### `nemoclaw deploy`
 
 Deploy NemoClaw to a remote GPU instance through [Brev](https://brev.nvidia.com).
-The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present, and OpenShell on the VM, then runs setup and connects to the sandbox.
+The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present, and OpenShell on the VM, then runs the host setup script and connects to the sandbox.
 
 ```console
 $ nemoclaw deploy <instance-name>
@@ -116,6 +118,49 @@ Connect to a sandbox by name.
 
 ```console
 $ nemoclaw my-assistant connect
+```
+
+### `nemoclaw <name> status`
+
+Show sandbox status, health, and inference configuration.
+
+```console
+$ nemoclaw my-assistant status
+```
+
+### `nemoclaw <name> logs`
+
+View sandbox logs.
+Use `--follow` to stream output in real time.
+
+```console
+$ nemoclaw my-assistant logs [--follow]
+```
+
+### `nemoclaw <name> destroy`
+
+Stop the NIM container and delete the sandbox.
+This removes the sandbox from the registry.
+
+```console
+$ nemoclaw my-assistant destroy
+```
+
+### `nemoclaw <name> policy-add`
+
+Add a policy preset to a sandbox.
+Presets extend the baseline network policy with additional endpoints.
+
+```console
+$ nemoclaw my-assistant policy-add
+```
+
+### `nemoclaw <name> policy-list`
+
+List available policy presets and show which ones are applied to the sandbox.
+
+```console
+$ nemoclaw my-assistant policy-list
 ```
 
 ### `nemoclaw term`
@@ -147,8 +192,29 @@ $ nemoclaw stop
 
 ### `nemoclaw status`
 
-Show the status of running auxiliary services.
+Show the sandbox list and the status of auxiliary services.
 
 ```console
 $ nemoclaw status
 ```
+
+## Legacy Commands
+
+The following commands are deprecated or for specific platforms.
+Prefer `nemoclaw onboard` for new installs.
+
+### `nemoclaw setup` (deprecated)
+
+Legacy host-side setup.
+Runs the same steps as `nemoclaw onboard` but without the interactive wizard.
+Use `nemoclaw onboard` instead.
+
+```console
+$ nemoclaw setup
+```
+
+### `nemoclaw setup-spark`
+
+Set up NemoClaw on DGX Spark.
+This command applies cgroup v2 and Docker fixes required for Ubuntu 24.04.
+Run with `sudo` on the Spark host.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -115,7 +115,7 @@ $ nemoclaw list
 ### `nemoclaw deploy`
 
 Deploy NemoClaw to a remote GPU instance through [Brev](https://brev.nvidia.com).
-The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present, and OpenShell on the VM, then runs the host setup script and connects to the sandbox.
+The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present, and OpenShell on the VM, then runs the nemoclaw setup and connects to the sandbox.
 
 ```console
 $ nemoclaw deploy <instance-name>
@@ -207,21 +207,6 @@ Show the sandbox list and the status of auxiliary services.
 
 ```console
 $ nemoclaw status
-```
-
-## Legacy Commands
-
-The following commands are deprecated or for specific platforms.
-Prefer `nemoclaw onboard` for new installs.
-
-### `nemoclaw setup` (deprecated)
-
-Legacy host-side setup.
-Runs the same steps as `nemoclaw onboard` but without the interactive wizard.
-Use `nemoclaw onboard` instead.
-
-```console
-$ nemoclaw setup
 ```
 
 ### `nemoclaw setup-spark`

--- a/docs/reference/inference-profiles.md
+++ b/docs/reference/inference-profiles.md
@@ -58,7 +58,7 @@ The default profile routes inference to NVIDIA's hosted API through [build.nvidi
 - **Credential:** `NVIDIA_API_KEY` environment variable
 
 Get an API key from [build.nvidia.com](https://build.nvidia.com).
-The `nemoclaw setup` command prompts for this key and stores it in `~/.nemoclaw/credentials.json`.
+The `nemoclaw onboard` command prompts for this key and stores it in `~/.nemoclaw/credentials.json`.
 
 ```console
 $ openshell inference set --provider nvidia-nim --model nvidia/nemotron-3-super-120b-a12b

--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -127,10 +127,10 @@ This opens a split tmux session with the TUI on the left and the agent on the ri
 
 ### Static Changes
 
-Edit `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` and re-run setup:
+Edit `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` and re-run the onboard wizard:
 
 ```console
-$ nemoclaw setup
+$ nemoclaw onboard
 ```
 
 ### Dynamic Changes

--- a/spark-install.md
+++ b/spark-install.md
@@ -118,7 +118,7 @@ openshell sandbox connect nemoclaw
 nemoclaw-start openclaw agent --agent main --local -m 'hello' --session-id test
 
 # Monitor network egress (separate terminal)
-nemoclaw term
+openshell term
 ```
 
 ## Architecture Notes

--- a/spark-install.md
+++ b/spark-install.md
@@ -89,10 +89,10 @@ sudo usermod -aG docker $USER
 newgrp docker  # or log out and back in
 ```
 
-### Then run normal setup
+### Then run the onboard wizard
 
 ```bash
-nemoclaw setup
+nemoclaw onboard
 ```
 
 ## Known Issues


### PR DESCRIPTION
## Summary

Updates documentation to match the current CLI surface: `nemoclaw onboard` is the recommended setup path, and `nemoclaw setup` is deprecated. Also documents previously missing commands and clarifies the deploy flow.

## Changes

- **Replace deprecated commands**: `nemoclaw setup` → `nemoclaw onboard` across README, commands reference, inference profiles, network policy docs, monitoring, deployment, and spark-install
- **Commands reference**:
  - Add `nemoclaw onboard` as the primary setup command
  - Add `nemoclaw list`, `nemoclaw <name> destroy`, `nemoclaw <name> policy-add`, `nemoclaw <name> policy-list`
  - Move `nemoclaw setup` to a Legacy section with deprecation notice
  - Document `nemoclaw setup-spark` for DGX Spark
- **Deploy doc**: Clarify that deploy runs the host setup script (not `nemoclaw setup`), and fix reconnect instructions
- **Network policy**: Use onboard for applying static policy changes

## Related issues

- Closes [#14](https://github.com/NVIDIA/NemoClaw/issues/14) — Clarify deprecated workflows
- Closes [#15](https://github.com/NVIDIA/NemoClaw/issues/15) — Replace deprecated quickstart commands