### PR TITLE
fix: use registry-backed port for NIM health checks in nimStatus()

### DIFF
--- a/bin/lib/nim.js
+++ b/bin/lib/nim.js
@@ -5,6 +5,7 @@
 
 const { run, runCapture } = require("./runner");
 const nimImages = require("./nim-images.json");
+const registry = require("./registry");
 
 function containerName(sandboxName) {
   return `nemoclaw-nim-${sandboxName}`;
@@ -140,6 +141,14 @@ function startNimContainer(sandboxName, model, port = 8000) {
   run(
     `docker run -d --gpus all -p ${port}:8000 --name ${name} --shm-size 16g ${image}`
   );
+
+  // Persist the chosen host port so nimStatus() can resolve it later,
+  // even for callers that do not go through onboard.js.
+  // updateSandbox is a no-op if the sandbox is not yet registered (e.g. first
+  // call during onboarding before registerSandbox). onboard.js also stores
+  // nimPort explicitly in its own updateSandbox call, so nothing is lost.
+  registry.updateSandbox(sandboxName, { nimPort: port });
+
   return name;
 }
 
@@ -181,9 +190,12 @@ function nimStatus(sandboxName) {
     );
     if (!state) return { running: false, container: name };
 
+    const sb = registry.getSandbox(sandboxName);
+    const port = (sb && sb.nimPort) ? parseInt(sb.nimPort, 10) : 8000;
+
     let healthy = false;
     if (state === "running") {
-      const health = runCapture(`curl -sf http://localhost:8000/v1/models 2>/dev/null`, {
+      const health = runCapture(`curl -sf http://localhost:${port}/v1/models 2>/dev/null`, {
         ignoreError: true,
       });
       healthy = !!health;

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -191,6 +191,7 @@ async function setupNim(sandboxName, gpu) {
   let model = null;
   let provider = "nvidia-nim";
   let nimContainer = null;
+  let nimPort = 8000;
 
   // Detect local inference options
   const hasOllama = !!runCapture("command -v ollama", { ignoreError: true });
@@ -266,10 +267,10 @@ async function setupNim(sandboxName, gpu) {
         nim.pullNimImage(model);
 
         console.log("  Starting NIM container...");
-        nimContainer = nim.startNimContainer(sandboxName, model);
+        nimContainer = nim.startNimContainer(sandboxName, model, nimPort);
 
         console.log("  Waiting for NIM to become healthy...");
-        if (!nim.waitForNimHealth()) {
+        if (!nim.waitForNimHealth(nimPort)) {
           console.error("  NIM failed to start. Falling back to cloud API.");
           model = null;
           nimContainer = null;
@@ -309,7 +310,7 @@ async function setupNim(sandboxName, gpu) {
     console.log(`  Using NVIDIA Cloud API with model: ${model}`);
   }
 
-  registry.updateSandbox(sandboxName, { model, provider, nimContainer });
+  registry.updateSandbox(sandboxName, { model, provider, nimContainer, nimPort });
 
   return { model, provider };
 }
@@ -332,12 +333,14 @@ async function setupInference(sandboxName, model, provider) {
       { ignoreError: true }
     );
   } else if (provider === "vllm-local") {
+    const sb = registry.getSandbox(sandboxName);
+    const vllmPort = (sb && sb.nimPort) ? sb.nimPort : 8000;
     run(
       `openshell provider create --name vllm-local --type openai ` +
       `--credential "OPENAI_API_KEY=dummy" ` +
-      `--config "OPENAI_BASE_URL=${HOST_GATEWAY_URL}:8000/v1" 2>&1 || ` +
+      `--config "OPENAI_BASE_URL=${HOST_GATEWAY_URL}:${vllmPort}/v1" 2>&1 || ` +
       `openshell provider update vllm-local --credential "OPENAI_API_KEY=dummy" ` +
-      `--config "OPENAI_BASE_URL=${HOST_GATEWAY_URL}:8000/v1" 2>&1 || true`,
+      `--config "OPENAI_BASE_URL=${HOST_GATEWAY_URL}:${vllmPort}/v1" 2>&1 || true`,
       { ignoreError: true }
     );
     run(

--- a/bin/lib/registry.js
+++ b/bin/lib/registry.js
@@ -45,6 +45,7 @@ function registerSandbox(entry) {
     createdAt: entry.createdAt || new Date().toISOString(),
     model: entry.model || null,
     nimContainer: entry.nimContainer || null,
+    nimPort: entry.nimPort || null,
     provider: entry.provider || null,
     gpuEnabled: entry.gpuEnabled || false,
     policies: entry.policies || [],

--- a/test/nim.test.js
+++ b/test/nim.test.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const { describe, it } = require("node:test");
+const { describe, it, before, after } = require("node:test");
 const assert = require("node:assert/strict");
 
 const nim = require("../bin/lib/nim");
@@ -72,6 +72,109 @@ describe("nim", () => {
     it("returns not running for nonexistent container", () => {
       const st = nim.nimStatus("nonexistent-test-xyz");
       assert.equal(st.running, false);
+    });
+  });
+
+  describe("nimStatus (stubbed runner + registry)", () => {
+    let nimStubbed;
+    let captureImpl;
+    const runnerPath = require.resolve("../bin/lib/runner");
+    const registryPath = require.resolve("../bin/lib/registry");
+    const nimPath = require.resolve("../bin/lib/nim");
+    let savedRunner;
+    let savedRegistry;
+    let savedNim;
+
+    before(() => {
+      savedRunner = require.cache[runnerPath];
+      savedRegistry = require.cache[registryPath];
+      savedNim = require.cache[nimPath];
+
+      // Inject mock runner — captureImpl is a shared variable so tests can swap it
+      require.cache[runnerPath] = {
+        id: runnerPath,
+        filename: runnerPath,
+        loaded: true,
+        exports: {
+          run: () => {},
+          runCapture: (...args) => (captureImpl ? captureImpl(...args) : null),
+          ROOT: "",
+          SCRIPTS: "",
+        },
+      };
+
+      // Inject mock registry — default: nimPort 9000
+      require.cache[registryPath] = {
+        id: registryPath,
+        filename: registryPath,
+        loaded: true,
+        exports: {
+          getSandbox: () => ({ nimPort: 9000 }),
+        },
+      };
+
+      // Force nim.js to reload and destructure from our mocked runner
+      delete require.cache[nimPath];
+      nimStubbed = require("../bin/lib/nim");
+    });
+
+    after(() => {
+      require.cache[runnerPath] = savedRunner;
+      require.cache[registryPath] = savedRegistry;
+      // Restore original nim so other test suites are unaffected
+      delete require.cache[nimPath];
+      if (savedNim) require.cache[nimPath] = savedNim;
+    });
+
+    it("returns running+healthy when container running and health check succeeds on port 9000", () => {
+      captureImpl = (cmd) => {
+        if (cmd.includes("docker inspect")) return "running";
+        if (cmd.includes("curl")) return '{"data":[]}';
+        return null;
+      };
+
+      const st = nimStubbed.nimStatus("test-sandbox");
+      assert.equal(st.running, true);
+      assert.equal(st.healthy, true);
+    });
+
+    it("health check URL uses port from registry (port 9000)", () => {
+      let curlCmd = null;
+      captureImpl = (cmd) => {
+        if (cmd.includes("docker inspect")) return "running";
+        if (cmd.includes("curl")) {
+          curlCmd = cmd;
+          return '{"data":[]}';
+        }
+        return null;
+      };
+
+      nimStubbed.nimStatus("test-sandbox");
+      assert.ok(curlCmd, "curl should have been called");
+      assert.ok(curlCmd.includes(":9000/"), `Expected :9000/ in curl URL, got: ${curlCmd}`);
+    });
+
+    it("defaults to port 8000 when no nimPort stored in registry (backwards compat)", () => {
+      // Override getSandbox to simulate no stored port
+      require.cache[registryPath].exports.getSandbox = () => null;
+
+      let curlCmd = null;
+      captureImpl = (cmd) => {
+        if (cmd.includes("docker inspect")) return "running";
+        if (cmd.includes("curl")) {
+          curlCmd = cmd;
+          return '{"data":[]}';
+        }
+        return null;
+      };
+
+      const st = nimStubbed.nimStatus("test-sandbox");
+      assert.equal(st.running, true);
+      assert.equal(st.healthy, true);
+      assert.ok(curlCmd && curlCmd.includes(":8000/"), `Expected :8000/ in curl URL, got: ${curlCmd}`);
+
+      // Restore default getSandbox for subsequent tests
+      require.cache[registryPath].exports.getSandbox = () => ({ nimPort: 9000 });
     });
   });
 });


### PR DESCRIPTION
## Summary

`nimStatus()` hardcodes health checks to `localhost:8000`, ignoring the `port` parameter accepted by `startNimContainer()`. If a NIM container is started on a non-default port (e.g. 9000), `nimStatus()` always reports `healthy: false`.

## Changes

- **`bin/lib/nim.js`**: `nimStatus()` now reads `nimPort` from the sandbox registry (defaulting to `8000`). `startNimContainer()` persists `nimPort` after a successful launch so all callers of the exported API are covered.
- **`bin/lib/registry.js`**: Added `nimPort` to the `registerSandbox()` schema.
- **`bin/lib/onboard.js`**: Threads `nimPort` through `startNimContainer()`, `waitForNimHealth()`, the registry update, and the `vllm-local` provider URL.
- **`test/nim.test.js`**: Three new regression tests — health check on port 9000, URL assertion, and backwards-compat fallback to 8000 when no `nimPort` is stored.

## Testing

```
npm test
# 41 passed, 0 failed
```

## Backwards Compatibility

- Existing sandboxes without `nimPort` metadata default to `8000`
- No function signatures changed for external callers
- `updateSandbox()` safely no-ops if called before `registerSandbox()`