### PR TITLE
docs: fix misleading OpenClaw install note and remove unsupported deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ NVIDIA NemoClaw is an open source stack that simplifies running [OpenClaw](https
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
 > [!NOTE]
-> NemoClaw currently requires a fresh installation of OpenClaw.
+> NemoClaw creates a fresh OpenClaw instance inside the sandbox during onboarding.
 
 <!-- start-quickstart-guide -->
 
@@ -167,7 +167,6 @@ Run these on the host to set up, connect to, and manage sandboxes.
 | Command                              | Description                                            |
 |--------------------------------------|--------------------------------------------------------|
 | `nemoclaw onboard`                  | Interactive setup wizard: gateway, providers, sandbox. |
-| `nemoclaw deploy <instance>` (**experimental**)         | Deploy to a remote GPU instance through Brev.          |
 | `nemoclaw <name> connect`            | Open an interactive shell inside the sandbox.          |
 | `openshell term`                     | Launch the OpenShell TUI for monitoring and approvals. |
 | `nemoclaw start` / `stop` / `status` | Manage auxiliary services (Telegram bridge, tunnel).   |


### PR DESCRIPTION
Fixes #322
Fixes #323

## Summary

This PR addresses two documentation issues in the `README.md`:

1. **Misleading OpenClaw installation note (#322):** The previous note stated that "NemoClaw currently requires a fresh installation of OpenClaw," which implied a manual prerequisite step. It has been reworded to clarify that NemoClaw handles the creation of a fresh OpenClaw instance inside the sandbox during the onboarding process.
2. **Unsupported `deploy` command (#323):** The `nemoclaw deploy <instance>` command was listed in the Key Commands table but is not part of the currently supported scope. It has been removed to avoid setting incorrect expectations.

## Changes
- Reworded the Quick Start note regarding OpenClaw installation.
- Removed the `nemoclaw deploy` row from the Key Commands table.