### PR TITLE
feat(sandbox): install nano in sandbox images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip python3-venv \
         curl git ca-certificates \
         iproute2 \
+        nano \
     && rm -rf /var/lib/apt/lists/*
 
 # Create sandbox user (matches OpenShell convention)

--- a/test/Dockerfile.sandbox
+++ b/test/Dockerfile.sandbox
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip python3-venv \
         curl git ca-certificates \
         iproute2 \
+        nano \
     && rm -rf /var/lib/apt/lists/*
 
 # Create sandbox user (matches OpenShell convention)

--- a/test/dockerfile-packages.test.js
+++ b/test/dockerfile-packages.test.js
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function read(relPath) {
+  return fs.readFileSync(path.join(__dirname, "..", relPath), "utf8");
+}
+
+function packagesFromDockerfile(contents) {
+  const match = contents.match(/apt-get install -y --no-install-recommends \\\n([\s\S]*?)\n\s*&& rm -rf/);
+  assert.ok(match, "expected apt-get install block");
+
+  return match[1]
+    .split("\n")
+    .map((line) => line.replace(/\\/, "").trim())
+    .filter(Boolean);
+}
+
+describe("sandbox image package list", () => {
+  it("includes nano in the production sandbox image", () => {
+    const packages = packagesFromDockerfile(read("Dockerfile"));
+    assert.ok(packages.includes("nano"), "expected production sandbox image to install nano");
+  });
+
+  it("includes nano in the test sandbox image", () => {
+    const packages = packagesFromDockerfile(read("test/Dockerfile.sandbox"));
+    assert.ok(packages.includes("nano"), "expected test sandbox image to install nano");
+  });
+});


### PR DESCRIPTION
Fixes #344

## Summary

- add `nano` to the production sandbox image
- add `nano` to the test sandbox image so fixtures match runtime expectations
- add a regression test that keeps both Dockerfiles aligned on this package

## Test plan

- [x] `node --test test/dockerfile-packages.test.js`
- [x] `npm test`