### PR TITLE
docs: document workspace file persistence and backup/restore guidance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,16 @@ Egress control, operator approval flow, and policy configuration.
 {bdg-secondary}`Reference`
 :::
 
+:::{grid-item-card} Workspace Files
+:link: workspace/workspace-files
+:link-type: doc
+
+Understand SOUL.md, USER.md, and other workspace files, plus backup and restore.
+
++++
+{bdg-secondary}`Concept`
+:::
+
 :::{grid-item-card} How-To Guides
 :link: inference/switch-inference-providers
 :link-type: doc
@@ -219,6 +229,14 @@ Customize the Network Policy <network-policy/customize-network-policy>
 
 Deploy to a Remote GPU Instance <deployment/deploy-to-remote-gpu>
 Set Up the Telegram Bridge <deployment/set-up-telegram-bridge>
+```
+
+```{toctree}
+:caption: Workspace
+:hidden:
+
+Workspace Files <workspace/workspace-files>
+Backup & Restore <workspace/backup-restore>
 ```
 
 ```{toctree}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -174,11 +174,11 @@ $ nemoclaw my-assistant logs [--follow]
 Stop the NIM container and delete the sandbox.
 This removes the sandbox from the registry.
 
-```{warning}
+:::{warning}
 This command permanently deletes the sandbox **and its persistent volume**.
 All [workspace files](../workspace/workspace-files.md) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
 Back up your workspace first — see [Backup and Restore](../workspace/backup-restore.md).
-```
+:::
 
 ```console
 $ nemoclaw my-assistant destroy

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -174,6 +174,12 @@ $ nemoclaw my-assistant logs [--follow]
 Stop the NIM container and delete the sandbox.
 This removes the sandbox from the registry.
 
+```{warning}
+This command permanently deletes the sandbox **and its persistent volume**.
+All [workspace files](../workspace/workspace-files.md) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
+Back up your workspace first — see [Backup and Restore](../workspace/backup-restore.md).
+```
+
 ```console
 $ nemoclaw my-assistant destroy
 ```

--- a/docs/workspace/backup-restore.md
+++ b/docs/workspace/backup-restore.md
@@ -73,7 +73,7 @@ The repository includes a convenience script at `scripts/backup-workspace.sh`.
 ```console
 $ ./scripts/backup-workspace.sh backup my-assistant
 Backing up workspace from sandbox 'my-assistant'...
