### PR TITLE
chore: add SPDX license header to write-auth-profile.py

### DIFF
--- a/scripts/write-auth-profile.py
+++ b/scripts/write-auth-profile.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 


### PR DESCRIPTION
## Summary

- Add the standard Apache-2.0 SPDX header to `scripts/write-auth-profile.py`

This is the only script in `scripts/` missing the license header. Every other `.sh`, `.js`, and `.py` file already carries it.

## Test plan

- [x] `python3 -c "import py_compile; py_compile.compile('scripts/write-auth-profile.py', doraise=True)"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)