### PR TITLE
docs: fix CLI reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Run these inside the OpenClaw CLI. These commands are under active development a
 | `openclaw nemoclaw status`                 | Show sandbox health, blueprint state, and inference.     |
 | `openclaw nemoclaw logs [-f]`              | Stream blueprint execution and sandbox logs.             |
 
-See the full [CLI reference](https://docs.nvidia.com/nemoclaw/latest/reference/commands.md) for all commands, flags, and options.
+See the full [CLI reference](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html) for all commands, flags, and options.
 
 > **Known limitations:**
 > - The `openclaw nemoclaw` plugin commands are under active development. Use the `nemoclaw` host CLI as the primary interface.


### PR DESCRIPTION
## Summary
The CLI reference link redirect to [.md](https://docs.nvidia.com/nemoclaw/latest/reference/commands.md) which cause 404 not found.

## Changes
Change `.md` to `.html`

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `make check` passes.
- [ ] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [x] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] `make format` applied (TypeScript and Python).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [x] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.
