### PR TITLE
docs: link to DGX Spark installation guide from Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Follow these steps to get started with NemoClaw and your first sandboxed OpenCla
 
 Check the prerequisites before you start to ensure you have the necessary software and hardware to run NemoClaw.
 
+> [!NOTE]
+> **DGX Spark users:** Follow the [DGX Spark installation guide](docs/spark-install.md) instead of the steps below.
+
 #### Hardware
 
 | Resource | Minimum        | Recommended      |


### PR DESCRIPTION
Closes #321

Added a note in the Prerequisites section linking to `docs/spark-install.md` so DGX Spark users can find the correct setup path without following the main install flow and hitting opaque errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prerequisite note for DGX Spark users, directing them to follow the dedicated DGX Spark installation guide for setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->