### PR TITLE
fix: install Node.js 22 to match scripts/install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,7 @@ install_nodejs() {
   bash "$nvm_tmp"
   rm -f "$nvm_tmp"
   ensure_nvm_loaded
-  nvm install 24
+  nvm install 22
   info "Node.js installed: $(node --version)"
 }
 


### PR DESCRIPTION
## Summary
Fixes #162 — one-line fix. `install.sh` installed Node 24 but `scripts/install.sh` resets nvm default to 22, so nemoclaw disappears in new shells.

Changed `nvm install 24` → `nvm install 22`.