### PR TITLE
docs: add reconnect/restart steps after reboot to troubleshooting guide

### DIFF
--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -143,6 +143,51 @@ $ colima status
 
 ## Runtime
 
+### Reconnecting after a reboot
+
+After a machine reboot, the Docker daemon, OpenShell gateway, and sandbox containers stop.
+Follow these steps to restore your previous NemoClaw session.
+
+1. Verify that Docker is running:
+```console
+   $ sudo systemctl start docker
+```
+
+   On macOS with Docker Desktop, open the Docker Desktop application and wait for it to finish starting.
+
+2. Check the sandbox state from the host:
+```console
+   $ openshell sandbox list
+```
+
+   This shows whether your sandbox still exists but is stopped, or has been removed entirely.
+
+3. Check NemoClaw status:
+```console
+   $ nemoclaw status
+```
+
+   This lists registered sandboxes and the state of auxiliary services.
+
+4. If the sandbox is listed but stopped, reconnect:
+```console
+   $ nemoclaw <name> connect
+```
+
+   Replace `<name>` with your sandbox name, for example `my-assistant`.
+
+5. If the sandbox no longer exists, re-run the onboard wizard to recreate it:
+```console
+   $ nemoclaw onboard
+```
+
+   The wizard recreates the sandbox from the same blueprint and policy definitions.
+
+6. If you were running auxiliary services (Telegram bridge, tunnel), restart them:
+```console
+   $ nemoclaw start
+```
+
 ### Sandbox shows as stopped
 
 The sandbox may have been stopped or deleted.


### PR DESCRIPTION
Adds a "Reconnecting after a reboot" section to the troubleshooting guide with step-by-step instructions for restoring a NemoClaw session after a machine restart.

Fixes #469

## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Adds a "Reconnecting after a reboot" section to the troubleshooting guide with step-by-step instructions for restoring a NemoClaw session after a machine restart. Also clarifies the existing "Sandbox shows as stopped" entry to distinguish reboot scenarios from other causes.

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

Fixes #469

## Changes
<!-- Bullet list of key changes. -->

- Added "Reconnecting after a reboot" section to `docs/reference/troubleshooting.md`
- Steps cover verifying Docker, checking sandbox state with `openshell sandbox list` and `nemoclaw status`, reconnecting with `nemoclaw <name> connect`, re-running onboard if needed, and restarting auxiliary services
- Updated "Sandbox shows as stopped" to clarify non-reboot scenarios

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `make check` passes.
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

Note: These steps are based on the existing CLI reference and README documentation. I have not tested the full reboot flow end-to-end on a live NemoClaw installation. Would appreciate a maintainer verifying the exact reconnect behavior before merging.

## Checklist
### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [x] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] `make format` applied (TypeScript and Python).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [x] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting guide with step-by-step recovery instructions for reconnecting after a reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->