### PR TITLE
docs: add curl uninstall flag example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ The script removes sandboxes, the NemoClaw gateway and providers, related Docker
 | `--keep-openshell` | Leave the `openshell` binary installed.              |
 | `--delete-models`  | Also remove NemoClaw-pulled Ollama models.           |
 
+For example, to skip the confirmation prompt:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash -s -- --yes
+```
+
 <!-- end-quickstart-guide -->
 
 ---


### PR DESCRIPTION
## Summary
- add a curl uninstall example after the README uninstall flags table
- show how to pass `--yes` through `bash -s --`
- make the documented uninstall flags directly actionable

## Testing
- reviewed the README uninstall section locally
- verified the example matches the documented curl uninstall flow

Closes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an additional uninstall usage example demonstrating how to suppress the confirmation prompt when running the uninstall script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->