### PR TITLE
fix(gpu): add WSL2 GPU support and ollama provider on Linux

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -148,6 +148,17 @@ async function startGateway(gpu) {
   // Give DNS a moment to propagate
   require("child_process").spawnSync("sleep", ["5"]);
 
+  // WSL2 GPU fix — CDI mode + libdxcore.so + node label
+  if (gpu && gpu.nimCapable && fs.existsSync("/dev/dxg")) {
+    console.log("  WSL2 detected — applying GPU CDI fixes...");
+    const fixScript = path.join(ROOT, "wsl2-gpu-fix.sh");
+    if (fs.existsSync(fixScript)) {
+      run(`bash "${fixScript}" nemoclaw`, { ignoreError: true });
+    } else {
+      console.log("  Warning: wsl2-gpu-fix.sh not found at " + fixScript);
+      console.log("  GPU sandbox creation may fail on WSL2. See: https://github.com/NVIDIA/OpenShell/issues/404");
+    }
+  }
 }
 
 // ── Step 3: Sandbox ──────────────────────────────────────────────

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -88,6 +88,17 @@ for i in 1 2 3 4 5; do
 done
 info "Gateway is healthy"
 
+# 1b. WSL2 GPU fix — CDI mode + libdxcore.so + node label
+if [ -c /dev/dxg ] && command -v nvidia-smi > /dev/null 2>&1; then
+  info "WSL2 detected — applying GPU CDI fixes..."
+  WSL2_FIX="${REPO_DIR}/wsl2-gpu-fix.sh"
+  if [ -x "$WSL2_FIX" ]; then
+    bash "$WSL2_FIX" nemoclaw
+  else
+    warn "wsl2-gpu-fix.sh not found at $WSL2_FIX — GPU sandbox may fail on WSL2"
+  fi
+fi
+
 # 2. CoreDNS fix (Colima only)
 if [ -S "$HOME/.colima/default/docker.sock" ]; then
   info "Patching CoreDNS for Colima..."
@@ -113,19 +124,24 @@ if curl -s http://localhost:8000/v1/models > /dev/null 2>&1 || python3 -c "impor
     "OPENAI_BASE_URL=http://host.openshell.internal:8000/v1"
 fi
 
-# 4a. Ollama (macOS local inference)
-if [ "$(uname -s)" = "Darwin" ]; then
-  if ! command -v ollama > /dev/null 2>&1; then
-    info "Installing Ollama..."
-    brew install ollama 2>/dev/null || warn "Ollama install failed (brew required). Install manually: https://ollama.com"
+# 4a. Ollama (local inference — macOS or Linux)
+if command -v ollama > /dev/null 2>&1 || curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+  if ! curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+    info "Starting Ollama service..."
+    OLLAMA_HOST=0.0.0.0:11434 ollama serve > /dev/null 2>&1 &
+    sleep 2
   fi
+  upsert_provider \
+    "ollama-local" \
+    "openai" \
+    "OPENAI_API_KEY=ollama" \
+    "OPENAI_BASE_URL=http://host.openshell.internal:11434/v1"
+elif [ "$(uname -s)" = "Darwin" ] && ! command -v ollama > /dev/null 2>&1; then
+  info "Installing Ollama..."
+  brew install ollama 2>/dev/null || warn "Ollama install failed. Install manually: https://ollama.com"
   if command -v ollama > /dev/null 2>&1; then
-    # Start Ollama service if not running
-    if ! curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
-      info "Starting Ollama service..."
-      OLLAMA_HOST=0.0.0.0:11434 ollama serve > /dev/null 2>&1 &
-      sleep 2
-    fi
+    OLLAMA_HOST=0.0.0.0:11434 ollama serve > /dev/null 2>&1 &
+    sleep 2
     upsert_provider \
       "ollama-local" \
       "openai" \

