### PR TITLE
feat: add cargo, go, apt, and ghcr policy presets

### DIFF
--- a/nemoclaw-blueprint/policies/presets/apt.yaml
+++ b/nemoclaw-blueprint/policies/presets/apt.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: apt
+  description: "Debian and Ubuntu package repositories"
+
+network_policies:
+  apt_repositories:
+    name: apt_repositories
+    endpoints:
+      - host: archive.ubuntu.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+      - host: security.ubuntu.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+      - host: deb.debian.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/apt.yaml
+++ b/nemoclaw-blueprint/policies/presets/apt.yaml
@@ -11,22 +11,14 @@ network_policies:
     endpoints:
       - host: archive.ubuntu.com
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: security.ubuntu.com
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: deb.debian.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/bin/apt-get }
+      - { path: /usr/bin/apt }

--- a/nemoclaw-blueprint/policies/presets/apt.yaml
+++ b/nemoclaw-blueprint/policies/presets/apt.yaml
@@ -11,25 +11,13 @@ network_policies:
     endpoints:
       - host: archive.ubuntu.com
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: security.ubuntu.com
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: deb.debian.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/bin/apt-get }

--- a/nemoclaw-blueprint/policies/presets/apt.yaml
+++ b/nemoclaw-blueprint/policies/presets/apt.yaml
@@ -11,13 +11,25 @@ network_policies:
     endpoints:
       - host: archive.ubuntu.com
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
       - host: security.ubuntu.com
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
       - host: deb.debian.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/bin/apt-get }

--- a/nemoclaw-blueprint/policies/presets/cargo.yaml
+++ b/nemoclaw-blueprint/policies/presets/cargo.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: cargo
+  description: "Rust Cargo registry access"
+
+network_policies:
+  cargo_registry:
+    name: cargo_registry
+    endpoints:
+      - host: crates.io
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+      - host: static.crates.io
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+      - host: index.crates.io
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/cargo.yaml
+++ b/nemoclaw-blueprint/policies/presets/cargo.yaml
@@ -11,22 +11,13 @@ network_policies:
     endpoints:
       - host: crates.io
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: static.crates.io
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: index.crates.io
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/cargo/bin/cargo }

--- a/nemoclaw-blueprint/policies/presets/cargo.yaml
+++ b/nemoclaw-blueprint/policies/presets/cargo.yaml
@@ -11,25 +11,13 @@ network_policies:
     endpoints:
       - host: crates.io
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: static.crates.io
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: index.crates.io
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/cargo/bin/cargo }

--- a/nemoclaw-blueprint/policies/presets/cargo.yaml
+++ b/nemoclaw-blueprint/policies/presets/cargo.yaml
@@ -11,13 +11,25 @@ network_policies:
     endpoints:
       - host: crates.io
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
       - host: static.crates.io
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
       - host: index.crates.io
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/cargo/bin/cargo }

--- a/nemoclaw-blueprint/policies/presets/ghcr.yaml
+++ b/nemoclaw-blueprint/policies/presets/ghcr.yaml
@@ -16,4 +16,4 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
+          - allow: { method: POST, path: "/v2/**" }

--- a/nemoclaw-blueprint/policies/presets/ghcr.yaml
+++ b/nemoclaw-blueprint/policies/presets/ghcr.yaml
@@ -11,7 +11,12 @@ network_policies:
     endpoints:
       - host: ghcr.io
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/v2/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/bin/docker }

