### PR TITLE
fix(telegram): unify sandbox env var to NEMOCLAW_SANDBOX

### DIFF
--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -140,6 +140,7 @@ do_start() {
 
   # Telegram bridge (only if token provided)
   if [ -n "${TELEGRAM_BOT_TOKEN:-}" ]; then
+    export NEMOCLAW_SANDBOX="$SANDBOX_NAME"
     start_service telegram-bridge \
       node "$REPO_DIR/scripts/telegram-bridge.js"
   fi

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -12,7 +12,7 @@
  * Env:
  *   TELEGRAM_BOT_TOKEN  — from @BotFather
  *   NVIDIA_API_KEY      — for inference
- *   SANDBOX_NAME        — sandbox name (default: nemoclaw)
+ *   NEMOCLAW_SANDBOX    — sandbox name (default: nemoclaw; legacy SANDBOX_NAME also accepted)
  *   ALLOWED_CHAT_IDS    — comma-separated Telegram chat IDs to accept (optional, accepts all if unset)
  */
 
@@ -21,7 +21,7 @@ const { execSync, spawn } = require("child_process");
 
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const API_KEY = process.env.NVIDIA_API_KEY;
-const SANDBOX = process.env.SANDBOX_NAME || "nemoclaw";
+const SANDBOX = process.env.NEMOCLAW_SANDBOX || process.env.SANDBOX_NAME || "nemoclaw";
 const ALLOWED_CHATS = process.env.ALLOWED_CHAT_IDS
   ? process.env.ALLOWED_CHAT_IDS.split(",").map((s) => s.trim())
   : null;


### PR DESCRIPTION
## Summary
- Telegram bridge used `SANDBOX_NAME` while the rest of the codebase uses the `NEMOCLAW_` prefix convention
- Bridge now reads `NEMOCLAW_SANDBOX` with `SANDBOX_NAME` fallback for backward compat
- `start-services.sh` exports `NEMOCLAW_SANDBOX` before launching the bridge

Fixes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for the NEMOCLAW_SANDBOX environment variable for sandbox configuration, maintaining backward compatibility with existing deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->