### PR TITLE
fix: unignore nemoclaw/dist in .dockerignore for OpenShell builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 /dist
+!nemoclaw/dist
 .git
 *.pyc
 __pycache__


### PR DESCRIPTION
## Summary

- Add `!nemoclaw/dist` negation pattern to `.dockerignore` so OpenShell's build engine includes the pre-built plugin files

## Problem

The `/dist` pattern is intended to exclude a top-level `dist/` directory, but OpenShell's build engine interprets it broadly and also excludes `nemoclaw/dist/`, causing `openshell sandbox create --from Dockerfile` to fail:

```
COPY failed: file not found in build context or excluded by .dockerignore: stat nemoclaw/dist/: file does not exist
```

Standard Docker (BuildKit) handles `/dist` correctly as root-only, so `docker build .` works fine — masking the issue during local development.

## Fix

A `.dockerignore` negation pattern (`!nemoclaw/dist`) explicitly re-includes the subdirectory while preserving the original intent.

Fixes #126

## Test plan

- [ ] `openshell sandbox create --from ./Dockerfile --name test -- echo ok` succeeds
- [ ] `docker build .` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)