### PR TITLE
fix: prevent nvm/fnm from overriding fake stubs in installer tests

### DIFF
--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -51,7 +51,7 @@ exit 98
       cwd: path.join(__dirname, ".."),
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
       },
@@ -122,7 +122,7 @@ exit 98
       cwd: tmp,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
@@ -178,7 +178,7 @@ exit 98
       cwd: tmp,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
@@ -259,7 +259,7 @@ echo "Darwin"
       cwd: path.join(__dirname, ".."),
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_TEST_SOCKET_PATHS: `${colimaSocket}:${dockerDesktopSocket}`,
@@ -346,7 +346,7 @@ exit 0
       input: scriptContents,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
@@ -436,7 +436,7 @@ exit 0
       cwd: tmp,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...process.env, NVM_DIR: "", FNM_DIR: "",
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",


### PR DESCRIPTION
## Summary

Installer preflight tests fail on machines with nvm or fnm installed. The test stubs for `node` and `npm` get silently overridden by the real binaries.

## Root Cause

All 6 `spawnSync` calls in `install-preflight.test.js` spread `...process.env`, which leaks `NVM_DIR` (and `FNM_DIR`) into the child process. The installer's `ensure_nvm_loaded()` then sources `$NVM_DIR/nvm.sh`, which prepends the real Node.js bin directory to `PATH` — overriding the fake `node`/`npm` stubs the test set up.

## Fix

Set `NVM_DIR: ""` and `FNM_DIR: ""` in each spawn's env to neutralize version manager detection without removing other needed env vars.

## Changes

- `test/install-preflight.test.js` — 6 lines changed (one per `spawnSync` call)

## Test plan

- [x] All 21 tests pass on macOS with nvm installed (previously 18/21)
- [x] No behavioral change to the installer itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened installer test isolation by controlling environment variables during test execution, ensuring more reliable and consistent testing of the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->