### PR TITLE
docs: document long-output CLI workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ sandbox@my-assistant:~$ openclaw tui
 
 Send a test message to the agent and verify you receive a response.
 
+> [!NOTE]
+> The TUI is best for interactive back-and-forth. If you need the full text of a long response (for example, large code generation output), use the CLI instead:
+>
+> ```console
+> sandbox@my-assistant:~$ openclaw agent --agent main --local -m "<prompt>" --session-id <id>
+> ```
+>
+> This prints the complete response directly in the terminal and avoids relying on the TUI view for long output.
+
 #### OpenClaw CLI
 
 Use the OpenClaw CLI to send a single message and print the response:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -52,6 +52,14 @@ Use this after launch to connect and chat with the agent through the TUI or CLI.
 $ nemoclaw my-assistant connect
 ```
 
+If the TUI view is not a good fit for very long responses, use the CLI form instead:
+
+```console
+$ openclaw agent --agent main --local -m "<prompt>" --session-id <id>
+```
+
+This is the recommended workaround when you need the full response printed directly in the terminal.
+
 ### `openclaw nemoclaw status`
 
 Display sandbox health, blueprint run state, and inference configuration.


### PR DESCRIPTION
## Summary
- document a workaround for long responses that may not fit well in the OpenClaw TUI view
- add the workaround to both the README quickstart and the command reference
- point users to `openclaw agent --agent main --local -m "<prompt>" --session-id <id>` when they need the full response printed directly in the terminal

## Root cause
The issue is documentation/UX, not runtime behavior: the CLI workaround exists, but it was not documented where users are most likely to look when the TUI truncates or visually clips long output.

## Validation
- verified the new note appears in `README.md`
- verified the same workaround appears in `docs/reference/commands.md`
- confirmed the diff is scoped to the two documentation files only

Fixes #324
