### PR TITLE
Fix install wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ NVIDIA NemoClaw is an open source stack that simplifies running [OpenClaw](https
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
 > [!NOTE]
-> NemoClaw currently requires a fresh installation of OpenClaw.
+> NemoClaw currently creates a fresh installation of OpenClaw.
 
 <!-- start-quickstart-guide -->
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -23,7 +23,7 @@ status: published
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
 :::{note}
-NemoClaw currently requires a fresh installation of OpenClaw.
+NemoClaw currently creates a fresh installation of OpenClaw.
 :::
 
 ```{include} ../../README.md


### PR DESCRIPTION
There has been some confusion about this wording to changing `requires` => `creates`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start and getting started documentation to clarify that NemoClaw creates a fresh installation of OpenClaw.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->