### PR TITLE
test: add CLI dispatch and NIM model tests (17 new tests)

### DIFF
--- a/test/cli-dispatch.test.js
+++ b/test/cli-dispatch.test.js
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+const CLI = path.join(__dirname, "..", "bin", "nemoclaw.js");
+
+describe("nemoclaw CLI dispatch", () => {
+  it("--help exits 0 and prints usage", () => {
+    const out = execFileSync("node", [CLI, "--help"], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    assert.ok(out.includes("nemoclaw"), "should mention nemoclaw");
+    assert.ok(out.includes("onboard"), "should list onboard command");
+    assert.ok(out.includes("deploy"), "should list deploy command");
+  });
+
+  it("help subcommand exits 0", () => {
+    const out = execFileSync("node", [CLI, "help"], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    assert.ok(out.includes("Sandbox Management"), "should show Sandbox Management section");
+  });
+
+  it("-h is an alias for --help", () => {
+    const out = execFileSync("node", [CLI, "-h"], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    assert.ok(out.includes("nemoclaw"), "should mention nemoclaw");
+  });
+
+  it("unknown command exits non-zero", () => {
+    try {
+      execFileSync("node", [CLI, "nonexistent-cmd-xyz"], {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: "pipe",
+      });
+      assert.fail("should have thrown");
+    } catch (err) {
+      assert.ok(err.status !== 0, "should exit non-zero");
+      assert.ok(err.stderr.includes("Unknown command"), "should mention Unknown command");
+    }
+  });
+
+  it("list command exits 0 when no sandboxes registered", () => {
+    // Uses a temp HOME so registry is empty
+    const out = execFileSync("node", [CLI, "list"], {
+      encoding: "utf-8",
+      timeout: 5000,
+      env: { ...process.env, HOME: "/tmp/nemoclaw-test-empty-" + Date.now() },
+    });
+    assert.ok(
+      out.includes("No sandboxes") || out.includes("nemoclaw onboard"),
+      "should indicate no sandboxes or suggest onboard",
+    );
+  });
+});

--- a/test/nim-extra.test.js
+++ b/test/nim-extra.test.js
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const nim = require("../bin/lib/nim");
+
+describe("nim — extended coverage", () => {
+  describe("getImageForModel edge cases", () => {
+    it("returns null for empty string", () => {
+      assert.equal(nim.getImageForModel(""), null);
+    });
+
+    it("returns null for undefined", () => {
+      assert.equal(nim.getImageForModel(undefined), null);
+    });
+
+    it("returns null for partial model name", () => {
+      assert.equal(nim.getImageForModel("nvidia/nemotron"), null);
+    });
+
+    it("is case-sensitive", () => {
+      assert.equal(nim.getImageForModel("NVIDIA/NEMOTRON-3-NANO-30B-A3B"), null);
+    });
+  });
+
+  describe("listModels content checks", () => {
+    it("includes nemotron-3-super model", () => {
+      const models = nim.listModels();
+      const superModel = models.find((m) => m.name.includes("nemotron-3-super"));
+      assert.ok(superModel, "should list nemotron-3-super model");
+      assert.ok(superModel.image.includes("nvcr.io"), "image should be from nvcr.io");
+    });
+
+    it("all images point to nvcr.io/nim registry", () => {
+      for (const m of nim.listModels()) {
+        assert.ok(
+          m.image.startsWith("nvcr.io/nim/"),
+          `${m.name} image should start with nvcr.io/nim/, got: ${m.image}`,
+        );
+      }
+    });
+
+    it("no duplicate model names", () => {
+      const names = nim.listModels().map((m) => m.name);
+      assert.equal(new Set(names).size, names.length, "duplicate model names found");
+    });
+
+    it("no duplicate images", () => {
+      const images = nim.listModels().map((m) => m.image);
+      assert.equal(new Set(images).size, images.length, "duplicate images found");
+    });
+  });
+
+  describe("containerName variations", () => {
+    it("handles hyphenated names", () => {
+      assert.equal(nim.containerName("my-sandbox"), "nemoclaw-nim-my-sandbox");
+    });
+
+    it("handles underscored names", () => {
+      assert.equal(nim.containerName("my_sandbox"), "nemoclaw-nim-my_sandbox");
+    });
+
+    it("handles single character name", () => {
+      assert.equal(nim.containerName("x"), "nemoclaw-nim-x");
+    });
+
+    it("handles empty string", () => {
+      assert.equal(nim.containerName(""), "nemoclaw-nim-");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `test/cli-dispatch.test.js` (5 tests): validates `--help`/`help`/`-h` output, unknown-command error exit, and empty-registry `list` behavior
- Adds `test/nim-extra.test.js` (12 tests): edge cases for `getImageForModel` (empty, undefined, partial, case-sensitive), `listModels` content checks (nvcr.io prefix, no duplicate names/images), and `containerName` variations
- Total test count: 53 → 70

## Test plan
- [ ] `node --test test/*.test.js` passes all 70 tests (56 on current main + 14 from this PR, noting some were added in parallel PRs)
- [ ] No changes to production code