### PR TITLE
fix: use SSH to stream sandbox logs instead of non-existent openshell subcommand

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -288,8 +288,56 @@ function sandboxStatus(sandboxName) {
 }
 
 function sandboxLogs(sandboxName, follow) {
-  const followFlag = follow ? " --follow" : "";
-  run(`openshell sandbox logs "${sandboxName}"${followFlag}`);
+  // Verify sandbox exists and is running (exits non-zero for deleted/stopped sandboxes)
+  try {
+    execSync(`openshell sandbox get "${sandboxName}"`, {
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch {
+    console.log(`  Sandbox '${sandboxName}' is not running. No live logs available.`);
+    return;
+  }
+
+  // Get SSH config for the sandbox
+  let sshConfig;
+  try {
+    sshConfig = execSync(`openshell sandbox ssh-config "${sandboxName}"`, {
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch {
+    console.log(`  Sandbox '${sandboxName}' is not running. No live logs available.`);
+    return;
+  }
+
+  // Write temp ssh config
+  const confPath = `/tmp/nemoclaw-logs-${process.pid}.conf`;
+  fs.writeFileSync(confPath, sshConfig);
+
+  console.log(`  Streaming logs from sandbox '${sandboxName}'...`);
+  console.log("");
+
+  const tailCmd = follow
+    ? "tail -f -n 50 /tmp/nemoclaw.log /tmp/openclaw.log 2>/dev/null"
+    : "tail -n 50 /tmp/nemoclaw.log /tmp/openclaw.log 2>/dev/null";
+
+  const result = spawnSync("ssh", [
+    "-T", "-F", confPath,
+    "-o", "StrictHostKeyChecking=no",
+    "-o", "UserKnownHostsFile=/dev/null",
+    "-o", "LogLevel=ERROR",
+    `openshell-${sandboxName}`,
+    tailCmd,
+  ], { stdio: "inherit" });
+
+  try { fs.unlinkSync(confPath); } catch {}
+
+  if (result.status !== 0 && result.status !== null && !follow) {
+    console.error(`  Failed to stream logs (exit ${result.status})`);
+  }
 }
 
 async function sandboxPolicyAdd(sandboxName) {
@@ -353,7 +401,7 @@ function help() {
     nemoclaw list                    List all sandboxes
     nemoclaw <name> connect          Connect to a sandbox
     nemoclaw <name> status           Show sandbox status and health
-    nemoclaw <name> logs [--follow]  View sandbox logs
+    nemoclaw <name> logs [-f|--follow]  View sandbox logs
     nemoclaw <name> destroy          Stop NIM + delete sandbox
 
   Policy Presets:
@@ -416,7 +464,7 @@ const [cmd, ...args] = process.argv.slice(2);
     switch (action) {
       case "connect":     sandboxConnect(cmd); break;
       case "status":      sandboxStatus(cmd); break;
-      case "logs":        sandboxLogs(cmd, actionArgs.includes("--follow")); break;
+      case "logs":        sandboxLogs(cmd, actionArgs.includes("--follow") || actionArgs.includes("-f")); break;
       case "policy-add":  await sandboxPolicyAdd(cmd); break;
       case "policy-list": sandboxPolicyList(cmd); break;
       case "destroy":     sandboxDestroy(cmd); break;


### PR DESCRIPTION
## Summary
- Fixes #424 — `nemoclaw <name> logs --follow` was calling `openshell sandbox logs`, which doesn't exist in openshell v0.1.0
- Rewrote `sandboxLogs` to use the SSH pattern (same as `telegram-bridge.js` and `test-full-e2e.sh`): verify sandbox via `openshell sandbox get`, get SSH config via `openshell sandbox ssh-config`, then `ssh -F <config> openshell-<name> 'tail [-f] -n 50 /tmp/nemoclaw.log /tmp/openclaw.log'`
- Added `-f` as short alias for `--follow`

## Test plan
- [ ] `nemoclaw <name> logs` — shows last 50 lines, exits 0
- [ ] `nemoclaw <name> logs --follow` — streams in real time, Ctrl+C exits cleanly
- [ ] `nemoclaw <name> logs -f` — same as --follow
- [ ] Stopped/deleted sandbox — prints "not running" message, exits 0
- [ ] `node --test test/cli.test.js` — 7/7 pass
- [ ] No orphan ssh/tail processes after Ctrl+C
- [ ] `nemoclaw <name> status` and `nemoclaw <name> connect` — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for both `-f` and `--follow` flags when fetching sandbox logs.

* **Bug Fixes**
  * Improved sandbox log retrieval with pre-flight verification to ensure the sandbox is running and accessible before attempting to fetch logs.
  * Enhanced error handling for log operations with clearer feedback when sandbox access fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->