### PR TITLE
docs: add discord channel to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ See the full [CLI reference](https://docs.nvidia.com/nemoclaw/latest/reference/c
 
 Refer to the documentation for more information on NemoClaw.
 
-- [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html): Learn what NemoClaw does and how it fits together
-- [How It Works](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html): Learn about the plugin, blueprint, and sandbox lifecycle
-- [Architecture](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html): Learn about the plugin structure, blueprint lifecycle, and sandbox environment
-- [Inference Profiles](https://docs.nvidia.com/nemoclaw/latest/reference/inference-profiles.html): Learn about the NVIDIA cloud inference configuration
-- [Network Policies](https://docs.nvidia.com/nemoclaw/latest/reference/network-policies.html): Learn about egress control and policy customization
-- [CLI Commands](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html): Learn about the full command reference
-- [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html): Troubleshoot common issues and resolution steps
-- [Discord](https://discord.com/channels/1019361803752456192/1482072289511211200): Join the community for questions and discussion
+- [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html): Learn what NemoClaw does and how it fits together.
+- [How It Works](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html): Learn about the plugin, blueprint, and sandbox lifecycle.
+- [Architecture](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html): Learn about the plugin structure, blueprint lifecycle, and sandbox environment.
+- [Inference Profiles](https://docs.nvidia.com/nemoclaw/latest/reference/inference-profiles.html): Learn about the NVIDIA cloud inference configuration.
+- [Network Policies](https://docs.nvidia.com/nemoclaw/latest/reference/network-policies.html): Learn about egress control and policy customization.
+- [CLI Commands](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html): Learn about the full command reference.
+- [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html): Troubleshoot common issues and resolution steps.
+- [Discord](https://discord.gg/XFpfPv9Uvx): Join the community for questions and discussion.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -213,13 +213,14 @@ See the full [CLI reference](https://docs.nvidia.com/nemoclaw/latest/reference/c
 
 Refer to the documentation for more information on NemoClaw.
 
-- [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html): what NemoClaw does and how it fits together
-- [How It Works](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html): plugin, blueprint, and sandbox lifecycle
-- [Architecture](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html): plugin structure, blueprint lifecycle, and sandbox environment
-- [Inference Profiles](https://docs.nvidia.com/nemoclaw/latest/reference/inference-profiles.html): NVIDIA cloud inference configuration
-- [Network Policies](https://docs.nvidia.com/nemoclaw/latest/reference/network-policies.html): egress control and policy customization
-- [CLI Commands](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html): full command reference
-- [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html): common issues and resolution steps
+- [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html): Learn what NemoClaw does and how it fits together
+- [How It Works](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html): Learn about the plugin, blueprint, and sandbox lifecycle
+- [Architecture](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html): Learn about the plugin structure, blueprint lifecycle, and sandbox environment
+- [Inference Profiles](https://docs.nvidia.com/nemoclaw/latest/reference/inference-profiles.html): Learn about the NVIDIA cloud inference configuration
+- [Network Policies](https://docs.nvidia.com/nemoclaw/latest/reference/network-policies.html): Learn about egress control and policy customization
+- [CLI Commands](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html): Learn about the full command reference
+- [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html): Troubleshoot common issues and resolution steps
+- [Discord](https://discord.com/channels/1019361803752456192/1482072289511211200): Join the community for questions and discussion
 
 ## License
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ html_theme_options = {
         },
         {
             "name": "NemoClaw Discord",
-            "url": "https://discord.com/invite/nvidiadeveloper",
+            "url": "https://discord.gg/XFpfPv9Uvx",
             "icon": "fa-brands fa-discord",
             "type": "fontawesome",
         },

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,9 +97,15 @@ html_theme_options = {
     # "public_docs_features": True, # TODO: Uncomment this when the docs are public
     "icon_links": [
         {
-            "name": "GitHub",
+            "name": "NVIDIA NemoClaw GitHub",
             "url": "https://github.com/NVIDIA/NemoClaw",
             "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+        {
+            "name": "NVIDIA NemoClaw Discord Forum",
+            "url": "https://discord.com/channels/1019361803752456192/1482072289511211200",
+            "icon": "fa-brands fa-discord",
             "type": "fontawesome",
         },
     ],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ html_theme_options = {
         },
         {
             "name": "NemoClaw Discord",
-            "url": "https://discord.com/channels/1019361803752456192/1482072289511211200",
+            "url": "https://discord.com/invite/nvidiadeveloper",
             "icon": "fa-brands fa-discord",
             "type": "fontawesome",
         },

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,13 +97,13 @@ html_theme_options = {
     # "public_docs_features": True, # TODO: Uncomment this when the docs are public
     "icon_links": [
         {
-            "name": "NVIDIA NemoClaw GitHub",
+            "name": "NemoClaw GitHub",
             "url": "https://github.com/NVIDIA/NemoClaw",
             "icon": "fa-brands fa-github",
             "type": "fontawesome",
         },
         {
-            "name": "NVIDIA NemoClaw Discord Forum",
+            "name": "NemoClaw Discord",
             "url": "https://discord.com/channels/1019361803752456192/1482072289511211200",
             "icon": "fa-brands fa-discord",
             "type": "fontawesome",

--- a/docs/index.md
+++ b/docs/index.md
@@ -244,5 +244,5 @@ Troubleshooting <reference/troubleshooting>
 :hidden:
 
 resources/license
-Discord <https://discord.com/invite/nvidiadeveloper>
+Discord <https://discord.gg/XFpfPv9Uvx>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -244,4 +244,5 @@ Troubleshooting <reference/troubleshooting>
 :hidden:
 
 resources/license
+Discord <https://discord.com/channels/1019361803752456192/1482072289511211200>
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -244,5 +244,5 @@ Troubleshooting <reference/troubleshooting>
 :hidden:
 
 resources/license
-Discord <https://discord.com/channels/1019361803752456192/1482072289511211200>
+Discord <https://discord.com/invite/nvidiadeveloper>
 ```

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -26,7 +26,6 @@ This page covers common issues you may encounter when installing, onboarding, or
 
 :::{admonition} Get Help
 :class: tip
-:icon: fa-brands fa-discord
 
 If your issue is not listed here, join the [NemoClaw Discord](https://discord.com/channels/1019361803752456192/1482072289511211200) to ask questions and get help from the community. You can also [file an issue on GitHub](https://github.com/NVIDIA/NemoClaw/issues/new).
 :::

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -27,7 +27,7 @@ This page covers common issues you may encounter when installing, onboarding, or
 :::{admonition} Get Help
 :class: tip
 
-If your issue is not listed here, join the [NemoClaw Discord](https://discord.com/invite/nvidiadeveloper) to ask questions and get help from the community. You can also [file an issue on GitHub](https://github.com/NVIDIA/NemoClaw/issues/new).
+If your issue is not listed here, join the [NemoClaw Discord channel](https://discord.gg/XFpfPv9Uvx) to ask questions and get help from the community. You can also [file an issue on GitHub](https://github.com/NVIDIA/NemoClaw/issues/new).
 :::
 
 ## Installation

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -24,6 +24,13 @@ status: published
 
 This page covers common issues you may encounter when installing, onboarding, or running NemoClaw, along with their resolution steps.
 
+:::{admonition} Get Help
+:class: tip
+:icon: fa-brands fa-discord
+
+If your issue is not listed here, join the [NemoClaw Discord](https://discord.com/channels/1019361803752456192/1482072289511211200) to ask questions and get help from the community. You can also [file an issue on GitHub](https://github.com/NVIDIA/NemoClaw/issues/new).
+:::
+
 ## Installation
 
 ### `nemoclaw` not found after install

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -27,7 +27,7 @@ This page covers common issues you may encounter when installing, onboarding, or
 :::{admonition} Get Help
 :class: tip
 
-If your issue is not listed here, join the [NemoClaw Discord](https://discord.com/channels/1019361803752456192/1482072289511211200) to ask questions and get help from the community. You can also [file an issue on GitHub](https://github.com/NVIDIA/NemoClaw/issues/new).
+If your issue is not listed here, join the [NemoClaw Discord](https://discord.com/invite/nvidiadeveloper) to ask questions and get help from the community. You can also [file an issue on GitHub](https://github.com/NVIDIA/NemoClaw/issues/new).
 :::
 
 ## Installation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed the footer GitHub label to "NemoClaw GitHub" to reinforce project branding across site chrome.
  * Added a "NemoClaw Discord" community link to the site footer, Resources list, and the README “Learn More” section for community support.
  * Added a prominent “Get Help” tip on the troubleshooting page directing users to the Discord channel and GitHub issues for assistance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->