### PR TITLE
fix: repair broken pypi and npm policy presets

### DIFF
--- a/bin/lib/policies.js
+++ b/bin/lib/policies.js
@@ -91,11 +91,39 @@ function applyPreset(sandboxName, presetName) {
     );
   } catch {}
 
-  const currentPolicy = parseCurrentPolicy(rawPolicy);
+  let currentPolicy = parseCurrentPolicy(rawPolicy);
 
-  // Merge: inject preset entries under the existing network_policies key
+  // Merge: inject preset entries under the existing network_policies key.
+  // Skip entries whose top-level key already exists in the current policy
+  // to avoid duplicating endpoints (e.g. npm preset vs base npm_registry).
   let merged;
   if (currentPolicy && currentPolicy.includes("network_policies:")) {
+    // Filter out preset entries whose key already exists in the policy.
+    // Preset entries look like "  key_name:\n    name: ..."
+    const filteredEntries = presetEntries
+      .split(/\n(?=  \S)/)
+      .filter((block) => {
+        const keyMatch = block.match(/^\s{2}(\S+):/);
+        if (!keyMatch) return true;
+        const key = keyMatch[1];
+        // Check if this key already exists in current policy
+        const keyRegex = new RegExp(`^\\s{2}${key}:`, "m");
+        return !keyRegex.test(currentPolicy);
+      })
+      .join("\n");
+
+    if (!filteredEntries.trim()) {
+      console.log(`  Preset '${presetName}' endpoints already present in policy — skipping merge.`);
+      // Still record it in the registry
+      const sandbox = registry.getSandbox(sandboxName);
+      if (sandbox) {
+        const pols = sandbox.policies || [];
+        if (!pols.includes(presetName)) pols.push(presetName);
+        registry.updateSandbox(sandboxName, { policies: pols });
+      }
+      return true;
+    }
+
     // Find the network_policies: line and append the new entries after it
     // We need to insert before the next top-level key or end of file
     const lines = currentPolicy.split("\n");
@@ -115,7 +143,7 @@ function applyPreset(sandboxName, presetName) {
 
       if (inNetworkPolicies && isTopLevel && !inserted) {
         // We hit the next top-level key — insert preset entries before it
-        result.push(presetEntries);
+        result.push(filteredEntries);
         inserted = true;
         inNetworkPolicies = false;
       }
@@ -125,7 +153,7 @@ function applyPreset(sandboxName, presetName) {
 
     // If network_policies was the last section, append at end
     if (inNetworkPolicies && !inserted) {
-      result.push(presetEntries);
+      result.push(filteredEntries);
     }
 
     merged = result.join("\n");


### PR DESCRIPTION
## Summary

Fixes #19 — `pypi` and `npm` policy presets now apply correctly.

**Bug 1 — TypeError on apply:** `currentPolicy` was declared with `const` but reassigned when the sandbox had no `network_policies` section, throwing `TypeError: Assignment to constant variable` at runtime. Fixed by using `let`.

**Bug 2 — Duplicate endpoints:** Applying the `npm` preset blindly appended `registry.npmjs.org` even though the base sandbox policy already includes it via `npm_registry`. Now preset entries are deduplicated — keys already present in the policy are skipped with an informational message.

## Test plan

- [x] All 29 tests pass (policies + cli + registry)
- [ ] Manual: apply `pypi` preset to a sandbox → should succeed without TypeError
- [ ] Manual: apply `npm` preset → should skip duplicate `registry.npmjs.org` and print info message
- [ ] Manual: apply `discord` preset (no overlap with base) → should merge normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)