### PR TITLE
fix(install): redirect stdin from /dev/tty when run via curl pipe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -278,8 +278,16 @@ run_onboard() {
   info "Running nemoclaw onboard…"
   if [ "${NON_INTERACTIVE:-}" = "1" ]; then
     nemoclaw onboard --non-interactive
-  else
+  elif [ -t 0 ]; then
+    # stdin is already a terminal — run interactively as normal
     nemoclaw onboard
+  elif ( : </dev/tty ) 2>/dev/null; then
+    # stdin is a pipe (e.g. curl | bash) but a terminal is available —
+    # redirect stdin from /dev/tty so interactive prompts work
+    nemoclaw onboard </dev/tty
+  else
+    warn "No terminal available — skipping interactive onboard."
+    info "Run 'nemoclaw onboard' manually to complete setup."
   fi
 }
 

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -445,4 +445,75 @@ exit 0
     assert.equal(fs.readlinkSync(shimPath), path.join(prefix, "bin", "nemoclaw"));
     assert.match(`${result.stdout}${result.stderr}`, /Created user-local shim/);
   });
+
+  it("does not hang when installer is piped via stdin (curl | bash)", () => {
+    // Simulates: curl -fsSL https://nvidia.com/nemoclaw.sh | bash
+    // Before the fix, nemoclaw onboard received EOF on stdin (the pipe)
+    // instead of terminal input, causing it to hang or silently exit.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-pipe-onboard-"));
+    const fakeBin = path.join(tmp, "bin");
+    const prefix = path.join(tmp, "prefix");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+    writeExecutable(
+      path.join(fakeBin, "node"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ] || [ "$1" = "-v" ]; then
+  echo "v22.14.0"
+  exit 0
+fi
+exit 99
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "--version" ]; then
+  echo "10.9.2"
+  exit 0
+fi
+if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
+  echo "$NPM_PREFIX"
+  exit 0
+fi
+if [ "$1" = "install" ] && [ "$2" = "-g" ] && [ "$3" = "${GITHUB_INSTALL_URL}" ]; then
+  cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
+#!/usr/bin/env bash
+if [ "$1" = "onboard" ]; then exit 0; fi
+if [ "$1" = "--version" ]; then echo "v0.1.0-test"; exit 0; fi
+exit 0
+EOS
+  chmod +x "$NPM_PREFIX/bin/nemoclaw"
+  exit 0
+fi
+echo "unexpected npm invocation: $*" >&2
+exit 98
+`,
+    );
+
+    // Pipe the installer via stdin to simulate curl | bash
+    const scriptContents = fs.readFileSync(INSTALLER, "utf-8");
+    const result = spawnSync("bash", [], {
+      cwd: tmp,
+      input: scriptContents,
+      encoding: "utf-8",
+      timeout: 15000,
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NPM_PREFIX: prefix,
+      },
+    });
+
+    const output = `${result.stdout}${result.stderr}`;
+    assert.equal(result.status, 0);
+    assert.match(output, /Installation complete/);
+    // When piped without a controlling terminal, onboard should be skipped
+    // with a helpful message instead of hanging on EOF
+    assert.match(output, /No terminal available|Running nemoclaw onboard/);
+  });
 });


### PR DESCRIPTION
## Summary

When `install.sh` is run via `curl | bash`, bash's stdin is the pipe (reading the script), not the terminal. The interactive `nemoclaw onboard` wizard at step [3/7] reads EOF instead of keyboard input and silently exits, leaving a half-initialized Docker gateway blocking port 8080 on subsequent runs.

- Detect whether stdin is already a terminal (`[ -t 0 ]`) — if so, run onboard normally
- If stdin is a pipe but `/dev/tty` is accessible, redirect stdin from `/dev/tty` so interactive prompts work
- If no terminal is available at all (headless CI), skip onboard gracefully and print instructions to run it manually

## Changes

| File | Change |
|------|--------|
| `install.sh` | Three-way check in `run_onboard()`: TTY stdin → direct, pipe + `/dev/tty` → redirect, no terminal → skip with message |
| `test/install-preflight.test.js` | New test: pipes `install.sh` via stdin (simulating `curl \| bash`) and verifies the installer completes without hanging |

## Test plan

- [x] `npm test` — all tests related to `install.sh` pass (7/7 in installer suite)
- [x] New test: pipes installer via stdin, verifies exit 0 + "Installation complete" output
- [x] Pre-existing failures in `runtime-shell.test.js` and `scripts/install.sh` curl-pipe test are unrelated (verified on unmodified `main`)

Fixes #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved installer to work seamlessly with piped input (e.g., curl | bash)
  * Enhanced interactive onboarding to adapt to different terminal environments with fallback messaging

* **Tests**
  * Added test coverage for piped installer scenarios to ensure non-blocking behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->