### PR TITLE
docs: update messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@
 [![Project Status](https://img.shields.io/badge/status-alpha-orange)](https://github.com/NVIDIA/NemoClaw/blob/main/docs/about/release-notes.md)
 <!-- end-badges -->
 
-NVIDIA NemoClaw is an open source stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants safely. It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of [NVIDIA Agent Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest), a secure environment for running autonomous agents, with inference routed through [NVIDIA cloud](https://build.nvidia.com).
+NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants safely. It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of [NVIDIA Agent Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest), a secure environment for running autonomous agents, and open source models such as [NVIDIA Nemotron](https://build.nvidia.com).
 
 > **Alpha software**
 > 
-> NemoClaw is early-stage. Expect rough edges. We are building toward production-ready sandbox orchestration, but the starting point is getting your own environment up and running.
+> NemoClaw is available in early preview starting March 16, 2026.
 > Interfaces, APIs, and behavior may change without notice as we iterate on the design.
-> The project is shared to gather feedback and enable early experimentation, but it
-> should not yet be considered production-ready.
+> The project is shared to gather feedback and enable early experimentation.
 > We welcome issues and discussion from the community while the project evolves.
 
 ---
@@ -98,11 +97,13 @@ Connect to the sandbox, then chat with the agent through the TUI or the CLI.
 
 #### Connect to the Sandbox
 
+Run the following command to connect to the sandbox:
+
 ```bash
 nemoclaw my-assistant connect
 ```
 
-This opens the sandbox shell `sandbox@my-assistant:~$` where you can run `openclaw` commands.
+This connects you to the sandbox shell `sandbox@my-assistant:~$` where you can run `openclaw` commands.
 
 #### OpenClaw TUI
 

--- a/docs/about/how-it-works.md
+++ b/docs/about/how-it-works.md
@@ -20,8 +20,7 @@ status: published
 
 # How NemoClaw Works
 
-NemoClaw combines a lightweight CLI plugin with a versioned blueprint to move OpenClaw into a controlled sandbox.
-This page explains the key concepts at a high level.
+This page explains the key concepts about NemoClaw at a high level.
 
 ## How It Fits Together
 

--- a/docs/about/how-it-works.md
+++ b/docs/about/how-it-works.md
@@ -20,6 +20,7 @@ status: published
 
 # How NemoClaw Works
 
+NemoClaw combines a lightweight CLI plugin with a versioned blueprint to move OpenClaw into a controlled sandbox.
 This page explains the key concepts about NemoClaw at a high level.
 
 ## How It Fits Together

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -2,8 +2,8 @@
 title:
   page: "NemoClaw Overview — What It Does and How It Fits Together"
   nav: "Overview"
-description: "NemoClaw sandboxes OpenClaw with NVIDIA inference and declarative policy."
-keywords: ["nemoclaw overview", "openclaw openshell sandbox plugin"]
+description: "NemoClaw is an open source reference stack that simplifies running OpenClaw always-on assistants safely."
+keywords: ["nemoclaw overview", "openclaw always-on assistants", "nvidia openshell", "nvidia nemotron"]
 topics: ["generative_ai", "ai_agents"]
 tags: ["openclaw", "openshell", "sandboxing", "inference_routing", "blueprints"]
 content:
@@ -20,8 +20,9 @@ status: published
 
 # Overview
 
-NemoClaw is the [OpenClaw](https://openclaw.ai) plugin for [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell).
-It moves OpenClaw into a sandboxed environment where every network request, file access, and inference call is governed by declarative policy.
+NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants safely. It incorporates policy-based privacy and security guardrails, giving users control over their agents' behavior and data handling. This enables self-evolving claws to run more safely in clouds, on prem, RTX PCs, and DGX Spark.
+
+NemoClaw uses open source models, such as [NVIDIA Nemotron](https://build.nvidia.com), alongside the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of the [NVIDIA Agent Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest), a secure environment designed for executing claws more safely. By combining open source models with built-in safety measures, NemoClaw simplifies and secures AI agent deployment.
 
 | Capability              | Description                                                                                                                                          |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -20,7 +20,7 @@ status: published
 
 # Release Notes
 
-NVIDIA NemoClaw is in active development and follows a frequent release cadence. Use the following GitHub resources directly.
+NVIDIA NemoClaw is available in early preview starting March 16, 2026. Use the following GitHub resources to track changes.
 
 | Resource | Description |
 |---|---|

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 title:
   page: "NVIDIA NemoClaw Developer Guide"
   nav: "NemoClaw"
-description: "Sandbox OpenClaw with NVIDIA inference routing and strict network policies."
-keywords: ["nemoclaw sandboxed ai agent", "openclaw openshell plugin"]
+description: "NemoClaw is an open source reference stack that simplifies running OpenClaw always-on assistants more safely, with a single command."
+keywords: ["nemoclaw open source reference stack", "openclaw always-on assistants", "nvidia openshell", "nvidia nemotron"]
 topics: ["generative_ai", "ai_agents"]
 tags: ["openclaw", "openshell", "sandboxing", "inference_routing", "nemoclaw"]
 content:
@@ -25,9 +25,8 @@ status: published
 :end-before: <!-- end-badges -->
 ```
 
-NemoClaw is the OpenClaw plugin for [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell).
-It runs OpenClaw inside a sandboxed environment with NVIDIA cloud inference, such as Nemotron 3 Super 120B through [build.nvidia.com](https://build.nvidia.com).
-The sandbox enforces strict network policies and operator-controlled egress approval.
+NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants safely.
+It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of [NVIDIA Agent Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest), a secure environment for running autonomous agents, and open source models like [NVIDIA Nemotron](https://build.nvidia.com).
 
 ## Get Started
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reframed product positioning to present NemoClaw as an open-source reference stack and emphasize open-source models (e.g., NVIDIA Nemotron)
  * Updated availability language to state an early preview starting March 16, 2026
  * Adjusted overview and front-matter to highlight policy-based privacy/security guardrails and user control
  * Clarified onboarding and sandbox connection instructions for improved readability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->