### PR TITLE
fix(blueprint): reject empty digest instead of silently passing verification

### DIFF
--- a/nemoclaw/src/blueprint/verify.test.ts
+++ b/nemoclaw/src/blueprint/verify.test.ts
@@ -120,8 +120,9 @@ describe("verifyBlueprintDigest", () => {
       const result = verifyBlueprintDigest("/fake/path", manifest);
 
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toContain("missing");
+      expect(result.errors).toEqual([
+        "Blueprint manifest is missing a digest — cannot verify integrity",
+      ]);
     });
 
     it("returns valid: false when digest is undefined", () => {
@@ -131,8 +132,21 @@ describe("verifyBlueprintDigest", () => {
       const result = verifyBlueprintDigest("/fake/path", manifest);
 
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toContain("missing");
+      expect(result.errors).toEqual([
+        "Blueprint manifest is missing a digest — cannot verify integrity",
+      ]);
+    });
+
+    it("skips directory hashing when digest is missing", () => {
+      mockDirectory(MOCK_FILES);
+      const manifest = makeManifest({ digest: "" });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.valid).toBe(false);
+      expect(result.actualDigest).toBe("");
+      // readdirSync should not be called — no I/O for invalid manifests
+      expect(readdirSync).not.toHaveBeenCalled();
     });
   });
 
