### PR TITLE
fix(install): check ports 8080 and 18789 are free before starting gateway

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,47 @@ version_major() {
   printf '%s\n' "${1#v}" | cut -d. -f1
 }
 
+# ── Port availability preflight ──────────────────────────────────────
+# NemoClaw requires two ports to be free before setup starts:
+#   NEMOCLAW_GATEWAY_PORT   (default 8080)  – OpenShell gateway
+#   NEMOCLAW_DASHBOARD_PORT (default 18789) – OpenClaw dashboard
+# Override via env var to avoid killing existing services.
+NEMOCLAW_GATEWAY_PORT="${NEMOCLAW_GATEWAY_PORT:-8080}"
+NEMOCLAW_DASHBOARD_PORT="${NEMOCLAW_DASHBOARD_PORT:-18789}"
+
+_port_in_use() {
+  local p="$1"
+  if command -v ss &>/dev/null; then
+    ss -tlnH 2>/dev/null | awk '{print $4}' | grep -q ":${p}$"
+    return $?
+  elif command -v netstat &>/dev/null; then
+    netstat -tlnH 2>/dev/null | awk '{print $4}' | grep -q ":${p}$"
+    return $?
+  fi
+  return 1
+}
+
+check_required_ports() {
+  local failed=0
+  for spec in "${NEMOCLAW_GATEWAY_PORT}:gateway" "${NEMOCLAW_DASHBOARD_PORT}:dashboard"; do
+    local port="${spec%%:*}" label="${spec##*:}"
+    if _port_in_use "$port"; then
+      echo "[ERROR] Port $port ($label) is already in use."                      >&2
+      echo "[ERROR]   Find the process : ss -tlnp | grep :$port"                 >&2
+      echo "[ERROR]   Or override      : export NEMOCLAW_${label^^}_PORT=<free>" >&2
+      failed=1
+    fi
+  done
+  if [ "$failed" -eq 1 ]; then
+    echo "" >&2
+    echo "[ERROR] Free the ports above (or set override env vars), then re-run." >&2
+    exit 1
+  fi
+  echo "[INFO]  Ports ${NEMOCLAW_GATEWAY_PORT} (gateway) and ${NEMOCLAW_DASHBOARD_PORT} (dashboard) are free."
+}
+# ─────────────────────────────────────────────────────────────────────
+
+
 ensure_supported_runtime() {
   command_exists node || error "${RUNTIME_REQUIREMENT_MSG} Node.js was not found on PATH."
   command_exists npm || error "${RUNTIME_REQUIREMENT_MSG} npm was not found on PATH."
@@ -98,6 +139,7 @@ install_nodejs() {
     || { rm -f "$nvm_tmp"; error "Failed to download nvm installer"; }
   local actual_hash
   if command_exists sha256sum; then
+check_required_ports
     actual_hash="$(sha256sum "$nvm_tmp" | awk '{print $1}')"
   elif command_exists shasum; then
     actual_hash="$(shasum -a 256 "$nvm_tmp" | awk '{print $1}')"


### PR DESCRIPTION

Fixes #51

`install.sh` starts the OpenShell gateway on port `8080` and the OpenClaw dashboard on port `18789` without checking whether those ports are already in use. Users with existing Docker containers or other services on those ports get a cryptic startup failure with no actionable guidance.

## Problem

When a port is occupied, the installer fails deep in gateway startup with no clear message:
```
Error: listen tcp 0.0.0.0:8080: bind: address already in use
```

There is no named error, no suggestion to check ports, and no way to override without editing the script.

## Fix

Adds `check_required_ports()` to the `[1/7] Preflight checks` step, before any gateway or sandbox setup begins:

- Detects conflicts using `ss` (iproute2) with `netstat` as fallback
- Prints a clear, named error identifying the conflicting port and service
- Documents `NEMOCLAW_GATEWAY_PORT` and `NEMOCLAW_DASHBOARD_PORT` env-var overrides so users can switch ports without stopping existing services
- Degrades gracefully (warns only) when neither `ss` nor `netstat` is available

## Example output when a port is occupied
```
[ERROR] Port 8080 (gateway) is already in use.
[ERROR]   Check: ss -tlnp | grep :8080
[ERROR]   Override: export NEMOCLAW_GATEWAY_PORT=<free-port>
[ERROR] Free conflicting ports (or override via env vars) then re-run.
```