### PR TITLE
feat: add Token Overdrive local inference provider (llama.cpp DMR router)

### DIFF
--- a/bin/lib/inference-config.js
+++ b/bin/lib/inference-config.js
@@ -14,7 +14,7 @@ const CLOUD_MODEL_OPTIONS = [
 const DEFAULT_ROUTE_PROFILE = "inference-local";
 const DEFAULT_ROUTE_CREDENTIAL_ENV = "OPENAI_API_KEY";
 const MANAGED_PROVIDER_ID = "inference";
-const { DEFAULT_OLLAMA_MODEL } = require("./local-inference");
+const { DEFAULT_OLLAMA_MODEL, DEFAULT_YAMA_MODEL } = require("./local-inference");
 
 function getProviderSelectionConfig(provider, model) {
   switch (provider) {
@@ -51,14 +51,28 @@ function getProviderSelectionConfig(provider, model) {
         provider,
         providerLabel: "Local Ollama",
       };
+    case "token-overdrive":
+      return {
+        endpointType: "custom",
+        endpointUrl: INFERENCE_ROUTE_URL,
+        ncpPartner: null,
+        model: model || DEFAULT_YAMA_MODEL,
+        profile: DEFAULT_ROUTE_PROFILE,
+        credentialEnv: DEFAULT_ROUTE_CREDENTIAL_ENV,
+        provider,
+        providerLabel: "Token Overdrive (llama.cpp DMR)",
+      };
     default:
       return null;
   }
 }
 
 function getOpenClawPrimaryModel(provider, model) {
-  const resolvedModel =
-    model || (provider === "ollama-local" ? DEFAULT_OLLAMA_MODEL : DEFAULT_CLOUD_MODEL);
+  const localDefault =
+    provider === "ollama-local" ? DEFAULT_OLLAMA_MODEL :
+    provider === "token-overdrive" ? DEFAULT_YAMA_MODEL :
+    DEFAULT_CLOUD_MODEL;
+  const resolvedModel = model || localDefault;
   return resolvedModel ? `${MANAGED_PROVIDER_ID}/${resolvedModel}` : null;
 }
 
@@ -66,6 +80,7 @@ module.exports = {
   CLOUD_MODEL_OPTIONS,
   DEFAULT_CLOUD_MODEL,
   DEFAULT_OLLAMA_MODEL,
+  DEFAULT_YAMA_MODEL,
   DEFAULT_ROUTE_CREDENTIAL_ENV,
   DEFAULT_ROUTE_PROFILE,
   INFERENCE_ROUTE_URL,

--- a/bin/lib/local-inference.js
+++ b/bin/lib/local-inference.js
@@ -5,12 +5,18 @@ const HOST_GATEWAY_URL = "http://host.openshell.internal";
 const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
 const DEFAULT_OLLAMA_MODEL = "nemotron-3-nano:30b";
 
+// token-overdrive: llama.cpp DMR router (OpenAI-compatible, port 8101, Metal-accelerated)
+const YAMA_PORT = 8101;
+const DEFAULT_YAMA_MODEL = "qwen35-35b-a3b"; // 60 tps on Apple Silicon
+
 function getLocalProviderBaseUrl(provider) {
   switch (provider) {
     case "vllm-local":
       return `${HOST_GATEWAY_URL}:8000/v1`;
     case "ollama-local":
       return `${HOST_GATEWAY_URL}:11434/v1`;
+    case "token-overdrive":
+      return `${HOST_GATEWAY_URL}:${YAMA_PORT}/v1`;
     default:
       return null;
   }
@@ -22,6 +28,8 @@ function getLocalProviderHealthCheck(provider) {
       return "curl -sf http://localhost:8000/v1/models 2>/dev/null";
     case "ollama-local":
       return "curl -sf http://localhost:11434/api/tags 2>/dev/null";
+    case "token-overdrive":
+      return `curl -sf http://localhost:${YAMA_PORT}/v1/models 2>/dev/null`;
     default:
       return null;
   }
@@ -33,6 +41,8 @@ function getLocalProviderContainerReachabilityCheck(provider) {
       return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`;
     case "ollama-local":
       return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`;
+    case "token-overdrive":
+      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:${YAMA_PORT}/v1/models 2>/dev/null`;
     default:
       return null;
   }
@@ -56,6 +66,11 @@ function validateLocalProvider(provider, runCapture) {
         return {
           ok: false,
           message: "Local Ollama was selected, but nothing is responding on http://localhost:11434.",
+        };
+      case "token-overdrive":
+        return {
+          ok: false,
+          message: `Local yama (llama.cpp DMR router) was selected, but nothing is responding on http://localhost:${YAMA_PORT}. Start the router with: python3 scripts/run_dmr_router_workflow.py --model <model-id>`,
         };
       default:
         return { ok: false, message: "The selected local inference provider is unavailable." };
@@ -85,9 +100,61 @@ function validateLocalProvider(provider, runCapture) {
         message:
           "Local Ollama is responding on localhost, but containers cannot reach http://host.openshell.internal:11434. Ensure Ollama listens on 0.0.0.0:11434 instead of 127.0.0.1 so sandboxes can reach it.",
       };
+    case "token-overdrive":
+      return {
+        ok: false,
+        message:
+          `Local yama router is responding on localhost, but containers cannot reach http://host.openshell.internal:${YAMA_PORT}. Ensure llama-server binds to 0.0.0.0:${YAMA_PORT} (add --host 0.0.0.0 to the router preset).`,
+      };
     default:
       return { ok: false, message: "The selected local inference provider is unavailable from containers." };
   }
+}
+
+function getYamaModelOptions(runCapture) {
+  const output = runCapture(`curl -sf http://localhost:${YAMA_PORT}/v1/models 2>/dev/null`, { ignoreError: true });
+  if (!output) return [DEFAULT_YAMA_MODEL];
+  try {
+    const parsed = JSON.parse(output);
+    const ids = (parsed.data || []).map((m) => m.id).filter(Boolean);
+    return ids.length > 0 ? ids : [DEFAULT_YAMA_MODEL];
+  } catch {
+    return [DEFAULT_YAMA_MODEL];
+  }
+}
+
+function getDefaultYamaModel(runCapture) {
+  const models = getYamaModelOptions(runCapture);
+  return models.includes(DEFAULT_YAMA_MODEL) ? DEFAULT_YAMA_MODEL : models[0];
+}
+
+function getYamaProbeCommand(model, timeoutSeconds = 30) {
+  const payload = JSON.stringify({
+    model,
+    messages: [{ role: "user", content: "hello" }],
+    max_tokens: 8,
+    stream: false,
+  });
+  return `curl -sS --max-time ${timeoutSeconds} http://localhost:${YAMA_PORT}/v1/chat/completions -H 'Content-Type: application/json' -d '${payload.replace(/'/g, "'\\''")}' 2>/dev/null`;
+}
+
+function validateYamaModel(model, runCapture) {
+  const output = runCapture(getYamaProbeCommand(model), { ignoreError: true });
+  if (!output) {
+    return {
+      ok: false,
+      message:
+        `yama model '${model}' did not answer the probe. The DMR router may need to load it first. ` +
+        `Run: python3 scripts/run_dmr_router_workflow.py --model ${model}`,
+    };
+  }
+  try {
+    const parsed = JSON.parse(output);
+    if (parsed && typeof parsed.error === "string" && parsed.error.trim()) {
+      return { ok: false, message: `yama model '${model}' probe failed: ${parsed.error.trim()}` };
+    }
+  } catch {}
+  return { ok: true };
 }
 
 function parseOllamaList(output) {
@@ -165,15 +232,21 @@ function validateOllamaModel(model, runCapture) {
 module.exports = {
   CONTAINER_REACHABILITY_IMAGE,
   DEFAULT_OLLAMA_MODEL,
+  DEFAULT_YAMA_MODEL,
   HOST_GATEWAY_URL,
+  YAMA_PORT,
   getDefaultOllamaModel,
+  getDefaultYamaModel,
   getLocalProviderBaseUrl,
   getLocalProviderContainerReachabilityCheck,
   getLocalProviderHealthCheck,
   getOllamaModelOptions,
   getOllamaProbeCommand,
   getOllamaWarmupCommand,
+  getYamaModelOptions,
+  getYamaProbeCommand,
   parseOllamaList,
   validateOllamaModel,
+  validateYamaModel,
   validateLocalProvider,
 };

--- a/bin/lib/token-overdrive-models.json
+++ b/bin/lib/token-overdrive-models.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "description": "Token Overdrive local model catalog — llama.cpp DMR router, Metal-accelerated (Apple Silicon)",
+  "port": 8101,
+  "models": [
+    {
+      "id": "qwen35-35b-a3b",
+      "display_name": "Qwen3.5-35B-A3B",
+      "canonical_id": "qwen3.5-35b-a3b",
+      "provider": "docker-model-runner",
+      "observed_decode_tps": 60.19,
+      "recommended_ctx_size": 32768,
+      "recommended_for": ["general", "tool-use", "coding"],
+      "notes": "Fastest local model at 60 tps on Apple Silicon. MoE architecture runs efficiently on Metal."
+    },
+    {
+      "id": "qwen35-27b",
+      "display_name": "Qwen3.5-27B",
+      "canonical_id": "qwen3.5-27b",
+      "provider": "docker-model-runner",
+      "observed_decode_tps": 17.06,
+      "recommended_ctx_size": 32768,
+      "recommended_for": ["general", "quality", "reasoning"],
+      "notes": "Dense model, higher quality output at lower throughput."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **Token Overdrive** as a fourth local inference provider alongside `nim-local`, `ollama-local`, and `vllm-local`.

Token Overdrive is backed by a custom llama.cpp fork with a Dynamic Model Router that enables hot-swapping GGUF models without server restart. It runs Metal-accelerated on Apple Silicon and exposes a standard OpenAI-compatible API on port 8101.

- **Provider ID**: `token-overdrive`
- **Port**: `8101`
- **API**: OpenAI-compatible (`/v1/models`, `/v1/chat/completions`)
- **Default model**: `qwen35-35b-a3b` (60 tps on Apple Silicon)
- **Health check**: `GET /v1/models`
- **Model discovery**: live query of running router's `/v1/models` endpoint

## Changes

| File | What changed |
|---|---|
| `bin/lib/local-inference.js` | `token-overdrive` case in all provider switch blocks; `getYamaModelOptions`, `getDefaultYamaModel`, `getYamaProbeCommand`, `validateYamaModel` |
| `bin/lib/inference-config.js` | `token-overdrive` provider config with label "Token Overdrive (llama.cpp DMR)"; correct default model in `getOpenClawPrimaryModel` |
| `bin/lib/token-overdrive-models.json` | Local model catalog (two tuned models with observed tps) |

## Test plan

- [ ] `getLocalProviderHealthCheck("token-overdrive")` returns correct curl command for port 8101
- [ ] `validateLocalProvider("token-overdrive", ...)` returns descriptive error when router not running
- [ ] `getYamaModelOptions` returns `["qwen35-35b-a3b"]` fallback when router unreachable
- [ ] `getProviderSelectionConfig("token-overdrive")` returns correct `providerLabel`
- [ ] `getOpenClawPrimaryModel("token-overdrive", null)` resolves to `inference/qwen35-35b-a3b`
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Token Overdrive as a new local inference provider option
  * Added Qwen3.5-35B-A3B and Qwen3.5-27B model support for local inference
  * Enhanced model discovery and validation capabilities for local providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->