### PR TITLE
fix: propagate SANDBOX_NAME to telegram bridge and resolve openshell path

### DIFF
--- a/bin/lib/resolve-openshell.js
+++ b/bin/lib/resolve-openshell.js
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+
+/**
+ * Resolve the openshell binary path.
+ *
+ * Checks `command -v` first (must return an absolute path to prevent alias
+ * injection), then falls back to common installation directories.
+ *
+ * @param {object} [opts] DI overrides for testing
+ * @param {string|null} [opts.commandVResult] Mock result (undefined = run real command)
+ * @param {function} [opts.checkExecutable] (path) => boolean
+ * @param {string} [opts.home] HOME override
+ * @returns {string|null} Absolute path to openshell, or null if not found
+ */
+function resolveOpenshell(opts = {}) {
+  const home = opts.home || process.env.HOME || "/tmp";
+
+  // Step 1: command -v
+  if (opts.commandVResult === undefined) {
+    try {
+      const found = execSync("command -v openshell", { encoding: "utf-8" }).trim();
+      if (found.startsWith("/")) return found;
+    } catch {}
+  } else if (opts.commandVResult && opts.commandVResult.startsWith("/")) {
+    return opts.commandVResult;
+  }
+
+  // Step 2: fallback candidates
+  const checkExecutable = opts.checkExecutable || ((p) => {
+    try { fs.accessSync(p, fs.constants.X_OK); return true; } catch { return false; }
+  });
+
+  const candidates = [
+    `${home}/.local/bin/openshell`,
+    "/usr/local/bin/openshell",
+    "/usr/bin/openshell",
+  ];
+  for (const p of candidates) {
+    if (checkExecutable(p)) return p;
+  }
+
+  return null;
+}
+
+module.exports = { resolveOpenshell };

