### PR TITLE
fix: validate and quote sandbox name in shell commands

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -150,13 +150,15 @@ async function startGateway(gpu) {
 async function createSandbox(gpu) {
   step(3, 7, "Creating sandbox");
 
-  const nameAnswer = await prompt("  Sandbox name [my-assistant]: ");
-  const sandboxName = (nameAnswer || "my-assistant").trim();
+  const nameAnswer = await prompt("  Sandbox name (lowercase, numbers, hyphens) [my-assistant]: ");
+  const sandboxName = (nameAnswer || "my-assistant").trim().toLowerCase();
 
-  // Validate sandbox name — alphanumeric, hyphens, and underscores only
-  if (!/^[a-zA-Z0-9_-]+$/.test(sandboxName)) {
+  // Validate: RFC 1123 subdomain — lowercase alphanumeric and hyphens,
+  // must start and end with alphanumeric (required by Kubernetes/OpenShell)
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(sandboxName)) {
     console.error(`  Invalid sandbox name: '${sandboxName}'`);
-    console.error("  Names must contain only letters, numbers, hyphens, and underscores.");
+    console.error("  Names must be lowercase, contain only letters, numbers, and hyphens,");
+    console.error("  and must start and end with a letter or number.");
     process.exit(1);
   }
 

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -151,7 +151,14 @@ async function createSandbox(gpu) {
   step(3, 7, "Creating sandbox");
 
   const nameAnswer = await prompt("  Sandbox name [my-assistant]: ");
-  const sandboxName = nameAnswer || "my-assistant";
+  const sandboxName = (nameAnswer || "my-assistant").trim();
+
+  // Validate sandbox name — alphanumeric, hyphens, and underscores only
+  if (!/^[a-zA-Z0-9_-]+$/.test(sandboxName)) {
+    console.error(`  Invalid sandbox name: '${sandboxName}'`);
+    console.error("  Names must contain only letters, numbers, hyphens, and underscores.");
+    process.exit(1);
+  }
 
   // Check if sandbox already exists in registry
   const existing = registry.getSandbox(sandboxName);
@@ -162,7 +169,7 @@ async function createSandbox(gpu) {
       return sandboxName;
     }
     // Destroy old sandbox
-    run(`openshell sandbox delete ${sandboxName} 2>/dev/null || true`, { ignoreError: true });
+    run(`openshell sandbox delete "${sandboxName}" 2>/dev/null || true`, { ignoreError: true });
     registry.removeSandbox(sandboxName);
   }
 
@@ -181,7 +188,7 @@ async function createSandbox(gpu) {
   const basePolicyPath = path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
   const createArgs = [
     `--from "${buildCtx}/Dockerfile"`,
-    `--name ${sandboxName}`,
+    `--name "${sandboxName}"`,
     `--policy "${basePolicyPath}"`,
   ];
   if (gpu && gpu.nimCapable) createArgs.push("--gpu");
@@ -195,7 +202,7 @@ async function createSandbox(gpu) {
   run(`openshell sandbox create ${createArgs.join(" ")} -- env ${envArgs.join(" ")} nemoclaw-start 2>&1 | awk '/Sandbox allocated/{if(!seen){print;seen=1}next}1'`);
 
   // Forward dashboard port separately
-  run(`openshell forward start --background 18789 ${sandboxName}`, { ignoreError: true });
+  run(`openshell forward start --background 18789 "${sandboxName}"`, { ignoreError: true });
 
   // Clean up build context
   run(`rm -rf "${buildCtx}"`, { ignoreError: true });

--- a/bin/lib/policies.js
+++ b/bin/lib/policies.js
@@ -86,7 +86,7 @@ function applyPreset(sandboxName, presetName) {
   let rawPolicy = "";
   try {
     rawPolicy = runCapture(
-      `openshell policy get --full ${sandboxName} 2>/dev/null`,
+      `openshell policy get --full "${sandboxName}" 2>/dev/null`,
       { ignoreError: true }
     );
   } catch {}
@@ -146,7 +146,7 @@ function applyPreset(sandboxName, presetName) {
   fs.writeFileSync(tmpFile, merged, "utf-8");
 
   try {
-    run(`openshell policy set --policy "${tmpFile}" --wait ${sandboxName}`);
+    run(`openshell policy set --policy "${tmpFile}" --wait "${sandboxName}"`);
     console.log(`  Applied preset: ${presetName}`);
   } finally {
     fs.unlinkSync(tmpFile);

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -188,8 +188,8 @@ function listSandboxes() {
 
 function sandboxConnect(sandboxName) {
   // Ensure port forward is alive before connecting
-  run(`openshell forward start --background 18789 ${sandboxName} 2>/dev/null || true`, { ignoreError: true });
-  run(`openshell sandbox connect ${sandboxName}`);
+  run(`openshell forward start --background 18789 "${sandboxName}" 2>/dev/null || true`, { ignoreError: true });
+  run(`openshell sandbox connect "${sandboxName}"`);
 }
 
 function sandboxStatus(sandboxName) {
@@ -204,7 +204,7 @@ function sandboxStatus(sandboxName) {
   }
 
   // openshell info
-  run(`openshell sandbox get ${sandboxName} 2>/dev/null || true`, { ignoreError: true });
+  run(`openshell sandbox get "${sandboxName}" 2>/dev/null || true`, { ignoreError: true });
 
   // NIM health
   const nimStat = nim.nimStatus(sandboxName);
@@ -217,7 +217,7 @@ function sandboxStatus(sandboxName) {
 
 function sandboxLogs(sandboxName, follow) {
   const followFlag = follow ? " --follow" : "";
-  run(`openshell sandbox logs ${sandboxName}${followFlag}`);
+  run(`openshell sandbox logs "${sandboxName}"${followFlag}`);
 }
 
 async function sandboxPolicyAdd(sandboxName) {
@@ -260,7 +260,7 @@ function sandboxDestroy(sandboxName) {
   nim.stopNimContainer(sandboxName);
 
   console.log(`  Deleting sandbox '${sandboxName}'...`);
-  run(`openshell sandbox delete ${sandboxName} 2>/dev/null || true`, { ignoreError: true });
+  run(`openshell sandbox delete "${sandboxName}" 2>/dev/null || true`, { ignoreError: true });
 
   registry.removeSandbox(sandboxName);
   console.log(`  ✓ Sandbox '${sandboxName}' destroyed`);


### PR DESCRIPTION
## Summary
Closes #166, closes #202

Two sandbox name issues:
1. Unquoted `${sandboxName}` in shell commands across `onboard.js`, `policies.js`, and `nemoclaw.js` caused argument parsing failures
2. Capital letters in sandbox names caused Kubernetes rejection (RFC 1123 requires lowercase)

**Changes:**
- Auto-lowercase and `.trim()` the sandbox name from user input
- Validate against RFC 1123 subdomain rules (`/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/`)
- Prompt now shows the naming rules
- Quoted `${sandboxName}` in all shell commands across 3 files (onboard.js, policies.js, nemoclaw.js)
- Clear error message on invalid names

## Test results

### Validation logic (23 assertions, 0 failures)

| Input | Expected | Result |
|-------|----------|--------|
| `My-Assistant` | auto-lower → `my-assistant`, valid | PASS |
| `ALLCAPS` | auto-lower → `allcaps`, valid | PASS |
| `TestBox` | auto-lower → `testbox`, valid | PASS |
| `my-assistant` | valid | PASS |
| `sandbox1` | valid | PASS |
| `a` | valid | PASS |
| `a-b-c` | valid | PASS |
| `  my-assistant  ` | trimmed, valid | PASS |
| `""` (empty) | rejected | PASS |
| `"   "` (whitespace) | rejected | PASS |
| `-start` | rejected (starts with hyphen) | PASS |
| `end-` | rejected (ends with hyphen) | PASS |
| `has_underscore` | rejected (not RFC 1123) | PASS |
| `has space` | rejected | PASS |
| `semi;colon` | rejected | PASS |
| `$(whoami)` | rejected (shell injection) | PASS |
| `null` / `undefined` | rejected (empty) | PASS |

### Real openshell E2E

Input `TestCaps` at the sandbox name prompt → auto-lowered to `testcaps` → sandbox created successfully on real openshell. On main without this fix, the same input produces a Kubernetes RFC 1123 error.

### Shell command quoting sweep (0 unquoted)

`grep -rn 'run(' bin/ --include='*.js' | grep sandboxName | grep -v '"${sandboxName}"'` returns zero matches across `onboard.js`, `policies.js`, and `nemoclaw.js`.

### E2E inference

Sandbox created on this branch, provider configured, agent prompt sent to Nemotron 3 Super 120B through real OpenShell gateway → response received.