### PR TITLE
feat: add Linux and Podman socket detection to platform.js

### DIFF
--- a/bin/lib/platform.js
+++ b/bin/lib/platform.js
@@ -55,6 +55,7 @@ function findColimaDockerSocket(opts = {}) {
 function getDockerSocketCandidates(opts = {}) {
   const home = opts.home ?? process.env.HOME ?? "/tmp";
   const platform = opts.platform ?? process.platform;
+  const uid = opts.uid ?? (process.getuid ? process.getuid() : 1000);
 
   if (platform === "darwin") {
     return [
@@ -63,7 +64,15 @@ function getDockerSocketCandidates(opts = {}) {
     ];
   }
 
-  return [];
+  // Linux (native Docker, WSL2, Podman)
+  return [
+    path.join(home, ".docker/run/docker.sock"),
+    "/run/docker.sock",
+    "/var/run/docker.sock",
+    path.join(home, ".local/share/containers/podman/machine/podman.sock"),
+    `/run/user/${uid}/podman/podman.sock`,
+    path.join(home, ".local/share/containers/podman/machine/qemu/podman.sock"),
+  ];
 }
 
 function detectDockerHost(opts = {}) {

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -50,8 +50,22 @@ describe("platform helpers", () => {
       ]);
     });
 
-    it("does not auto-detect sockets on Linux", () => {
-      assert.deepEqual(getDockerSocketCandidates({ platform: "linux", home: "/tmp/test-home" }), []);
+    it("returns Linux candidates in priority order", () => {
+      const home = "/home/test";
+      const candidates = getDockerSocketCandidates({ platform: "linux", home, uid: 1000 });
+      assert.deepEqual(candidates, [
+        path.join(home, ".docker/run/docker.sock"),
+        "/run/docker.sock",
+        "/var/run/docker.sock",
+        path.join(home, ".local/share/containers/podman/machine/podman.sock"),
+        "/run/user/1000/podman/podman.sock",
+        path.join(home, ".local/share/containers/podman/machine/qemu/podman.sock"),
+      ]);
+    });
+
+    it("uses correct uid for rootless Podman path", () => {
+      const candidates = getDockerSocketCandidates({ platform: "linux", home: "/home/test", uid: 5000 });
+      assert.ok(candidates.includes("/run/user/5000/podman/podman.sock"));
     });
   });
 
@@ -124,9 +138,118 @@ describe("platform helpers", () => {
           env: {},
           platform: "linux",
           home: "/tmp/test-home",
+          uid: 1000,
           existsSync: () => false,
         }),
         null,
+      );
+    });
+
+    it("detects native Docker socket on Linux", () => {
+      assert.deepEqual(
+        detectDockerHost({
+          env: {},
+          platform: "linux",
+          home: "/home/test",
+          uid: 1000,
+          existsSync: (p) => p === "/run/docker.sock",
+        }),
+        {
+          dockerHost: "unix:///run/docker.sock",
+          source: "socket",
+          socketPath: "/run/docker.sock",
+        },
+      );
+    });
+
+    it("detects /var/run/docker.sock fallback on Linux", () => {
+      assert.deepEqual(
+        detectDockerHost({
+          env: {},
+          platform: "linux",
+          home: "/home/test",
+          uid: 1000,
+          existsSync: (p) => p === "/var/run/docker.sock",
+        }),
+        {
+          dockerHost: "unix:///var/run/docker.sock",
+          source: "socket",
+          socketPath: "/var/run/docker.sock",
+        },
+      );
+    });
+
+    it("prefers Docker Desktop over native Linux socket", () => {
+      const home = "/home/test";
+      const ddPath = path.join(home, ".docker/run/docker.sock");
+      assert.deepEqual(
+        detectDockerHost({
+          env: {},
+          platform: "linux",
+          home,
+          uid: 1000,
+          existsSync: (p) => p === ddPath || p === "/run/docker.sock",
+        }),
+        {
+          dockerHost: `unix://${ddPath}`,
+          source: "socket",
+          socketPath: ddPath,
+        },
+      );
+    });
+
+    it("prefers native Docker over Podman on Linux", () => {
+      const home = "/home/test";
+      const podmanPath = path.join(home, ".local/share/containers/podman/machine/podman.sock");
+      assert.deepEqual(
+        detectDockerHost({
+          env: {},
+          platform: "linux",
+          home,
+          uid: 1000,
+          existsSync: (p) => p === "/run/docker.sock" || p === podmanPath,
+        }),
+        {
+          dockerHost: "unix:///run/docker.sock",
+          source: "socket",
+          socketPath: "/run/docker.sock",
+        },
+      );
+    });
+
+    it("falls back to Podman on Linux when Docker absent", () => {
+      const home = "/home/test";
+      const podmanPath = path.join(home, ".local/share/containers/podman/machine/podman.sock");
+      assert.deepEqual(
+        detectDockerHost({
+          env: {},
+          platform: "linux",
+          home,
+          uid: 1000,
+          existsSync: (p) => p === podmanPath,
+        }),
+        {
+          dockerHost: `unix://${podmanPath}`,
+          source: "socket",
+          socketPath: podmanPath,
+        },
+      );
+    });
+
+    it("detects rootless Podman on Linux", () => {
+      assert.deepEqual(
+        detectDockerHost({
+          env: {},
+          platform: "linux",
+          home: "/home/test",
+          uid: 1001,
+          existsSync: (p) => p === "/run/user/1001/podman/podman.sock",
+        }),
+        {
+          dockerHost: "unix:///run/user/1001/podman/podman.sock",
+          source: "socket",
+          socketPath: "/run/user/1001/podman/podman.sock",
+        },
       );
     });
   });


### PR DESCRIPTION
## Summary

The `platform.js` module introduced in #295 provides socket detection for macOS (Colima and Docker Desktop) but does not yet include Linux candidates — `getDockerSocketCandidates()` returns an empty array on non-Darwin platforms. This means `detectDockerHost()` relies entirely on `DOCKER_HOST` being pre-set on Linux, WSL2, and Podman environments.

This adds the standard Linux socket paths and Podman support to complete cross-platform coverage.

Addresses #137

### Changes

**`bin/lib/platform.js`** — Extend `getDockerSocketCandidates()` for Linux with:
- `~/.docker/run/docker.sock` (Docker Desktop for Linux)
- `/run/docker.sock` (native Docker / WSL2)
- `/var/run/docker.sock` (native Docker fallback)
- `~/.local/share/containers/podman/machine/podman.sock` (Podman machine)
- `/run/user/<uid>/podman/podman.sock` (rootless Podman)
- `~/.local/share/containers/podman/machine/qemu/podman.sock` (Podman QEMU)

Priority: Docker Desktop > native Docker > Podman

**`test/platform.test.js`** — 8 new tests (1 upstream test replaced), covering Linux candidate list, UID substitution, native Docker detection, /var/run fallback, Docker Desktop > native priority, native > Podman priority, Podman fallback, and rootless Podman.

## Test plan

### Automated Tests
```
node --test test/platform.test.js
```

22 tests (15 existing, 1 replaced, 8 added). All pass.