### PR TITLE
fix: resolve PATH issues after nvm installs Node.js

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -42,7 +42,7 @@ function isOpenshellInstalled() {
 
 function installOpenshell() {
   console.log("  Installing openshell CLI...");
-  run(`bash "${path.join(SCRIPTS, "install.sh")}"`, { ignoreError: true });
+  run(`bash "${path.join(SCRIPTS, "install-openshell.sh")}"`, { ignoreError: true });
   return isOpenshellInstalled();
 }
 

--- a/install.sh
+++ b/install.sh
@@ -231,12 +231,15 @@ verify_nemoclaw() {
     warn "Or for zsh:"
     warn "  echo 'export PATH=\"$npm_bin:\$PATH\"' >> ~/.zshrc"
     warn "  source ~/.zshrc"
+    warn ""
+    warn "Continuing — nemoclaw is installed but requires a PATH update."
+    return 0
   else
     warn "Could not locate the nemoclaw executable."
     warn "Try running:  npm install -g nemoclaw"
   fi
 
-  error "Installation failed: nemoclaw --help could not be executed."
+  error "Installation failed: nemoclaw binary not found."
 }
 
 # ---------------------------------------------------------------------------
@@ -245,6 +248,38 @@ verify_nemoclaw() {
 run_onboard() {
   info "Running nemoclaw onboard…"
   nemoclaw onboard
+}
+
+# ---------------------------------------------------------------------------
+# 6. Post-install message
+# ---------------------------------------------------------------------------
+post_install_message() {
+  # Only show shell reload instructions when Node was installed via a
+  # version manager that modifies PATH in shell profile files.
+  # nvm and fnm require sourcing the profile; nodesource/brew install to
+  # system paths already on PATH.
+  if [[ ! -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]]; then
+    return 0
+  fi
+
+  local profile="$HOME/.bashrc"
+  if [[ -n "${ZSH_VERSION:-}" ]] || [[ "$(basename "${SHELL:-}")" == "zsh" ]]; then
+    profile="$HOME/.zshrc"
+  elif [[ ! -f "$HOME/.bashrc" && -f "$HOME/.profile" ]]; then
+    profile="$HOME/.profile"
+  fi
+
+  echo ""
+  echo "  ──────────────────────────────────────────────────"
+  warn "Your current shell may not have the updated PATH."
+  echo ""
+  echo "  To use nemoclaw now, run:"
+  echo ""
+  echo "    source $profile"
+  echo ""
+  echo "  Or open a new terminal window."
+  echo "  ──────────────────────────────────────────────────"
+  echo ""
 }
 
 # ---------------------------------------------------------------------------
@@ -258,6 +293,7 @@ main() {
   # install_or_upgrade_ollama
   install_nemoclaw
   verify_nemoclaw
+  post_install_message
   run_onboard
 
   info "=== Installation complete ==="

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install the openshell CLI binary. Supports Linux and macOS (x86_64 and aarch64).
+
+set -euo pipefail
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS/$ARCH" in
+  Darwin/x86_64|Darwin/amd64)   ASSET="openshell-x86_64-apple-darwin.tar.gz" ;;
+  Darwin/aarch64|Darwin/arm64)  ASSET="openshell-aarch64-apple-darwin.tar.gz" ;;
+  Linux/x86_64|Linux/amd64)     ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
+  Linux/aarch64|Linux/arm64)    ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
+  *) echo "Unsupported platform: $OS/$ARCH"; exit 1 ;;
+esac
+
+tmpdir="$(mktemp -d)"
+curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/latest/download/$ASSET" \
+  -o "$tmpdir/openshell.tar.gz"
+tar xzf "$tmpdir/openshell.tar.gz" -C "$tmpdir"
+
+if [ -w /usr/local/bin ]; then
+  install -m 755 "$tmpdir/openshell" /usr/local/bin/openshell
+else
+  sudo install -m 755 "$tmpdir/openshell" /usr/local/bin/openshell
+fi
+
+rm -rf "$tmpdir"
+echo "openshell $(openshell --version 2>&1 || echo 'installed')"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,31 @@ info()  { echo -e "${GREEN}[install]${NC} $1"; }
 warn()  { echo -e "${YELLOW}[install]${NC} $1"; }
 fail()  { echo -e "${RED}[install]${NC} $1"; exit 1; }
 
+# Ensure nvm environment is loaded in the current shell.
+ensure_nvm_loaded() {
+  if [ -z "${NVM_DIR:-}" ]; then
+    export NVM_DIR="$HOME/.nvm"
+  fi
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$NVM_DIR/nvm.sh"
+  fi
+}
+
+# Refresh PATH so that npm global bin is discoverable.
+refresh_path() {
+  ensure_nvm_loaded
+
+  local npm_bin
+  npm_bin="$(npm config get prefix 2>/dev/null)/bin" || true
+  if [ -n "$npm_bin" ] && [ -d "$npm_bin" ]; then
+    case ":$PATH:" in
+      *":$npm_bin:"*) ;;  # already on PATH
+      *) export PATH="$npm_bin:$PATH" ;;
+    esac
+  fi
+}
+
 MIN_NODE_MAJOR=20
 MIN_NPM_MAJOR=10
 RECOMMENDED_NODE_MAJOR=22
@@ -48,6 +73,9 @@ NEED_RESHIM=false
 if command -v asdf > /dev/null 2>&1 && asdf plugin list 2>/dev/null | grep -q nodejs; then
   NODE_MGR="asdf"
 elif [ -n "${NVM_DIR:-}" ] && [ -s "${NVM_DIR}/nvm.sh" ]; then