--- a/wsl2-gpu-fix.sh
+++ b/wsl2-gpu-fix.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# wsl2-gpu-fix.sh — Apply WSL2 GPU fixes to an OpenShell gateway
+# Run after: openshell gateway start --gpu
+# Usage: ./wsl2-gpu-fix.sh [gateway-name]
+#
+# This script applies the same fixes as the PR (NVIDIA/OpenShell#411)
+# at runtime, until the upstream image ships with WSL2 support.
+
+set -euo pipefail
+
+GATEWAY="${1:-nemoclaw}"
+echo "Applying WSL2 GPU fixes to gateway '$GATEWAY'..."
+
+# Check gateway is up
+if ! openshell status 2>&1 | grep -q "Connected"; then
+    echo "Error: gateway not connected. Start it first: openshell gateway start --gpu --name $GATEWAY"
+    exit 1
+fi
+
+# Check we're on WSL2
+if [ ! -c /dev/dxg ] 2>/dev/null; then
+    echo "Not WSL2 (/dev/dxg absent) — no fixes needed"
+    exit 0
+fi
+
+echo "[1/4] Generating CDI spec with GPU UUIDs and libdxcore.so..."
+openshell doctor exec -- sh -c '
+mkdir -p /var/run/cdi
+
+# Gather info
+GPU_UUID=$(nvidia-smi --query-gpu=gpu_uuid --format=csv,noheader 2>/dev/null | tr -d " " | head -1)
+DXCORE_PATH=$(find /usr/lib -name "libdxcore.so" 2>/dev/null | head -1)
+DXCORE_DIR=$(dirname "$DXCORE_PATH" 2>/dev/null || echo "/usr/lib/x86_64-linux-gnu")
+DRIVER_DIR=$(ls -d /usr/lib/wsl/drivers/nv*.inf_amd64_* 2>/dev/null | head -1)
+
+if [ -z "$DRIVER_DIR" ]; then
+    echo "Error: no NVIDIA WSL driver store found"
+    exit 1
+fi
+
+# Write complete CDI spec from scratch (avoids fragile sed patching)
+cat > /var/run/cdi/nvidia.yaml << CDIEOF
+---
+cdiVersion: "0.5.0"
+kind: nvidia.com/gpu
+devices:
+    - name: all
+      containerEdits:
+        deviceNodes:
+            - path: /dev/dxg
+    - name: "${GPU_UUID}"
+      containerEdits:
+        deviceNodes:
+            - path: /dev/dxg
+    - name: "0"
+      containerEdits:
+        deviceNodes:
+            - path: /dev/dxg
+containerEdits:
+    env:
+        - NVIDIA_VISIBLE_DEVICES=void
+    hooks:
+        - hookName: createContainer
+          path: /usr/bin/nvidia-cdi-hook
+          args:
+            - nvidia-cdi-hook
+            - create-symlinks
+            - --link
+            - ${DRIVER_DIR}/nvidia-smi::/usr/bin/nvidia-smi
+          env:
+            - NVIDIA_CTK_DEBUG=false
+        - hookName: createContainer
+          path: /usr/bin/nvidia-cdi-hook
+          args:
+            - nvidia-cdi-hook
+            - update-ldcache
+            - --folder
+            - ${DRIVER_DIR}
+            - --folder
+            - ${DXCORE_DIR}
+          env:
+            - NVIDIA_CTK_DEBUG=false
+    mounts:
+        - hostPath: ${DXCORE_PATH}
+          containerPath: ${DXCORE_PATH}
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libcuda.so.1.1
+          containerPath: ${DRIVER_DIR}/libcuda.so.1.1
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libcuda_loader.so
+          containerPath: ${DRIVER_DIR}/libcuda_loader.so
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libnvdxgdmal.so.1
+          containerPath: ${DRIVER_DIR}/libnvdxgdmal.so.1
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libnvidia-ml.so.1
+          containerPath: ${DRIVER_DIR}/libnvidia-ml.so.1
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libnvidia-ml_loader.so
+          containerPath: ${DRIVER_DIR}/libnvidia-ml_loader.so
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/libnvidia-ptxjitcompiler.so.1
+          containerPath: ${DRIVER_DIR}/libnvidia-ptxjitcompiler.so.1
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/nvcubins.bin
+          containerPath: ${DRIVER_DIR}/nvcubins.bin
+          options: [ro, nosuid, nodev, rbind, rprivate]
+        - hostPath: ${DRIVER_DIR}/nvidia-smi
+          containerPath: ${DRIVER_DIR}/nvidia-smi
+          options: [ro, nosuid, nodev, rbind, rprivate]
+CDIEOF
+
+nvidia-ctk cdi list 2>&1
+'
+
+echo "[2/4] Switching nvidia runtime to CDI mode..."
+openshell doctor exec -- sed -i 's/mode = "auto"/mode = "cdi"/' /etc/nvidia-container-runtime/config.toml
+
+echo "[3/4] Labeling node with NVIDIA PCI vendor..."
+openshell doctor exec -- sh -c '
+NODE=$(kubectl get nodes -o jsonpath="{.items[0].metadata.name}")
+kubectl label node $NODE feature.node.kubernetes.io/pci-10de.present=true --overwrite
+' 2>&1
+
+echo "[4/4] Waiting for nvidia-device-plugin..."
+for i in $(seq 1 60); do
+    GPU=$(openshell doctor exec -- kubectl get nodes -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}' 2>/dev/null || true)
+    if [ "$GPU" = "1" ]; then
+        echo "GPU ready: nvidia.com/gpu=$GPU"
+        break
+    fi
+    [ "$((i % 10))" = "0" ] && echo "  still waiting ($i/60)..."
+    sleep 2
+done
+
+if [ "$GPU" != "1" ]; then
+    echo "Warning: GPU resource not yet advertised after 120s"
+    echo "Checking device plugin pods..."
+    openshell doctor exec -- kubectl -n nvidia-device-plugin get pods 2>&1
+    exit 1
+fi
+
+echo ""
+echo "WSL2 GPU fixes applied successfully."
+echo "Sandbox creation with --gpu should now work."


