### PR TITLE
fix: align docs with current CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,17 +139,23 @@ When the agent tries to reach an unlisted host, OpenShell blocks the request and
 
 ## Key Commands
 
-### Host commands (`nemoclaw`)
+### Host commands
 
 Run these on the host to set up, connect to, and manage sandboxes.
 
-| Command                              | Description                                            |
-|--------------------------------------|--------------------------------------------------------|
-| `nemoclaw setup`                     | Full host-side setup: gateway, providers, sandbox.     |
-| `nemoclaw deploy <instance>`         | Deploy to a remote GPU instance through Brev.          |
-| `nemoclaw <name> connect`            | Open an interactive shell inside the sandbox.          |
-| `nemoclaw term`                      | Launch the OpenShell TUI for monitoring and approvals. |
-| `nemoclaw start` / `stop` / `status` | Manage auxiliary services (Telegram bridge, tunnel).   |
+| Command                              | Description                                                      |
+|--------------------------------------|------------------------------------------------------------------|
+| `nemoclaw onboard`                   | Interactive setup wizard for creating a sandbox.                 |
+| `nemoclaw setup`                     | Legacy setup wrapper. Deprecated in favor of `nemoclaw onboard`. |
+| `nemoclaw deploy <instance>`         | Deploy to a remote GPU instance through Brev.                    |
+| `nemoclaw list`                      | List registered sandboxes.                                       |
+| `nemoclaw <name> connect`            | Open an interactive shell inside the sandbox.                    |
+| `nemoclaw <name> status`             | Show sandbox status, inference provider, and policy presets.     |
+| `nemoclaw <name> logs [--follow]`    | Stream sandbox logs.                                             |
+| `openshell term`                     | Launch the OpenShell TUI for monitoring and approvals.           |
+| `nemoclaw start` / `stop` / `status` | Manage auxiliary services (Telegram bridge, tunnel).             |
+
+For remote Brev instances, SSH to the instance first and then run `openshell term`.
 
 ### Plugin commands (`openclaw nemoclaw`)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Check the prerequisites before you start to ensure you have the necessary softwa
 
 - Linux Ubuntu 22.04 LTS releases and later
 - Docker installed and running
-- [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) installed
+
+The `nemoclaw onboard` flow installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) CLI automatically if it is not already present.
 
 ### Install NemoClaw and Onboard OpenClaw Agent
 

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -43,8 +43,8 @@ The deploy script performs the following steps on the VM:
 
 1. Installs Docker and the NVIDIA Container Toolkit if a GPU is present.
 2. Installs the OpenShell CLI.
-3. Runs `nemoclaw setup` to create the gateway, register providers, and launch the sandbox.
-4. Starts auxiliary services, such as the Telegram bridge and cloudflared tunnel.
+3. Runs the remote setup flow to create the gateway, register providers, and launch the sandbox.
+4. Starts auxiliary services, such as the Telegram bridge and cloudflared tunnel, when they are configured.
 
 ## Connect to the Remote Sandbox
 
@@ -61,7 +61,8 @@ This opens an interactive shell inside the remote sandbox.
 Open the OpenShell TUI on the remote instance to monitor activity and approve network requests:
 
 ```console
-$ nemoclaw term <instance-name>
+$ ssh <instance-name>
+$ openshell term
 ```
 
 ## Verify Inference

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -37,7 +37,7 @@ $ openshell inference set --provider nvidia-nim --model nvidia/nemotron-3-super-
 ```
 
 This profile requires the `NVIDIA_API_KEY` environment variable.
-The `nemoclaw setup` command stores this key in `~/.nemoclaw/credentials.json` on first run.
+The `nemoclaw onboard` flow stores this key in `~/.nemoclaw/credentials.json` on first run.
 
 ## Switch to Local vLLM
 

--- a/docs/monitoring/monitor-sandbox-activity.md
+++ b/docs/monitoring/monitor-sandbox-activity.md
@@ -84,7 +84,8 @@ $ openshell term
 For a remote sandbox:
 
 ```console
-$ nemoclaw term <instance-name>
+$ ssh <instance-name>
+$ openshell term
 ```
 
 The TUI shows the following information:
@@ -117,7 +118,7 @@ The following table lists common problems and their resolution steps:
 
 | Symptom | Resolution |
 |---|---|
-| Sandbox shows as stopped | Run `nemoclaw setup` to recreate the sandbox. |
+| Sandbox shows as stopped | Run `nemoclaw onboard` to recreate the sandbox. |
 | Inference requests time out | Verify the provider endpoint is reachable. Check `openclaw nemoclaw status` for the active endpoint. |
 | Agent cannot reach an external host | Open the TUI with `openshell term` and approve the blocked request, or add the endpoint to the policy. |
 | Blueprint run failed | Run `openclaw nemoclaw logs --run-id <id>` to view the error output for the failed run. |

--- a/docs/network-policy/approve-network-requests.md
+++ b/docs/network-policy/approve-network-requests.md
@@ -39,7 +39,8 @@ $ openshell term
 For a remote sandbox, pass the instance name:
 
 ```console
-$ nemoclaw term my-gpu-box
+$ ssh my-gpu-box
+$ openshell term
 ```
 
 The TUI displays the sandbox state, active inference provider, and a live feed of network activity.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -49,13 +49,14 @@ Each entry in the `network` section defines an endpoint group with the following
 
 ### Re-Run Setup
 
-Apply the updated policy by re-running setup:
+Apply the updated policy by re-running the host setup flow:
 
 ```console
