### PR TITLE
feat: install/uninstall DX sugar

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -97,6 +97,7 @@ function streamSandboxCreate(command) {
   let pending = "";
   let lastPrintedLine = "";
   let sawProgress = false;
+  let settled = false;
 
   function shouldShowLine(line) {
     return (
@@ -136,7 +137,20 @@ function streamSandboxCreate(command) {
   child.stderr.on("data", onChunk);
 
   return new Promise((resolve) => {
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      if (pending) flushLine(pending);
+      const detail = error && error.code
+        ? `spawn failed: ${error.message} (${error.code})`
+        : `spawn failed: ${error.message}`;
+      lines.push(detail);
+      resolve({ status: 1, output: lines.join("\n"), sawProgress: false });
+    });
+
     child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
       if (pending) flushLine(pending);
       resolve({ status: code ?? 1, output: lines.join("\n"), sawProgress });
     });
@@ -237,7 +251,6 @@ function isOpenshellInstalled() {
 }
 
 function installOpenshell() {
-  console.log("  Installing openshell CLI...");
   const result = spawnSync("bash", [path.join(SCRIPTS, "install-openshell.sh")], {
     cwd: ROOT,
     env: process.env,
@@ -332,7 +345,7 @@ async function preflight() {
 
   // OpenShell CLI
   if (!isOpenshellInstalled()) {
-    console.log("  openshell CLI not found. Attempting to install...");
+    console.log("  openshell CLI not found. Installing...");
     if (!installOpenshell()) {
       console.error("  Failed to install openshell CLI.");
       console.error("  Install manually: https://github.com/NVIDIA/OpenShell/releases");
@@ -1009,6 +1022,7 @@ function printDashboard(sandboxName, model, provider) {
   console.log(`  Model        ${model} (${providerLabel})`);
   console.log(`  NIM          ${nimLabel}`);
   console.log(`  ${"─".repeat(50)}`);
+  console.log(`  Next:`);
   console.log(`  Run:         nemoclaw ${sandboxName} connect`);
   console.log(`  Status:      nemoclaw ${sandboxName} status`);
   console.log(`  Logs:        nemoclaw ${sandboxName} logs --follow`);

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -8,6 +8,7 @@
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { spawn, spawnSync } = require("child_process");
 const { ROOT, SCRIPTS, run, runCapture, shellQuote } = require("./runner");
 const {
   getDefaultOllamaModel,
@@ -33,6 +34,9 @@ const nim = require("./nim");
 const policies = require("./policies");
 const { checkPortAvailable } = require("./preflight");
 const EXPERIMENTAL = process.env.NEMOCLAW_EXPERIMENTAL === "1";
+const USE_COLOR = !process.env.NO_COLOR && !!process.stdout.isTTY;
+const DIM = USE_COLOR ? "\x1b[2m" : "";
+const RESET = USE_COLOR ? "\x1b[0m" : "";
 
 // Non-interactive mode: set by --non-interactive flag or env var.
 // When active, all prompts use env var overrides or sensible defaults.
@@ -42,13 +46,17 @@ function isNonInteractive() {
   return NON_INTERACTIVE;
 }
 
+function note(message) {
+  console.log(`${DIM}${message}${RESET}`);
+}
+
 // Prompt wrapper: returns env var value or default in non-interactive mode,
 // otherwise prompts the user interactively.
 async function promptOrDefault(question, envVar, defaultValue) {
   if (isNonInteractive()) {
     const val = envVar ? process.env[envVar] : null;
     const result = val || defaultValue;
-    console.log(`  [non-interactive] ${question.trim()} → ${result}`);
+    note(`  [non-interactive] ${question.trim()} → ${result}`);
     return result;
   }
   return prompt(question);
@@ -76,6 +84,63 @@ function isSandboxReady(output, sandboxName) {
  */
 function hasStaleGateway(gwInfoOutput) {
   return typeof gwInfoOutput === "string" && gwInfoOutput.length > 0 && gwInfoOutput.includes("nemoclaw");
+}
+
+function streamSandboxCreate(command) {
+  const child = spawn("bash", ["-lc", command], {
+    cwd: ROOT,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const lines = [];
+  let pending = "";
+  let lastPrintedLine = "";
+  let sawProgress = false;
+
+  function shouldShowLine(line) {
+    return (
+      /^  Building image /.test(line) ||
+      /^  Context: /.test(line) ||
+      /^  Gateway: /.test(line) ||
+      /^Successfully built /.test(line) ||
+      /^Successfully tagged /.test(line) ||
+      /^  Built image /.test(line) ||
+      /^  Pushing image /.test(line) ||
+      /^\s*\[progress\]/.test(line) ||
+      /^  Image .*available in the gateway/.test(line) ||
+      /^Created sandbox: /.test(line) ||
+      /^✓ /.test(line)
+    );
+  }
+
+  function flushLine(rawLine) {
+    const line = rawLine.replace(/\r/g, "").trimEnd();
+    if (!line) return;
+    lines.push(line);
+    if (shouldShowLine(line) && line !== lastPrintedLine) {
+      console.log(line);
+      lastPrintedLine = line;
+      sawProgress = true;
+    }
+  }
+
+  function onChunk(chunk) {
+    pending += chunk.toString();
+    const parts = pending.split("\n");
+    pending = parts.pop();
+    parts.forEach(flushLine);
+  }
+
+  child.stdout.on("data", onChunk);
+  child.stderr.on("data", onChunk);
+
+  return new Promise((resolve) => {
+    child.on("close", (code) => {
+      if (pending) flushLine(pending);
+      resolve({ status: code ?? 1, output: lines.join("\n"), sawProgress });
+    });
+  });
 }
 
 function step(n, total, msg) {
@@ -173,7 +238,19 @@ function isOpenshellInstalled() {
 
 function installOpenshell() {
   console.log("  Installing openshell CLI...");
-  run(`bash "${path.join(SCRIPTS, "install-openshell.sh")}"`, { ignoreError: true });
+  const result = spawnSync("bash", [path.join(SCRIPTS, "install-openshell.sh")], {
+    cwd: ROOT,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) {
+    const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
+    if (output) {
+      console.error(output);
+    }
+    return false;
+  }
   const localBin = process.env.XDG_BIN_HOME || path.join(process.env.HOME || "", ".local", "bin");
   if (fs.existsSync(path.join(localBin, "openshell")) && !process.env.PATH.split(path.delimiter).includes(localBin)) {
     process.env.PATH = `${localBin}${path.delimiter}${process.env.PATH}`;
@@ -408,7 +485,7 @@ async function createSandbox(gpu) {
         console.error("  Set NEMOCLAW_RECREATE_SANDBOX=1 to recreate it in non-interactive mode.");
         process.exit(1);
       }
-      console.log(`  [non-interactive] Sandbox '${sandboxName}' exists — recreating`);
+      note(`  [non-interactive] Sandbox '${sandboxName}' exists — recreating`);
     } else {
       const recreate = await prompt(`  Sandbox '${sandboxName}' already exists. Recreate? [y/N]: `);
       if (recreate.toLowerCase() !== "y") {
@@ -460,9 +537,8 @@ async function createSandbox(gpu) {
   // from openshell because bash returns the status of the last pipeline
   // command (awk, always 0) unless pipefail is set. Removing the pipe
   // lets the real exit code flow through to run().
-  const createResult = run(
-    `openshell sandbox create ${createArgs.join(" ")} -- env ${envArgs.join(" ")} nemoclaw-start 2>&1`,
-    { ignoreError: true }
+  const createResult = await streamSandboxCreate(
+    `openshell sandbox create ${createArgs.join(" ")} -- env ${envArgs.join(" ")} nemoclaw-start 2>&1`
   );
 
   // Clean up build context regardless of outcome
@@ -471,6 +547,10 @@ async function createSandbox(gpu) {
   if (createResult.status !== 0) {
     console.error("");
     console.error(`  Sandbox creation failed (exit ${createResult.status}).`);
+    if (createResult.output) {
+      console.error("");
+      console.error(createResult.output);
+    }
     console.error("  Try:  openshell sandbox list        # check gateway state");
     console.error("  Try:  nemoclaw onboard              # retry from scratch");
     process.exit(createResult.status || 1);
@@ -580,7 +660,7 @@ async function setupNim(sandboxName, gpu) {
         console.error(`  Requested provider '${providerKey}' is not available in this environment.`);
         process.exit(1);
       }
-      console.log(`  [non-interactive] Provider: ${selected.key}`);
+      note(`  [non-interactive] Provider: ${selected.key}`);
     } else {
       const suggestions = [];
       if (vllmRunning) suggestions.push("vLLM");
@@ -621,7 +701,7 @@ async function setupNim(sandboxName, gpu) {
           } else {
             sel = models[0];
           }
-          console.log(`  [non-interactive] NIM model: ${sel.name}`);
+          note(`  [non-interactive] NIM model: ${sel.name}`);
         } else {
           console.log("");
           console.log("  Models that fit your GPU:");
@@ -824,21 +904,12 @@ async function setupPolicies(sandboxName) {
   const allPresets = policies.listPresets();
   const applied = policies.getAppliedPresets(sandboxName);
 
-  console.log("");
-  console.log("  Available policy presets:");
-  allPresets.forEach((p) => {
-    const marker = applied.includes(p.name) ? "●" : "○";
-    const suggested = suggestions.includes(p.name) ? " (suggested)" : "";
-    console.log(`    ${marker} ${p.name} — ${p.description}${suggested}`);
-  });
-  console.log("");
-
   if (isNonInteractive()) {
     const policyMode = (process.env.NEMOCLAW_POLICY_MODE || "suggested").trim().toLowerCase();
     let selectedPresets = suggestions;
 
     if (policyMode === "skip" || policyMode === "none" || policyMode === "no") {
-      console.log("  [non-interactive] Skipping policy presets.");
+      note("  [non-interactive] Skipping policy presets.");
       return;
     }
 
@@ -870,7 +941,7 @@ async function setupPolicies(sandboxName) {
       console.error(`  Sandbox '${sandboxName}' was not ready for policy application.`);
       process.exit(1);
     }
-    console.log(`  [non-interactive] Applying policy presets: ${selectedPresets.join(", ")}`);
+    note(`  [non-interactive] Applying policy presets: ${selectedPresets.join(", ")}`);
     for (const name of selectedPresets) {
       for (let attempt = 0; attempt < 3; attempt += 1) {
         try {
@@ -886,6 +957,15 @@ async function setupPolicies(sandboxName) {
       }
     }
   } else {
+    console.log("");
+    console.log("  Available policy presets:");
+    allPresets.forEach((p) => {
+      const marker = applied.includes(p.name) ? "●" : "○";
+      const suggested = suggestions.includes(p.name) ? " (suggested)" : "";
+      console.log(`    ${marker} ${p.name} — ${p.description}${suggested}`);
+    });
+    console.log("");
+
     const answer = await prompt(`  Apply suggested presets (${suggestions.join(", ")})? [Y/n/list]: `);
 
     if (answer.toLowerCase() === "n") {
@@ -943,7 +1023,7 @@ async function onboard(opts = {}) {
 
   console.log("");
   console.log("  NemoClaw Onboarding");
-  if (isNonInteractive()) console.log("  (non-interactive mode)");
+  if (isNonInteractive()) note("  (non-interactive mode)");
   console.log("  ===================");
 
   const gpu = await preflight();

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -7,6 +7,19 @@ const path = require("path");
 const fs = require("fs");
 const os = require("os");
 
+// ---------------------------------------------------------------------------
+// Color / style — respects NO_COLOR and non-TTY environments.
+// Uses exact NVIDIA green #76B900 on truecolor terminals; 256-color otherwise.
+// ---------------------------------------------------------------------------
+const _useColor = !process.env.NO_COLOR && !!process.stdout.isTTY;
+const _tc = _useColor && (process.env.COLORTERM === "truecolor" || process.env.COLORTERM === "24bit");
+const G = _useColor ? (_tc ? "\x1b[38;2;118;185;0m" : "\x1b[38;5;148m") : "";
+const B = _useColor ? "\x1b[1m" : "";
+const D = _useColor ? "\x1b[2m" : "";
+const R = _useColor ? "\x1b[0m" : "";
+const RD = _useColor ? "\x1b[1;31m" : "";
+const YW = _useColor ? "\x1b[1;33m" : "";
+
 const { ROOT, SCRIPTS, run, runCapture, runInteractive, shellQuote, validateName } = require("./lib/runner");
 const {
   ensureApiKey,
@@ -23,7 +36,7 @@ const policies = require("./lib/policies");
 const GLOBAL_COMMANDS = new Set([
   "onboard", "list", "deploy", "setup", "setup-spark",
   "start", "stop", "status", "debug", "uninstall",
-  "help", "--help", "-h",
+  "help", "--help", "-h", "--version", "-v",
 ]);
 
 const REMOTE_UNINSTALL_URL = "https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh";
@@ -135,16 +148,19 @@ async function deploy(instanceName) {
 
   run(`brev refresh`, { ignoreError: true });
 
-  console.log("  Waiting for SSH...");
+  process.stdout.write(`  Waiting for SSH `);
   for (let i = 0; i < 60; i++) {
     try {
       execFileSync("ssh", ["-o", "ConnectTimeout=5", "-o", "StrictHostKeyChecking=no", name, "echo", "ok"], { encoding: "utf-8", stdio: "ignore" });
+      process.stdout.write(` ${G}✓${R}\n`);
       break;
     } catch {
       if (i === 59) {
+        process.stdout.write("\n");
         console.error(`  Timed out waiting for SSH to ${name}`);
         process.exit(1);
       }
+      process.stdout.write(".");
       spawnSync("sleep", ["3"]);
     }
   }
@@ -350,7 +366,19 @@ function sandboxPolicyList(sandboxName) {
   console.log("");
 }
 
-function sandboxDestroy(sandboxName) {
+async function sandboxDestroy(sandboxName, args = []) {
+  const skipConfirm = args.includes("--yes") || args.includes("--force");
+  if (!skipConfirm) {
+    const { prompt: askPrompt } = require("./lib/credentials");
+    const answer = await askPrompt(
+      `  ${YW}Destroy sandbox '${sandboxName}'?${R} This cannot be undone. [y/N]: `,
+    );
+    if (answer.trim().toLowerCase() !== "y" && answer.trim().toLowerCase() !== "yes") {
+      console.log("  Cancelled.");
+      return;
+    }
+  }
+
   console.log(`  Stopping NIM for '${sandboxName}'...`);
   nim.stopNimContainer(sandboxName);
 
@@ -358,36 +386,37 @@ function sandboxDestroy(sandboxName) {
   run(`openshell sandbox delete ${shellQuote(sandboxName)} 2>/dev/null || true`, { ignoreError: true });
 
   registry.removeSandbox(sandboxName);
-  console.log(`  ✓ Sandbox '${sandboxName}' destroyed`);
+  console.log(`  ${G}✓${R} Sandbox '${sandboxName}' destroyed`);
 }
 
 // ── Help ─────────────────────────────────────────────────────────
 
 function help() {
+  const pkg = require(path.join(__dirname, "..", "package.json"));
   console.log(`
-  nemoclaw — NemoClaw CLI
+  ${B}${G}NemoClaw${R}  ${D}v${pkg.version}${R}
+  ${D}Deploy more secure, always-on AI assistants with a single command.${R}
 
-  Getting Started:
-    nemoclaw onboard                 Interactive setup wizard (recommended)
-    nemoclaw setup                   Legacy setup (deprecated, use onboard)
-    nemoclaw setup-spark             Set up on DGX Spark (fixes cgroup v2 + Docker)
+  ${G}Getting Started:${R}
+    ${B}nemoclaw onboard${R}                 Configure inference endpoint and credentials
+    nemoclaw setup-spark             Set up on DGX Spark ${D}(fixes cgroup v2 + Docker)${R}
 
-  Sandbox Management:
-    nemoclaw list                    List all sandboxes
-    nemoclaw <name> connect          Connect to a sandbox
-    nemoclaw <name> status           Show sandbox status and health
-    nemoclaw <name> logs [--follow]  View sandbox logs
-    nemoclaw <name> destroy          Stop NIM + delete sandbox
+  ${G}Sandbox Management:${R}
+    ${B}nemoclaw list${R}                    List all sandboxes
+    nemoclaw <name> connect          Shell into a running sandbox
+    nemoclaw <name> status           Sandbox health + NIM status
+    nemoclaw <name> logs ${D}[--follow]${R}  Stream sandbox logs
+    nemoclaw <name> destroy          Stop NIM + delete sandbox ${D}(--yes to skip prompt)${R}
 
-  Policy Presets:
-    nemoclaw <name> policy-add       Add a policy preset to a sandbox
-    nemoclaw <name> policy-list      List presets (● = applied)
+  ${G}Policy Presets:${R}
+    nemoclaw <name> policy-add       Add a network or filesystem policy preset
+    nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
-  Deploy:
+  ${G}Deploy:${R}
     nemoclaw deploy <instance>       Deploy to a Brev VM and start services
 
-  Services:
-    nemoclaw start                   Start services (Telegram, tunnel)
+  ${G}Services:${R}
+    nemoclaw start                   Start auxiliary services ${D}(Telegram, tunnel)${R}
     nemoclaw stop                    Stop all services
     nemoclaw status                  Show sandbox list and service status
 
@@ -398,13 +427,14 @@ function help() {
   Cleanup:
     nemoclaw uninstall [flags]       Run uninstall.sh (local first, curl fallback)
 
-  Uninstall flags:
+  ${G}Uninstall flags:${R}
     --yes                            Skip the confirmation prompt
     --keep-openshell                 Leave the openshell binary installed
     --delete-models                  Remove NemoClaw-pulled Ollama models
 
-  Credentials are prompted on first use, then saved securely
-  in ~/.nemoclaw/credentials.json (mode 600).
+  ${D}Powered by NVIDIA OpenShell · Nemotron · Agent Toolkit
+  Credentials saved in ~/.nemoclaw/credentials.json (mode 600)${R}
+  ${D}https://www.nvidia.com/nemoclaw${R}
 `);
 }
 
@@ -432,6 +462,12 @@ const [cmd, ...args] = process.argv.slice(2);
       case "debug":       debug(args); break;
       case "uninstall":   uninstall(args); break;
       case "list":        listSandboxes(); break;
+      case "--version":
+      case "-v": {
+        const pkg = require(path.join(__dirname, "..", "package.json"));
+        console.log(`nemoclaw v${pkg.version}`);
+        break;
+      }
       default:            help(); break;
     }
     return;
@@ -450,7 +486,7 @@ const [cmd, ...args] = process.argv.slice(2);
       case "logs":        sandboxLogs(cmd, actionArgs.includes("--follow")); break;
       case "policy-add":  await sandboxPolicyAdd(cmd); break;
       case "policy-list": sandboxPolicyList(cmd); break;
-      case "destroy":     sandboxDestroy(cmd); break;
+      case "destroy":     await sandboxDestroy(cmd, actionArgs); break;
       default:
         console.error(`  Unknown action: ${action}`);
         console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, destroy`);

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,10 @@ TOTAL_STEPS=3
 if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
   if [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]]; then
     C_GREEN=$'\033[38;2;118;185;0m'   # #76B900 — exact NVIDIA green
+    C_CLAW=$'\033[38;2;255;77;77m'    # #ff4d4d — OpenClaw red
   else
     C_GREEN=$'\033[38;5;148m'          # closest 256-color on dark backgrounds
+    C_CLAW=$'\033[38;5;210m'           # closest 256-color for #ff4d4d
   fi
   C_BOLD=$'\033[1m'
   C_DIM=$'\033[2m'
@@ -27,7 +29,7 @@ if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
   C_WHITE=$'\033[1;37m'
   C_RESET=$'\033[0m'
 else
-  C_GREEN='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_CYAN='' C_WHITE='' C_RESET=''
+  C_GREEN='' C_CLAW='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_CYAN='' C_WHITE='' C_RESET=''
 fi
 
 # ---------------------------------------------------------------------------
@@ -49,12 +51,12 @@ step() {
 print_banner() {
   printf "\n"
   # ANSI Shadow ASCII art — hand-crafted, no figlet dependency
-  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ${C_RESET}${C_CLAW}${C_BOLD}██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗${C_RESET}${C_CLAW}${C_BOLD}██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║${C_RESET}${C_CLAW}${C_BOLD}██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║${C_RESET}${C_CLAW}${C_BOLD}██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝${C_RESET}${C_CLAW}${C_BOLD}╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ${C_RESET}${C_CLAW}${C_BOLD}╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
   printf "\n"
   printf "  ${C_DIM}Deploy more secure, always-on AI assistants with a single command.  v%s${C_RESET}\n" "$NEMOCLAW_VERSION"
   printf "\n"
@@ -64,7 +66,7 @@ print_done() {
   local elapsed=$(( SECONDS - _INSTALL_START ))
   info "=== Installation complete ==="
   printf "\n"
-  printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$elapsed"
+  printf "  ${C_GREEN}${C_BOLD}Nemo${C_RESET}${C_CLAW}${C_BOLD}Claw${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$elapsed"
   printf "\n"
   printf "  Your secured AI agent stack is live.\n"
   printf "  ${C_DIM}Sandbox in, break things, and tell us what you find.${C_RESET}\n"

--- a/install.sh
+++ b/install.sh
@@ -26,10 +26,9 @@ if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
   C_RED=$'\033[1;31m'
   C_YELLOW=$'\033[1;33m'
   C_CYAN=$'\033[1;36m'
-  C_WHITE=$'\033[1;37m'
   C_RESET=$'\033[0m'
 else
-  C_GREEN='' C_CLAW='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_CYAN='' C_WHITE='' C_RESET=''
+  C_GREEN='' C_CLAW='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_CYAN='' C_RESET=''
 fi
 
 # ---------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -104,6 +104,8 @@ print_done() {
   printf "\n"
   printf "  ${C_GREEN}Your OpenClaw Sandbox is live.${C_RESET}\n"
   printf "  ${C_DIM}Sandbox in, break things, and tell us what you find.${C_RESET}\n"
+  printf "\n"
+  printf "  ${C_GREEN}Next:${C_RESET}\n"
   printf "  %s$%s nemoclaw %s connect\n" "$C_GREEN" "$C_RESET" "$sandbox_name"
   printf "  %ssandbox@%s$%s openclaw tui\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
   printf "\n"
@@ -433,7 +435,8 @@ pre_extract_openclaw() {
 install_nemoclaw() {
   if [[ -f "./package.json" ]] && grep -q '"name": "nemoclaw"' ./package.json 2>/dev/null; then
     info "NemoClaw package.json found in current directory — installing from source…"
-    pre_extract_openclaw "$(pwd)" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+    spin "Preparing OpenClaw package" bash -lc "$(declare -f pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$(pwd)" || \
+      warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
     spin "Installing NemoClaw dependencies" npm install --ignore-scripts
     spin "Building NemoClaw plugin" bash -lc 'cd nemoclaw && npm install --ignore-scripts && npm run build'
     spin "Linking NemoClaw CLI" npm link
@@ -446,7 +449,8 @@ install_nemoclaw() {
     rm -rf "$nemoclaw_src"
     mkdir -p "$(dirname "$nemoclaw_src")"
     spin "Cloning NemoClaw source" git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$nemoclaw_src"
-    pre_extract_openclaw "$nemoclaw_src" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+    spin "Preparing OpenClaw package" bash -lc "$(declare -f pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$nemoclaw_src" || \
+      warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
     spin "Installing NemoClaw dependencies" bash -lc "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
     spin "Building NemoClaw plugin" bash -lc "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
     spin "Linking NemoClaw CLI" bash -lc "cd \"$nemoclaw_src\" && npm link"

--- a/install.sh
+++ b/install.sh
@@ -6,12 +6,124 @@
 
 set -euo pipefail
 
+NEMOCLAW_VERSION="0.1.0"
+TOTAL_STEPS=3
+
+# ---------------------------------------------------------------------------
+# Color / style — disabled when NO_COLOR is set or stdout is not a TTY.
+# Uses exact NVIDIA green #76B900 on truecolor terminals; 256-color otherwise.
+# ---------------------------------------------------------------------------
+if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
+  if [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]]; then
+    C_GREEN=$'\033[38;2;118;185;0m'   # #76B900 — exact NVIDIA green
+  else
+    C_GREEN=$'\033[38;5;148m'          # closest 256-color on dark backgrounds
+  fi
+  C_BOLD=$'\033[1m'
+  C_DIM=$'\033[2m'
+  C_RED=$'\033[1;31m'
+  C_YELLOW=$'\033[1;33m'
+  C_CYAN=$'\033[1;36m'
+  C_WHITE=$'\033[1;37m'
+  C_RESET=$'\033[0m'
+else
+  C_GREEN='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_CYAN='' C_WHITE='' C_RESET=''
+fi
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$*"; }
-warn()  { printf '\033[1;33m[WARN]\033[0m  %s\n' "$*"; }
-error() { printf '\033[1;31m[ERROR]\033[0m %s\n' "$*"; exit 1; }
+info()  { printf "${C_CYAN}[INFO]${C_RESET}  %s\n" "$*"; }
+warn()  { printf "${C_YELLOW}[WARN]${C_RESET}  %s\n" "$*"; }
+error() { printf "${C_RED}[ERROR]${C_RESET} %s\n" "$*" >&2; exit 1; }
+ok()    { printf "  ${C_GREEN}✓${C_RESET}  %s\n" "$*"; }
+
+# step N "Description" — numbered section header
+step() {
+  local n=$1 msg=$2
+  printf "\n${C_GREEN}[%s/%s]${C_RESET} ${C_BOLD}%s${C_RESET}\n" \
+    "$n" "$TOTAL_STEPS" "$msg"
+  printf "  ${C_DIM}──────────────────────────────────────────────────${C_RESET}\n"
+}
+
+print_banner() {
+  printf "\n"
+  # ANSI Shadow ASCII art — hand-crafted, no figlet dependency
+  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
+  printf "\n"
+  printf "  ${C_DIM}Deploy more secure, always-on AI assistants with a single command.  v%s${C_RESET}\n" "$NEMOCLAW_VERSION"
+  printf "\n"
+}
+
+print_done() {
+  local elapsed=$(( SECONDS - _INSTALL_START ))
+  info "=== Installation complete ==="
+  printf "\n"
+  printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$elapsed"
+  printf "\n"
+  printf "  Your secured AI agent stack is live.\n"
+  printf "  ${C_DIM}Sandbox in, break things, and tell us what you find.${C_RESET}\n"
+  printf "\n"
+  printf "  ${C_BOLD}GitHub${C_RESET}  ${C_DIM}https://github.com/nvidia/nemoclaw${C_RESET}\n"
+  printf "  ${C_BOLD}Docs${C_RESET}    ${C_DIM}https://docs.nvidia.com/nemoclaw/latest/${C_RESET}\n"
+  printf "\n"
+}
+
+usage() {
+  printf "\n"
+  printf "  ${C_BOLD}NemoClaw Installer${C_RESET}  ${C_DIM}v%s${C_RESET}\n\n" "$NEMOCLAW_VERSION"
+  printf "  ${C_DIM}Usage:${C_RESET}\n"
+  printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash\n"
+  printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
+  printf "  ${C_DIM}Options:${C_RESET}\n"
+  printf "    --non-interactive    Skip prompts (uses env vars / defaults)\n"
+  printf "    --version            Print installer version and exit\n"
+  printf "    --help               Show this help message and exit\n\n"
+  printf "  ${C_DIM}Environment:${C_RESET}\n"
+  printf "    NVIDIA_API_KEY                API key (skips credential prompt)\n"
+  printf "    NEMOCLAW_NON_INTERACTIVE=1    Same as --non-interactive\n"
+  printf "\n"
+}
+
+# spin "label" cmd [args...]
+#   Runs a command in the background, showing a braille spinner until it exits.
+#   Stdout/stderr are captured; dumped only on failure.
+#   Falls back to plain output when stdout is not a TTY (CI / piped installs).
+spin() {
+  local msg="$1"; shift
+
+  if [[ ! -t 1 ]]; then
+    info "$msg"
+    "$@"
+    return
+  fi
+
+  local log; log=$(mktemp)
+  "$@" >"$log" 2>&1 &
+  local pid=$! i=0
+  local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+
+  while kill -0 "$pid" 2>/dev/null; do
+    printf "\r  ${C_GREEN}%s${C_RESET}  %s" "${frames[$((i++ % 10))]}" "$msg"
+    sleep 0.08
+  done
+
+  wait "$pid"; local status=$?
+  if [[ $status -eq 0 ]]; then
+    printf "\r  ${C_GREEN}✓${C_RESET}  %s\n" "$msg"
+  else
+    printf "\r  ${C_RED}✗${C_RESET}  %s\n\n" "$msg"
+    cat "$log" >&2
+    printf "\n"
+  fi
+  rm -f "$log"
+  return $status
+}
 
 command_exists() { command -v "$1" &>/dev/null; }
 
@@ -136,10 +248,10 @@ install_nodejs() {
     error "nvm installer integrity check failed\n  Expected: $NVM_SHA256\n  Actual:   $actual_hash"
   fi
   info "nvm installer integrity verified"
-  bash "$nvm_tmp"
+  spin "Installing nvm..." bash "$nvm_tmp"
   rm -f "$nvm_tmp"
   ensure_nvm_loaded
-  nvm install 22
+  spin "Installing Node.js 22..." bash -c ". \"$NVM_DIR/nvm.sh\" && nvm install 22 --no-progress"
   info "Node.js installed: $(node --version)"
 }
 
@@ -385,23 +497,31 @@ main() {
   for arg in "$@"; do
     case "$arg" in
       --non-interactive) NON_INTERACTIVE=1 ;;
+      --version) printf "nemoclaw-installer v%s\n" "$NEMOCLAW_VERSION"; exit 0 ;;
+      --help|-h) usage; exit 0 ;;
     esac
   done
   # Also honor env var
   NON_INTERACTIVE="${NON_INTERACTIVE:-${NEMOCLAW_NON_INTERACTIVE:-}}"
   export NEMOCLAW_NON_INTERACTIVE="${NON_INTERACTIVE}"
 
-  info "=== NemoClaw Installer ==="
+  _INSTALL_START=$SECONDS
+  print_banner
 
+  step 1 "Node.js"
   install_nodejs
   ensure_supported_runtime
+
+  step 2 "NemoClaw CLI"
   # install_or_upgrade_ollama
   install_nemoclaw
   verify_nemoclaw
   post_install_message
+
+  step 3 "Onboarding"
   run_onboard
 
-  info "=== Installation complete ==="
+  print_done
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,20 @@
 
 set -euo pipefail
 
-NEMOCLAW_VERSION="0.1.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_NEMOCLAW_VERSION="0.1.0"
 TOTAL_STEPS=3
+
+resolve_installer_version() {
+  local package_json="${SCRIPT_DIR}/package.json"
+  local version=""
+  if [[ -f "$package_json" ]]; then
+    version="$(sed -nE 's/^[[:space:]]*"version":[[:space:]]*"([^"]+)".*/\1/p' "$package_json" | head -1)"
+  fi
+  printf "%s" "${version:-$DEFAULT_NEMOCLAW_VERSION}"
+}
+
+NEMOCLAW_VERSION="$(resolve_installer_version)"
 
 # ---------------------------------------------------------------------------
 # Color / style — disabled when NO_COLOR is set or stdout is not a TTY.
@@ -16,10 +28,8 @@ TOTAL_STEPS=3
 if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
   if [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]]; then
     C_GREEN=$'\033[38;2;118;185;0m'   # #76B900 — exact NVIDIA green
-    C_CLAW=$'\033[38;2;255;77;77m'    # #ff4d4d — OpenClaw red
   else
     C_GREEN=$'\033[38;5;148m'          # closest 256-color on dark backgrounds
-    C_CLAW=$'\033[38;5;210m'           # closest 256-color for #ff4d4d
   fi
   C_BOLD=$'\033[1m'
   C_DIM=$'\033[2m'
@@ -28,7 +38,7 @@ if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
   C_CYAN=$'\033[1;36m'
   C_RESET=$'\033[0m'
 else
-  C_GREEN='' C_CLAW='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_CYAN='' C_RESET=''
+  C_GREEN='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_CYAN='' C_RESET=''
 fi
 
 # ---------------------------------------------------------------------------
@@ -38,6 +48,29 @@ info()  { printf "${C_CYAN}[INFO]${C_RESET}  %s\n" "$*"; }
 warn()  { printf "${C_YELLOW}[WARN]${C_RESET}  %s\n" "$*"; }
 error() { printf "${C_RED}[ERROR]${C_RESET} %s\n" "$*" >&2; exit 1; }
 ok()    { printf "  ${C_GREEN}✓${C_RESET}  %s\n" "$*"; }
+
+resolve_default_sandbox_name() {
+  local registry_file="${HOME}/.nemoclaw/sandboxes.json"
+  local sandbox_name="${NEMOCLAW_SANDBOX_NAME:-}"
+
+  if [[ -z "$sandbox_name" && -f "$registry_file" ]] && command_exists node; then
+    sandbox_name="$(
+      node -e '
+        const fs = require("fs");
+        const file = process.argv[1];
+        try {
+          const data = JSON.parse(fs.readFileSync(file, "utf8"));
+          const sandboxes = data.sandboxes || {};
+          const preferred = data.defaultSandbox;
+          const name = (preferred && sandboxes[preferred] && preferred) || Object.keys(sandboxes)[0] || "";
+          process.stdout.write(name);
+        } catch {}
+      ' "$registry_file" 2>/dev/null || true
+    )"
+  fi
+
+  printf "%s" "${sandbox_name:-my-assistant}"
+}
 
 # step N "Description" — numbered section header
 step() {
@@ -50,12 +83,12 @@ step() {
 print_banner() {
   printf "\n"
   # ANSI Shadow ASCII art — hand-crafted, no figlet dependency
-  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ${C_RESET}${C_CLAW}${C_BOLD}██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗${C_RESET}${C_CLAW}${C_BOLD}██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║${C_RESET}${C_CLAW}${C_BOLD}██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║${C_RESET}${C_CLAW}${C_BOLD}██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝${C_RESET}${C_CLAW}${C_BOLD}╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ${C_RESET}${C_CLAW}${C_BOLD}╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
   printf "\n"
   printf "  ${C_DIM}Deploy more secure, always-on AI assistants with a single command.  v%s${C_RESET}\n" "$NEMOCLAW_VERSION"
   printf "\n"
@@ -63,12 +96,16 @@ print_banner() {
 
 print_done() {
   local elapsed=$(( SECONDS - _INSTALL_START ))
+  local sandbox_name
+  sandbox_name="$(resolve_default_sandbox_name)"
   info "=== Installation complete ==="
   printf "\n"
-  printf "  ${C_GREEN}${C_BOLD}Nemo${C_RESET}${C_CLAW}${C_BOLD}Claw${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$elapsed"
+  printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$elapsed"
   printf "\n"
-  printf "  Your secured AI agent stack is live.\n"
+  printf "  ${C_GREEN}Your OpenClaw Sandbox is live.${C_RESET}\n"
   printf "  ${C_DIM}Sandbox in, break things, and tell us what you find.${C_RESET}\n"
+  printf "  %s$%s nemoclaw %s connect\n" "$C_GREEN" "$C_RESET" "$sandbox_name"
+  printf "  %ssandbox@%s$%s openclaw tui\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
   printf "\n"
   printf "  ${C_BOLD}GitHub${C_RESET}  ${C_DIM}https://github.com/nvidia/nemoclaw${C_RESET}\n"
   printf "  ${C_BOLD}Docs${C_RESET}    ${C_DIM}https://docs.nvidia.com/nemoclaw/latest/${C_RESET}\n"
@@ -83,11 +120,22 @@ usage() {
   printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
   printf "  ${C_DIM}Options:${C_RESET}\n"
   printf "    --non-interactive    Skip prompts (uses env vars / defaults)\n"
-  printf "    --version            Print installer version and exit\n"
+  printf "    --version, -v        Print installer version and exit\n"
   printf "    --help               Show this help message and exit\n\n"
   printf "  ${C_DIM}Environment:${C_RESET}\n"
   printf "    NVIDIA_API_KEY                API key (skips credential prompt)\n"
   printf "    NEMOCLAW_NON_INTERACTIVE=1    Same as --non-interactive\n"
+  printf "    NEMOCLAW_SANDBOX_NAME         Sandbox name to create/use\n"
+  printf "    NEMOCLAW_RECREATE_SANDBOX=1   Recreate an existing sandbox\n"
+  printf "    NEMOCLAW_PROVIDER             cloud | ollama | nim | vllm\n"
+  printf "    NEMOCLAW_MODEL                Inference model to configure\n"
+  printf "    NEMOCLAW_POLICY_MODE          suggested | custom | skip\n"
+  printf "    NEMOCLAW_POLICY_PRESETS       Comma-separated policy presets\n"
+  printf "    NEMOCLAW_EXPERIMENTAL=1       Show experimental/local options\n"
+  printf "    CHAT_UI_URL                   Chat UI URL to open after setup\n"
+  printf "    DISCORD_BOT_TOKEN             Auto-enable Discord policy support\n"
+  printf "    SLACK_BOT_TOKEN               Auto-enable Slack policy support\n"
+  printf "    TELEGRAM_BOT_TOKEN            Auto-enable Telegram policy support\n"
   printf "\n"
 }
 
@@ -504,7 +552,7 @@ main() {
   for arg in "$@"; do
     case "$arg" in
       --non-interactive) NON_INTERACTIVE=1 ;;
-      --version) printf "nemoclaw-installer v%s\n" "$NEMOCLAW_VERSION"; exit 0 ;;
+      --version|-v) printf "nemoclaw-installer v%s\n" "$NEMOCLAW_VERSION"; exit 0 ;;
       --help|-h) usage; exit 0 ;;
       *) usage; error "Unknown option: $arg" ;;
     esac

--- a/install.sh
+++ b/install.sh
@@ -256,9 +256,9 @@ install_nodejs() {
   spin "Installing nvm..." bash "$nvm_tmp"
   rm -f "$nvm_tmp"
   ensure_nvm_loaded
-  spin "Installing Node.js 22..." bash -c ". \"$NVM_DIR/nvm.sh\" && nvm install 22 --no-progress"
+  spin "Installing Node.js ${RECOMMENDED_NODE_MAJOR}..." bash -c ". \"$NVM_DIR/nvm.sh\" && nvm install ${RECOMMENDED_NODE_MAJOR} --no-progress"
   ensure_nvm_loaded
-  nvm use 22 --silent
+  nvm use "${RECOMMENDED_NODE_MAJOR}" --silent
   info "Node.js installed: $(node --version)"
 }
 
@@ -506,6 +506,7 @@ main() {
       --non-interactive) NON_INTERACTIVE=1 ;;
       --version) printf "nemoclaw-installer v%s\n" "$NEMOCLAW_VERSION"; exit 0 ;;
       --help|-h) usage; exit 0 ;;
+      *) usage; error "Unknown option: $arg" ;;
     esac
   done
   # Also honor env var
@@ -526,7 +527,11 @@ main() {
   post_install_message
 
   step 3 "Onboarding"
-  run_onboard
+  if command_exists nemoclaw; then
+    run_onboard
+  else
+    warn "Skipping onboarding — nemoclaw is not on PATH. Run 'nemoclaw onboard' after updating your PATH."
+  fi
 
   print_done
 }

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,11 @@ spin() {
     sleep 0.08
   done
 
-  wait "$pid"; local status=$?
+  if wait "$pid"; then
+    local status=0
+  else
+    local status=$?
+  fi
   if [[ $status -eq 0 ]]; then
     printf "\r  ${C_GREEN}✓${C_RESET}  %s\n" "$msg"
   else
@@ -253,6 +257,8 @@ install_nodejs() {
   rm -f "$nvm_tmp"
   ensure_nvm_loaded
   spin "Installing Node.js 22..." bash -c ". \"$NVM_DIR/nvm.sh\" && nvm install 22 --no-progress"
+  ensure_nvm_loaded
+  nvm use 22 --silent
   info "Node.js installed: $(node --version)"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ print_banner() {
   printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
   printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
   printf "\n"
-  printf "  ${C_DIM}Deploy more secure, always-on AI assistants with a single command.  v%s${C_RESET}\n" "$NEMOCLAW_VERSION"
+  printf "  ${C_DIM}Launch OpenClaw in an OpenShell sandbox.  v%s${C_RESET}\n" "$NEMOCLAW_VERSION"
   printf "\n"
 }
 
@@ -434,9 +434,9 @@ install_nemoclaw() {
   if [[ -f "./package.json" ]] && grep -q '"name": "nemoclaw"' ./package.json 2>/dev/null; then
     info "NemoClaw package.json found in current directory — installing from source…"
     pre_extract_openclaw "$(pwd)" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
-    npm install --ignore-scripts
-    (cd nemoclaw && npm install --ignore-scripts && npm run build)
-    npm link
+    spin "Installing NemoClaw dependencies" npm install --ignore-scripts
+    spin "Building NemoClaw plugin" bash -lc 'cd nemoclaw && npm install --ignore-scripts && npm run build'
+    spin "Linking NemoClaw CLI" npm link
   else
     info "Installing NemoClaw from GitHub…"
     # Clone first so we can pre-extract openclaw before npm install (GH-503).
@@ -445,9 +445,11 @@ install_nemoclaw() {
     local nemoclaw_src="${HOME}/.nemoclaw/source"
     rm -rf "$nemoclaw_src"
     mkdir -p "$(dirname "$nemoclaw_src")"
-    git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$nemoclaw_src"
+    spin "Cloning NemoClaw source" git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$nemoclaw_src"
     pre_extract_openclaw "$nemoclaw_src" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
-    (cd "$nemoclaw_src" && npm install --ignore-scripts && cd nemoclaw && npm install --ignore-scripts && npm run build && cd .. && npm link)
+    spin "Installing NemoClaw dependencies" bash -lc "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
+    spin "Building NemoClaw plugin" bash -lc "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
+    spin "Linking NemoClaw CLI" bash -lc "cd \"$nemoclaw_src\" && npm link"
   fi
 
   refresh_path

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -17,6 +17,40 @@ function writeExecutable(target, contents) {
   fs.writeFileSync(target, contents, { mode: 0o755 });
 }
 
+// ---------------------------------------------------------------------------
+// Helpers shared across suites
+// ---------------------------------------------------------------------------
+
+/** Fake node that reports v22.14.0. */
+function writeNodeStub(fakeBin) {
+  writeExecutable(
+    path.join(fakeBin, "node"),
+    `#!/usr/bin/env bash
+if [ "$1" = "--version" ] || [ "$1" = "-v" ]; then echo "v22.14.0"; exit 0; fi
+exit 99`,
+  );
+}
+
+/**
+ * Minimal npm stub. Handles --version, config-get-prefix, and a custom
+ * install handler injected as a shell snippet via NPM_INSTALL_HANDLER.
+ */
+function writeNpmStub(fakeBin, installSnippet = "exit 0") {
+  writeExecutable(
+    path.join(fakeBin, "npm"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "--version" ]; then echo "10.9.2"; exit 0; fi
+if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then echo "$NPM_PREFIX"; exit 0; fi
+if [ "$1" = "install" ] || [ "$1" = "link" ] || [ "$1" = "uninstall" ]; then
+  ${installSnippet}
+fi
+echo "unexpected npm invocation: $*" >&2; exit 98`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
 describe("installer runtime preflight", () => {
   it("fails fast with a clear message on unsupported Node.js and npm", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-preflight-"));
@@ -436,6 +470,110 @@ exit 0
     assert.equal(result.status, 0);
     assert.match(output, /Installation complete!/);
     assert.match(output, /nemoclaw v0\.1\.0-test is ready/);
+  });
+
+  it("--help exits 0 and shows install usage", () => {
+    const result = spawnSync("bash", [INSTALLER, "--help"], {
+      cwd: path.join(__dirname, ".."),
+      encoding: "utf-8",
+    });
+
+    assert.equal(result.status, 0);
+    const output = `${result.stdout}${result.stderr}`;
+    assert.match(output, /NemoClaw Installer/);
+    assert.match(output, /--non-interactive/);
+    assert.match(output, /--version/);
+    assert.match(output, /nvidia\.com\/nemoclaw\.sh/);
+  });
+
+  it("--version exits 0 and prints the version number", () => {
+    const result = spawnSync("bash", [INSTALLER, "--version"], {
+      cwd: path.join(__dirname, ".."),
+      encoding: "utf-8",
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(`${result.stdout}${result.stderr}`, /nemoclaw-installer v\d+\.\d+\.\d+/);
+  });
+
+  it("uses npm install + npm link for a source checkout (no -g)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-source-"));
+    const fakeBin = path.join(tmp, "bin");
+    const prefix = path.join(tmp, "prefix");
+    const npmLog = path.join(tmp, "npm.log");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+    writeNodeStub(fakeBin);
+    writeNpmStub(
+      fakeBin,
+      `printf '%s\\n' "$*" >> "$NPM_LOG_PATH"
+if [ "$1" = "install" ]; then exit 0; fi
+if [ "$1" = "link" ]; then
+  cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
+#!/usr/bin/env bash
+if [ "$1" = "onboard" ] || [ "$1" = "--version" ]; then exit 0; fi
+exit 0
+EOS
+  chmod +x "$NPM_PREFIX/bin/nemoclaw"
+  exit 0
+fi`,
+    );
+
+    // Write a package.json that triggers the source-checkout path.
+    // Must use spaces after colons to match the grep in install.sh.
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
+    );
+
+    const result = spawnSync("bash", [INSTALLER], {
+      cwd: tmp,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NPM_PREFIX: prefix,
+        NPM_LOG_PATH: npmLog,
+      },
+    });
+
+    assert.equal(result.status, 0);
+    const log = fs.readFileSync(npmLog, "utf-8");
+    // install (no -g) and link must both have been called
+    assert.match(log, /^install(?!\s+-g)/m);
+    assert.match(log, /^link/m);
+    // the GitHub URL must NOT appear — this is a local install
+    assert.doesNotMatch(log, new RegExp(GITHUB_INSTALL_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  });
+
+  it("spin() non-TTY: dumps wrapped-command output and exits non-zero on failure", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-spin-fail-"));
+    const fakeBin = path.join(tmp, "bin");
+    const prefix = path.join(tmp, "prefix");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+    writeNodeStub(fakeBin);
+    // npm install -g fails with a recognisable message
+    writeNpmStub(fakeBin, `echo "ENOTFOUND simulated network error" >&2; exit 1`);
+
+    const result = spawnSync("bash", [INSTALLER], {
+      cwd: tmp,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NPM_PREFIX: prefix,
+      },
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stdout}${result.stderr}`, /ENOTFOUND simulated network error/);
   });
 
   it("creates a user-local shim when npm installs outside the current PATH", () => {

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -27,6 +27,13 @@ function writeNodeStub(fakeBin) {
     path.join(fakeBin, "node"),
     `#!/usr/bin/env bash
 if [ "$1" = "--version" ] || [ "$1" = "-v" ]; then echo "v22.14.0"; exit 0; fi
+if [ "$1" = "-e" ]; then
+  if [[ "$2" == *"dependencies.openclaw"* ]]; then
+    echo "2026.3.11"
+    exit 0
+  fi
+  exit 0
+fi
 exit 99`,
   );
 }
@@ -42,7 +49,7 @@ function writeNpmStub(fakeBin, installSnippet = "exit 0") {
 set -euo pipefail
 if [ "$1" = "--version" ]; then echo "10.9.2"; exit 0; fi
 if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then echo "$NPM_PREFIX"; exit 0; fi
-if [ "$1" = "install" ] || [ "$1" = "link" ] || [ "$1" = "uninstall" ]; then
+if [ "$1" = "install" ] || [ "$1" = "link" ] || [ "$1" = "uninstall" ] || [ "$1" = "pack" ] || [ "$1" = "run" ]; then
   ${installSnippet}
 fi
 echo "unexpected npm invocation: $*" >&2; exit 98`,
@@ -483,11 +490,24 @@ exit 0
     assert.match(output, /NemoClaw Installer/);
     assert.match(output, /--non-interactive/);
     assert.match(output, /--version/);
+    assert.match(output, /NEMOCLAW_PROVIDER/);
+    assert.match(output, /NEMOCLAW_POLICY_MODE/);
+    assert.match(output, /NEMOCLAW_SANDBOX_NAME/);
     assert.match(output, /nvidia\.com\/nemoclaw\.sh/);
   });
 
   it("--version exits 0 and prints the version number", () => {
     const result = spawnSync("bash", [INSTALLER, "--version"], {
+      cwd: path.join(__dirname, ".."),
+      encoding: "utf-8",
+    });
+
+    assert.equal(result.status, 0);
+    assert.match(`${result.stdout}${result.stderr}`, /nemoclaw-installer v\d+\.\d+\.\d+/);
+  });
+
+  it("-v exits 0 and prints the version number", () => {
+    const result = spawnSync("bash", [INSTALLER, "-v"], {
       cwd: path.join(__dirname, ".."),
       encoding: "utf-8",
     });
@@ -508,7 +528,14 @@ exit 0
     writeNpmStub(
       fakeBin,
       `printf '%s\\n' "$*" >> "$NPM_LOG_PATH"
+if [ "$1" = "pack" ]; then
+  tmpdir="$4"
+  mkdir -p "$tmpdir/package"
+  tar -czf "$tmpdir/openclaw-2026.3.11.tgz" -C "$tmpdir" package
+  exit 0
+fi
 if [ "$1" = "install" ]; then exit 0; fi
+if [ "$1" = "run" ] && [ "$2" = "build" ]; then exit 0; fi
 if [ "$1" = "link" ]; then
   cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
 #!/usr/bin/env bash
@@ -525,6 +552,11 @@ fi`,
     fs.writeFileSync(
       path.join(tmp, "package.json"),
       JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
+    );
+    fs.mkdirSync(path.join(tmp, "nemoclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, "nemoclaw", "package.json"),
+      JSON.stringify({ name: "nemoclaw-plugin", version: "0.1.0" }, null, 2),
     );
 
     const result = spawnSync("bash", [INSTALLER], {
@@ -557,8 +589,30 @@ fi`,
     fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
 
     writeNodeStub(fakeBin);
-    // npm install -g fails with a recognisable message
-    writeNpmStub(fakeBin, `echo "ENOTFOUND simulated network error" >&2; exit 1`);
+    writeExecutable(
+      path.join(fakeBin, "git"),
+      `#!/usr/bin/env bash
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0
+`,
+    );
+    writeNpmStub(
+      fakeBin,
+      `if [ "$1" = "pack" ]; then
+  echo "ENOTFOUND simulated network error" >&2
+  exit 1
+fi
+if [ "$1" = "install" ] || [ "$1" = "run" ] || [ "$1" = "link" ]; then
+  echo "ENOTFOUND simulated network error" >&2
+  exit 1
+fi`,
+    );
 
     const result = spawnSync("bash", [INSTALLER], {
       cwd: tmp,

--- a/test/uninstall.test.js
+++ b/test/uninstall.test.js
@@ -30,27 +30,31 @@ describe("uninstall CLI flags", () => {
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
 
-    // Provide stub executables so the uninstaller can run its steps as no-ops
-    for (const cmd of ["npm", "openshell", "docker", "ollama", "pgrep"]) {
-      fs.writeFileSync(path.join(fakeBin, cmd), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    try {
+      // Provide stub executables so the uninstaller can run its steps as no-ops
+      for (const cmd of ["npm", "openshell", "docker", "ollama", "pgrep"]) {
+        fs.writeFileSync(path.join(fakeBin, cmd), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+      }
+
+      const result = spawnSync("bash", [UNINSTALL_SCRIPT, "--yes"], {
+        cwd: path.join(__dirname, ".."),
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmp,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          SCRIPT_DIR: path.join(__dirname, ".."),
+        },
+      });
+
+      assert.equal(result.status, 0);
+      // Banner and bye statement should be present
+      const output = `${result.stdout}${result.stderr}`;
+      assert.match(output, /NemoClaw/);
+      assert.match(output, /Claws retracted/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
     }
-
-    const result = spawnSync("bash", [UNINSTALL_SCRIPT, "--yes"], {
-      cwd: path.join(__dirname, ".."),
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmp,
-        PATH: `${fakeBin}:/usr/bin:/bin`,
-        SCRIPT_DIR: path.join(__dirname, ".."),
-      },
-    });
-
-    assert.equal(result.status, 0);
-    // Banner and bye statement should be present
-    const output = `${result.stdout}${result.stderr}`;
-    assert.match(output, /NemoClaw/);
-    assert.match(output, /Claws retracted/);
   });
 });
 

--- a/test/uninstall.test.js
+++ b/test/uninstall.test.js
@@ -10,6 +10,50 @@ const { spawnSync } = require("node:child_process");
 
 const UNINSTALL_SCRIPT = path.join(__dirname, "..", "uninstall.sh");
 
+describe("uninstall CLI flags", () => {
+  it("--help exits 0 and shows usage", () => {
+    const result = spawnSync("bash", [UNINSTALL_SCRIPT, "--help"], {
+      cwd: path.join(__dirname, ".."),
+      encoding: "utf-8",
+    });
+
+    assert.equal(result.status, 0);
+    const output = `${result.stdout}${result.stderr}`;
+    assert.match(output, /NemoClaw Uninstaller/);
+    assert.match(output, /--yes/);
+    assert.match(output, /--keep-openshell/);
+    assert.match(output, /--delete-models/);
+  });
+
+  it("--yes skips the confirmation prompt and completes successfully", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-yes-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    // Provide stub executables so the uninstaller can run its steps as no-ops
+    for (const cmd of ["npm", "openshell", "docker", "ollama", "pgrep"]) {
+      fs.writeFileSync(path.join(fakeBin, cmd), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    }
+
+    const result = spawnSync("bash", [UNINSTALL_SCRIPT, "--yes"], {
+      cwd: path.join(__dirname, ".."),
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        SCRIPT_DIR: path.join(__dirname, ".."),
+      },
+    });
+
+    assert.equal(result.status, 0);
+    // Banner and bye statement should be present
+    const output = `${result.stdout}${result.stderr}`;
+    assert.match(output, /NemoClaw/);
+    assert.match(output, /Claws retracted/);
+  });
+});
+
 describe("uninstall helpers", () => {
   it("returns the expected gateway volume candidate", () => {
     const result = spawnSync(

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -287,9 +287,8 @@ remove_openshell_resources() {
 remove_nemoclaw_cli() {
   if command -v npm > /dev/null 2>&1; then
     npm unlink -g nemoclaw > /dev/null 2>&1 || true
-    if spin "Removing nemoclaw npm package..." \
-        npm uninstall -g --loglevel=error nemoclaw; then
-      : # spin already printed ✓
+    if npm uninstall -g --loglevel=error nemoclaw > /dev/null 2>&1; then
+      info "Removed global nemoclaw npm package"
     else
       warn "Global nemoclaw npm package not found or already removed"
     fi
@@ -300,6 +299,12 @@ remove_nemoclaw_cli() {
   if [ -L "${NEMOCLAW_SHIM_DIR}/nemoclaw" ] || [ -f "${NEMOCLAW_SHIM_DIR}/nemoclaw" ]; then
     remove_path "${NEMOCLAW_SHIM_DIR}/nemoclaw"
   fi
+}
+
+remove_docker_resources() {
+  remove_related_docker_containers
+  remove_related_docker_images
+  remove_related_docker_volumes
 }
 
 remove_nemoclaw_state() {
@@ -520,12 +525,10 @@ main() {
   remove_openshell_resources
 
   step 3 "NemoClaw CLI"
-  remove_nemoclaw_cli
+  spin "Removing NemoClaw CLI..." remove_nemoclaw_cli
 
   step 4 "Docker resources"
-  remove_related_docker_containers
-  remove_related_docker_images
-  remove_related_docker_volumes
+  spin "Removing Docker resources..." remove_docker_resources
 
   step 5 "Ollama models"
   remove_optional_ollama_models

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,14 +15,96 @@
 
 set -euo pipefail
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+# ---------------------------------------------------------------------------
+# Color / style — disabled when NO_COLOR is set or stdout is not a TTY.
+# Uses exact NVIDIA green #76B900 on truecolor terminals; 256-color otherwise.
+# ---------------------------------------------------------------------------
+if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
+  if [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]]; then
+    C_GREEN=$'\033[38;2;118;185;0m'   # #76B900 — exact NVIDIA green
+  else
+    C_GREEN=$'\033[38;5;148m'          # closest 256-color on dark backgrounds
+  fi
+  C_BOLD=$'\033[1m'
+  C_DIM=$'\033[2m'
+  C_RED=$'\033[1;31m'
+  C_YELLOW=$'\033[1;33m'
+  C_WHITE=$'\033[1;37m'
+  C_RESET=$'\033[0m'
+else
+  C_GREEN='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_WHITE='' C_RESET=''
+fi
 
-info() { echo -e "${GREEN}[uninstall]${NC} $1"; }
-warn() { echo -e "${YELLOW}[uninstall]${NC} $1"; }
-fail() { echo -e "${RED}[uninstall]${NC} $1"; exit 1; }
+info() { printf "${C_GREEN}[uninstall]${C_RESET} %s\n" "$*"; }
+warn() { printf "${C_YELLOW}[uninstall]${C_RESET} %s\n" "$*"; }
+fail() { printf "${C_RED}[uninstall]${C_RESET} %s\n" "$*" >&2; exit 1; }
+ok()   { printf "  ${C_GREEN}✓${C_RESET}  %s\n" "$*"; }
+
+# spin "label" cmd [args...]  — spinner wrapper, same as installer.
+spin() {
+  local msg="$1"; shift
+
+  if [[ ! -t 1 ]]; then
+    info "$msg"
+    "$@"
+    return
+  fi
+
+  local log; log=$(mktemp)
+  "$@" >"$log" 2>&1 &
+  local pid=$! i=0
+  local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+
+  while kill -0 "$pid" 2>/dev/null; do
+    printf "\r  ${C_GREEN}%s${C_RESET}  %s" "${frames[$((i++ % 10))]}" "$msg"
+    sleep 0.08
+  done
+
+  wait "$pid"; local status=$?
+  if [[ $status -eq 0 ]]; then
+    printf "\r  ${C_GREEN}✓${C_RESET}  %s\n" "$msg"
+  else
+    printf "\r  ${C_RED}✗${C_RESET}  %s\n\n" "$msg"
+    cat "$log" >&2
+    printf "\n"
+  fi
+  rm -f "$log"
+  return $status
+}
+
+UNINSTALL_TOTAL_STEPS=6
+
+# step N "Description"
+step() {
+  local n=$1 msg=$2
+  printf "\n${C_GREEN}[%s/%s]${C_RESET} ${C_BOLD}%s${C_RESET}\n" \
+    "$n" "$UNINSTALL_TOTAL_STEPS" "$msg"
+  printf "  ${C_DIM}──────────────────────────────────────────────────${C_RESET}\n"
+}
+
+print_banner() {
+  printf "\n"
+  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
+  printf "\n"
+  printf "  ${C_DIM}Uninstaller — This will remove all NemoClaw-managed resources.${C_RESET}\n"
+  printf "  ${C_DIM}Docker, Node.js, Ollama, and npm are preserved.${C_RESET}\n"
+  printf "\n"
+}
+
+print_bye() {
+  printf "\n"
+  printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}\n"
+  printf "\n"
+  printf "  ${C_BOLD}${C_WHITE}Claws retracted.${C_RESET}  ${C_DIM}Until next time.${C_RESET}\n"
+  printf "\n"
+  printf "  ${C_DIM}https://www.nvidia.com/nemoclaw${C_RESET}\n"
+  printf "\n"
+}
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NEMOCLAW_STATE_DIR="${HOME}/.nemoclaw"
@@ -40,15 +122,16 @@ KEEP_OPEN_SHELL=false
 DELETE_MODELS=false
 
 usage() {
-  cat <<'EOF'
-Usage: ./uninstall.sh [--yes] [--keep-openshell] [--delete-models]
-
-Options:
-  --yes             Skip the confirmation prompt
-  --keep-openshell  Leave the openshell binary installed
-  --delete-models   Remove NemoClaw-pulled Ollama models
-  -h, --help        Show this help
-EOF
+  printf "\n"
+  printf "  ${C_BOLD}NemoClaw Uninstaller${C_RESET}\n\n"
+  printf "  ${C_DIM}Usage:${C_RESET}\n"
+  printf "    ./uninstall.sh [--yes] [--keep-openshell] [--delete-models]\n\n"
+  printf "  ${C_GREEN}Options:${C_RESET}\n"
+  printf "    --yes             Skip the confirmation prompt\n"
+  printf "    --keep-openshell  Leave the openshell binary installed\n"
+  printf "    --delete-models   Remove NemoClaw-pulled Ollama models\n"
+  printf "    -h, --help        Show this help\n"
+  printf "\n"
 }
 
 while [ $# -gt 0 ]; do
@@ -80,15 +163,21 @@ confirm() {
     return 0
   fi
 
-  echo ""
-  warn "This will remove all OpenShell sandboxes, NemoClaw-managed gateway/providers,"
-  warn "related Docker images, and local state under ~/.nemoclaw, ~/.config/openshell,"
-  warn "and ~/.config/nemoclaw."
-  warn "It will not uninstall Docker, Ollama, npm, Node.js, or other shared tooling."
-  if [ "$DELETE_MODELS" = false ]; then
-    warn "Ollama models are preserved by default. Re-run with --delete-models to remove them."
+  printf "\n"
+  printf "  ${C_YELLOW}What will be removed:${C_RESET}\n"
+  printf "  ${C_DIM}  · All OpenShell sandboxes, gateway, and NemoClaw-managed providers${C_RESET}\n"
+  printf "  ${C_DIM}  · Related Docker containers, images, and volumes${C_RESET}\n"
+  printf "  ${C_DIM}  · ~/.nemoclaw  ~/.config/openshell  ~/.config/nemoclaw${C_RESET}\n"
+  printf "  ${C_DIM}  · Global nemoclaw npm package${C_RESET}\n"
+  if [ "$DELETE_MODELS" = true ]; then
+    printf "  ${C_DIM}  · Ollama models: %s${C_RESET}\n" "${OLLAMA_MODELS[*]}"
+  else
+    printf "  ${C_DIM}  · Ollama models: ${C_RESET}${C_GREEN}kept${C_RESET}${C_DIM} (pass --delete-models to remove)${C_RESET}\n"
   fi
-  printf "Continue? [y/N] "
+  printf "\n"
+  printf "  ${C_DIM}Docker, Node.js, npm, and Ollama are not touched.${C_RESET}\n"
+  printf "\n"
+  printf "  ${C_BOLD}Continue?${C_RESET} [y/N] "
   local reply=""
   if [ -t 2 ] && read -r reply 0</dev/tty 2>/dev/null; then
     :
@@ -199,8 +288,9 @@ remove_openshell_resources() {
 remove_nemoclaw_cli() {
   if command -v npm > /dev/null 2>&1; then
     npm unlink -g nemoclaw > /dev/null 2>&1 || true
-    if npm uninstall -g nemoclaw > /dev/null 2>&1; then
-      info "Removed global nemoclaw npm package"
+    if spin "Removing nemoclaw npm package..." \
+        npm uninstall -g --loglevel=error nemoclaw; then
+      : # spin already printed ✓
     else
       warn "Global nemoclaw npm package not found or already removed"
     fi
@@ -420,43 +510,33 @@ remove_openshell_binary() {
 }
 
 main() {
+  print_banner
   confirm
 
-  info "Stopping NemoClaw helper services..."
+  step 1 "Stopping services"
   stop_helper_services
-
-  info "Stopping local OpenShell forward processes..."
   stop_openshell_forward_processes
 
-  info "Removing OpenShell resources created for NemoClaw..."
+  step 2 "OpenShell resources"
   remove_openshell_resources
 
-  info "Removing global nemoclaw install..."
+  step 3 "NemoClaw CLI"
   remove_nemoclaw_cli
 
-  info "Removing related Docker containers..."
+  step 4 "Docker resources"
   remove_related_docker_containers
-
-  info "Removing related Docker images..."
   remove_related_docker_images
-
-  info "Removing related Docker volumes..."
   remove_related_docker_volumes
 
-  info "Removing optional Ollama models..."
+  step 5 "Ollama models"
   remove_optional_ollama_models
 
-  info "Removing runtime temp artifacts..."
+  step 6 "State and binaries"
   remove_runtime_temp_artifacts
-
-  info "Removing openshell binary..."
   remove_openshell_binary
-
-  info "Removing NemoClaw state..."
   remove_nemoclaw_state
 
-  echo ""
-  info "Uninstall complete."
+  print_bye
 }
 
 if [ "${BASH_SOURCE[0]-}" = "$0" ] || { [ -z "${BASH_SOURCE[0]-}" ] && { [ "$0" = "bash" ] || [ "$0" = "-bash" ]; }; }; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,8 +22,10 @@ set -euo pipefail
 if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
   if [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]]; then
     C_GREEN=$'\033[38;2;118;185;0m'   # #76B900 — exact NVIDIA green
+    C_CLAW=$'\033[38;2;255;77;77m'    # #ff4d4d — OpenClaw red
   else
     C_GREEN=$'\033[38;5;148m'          # closest 256-color on dark backgrounds
+    C_CLAW=$'\033[38;5;210m'           # closest 256-color for #ff4d4d
   fi
   C_BOLD=$'\033[1m'
   C_DIM=$'\033[2m'
@@ -32,7 +34,7 @@ if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
   C_WHITE=$'\033[1;37m'
   C_RESET=$'\033[0m'
 else
-  C_GREEN='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_WHITE='' C_RESET=''
+  C_GREEN='' C_CLAW='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_WHITE='' C_RESET=''
 fi
 
 info() { printf "${C_GREEN}[uninstall]${C_RESET} %s\n" "$*"; }
@@ -84,12 +86,12 @@ step() {
 
 print_banner() {
   printf "\n"
-  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ${C_RESET}${C_CLAW}${C_BOLD}██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗${C_RESET}${C_CLAW}${C_BOLD}██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║${C_RESET}${C_CLAW}${C_BOLD}██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║${C_RESET}${C_CLAW}${C_BOLD}██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝${C_RESET}${C_CLAW}${C_BOLD}╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ${C_RESET}${C_CLAW}${C_BOLD}╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
   printf "\n"
   printf "  ${C_DIM}Uninstaller — This will remove all NemoClaw-managed resources.${C_RESET}\n"
   printf "  ${C_DIM}Docker, Node.js, Ollama, and npm are preserved.${C_RESET}\n"
@@ -98,7 +100,7 @@ print_banner() {
 
 print_bye() {
   printf "\n"
-  printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD}Nemo${C_RESET}${C_CLAW}${C_BOLD}Claw${C_RESET}\n"
   printf "\n"
   printf "  ${C_BOLD}${C_WHITE}Claws retracted.${C_RESET}  ${C_DIM}Until next time.${C_RESET}\n"
   printf "\n"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,19 +22,16 @@ set -euo pipefail
 if [[ -z "${NO_COLOR:-}" && -t 1 ]]; then
   if [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]]; then
     C_GREEN=$'\033[38;2;118;185;0m'   # #76B900 — exact NVIDIA green
-    C_CLAW=$'\033[38;2;255;77;77m'    # #ff4d4d — OpenClaw red
   else
     C_GREEN=$'\033[38;5;148m'          # closest 256-color on dark backgrounds
-    C_CLAW=$'\033[38;5;210m'           # closest 256-color for #ff4d4d
   fi
   C_BOLD=$'\033[1m'
   C_DIM=$'\033[2m'
   C_RED=$'\033[1;31m'
   C_YELLOW=$'\033[1;33m'
-  C_WHITE=$'\033[1;37m'
   C_RESET=$'\033[0m'
 else
-  C_GREEN='' C_CLAW='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_WHITE='' C_RESET=''
+  C_GREEN='' C_BOLD='' C_DIM='' C_RED='' C_YELLOW='' C_RESET=''
 fi
 
 info() { printf "${C_GREEN}[uninstall]${C_RESET} %s\n" "$*"; }
@@ -86,23 +83,23 @@ step() {
 
 print_banner() {
   printf "\n"
-  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ${C_RESET}${C_CLAW}${C_BOLD}██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗${C_RESET}${C_CLAW}${C_BOLD}██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║${C_RESET}${C_CLAW}${C_BOLD}██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║${C_RESET}${C_CLAW}${C_BOLD}██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝${C_RESET}${C_CLAW}${C_BOLD}╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
-  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ${C_RESET}${C_CLAW}${C_BOLD}╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ████╗  ██║██╔════╝████╗ ████║██╔═══██╗██╔════╝██║     ██╔══██╗██║    ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██╔██╗ ██║█████╗  ██╔████╔██║██║   ██║██║     ██║     ███████║██║ █╗ ██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║╚██╗██║██╔══╝  ██║╚██╔╝██║██║   ██║██║     ██║     ██╔══██║██║███╗██║${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
   printf "\n"
-  printf "  ${C_DIM}Uninstaller — This will remove all NemoClaw-managed resources.${C_RESET}\n"
+  printf "  ${C_DIM}Uninstaller — This will remove all NemoClaw resources.${C_RESET}\n"
   printf "  ${C_DIM}Docker, Node.js, Ollama, and npm are preserved.${C_RESET}\n"
   printf "\n"
 }
 
 print_bye() {
   printf "\n"
-  printf "  ${C_GREEN}${C_BOLD}Nemo${C_RESET}${C_CLAW}${C_BOLD}Claw${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}\n"
   printf "\n"
-  printf "  ${C_BOLD}${C_WHITE}Claws retracted.${C_RESET}  ${C_DIM}Until next time.${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD}Claws retracted.${C_RESET}  ${C_DIM}Until next time.${C_RESET}\n"
   printf "\n"
   printf "  ${C_DIM}https://www.nvidia.com/nemoclaw${C_RESET}\n"
   printf "\n"
@@ -167,7 +164,7 @@ confirm() {
 
   printf "\n"
   printf "  ${C_YELLOW}What will be removed:${C_RESET}\n"
-  printf "  ${C_DIM}  · All OpenShell sandboxes, gateway, and NemoClaw-managed providers${C_RESET}\n"
+  printf "  ${C_DIM}  · All OpenShell sandboxes, gateway, and NemoClaw providers${C_RESET}\n"
   printf "  ${C_DIM}  · Related Docker containers, images, and volumes${C_RESET}\n"
   printf "  ${C_DIM}  · ~/.nemoclaw  ~/.config/openshell  ~/.config/nemoclaw${C_RESET}\n"
   printf "  ${C_DIM}  · Global nemoclaw npm package${C_RESET}\n"


### PR DESCRIPTION
## Summary

- **ANSI Shadow banner refresh**: all-green NVIDIA-styled banner for `install.sh` and `uninstall.sh` with truecolor and 256-color fallbacks; `NO_COLOR` respected
- **Pure-bash braille spinner** wrapping slow `npm install`, `nvm install`, and dependency steps with clean non-TTY fallback
- **Numbered step headers** with dim dividers for clearer install/uninstall progress
- **Installer flags**: `--help`, `--version`, and `-v`; expanded help now documents the useful non-interactive onboarding environment variables
- **Completion copy refresh**: installer footer now derives the sandbox name and prints the next commands directly (`$ nemoclaw <sandbox> connect`, `sandbox@<sandbox>$ openclaw tui`)
- **Uninstaller UX**: matching all-green banner/signoff and simplified resource wording (`NemoClaw resources`, `NemoClaw providers`)
- **Terminal contrast cleanup**: removed hardcoded bright-white command text in favor of green prompts plus default terminal foreground for command text
- **`withSpinner<T>()`** helper in `onboard.ts` for slow async validation steps
- **`promptSelect`** updated with NVIDIA green default marker (`▶`) and dimmed hints
- **Regression tests** for `--help`, `--version`, `-v`, non-TTY spinner failure output, and interactive/non-interactive install paths

Install Header
<img width="1246" height="340" alt="image" src="https://github.com/user-attachments/assets/56338a87-ad8a-482d-a83c-01e889d3ae25" />

Install Footer
<img width="936" height="488" alt="image" src="https://github.com/user-attachments/assets/36c512ba-565a-4c76-8182-7b9b80392ea9" />

Uninstall Header
<img width="1218" height="400" alt="image" src="https://github.com/user-attachments/assets/3f5716be-ee1e-4d5c-89ff-d59d6cf189cd" />

Uninstall Footer
<img width="674" height="224" alt="image" src="https://github.com/user-attachments/assets/92a3e70e-15ac-427f-a10d-b6eaa75d7c4a" />

NO_COLOR=1
<img width="1252" height="324" alt="image" src="https://github.com/user-attachments/assets/a24a99cf-8228-4599-a963-1340c6b02bdb" />

## Test plan

- [x] `node --test test/install-preflight.test.js` — installer tests pass
- [x] `node --test test/uninstall.test.js` — uninstaller tests pass
- [x] `node --test test/cli.test.js` — help sections and dispatch tests pass
- [x] Manual: `bash install.sh --help` shows usage and environment variables and exits 0
- [x] Manual: `bash uninstall.sh --help` shows usage and exits 0
- [x] Manual: run installer in a TTY — banner/footer render cleanly on dark and light terminals
- [x] Manual: `NO_COLOR=1 bash install.sh` — no color codes in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version information display capability
  * Interactive confirmation prompts for sandbox deletion with option to skip

* **Improvements**
  * Enhanced terminal output with color styling and visual status indicators
  * Improved operation feedback with progress spinners and step indicators
  * Better SSH readiness messaging with incremental progress updates
  * Respects `NO_COLOR` environment variable for terminal styling preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->