### PR TITLE
fix: resolve inference.local DNS inside sandbox on macOS

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -396,6 +396,16 @@ async function startGateway(gpu) {
     console.log("  Patching CoreDNS for Colima...");
     run(`bash "${path.join(SCRIPTS, "fix-coredns.sh")}" nemoclaw 2>&1 || true`, { ignoreError: true });
   }
+
+  // Fix inference.local DNS on macOS — required for local Ollama/vLLM inference.
+  // On macOS, the OpenShell gateway does not inject inference.local into k3s
+  // CoreDNS, so sandbox pods cannot resolve the inference proxy endpoint.
+  // See: https://github.com/NVIDIA/NemoClaw/issues/260
+  if (process.platform === "darwin") {
+    console.log("  Patching inference.local DNS for macOS...");
+    run(`bash "${path.join(SCRIPTS, "fix-inference-dns-macos.sh")}" nemoclaw 2>&1 || true`, { ignoreError: true });
+  }
+
   // Give DNS a moment to propagate
   sleep(5);
 }

--- a/scripts/fix-inference-dns-macos.sh
+++ b/scripts/fix-inference-dns-macos.sh
@@ -63,8 +63,8 @@ if [ -z "$TARGET_IP" ]; then
   exit 0
 fi
 
-# Basic IP format validation — reject unexpected kubectl output
-if ! echo "$TARGET_IP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+# Strict IPv4 validation — reject out-of-range octets and unexpected output
+if ! echo "$TARGET_IP" | grep -qE '^((25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})$'; then
   echo "WARN: Invalid IP format '$TARGET_IP'. DNS fix skipped."
   exit 0
 fi

--- a/scripts/fix-inference-dns-macos.sh
+++ b/scripts/fix-inference-dns-macos.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fix inference.local DNS resolution inside k3s sandbox pods on macOS.
+#
+# Problem: On macOS (Docker Desktop / Colima), inference.local does not
+# resolve inside sandbox pods. The OpenShell gateway on Linux injects
+# this hostname into k3s CoreDNS automatically, but on macOS this step
+# is skipped, causing sandbox pods to fail when reaching the inference
+# proxy at https://inference.local/v1.
+#
+# Fix: Patch the CoreDNS Corefile configmap to add an inline hosts entry
+# for inference.local, pointing to the Traefik ingress ClusterIP (which
+# proxies inference requests through the OpenShell provider routing).
+#
+# See: https://github.com/NVIDIA/NemoClaw/issues/260
+#
+# Usage: ./scripts/fix-inference-dns-macos.sh [gateway-name]
+
+set -euo pipefail
+
+GATEWAY_NAME="${1:-nemoclaw}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./lib/runtime.sh
+. "$SCRIPT_DIR/lib/runtime.sh"
+
+# Only needed on macOS
+if [ "$(uname -s)" != "Darwin" ]; then
+  exit 0
+fi
+
+# Find the openshell cluster container
+CLUSTERS="$(docker ps --filter "name=openshell-cluster" --format '{{.Names}}' 2>/dev/null || true)"
+CLUSTER="$(select_openshell_cluster_container "$GATEWAY_NAME" "$CLUSTERS" || true)"
+if [ -z "$CLUSTER" ]; then
+  echo "WARN: Could not find openshell cluster container. Skipping inference.local DNS fix."
+  exit 0
+fi
+
+# Get current CoreDNS Corefile from the configmap
+COREFILE="$(docker exec "$CLUSTER" kubectl get configmap coredns -n kube-system -o jsonpath='{.data.Corefile}' 2>/dev/null || true)"
+if [ -z "$COREFILE" ]; then
+  echo "WARN: Could not read CoreDNS Corefile. Skipping inference.local DNS fix."
+  exit 0
+fi
+
+# Check if inference.local is already configured
+if echo "$COREFILE" | grep -q 'inference\.local'; then
+  echo "inference.local already in CoreDNS config."
+  exit 0
+fi
+
+# Determine target IP for inference.local.
+# Try Traefik service ClusterIP first (k3s default ingress controller that
+# handles inference routing), then fall back to the k3s node internal IP.
+TARGET_IP="$(docker exec "$CLUSTER" kubectl get svc traefik -n kube-system -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+if [ -z "$TARGET_IP" ]; then
+  TARGET_IP="$(docker exec "$CLUSTER" kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null || true)"
+fi
+if [ -z "$TARGET_IP" ]; then
+  echo "WARN: Could not determine target IP for inference.local. DNS fix skipped."
+  exit 0
+fi
+
+echo "Patching CoreDNS: inference.local -> $TARGET_IP"
+
+# Inject inference.local into the hosts block of the Corefile as an inline
+# entry. CoreDNS processes inline entries alongside the hosts file.
+export TARGET_IP
+PATCHED_COREFILE="$(python3 -c "
+import sys, os
+corefile = sys.stdin.read()
+target_ip = os.environ['TARGET_IP']
+marker = 'hosts /etc/coredns/NodeHosts {'
+if marker in corefile:
+    corefile = corefile.replace(
+        marker,
+        marker + '\n      ' + target_ip + ' inference.local'
+    )
+else:
+    # No NodeHosts block found — inject a standalone hosts block before
+    # the forward directive so inference.local still resolves.
+    inject = '    hosts {\n      ' + target_ip + ' inference.local\n      fallthrough\n    }\n'
+    if 'forward .' in corefile:
+        corefile = corefile.replace('    forward .', inject + '    forward .')
+    else:
+        # Last resort: append before closing brace
+        corefile = corefile.rstrip().rstrip('}') + inject + '}\n'
+print(corefile, end='')
+" <<< "$COREFILE")"
+
+# Build JSON patch with proper escaping
+PATCH_JSON="$(python3 -c "
+import json, sys
+corefile = sys.stdin.read()
+print(json.dumps({'data': {'Corefile': corefile}}))
+" <<< "$PATCHED_COREFILE")"
+
+docker exec "$CLUSTER" kubectl patch configmap coredns -n kube-system --type merge -p "$PATCH_JSON" > /dev/null
+
+# Restart CoreDNS to pick up the change immediately (otherwise reload is 15s)
+docker exec "$CLUSTER" kubectl rollout restart deploy/coredns -n kube-system > /dev/null 2>&1 || true
+docker exec "$CLUSTER" kubectl rollout status deploy/coredns -n kube-system --timeout=30s > /dev/null 2>&1 || true
+
+echo "Done: inference.local -> $TARGET_IP"

