### PR TITLE
Fix #166: Quote sandbox names in shell commands

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -58,6 +58,19 @@ async function promptOrDefault(question, envVar, defaultValue) {
 // ── Helpers ──────────────────────────────────────────────────────
 
 /**
+ * Escapes a string for safe use in shell commands.
+ * Wraps in single quotes and handles embedded single quotes.
+ */
+function shellEscape(str) {
+  if (typeof str !== "string") {
+    throw new Error("shellEscape: expected string argument");
+  }
+  // Use single quotes and escape any embedded single quotes
+  // by ending the quote, adding an escaped quote, and starting a new quote
+  return "'" + str.replace(/'/g, "'\"'\"'") + "'";
+}
+
+/**
  * Check if a sandbox is in Ready state from `openshell sandbox list` output.
  * Strips ANSI codes and exact-matches the sandbox name in the first column.
  */
@@ -438,7 +451,7 @@ async function createSandbox(gpu) {
       }
     }
     // Destroy old sandbox
-    run(`openshell sandbox delete "${sandboxName}" 2>/dev/null || true`, { ignoreError: true });
+    run(`openshell sandbox delete ${shellEscape(sandboxName)} 2>/dev/null || true`, { ignoreError: true });
     registry.removeSandbox(sandboxName);
   }
 
@@ -457,7 +470,7 @@ async function createSandbox(gpu) {
   const basePolicyPath = path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
   const createArgs = [
     `--from "${buildCtx}/Dockerfile"`,
-    `--name "${sandboxName}"`,
+    `--name ${shellEscape(sandboxName)}`,
     `--policy "${basePolicyPath}"`,
   ];
   // --gpu is intentionally omitted. See comment in startGateway().
@@ -525,7 +538,7 @@ async function createSandbox(gpu) {
   // which would silently prevent the new sandbox's dashboard from being reachable.
   run(`openshell forward stop 18789 2>/dev/null || true`, { ignoreError: true });
   // Forward dashboard port to the new sandbox
-  run(`openshell forward start --background 18789 "${sandboxName}"`, { ignoreError: true });
+  run(`openshell forward start --background 18789 ${shellEscape(sandboxName)}`, { ignoreError: true });
 
   // Register only after confirmed ready — prevents phantom entries
   registry.registerSandbox({

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -58,19 +58,6 @@ async function promptOrDefault(question, envVar, defaultValue) {
 // ── Helpers ──────────────────────────────────────────────────────
 
 /**
- * Escapes a string for safe use in shell commands.
- * Wraps in single quotes and handles embedded single quotes.
- */
-function shellEscape(str) {
-  if (typeof str !== "string") {
-    throw new Error("shellEscape: expected string argument");
-  }
-  // Use single quotes and escape any embedded single quotes
-  // by ending the quote, adding an escaped quote, and starting a new quote
-  return "'" + str.replace(/'/g, "'\"'\"'") + "'";
-}
-
-/**
  * Check if a sandbox is in Ready state from `openshell sandbox list` output.
  * Strips ANSI codes and exact-matches the sandbox name in the first column.
  */
@@ -451,7 +438,7 @@ async function createSandbox(gpu) {
       }
     }
     // Destroy old sandbox
-    run(`openshell sandbox delete ${shellEscape(sandboxName)} 2>/dev/null || true`, { ignoreError: true });
+    run(`openshell sandbox delete ${shellQuote(sandboxName)} 2>/dev/null || true`, { ignoreError: true });
     registry.removeSandbox(sandboxName);
   }
 
@@ -470,7 +457,7 @@ async function createSandbox(gpu) {
   const basePolicyPath = path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
   const createArgs = [
     `--from "${buildCtx}/Dockerfile"`,
-    `--name ${shellEscape(sandboxName)}`,
+    `--name ${shellQuote(sandboxName)}`,
     `--policy "${basePolicyPath}"`,
   ];
   // --gpu is intentionally omitted. See comment in startGateway().
@@ -538,7 +525,7 @@ async function createSandbox(gpu) {
   // which would silently prevent the new sandbox's dashboard from being reachable.
   run(`openshell forward stop 18789 2>/dev/null || true`, { ignoreError: true });
   // Forward dashboard port to the new sandbox
-  run(`openshell forward start --background 18789 ${shellEscape(sandboxName)}`, { ignoreError: true });
+  run(`openshell forward start --background 18789 ${shellQuote(sandboxName)}`, { ignoreError: true });
 
   // Register only after confirmed ready — prevents phantom entries
   registry.registerSandbox({

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -221,7 +221,7 @@ function sleep(seconds) {
 
 function waitForSandboxReady(sandboxName, attempts = 10, delaySeconds = 2) {
   for (let i = 0; i < attempts; i += 1) {
-    const exists = runCapture(`openshell sandbox get "${sandboxName}" 2>/dev/null`, { ignoreError: true });
+    const exists = runCapture(`openshell sandbox get ${shellQuote(sandboxName)} 2>/dev/null`, { ignoreError: true });
     if (exists) return true;
     sleep(delaySeconds);
   }
@@ -507,7 +507,7 @@ async function createSandbox(gpu) {
   if (!ready) {
     // Clean up the orphaned sandbox so the next onboard retry with the same
     // name doesn't fail on "sandbox already exists".
-    const delResult = run(`openshell sandbox delete "${sandboxName}" 2>/dev/null || true`, { ignoreError: true });
+    const delResult = run(`openshell sandbox delete ${shellQuote(sandboxName)} 2>/dev/null || true`, { ignoreError: true });
     console.error("");
     console.error(`  Sandbox '${sandboxName}' was created but did not become ready within 60s.`);
     if (delResult.status === 0) {
@@ -800,7 +800,7 @@ async function setupOpenclaw(sandboxName, model, provider) {
       onboardedAt: new Date().toISOString(),
     };
     const script = buildSandboxConfigSyncScript(sandboxConfig);
-    run(`cat <<'EOF_NEMOCLAW_SYNC' | openshell sandbox connect "${sandboxName}"
+    run(`cat <<'EOF_NEMOCLAW_SYNC' | openshell sandbox connect ${shellQuote(sandboxName)}
 ${script}
 EOF_NEMOCLAW_SYNC`, { stdio: ["ignore", "ignore", "inherit"] });
   }


### PR DESCRIPTION
## Summary

- Add `shellEscape()` helper function that wraps strings in single quotes and safely handles embedded single quotes (replacing the previous `"${sandboxName}"` double-quote interpolation)
- Apply `shellEscape()` to all three shell commands that use `sandboxName`:
  - `openshell sandbox delete`
  - `openshell sandbox create --name`
  - `openshell forward start`

This is a re-submission of the quoting fix originally in PR #211, which was accidentally opened with `main` as both the head and base branch. Only the quoting/escaping changes are included here — the lowercase normalization changes are tracked separately in PR #212.

## Test plan

- [ ] Onboard with a normal sandbox name (e.g. `my-assistant`) — should work as before
- [ ] Verify `shellEscape()` correctly handles names containing single quotes (e.g. `it's`) — should produce `'it'"'"'s'`
- [ ] Verify the three shell invocations (`sandbox delete`, `sandbox create --name`, `forward start`) all use the escaped name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety of sandbox commands so names with special or shell-sensitive characters no longer cause failures.
  * Increased reliability of sandbox lifecycle actions (create, delete, connect, port forwarding) without changing public interfaces or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->