### PR TITLE
fix: parameterize sandbox name in setup.sh instead of hardcoding

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -47,7 +47,9 @@ async function setup() {
   console.log("     Running legacy setup.sh for backwards compatibility...");
   console.log("");
   await ensureApiKey();
-  run(`bash "${SCRIPTS}/setup.sh"`);
+  const { defaultSandbox } = registry.listSandboxes();
+  const safeName = defaultSandbox && /^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(defaultSandbox) ? defaultSandbox : "";
+  run(`bash "${SCRIPTS}/setup.sh" ${safeName}`);
 }
 
 async function setupSpark() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,7 +11,7 @@
 #
 # Usage:
 #   export NVIDIA_API_KEY=nvapi-...
-#   ./scripts/setup.sh
+#   ./scripts/setup.sh [sandbox-name]
 #
 # What it does:
 #   1. Starts an OpenShell gateway (or reuses existing)
@@ -70,6 +70,8 @@ command -v docker > /dev/null || fail "docker not found"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SANDBOX_NAME="${1:-nemoclaw}"
+info "Using sandbox name: ${SANDBOX_NAME}"
 
 # 1. Gateway — always start fresh to avoid stale state
 info "Starting OpenShell gateway..."
@@ -139,8 +141,8 @@ info "Setting inference route to nvidia-nim / Nemotron 3 Super..."
 openshell inference set --no-verify --provider nvidia-nim --model nvidia/nemotron-3-super-120b-a12b > /dev/null 2>&1
 
 # 5. Build and create sandbox
-info "Deleting old nemoclaw sandbox (if any)..."
-openshell sandbox delete nemoclaw > /dev/null 2>&1 || true
+info "Deleting old ${SANDBOX_NAME} sandbox (if any)..."
+openshell sandbox delete "$SANDBOX_NAME" > /dev/null 2>&1 || true
 
 info "Building and creating NemoClaw sandbox (this takes a few minutes on first run)..."
 
@@ -162,7 +164,7 @@ fi
 # detect failures. The raw log is kept on failure for debugging.
 CREATE_LOG=$(mktemp /tmp/nemoclaw-create-XXXXXX.log)
 set +e
-openshell sandbox create --from "$BUILD_CTX/Dockerfile" --name nemoclaw \
+openshell sandbox create --from "$BUILD_CTX/Dockerfile" --name "$SANDBOX_NAME" \
   --provider nvidia-nim \
   -- env NVIDIA_API_KEY="$NVIDIA_API_KEY" > "$CREATE_LOG" 2>&1
 CREATE_RC=$?
@@ -183,20 +185,20 @@ rm -f "$CREATE_LOG"
 
 # Verify sandbox is Ready (not just that a record exists)
 # Strip ANSI color codes before checking phase
-SANDBOX_LINE=$(openshell sandbox list 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep "nemoclaw")
+SANDBOX_LINE=$(openshell sandbox list 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | awk -v name="$SANDBOX_NAME" '$1 == name { print; exit }')
 if ! echo "$SANDBOX_LINE" | grep -q "Ready"; then
   SANDBOX_PHASE=$(echo "$SANDBOX_LINE" | awk '{print $NF}')
   echo ""
   warn "Sandbox phase: ${SANDBOX_PHASE:-unknown}"
   # Check for common failure modes
-  SB_DETAIL=$(openshell sandbox get nemoclaw 2>&1 || true)
+  SB_DETAIL=$(openshell sandbox get "$SANDBOX_NAME" 2>&1 || true)
   if echo "$SB_DETAIL" | grep -qi "ImagePull\|ErrImagePull\|image.*not found"; then
     warn "Image pull failure detected. The sandbox image was built inside the"
     warn "gateway but k3s can't find it. This is a known openshell issue."
     warn "Workaround: run 'openshell gateway destroy && openshell gateway start'"
     warn "and re-run this script."
   fi
-  fail "Sandbox created but not Ready (phase: ${SANDBOX_PHASE:-unknown}). Check 'openshell sandbox get nemoclaw'."
+  fail "Sandbox created but not Ready (phase: ${SANDBOX_PHASE:-unknown}). Check 'openshell sandbox get ${SANDBOX_NAME}'."
 fi
 
 # 6. Done

