### PR TITLE
fix: reduce auto-pair timeout and add skip/configure env vars

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -8,6 +8,8 @@
 # Optional env:
 #   NVIDIA_API_KEY   API key for NVIDIA-hosted inference
 #   CHAT_UI_URL      Browser origin that will access the forwarded dashboard
+#   NEMOCLAW_SKIP_AUTO_PAIR     Set to 1/true/yes to disable auto-pair watcher
+#   NEMOCLAW_AUTO_PAIR_TIMEOUT  Auto-pair timeout in seconds (default: 120)
 
 set -euo pipefail
 
@@ -108,14 +110,28 @@ PYTOKEN
 }
 
 start_auto_pair() {
+  case "${NEMOCLAW_SKIP_AUTO_PAIR:-}" in
+    1|true|yes|TRUE|YES)
+      echo "[gateway] auto-pair watcher skipped (NEMOCLAW_SKIP_AUTO_PAIR is set)"
+      return
+      ;;
+  esac
   nohup python3 - <<'PYAUTOPAIR' >> /tmp/gateway.log 2>&1 &
 import json
+import os
 import subprocess
 import time
 
-DEADLINE = time.time() + 600
+try:
+    timeout = int(os.environ.get('NEMOCLAW_AUTO_PAIR_TIMEOUT', '120'))
+    if timeout < 0:
+        timeout = 120
+except ValueError:
+    timeout = 120
+DEADLINE = time.time() + timeout
 QUIET_POLLS = 0
 APPROVED = 0
+print(f'[auto-pair] watcher launched (timeout={timeout}s)')
 
 def run(*args):
     proc = subprocess.run(args, capture_output=True, text=True)

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -114,8 +114,8 @@ PYTOKEN
 
 # Launch a background watcher that auto-approves pending device-pair requests.
 start_auto_pair() {
-  case "${NEMOCLAW_SKIP_AUTO_PAIR:-}" in
-    1|true|yes|TRUE|YES)
+  case "$(echo "${NEMOCLAW_SKIP_AUTO_PAIR:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes)
       echo "[gateway] auto-pair watcher skipped (NEMOCLAW_SKIP_AUTO_PAIR is set)"
       return
       ;;
@@ -128,7 +128,7 @@ import time
 
 try:
     timeout = int(os.environ.get('NEMOCLAW_AUTO_PAIR_TIMEOUT', '120'))
-    if timeout < 0:
+    if timeout <= 0:
         timeout = 120
 except ValueError:
     timeout = 120

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -139,8 +139,12 @@ print(f'[auto-pair] watcher launched (timeout={timeout}s)')
 
 def run(*args):
     """Run a subprocess and return (returncode, stdout, stderr)."""
-    proc = subprocess.run(args, capture_output=True, text=True)
-    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    remaining = max(1, int(DEADLINE - time.time()))
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=remaining)
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 124, '', f'subprocess timed out after {remaining}s'
 
 while time.time() < DEADLINE:
     rc, out, err = run('openclaw', 'devices', 'list', '--json')

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -17,6 +17,7 @@ NEMOCLAW_CMD=("$@")
 CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:18789}"
 PUBLIC_PORT=18789
 
+# Patch the OpenClaw JSON config with sandbox-safe gateway defaults.
 fix_openclaw_config() {
   python3 - <<'PYCFG'
 import json
@@ -59,6 +60,7 @@ os.chmod(config_path, 0o600)
 PYCFG
 }
 
+# Write an NVIDIA auth-profile if NVIDIA_API_KEY is set.
 write_auth_profile() {
   if [ -z "${NVIDIA_API_KEY:-}" ]; then
     return
@@ -81,6 +83,7 @@ os.chmod(path, 0o600)
 PYAUTH
 }
 
+# Print the local and remote dashboard URLs, appending the auth token if present.
 print_dashboard_urls() {
   local token chat_ui_base local_url remote_url
 
@@ -109,6 +112,7 @@ PYTOKEN
   echo "[gateway] Remote UI: ${remote_url}"
 }
 
+# Launch a background watcher that auto-approves pending device-pair requests.
 start_auto_pair() {
   case "${NEMOCLAW_SKIP_AUTO_PAIR:-}" in
     1|true|yes|TRUE|YES)

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -134,6 +134,7 @@ APPROVED = 0
 print(f'[auto-pair] watcher launched (timeout={timeout}s)')
 
 def run(*args):
+    """Run a subprocess and return (returncode, stdout, stderr)."""
     proc = subprocess.run(args, capture_output=True, text=True)
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -120,6 +120,8 @@ start_auto_pair() {
       return
       ;;
   esac
+  local pair_timeout="${NEMOCLAW_AUTO_PAIR_TIMEOUT:-120}"
+  echo "[gateway] auto-pair watcher launching (timeout=${pair_timeout}s)"
   nohup python3 - <<'PYAUTOPAIR' >> /tmp/gateway.log 2>&1 &
 import json
 import os


### PR DESCRIPTION
## Summary

- Reduce default auto-pair watcher timeout from 600s to 120s — pairing typically converges in <10s, 10 minutes is unnecessarily long
- Add `NEMOCLAW_AUTO_PAIR_TIMEOUT` env var to configure the timeout for environments that need longer convergence windows
- Add `NEMOCLAW_SKIP_AUTO_PAIR` env var to disable the watcher entirely in automated/CI deployments
- Add per-subprocess timeout to prevent hung `openclaw devices` calls from defeating the watcher deadline
- Echo configured timeout to the terminal before the watcher launches in the background

## Test plan

### Automated Tests
```
npm test
```

### Manual Verification
```bash
# Default behavior (120s timeout)
nemoclaw onboard
# Expect log: auto-pair watcher launching (timeout=120s)

# Custom timeout
NEMOCLAW_AUTO_PAIR_TIMEOUT=300 nemoclaw onboard

# Skip auto-pair
NEMOCLAW_SKIP_AUTO_PAIR=1 nemoclaw onboard
# Expect log: auto-pair watcher skipped
```