-Backup saved to /home/user/.nemoclaw/backups/20260320-120000/
+Backup saved to /home/user/.nemoclaw/backups/20260320-120000/ (6 items)
 ```
 
 ### Restore

--- a/docs/workspace/backup-restore.md
+++ b/docs/workspace/backup-restore.md
@@ -1,0 +1,110 @@
+---
+title:
+  page: "Backup and Restore Workspace Files"
+  nav: "Backup & Restore"
+description: "How to back up and restore OpenClaw workspace files before destructive operations."
+keywords: ["nemoclaw backup", "nemoclaw restore", "workspace backup", "openshell sandbox download upload"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "sandboxing", "workspace", "backup"]
+content:
+  type: how_to
+  difficulty: technical_beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Backup and Restore Workspace Files
+
+Workspace files define your agent's personality, memory, and user context.
+They persist across sandbox restarts but are **permanently deleted** when you run `nemoclaw <name> destroy`.
+
+This guide covers manual backup with CLI commands and an automated script.
+
+## When to Back Up
+
+- **Before running `nemoclaw <name> destroy`**
+- Before major NemoClaw version upgrades
+- Periodically, if you've invested time customizing your agent
+
+## Manual Backup
+
+Use `openshell sandbox download` to copy files from the sandbox to your host.
+
+```console
+$ SANDBOX=my-assistant
+$ BACKUP_DIR=~/.nemoclaw/backups/$(date +%Y%m%d-%H%M%S)
+$ mkdir -p "$BACKUP_DIR"
+
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/SOUL.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/USER.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/IDENTITY.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/AGENTS.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/MEMORY.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/memory/ "$BACKUP_DIR/memory/"
+```
+
+## Manual Restore
+
+Use `openshell sandbox upload` to push files back into a sandbox.
+
+```console
+$ SANDBOX=my-assistant
+$ BACKUP_DIR=~/.nemoclaw/backups/20260320-120000  # pick a timestamp
+
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/SOUL.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/USER.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/IDENTITY.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/AGENTS.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/MEMORY.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/memory/" /sandbox/.openclaw/workspace/memory/
+```
+
+## Using the Backup Script
+
+The repository includes a convenience script at `scripts/backup-workspace.sh`.
+
+### Backup
+
+```console
+$ ./scripts/backup-workspace.sh backup my-assistant
+Backing up workspace from sandbox 'my-assistant'...
+Backup saved to /home/user/.nemoclaw/backups/20260320-120000/
+```
+
+### Restore
+
+Restore from the most recent backup:
+
+```console
+$ ./scripts/backup-workspace.sh restore my-assistant
+```
+
+Restore from a specific timestamp:
+
+```console
+$ ./scripts/backup-workspace.sh restore my-assistant 20260320-120000
+```
+
+## Verifying a Backup
+
+List backed-up files to confirm completeness:
+
+```console
+$ ls -la ~/.nemoclaw/backups/20260320-120000/
+AGENTS.md
+IDENTITY.md
+MEMORY.md
+SOUL.md
+USER.md
+memory/
+```
+
+## Next Steps
+
+- [Workspace Files overview](workspace-files.md) — learn what each file does
+- [Commands reference](../reference/commands.md)

--- a/docs/workspace/workspace-files.md
+++ b/docs/workspace/workspace-files.md
@@ -1,6 +1,6 @@
 ---
 title:
-  page: "Workspace Files — SOUL.md, USER.md, IDENTITY.md, and AGENTS.md"
+  page: "Workspace Files"
   nav: "Workspace Files"
 description: "What workspace personality and configuration files are, where they live, and how they persist across sandbox restarts."
 keywords: ["nemoclaw workspace files", "soul.md", "user.md", "identity.md", "agents.md", "sandbox persistence"]
@@ -38,7 +38,7 @@ These files live at `/sandbox/.openclaw/workspace/` and are collectively called 
 
 All workspace files reside inside the sandbox filesystem:
 
-```
+```text
 /sandbox/.openclaw/workspace/
 ├── AGENTS.md
 ├── IDENTITY.md
@@ -59,15 +59,15 @@ Understanding when these files persist and when they are lost is critical.
 Sandbox restarts (`nemoclaw <name> restart` or `openshell sandbox restart`) preserve workspace files.
 The sandbox uses a **Persistent Volume Claim (PVC)** that outlives individual container restarts.
 
-### Lost: Gateway Destroy
+### Lost: Sandbox Destroy
 
 Running `nemoclaw <name> destroy` **deletes the sandbox and its PVC**.
 All workspace files are permanently lost unless you back them up first.
 
-```{warning}
+:::{warning}
 Always back up your workspace files before running `nemoclaw <name> destroy`.
 See [Backup and Restore](backup-restore.md) for instructions.
-```
+:::
 
 ## Editing Workspace Files
 

--- a/docs/workspace/workspace-files.md
+++ b/docs/workspace/workspace-files.md
@@ -1,0 +1,83 @@
+---
+title:
+  page: "Workspace Files — SOUL.md, USER.md, IDENTITY.md, and AGENTS.md"
+  nav: "Workspace Files"
+description: "What workspace personality and configuration files are, where they live, and how they persist across sandbox restarts."
+keywords: ["nemoclaw workspace files", "soul.md", "user.md", "identity.md", "agents.md", "sandbox persistence"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "sandboxing", "workspace", "persistence"]
+content:
+  type: concept
+  difficulty: technical_beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Workspace Files
+
+OpenClaw stores its personality, user context, and behavioral configuration in a set of Markdown files inside the sandbox.
+These files live at `/sandbox/.openclaw/workspace/` and are collectively called **workspace files**.
+
+## File Reference
+
+| File | Purpose |
+|---|---|
+| `SOUL.md` | Defines the agent's persona, tone, and communication style. |
+| `USER.md` | Stores information about the human the agent assists. |
+| `IDENTITY.md` | Short identity card — name, language, emoji, creature type. |
+| `AGENTS.md` | Behavioral rules, memory conventions, safety guidelines, and session workflow. |
+| `MEMORY.md` | Curated long-term memory distilled from daily notes. |
+| `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. |
+
+## Where They Live
+
+All workspace files reside inside the sandbox filesystem:
+
+```
+/sandbox/.openclaw/workspace/
+├── AGENTS.md
+├── IDENTITY.md
+├── MEMORY.md
+├── SOUL.md
+├── USER.md
+└── memory/
+    ├── 2026-03-18.md
+    └── 2026-03-19.md
+```
+
+## Persistence Behavior
+
+Understanding when these files persist and when they are lost is critical.
+
+### Survives: Sandbox Restart
+
+Sandbox restarts (`nemoclaw <name> restart` or `openshell sandbox restart`) preserve workspace files.
+The sandbox uses a **Persistent Volume Claim (PVC)** that outlives individual container restarts.
+
+### Lost: Gateway Destroy
+
+Running `nemoclaw <name> destroy` **deletes the sandbox and its PVC**.
+All workspace files are permanently lost unless you back them up first.
+
+```{warning}
+Always back up your workspace files before running `nemoclaw <name> destroy`.
+See [Backup and Restore](backup-restore.md) for instructions.
+```
+
+## Editing Workspace Files
+
+The agent reads these files at the start of every session.
+You can edit them in two ways:
+
+1. **Let the agent do it** — Ask your agent to update its persona, memory, or user context.
+2. **Edit manually** — Use `openshell sandbox shell` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
+
+## Next Steps
+
+- [Backup and Restore workspace files](backup-restore.md)
+- [Commands reference](../reference/commands.md)

