### PR TITLE
docs: clarify NemoClaw onboard manages OpenClaw install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ NVIDIA NemoClaw is an open source stack that simplifies running [OpenClaw](https
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
 :::{note}
-NemoClaw currently requires a fresh installation of OpenClaw.
+NemoClaw creates a fresh OpenClaw instance inside the sandbox during onboarding. For net-new installs, the recommended path may be OpenShell-native setup instead. If OpenClaw is already installed on the host, consider the migrate flow instead of a fresh launch.
 :::
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- reword the Quick Start note in `README.md`
- clarify that NemoClaw creates the fresh OpenClaw instance during onboarding
- remove the implication that users must manually install OpenClaw before getting started

## Root cause
The existing note said NemoClaw "requires a fresh installation of OpenClaw," which reads like a manual prerequisite. But the onboard flow handles that setup inside the sandbox, so the note was misleading.

## Validation
- verified the README Quick Start note now says: `NemoClaw creates a fresh OpenClaw instance inside the sandbox during onboarding.`
- confirmed the diff is scoped to `README.md` only

Fixes #322
