### PR TITLE
Add nemoclaw_clean.sh to free ports 8080 and 18789 before re-onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Run these on the host to set up, connect to, and manage sandboxes.
 | `openshell term`                     | Launch the OpenShell TUI for monitoring and approvals. |
 | `nemoclaw start` / `stop` / `status` | Manage auxiliary services (Telegram bridge, tunnel).   |
 
+**Re-running onboard:** If a second `nemoclaw onboard` fails with port 8080 or 18789 already in use (e.g. after a previous sandbox or gateway session), run the cleanup script from the repo root then onboard again: `./nemoclaw_clean.sh` then `nemoclaw onboard`. See [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html) for details.
+
 ### Plugin commands (`openclaw nemoclaw`)
 
 Run these inside the OpenClaw CLI. These commands are under active development and may not all be functional yet.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -84,9 +84,17 @@ Add the `export` line to your `~/.bashrc` or `~/.zshrc` to make it permanent, th
 
 ### Port already in use
 
-The NemoClaw gateway uses port `18789` by default.
-If another process is already bound to this port, onboarding fails.
-Identify the conflicting process, verify it is safe to stop, and terminate it:
+The NemoClaw gateway and dashboard use ports `8080` and `18789` by default.
+If another process is already bound to one of these ports (for example when re-running onboard after a previous session), onboarding fails.
+
+**Re-running onboard (e.g. on DGX Spark):** From the NemoClaw repo root, run the cleanup script to free ports and stop OpenShell forwards, then retry:
+
+```console
+$ ./nemoclaw_clean.sh
+$ nemoclaw onboard
+```
+
+**Manual cleanup:** Otherwise, identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```console
 $ lsof -i :18789

--- a/nemoclaw_clean.sh
+++ b/nemoclaw_clean.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Kill any processes listening on 8080 or 18789
+for p in 8080 18789; do
+  sudo lsof -t -i :$p -sTCP:LISTEN | xargs -r sudo kill
+done
+
+# Stop all OpenShell forwards that use port 18789
+openshell forward list 2>/dev/null | awk 'NR>1 {print $1, $2}' | while read port sandbox; do
+  if [ "$port" = "18789" ]; then
+    openshell forward stop "$port" "$sandbox"
+  fi
+done

--- a/spark-install.md
+++ b/spark-install.md
@@ -103,7 +103,21 @@ nemoclaw onboard
 | Docker permission denied | Fixed in `setup-spark` | `usermod -aG docker` |
 | CoreDNS CrashLoop after setup | Fixed in `fix-coredns.sh` | Uses container gateway IP, not 127.0.0.11 |
 | Image pull failure (k3s can't find built image) | OpenShell bug | `openshell gateway destroy && openshell gateway start`, re-run setup |
+| Port 8080 or 18789 in use on re-onboard | Common | Run `./nemoclaw_clean.sh` then `nemoclaw onboard` (see [Re-running onboard](#re-running-onboard)) |
 | GPU passthrough | Untested on Spark | Should work with `--gpu` flag if NVIDIA Container Toolkit is configured |
+
+### Re-running onboard
+
+If you run `nemoclaw onboard` a second time (or after a previous sandbox/gateway session), the OpenShell gateway or port forwards may still be holding ports 8080 and 18789. The CLI will report that the port is not available.
+
+From the NemoClaw repo root, run the cleanup script to free those ports and stop OpenShell forwards, then onboard again:
+
+```bash
+./nemoclaw_clean.sh
+nemoclaw onboard
+```
+
+This is required only when you want to start a fresh onboard and the previous session did not tear down cleanly.
 
 ## Verifying Your Install
 


### PR DESCRIPTION
Fixes #397 

This adds a helper script `nemoclaw_clean.sh` to improve the DX when re-running
`nemoclaw onboard` on DGX Spark.

- Kills any processes listening on ports 8080 and 18789
- Stops OpenShell forwards that use port 18789

This addresses repeated onboarding failures caused by lingering OpenShell
gateway / ssh-proxy processes that keep those ports occupied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cleanup utility to terminate local services and clear stale forwarding sessions so onboarding can be retried reliably.

* **Documentation**
  * Added "Re-running onboard" troubleshooting guidance and Known Issues entry explaining that gateway/dashboard can occupy ports 8080 and 18789 and instructing users to run the cleanup utility then retry onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->