-$ nemoclaw setup
+$ nemoclaw onboard
 ```
 
-Setup picks up the modified policy file and applies it to the sandbox.
+If you are following the legacy wrapper workflow, use `nemoclaw setup` instead.
+The setup flow picks up the modified policy file and applies it to the sandbox.
 
 ### Verify the Policy
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -91,15 +91,32 @@ The `/nemoclaw` slash command is available inside the OpenClaw chat interface fo
 
 The `nemoclaw` binary handles host-side operations that run outside the OpenClaw plugin context.
 
+### `nemoclaw onboard`
+
+Run the guided host-side setup flow to configure inference, create a sandbox, and apply policy presets.
+
+```console
+$ nemoclaw onboard
+```
+
+The first run prompts for your NVIDIA API key and saves it to `~/.nemoclaw/credentials.json`.
+
 ### `nemoclaw setup`
 
-Run the full host-side setup: start an OpenShell gateway, register inference providers, build the sandbox image, and create the sandbox.
+Run the legacy host-side setup wrapper.
+This command is deprecated in favor of `nemoclaw onboard`.
 
 ```console
 $ nemoclaw setup
 ```
 
-The first run prompts for your NVIDIA API key and saves it to `~/.nemoclaw/credentials.json`.
+### `nemoclaw setup-spark`
+
+Apply the DGX Spark-specific setup flow, including the cgroup v2 and Docker workarounds used by NemoClaw.
+
+```console
+$ nemoclaw setup-spark
+```
 
 ### `nemoclaw deploy`
 
@@ -110,6 +127,14 @@ The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present,
 $ nemoclaw deploy <instance-name>
 ```
 
+### `nemoclaw list`
+
+List registered sandboxes on the host.
+
+```console
+$ nemoclaw list
+```
+
 ### `nemoclaw <name> connect`
 
 Connect to a sandbox by name.
@@ -118,14 +143,55 @@ Connect to a sandbox by name.
 $ nemoclaw my-assistant connect
 ```
 
-### `nemoclaw term`
+### `nemoclaw <name> status`
+
+Show the registered sandbox metadata, the current OpenShell sandbox state, and local NIM health.
+
+```console
+$ nemoclaw my-assistant status
+```
+
+### `nemoclaw <name> logs`
+
+View sandbox logs, with optional follow mode.
+
+```console
+$ nemoclaw my-assistant logs [--follow]
+```
+
+### `nemoclaw <name> policy-add`
+
+Interactively apply a policy preset to a sandbox.
+
+```console
+$ nemoclaw my-assistant policy-add
+```
+
+### `nemoclaw <name> policy-list`
+
+List policy presets and show which ones are already applied to the sandbox.
+
+```console
+$ nemoclaw my-assistant policy-list
+```
+
+### `nemoclaw <name> destroy`
+
+Stop the local NIM container for a sandbox and delete the sandbox.
+
+```console
+$ nemoclaw my-assistant destroy
+```
+
+### `openshell term`
 
 Open the OpenShell TUI to monitor sandbox activity and approve network egress requests.
 
 ```console
-$ nemoclaw term                  # local
-$ nemoclaw term my-gpu-box       # remote Brev instance
+$ openshell term
 ```
+
+For remote Brev instances, SSH to the VM first and then run `openshell term`.
 
 ### `nemoclaw start`
 
@@ -147,7 +213,7 @@ $ nemoclaw stop
 
 ### `nemoclaw status`
 
-Show the status of running auxiliary services.
+Show the registered sandboxes and the status of auxiliary services.
 
 ```console
 $ nemoclaw status

--- a/docs/reference/inference-profiles.md
+++ b/docs/reference/inference-profiles.md
@@ -58,7 +58,7 @@ The default profile routes inference to NVIDIA's hosted API through [build.nvidi
 - **Credential:** `NVIDIA_API_KEY` environment variable
 
 Get an API key from [build.nvidia.com](https://build.nvidia.com).
-The `nemoclaw setup` command prompts for this key and stores it in `~/.nemoclaw/credentials.json`.
+The `nemoclaw onboard` flow prompts for this key and stores it in `~/.nemoclaw/credentials.json`.
 
 ```console
 $ openshell inference set --provider nvidia-nim --model nvidia/nemotron-3-super-120b-a12b

--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -127,10 +127,10 @@ This opens a split tmux session with the TUI on the left and the agent on the ri
 
 ### Static Changes
 
-Edit `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` and re-run setup:
+Edit `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` and re-run the host setup flow:
 
 ```console
-$ nemoclaw setup
+$ nemoclaw onboard
 ```
 
 ### Dynamic Changes

--- a/spark-install.md
+++ b/spark-install.md
@@ -118,7 +118,7 @@ openshell sandbox connect nemoclaw
 nemoclaw-start openclaw agent --agent main --local -m 'hello' --session-id test
 
 # Monitor network egress (separate terminal)
-nemoclaw term
+openshell term
 ```
 
 ## Architecture Notes


### PR DESCRIPTION
## Summary
- align the docs with the current CLI
- replace removed `nemoclaw term` references with `openshell term`
- document `nemoclaw onboard` as the recommended setup flow and `nemoclaw setup` as legacy

## Testing
- npm test