### PR TITLE
docs(network): clarify host-side policy editing

### DIFF
--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -40,8 +40,8 @@ Create or edit policy files on the host, then apply them to the sandbox.
 Before creating a custom policy file, check whether an existing preset already covers the service you need:
 
 ```console
-$ nemoclaw <name> policy-list
-$ nemoclaw <name> policy-add
+nemoclaw <name> policy-list
+nemoclaw <name> policy-add
 ```
 
 Use `policy-add` for built-in presets such as `slack`, `telegram`, `npm`, or `pypi`.
@@ -72,7 +72,7 @@ Each entry in the `network_policies` section defines an endpoint group with the 
 Apply the updated policy by re-running the onboard wizard:
 
 ```console
-$ nemoclaw onboard
+nemoclaw onboard
 ```
 
 The wizard picks up the modified policy file and applies it to the sandbox.
@@ -82,7 +82,7 @@ The wizard picks up the modified policy file and applies it to the sandbox.
 Check that the sandbox is running with the updated policy:
 
 ```console
-$ nemoclaw <name> status
+nemoclaw <name> status
 ```
 
 ## Dynamic Changes
@@ -119,7 +119,7 @@ network_policies:
 Use the OpenShell CLI to apply the policy update:
 
 ```console
-$ openshell policy set <policy-file>
+openshell policy set <policy-file>
 ```
 
 The change takes effect immediately.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -27,18 +27,36 @@ NemoClaw supports both static policy changes that persist across restarts and dy
 
 ## Prerequisites
 
-- A running NemoClaw sandbox for dynamic changes, or the NemoClaw source repository for static changes.
+- A running NemoClaw sandbox for dynamic changes.
+- The NemoClaw source repository if you want to change the baseline policy permanently for future sandboxes.
 - The OpenShell CLI on your `PATH`.
+
+Do not try to edit policy files from inside the sandbox shell.
+The sandbox image intentionally omits editors such as `vim` and `nano`, does not provide `sudo`, and does not allow package-manager writes to system paths.
+Create or edit policy files on the host, then apply them to the sandbox.
+
+## Use Presets First
+
+Before creating a custom policy file, check whether an existing preset already covers the service you need:
+
+```console
+$ nemoclaw <name> policy-list
+$ nemoclaw <name> policy-add
+```
+
+Use `policy-add` for built-in presets such as `slack`, `telegram`, `npm`, or `pypi`.
+Create a custom policy file only when you need to allow a host that is not covered by an existing preset.
 
 ## Static Changes
 
 Static changes modify the baseline policy file and take effect after the next sandbox creation.
+Use this path when you are working from a local NemoClaw checkout and want every future sandbox to inherit the change.
 
 ### Edit the Policy File
 
-Open `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` and add or modify endpoint entries.
+On the host, open `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` from the NemoClaw source tree and add or modify endpoint entries.
 
-Each entry in the `network` section defines an endpoint group with the following fields:
+Each entry in the `network_policies` section defines an endpoint group with the following fields:
 
 `endpoints`
 : Host and port pairs that the sandbox can reach.
@@ -70,11 +88,31 @@ $ nemoclaw <name> status
 ## Dynamic Changes
 
 Dynamic changes apply a policy update to a running sandbox without restarting it.
+Use this path when you installed NemoClaw already and want to allow an additional endpoint without rebuilding the baseline blueprint.
 
 ### Create a Policy File
 
-Create a YAML file with the endpoints to add.
+On the host, create a YAML file with the endpoints to add.
 Follow the same format as the baseline policy in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`.
+
+For example, to allow a weather API from `curl`, create a file such as `weather-policy.yaml`:
+
+```yaml
+version: 1
+network_policies:
+  weather:
+    name: weather
+    endpoints:
+      - host: api.weather.gov
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+    binaries:
+      - { path: /usr/bin/curl }
+```
 
 ### Apply the Policy
 


### PR DESCRIPTION
Addresses #149

## Summary
- clarify that policy files should be edited on the host, not from inside the sandbox shell
- point readers to `policy-list` and `policy-add` before custom YAML edits
- fix the docs to reference the actual `network_policies` section name and add a host-side dynamic policy example

## Test plan
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified prerequisites: a running sandbox is only needed for dynamic changes; the source repository is required only for permanent baseline edits.
  * Explicitly prohibit editing policies inside the sandbox; create/edit policy files on the host before applying.
  * Added "Use Presets First" workflow with commands to list/add presets.
  * Renamed `network` → `network_policies`, clarified endpoint/rule fields, added a concrete YAML example.
  * Updated CLI/OpenShell examples and formatting; clarified dynamic updates can add endpoints without rebuilding the baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->