### PR TITLE
ci: publish to npm on version tag push (Fixes #71)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,36 @@
+# Publish to npm when a version tag is pushed (e.g. v0.1.1).
+# Requires NPM_TOKEN secret in repository settings (automation token from npmjs.org).
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            npm publish --provenance --access public --tag next
+          else
+            npm publish --provenance --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,12 +9,15 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: "22"
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that publishes the package to npm when a version tag is pushed (e.g. `v0.1.1`).

Fixes #71.

## Changes

- **`.github/workflows/publish-npm.yml`** — On `push` of tags matching `v*`:
  - Checkout, setup Node 20, `npm ci`, `npm test`
  - `npm publish --provenance --access public` using `NPM_TOKEN` secret

## Maintainer setup

Before the first tag-based release, add an **NPM_TOKEN** secret in the repo:

1. On [npmjs.org](https://www.npmjs.com/) create an **Automation** token (or use an existing publish token).
2. In this repo: **Settings → Secrets and variables → Actions → New repository secret** → name `NPM_TOKEN`, value = the token.

No new unit tests (CI/workflow only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated package publishing workflow that triggers on version tag pushes.
  * Runs CI and tests before publishing, uses a repository authentication token, and publishes with provenance and public access.
  * Pre-release/preview tags (containing a hyphen) are routed to the "next" channel; regular release tags publish to the default channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->