--- a/nemoclaw-blueprint/policies/presets/ghcr.yaml
+++ b/nemoclaw-blueprint/policies/presets/ghcr.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: ghcr
+  description: "GitHub Container Registry access"
+
+network_policies:
+  ghcr_registry:
+    name: ghcr_registry
+    endpoints:
+      - host: ghcr.io
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/ghcr.yaml
+++ b/nemoclaw-blueprint/policies/presets/ghcr.yaml
@@ -11,12 +11,7 @@ network_policies:
     endpoints:
       - host: ghcr.io
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/v2/**" }
+        access: full
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/bin/docker }

--- a/nemoclaw-blueprint/policies/presets/ghcr.yaml
+++ b/nemoclaw-blueprint/policies/presets/ghcr.yaml
@@ -11,9 +11,7 @@ network_policies:
     endpoints:
       - host: ghcr.io
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/v2/**" }
+        access: full
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/bin/docker }

--- a/nemoclaw-blueprint/policies/presets/go.yaml
+++ b/nemoclaw-blueprint/policies/presets/go.yaml
@@ -11,26 +11,14 @@ network_policies:
     endpoints:
       - host: proxy.golang.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: sum.golang.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       # Module archives are served from Google Cloud Storage
       - host: storage.googleapis.com
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/golang/**" }
+        access: full
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/go/bin/go }

--- a/nemoclaw-blueprint/policies/presets/go.yaml
+++ b/nemoclaw-blueprint/policies/presets/go.yaml
@@ -11,13 +11,26 @@ network_policies:
     endpoints:
       - host: proxy.golang.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
       - host: sum.golang.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+      # Module archives are served from Google Cloud Storage
       - host: storage.googleapis.com
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/golang/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/go/bin/go }

--- a/nemoclaw-blueprint/policies/presets/go.yaml
+++ b/nemoclaw-blueprint/policies/presets/go.yaml
@@ -29,4 +29,4 @@ network_policies:
         enforcement: enforce
         tls: terminate
         rules:
-          - allow: { method: GET, path: "/**" }
+          - allow: { method: GET, path: "/proxy-golang-org/**" }

--- a/nemoclaw-blueprint/policies/presets/go.yaml
+++ b/nemoclaw-blueprint/policies/presets/go.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: go
+  description: "Go module proxy and checksum database"
+
+network_policies:
+  go_proxy:
+    name: go_proxy
+    endpoints:
+      - host: proxy.golang.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+      - host: sum.golang.org
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+      - host: storage.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/go.yaml
+++ b/nemoclaw-blueprint/policies/presets/go.yaml
@@ -11,22 +11,13 @@ network_policies:
     endpoints:
       - host: proxy.golang.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: sum.golang.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: storage.googleapis.com
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/proxy-golang-org/**" }
+        access: full
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/go/bin/go }

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -9,9 +9,9 @@ const policies = require("../bin/lib/policies");
 
 describe("policies", () => {
   describe("listPresets", () => {
-    it("returns all 9 presets", () => {
+    it("returns all 13 presets", () => {
       const presets = policies.listPresets();
-      assert.equal(presets.length, 9);
+      assert.equal(presets.length, 13);
     });
 
     it("each preset has name and description", () => {
@@ -23,7 +23,7 @@ describe("policies", () => {
 
     it("returns expected preset names", () => {
       const names = policies.listPresets().map((p) => p.name).sort();
-      const expected = ["discord", "docker", "huggingface", "jira", "npm", "outlook", "pypi", "slack", "telegram"];
+      const expected = ["apt", "cargo", "discord", "docker", "ghcr", "go", "huggingface", "jira", "npm", "outlook", "pypi", "slack", "telegram"];
       assert.deepEqual(names, expected);
     });
   });
@@ -113,6 +113,38 @@ describe("policies", () => {
         const content = policies.loadPreset(p.name);
         assert.ok(content.includes("network_policies:"), `${p.name} missing network_policies`);
       }
+    });
+  });
+
+  describe("new preset endpoints", () => {
+    it("cargo preset has crates.io endpoints", () => {
+      const content = policies.loadPreset("cargo");
+      const hosts = policies.getPresetEndpoints(content);
+      assert.ok(hosts.includes("crates.io"));
+      assert.ok(hosts.includes("static.crates.io"));
+      assert.ok(hosts.includes("index.crates.io"));
+    });
+
+    it("go preset has proxy and sum endpoints", () => {
+      const content = policies.loadPreset("go");
+      const hosts = policies.getPresetEndpoints(content);
+      assert.ok(hosts.includes("proxy.golang.org"));
+      assert.ok(hosts.includes("sum.golang.org"));
+      assert.ok(hosts.includes("storage.googleapis.com"));
+    });
+
+    it("apt preset has ubuntu and debian endpoints", () => {
+      const content = policies.loadPreset("apt");
+      const hosts = policies.getPresetEndpoints(content);
+      assert.ok(hosts.includes("archive.ubuntu.com"));
+      assert.ok(hosts.includes("security.ubuntu.com"));
+      assert.ok(hosts.includes("deb.debian.org"));
+    });
+
+    it("ghcr preset has registry and token endpoints", () => {
+      const content = policies.loadPreset("ghcr");
+      const hosts = policies.getPresetEndpoints(content);
+      assert.ok(hosts.includes("ghcr.io"));
     });
   });
 });

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -9,9 +9,11 @@ const policies = require("../bin/lib/policies");
 
 describe("policies", () => {
   describe("listPresets", () => {
-    it("returns all 13 presets", () => {
+    const expected = ["apt", "cargo", "discord", "docker", "ghcr", "go", "huggingface", "jira", "npm", "outlook", "pypi", "slack", "telegram"];
+
+    it("returns all presets", () => {
       const presets = policies.listPresets();
-      assert.equal(presets.length, 13);
+      assert.equal(presets.length, expected.length);
     });
 
     it("each preset has name and description", () => {
@@ -23,7 +25,6 @@ describe("policies", () => {
 
     it("returns expected preset names", () => {
       const names = policies.listPresets().map((p) => p.name).sort();
-      const expected = ["apt", "cargo", "discord", "docker", "ghcr", "go", "huggingface", "jira", "npm", "outlook", "pypi", "slack", "telegram"];
       assert.deepEqual(names, expected);
     });
   });
@@ -141,7 +142,7 @@ describe("policies", () => {
       assert.ok(hosts.includes("deb.debian.org"));
     });
 
-    it("ghcr preset has registry and token endpoints", () => {
+    it("ghcr preset has registry endpoint", () => {
       const content = policies.loadPreset("ghcr");
       const hosts = policies.getPresetEndpoints(content);
       assert.ok(hosts.includes("ghcr.io"));


### PR DESCRIPTION
## Summary

- Add 4 new network policy presets for package ecosystems with no existing coverage: **Cargo** (Rust), **Go modules**, **apt** (Debian/Ubuntu), and **GHCR** (GitHub Container Registry)
- Each preset uses `access: full` with binary restrictions, consistent with the upstream direction for package manager presets (see #356)
- Update preset count assertion and add endpoint validation tests for all 4 new presets

Related to #19 — expanding preset coverage so additional package managers work inside the sandbox out of the box

## Motivation

The sandbox ships with presets for npm, PyPI, Docker Hub, and a few messaging services, but developers using Rust, Go, Debian-based system packages, or GitHub Container Registry have no preset available. These 4 presets cover the most common gaps.

## Test plan

### Automated Tests
```
node --test test/policies.test.js
```

18 tests covering preset listing, endpoint extraction, YAML schema validation, and new preset endpoint verification.