### PR TITLE
Fix uninstall.sh for curl-to-bash execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 If you use nvm or fnm to manage Node.js, the installer may not update your current shell's PATH.
 If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
 
-To uninstall NemoClaw and remove its local state, run:
+To uninstall NemoClaw and remove its local state, run the script pinned to commit `cfedd1e80847e5a46b3c50cf73d6e0cfdbb43d46`:
 
 ```console
-$ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash
+$ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/cfedd1e80847e5a46b3c50cf73d6e0cfdbb43d46/uninstall.sh | bash
 ```
 
 When the install completes, a summary confirms the running environment:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.
 
 To uninstall NemoClaw and remove its local state, run:
 
-```console
+```bash
 curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Download and run the installer script.
 The script installs Node.js if it is not already present, then runs the guided onboard wizard to create a sandbox, configure inference, and apply security policies.
 
 ```console
-$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
 If you use nvm or fnm to manage Node.js, the installer may not update your current shell's PATH.
@@ -80,7 +80,7 @@ If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.
 To uninstall NemoClaw and remove its local state, run:
 
 ```console
-$ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash
 ```
 
 When the install completes, a summary confirms the running environment:
@@ -103,7 +103,7 @@ Logs:        nemoclaw my-assistant logs --follow
 Connect to the sandbox, then chat with the agent through the TUI or the CLI.
 
 ```console
-$ nemoclaw my-assistant connect
+nemoclaw my-assistant connect
 ```
 
 #### OpenClaw TUI

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 If you use nvm or fnm to manage Node.js, the installer may not update your current shell's PATH.
 If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
 
+To uninstall NemoClaw and remove its local state, run:
+
+```console
+$ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash
+```
+
 When the install completes, a summary confirms the running environment:
 
 ```

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 If you use nvm or fnm to manage Node.js, the installer may not update your current shell's PATH.
 If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
 
-To uninstall NemoClaw and remove its local state, run the script pinned to commit `cfedd1e80847e5a46b3c50cf73d6e0cfdbb43d46`:
+To uninstall NemoClaw and remove its local state, run:
 
 ```console
-$ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/cfedd1e80847e5a46b3c50cf73d6e0cfdbb43d46/uninstall.sh | bash
+$ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash
 ```
 
 When the install completes, a summary confirms the running environment:

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -47,6 +47,19 @@ function resolveUninstallScript() {
   return null;
 }
 
+function exitWithSpawnResult(result) {
+  if (result.status !== null) {
+    process.exit(result.status);
+  }
+
+  if (result.signal) {
+    const signalNumber = os.constants.signals[result.signal];
+    process.exit(signalNumber ? 128 + signalNumber : 1);
+  }
+
+  process.exit(1);
+}
+
 // ── Commands ─────────────────────────────────────────────────────
 
 async function onboard(args) {
@@ -184,7 +197,7 @@ function uninstall(args) {
       cwd: ROOT,
       env: process.env,
     });
-    process.exit(result.status || 0);
+    exitWithSpawnResult(result);
   }
 
   console.log(`  Local uninstall script not found; falling back to ${REMOTE_UNINSTALL_URL}`);
@@ -197,7 +210,7 @@ function uninstall(args) {
     cwd: ROOT,
     env: process.env,
   });
