### PR TITLE
fix: verify nemoclaw is on PATH after install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -160,6 +160,36 @@ install_nemoclaw() {
 }
 
 # ---------------------------------------------------------------------------
+# 3b. Verify nemoclaw is on PATH
+# ---------------------------------------------------------------------------
+verify_on_path() {
+  if command_exists nemoclaw; then
+    info "nemoclaw is on PATH: $(command -v nemoclaw)"
+    return
+  fi
+
+  # Determine where npm put the binary
+  local npm_bin
+  npm_bin="$(npm prefix -g 2>/dev/null)/bin"
+
+  if [[ -x "${npm_bin}/nemoclaw" ]]; then
+    warn "nemoclaw was installed to ${npm_bin} but that directory is not on your PATH."
+    warn "Add it by running:"
+    warn ""
+    warn "  export PATH=\"${npm_bin}:\$PATH\""
+    warn ""
+    warn "To make this permanent, append the line above to your shell profile (~/.bashrc, ~/.zshrc, etc.)."
+
+    # Temporarily add to PATH so onboard can proceed
+    export PATH="${npm_bin}:${PATH}"
+    info "Temporarily added ${npm_bin} to PATH for this session."
+  else
+    warn "Could not locate the nemoclaw binary after installation."
+    warn "Try running: npm bin -g"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # 4. Onboard
 # ---------------------------------------------------------------------------
 run_onboard() {
@@ -177,6 +207,7 @@ main() {
   ensure_supported_runtime
   # install_or_upgrade_ollama
   install_nemoclaw
+  verify_on_path
   run_onboard
 
   info "=== Installation complete ==="


### PR DESCRIPTION
## Summary

Fixes #9 — the installer now verifies that `nemoclaw` is accessible on PATH after installation.

- After `npm install`/`npm link`, checks `command -v nemoclaw`
- If not found, locates the npm global bin directory and shows the exact `export PATH=...` command the user needs
- Temporarily adds the directory to PATH so onboarding can proceed in the same session
- Works with nvm, non-standard npm prefixes, and source installs

## Test plan

- [x] Shell syntax check passes (`bash -n install.sh`)
- [x] Existing tests pass (19/19)
- [ ] Manual: install with nvm where npm global bin is not on PATH → should show the export command
- [ ] Manual: install normally → should show "nemoclaw is on PATH: /path/to/nemoclaw"

🤖 Generated with [Claude Code](https://claude.com/claude-code)