### PR TITLE
docs: remove duplicated content in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,7 @@ Send a test message to the agent and verify you receive a response.
 
 > **ℹ️ Note**
 >
-> The TUI is best for interactive back-and-forth. If you need the full text of a long response (for example, large code generation output), use the CLI instead:
->
-> ```bash
-> openclaw agent --agent main --local -m "<prompt>" --session-id <id>
-> ```
->
-> This prints the complete response directly in the terminal and avoids relying on the TUI view for long output.
+> The TUI is best for interactive back-and-forth. If you need the full text of a long response such as a large code generation output, use the CLI instead.
 
 #### OpenClaw CLI
 
@@ -132,6 +126,8 @@ In the sandbox shell, run the following command to send a single message and pri
 ```bash
 openclaw agent --agent main --local -m "hello" --session-id test
 ```
+
+This prints the complete response directly in the terminal and avoids relying on the TUI view for long output.
 
 ### Uninstall
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Project Status](https://img.shields.io/badge/status-alpha-orange)](https://github.com/NVIDIA/NemoClaw/blob/main/docs/about/release-notes.md)
 <!-- end-badges -->
 
-NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants safely. It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of [NVIDIA Agent Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest), a secure environment for running autonomous agents, and open source models such as [NVIDIA Nemotron](https://build.nvidia.com).
+NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants safely. It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of NVIDIA Agent Toolkit, a secure environment for running autonomous agents, and open source models such as [NVIDIA Nemotron](https://build.nvidia.com).
 
 > **Alpha software**
 > 

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -22,7 +22,7 @@ status: published
 
 NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants safely. It incorporates policy-based privacy and security guardrails, giving users control over their agents' behavior and data handling. This enables self-evolving claws to run more safely in clouds, on prem, RTX PCs, and DGX Spark.
 
-NemoClaw uses open source models, such as [NVIDIA Nemotron](https://build.nvidia.com), alongside the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of the [NVIDIA Agent Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest), a secure environment designed for executing claws more safely. By combining open source models with built-in safety measures, NemoClaw simplifies and secures AI agent deployment.
+NemoClaw uses open source models, such as [NVIDIA Nemotron](https://build.nvidia.com), alongside the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of the NVIDIA Agent Toolkit, a secure environment designed for executing claws more safely. By combining open source models with built-in safety measures, NemoClaw simplifies and secures AI agent deployment.
 
 | Capability              | Description                                                                                                                                          |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ status: published
 ```
 
 NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants safely.
-It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of [NVIDIA Agent Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest), a secure environment for running autonomous agents, and open source models like [NVIDIA Nemotron](https://build.nvidia.com).
+It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of NVIDIA Agent Toolkit, a secure environment for running autonomous agents, and open source models like [NVIDIA Nemotron](https://build.nvidia.com).
 
 ## Get Started
 


### PR DESCRIPTION
Rephrase note about using CLI for long responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance to use the CLI for long responses and noted the CLI prints complete output in the terminal (avoiding the TUI for large outputs).
  * Removed explicit documentation URLs, replacing them with references to the “NVIDIA Agent Toolkit” in overview and index content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->