### PR TITLE
feat: add azure-nim inference profile for Microsoft Foundry-hosted NIM endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,14 @@ When something goes wrong, errors may originate from either NemoClaw or the Open
 
 ## Inference Profiles
 
-Inference requests from the agent never leave the sandbox directly. OpenShell intercepts every call and routes it to the configured provider. NemoClaw ships with three profiles:
+Inference requests from the agent never leave the sandbox directly. OpenShell intercepts every call and routes it to the configured provider. NemoClaw ships with four profiles:
 
-| Profile     | Provider     | Model                               | Use Case                                       |
-|-------------|--------------|--------------------------------------|-------------------------------------------------|
-| `default`   | NVIDIA cloud | `nvidia/nemotron-3-super-120b-a12b` | Production. Requires an NVIDIA API key.         |
-| `nim-local` | Local NIM    | `nvidia/nemotron-3-super-120b-a12b` | On-premises. NIM deployed as a local container. |
-| `vllm`      | vLLM         | `nvidia/nemotron-3-nano-30b-a3b`    | Local development. vLLM on the host.            |
+| Profile     | Provider         | Model                               | Use Case                                             |
+|-------------|------------------|--------------------------------------|------------------------------------------------------|
+| `default`   | NVIDIA cloud     | `nvidia/nemotron-3-super-120b-a12b` | Production. Requires an NVIDIA API key.               |
+| `nim-local` | Local NIM        | `nvidia/nemotron-3-super-120b-a12b` | On-premises. NIM deployed as a local container.       |
+| `azure-nim` | Azure-hosted NIM | `nvidia/nemotron-3-super-120b-a12b` | Enterprise. NIM on Microsoft Foundry.                 |
+| `vllm`      | vLLM             | `nvidia/nemotron-3-nano-30b-a3b`    | Local development. vLLM on the host.                  |
 
 Select a profile at launch with `--profile`, or switch at runtime without restarting the sandbox:
 

--- a/docs/reference/inference-profiles.md
+++ b/docs/reference/inference-profiles.md
@@ -1,11 +1,11 @@
 ---
 title:
-  page: "NemoClaw Inference Profiles — NVIDIA Cloud, NIM, and vLLM"
+  page: "NemoClaw Inference Profiles — NVIDIA Cloud, NIM, Azure, and vLLM"
   nav: "Inference Profiles"
-description: "Configuration reference for NVIDIA cloud, local NIM, and vLLM profiles."
-keywords: ["nemoclaw inference profiles", "nemoclaw nvidia nim vllm provider"]
+description: "Configuration reference for NVIDIA cloud, local NIM, Azure-hosted NIM, and vLLM profiles."
+keywords: ["nemoclaw inference profiles", "nemoclaw nvidia nim vllm provider", "azure nim", "microsoft foundry"]
 topics: ["generative_ai", "ai_agents"]
-tags: ["openclaw", "openshell", "inference_routing", "nim", "vllm", "llms"]
+tags: ["openclaw", "openshell", "inference_routing", "nim", "vllm", "llms", "azure-nim"]
 content:
   type: reference
   difficulty: intermediate
@@ -20,7 +20,7 @@ status: published
 
 # Inference Profiles
 
-NemoClaw ships with three inference profiles defined in `blueprint.yaml`.
+NemoClaw ships with four inference profiles defined in `blueprint.yaml`.
 Each profile configures an OpenShell inference provider and model route.
 The agent inside the sandbox uses whichever profile is active.
 Inference requests are routed transparently through the OpenShell gateway.
@@ -31,6 +31,7 @@ Inference requests are routed transparently through the OpenShell gateway.
 |---|---|---|---|---|
 | `default` | NVIDIA cloud | `nvidia/nemotron-3-super-120b-a12b` | `integrate.api.nvidia.com` | Production. Requires an NVIDIA API key. |
 | `nim-local` | Local NIM service | `nvidia/nemotron-3-super-120b-a12b` | `nim-service.local:8000` | On-premises. NIM deployed as a local pod. |
+| `azure-nim` | Azure-hosted NIM | `nvidia/nemotron-3-super-120b-a12b` | User-provided Azure endpoint | Enterprise. NIM on Microsoft Foundry. |
 | `vllm` | vLLM | `nvidia/nemotron-3-nano-30b-a3b` | `host.openshell.internal:8000` | Local development. vLLM on the host. |
 
 ## Available Models
