### PR TITLE
fix(onboard): fall back to provider update when nvidia-nim already exists (Fixes #447)

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -721,15 +721,32 @@ async function setupNim(sandboxName, gpu) {
 
 // ── Step 5: Inference provider ───────────────────────────────────
 
+/**
+ * Build an openshell provider create-or-update command string.
+ * Falls back to `provider update` when `provider create` fails (e.g. provider
+ * already exists from a previous onboard attempt).
+ */
+function buildProviderCommand(name, credentialPair, baseUrl) {
+  const create =
+    `openshell provider create --name ${name} --type openai ` +
+    `--credential "${credentialPair}" ` +
+    `--config "OPENAI_BASE_URL=${baseUrl}"`;
+  const update =
+    `openshell provider update ${name} --credential "${credentialPair}" ` +
+    `--config "OPENAI_BASE_URL=${baseUrl}"`;
+  return `${create} 2>&1 || ${update} 2>&1 || true`;
+}
+
 async function setupInference(sandboxName, model, provider) {
   step(5, 7, "Setting up inference provider");
 
   if (provider === "nvidia-nim") {
-    // Create nvidia-nim provider
     run(
-      `openshell provider create --name nvidia-nim --type openai ` +
-      `--credential "NVIDIA_API_KEY=${process.env.NVIDIA_API_KEY}" ` +
-      `--config "OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1" 2>&1 || true`,
+      buildProviderCommand(
+        "nvidia-nim",
+        `NVIDIA_API_KEY=${process.env.NVIDIA_API_KEY}`,
+        "https://integrate.api.nvidia.com/v1"
+      ),
       { ignoreError: true }
     );
     run(
@@ -744,11 +761,7 @@ async function setupInference(sandboxName, model, provider) {
     }
     const baseUrl = getLocalProviderBaseUrl(provider);
     run(
-      `openshell provider create --name vllm-local --type openai ` +
-      `--credential "OPENAI_API_KEY=dummy" ` +
-      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || ` +
-      `openshell provider update vllm-local --credential "OPENAI_API_KEY=dummy" ` +
-      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || true`,
+      buildProviderCommand("vllm-local", "OPENAI_API_KEY=dummy", baseUrl),
       { ignoreError: true }
     );
     run(
@@ -764,11 +777,7 @@ async function setupInference(sandboxName, model, provider) {
     }
     const baseUrl = getLocalProviderBaseUrl(provider);
     run(
-      `openshell provider create --name ollama-local --type openai ` +
-      `--credential "OPENAI_API_KEY=ollama" ` +
-      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || ` +
-      `openshell provider update ollama-local --credential "OPENAI_API_KEY=ollama" ` +
-      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || true`,
+      buildProviderCommand("ollama-local", "OPENAI_API_KEY=ollama", baseUrl),
       { ignoreError: true }
     );
     run(
@@ -964,4 +973,4 @@ async function onboard(opts = {}) {
   printDashboard(sandboxName, model, provider);
 }
 
-module.exports = { buildSandboxConfigSyncScript, hasStaleGateway, isSandboxReady, onboard, setupNim };
+module.exports = { buildProviderCommand, buildSandboxConfigSyncScript, hasStaleGateway, isSandboxReady, onboard, setupNim };

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -4,7 +4,58 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 
-const { buildSandboxConfigSyncScript } = require("../bin/lib/onboard");
+const { buildProviderCommand, buildSandboxConfigSyncScript } = require("../bin/lib/onboard");
+
+describe("buildProviderCommand", () => {
+  it("includes both create and update fallback for nvidia-nim", () => {
+    const cmd = buildProviderCommand(
+      "nvidia-nim",
+      "NVIDIA_API_KEY=nvapi-test123",
+      "https://integrate.api.nvidia.com/v1"
+    );
+    assert.match(cmd, /openshell provider create --name nvidia-nim/);
+    assert.match(cmd, /openshell provider update nvidia-nim/);
+    assert.match(cmd, /NVIDIA_API_KEY=nvapi-test123/);
+    assert.match(cmd, /OPENAI_BASE_URL=https:\/\/integrate\.api\.nvidia\.com\/v1/);
+  });
+
+  it("includes both create and update fallback for vllm-local", () => {
+    const cmd = buildProviderCommand(
+      "vllm-local",
+      "OPENAI_API_KEY=dummy",
+      "http://host.containers.internal:8000/v1"
+    );
+    assert.match(cmd, /openshell provider create --name vllm-local/);
+    assert.match(cmd, /openshell provider update vllm-local/);
+  });
+
+  it("includes both create and update fallback for ollama-local", () => {
+    const cmd = buildProviderCommand(
+      "ollama-local",
+      "OPENAI_API_KEY=ollama",
+      "http://host.containers.internal:11434/v1"
+    );
+    assert.match(cmd, /openshell provider create --name ollama-local/);
+    assert.match(cmd, /openshell provider update ollama-local/);
+  });
+
+  it("credential appears in both create and update branches", () => {
+    const cmd = buildProviderCommand(
+      "nvidia-nim",
+      "NVIDIA_API_KEY=nvapi-secret",
+      "https://integrate.api.nvidia.com/v1"
+    );
+    const parts = cmd.split("||");
+    assert.ok(parts.length >= 2, "should have create || update || true");
+    assert.match(parts[0], /NVIDIA_API_KEY=nvapi-secret/);
+    assert.match(parts[1], /NVIDIA_API_KEY=nvapi-secret/);
+  });
+
+  it("ends with || true for error suppression", () => {
+    const cmd = buildProviderCommand("test", "KEY=val", "http://localhost:8000/v1");
+    assert.ok(cmd.trimEnd().endsWith("|| true"));
+  });
+});
 
 describe("onboard helpers", () => {
   it("builds a sandbox sync script that writes config and updates the selected model", () => {


### PR DESCRIPTION
## Summary

After `nemoclaw onboard`, the NVIDIA API key is saved to `~/.nemoclaw/credentials.json` but silently fails to register in the OpenShell gateway when the `nvidia-nim` provider already exists (e.g. from a previous partial onboard attempt). The `openshell provider create` command fails because the provider exists, and unlike the `vllm-local` and `ollama-local` paths there was no fallback to `openshell provider update`. Users see a working install but inference never responds.

Fixes #447

## Changes

- **bin/lib/onboard.js**: Extracted `buildProviderCommand(name, credentialPair, baseUrl)` — pure helper that builds a create-or-update command string with `openshell provider create ... || openshell provider update ... || true`. The `nvidia-nim` provider setup now uses this helper (adding the missing `update` fallback). Refactored `vllm-local` and `ollama-local` to use the same helper for consistency.
- **test/onboard.test.js**: Added 5 unit tests for `buildProviderCommand` — verifies create+update fallback for all three providers, credential presence in both branches, and `|| true` termination.

## Testing

- `npm test` — all onboard/inference tests pass (5 new for `buildProviderCommand`).
- The fix ensures that if the `nvidia-nim` provider already exists, the command falls back to `openshell provider update` to register the API key, matching the existing behavior of `vllm-local` and `ollama-local`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved reliability of provider setup with enhanced fallback error handling
  * Refactored provider configuration logic to reduce code duplication
  * Expanded test coverage for provider initialization workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->