### PR TITLE
fix(onboard): pass user-chosen sandbox name to setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -207,6 +207,9 @@ rm -f "$CREATE_LOG"
 # Verify sandbox is Ready (not just that a record exists)
 # Strip ANSI color codes before checking phase
 SANDBOX_LINE=$(openshell sandbox list 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | awk -v name="$SANDBOX_NAME" '$1 == name { print; exit }')
+if [ -z "$SANDBOX_LINE" ]; then
+  fail "Sandbox '$SANDBOX_NAME' not found in 'openshell sandbox list'."
+fi
 if ! echo "$SANDBOX_LINE" | grep -q "Ready"; then
   SANDBOX_PHASE=$(echo "$SANDBOX_LINE" | awk '{print $NF}')
   echo ""


### PR DESCRIPTION
## Summary
- `setup.sh` hardcodes `--name nemoclaw` in 5 places, ignoring the custom name chosen in the onboard wizard
- Now accepts sandbox name as `$1` argument (defaults to `nemoclaw` for backward compat)
- Replaces all hardcoded references: `sandbox delete`, `sandbox create --name`, `sandbox list | grep`, `sandbox get`, and the error message

Fixes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup accepts an optional sandbox-name argument and applies it across creation, deletion, listing, status checks, and diagnostics.

* **Bug Fixes**
  * Script now fails early with a clear “sandbox not found” error when the specified sandbox name doesn't exist, preventing misleading readiness checks.

* **Documentation**
  * Usage/help text and error/status messages updated to reflect and clarify sandbox-name behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->