### PR TITLE
fix: harden test-inference scripts with error handling and cleanup

### DIFF
--- a/scripts/test-inference-local.sh
+++ b/scripts/test-inference-local.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
-# Test inference.local routing through OpenShell provider (local vLLM)
-echo '{"model":"nvidia/nemotron-3-nano-30b-a3b","messages":[{"role":"user","content":"say hello"}]}' > /tmp/req.json
-curl -s https://inference.local/v1/chat/completions -H "Content-Type: application/json" -d @/tmp/req.json
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Test inference.local routing through OpenShell provider (local vLLM).
+
+set -euo pipefail
+
+REQ_FILE="$(mktemp /tmp/nemoclaw-test-req-XXXXXX.json)"
+trap 'rm -f "$REQ_FILE"' EXIT
+
+cat > "$REQ_FILE" <<'JSON'
+{"model":"nvidia/nemotron-3-nano-30b-a3b","messages":[{"role":"user","content":"say hello"}]}
+JSON
+
+curl -sf --max-time 30 https://inference.local/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d @"$REQ_FILE"
+echo ""

--- a/scripts/test-inference.sh
+++ b/scripts/test-inference.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
-# Test inference.local routing through OpenShell provider
-echo '{"model":"nvidia/nemotron-3-super-120b-a12b","messages":[{"role":"user","content":"say hello"}]}' > /tmp/req.json
-curl -s https://inference.local/v1/chat/completions -H "Content-Type: application/json" -d @/tmp/req.json
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Test inference.local routing through OpenShell provider (NVIDIA cloud).
+
+set -euo pipefail
+
+REQ_FILE="$(mktemp /tmp/nemoclaw-test-req-XXXXXX.json)"
+trap 'rm -f "$REQ_FILE"' EXIT
+
+cat > "$REQ_FILE" <<'JSON'
+{"model":"nvidia/nemotron-3-super-120b-a12b","messages":[{"role":"user","content":"say hello"}]}
+JSON
+
+curl -sf --max-time 30 https://inference.local/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d @"$REQ_FILE"
+echo ""


### PR DESCRIPTION
## Summary
- Adds missing SPDX license headers to `scripts/test-inference.sh` and `scripts/test-inference-local.sh`
- Adds `set -euo pipefail` for strict error handling
- Uses `mktemp` instead of hardcoded `/tmp/req.json` to avoid collisions between concurrent runs
- Adds `trap` to clean up the temp file on exit
- Adds `-f` (fail on HTTP errors) and `--max-time 30` to `curl` so failures are visible

## Test plan
- [ ] `bash -n scripts/test-inference.sh` passes syntax check
- [ ] `bash -n scripts/test-inference-local.sh` passes syntax check
- [ ] No changes to production code