### PR TITLE
fix: skip --gpu on WSL2 where GPU passthrough to k3s is unsupported

### DIFF
--- a/bin/lib/nim.js
+++ b/bin/lib/nim.js
@@ -3,6 +3,7 @@
 //
 // NIM container management — pull, start, stop, health-check NIM images.
 
+const fs = require("fs");
 const { run, runCapture } = require("./runner");
 const nimImages = require("./nim-images.json");
 
@@ -23,7 +24,21 @@ function listModels() {
   }));
 }
 
+function isWSL2() {
+  // WSL2 exposes nvidia-smi at the host layer but cannot pass the GPU
+  // through to containers managed by Docker Desktop (k3s inside the
+  // gateway container never gets the device).
+  try {
+    const version = fs.readFileSync("/proc/version", "utf-8");
+    return /microsoft|wsl/i.test(version);
+  } catch {
+    return false;
+  }
+}
+
 function detectGpu() {
+  const wsl2 = isWSL2();
+
   // Try NVIDIA first — query VRAM
   try {
     const output = runCapture(
@@ -40,7 +55,8 @@ function detectGpu() {
           count: perGpuMB.length,
           totalMemoryMB,
           perGpuMB: perGpuMB[0],
-          nimCapable: true,
+          nimCapable: !wsl2,
+          wsl2,
         };
       }
     }
@@ -64,8 +80,9 @@ function detectGpu() {
         count: 1,
         totalMemoryMB,
         perGpuMB: totalMemoryMB,
-        nimCapable: true,
+        nimCapable: !wsl2,
         spark: true,
+        wsl2,
       };
     }
   } catch {}
@@ -199,6 +216,7 @@ module.exports = {
   getImageForModel,
   listModels,
   detectGpu,
+  isWSL2,
   pullNimImage,
   startNimContainer,
   waitForNimHealth,

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -92,7 +92,11 @@ async function preflight() {
 
   // GPU
   const gpu = nim.detectGpu();
-  if (gpu && gpu.type === "nvidia") {
+  if (gpu && gpu.type === "nvidia" && gpu.wsl2) {
+    console.log(`  ✓ NVIDIA GPU detected: ${gpu.count} GPU(s), ${gpu.totalMemoryMB} MB VRAM`);
+    console.log("  ⓘ WSL2 detected — GPU passthrough to containers is not supported");
+    console.log("    Gateway and sandbox will start without --gpu. Cloud inference will be used.");
+  } else if (gpu && gpu.type === "nvidia") {
     console.log(`  ✓ NVIDIA GPU detected: ${gpu.count} GPU(s), ${gpu.totalMemoryMB} MB VRAM`);
   } else if (gpu && gpu.type === "apple") {
     console.log(`  ✓ Apple GPU detected: ${gpu.name}${gpu.cores ? ` (${gpu.cores} cores)` : ""}, ${gpu.totalMemoryMB} MB unified memory`);

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,7 +75,10 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 info "Starting OpenShell gateway..."
 openshell gateway destroy -g nemoclaw > /dev/null 2>&1 || true
 GATEWAY_ARGS=(--name nemoclaw)
-command -v nvidia-smi > /dev/null 2>&1 && GATEWAY_ARGS+=(--gpu)
+# WSL2: nvidia-smi works but GPU can't pass through to k3s inside Docker Desktop
+if command -v nvidia-smi > /dev/null 2>&1 && ! grep -qi "microsoft\|wsl" /proc/version 2>/dev/null; then
+  GATEWAY_ARGS+=(--gpu)
+fi
 openshell gateway start "${GATEWAY_ARGS[@]}" 2>&1 | grep -E "Gateway|✓|Error|error" || true
 
 # Verify gateway is actually healthy (may need a moment after start)

--- a/test/wsl2.test.js
+++ b/test/wsl2.test.js
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isWSL2, detectGpu } = require("../bin/lib/nim");
+
+describe("isWSL2", () => {
+  it("returns a boolean", () => {
+    assert.equal(typeof isWSL2(), "boolean");
+  });
+
+  it("returns false on non-linux platforms", () => {
+    // /proc/version does not exist on macOS/Windows, so isWSL2() returns false.
+    if (process.platform !== "linux") {
+      assert.equal(isWSL2(), false);
+    }
+  });
+
+  it("does not throw on any platform", () => {
+    assert.doesNotThrow(() => isWSL2());
+  });
+});
+
+describe("detectGpu WSL2 awareness", () => {
+  it("returns an object or null", () => {
+    const gpu = detectGpu();
+    assert.ok(gpu === null || typeof gpu === "object");
+  });
+
+  it("includes wsl2 field when nvidia GPU detected", () => {
+    const gpu = detectGpu();
+    if (gpu && gpu.type === "nvidia") {
+      assert.equal(typeof gpu.wsl2, "boolean");
+      // On WSL2, nimCapable should be false despite GPU presence
+      if (gpu.wsl2) {
+        assert.equal(gpu.nimCapable, false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`nemoclaw onboard` forces `--gpu` on both `openshell gateway start` and `openshell sandbox create` whenever `nvidia-smi` is detected. On WSL2 with Docker Desktop, `nvidia-smi` works at the host layer but the GPU cannot be passed through to the k3s cluster inside the OpenShell gateway container. The result is a dead sandbox that immediately reports `"not found"` on every subsequent command.

There is no `--no-gpu` flag, environment variable, or config option to override this.

**Affected users:** Everyone on WSL2 with any NVIDIA GPU.

**Confirmed on:**
- RTX 5090 Laptop + WSL2 Ubuntu 24.04 + Docker Desktop
- RTX 5070 Ti + WSL2 ([NVIDIA Forums #363769](https://forums.developer.nvidia.com/t/bug-rtx-5070-ti-sandbox-notfound-access-denied-on-nemoclaw-onboarding-wsl2/363769))

Fixes #208 

## Solution

Detect WSL2 via `/proc/version` (which contains "microsoft" or "WSL" on WSL2 kernels) and set `nimCapable: false`. The existing `if (gpu && gpu.nimCapable)` guards in `onboard.js` (lines 116, 187) automatically skip `--gpu`. Cloud inference works normally through the OpenShell proxy.

### Changes

| File | Change |
|------|--------|
| `bin/lib/nim.js` | Add `isWSL2()` helper; set `nimCapable: false` and `wsl2: true` on WSL2 |
| `bin/lib/onboard.js` | Add WSL2 info message during preflight GPU detection |
| `scripts/setup.sh` | Add WSL2 check to legacy gateway start path |
| `test/wsl2.test.js` | Tests for `isWSL2()` and `detectGpu()` WSL2 awareness |

### What does NOT change

- Native Linux with NVIDIA GPU: `nimCapable` stays `true`, no behavior change
- macOS: already `nimCapable: false`, no behavior change
- DGX Spark / DGX Station: not WSL2, no behavior change
- All 13 existing tests pass unchanged

## Testing
```bash
node --test test/preflight.test.js test/wsl2.test.js
# 18 pass, 0 fail
```

Manual verification on WSL2 Ubuntu 24.04 + RTX 5090: `nemoclaw onboard` completes, sandbox stays alive, `openclaw tui` connects via cloud inference.
