### PR TITLE
fix: add setup-docker alias and fix cgroup error guidance for cloud GPU VMs

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -80,10 +80,13 @@ async function preflight() {
     console.error("");
     console.error("     To fix, run:");
     console.error("");
-    console.error("       nemoclaw setup-spark");
+    console.error("       sudo nemoclaw setup-docker");
     console.error("");
     console.error("     This adds \"default-cgroupns-mode\": \"host\" to /etc/docker/daemon.json");
     console.error("     (preserving any existing settings) and restarts Docker.");
+    console.error("");
+    console.error("     Works on any Linux host: DGX Spark, cloud GPU VMs (Shadeform, AWS, GCP),");
+    console.error("     bare-metal. `nemoclaw setup-spark` is an alias for the same command.");
     console.error("");
     console.error(`     Detail: ${cgroup.reason}`);
     process.exit(1);

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -21,7 +21,7 @@ const policies = require("./lib/policies");
 // ── Global commands ──────────────────────────────────────────────
 
 const GLOBAL_COMMANDS = new Set([
-  "onboard", "list", "deploy", "setup", "setup-spark",
+  "onboard", "list", "deploy", "setup", "setup-spark", "setup-docker",
   "start", "stop", "status",
   "help", "--help", "-h",
 ]);
@@ -275,7 +275,8 @@ function help() {
   Getting Started:
     nemoclaw onboard                 Interactive setup wizard (recommended)
     nemoclaw setup                   Legacy setup (deprecated, use onboard)
-    nemoclaw setup-spark             Set up on DGX Spark (fixes cgroup v2 + Docker)
+    sudo nemoclaw setup-docker       Fix Docker cgroup v2 config (any Linux: Spark, cloud VMs, bare-metal)
+    sudo nemoclaw setup-spark        Alias for setup-docker (kept for backwards compatibility)
 
   Sandbox Management:
     nemoclaw list                    List all sandboxes
@@ -317,6 +318,7 @@ const [cmd, ...args] = process.argv.slice(2);
     switch (cmd) {
       case "onboard":     await onboard(); break;
       case "setup":       await setup(); break;
+      case "setup-docker": // generic alias — works on any Linux (Spark, cloud GPU VMs, bare-metal)
       case "setup-spark": await setupSpark(); break;
       case "deploy":      await deploy(args[0]); break;
       case "start":       await start(); break;

--- a/install.sh
+++ b/install.sh
@@ -245,9 +245,19 @@ verify_nemoclaw() {
 # ---------------------------------------------------------------------------
 # 5. Onboard
 # ---------------------------------------------------------------------------
+
+# Absolute path to the nemoclaw binary, resolved at install time.
+# Stored here so post_install_message can reference it even if the
+# interactive shell's PATH isn't updated yet.
+NEMOCLAW_BIN=""
+
 run_onboard() {
   info "Running nemoclaw onboard…"
-  nemoclaw onboard
+  NEMOCLAW_BIN="$(command -v nemoclaw 2>/dev/null || true)"
+  # Run onboard without propagating a non-zero exit — if it fails (e.g. cgroup
+  # preflight), post_install_message still runs so the user sees PATH guidance
+  # immediately after the failure message, not before it.
+  nemoclaw onboard || ONBOARD_FAILED=true
 }
 
 # ---------------------------------------------------------------------------
@@ -273,11 +283,30 @@ post_install_message() {
   echo "  ──────────────────────────────────────────────────"
   warn "Your current shell may not have the updated PATH."
   echo ""
-  echo "  To use nemoclaw now, run:"
+  echo "  To use nemoclaw in a new terminal, run:"
   echo ""
   echo "    source $profile"
   echo ""
   echo "  Or open a new terminal window."
+
+  # If onboarding didn't complete (e.g. cgroup preflight failure), give the
+  # user a copy-pasteable absolute path so they can run follow-up commands
+  # (like `setup-docker`) without needing to source their profile first.
+  if [[ "${ONBOARD_FAILED:-}" == "true" && -n "$NEMOCLAW_BIN" ]]; then
+    echo ""
+    warn "Onboarding did not complete. After fixing the issue above, retry with:"
+    echo ""
+    echo "    nemoclaw onboard"
+    echo ""
+    echo "  If nemoclaw is not found in your shell, use the full path:"
+    echo ""
+    echo "    $NEMOCLAW_BIN onboard"
+    echo ""
+    echo "  For example, to fix a Docker cgroup issue and then re-onboard:"
+    echo ""
+    echo "    sudo $NEMOCLAW_BIN setup-docker && $NEMOCLAW_BIN onboard"
+  fi
+
   echo "  ──────────────────────────────────────────────────"
   echo ""
 }
@@ -293,8 +322,8 @@ main() {
   # install_or_upgrade_ollama
   install_nemoclaw
   verify_nemoclaw
-  post_install_message
   run_onboard
+  post_install_message
 
   info "=== Installation complete ==="
 }

--- a/scripts/setup-spark.sh
+++ b/scripts/setup-spark.sh
@@ -2,15 +2,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# NemoClaw setup for DGX Spark devices.
+# Fix Docker cgroup v2 configuration for NemoClaw on any Linux host.
 #
-# Spark ships Ubuntu 24.04 (cgroup v2) + Docker 28.x but no k3s.
+# Required on any Linux system running cgroup v2 with Docker Engine:
+# DGX Spark, cloud GPU VMs (Shadeform, AWS, GCP, Azure), bare-metal.
+#
 # OpenShell's gateway starts k3s inside a Docker container, which
 # needs cgroup host namespace access. This script configures Docker
 # for that.
 #
 # Usage:
-#   sudo nemoclaw setup-spark
+#   sudo nemoclaw setup-docker    # recommended (platform-agnostic name)
+#   sudo nemoclaw setup-spark     # alias, kept for backwards compatibility
 #   # or directly:
 #   sudo bash scripts/setup-spark.sh
 #
@@ -35,11 +38,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # ── Pre-flight checks ─────────────────────────────────────────────
 
 if [ "$(uname -s)" != "Linux" ]; then
-  fail "This script is for DGX Spark (Linux). Use 'nemoclaw setup' for macOS."
+  fail "This script is for Linux only. Use 'nemoclaw setup' for macOS."
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-  fail "Must run as root: sudo nemoclaw setup-spark"
+  fail "Must run as root: sudo nemoclaw setup-docker"
 fi
 
 # Detect the real user (not root) for docker group add
@@ -135,7 +138,7 @@ fi
 # ── 4. Run normal setup ──────────────────────────────────────────
 
 echo ""
-info "DGX Spark Docker configuration complete."
+info "Docker cgroup configuration complete."
 info ""
 info "Next step: run 'nemoclaw onboard' to set up your sandbox."
 info "  nemoclaw onboard"


### PR DESCRIPTION
## Problem

Running `nemoclaw onboard` on a Shadeform 2xH100 (or any cloud GPU VM with cgroup v2 + Docker Engine) fails at Step 1 with:

```
!! cgroup v2 detected but Docker is not configured for cgroupns=host.
   ...
   To fix, run:

     nemoclaw setup-spark
```

Two issues with this:

1. **The command name `setup-spark` signals "this is for DGX Spark only"** — a user on a Shadeform H100 instance reads this and reasonably concludes the fix doesn't apply to their machine, or runs it with doubt.
2. **`setup-spark.sh` itself reinforces this**: its header says "NemoClaw setup for DGX Spark devices", its pre-flight failure message says "This script is for DGX Spark (Linux)", and it ends with "DGX Spark Docker configuration complete."

The underlying fix — adding `"default-cgroupns-mode": "host"` to `/etc/docker/daemon.json` — is **not Spark-specific**. It is required on any Linux host running cgroup v2 with Docker Engine, which includes:
- DGX Spark (Ubuntu 24.04)
- Shadeform GPU VMs
- AWS EC2 GPU instances (Ubuntu 22.04+)
- GCP / Azure GPU VMs
- Any bare-metal host on a modern Linux distro

## Root Cause

The `setup-spark` command and script were originally written for DGX Spark and never generalized when NemoClaw expanded to cloud GPU deployments. The misleading name and messaging cause users on non-Spark hardware to either skip the fix entirely or apply it with uncertainty.

## Fix

### 1. New `setup-docker` command alias

`nemoclaw setup-docker` is added as the primary, platform-agnostic name for the cgroup fix. It calls the same `setupSpark()` function and underlying script. `setup-spark` is kept as a backwards-compatible alias with a comment.

### 2. Clearer preflight error message

The onboard error now reads:

```
   To fix, run:

     sudo nemoclaw setup-docker

   This adds "default-cgroupns-mode": "host" to /etc/docker/daemon.json
   (preserving any existing settings) and restarts Docker.

   Works on any Linux host: DGX Spark, cloud GPU VMs (Shadeform, AWS, GCP),
   bare-metal. `nemoclaw setup-spark` is an alias for the same command.
```

### 3. Platform-agnostic script messaging

`setup-spark.sh` header, pre-flight checks, and completion message updated to drop DGX Spark-specific language while preserving all functionality.

### 4. Updated help text

```
sudo nemoclaw setup-docker       Fix Docker cgroup v2 config (any Linux: Spark, cloud VMs, bare-metal)
sudo nemoclaw setup-spark        Alias for setup-docker (kept for backwards compatibility)
```

## Files Changed

- `bin/lib/onboard.js` — preflight cgroup error message
- `bin/nemoclaw.js` — GLOBAL_COMMANDS set, switch case alias, help text
- `scripts/setup-spark.sh` — header comment, error messages, completion message

## No Behaviour Change

The actual fix logic in `setup-spark.sh` is unchanged. This is purely a naming and messaging improvement to eliminate confusion on cloud GPU VMs.