### PR TITLE
fix: detect Podman container socket with Colima fallback priority

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -27,7 +27,14 @@ function isDockerRunning() {
     runCapture("docker info", { ignoreError: false });
     return true;
   } catch {
-    return false;
+    // Podman fallback — rootless Podman can substitute for Docker
+    try {
+      runCapture("podman info", { ignoreError: false });
+      console.log("  ⓘ Using Podman (note: --add-host=host-gateway may not resolve, see issue #116)");
+      return true;
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -22,22 +22,25 @@ function step(n, total, msg) {
   console.log(`  ${"─".repeat(50)}`);
 }
 
-function isDockerRunning() {
+/**
+ * Detect which container runtime is available.
+ * @returns {"docker"|"podman"|null} Runtime name or null if none found.
+ */
+function detectContainerRuntime() {
   try {
     runCapture("docker info", { ignoreError: false });
-    return true;
+    return "docker";
   } catch {
-    // Podman fallback — rootless Podman can substitute for Docker
     try {
       runCapture("podman info", { ignoreError: false });
-      console.log("  ⓘ Using Podman (note: --add-host=host-gateway may not resolve, see issue #116)");
-      return true;
+      return "podman";
     } catch {
-      return false;
+      return null;
     }
   }
 }
 
+/** @returns {boolean} True if openshell CLI is on PATH. */
 function isOpenshellInstalled() {
   try {
     runCapture("command -v openshell");
@@ -58,12 +61,17 @@ function installOpenshell() {
 async function preflight() {
   step(1, 7, "Preflight checks");
 
-  // Docker
-  if (!isDockerRunning()) {
-    console.error("  Docker is not running. Please start Docker and try again.");
+  // Container runtime
+  const runtime = detectContainerRuntime();
+  if (!runtime) {
+    console.error("  Neither Docker nor Podman is running. Please start a container runtime and try again.");
     process.exit(1);
   }
-  console.log("  ✓ Docker is running");
+  if (runtime === "podman") {
+    console.log("  ✓ Podman is running (note: --add-host=host-gateway may not resolve, see issue #116)");
+  } else {
+    console.log("  ✓ Docker is running");
+  }
 
   // OpenShell CLI
   if (!isOpenshellInstalled()) {

--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -8,18 +8,43 @@ const fs = require("fs");
 const ROOT = path.resolve(__dirname, "..", "..");
 const SCRIPTS = path.join(ROOT, "scripts");
 
-// Auto-detect Colima Docker socket (legacy ~/.colima or XDG ~/.config/colima)
-if (!process.env.DOCKER_HOST) {
-  const home = process.env.HOME || "/tmp";
+/**
+ * Detect a container runtime socket (Colima first, then Podman).
+ * Returns the socket path or null.
+ *
+ * @param {object} [opts] — DI overrides for testing
+ * @param {string} [opts.home] — HOME directory override
+ * @param {function} [opts.existsSync] — fs.existsSync override
+ * @param {number} [opts.uid] — process UID override for rootless Podman
+ */
+function detectContainerSocket(opts) {
+  const home = (opts && opts.home) || process.env.HOME || "/tmp";
+  const exists = (opts && opts.existsSync) || fs.existsSync;
+  const uid = (opts && opts.uid !== undefined) ? opts.uid : (process.getuid ? process.getuid() : 1000);
+
   const candidates = [
+    // Colima (preferred — existing behavior)
     path.join(home, ".colima/default/docker.sock"),
     path.join(home, ".config/colima/default/docker.sock"),
+    // Podman machine
+    path.join(home, ".local/share/containers/podman/machine/podman.sock"),
+    `/run/user/${uid}/podman/podman.sock`,
+    path.join(home, ".local/share/containers/podman/machine/qemu/podman.sock"),
   ];
+
   for (const sock of candidates) {
-    if (fs.existsSync(sock)) {
-      process.env.DOCKER_HOST = `unix://${sock}`;
-      break;
+    if (exists(sock)) {
+      return sock;
     }
+  }
+  return null;
+}
+
+// Auto-detect container socket if DOCKER_HOST not already set
+if (!process.env.DOCKER_HOST) {
+  const sock = detectContainerSocket();
+  if (sock) {
+    process.env.DOCKER_HOST = `unix://${sock}`;
   }
 }
 
@@ -52,4 +77,4 @@ function runCapture(cmd, opts = {}) {
   }
 }
 
-module.exports = { ROOT, SCRIPTS, run, runCapture };
+module.exports = { ROOT, SCRIPTS, run, runCapture, detectContainerSocket };

--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -48,6 +48,7 @@ if (!process.env.DOCKER_HOST) {
   }
 }
 
+/** @param {string} cmd - Shell command to execute. @param {object} [opts] */
 function run(cmd, opts = {}) {
   const result = spawnSync("bash", ["-c", cmd], {
     stdio: "inherit",
@@ -62,6 +63,7 @@ function run(cmd, opts = {}) {
   return result;
 }
 
+/** @param {string} cmd - Shell command. @returns {string} Trimmed stdout. */
 function runCapture(cmd, opts = {}) {
   try {
     return execSync(cmd, {

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+
+const { detectContainerSocket } = require("../bin/lib/runner");
+
+describe("detectContainerSocket", () => {
+  it("returns null when no sockets exist", () => {
+    const result = detectContainerSocket({
+      home: "/nonexistent",
+      existsSync: () => false,
+      uid: 1000,
+    });
+    assert.equal(result, null);
+  });
+
+  it("prefers Colima over Podman when both exist", () => {
+    const colimaPath = "/home/test/.colima/default/docker.sock";
+    const podmanPath = "/home/test/.local/share/containers/podman/machine/podman.sock";
+
+    const result = detectContainerSocket({
+      home: "/home/test",
+      existsSync: (p) => p === colimaPath || p === podmanPath,
+      uid: 1000,
+    });
+    assert.equal(result, colimaPath);
+  });
+
+  it("falls back to Podman when Colima absent", () => {
+    const podmanPath = "/home/test/.local/share/containers/podman/machine/podman.sock";
+
+    const result = detectContainerSocket({
+      home: "/home/test",
+      existsSync: (p) => p === podmanPath,
+      uid: 1000,
+    });
+    assert.equal(result, podmanPath);
+  });
+
+  it("detects rootless Podman socket", () => {
+    const uid = 1001;
+    const rootlessPath = `/run/user/${uid}/podman/podman.sock`;
+
+    const result = detectContainerSocket({
+      home: "/home/test",
+      existsSync: (p) => p === rootlessPath,
+      uid,
+    });
+    assert.equal(result, rootlessPath);
+  });
+
+  it("detects XDG Colima socket", () => {
+    const xdgPath = "/home/test/.config/colima/default/docker.sock";
+
+    const result = detectContainerSocket({
+      home: "/home/test",
+      existsSync: (p) => p === xdgPath,
+      uid: 1000,
+    });
+    assert.equal(result, xdgPath);
+  });
+
+  it("detects Podman QEMU socket path", () => {
+    const qemuPath = "/home/test/.local/share/containers/podman/machine/qemu/podman.sock";
+    const result = detectContainerSocket({
+      home: "/home/test",
+      existsSync: (p) => p === qemuPath,
+      uid: 1000,
+    });
+    assert.equal(result, qemuPath);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `detectContainerSocket(opts)` with dependency injection for testability
- Add Podman socket candidates: `~/.local/share/containers/podman/machine/podman.sock`, `/run/user/$UID/podman/podman.sock`, and QEMU variant
- Colima sockets are checked first to preserve existing behavior for current users
- Add Podman fallback to `isDockerRunning()` in onboard — tries `podman info` if `docker info` fails, with a warning about `--add-host=host-gateway` limitations

Closes #116

## Test plan

### Automated Tests
```
npm test
```

New `detectContainerSocket` test suite (6 tests):
1. No sockets exist → returns `null`
2. Colima preferred over Podman when both exist
3. Falls back to Podman when Colima absent
4. Detects rootless Podman socket (`/run/user/$UID/podman/podman.sock`)
5. Detects XDG Colima socket (`~/.config/colima/default/docker.sock`)
6. Detects Podman QEMU socket path

### Hardware Validation

Validated socket detection against real filesystem layouts:

| Machine | OS | Runtime | Socket found | Path |
|---------|-----|---------|-------------|------|
| kobe (Mac mini M2) | macOS 26.2 | Colima + Docker 29.2 | Colima legacy | `~/.colima/default/docker.sock` |
| spark0 (DGX Spark) | Ubuntu 24.04 | Docker 28.5.1 native | N/A (DOCKER_HOST not needed) | Default `/var/run/docker.sock` |
| spark1 (DGX Spark) | Ubuntu 24.04 | Docker 29.1.3 native | N/A | Default `/var/run/docker.sock` |

On kobe, `docker ps` through the detected Colima socket confirmed 4 running containers. Colima XDG path (`~/.config/colima/`) and Podman paths were not present, matching test expectations for a Colima-only setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Podman added as a fallback container runtime when Docker is unavailable.
  * Improved runtime detection to recognize Colima and additional container socket locations for better compatibility.
  * Preflight messages adjusted: runtime-specific success messages (Podman vs Docker) and a combined notice when no runtime is detected.

* **Tests**
  * Added test coverage for container socket detection across multiple runtime and socket scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->