### PR TITLE
security: add binaries restriction to all policy presets and base telegram entry

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -165,3 +165,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/bot*/**" }
           - allow: { method: POST, path: "/bot*/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/discord.yaml
+++ b/nemoclaw-blueprint/policies/presets/discord.yaml
@@ -32,3 +32,5 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/docker.yaml
+++ b/nemoclaw-blueprint/policies/presets/docker.yaml
@@ -41,3 +41,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/huggingface.yaml
+++ b/nemoclaw-blueprint/policies/presets/huggingface.yaml
@@ -32,3 +32,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/jira.yaml
+++ b/nemoclaw-blueprint/policies/presets/jira.yaml
@@ -33,3 +33,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/npm.yaml
+++ b/nemoclaw-blueprint/policies/presets/npm.yaml
@@ -23,3 +23,6 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/npm }

--- a/nemoclaw-blueprint/policies/presets/outlook.yaml
+++ b/nemoclaw-blueprint/policies/presets/outlook.yaml
@@ -41,3 +41,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/pypi.yaml
+++ b/nemoclaw-blueprint/policies/presets/pypi.yaml
@@ -23,3 +23,7 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/pip }
+      - { path: /usr/bin/pip3 }

--- a/nemoclaw-blueprint/policies/presets/slack.yaml
+++ b/nemoclaw-blueprint/policies/presets/slack.yaml
@@ -33,3 +33,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/telegram.yaml
+++ b/nemoclaw-blueprint/policies/presets/telegram.yaml
@@ -17,3 +17,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/bot*/**" }
           - allow: { method: POST, path: "/bot*/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }


### PR DESCRIPTION
## Summary

Fixes #272 — all 9 policy presets and the base policy `telegram` entry are missing `binaries:` restrictions. Without this field, any binary inside the sandbox (`curl`, `python3`, `node`) can directly communicate with allowed endpoints, bypassing openclaw's tool control and audit logging.

An attacker exploiting prompt injection can supply their own API credentials (e.g. their own Telegram bot token, Slack webhook URL) and use the already-permitted network path to exfiltrate sandbox data — without needing any credentials from the victim.

## Changes

Added `binaries:` field to:

| File | Allowed binaries |
|---|---|
| `openclaw-sandbox.yaml` (telegram) | `openclaw` |
| `presets/discord.yaml` | `openclaw` |
| `presets/docker.yaml` | `openclaw` |
| `presets/huggingface.yaml` | `openclaw` |
| `presets/jira.yaml` | `openclaw` |
| `presets/npm.yaml` | `openclaw`, `npm` |
| `presets/outlook.yaml` | `openclaw` |
| `presets/pypi.yaml` | `openclaw`, `pip`, `pip3` |
| `presets/slack.yaml` | `openclaw` |
| `presets/telegram.yaml` | `openclaw` |

This matches the pattern already used by `claude_code`, `nvidia`, `clawhub`, `openclaw_api`, `openclaw_docs`, and `npm_registry` entries in the base policy.

## Test plan

- [ ] Apply a preset (e.g. slack) and verify `openclaw` can still reach the endpoint
- [ ] Verify `curl` / `python3` direct requests to the same endpoint are blocked
- [ ] Verify `npm install` still works with the npm preset applied
- [ ] Verify `pip install` still works with the pypi preset applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated policy configurations across multiple integration presets (Discord, Docker, HuggingFace, Jira, npm, Outlook, PyPI, Slack, Telegram) with executable path definitions to enhance policy enforcement consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->