### PR TITLE
fix: use execFile with arg arrays to prevent command injection

### DIFF
--- a/nemoclaw/src/commands/status.ts
+++ b/nemoclaw/src/commands/status.ts
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { promisify } from "node:util";
 import type { PluginLogger, NemoClawConfig } from "../index.js";
 import { loadState } from "../blueprint/state.js";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Detect whether the plugin is running inside an OpenShell sandbox.
@@ -128,7 +128,7 @@ async function getSandboxStatus(sandboxName: string, insideSandbox: boolean): Pr
     return { name: sandboxName, running: false, uptime: null, insideSandbox: true };
   }
   try {
-    const { stdout } = await execAsync(`openshell sandbox status ${sandboxName} --json`, {
+    const { stdout } = await execFileAsync("openshell", ["sandbox", "status", sandboxName, "--json"], {
       timeout: 5000,
     });
     const parsed = JSON.parse(stdout) as SandboxStatusResponse;
@@ -162,7 +162,7 @@ async function getInferenceStatus(insideSandbox: boolean): Promise<InferenceStat
     return { configured: false, provider: null, model: null, endpoint: null, insideSandbox: true };
   }
   try {
-    const { stdout } = await execAsync("openshell inference get --json", {
+    const { stdout } = await execFileAsync("openshell", ["inference", "get", "--json"], {
       timeout: 5000,
     });
     const parsed = JSON.parse(stdout) as InferenceStatusResponse;


### PR DESCRIPTION
## Summary
- Replace `exec()` with `execFile()` in `status.ts` to eliminate shell command injection risk
- Pass arguments as an array instead of interpolating into a command string, so shell metacharacters in `sandboxName` are treated as literals
- `execFile()` does not spawn a shell, so args like `; rm -rf /` in a tampered sandbox name have no effect

## Details
`getSandboxStatus()` interpolates `sandboxName` into a shell command string passed to `exec()`. If `sandboxName` is ever sourced from a tampered config or user input, this is a command injection vector. `execFile()` with an args array bypasses the shell entirely.

Also updated `getInferenceStatus()` for consistency, even though it has no user-controlled input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal command execution for OpenShell status and inference queries. The status check and inference retrieval functionality remain unchanged with the same error handling and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->