### PR TITLE
feat: add Ollama Cloud model support

### DIFF
--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -11,6 +11,7 @@ profiles:
   - ncp
   - nim-local
   - vllm
+  - ollama
 
 description: |
   NemoClaw blueprint: orchestrates OpenClaw sandbox creation, migration,
@@ -53,6 +54,20 @@ components:
         model: "nvidia/nemotron-3-nano-30b-a3b"
         credential_env: "OPENAI_API_KEY"
         credential_default: "dummy"
+
+      # Ollama: local (http://host.openshell.internal:11434/v1) or cloud
+      # (https://ollama.com/v1). dynamic_endpoint: true lets the runner accept
+      # an --endpoint-url override so the same profile serves both cases.
+      # Local instances use credential_default "ollama"; cloud requires a real
+      # OLLAMA_API_KEY from ollama.com/settings/api-keys.
+      ollama:
+        provider_type: "openai"
+        provider_name: "ollama-local"
+        endpoint: "http://host.openshell.internal:11434/v1"
+        model: "llama3.2"
+        credential_env: "OLLAMA_API_KEY"
+        credential_default: "ollama"
+        dynamic_endpoint: true
 
   policy:
     base: "sandboxes/openclaw/policy.yaml"

--- a/nemoclaw/src/commands/onboard.ts
+++ b/nemoclaw/src/commands/onboard.ts
@@ -80,8 +80,9 @@ function resolveCredentialEnv(endpointType: EndpointType): string {
     case "nim-local":
       return "NIM_API_KEY";
     case "vllm":
-    case "ollama":
       return "OPENAI_API_KEY";
+    case "ollama":
+      return "OLLAMA_API_KEY";
   }
 }
 
@@ -89,7 +90,7 @@ function isNonInteractive(opts: OnboardOptions): boolean {
   if (!opts.endpoint || !opts.model) return false;
   const ep = opts.endpoint as EndpointType;
   if (endpointRequiresApiKey(ep) && !opts.apiKey) return false;
-  if ((ep === "ncp" || ep === "nim-local" || ep === "custom") && !opts.endpointUrl) return false;
+  if ((ep === "ncp" || ep === "nim-local" || ep === "custom" || ep === "ollama") && !opts.endpointUrl) return false;
   if (ep === "ncp" && !opts.ncpPartner) return false;
   return true;
 }
@@ -165,9 +166,9 @@ async function promptEndpoint(
       hint: "experimental — local development",
     },
     {
-      label: "Local Ollama [experimental]",
+      label: "Ollama (local or cloud) [experimental]",
       value: "ollama",
-      hint: `experimental — ${ollama.installed ? "installed locally" : "localhost:11434"}`,
+      hint: `experimental — localhost:11434 or any remote Ollama endpoint`,
     },
   ])) as EndpointType;
 }
@@ -252,7 +253,12 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
       endpointUrl = `${HOST_GATEWAY_URL}:8000/v1`;
       break;
     case "ollama":
-      endpointUrl = opts.endpointUrl ?? `${HOST_GATEWAY_URL}:11434/v1`;
+      endpointUrl =
+        opts.endpointUrl ??
+        (await promptInput(
+          "Ollama endpoint URL (local or remote cloud instance)",
+          `${HOST_GATEWAY_URL}:11434/v1`,
+        ));
       break;
     case "custom":
       endpointUrl = opts.endpointUrl ?? (await promptInput("Custom endpoint URL"));
@@ -265,13 +271,25 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
   }
 
   const credentialEnv = resolveCredentialEnv(endpointType);
