### PR TITLE
fix: make onboard robust when rerun after a failed install

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -130,15 +130,32 @@ async function createSandbox(gpu) {
   const nameAnswer = await prompt("  Sandbox name [my-assistant]: ");
   const sandboxName = nameAnswer || "my-assistant";
 
-  // Check if sandbox already exists in registry
-  const existing = registry.getSandbox(sandboxName);
-  if (existing) {
-    const recreate = await prompt(`  Sandbox '${sandboxName}' already exists. Recreate? [y/N]: `);
+  // Check if sandbox already exists — look at both the registry and the
+  // actual OpenShell state.  A previous failed onboard may have created a
+  // sandbox in OpenShell without registering it (see #22), or vice-versa.
+  const existsInRegistry = !!registry.getSandbox(sandboxName);
+  const existsInOpenshell = !!runCapture(
+    `openshell sandbox status ${sandboxName} --json 2>/dev/null`,
+    { ignoreError: true }
+  );
+
+  if (existsInRegistry || existsInOpenshell) {
+    const where = existsInRegistry && existsInOpenshell
+      ? "registered and running"
+      : existsInRegistry
+        ? "registered (but not found in OpenShell)"
+        : "found in OpenShell (but not registered)";
+    const recreate = await prompt(`  Sandbox '${sandboxName}' already exists (${where}). Recreate? [y/N]: `);
     if (recreate.toLowerCase() !== "y") {
       console.log("  Keeping existing sandbox.");
+      // Sync: if it exists in OpenShell but not in the registry, register it
+      if (existsInOpenshell && !existsInRegistry) {
+        registry.registerSandbox({ name: sandboxName, gpuEnabled: !!gpu });
+        console.log(`  ✓ Re-registered '${sandboxName}' in local registry.`);
+      }
       return sandboxName;
     }
-    // Destroy old sandbox
+    // Clean up both sides before recreating
     run(`openshell sandbox delete ${sandboxName} 2>/dev/null || true`, { ignoreError: true });
     registry.removeSandbox(sandboxName);
   }


### PR DESCRIPTION
## Summary

Fixes #23 — `nemoclaw onboard` now handles reruns gracefully without requiring `uninstall.sh`.

**Root cause:** After a failed onboard, the sandbox could exist in OpenShell but not in the local registry (or vice versa). The code only checked the registry, so it either tried to create a duplicate or missed the orphan entirely.

**Fix:** `createSandbox()` now checks both the registry and OpenShell:
- Shows which side has the sandbox (e.g. "found in OpenShell but not registered")
- Keeping an orphan sandbox re-syncs the registry automatically
- Recreating cleans up both sides before proceeding

## Test plan

- [x] Existing tests pass (19/19)
- [ ] Manual: run `nemoclaw onboard`, kill during sandbox creation, rerun → should detect orphan and offer to recreate or keep
- [ ] Manual: run `nemoclaw onboard` after successful install → should detect existing sandbox and offer to reconfigure

🤖 Generated with [Claude Code](https://claude.com/claude-code)