### PR TITLE
ci: add GitHub Actions workflow to run tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install host dependencies
+        run: npm ci
+
+      - name: Install plugin dependencies
+        run: cd nemoclaw && npm ci
+
+      - name: Build TypeScript plugin
+        run: cd nemoclaw && npm run build
+
+      - name: Run tests
+        run: node --test test/*.test.js


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` that runs on every push to `main` and every pull request
- Installs dependencies, builds the TypeScript plugin, and runs `node --test test/*.test.js`
- Tests against Node.js 20 and 22 (matching the project's minimum supported version)

Currently there is no CI in the repository — reviewers must run tests locally. This workflow gives maintainers automated pass/fail feedback on every PR.

## Test plan
- [ ] Workflow triggers on this PR itself (check the Actions tab)
- [ ] No changes to production code