### PR TITLE
feat: add Jetson Orin Nano support (GPU detection, iptables fix, nemotron-3-nano:4b default)

### DIFF
--- a/bin/lib/local-inference.js
+++ b/bin/lib/local-inference.js
@@ -101,19 +101,31 @@ function parseOllamaList(output) {
     .filter(Boolean);
 }
 
-function getOllamaModelOptions(runCapture) {
+/**
+ * Returns available Ollama model names from `ollama list`, falling back to
+ * the platform-appropriate default when the CLI is unavailable.
+ */
+function getOllamaModelOptions(runCapture, gpu) {
   const output = runCapture("ollama list 2>/dev/null", { ignoreError: true });
   const parsed = parseOllamaList(output);
   if (parsed.length > 0) {
     return parsed;
   }
+  // Jetson: fall back to the 4B model that fits in 8GB unified memory
+  // instead of the 30B default which would OOM.
+  if (gpu && gpu.jetson) {
+    return [DEFAULT_OLLAMA_MODEL_JETSON];
+  }
   return [DEFAULT_OLLAMA_MODEL];
 }
 
+/**
+ * Returns the best default Ollama model for the current platform.
+ * On Jetson Orin Nano (8GB unified memory) this returns nemotron-3-nano:4b;
+ * on all other platforms it returns nemotron-3-nano:30b.
+ */
 function getDefaultOllamaModel(runCapture, gpu) {
-  const models = getOllamaModelOptions(runCapture);
-  // Jetson Orin Nano has limited unified memory (8GB) — prefer the 4B
-  // quantized model which fits comfortably, over the 30B default.
+  const models = getOllamaModelOptions(runCapture, gpu);
   if (gpu && gpu.jetson) {
     if (models.includes(DEFAULT_OLLAMA_MODEL_JETSON)) return DEFAULT_OLLAMA_MODEL_JETSON;
     return models[0];

--- a/bin/lib/local-inference.js
+++ b/bin/lib/local-inference.js
@@ -4,6 +4,7 @@
 const HOST_GATEWAY_URL = "http://host.openshell.internal";
 const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
 const DEFAULT_OLLAMA_MODEL = "nemotron-3-nano:30b";
+const DEFAULT_OLLAMA_MODEL_JETSON = "nemotron-3-nano:4b";
 
 function getLocalProviderBaseUrl(provider) {
   switch (provider) {
@@ -109,8 +110,14 @@ function getOllamaModelOptions(runCapture) {
   return [DEFAULT_OLLAMA_MODEL];
 }
 
-function getDefaultOllamaModel(runCapture) {
+function getDefaultOllamaModel(runCapture, gpu) {
   const models = getOllamaModelOptions(runCapture);
+  // Jetson Orin Nano has limited unified memory (8GB) — prefer the 4B
+  // quantized model which fits comfortably, over the 30B default.
+  if (gpu && gpu.jetson) {
+    if (models.includes(DEFAULT_OLLAMA_MODEL_JETSON)) return DEFAULT_OLLAMA_MODEL_JETSON;
+    return models[0];
+  }
   return models.includes(DEFAULT_OLLAMA_MODEL) ? DEFAULT_OLLAMA_MODEL : models[0];
 }
 
@@ -165,6 +172,7 @@ function validateOllamaModel(model, runCapture) {
 module.exports = {
   CONTAINER_REACHABILITY_IMAGE,
   DEFAULT_OLLAMA_MODEL,
+  DEFAULT_OLLAMA_MODEL_JETSON,
   HOST_GATEWAY_URL,
   getDefaultOllamaModel,
   getLocalProviderBaseUrl,

--- a/bin/lib/nim.js
+++ b/bin/lib/nim.js
@@ -46,14 +46,16 @@ function detectGpu() {
     }
   } catch {}
 
-  // Fallback: DGX Spark (GB10) — VRAM not queryable due to unified memory architecture
+  // Fallback: unified-memory NVIDIA platforms where nvidia-smi reports [N/A]
+  // for memory.total. Query GPU name once and check for DGX Spark or Jetson.
   try {
     const nameOutput = runCapture(
       "nvidia-smi --query-gpu=name --format=csv,noheader,nounits",
       { ignoreError: true }
     );
+
+    // DGX Spark (GB10) — 128GB unified memory shared with Grace CPU
     if (nameOutput && nameOutput.includes("GB10")) {
-      // GB10 has 128GB unified memory shared with Grace CPU — use system RAM
       let totalMemoryMB = 0;
       try {
         const memLine = runCapture("free -m | awk '/Mem:/ {print $2}'", { ignoreError: true });
@@ -68,16 +70,14 @@ function detectGpu() {
         spark: true,
       };
     }
-  } catch {}
 
-  // Fallback: NVIDIA Jetson (Orin, Thor, etc.) — unified memory, nvidia-smi
-  // reports [N/A] for memory.total. Detect via GPU name or device-tree model.
-  try {
-    const nameOutput = runCapture(
-      "nvidia-smi --query-gpu=name --format=csv,noheader,nounits",
-      { ignoreError: true }
-    );
-    const isJetsonGpu = nameOutput && /orin|thor/i.test(nameOutput);
+    // NVIDIA Jetson — unified memory, nvidia-smi reports GPU name containing
+    // "Orin" or "Thor" but without discrete GPU identifiers like
+    // GeForce/RTX/Quadro. Tested on Jetson Orin Nano Super (JetPack 6.x).
+    // Other Jetson variants may also work via /proc/device-tree/model fallback.
+    const isJetsonGpu = nameOutput &&
+      /orin|thor/i.test(nameOutput) &&
+      !/geforce|rtx|quadro/i.test(nameOutput);
     const dtModel = runCapture(
       "cat /proc/device-tree/model 2>/dev/null | tr -d '\\0'",
       { ignoreError: true }

--- a/bin/lib/nim.js
+++ b/bin/lib/nim.js
@@ -70,6 +70,38 @@ function detectGpu() {
     }
   } catch {}
 
+  // Fallback: NVIDIA Jetson (Orin, Thor, etc.) — unified memory, nvidia-smi
+  // reports [N/A] for memory.total. Detect via GPU name or device-tree model.
+  try {
+    const nameOutput = runCapture(
+      "nvidia-smi --query-gpu=name --format=csv,noheader,nounits",
+      { ignoreError: true }
+    );
+    const isJetsonGpu = nameOutput && /orin|thor/i.test(nameOutput);
+    const dtModel = runCapture(
+      "cat /proc/device-tree/model 2>/dev/null | tr -d '\\0'",
+      { ignoreError: true }
+    );
+    const isJetsonDt = dtModel && /jetson/i.test(dtModel);
+
+    if (isJetsonGpu || isJetsonDt) {
+      let totalMemoryMB = 0;
+      try {
+        const memLine = runCapture("free -m | awk '/Mem:/ {print $2}'", { ignoreError: true });
+        if (memLine) totalMemoryMB = parseInt(memLine.trim(), 10) || 0;
+      } catch {}
+      return {
+        type: "nvidia",
+        name: dtModel || nameOutput || "Jetson",
+        count: 1,
+        totalMemoryMB,
+        perGpuMB: totalMemoryMB,
+        nimCapable: false,
+        jetson: true,
+      };
+    }
+  } catch {}
+
   // macOS: detect Apple Silicon or discrete GPU
   if (process.platform === "darwin") {
     try {

--- a/bin/lib/nim.js
+++ b/bin/lib/nim.js
@@ -23,6 +23,11 @@ function listModels() {
   }));
 }
 
+/**
+ * Detects the GPU on the current system. Returns an object describing the GPU
+ * type, memory, and capabilities, or null if no GPU is found. Supports
+ * discrete NVIDIA GPUs, DGX Spark (GB10), Jetson (Orin/Thor), and Apple Silicon.
+ */
 function detectGpu() {
   // Try NVIDIA first — query VRAM
   try {

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -276,6 +276,14 @@ async function preflight() {
   }
   console.log(`  ✓ openshell CLI: ${runCapture("openshell --version 2>/dev/null || echo unknown", { ignoreError: true })}`);
 
+  // Clean up any existing nemoclaw gateway before checking ports —
+  // a previous onboard run may have left the gateway running, which
+  // would block port 8080 and cause a confusing "port in use" error.
+  run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });
+  // Also kill any leftover openclaw-gateway processes holding port 18789.
+  run("sudo kill $(lsof -ti :18789) 2>/dev/null || true", { ignoreError: true });
+  sleep(2);
+
   // Required ports — gateway (8080) and dashboard (18789)
   const requiredPorts = [
     { port: 8080, label: "OpenShell gateway" },
@@ -313,7 +321,10 @@ async function preflight() {
 
   // GPU
   const gpu = nim.detectGpu();
-  if (gpu && gpu.type === "nvidia") {
+  if (gpu && gpu.type === "nvidia" && gpu.jetson) {
+    console.log(`  ✓ NVIDIA Jetson detected: ${gpu.name}, ${gpu.totalMemoryMB} MB unified memory`);
+    console.log("  ⓘ NIM containers not supported on Jetson — will use Ollama or cloud inference");
+  } else if (gpu && gpu.type === "nvidia") {
     console.log(`  ✓ NVIDIA GPU detected: ${gpu.count} GPU(s), ${gpu.totalMemoryMB} MB VRAM`);
   } else if (gpu && gpu.type === "apple") {
     console.log(`  ✓ Apple GPU detected: ${gpu.name}${gpu.cores ? ` (${gpu.cores} cores)` : ""}, ${gpu.totalMemoryMB} MB unified memory`);
@@ -325,13 +336,79 @@ async function preflight() {
   return gpu;
 }
 
+// ── Jetson gateway image patch ───────────────────────────────────
+//
+// JetPack kernels (Tegra) ship without nft_chain_filter and related
+// nf_tables modules. The OpenShell gateway image embeds k3s, whose
+// network policy controller calls iptables in nf_tables mode by default.
+// Without kernel support the controller panics on startup.
+//
+// This function rebuilds the gateway image locally, switching the
+// default iptables alternative to iptables-legacy so all rule
+// manipulation uses the classic xtables backend that Tegra kernels
+// fully support.
+
+function getGatewayImageTag() {
+  const openshellVersion = runCapture("openshell --version 2>/dev/null", { ignoreError: true }) || "";
+  const match = openshellVersion.match(/(\d+\.\d+\.\d+)/);
+  return match ? match[1] : "latest";
+}
+
+function patchGatewayImageForJetson() {
+  const tag = getGatewayImageTag();
+  const image = `ghcr.io/nvidia/openshell/cluster:${tag}`;
+
+  // Check if already patched (look for our label)
+  const inspectOut = runCapture(
+    `docker inspect --format='{{index .Config.Labels "io.nemoclaw.jetson-patched"}}' "${image}" 2>/dev/null`,
+    { ignoreError: true }
+  ).trim();
+  if (inspectOut === "true") {
+    console.log("  ✓ Gateway image already patched for Jetson");
+    return;
+  }
+
+  console.log("  Patching gateway image for Jetson (iptables-legacy)...");
+
+  const os = require("os");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-jetson-"));
+  const dockerfile = path.join(tmpDir, "Dockerfile");
+  fs.writeFileSync(
+    dockerfile,
+    [
+      `FROM ${image}`,
+      `RUN if command -v update-alternatives >/dev/null 2>&1; then \\`,
+      `      update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true; \\`,
+      `      update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true; \\`,
+      `    elif [ -f /usr/sbin/iptables-legacy ]; then \\`,
+      `      ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables; \\`,
+      `      ln -sf /usr/sbin/ip6tables-legacy /usr/sbin/ip6tables; \\`,
+      `    fi`,
+      `LABEL io.nemoclaw.jetson-patched="true"`,
+      "",
+    ].join("\n")
+  );
+
+  run(`docker build --quiet -t ${image} "${tmpDir}"`, { ignoreError: false });
+  run(`rm -rf "${tmpDir}"`, { ignoreError: true });
+  console.log("  ✓ Gateway image patched for Jetson (iptables-legacy)");
+}
+
 // ── Step 2: Gateway ──────────────────────────────────────────────
 
 async function startGateway(gpu) {
   step(2, 7, "Starting OpenShell gateway");
 
-  // Destroy old gateway
-  run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });
+  // Old gateway was already destroyed in preflight() to free ports.
+
+  // Jetson (Tegra kernel): The k3s container image ships iptables v1.8.10 in
+  // nf_tables mode, but JetPack kernels lack the nft_chain_filter module,
+  // causing the k3s network policy controller to panic on startup.
+  // Workaround: rebuild the gateway image locally with iptables-legacy as the
+  // default so iptables commands use the legacy (xtables) backend instead.
+  if (gpu && gpu.jetson) {
+    patchGatewayImageForJetson();
+  }
 
   const gwArgs = ["--name", "nemoclaw"];
   // Do NOT pass --gpu here. On DGX Spark (and most GPU hosts), inference is

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -348,12 +348,19 @@ async function preflight() {
 // manipulation uses the classic xtables backend that Tegra kernels
 // fully support.
 
+/** Extracts the semver tag from the installed openshell CLI version. */
 function getGatewayImageTag() {
   const openshellVersion = runCapture("openshell --version 2>/dev/null", { ignoreError: true }) || "";
   const match = openshellVersion.match(/(\d+\.\d+\.\d+)/);
   return match ? match[1] : "latest";
 }
 
+/**
+ * Rebuilds the OpenShell gateway container image with iptables-legacy as the
+ * default backend. Idempotent — skips rebuild if the image is already patched
+ * (checked via Docker label). Required on Jetson because the Tegra kernel
+ * lacks nft_chain_filter modules that k3s's network policy controller needs.
+ */
 function patchGatewayImageForJetson() {
   const tag = getGatewayImageTag();
   const image = `ghcr.io/nvidia/openshell/cluster:${tag}`;

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -143,9 +143,9 @@ async function promptCloudModel() {
   return (CLOUD_MODEL_OPTIONS[index] || CLOUD_MODEL_OPTIONS[0]).id;
 }
 
-async function promptOllamaModel() {
+async function promptOllamaModel(gpu) {
   const options = getOllamaModelOptions(runCapture);
-  const defaultModel = getDefaultOllamaModel(runCapture);
+  const defaultModel = getDefaultOllamaModel(runCapture, gpu);
   const defaultIndex = Math.max(0, options.indexOf(defaultModel));
 
   console.log("");
@@ -280,8 +280,8 @@ async function preflight() {
   // a previous onboard run may have left the gateway running, which
   // would block port 8080 and cause a confusing "port in use" error.
   run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });
-  // Also kill any leftover openclaw-gateway processes holding port 18789.
-  run("sudo kill $(lsof -ti :18789) 2>/dev/null || true", { ignoreError: true });
+  // Kill only nemoclaw-owned openclaw-gateway processes holding port 18789.
+  run("kill $(lsof -ti :18789 -c openclaw) 2>/dev/null || true", { ignoreError: true });
   sleep(2);
 
   // Required ports — gateway (8080) and dashboard (18789)
@@ -369,6 +369,7 @@ function patchGatewayImageForJetson() {
   }
 
   console.log("  Patching gateway image for Jetson (iptables-legacy)...");
+  console.log("  (this may take a moment on first run if the base image needs to be pulled)");
 
   const os = require("os");
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-jetson-"));
@@ -389,7 +390,7 @@ function patchGatewayImageForJetson() {
     ].join("\n")
   );
 
-  run(`docker build --quiet -t ${image} "${tmpDir}"`, { ignoreError: false });
+  run(`docker build --quiet -t "${image}" "${tmpDir}"`, { ignoreError: false });
   run(`rm -rf "${tmpDir}"`, { ignoreError: true });
   console.log("  ✓ Gateway image patched for Jetson (iptables-legacy)");
 }
@@ -671,9 +672,9 @@ async function setupNim(sandboxName, gpu) {
       console.log("  ✓ Using Ollama on localhost:11434");
       provider = "ollama-local";
       if (isNonInteractive()) {
-        model = requestedModel || getDefaultOllamaModel(runCapture);
+        model = requestedModel || getDefaultOllamaModel(runCapture, gpu);
       } else {
-        model = await promptOllamaModel();
+        model = await promptOllamaModel(gpu);
       }
     } else if (selected.key === "install-ollama") {
       console.log("  Installing Ollama via Homebrew...");
@@ -684,9 +685,9 @@ async function setupNim(sandboxName, gpu) {
       console.log("  ✓ Using Ollama on localhost:11434");
       provider = "ollama-local";
       if (isNonInteractive()) {
-        model = requestedModel || getDefaultOllamaModel(runCapture);
+        model = requestedModel || getDefaultOllamaModel(runCapture, gpu);
       } else {
-        model = await promptOllamaModel();
+        model = await promptOllamaModel(gpu);
       }
     } else if (selected.key === "vllm") {
       console.log("  ✓ Using existing vLLM on localhost:8000");

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -21,7 +21,7 @@ const policies = require("./lib/policies");
 // ── Global commands ──────────────────────────────────────────────
 
 const GLOBAL_COMMANDS = new Set([
-  "onboard", "list", "deploy", "setup", "setup-spark",
+  "onboard", "list", "deploy", "setup", "setup-spark", "setup-jetson",
   "start", "stop", "status",
   "help", "--help", "-h",
 ]);
@@ -55,6 +55,10 @@ async function setup() {
 async function setupSpark() {
   await ensureApiKey();
   run(`sudo -E NVIDIA_API_KEY="${process.env.NVIDIA_API_KEY}" bash "${SCRIPTS}/setup-spark.sh"`);
+}
+
+async function setupJetson() {
+  run(`sudo -E bash "${SCRIPTS}/setup-jetson.sh"`);
 }
 
 async function deploy(instanceName) {
@@ -289,6 +293,7 @@ function help() {
     nemoclaw onboard                 Interactive setup wizard (recommended)
     nemoclaw setup                   Legacy setup (deprecated, use onboard)
     nemoclaw setup-spark             Set up on DGX Spark (fixes cgroup v2 + Docker)
+    nemoclaw setup-jetson            Set up on Jetson (NVIDIA runtime + iptables fix)
 
   Sandbox Management:
     nemoclaw list                    List all sandboxes
@@ -331,6 +336,7 @@ const [cmd, ...args] = process.argv.slice(2);
       case "onboard":     await onboard(args); break;
       case "setup":       await setup(); break;
       case "setup-spark": await setupSpark(); break;
+      case "setup-jetson": await setupJetson(); break;
       case "deploy":      await deploy(args[0]); break;
       case "start":       await start(); break;
       case "stop":        stop(); break;

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -60,6 +60,10 @@ if ! echo "$JETSON_MODEL" | grep -qi "jetson"; then
   if ! echo "$GPU_NAME" | grep -qiE "orin|thor"; then
     fail "This does not appear to be a Jetson device. Use 'nemoclaw onboard' directly."
   fi
+  # Exclude discrete GPUs that happen to contain matching strings
+  if echo "$GPU_NAME" | grep -qiE "geforce|rtx|quadro"; then
+    fail "Discrete GPU detected ('$GPU_NAME'). This script is for Jetson only."
+  fi
   JETSON_MODEL="${GPU_NAME}"
 fi
 
@@ -108,7 +112,7 @@ try:
     if 'nvidia' in runtimes:
         sys.exit(0)
     sys.exit(1)
-except:
+except (IOError, ValueError, KeyError):
     sys.exit(1)
 " 2>/dev/null; then
       info "NVIDIA runtime already configured in Docker daemon"
@@ -119,7 +123,7 @@ import json
 try:
     with open('$DAEMON_JSON') as f:
         d = json.load(f)
-except:
+except (IOError, ValueError, KeyError):
     d = {}
 d.setdefault('runtimes', {})['nvidia'] = {
     'path': 'nvidia-container-runtime',
@@ -172,7 +176,11 @@ fi
 
 if [ "$NEEDS_RESTART" = true ]; then
   info "Restarting Docker daemon..."
-  systemctl restart docker
+  if command -v systemctl > /dev/null 2>&1; then
+    systemctl restart docker
+  else
+    service docker restart 2>/dev/null || dockerd &
+  fi
   for i in 1 2 3 4 5 6 7 8 9 10; do
     if docker info > /dev/null 2>&1; then
       break

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -40,6 +40,10 @@ if [ "$(uname -s)" != "Linux" ]; then
   fail "This script is for NVIDIA Jetson (Linux). Use 'nemoclaw setup' for macOS."
 fi
 
+if [ "$(uname -m)" != "aarch64" ]; then
+  fail "Jetson devices are aarch64. This system is $(uname -m)."
+fi
+
 if [ "$(id -u)" -ne 0 ]; then
   fail "Must run as root: sudo nemoclaw setup-jetson"
 fi
@@ -65,6 +69,7 @@ info "Detected Jetson platform: ${JETSON_MODEL}"
 REAL_USER="${SUDO_USER:-$(logname 2>/dev/null || echo "")}"
 
 command -v docker > /dev/null || fail "Docker not found. Install docker.io: sudo apt-get install -y docker.io"
+command -v python3 > /dev/null || fail "python3 not found. Install with: sudo apt-get install -y python3-minimal"
 
 # ── 1. Docker group ───────────────────────────────────────────────
 

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# NemoClaw setup for NVIDIA Jetson devices (Orin Nano, Orin NX, AGX Orin, Thor).
+#
+# Jetson devices use unified memory and a Tegra kernel that lacks nf_tables
+# chain modules (nft_chain_filter, nft_chain_nat, etc.). The OpenShell gateway
+# runs k3s inside a Docker container, and k3s's network policy controller
+# uses iptables in nf_tables mode by default, which panics on Tegra kernels.
+#
+# This script prepares the Jetson host so that `nemoclaw onboard` succeeds:
+#   1. Verifies Jetson platform
+#   2. Ensures NVIDIA Container Runtime is configured for Docker
+#   3. Loads required kernel modules (br_netfilter, xt_comment)
+#   4. Configures Docker daemon with default-runtime=nvidia
+#
+# The iptables-legacy patch for the gateway container image is handled
+# automatically by `nemoclaw onboard` when it detects a Jetson GPU.
+#
+# Usage:
+#   sudo nemoclaw setup-jetson
+#   # or directly:
+#   sudo bash scripts/setup-jetson.sh
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}>>>${NC} $1"; }
+warn() { echo -e "${YELLOW}>>>${NC} $1"; }
+fail() { echo -e "${RED}>>>${NC} $1"; exit 1; }
+
+# ── Pre-flight checks ─────────────────────────────────────────────
+
+if [ "$(uname -s)" != "Linux" ]; then
+  fail "This script is for NVIDIA Jetson (Linux). Use 'nemoclaw setup' for macOS."
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+  fail "Must run as root: sudo nemoclaw setup-jetson"
+fi
+
+# Verify Jetson platform
+JETSON_MODEL=""
+if [ -f /proc/device-tree/model ]; then
+  JETSON_MODEL=$(tr -d '\0' < /proc/device-tree/model)
+fi
+
+if ! echo "$JETSON_MODEL" | grep -qi "jetson"; then
+  # Also check nvidia-smi for Orin GPU name
+  GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits 2>/dev/null || echo "")
+  if ! echo "$GPU_NAME" | grep -qiE "orin|thor"; then
+    fail "This does not appear to be a Jetson device. Use 'nemoclaw onboard' directly."
+  fi
+  JETSON_MODEL="${GPU_NAME}"
+fi
+
+info "Detected Jetson platform: ${JETSON_MODEL}"
+
+# Detect the real user (not root) for docker group add
+REAL_USER="${SUDO_USER:-$(logname 2>/dev/null || echo "")}"
+
+command -v docker > /dev/null || fail "Docker not found. Install docker.io: sudo apt-get install -y docker.io"
+
+# ── 1. Docker group ───────────────────────────────────────────────
+
+if [ -n "$REAL_USER" ]; then
+  if id -nG "$REAL_USER" | grep -qw docker; then
+    info "User '$REAL_USER' already in docker group"
+  else
+    info "Adding '$REAL_USER' to docker group..."
+    usermod -aG docker "$REAL_USER"
+    info "Added. Group will take effect on next login (or use 'newgrp docker')."
+  fi
+fi
+
+# ── 2. NVIDIA Container Runtime ──────────────────────────────────
+#
+# Jetson JetPack pre-installs nvidia-container-runtime but Docker may
+# not be configured to use it as the default runtime.
+
+DAEMON_JSON="/etc/docker/daemon.json"
+NEEDS_RESTART=false
+
+configure_nvidia_runtime() {
+  if ! command -v nvidia-container-runtime > /dev/null 2>&1; then
+    warn "nvidia-container-runtime not found. GPU passthrough may not work."
+    warn "Install with: sudo apt-get install -y nvidia-container-toolkit"
+    return
+  fi
+
+  if [ -f "$DAEMON_JSON" ]; then
+    # Check if nvidia runtime is already configured
+    if python3 -c "
+import json, sys
+try:
+    d = json.load(open('$DAEMON_JSON'))
+    runtimes = d.get('runtimes', {})
+    if 'nvidia' in runtimes:
+        sys.exit(0)
+    sys.exit(1)
+except:
+    sys.exit(1)
+" 2>/dev/null; then
+      info "NVIDIA runtime already configured in Docker daemon"
+    else
+      info "Adding NVIDIA runtime to Docker daemon config..."
+      python3 -c "
+import json
+try:
+    with open('$DAEMON_JSON') as f:
+        d = json.load(f)
+except:
+    d = {}
+d.setdefault('runtimes', {})['nvidia'] = {
+    'path': 'nvidia-container-runtime',
+    'runtimeArgs': []
+}
+d['default-runtime'] = 'nvidia'
+with open('$DAEMON_JSON', 'w') as f:
+    json.dump(d, f, indent=2)
+"
+      NEEDS_RESTART=true
+    fi
+  else
+    info "Creating Docker daemon config with NVIDIA runtime..."
+    mkdir -p "$(dirname "$DAEMON_JSON")"
+    cat > "$DAEMON_JSON" <<'DAEMONJSON'
+{
+  "runtimes": {
+    "nvidia": {
+      "path": "nvidia-container-runtime",
+      "runtimeArgs": []
+    }
+  },
+  "default-runtime": "nvidia"
+}
+DAEMONJSON
+    NEEDS_RESTART=true
+  fi
+}
+
+configure_nvidia_runtime
+
+# ── 3. Kernel modules ────────────────────────────────────────────
+
+info "Loading required kernel modules..."
+modprobe br_netfilter 2>/dev/null || warn "Could not load br_netfilter"
+modprobe xt_comment 2>/dev/null || warn "Could not load xt_comment"
+
+# Persist across reboots
+MODULES_FILE="/etc/modules-load.d/nemoclaw-jetson.conf"
+if [ ! -f "$MODULES_FILE" ]; then
+  info "Persisting kernel modules for boot..."
+  cat > "$MODULES_FILE" <<'MODULES'
+# NemoClaw: required for k3s networking inside Docker
+br_netfilter
+xt_comment
+MODULES
+fi
+
+# ── 4. Restart Docker if needed ──────────────────────────────────
+
+if [ "$NEEDS_RESTART" = true ]; then
+  info "Restarting Docker daemon..."
+  systemctl restart docker
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    if docker info > /dev/null 2>&1; then
+      break
+    fi
+    [ "$i" -eq 10 ] && fail "Docker didn't come back after restart. Check 'systemctl status docker'."
+    sleep 2
+  done
+  info "Docker restarted with NVIDIA runtime"
+fi
+
+# ── Done ─────────────────────────────────────────────────────────
+
+echo ""
+info "Jetson setup complete."
+info ""
+info "Device: ${JETSON_MODEL}"
+info ""
+info "Next step: run 'nemoclaw onboard' to set up your sandbox."
+info "  nemoclaw onboard"
+info ""
+info "The onboard wizard will automatically patch the gateway image"
+info "for Jetson iptables compatibility."

--- a/test/local-inference.test.js
+++ b/test/local-inference.test.js
@@ -7,6 +7,7 @@ const assert = require("node:assert/strict");
 const {
   CONTAINER_REACHABILITY_IMAGE,
   DEFAULT_OLLAMA_MODEL,
+  DEFAULT_OLLAMA_MODEL_JETSON,
   getDefaultOllamaModel,
   getLocalProviderBaseUrl,
   getLocalProviderContainerReachabilityCheck,
@@ -18,6 +19,8 @@ const {
   validateOllamaModel,
   validateLocalProvider,
 } = require("../bin/lib/local-inference");
+
+const FAKE_JETSON_GPU = { type: "nvidia", jetson: true, totalMemoryMB: 7619 };
 
 describe("local inference helpers", () => {
   it("returns the expected base URL for vllm-local", () => {
@@ -116,6 +119,26 @@ describe("local inference helpers", () => {
     assert.equal(
       getDefaultOllamaModel(() => "qwen3:32b  abc  20 GB  now\ngemma3:4b  def  3 GB  now"),
       "qwen3:32b",
+    );
+  });
+
+  it("returns jetson 4b model as default on jetson when available", () => {
+    const list = `nemotron-3-nano:4b  abc  2.8 GB  now\nqwen3:32b  def  20 GB  now`;
+    assert.equal(
+      getDefaultOllamaModel(() => list, FAKE_JETSON_GPU),
+      DEFAULT_OLLAMA_MODEL_JETSON,
+    );
+  });
+
+  it("falls back to jetson 4b model when ollama list is empty on jetson", () => {
+    assert.deepEqual(getOllamaModelOptions(() => "", FAKE_JETSON_GPU), [DEFAULT_OLLAMA_MODEL_JETSON]);
+    assert.equal(getDefaultOllamaModel(() => "", FAKE_JETSON_GPU), DEFAULT_OLLAMA_MODEL_JETSON);
+  });
+
+  it("falls back to first available model on jetson when 4b is absent", () => {
+    assert.equal(
+      getDefaultOllamaModel(() => "qwen3:4b  abc  3 GB  now", FAKE_JETSON_GPU),
+      "qwen3:4b",
     );
   });
 

--- a/test/nim.test.js
+++ b/test/nim.test.js
@@ -6,6 +6,12 @@ const assert = require("node:assert/strict");
 
 const nim = require("../bin/lib/nim");
 
+// Detect GPU once for conditional test gating.
+const detectedGpu = nim.detectGpu();
+const isDiscreteNvidia = detectedGpu && detectedGpu.type === "nvidia" && !detectedGpu.jetson;
+const isJetson = detectedGpu && detectedGpu.type === "nvidia" && detectedGpu.jetson;
+const isApple = detectedGpu && detectedGpu.type === "apple";
+
 describe("nim", () => {
   describe("listModels", () => {
     it("returns 5 models", () => {
@@ -52,27 +58,20 @@ describe("nim", () => {
       }
     });
 
-    it("nvidia (discrete) type is nimCapable", () => {
-      const gpu = nim.detectGpu();
-      if (gpu && gpu.type === "nvidia" && !gpu.jetson) {
-        assert.equal(gpu.nimCapable, true);
-      }
+    it("nvidia (discrete) type is nimCapable", { skip: !isDiscreteNvidia }, () => {
+      assert.equal(detectedGpu.nimCapable, true);
     });
 
-    it("nvidia (jetson) type is not nimCapable", () => {
-      const gpu = nim.detectGpu();
-      if (gpu && gpu.type === "nvidia" && gpu.jetson) {
-        assert.equal(gpu.nimCapable, false);
-        assert.ok(gpu.name, "jetson gpu should have name");
-      }
+    it("nvidia (jetson) type is not nimCapable", { skip: !isJetson }, () => {
+      assert.equal(detectedGpu.nimCapable, false);
+      assert.ok(detectedGpu.name, "jetson gpu should have name");
+      assert.ok(detectedGpu.jetson === true, "jetson flag should be true");
+      assert.ok(detectedGpu.totalMemoryMB > 0, "should report unified memory");
     });
 
-    it("apple type is not nimCapable", () => {
-      const gpu = nim.detectGpu();
-      if (gpu && gpu.type === "apple") {
-        assert.equal(gpu.nimCapable, false);
-        assert.ok(gpu.name, "apple gpu should have name");
-      }
+    it("apple type is not nimCapable", { skip: !isApple }, () => {
+      assert.equal(detectedGpu.nimCapable, false);
+      assert.ok(detectedGpu.name, "apple gpu should have name");
     });
   });
 

--- a/test/nim.test.js
+++ b/test/nim.test.js
@@ -52,10 +52,18 @@ describe("nim", () => {
       }
     });
 
-    it("nvidia type is nimCapable", () => {
+    it("nvidia (discrete) type is nimCapable", () => {
       const gpu = nim.detectGpu();
-      if (gpu && gpu.type === "nvidia") {
+      if (gpu && gpu.type === "nvidia" && !gpu.jetson) {
         assert.equal(gpu.nimCapable, true);
+      }
+    });
+
+    it("nvidia (jetson) type is not nimCapable", () => {
+      const gpu = nim.detectGpu();
+      if (gpu && gpu.type === "nvidia" && gpu.jetson) {
+        assert.equal(gpu.nimCapable, false);
+        assert.ok(gpu.name, "jetson gpu should have name");
       }
     });
 


### PR DESCRIPTION
## Summary

Adds support for running NemoClaw on **Jetson Orin Nano Super** (8GB, JetPack 6.x, kernel 5.15.148-tegra).

**Before**: `nemoclaw onboard` fails immediately — GPU not detected, k3s panics on iptables nf_tables incompatibility.
**After**: Full onboard completes with Ollama + nemotron-3-nano:4b running locally.

### Changes

- **Jetson GPU detection** (`nim.js`): `nvidia-smi` reports `[N/A]` for `memory.total` on Jetson (unified memory). Added fallback detection via GPU name + `/proc/device-tree/model`, reading system RAM with `free(1)`. Other Jetson variants (Orin NX, AGX Orin, Thor) may also work via the device-tree fallback but are **untested**.
- **iptables-legacy patch** (`onboard.js`): JetPack/Tegra kernels lack `nft_chain_filter` nf_tables modules. On Jetson, the onboard wizard automatically rebuilds the gateway container image with `iptables-legacy` as the default backend (idempotent via Docker label).
- **Default model for Jetson** (`local-inference.js`): The default `nemotron-3-nano:30b` does not fit in 8GB unified memory. Jetson defaults to `nemotron-3-nano:4b` instead.
- **Port conflict fix** (`onboard.js`): Destroy stale gateways and kill orphaned `openclaw` processes before port checks, preventing repeated "port 8080/18789 in use" errors on re-runs.
- **`setup-jetson` command** (`nemoclaw.js`, `setup-jetson.sh`): New host-level preparation command (similar to `setup-spark`) that configures Docker with NVIDIA runtime and loads required kernel modules.
- **Test fix** (`nim.test.js`): Updated "nvidia type is nimCapable" assertion to handle Jetson (`nimCapable: false`).

## Files changed

| File | Change |
|------|--------|
| `bin/lib/nim.js` | Jetson GPU detection (merged with Spark detection block) |
| `bin/lib/onboard.js` | iptables-legacy image patch, stale gateway cleanup, gpu-aware model selection |
| `bin/lib/local-inference.js` | `nemotron-3-nano:4b` default for Jetson |
| `bin/nemoclaw.js` | Register `setup-jetson` command |
| `scripts/setup-jetson.sh` | New host setup script (aarch64/python3 checks) |
| `test/nim.test.js` | Jetson-aware nimCapable test |

## Test plan

- [x] `node --test test/nim.test.js` — 10 pass, 0 fail
- [x] GPU detection returns correct device name and 7619 MB unified memory
- [x] Gateway image patch applies iptables-legacy (no more k3s panic)
- [x] Gateway starts, sandbox reaches Phase: Ready
- [x] Re-running `nemoclaw onboard` no longer fails on port conflicts
- [x] Default model selection returns `nemotron-3-nano:4b` on Jetson

### Tested hardware
- **Jetson Orin Nano Super** (8GB, JetPack 6.x, kernel 5.15.148-tegra)

### Not tested (may work via device-tree fallback)
- Jetson Orin NX, AGX Orin, Thor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect NVIDIA Jetson hosts and surface Jetson-specific messaging during onboarding.
  * Added a CLI command and host-side installer to prepare Jetson devices for onboarding.
  * Automatically patch the gateway image on Jetson for iptables compatibility.

* **Behavior Changes**
  * Jetson devices report unified-memory details, are marked as not supporting NIM containers, and prefer a Jetson-optimized local model by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->