### PR TITLE
fix(telegram): read model from sandbox registry instead of hardcoding

### DIFF
--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -20,6 +20,7 @@ const https = require("https");
 const { execFileSync, spawn } = require("child_process");
 const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
 const { shellQuote, validateName } = require("../bin/lib/runner");
+const registry = require("../bin/lib/registry");
 
 const OPENSHELL = resolveOpenshell();
 if (!OPENSHELL) {
@@ -260,9 +261,11 @@ async function main() {
   console.log("  ┌─────────────────────────────────────────────────────┐");
   console.log("  │  NemoClaw Telegram Bridge                          │");
   console.log("  │                                                     │");
+  const sandboxInfo = registry.getSandbox(SANDBOX);
+  const model = sandboxInfo?.model || "nvidia/nemotron-3-super-120b-a12b";
   console.log(`  │  Bot:      @${(me.result.username + "                    ").slice(0, 37)}│`);
   console.log("  │  Sandbox:  " + (SANDBOX + "                              ").slice(0, 40) + "│");
-  console.log("  │  Model:    nvidia/nemotron-3-super-120b-a12b       │");
+  console.log(`  │  Model:    ${(model + "                                        ").slice(0, 40)}│`);
   console.log("  │                                                     │");
   console.log("  │  Messages are forwarded to the OpenClaw agent      │");
   console.log("  │  inside the sandbox. Run 'openshell term' in       │");

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -185,9 +185,12 @@ async function poll() {
 
         // Handle /start
         if (msg.text === "/start") {
+          const info = registry.getSandbox(SANDBOX);
+          const startModel = info?.model || "nvidia/nemotron-3-super-120b-a12b";
+          const startProvider = info?.provider || "nvidia-nim";
           await sendMessage(
             chatId,
-            "🦀 *NemoClaw* — powered by Nemotron 3 Super 120B\n\n" +
+            `🦀 *NemoClaw* — ${startProvider} / ${startModel}\n\n` +
               "Send me a message and I'll run it through the OpenClaw agent " +
               "inside an OpenShell sandbox.\n\n" +
               "If the agent needs external access, the TUI will prompt for approval.",
@@ -263,8 +266,10 @@ async function main() {
   console.log("  │                                                     │");
   const sandboxInfo = registry.getSandbox(SANDBOX);
   const model = sandboxInfo?.model || "nvidia/nemotron-3-super-120b-a12b";
+  const provider = sandboxInfo?.provider || "nvidia-nim";
   console.log(`  │  Bot:      @${(me.result.username + "                    ").slice(0, 37)}│`);
   console.log("  │  Sandbox:  " + (SANDBOX + "                              ").slice(0, 40) + "│");
+  console.log(`  │  Provider: ${(provider + "                                        ").slice(0, 40)}│`);
   console.log(`  │  Model:    ${(model + "                                        ").slice(0, 40)}│`);
   console.log("  │                                                     │");
   console.log("  │  Messages are forwarded to the OpenClaw agent      │");

--- a/test/telegram-bridge-banner.test.js
+++ b/test/telegram-bridge-banner.test.js
@@ -96,4 +96,88 @@ describe("telegram bridge banner", () => {
     // Clean up
     fs.rmSync(tmp, { recursive: true, force: true });
   });
+
+  it("/start response uses registry provider and model instead of hardcoding", () => {
+    const bridgeSrc = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "telegram-bridge.js"),
+      "utf-8",
+    );
+
+    // The /start handler must not contain a hardcoded model name string
+    const startBlock = bridgeSrc.slice(
+      bridgeSrc.indexOf('"/start"'),
+      bridgeSrc.indexOf("continue;", bridgeSrc.indexOf('"/start"')),
+    );
+    assert.ok(startBlock.length > 0, "should find the /start handler block");
+    assert.doesNotMatch(
+      startBlock,
+      /Nemotron 3 Super 120B/,
+      "/start handler should not contain hardcoded 'Nemotron 3 Super 120B'",
+    );
+    // Must reference the registry for both provider and model
+    assert.match(
+      startBlock,
+      /registry\.getSandbox/,
+      "/start handler should look up the sandbox from the registry",
+    );
+    assert.match(
+      startBlock,
+      /provider/i,
+      "/start handler should reference the provider",
+    );
+  });
+
+  it("/start response reflects configured provider and model from registry", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-start-test-"));
+    const registryDir = path.join(tmp, ".nemoclaw");
+    fs.mkdirSync(registryDir, { recursive: true });
+
+    const registryData = {
+      sandboxes: {
+        "test-sandbox": {
+          name: "test-sandbox",
+          createdAt: new Date().toISOString(),
+          model: "qwen2.5:14b-instruct",
+          provider: "ollama-local",
+          gpuEnabled: false,
+          policies: [],
+        },
+      },
+      defaultSandbox: "test-sandbox",
+    };
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify(registryData, null, 2),
+    );
+
+    const { spawnSync } = require("node:child_process");
+    const result = spawnSync(
+      "node",
+      [
+        "-e",
+        `
+        const registry = require("./bin/lib/registry");
+        const info = registry.getSandbox("test-sandbox");
+        const model = info?.model || "nvidia/nemotron-3-super-120b-a12b";
+        const provider = info?.provider || "nvidia-nim";
+        const startMsg = "\u{1F980} *NemoClaw* — " + provider + " / " + model;
+        console.log(startMsg);
+        `,
+      ],
+      {
+        cwd: path.join(__dirname, ".."),
+        encoding: "utf-8",
+        timeout: 5000,
+        env: { ...process.env, HOME: tmp },
+      },
+    );
+
+    assert.equal(result.status, 0, `script failed: ${result.stderr}`);
+    const output = result.stdout;
+    assert.match(output, /ollama-local/, "/start should contain the configured provider");
+    assert.match(output, /qwen2\.5:14b-instruct/, "/start should contain the configured model");
+    assert.doesNotMatch(output, /Nemotron/, "/start should not contain the hardcoded default");
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
 });

--- a/test/telegram-bridge-banner.test.js
+++ b/test/telegram-bridge-banner.test.js
@@ -6,20 +6,45 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+/**
+ * Helper: create a temp dir with a sandbox registry containing a non-default
+ * model and provider. Returns the temp dir path. Caller must clean up.
+ */
+function createTestRegistry(sandboxName, model, provider) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-bridge-test-"));
+  const registryDir = path.join(tmp, ".nemoclaw");
+  fs.mkdirSync(registryDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(registryDir, "sandboxes.json"),
+    JSON.stringify({
+      sandboxes: {
+        [sandboxName]: {
+          name: sandboxName,
+          createdAt: new Date().toISOString(),
+          model,
+          provider,
+          gpuEnabled: false,
+          policies: [],
+        },
+      },
+      defaultSandbox: sandboxName,
+    }, null, 2),
+  );
+  return tmp;
+}
 
 describe("telegram bridge banner", () => {
   it("reads the model from the sandbox registry instead of hardcoding it", () => {
-    // The banner source should reference registry.getSandbox, not a hardcoded model string
     const bridgeSrc = fs.readFileSync(
       path.join(__dirname, "..", "scripts", "telegram-bridge.js"),
       "utf-8",
     );
 
-    // Must import and use the registry
     assert.match(bridgeSrc, /require\(.*registry.*\)/, "should import the registry module");
     assert.match(bridgeSrc, /getSandbox/, "should call getSandbox to look up the model");
 
-    // The banner Model line must use a variable, not a hardcoded model name
     const bannerLines = bridgeSrc.split("\n").filter((l) => l.includes("Model:") && l.includes("│"));
     assert.ok(bannerLines.length > 0, "should have a Model banner line");
     for (const line of bannerLines) {
@@ -31,70 +56,44 @@ describe("telegram bridge banner", () => {
     }
   });
 
+  // Note: the behavioral tests below use registry.getSandbox() directly rather
+  // than executing the full telegram-bridge.js script.  The bridge requires a
+  // valid TELEGRAM_BOT_TOKEN and running openshell binary to start, so it
+  // cannot be launched in a test environment.  The structural test above guards
+  // against regressions in the source, and the behavioral tests verify the
+  // registry lookup contract that the bridge depends on.
+
   it("displays a non-default model from the sandbox registry in the banner", () => {
-    // Behavioral test: set up a registry with a non-default model,
-    // then require the banner-building logic and verify the output.
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-banner-test-"));
-    const registryDir = path.join(tmp, ".nemoclaw");
-    fs.mkdirSync(registryDir, { recursive: true });
-
-    // Write a sandbox registry with a non-default model
-    const registryData = {
-      sandboxes: {
-        "test-sandbox": {
-          name: "test-sandbox",
-          createdAt: new Date().toISOString(),
-          model: "ollama/llama3",
-          provider: "ollama-local",
-          gpuEnabled: false,
-          policies: [],
+    const tmp = createTestRegistry("test-sandbox", "ollama/llama3", "ollama-local");
+    try {
+      const result = spawnSync(
+        "node",
+        [
+          "-e",
+          `
+          const registry = require("./bin/lib/registry");
+          const sandboxInfo = registry.getSandbox("test-sandbox");
+          const model = sandboxInfo?.model || "nvidia/nemotron-3-super-120b-a12b";
+          const provider = sandboxInfo?.provider || "nvidia-nim";
+          console.log("MODEL=" + model);
+          console.log("PROVIDER=" + provider);
+          `,
+        ],
+        {
+          cwd: path.join(__dirname, ".."),
+          encoding: "utf-8",
+          timeout: 5000,
+          env: { ...process.env, HOME: tmp },
         },
-      },
-      defaultSandbox: "test-sandbox",
-    };
-    fs.writeFileSync(
-      path.join(registryDir, "sandboxes.json"),
-      JSON.stringify(registryData, null, 2),
-    );
+      );
 
-    // Run a script that loads the registry with HOME pointed at our temp dir,
-    // looks up the sandbox, and prints what the banner model line would be
-    const { spawnSync } = require("node:child_process");
-    const result = spawnSync(
-      "node",
-      [
-        "-e",
-        `
-        const registry = require("./bin/lib/registry");
-        const sandboxInfo = registry.getSandbox("test-sandbox");
-        const model = sandboxInfo?.model || "nvidia/nemotron-3-super-120b-a12b";
-        const line = "  │  Model:    " + (model + "                                        ").slice(0, 40) + "│";
-        console.log(line);
-        console.log("MODEL=" + model);
-        `,
-      ],
-      {
-        cwd: path.join(__dirname, ".."),
-        encoding: "utf-8",
-        timeout: 5000,
-        env: { ...process.env, HOME: tmp },
-      },
-    );
-
-    assert.equal(result.status, 0, `script failed: ${result.stderr}`);
-    const output = result.stdout;
-
-    // The banner must show the registry model, not the hardcoded default
-    assert.match(output, /MODEL=ollama\/llama3/, "should resolve the model from the registry");
-    assert.match(output, /ollama\/llama3/, "banner line should contain the registry model");
-    assert.doesNotMatch(
-      output,
-      /nemotron-3-super/,
-      "banner should not fall back to the hardcoded default when registry has a model",
-    );
-
-    // Clean up
-    fs.rmSync(tmp, { recursive: true, force: true });
+      assert.equal(result.status, 0, `script failed: ${result.stderr}`);
+      assert.match(result.stdout, /MODEL=ollama\/llama3/);
+      assert.match(result.stdout, /PROVIDER=ollama-local/);
+      assert.doesNotMatch(result.stdout, /nemotron-3-super/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("/start response uses registry provider and model instead of hardcoding", () => {
@@ -103,7 +102,6 @@ describe("telegram bridge banner", () => {
       "utf-8",
     );
 
-    // The /start handler must not contain a hardcoded model name string
     const startBlock = bridgeSrc.slice(
       bridgeSrc.indexOf('"/start"'),
       bridgeSrc.indexOf("continue;", bridgeSrc.indexOf('"/start"')),
@@ -114,7 +112,6 @@ describe("telegram bridge banner", () => {
       /Nemotron 3 Super 120B/,
       "/start handler should not contain hardcoded 'Nemotron 3 Super 120B'",
     );
-    // Must reference the registry for both provider and model
     assert.match(
       startBlock,
       /registry\.getSandbox/,
@@ -128,56 +125,35 @@ describe("telegram bridge banner", () => {
   });
 
   it("/start response reflects configured provider and model from registry", () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-start-test-"));
-    const registryDir = path.join(tmp, ".nemoclaw");
-    fs.mkdirSync(registryDir, { recursive: true });
-
-    const registryData = {
-      sandboxes: {
-        "test-sandbox": {
-          name: "test-sandbox",
-          createdAt: new Date().toISOString(),
-          model: "qwen2.5:14b-instruct",
-          provider: "ollama-local",
-          gpuEnabled: false,
-          policies: [],
+    const tmp = createTestRegistry("test-sandbox", "qwen2.5:14b-instruct", "ollama-local");
+    try {
+      const result = spawnSync(
+        "node",
+        [
+          "-e",
+          `
+          const registry = require("./bin/lib/registry");
+          const info = registry.getSandbox("test-sandbox");
+          const model = info?.model || "nvidia/nemotron-3-super-120b-a12b";
+          const provider = info?.provider || "nvidia-nim";
+          const startMsg = "\u{1F980} *NemoClaw* — " + provider + " / " + model;
+          console.log(startMsg);
+          `,
+        ],
+        {
+          cwd: path.join(__dirname, ".."),
+          encoding: "utf-8",
+          timeout: 5000,
+          env: { ...process.env, HOME: tmp },
         },
-      },
-      defaultSandbox: "test-sandbox",
-    };
-    fs.writeFileSync(
-      path.join(registryDir, "sandboxes.json"),
-      JSON.stringify(registryData, null, 2),
-    );
+      );
 
-    const { spawnSync } = require("node:child_process");
-    const result = spawnSync(
-      "node",
-      [
-        "-e",
-        `
-        const registry = require("./bin/lib/registry");
-        const info = registry.getSandbox("test-sandbox");
-        const model = info?.model || "nvidia/nemotron-3-super-120b-a12b";
-        const provider = info?.provider || "nvidia-nim";
-        const startMsg = "\u{1F980} *NemoClaw* — " + provider + " / " + model;
-        console.log(startMsg);
-        `,
-      ],
-      {
-        cwd: path.join(__dirname, ".."),
-        encoding: "utf-8",
-        timeout: 5000,
-        env: { ...process.env, HOME: tmp },
-      },
-    );
-
-    assert.equal(result.status, 0, `script failed: ${result.stderr}`);
-    const output = result.stdout;
-    assert.match(output, /ollama-local/, "/start should contain the configured provider");
-    assert.match(output, /qwen2\.5:14b-instruct/, "/start should contain the configured model");
-    assert.doesNotMatch(output, /Nemotron/, "/start should not contain the hardcoded default");
-
-    fs.rmSync(tmp, { recursive: true, force: true });
+      assert.equal(result.status, 0, `script failed: ${result.stderr}`);
+      assert.match(result.stdout, /ollama-local/);
+      assert.match(result.stdout, /qwen2\.5:14b-instruct/);
+      assert.doesNotMatch(result.stdout, /Nemotron/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/test/telegram-bridge-banner.test.js
+++ b/test/telegram-bridge-banner.test.js
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+describe("telegram bridge banner", () => {
+  it("reads the model from the sandbox registry instead of hardcoding it", () => {
+    // The banner source should reference registry.getSandbox, not a hardcoded model string
+    const bridgeSrc = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "telegram-bridge.js"),
+      "utf-8",
+    );
+
+    // Must import and use the registry
+    assert.match(bridgeSrc, /require\(.*registry.*\)/, "should import the registry module");
+    assert.match(bridgeSrc, /getSandbox/, "should call getSandbox to look up the model");
+
+    // The banner Model line must use a variable, not a hardcoded model name
+    const bannerLines = bridgeSrc.split("\n").filter((l) => l.includes("Model:") && l.includes("│"));
+    assert.ok(bannerLines.length > 0, "should have a Model banner line");
+    for (const line of bannerLines) {
+      assert.doesNotMatch(
+        line,
+        /["'].*nemotron.*["']/,
+        "Model banner line should not contain a hardcoded model string literal",
+      );
+    }
+  });
+});

--- a/test/telegram-bridge-banner.test.js
+++ b/test/telegram-bridge-banner.test.js
@@ -30,4 +30,70 @@ describe("telegram bridge banner", () => {
       );
     }
   });
+
+  it("displays a non-default model from the sandbox registry in the banner", () => {
+    // Behavioral test: set up a registry with a non-default model,
+    // then require the banner-building logic and verify the output.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-banner-test-"));
+    const registryDir = path.join(tmp, ".nemoclaw");
+    fs.mkdirSync(registryDir, { recursive: true });
+
+    // Write a sandbox registry with a non-default model
+    const registryData = {
+      sandboxes: {
+        "test-sandbox": {
+          name: "test-sandbox",
+          createdAt: new Date().toISOString(),
+          model: "ollama/llama3",
+          provider: "ollama-local",
+          gpuEnabled: false,
+          policies: [],
+        },
+      },
+      defaultSandbox: "test-sandbox",
+    };
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify(registryData, null, 2),
+    );
+
+    // Run a script that loads the registry with HOME pointed at our temp dir,
+    // looks up the sandbox, and prints what the banner model line would be
+    const { spawnSync } = require("node:child_process");
+    const result = spawnSync(
+      "node",
+      [
+        "-e",
+        `
+        const registry = require("./bin/lib/registry");
+        const sandboxInfo = registry.getSandbox("test-sandbox");
+        const model = sandboxInfo?.model || "nvidia/nemotron-3-super-120b-a12b";
+        const line = "  │  Model:    " + (model + "                                        ").slice(0, 40) + "│";
+        console.log(line);
+        console.log("MODEL=" + model);
+        `,
+      ],
+      {
+        cwd: path.join(__dirname, ".."),
+        encoding: "utf-8",
+        timeout: 5000,
+        env: { ...process.env, HOME: tmp },
+      },
+    );
+
+    assert.equal(result.status, 0, `script failed: ${result.stderr}`);
+    const output = result.stdout;
+
+    // The banner must show the registry model, not the hardcoded default
+    assert.match(output, /MODEL=ollama\/llama3/, "should resolve the model from the registry");
+    assert.match(output, /ollama\/llama3/, "banner line should contain the registry model");
+    assert.doesNotMatch(
+      output,
+      /nemotron-3-super/,
+      "banner should not fall back to the hardcoded default when registry has a model",
+    );
+
+    // Clean up
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary

The Telegram bridge banner always displays `nvidia/nemotron-3-super-120b-a12b` regardless of the actual configured inference provider. Users running Ollama, vLLM, or any non-default provider see a misleading model identity in the bridge startup output.

## Fix

Read the model from the host-side sandbox registry (`~/.nemoclaw/sandboxes.json`) which `nemoclaw onboard` populates with the actual provider and model selection. Fall back to the default model only if the registry entry is missing.

## Changes

| File | Change |
|------|--------|
| `scripts/telegram-bridge.js` | Import registry, look up sandbox by name, use `sandboxInfo.model` in banner |
| `test/telegram-bridge-banner.test.js` | Regression test: verify banner uses registry lookup and has no hardcoded model string |

## Test plan

- [x] Banner formatting matches original width (56 chars) for all model lengths
- [x] `npm test` — 14/14 related tests pass (registry + banner + CLI)
- [x] Regression test verifies the banner line uses a variable, not a literal model string

Fixes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup banner and /start welcome message now display the configured provider and model (formatted/truncated), falling back to sensible defaults only when no configuration is present instead of a fixed model string.

* **Tests**
  * Added tests to verify banner and /start outputs reflect configured provider/model and no longer include the old hard-coded model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Josue Balandrano Coronel <josuebc@pm.me>