### PR TITLE
fix(telegram-bridge): read defaultSandbox from config instead of hardcoding

### DIFF
--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -19,6 +19,7 @@
 const https = require("https");
 const fs = require("fs");
 const path = require("path");
+const os = require("os");
 const { execSync, spawn } = require("child_process");
 const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
 
@@ -32,11 +33,16 @@ const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const API_KEY = process.env.NVIDIA_API_KEY;
 
 function readDefaultSandbox() {
-  const configPath = path.join(process.env.HOME, ".nemoclaw", "sandboxes.json");
+  const configPath = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
   try {
     const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
     if (config.defaultSandbox) return config.defaultSandbox;
-  } catch {}
+    console.warn("[warn] sandboxes.json has no defaultSandbox field — falling back to SANDBOX_NAME or \"nemoclaw\"");
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      console.warn(`[warn] could not read sandboxes.json: ${err.message} — falling back to SANDBOX_NAME or "nemoclaw"`);
+    }
+  }
   return null;
 }
 

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -17,6 +17,8 @@
  */
 
 const https = require("https");
+const fs = require("fs");
+const path = require("path");
 const { execSync, spawn } = require("child_process");
 const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
 
@@ -28,7 +30,17 @@ if (!OPENSHELL) {
 
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const API_KEY = process.env.NVIDIA_API_KEY;
-const SANDBOX = process.env.SANDBOX_NAME || "nemoclaw";
+
+function readDefaultSandbox() {
+  const configPath = path.join(process.env.HOME, ".nemoclaw", "sandboxes.json");
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    if (config.defaultSandbox) return config.defaultSandbox;
+  } catch {}
+  return null;
+}
+
+const SANDBOX = process.env.SANDBOX_NAME || readDefaultSandbox() || "nemoclaw";
 const ALLOWED_CHATS = process.env.ALLOWED_CHAT_IDS
   ? process.env.ALLOWED_CHAT_IDS.split(",").map((s) => s.trim())
   : null;
@@ -96,7 +108,7 @@ function runAgentInSandbox(message, sessionId) {
 
     // Write temp ssh config
     const confPath = `/tmp/nemoclaw-tg-ssh-${sessionId}.conf`;
-    require("fs").writeFileSync(confPath, sshConfig);
+    fs.writeFileSync(confPath, sshConfig);
 
     const escaped = message.replace(/'/g, "'\\''");
     const cmd = `export NVIDIA_API_KEY='${API_KEY}' && nemoclaw-start openclaw agent --agent main --local -m '${escaped}' --session-id 'tg-${sessionId}'`;
@@ -113,7 +125,7 @@ function runAgentInSandbox(message, sessionId) {
     proc.stderr.on("data", (d) => (stderr += d.toString()));
 
     proc.on("close", (code) => {
-      try { require("fs").unlinkSync(confPath); } catch {}
+      try { fs.unlinkSync(confPath); } catch {}
 
       // Extract the actual agent response — skip setup lines
       const lines = stdout.split("\n");


### PR DESCRIPTION

 ## Summary
  The Telegram bridge was hardcoding "nemoclaw" as the sandbox name. If you named your sandbox anything else during onboarding, messages would silently never reach the
  agent. Now it reads `defaultSandbox` from `~/.nemoclaw/sandboxes.json` instead.

  ## Related Issue
  Fixes #445

  ## Changes
  - Read `defaultSandbox` from `~/.nemoclaw/sandboxes.json` before falling back to hardcoded name
  - Fallback order: `SANDBOX_NAME` env var → config file → `"nemoclaw"`
  - Moved `require("fs")` to top-level since it's now used at startup

  ## Type of Change
  - [x] Code change for a new feature, bug fix, or refactor.

  ## Testing
  - `npm test` — 22/22 pass
  - `make check` / `make format` — targets don't exist in the repo

  ## Checklist

  ### General
  - [x] I have read and followed the [contributing guide](CONTRIBUTING.md).

  ### Code Changes
  - [x] No secrets, API keys, or credentials committed.
  - [x] No user-facing behavior changes that need doc updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a local settings file to set a default sandbox, used if no environment override is present.
  * Sandbox selection now prefers environment setting, then local settings, then a built-in default.

* **Bug Fixes / Reliability**
  * Improved handling of temporary SSH config files and error/fallback behavior when the local settings file is missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->