--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -37,6 +37,7 @@ do_backup() {
     ts="$(date +%Y%m%d-%H%M%S)"
     local dest="${BACKUP_BASE}/${ts}"
 
+    mkdir -p -m 0700 "$BACKUP_BASE"
     mkdir -p "$dest"
     echo "Backing up workspace from sandbox '${sandbox}'..."
 
@@ -58,7 +59,7 @@ do_backup() {
     done
 
     if [ "$count" -eq 0 ]; then
-        rmdir "$dest" 2>/dev/null || true
+        rm -rf "$dest" 2>/dev/null || true
         die "No files were backed up. Check that the sandbox '${sandbox}' exists and has workspace files."
     fi
 
@@ -84,17 +85,27 @@ do_restore() {
     local count=0
     for f in "${FILES[@]}"; do
         if [ -f "${src}/${f}" ]; then
-            openshell sandbox upload "$sandbox" "${src}/${f}" "${WORKSPACE_PATH}/"
-            count=$((count + 1))
+            if openshell sandbox upload "$sandbox" "${src}/${f}" "${WORKSPACE_PATH}/" 2>/dev/null; then
+                count=$((count + 1))
+            else
+                echo "  Failed to restore ${f}"
+            fi
         fi
     done
 
     for d in "${DIRS[@]}"; do
         if [ -d "${src}/${d}" ]; then
-            openshell sandbox upload "$sandbox" "${src}/${d}/" "${WORKSPACE_PATH}/${d}/"
-            count=$((count + 1))
+            if openshell sandbox upload "$sandbox" "${src}/${d}/" "${WORKSPACE_PATH}/${d}/" 2>/dev/null; then
+                count=$((count + 1))
+            else
+                echo "  Failed to restore ${d}/"
+            fi
         fi
     done
+
+    if [ "$count" -eq 0 ]; then
+        die "No files were restored. Check that the sandbox '${sandbox}' is running."
+    fi
 
     echo "Restored ${count} items to sandbox '${sandbox}'."
 }

--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -37,8 +37,10 @@ do_backup() {
     ts="$(date +%Y%m%d-%H%M%S)"
     local dest="${BACKUP_BASE}/${ts}"
 
-    mkdir -p -m 0700 "$BACKUP_BASE"
+    mkdir -p "$BACKUP_BASE"
+    chmod 0700 "${HOME}/.nemoclaw" "$BACKUP_BASE" 2>/dev/null || true
     mkdir -p "$dest"
+    chmod 0700 "$dest"
     echo "Backing up workspace from sandbox '${sandbox}'..."
 
     local count=0

--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+WORKSPACE_PATH="/sandbox/.openclaw/workspace"
+BACKUP_BASE="${HOME}/.nemoclaw/backups"
+FILES=(SOUL.md USER.md IDENTITY.md AGENTS.md MEMORY.md)
+DIRS=(memory)
+
+usage() {
+    cat <<EOF
+Usage:
+  $(basename "$0") backup  <sandbox-name>
+  $(basename "$0") restore <sandbox-name> [timestamp]
+
+Commands:
+  backup   Download workspace files from a sandbox to a timestamped local backup.
+  restore  Upload workspace files from a local backup into a sandbox.
+           If no timestamp is given, the most recent backup is used.
+
+Backup location: ${BACKUP_BASE}/<timestamp>/
+EOF
+    exit 1
+}
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' is required but not found in PATH."
+}
+
+do_backup() {
+    local sandbox="$1"
+    local ts
+    ts="$(date +%Y%m%d-%H%M%S)"
+    local dest="${BACKUP_BASE}/${ts}"
+
+    mkdir -p "$dest"
+    echo "Backing up workspace from sandbox '${sandbox}'..."
+
+    local count=0
+    for f in "${FILES[@]}"; do
+        if openshell sandbox download "$sandbox" "${WORKSPACE_PATH}/${f}" "${dest}/" 2>/dev/null; then
+            count=$((count + 1))
+        else
+            echo "  Skipped ${f} (not found or download failed)"
+        fi
+    done
+
+    for d in "${DIRS[@]}"; do
+        if openshell sandbox download "$sandbox" "${WORKSPACE_PATH}/${d}/" "${dest}/${d}/" 2>/dev/null; then
+            count=$((count + 1))
+        else
+            echo "  Skipped ${d}/ (not found or download failed)"
+        fi
+    done
+
+    if [ "$count" -eq 0 ]; then
+        rmdir "$dest" 2>/dev/null || true
+        die "No files were backed up. Check that the sandbox '${sandbox}' exists and has workspace files."
+    fi
+
+    echo "Backup saved to ${dest}/ (${count} items)"
+}
+
+do_restore() {
+    local sandbox="$1"
+    local ts="${2:-}"
+
+    if [ -z "$ts" ]; then
+        # Find the most recent backup
+        ts="$(ls -1 "$BACKUP_BASE" 2>/dev/null | sort -r | head -n1)"
+        [ -n "$ts" ] || die "No backups found in ${BACKUP_BASE}/"
+        echo "Using most recent backup: ${ts}"
+    fi
+
+    local src="${BACKUP_BASE}/${ts}"
+    [ -d "$src" ] || die "Backup directory not found: ${src}"
+
+    echo "Restoring workspace to sandbox '${sandbox}' from ${src}..."
+
+    local count=0
+    for f in "${FILES[@]}"; do
+        if [ -f "${src}/${f}" ]; then
+            openshell sandbox upload "$sandbox" "${src}/${f}" "${WORKSPACE_PATH}/"
+            count=$((count + 1))
+        fi
+    done
+
+    for d in "${DIRS[@]}"; do
+        if [ -d "${src}/${d}" ]; then
+            openshell sandbox upload "$sandbox" "${src}/${d}/" "${WORKSPACE_PATH}/${d}/"
+            count=$((count + 1))
+        fi
+    done
+
+    echo "Restored ${count} items to sandbox '${sandbox}'."
+}
+
+# --- Main ---
+
+[ $# -ge 2 ] || usage
+require_cmd openshell
+
+action="$1"
+sandbox="$2"
+shift 2
+
+case "$action" in
+    backup)  do_backup "$sandbox" ;;
+    restore) do_restore "$sandbox" "$@" ;;
+    *)       usage ;;
+esac