### PR DESCRIPTION
Not sure this is warranted, the upstream openshell fix will hopefully solve at the root, but this unblocked me (@tyeth) so here it is.

## Summary

- Add `wsl2-gpu-fix.sh` that auto-configures CDI-based GPU injection on WSL2 after gateway creation
- Hook it into both `onboard.js` (interactive wizard) and `setup.sh` (legacy script)
- Fix ollama provider creation to work on Linux, not just macOS

## Problem

On WSL2, `nemoclaw onboard` with GPU fails because:
1. The OpenShell gateway's nvidia-device-plugin can't detect GPUs (NVML fails without `libdxcore.so`, NFD can't see PCI)
2. The ollama-local provider is only created on macOS (`uname -s = Darwin` check), so Linux/WSL2 users can't use local inference via ollama

Full root cause analysis: NVIDIA/OpenShell#404

## Changes

### `wsl2-gpu-fix.sh` (new)
Runs after gateway start on WSL2. Writes a complete CDI spec with:
- `/dev/dxg` device node (WSL2's GPU interface)
- Per-GPU UUID and index entries (device plugin allocates by UUID)
- `libdxcore.so` mount (nvidia-ctk bug omits it — NVIDIA/nvidia-container-toolkit#1739)
- All WSL driver store library mounts
- Switches nvidia runtime from `auto` to `cdi` mode
- Labels node with `pci-10de.present=true` (NFD can't see NVIDIA PCI on WSL2)

### `bin/lib/onboard.js`
After gateway health check, detects WSL2 (`/dev/dxg`) and runs `wsl2-gpu-fix.sh`.

### `scripts/setup.sh`
- Same WSL2 fix hook after gateway start
- Ollama provider creation now works on any platform where ollama is installed or running

## Testing

Tested end-to-end on:
- **Hardware**: Framework 16, AMD Ryzen AI 7 350, NVIDIA RTX 5070 (8GB VRAM), 96GB DDR5
- **OS**: WSL2 (Linux 6.6.87.2-microsoft-standard-WSL2)
- **Flow**: `nemoclaw onboard` -> gateway with GPU -> WSL2 fix auto-applied -> sandbox created -> local inference via ollama nemotron 70B working

## Related

- NVIDIA/OpenShell#404 — Root cause analysis
- NVIDIA/OpenShell#411 — Upstream entrypoint fix (permanent solution when image ships)
- NVIDIA/nvidia-container-toolkit#1739 — libdxcore.so CDI generation bug

## Agent Investigation

Diagnosed and tested using `openshell doctor` commands. Iteratively debugged CDI spec generation, NVML init failures, and pod runtime errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WSL2 GPU acceleration support with automatic NVIDIA GPU detection and configuration for WSL2 environments.
  * Extended Ollama local inference setup to work cross-platform with improved service startup handling.

* **Bug Fixes**
  * Improved GPU detection and workarounds for WSL2 environment compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->