### PR TITLE
fix: deploy script compatibility with current Brev CLI and non-ubuntu hosts

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -75,39 +75,55 @@ async function deploy(instanceName) {
     process.exit(1);
   }
 
+  // Check if instance is already reachable via SSH (brev ls has an interactive
+  // spinner that hangs in non-interactive contexts, so we avoid it).
   let exists = false;
   try {
-    const out = execSync("brev ls 2>&1", { encoding: "utf-8" });
-    exists = out.includes(name);
+    execSync(`ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no ${name} 'echo ok' 2>/dev/null`, { encoding: "utf-8", stdio: "pipe" });
+    exists = true;
   } catch {}
 
   if (!exists) {
+    // Also try brev ls with a timeout as a fallback
+    try {
+      const out = execSync("timeout 10 brev ls 2>&1", { encoding: "utf-8" });
+      exists = out.includes(name);
+    } catch {}
+  }
+
+  if (!exists) {
     console.log(`  Creating Brev instance '${name}' (${gpu})...`);
-    run(`brev create ${name} --gpu "${gpu}"`);
+    run(`brev create ${name} --type "${gpu}"`);
+    console.log("  Refreshing Brev...");
+    try { execSync("timeout 15 brev refresh 2>&1", { encoding: "utf-8" }); } catch {}
   } else {
     console.log(`  Brev instance '${name}' already exists.`);
   }
 
-  run(`brev refresh`, { ignoreError: true });
-
-  console.log("  Waiting for SSH...");
+  console.log("  [1/6] Waiting for SSH...");
   for (let i = 0; i < 60; i++) {
     try {
       execSync(`ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no ${name} 'echo ok' 2>/dev/null`, { encoding: "utf-8", stdio: "pipe" });
+      console.log("  [1/6] SSH connected.");
       break;
     } catch {
       if (i === 59) {
         console.error(`  Timed out waiting for SSH to ${name}`);
         process.exit(1);
       }
+      if (i % 5 === 0) console.log(`  [1/6] Still waiting for SSH... (${i * 3}s)`);
       spawnSync("sleep", ["3"]);
     }
   }
 
-  console.log("  Syncing NemoClaw to VM...");
-  run(`ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'mkdir -p /home/ubuntu/nemoclaw'`);
-  run(`rsync -az --delete --exclude node_modules --exclude .git --exclude src -e "ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR" "${ROOT}/scripts" "${ROOT}/Dockerfile" "${ROOT}/nemoclaw" "${ROOT}/nemoclaw-blueprint" "${ROOT}/bin" "${ROOT}/package.json" ${name}:/home/ubuntu/nemoclaw/`);
+  console.log("  [2/6] Creating remote directory...");
+  run(`ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'mkdir -p ~/nemoclaw'`);
 
+  console.log("  [3/6] Syncing NemoClaw files to VM (rsync)...");
+  run(`rsync -az --progress --delete --exclude node_modules --exclude .git --exclude src -e "ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR" "${ROOT}/scripts" "${ROOT}/Dockerfile" "${ROOT}/nemoclaw" "${ROOT}/nemoclaw-blueprint" "${ROOT}/bin" "${ROOT}/package.json" ${name}:~/nemoclaw/`);
+  console.log("  [3/6] Sync complete.");
+
+  console.log("  [4/6] Writing environment config...");
   const envLines = [`NVIDIA_API_KEY=${process.env.NVIDIA_API_KEY}`];
   const ghToken = process.env.GITHUB_TOKEN;
   if (ghToken) envLines.push(`GITHUB_TOKEN=${ghToken}`);
