### PR TITLE
fix: repair pypi and npm policy presets for package manager traffic

### DIFF
--- a/nemoclaw-blueprint/policies/presets/npm.yaml
+++ b/nemoclaw-blueprint/policies/presets/npm.yaml
@@ -16,9 +16,9 @@ network_policies:
         port: 443
         access: full
     binaries:
-      - { path: /usr/local/bin/npm }
-      - { path: /usr/local/bin/npx }
-      - { path: /usr/local/bin/node }
-      - { path: /usr/local/bin/yarn }
-      - { path: /usr/bin/npm }
-      - { path: /usr/bin/node }
+      - { path: /usr/local/bin/npm* }
+      - { path: /usr/local/bin/npx* }
+      - { path: /usr/local/bin/node* }
+      - { path: /usr/local/bin/yarn* }
+      - { path: /usr/bin/npm* }
+      - { path: /usr/bin/node* }

--- a/nemoclaw-blueprint/policies/presets/npm.yaml
+++ b/nemoclaw-blueprint/policies/presets/npm.yaml
@@ -11,15 +11,14 @@ network_policies:
     endpoints:
       - host: registry.npmjs.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: registry.yarnpkg.com
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
+    binaries:
+      - { path: /usr/local/bin/npm }
+      - { path: /usr/local/bin/npx }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/local/bin/yarn }
+      - { path: /usr/bin/npm }
+      - { path: /usr/bin/node }

--- a/nemoclaw-blueprint/policies/presets/pypi.yaml
+++ b/nemoclaw-blueprint/policies/presets/pypi.yaml
@@ -11,15 +11,17 @@ network_policies:
     endpoints:
       - host: pypi.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
       - host: files.pythonhosted.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
+    binaries:
+      - { path: /usr/bin/python3 }
+      - { path: /usr/bin/pip3 }
+      - { path: /usr/bin/pip }
+      - { path: /usr/local/bin/pip }
+      - { path: /usr/local/bin/pip3 }
+      - { path: /sandbox/.venv/bin/python* }
+      - { path: /sandbox/.venv/bin/pip* }
+      - { path: /sandbox/.uv/python/**/python* }
+      - { path: /sandbox/.local/bin/pip* }

--- a/nemoclaw-blueprint/policies/presets/pypi.yaml
+++ b/nemoclaw-blueprint/policies/presets/pypi.yaml
@@ -16,11 +16,10 @@ network_policies:
         port: 443
         access: full
     binaries:
-      - { path: /usr/bin/python3 }
-      - { path: /usr/bin/pip3 }
-      - { path: /usr/bin/pip }
-      - { path: /usr/local/bin/pip }
-      - { path: /usr/local/bin/pip3 }
+      - { path: /usr/bin/python3* }
+      - { path: /usr/bin/pip* }
+      - { path: /usr/local/bin/python3* }
+      - { path: /usr/local/bin/pip* }
       - { path: /sandbox/.venv/bin/python* }
       - { path: /sandbox/.venv/bin/pip* }
       - { path: /sandbox/.uv/python/**/python* }

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -114,5 +114,45 @@ describe("policies", () => {
         assert.ok(content.includes("network_policies:"), `${p.name} missing network_policies`);
       }
     });
+
+    it("package-manager presets use access: full (not tls: terminate)", () => {
+      // Package managers (pip, npm, yarn) use CONNECT tunneling which breaks
+      // under tls: terminate. Ensure these presets use access: full like the
+      // github policy in openclaw-sandbox.yaml.
+      const packagePresets = ["pypi", "npm"];
+      for (const name of packagePresets) {
+        const content = policies.loadPreset(name);
+        assert.ok(content, `preset not found: ${name}`);
+        assert.ok(
+          !content.includes("tls: terminate"),
+          `${name} preset must not use tls: terminate (breaks CONNECT tunneling)`
+        );
+        assert.ok(
+          content.includes("access: full"),
+          `${name} preset must use access: full for package manager compatibility`
+        );
+      }
+    });
+
+    it("package-manager presets include binaries section", () => {
+      // Without binaries, the proxy can't match pip/npm traffic to the policy
+      // and returns 403.
+      const packagePresets = [
+        { name: "pypi", expectedBinary: "python" },
+        { name: "npm", expectedBinary: "npm" },
+      ];
+      for (const { name, expectedBinary } of packagePresets) {
+        const content = policies.loadPreset(name);
+        assert.ok(content, `preset not found: ${name}`);
+        assert.ok(
+          content.includes("binaries:"),
+          `${name} preset must include a binaries section`
+        );
+        assert.ok(
+          content.includes(expectedBinary),
+          `${name} preset binaries must include ${expectedBinary}`
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes #19.

## Summary

- Switch pypi and npm presets from `tls: terminate` + REST rules to `access: full` (enables CONNECT tunneling)
- Add `binaries` sections with glob patterns so OpenShell's proxy can match pip/npm/node traffic to the policy
- Use glob patterns (`python3*`, `node*`) because OpenShell resolves symlinks before matching — `/usr/bin/python3` is a symlink to `/usr/bin/python3.11` on Debian

Credit to @futhgar (PR #36) for identifying the `access: full` fix.

## Problem

The onboard wizard suggests pypi and npm presets, but `pip install` and `npm install` fail with 403 errors inside the sandbox. Two issues:
1. `tls: terminate` breaks CONNECT tunneling that package managers need
2. Missing `binaries` section means OpenShell's proxy can't match pip/npm traffic to the policy

## Test plan

- [x] 66/66 unit tests pass (including 2 new preset validation tests)
- [x] `pip install requests` succeeds inside sandbox after applying pypi preset
- [x] Preset YAML validated: access: full, no tls: terminate, binaries present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified policy configurations for npm and PyPI package managers with streamlined access models
  * Added allowlists for common package manager and Python executables across standard system and sandbox locations

* **Tests**
  * Added validation tests for policy preset structure and binary path compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->