### PR TITLE
test: add unit tests for onboard, logs, and connect modules

### DIFF
--- a/nemoclaw/src/commands/connect.test.ts
+++ b/nemoclaw/src/commands/connect.test.ts
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginLogger } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+// Import after mocks are set up
+const { spawn } = await import("node:child_process");
+const { cliConnect } = await import("./connect.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function captureLogger(): { lines: string[]; logger: PluginLogger } {
+  const lines: string[] = [];
+  return {
+    lines,
+    logger: {
+      info: (msg: string) => lines.push(msg),
+      warn: (msg: string) => lines.push(`WARN: ${msg}`),
+      error: (msg: string) => lines.push(`ERROR: ${msg}`),
+      debug: (_msg: string) => {},
+    },
+  };
+}
+
+/** Create a mock spawn that emits events. */
+function mockSpawnProc(exitCode: number | null = 0, error?: Error) {
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const proc = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+      return proc;
+    }),
+    emit: (event: string, ...args: unknown[]) => {
+      for (const h of handlers[event] ?? []) h(...args);
+    },
+  };
+
+  vi.mocked(spawn).mockReturnValue(proc as never);
+
+  // Schedule events asynchronously so the promise in cliConnect can attach listeners
+  setTimeout(() => {
+    if (error) {
+      proc.emit("error", error);
+    } else {
+      proc.emit("close", exitCode);
+    }
+  }, 0);
+
+  return proc;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("cliConnect", () => {
+  it("spawns openshell sandbox connect with correct sandbox name", async () => {
+    mockSpawnProc(0);
+
+    const { lines, logger } = captureLogger();
+    await cliConnect({ sandbox: "openclaw", logger });
+
+    expect(spawn).toHaveBeenCalledWith(
+      "openshell",
+      ["sandbox", "connect", "openclaw"],
+      { stdio: "inherit" },
+    );
+    const output = lines.join("\n");
+    expect(output).toContain("Connecting to OpenClaw sandbox: openclaw");
+    expect(output).toContain("Type 'exit' to return to your host shell");
+  });
+
+  it("uses the provided sandbox name", async () => {
+    mockSpawnProc(0);
+
+    const { logger } = captureLogger();
+    await cliConnect({ sandbox: "my-custom-sandbox", logger });
+
+    expect(spawn).toHaveBeenCalledWith(
+      "openshell",
+      ["sandbox", "connect", "my-custom-sandbox"],
+      { stdio: "inherit" },
+    );
+  });
+
+  it("logs ENOENT error when openshell is not installed", async () => {
+    mockSpawnProc(null, new Error("ENOENT: spawn openshell not found"));
+
+    const { lines, logger } = captureLogger();
+    await cliConnect({ sandbox: "openclaw", logger });
+
+    const output = lines.join("\n");
+    expect(output).toContain("openshell CLI not found");
+  });
+
+  it("logs generic error on non-ENOENT spawn failure", async () => {
+    mockSpawnProc(null, new Error("permission denied"));
+
+    const { lines, logger } = captureLogger();
+    await cliConnect({ sandbox: "openclaw", logger });
+
+    const output = lines.join("\n");
+    expect(output).toContain("Connection failed: permission denied");
+  });
+
+  it("logs exit code error on non-zero exit", async () => {
+    mockSpawnProc(127);
+
+    const { lines, logger } = captureLogger();
+    await cliConnect({ sandbox: "openclaw", logger });
+
+    const output = lines.join("\n");
+    expect(output).toContain("exited with code 127");
+    expect(output).toContain("openclaw nemoclaw status");
+  });
+
+  it("does not log error on successful exit (code 0)", async () => {
+    mockSpawnProc(0);
+
+    const { lines, logger } = captureLogger();
+    await cliConnect({ sandbox: "openclaw", logger });
+
+    const output = lines.join("\n");
+    expect(output).not.toContain("exited with code");
+    expect(output).not.toContain("ERROR:");
+  });
+
+  it("does not log error on null exit code", async () => {
+    mockSpawnProc(null);
+
+    const { lines, logger } = captureLogger();
+    await cliConnect({ sandbox: "openclaw", logger });
+
+    const output = lines.join("\n");
+    expect(output).not.toContain("exited with code");
+  });
+});

