### PR TITLE
ci: add blueprint/policy validation job and scheduled E2E workflow

### DIFF
--- a/.github/workflows/e2e-scheduled.yaml
+++ b/.github/workflows/e2e-scheduled.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: E2E Scheduled
+
+on:
+  schedule:
+    - cron: '0 8 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: e2e-full
+  cancel-in-progress: true
+
+jobs:
+  live-inference:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install and build
+        run: |
+          npm install && npm link
+          cd nemoclaw && npm install && npm run build && cd ..
+
+      - name: Install OpenShell
+        run: bash scripts/install-openshell.sh
+
+      - name: Run full E2E
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+        run: bash test/e2e/test-full-e2e.sh
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-full-logs-${{ github.run_id }}
+          path: /tmp/nemoclaw-*.log
+          retention-days: 7
+
+  notify-on-failure:
+    runs-on: ubuntu-latest
+    needs: live-inference
+    if: failure()
+    steps:
+      - name: Create issue on failure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `E2E Full pipeline failed — ${new Date().toISOString().split('T')[0]}`;
+            const body = `The scheduled full E2E pipeline failed.\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug', 'ci']
+            });

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,3 +56,42 @@ jobs:
 
       - name: Run sandbox E2E tests
         run: docker run --rm -v "${{ github.workspace }}/test:/opt/test" nemoclaw-sandbox-test /opt/test/e2e-test.sh
+
+  validate-profiles:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate blueprint and policy presets
+        run: |
+          python3 -c "
+          import yaml, os, sys
+
+          bp = yaml.safe_load(open('nemoclaw-blueprint/blueprint.yaml'))
+          for p in ['default', 'ncp', 'nim-local', 'vllm']:
+              assert p in bp['components']['inference']['profiles'], f'Missing profile: {p}'
+              cfg = bp['components']['inference']['profiles'][p]
+              assert 'provider_type' in cfg and 'model' in cfg
+          print('Blueprint: 4/4 profiles OK')
+
+          for f in sorted(os.listdir('nemoclaw-blueprint/policies/presets')):
+              if f.endswith('.yaml'):
+                  data = yaml.safe_load(open(f'nemoclaw-blueprint/policies/presets/{f}'))
+                  assert data and 'network_policies' in data, f'{f}: invalid'
+          print('Policy presets: all OK')
+
+          policy = yaml.safe_load(open('nemoclaw-blueprint/policies/openclaw-sandbox.yaml'))
+          assert 'version' in policy, 'Base policy missing version'
+          assert 'network_policies' in policy, 'Base policy missing network_policies'
+          print('Base policy: OK')
+          "


### PR DESCRIPTION
Add validate-profiles job to pr.yaml that checks:
- All 4 inference profiles exist in blueprint.yaml
- All policy preset YAMLs have valid structure
- Base sandbox policy has required fields

Add e2e-scheduled.yaml for daily live inference E2E:
- Runs test/e2e/test-full-e2e.sh on weekday mornings
- Auto-creates GitHub issue on failure
- Requires NVIDIA_API_KEY secret (not yet configured)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a scheduled end-to-end test workflow that runs on weekdays, can be triggered manually, collects logs on failures, and automatically files an issue when runs fail.
  * Added pull-request validation checks for configuration blueprints and policy presets to ensure required inference profiles and network policy fields are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->