### PR TITLE
chore: add issue templates and improve PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug Report
+description: Report a bug you confirmed and could not fix.
+labels: ["bug", "status: triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Run `nemoclaw onboard`
+        2. Select "local" inference
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node.js version, Docker version, NemoClaw version, and any other relevant details.
+      placeholder: |
+        - OS: macOS 15.2 / Ubuntu 24.04 / Windows 11 + WSL2
+        - Node.js: v20.x
+        - Docker: Docker Desktop 4.x / Docker Engine 27.x
+        - NemoClaw: v0.x.x (output of `nemoclaw --version`)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log output, error messages, or stack traces.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I confirmed this bug is reproducible
+          required: true
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability?
+    url: https://github.com/NVIDIA/NemoClaw/blob/main/SECURITY.md
+    about: >
+      Do not report security vulnerabilities through GitHub issues. Follow
+      the disclosure process in SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/doc_issue.yml
+++ b/.github/ISSUE_TEMPLATE/doc_issue.yml
@@ -1,0 +1,42 @@
+name: Documentation Issue
+description: Report incorrect, missing, or unclear documentation.
+labels: ["documentation", "status: triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is wrong, missing, or unclear in the docs?
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Affected Page
+      description: URL or file path of the doc page (e.g., docs/get-started/quickstart.md).
+      placeholder: docs/reference/commands.md
+    validations:
+      required: false
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      options:
+        - "Inaccurate information"
+        - "Missing documentation"
+        - "Unclear or confusing"
+        - "Broken link or cross-reference"
+        - "Formatting or rendering problem"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Fix
+      description: If you know what the correct content should be, describe it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,22 +1,51 @@
-name: Feature/Enhancement Request
-+description: Submit a feature request other enhancement to help us improve NemoClaw
-labels: ["status: triage"]
+name: Feature Request
+description: Propose a feature with a design. Not a "please build this" request.
+labels: ["enhancement", "status: triage"]
 body:
   - type: textarea
-    id: desc
+    id: problem
     attributes:
-      label: Proposed Change
-      placeholder: Describe the feature or provider integration...
+      label: Problem Statement
+      description: What problem does this solve? Why does it matter?
     validations:
       required: true
-  - type: dropdown
-    id: cat
+
+  - type: textarea
+    id: design
     attributes:
-      label: Suggested Category
-      options: 
+      label: Proposed Design
+      description: |
+        How should this work? Describe the system behavior, components involved, and user-facing interface.
+        This should be a design, not a wish list.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you evaluate? Why is the proposed design better?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
         - "enhancement: feature"
         - "enhancement: provider"
         - "enhancement: platform"
         - "enhancement: testing"
     validations:
       required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: This is a design proposal, not a "please build this" request
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,28 +9,32 @@
 
 ## Type of Change
 <!-- Check the one that applies. -->
-- [ ] Code change (new feature, bug fix, refactor)
-- [ ] Code change with doc updates
-- [ ] Doc only — prose changes (no code sample modifications)
-- [ ] Doc only — includes code sample changes
+- [ ] Code change for a new feature, bug fix, or refactor.
+- [ ] Code change with doc updates.
+- [ ] Doc only. Prose changes without code sample modifications.
+- [ ] Doc only. Includes code sample changes.
 
 ## Testing
 <!-- What testing was done? -->
-- [ ] `make check` passes
-- [ ] `npm test` passes
-- [ ] `make docs` builds without warnings (for doc changes)
+- [ ] `make check` passes.
+- [ ] `npm test` passes.
+- [ ] `make docs` builds without warnings. (for doc-only changes)
 
 ## Checklist
 
-### Code changes
-<!-- Skip if this is a doc-only PR. -->
-- [ ] `make format` applied (TypeScript and Python)
-- [ ] Tests added or updated for new or changed behavior
-- [ ] No secrets, API keys, or credentials committed
-- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs)
+### General
+- [ ] I have read and followed the [contributing guide](CONTRIBUTING.md).
+- [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)
 
-### Doc changes
+### Code Changes
+<!-- Skip if this is a doc-only PR. -->
+- [ ] `make format` applied (TypeScript and Python).
+- [ ] Tests added or updated for new or changed behavior.
+- [ ] No secrets, API keys, or credentials committed.
+- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).
+
+### Doc Changes
 <!-- Skip if this PR has no doc changes. -->
 - [ ] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
-- [ ] New pages include SPDX license header and frontmatter (if creating a new page)
-- [ ] Cross-references and links verified
+- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
+- [ ] Cross-references and links verified.


### PR DESCRIPTION
## Summary

Add structured issue templates for bug reports, feature requests, and documentation issues. Enhance the PR template with contribution checklists aligned to the project's CONTRIBUTING.md guidelines.

## Changes

- Add bug report issue template with required reproduction steps, environment details, and a reproducibility checklist.
- Add documentation issue template with affected page field, issue type dropdown, and optional suggested fix.
- Enhance feature request template to require a problem statement, proposed design, and a "not a wish list" gate.
- Add config.yml to disable blank issues and redirect security reports to SECURITY.md.
- Improve PR template with a "Type of Change" selector, separate checklists for code and doc changes, and a reference to the `update-docs` agent skill.

## Type of Change

- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [ ] `make check` passes.
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [x] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Doc Changes
- [x] Follows the [style guide](docs/CONTRIBUTING.md).
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.