### PR DESCRIPTION
## Summary

Addresses #434 — documents the persistence behavior of workspace files (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md) and provides backup/restore guidance.

## Changes

- **`docs/workspace/workspace-files.md`** — New page explaining what workspace files are, where they live (`/sandbox/.openclaw/workspace/`), that they survive sandbox restarts (PVC) but are lost on `gateway destroy`.
- **`docs/workspace/backup-restore.md`** — How-to guide for manual backup/restore with `openshell sandbox download/upload` commands, plus usage of the convenience script.
- **`scripts/backup-workspace.sh`** — Bash script for automated backup and restore of workspace files. Supports `backup <sandbox>` and `restore <sandbox> [timestamp]`.
- **`docs/reference/commands.md`** — Added warning to `nemoclaw <name> destroy` about permanent workspace data loss.
- **`docs/index.md`** — Added Workspace section to navigation and Explore grid.

Closes #434

---
AI-assisted: Built with Claude, reviewed by human.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Workspace Files" overview describing file types, lifecycle, and editing workflows
  * Added a "Backup & Restore" guide with when/how to back up and verify workspace data
  * Clarified a warning that destroying a sandbox permanently deletes workspace data
  * Added a "Workspace Files" card to the homepage Explore grid and workspace navigation links

* **New Features**
  * Added a CLI backup-and-restore utility to save timestamped workspace backups and restore them to sandboxes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->