### PR TITLE
fix: add !nemoclaw/dist exception to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 /dist
+!nemoclaw/dist
 .git
 *.pyc
 __pycache__


### PR DESCRIPTION
Closes #126.

## Summary

- Add `!nemoclaw/dist` negation pattern to `.dockerignore` so OpenShell's build engine includes the pre-built plugin files in the Docker build context

## Problem

The `/dist` entry in `.dockerignore` is intended to exclude only the root-level `dist/` directory. Standard Docker (BuildKit) interprets `/dist` as root-only, so `docker build` works fine. However, **OpenShell's build engine** interprets `/dist` more broadly and also excludes `nemoclaw/dist/`, causing `openshell sandbox create --from Dockerfile` to fail:

```
COPY failed: file not found in build context or excluded by .dockerignore: stat nemoclaw/dist/: file does not exist
```

## Fix

One-line addition — a negation pattern `!nemoclaw/dist` after `/dist`, matching the exception already present in `.gitignore` (line 3).

## Test plan

All tests run against this change on macOS (Docker Desktop):

- [x] `docker build --no-cache -f Dockerfile .` — **PASS** (COPY nemoclaw/dist/ succeeds)
- [x] `docker build --no-cache -f test/Dockerfile.sandbox .` — **PASS**
- [x] `bash test/e2e/test-full-e2e.sh` (full live E2E: install → onboard → inference against NVIDIA Cloud API) — **all assertions PASS**
- [x] `openshell sandbox create --name test-126 --from Dockerfile` — **PASS** (the exact command from the bug report); sandbox destroyed after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to adjust included build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->