### PR TITLE
fix: const-to-let for currentPolicy reassignment

### DIFF
--- a/bin/lib/policies.js
+++ b/bin/lib/policies.js
@@ -105,7 +105,7 @@ function applyPreset(sandboxName, presetName) {
     );
   } catch {}
 
-  const currentPolicy = parseCurrentPolicy(rawPolicy);
+  let currentPolicy = parseCurrentPolicy(rawPolicy);
 
   // Merge: inject preset entries under the existing network_policies key
   let merged;


### PR DESCRIPTION
## Summary

- Fix runtime `TypeError: Assignment to constant variable` when `applyPreset()` encounters a sandbox with an existing policy that has no `version:` field

`currentPolicy` was declared `const` but conditionally reassigned on the branch that prepends `version: 1\n`. Changing to `let` fixes the crash.

Spotted by @dnandakumar-nv in https://github.com/NVIDIA/NemoClaw/pull/49#issuecomment-4077005907.

## Test plan

- [x] All 56 unit tests pass