### PR TITLE
fix: install Node.js 22 (not 24) in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,7 @@ install_nodejs() {
   bash "$nvm_tmp"
   rm -f "$nvm_tmp"
   ensure_nvm_loaded
-  nvm install 24
+  nvm install ${RECOMMENDED_NODE_MAJOR}
   info "Node.js installed: $(node --version)"
 }
 


### PR DESCRIPTION
## Summary
- Line 116 hardcodes `nvm install 24` but `RECOMMENDED_NODE_MAJOR=22` (line 20)
- `scripts/install.sh` correctly installs 22; this mismatch causes `nemoclaw` to vanish from PATH when nvm default is reset
- Use `${RECOMMENDED_NODE_MAJOR}` variable instead of hardcoded version

Fixes #162

## Test plan

### Automated Tests
```
npm test
```

### Manual Testing
- Run `bash install.sh` on a system without Node.js
- Verify Node.js 22.x is installed (not 24)
- Verify `nemoclaw` is on PATH after installation