### PR TITLE
fix(docs): render MD note block properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ NVIDIA NemoClaw is an open source stack that simplifies running [OpenClaw](https
 
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
-:::{note}
-NemoClaw currently requires a fresh installation of OpenClaw.
-:::
+> [!NOTE]
+> NemoClaw currently requires a fresh installation of OpenClaw.
 
 ### Prerequisites
 


### PR DESCRIPTION
Fixes the README's note block to render properly in github markdown.