-  const requiresApiKey = endpointRequiresApiKey(endpointType);
+  // Cloud Ollama (https://) requires an API key; local Ollama (http://) does not.
+  const isCloudOllama = endpointType === "ollama" && endpointUrl.startsWith("https://");
+  const requiresApiKey = endpointRequiresApiKey(endpointType) || isCloudOllama;
 
   // Step 3: Credential
   let apiKey = defaultCredentialForEndpoint(endpointType);
   if (requiresApiKey) {
     if (opts.apiKey) {
       apiKey = opts.apiKey;
+    } else if (isCloudOllama) {
+      const envKey = process.env.OLLAMA_API_KEY;
+      if (envKey) {
+        logger.info(`Detected OLLAMA_API_KEY in environment (${maskApiKey(envKey)})`);
+        const useEnv = nonInteractive ? true : await promptConfirm("Use this key?");
+        apiKey = useEnv ? envKey : await promptInput("Enter your Ollama Cloud API key");
+      } else {
+        logger.info("Get an API key from: https://ollama.com/settings/api-keys");
+        apiKey = await promptInput("Enter your Ollama Cloud API key");
+      }
     } else {
       const envKey = process.env.NVIDIA_API_KEY;
       if (envKey) {
@@ -324,14 +342,29 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
   if (opts.model) {
     model = opts.model;
   } else {
-    // Build model options: prefer Nemotron models from the endpoint, fall back to defaults
-    const nemotronModels = validation.models.filter((m) => m.includes("nemotron"));
-    const modelOptions =
-      nemotronModels.length > 0
-        ? nemotronModels.map((id) => ({ label: id, value: id }))
-        : DEFAULT_MODELS.map((m) => ({ label: `${m.label} (${m.id})`, value: m.id }));
+    const isCloudOllamaEndpoint = endpointType === "ollama" && endpointUrl.startsWith("https://");
 
-    model = await promptSelect("Select your primary model:", modelOptions);
+    if (isCloudOllamaEndpoint) {
+      // For Ollama Cloud: show cloud-aware model list (including Nemotron Super cloud variant)
+      const cloudModels = validation.models.length > 0
+        ? validation.models.map((id) => ({ label: id, value: id }))
+        : [
+            { label: "Nemotron 3 Super 120B — cloud (nemotron-3-super:cloud)", value: "nemotron-3-super:cloud" },
+            { label: "GPT-OSS 120B — cloud (gpt-oss:120b)", value: "gpt-oss:120b" },
+            { label: "Llama 3.1 70B (llama3.1:70b)", value: "llama3.1:70b" },
+            { label: "Llama 3.2 3B (llama3.2)", value: "llama3.2" },
+          ];
+      model = await promptSelect("Select your primary model:", cloudModels);
+    } else {
+      // Build model options: prefer Nemotron models from the endpoint, fall back to defaults
+      const nemotronModels = validation.models.filter((m) => m.includes("nemotron"));
+      const modelOptions =
+        nemotronModels.length > 0
+          ? nemotronModels.map((id) => ({ label: id, value: id }))
+          : DEFAULT_MODELS.map((m) => ({ label: `${m.label} (${m.id})`, value: m.id }));
+
+      model = await promptSelect("Select your primary model:", modelOptions);
+    }
   }
 
   // Step 6: Resolve profile

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -244,6 +244,65 @@ export default function register(api: OpenClawPluginApi): void {
     ],
   });
 
+  // Register Ollama provider when onboarded to an Ollama endpoint (local or cloud).
+  // Uses the OpenAI-compatible /v1 API. Cloud endpoint: https://ollama.com/v1.
+  if (onboardCfg?.endpointType === "ollama") {
+    const isCloud = onboardCfg.endpointUrl.startsWith("https://");
+    const ollamaEndpointLabel = isCloud ? `cloud (${onboardCfg.endpointUrl})` : "local";
+    api.registerProvider({
+      id: "ollama",
+      label: `Ollama (${ollamaEndpointLabel})`,
+      docsPath: "https://ollama.com/library",
+      aliases: ["ollama"],
+      envVars: ["OLLAMA_API_KEY"],
+      models: {
+        chat: [
+          // Cloud-only models (offloaded to Ollama's cloud service)
+          ...(isCloud
+            ? [
+                {
+                  id: "nemotron-3-super:cloud",
+                  label: "Nemotron 3 Super 120B (Ollama Cloud)",
+                  contextWindow: 131072,
+                  maxOutput: 8192,
+                },
+                {
+                  id: "gpt-oss:120b",
+                  label: "GPT-OSS 120B (Ollama Cloud)",
+                  contextWindow: 131072,
+                  maxOutput: 8192,
+                },
+              ]
+            : []),
+          // Models available on both local and cloud
+          { id: "llama3.2", label: "Llama 3.2 3B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "llama3.2:1b", label: "Llama 3.2 1B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "llama3.1", label: "Llama 3.1 8B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "llama3.1:70b", label: "Llama 3.1 70B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "mistral", label: "Mistral 7B", contextWindow: 32768, maxOutput: 4096 },
+          { id: "mistral-nemo", label: "Mistral Nemo 12B", contextWindow: 131072, maxOutput: 4096 },
+          { id: "gemma3", label: "Gemma 3 4B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "gemma3:27b", label: "Gemma 3 27B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "qwen2.5", label: "Qwen 2.5 7B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "qwen2.5:72b", label: "Qwen 2.5 72B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "phi4", label: "Phi-4 14B", contextWindow: 16384, maxOutput: 4096 },
+          { id: "deepseek-r1", label: "DeepSeek R1 7B", contextWindow: 131072, maxOutput: 8192 },
+          { id: "deepseek-r1:70b", label: "DeepSeek R1 70B", contextWindow: 131072, maxOutput: 8192 },
+        ],
+      },
+      auth: [
+        {
+          type: "bearer",
+          envVar: "OLLAMA_API_KEY",
+          headerName: "Authorization",
+          label: isCloud
+            ? "Ollama Cloud API key (OLLAMA_API_KEY) — from ollama.com/settings/api-keys"
+            : "Ollama API key (OLLAMA_API_KEY) — use 'ollama' for local instances",
+        },
+      ],
+    });
+  }
+
   const bannerEndpoint = onboardCfg?.endpointType ?? "build.nvidia.com";
   const bannerModel = onboardCfg?.model ?? "nvidia/nemotron-3-super-120b-a12b";
 


### PR DESCRIPTION
Wires up the partially-stubbed Ollama endpoint into a fully working provider, covering both local (localhost:11434) and remote/cloud (https://ollama.com/v1) Ollama instances.

Changes:
- blueprint.yaml: add 'ollama' to profiles list; define ollama inference profile with dynamic_endpoint: true, OLLAMA_API_KEY credential, and credential_default "ollama" for keyless local usage
- onboard.ts: prompt for endpoint URL (default: host gateway) instead of hardcoding localhost; detect cloud Ollama (https://) and require OLLAMA_API_KEY; show cloud-aware model picker with nemotron-3-super:cloud and gpt-oss:120b as top options; update endpoint label to reflect local-or-cloud support; require --endpoint-url in non-interactive mode
- index.ts: register Ollama provider when onboard config shows ollama endpoint type; surface cloud-only models (nemotron-3-super:cloud, gpt-oss:120b) when endpoint is HTTPS; include broad local model catalog (Llama 3.x, Mistral, Gemma 3, Qwen 2.5, Phi-4, DeepSeek R1); auth label dynamically references ollama.com/settings/api-keys for cloud