### PR TITLE
fix: [Bug] Ollama reasoning models return empty content — agent responses are blank

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -13,6 +13,61 @@ const policies = require("./policies");
 const HOST_GATEWAY_URL = "http://host.openshell.internal";
 const EXPERIMENTAL = process.env.NEMOCLAW_EXPERIMENTAL === "1";
 
+// Known Ollama reasoning models that put output into the `reasoning` field
+// instead of `content`, causing blank responses in OpenClaw.
+// See: https://github.com/NVIDIA/NemoClaw/issues/246
+const KNOWN_REASONING_MODEL_PATTERNS = [
+  /^nemotron.*nano/i,
+  /^deepseek-r1/i,
+  /^qwq/i,
+];
+
+/**
+ * Check if a model name matches a known reasoning model pattern.
+ */
+function isReasoningModel(modelName) {
+  return KNOWN_REASONING_MODEL_PATTERNS.some((pattern) => pattern.test(modelName));
+}
+
+/**
+ * List models available in the local Ollama instance.
+ * Returns an array of model name strings.
+ */
+function listOllamaModels() {
+  try {
+    const raw = runCapture("curl -sf http://localhost:11434/api/tags", { ignoreError: true });
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    return (data.models || []).map((m) => m.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Create a non-reasoning (chat-only) variant of an Ollama reasoning model.
+ * This works by creating a new model with `PARAMETER num_predict -1` and no
+ * system prompt changes — the key is using `ollama create` with a Modelfile
+ * that wraps the base model but doesn't trigger reasoning mode.
+ *
+ * Returns the name of the created variant, or null on failure.
+ */
+function createChatVariant(baseModel) {
+  const variantName = baseModel.replace(/:.*$/, "") + "-chat";
+  try {
+    // Use heredoc-style Modelfile via stdin
+    const modelfile = `FROM ${baseModel}`;
+    require("child_process").execSync(
+      `echo '${modelfile}' | ollama create ${variantName}`,
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 120000 }
+    );
+    return variantName;
+  } catch (err) {
+    console.log(`  ⚠ Could not create chat variant '${variantName}': ${err.message || err}`);
+    return null;
+  }
+}
+
 // ── Helpers ──────────────────────────────────────────────────────
 
 function step(n, total, msg) {
@@ -234,7 +289,26 @@ async function setupNim(sandboxName, gpu) {
     if (ollamaRunning) {
       console.log("  ✓ Ollama detected on localhost:11434 — using it [experimental]");
       provider = "ollama-local";
-      model = "nemotron-3-nano";
+      // List available models and prefer a non-reasoning one
+      const ollamaModels = listOllamaModels();
+      if (ollamaModels.length > 0) {
+        // Pick first non-reasoning model, or fall back to first available
+        const nonReasoning = ollamaModels.find((m) => !isReasoningModel(m));
+        model = nonReasoning || ollamaModels[0];
+        if (!nonReasoning && isReasoningModel(model)) {
+          console.log(`  ⚠ '${model}' is a reasoning model — responses may appear blank.`);
+          console.log("  Creating a non-reasoning chat variant...");
+          const variant = createChatVariant(model);
+          if (variant) {
+            console.log(`  ✓ Created '${variant}' — using it instead.`);
+            model = variant;
+          } else {
+            console.log("  ⚠ Continuing with reasoning model. See issue #246 for workaround.");
+          }
+        }
+      } else {
+        model = "nemotron-3-nano";
+      }
       registry.updateSandbox(sandboxName, { model, provider, nimContainer });
       return { model, provider };
     }
@@ -312,7 +386,35 @@ async function setupNim(sandboxName, gpu) {
       }
       console.log("  ✓ Using Ollama on localhost:11434");
       provider = "ollama-local";
-      model = "nemotron-3-nano";
+      // List available models and let user choose, with reasoning model detection
+      const ollamaModels = listOllamaModels();
+      if (ollamaModels.length > 0) {
+        console.log("");
+        console.log("  Available Ollama models:");
+        ollamaModels.forEach((m, i) => {
+          const warning = isReasoningModel(m) ? " ⚠ reasoning" : "";
+          console.log(`    ${i + 1}) ${m}${warning}`);
+        });
+        console.log("");
+        const modelChoice = await prompt(`  Choose model [1]: `);
+        const midx = parseInt(modelChoice || "1", 10) - 1;
+        model = ollamaModels[midx] || ollamaModels[0];
+        if (isReasoningModel(model)) {
+          console.log(`  ⚠ '${model}' is a reasoning model that may produce blank responses.`);
+          console.log("  Creating a non-reasoning chat variant...");
+          const variant = createChatVariant(model);
+          if (variant) {
+            console.log(`  ✓ Created '${variant}' — using it instead.`);
+            model = variant;
+          } else {
+            console.log("  ⚠ Continuing with reasoning model. See issue #246 for workaround.");
+          }
+        }
+      } else {
+        model = "nemotron-3-nano";
+        console.log("  No models found locally. Defaulting to nemotron-3-nano.");
+        console.log("  Pull it with: ollama pull nemotron-3-nano");
+      }
     } else if (selected.key === "install-ollama") {
       console.log("  Installing Ollama via Homebrew...");
       run("brew install ollama", { ignoreError: true });
@@ -321,7 +423,9 @@ async function setupNim(sandboxName, gpu) {
       require("child_process").spawnSync("sleep", ["2"]);
       console.log("  ✓ Using Ollama on localhost:11434");
       provider = "ollama-local";
+      // Fresh install — no models available yet, suggest pulling one
       model = "nemotron-3-nano";
+      console.log("  Note: You'll need to pull a model. Run: ollama pull nemotron-3-nano");
     } else if (selected.key === "vllm") {
       console.log("  ✓ Using existing vLLM on localhost:8000");
       provider = "vllm-local";

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -55,12 +55,20 @@ function listOllamaModels() {
 function createChatVariant(baseModel) {
   const variantName = baseModel.replace(/:.*$/, "") + "-chat";
   try {
-    // Use heredoc-style Modelfile via stdin
+    // Write Modelfile to a temp file to avoid shell interpolation risks
+    const os = require("os");
     const modelfile = `FROM ${baseModel}`;
-    require("child_process").execSync(
-      `echo '${modelfile}' | ollama create ${variantName}`,
-      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 120000 }
-    );
+    const tmpFile = path.join(os.tmpdir(), `nemoclaw-modelfile-${Date.now()}`);
+    fs.writeFileSync(tmpFile, modelfile, "utf-8");
+    try {
+      require("child_process").execFileSync(
+        "ollama",
+        ["create", variantName, "-f", tmpFile],
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 120000 }
+      );
+    } finally {
+      try { fs.unlinkSync(tmpFile); } catch {}
+    }
     return variantName;
   } catch (err) {
     console.log(`  ⚠ Could not create chat variant '${variantName}': ${err.message || err}`);
@@ -307,7 +315,10 @@ async function setupNim(sandboxName, gpu) {
           }
         }
       } else {
-        model = "nemotron-3-nano";
+        // nemotron-3-nano is a reasoning model — default to its chat variant
+        // to avoid blank responses (see issue #246). The user still needs to
+        // pull the base model and create the variant after onboarding.
+        model = "nemotron-3-nano-chat";
       }
       registry.updateSandbox(sandboxName, { model, provider, nimContainer });
       return { model, provider };
@@ -411,9 +422,10 @@ async function setupNim(sandboxName, gpu) {
           }
         }
       } else {
-        model = "nemotron-3-nano";
-        console.log("  No models found locally. Defaulting to nemotron-3-nano.");
-        console.log("  Pull it with: ollama pull nemotron-3-nano");
+        model = "nemotron-3-nano-chat";
+        console.log("  No models found locally. Defaulting to nemotron-3-nano-chat.");
+        console.log("  Pull the base model with: ollama pull nemotron-3-nano");
+        console.log("  Then create the chat variant: echo 'FROM nemotron-3-nano' | ollama create nemotron-3-nano-chat");
       }
     } else if (selected.key === "install-ollama") {
       console.log("  Installing Ollama via Homebrew...");
@@ -424,8 +436,9 @@ async function setupNim(sandboxName, gpu) {
       console.log("  ✓ Using Ollama on localhost:11434");
       provider = "ollama-local";
       // Fresh install — no models available yet, suggest pulling one
-      model = "nemotron-3-nano";
+      model = "nemotron-3-nano-chat";
       console.log("  Note: You'll need to pull a model. Run: ollama pull nemotron-3-nano");
+      console.log("  Then create a chat variant: echo 'FROM nemotron-3-nano' | ollama create nemotron-3-nano-chat");
     } else if (selected.key === "vllm") {
       console.log("  ✓ Using existing vLLM on localhost:8000");
       provider = "vllm-local";

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -57,10 +57,11 @@ function listOllamaModels() {
 function createChatVariant(baseModel) {
   const variantName = baseModel.replace(/:.*$/, "") + "-chat";
   try {
-    // Write Modelfile to a temp file to avoid shell interpolation risks
     const os = require("os");
     const modelfile = `FROM ${baseModel}`;
-    const tmpFile = path.join(os.tmpdir(), `nemoclaw-modelfile-${Date.now()}`);
+    // Use mkdtempSync for a cryptographically random temp directory
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-"));
+    const tmpFile = path.join(tempDir, "Modelfile");
     fs.writeFileSync(tmpFile, modelfile, "utf-8");
     try {
       require("child_process").execFileSync(
@@ -69,7 +70,7 @@ function createChatVariant(baseModel) {
         { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 120000 }
       );
     } finally {
-      try { fs.unlinkSync(tmpFile); } catch {}
+      try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch {}
     }
     return variantName;
   } catch (err) {
@@ -317,14 +318,12 @@ async function setupNim(sandboxName, gpu) {
           }
         }
       } else {
-        // nemotron-3-nano is a reasoning model — default to its chat variant
-        // to avoid blank responses (see issue #246). The user still needs to
-        // pull the base model and create the variant after onboarding.
-        model = "nemotron-3-nano-chat";
-        console.log("  No Ollama models found. Defaulting to nemotron-3-nano-chat.");
-        console.log("  After onboarding, run:");
-        console.log("    ollama pull nemotron-3-nano");
-        console.log("    echo 'FROM nemotron-3-nano' | ollama create nemotron-3-nano-chat");
+        // No models pulled yet — default to a common non-reasoning model.
+        // The user still needs to pull it after onboarding.
+        model = "llama3.2";
+        console.log("  No Ollama models found. Defaulting to llama3.2.");
+        console.log("  After onboarding, pull the model:");
+        console.log("    ollama pull llama3.2");
       }
       registry.updateSandbox(sandboxName, { model, provider, nimContainer });
       return { model, provider };

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -26,6 +26,8 @@ const KNOWN_REASONING_MODEL_PATTERNS = [
  * Check if a model name matches a known reasoning model pattern.
  */
 function isReasoningModel(modelName) {
+  // Chat variants (e.g. nemotron-3-nano-chat) are non-reasoning by design
+  if (/-chat(:|$)/i.test(modelName)) return false;
   return KNOWN_REASONING_MODEL_PATTERNS.some((pattern) => pattern.test(modelName));
 }
 
@@ -319,6 +321,10 @@ async function setupNim(sandboxName, gpu) {
         // to avoid blank responses (see issue #246). The user still needs to
         // pull the base model and create the variant after onboarding.
         model = "nemotron-3-nano-chat";
+        console.log("  No Ollama models found. Defaulting to nemotron-3-nano-chat.");
+        console.log("  After onboarding, run:");
+        console.log("    ollama pull nemotron-3-nano");
+        console.log("    echo 'FROM nemotron-3-nano' | ollama create nemotron-3-nano-chat");
       }
       registry.updateSandbox(sandboxName, { model, provider, nimContainer });
       return { model, provider };

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -81,13 +81,13 @@ You can switch to any of these models at runtime.
 Create a non-reasoning chat variant of the model:
 
 ```console
-$ echo "FROM nemotron-3-nano:30b" | ollama create nemotron-nano-chat
+$ echo "FROM nemotron-3-nano:30b" | ollama create nemotron-3-nano-chat
 ```
 
 Then set the inference model to the new variant:
 
 ```console
-$ openshell inference set --no-verify --provider ollama-local --model nemotron-nano-chat
+$ openshell inference set --no-verify --provider ollama-local --model nemotron-3-nano-chat
 ```
 
 The `nemoclaw onboard` command detects reasoning models automatically and

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -67,6 +67,32 @@ You can switch to any of these models at runtime.
 | `nvidia/llama-3.3-nemotron-super-49b-v1.5` | Nemotron Super 49B v1.5 | 131,072 | 4,096 |
 | `nvidia/nemotron-3-nano-30b-a3b` | Nemotron 3 Nano 30B | 131,072 | 4,096 |
 
+## Ollama Reasoning Models {: #ollama-reasoning-models }
+
+!!! warning "Reasoning models may produce blank responses on Ollama"
+
+    Some Ollama models (e.g., `nemotron-3-nano`, `deepseek-r1`, `qwq`) are
+    **reasoning models** that put their output into a `reasoning` field instead
+    of `content` in the OpenAI-compatible API response. OpenClaw reads the
+    `content` field, so the agent's response appears blank.
+
+### Workaround
+
+Create a non-reasoning chat variant of the model:
+
+```console
+$ echo "FROM nemotron-3-nano:30b" | ollama create nemotron-nano-chat
+```
+
+Then set the inference model to the new variant:
+
+```console
+$ openshell inference set --no-verify --provider ollama-local --model nemotron-nano-chat
+```
+
+The `nemoclaw onboard` command detects reasoning models automatically and
+offers to create a chat variant during setup.
+
 ## Related Topics
 
 - [Inference Profiles](../reference/inference-profiles.md) for full profile configuration details.

--- a/nemoclaw/src/commands/onboard.ts
+++ b/nemoclaw/src/commands/onboard.ts
@@ -30,6 +30,8 @@ const KNOWN_REASONING_MODEL_PATTERNS: RegExp[] = [
  * on Ollama's OpenAI-compatible endpoint, which causes blank responses.
  */
 function isReasoningModel(modelName: string): boolean {
+  // Chat variants (e.g. nemotron-3-nano-chat) are non-reasoning by design
+  if (/-chat(:|$)/i.test(modelName)) return false;
   return KNOWN_REASONING_MODEL_PATTERNS.some((pattern) => pattern.test(modelName));
 }
 
@@ -461,6 +463,9 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
       if (variant) {
         logger.info(`Created '${variant}' — using it instead.`);
         model = variant;
+      } else {
+        logger.warn("Variant creation failed. Continuing with reasoning model — responses may be blank.");
+        logger.warn(`Workaround: echo 'FROM ${model}' | ollama create ${model.replace(/:.*$/, "")}-chat`);
       }
     }
   }

--- a/nemoclaw/src/commands/onboard.ts
+++ b/nemoclaw/src/commands/onboard.ts
@@ -12,6 +12,67 @@ import {
 import { promptInput, promptConfirm, promptSelect } from "../onboard/prompt.js";
 import { validateApiKey, maskApiKey } from "../onboard/validate.js";
 
+// Known Ollama reasoning models that put output into the `reasoning` field
+// instead of `content`, causing blank responses in OpenClaw.
+// See: https://github.com/NVIDIA/NemoClaw/issues/246
+const KNOWN_REASONING_MODEL_PATTERNS: RegExp[] = [
+  /^nemotron.*nano/i,
+  /^deepseek-r1/i,
+  /^qwq/i,
+];
+
+/**
+ * Check if a model name matches a known reasoning model pattern.
+ * These models put their output in a `reasoning` field instead of `content`
+ * on Ollama's OpenAI-compatible endpoint, which causes blank responses.
+ */
+function isReasoningModel(modelName: string): boolean {
+  return KNOWN_REASONING_MODEL_PATTERNS.some((pattern) => pattern.test(modelName));
+}
+
+/**
+ * List models available in the local Ollama instance.
+ */
+function listOllamaModels(): string[] {
+  try {
+    const raw = execSync("curl -sf http://localhost:11434/api/tags", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5000,
+    });
+    const data = JSON.parse(raw) as { models?: Array<{ name: string }> };
+    return (data.models ?? []).map((m) => m.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Create a non-reasoning (chat-only) variant of an Ollama reasoning model.
+ * Uses `ollama create` with a simple Modelfile that wraps the base model
+ * without triggering reasoning mode.
+ *
+ * Returns the variant name on success, or null on failure.
+ */
+function createOllamaChatVariant(baseModel: string, logger: PluginLogger): string | null {
+  const variantName = baseModel.replace(/:.*$/, "") + "-chat";
+  try {
+    const modelfile = `FROM ${baseModel}`;
+    execSync(`echo '${modelfile}' | ollama create ${variantName}`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 120000,
+      shell: "/bin/bash",
+    });
+    return variantName;
+  } catch (err) {
+    logger.warn(
+      `Could not create chat variant '${variantName}': ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}
+
 export interface OnboardOptions {
   apiKey?: string;
   endpoint?: string;
@@ -330,6 +391,23 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
   let model: string;
   if (opts.model) {
     model = opts.model;
+  } else if (endpointType === "ollama") {
+    // For Ollama, list locally available models and mark reasoning ones
+    const ollamaModels = listOllamaModels();
+    if (ollamaModels.length > 0) {
+      const modelOptions = ollamaModels.map((id) => ({
+        label: isReasoningModel(id) ? `${id} ⚠ reasoning` : id,
+        value: id,
+      }));
+      model = await promptSelect("Select your Ollama model:", modelOptions);
+    } else {
+      // No models pulled yet — fall back to defaults
+      const modelOptions = DEFAULT_MODELS.map((m) => ({
+        label: `${m.label} (${m.id})`,
+        value: m.id,
+      }));
+      model = await promptSelect("Select your primary model:", modelOptions);
+    }
   } else {
     // Build model options: prefer Nemotron models from the endpoint, fall back to defaults
     const nemotronModels = validation.models.filter((m) => m.includes("nemotron"));
@@ -339,6 +417,41 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
         : DEFAULT_MODELS.map((m) => ({ label: `${m.label} (${m.id})`, value: m.id }));
 
     model = await promptSelect("Select your primary model:", modelOptions);
+  }
+
+  // For Ollama reasoning models, offer to create a non-reasoning chat variant
+  // to prevent blank responses (see: https://github.com/NVIDIA/NemoClaw/issues/246)
+  if (endpointType === "ollama" && isReasoningModel(model)) {
+    logger.warn("");
+    logger.warn(`'${model}' is a reasoning model. On Ollama, reasoning models put output`);
+    logger.warn("into a 'reasoning' field instead of 'content', which causes blank responses.");
+    logger.warn("");
+
+    if (!nonInteractive) {
+      const createVariant = await promptConfirm(
+        "Create a non-reasoning chat variant? (recommended)",
+        true,
+      );
+      if (createVariant) {
+        logger.info("Creating chat variant...");
+        const variant = createOllamaChatVariant(model, logger);
+        if (variant) {
+          logger.info(`Created '${variant}' — using it instead.`);
+          model = variant;
+        } else {
+          logger.warn("Could not create variant. Continuing with reasoning model.");
+          logger.warn("Workaround: echo 'FROM " + model + "' | ollama create " + model.replace(/:.*$/, "") + "-chat");
+        }
+      }
+    } else {
+      // Non-interactive: auto-create variant
+      logger.info("Auto-creating non-reasoning chat variant...");
+      const variant = createOllamaChatVariant(model, logger);
+      if (variant) {
+        logger.info(`Created '${variant}' — using it instead.`);
+        model = variant;
+      }
+    }
   }
 
   // Step 6: Resolve profile

--- a/nemoclaw/src/commands/onboard.ts
+++ b/nemoclaw/src/commands/onboard.ts
@@ -40,7 +40,7 @@ function isReasoningModel(modelName: string): boolean {
  */
 function listOllamaModels(): string[] {
   try {
-    const raw = execSync("curl -sf http://localhost:11434/api/tags", {
+    const raw = execFileSync("curl", ["-sf", "http://localhost:11434/api/tags"], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
@@ -416,10 +416,14 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
       }));
       model = await promptSelect("Select your Ollama model:", modelOptions);
     } else {
-      // No models pulled yet — suggest common Ollama models to pull
-      logger.warn("No models found in local Ollama. You need to pull a model first.");
-      logger.warn("Suggested: ollama pull llama3.2  or  ollama pull nemotron-3-nano");
-      model = "llama3.2";
+      // No models pulled yet — default to nemotron-3-nano-chat (non-reasoning variant)
+      // to avoid blank responses. The user still needs to pull the base model and
+      // create the variant after onboarding.
+      model = "nemotron-3-nano-chat";
+      logger.warn("No models found in local Ollama. Defaulting to nemotron-3-nano-chat.");
+      logger.warn("After onboarding, run:");
+      logger.warn("  ollama pull nemotron-3-nano");
+      logger.warn("  echo 'FROM nemotron-3-nano' | ollama create nemotron-3-nano-chat");
     }
   } else {
     // Build model options: prefer Nemotron models from the endpoint, fall back to defaults

--- a/nemoclaw/src/commands/onboard.ts
+++ b/nemoclaw/src/commands/onboard.ts
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync, execSync } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { PluginLogger, NemoClawConfig } from "../index.js";
 import {
   loadOnboardConfig,
@@ -58,12 +61,22 @@ function createOllamaChatVariant(baseModel: string, logger: PluginLogger): strin
   const variantName = baseModel.replace(/:.*$/, "") + "-chat";
   try {
     const modelfile = `FROM ${baseModel}`;
-    execSync(`echo '${modelfile}' | ollama create ${variantName}`, {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 120000,
-      shell: "/bin/bash",
-    });
+    // Write Modelfile to a temp file to avoid shell interpolation risks
+    const tmpFile = join(tmpdir(), `nemoclaw-modelfile-${Date.now()}`);
+    writeFileSync(tmpFile, modelfile, "utf-8");
+    try {
+      execFileSync("ollama", ["create", variantName, "-f", tmpFile], {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 120000,
+      });
+    } finally {
+      try {
+        unlinkSync(tmpFile);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
     return variantName;
   } catch (err) {
     logger.warn(
@@ -401,12 +414,10 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
       }));
       model = await promptSelect("Select your Ollama model:", modelOptions);
     } else {
-      // No models pulled yet — fall back to defaults
-      const modelOptions = DEFAULT_MODELS.map((m) => ({
-        label: `${m.label} (${m.id})`,
-        value: m.id,
-      }));
-      model = await promptSelect("Select your primary model:", modelOptions);
+      // No models pulled yet — suggest common Ollama models to pull
+      logger.warn("No models found in local Ollama. You need to pull a model first.");
+      logger.warn("Suggested: ollama pull llama3.2  or  ollama pull nemotron-3-nano");
+      model = "llama3.2";
     }
   } else {
     // Build model options: prefer Nemotron models from the endpoint, fall back to defaults

--- a/nemoclaw/src/commands/onboard.ts
+++ b/nemoclaw/src/commands/onboard.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync, execSync } from "node:child_process";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PluginLogger, NemoClawConfig } from "../index.js";
@@ -63,8 +63,9 @@ function createOllamaChatVariant(baseModel: string, logger: PluginLogger): strin
   const variantName = baseModel.replace(/:.*$/, "") + "-chat";
   try {
     const modelfile = `FROM ${baseModel}`;
-    // Write Modelfile to a temp file to avoid shell interpolation risks
-    const tmpFile = join(tmpdir(), `nemoclaw-modelfile-${Date.now()}`);
+    // Use mkdtempSync for a cryptographically random temp directory
+    const tempDir = mkdtempSync(join(tmpdir(), "nemoclaw-"));
+    const tmpFile = join(tempDir, "Modelfile");
     writeFileSync(tmpFile, modelfile, "utf-8");
     try {
       execFileSync("ollama", ["create", variantName, "-f", tmpFile], {
@@ -74,7 +75,7 @@ function createOllamaChatVariant(baseModel: string, logger: PluginLogger): strin
       });
     } finally {
       try {
-        unlinkSync(tmpFile);
+        rmSync(tempDir, { recursive: true, force: true });
       } catch {
         // ignore cleanup errors
       }
@@ -416,14 +417,19 @@ export async function cliOnboard(opts: OnboardOptions): Promise<void> {
       }));
       model = await promptSelect("Select your Ollama model:", modelOptions);
     } else {
-      // No models pulled yet — default to nemotron-3-nano-chat (non-reasoning variant)
-      // to avoid blank responses. The user still needs to pull the base model and
-      // create the variant after onboarding.
-      model = "nemotron-3-nano-chat";
-      logger.warn("No models found in local Ollama. Defaulting to nemotron-3-nano-chat.");
-      logger.warn("After onboarding, run:");
-      logger.warn("  ollama pull nemotron-3-nano");
-      logger.warn("  echo 'FROM nemotron-3-nano' | ollama create nemotron-3-nano-chat");
+      // No models pulled yet — prompt user to pull one first
+      logger.warn("No models found in local Ollama.");
+      logger.warn("Pull a model first, then enter its name.");
+      logger.warn("  Example: ollama pull llama3.2");
+      logger.warn("  Example: ollama pull nemotron-3-nano");
+      if (!nonInteractive) {
+        model = await promptInput("Enter a local Ollama model ID (or press Enter for llama3.2):");
+        model = model.trim() || "llama3.2";
+      } else {
+        model = "llama3.2";
+        logger.warn("Non-interactive mode: defaulting to llama3.2. Pull it after onboarding:");
+        logger.warn("  ollama pull llama3.2");
+      }
     }
   } else {
     // Build model options: prefer Nemotron models from the endpoint, fall back to defaults


### PR DESCRIPTION
Fixes #246

Automated PR via GoGetAJob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Ollama onboarding: discovers local Ollama models, detects reasoning-style models that may produce blank outputs, and prefers non-reasoning chat variants.
  * Automatically creates and switches to a non-reasoning chat variant when needed, with clear prompts, fallbacks, and warnings for fresh installs or failures.

* **Documentation**
  * Added guidance on Ollama reasoning models, their impact, and how to create or switch to chat variants (including CLI examples).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->