### PR TITLE
Add error handling for gateway startup

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -879,7 +879,7 @@ async function onboard(opts = {}) {
     try {
   await startGateway(gpu);
         } catch (error) {
-          await destroyGateway();
+          await run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });();
           throw error;
         }
   const sandboxName = await createSandbox(gpu);

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -879,7 +879,7 @@ async function onboard(opts = {}) {
     try {
   await startGateway(gpu);
         } catch (error) {
-          await run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });();
+          run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });
           throw error;
         }
   const sandboxName = await createSandbox(gpu);

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -876,7 +876,12 @@ async function onboard(opts = {}) {
   console.log("  ===================");
 
   const gpu = await preflight();
+    try {
   await startGateway(gpu);
+        } catch (error) {
+          await destroyGateway();
+          throw error;
+        }
   const sandboxName = await createSandbox(gpu);
   const { model, provider } = await setupNim(sandboxName, gpu);
   await setupInference(sandboxName, model, provider);

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -876,12 +876,12 @@ async function onboard(opts = {}) {
   console.log("  ===================");
 
   const gpu = await preflight();
-    try {
-  await startGateway(gpu);
-        } catch (error) {
-          run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });
-          throw error;
-        }
+  try {
+    await startGateway(gpu);
+  } catch (error) {
+    run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });
+    throw error;
+  }
   const sandboxName = await createSandbox(gpu);
   const { model, provider } = await setupNim(sandboxName, gpu);
   await setupInference(sandboxName, model, provider);


### PR DESCRIPTION
Handle errors during gateway startup by destroying the gateway if an error occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding error handling: if gateway initialization fails, the system now attempts to clean up any partially created gateway resources, suppresses cleanup failures, and then surfaces the original error. This reduces leftover resources and provides a more reliable, predictable setup experience, minimizing the need for manual cleanup after failed onboarding attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->