### PR TITLE
fix(telegram): resolve openshell path for child processes

### DIFF
--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -129,6 +129,11 @@ do_start() {
 
   command -v node > /dev/null || fail "node not found. Install Node.js first."
 
+  # Ensure ~/.local/bin is in PATH so child processes can find openshell
+  if [ -d "$HOME/.local/bin" ] && ! echo "$PATH" | tr ':' '\n' | grep -qx "$HOME/.local/bin"; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
+
   # Verify sandbox is running
   if command -v openshell > /dev/null 2>&1; then
     if ! openshell sandbox list 2>&1 | grep -q "Ready"; then
@@ -140,6 +145,11 @@ do_start() {
 
   # Telegram bridge (only if token provided)
   if [ -n "${TELEGRAM_BOT_TOKEN:-}" ]; then
+    # Resolve openshell absolute path so child processes find it regardless of PATH
+    OPENSHELL_BIN="$(command -v openshell 2>/dev/null || true)"
+    if [ -n "$OPENSHELL_BIN" ]; then
+      export OPENSHELL_BIN
+    fi
     SANDBOX_NAME="$SANDBOX_NAME" start_service telegram-bridge \
       node "$REPO_DIR/scripts/telegram-bridge.js"
   fi

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -17,7 +17,7 @@
  */
 
 const https = require("https");
-const { execSync, spawn } = require("child_process");
+const { execFileSync, spawn } = require("child_process");
 const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
 
 const OPENSHELL = resolveOpenshell();
@@ -92,7 +92,11 @@ async function sendTyping(chatId) {
 
 function runAgentInSandbox(message, sessionId) {
   return new Promise((resolve) => {
-    const sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${SANDBOX}"`, { encoding: "utf-8" });
+    const sshConfig = execFileSync(
+      OPENSHELL,
+      ["sandbox", "ssh-config", SANDBOX],
+      { encoding: "utf-8" },
+    );
 
     // Write temp ssh config
     const confPath = `/tmp/nemoclaw-tg-ssh-${sessionId}.conf`;


### PR DESCRIPTION
## Summary
- Telegram bridge fails with `openshell: not found` because `~/.local/bin` isn't in PATH for child processes spawned via `nohup`
- `start-services.sh` now adds `~/.local/bin` to PATH if missing, resolves `openshell` to its absolute path via `command -v`, and exports it as `OPENSHELL_BIN`
- Bridge reads `OPENSHELL_BIN` env var (falls back to bare `openshell`)

Fixes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved startup reliability for the Telegram bridge by deterministically locating the required helper binary and ensuring user-local bin is included in PATH so child processes can find executables.
  * Exposes the resolved helper binary path to downstream processes for more consistent startup behavior.
  * Made the bridge’s retrieval of SSH configuration more robust by invoking the helper directly rather than through a shell command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->