### PR TITLE
fix(docker): exclude only root /dist, keep nemoclaw/dist/ for builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 /dist
+!nemoclaw/dist
 .git
 *.pyc
 __pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 /dist
-!nemoclaw/dist
+# Keep nemoclaw/dist/ — compiled plugin output needed by Dockerfile COPY (#196, #126)
+!nemoclaw/dist/
 .git
 *.pyc
 __pycache__


### PR DESCRIPTION
## Summary
- `.dockerignore` has `/dist` which excludes `nemoclaw/dist/`, breaking the Docker build at the `COPY` step
- Adds `!nemoclaw/dist` exception so the root-level `dist/` is still ignored but the plugin's compiled output is preserved

Fixes #196
Fixes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker ignore rules so previously excluded distribution output is now included in the build context.
  * Ensures those distribution files are available during image build and included in the final container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->