### PR TITLE
fix: support XDG-compliant Colima Docker socket path

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -109,8 +109,12 @@ async function startGateway(gpu) {
   }
 
   // CoreDNS fix — always run. k3s-inside-Docker has broken DNS on all platforms.
-  const colimaSocket = path.join(process.env.HOME || "/tmp", ".colima/default/docker.sock");
-  if (fs.existsSync(colimaSocket)) {
+  const home = process.env.HOME || "/tmp";
+  const colimaSocket = [
+    path.join(home, ".colima/default/docker.sock"),
+    path.join(home, ".config/colima/default/docker.sock"),
+  ].find((s) => fs.existsSync(s));
+  if (colimaSocket) {
     console.log("  Patching CoreDNS for Colima...");
     run(`bash "${path.join(SCRIPTS, "fix-coredns.sh")}" 2>&1 || true`, { ignoreError: true });
   }

--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -8,11 +8,18 @@ const fs = require("fs");
 const ROOT = path.resolve(__dirname, "..", "..");
 const SCRIPTS = path.join(ROOT, "scripts");
 
-// Auto-detect Colima Docker socket
+// Auto-detect Colima Docker socket (legacy ~/.colima or XDG ~/.config/colima)
 if (!process.env.DOCKER_HOST) {
-  const colimaSocket = path.join(process.env.HOME || "/tmp", ".colima/default/docker.sock");
-  if (fs.existsSync(colimaSocket)) {
-    process.env.DOCKER_HOST = `unix://${colimaSocket}`;
+  const home = process.env.HOME || "/tmp";
+  const candidates = [
+    path.join(home, ".colima/default/docker.sock"),
+    path.join(home, ".config/colima/default/docker.sock"),
+  ];
+  for (const sock of candidates) {
+    if (fs.existsSync(sock)) {
+      process.env.DOCKER_HOST = `unix://${sock}`;
+      break;
+    }
   }
 }
 

--- a/scripts/fix-coredns.sh
+++ b/scripts/fix-coredns.sh
@@ -19,13 +19,22 @@
 set -euo pipefail
 
 GATEWAY_NAME="${1:-}"
-COLIMA_SOCKET="$HOME/.colima/default/docker.sock"
+
+# Find Colima socket (legacy or XDG path)
+COLIMA_SOCKET=""
+for _sock in "$HOME/.colima/default/docker.sock" "$HOME/.config/colima/default/docker.sock"; do
+  if [ -S "$_sock" ]; then
+    COLIMA_SOCKET="$_sock"
+    break
+  fi
+done
+unset _sock
 
 if [ -z "${DOCKER_HOST:-}" ]; then
-  if [ -S "$COLIMA_SOCKET" ]; then
+  if [ -n "$COLIMA_SOCKET" ]; then
     export DOCKER_HOST="unix://$COLIMA_SOCKET"
   else
-    echo "Skipping CoreDNS patch: Colima socket not found at $COLIMA_SOCKET."
+    echo "Skipping CoreDNS patch: Colima socket not found."
     exit 0
   fi
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -51,12 +51,16 @@ upsert_provider() {
   fi
 }
 
-# Resolve DOCKER_HOST for Colima if needed
+# Resolve DOCKER_HOST for Colima if needed (legacy ~/.colima or XDG ~/.config/colima)
 if [ -z "${DOCKER_HOST:-}" ]; then
-  if [ -S "$HOME/.colima/default/docker.sock" ]; then
-    export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
-    warn "Using Colima Docker socket"
-  fi
+  for _sock in "$HOME/.colima/default/docker.sock" "$HOME/.config/colima/default/docker.sock"; do
+    if [ -S "$_sock" ]; then
+      export DOCKER_HOST="unix://$_sock"
+      warn "Using Colima Docker socket: $_sock"
+      break
+    fi
+  done
+  unset _sock
 fi
 
 # Check prerequisites


### PR DESCRIPTION
## Summary

- Adds support for the XDG-compliant Colima socket path (`~/.config/colima/default/docker.sock`) in addition to the legacy path (`~/.colima/default/docker.sock`)
- Updates socket detection logic consistently across `onboard.js`, `runner.js`, `fix-coredns.sh`, and `setup.sh`
- Both paths are checked with the legacy path preferred for backward compatibility

## Motivation

Newer Colima versions following the XDG Base Directory Specification place the Docker socket at `~/.config/colima/default/docker.sock` instead of `~/.colima/default/docker.sock`. This caused NemoClaw to fail to detect the Colima Docker socket on systems using the XDG layout.

## Changes

| File | Change |
|------|--------|
| `bin/lib/onboard.js` | Check both socket paths when patching CoreDNS |
| `bin/lib/runner.js` | Check both socket paths for `DOCKER_HOST` auto-detection |
| `scripts/fix-coredns.sh` | Loop over both socket paths in shell script |
| `scripts/setup.sh` | Loop over both socket paths for Docker host resolution |