### PR TITLE
fix: Update image tag for nemotron-3-nano

### DIFF
--- a/bin/lib/nim-images.json
+++ b/bin/lib/nim-images.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "nvidia/nemotron-3-nano-30b-a3b",
-      "image": "nvcr.io/nim/nvidia/nemotron-3-nano-30b-a3b:latest",
+      "image": "nvcr.io/nim/nvidia/nemotron-3-nano:latest",
       "minGpuMemoryMB": 8192
     },
     {


### PR DESCRIPTION
https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nemotron-3-nano?version=latest

The tag doesn't match the image, unlike all other images.
Issue #66