--- a/nemoclaw/src/commands/connect.test.ts
+++ b/nemoclaw/src/commands/connect.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { PluginLogger } from "../index.js";
+import { captureLogger, mockSpawnProc } from "../test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -17,51 +17,6 @@ const { spawn } = await import("node:child_process");
 const { cliConnect } = await import("./connect.js");
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function captureLogger(): { lines: string[]; logger: PluginLogger } {
-  const lines: string[] = [];
-  return {
-    lines,
-    logger: {
-      info: (msg: string) => lines.push(msg),
-      warn: (msg: string) => lines.push(`WARN: ${msg}`),
-      error: (msg: string) => lines.push(`ERROR: ${msg}`),
-      debug: (_msg: string) => {},
-    },
-  };
-}
-
-/** Create a mock spawn that emits events. */
-function mockSpawnProc(exitCode: number | null = 0, error?: Error) {
-  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-  const proc = {
-    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-      if (!handlers[event]) handlers[event] = [];
-      handlers[event].push(handler);
-      return proc;
-    }),
-    emit: (event: string, ...args: unknown[]) => {
-      for (const h of handlers[event] ?? []) h(...args);
-    },
-  };
-
-  vi.mocked(spawn).mockReturnValue(proc as never);
-
-  // Schedule events asynchronously so the promise in cliConnect can attach listeners
-  setTimeout(() => {
-    if (error) {
-      proc.emit("error", error);
-    } else {
-      proc.emit("close", exitCode);
-    }
-  }, 0);
-
-  return proc;
-}
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -71,7 +26,7 @@ beforeEach(() => {
 
 describe("cliConnect", () => {
   it("spawns openshell sandbox connect with correct sandbox name", async () => {
-    mockSpawnProc(0);
+    mockSpawnProc(vi.mocked(spawn), 0);
 
     const { lines, logger } = captureLogger();
     await cliConnect({ sandbox: "openclaw", logger });
@@ -87,7 +42,7 @@ describe("cliConnect", () => {
   });
 
   it("uses the provided sandbox name", async () => {
-    mockSpawnProc(0);
+    mockSpawnProc(vi.mocked(spawn), 0);
 
     const { logger } = captureLogger();
     await cliConnect({ sandbox: "my-custom-sandbox", logger });
@@ -100,7 +55,7 @@ describe("cliConnect", () => {
   });
 
   it("logs ENOENT error when openshell is not installed", async () => {
-    mockSpawnProc(null, new Error("ENOENT: spawn openshell not found"));
+    mockSpawnProc(vi.mocked(spawn), null, new Error("ENOENT: spawn openshell not found"));
 
     const { lines, logger } = captureLogger();
     await cliConnect({ sandbox: "openclaw", logger });
@@ -110,7 +65,7 @@ describe("cliConnect", () => {
   });
 
   it("logs generic error on non-ENOENT spawn failure", async () => {
-    mockSpawnProc(null, new Error("permission denied"));
+    mockSpawnProc(vi.mocked(spawn), null, new Error("permission denied"));
 
     const { lines, logger } = captureLogger();
     await cliConnect({ sandbox: "openclaw", logger });
@@ -120,7 +75,7 @@ describe("cliConnect", () => {
   });
 
   it("logs exit code error on non-zero exit", async () => {
-    mockSpawnProc(127);
+    mockSpawnProc(vi.mocked(spawn), 127);
 
     const { lines, logger } = captureLogger();
     await cliConnect({ sandbox: "openclaw", logger });
@@ -131,7 +86,7 @@ describe("cliConnect", () => {
   });
 
   it("does not log error on successful exit (code 0)", async () => {
-    mockSpawnProc(0);
+    mockSpawnProc(vi.mocked(spawn), 0);
 
     const { lines, logger } = captureLogger();
     await cliConnect({ sandbox: "openclaw", logger });
@@ -142,7 +97,7 @@ describe("cliConnect", () => {
   });
 
   it("does not log error on null exit code", async () => {
-    mockSpawnProc(null);
+    mockSpawnProc(vi.mocked(spawn), null);
 
     const { lines, logger } = captureLogger();
     await cliConnect({ sandbox: "openclaw", logger });

--- a/nemoclaw/src/commands/connect.test.ts
+++ b/nemoclaw/src/commands/connect.test.ts
@@ -54,7 +54,7 @@ describe("cliConnect", () => {
     );
   });
 
-  it("logs ENOENT error when openshell is not installed", async () => {
+  it("logs ENOENT error and exit guidance when openshell is not installed", async () => {
     mockSpawnProc(vi.mocked(spawn), null, new Error("ENOENT: spawn openshell not found"));
 
     const { lines, logger } = captureLogger();
@@ -62,9 +62,12 @@ describe("cliConnect", () => {
 
     const output = lines.join("\n");
     expect(output).toContain("openshell CLI not found");
+    // After spawn error, resolve(1) triggers the exit code guidance
+    expect(output).toContain("exited with code 1");
+    expect(output).toContain("openclaw nemoclaw status");
   });
 
-  it("logs generic error on non-ENOENT spawn failure", async () => {
+  it("logs generic error and exit guidance on non-ENOENT spawn failure", async () => {
     mockSpawnProc(vi.mocked(spawn), null, new Error("permission denied"));
 
     const { lines, logger } = captureLogger();
@@ -72,6 +75,9 @@ describe("cliConnect", () => {
 
     const output = lines.join("\n");
     expect(output).toContain("Connection failed: permission denied");
+    // After spawn error, resolve(1) triggers the exit code guidance
+    expect(output).toContain("exited with code 1");
+    expect(output).toContain("openclaw nemoclaw status");
   });
 
   it("logs exit code error on non-zero exit", async () => {

--- a/nemoclaw/src/commands/logs.test.ts
+++ b/nemoclaw/src/commands/logs.test.ts
@@ -3,7 +3,8 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { NemoClawState } from "../blueprint/state.js";
-import type { PluginLogger, NemoClawConfig } from "../index.js";
+import type { NemoClawConfig } from "../index.js";
+import { captureLogger, mockSpawnProc } from "../test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -47,19 +48,6 @@ const defaultConfig: NemoClawConfig = {
   inferenceProvider: "nvidia",
 };
 
-function captureLogger(): { lines: string[]; logger: PluginLogger } {
-  const lines: string[] = [];
-  return {
-    lines,
-    logger: {
-      info: (msg: string) => lines.push(msg),
-      warn: (msg: string) => lines.push(`WARN: ${msg}`),
-      error: (msg: string) => lines.push(`ERROR: ${msg}`),
-      debug: (_msg: string) => {},
-    },
-  };
-}
-
 /**
  * Make the exec mock resolve with the given stdout, or reject if error is set.
  * Routes by command substring.
@@ -85,33 +73,6 @@ function mockExec(responses: Record<string, string | Error>): void {
 }
 
 /** Create a mock spawn that emits events. */
-function mockSpawnProc(exitCode: number | null = 0, error?: Error) {
-  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-  const proc = {
-    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-      if (!handlers[event]) handlers[event] = [];
-      handlers[event].push(handler);
-      return proc;
-    }),
-    emit: (event: string, ...args: unknown[]) => {
-      for (const h of handlers[event] ?? []) h(...args);
-    },
-  };
-
-  vi.mocked(spawn).mockReturnValue(proc as never);
-
-  // Schedule events asynchronously so the promise in cliLogs can attach listeners
-  setTimeout(() => {
-    if (error) {
-      proc.emit("error", error);
-    } else {
-      proc.emit("close", exitCode);
-    }
-  }, 0);
-
-  return proc;
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -149,7 +110,7 @@ describe("cliLogs", () => {
       mockExec({
         "sandbox get": JSON.stringify({ state: "running" }),
       });
-      mockSpawnProc(0);
+      mockSpawnProc(vi.mocked(spawn), 0);
 
       const { logger } = captureLogger();
       await cliLogs({
@@ -171,7 +132,7 @@ describe("cliLogs", () => {
       mockExec({
         "sandbox get": JSON.stringify({ state: "running" }),
       });
-      mockSpawnProc(0);
+      mockSpawnProc(vi.mocked(spawn), 0);
 
       const { logger } = captureLogger();
       await cliLogs({
@@ -193,7 +154,7 @@ describe("cliLogs", () => {
       mockExec({
         "sandbox get": JSON.stringify({ state: "running" }),
       });
-      mockSpawnProc(0);
+      mockSpawnProc(vi.mocked(spawn), 0);
 
       const { logger } = captureLogger();
       await cliLogs({
@@ -286,7 +247,7 @@ describe("cliLogs", () => {
       mockExec({
         "sandbox get": JSON.stringify({ state: "running" }),
       });
-      mockSpawnProc(0);
+      mockSpawnProc(vi.mocked(spawn), 0);
 
       const { logger } = captureLogger();
       await cliLogs({
@@ -309,7 +270,7 @@ describe("cliLogs", () => {
       mockExec({
         "sandbox get": JSON.stringify({ state: "running" }),
       });
-      mockSpawnProc(null, new Error("ENOENT: openshell not found"));
+      mockSpawnProc(vi.mocked(spawn), null, new Error("ENOENT: openshell not found"));
 
       const { lines, logger } = captureLogger();
       await cliLogs({

--- a/nemoclaw/src/commands/logs.test.ts
+++ b/nemoclaw/src/commands/logs.test.ts
@@ -10,10 +10,27 @@ import { captureLogger, mockSpawnProc } from "../test-helpers.js";
 // Mocks
 // ---------------------------------------------------------------------------
 
-vi.mock("node:child_process", () => ({
-  exec: vi.fn(),
-  spawn: vi.fn(),
-}));
+vi.mock("node:child_process", async () => {
+  const { promisify } = await import("node:util");
+  const execFn = vi.fn();
+  // Attach a custom promisify that mirrors the real exec behaviour:
+  // the raw callback uses (err, stdout, stderr); promisify folds them
+  // into { stdout, stderr } just like the real Node implementation.
+  Object.defineProperty(execFn, promisify.custom, {
+    value: (...args: unknown[]) =>
+      new Promise((resolve, reject) => {
+        (execFn as Function)(...args, (err: Error | null, stdout: string, stderr: string) => {
+          if (err) {
+            Object.assign(err, { stdout, stderr });
+            reject(err);
+          } else {
+            resolve({ stdout, stderr });
+          }
+        });
+      }),
+  });
+  return { exec: execFn, spawn: vi.fn() };
+});
 
 vi.mock("../blueprint/state.js", () => ({
   loadState: vi.fn(),
@@ -51,24 +68,29 @@ const defaultConfig: NemoClawConfig = {
 /**
  * Make the exec mock resolve with the given stdout, or reject if error is set.
  * Routes by command substring.
+ *
+ * Uses the real Node `exec` callback signature `(err, stdout, stderr)` so that
+ * `util.promisify(exec)` — which is what production code calls — receives
+ * the three positional arguments it expects before folding them into
+ * `{ stdout, stderr }`.
  */
 function mockExec(responses: Record<string, string | Error>): void {
   vi.mocked(exec).mockImplementation(((
     cmd: string,
     _opts: unknown,
-    callback?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    callback?: (err: Error | null, stdout: string, stderr: string) => void,
   ) => {
     for (const [substring, response] of Object.entries(responses)) {
       if (cmd.includes(substring)) {
         if (response instanceof Error) {
-          callback?.(response, { stdout: "", stderr: response.message });
+          callback?.(response, "", response.message);
         } else {
-          callback?.(null, { stdout: response, stderr: "" });
+          callback?.(null, response, "");
         }
         return;
       }
     }
-    callback?.(new Error(`command not found: ${cmd}`), { stdout: "", stderr: "" });
+    callback?.(new Error(`command not found: ${cmd}`), "", "");
   }) as typeof exec);
 }
 

--- a/nemoclaw/src/commands/logs.test.ts
+++ b/nemoclaw/src/commands/logs.test.ts
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NemoClawState } from "../blueprint/state.js";
+import type { PluginLogger, NemoClawConfig } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("../blueprint/state.js", () => ({
+  loadState: vi.fn(),
+}));
+
+// Import after mocks are set up
+const { exec, spawn } = await import("node:child_process");
+const { loadState } = await import("../blueprint/state.js");
+const { cliLogs } = await import("./logs.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function blankState(): NemoClawState {
+  return {
+    lastRunId: null,
+    lastAction: null,
+    blueprintVersion: null,
+    sandboxName: null,
+    migrationSnapshot: null,
+    hostBackupPath: null,
+    createdAt: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+const defaultConfig: NemoClawConfig = {
+  blueprintVersion: "latest",
+  blueprintRegistry: "ghcr.io/nvidia/nemoclaw-blueprint",
+  sandboxName: "openclaw",
+  inferenceProvider: "nvidia",
+};
+
+function captureLogger(): { lines: string[]; logger: PluginLogger } {
+  const lines: string[] = [];
+  return {
+    lines,
+    logger: {
+      info: (msg: string) => lines.push(msg),
+      warn: (msg: string) => lines.push(`WARN: ${msg}`),
+      error: (msg: string) => lines.push(`ERROR: ${msg}`),
+      debug: (_msg: string) => {},
+    },
+  };
+}
+
+/**
+ * Make the exec mock resolve with the given stdout, or reject if error is set.
+ * Routes by command substring.
+ */
+function mockExec(responses: Record<string, string | Error>): void {
+  vi.mocked(exec).mockImplementation(((
+    cmd: string,
+    _opts: unknown,
+    callback?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    for (const [substring, response] of Object.entries(responses)) {
+      if (cmd.includes(substring)) {
+        if (response instanceof Error) {
+          callback?.(response, { stdout: "", stderr: response.message });
+        } else {
+          callback?.(null, { stdout: response, stderr: "" });
+        }
+        return;
+      }
+    }
+    callback?.(new Error(`command not found: ${cmd}`), { stdout: "", stderr: "" });
+  }) as typeof exec);
+}
+
+/** Create a mock spawn that emits events. */
+function mockSpawnProc(exitCode: number | null = 0, error?: Error) {
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const proc = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+      return proc;
+    }),
+    emit: (event: string, ...args: unknown[]) => {
+      for (const h of handlers[event] ?? []) h(...args);
+    },
+  };
+
+  vi.mocked(spawn).mockReturnValue(proc as never);
+
+  // Schedule events asynchronously so the promise in cliLogs can attach listeners
+  setTimeout(() => {
+    if (error) {
+      proc.emit("error", error);
+    } else {
+      proc.emit("close", exitCode);
+    }
+  }, 0);
+
+  return proc;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(loadState).mockReturnValue(blankState());
+  mockExec({});
+});
+
+describe("cliLogs", () => {
+  describe("sandbox not running", () => {
+    it("shows 'not running' message when sandbox is not active", async () => {
+      mockExec({
+        "sandbox get": new Error("not found"),
+      });
+
+      const { lines, logger } = captureLogger();
+      await cliLogs({
+        follow: false,
+        lines: 50,
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      const output = lines.join("\n");
+      expect(output).toContain("not running");
+      expect(output).toContain("No live logs available");
+      expect(spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sandbox running", () => {
+    it("spawns openshell with correct args for basic log viewing", async () => {
+      mockExec({
+        "sandbox get": JSON.stringify({ state: "running" }),
+      });
+      mockSpawnProc(0);
+
+      const { logger } = captureLogger();
+      await cliLogs({
+        follow: false,
+        lines: 50,
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      expect(spawn).toHaveBeenCalledWith(
+        "openshell",
+        ["sandbox", "connect", "openclaw", "--", "tail", "-n", "50",
+         "/tmp/nemoclaw.log", "/tmp/openclaw.log"],
+        { stdio: ["ignore", "inherit", "inherit"] },
+      );
+    });
+
+    it("adds -f flag when --follow is set", async () => {
+      mockExec({
+        "sandbox get": JSON.stringify({ state: "running" }),
+      });
+      mockSpawnProc(0);
+
+      const { logger } = captureLogger();
+      await cliLogs({
+        follow: true,
+        lines: 100,
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      expect(spawn).toHaveBeenCalledWith(
+        "openshell",
+        ["sandbox", "connect", "openclaw", "--", "tail", "-f", "-n", "100",
+         "/tmp/nemoclaw.log", "/tmp/openclaw.log"],
+        { stdio: ["ignore", "inherit", "inherit"] },
+      );
+    });
+
+    it("sets -n value from --lines flag", async () => {
+      mockExec({
+        "sandbox get": JSON.stringify({ state: "running" }),
+      });
+      mockSpawnProc(0);
+
+      const { logger } = captureLogger();
+      await cliLogs({
+        follow: false,
+        lines: 200,
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      expect(spawn).toHaveBeenCalledWith(
+        "openshell",
+        expect.arrayContaining(["-n", "200"]),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("--run-id / state run info", () => {
+    it("shows run info from state when runId is provided", async () => {
+      vi.mocked(loadState).mockReturnValue({
+        ...blankState(),
+        lastRunId: "run-abc123",
+        lastAction: "migrate",
+      });
+      mockExec({
+        "sandbox get": new Error("not found"),
+      });
+
+      const { lines, logger } = captureLogger();
+      await cliLogs({
+        follow: false,
+        lines: 50,
+        runId: "run-custom-id",
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      const output = lines.join("\n");
+      expect(output).toContain("Blueprint run: run-custom-id");
+      expect(output).toContain("Action: migrate");
+    });
+
+    it("shows last run from state when no runId is provided", async () => {
+      vi.mocked(loadState).mockReturnValue({
+        ...blankState(),
+        lastRunId: "run-from-state",
+        lastAction: "deploy",
+      });
+      mockExec({
+        "sandbox get": new Error("not found"),
+      });
+
+      const { lines, logger } = captureLogger();
+      await cliLogs({
+        follow: false,
+        lines: 50,
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      const output = lines.join("\n");
+      expect(output).toContain("Blueprint run: run-from-state");
+      expect(output).toContain("Action: deploy");
+    });
+
+    it("does not show run info when no runId and state has none", async () => {
+      mockExec({
+        "sandbox get": new Error("not found"),
+      });
+
+      const { lines, logger } = captureLogger();
+      await cliLogs({
+        follow: false,
+        lines: 50,
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      const output = lines.join("\n");
+      expect(output).not.toContain("Blueprint run:");
+    });
+  });
+
+  describe("sandbox name resolution", () => {
+    it("uses state.sandboxName when available", async () => {
+      vi.mocked(loadState).mockReturnValue({
+        ...blankState(),
+        sandboxName: "my-sandbox",
+      });
+      mockExec({
+        "sandbox get": JSON.stringify({ state: "running" }),
+      });
+      mockSpawnProc(0);
+
+      const { logger } = captureLogger();
+      await cliLogs({
+        follow: false,
+        lines: 50,
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      expect(exec).toHaveBeenCalledWith(
+        expect.stringContaining("my-sandbox"),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("spawn error handling", () => {
+    it("logs error when spawn emits an error", async () => {
+      mockExec({
+        "sandbox get": JSON.stringify({ state: "running" }),
+      });
+      mockSpawnProc(null, new Error("ENOENT: openshell not found"));
+
+      const { lines, logger } = captureLogger();
+      await cliLogs({
+        follow: false,
+        lines: 50,
+        logger,
+        pluginConfig: defaultConfig,
+      });
+
+      const output = lines.join("\n");
+      expect(output).toContain("Failed to stream logs");
+      expect(output).toContain("ENOENT");
+    });
+  });
+});

--- a/nemoclaw/src/onboard/config.test.ts
+++ b/nemoclaw/src/onboard/config.test.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NemoClawOnboardConfig } from "./config.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// In-memory filesystem store
+const fsStore: Record<string, string> = {};
+let dirCreated = false;
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn((path: string) => path in fsStore || (path.endsWith(".nemoclaw") && dirCreated)),
+  mkdirSync: vi.fn((_path: string) => {
+    dirCreated = true;
+  }),
+  readFileSync: vi.fn((path: string) => {
+    if (path in fsStore) return fsStore[path];
+    throw new Error(`ENOENT: no such file or directory, open '${path}'`);
+  }),
+  writeFileSync: vi.fn((path: string, data: string) => {
+    fsStore[path] = data;
+  }),
+  unlinkSync: vi.fn((path: string) => {
+    delete fsStore[path];
+  }),
+}));
+
+// Import after mocks are set up
+const { loadOnboardConfig, saveOnboardConfig, clearOnboardConfig } = await import("./config.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sampleConfig(): NemoClawOnboardConfig {
+  return {
+    endpointType: "build",
+    endpointUrl: "https://integrate.api.nvidia.com/v1",
+    ncpPartner: null,
+    model: "nvidia/nemotron-3-super-120b-a12b",
+    profile: "default",
+    credentialEnv: "NVIDIA_API_KEY",
+    onboardedAt: "2026-03-15T10:30:00.000Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // Clear in-memory filesystem
+  for (const key of Object.keys(fsStore)) {
+    delete fsStore[key];
+  }
+  dirCreated = false;
+});
+
+describe("loadOnboardConfig", () => {
+  it("returns null when config file does not exist", () => {
+    const result = loadOnboardConfig();
+    expect(result).toBeNull();
+  });
+});
+
+describe("saveOnboardConfig + loadOnboardConfig", () => {
+  it("round-trips a config through save and load", () => {
+    const config = sampleConfig();
+
+    saveOnboardConfig(config);
+    const loaded = loadOnboardConfig();
+
+    expect(loaded).toEqual(config);
+  });
+
+  it("overwrites existing config on second save", () => {
+    const config1 = sampleConfig();
+    saveOnboardConfig(config1);
+
+    const config2: NemoClawOnboardConfig = {
+      ...config1,
+      model: "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+      endpointType: "nim-local",
+    };
+    saveOnboardConfig(config2);
+
+    const loaded = loadOnboardConfig();
+    expect(loaded).toEqual(config2);
+    expect(loaded!.model).toBe("nvidia/llama-3.1-nemotron-ultra-253b-v1");
+  });
+});
+
+describe("clearOnboardConfig", () => {
+  it("removes an existing config", () => {
+    saveOnboardConfig(sampleConfig());
+    expect(loadOnboardConfig()).not.toBeNull();
+
+    clearOnboardConfig();
+    expect(loadOnboardConfig()).toBeNull();
+  });
+
+  it("does not throw when config file does not exist", () => {
+    expect(() => clearOnboardConfig()).not.toThrow();
+  });
+});

--- a/nemoclaw/src/onboard/validate.test.ts
+++ b/nemoclaw/src/onboard/validate.test.ts
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Import after mocks are set up
+const { validateApiKey, maskApiKey } = await import("./validate.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockResponse(status: number, body: unknown, ok?: boolean): Response {
+  return {
+    ok: ok ?? (status >= 200 && status < 300),
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("validateApiKey", () => {
+  const endpoint = "https://integrate.api.nvidia.com/v1";
+  const apiKey = "nvapi-testapikey1234567890";
+
+  it("returns valid with model list on successful response", async () => {
+    mockFetch.mockResolvedValue(
+      mockResponse(200, {
+        data: [{ id: "model-a" }, { id: "model-b" }],
+      }),
+    );
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(true);
+    expect(result.models).toEqual(["model-a", "model-b"]);
+    expect(result.error).toBeNull();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://integrate.api.nvidia.com/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${apiKey}` },
+      }),
+    );
+  });
+
+  it("returns valid with empty model list when data is missing", async () => {
+    mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(true);
+    expect(result.models).toEqual([]);
+    expect(result.error).toBeNull();
+  });
+
+  it("strips trailing slashes from endpoint URL", async () => {
+    mockFetch.mockResolvedValue(mockResponse(200, { data: [] }));
+
+    await validateApiKey(apiKey, "https://example.com/v1///");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/v1/models",
+      expect.anything(),
+    );
+  });
+
+  it("returns error on 401 Unauthorized", async () => {
+    mockFetch.mockResolvedValue(mockResponse(401, "Unauthorized", false));
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(false);
+    expect(result.models).toEqual([]);
+    expect(result.error).toContain("HTTP 401");
+    expect(result.error).toContain("Unauthorized");
+  });
+
+  it("returns error on 403 Forbidden", async () => {
+    mockFetch.mockResolvedValue(mockResponse(403, "Forbidden", false));
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(false);
+    expect(result.models).toEqual([]);
+    expect(result.error).toContain("HTTP 403");
+  });
+
+  it("returns error on 500 Internal Server Error", async () => {
+    mockFetch.mockResolvedValue(
+      mockResponse(500, "Internal Server Error", false),
+    );
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("HTTP 500");
+  });
+
+  it("truncates long error bodies to 200 characters", async () => {
+    const longBody = "x".repeat(500);
+    mockFetch.mockResolvedValue(mockResponse(400, longBody, false));
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(false);
+    // The error contains "HTTP 400: " prefix + 200 chars of body
+    expect(result.error!.length).toBeLessThanOrEqual("HTTP 400: ".length + 200);
+  });
+
+  it("returns timeout error on AbortError", async () => {
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+    mockFetch.mockRejectedValue(abortError);
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(false);
+    expect(result.models).toEqual([]);
+    expect(result.error).toBe("Request timed out (10s)");
+  });
+
+  it("returns error message on network failure", async () => {
+    mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(false);
+    expect(result.models).toEqual([]);
+    expect(result.error).toBe("fetch failed");
+  });
+
+  it("handles non-Error rejection gracefully", async () => {
+    mockFetch.mockRejectedValue("some string error");
+
+    const result = await validateApiKey(apiKey, endpoint);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("some string error");
+  });
+});
+
+describe("maskApiKey", () => {
+  it("masks short keys (≤ 8 chars) completely", () => {
+    expect(maskApiKey("abc")).toBe("****");
+    expect(maskApiKey("12345678")).toBe("****");
+  });
+
+  it("masks nvapi- prefixed keys with prefix preserved", () => {
+    expect(maskApiKey("nvapi-abcdefghijk")).toBe("nvapi-****hijk");
+  });
+
+  it("masks regular keys showing last 4 characters", () => {
+    expect(maskApiKey("sk-1234567890abcdef")).toBe("****cdef");
+  });
+
+  it("masks keys that are exactly 9 characters", () => {
+    expect(maskApiKey("123456789")).toBe("****6789");
+  });
+});

--- a/nemoclaw/src/onboard/validate.test.ts
+++ b/nemoclaw/src/onboard/validate.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
 
 describe("validateApiKey", () => {
   const endpoint = "https://integrate.api.nvidia.com/v1";
-  const apiKey = "nvapi-testapikey1234567890";
+  const apiKey = "test-api-key-placeholder";
 
   it("returns valid with model list on successful response", async () => {
     mockFetch.mockResolvedValue(

--- a/nemoclaw/src/test-helpers.ts
+++ b/nemoclaw/src/test-helpers.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared test helpers used across multiple test files.
+ */
+
+import { vi } from "vitest";
+import type { PluginLogger } from "./index.js";
+
+/** Create a logger that captures all info() calls into an array. */
+export function captureLogger(): { lines: string[]; logger: PluginLogger } {
+  const lines: string[] = [];
+  return {
+    lines,
+    logger: {
+      info: (msg: string) => lines.push(msg),
+      warn: (msg: string) => lines.push(`WARN: ${msg}`),
+      error: (msg: string) => lines.push(`ERROR: ${msg}`),
+      debug: (_msg: string) => {},
+    },
+  };
+}
+
+/**
+ * Create a mock child process that emits close/error events asynchronously.
+ * Requires `spawn` to be mocked via `vi.mock("node:child_process")`.
+ */
+export function mockSpawnProc(
+  spawnMock: ReturnType<typeof vi.fn>,
+  exitCode: number | null = 0,
+  error?: Error,
+) {
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const proc = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+      return proc;
+    }),
+    emit: (event: string, ...args: unknown[]) => {
+      for (const h of handlers[event] ?? []) h(...args);
+    },
+  };
+
+  spawnMock.mockReturnValue(proc as never);
+
+  // Schedule events asynchronously so the caller's promise can attach listeners
+  setTimeout(() => {
+    if (error) {
+      proc.emit("error", error);
+    } else {
+      proc.emit("close", exitCode);
+    }
+  }, 0);
+
+  return proc;
+}


### PR DESCRIPTION
## Summary

Adds **35 new unit tests** across 4 test files, covering critical modules that previously had zero test coverage. Complements the existing `status.test.ts` (22 tests) to bring the total to **57 tests**.

No source files were modified — this PR only adds test files.

## New test files

| File | Tests | What it covers |
|---|---|---|
| `src/onboard/validate.test.ts` | 14 | `validateApiKey`: successful validation, HTTP 401/403/500, timeout (AbortError), network failure, non-Error rejection, trailing-slash stripping, body truncation. `maskApiKey`: short keys, `nvapi-` prefix, regular keys, boundary lengths. |
| `src/onboard/config.test.ts` | 5 | `saveOnboardConfig`/`loadOnboardConfig` round-trip, overwrite behavior, missing file returns `null`, `clearOnboardConfig` removes file, no-throw on missing file. |
| `src/commands/logs.test.ts` | 9 | Sandbox not running → message, sandbox running → correct `openshell` spawn args, `--follow` adds `-f`, `--lines` sets `-n`, `--run-id` shows run info, state fallback, sandbox name from state, spawn error handling. |
| `src/commands/connect.test.ts` | 7 | Correct spawn args, `ENOENT` → "openshell not found" error, generic spawn error, non-zero exit code logging, success/null exit code handling. |

## Why these modules

The onboard flow is where the majority of user-facing bugs originate (#22, #93, #152, #197, #201, #208, #210, #245). With CI now running on PRs (#261), these tests will catch regressions in the most sensitive code paths.

## Test conventions

All tests follow the patterns established in `status.test.ts`:
- vitest with `vi.mock` for `node:fs` and `node:child_process`
- `captureLogger()` pattern for output assertions
- `resetAllMocks()` in `beforeEach`
- SPDX Apache-2.0 license headers

## Verification

```
$ cd nemoclaw && npm test

 ✓ src/onboard/validate.test.ts (14 tests) 10ms
 ✓ src/onboard/config.test.ts (5 tests) 12ms
 ✓ src/commands/logs.test.ts (9 tests) 17ms
 ✓ src/commands/connect.test.ts (7 tests) 23ms
 ✓ src/commands/status.test.ts (22 tests) 23ms

 Test Files  5 passed (5)
       Tests  57 passed (57)
    Duration  298ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the connect command covering sandbox handling, spawn errors, and exit-code logging.
  * Added extensive logs command tests for streaming, follow/lines flags, run info display, sandbox resolution, and spawn error handling.
  * Added onboard config tests for load/save/clear round-trips and edge cases.
  * Added API key validation and masking tests (success, HTTP errors, timeouts, masking).
  * Added shared test helpers to capture logs and mock subprocess behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->