@@ -78,6 +79,25 @@ The sandbox network policy includes a `nim_service` entry that allows traffic to
 ```console
 $ openshell inference set --provider nim-local --model nvidia/nemotron-3-super-120b-a12b
 ```
+
+## `azure-nim` -- Azure-Hosted NIM
+
+Routes inference to an NVIDIA NIM deployment hosted on Microsoft Foundry.
+
+- **Provider type:** `openai`, which uses the OpenAI-compatible API
+- **Endpoint:** User-provided Microsoft Foundry endpoint URL (e.g., `https://<deployment>.services.ai.azure.com/v1`)
+- **Model:** `nvidia/nemotron-3-super-120b-a12b`
+- **Credential:** `AZURE_NIM_API_KEY` environment variable
+
+Deploy a NIM model through the Microsoft Foundry model catalog.
+Set the `AZURE_NIM_API_KEY` to your endpoint API key.
+
+```console
+$ export AZURE_NIM_API_KEY=<your-azure-endpoint-key>
+$ openshell inference set --provider azure-nim --model nvidia/nemotron-3-super-120b-a12b
+```
+
+The sandbox network policy includes an `azure_nim` entry that allows egress to `*.inference.ml.azure.com` and `*.services.ai.azure.com` on port 443 (Microsoft Foundry endpoints).
 
 ## `vllm` -- Local vLLM
 

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -10,6 +10,7 @@ profiles:
   - default
   - ncp
   - nim-local
+  - azure-nim
   - vllm
 
 description: |
@@ -46,6 +47,14 @@ components:
         model: "nvidia/nemotron-3-super-120b-a12b"
         credential_env: "NIM_API_KEY"
 
+      azure-nim:
+        provider_type: "openai"
+        provider_name: "azure-nim"
+        endpoint: ""  # User-provided Microsoft Foundry endpoint URL
+        model: "nvidia/nemotron-3-super-120b-a12b"
+        credential_env: "AZURE_NIM_API_KEY"
+        dynamic_endpoint: true
+
       vllm:
         provider_type: "openai"
         provider_name: "vllm-local"
@@ -62,4 +71,13 @@ components:
         endpoints:
           - host: "nim-service.local"
             port: 8000
+            protocol: rest
+      azure_nim:
+        name: azure_nim
+        endpoints:
+          - host: "*.inference.ml.azure.com"
+            port: 443
+            protocol: rest
+          - host: "*.services.ai.azure.com"
+            port: 443
             protocol: rest

--- a/nemoclaw/src/commands/onboard.ts
+++ b/nemoclaw/src/commands/onboard.ts
@@ -22,7 +22,7 @@ export interface OnboardOptions {
   pluginConfig: NemoClawConfig;
 }
 
-const ENDPOINT_TYPES: EndpointType[] = ["build", "ncp", "nim-local", "vllm", "ollama", "custom"];
+const ENDPOINT_TYPES: EndpointType[] = ["build", "ncp", "nim-local", "azure-nim", "vllm", "ollama", "custom"];
 
 const BUILD_ENDPOINT_URL = "https://integrate.api.nvidia.com/v1";
 const HOST_GATEWAY_URL = "http://host.openshell.internal";