@@ -115,21 +131,23 @@ async function deploy(instanceName) {
   if (tgToken) envLines.push(`TELEGRAM_BOT_TOKEN=${tgToken}`);
   const envTmp = path.join(os.tmpdir(), `nemoclaw-env-${Date.now()}`);
   fs.writeFileSync(envTmp, envLines.join("\n") + "\n", { mode: 0o600 });
-  run(`scp -q -o StrictHostKeyChecking=no -o LogLevel=ERROR "${envTmp}" ${name}:/home/ubuntu/nemoclaw/.env`);
+  run(`scp -q -o StrictHostKeyChecking=no -o LogLevel=ERROR "${envTmp}" ${name}:~/nemoclaw/.env`);
   fs.unlinkSync(envTmp);
+  console.log("  [4/6] Environment config written.");
 
-  console.log("  Running setup...");
-  run(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && bash scripts/brev-setup.sh'`);
+  console.log("  [5/6] Running setup (this may take several minutes)...");
+  run(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd ~/nemoclaw && set -a && . .env && set +a && bash scripts/brev-setup.sh'`);
+  console.log("  [5/6] Setup complete.");
 
   if (tgToken) {
     console.log("  Starting services...");
-    run(`ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && bash scripts/start-services.sh'`);
+    run(`ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd ~/nemoclaw && set -a && . .env && set +a && bash scripts/start-services.sh'`);
   }
 
   console.log("");
-  console.log("  Connecting to sandbox...");
+  console.log("  [6/6] Connecting to sandbox...");
   console.log("");
-  run(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell sandbox connect nemoclaw'`);
+  run(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd ~/nemoclaw && set -a && . .env && set +a && openshell sandbox connect nemoclaw'`);
 }
 
 async function start() {

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -82,6 +82,36 @@ $ export NEMOCLAW_GPU="a2-highgpu-1g:nvidia-tesla-a100:2"
 $ nemoclaw deploy <instance-name>
 ```
 
+### Choosing a cost-effective instance for experimentation
+
+The default A100 instance (`a2-highgpu-1g:nvidia-tesla-a100:1`) costs approximately $4.41/hr on GCP.
+Since the default inference path routes through the NVIDIA cloud API (not a local model), the GPU on the VM is mostly idle.
+For experimentation and testing with cloud inference, a smaller, cheaper instance is sufficient:
+
+```console
+$ export NEMOCLAW_GPU="hyperstack_A4000"
+$ nemoclaw deploy <instance-name>
+```
+
+Use `brev search --sort price` to list available instance types and pricing.
+
+| Instance | GPU | VRAM | Approx. $/hr | Notes |
+|---|---|---|---|---|
+| `hyperstack_A4000` | A4000 | 16 GB | $0.18 | Cheapest option, sufficient for cloud inference |
+| `g4dn.xlarge` | T4 | 16 GB | $0.63 | AWS, stoppable and rebootable |
+| `a2-highgpu-1g:nvidia-tesla-a100:1` | A100 | 40 GB | $4.41 | Default, needed only for local NIM inference |
+
+:::{note}
+A GPU is only required on the VM if you plan to run local inference via NIM or vLLM.
+When using NVIDIA cloud inference (the default), the GPU is not used for model serving.
+:::
+
+Remember to delete the instance when you are finished to avoid ongoing charges:
+
+```console
+$ brev delete <instance-name>
+```
+
 ## Related Topics
 
 - [Set Up the Telegram Bridge](set-up-telegram-bridge.md) to interact with the remote agent through Telegram.

--- a/scripts/brev-setup.sh
+++ b/scripts/brev-setup.sh
@@ -76,10 +76,6 @@ fi
 # --- 3. openshell CLI (binary release, not pip) ---
 if ! command -v openshell > /dev/null 2>&1; then
   info "Installing openshell CLI from GitHub release..."
-  if ! command -v gh > /dev/null 2>&1; then
-    sudo apt-get update -qq > /dev/null 2>&1
-    sudo apt-get install -y -qq gh > /dev/null 2>&1
-  fi
   ARCH="$(uname -m)"
   case "$ARCH" in
     x86_64|amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
@@ -87,8 +83,11 @@ if ! command -v openshell > /dev/null 2>&1; then
     *) fail "Unsupported architecture: $ARCH" ;;
   esac
   tmpdir="$(mktemp -d)"
-  GH_TOKEN="${GITHUB_TOKEN:-}" gh release download --repo NVIDIA/OpenShell \
-    --pattern "$ASSET" --dir "$tmpdir"
+  # Download from GitHub releases using curl (no gh auth required for public repos)
+  RELEASE_URL="$(curl -fsSL https://api.github.com/repos/NVIDIA/OpenShell/releases/latest \
+    | grep "browser_download_url.*${ASSET}" | head -1 | cut -d '"' -f 4)"
+  [ -n "$RELEASE_URL" ] || fail "Could not find release asset $ASSET"
+  curl -fsSL "$RELEASE_URL" -o "$tmpdir/$ASSET"
   tar xzf "$tmpdir/$ASSET" -C "$tmpdir"
   sudo install -m 755 "$tmpdir/openshell" /usr/local/bin/openshell
   rm -rf "$tmpdir"


### PR DESCRIPTION
## Summary
- **Brev CLI compat**: `--gpu` → `--type`, work around interactive spinner hangs in `brev ls`/`brev refresh`
- **Non-ubuntu hosts**: Replace hardcoded `/home/ubuntu` paths with `~` (e.g. Hyperstack uses `shadeform` user)
- **OpenShell download**: Replace `gh release download` (requires auth) with `curl` against public GitHub releases API
- **Progress logging**: Added numbered steps `[1/6]` through `[6/6]` so operators can see deploy progress
- **GPU docs**: Document cost-effective instance options for experimentation (hyperstack_A4000 at $0.18/hr vs default A100 at $4.41/hr)

## Test plan
- [x] Deployed to Brev Hyperstack A4000 instance and confirmed full setup completes
- [x] Verified sandbox connects and OpenClaw agent responds via NVIDIA cloud inference
- [ ] Test deploy on a GCP-based instance to confirm `~` works for ubuntu user too
- [ ] Test deploy with a fresh Brev account (no existing instances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)