### PR TITLE
test: add unit tests for eject and slash command handlers

### DIFF
--- a/nemoclaw/src/commands/eject.test.ts
+++ b/nemoclaw/src/commands/eject.test.ts
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NemoClawState } from "../blueprint/state.js";
+import type { PluginLogger, NemoClawConfig } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => false),
+}));
+
+vi.mock("../blueprint/state.js", () => ({
+  loadState: vi.fn(),
+  clearState: vi.fn(),
+}));
+
+vi.mock("../blueprint/exec.js", () => ({
+  execBlueprint: vi.fn(),
+}));
+
+vi.mock("./migration-state.js", () => ({
+  restoreSnapshotToHost: vi.fn(),
+}));
+
+const { existsSync } = await import("node:fs");
+const { loadState, clearState } = await import("../blueprint/state.js");
+const { execBlueprint } = await import("../blueprint/exec.js");
+const { restoreSnapshotToHost } = await import("./migration-state.js");
+const { cliEject } = await import("./eject.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function blankState(): NemoClawState {
+  return {
+    lastRunId: null,
+    lastAction: null,
+    blueprintVersion: null,
+    sandboxName: null,
+    migrationSnapshot: null,
+    hostBackupPath: null,
+    createdAt: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function deployedState(): NemoClawState {
+  return {
+    lastRunId: "run-a1b2c3d4",
+    lastAction: "migrate",
+    blueprintVersion: "0.1.0",
+    sandboxName: "openclaw",
+    migrationSnapshot: "/root/.nemoclaw/snapshots/2026-03-15",
+    hostBackupPath: "/root/.nemoclaw/backups/host-backup",
+    createdAt: "2026-03-15T10:30:00.000Z",
+    updatedAt: "2026-03-15T10:32:45.000Z",
+  };
+}
+
+const defaultConfig: NemoClawConfig = {
+  blueprintVersion: "latest",
+  blueprintRegistry: "ghcr.io/nvidia/nemoclaw-blueprint",
+  sandboxName: "openclaw",
+  inferenceProvider: "nvidia",
+};
+
+function captureLogger(): { lines: string[]; logger: PluginLogger } {
+  const lines: string[] = [];
+  return {
+    lines,
+    logger: {
+      info: (msg: string) => lines.push(msg),
+      warn: (msg: string) => lines.push(`WARN: ${msg}`),
+      error: (msg: string) => lines.push(`ERROR: ${msg}`),
+      debug: (_msg: string) => {},
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(existsSync).mockReturnValue(false);
+  vi.mocked(loadState).mockReturnValue(blankState());
+});
+
+describe("cliEject", () => {
+  // =========================================================================
+  // Guard: no deployment
+  // =========================================================================
+  describe("no deployment found", () => {
+    it("errors when state has no lastAction", async () => {
+      const { lines, logger } = captureLogger();
+
+      await cliEject({ confirm: true, logger, pluginConfig: defaultConfig });
+
+      expect(lines.join("\n")).toContain("No NemoClaw deployment found");
+      expect(clearState).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Guard: no snapshot
+  // =========================================================================
+  describe("no migration snapshot", () => {
+    it("errors when neither snapshot nor backup path exists in state", async () => {
+      vi.mocked(loadState).mockReturnValue({
+        ...deployedState(),
+        migrationSnapshot: null,
+        hostBackupPath: null,
+      });
+
+      const { lines, logger } = captureLogger();
+      await cliEject({ confirm: true, logger, pluginConfig: defaultConfig });
+
+      expect(lines.join("\n")).toContain("No migration snapshot found");
+      expect(lines.join("\n")).toContain("--skip-backup");
+    });
+  });
+
+  // =========================================================================
+  // Guard: snapshot directory missing on disk
+  // =========================================================================
+  describe("snapshot directory missing on disk", () => {
+    it("errors when snapshot openclaw dir does not exist", async () => {
+      vi.mocked(loadState).mockReturnValue(deployedState());
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const { lines, logger } = captureLogger();
+      await cliEject({ confirm: true, logger, pluginConfig: defaultConfig });
+
+      expect(lines.join("\n")).toContain("Snapshot directory not found");
+    });
+  });
+
+  // =========================================================================
+  // Dry run (--confirm not passed)
+  // =========================================================================
+  describe("dry run without --confirm", () => {
+    it("shows planned steps without executing", async () => {
+      vi.mocked(loadState).mockReturnValue(deployedState());
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const { lines, logger } = captureLogger();
+      await cliEject({ confirm: false, logger, pluginConfig: defaultConfig });
+
+      const output = lines.join("\n");
+      expect(output).toContain("Eject will:");
+      expect(output).toContain("Stop the OpenShell sandbox");
+      expect(output).toContain("Rollback blueprint state");
+      expect(output).toContain("Restore ~/.openclaw from snapshot");
+      expect(output).toContain("Run with --confirm to proceed");
+      expect(execBlueprint).not.toHaveBeenCalled();
+      expect(restoreSnapshotToHost).not.toHaveBeenCalled();
+      expect(clearState).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Confirmed eject — happy path
+  // =========================================================================
+  describe("confirmed eject — success", () => {
+    beforeEach(() => {
+      vi.mocked(loadState).mockReturnValue(deployedState());
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(execBlueprint).mockResolvedValue({ success: true, output: "", runId: "run-a1b2c3d4" });
+      vi.mocked(restoreSnapshotToHost).mockReturnValue(true);
+    });
+
+    it("runs blueprint rollback, restores host, and clears state", async () => {
+      const { lines, logger } = captureLogger();
+      await cliEject({ confirm: true, logger, pluginConfig: defaultConfig });
+
+      expect(execBlueprint).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "rollback",
+          profile: "default",
+          runId: "run-a1b2c3d4",
+        }),
+        logger,
+      );
+      expect(restoreSnapshotToHost).toHaveBeenCalledWith(
+        "/root/.nemoclaw/snapshots/2026-03-15",
+        logger,
+      );
+      expect(clearState).toHaveBeenCalled();
+      expect(lines.join("\n")).toContain("Eject complete");
+    });
+
+    it("uses custom runId when provided", async () => {
+      const { logger } = captureLogger();
+      await cliEject({ confirm: true, runId: "custom-run", logger, pluginConfig: defaultConfig });
+
+      expect(execBlueprint).toHaveBeenCalledWith(
+        expect.objectContaining({ runId: "custom-run" }),
+        logger,
+      );
+    });
+  });
+
+  // =========================================================================
+  // Confirmed eject — blueprint rollback fails
+  // =========================================================================
+  describe("confirmed eject — blueprint rollback fails", () => {
+    it("warns but continues with host restoration", async () => {
+      vi.mocked(loadState).mockReturnValue(deployedState());
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(execBlueprint).mockResolvedValue({ success: false, output: "rollback error", runId: "run-a1b2c3d4" });
+      vi.mocked(restoreSnapshotToHost).mockReturnValue(true);
+
+      const { lines, logger } = captureLogger();
+      await cliEject({ confirm: true, logger, pluginConfig: defaultConfig });
+
+      const output = lines.join("\n");
+      expect(output).toContain("WARN:");
+      expect(output).toContain("rollback error");
+      expect(output).toContain("Continuing with host restoration");
+      expect(restoreSnapshotToHost).toHaveBeenCalled();
+      expect(clearState).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Confirmed eject — host restoration fails
+  // =========================================================================
+  describe("confirmed eject — host restoration fails", () => {
+    it("shows manual restore path and does not clear state", async () => {
+      vi.mocked(loadState).mockReturnValue(deployedState());
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(execBlueprint).mockResolvedValue({ success: true, output: "", runId: "run-a1b2c3d4" });
+      vi.mocked(restoreSnapshotToHost).mockReturnValue(false);
+
+      const { lines, logger } = captureLogger();
+      await cliEject({ confirm: true, logger, pluginConfig: defaultConfig });
+
+      expect(lines.join("\n")).toContain("Manual restore available at");
+      expect(clearState).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Edge: no blueprint path on disk — skips rollback
+  // =========================================================================
+  describe("skips blueprint rollback when blueprint path missing", () => {
+    it("proceeds directly to host restoration", async () => {
+      vi.mocked(loadState).mockReturnValue(deployedState());
+      // existsSync returns true for snapshot dir, false for blueprint path
+      vi.mocked(existsSync).mockImplementation((p: string | URL | Buffer) => {
+        const path = String(p);
+        return path.includes("snapshots") || path.includes("openclaw");
+      });
+      vi.mocked(restoreSnapshotToHost).mockReturnValue(true);
+
+      const { logger } = captureLogger();
+      await cliEject({ confirm: true, logger, pluginConfig: defaultConfig });
+
+      expect(execBlueprint).not.toHaveBeenCalled();
+      expect(restoreSnapshotToHost).toHaveBeenCalled();
+      expect(clearState).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Edge: falls back to hostBackupPath
+  // =========================================================================
+  describe("falls back to hostBackupPath when migrationSnapshot is null", () => {
+    it("uses hostBackupPath for restore", async () => {
+      vi.mocked(loadState).mockReturnValue({
+        ...deployedState(),
+        migrationSnapshot: null,
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(execBlueprint).mockResolvedValue({ success: true, output: "", runId: "run-a1b2c3d4" });
+      vi.mocked(restoreSnapshotToHost).mockReturnValue(true);
+
+      const { logger } = captureLogger();
+      await cliEject({ confirm: true, logger, pluginConfig: defaultConfig });
+
+      expect(restoreSnapshotToHost).toHaveBeenCalledWith(
+        "/root/.nemoclaw/backups/host-backup",
+        logger,
+      );
+    });
+  });
+});

--- a/nemoclaw/src/commands/slash.test.ts
+++ b/nemoclaw/src/commands/slash.test.ts
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NemoClawState } from "../blueprint/state.js";
+import type { PluginCommandContext, OpenClawPluginApi } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../blueprint/state.js", () => ({
+  loadState: vi.fn(),
+}));
+
+vi.mock("../onboard/config.js", () => ({
+  loadOnboardConfig: vi.fn(),
+}));
+
+const { loadState } = await import("../blueprint/state.js");
+const { loadOnboardConfig } = await import("../onboard/config.js");
+const { handleSlashCommand } = await import("./slash.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function blankState(): NemoClawState {
+  return {
+    lastRunId: null,
+    lastAction: null,
+    blueprintVersion: null,
+    sandboxName: null,
+    migrationSnapshot: null,
+    hostBackupPath: null,
+    createdAt: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function populatedState(): NemoClawState {
+  return {
+    lastRunId: "run-a1b2c3d4",
+    lastAction: "migrate",
+    blueprintVersion: "0.1.0",
+    sandboxName: "openclaw",
+    migrationSnapshot: "/root/.nemoclaw/snapshots/pre-migrate.tar.gz",
+    hostBackupPath: "/root/.nemoclaw/backups/host-backup",
+    createdAt: "2026-03-15T10:30:00.000Z",
+    updatedAt: "2026-03-15T10:32:45.000Z",
+  };
+}
+
+function makeContext(args?: string): PluginCommandContext {
+  return {
+    channel: "test",
+    isAuthorizedSender: true,
+    args,
+    commandBody: `/nemoclaw ${args ?? ""}`,
+    config: {},
+  };
+}
+
+const stubApi = {} as OpenClawPluginApi;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(loadState).mockReturnValue(blankState());
+  vi.mocked(loadOnboardConfig).mockReturnValue(null);
+});
+
+describe("handleSlashCommand", () => {
+  // =========================================================================
+  // Help (default)
+  // =========================================================================
+  describe("help — default subcommand", () => {
+    it("shows help when no args", () => {
+      const result = handleSlashCommand(makeContext(), stubApi);
+
+      expect(result.text).toContain("**NemoClaw**");
+      expect(result.text).toContain("`status`");
+      expect(result.text).toContain("`eject`");
+      expect(result.text).toContain("`onboard`");
+    });
+
+    it("shows help for unrecognized subcommand", () => {
+      const result = handleSlashCommand(makeContext("unknown"), stubApi);
+
+      expect(result.text).toContain("**NemoClaw**");
+    });
+  });
+
+  // =========================================================================
+  // Status
+  // =========================================================================
+  describe("status subcommand", () => {
+    it("shows 'no operations' when state is blank", () => {
+      const result = handleSlashCommand(makeContext("status"), stubApi);
+
+      expect(result.text).toContain("No operations performed yet");
+      expect(result.text).toContain("openclaw nemoclaw launch");
+    });
+
+    it("shows state details when operations have been performed", () => {
+      vi.mocked(loadState).mockReturnValue(populatedState());
+
+      const result = handleSlashCommand(makeContext("status"), stubApi);
+
+      expect(result.text).toContain("**NemoClaw Status**");
+      expect(result.text).toContain("Last action: migrate");
+      expect(result.text).toContain("Blueprint: 0.1.0");
+      expect(result.text).toContain("Run ID: run-a1b2c3d4");
+      expect(result.text).toContain("Sandbox: openclaw");
+    });
+
+    it("includes rollback snapshot when present", () => {
+      vi.mocked(loadState).mockReturnValue(populatedState());
+
+      const result = handleSlashCommand(makeContext("status"), stubApi);
+
+      expect(result.text).toContain("Rollback snapshot:");
+      expect(result.text).toContain("/root/.nemoclaw/snapshots/pre-migrate.tar.gz");
+    });
+
+    it("omits rollback section when no snapshot", () => {
+      vi.mocked(loadState).mockReturnValue({
+        ...populatedState(),
+        migrationSnapshot: null,
+      });
+
+      const result = handleSlashCommand(makeContext("status"), stubApi);
+
+      expect(result.text).not.toContain("Rollback snapshot:");
+    });
+  });
+
+  // =========================================================================
+  // Eject
+  // =========================================================================
+  describe("eject subcommand", () => {
+    it("shows 'nothing to eject' when no deployment", () => {
+      const result = handleSlashCommand(makeContext("eject"), stubApi);
+
+      expect(result.text).toContain("No NemoClaw deployment found");
+    });
+
+    it("shows 'manual rollback required' when no snapshot", () => {
+      vi.mocked(loadState).mockReturnValue({
+        ...populatedState(),
+        migrationSnapshot: null,
+        hostBackupPath: null,
+      });
+
+      const result = handleSlashCommand(makeContext("eject"), stubApi);
+
+      expect(result.text).toContain("No migration snapshot found");
+      expect(result.text).toContain("Manual rollback required");
+    });
+
+    it("shows eject instructions with snapshot path", () => {
+      vi.mocked(loadState).mockReturnValue(populatedState());
+
+      const result = handleSlashCommand(makeContext("eject"), stubApi);
+
+      expect(result.text).toContain("**Eject from NemoClaw**");
+      expect(result.text).toContain("openclaw nemoclaw eject --confirm");
+      expect(result.text).toContain("/root/.nemoclaw/snapshots/pre-migrate.tar.gz");
+    });
+
+    it("falls back to hostBackupPath when no migrationSnapshot", () => {
+      vi.mocked(loadState).mockReturnValue({
+        ...populatedState(),
+        migrationSnapshot: null,
+      });
+
+      const result = handleSlashCommand(makeContext("eject"), stubApi);
+
+      expect(result.text).toContain("/root/.nemoclaw/backups/host-backup");
+    });
+  });
+
+  // =========================================================================
+  // Onboard
+  // =========================================================================
+  describe("onboard subcommand", () => {
+    it("shows setup instructions when no config", () => {
+      const result = handleSlashCommand(makeContext("onboard"), stubApi);
+
+      expect(result.text).toContain("**NemoClaw Onboarding**");
+      expect(result.text).toContain("No configuration found");
+      expect(result.text).toContain("openclaw nemoclaw onboard");
+    });
+
+    it("shows current onboard config when configured", () => {
+      vi.mocked(loadOnboardConfig).mockReturnValue({
+        endpointType: "build",
+        endpointUrl: "https://integrate.api.nvidia.com/v1",
+        ncpPartner: null,
+        model: "nvidia/nemotron-3-super-120b-a12b",
+        profile: "default",
+        credentialEnv: "NVIDIA_API_KEY",
+        onboardedAt: "2026-03-15T10:00:00.000Z",
+      });
+
+      const result = handleSlashCommand(makeContext("onboard"), stubApi);
+
+      expect(result.text).toContain("**NemoClaw Onboard Status**");
+      expect(result.text).toContain("Endpoint: build");
+      expect(result.text).toContain("Model: nvidia/nemotron-3-super-120b-a12b");
+      expect(result.text).toContain("$NVIDIA_API_KEY");
+    });
+
+    it("includes NCP partner when present", () => {
+      vi.mocked(loadOnboardConfig).mockReturnValue({
+        endpointType: "ncp",
+        endpointUrl: "https://partner.api.nvidia.com/v1",
+        ncpPartner: "acme-corp",
+        model: "nvidia/nemotron-3-super-120b-a12b",
+        profile: "ncp",
+        credentialEnv: "NVIDIA_API_KEY",
+        onboardedAt: "2026-03-15T10:00:00.000Z",
+      });
+
+      const result = handleSlashCommand(makeContext("onboard"), stubApi);
+
+      expect(result.text).toContain("NCP Partner: acme-corp");
+    });
+  });
+
+  // =========================================================================
+  // Edge cases
+  // =========================================================================
+  describe("edge cases", () => {
+    it("trims whitespace from args", () => {
+      const result = handleSlashCommand(makeContext("  status  "), stubApi);
+
+      expect(result.text).toContain("No operations performed yet");
+    });
+
+    it("uses first word only as subcommand", () => {
+      const result = handleSlashCommand(makeContext("status extra args"), stubApi);
+
+      expect(result.text).toContain("No operations performed yet");
+    });
+  });
+});


### PR DESCRIPTION
Add vitest coverage for eject.ts (12 tests) and slash.ts (13 tests), the two command modules without tests. Follows status.test.ts mock pattern.