### PR TITLE
docs: fix misleading OpenClaw note and remove unsupported deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ NVIDIA NemoClaw is an open source stack that simplifies running [OpenClaw](https
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
 > [!NOTE]
-> NemoClaw currently requires a fresh installation of OpenClaw.
+> NemoClaw creates a fresh OpenClaw instance inside the sandbox during onboarding.
 
 <!-- start-quickstart-guide -->
 
@@ -181,7 +181,6 @@ Run these on the host to set up, connect to, and manage sandboxes.
 | Command                              | Description                                            |
 |--------------------------------------|--------------------------------------------------------|
 | `nemoclaw onboard`                  | Interactive setup wizard: gateway, providers, sandbox. |
-| `nemoclaw deploy <instance>` (**experimental**)         | Deploy to a remote GPU instance through Brev.          |
 | `nemoclaw <name> connect`            | Open an interactive shell inside the sandbox.          |
 | `openshell term`                     | Launch the OpenShell TUI for monitoring and approvals. |
 | `nemoclaw start` / `stop` / `status` | Manage auxiliary services (Telegram bridge, tunnel).   |


### PR DESCRIPTION
Closes #322, closes #323.

## Summary

- Replace "requires a fresh installation of OpenClaw" with "creates a fresh OpenClaw instance inside the sandbox during onboarding" — the old note implied a manual step that doesn't exist
- Remove `nemoclaw deploy` from Key Commands table — remote deployment is not in the current supported scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding messaging to clarify that NemoClaw creates a new OpenClaw instance inside the sandbox during setup, rather than requiring a fresh installation.
  * Removed the experimental host command entry from documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->