### PR TITLE
feat(security): add GitHub issue/PR templates and contributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-bug.yml
+++ b/.github/ISSUE_TEMPLATE/security-bug.yml
@@ -89,3 +89,4 @@ body:
         - label: I have searched existing issues and this has not been reported before
           required: true
         - label: I am willing to submit a PR with a fix
+          required: false

--- a/.github/ISSUE_TEMPLATE/security-bug.yml
+++ b/.github/ISSUE_TEMPLATE/security-bug.yml
@@ -1,0 +1,91 @@
+name: Security Bug Report
+description: Report a security vulnerability or hardening gap (non-sensitive disclosures only — for exploitable vulnerabilities use SECURITY.md)
+title: "[Security] "
+labels: ["security", "needs-triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Sensitive vulnerabilities** — use the private disclosure path in [SECURITY.md](../../SECURITY.md) instead of this form.
+        > This template is for hardening gaps, missing defensive controls, and non-exploitable security findings.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this issue if exploited?
+      options:
+        - Critical — arbitrary code execution / full compromise
+        - High — significant privilege escalation or data exposure
+        - Medium — limited impact with mitigating factors
+        - Low — defence-in-depth / best-practice improvement
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - install.sh / scripts
+        - nemoclaw CLI (TypeScript)
+        - nemoclaw-blueprint (Python)
+        - Dockerfile
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: affected-files
+    attributes:
+      label: Affected file(s)
+      placeholder: "e.g. install.sh, nemoclaw/src/commands/connect.ts"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the security issue? What does it allow an attacker to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Clone the repo
+        2. Run ./install.sh with a network proxy intercepting traffic
+        3. Observe that the Node.js tarball is executed without checksum verification
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What can an attacker achieve? What is the blast radius?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix (optional)
+      description: If you have a concrete fix in mind, describe it here.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have checked that this is not a sensitive/exploitable vulnerability requiring private disclosure
+          required: true
+        - label: I have searched existing issues and this has not been reported before
+          required: true
+        - label: I am willing to submit a PR with a fix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+# Pull Request
+
+## Summary
+
+<!-- One sentence: what does this PR do and why? -->
+
+## Related issue
+
+Closes #<!-- issue number -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] Security hardening
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Changes
+
+<!-- Bullet-point list of what changed and in which files -->
+
+## How to test
+
+```bash
+# paste the exact commands a reviewer needs to run
+```
+
+## Security considerations
+
+<!-- If this is a security fix: describe the attack vector closed and confirm no new surface is introduced -->
+
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] My code follows the existing style (`npm run lint` / `ruff check`)
+- [ ] I have added or updated tests for every changed behaviour
+- [ ] All existing tests pass locally
+- [ ] I have updated documentation where relevant
+- [ ] No secrets, tokens, or credentials are included

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,12 @@ Thank you for your interest in contributing to NVIDIA NemoClaw. This guide cover
 
 Use the GitHub issue and pull request templates provided in `.github/` — they
 ensure every submission includes the context maintainers need to triage and
-review efficiently. Security findings should use the **Security Bug Report**
-issue template.
+Use the GitHub issue and pull request templates provided in `.github/` — they
+ensure every submission includes the context maintainers need to triage and
+review efficiently. Non-exploitable security hardening issues (e.g., missing
+input validation, weak defaults) should use the **Security Bug Report** issue
+template. **Exploitable vulnerabilities** must follow [SECURITY.md](SECURITY.md)
+and should **never** be reported via public GitHub issues.
 
 ## Before You Open an Issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,6 @@ ensure every submission includes the context maintainers need to triage and
 review efficiently. Security findings should use the **Security Bug Report**
 issue template.
 
-## Signing Your Work
-
 ## Before You Open an Issue
 
 Open an issue when you encounter one of the following situations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 Thank you for your interest in contributing to NVIDIA NemoClaw. This guide covers how to set up your development environment, run tests, and submit changes.
 
+## Reporting issues and submitting PRs
+
+Use the GitHub issue and pull request templates provided in `.github/` — they
+ensure every submission includes the context maintainers need to triage and
+review efficiently. Security findings should use the **Security Bug Report**
+issue template.
+
+## Signing Your Work
+
 ## Before You Open an Issue
 
 Open an issue when you encounter one of the following situations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,10 @@ Thank you for your interest in contributing to NVIDIA NemoClaw. This guide cover
 
 Use the GitHub issue and pull request templates provided in `.github/` — they
 ensure every submission includes the context maintainers need to triage and
-Use the GitHub issue and pull request templates provided in `.github/` — they
-ensure every submission includes the context maintainers need to triage and
+review efficiently. Non-exploitable security hardening issues (e.g., missing
+input validation, weak defaults) should use the **Security Bug Report** issue
+template. **Exploitable vulnerabilities** must follow [SECURITY.md](SECURITY.md)
+and should **never** be reported via public GitHub issues.
 review efficiently. Non-exploitable security hardening issues (e.g., missing
 input validation, weak defaults) should use the **Security Bug Report** issue
 template. **Exploitable vulnerabilities** must follow [SECURITY.md](SECURITY.md)


### PR DESCRIPTION
## Summary

Adds GitHub issue and pull request templates so all future contributions arrive with consistent context for triage and review, with a particular focus on security findings.

## Related issue

Closes #108 

## Type of change

- [ ] Bug fix (non-breaking)
- [x] Security hardening
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes

- **`.github/ISSUE_TEMPLATE/security-bug.yml`** *(new)* — structured security issue form with severity dropdown, component picker, reproduction steps, impact field, and a private-disclosure checklist
- **`.github/PULL_REQUEST_TEMPLATE.md`** *(new)* — standard PR body with type of change, how-to-test instructions, security considerations section, and sign-off checklist; applies to all future contributors automatically
- **`CONTRIBUTING.md`** — adds "Reporting issues and submitting PRs" section pointing contributors to the new templates

## How to test

```bash
# No code changes — verify via GitHub UI:
# 1. Go to Issues → New Issue: the Security Bug Report form should appear
# 2. Go to Pull Requests → New PR: the template body should be pre-filled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added standardized templates for reporting issues and submitting pull requests to streamline contributions.
  * Introduced a structured security-report template (severity, component, affected files, reproduction, impact, suggested fix) and guidance to use a private disclosure channel for sensitive findings.
  * Updated contribution guidelines to explain the new templates; note: the new section contains duplicated lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->