### PR TITLE
docs: add common installation troubleshooting entries

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -38,3 +38,7 @@ NemoClaw currently requires a fresh installation of OpenClaw.
 - [Customize the network policy](../network-policy/customize-network-policy.md) to pre-approve trusted domains.
 - [Deploy to a remote GPU instance](../deployment/deploy-to-remote-gpu.md) for always-on operation.
 - [Monitor sandbox activity](../monitoring/monitor-sandbox-activity.md) through the OpenShell TUI.
+
+### Troubleshooting
+
+If you run into issues during installation or onboarding, refer to the [Troubleshooting guide](../reference/troubleshooting.md) for common error messages and resolution steps.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -84,13 +84,14 @@ Add the `export` line to your `~/.bashrc` or `~/.zshrc` to make it permanent, th
 
 The NemoClaw gateway uses port `18789` by default.
 If another process is already bound to this port, onboarding fails.
-Identify and stop the conflicting process:
+Identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```console
 $ lsof -i :18789
 $ kill <PID>
 ```
 
+If the process does not exit, use `kill -9 <PID>` to force-terminate it.
 Then retry onboarding.
 
 ## Onboarding

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -18,6 +18,8 @@ status: published
   SPDX-License-Identifier: Apache-2.0
 -->
 
+<!-- markdownlint-disable MD014 -->
+
 # Troubleshooting
 
 This page covers common issues you may encounter when installing, onboarding, or running NemoClaw, along with their resolution steps.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -37,6 +37,62 @@ The installer checks for a supported OS and architecture before proceeding.
 NemoClaw requires Linux Ubuntu 22.04 LTS or later.
 If you see an unsupported platform error, verify that you are running on a supported Linux distribution.
 
+### Node.js version is too old
+
+NemoClaw requires Node.js 20 or later.
+If the installer exits with a Node.js version error, check your current version:
+
+```console
+$ node --version
+```
+
+If the version is below 20, install a supported release.
+If you use nvm, run:
+
+```console
+$ nvm install 20
+$ nvm use 20
+```
+
+Then re-run the installer.
+
+### Docker is not running
+
+The installer and onboard wizard require Docker to be running.
+If you see a Docker connection error, start the Docker daemon:
+
+```console
+$ sudo systemctl start docker
+```
+
+On macOS with Docker Desktop, open the Docker Desktop application and wait for it to finish starting before retrying.
+
+### npm install fails with permission errors
+
+If `npm install` fails with an `EACCES` permission error, do not run npm with `sudo`.
+Instead, configure npm to use a directory you own:
+
+```console
+$ mkdir -p ~/.npm-global
+$ npm config set prefix ~/.npm-global
+$ export PATH=~/.npm-global/bin:$PATH
+```
+
+Add the `export` line to your `~/.bashrc` or `~/.zshrc` to make it permanent, then re-run the installer.
+
+### Port already in use
+
+The NemoClaw gateway uses port `18789` by default.
+If another process is already bound to this port, onboarding fails.
+Identify and stop the conflicting process:
+
+```console
+$ lsof -i :18789
+$ kill <PID>
+```
+
+Then retry onboarding.
+
 ## Onboarding
 
 ### Cgroup v2 errors during onboard


### PR DESCRIPTION
## Summary

Closes #364

Adds four new entries to the **Installation** section of `docs/reference/troubleshooting.md`, covering the most common failures new users encounter before `nemoclaw onboard` even runs:

- **Node.js version too old** — check version, upgrade via nvm
- **Docker not running** — `systemctl start docker` on Linux, Docker Desktop on macOS
- **npm EACCES permission errors** — configure npm prefix instead of using sudo
- **Port already in use** — identify and stop the conflicting process with `lsof`

Also adds a **Troubleshooting** link at the end of `docs/get-started/quickstart.md` so users who hit problems during installation can find the guide immediately.

## Test plan

- [ ] Read through each new entry and verify the commands are correct
- [ ] Confirm the troubleshooting link in quickstart.md resolves to the right page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Troubleshooting" section to the Quickstart guide linking to detailed help.
  * Expanded the troubleshooting reference with practical guidance for common setup issues: Node.js version mismatches, Docker not running, npm permission errors, and port conflicts during onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->