### PR TITLE
fix: use CONNECT tunnel for WebSocket endpoints in Discord/Slack presets

### DIFF
--- a/nemoclaw-blueprint/policies/presets/discord.yaml
+++ b/nemoclaw-blueprint/policies/presets/discord.yaml
@@ -17,14 +17,16 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+          - allow: { method: PUT, path: "/**" }
+          - allow: { method: PATCH, path: "/**" }
+          - allow: { method: DELETE, path: "/**" }
+      # WebSocket gateway — must use access:full (CONNECT tunnel) instead
+      # of protocol:rest. The proxy's HTTP idle timeout (~2 min) kills
+      # long-lived WebSocket connections; a CONNECT tunnel avoids
+      # HTTP-level timeouts entirely. See #409.
       - host: gateway.discord.gg
         port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
+        access: full
       - host: cdn.discordapp.com
         port: 443
         protocol: rest
@@ -32,5 +34,16 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
+<<<<<<< HEAD
     binaries:
       - { path: /usr/local/bin/node }
+=======
+      # Media/attachment uploads use a separate domain
+      - host: media.discordapp.net
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+>>>>>>> b926698 (fix: use CONNECT tunnel for WebSocket endpoints in Discord/Slack presets)

--- a/nemoclaw-blueprint/policies/presets/discord.yaml
+++ b/nemoclaw-blueprint/policies/presets/discord.yaml
@@ -20,8 +20,8 @@ network_policies:
           - allow: { method: PUT, path: "/**" }
           - allow: { method: PATCH, path: "/**" }
           - allow: { method: DELETE, path: "/**" }
-      # WebSocket gateway — must use access:full (CONNECT tunnel) instead
-      # of protocol:rest. The proxy's HTTP idle timeout (~2 min) kills
+      # WebSocket gateway — must use access: full (CONNECT tunnel) instead
+      # of protocol: rest. The proxy's HTTP idle timeout (~2 min) kills
       # long-lived WebSocket connections; a CONNECT tunnel avoids
       # HTTP-level timeouts entirely. See #409.
       - host: gateway.discord.gg
@@ -34,11 +34,7 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
-<<<<<<< HEAD
-    binaries:
-      - { path: /usr/local/bin/node }
-=======
-      # Media/attachment uploads use a separate domain
+      # Media/attachment access (read-only, proxied through Discord CDN)
       - host: media.discordapp.net
         port: 443
         protocol: rest
@@ -46,4 +42,5 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
->>>>>>> b926698 (fix: use CONNECT tunnel for WebSocket endpoints in Discord/Slack presets)
+    binaries:
+      - { path: /usr/local/bin/node }

--- a/nemoclaw-blueprint/policies/presets/slack.yaml
+++ b/nemoclaw-blueprint/policies/presets/slack.yaml
@@ -3,7 +3,7 @@
 
 preset:
   name: slack
-  description: "Slack API and webhooks access"
+  description: "Slack API, Socket Mode, and webhooks access"
 
 network_policies:
   slack:
@@ -33,5 +33,13 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+      # Socket Mode WebSocket — requires CONNECT tunnel to avoid
+      # HTTP idle timeout killing the persistent connection. See #409.
+      - host: wss-primary.slack.com
+        port: 443
+        access: full
+      - host: wss-backup.slack.com
+        port: 443
+        access: full
     binaries:
       - { path: /usr/local/bin/node }


### PR DESCRIPTION
## Summary

The Discord and Slack network policy presets configure WebSocket endpoints with `protocol: rest` + `tls: terminate`, which routes traffic through the egress proxy's HTTP layer. The proxy's hardcoded idle timeout (~2 minutes) kills the WebSocket connection, causing `discord.js` (and Slack Socket Mode) to enter a reconnect loop with ~50% uptime.

## Root Cause

`protocol: rest` with `tls: terminate` means the proxy intercepts and inspects HTTP traffic. For WebSocket connections, this means the proxy sees an idle HTTP connection after the upgrade handshake and kills it after the idle timeout.

`access: full` creates a CONNECT tunnel — the proxy just forwards raw TCP bytes without HTTP-level inspection or timeouts. This is exactly what WebSocket connections need.

## Changes

**Discord preset:**
- `gateway.discord.gg`: changed from `protocol: rest` → `access: full` (WebSocket gateway)
- `discord.com`: added PUT/PATCH/DELETE methods (message editing, reactions, channel management)
- Added `media.discordapp.net` endpoint (attachment/media access)

**Slack preset:**
- Added `wss-primary.slack.com` and `wss-backup.slack.com` with `access: full` (Socket Mode WebSocket endpoints)

## Security Considerations

- `access: full` bypasses HTTP-level inspection for the WebSocket endpoints only
- REST API endpoints (`discord.com`, `api.slack.com`) remain under `protocol: rest` with method/path rules
- This matches the existing pattern used for `github.com` and `registry.npmjs.org` in the baseline sandbox policy

## What This Doesn't Fix

The hardcoded ~2-minute idle timeout in the `openshell-sandbox` binary still affects any `protocol: rest` endpoint with long-lived connections (SSE streams, etc.). That requires an upstream fix in OpenShell. This PR fixes the most common case: WebSocket-based messaging plugins.

Partially addresses #409. Related: #361 (WhatsApp Web, same root cause).

AI-assisted: Built with Claude, reviewed by human.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord endpoint now supports PUT, PATCH, and DELETE in addition to GET/POST.
  * Added Socket Mode WebSocket endpoints for Slack with full WebSocket access.
  * Discord gateway now operates in full-access mode on port 443.

* **Updates**
  * CDN endpoint restricted to GET-only; media/attachment host switched to media.discordapp.net with TLS/enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->