### PR TITLE
security: harden gateway auth defaults and restrict auto-pair

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -6,8 +6,9 @@
 # gateway inside the sandbox so the forwarded host port has a live upstream.
 #
 # Optional env:
-#   NVIDIA_API_KEY   API key for NVIDIA-hosted inference
-#   CHAT_UI_URL      Browser origin that will access the forwarded dashboard
+#   NVIDIA_API_KEY                API key for NVIDIA-hosted inference
+#   CHAT_UI_URL                  Browser origin that will access the forwarded dashboard
+#   NEMOCLAW_DISABLE_DEVICE_AUTH Set to "1" to skip device-pairing auth (development only)
 
 set -euo pipefail
 
@@ -42,9 +43,11 @@ if chat_origin not in origins:
 
 gateway = cfg.setdefault('gateway', {})
 gateway['mode'] = 'local'
+disable_device_auth = os.environ.get('NEMOCLAW_DISABLE_DEVICE_AUTH', '') == '1'
+allow_insecure = parsed.scheme != 'https'
 gateway['controlUi'] = {
-    'allowInsecureAuth': True,
-    'dangerouslyDisableDeviceAuth': True,
+    'allowInsecureAuth': allow_insecure,
+    'dangerouslyDisableDeviceAuth': disable_device_auth,
     'allowedOrigins': origins,
 }
 gateway['trustedProxies'] = ['127.0.0.1', '::1']
@@ -136,14 +139,23 @@ while time.time() < DEADLINE:
 
     if pending:
         QUIET_POLLS = 0
+        ALLOWED_CLIENTS = {'openclaw-control-ui'}
+        ALLOWED_MODES = {'webchat'}
         for device in pending:
-            request_id = (device or {}).get('requestId')
+            if not isinstance(device, dict):
+                continue
+            client_id = device.get('clientId', '')
+            client_mode = device.get('clientMode', '')
+            if client_id not in ALLOWED_CLIENTS and client_mode not in ALLOWED_MODES:
+                print(f'[auto-pair] rejected unknown client={client_id} mode={client_mode}')
+                continue
+            request_id = device.get('requestId')
             if not request_id:
                 continue
             arc, aout, aerr = run('openclaw', 'devices', 'approve', request_id, '--json')
             if arc == 0:
                 APPROVED += 1
-                print(f'[auto-pair] approved request={request_id}')
+                print(f'[auto-pair] approved request={request_id} client={client_id}')
             elif aout or aerr:
                 print(f'[auto-pair] approve failed request={request_id}: {(aerr or aout)[:400]}')
         time.sleep(1)


### PR DESCRIPTION
## Summary

Fixes #117 — Insecure authentication configuration in gateway setup.

The gateway's `controlUi` config unconditionally set `dangerouslyDisableDeviceAuth: True` and `allowInsecureAuth: True`. This was added as a temporary workaround (commit `5fb629f`, message: *"Disable deviceauth temporarily"*) but was never reverted. While the current `main` branch is protected by sandbox network isolation and `gateway.mode = 'local'`, these settings become dangerous if combined with a LAN-bind change (e.g. PR #114) or a cloudflared tunnel in remote deployments — resulting in an unauthenticated, publicly reachable dashboard.

## Changes

### 1. `dangerouslyDisableDeviceAuth` — default to `false`

Device-pairing auth is now **enabled by default**. For development or headless environments that genuinely need it disabled, set `NEMOCLAW_DISABLE_DEVICE_AUTH=1` explicitly.

```python
# Before
'dangerouslyDisableDeviceAuth': True,

# After
disable_device_auth = os.environ.get('NEMOCLAW_DISABLE_DEVICE_AUTH', '') == '1'
'dangerouslyDisableDeviceAuth': disable_device_auth,
```

### 2. `allowInsecureAuth` — derive from URL scheme

Instead of unconditionally allowing insecure auth, it is now enabled only when `CHAT_UI_URL` uses `http://` (local development). When `https://` is configured (production/remote), insecure auth is automatically disabled.

```python
# Before
'allowInsecureAuth': True,

# After
allow_insecure = parsed.scheme != 'https'
'allowInsecureAuth': allow_insecure,
```

### 3. `start_auto_pair` — restrict to known client types

The auto-pair watcher previously approved **every** pending device request unconditionally. It now only approves devices with recognized `clientId` (`openclaw-control-ui`) or `clientMode` (`webchat`). Unknown clients are logged and rejected.

```python
# Before
for device in pending:
    request_id = (device or {}).get('requestId')
    ...
    run('openclaw', 'devices', 'approve', request_id, '--json')

# After
ALLOWED_CLIENTS = {'openclaw-control-ui'}
ALLOWED_MODES = {'webchat'}
for device in pending:
    if client_id not in ALLOWED_CLIENTS and client_mode not in ALLOWED_MODES:
        print(f'[auto-pair] rejected unknown client={client_id} ...')
        continue
    ...
```

## Test plan

- [ ] Default onboarding: gateway starts with device auth enabled, Control UI pairing works via auto-pair
- [ ] `NEMOCLAW_DISABLE_DEVICE_AUTH=1`: device auth is disabled (backward-compatible escape hatch)
- [ ] `CHAT_UI_URL=https://...`: `allowInsecureAuth` is `false`
- [ ] `CHAT_UI_URL=http://127.0.0.1:18789` (default): `allowInsecureAuth` is `true`
- [ ] Unknown device type connecting to gateway: auto-pair rejects and logs
- [ ] `openclaw-control-ui` / `webchat` devices: auto-pair approves as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable configuration options to disable device authentication and whitelist approved clients and modes for enhanced security control.

* **Improvements**
  * Enhanced device pairing validation to filter requests based on client and mode whitelist settings; improved logging for approved devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->