### PR TITLE
test: add coverage for blueprint state and resolve modules (13 new tests)

### DIFF
--- a/test/blueprint-resolve.test.js
+++ b/test/blueprint-resolve.test.js
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+let origHome;
+let tmpHome;
+
+beforeEach(() => {
+  origHome = process.env.HOME;
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-"));
+  process.env.HOME = tmpHome;
+  delete require.cache[require.resolve("../nemoclaw/dist/blueprint/resolve.js")];
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function loadModule() {
+  return require("../nemoclaw/dist/blueprint/resolve.js");
+}
+
+// Write a minimal blueprint.yaml into the cache directory.
+function writeCachedBlueprint(version, content) {
+  const dir = path.join(tmpHome, ".nemoclaw", "blueprints", version);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "blueprint.yaml"), content, "utf-8");
+  return dir;
+}
+
+describe("blueprint resolve", () => {
+  it("getCacheDir returns path under HOME", () => {
+    const { getCacheDir } = loadModule();
+    assert.ok(getCacheDir().startsWith(tmpHome));
+    assert.ok(getCacheDir().includes(".nemoclaw"));
+  });
+
+  it("getCachedBlueprintPath includes version", () => {
+    const { getCachedBlueprintPath } = loadModule();
+    const p = getCachedBlueprintPath("0.1.0");
+    assert.ok(p.endsWith("0.1.0"));
+  });
+
+  it("isCached returns false when no blueprint exists", () => {
+    const { isCached } = loadModule();
+    assert.equal(isCached("0.1.0"), false);
+  });
+
+  it("isCached returns true after writing blueprint.yaml", () => {
+    writeCachedBlueprint("0.2.0", "version: 0.2.0\n");
+    const { isCached } = loadModule();
+    assert.equal(isCached("0.2.0"), true);
+  });
+
+  it("readCachedManifest returns null when not cached", () => {
+    const { readCachedManifest } = loadModule();
+    assert.equal(readCachedManifest("0.9.9"), null);
+  });
+
+  it("readCachedManifest parses version field", () => {
+    writeCachedBlueprint("0.1.0", [
+      'version: "0.1.0"',
+      'min_openshell_version: "0.1.0"',
+      'min_openclaw_version: "2026.3.0"',
+      "digest: abc123",
+      "",
+    ].join("\n"));
+    const { readCachedManifest } = loadModule();
+    const m = readCachedManifest("0.1.0");
+    assert.ok(m);
+    assert.equal(m.version, '"0.1.0"');
+    assert.equal(m.digest, "abc123");
+  });
+
+  it("readCachedManifest returns default profiles when missing", () => {
+    writeCachedBlueprint("0.3.0", "version: 0.3.0\n");
+    const { readCachedManifest } = loadModule();
+    const m = readCachedManifest("0.3.0");
+    assert.ok(m);
+    assert.deepEqual(m.profiles, ["default"]);
+  });
+});

--- a/test/blueprint-state.test.js
+++ b/test/blueprint-state.test.js
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+let origHome;
+let tmpHome;
+
+beforeEach(() => {
+  origHome = process.env.HOME;
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-state-"));
+  process.env.HOME = tmpHome;
+  delete require.cache[require.resolve("../nemoclaw/dist/blueprint/state.js")];
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function loadModule() {
+  return require("../nemoclaw/dist/blueprint/state.js");
+}
+
+describe("blueprint state", () => {
+  it("returns blank state when no file exists", () => {
+    const { loadState } = loadModule();
+    const state = loadState();
+    assert.equal(state.lastRunId, null);
+    assert.equal(state.lastAction, null);
+    assert.equal(state.sandboxName, null);
+    assert.equal(typeof state.updatedAt, "string");
+  });
+
+  it("saves and loads state round-trip", () => {
+    const { saveState, loadState } = loadModule();
+    const state = loadState();
+    state.lastRunId = "nc-20260317-abc12345";
+    state.lastAction = "apply";
+    state.sandboxName = "my-sandbox";
+    state.blueprintVersion = "0.1.0";
+    saveState(state);
+
+    const loaded = loadState();
+    assert.equal(loaded.lastRunId, "nc-20260317-abc12345");
+    assert.equal(loaded.lastAction, "apply");
+    assert.equal(loaded.sandboxName, "my-sandbox");
+    assert.equal(loaded.blueprintVersion, "0.1.0");
+  });
+
+  it("sets updatedAt on save", () => {
+    const { saveState, loadState } = loadModule();
+    const state = loadState();
+    const before = new Date().toISOString();
+    saveState(state);
+    const loaded = loadState();
+    assert.ok(loaded.updatedAt >= before);
+  });
+
+  it("sets createdAt on first save only", () => {
+    const { saveState, loadState } = loadModule();
+    const state = loadState();
+    saveState(state);
+    const first = loadState();
+    const createdAt = first.createdAt;
+
+    // Second save should not change createdAt
+    first.lastAction = "plan";
+    saveState(first);
+    const second = loadState();
+    assert.equal(second.createdAt, createdAt);
+  });
+
+  it("creates .nemoclaw/state directory", () => {
+    const { loadState } = loadModule();
+    loadState();
+    assert.ok(fs.existsSync(path.join(tmpHome, ".nemoclaw", "state")));
+  });
+
+  it("clears state back to blank", () => {
+    const { saveState, clearState, loadState } = loadModule();
+    const state = loadState();
+    state.lastRunId = "nc-test";
+    state.lastAction = "apply";
+    saveState(state);
+
+    clearState();
+    const cleared = loadState();
+    assert.equal(cleared.lastRunId, null);
+    assert.equal(cleared.lastAction, null);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `test/blueprint-state.test.js` — 6 tests for the state lifecycle (blank load, save/load round-trip, `createdAt` immutability, `clearState`)
- Add `test/blueprint-resolve.test.js` — 7 tests for blueprint cache resolution (`getCacheDir`, `getCachedBlueprintPath`, `isCached`, `readCachedManifest` with profiles fallback)

All tests use isolated temp `HOME` directories — no side effects on the real filesystem.

## Test plan

- [x] `node --test test/blueprint-state.test.js test/blueprint-resolve.test.js` — 13/13 pass
- [x] `node --test test/*.test.js` — full suite 65/65 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)