### PR TITLE
fix: auto-detect vLLM model ID and route local inference through gate…

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -773,7 +773,25 @@ async function setupNim(sandboxName, gpu) {
     } else if (selected.key === "vllm") {
       console.log("  ✓ Using existing vLLM on localhost:8000");
       provider = "vllm-local";
-      model = "vllm-local";
+      // Query vLLM for the actual model ID
+      const vllmModelsRaw = runCapture("curl -sf http://localhost:8000/v1/models 2>/dev/null", { ignoreError: true });
+      try {
+        const vllmModels = JSON.parse(vllmModelsRaw);
+        if (vllmModels.data && vllmModels.data.length > 0) {
+          model = vllmModels.data[0].id;
+          if (!isSafeModelId(model)) {
+            console.error(`  Detected model ID contains invalid characters: ${model}`);
+            process.exit(1);
+          }
+          console.log(`  Detected model: ${model}`);
+        } else {
+          console.error("  Could not detect model from vLLM. Please specify manually.");
+          process.exit(1);
+        }
+      } catch {
+        console.error("  Could not query vLLM models endpoint. Is vLLM running on localhost:8000?");
+        process.exit(1);
+      }
     }
     // else: cloud — fall through to default below
   }


### PR DESCRIPTION
*Rebased with main that contained fix with one of the two issues.*

When selecting vLLM during `nemoclaw onboard`, the model name was hardcoded to `vllm-local` instead of the actual model ID served by vLLM (e.g. `nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8`). This causes `404 The model 'vllm-local' does not exist` at inference time.

Now queries vLLM's `/v1/models` endpoint to auto-detect the model ID, and validates it via `isSafeModelId` before interpolating into shell commands.

Ref: #315 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection of local vLLM models to remove manual configuration.

* **Bug Fixes**
  * Improved validation and clearer error messages when local vLLM model discovery fails (invalid model IDs, empty model list, or fetch/parsing errors).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->