@@ -167,6 +181,45 @@ describe("verifyBlueprintDigest", () => {
       ];
       mockDirectory(unsortedFiles);
       const digest = expectedDigest(unsortedFiles);
+      const manifest = makeManifest({ digest });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.valid).toBe(true);
+      expect(result.actualDigest).toBe(digest);
+    });
+  });
+
+  describe("nested directory", () => {
+    it("includes files from subdirectories with prefix paths", () => {
+      // Set up mocks for a directory with a nested subdirectory:
+      //   /fake/path/
+      //     file.txt      → "root content"
+      //     subdir/
+      //       nested.txt  → "nested content"
+      vi.mocked(readdirSync).mockImplementation((dirPath: unknown) => {
+        const p = String(dirPath);
+        if (p.endsWith("subdir")) return ["nested.txt"] as unknown as ReturnType<typeof readdirSync>;
+        return ["file.txt", "subdir"] as unknown as ReturnType<typeof readdirSync>;
+      });
+      vi.mocked(statSync).mockImplementation((filePath: unknown) => {
+        const p = String(filePath);
+        return {
+          isDirectory: () => p.endsWith("subdir"),
+        } as ReturnType<typeof statSync>;
+      });
+      vi.mocked(readFileSync).mockImplementation((filePath: unknown) => {
+        const p = String(filePath);
+        if (p.endsWith("nested.txt")) return Buffer.from("nested content");
+        return Buffer.from("root content");
+      });
+
+      // Expected digest uses prefix paths: "file.txt" and "subdir/nested.txt"
+      const nestedFiles: MockFile[] = [
+        { path: "file.txt", content: "root content" },
+        { path: "subdir/nested.txt", content: "nested content" },
+      ];
+      const digest = expectedDigest(nestedFiles);
       const manifest = makeManifest({ digest });
 
       const result = verifyBlueprintDigest("/fake/path", manifest);

--- a/nemoclaw/src/blueprint/verify.test.ts
+++ b/nemoclaw/src/blueprint/verify.test.ts
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash } from "node:crypto";
+import type { BlueprintManifest } from "./resolve.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — control what computeDirectoryDigest sees on the filesystem
+// ---------------------------------------------------------------------------
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+  statSync: vi.fn(),
+}));
+
+const { readFileSync, readdirSync, statSync } = await import("node:fs");
+const { verifyBlueprintDigest, checkCompatibility } = await import("./verify.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockFile {
+  path: string;
+  content: string;
+}
+
+/** Compute the expected SHA-256 digest for a flat directory with the given files. */
+function expectedDigest(files: MockFile[]): string {
+  const hash = createHash("sha256");
+  const sorted = [...files].sort((a, b) => a.path.localeCompare(b.path));
+  for (const f of sorted) {
+    hash.update(f.path);
+    hash.update(f.content);
+  }
+  return hash.digest("hex");
+}
+
+/** Set up fs mocks for a flat directory with the given files. */
+function mockDirectory(files: MockFile[]): void {
+  vi.mocked(readdirSync).mockReturnValue(
+    files.map((f) => f.path) as unknown as ReturnType<typeof readdirSync>,
+  );
+  vi.mocked(statSync).mockReturnValue({
+    isDirectory: () => false,
+  } as ReturnType<typeof statSync>);
+  vi.mocked(readFileSync).mockImplementation((filePath: unknown) => {
+    const p = String(filePath);
+    const file = files.find((f) => p.endsWith(f.path));
+    return Buffer.from(file?.content ?? "");
+  });
+}
+
+function makeManifest(overrides: Partial<BlueprintManifest> = {}): BlueprintManifest {
+  return {
+    version: "1.0.0",
+    minOpenShellVersion: "0.1.0",
+    minOpenClawVersion: "0.1.0",
+    profiles: ["default"],
+    digest: "placeholder",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const MOCK_FILES: MockFile[] = [
+  { path: "blueprint.yaml", content: "version: 1.0.0\ndigest: abc" },
+  { path: "runner.py", content: "print('hello')" },
+];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// verifyBlueprintDigest
+// ---------------------------------------------------------------------------
+
+describe("verifyBlueprintDigest", () => {
+  describe("happy path", () => {
+    it("returns valid: true when digest matches", () => {
+      mockDirectory(MOCK_FILES);
+      const digest = expectedDigest(MOCK_FILES);
+      const manifest = makeManifest({ digest });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+      expect(result.actualDigest).toBe(digest);
+      expect(result.expectedDigest).toBe(digest);
+    });
+  });
+
+  describe("digest mismatch", () => {
+    it("returns valid: false with error when digest does not match", () => {
+      mockDirectory(MOCK_FILES);
+      const manifest = makeManifest({ digest: "wrong-digest-value" });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain("Digest mismatch");
+      expect(result.errors[0]).toContain("wrong-digest-value");
+      expect(result.errors[0]).toContain(result.actualDigest);
+    });
+  });
+
+  describe("empty digest — the bug fix", () => {
+    it("returns valid: false when manifest.digest is empty string", () => {
+      mockDirectory(MOCK_FILES);
+      const manifest = makeManifest({ digest: "" });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain("missing");
+    });
+
+    it("returns valid: false when digest is undefined", () => {
+      mockDirectory(MOCK_FILES);
+      const manifest = makeManifest({ digest: undefined as unknown as string });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain("missing");
+    });
+  });
+
+  describe("result fields", () => {
+    it("populates actualDigest from directory computation", () => {
+      mockDirectory(MOCK_FILES);
+      const digest = expectedDigest(MOCK_FILES);
+      const manifest = makeManifest({ digest });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.actualDigest).toBe(digest);
+    });
+
+    it("populates expectedDigest from manifest.digest", () => {
+      mockDirectory(MOCK_FILES);
+      const manifest = makeManifest({ digest: "custom-expected-value" });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.expectedDigest).toBe("custom-expected-value");
+    });
+  });
+
+  describe("multi-file directory", () => {
+    it("computes digest across all files sorted by path", () => {
+      // Files in non-sorted order — digest should still match
+      const unsortedFiles: MockFile[] = [
+        { path: "c.txt", content: "third" },
+        { path: "a.txt", content: "first" },
+        { path: "b.txt", content: "second" },
+      ];
+      mockDirectory(unsortedFiles);
+      const digest = expectedDigest(unsortedFiles);
+      const manifest = makeManifest({ digest });
+
+      const result = verifyBlueprintDigest("/fake/path", manifest);
+
+      expect(result.valid).toBe(true);
+      expect(result.actualDigest).toBe(digest);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkCompatibility
+// ---------------------------------------------------------------------------
+
+describe("checkCompatibility", () => {
+  describe("versions satisfied", () => {
+    it("returns no errors when all versions meet minimums", () => {
+      const manifest = makeManifest({
+        minOpenShellVersion: "1.0.0",
+        minOpenClawVersion: "2.0.0",
+      });
+
+      const errors = checkCompatibility(manifest, "1.2.0", "2.5.0");
+
+      expect(errors).toEqual([]);
+    });
+
+    it("returns no errors when actual equals minimum", () => {
+      const manifest = makeManifest({
+        minOpenShellVersion: "1.0.0",
+        minOpenClawVersion: "2.0.0",
+      });
+
+      const errors = checkCompatibility(manifest, "1.0.0", "2.0.0");
+
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe("newer actual version", () => {
+    it("accepts newer major version", () => {
+      const manifest = makeManifest({ minOpenShellVersion: "1.0.0" });
+      expect(checkCompatibility(manifest, "2.0.0", "99.0.0")).toEqual([]);
+    });
+
+    it("accepts newer minor version", () => {
+      const manifest = makeManifest({ minOpenShellVersion: "1.0.0" });
+      expect(checkCompatibility(manifest, "1.1.0", "99.0.0")).toEqual([]);
+    });
+
+    it("accepts newer patch version", () => {
+      const manifest = makeManifest({ minOpenShellVersion: "1.0.0" });
+      expect(checkCompatibility(manifest, "1.0.1", "99.0.0")).toEqual([]);
+    });
+  });
+
+  describe("older actual version — should fail", () => {
+    it("returns error when openshell version is too old", () => {
+      const manifest = makeManifest({ minOpenShellVersion: "1.0.0" });
+
+      const errors = checkCompatibility(manifest, "0.9.0", "99.0.0");
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("OpenShell");
+    });
+
+    it("returns error when openclaw version is too old", () => {
+      const manifest = makeManifest({ minOpenClawVersion: "2.0.0" });
+
+      const errors = checkCompatibility(manifest, "99.0.0", "1.9.0");
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("OpenClaw");
+    });
+
+    it("returns two errors when both versions are too old", () => {
+      const manifest = makeManifest({
+        minOpenShellVersion: "2.0.0",
+        minOpenClawVersion: "3.0.0",
+      });
+
+      const errors = checkCompatibility(manifest, "1.0.0", "2.0.0");
+
+      expect(errors).toHaveLength(2);
+    });
+  });
+
+  describe("missing minimum version — skips check", () => {
+    it("skips openshell check when minOpenShellVersion is empty", () => {
+      const manifest = makeManifest({ minOpenShellVersion: "" });
+
+      const errors = checkCompatibility(manifest, "0.0.1", "99.0.0");
+
+      // No error for openshell despite very old version
+      const openshellErrors = errors.filter((e) => e.includes("OpenShell"));
+      expect(openshellErrors).toEqual([]);
+    });
+
+    it("skips openclaw check when minOpenClawVersion is empty", () => {
+      const manifest = makeManifest({ minOpenClawVersion: "" });
+
+      const errors = checkCompatibility(manifest, "99.0.0", "0.0.1");
+
+      const openclawErrors = errors.filter((e) => e.includes("OpenClaw"));
+      expect(openclawErrors).toEqual([]);
+    });
+  });
+
+  describe("version string edge cases", () => {
+    it("handles two-segment versions like '1.0'", () => {
+      const manifest = makeManifest({ minOpenShellVersion: "1.0.0" });
+
+      // "1.0" should satisfy "1.0.0" — missing segment treated as 0
+      const errors = checkCompatibility(manifest, "1.0", "99.0.0");
+
+      expect(errors).toEqual([]);
+    });
+
+    it("handles four-segment versions", () => {
+      const manifest = makeManifest({ minOpenShellVersion: "1.0.0" });
+
+      const errors = checkCompatibility(manifest, "1.0.0.1", "99.0.0");
+
+      expect(errors).toEqual([]);
+    });
+
+    it("handles year-based versions like '2026.3.11'", () => {
+      const manifest = makeManifest({ minOpenClawVersion: "2026.3.0" });
+
+      const errors = checkCompatibility(manifest, "99.0.0", "2026.3.11");
+
+      expect(errors).toEqual([]);
+    });
+  });
+});

--- a/nemoclaw/src/blueprint/verify.ts
+++ b/nemoclaw/src/blueprint/verify.ts
@@ -20,7 +20,9 @@ export function verifyBlueprintDigest(
   const errors: string[] = [];
   const actualDigest = computeDirectoryDigest(blueprintPath);
 
-  if (manifest.digest && manifest.digest !== actualDigest) {
+  if (!manifest.digest) {
+    errors.push("Blueprint manifest is missing a digest — cannot verify integrity");
+  } else if (manifest.digest !== actualDigest) {
     errors.push(`Digest mismatch: expected ${manifest.digest}, got ${actualDigest}`);
   }
 

--- a/nemoclaw/src/blueprint/verify.ts
+++ b/nemoclaw/src/blueprint/verify.ts
@@ -18,12 +18,15 @@ export function verifyBlueprintDigest(
   manifest: BlueprintManifest,
 ): VerificationResult {
   const errors: string[] = [];
-  const actualDigest = computeDirectoryDigest(blueprintPath);
+  let actualDigest = "";
 
   if (!manifest.digest) {
     errors.push("Blueprint manifest is missing a digest — cannot verify integrity");
-  } else if (manifest.digest !== actualDigest) {
-    errors.push(`Digest mismatch: expected ${manifest.digest}, got ${actualDigest}`);
+  } else {
+    actualDigest = computeDirectoryDigest(blueprintPath);
+    if (manifest.digest !== actualDigest) {
+      errors.push(`Digest mismatch: expected ${manifest.digest}, got ${actualDigest}`);
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

- Fix silent verification bypass when blueprint manifest has an empty or missing digest
- Add comprehensive test suite for `verify.ts` (20 tests covering digest verification and version compatibility)

## Problem

`verifyBlueprintDigest()` uses a falsy guard on `manifest.digest`:

```typescript
if (manifest.digest && manifest.digest !== actualDigest) {
```

When `parseManifestHeader` returns `""` for a missing `digest:` field (the regex `match?.[1]?.trim() ?? ""` produces empty string), the condition short-circuits to `false`. The function returns `{ valid: true }` despite performing no integrity check.

Both `cliLaunch` (line 59) and `cliMigrate` (line 92) trust `verification.valid` and proceed with deployment. A blueprint without a digest field silently bypasses integrity verification.

## Fix

Replace the falsy guard with an explicit empty-check:

```typescript
if (!manifest.digest) {
    errors.push("Blueprint manifest is missing a digest — cannot verify integrity");
} else if (manifest.digest !== actualDigest) {
    errors.push(`Digest mismatch: expected ${manifest.digest}, got ${actualDigest}`);
}
```

**Note:** The same falsy-guard pattern in `checkCompatibility` for `minOpenShellVersion` / `minOpenClawVersion` is semantically correct — a missing minimum version means "no requirement." The digest field has opposite semantics: missing means "cannot verify," not "verification unnecessary."

## Tests added

| Group | Tests | Coverage |
|-------|-------|----------|
| `verifyBlueprintDigest` — happy path | Digest matches | ✅ |
| `verifyBlueprintDigest` — mismatch | Wrong digest detected | ✅ |
| `verifyBlueprintDigest` — empty digest (bug fix) | Empty string and undefined both fail | ✅ |
| `verifyBlueprintDigest` — result fields | actualDigest and expectedDigest populated correctly | ✅ |
| `verifyBlueprintDigest` — multi-file | Digest computed across sorted files | ✅ |
| `checkCompatibility` — satisfied | Equal and newer versions pass | ✅ |
| `checkCompatibility` — too old | OpenShell, OpenClaw, and both-too-old detected | ✅ |
| `checkCompatibility` — missing minimum | Empty min version skips check (correct behavior) | ✅ |
| `checkCompatibility` — edge cases | Two-segment, four-segment, year-based versions | ✅ |

## Test plan

- [x] All 20 new tests pass (`npx vitest run` — 42 total, 0 failures)
- [x] Existing `status.test.ts` tests unaffected
- [x] Fix is minimal (4-line change in `verify.ts`)
- [x] Test file follows existing patterns from `status.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Digest verification now skips hashing when a manifest digest is absent and reports a clear "cannot verify integrity" error; mismatches continue to report expected vs actual digests.

* **Tests**
  * Added comprehensive tests for blueprint verification and compatibility: digest validation (including sorting, nested directories, missing digests, and mismatch reporting) and version-compatibility edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->