### PR TITLE
docs: link DGX Spark setup guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The sandbox image is approximately 2.4 GB compressed. During image push, the Doc
 | macOS | Podman | Not supported yet. NemoClaw currently depends on OpenShell support for Podman on macOS. |
 | Windows WSL | Docker Desktop (WSL backend) | Supported target path |
 
+> [!TIP]
+> **DGX Spark users:** Follow the [DGX Spark setup guide](spark-install.md) instead — it covers Spark-specific prerequisites (cgroup v2, Docker configuration) before running the standard installer.
+
 ### Install NemoClaw and Onboard OpenClaw Agent
 
 Download and run the installer script.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The sandbox image is approximately 2.4 GB compressed. During image push, the Doc
 | Windows WSL | Docker Desktop (WSL backend) | Supported target path |
 
 > [!TIP]
-> **DGX Spark users:** Follow the [DGX Spark setup guide](spark-install.md) instead — it covers Spark-specific prerequisites (cgroup v2, Docker configuration) before running the standard installer.
+> For DGX Spark, follow the [DGX Spark setup guide](spark-install.md). It covers Spark-specific prerequisites, such as cgroup v2 and Docker configuration, before running the standard installer.
 
 ### Install NemoClaw and Onboard OpenClaw Agent
 


### PR DESCRIPTION
Closes #321.

## Summary

- Add a tip box before the install section directing DGX Spark users to `spark-install.md`

## Problem

Spark users following the main Quick Start hit opaque errors because Spark-specific prerequisites (cgroup v2, Docker configuration) are only documented in `spark-install.md`, which the README never links to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a callout in the "Container Runtime Support" section advising DGX Spark users to complete the Spark setup guide before running the standard installer, and calling out Spark-specific prerequisites (e.g., cgroup v2 and Docker configuration). No other installation instructions or documentation structure were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->