### PR TITLE
test: add coverage for onboard config and maskApiKey (12 new tests)

### DIFF
--- a/test/onboard-config.test.js
+++ b/test/onboard-config.test.js
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+// The config module reads process.env.HOME to locate ~/.nemoclaw/config.json.
+// We override HOME to an isolated temp directory so tests never touch real config.
+let origHome;
+let tmpHome;
+
+beforeEach(() => {
+  origHome = process.env.HOME;
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cfg-"));
+  process.env.HOME = tmpHome;
+
+  // Force re-require so the module picks up the new HOME
+  delete require.cache[require.resolve("../nemoclaw/dist/onboard/config.js")];
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function loadModule() {
+  return require("../nemoclaw/dist/onboard/config.js");
+}
+
+const SAMPLE_CONFIG = {
+  endpointType: "build",
+  endpointUrl: "https://integrate.api.nvidia.com/v1",
+  ncpPartner: null,
+  model: "nvidia/nemotron-3-super-120b-a12b",
+  profile: "default",
+  credentialEnv: "NVIDIA_API_KEY",
+  onboardedAt: "2026-03-17T00:00:00.000Z",
+};
+
+describe("onboard config", () => {
+  it("returns null when no config exists", () => {
+    const { loadOnboardConfig } = loadModule();
+    assert.equal(loadOnboardConfig(), null);
+  });
+
+  it("saves and loads config round-trip", () => {
+    const { saveOnboardConfig, loadOnboardConfig } = loadModule();
+    saveOnboardConfig(SAMPLE_CONFIG);
+    const loaded = loadOnboardConfig();
+    assert.deepEqual(loaded, SAMPLE_CONFIG);
+  });
+
+  it("creates .nemoclaw directory if missing", () => {
+    const { saveOnboardConfig } = loadModule();
+    saveOnboardConfig(SAMPLE_CONFIG);
+    const configDir = path.join(tmpHome, ".nemoclaw");
+    assert.ok(fs.existsSync(configDir));
+  });
+
+  it("clears config", () => {
+    const { saveOnboardConfig, clearOnboardConfig, loadOnboardConfig } = loadModule();
+    saveOnboardConfig(SAMPLE_CONFIG);
+    assert.notEqual(loadOnboardConfig(), null);
+    clearOnboardConfig();
+    assert.equal(loadOnboardConfig(), null);
+  });
+
+  it("clear is safe when no config exists", () => {
+    const { clearOnboardConfig } = loadModule();
+    // Should not throw
+    clearOnboardConfig();
+  });
+
+  it("overwrites existing config on save", () => {
+    const { saveOnboardConfig, loadOnboardConfig } = loadModule();
+    saveOnboardConfig(SAMPLE_CONFIG);
+
+    const updated = { ...SAMPLE_CONFIG, model: "nvidia/nemotron-3-nano-30b-a3b" };
+    saveOnboardConfig(updated);
+
+    const loaded = loadOnboardConfig();
+    assert.equal(loaded.model, "nvidia/nemotron-3-nano-30b-a3b");
+  });
+});

--- a/test/onboard-validate.test.js
+++ b/test/onboard-validate.test.js
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { maskApiKey } = require("../nemoclaw/dist/onboard/validate.js");
+
+describe("maskApiKey", () => {
+  it("masks short keys entirely", () => {
+    assert.equal(maskApiKey("abcd"), "****");
+    assert.equal(maskApiKey("12345678"), "****");
+  });
+
+  it("preserves last 4 chars of long keys", () => {
+    assert.equal(maskApiKey("abcdefghij"), "****ghij");
+  });
+
+  it("handles nvapi- prefix", () => {
+    assert.equal(maskApiKey("nvapi-abcdefghijklmnop"), "nvapi-****mnop");
+  });
+
+  it("handles nvapi- prefix with exact boundary", () => {
+    // "nvapi-abc" is 9 chars (> 8), last4 = "-abc"
+    assert.equal(maskApiKey("nvapi-abc"), "nvapi-****-abc");
+    const result = maskApiKey("nvapi-abcdefghi");
+    assert.ok(result.startsWith("nvapi-****"));
+    assert.ok(result.endsWith("fghi"));
+  });
+
+  it("masks non-nvapi long keys", () => {
+    const result = maskApiKey("sk-1234567890abcdef");
+    assert.equal(result, "****cdef");
+  });
+
+  it("masks empty-ish keys", () => {
+    assert.equal(maskApiKey(""), "****");
+    assert.equal(maskApiKey("ab"), "****");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `test/onboard-validate.test.js` — 6 tests for `maskApiKey` covering short keys, `nvapi-` prefix, boundary lengths, and standard keys
- Add `test/onboard-config.test.js` — 6 tests for config lifecycle (`loadOnboardConfig`, `saveOnboardConfig`, `clearOnboardConfig`) using isolated temp directories

All tests use `node:test` and run alongside existing tests with `node --test test/*.test.js`.

## Test plan

- [x] `node --test test/onboard-validate.test.js test/onboard-config.test.js` — 12/12 pass
- [x] `node --test test/*.test.js` — full suite 64/64 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)