### PR TITLE
feat: add CLI metrics collection and stats command

### DIFF
--- a/bin/lib/metrics.js
+++ b/bin/lib/metrics.js
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lightweight metrics collection for NemoClaw.
+// Events are stored as newline-delimited JSON (JSONL) at ~/.nemoclaw/metrics.jsonl.
+// No external dependencies — uses only Node.js built-ins.
+
+const fs = require("fs");
+const path = require("path");
+
+const METRICS_DIR = path.join(process.env.HOME || "/tmp", ".nemoclaw");
+const METRICS_FILE = path.join(METRICS_DIR, "metrics.jsonl");
+
+/**
+ * Record a timestamped event.
+ *
+ * @param {string} type    Event type (e.g. "sandbox_connect", "policy_apply")
+ * @param {object} [data]  Arbitrary metadata attached to the event
+ */
+function recordEvent(type, data = {}) {
+  try {
+    fs.mkdirSync(METRICS_DIR, { recursive: true, mode: 0o700 });
+    const event = {
+      ts: new Date().toISOString(),
+      type,
+      ...data,
+    };
+    fs.appendFileSync(METRICS_FILE, JSON.stringify(event) + "\n", { mode: 0o600 });
+  } catch {
+    // Metrics are best-effort — never crash the CLI.
+  }
+}
+
+/**
+ * Load all recorded events, optionally filtered.
+ *
+ * @param {object}  [opts]
+ * @param {string}  [opts.sandbox]  Only events for this sandbox
+ * @param {string}  [opts.type]     Only events of this type
+ * @param {string}  [opts.since]    ISO timestamp lower bound
+ * @returns {object[]}
+ */
+function loadEvents(opts = {}) {
+  if (!fs.existsSync(METRICS_FILE)) return [];
+
+  const lines = fs.readFileSync(METRICS_FILE, "utf-8").trim().split("\n").filter(Boolean);
+  let events = [];
+
+  for (const line of lines) {
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // Skip malformed lines.
+    }
+  }
+
+  if (opts.sandbox) {
+    events = events.filter((e) => e.sandbox === opts.sandbox);
+  }
+  if (opts.type) {
+    events = events.filter((e) => e.type === opts.type);
+  }
+  if (opts.since) {
+    events = events.filter((e) => e.ts >= opts.since);
+  }
+
+  return events;
+}
+
+/**
+ * Compute aggregate statistics from recorded events.
+ *
+ * @param {string} [sandboxName]  Scope stats to a single sandbox
+ * @returns {object}
+ */
+function getStats(sandboxName) {
+  const events = sandboxName ? loadEvents({ sandbox: sandboxName }) : loadEvents();
+
+  if (events.length === 0) {
+    return { totalEvents: 0, byType: {}, bySandbox: {}, firstEvent: null, lastEvent: null };
+  }
+
+  const byType = {};
+  const bySandbox = {};
+
+  for (const e of events) {
+    // Count by type
+    byType[e.type] = (byType[e.type] || 0) + 1;
+
+    // Count by sandbox
+    if (e.sandbox) {
+      if (!bySandbox[e.sandbox]) {
+        bySandbox[e.sandbox] = { events: 0, byType: {} };
+      }
+      bySandbox[e.sandbox].events += 1;
+      bySandbox[e.sandbox].byType[e.type] = (bySandbox[e.sandbox].byType[e.type] || 0) + 1;
+    }
+  }
+
+  return {
+    totalEvents: events.length,
+    byType,
+    bySandbox,
+    firstEvent: events[0].ts,
+    lastEvent: events[events.length - 1].ts,
+  };
+}
+
+/**
+ * Delete all recorded metrics.
+ */
+function resetMetrics() {
+  try {
+    if (fs.existsSync(METRICS_FILE)) {
+      fs.unlinkSync(METRICS_FILE);
+    }
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Return the path to the metrics file (useful for tests).
+ */
+function metricsPath() {
+  return METRICS_FILE;
+}
+
+module.exports = {
+  recordEvent,
+  loadEvents,
+  getStats,
+  resetMetrics,
+  metricsPath,
+};

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -17,12 +17,13 @@ const {
 const registry = require("./lib/registry");
 const nim = require("./lib/nim");
 const policies = require("./lib/policies");
+const metrics = require("./lib/metrics");
 
 // ── Global commands ──────────────────────────────────────────────
 
 const GLOBAL_COMMANDS = new Set([
   "onboard", "list", "deploy", "setup", "setup-spark",
-  "start", "stop", "status",
+  "start", "stop", "status", "stats",
   "help", "--help", "-h",
 ]);
 
@@ -30,7 +31,9 @@ const GLOBAL_COMMANDS = new Set([
 
 async function onboard() {
   const { onboard: runOnboard } = require("./lib/onboard");
+  metrics.recordEvent("onboard_start");
   await runOnboard();
+  metrics.recordEvent("onboard_complete");
 }
 
 async function setup() {
@@ -187,6 +190,7 @@ function listSandboxes() {
 // ── Sandbox-scoped actions ───────────────────────────────────────
 
 function sandboxConnect(sandboxName) {
+  metrics.recordEvent("sandbox_connect", { sandbox: sandboxName });
   // Ensure port forward is alive before connecting
   run(`openshell forward start --background 18789 ${sandboxName} 2>/dev/null || true`, { ignoreError: true });
   run(`openshell sandbox connect ${sandboxName}`);
@@ -240,6 +244,7 @@ async function sandboxPolicyAdd(sandboxName) {
   if (confirm.toLowerCase() === "n") return;
 
   policies.applyPreset(sandboxName, answer);
+  metrics.recordEvent("policy_apply", { sandbox: sandboxName, preset: answer });
 }
 
 function sandboxPolicyList(sandboxName) {
@@ -256,6 +261,7 @@ function sandboxPolicyList(sandboxName) {
 }
 
 function sandboxDestroy(sandboxName) {
+  metrics.recordEvent("sandbox_destroy", { sandbox: sandboxName });
   console.log(`  Stopping NIM for '${sandboxName}'...`);
   nim.stopNimContainer(sandboxName);
 
@@ -264,6 +270,81 @@ function sandboxDestroy(sandboxName) {
 
   registry.removeSandbox(sandboxName);
   console.log(`  ✓ Sandbox '${sandboxName}' destroyed`);
+}
+
+// ── Stats ────────────────────────────────────────────────────────
+
+function showStats(opts = {}) {
+  const reset = opts.reset || false;
+
+  if (reset) {
+    metrics.resetMetrics();
+    console.log("  ✓ Metrics cleared.");
+    return;
+  }
+
+  const stats = metrics.getStats();
+
+  console.log("");
+  console.log("  NemoClaw Metrics");
+  console.log("  ================");
+  console.log("");
+
+  if (stats.totalEvents === 0) {
+    console.log("  No events recorded yet. Metrics are collected as you use NemoClaw.");
+    console.log("");
+    return;
+  }
+
+  console.log(`  Total events:  ${stats.totalEvents}`);
+  console.log(`  First event:   ${stats.firstEvent}`);
+  console.log(`  Last event:    ${stats.lastEvent}`);
+  console.log("");
+
+  console.log("  Events by type:");
+  for (const [type, count] of Object.entries(stats.byType).sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${type.padEnd(24)} ${count}`);
+  }
+  console.log("");
+
+  const sandboxNames = Object.keys(stats.bySandbox);
+  if (sandboxNames.length > 0) {
+    console.log("  Events by sandbox:");
+    for (const name of sandboxNames) {
+      const sb = stats.bySandbox[name];
+      console.log(`    ${name.padEnd(20)} ${sb.events} events`);
+      for (const [type, count] of Object.entries(sb.byType)) {
+        console.log(`      ${type.padEnd(22)} ${count}`);
+      }
+    }
+    console.log("");
+  }
+}
+
+function sandboxStats(sandboxName) {
+  const stats = metrics.getStats(sandboxName);
+
+  console.log("");
+  console.log(`  Metrics for sandbox '${sandboxName}'`);
+  console.log("  " + "=".repeat(30 + sandboxName.length));
+  console.log("");
+
+  if (stats.totalEvents === 0) {
+    console.log("  No events recorded for this sandbox.");
+    console.log("");
+    return;
+  }
+
+  console.log(`  Total events:  ${stats.totalEvents}`);
+  console.log(`  First event:   ${stats.firstEvent}`);
+  console.log(`  Last event:    ${stats.lastEvent}`);
+  console.log("");
+
+  console.log("  Events by type:");
+  for (const [type, count] of Object.entries(stats.byType).sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${type.padEnd(24)} ${count}`);
+  }
+  console.log("");
 }
 
 // ── Help ─────────────────────────────────────────────────────────
@@ -287,6 +368,11 @@ function help() {
   Policy Presets:
     nemoclaw <name> policy-add       Add a policy preset to a sandbox
     nemoclaw <name> policy-list      List presets (● = applied)
+
+  Metrics:
+    nemoclaw stats                   Show aggregate usage metrics
+    nemoclaw stats --reset           Clear all recorded metrics
+    nemoclaw <name> stats            Show metrics for a specific sandbox
 
   Deploy:
     nemoclaw deploy <instance>       Deploy to a Brev VM and start services
@@ -323,6 +409,7 @@ const [cmd, ...args] = process.argv.slice(2);
       case "stop":        stop(); break;
       case "status":      showStatus(); break;
       case "list":        listSandboxes(); break;
+      case "stats":       showStats({ reset: args.includes("--reset") }); break;
       default:            help(); break;
     }
     return;
@@ -340,10 +427,11 @@ const [cmd, ...args] = process.argv.slice(2);
       case "logs":        sandboxLogs(cmd, actionArgs.includes("--follow")); break;
       case "policy-add":  await sandboxPolicyAdd(cmd); break;
       case "policy-list": sandboxPolicyList(cmd); break;
+      case "stats":       sandboxStats(cmd); break;
       case "destroy":     sandboxDestroy(cmd); break;
       default:
         console.error(`  Unknown action: ${action}`);
-        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, destroy`);
+        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, stats, destroy`);
         process.exit(1);
     }
     return;

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+// Point HOME to an isolated temp directory so tests never touch real metrics.
+const TEST_HOME = path.join(os.tmpdir(), `nemoclaw-metrics-test-${Date.now()}`);
+process.env.HOME = TEST_HOME;
+
+// Re-require after setting HOME so the module picks up the test directory.
+delete require.cache[require.resolve("../bin/lib/metrics")];
+const metrics = require("../bin/lib/metrics");
+
+function cleanup() {
+  try {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  } catch {}
+}
+
+describe("metrics", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("recordEvent creates the metrics file", () => {
+    metrics.recordEvent("test_event", { sandbox: "s1" });
+    assert.ok(fs.existsSync(metrics.metricsPath()));
+  });
+
+  it("loadEvents returns recorded events", () => {
+    metrics.recordEvent("sandbox_connect", { sandbox: "alpha" });
+    metrics.recordEvent("sandbox_connect", { sandbox: "beta" });
+    metrics.recordEvent("policy_apply", { sandbox: "alpha", preset: "slack" });
+
+    const all = metrics.loadEvents();
+    assert.equal(all.length, 3);
+    assert.equal(all[0].type, "sandbox_connect");
+    assert.equal(all[0].sandbox, "alpha");
+  });
+
+  it("loadEvents filters by sandbox", () => {
+    metrics.recordEvent("sandbox_connect", { sandbox: "a" });
+    metrics.recordEvent("sandbox_connect", { sandbox: "b" });
+
+    const filtered = metrics.loadEvents({ sandbox: "a" });
+    assert.equal(filtered.length, 1);
+    assert.equal(filtered[0].sandbox, "a");
+  });
+
+  it("loadEvents filters by type", () => {
+    metrics.recordEvent("sandbox_connect", { sandbox: "a" });
+    metrics.recordEvent("policy_apply", { sandbox: "a", preset: "slack" });
+
+    const filtered = metrics.loadEvents({ type: "policy_apply" });
+    assert.equal(filtered.length, 1);
+    assert.equal(filtered[0].preset, "slack");
+  });
+
+  it("getStats computes aggregates", () => {
+    metrics.recordEvent("sandbox_connect", { sandbox: "s1" });
+    metrics.recordEvent("sandbox_connect", { sandbox: "s1" });
+    metrics.recordEvent("policy_apply", { sandbox: "s1", preset: "slack" });
+    metrics.recordEvent("sandbox_connect", { sandbox: "s2" });
+    metrics.recordEvent("sandbox_destroy", { sandbox: "s2" });
+
+    const stats = metrics.getStats();
+    assert.equal(stats.totalEvents, 5);
+    assert.equal(stats.byType["sandbox_connect"], 3);
+    assert.equal(stats.byType["policy_apply"], 1);
+    assert.equal(stats.byType["sandbox_destroy"], 1);
+    assert.equal(stats.bySandbox["s1"].events, 3);
+    assert.equal(stats.bySandbox["s2"].events, 2);
+    assert.ok(stats.firstEvent);
+    assert.ok(stats.lastEvent);
+  });
+
+  it("getStats scoped to sandbox", () => {
+    metrics.recordEvent("sandbox_connect", { sandbox: "s1" });
+    metrics.recordEvent("sandbox_connect", { sandbox: "s2" });
+
+    const stats = metrics.getStats("s1");
+    assert.equal(stats.totalEvents, 1);
+  });
+
+  it("getStats returns empty stats when no events", () => {
+    const stats = metrics.getStats();
+    assert.equal(stats.totalEvents, 0);
+    assert.equal(stats.firstEvent, null);
+  });
+
+  it("resetMetrics clears all events", () => {
+    metrics.recordEvent("sandbox_connect", { sandbox: "s1" });
+    assert.equal(metrics.loadEvents().length, 1);
+
+    metrics.resetMetrics();
+    assert.equal(metrics.loadEvents().length, 0);
+  });
+
+  it("handles malformed lines gracefully", () => {
+    // Write a valid event then corrupt a line
+    metrics.recordEvent("sandbox_connect", { sandbox: "s1" });
+    fs.appendFileSync(metrics.metricsPath(), "not-valid-json\n");
+    metrics.recordEvent("sandbox_destroy", { sandbox: "s1" });
+
+    const events = metrics.loadEvents();
+    assert.equal(events.length, 2, "should skip malformed line");
+  });
+
+  it("stats command exits 0 via CLI", () => {
+    const { execSync } = require("child_process");
+    const CLI = path.join(__dirname, "..", "bin", "nemoclaw.js");
+    const result = execSync(`node "${CLI}" stats`, {
+      encoding: "utf-8",
+      timeout: 10000,
+      env: { ...process.env, HOME: TEST_HOME },
+    });
+    assert.ok(result.includes("NemoClaw Metrics"), "should show metrics header");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #30

- Add lightweight, local-only usage metrics to the NemoClaw CLI
- Events stored as JSONL at `~/.nemoclaw/metrics.jsonl` — never leave the machine
- New `nemoclaw stats` command for aggregate and per-sandbox usage visibility
- Best-effort recording (never crashes the CLI on failure)

## What's tracked

| Event | Trigger |
|---|---|
| `onboard_start` / `onboard_complete` | Setup wizard |
| `sandbox_connect` | Each sandbox connection |
| `sandbox_destroy` | Sandbox deletion |
| `policy_apply` | Policy preset application |

## New commands

```
nemoclaw stats              # Aggregate metrics across all sandboxes
nemoclaw stats --reset      # Clear all recorded metrics
nemoclaw <name> stats       # Per-sandbox metrics
```

## Changes

- **New:** `bin/lib/metrics.js` — core metrics module (JSONL recording, filtering, aggregation)
- **New:** `test/metrics.test.js` — 10 unit tests using `node:test`
- **Modified:** `bin/nemoclaw.js` — added stats commands + instrumented existing commands

## Design decisions

- **JSONL format** — append-only, no file locking needed, easy to parse
- **Best-effort** — all metric recording is wrapped in try/catch, never affects CLI behavior
- **Zero new dependencies** — only Node.js built-ins (fs, path)
- **Local-only** — no network calls, no telemetry, data stays on the machine

## Test plan

- [x] All 48 existing + new tests pass (`node --test test/*.test.js`)
- [x] Zero regressions on existing CLI, registry, policies, NIM tests
- [x] No new dependencies added
- [x] SPDX license headers on all new files
- [x] DCO sign-off included
- [x] Rebased on latest main (conflict from #27 easter egg removal resolved)