### PR TITLE
fix: use sudo for npm installation if needed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,15 @@ error() { printf '\033[1;31m[ERROR]\033[0m %s\n' "$*"; exit 1; }
 
 command_exists() { command -v "$1" &>/dev/null; }
 
+# Use sudo for npm global installs when the prefix is not writable by the current user.
+needs_sudo_for_npm() {
+  local prefix
+  prefix="$(npm config get prefix 2>/dev/null)"
+  [[ -n "$prefix" ]] && [[ ! -w "$prefix" ]]
+}
+
+SUDO_NPM=""
+
 MIN_NODE_MAJOR=20
 MIN_NPM_MAJOR=10
 RECOMMENDED_NODE_MAJOR=22
@@ -172,13 +181,18 @@ install_or_upgrade_ollama() {
 # 3. NemoClaw
 # ---------------------------------------------------------------------------
 install_nemoclaw() {
+  if needs_sudo_for_npm; then
+    info "npm global prefix is not writable — will use sudo for global installs."
+    SUDO_NPM="sudo"
+  fi
+
   if [[ -f "./package.json" ]] && grep -q '"name": "nemoclaw"' ./package.json 2>/dev/null; then
     info "NemoClaw package.json found in current directory — installing from source…"
-    npm install && npm link
+    npm install && $SUDO_NPM npm link
   else
     info "Installing NemoClaw from npm…"
     # Revert once https://github.com/NVIDIA/NemoClaw/issues/71 is complete and the package is published
-    npm install -g git+ssh://git@github.com/nvidia/NemoClaw.git
+    $SUDO_NPM npm install -g git+ssh://git@github.com/nvidia/NemoClaw.git
   fi
 
   refresh_path


### PR DESCRIPTION
If user already has an existing node installation, the installation might fail silently due to folder permissions.

```bash
npm error Error: EACCES: permission denied, rename '/usr/lib/node_modules/nemoclaw' -> '/usr/lib/node_modules/.nemoclaw-z188BoW2'

-> ls -alh /usr/lib/node_modules
drwxr-xr-x  4 root root 4.0K Mar 16 20:14 .
```

Also I've faced another similar issue

```bash
npm error Error: EACCES: permission denied, symlink '../lib/node_modules/nemoclaw/bin/nemoclaw.js' -> '/usr/bin/nemoclaw'
```

This modification would spawn npm install with root privilage if needed to fix this warning.

It fixed my issue in my case.