### PR TITLE
docs: add community agent templates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ See the full [CLI reference](https://docs.nvidia.com/nemoclaw/latest/reference/c
 
 ---
 
+## Community Agent Templates
+
+Get started quickly with pre-built SOUL.md templates. The [awesome-openclaw-agents](https://github.com/mergisi/awesome-openclaw-agents) repository has 177 production-ready agent configs across 24 categories.
+
+```console
+$ git clone https://github.com/mergisi/awesome-openclaw-agents.git
+$ cp awesome-openclaw-agents/agents/business/sdr-outbound/SOUL.md /sandbox/agents/
+$ nemoclaw my-agent connect
+```
+
+Categories include: Business, Development, Marketing, DevOps, Finance, Healthcare, HR, Legal, Security, E-Commerce, Education, Creative, SaaS, Compliance, Voice, Automation, and more.
+
+---
+
 ## Learn More
 
 Refer to the documentation for more information on NemoClaw.


### PR DESCRIPTION
## What

Adds a "Community Agent Templates" section to the README, linking to [awesome-openclaw-agents](https://github.com/mergisi/awesome-openclaw-agents) (177 templates, 24 categories, 700+ stars).

Includes a quick start example showing how to copy a template into a NemoClaw sandbox.

## Why

New users often ask "what agent should I build?" Pre-built templates lower the barrier to getting started with NemoClaw. Instead of writing a SOUL.md from scratch, users can pick from 177 tested configs.

## Relates to

- #74 (Integration discussion)

## Checklist

- [x] Docs-only change (1 file, 14 lines added)
- [x] Placed before "Learn More" section
- [x] Includes working bash example