### PR TITLE
docs: align with current CLI, onboard recommended and setup legacy (Fixes #38)

### DIFF
--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -60,7 +60,7 @@ The deploy script performs the following steps on the VM:
 
 1. Installs Docker and the NVIDIA Container Toolkit if a GPU is present.
 2. Installs the OpenShell CLI.
-3. Runs the nemoclaw setup to create the gateway, register providers, and launch the sandbox.
+3. Runs `nemoclaw onboard` (the setup wizard) to create the gateway, register providers, and launch the sandbox.
 4. Starts auxiliary services, such as the Telegram bridge and cloudflared tunnel.
 
 ## Connect to the Remote Sandbox

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -56,7 +56,7 @@ $ nemoclaw --version
 
 ### `nemoclaw onboard`
 
-Run the interactive setup wizard.
+Run the interactive setup wizard (recommended for new installs).
 The wizard creates an OpenShell gateway, registers inference providers, builds the sandbox image, and creates the sandbox.
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
@@ -67,6 +67,7 @@ $ nemoclaw onboard
 The wizard prompts for a provider first, then collects the provider credential if needed.
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.
 Credentials are stored in `~/.nemoclaw/credentials.json`.
+The legacy `nemoclaw setup` command is deprecated; use `nemoclaw onboard` instead.
 
 The wizard prompts for a sandbox name.
 Names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.
@@ -90,7 +91,7 @@ The `nemoclaw deploy` command is experimental and may not work as expected.
 :::
 
 Deploy NemoClaw to a remote GPU instance through [Brev](https://brev.nvidia.com).
-The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present, and OpenShell on the VM, then runs the nemoclaw setup and connects to the sandbox.
+The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present, and OpenShell on the VM, then runs `nemoclaw onboard` and connects to the sandbox.
 
 ```console
 $ nemoclaw deploy <instance-name>
@@ -232,11 +233,10 @@ The CLI uses the local `uninstall.sh` first and falls back to the hosted script 
 $ nemoclaw uninstall [--yes] [--keep-openshell] [--delete-models]
 ```
 
-### `nemoclaw setup` (deprecated)
+### Legacy `nemoclaw setup`
 
-Run the legacy setup workflow for backwards compatibility.
-NemoClaw prints a deprecation warning, then runs the older `setup.sh` path.
-Prefer `nemoclaw onboard` for new installs and reconfiguration.
+Deprecated. Use `nemoclaw onboard` instead.
+The legacy setup command runs the old setup script for backwards compatibility only.
 
 ```console
 $ nemoclaw setup


### PR DESCRIPTION
## Summary

Aligns documentation with the current CLI: documents `nemoclaw onboard` as the recommended setup flow and `nemoclaw setup` as legacy, and updates deploy docs to refer to onboard.

Fixes #38.

## Changes

- **docs/reference/commands.md**
  - `nemoclaw onboard`: marked as “recommended for new installs” and added a note that the legacy `nemoclaw setup` command is deprecated.
  - Deploy description: “runs the nemoclaw setup” → “runs \`nemoclaw onboard\`”.
  - Added **Legacy: `nemoclaw setup`** subsection with deprecation note.
- **docs/deployment/deploy-to-remote-gpu.md**
  - Step 3: “Runs the nemoclaw setup” → “Runs \`nemoclaw onboard\` (the setup wizard)”.

(No remaining “nemoclaw term” references were found in the repo; docs already use `openshell term`.)

## Testing

- `npm test` — all tests pass. No new unit tests (docs-only change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Deployment guide updated to instruct using the recommended "nemoclaw onboard" setup wizard for remote VM provisioning.
  * Added a deprecation notice: the legacy "nemoclaw setup" is deprecated; new installs should use "nemoclaw onboard".
  * Command reference revised to reflect the onboard workflow and clarify that the legacy setup remains only for backward-compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->