### PR TITLE
fix: use openshell logs instead of nonexistent sandbox logs (#424)

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -229,8 +229,8 @@ function sandboxStatus(sandboxName) {
 }
 
 function sandboxLogs(sandboxName, follow) {
-  const followFlag = follow ? " --follow" : "";
-  run(`openshell sandbox logs "${sandboxName}"${followFlag}`);
+  const followFlag = follow ? " --tail" : "";
+  run(`openshell logs "${sandboxName}"${followFlag}`);
 }
 
 async function sandboxPolicyAdd(sandboxName) {


### PR DESCRIPTION
`openshell sandbox logs` does not exist; the correct command is the `openshell logs`. Also fixes the follow flag from --follow to --tail to match the openshell CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the logs command implementation to use the correct OpenShell CLI subcommand interface and argument format. The user-facing `--follow` flag behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->