@@ -43,6 +43,8 @@ function resolveProfile(endpointType: EndpointType): string {
       return "ncp";
     case "nim-local":
       return "nim-local";
+    case "azure-nim":
+      return "azure-nim";
     case "vllm":
       return "vllm";
     case "ollama":
@@ -59,6 +61,8 @@ function resolveProviderName(endpointType: EndpointType): string {
       return "nvidia-ncp";
     case "nim-local":
       return "nim-local";
+    case "azure-nim":
+      return "azure-nim";
     case "vllm":
       return "vllm-local";
     case "ollama":
@@ -74,6 +78,8 @@ function resolveCredentialEnv(endpointType: EndpointType): string {
       return "NVIDIA_API_KEY";
     case "nim-local":
       return "NIM_API_KEY";
+    case "azure-nim":
+      return "AZURE_NIM_API_KEY";
     case "vllm":
     case "ollama":
       return "OPENAI_API_KEY";
@@ -84,7 +90,7 @@ function isNonInteractive(opts: OnboardOptions): boolean {
   if (!opts.endpoint || !opts.model) return false;
   const ep = opts.endpoint as EndpointType;
   if (endpointRequiresApiKey(ep) && !opts.apiKey) return false;
-  if ((ep === "ncp" || ep === "nim-local" || ep === "custom") && !opts.endpointUrl) return false;
+  if ((ep === "ncp" || ep === "nim-local" || ep === "azure-nim" || ep === "custom") && !opts.endpointUrl) return false;
   if (ep === "ncp" && !opts.ncpPartner) return false;
   return true;
 }
@@ -94,6 +100,7 @@ function endpointRequiresApiKey(endpointType: EndpointType): boolean {
     endpointType === "build" ||
     endpointType === "ncp" ||
     endpointType === "nim-local" ||
+    endpointType === "azure-nim" ||
     endpointType === "custom"
   );
 }
@@ -199,6 +206,11 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
           hint: "your own NIM container deployment",
         },
         {
+          label: "Azure-hosted NIM",
+          value: "azure-nim",
+          hint: "NIM on Microsoft Foundry",
+        },
+        {
           label: "Local vLLM",
           value: "vllm",
           hint: "local development",
@@ -231,6 +243,11 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
         opts.endpointUrl ??
         (await promptInput("NIM endpoint URL", "http://nim-service.local:8000/v1"));
       break;
+    case "azure-nim":
+      endpointUrl =
+        opts.endpointUrl ??
+        (await promptInput("Azure NIM endpoint URL (e.g., https://<deployment>.services.ai.azure.com/v1)"));
+      break;
     case "vllm":
       endpointUrl = `${HOST_GATEWAY_URL}:8000/v1`;
       break;
@@ -255,6 +272,16 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
   if (requiresApiKey) {
     if (opts.apiKey) {
       apiKey = opts.apiKey;
+    } else if (endpointType === "azure-nim") {
+      const envKey = process.env.AZURE_NIM_API_KEY;
+      if (envKey) {
+        logger.info(`Detected AZURE_NIM_API_KEY in environment (${maskApiKey(envKey)})`);
+        const useEnv = nonInteractive ? true : await promptConfirm("Use this key?");
+        apiKey = useEnv ? envKey : await promptInput("Enter your Azure NIM API key");
+      } else {
+        logger.info("Get an API key from your Microsoft Foundry endpoint or use an Entra ID token.");
+        apiKey = await promptInput("Enter your Azure NIM API key");
+      }
     } else {
       const envKey = process.env.NVIDIA_API_KEY;
       if (envKey) {

--- a/nemoclaw/src/onboard/config.ts
+++ b/nemoclaw/src/onboard/config.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 
 const CONFIG_DIR = join(process.env.HOME ?? "/tmp", ".nemoclaw");
 
-export type EndpointType = "build" | "ncp" | "nim-local" | "vllm" | "ollama" | "custom";
+export type EndpointType = "build" | "ncp" | "nim-local" | "azure-nim" | "vllm" | "ollama" | "custom";
 
 export interface NemoClawOnboardConfig {
   endpointType: EndpointType;

--- a/test/e2e-test.sh
+++ b/test/e2e-test.sh
@@ -44,8 +44,9 @@ profiles = bp['components']['inference']['profiles']
 assert 'default' in profiles, 'Missing default profile'
 assert 'vllm' in profiles, 'Missing vllm profile'
 assert 'nim-local' in profiles, 'Missing nim-local profile'
+assert 'azure-nim' in profiles, 'Missing azure-nim profile'
 print(f'Profiles: {list(profiles.keys())}')
-" && pass "Blueprint YAML valid with all 3 profiles" || fail "Blueprint YAML invalid"
+" && pass "Blueprint YAML valid with all 4 profiles" || fail "Blueprint YAML invalid"
 
 # -------------------------------------------------------
 info "4. Verify blueprint runner plan command"


### PR DESCRIPTION
Closes #58

Add a new `azure-nim` profile to `blueprint.yaml` and the TypeScript onboarding flow for routing inference to NVIDIA NIM deployments on Microsoft Foundry.

## Changes

- `blueprint.yaml`: new `azure-nim` profile with `dynamic_endpoint` support
- `blueprint.yaml`: `azure_nim` network policy for `*.inference.ml.azure.com` and `*.services.ai.azure.com`
- `onboard/config.ts`: add `azure-nim` to `EndpointType` union
- `onboard.ts`: `azure-nim` in all switch statements, interactive prompt, and credential flow
- `inference-profiles.md`: document the new profile
- `README.md`: update profile summary table (3 → 4 profiles)
- `e2e-test.sh`: assert `azure-nim` profile exists

## Why

NVIDIA NIM is available on Azure via Microsoft Foundry but there's no corresponding inference profile. This adds enterprise Azure deployment support with Entra ID / API key auth and network policy egress rules for Microsoft Foundry endpoints.