### PR TITLE
fix: use nvcr.io/nim/nvidia/nemotron-3-nano for NIM local pull (Fixes #66)

### DIFF
--- a/bin/lib/nim-images.json
+++ b/bin/lib/nim-images.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "nvidia/nemotron-3-nano-30b-a3b",
-      "image": "nvcr.io/nim/nvidia/nemotron-3-nano-30b-a3b:latest",
+      "image": "nvcr.io/nim/nvidia/nemotron-3-nano:latest",
       "minGpuMemoryMB": 8192
     },
     {

--- a/test/nim.test.js
+++ b/test/nim.test.js
@@ -22,7 +22,7 @@ describe("nim", () => {
 
   describe("getImageForModel", () => {
     it("returns correct image for known model", () => {
-      expect(nim.getImageForModel("nvidia/nemotron-3-nano-30b-a3b")).toBe("nvcr.io/nim/nvidia/nemotron-3-nano-30b-a3b:latest");
+      expect(nim.getImageForModel("nvidia/nemotron-3-nano-30b-a3b")).toBe("nvcr.io/nim/nvidia/nemotron-3-nano:latest");
     });
 
     it("returns null for unknown model", () => {


### PR DESCRIPTION
## Summary

Fixes #66. Local NIM onboarding was failing when selecting the Nemotron 3 Nano 30B model because `docker pull nvcr.io/nim/nvidia/nemotron-3-nano-30b-a3b:latest` returns Access Denied from nvcr.io. The image that is actually published and pullable is `nvcr.io/nim/nvidia/nemotron-3-nano:latest`.

## Changes

- **bin/lib/nim-images.json**: Map model `nvidia/nemotron-3-nano-30b-a3b` to image `nvcr.io/nim/nvidia/nemotron-3-nano:latest` instead of `nvcr.io/nim/nvidia/nemotron-3-nano-30b-a3b:latest`.
- **test/nim.test.js**: Update the `getImageForModel` expectation to the new image.

The model identifier (`nvidia/nemotron-3-nano-30b-a3b`) is unchanged so API/config compatibility is preserved; only the Docker image used for the local NIM container is corrected.

## Testing

- `npm test` (including `getImageForModel` and nim suite) passes.

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container image reference for the Nemotron 3 Nano model to a different image tag.

* **Tests**
  * Adjusted unit test expectations to match the new image reference for the Nemotron 3 Nano model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->