--- a/test/setup-sandbox-name.test.js
+++ b/test/setup-sandbox-name.test.js
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verify that setup.sh uses a parameterized sandbox name instead of
+// hardcoding "nemoclaw". Gateway name must stay hardcoded.
+//
+// See: https://github.com/NVIDIA/NemoClaw/issues/197
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { execSync } = require("node:child_process");
+
+const ROOT = path.resolve(__dirname, "..");
+
+describe("setup.sh sandbox name parameterization (#197)", () => {
+  const content = fs.readFileSync(path.join(ROOT, "scripts/setup.sh"), "utf-8");
+
+  it("accepts sandbox name as $1 with default", () => {
+    assert.ok(
+      content.includes('SANDBOX_NAME="${1:-nemoclaw}"'),
+      'setup.sh must accept sandbox name as $1 with default "nemoclaw"'
+    );
+  });
+
+  it("sandbox create uses $SANDBOX_NAME, not hardcoded", () => {
+    const createLine = content.match(/openshell sandbox create.*--name\s+(\S+)/);
+    assert.ok(createLine, "Could not find openshell sandbox create --name");
+    assert.ok(
+      createLine[1].includes("$SANDBOX_NAME") || createLine[1].includes('"$SANDBOX_NAME"'),
+      `sandbox create --name must use $SANDBOX_NAME, found: ${createLine[1]}`
+    );
+  });
+
+  it("sandbox delete uses $SANDBOX_NAME, not hardcoded", () => {
+    const deleteLine = content.match(/openshell sandbox delete\s+(\S+)/);
+    assert.ok(deleteLine, "Could not find openshell sandbox delete");
+    assert.ok(
+      deleteLine[1].includes("$SANDBOX_NAME") || deleteLine[1].includes('"$SANDBOX_NAME"'),
+      `sandbox delete must use $SANDBOX_NAME, found: ${deleteLine[1]}`
+    );
+  });
+
+  it("sandbox get uses $SANDBOX_NAME, not hardcoded", () => {
+    const getLine = content.match(/openshell sandbox get\s+(\S+)/);
+    assert.ok(getLine, "Could not find openshell sandbox get");
+    assert.ok(
+      getLine[1].includes("$SANDBOX_NAME") || getLine[1].includes('"$SANDBOX_NAME"'),
+      `sandbox get must use $SANDBOX_NAME, found: ${getLine[1]}`
+    );
+  });
+
+  it("gateway name stays hardcoded to nemoclaw", () => {
+    assert.ok(
+      content.includes("gateway destroy -g nemoclaw"),
+      "gateway destroy must use hardcoded nemoclaw (gateway != sandbox)"
+    );
+    assert.ok(
+      content.includes("--name nemoclaw"),
+      "gateway start --name must use hardcoded nemoclaw"
+    );
+  });
+
+  it("$1 arg actually sets SANDBOX_NAME in bash", () => {
+    const result = execSync(
+      'bash -c \'SANDBOX_NAME="${1:-nemoclaw}"; echo "$SANDBOX_NAME"\' -- my-test-box',
+      { encoding: "utf-8" }
+    ).trim();
+    assert.equal(result, "my-test-box");
+  });
+
+  it("no arg defaults to nemoclaw in bash", () => {
+    const result = execSync(
+      'bash -c \'SANDBOX_NAME="${1:-nemoclaw}"; echo "$SANDBOX_NAME"\'',
+      { encoding: "utf-8" }
+    ).trim();
+    assert.equal(result, "nemoclaw");
+  });
+});


### PR DESCRIPTION
Closes #197.

## Summary

- `setup.sh` accepts sandbox name as `$1` (default: `nemoclaw`)
- All sandbox operations (`create`, `delete`, `get`, `list` grep) use `$SANDBOX_NAME`
- Gateway name stays hardcoded to `nemoclaw` (gateway and sandbox names are independent)
- `nemoclaw setup` (legacy command) passes the default sandbox name from the registry
- 7 regression tests verify parameterization and that gateway name stays hardcoded

## Problem

The onboard wizard lets users choose a custom sandbox name stored in `~/.nemoclaw/sandboxes.json`, but `setup.sh` hardcoded `--name nemoclaw` everywhere. This created a split-brain: NemoClaw's registry had the custom name, OpenShell had "nemoclaw", and every subsequent command (connect, policy, bridge) failed with "sandbox not found."

## Test plan

- [x] 71/71 unit tests pass (64 existing + 7 new)
- [x] Custom name: `bash scripts/setup.sh test-197` creates sandbox named `test-197`
- [x] Default behavior: `bash scripts/setup.sh` creates sandbox named `nemoclaw`
- [x] Gateway name stays hardcoded `nemoclaw` in all gateway operations
- [x] No remaining hardcoded sandbox "nemoclaw" in sandbox operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The setup process now supports configurable sandbox names based on registry defaults, enabling more flexible environment initialization instead of using a hardcoded naming convention.

* **Tests**
  * Added test suite to validate sandbox name parameterization, ensuring correct default behavior, proper argument handling, and accurate sandbox operation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->