### PR TITLE
Reattach curl installer onboarding to tty

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -278,8 +278,13 @@ run_onboard() {
   info "Running nemoclaw onboard…"
   if [ "${NON_INTERACTIVE:-}" = "1" ]; then
     nemoclaw onboard --non-interactive
-  else
+  elif [ -t 0 ]; then
     nemoclaw onboard
+  elif [ -r /dev/tty ]; then
+    info "Installer stdin is piped; attaching onboarding to /dev/tty…"
+    nemoclaw onboard < /dev/tty
+  else
+    error "Interactive onboarding requires a TTY. Re-run in a terminal or set NEMOCLAW_NON_INTERACTIVE=1."
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -280,9 +280,12 @@ run_onboard() {
     nemoclaw onboard --non-interactive
   elif [ -t 0 ]; then
     nemoclaw onboard
-  elif [ -r /dev/tty ]; then
+  elif exec 3</dev/tty; then
     info "Installer stdin is piped; attaching onboarding to /dev/tty…"
-    nemoclaw onboard < /dev/tty
+    local status=0
+    nemoclaw onboard <&3 || status=$?
+    exec 3<&-
+    return "$status"
   else
     error "Interactive onboarding requires a TTY. Re-run in a terminal or set NEMOCLAW_NON_INTERACTIVE=1."
   fi

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -125,6 +125,7 @@ exit 98
         ...process.env,
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
         NPM_PREFIX: prefix,
         NPM_LOG_PATH: npmLog,
       },
@@ -180,6 +181,7 @@ exit 98
         ...process.env,
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
         NPM_PREFIX: prefix,
       },
     });
@@ -436,6 +438,7 @@ exit 0
         ...process.env,
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
         NPM_PREFIX: prefix,
       },
     });

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -349,6 +349,7 @@ exit 0
         ...process.env,
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
         NPM_PREFIX: prefix,
       },
     });


### PR DESCRIPTION
## Summary
- reattach interactive onboarding to `/dev/tty` when the installer is run from piped stdin
- preserve existing behavior for direct interactive and non-interactive installs
- fail clearly if interactive onboarding is requested without any TTY available

Fixes #376.

## Testing
- `bash -n install.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding now correctly detects interactive terminals, handles piped input by attaching to an available terminal when possible, and respects explicit non-interactive mode.
  * Clearer error messaging when onboarding cannot run in the current environment, instructing users to retry in a terminal or enable non-interactive mode.

* **Tests**
  * Installer preflight tests updated to exercise non-interactive invocations by setting the non-interactive environment flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->