### PR TITLE
feat(skills): add hindsight-memory skill for persistent agent memory

### DIFF
--- a/.agents/skills/hindsight-memory/SKILL.md
+++ b/.agents/skills/hindsight-memory/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: hindsight-memory
+description: Teach sandboxed agents how to use Hindsight for persistent memory across ephemeral sandbox sessions. Trigger keywords - add memory, persistent memory, remember, recall, hindsight, retain context, memory skill.
+---
+
+# Hindsight Memory Skill
+
+This skill teaches sandboxed OpenClaw agents how to use [Hindsight](https://github.com/vectorize-io/hindsight) for persistent memory across ephemeral sandbox sessions.
+
+## Why This Matters
+
+Sandboxes are isolated and disposable. When a sandbox is destroyed, everything the agent learned is lost. Hindsight solves this by providing a structured memory API that agents can call from inside the sandbox to recall past context and store new learnings.
+
+## Prerequisites
+
+- Hindsight server running (either locally via `hindsight-embed` or externally)
+- Network policy allows egress to Hindsight endpoint
+- `HINDSIGHT_URL` environment variable set in the sandbox
+
+## Workflows
+
+### 1. Recall Before Work
+
+Before starting any task, query past context to understand what has already been discussed or learned:
+
+```bash
+hindsight recall --query "<task description or topic>"
+```
+
+Example: If the user asks to "fix the authentication bug", first recall what previous work has been done on authentication.
+
+### 2. Retain After Work
+
+After completing work, immediately store learnings. Sandboxes can be destroyed anytime:
+
+```bash
+hindsight retain --content "<what was learned>" --tags "<relevant tags>"
+```
+
+Example: After fixing a bug, retain the root cause and solution approach.
+
+### 3. Reflect for Synthesis
+
+Get synthesized answers from multiple memories:
+
+```bash
+hindsight reflect --question "<question about past context>"
+```
+
+### 4. Bulk File Ingestion
+
+Retain logs, reports, and investigation notes:
+
+```bash
+hindsight retain --file /path/to/file.txt --tags "logs,investigation"
+```
+
+### 5. Cross-Sandbox Continuity
+
+Pick up where previous sessions left off. The agent should always:
+1. On session start, recall the user's preferences and ongoing projects
+2. On session end, retain any new learnings
+
+## NemoClaw Integration
+
+### Setup
+
+1. Add Hindsight to network policy (see `example-policy.yaml`)
+2. During onboard or migrate, ensure `HINDSIGHT_URL` is set
+3. Optionally set `HINDSIGHT_API_KEY` if using external Hindsight service
+
+### Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `HINDSIGHT_URL` | Hindsight server URL (e.g., `http://hindsight:8080`) | Yes |
+| `HINDSIGHT_API_KEY` | API key for external Hindsight service | No |
+
+### Commands in NemoClaw
+
+Inside the sandbox, use the Hindsight CLI directly:
+
+```bash
+# Recall past context
+hindsight recall --query "authentication"
+
+# Retain a learning
+hindsight retain --content "User prefers dark mode UI" --tags preferences
+
+# Reflect on multiple memories
+hindsight reflect --question "What bugs has the user reported?"
+
+# List memory banks
+hindsight banks list
+```
+
+## Memory Bank Strategy
+
+For OpenClaw agents, consider these memory banks:
+
+- **user-profile**: User preferences, communication style, project context
+- **session-notes**: Ongoing work, pending tasks, recent discoveries
+- **knowledge-base**: Technical learnings, bug resolutions, architectural decisions
+
+## Best Practices
+
+1. **Recall early** — Query memory at the start of each user interaction
+2. **Retain often** — Store learnings immediately after any significant work
+3. **Use tags** — Organize memories with consistent tags for better recall
+4. **Reflect before major decisions** — Synthesize past context before suggesting changes
+5. **Retention triggers** — Retain after: bug fixes, architecture decisions, user preferences expressed, configuration changes
+
+## Example Scenarios
+
+### Scenario: User Asks About Previous Work
+
+```
+User: Can you help me with the API?
+Agent: [calls hindsight recall --query "API development"]
+Agent: I see you worked on the REST API last week. You added rate limiting and fixed the authentication endpoint. Would you like me to continue from there?
+```
+
+### Scenario: Learning User Preference
+
+```
+User: I prefer using TypeScript over JavaScript
+Agent: [calls hindsight retain --content "User prefers TypeScript over JavaScript" --tags preferences,typescript]
+Agent: Got it! I'll keep that in mind for any code recommendations.
+```
+
+### Scenario: Cross-Session Continuity
+
+```
+User: Continue where we left off yesterday
+Agent: [calls hindsight recall --query "unfinished work"]
+Agent: Yesterday we were working on the database migration. You had migrated 3 of 5 tables. Shall I continue with table 4?
+```

--- a/.agents/skills/hindsight-memory/cli-reference.md
+++ b/.agents/skills/hindsight-memory/cli-reference.md
@@ -1,0 +1,166 @@
+# Hindsight CLI Reference
+
+Command-line reference for Hindsight memory operations in the sandbox.
+
+## Installation
+
+```bash
+# Inside the sandbox
+pip install hindsight
+# or
+npm install -g hindsight
+```
+
+## Commands
+
+### recall
+
+Query past context from memory.
+
+```bash
+hindsight recall --query "<search term>" [flags]
+```
+
+**Flags:**
+- `--query, -q` (string): Search query (required)
+- `--limit, -l` (int): Number of results (default: 5)
+- `--bank` (string): Specific memory bank to search
+- `--format` (string): Output format (json, text)
+
+**Example:**
+```bash
+hindsight recall --query "authentication bug" --limit 3
+hindsight recall -q "preferences" --bank user-profile
+```
+
+### retain
+
+Store new learnings in memory.
+
+```bash
+hindsight retain --content "<text>" [flags]
+```
+
+**Flags:**
+- `--content, -c` (string): Content to store (required)
+- `--tags, -t` (string): Comma-separated tags
+- `--bank` (string): Target memory bank (default: default)
+- `--metadata` (string): JSON metadata
+
+**Example:**
+```bash
+hindsight retain --content "Fixed bug by updating auth middleware" --tags bugfix,auth
+hindsight retain -c "User prefers dark mode" -t preferences
+```
+
+### reflect
+
+Synthesize answers from multiple memories.
+
+```bash
+hindsight reflect --question "<question>" [flags]
+```
+
+**Flags:**
+- `--question, -q` (string): Question to reflect on (required)
+- `--bank` (string): Memory bank to query
+
+**Example:**
+```bash
+hindsight reflect --question "What bugs has the user reported recently?"
+```
+
+### banks
+
+Manage memory banks.
+
+```bash
+hindsight banks <subcommand> [flags]
+```
+
+**Subcommands:**
+- `list` — List all memory banks
+- `create <name>` — Create a new bank
+- `delete <name>` — Delete a bank
+- `info <name>` — Show bank details
+
+**Example:**
+```bash
+hindsight banks list
+hindsight banks create user-profile
+hindsight banks info session-notes
+```
+
+### observations
+
+Manage synthesized observations.
+
+```bash
+hindsight observations <subcommand> [flags]
+```
+
+**Subcommands:**
+- `list` — List observations
+- `clear` — Clear all observations
+
+**Example:**
+```bash
+hindsight observations list
+```
+
+### mental-models
+
+Manage mental models (curated summaries).
+
+```bash
+hindsight mental-models <subcommand> [flags]
+```
+
+**Subcommands:**
+- `list` — List mental models
+- `create <name>` — Create a mental model
+- `get <name>` — Get mental model content
+
+**Example:**
+```bash
+hindsight mental-models list
+hindsight mental-models create user-preferences --content "User preferences summary"
+```
+
+### health
+
+Check Hindsight server health.
+
+```bash
+hindsight health
+```
+
+### version
+
+Show Hindsight version.
+
+```bash
+hindsight version
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HINDSIGHT_URL` | Server URL | `http://localhost:8080` |
+| `HINDSIGHT_API_KEY` | API key for auth | None |
+| `HINDSIGHT_BANK` | Default bank | `default` |
+
+## Exit Codes
+
+- `0` — Success
+- `1` — Error (invalid args, server unreachable, etc.)
+- `2` — Usage error
+
+## Output Formats
+
+Most commands support `--format json` for programmatic output:
+
+```bash
+hindsight recall --query "auth" --format json | jq '.memories[].content'
+```

--- a/.agents/skills/hindsight-memory/example-policy.yaml
+++ b/.agents/skills/hindsight-memory/example-policy.yaml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example network policy for Hindsight memory service.
+#
+# Two modes:
+#   1. Local: Hindsight runs on the host, sandbox connects via host network
+#   2. External: Hindsight runs as a cloud service, sandbox connects externally
+#
+# Usage:
+#   - Copy relevant section to openclaw-sandbox.yaml network_policies
+#   - Or apply dynamically: openshell policy set --file example-policy.yaml
+
+# ── Mode 1: Local Hindsight (host network) ───────────────────────────────
+# Use when hindsight-embed runs on the host machine.
+
+hindsight_local:
+  name: hindsight_local
+  description: Local Hindsight memory service on host
+  endpoints:
+    - host: host.docker.internal
+      port: 8080
+      protocol: rest
+      enforcement: enforce
+      tls: false
+      rules:
+        - allow: { method: "*", path: "/**" }
+  binaries:
+    - { path: /usr/local/bin/hindsight }
+
+# ── Mode 2: External Hindsight (cloud service) ───────────────────────────
+# Use when connecting to a hosted Hindsight service (Hindsight Cloud, etc.)
+
+hindsight_external:
+  name: hindsight_external
+  description: External Hindsight memory service
+  endpoints:
+    # Default Hindsight Cloud endpoint
+    - host: api.hindsight.vectorize.io
+      port: 443
+      protocol: rest
+      enforcement: enforce
+      tls: terminate
+      rules:
+        - allow: { method: "*", path: "/**" }
+  binaries:
+    - { path: /usr/local/bin/hindsight }
+
+# ── Alternative: Self-hosted on custom host ───────────────────────────────
+# Use when Hindsight is self-hosted at a custom URL.
+
+hindsight_custom:
+  name: hindsight_custom
+  description: Self-hosted Hindsight at custom URL
+  endpoints:
+    # Replace <your-hindsight-host> with your instance
+    - host: <your-hindsight-host>
+      port: 443
+      protocol: rest
+      enforcement: enforce
+      tls: terminate
+      rules:
+        - allow: { method: "*", path: "/**" }
+  binaries:
+    - { path: /usr/local/bin/hindsight }
+
+# ── Environment Variables ──────────────────────────────────────────────────
+# Add to your sandbox environment via openshell policy set or blueprint:
+#
+# environment:
+#   HINDSIGHT_URL: "http://host.docker.internal:8080"  # local
+#   # or
+#   HINDSIGHT_URL: "https://api.hindsight.vectorize.io"  # cloud
+#   # Optional: for external service with auth
+#   HINDSIGHT_API_KEY: "<your-api-key>"
+
+# ── Quick Apply ───────────────────────────────────────────────────────────
+# To add local Hindsight to existing policy:
+#   1. Add hindsight_local entry to network_policies in openclaw-sandbox.yaml
+#   2. Run: openclaw nemoclaw migrate --profile default
+#
+# Or apply dynamically without migration:
+#   openshell policy set --file example-policy.yaml --policy-name hindsight_local


### PR DESCRIPTION
## Summary

Add a new agent skill that teaches sandboxed agents how to use Hindsight for persistent memory across ephemeral sandbox sessions.

This addresses the issue where sandboxes are isolated and disposable — when a sandbox is destroyed, everything the agent learned is lost. Hindsight provides a structured memory API for agents to recall past context and store new learnings.

## Files Added

-  — Main skill documentation with setup and workflows
-  — Hindsight CLI command reference
-  — Network policy template for Hindsight API access

## What the Skill Covers

- **Recall before work** — query past context before starting tasks
- **Retain after work** — store learnings immediately (sandboxes can be destroyed anytime)
- **Reflect for synthesis** — get synthesized answers from multiple memories
- **Bulk file ingestion** — retain logs, reports, and investigation notes
- **Cross-sandbox continuity** — pick up where previous sessions left off

## Testing

- Documentation builds successfully (make docs)
- TypeScript check passes for nemoclaw package

Closes #37