### PR TITLE
fix(sandbox): add /usr/local/bin/node to binary allowlists

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -79,6 +79,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/claude }
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }
 
   github:
     name: github
@@ -112,6 +113,7 @@ network_policies:
           - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }
 
   openclaw_api:
     name: openclaw_api
@@ -126,6 +128,7 @@ network_policies:
           - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }
 
   openclaw_docs:
     name: openclaw_docs
@@ -139,6 +142,7 @@ network_policies:
           - allow: { method: GET, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }
 
   # npm registry — needed for `openclaw plugins install` and `npm install`
   npm_registry:
@@ -149,6 +153,7 @@ network_policies:
         access: full
     binaries:
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }
       - { path: /usr/local/bin/npm }
 
   # ── Messaging — pre-allowed for agent notifications ────────────


### PR DESCRIPTION
## Summary

OpenClaw is a Node.js script (`#!/usr/bin/env node`). The sandbox proxy allowlists outbound traffic by **kernel-level binary path**, so when `openclaw` runs, the OS sees `/usr/local/bin/node` as the actual binary — not `/usr/local/bin/openclaw`. Without `node` in the `binaries` list, all openclaw-initiated requests are silently blocked with HTTP 403.

This PR adds `/usr/local/bin/node` to the 5 sandbox policies in `openclaw-sandbox.yaml` that use the openclaw runtime:

- `nvidia` — inference calls hang without this
- `clawhub` — agent authentication fails
- `openclaw_api` — API calls blocked
- `openclaw_docs` — doc access blocked
- `npm_registry` — plugin installs fail

Policies that invoke different binaries are **not modified**:
- `claude_code` — invokes `/usr/local/bin/claude`
- `github` — invokes `/usr/bin/gh` and `/usr/bin/git`

Fixes #391

## Test plan

- [ ] Verify `openclaw agent` can reach NVIDIA inference endpoints from sandbox
- [ ] Verify `openclaw plugins install` works from sandbox
- [ ] Verify `claude_code` and `github` policies still work (no false positive from `node` addition)
- [ ] Confirm no other binaries (curl, wget, bash) are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sandbox network policies to permit Node.js binary access for network operations across multiple policy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->