-  process.exit(result.status || 0);
+  exitWithSpawnResult(result);
 }
 
 function showStatus() {

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -22,9 +22,30 @@ const policies = require("./lib/policies");
 
 const GLOBAL_COMMANDS = new Set([
   "onboard", "list", "deploy", "setup", "setup-spark",
-  "start", "stop", "status",
+  "start", "stop", "status", "uninstall",
   "help", "--help", "-h",
 ]);
+
+const REMOTE_UNINSTALL_URL = "https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh";
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function resolveUninstallScript() {
+  const candidates = [
+    path.join(ROOT, "uninstall.sh"),
+    path.join(__dirname, "..", "uninstall.sh"),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
 
 // ── Commands ─────────────────────────────────────────────────────
 
@@ -152,6 +173,31 @@ async function start() {
 
 function stop() {
   run(`bash "${SCRIPTS}/start-services.sh" --stop`);
+}
+
+function uninstall(args) {
+  const localScript = resolveUninstallScript();
+  if (localScript) {
+    console.log(`  Running local uninstall script: ${localScript}`);
+    const result = spawnSync("bash", [localScript, ...args], {
+      stdio: "inherit",
+      cwd: ROOT,
+      env: process.env,
+    });
+    process.exit(result.status || 0);
+  }
+
+  console.log(`  Local uninstall script not found; falling back to ${REMOTE_UNINSTALL_URL}`);
+  const forwardedArgs = args.map(shellQuote).join(" ");
+  const command = forwardedArgs.length > 0
+    ? `curl -fsSL ${shellQuote(REMOTE_UNINSTALL_URL)} | bash -s -- ${forwardedArgs}`
+    : `curl -fsSL ${shellQuote(REMOTE_UNINSTALL_URL)} | bash`;
+  const result = spawnSync("bash", ["-c", command], {
+    stdio: "inherit",
+    cwd: ROOT,
+    env: process.env,
+  });
+  process.exit(result.status || 0);
 }
 
 function showStatus() {
@@ -308,6 +354,12 @@ function help() {
     nemoclaw start                   Start services (Telegram, tunnel)
     nemoclaw stop                    Stop all services
     nemoclaw status                  Show sandbox list and service status
+    nemoclaw uninstall [flags]       Run uninstall.sh (local first, curl fallback)
+
+  Uninstall flags:
+    --yes                            Skip the confirmation prompt
+    --keep-openshell                 Leave the openshell binary installed
+    --delete-models                  Remove NemoClaw-pulled Ollama models
 
   Credentials are prompted on first use, then saved securely
   in ~/.nemoclaw/credentials.json (mode 600).
@@ -335,6 +387,7 @@ const [cmd, ...args] = process.argv.slice(2);
       case "start":       await start(); break;
       case "stop":        stop(); break;
       case "status":      showStatus(); break;
+      case "uninstall":   uninstall(args); break;
       case "list":        listSandboxes(); break;
       default:            help(); break;
     }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -454,6 +454,6 @@ main() {
   info "Uninstall complete."
 }
 
-if [ "${BASH_SOURCE[0]-}" = "$0" ] || [ "$0" = "bash" ] || [ "$0" = "-bash" ]; then
+if [ "${BASH_SOURCE[0]-}" = "$0" ] || { [ -z "${BASH_SOURCE[0]-}" ] && { [ "$0" = "bash" ] || [ "$0" = "-bash" ]; }; }; then
   main "$@"
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -89,7 +89,12 @@ confirm() {
     warn "Ollama models are preserved by default. Re-run with --delete-models to remove them."
   fi
   printf "Continue? [y/N] "
-  read -r reply
+  local reply=""
+  if [ -t 2 ] && read -r reply 0</dev/tty 2>/dev/null; then
+    :
+  else
+    read -r reply || true
+  fi
   case "$reply" in
     y|Y|yes|YES) ;;
     *) info "Aborted."; exit 0 ;;
@@ -429,9 +434,6 @@ main() {
   info "Removing global nemoclaw install..."
   remove_nemoclaw_cli
 
-  info "Removing NemoClaw state..."
-  remove_nemoclaw_state
-
   info "Removing related Docker containers..."
   remove_related_docker_containers
 
@@ -449,6 +451,9 @@ main() {
 
   info "Removing openshell binary..."
   remove_openshell_binary
+
+  info "Removing NemoClaw state..."
+  remove_nemoclaw_state
 
   echo ""
   info "Uninstall complete."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -454,6 +454,6 @@ main() {
   info "Uninstall complete."
 }
 
-if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+if [ "${BASH_SOURCE[0]-}" = "$0" ] || [ "$0" = "bash" ] || [ "$0" = "-bash" ]; then
   main "$@"
 fi


### PR DESCRIPTION
## Summary
- make the uninstall script entrypoint guard safe under `set -u`
- support stdin execution via `curl -fsSL ... | bash`
- preserve normal file-based execution

## Testing
- `bash -n uninstall.sh`
- validated a stdin execution path with the updated entrypoint guard

Closes #425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an uninstall command to the CLI to run the uninstall flow locally or via the provided remote script.
* **Refactor**
  * Improved uninstall script to better detect direct execution contexts and behave more robustly across shells.
* **Bug Fixes**
  * Made confirmation prompt input handling more reliable in TTY and non‑TTY environments.
  * Reordered uninstall steps so local state removal occurs after binary/container/image/volume cleanup.
* **Documentation**
  * Added an explicit uninstall section to Quick Start with a one‑line uninstall command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->