### PR TITLE
fix: node version miss match

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,7 @@ install_nodejs() {
   bash "$nvm_tmp"
   rm -f "$nvm_tmp"
   ensure_nvm_loaded
-  nvm install 24
+  nvm install ${RECOMMENDED_NODE_MAJOR}
   info "Node.js installed: $(node --version)"
 }
 


### PR DESCRIPTION
The node version in `scripts/install.sh` miss match with install.sh