### PR TITLE
docs: add nemoclaw onboard command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The script installs Node.js if it is not already present, then runs the guided o
 ```console
 $ curl -fsSL https://nvidia.com/nemoclaw.sh | bash
 ```
+```
+$ nemoclaw onboard
+```
 
 When the install completes, a summary confirms the running environment:
 


### PR DESCRIPTION
## Summary
   - Adds the 
  NemoClaw Onboarding
  ===================

  [1/7] Preflight checks
  ──────────────────────────────────────────────────
  ✓ Docker is running
  ✓ openshell CLI: openshell 0.0.9
  ✓ cgroup configuration OK
  ✓ Apple GPU detected: Apple M1 (7 cores), 8192 MB unified memory
  ⓘ NIM requires NVIDIA GPU — will use cloud inference

  [2/7] Starting OpenShell gateway
  ──────────────────────────────────────────────────
  ✓ Gateway is healthy

  [3/7] Creating sandbox
  ────────────────────────────────────────────────── command to the README installation section for Mac users

   ## Test plan
   - [ ] Verify the command renders correctly in the docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an onboarding example to the README showing users how to use the onboarding feature immediately after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->