--- a/bin/lib/resolve-openshell.js
+++ b/bin/lib/resolve-openshell.js
@@ -17,7 +17,7 @@ const fs = require("fs");
  * @returns {string|null} Absolute path to openshell, or null if not found
  */
 function resolveOpenshell(opts = {}) {
-  const home = opts.home || process.env.HOME || "/tmp";
+  const home = opts.home ?? process.env.HOME;
 
   // Step 1: command -v
   if (opts.commandVResult === undefined) {
@@ -35,7 +35,7 @@ function resolveOpenshell(opts = {}) {
   });
 
   const candidates = [
-    `${home}/.local/bin/openshell`,
+    ...(home && home.startsWith("/") ? [`${home}/.local/bin/openshell`] : []),
     "/usr/local/bin/openshell",
     "/usr/bin/openshell",
   ];

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -135,7 +135,8 @@ async function deploy(instanceName) {
 async function start() {
   await ensureApiKey();
   const { defaultSandbox } = registry.listSandboxes();
-  const sandboxEnv = defaultSandbox ? `SANDBOX_NAME="${defaultSandbox}"` : "";
+  const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
+  const sandboxEnv = safeName ? `SANDBOX_NAME="${safeName}"` : "";
   run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh"`);
 }
 

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -134,7 +134,9 @@ async function deploy(instanceName) {
 
 async function start() {
   await ensureApiKey();
-  run(`bash "${SCRIPTS}/start-services.sh"`);
+  const { defaultSandbox } = registry.listSandboxes();
+  const sandboxEnv = defaultSandbox ? `SANDBOX_NAME="${defaultSandbox}"` : "";
+  run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh"`);
 }
 
 function stop() {

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -140,7 +140,7 @@ do_start() {
 
   # Telegram bridge (only if token provided)
   if [ -n "${TELEGRAM_BOT_TOKEN:-}" ]; then
-    start_service telegram-bridge \
+    SANDBOX_NAME="$SANDBOX_NAME" start_service telegram-bridge \
       node "$REPO_DIR/scripts/telegram-bridge.js"
   fi
 

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -19,7 +19,7 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DASHBOARD_PORT="${DASHBOARD_PORT:-18789}"
 
 # ── Parse flags ──────────────────────────────────────────────────
-SANDBOX_NAME="${NEMOCLAW_SANDBOX:-default}"
+SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}"
 ACTION="start"
 
 while [ $# -gt 0 ]; do

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -18,29 +18,13 @@
 
 const https = require("https");
 const { execSync, spawn } = require("child_process");
+const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
 
-function resolveOpenshell() {
-  try {
-    const found = execSync("command -v openshell", { encoding: "utf-8" }).trim();
-    if (found.startsWith("/")) return found;
-  } catch {}
-  const home = process.env.HOME || "/tmp";
-  const candidates = [
-    `${home}/.local/bin/openshell`,
-    "/usr/local/bin/openshell",
-    "/usr/bin/openshell",
-  ];
-  for (const p of candidates) {
-    try {
-      require("fs").accessSync(p, require("fs").constants.X_OK);
-      return p;
-    } catch {}
-  }
+const OPENSHELL = resolveOpenshell();
+if (!OPENSHELL) {
   console.error("openshell not found on PATH or in common locations");
   process.exit(1);
 }
-
-const OPENSHELL = resolveOpenshell();
 
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const API_KEY = process.env.NVIDIA_API_KEY;

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -21,7 +21,8 @@ const { execSync, spawn } = require("child_process");
 
 function resolveOpenshell() {
   try {
-    return execSync("command -v openshell", { encoding: "utf-8" }).trim();
+    const found = execSync("command -v openshell", { encoding: "utf-8" }).trim();
+    if (found.startsWith("/")) return found;
   } catch {}
   const home = process.env.HOME || "/tmp";
   const candidates = [

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -19,6 +19,28 @@
 const https = require("https");
 const { execSync, spawn } = require("child_process");
 
+function resolveOpenshell() {
+  try {
+    return execSync("command -v openshell", { encoding: "utf-8" }).trim();
+  } catch {}
+  const home = process.env.HOME || "/tmp";
+  const candidates = [
+    `${home}/.local/bin/openshell`,
+    "/usr/local/bin/openshell",
+    "/usr/bin/openshell",
+  ];
+  for (const p of candidates) {
+    try {
+      require("fs").accessSync(p, require("fs").constants.X_OK);
+      return p;
+    } catch {}
+  }
+  console.error("openshell not found on PATH or in common locations");
+  process.exit(1);
+}
+
+const OPENSHELL = resolveOpenshell();
+
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const API_KEY = process.env.NVIDIA_API_KEY;
 const SANDBOX = process.env.SANDBOX_NAME || "nemoclaw";
@@ -85,7 +107,7 @@ async function sendTyping(chatId) {
 
 function runAgentInSandbox(message, sessionId) {
   return new Promise((resolve) => {
-    const sshConfig = execSync(`openshell sandbox ssh-config ${SANDBOX}`, { encoding: "utf-8" });
+    const sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${SANDBOX}"`, { encoding: "utf-8" });
 
     // Write temp ssh config
     const confPath = `/tmp/nemoclaw-tg-ssh-${sessionId}.conf`;

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+describe("service environment", () => {
+  describe("resolveOpenshell logic", () => {
+    // Extract and test the resolution algorithm without requiring openshell installed
+
+    function resolveOpenshellTestable(opts = {}) {
+      const commandVResult = opts.commandVResult; // string or null (throws)
+      const existingPaths = opts.existingPaths || [];
+      const home = opts.home || "/fakehome";
+
+      // Step 1: command -v result
+      if (commandVResult && commandVResult.startsWith("/")) {
+        return commandVResult;
+      }
+
+      // Step 2: fallback candidates
+      const candidates = [
+        `${home}/.local/bin/openshell`,
+        "/usr/local/bin/openshell",
+        "/usr/bin/openshell",
+      ];
+      for (const p of candidates) {
+        if (existingPaths.includes(p)) return p;
+      }
+
+      return null; // not found
+    }
+
+    it("returns command -v result when absolute path", () => {
+      assert.equal(
+        resolveOpenshellTestable({ commandVResult: "/usr/bin/openshell" }),
+        "/usr/bin/openshell"
+      );
+    });
+
+    it("rejects non-absolute command -v result (alias)", () => {
+      assert.equal(
+        resolveOpenshellTestable({ commandVResult: "openshell" }),
+        null
+      );
+    });
+
+    it("rejects alias definition from command -v", () => {
+      assert.equal(
+        resolveOpenshellTestable({ commandVResult: "alias openshell='echo pwned'" }),
+        null
+      );
+    });
+
+    it("falls back to ~/.local/bin when command -v fails", () => {
+      assert.equal(
+        resolveOpenshellTestable({
+          commandVResult: null,
+          existingPaths: ["/fakehome/.local/bin/openshell"],
+          home: "/fakehome",
+        }),
+        "/fakehome/.local/bin/openshell"
+      );
+    });
+
+    it("falls back to /usr/local/bin", () => {
+      assert.equal(
+        resolveOpenshellTestable({
+          commandVResult: null,
+          existingPaths: ["/usr/local/bin/openshell"],
+        }),
+        "/usr/local/bin/openshell"
+      );
+    });
+
+    it("falls back to /usr/bin", () => {
+      assert.equal(
+        resolveOpenshellTestable({
+          commandVResult: null,
+          existingPaths: ["/usr/bin/openshell"],
+        }),
+        "/usr/bin/openshell"
+      );
+    });
+
+    it("prefers ~/.local/bin over /usr/local/bin", () => {
+      assert.equal(
+        resolveOpenshellTestable({
+          commandVResult: null,
+          existingPaths: ["/fakehome/.local/bin/openshell", "/usr/local/bin/openshell"],
+          home: "/fakehome",
+        }),
+        "/fakehome/.local/bin/openshell"
+      );
+    });
+
+    it("returns null when openshell not found anywhere", () => {
+      assert.equal(
+        resolveOpenshellTestable({
+          commandVResult: null,
+          existingPaths: [],
+        }),
+        null
+      );
+    });
+  });
+
+  describe("SANDBOX_NAME defaulting", () => {
+    it("start-services.sh preserves existing SANDBOX_NAME", () => {
+      // Verify the bash variable expansion logic:
+      // SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}"
+      const result = execSync(
+        'SANDBOX_NAME=my-box bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}" && echo $SANDBOX_NAME\'',
+        { encoding: "utf-8" }
+      ).trim();
+      assert.equal(result, "my-box");
+    });
+
+    it("start-services.sh uses NEMOCLAW_SANDBOX over SANDBOX_NAME", () => {
+      const result = execSync(
+        'NEMOCLAW_SANDBOX=from-env SANDBOX_NAME=old bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}" && echo $SANDBOX_NAME\'',
+        { encoding: "utf-8" }
+      ).trim();
+      assert.equal(result, "from-env");
+    });
+
+    it("start-services.sh falls back to default when both unset", () => {
+      const result = execSync(
+        'bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}" && echo $SANDBOX_NAME\'',
+        { encoding: "utf-8" }
+      ).trim();
+      assert.equal(result, "default");
+    });
+  });
+});

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -85,24 +85,33 @@ describe("service environment", () => {
   describe("SANDBOX_NAME defaulting", () => {
     it("start-services.sh preserves existing SANDBOX_NAME", () => {
       const result = execSync(
-        'SANDBOX_NAME=my-box bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}" && echo $SANDBOX_NAME\'',
-        { encoding: "utf-8" }
+        'bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}"; export SANDBOX_NAME; bash -c "echo \\$SANDBOX_NAME"\'',
+        {
+          encoding: "utf-8",
+          env: { ...process.env, NEMOCLAW_SANDBOX: "", SANDBOX_NAME: "my-box" },
+        }
       ).trim();
       assert.equal(result, "my-box");
     });
 
     it("start-services.sh uses NEMOCLAW_SANDBOX over SANDBOX_NAME", () => {
       const result = execSync(
-        'NEMOCLAW_SANDBOX=from-env SANDBOX_NAME=old bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}" && echo $SANDBOX_NAME\'',
-        { encoding: "utf-8" }
+        'bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}"; export SANDBOX_NAME; bash -c "echo \\$SANDBOX_NAME"\'',
+        {
+          encoding: "utf-8",
+          env: { ...process.env, NEMOCLAW_SANDBOX: "from-env", SANDBOX_NAME: "old" },
+        }
       ).trim();
       assert.equal(result, "from-env");
     });
 
     it("start-services.sh falls back to default when both unset", () => {
       const result = execSync(
-        'bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}" && echo $SANDBOX_NAME\'',
-        { encoding: "utf-8" }
+        'bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}"; export SANDBOX_NAME; bash -c "echo \\$SANDBOX_NAME"\'',
+        {
+          encoding: "utf-8",
+          env: { ...process.env, NEMOCLAW_SANDBOX: "", SANDBOX_NAME: "" },
+        }
       ).trim();
       assert.equal(result, "default");
     });

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -4,62 +4,36 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { execSync } = require("child_process");
-const fs = require("fs");
-const path = require("path");
+const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
 
 describe("service environment", () => {
   describe("resolveOpenshell logic", () => {
-    // Extract and test the resolution algorithm without requiring openshell installed
-
-    function resolveOpenshellTestable(opts = {}) {
-      const commandVResult = opts.commandVResult; // string or null (throws)
-      const existingPaths = opts.existingPaths || [];
-      const home = opts.home || "/fakehome";
-
-      // Step 1: command -v result
-      if (commandVResult && commandVResult.startsWith("/")) {
-        return commandVResult;
-      }
-
-      // Step 2: fallback candidates
-      const candidates = [
-        `${home}/.local/bin/openshell`,
-        "/usr/local/bin/openshell",
-        "/usr/bin/openshell",
-      ];
-      for (const p of candidates) {
-        if (existingPaths.includes(p)) return p;
-      }
-
-      return null; // not found
-    }
-
     it("returns command -v result when absolute path", () => {
       assert.equal(
-        resolveOpenshellTestable({ commandVResult: "/usr/bin/openshell" }),
+        resolveOpenshell({ commandVResult: "/usr/bin/openshell" }),
         "/usr/bin/openshell"
       );
     });
 
     it("rejects non-absolute command -v result (alias)", () => {
       assert.equal(
-        resolveOpenshellTestable({ commandVResult: "openshell" }),
+        resolveOpenshell({ commandVResult: "openshell", checkExecutable: () => false }),
         null
       );
     });
 
     it("rejects alias definition from command -v", () => {
       assert.equal(
-        resolveOpenshellTestable({ commandVResult: "alias openshell='echo pwned'" }),
+        resolveOpenshell({ commandVResult: "alias openshell='echo pwned'", checkExecutable: () => false }),
         null
       );
     });
 
     it("falls back to ~/.local/bin when command -v fails", () => {
       assert.equal(
-        resolveOpenshellTestable({
+        resolveOpenshell({
           commandVResult: null,
-          existingPaths: ["/fakehome/.local/bin/openshell"],
+          checkExecutable: (p) => p === "/fakehome/.local/bin/openshell",
           home: "/fakehome",
         }),
         "/fakehome/.local/bin/openshell"
@@ -68,9 +42,9 @@ describe("service environment", () => {
 
     it("falls back to /usr/local/bin", () => {
       assert.equal(
-        resolveOpenshellTestable({
+        resolveOpenshell({
           commandVResult: null,
-          existingPaths: ["/usr/local/bin/openshell"],
+          checkExecutable: (p) => p === "/usr/local/bin/openshell",
         }),
         "/usr/local/bin/openshell"
       );
@@ -78,9 +52,9 @@ describe("service environment", () => {
 
     it("falls back to /usr/bin", () => {
       assert.equal(
-        resolveOpenshellTestable({
+        resolveOpenshell({
           commandVResult: null,
-          existingPaths: ["/usr/bin/openshell"],
+          checkExecutable: (p) => p === "/usr/bin/openshell",
         }),
         "/usr/bin/openshell"
       );
@@ -88,9 +62,9 @@ describe("service environment", () => {
 
     it("prefers ~/.local/bin over /usr/local/bin", () => {
       assert.equal(
-        resolveOpenshellTestable({
+        resolveOpenshell({
           commandVResult: null,
-          existingPaths: ["/fakehome/.local/bin/openshell", "/usr/local/bin/openshell"],
+          checkExecutable: (p) => p === "/fakehome/.local/bin/openshell" || p === "/usr/local/bin/openshell",
           home: "/fakehome",
         }),
         "/fakehome/.local/bin/openshell"
@@ -99,9 +73,9 @@ describe("service environment", () => {
 
     it("returns null when openshell not found anywhere", () => {
       assert.equal(
-        resolveOpenshellTestable({
+        resolveOpenshell({
           commandVResult: null,
-          existingPaths: [],
+          checkExecutable: () => false,
         }),
         null
       );
@@ -110,8 +84,6 @@ describe("service environment", () => {
 
   describe("SANDBOX_NAME defaulting", () => {
     it("start-services.sh preserves existing SANDBOX_NAME", () => {
-      // Verify the bash variable expansion logic:
-      // SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}"
       const result = execSync(
         'SANDBOX_NAME=my-box bash -c \'SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}" && echo $SANDBOX_NAME\'',
         { encoding: "utf-8" }


### PR DESCRIPTION
## Summary
- `start-services.sh` reads `NEMOCLAW_SANDBOX` but doesn't export `SANDBOX_NAME` to the telegram bridge subprocess — sandbox name mismatch (#198)
- `telegram-bridge.js` calls bare `openshell` which isn't on PATH when launched via `nohup` from systemd or cron (#199)
- Propagate `SANDBOX_NAME` env var to the bridge process
- Add `resolveOpenshell()` that checks `command -v`, then `~/.local/bin`, `/usr/local/bin`, `/usr/bin`
- Validate that `command -v` returns an absolute path (rejects aliases/functions)

Fixes #198
Fixes #199

## Test plan

### Automated Tests
```
npm test
```

### Manual Testing
- Run `NEMOCLAW_SANDBOX=my-sandbox ./scripts/start-services.sh`
- Verify the telegram bridge receives the correct sandbox name
- Remove openshell from PATH and verify the bridge finds it via fallback paths
- Check bridge logs for correct sandbox name and openshell path

### Hardware Validation

Path resolution logic validated on DGX Spark:

| Machine | `command -v openshell` | Fallback paths | Expected behavior |
|---------|----------------------|----------------|-------------------|
| spark-c231 | Not found | None present | `resolveOpenshell()` exits with clear error — correct |
| spark1 | Not found | None present | Same — correct |

openshell is installed during `nemoclaw onboard` (typically to `~/.local/bin/`), so it is expected to be absent on a pre-onboard system. The fallback chain (`~/.local/bin` → `/usr/local/bin` → `/usr/bin`) covers all standard installation locations. The absolute-path check (`startsWith("/")`) prevents alias injection in non-interactive shells.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection and validation of the required shell executable with explicit failure when not found.
  * Sandbox name handling now respects existing environment variables and only injects a sandbox context when valid.
  * Telegram bridge startup passes the resolved sandbox context so the bridge runs in the correct sandbox.

* **Tests**
  * Added tests for sandbox name expansion, environment override behavior, and shell-executable resolution and precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->