### PR TITLE
docs(readme): add macOS/Apple Silicon as supported platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The sandbox image is approximately 2.4 GB compressed. During image push, the Doc
 | Dependency | Version                          |
 |------------|----------------------------------|
 | Linux      | Ubuntu 22.04 LTS or later |
+* macOS 13 (Ventura) or later with [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
 | Node.js    | 20 or later |
 | npm        | 10 or later |
 | Docker     | Installed and running |


### PR DESCRIPTION
## Summary

Relates to #260

The **Prerequisites** section in `README.md` only lists `Linux Ubuntu 22.04 LTS` under Software requirements. This leaves macOS/Apple Silicon users with no guidance, despite NemoClaw working on macOS with Docker Desktop — confirmed in #260 by multiple contributors on M-series Macs.

## Change

Add **macOS 13 (Ventura) or later with Docker Desktop** as an explicitly supported platform in the Software prerequisites section.

## Context from issue #260

The following features are confirmed working on macOS/Apple Silicon:
- Install + sandbox creation 
- NVIDIA Cloud NIM inference 
- Security model (Landlock + seccomp + netns) 
- OpenClaw integration 

Not documenting macOS support causes confusion for Mac users who assume NemoClaw is Linux-only.

Docs-only change. Zero logic changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system prerequisites to specify macOS 13 (Ventura) or later as the minimum required version.
  * Added Docker Desktop to the list of required software components for installation and operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->