### PR TITLE
Fail fast on unsupported installer runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Check the prerequisites before you start to ensure you have the necessary softwa
 #### Software
 
 - Linux Ubuntu 22.04 LTS releases and later
+- Node.js 20+ and npm 10+ (the installer recommends Node.js 22)
 - Docker installed and running
 - [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) installed
 

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,11 @@ error() { printf '\033[1;31m[ERROR]\033[0m %s\n' "$*"; exit 1; }
 
 command_exists() { command -v "$1" &>/dev/null; }
 
+MIN_NODE_MAJOR=20
+MIN_NPM_MAJOR=10
+RECOMMENDED_NODE_MAJOR=22
+RUNTIME_REQUIREMENT_MSG="NemoClaw requires Node.js >=${MIN_NODE_MAJOR} and npm >=${MIN_NPM_MAJOR} (recommended Node.js ${RECOMMENDED_NODE_MAJOR})."
+
 # Compare two semver strings (major.minor.patch). Returns 0 if $1 >= $2.
 version_gte() {
   local IFS=.
@@ -25,6 +30,30 @@ version_gte() {
     if (( ai < bi )); then return 1; fi
   done
   return 0
+}
+
+version_major() {
+  printf '%s\n' "${1#v}" | cut -d. -f1
+}
+
+ensure_supported_runtime() {
+  command_exists node || error "${RUNTIME_REQUIREMENT_MSG} Node.js was not found on PATH."
+  command_exists npm || error "${RUNTIME_REQUIREMENT_MSG} npm was not found on PATH."
+
+  local node_version npm_version node_major npm_major
+  node_version="$(node --version 2>/dev/null || true)"
+  npm_version="$(npm --version 2>/dev/null || true)"
+  node_major="$(version_major "$node_version")"
+  npm_major="$(version_major "$npm_version")"
+
+  [[ "$node_major" =~ ^[0-9]+$ ]] || error "Could not determine Node.js version from '${node_version}'. ${RUNTIME_REQUIREMENT_MSG}"
+  [[ "$npm_major" =~ ^[0-9]+$ ]] || error "Could not determine npm version from '${npm_version}'. ${RUNTIME_REQUIREMENT_MSG}"
+
+  if (( node_major < MIN_NODE_MAJOR || npm_major < MIN_NPM_MAJOR )); then
+    error "Unsupported runtime detected: Node.js ${node_version:-unknown}, npm ${npm_version:-unknown}. ${RUNTIME_REQUIREMENT_MSG} Upgrade Node.js and rerun the installer."
+  fi
+
+  info "Runtime OK: Node.js ${node_version}, npm ${npm_version}"
 }
 
 # ---------------------------------------------------------------------------
@@ -144,6 +173,7 @@ main() {
   info "=== NemoClaw Installer ==="
 
   install_nodejs
+  ensure_supported_runtime
   # install_or_upgrade_ollama
   install_nemoclaw
   run_onboard

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,11 @@ info()  { echo -e "${GREEN}[install]${NC} $1"; }
 warn()  { echo -e "${YELLOW}[install]${NC} $1"; }
 fail()  { echo -e "${RED}[install]${NC} $1"; exit 1; }
 
+MIN_NODE_MAJOR=20
+MIN_NPM_MAJOR=10
+RECOMMENDED_NODE_MAJOR=22
+RUNTIME_REQUIREMENT_MSG="NemoClaw requires Node.js >=${MIN_NODE_MAJOR} and npm >=${MIN_NPM_MAJOR} (recommended Node.js ${RECOMMENDED_NODE_MAJOR})."
+
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
@@ -53,6 +58,30 @@ elif [ "$OS" = "Linux" ]; then
 fi
 
 info "Node.js manager: $NODE_MGR"
+
+version_major() {
+  printf '%s\n' "${1#v}" | cut -d. -f1
+}
+
+ensure_supported_runtime() {
+  command -v node > /dev/null 2>&1 || fail "${RUNTIME_REQUIREMENT_MSG} Node.js was not found on PATH."
+  command -v npm > /dev/null 2>&1 || fail "${RUNTIME_REQUIREMENT_MSG} npm was not found on PATH."
+
+  local node_version npm_version node_major npm_major
+  node_version="$(node -v 2>/dev/null || true)"
+  npm_version="$(npm --version 2>/dev/null || true)"
+  node_major="$(version_major "$node_version")"
+  npm_major="$(version_major "$npm_version")"
+
+  [[ "$node_major" =~ ^[0-9]+$ ]] || fail "Could not determine Node.js version from '${node_version}'. ${RUNTIME_REQUIREMENT_MSG}"
+  [[ "$npm_major" =~ ^[0-9]+$ ]] || fail "Could not determine npm version from '${npm_version}'. ${RUNTIME_REQUIREMENT_MSG}"
+
+  if (( node_major < MIN_NODE_MAJOR || npm_major < MIN_NPM_MAJOR )); then
+    fail "Unsupported runtime detected: Node.js ${node_version:-unknown}, npm ${npm_version:-unknown}. ${RUNTIME_REQUIREMENT_MSG} Upgrade Node.js and rerun the installer."
+  fi
+
+  info "Runtime OK: Node.js ${node_version}, npm ${npm_version}"
+}
 
 # ── Install Node.js 22 if needed ────────────────────────────────
 
@@ -107,6 +136,7 @@ install_node() {
 }
 
 install_node
+ensure_supported_runtime
 
 # ── Install Docker ───────────────────────────────────────────────
 

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const INSTALLER = path.join(__dirname, "..", "install.sh");
+
+function writeExecutable(target, contents) {
+  fs.writeFileSync(target, contents, { mode: 0o755 });
+}
+
+describe("installer runtime preflight", () => {
+  it("fails fast with a clear message on unsupported Node.js and npm", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-preflight-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "node"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  echo "v18.19.1"
+  exit 0
+fi
+echo "unexpected node invocation: $*" >&2
+exit 99
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  echo "9.8.1"
+  exit 0
+fi
+echo "unexpected npm invocation: $*" >&2
+exit 98
+`,
+    );
+
+    const result = spawnSync("bash", [INSTALLER], {
+      cwd: path.join(__dirname, ".."),
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+      },
+    });
+
+    const output = `${result.stdout}${result.stderr}`;
+    assert.notEqual(result.status, 0);
+    assert.match(output, /Unsupported runtime detected/);
+    assert.match(output, /Node\.js >=20 and npm >=10/);
+    assert.match(output, /v18\.19\.1/);
+    assert.match(output, /9\.8\.1/);
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit Node.js/npm runtime preflight checks to both installer entrypoints before any npm install step runs
- fail with a single clear error that states the minimum supported runtime and the recommended Node.js version
- document the supported Node.js/npm versions in the README prerequisites
- add a regression test that simulates Node.js 18 + npm 9 and proves the root installer exits early with the preflight message

## Linked issue
Fixes #10

## Verification
- `npm test`
