### PR TITLE
docs: remove shell prompt markers from copyable code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Check the prerequisites before you start to ensure you have the necessary softwa
 Download and run the installer script.
 The script installs Node.js if it is not already present, then runs the guided onboard wizard to create a sandbox, configure inference, and apply security policies.
 
-```console
-$ curl -fsSL https://nvidia.com/nemoclaw.sh | bash
+```bash
+curl -fsSL https://nvidia.com/nemoclaw.sh | bash
 ```
 
 When the install completes, a summary confirms the running environment:
@@ -66,8 +66,8 @@ Logs:        nemoclaw my-assistant logs --follow
 
 Connect to the sandbox, then chat with the agent through the TUI or the CLI.
 
-```console
-$ nemoclaw my-assistant connect
+```bash
+nemoclaw my-assistant connect
 ```
 
 #### OpenClaw TUI


### PR DESCRIPTION
## Summary

- Remove `$ ` prompt prefixes from Quick Start code blocks in `README.md` so that copy-pasting commands works without errors.
- Switch fenced code blocks from ` ```console ` to ` ```bash ` for the two user-runnable commands (`curl` installer and `nemoclaw connect`).

The `$ ` prefix is included when users click the copy button on GitHub, causing the pasted command to fail with `$: command not found`.

## Test plan

- [ ] Verify the copy button on the README code blocks copies clean commands without `$`.
- [ ] Confirm the quickstart docs page (which includes README content) renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code example formatting in README for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->