+  NODE_MGR="nvm"
+elif [ -s "$HOME/.nvm/nvm.sh" ]; then
+  export NVM_DIR="$HOME/.nvm"
   NODE_MGR="nvm"
 elif command -v fnm > /dev/null 2>&1; then
   NODE_MGR="fnm"
@@ -239,17 +267,41 @@ install_openshell
 # ── Install NemoClaw CLI ─────────────────────────────────────────
 
 info "Installing nemoclaw CLI..."
-npm install -g nemoclaw
+if [ "$NODE_MGR" = "nodesource" ]; then
+  sudo npm install -g nemoclaw
+else
+  npm install -g nemoclaw
+fi
 
 if [ "$NEED_RESHIM" = true ]; then
   info "Reshimming asdf..."
   asdf reshim nodejs
 fi
 
+refresh_path
+
 # ── Verify ───────────────────────────────────────────────────────
 
 if ! command -v nemoclaw > /dev/null 2>&1; then
-  fail "nemoclaw not found in PATH after install. Check your Node.js bin directory."
+  # Try refreshing PATH one more time
+  refresh_path
+fi
+
+if ! command -v nemoclaw > /dev/null 2>&1; then
+  npm_bin="$(npm config get prefix 2>/dev/null)/bin" || true
+  if [ -n "$npm_bin" ] && [ -x "$npm_bin/nemoclaw" ]; then
+    warn "nemoclaw installed at $npm_bin/nemoclaw but not on current PATH."
+    warn ""
+    warn "Add it to your shell profile:"
+    warn "  echo 'export PATH=\"$npm_bin:\$PATH\"' >> ~/.bashrc"
+    warn "  source ~/.bashrc"
+    warn ""
+    warn "Or for zsh:"
+    warn "  echo 'export PATH=\"$npm_bin:\$PATH\"' >> ~/.zshrc"
+    warn "  source ~/.zshrc"
+  else
+    fail "nemoclaw installation failed. Binary not found."
+  fi
 fi
 
 echo ""
@@ -258,3 +310,24 @@ info "nemoclaw $(nemoclaw --version 2>/dev/null || echo 'v0.1.0') is ready."
 echo ""
 echo "  Run \`nemoclaw onboard\` to get started"
 echo ""
+
+# ── Post-install: shell reload instructions ──────────────────
+
+if [ "$NODE_MGR" = "nvm" ] || [ "$NODE_MGR" = "fnm" ]; then
+  profile="$HOME/.bashrc"
+  if [ -n "${ZSH_VERSION:-}" ] || [ "$(basename "${SHELL:-}")" = "zsh" ]; then
+    profile="$HOME/.zshrc"
+  elif [ ! -f "$HOME/.bashrc" ] && [ -f "$HOME/.profile" ]; then
+    profile="$HOME/.profile"
+  fi
+  echo "  ──────────────────────────────────────────────────"
+  warn "Your current shell may not have the updated PATH."
+  echo ""
+  echo "  To use nemoclaw now, run:"
+  echo ""
+  echo "    source $profile"
+  echo ""
+  echo "  Or open a new terminal window."
+  echo "  ──────────────────────────────────────────────────"
+  echo ""
+fi


### PR DESCRIPTION
## Summary

Fixes #205. After `curl -fsSL https://nvidia.com/nemoclaw.sh | bash` installs Node.js via nvm, the parent shell doesn't have the updated PATH. Both `nemoclaw` and `node` are "command not found" until the user manually opens a new terminal.

**Root cause (primary):** The installer runs in a subshell via `curl | bash`. nvm sources into that subshell and updates PATH, but when the subshell exits, all PATH changes are lost.

**Root cause (secondary):** `onboard.js` called the full `scripts/install.sh` to install openshell, which unnecessarily reinstalled Node, Docker, and nemoclaw in a nested subprocess — compounding the PATH issue.

### Changes

**`scripts/install.sh`:**
- Add `ensure_nvm_loaded()` and `refresh_path()` to explicitly update PATH after npm installs nemoclaw
- Add nvm fallback detection for `$HOME/.nvm` when `NVM_DIR` is not exported (common in Docker containers)
- Soften verification: warn with instructions instead of hard-failing when the binary exists but isn't on PATH (install succeeded, PATH is stale)
- Add post-install message telling nvm/fnm users to run `source ~/.bashrc`
- Use `sudo` for `npm install -g` when `NODE_MGR=nodesource` (system Node requires root for global installs)

**`install.sh` (root):**
- Soften `verify_nemoclaw()` to return 0 when the binary exists but PATH is stale (was a hard error)
- Add `post_install_message()` function with shell reload instructions

**`bin/lib/onboard.js`:**
- Switch `installOpenshell()` to use dedicated `install-openshell.sh` instead of the full `scripts/install.sh`

**`scripts/install-openshell.sh` (new):**
- Dedicated openshell-only installer with macOS + Linux support and conditional sudo

## Test plan

- [x] 58/58 unit tests pass (`node --test test/*.test.js`)
- [x] 24/24 E2E tests pass (see #226)
- [x] Shell syntax check passes on all 3 scripts (`bash -n`)
- [x] Verified `install-openshell.sh` handles both Darwin and Linux asset names
- [x] Verified `refresh_path()` uses POSIX-compatible `case` for PATH dedup check
- [x] Verified post-install message detects correct shell profile (.bashrc vs .zshrc vs .profile)