### PR TITLE
docs(network-policy): clarify host-side policy editing

### DIFF
--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -28,6 +28,11 @@ NemoClaw supports both static policy changes that persist across restarts and dy
 - A running NemoClaw sandbox for dynamic changes, or the NemoClaw source repository for static changes.
 - The OpenShell CLI on your `PATH`.
 
+> [!IMPORTANT]
+> Make static policy edits on the host, not inside the sandbox.
+> The sandbox image is intentionally minimal and may not include editors or package-management tools.
+> Changes made only inside the sandbox are also ephemeral and are lost when the sandbox is recreated.
+
 ## Static Changes
 
 Static changes modify the baseline policy file and take effect after the next sandbox creation.
@@ -35,6 +40,14 @@ Static changes modify the baseline policy file and take effect after the next sa
 ### Edit the Policy File
 
 Open `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` and add or modify endpoint entries.
+
+If you only need one of the built-in presets, use `nemoclaw <name> policy-add` instead of editing YAML by hand:
+
+```console
+$ nemoclaw my-assistant policy-add
+```
+
+Use a manual YAML edit when you need to allow custom hosts that are not covered by a preset, such as an internal API or a weather service.
 
 Each entry in the `network` section defines an endpoint group with the following fields:
 
@@ -89,6 +102,16 @@ The change takes effect immediately.
 Dynamic changes apply only to the current session.
 When the sandbox stops, the running policy resets to the baseline defined in the policy file.
 To make changes permanent, update the static policy file and re-run setup.
+
+### Approve Requests Interactively
+
+For one-off access, you can approve blocked requests in the OpenShell TUI instead of editing the baseline policy:
+
+```console
+$ openshell term
+```
+
+This is useful when you want to test a destination before deciding whether it belongs in a permanent preset or custom policy file.
 
 ## Related Topics
 


### PR DESCRIPTION
Fixes #149

## Summary

- clarify that baseline policy edits belong on the host, not inside the sandbox
- point users to `nemoclaw <name> policy-add` when a preset is sufficient
- document `openshell term` as the one-off approval path before making a permanent policy change

## Test plan

- [x] `make docs-strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced network policy customization guide with host-sandbox configuration clarity.
  * Added instructions for using built-in preset policies and manual YAML editing guidance.
  * Introduced interactive approval workflow for blocked requests via OpenShell TUI.
  * Expanded policy configuration guidance and re-run procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->