### PR TITLE
fix: bind gateway to 0.0.0.0 and document remote dashboard access (Fixes #20)

### DIFF
--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -59,6 +59,30 @@ To reconnect after closing the session, run the deploy command again:
 $ nemoclaw deploy <instance-name>
 ```
 
+## Remote dashboard access
+
+When you access the dashboard from your laptop via SSH port-forward, set `CHAT_UI_URL` to the URL your browser uses.
+This ensures the gateway allows that origin and websocket connections succeed.
+
+The gateway inside the sandbox binds to all interfaces (`0.0.0.0`) by default so that port-forwarding works.
+The sandbox Control UI disables device auth; use the token in the dashboard URL to authenticate.
+
+1. On the remote host, ensure the sandbox is started with the origin you use in the browser.
+
+   ```console
+   $ export CHAT_UI_URL="http://YOUR_HOST_IP_OR_NAME:18789"
+   ```
+
+2. From your laptop, forward the dashboard port to the remote host.
+
+   ```console
+   $ ssh -L 18789:localhost:18789 <instance-name>
+   ```
+
+3. Open `http://127.0.0.1:18789/` (or the URL shown after sandbox start, including the `#token=...` fragment) in your browser.
+
+To bind the gateway to loopback only (e.g. when not using remote access), set `GATEWAY_BIND=loopback` in the sandbox environment.
+
 ## Monitor the Remote Sandbox
 
 SSH to the instance and run the OpenShell TUI to monitor activity and approve network requests:

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -11,7 +11,8 @@
 #
 # Optional env:
 #   NVIDIA_API_KEY   API key for NVIDIA-hosted inference
-#   CHAT_UI_URL      Browser origin that will access the forwarded dashboard
+#   CHAT_UI_URL      Browser origin that will access the forwarded dashboard (e.g. http://your-host:18789 for SSH port-forward)
+#   GATEWAY_BIND     Gateway bind mode: 'lan' (0.0.0.0, default for remote access) or 'loopback' (127.0.0.1 only)
 
 set -euo pipefail
 
@@ -66,6 +67,11 @@ verify_config_integrity() {
     echo "[SECURITY] Actual hash:   $(sha256sum /sandbox/.openclaw/openclaw.json)"
     return 1
   fi
+}
+
+fix_openclaw_config() {
+  SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+  python3 "${SCRIPTS_DIR}/write-openclaw-gateway-config.py"
 }
 
 write_auth_profile() {
@@ -206,6 +212,8 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "[SECURITY WARNING] Config integrity check failed — proceeding anyway (non-root mode)"
   fi
   write_auth_profile
+  export CHAT_UI_URL PUBLIC_PORT
+  fix_openclaw_config
 
   if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
     exec "${NEMOCLAW_CMD[@]}"
@@ -237,6 +245,8 @@ verify_config_integrity
 
 # Write auth profile as sandbox user (needs writable .openclaw-data)
 gosu sandbox bash -c "$(declare -f write_auth_profile); write_auth_profile"
+export CHAT_UI_URL PUBLIC_PORT
+fix_openclaw_config
 
 # If a command was passed (e.g., "openclaw agent ..."), run it as sandbox user
 if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then

--- a/scripts/write-openclaw-gateway-config.py
+++ b/scripts/write-openclaw-gateway-config.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Writes/updates OpenClaw gateway and model config (bind, controlUi, trustedProxies, default model).
+# Used by nemoclaw-start.sh and by tests. Set OPENCLAW_JSON_PATH to override config path (for tests).
+
+import json
+import os
+from urllib.parse import urlparse
+
+
+def main():
+    config_path = os.environ.get("OPENCLAW_JSON_PATH")
+    if not config_path:
+        home = os.environ.get("HOME", "/sandbox")
+        config_path = os.path.join(home, ".openclaw", "openclaw.json")
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+
+    cfg = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                cfg = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            cfg = {}
+
+    default_model = os.environ.get("NEMOCLAW_MODEL")
+    if default_model:
+        cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault("model", {})[
+            "primary"
+        ] = default_model
+
+    chat_ui_url = os.environ.get("CHAT_UI_URL", "http://127.0.0.1:18789")
+    parsed = urlparse(chat_ui_url)
+    chat_origin = (
+        f"{parsed.scheme}://{parsed.netloc}"
+        if parsed.scheme and parsed.netloc
+        else "http://127.0.0.1:18789"
+    )
+    local_origin = f"http://127.0.0.1:{os.environ.get('PUBLIC_PORT', '18789')}"
+    origins = [local_origin]
+    if chat_origin not in origins:
+        origins.append(chat_origin)
+
+    gateway = cfg.setdefault("gateway", {})
+    gateway["mode"] = "local"
+    gateway["bind"] = os.environ.get("GATEWAY_BIND", "lan")
+    # Sandbox defaults intentionally replace any preexisting controlUi settings.
+    gateway["controlUi"] = {
+        "allowInsecureAuth": True,
+        "dangerouslyDisableDeviceAuth": True,
+        "allowedOrigins": origins,
+    }
+    gateway["trustedProxies"] = ["127.0.0.1", "::1"]
+
+    with open(config_path, "w") as f:
+        json.dump(cfg, f, indent=2)
+    os.chmod(config_path, 0o600)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/gateway-config.test.js
+++ b/test/gateway-config.test.js
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.join(__dirname, "..", "scripts");
+const PYTHON_SCRIPT = path.join(SCRIPTS_DIR, "write-openclaw-gateway-config.py");
+
+function runGatewayConfigScript(env = {}) {
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-config-"));
+  const configPath = path.join(configDir, "openclaw.json");
+  const fullEnv = { ...process.env, OPENCLAW_JSON_PATH: configPath, ...env };
+  try {
+    execSync(`python3 "${PYTHON_SCRIPT}"`, { env: fullEnv, encoding: "utf-8" });
+    const content = fs.readFileSync(configPath, "utf-8");
+    return { config: JSON.parse(content), configPath };
+  } finally {
+    fs.rmSync(configDir, { recursive: true, force: true });
+  }
+}
+
+describe("write-openclaw-gateway-config.py (remote dashboard bind)", () => {
+  it("sets gateway.bind to lan by default for remote access", () => {
+    const { config } = runGatewayConfigScript();
+    expect(config.gateway?.bind).toBe("lan");
+  });
+
+  it("honors GATEWAY_BIND=loopback", () => {
+    const { config } = runGatewayConfigScript({ GATEWAY_BIND: "loopback" });
+    expect(config.gateway?.bind).toBe("loopback");
+  });
+
+  it("includes local and CHAT_UI_URL origins in allowedOrigins", () => {
+    const { config } = runGatewayConfigScript({
+      CHAT_UI_URL: "http://my-host:18789",
+      PUBLIC_PORT: "18789",
+    });
+    const origins = config.gateway?.controlUi?.allowedOrigins ?? [];
+    expect(origins).toContain("http://127.0.0.1:18789");
+    expect(origins).toContain("http://my-host:18789");
+  });
+
+  it("sets dangerouslyDisableDeviceAuth for sandbox so websocket works over port-forward", () => {
+    const { config } = runGatewayConfigScript();
+    expect(config.gateway?.controlUi?.dangerouslyDisableDeviceAuth).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

When NemoClaw runs on a remote host, the dashboard gateway bound to `127.0.0.1`, so forwarded browser connections could fail with "origin not allowed" or device-auth issues even when the port was forwarded. This change makes remote dashboard access work by binding the gateway to all interfaces by default and documenting the supported pattern.

Fixes #20.

## Changes

- **scripts/nemoclaw-start.sh**
  - Set `gateway.bind` to `lan` (OpenClaw listens on `0.0.0.0`) so port-forwarding from the host reaches the gateway. Optional env `GATEWAY_BIND` (default `lan`; use `loopback` to restrict to 127.0.0.1).
  - Document `CHAT_UI_URL` and `GATEWAY_BIND` in the script header.
  - Delegate config write to `scripts/write-openclaw-gateway-config.py` for reuse and testing.
- **scripts/write-openclaw-gateway-config.py** (new)
  - Standalone script that writes/updates OpenClaw gateway config (bind, controlUi, trustedProxies, default model). Uses `OPENCLAW_JSON_PATH` when set (for tests).
- **docs/deployment/deploy-to-remote-gpu.md**
  - Added "Remote dashboard access" section: set `CHAT_UI_URL` to the browser origin, use SSH port-forward, and open the dashboard URL with token; note that gateway binds to `0.0.0.0` by default and device auth is disabled for the sandbox UI.
- **test/gateway-config.test.js** (new)
  - Unit tests for the gateway config script: default `gateway.bind === 'lan'`, `GATEWAY_BIND=loopback` honored, `allowedOrigins` includes local and `CHAT_UI_URL` origin, `dangerouslyDisableDeviceAuth` true.

## Testing

- `npm test` passes (including the new gateway-config tests).
- No TypeScript under `nemoclaw/` was changed; build step not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote dashboard access via SSH port‑forwarding with automatic origin handling
  * GATEWAY_BIND option to restrict gateway binding to loopback
  * Automatic generation/updating of gateway configuration at startup

* **Documentation**
  * Step‑by‑step guide for connecting to the Control UI from a laptop, including token auth and port‑forwarding
  * Clarified CHAT_UI_URL and PUBLIC_PORT usage

* **Tests**
  * Added tests validating generated gateway configuration, bind behavior, allowed origins, and device‑auth setting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->