### PR TITLE
fix: macOS local inference DNS + oMLX provider + installer test fix

### DIFF
--- a/bin/lib/local-inference.js
+++ b/bin/lib/local-inference.js
@@ -1,41 +1,45 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const HOST_GATEWAY_URL = "http://host.openshell.internal";
+// On macOS (Docker Desktop), host.docker.internal resolves to the host.
+// On Linux, host.openshell.internal is injected by the network namespace.
+const IS_MACOS = process.platform === "darwin";
+const HOST_GATEWAY_URL = IS_MACOS
+  ? "http://host.docker.internal"
+  : "http://host.openshell.internal";
 const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
 const DEFAULT_OLLAMA_MODEL = "nemotron-3-nano:30b";
 
+const LOCAL_PROVIDER_PORTS = {
+  "vllm-local": 8000,
+  "ollama-local": 11434,
+  "omlx-local": 8080,
+};
+
 function getLocalProviderBaseUrl(provider) {
-  switch (provider) {
-    case "vllm-local":
-      return `${HOST_GATEWAY_URL}:8000/v1`;
-    case "ollama-local":
-      return `${HOST_GATEWAY_URL}:11434/v1`;
-    default:
-      return null;
-  }
+  const port = LOCAL_PROVIDER_PORTS[provider];
+  if (!port) return null;
+  return `${HOST_GATEWAY_URL}:${port}/v1`;
 }
 
 function getLocalProviderHealthCheck(provider) {
-  switch (provider) {
-    case "vllm-local":
-      return "curl -sf http://localhost:8000/v1/models 2>/dev/null";
-    case "ollama-local":
-      return "curl -sf http://localhost:11434/api/tags 2>/dev/null";
-    default:
-      return null;
+  const port = LOCAL_PROVIDER_PORTS[provider];
+  if (!port) return null;
+  if (provider === "ollama-local") {
+    return `curl -sf http://localhost:${port}/api/tags 2>/dev/null`;
   }
+  return `curl -sf http://localhost:${port}/v1/models 2>/dev/null`;
 }
 
 function getLocalProviderContainerReachabilityCheck(provider) {
-  switch (provider) {
-    case "vllm-local":
-      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`;
-    case "ollama-local":
-      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`;
-    default:
-      return null;
+  const port = LOCAL_PROVIDER_PORTS[provider];
+  if (!port) return null;
+  const addHost = IS_MACOS ? "" : "--add-host host.openshell.internal:host-gateway ";
+  const hostUrl = IS_MACOS ? "host.docker.internal" : "host.openshell.internal";
+  if (provider === "ollama-local") {
+    return `docker run --rm ${addHost}${CONTAINER_REACHABILITY_IMAGE} -sf http://${hostUrl}:${port}/api/tags 2>/dev/null`;
   }
+  return `docker run --rm ${addHost}${CONTAINER_REACHABILITY_IMAGE} -sf http://${hostUrl}:${port}/v1/models 2>/dev/null`;
 }
 
 function validateLocalProvider(provider, runCapture) {
@@ -46,20 +50,13 @@ function validateLocalProvider(provider, runCapture) {
 
   const output = runCapture(command, { ignoreError: true });
   if (!output) {
-    switch (provider) {
-      case "vllm-local":
-        return {
-          ok: false,
-          message: "Local vLLM was selected, but nothing is responding on http://localhost:8000.",
-        };
-      case "ollama-local":
-        return {
-          ok: false,
-          message: "Local Ollama was selected, but nothing is responding on http://localhost:11434.",
-        };
-      default:
-        return { ok: false, message: "The selected local inference provider is unavailable." };
-    }
+    const port = LOCAL_PROVIDER_PORTS[provider];
+    const names = { "vllm-local": "vLLM", "ollama-local": "Ollama", "omlx-local": "oMLX" };
+    const name = names[provider] || provider;
+    return {
+      ok: false,
+      message: `Local ${name} was selected, but nothing is responding on http://localhost:${port}.`,
+    };
   }
 
   const containerCommand = getLocalProviderContainerReachabilityCheck(provider);
@@ -72,22 +69,18 @@ function validateLocalProvider(provider, runCapture) {
     return { ok: true };
   }
 
-  switch (provider) {
-    case "vllm-local":
-      return {
-        ok: false,
-        message:
-          "Local vLLM is responding on localhost, but containers cannot reach http://host.openshell.internal:8000. Ensure the server is reachable from containers, not only from the host shell.",
-      };
-    case "ollama-local":
-      return {
-        ok: false,
-        message:
-          "Local Ollama is responding on localhost, but containers cannot reach http://host.openshell.internal:11434. Ensure Ollama listens on 0.0.0.0:11434 instead of 127.0.0.1 so sandboxes can reach it.",
-      };
-    default:
-      return { ok: false, message: "The selected local inference provider is unavailable from containers." };
+  const port = LOCAL_PROVIDER_PORTS[provider];
+  const hostUrl = IS_MACOS ? "host.docker.internal" : "host.openshell.internal";
+  const names = { "vllm-local": "vLLM", "ollama-local": "Ollama", "omlx-local": "oMLX" };
+  const name = names[provider] || provider;
+  let hint = `Ensure the server is reachable from containers, not only from the host shell.`;
+  if (provider === "ollama-local") {
+    hint = "Ensure Ollama listens on 0.0.0.0:11434 instead of 127.0.0.1 so sandboxes can reach it.";
   }
+  return {
+    ok: false,
+    message: `Local ${name} is responding on localhost, but containers cannot reach http://${hostUrl}:${port}. ${hint}`,
+  };
 }
 
 function parseOllamaList(output) {

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -782,6 +782,25 @@ async function setupInference(sandboxName, model, provider) {
       console.error(`  ${probe.message}`);
       process.exit(1);
     }
+  } else if (provider === "omlx-local") {
+    const validation = validateLocalProvider(provider, runCapture);
+    if (!validation.ok) {
+      console.error(`  ${validation.message}`);
+      process.exit(1);
+    }
+    const baseUrl = getLocalProviderBaseUrl(provider);
+    run(
+      `openshell provider create --name omlx-local --type openai ` +
+      `--credential "OPENAI_API_KEY=omlx" ` +
+      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || ` +
+      `openshell provider update omlx-local --credential "OPENAI_API_KEY=omlx" ` +
+      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || true`,
+      { ignoreError: true }
+    );
+    run(
+      `openshell inference set --no-verify --provider omlx-local --model ${model} 2>/dev/null || true`,
+      { ignoreError: true }
+    );
   }
 
   registry.updateSandbox(sandboxName, { model, provider });

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -51,7 +51,7 @@ exit 98
       cwd: path.join(__dirname, ".."),
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
       },
@@ -122,7 +122,7 @@ exit 98
       cwd: tmp,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
@@ -178,7 +178,7 @@ exit 98
       cwd: tmp,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
@@ -259,7 +259,7 @@ echo "Darwin"
       cwd: path.join(__dirname, ".."),
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_TEST_SOCKET_PATHS: `${colimaSocket}:${dockerDesktopSocket}`,
@@ -346,7 +346,7 @@ exit 0
       input: scriptContents,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
@@ -436,7 +436,7 @@ exit 0
       cwd: tmp,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",

--- a/test/local-inference.test.js
+++ b/test/local-inference.test.js
@@ -19,18 +19,28 @@ const {
   validateLocalProvider,
 } = require("../bin/lib/local-inference");
 
+const IS_MACOS = process.platform === "darwin";
+const EXPECTED_HOST = IS_MACOS ? "host.docker.internal" : "host.openshell.internal";
+
 describe("local inference helpers", () => {
   it("returns the expected base URL for vllm-local", () => {
     assert.equal(
       getLocalProviderBaseUrl("vllm-local"),
-      "http://host.openshell.internal:8000/v1",
+      `http://${EXPECTED_HOST}:8000/v1`,
     );
   });
 
   it("returns the expected base URL for ollama-local", () => {
     assert.equal(
       getLocalProviderBaseUrl("ollama-local"),
-      "http://host.openshell.internal:11434/v1",
+      `http://${EXPECTED_HOST}:11434/v1`,
+    );
+  });
+
+  it("returns the expected base URL for omlx-local", () => {
+    assert.equal(
+      getLocalProviderBaseUrl("omlx-local"),
+      `http://${EXPECTED_HOST}:8080/v1`,
     );
   });
 
@@ -41,11 +51,17 @@ describe("local inference helpers", () => {
     );
   });
 
-  it("returns the expected container reachability command for ollama-local", () => {
+  it("returns the expected health check command for omlx-local", () => {
     assert.equal(
-      getLocalProviderContainerReachabilityCheck("ollama-local"),
-      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`,
+      getLocalProviderHealthCheck("omlx-local"),
+      "curl -sf http://localhost:8080/v1/models 2>/dev/null",
     );
+  });
+
+  it("returns the expected container reachability command for ollama-local", () => {
+    const cmd = getLocalProviderContainerReachabilityCheck("ollama-local");
+    assert.match(cmd, new RegExp(`http://${EXPECTED_HOST.replace(/\./g, "\\.")}:11434/api/tags`));
+    assert.match(cmd, /docker run --rm/);
   });
 
   it("validates a reachable local provider", () => {
@@ -71,7 +87,7 @@ describe("local inference helpers", () => {
       return callCount === 1 ? '{"models":[]}' : "";
     });
     assert.equal(result.ok, false);
-    assert.match(result.message, /host\.openshell\.internal:11434/);
+    assert.match(result.message, new RegExp(`${EXPECTED_HOST.replace(/\./g, "\\.")}:11434`));
     assert.match(result.message, /0\.0\.0\.0:11434/);
   });
 


### PR DESCRIPTION
## Summary

- **Fixes macOS local inference DNS** — on Docker Desktop for Mac, `host.openshell.internal` doesn't resolve inside sandbox containers. Uses `host.docker.internal` on Darwin, which Docker Desktop resolves automatically. Linux behavior unchanged.
- **Adds oMLX as a local inference provider** (port 8080) alongside `vllm-local` and `ollama-local`. oMLX is the fastest MLX inference server for Apple Silicon with persistent KV caching — a natural fit for Mac users.
- **Fixes pre-existing installer test failures on machines with nvm** — `...process.env` leaked `NVM_DIR` into test spawns, causing `ensure_nvm_loaded()` to source the real `nvm.sh` and override fake node/npm stubs.

## Changes

### `bin/lib/local-inference.js`
- Platform-aware host gateway URL (`host.docker.internal` on macOS, `host.openshell.internal` on Linux)
- Consolidated provider port mapping table (vllm: 8000, ollama: 11434, omlx: 8080)
- oMLX health check and container reachability support

### `bin/lib/onboard.js`
- oMLX provider creation in the onboard flow (`openshell provider create --name omlx-local`)

### `test/local-inference.test.js`
- Platform-aware test expectations for host URLs
- Added oMLX base URL and health check tests

### `test/install-preflight.test.js`
- Set `NVM_DIR=""` and `FNM_DIR=""` in all 6 `spawnSync` envs to prevent real version managers from overriding fake stubs

## Test plan

- [x] All 21 tests pass (including previously broken `installer runtime preflight`)
- [ ] Run `nemoclaw onboard` with `omlx-local` on macOS Docker Desktop
- [ ] Verify sandbox can reach `host.docker.internal:8080` for oMLX inference
- [ ] Verify Linux behavior unchanged (uses `host.openshell.internal`)

Partially addresses #260

## Related

- #260 — macOS/Apple Silicon Support Tracking
- #224 — Docker Desktop socket detection on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for oMLX as a local inference provider option

* **Improvements**
  * Enhanced macOS compatibility for local inference providers with improved host gateway detection
  * Strengthened validation and error messaging for local provider setup and connectivity checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->