### PR TITLE
docs(monitoring): explain how to open the dashboard

### DIFF
--- a/docs/monitoring/monitor-sandbox-activity.md
+++ b/docs/monitoring/monitor-sandbox-activity.md
@@ -66,6 +66,14 @@ If the sandbox is running on a remote host, run the forward command on that host
 open the forwarded address from the same machine, or tunnel port `18789` back to your
 local workstation before opening the URL.
 
+For example, replace `<user>@<remote-host>` with your actual SSH login and run:
+
+```console
+$ ssh -L 18789:127.0.0.1:18789 <user>@<remote-host>
+```
+
+After the tunnel is established, open `http://127.0.0.1:18789` on your workstation.
+
 ## View Blueprint and Sandbox Logs
 
 Stream the most recent log output from the blueprint runner and sandbox:

--- a/docs/monitoring/monitor-sandbox-activity.md
+++ b/docs/monitoring/monitor-sandbox-activity.md
@@ -43,6 +43,29 @@ Key fields in the output include the following:
 
 Run `nemoclaw <name> status` on the host to check sandbox state. Use `openshell sandbox list` for the underlying sandbox details.
 
+## Open the OpenClaw Dashboard
+
+NemoClaw does not add a separate `openclaw dashboard` wrapper. Instead, it forwards
+the dashboard to local port `18789` on the host that is running the sandbox.
+
+If you already use the connect command, NemoClaw refreshes the port forward for you:
+
+```console
+$ nemoclaw my-assistant connect
+```
+
+To start or refresh the dashboard forward without opening an interactive shell:
+
+```console
+$ openshell forward start --background 18789 my-assistant
+```
+
+Then open `http://127.0.0.1:18789` in your browser.
+
+If the sandbox is running on a remote host, run the forward command on that host and
+open the forwarded address from the same machine, or tunnel port `18789` back to your
+local workstation before opening the URL.
+
 ## View Blueprint and Sandbox Logs
 
 Stream the most recent log output from the blueprint runner and sandbox:

--- a/docs/monitoring/monitor-sandbox-activity.md
+++ b/docs/monitoring/monitor-sandbox-activity.md
@@ -51,13 +51,13 @@ the dashboard to local port `18789` on the host that is running the sandbox.
 If you already use the connect command, NemoClaw refreshes the port forward for you:
 
 ```console
-$ nemoclaw my-assistant connect
+nemoclaw <sandbox-name> connect
 ```
 
 To start or refresh the dashboard forward without opening an interactive shell:
 
 ```console
-$ openshell forward start --background 18789 my-assistant
+openshell forward start --background 18789 <sandbox-name>
 ```
 
 Then open `http://127.0.0.1:18789` in your browser.
@@ -69,7 +69,7 @@ local workstation before opening the URL.
 For example, replace `<user>@<remote-host>` with your actual SSH login and run:
 
 ```console
-$ ssh -L 18789:127.0.0.1:18789 <user>@<remote-host>
+ssh -L 18789:127.0.0.1:18789 <user>@<remote-host>
 ```
 
 After the tunnel is established, open `http://127.0.0.1:18789` on your workstation.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -77,6 +77,7 @@ $ nemoclaw deploy <instance-name>
 ### `nemoclaw <name> connect`
 
 Connect to a sandbox by name.
+This command also refreshes the local dashboard port forward on `127.0.0.1:18789`.
 
 ```console
 $ nemoclaw my-assistant connect

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -80,7 +80,7 @@ Connect to a sandbox by name.
 This command also refreshes the local dashboard port forward on `127.0.0.1:18789`.
 
 ```console
-$ nemoclaw my-assistant connect
+nemoclaw <sandbox-name> connect
 ```
 
 ### `nemoclaw <name> status`


### PR DESCRIPTION
Fixes #293

## Summary

- document that NemoClaw exposes the OpenClaw dashboard through a local forward on port `18789`
- show how `nemoclaw <name> connect` refreshes that forward automatically
- add the same detail to the command reference for `nemoclaw <name> connect`

## Test plan

- [x] `make docs-strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added instructions for accessing the OpenClaw Dashboard via local port forwarding at http://127.0.0.1:18789.
  * Noted that the connect command refreshes the local dashboard port forward so the dashboard remains reachable.
  * Added guidance for starting or refreshing the forward in the background.
  * Added remote-host instructions showing how to use an SSH local port tunnel to access the dashboard from your workstation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->