### PR TITLE
chore: remove sphinx_llm.txt extension from docs config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,6 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinxcontrib.mermaid",
-    "sphinx_llm.txt",
     "json_output",
     "search_assets",
 ]


### PR DESCRIPTION
Remove the sphinx_llm.txt entry from the Sphinx extensions list in docs/conf.py, as it is not a valid/needed extension.