### PR TITLE
feat(scripts): parametrize model via NEMOCLAW_MODEL env var

### DIFF
--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -13,6 +13,7 @@
  *   TELEGRAM_BOT_TOKEN  — from @BotFather
  *   NVIDIA_API_KEY      — for inference
  *   SANDBOX_NAME        — sandbox name (default: nemoclaw)
+ *   NEMOCLAW_MODEL      — model ID to display (default: nvidia/nemotron-3-super-120b-a12b)
  *   ALLOWED_CHAT_IDS    — comma-separated Telegram chat IDs to accept (optional, accepts all if unset)
  */
 
@@ -29,6 +30,7 @@ if (!OPENSHELL) {
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const API_KEY = process.env.NVIDIA_API_KEY;
 const SANDBOX = process.env.SANDBOX_NAME || "nemoclaw";
+const MODEL = process.env.NEMOCLAW_MODEL || "nvidia/nemotron-3-super-120b-a12b";
 const ALLOWED_CHATS = process.env.ALLOWED_CHAT_IDS
   ? process.env.ALLOWED_CHAT_IDS.split(",").map((s) => s.trim())
   : null;
@@ -176,7 +178,7 @@ async function poll() {
         if (msg.text === "/start") {
           await sendMessage(
             chatId,
-            "🦀 *NemoClaw* — powered by Nemotron 3 Super 120B\n\n" +
+            `🦀 *NemoClaw* — powered by \`${MODEL}\`\n\n` +
               "Send me a message and I'll run it through the OpenClaw agent " +
               "inside an OpenShell sandbox.\n\n" +
               "If the agent needs external access, the TUI will prompt for approval.",
@@ -232,7 +234,7 @@ async function main() {
   console.log("  │                                                     │");
   console.log(`  │  Bot:      @${(me.result.username + "                    ").slice(0, 37)}│`);
   console.log("  │  Sandbox:  " + (SANDBOX + "                              ").slice(0, 40) + "│");
-  console.log("  │  Model:    nvidia/nemotron-3-super-120b-a12b       │");
+  console.log("  │  Model:    " + (MODEL + "                              ").slice(0, 40) + "│");
   console.log("  │                                                     │");
   console.log("  │  Messages are forwarded to the OpenClaw agent      │");
   console.log("  │  inside the sandbox. Run 'openshell term' in       │");

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -101,7 +101,7 @@ function runAgentInSandbox(message, sessionId) {
     require("fs").writeFileSync(confPath, sshConfig);
 
     const escaped = message.replace(/'/g, "'\\''");
-    const cmd = `export NVIDIA_API_KEY='${API_KEY}' && nemoclaw-start openclaw agent --agent main --local -m '${escaped}' --session-id 'tg-${sessionId}'`;
+    const cmd = `export NVIDIA_API_KEY='${API_KEY}' && export NEMOCLAW_MODEL='${MODEL}' && nemoclaw-start openclaw agent --agent main --local -m '${escaped}' --session-id 'tg-${sessionId}'`;
 
     const proc = spawn("ssh", ["-T", "-F", confPath, `openshell-${SANDBOX}`, cmd], {
       timeout: 120000,

--- a/scripts/test-inference-local.sh
+++ b/scripts/test-inference-local.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
 # Test inference.local routing through OpenShell provider (local vLLM)
-echo '{"model":"nvidia/nemotron-3-nano-30b-a3b","messages":[{"role":"user","content":"say hello"}]}' > /tmp/req.json
-curl -s https://inference.local/v1/chat/completions -H "Content-Type: application/json" -d @/tmp/req.json
+set -euo pipefail
+
+MODEL="${NEMOCLAW_MODEL:-nvidia/nemotron-3-nano-30b-a3b}"
+REQ_FILE="$(mktemp /tmp/nemoclaw-inference-req.XXXXXX.json)"
+trap 'rm -f "$REQ_FILE"' EXIT
+
+echo "{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"say hello\"}]}" > "$REQ_FILE"
+
+response=$(curl -sf https://inference.local/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d @"$REQ_FILE") || {
+  echo "error: inference request failed (is the local vLLM instance running?)" >&2
+  exit 1
+}
+
+echo "$response"

--- a/scripts/test-inference.sh
+++ b/scripts/test-inference.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
 # Test inference.local routing through OpenShell provider
-echo '{"model":"nvidia/nemotron-3-super-120b-a12b","messages":[{"role":"user","content":"say hello"}]}' > /tmp/req.json
-curl -s https://inference.local/v1/chat/completions -H "Content-Type: application/json" -d @/tmp/req.json
+set -euo pipefail
+
+MODEL="${NEMOCLAW_MODEL:-nvidia/nemotron-3-super-120b-a12b}"
+REQ_FILE="$(mktemp /tmp/nemoclaw-inference-req.XXXXXX.json)"
+trap 'rm -f "$REQ_FILE"' EXIT
+
+echo "{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"say hello\"}]}" > "$REQ_FILE"
+
+response=$(curl -sf https://inference.local/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d @"$REQ_FILE") || {
+  echo "error: inference request failed (is the sandbox running?)" >&2
+  exit 1
+}
+
+echo "$response"


### PR DESCRIPTION
## Summary

- Adds `NEMOCLAW_MODEL` env var to `telegram-bridge.js` — the startup banner and `/start` message now reflect the configured model. Defaults to `nvidia/nemotron-3-super-120b-a12b` so existing setups are unaffected.
- Hardens `test-inference.sh` and `test-inference-local.sh`: `set -euo pipefail`, `mktemp` for collision-safe temp files, `trap`-based cleanup, `curl -sf` with a clear error message on failure.

Follows the same env-var pattern already used for `SANDBOX_NAME`.

## Testing

```bash
# Default behavior unchanged
node scripts/telegram-bridge.js

# Override model
NEMOCLAW_MODEL=nvidia/nemotron-3-nano-30b-a3b node scripts/telegram-bridge.js

# Inference scripts
NEMOCLAW_MODEL=nvidia/nemotron-3-nano-30b-a3b bash scripts/test-inference.sh
NEMOCLAW_MODEL=nvidia/nemotron-3-nano-30b-a3b bash scripts/test-inference-local.sh
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configurable model selection via environment variables.
  * Improved error handling and reporting in test scripts, with stricter shell options and explicit failure messages.
  * Test scripts now use temporary request files with automatic cleanup.
  * Telegram bot messages and startup banner now display the currently selected model dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->