### PR TITLE
docs(quickstart): note sandbox create OOM failure

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -34,7 +34,7 @@ NemoClaw currently requires a fresh installation of OpenClaw.
 :end-before: <!-- end-quickstart-guide -->
 ```
 
-### Troubleshooting: `Creating sandbox` exits with `Killed` or `exit 137`
+## Troubleshooting: `Creating sandbox` exits with `Killed` or `exit 137`
 
 If `nemoclaw onboard` fails during **Creating sandbox** and the shell reports `Killed` or exit code `137`, the host likely ran out of memory while building or starting the sandbox image.
 
@@ -46,7 +46,7 @@ Before rerunning `nemoclaw onboard`:
 - Restart the shell session if the Docker or OpenShell processes were terminated by the OOM killer.
 - Retry the onboard flow after the host has enough free memory headroom for the image build and sandbox startup.
 
-### Next Steps
+## Next Steps
 
 - [Switch inference providers](../inference/switch-inference-providers.md) to use a different model or endpoint.
 - [Approve or deny network requests](../network-policy/approve-network-requests.md) when the agent tries to reach external hosts.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -34,6 +34,18 @@ NemoClaw currently requires a fresh installation of OpenClaw.
 :end-before: <!-- end-quickstart-guide -->
 ```
 
+### Troubleshooting: `Creating sandbox` exits with `Killed` or `exit 137`
+
+If `nemoclaw onboard` fails during **Creating sandbox** and the shell reports `Killed` or exit code `137`, the host likely ran out of memory while building or starting the sandbox image.
+
+Community reports have reproduced this on small VMs with 8 GB of RAM; retrying with more memory resolved the failure.
+
+Before rerunning `nemoclaw onboard`:
+
+- Increase the VM or host memory allocation.
+- Restart the shell session if the Docker or OpenShell processes were terminated by the OOM killer.
+- Retry the onboard flow after the host has enough free memory headroom for the image build and sandbox startup.
+
 ### Next Steps
 
 - [Switch inference providers](../inference/switch-inference-providers.md) to use a different model or endpoint.


### PR DESCRIPTION
Addresses #302

## Summary
- add a quickstart troubleshooting note for `Creating sandbox` failures that end with `Killed` or exit `137`
- explain that this usually indicates host-side memory pressure during sandbox build/start
- recommend increasing available memory before rerunning onboard

## Test plan
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Troubleshooting section for sandbox creation failures due to host out-of-memory, including a brief checklist (increase host/VM memory, restart shell if services were OOM‑killed, and retry once memory headroom is available).
  * Demoted the "Next Steps" heading level; linked guidance and links remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->