--- a/scripts/fix-inference-dns-macos.sh
+++ b/scripts/fix-inference-dns-macos.sh
@@ -63,6 +63,12 @@ if [ -z "$TARGET_IP" ]; then
   exit 0
 fi
 
+# Basic IP format validation — reject unexpected kubectl output
+if ! echo "$TARGET_IP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "WARN: Invalid IP format '$TARGET_IP'. DNS fix skipped."
+  exit 0
+fi
+
 echo "Patching CoreDNS: inference.local -> $TARGET_IP"
 
 # Inject inference.local into the hosts block of the Corefile as an inline


### PR DESCRIPTION
## Summary

On macOS (Docker Desktop and Colima), `inference.local` is never injected into the k3s CoreDNS configuration by the OpenShell gateway. This means sandbox pods cannot resolve the inference proxy endpoint at `https://inference.local/v1`, which breaks **all local inference** (Ollama, vLLM) on Apple Silicon machines.

This PR adds a lightweight DNS fix that runs automatically during `nemoclaw onboard` on macOS, making local Ollama inference work out of the box — no manual workarounds needed.

## Related Issue

Fixes #260 — *macOS/Apple Silicon Support Tracking — Known Gaps & Fixes*
Also addresses the DNS resolution aspect of #314.

## Changes

- **New file: `scripts/fix-inference-dns-macos.sh`** — Patches the CoreDNS Corefile configmap to add an inline hosts entry mapping `inference.local` → Traefik ingress ClusterIP (with node IP fallback). The script is idempotent and skips patching if `inference.local` is already present.
- **Modified: `bin/lib/onboard.js`** — Calls the DNS fix script during gateway setup (step 2) on Darwin, after the existing Colima CoreDNS fix and before sandbox creation.

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npm test` passes (167/167 tests, 0 failures).
- [x] Verified end-to-end on macOS 15.4 (Apple M4 Max, Docker Desktop 4.x):
  - `nemoclaw onboard` with `NEMOCLAW_PROVIDER=ollama` completes successfully
  - CoreDNS patched: `inference.local → 172.18.0.2` (Traefik ClusterIP)
  - Sandbox resolves `inference.local` and processes inference requests via local Ollama
- [x] Script is idempotent — re-running onboard does not duplicate the DNS entry.
- [x] Script is a no-op on Linux (`uname -s != Darwin` → exits cleanly).

### Reproduction steps (before this fix)

```bash
# On macOS with Ollama running:
NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_PROVIDER=ollama nemoclaw onboard
# Sandbox created, but inference requests fail:
# "inference.local" does not resolve inside the sandbox pod
```

### After this fix

```bash
# Same command now works:
NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_PROVIDER=ollama nemoclaw onboard
# Output includes: "Patching CoreDNS: inference.local -> 172.18.0.2"
# Sandbox successfully routes inference through local Ollama
```

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).

### Code Changes
- [x] No secrets, API keys, or credentials committed.
- [x] Tests added or updated for new or changed behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS-only DNS patch added during gateway startup to ensure inference.local resolves inside local cluster sandboxes.
  * Includes a helper script that attempts to inject a hosts mapping and reload DNS inside the local cluster; the step is best-effort and won’t block startup on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->