### PR TITLE
fix: use access: full for pypi and npm policy presets

### DIFF
--- a/nemoclaw-blueprint/policies/presets/npm.yaml
+++ b/nemoclaw-blueprint/policies/presets/npm.yaml
@@ -11,15 +11,7 @@ network_policies:
     endpoints:
       - host: registry.npmjs.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: registry.yarnpkg.com
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full

--- a/nemoclaw-blueprint/policies/presets/pypi.yaml
+++ b/nemoclaw-blueprint/policies/presets/pypi.yaml
@@ -11,15 +11,7 @@ network_policies:
     endpoints:
       - host: pypi.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: files.pythonhosted.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -88,5 +88,24 @@ describe("policies", () => {
         assert.ok(content.includes("network_policies:"), `${p.name} missing network_policies`);
       }
     });
+
+    it("package-manager presets use access: full (not tls: terminate)", () => {
+      // Package managers (pip, npm, yarn) use CONNECT tunneling which breaks
+      // under tls: terminate. Ensure these presets use access: full like the
+      // github policy in openclaw-sandbox.yaml.
+      const packagePresets = ["pypi", "npm"];
+      for (const name of packagePresets) {
+        const content = policies.loadPreset(name);
+        assert.ok(content, `preset not found: ${name}`);
+        assert.ok(
+          !content.includes("tls: terminate"),
+          `${name} preset must not use tls: terminate (breaks CONNECT tunneling)`
+        );
+        assert.ok(
+          content.includes("access: full"),
+          `${name} preset must use access: full for package manager compatibility`
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the `pypi` and `npm` policy presets so `pip install` and `npm install` work inside the sandbox.

## Problem

Both presets used `protocol: rest` with `tls: terminate`, which intercepts TLS and restricts traffic to explicit HTTP method rules. Package managers like `pip` and `npm` establish HTTPS connections via CONNECT tunneling, which the TLS-terminating proxy rejects with `403` errors. Users see green checkmarks during onboarding but package installs fail later.

## Fix

Switch both presets to `access: full`, matching the pattern already used by the `github` and `npm_registry` policies in the base sandbox config (`openclaw-sandbox.yaml` lines 88, 91, 149). This allows direct TLS passthrough so package managers can negotiate their own TLS sessions.

## Changes

- `nemoclaw-blueprint/policies/presets/pypi.yaml` — switch endpoints to `access: full`
- `nemoclaw-blueprint/policies/presets/npm.yaml` — switch endpoints to `access: full`

Fixes #19