### PR TITLE
fix: do not register sandbox when creation fails

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -169,15 +169,44 @@ async function createSandbox(gpu) {
   if (process.env.NVIDIA_API_KEY) {
     envArgs.push(`NVIDIA_API_KEY=${process.env.NVIDIA_API_KEY}`);
   }
-  run(`openshell sandbox create ${createArgs.join(" ")} -- env ${envArgs.join(" ")} nemoclaw-start 2>&1 | awk '/Sandbox allocated/{if(!seen){print;seen=1}next}1'`);
+
+  // Use pipefail so the pipe preserves the openshell exit code instead of
+  // silently succeeding because awk always exits 0.
+  const createResult = run(
+    `set -o pipefail; openshell sandbox create ${createArgs.join(" ")} -- env ${envArgs.join(" ")} nemoclaw-start 2>&1 | awk '/Sandbox allocated/{if(!seen){print;seen=1}next}1'`,
+    { ignoreError: true }
+  );
+
+  // Clean up build context regardless of outcome
+  run(`rm -rf "${buildCtx}"`, { ignoreError: true });
+
+  if (createResult.status !== 0) {
+    console.error(`  Sandbox creation failed (exit ${createResult.status}).`);
+    console.error("  Run 'openshell sandbox list' to check the underlying state.");
+    process.exit(createResult.status || 1);
+  }
+
+  // Verify the sandbox is actually running before registering it
+  const verifyStatus = runCapture(
+    `openshell sandbox status ${sandboxName} --json 2>/dev/null`,
+    { ignoreError: true }
+  );
+  let sandboxRunning = false;
+  try {
+    const parsed = JSON.parse(verifyStatus);
+    sandboxRunning = parsed.state === "running";
+  } catch {}
+
+  if (!sandboxRunning) {
+    console.error(`  Sandbox '${sandboxName}' was created but is not running.`);
+    console.error("  Run 'openshell sandbox list' and 'openshell sandbox logs " + sandboxName + "' to diagnose.");
+    process.exit(1);
+  }
 
   // Forward dashboard port separately
   run(`openshell forward start --background 18789 ${sandboxName}`, { ignoreError: true });
 
-  // Clean up build context
-  run(`rm -rf "${buildCtx}"`, { ignoreError: true });
-
-  // Register in registry
+  // Register in registry only after confirmed running
   registry.registerSandbox({
     name: sandboxName,
     gpuEnabled: !!gpu,


### PR DESCRIPTION
## Summary

Fixes #22 — the onboarding wizard records a sandbox in the registry even when `createSandbox()` fails.

**Root cause:** The `openshell sandbox create` command is piped through `awk` to deduplicate log lines. Since `awk` always exits 0, the `run()` helper sees a successful exit code even when sandbox creation fails. The sandbox is then registered in `~/.nemoclaw/sandboxes.json`, leaving the system in an inconsistent state.

**Fix:**
- Enable `set -o pipefail` in the shell command so the pipe preserves the `openshell` exit code
- Move build-context cleanup (`rm -rf`) before the exit-code check so temp files are always cleaned up, even on failure
- Add a post-creation verification step via `openshell sandbox status --json` that confirms the sandbox is actually running
- Only call `registry.registerSandbox()` after both checks pass

## Test plan

- [x] Existing tests pass (`node --test test/registry.test.js test/cli.test.js` — 19/19)
- [ ] Manual: run `nemoclaw onboard` with OpenShell gateway intentionally stopped → sandbox should NOT appear in `nemoclaw list`
- [ ] Manual: run `nemoclaw onboard` normally → sandbox appears in `nemoclaw list` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)