### PR TITLE
fix: add binaries to pypi/npm policy presets to prevent 403

### DIFF
--- a/nemoclaw-blueprint/policies/presets/npm.yaml
+++ b/nemoclaw-blueprint/policies/presets/npm.yaml
@@ -23,3 +23,8 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
+    # npm registry access is typically initiated by node (via npm/yarn).
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/local/bin/npm }
+      - { path: /usr/local/bin/yarn }

--- a/nemoclaw-blueprint/policies/presets/pypi.yaml
+++ b/nemoclaw-blueprint/policies/presets/pypi.yaml
@@ -23,3 +23,11 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
+    # Without binaries, OpenShell may treat the endpoint as not usable
+    # by any executable and return 403 Forbidden.
+    binaries:
+      - { path: /usr/local/bin/python }
+      - { path: /usr/local/bin/python3 }
+      - { path: /usr/local/bin/pip }
+      - { path: /usr/bin/python3 }
+      - { path: /usr/bin/pip }

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -114,5 +114,14 @@ describe("policies", () => {
         assert.ok(content.includes("network_policies:"), `${p.name} missing network_policies`);
       }
     });
+
+    it("pypi and npm presets include binaries (prevents 403)", () => {
+      const required = ["pypi", "npm"];
+      for (const name of required) {
+        const content = policies.loadPreset(name);
+        assert.ok(content && content.includes("binaries:"), `${name} missing binaries section`);
+        assert.ok(/-\s*\{\s*path:\s*\//.test(content), `${name} binaries must include at least one { path: ... } entry`);
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
  - Add `binaries` to `pypi` and `npm` policy presets so OpenShell can match the requesting executable for those endpoints.
  - Add a unit test to ensure `pypi`/`npm` presets always include `binaries`, preventing the same regression.
  Fixes #19
  ### Test plan
  - node --test test/policies.test.js
  ### Docs
  - No documentation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Network policy presets for npm and yarn now include executable path allowlists.
  * Network policy presets for Python and pip now include executable path allowlists, supporting common installation paths.

* **Tests**
  * Added tests to validate that executable path allowlists are properly defined in package manager policy presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->