### PR TITLE
fix(policy): add missing binaries to telegram policy entries

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -165,3 +165,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/bot*/**" }
           - allow: { method: POST, path: "/bot*/**" }
+    binaries:
+      - path: /usr/local/bin/node

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -159,11 +159,6 @@ network_policies:
     endpoints:
       - host: api.telegram.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/bot*/**" }
-          - allow: { method: POST, path: "/bot*/**" }
+        access: full
     binaries:
       - path: /usr/local/bin/node

--- a/nemoclaw-blueprint/policies/presets/telegram.yaml
+++ b/nemoclaw-blueprint/policies/presets/telegram.yaml
@@ -11,11 +11,6 @@ network_policies:
     endpoints:
       - host: api.telegram.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/bot*/**" }
-          - allow: { method: POST, path: "/bot*/**" }
+        access: full
     binaries:
       - path: /usr/local/bin/node

--- a/nemoclaw-blueprint/policies/presets/telegram.yaml
+++ b/nemoclaw-blueprint/policies/presets/telegram.yaml
@@ -17,3 +17,5 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/bot*/**" }
           - allow: { method: POST, path: "/bot*/**" }
+    binaries:
+      - path: /usr/local/bin/node


### PR DESCRIPTION
## Problem

### Issue 1: Missing `binaries` field (403 on CONNECT)
The `telegram` entries in `openclaw-sandbox.yaml` and `presets/telegram.yaml` lacked a `binaries:` field. The OPA engine treats absent `binaries` as deny-all, so the Node.js gateway (`openclaw-gateway`) was blocked from reaching `api.telegram.org` with 403 Forbidden on the CONNECT tunnel, despite the endpoint being listed in the policy.

A secondary issue: applying the `telegram` preset to a sandbox that already has the baseline `telegram` entry creates duplicate `api.telegram.org:443` definitions across two policy keys (`telegram` + `telegram_bot`), triggering an OPA `duplicated definition of local variable ep` error that breaks L7 enforcement entirely.

### Issue 2: Query strings stripped by L7 relay (403 no body)
`tls: terminate` + `protocol: rest` causes the L7 relay to strip query strings before forwarding requests to `api.telegram.org`. Telegram receives calls like `getUpdates` without parameters (e.g. `?timeout=30&offset=123`) and returns 403 with no response body.

## Fix

- Switched telegram endpoint from `tls: terminate` + path rules to `access: full` (passthrough tunnel) — preserves query strings and avoids TLS MITM
- Added `binaries: [{path: /usr/local/bin/node}]` to both entries so the Node.js gateway is permitted

## Testing

Verified on a live NemoClaw sandbox — proxy logs confirm connections switched from `CONNECT_L7` to plain `CONNECT`, and the Telegram bot API (`getUpdates`, `getMe`, `getWebhookInfo`, `sendMessage`) is fully operational.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Telegram API endpoint policies to use full access configuration instead of granular method and path restrictions.
  * Added binary access restrictions, limiting Telegram API connectivity to Node.js runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->