### PR TITLE
fix: add --ignore-scripts to npm install to unblock installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -219,14 +219,68 @@ install_or_upgrade_ollama() {
 # ---------------------------------------------------------------------------
 # 3. NemoClaw
 # ---------------------------------------------------------------------------
+# Work around openclaw tarball missing directory entries (GH-503).
+# npm's tar extractor hard-fails because the tarball is missing directory
+# entries for extensions/, skills/, and dist/plugin-sdk/config/. System tar
+# handles this fine. We pre-extract openclaw into node_modules BEFORE npm
+# install so npm sees the dependency is already satisfied and skips it.
+pre_extract_openclaw() {
+  local install_dir="$1"
+  local openclaw_version
+  openclaw_version=$(node -e "console.log(require('${install_dir}/package.json').dependencies.openclaw)" 2>/dev/null || echo "")
+
+  if [[ -z "$openclaw_version" ]]; then
+    warn "Could not determine openclaw version — skipping pre-extraction"
+    return 1
+  fi
+
+  info "Pre-extracting openclaw@${openclaw_version} with system tar (GH-503 workaround)…"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  if npm pack "openclaw@${openclaw_version}" --pack-destination "$tmpdir" > /dev/null 2>&1; then
+    local tgz
+    tgz="$(find "$tmpdir" -maxdepth 1 -name 'openclaw-*.tgz' -print -quit)"
+    if [[ -n "$tgz" && -f "$tgz" ]]; then
+      if mkdir -p "${install_dir}/node_modules/openclaw" \
+        && tar xzf "$tgz" -C "${install_dir}/node_modules/openclaw" --strip-components=1
+      then
+        info "openclaw pre-extracted successfully"
+      else
+        warn "Failed to extract openclaw tarball"
+        rm -rf "$tmpdir"
+        return 1
+      fi
+    else
+      warn "npm pack succeeded but tarball not found"
+      rm -rf "$tmpdir"
+      return 1
+    fi
+  else
+    warn "Failed to download openclaw tarball"
+    rm -rf "$tmpdir"
+    return 1
+  fi
+  rm -rf "$tmpdir"
+}
+
 install_nemoclaw() {
   if [[ -f "./package.json" ]] && grep -q '"name": "nemoclaw"' ./package.json 2>/dev/null; then
     info "NemoClaw package.json found in current directory — installing from source…"
-    npm install && npm link
+    pre_extract_openclaw "$(pwd)" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+    npm install --ignore-scripts
+    (cd nemoclaw && npm install --ignore-scripts && npm run build)
+    npm link
   else
     info "Installing NemoClaw from GitHub…"
-    # Revert once https://github.com/NVIDIA/NemoClaw/issues/71 is complete and the package is published
-    npm install -g git+https://github.com/NVIDIA/NemoClaw.git
+    # Clone first so we can pre-extract openclaw before npm install (GH-503).
+    # npm install -g git+https://... does this internally but we can't hook
+    # into its extraction pipeline, so we do it ourselves.
+    local nemoclaw_src="${HOME}/.nemoclaw/source"
+    rm -rf "$nemoclaw_src"
+    mkdir -p "$(dirname "$nemoclaw_src")"
+    git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$nemoclaw_src"
+    pre_extract_openclaw "$nemoclaw_src" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+    (cd "$nemoclaw_src" && npm install --ignore-scripts && cd nemoclaw && npm install --ignore-scripts && npm run build && cd .. && npm link)
   fi
 
   refresh_path

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -359,14 +359,68 @@ install_openshell() {
 
 install_openshell
 
+# ── Pre-extract openclaw workaround (GH-503) ────────────────────
+# The openclaw npm tarball is missing directory entries for extensions/,
+# skills/, and dist/plugin-sdk/config/. npm's tar extractor hard-fails on
+# these but system tar handles them fine. We pre-extract openclaw into
+# node_modules BEFORE npm install so npm sees the dep is already satisfied.
+pre_extract_openclaw() {
+  local install_dir="$1"
+  local openclaw_version
+  openclaw_version=$(node -e "console.log(require('${install_dir}/package.json').dependencies.openclaw)" 2>/dev/null) || openclaw_version=""
+
+  if [ -z "$openclaw_version" ]; then
+    warn "Could not determine openclaw version — skipping pre-extraction"
+    return 1
+  fi
+
+  info "Pre-extracting openclaw@${openclaw_version} with system tar (GH-503 workaround)…"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  if npm pack "openclaw@${openclaw_version}" --pack-destination "$tmpdir" > /dev/null 2>&1; then
+    local tgz
+    tgz="$(find "$tmpdir" -maxdepth 1 -name 'openclaw-*.tgz' -print -quit)"
+    if [ -n "$tgz" ] && [ -f "$tgz" ]; then
+      if mkdir -p "${install_dir}/node_modules/openclaw" \
+        && tar xzf "$tgz" -C "${install_dir}/node_modules/openclaw" --strip-components=1
+      then
+        info "openclaw pre-extracted successfully"
+      else
+        warn "Failed to extract openclaw tarball"
+        rm -rf "$tmpdir"
+        return 1
+      fi
+    else
+      warn "npm pack succeeded but tarball not found"
+      rm -rf "$tmpdir"
+      return 1
+    fi
+  else
+    warn "Failed to download openclaw tarball"
+    rm -rf "$tmpdir"
+    return 1
+  fi
+  rm -rf "$tmpdir"
+}
+
 # ── Install NemoClaw CLI ─────────────────────────────────────────
 
 info "Installing nemoclaw CLI..."
-if [ "$NODE_MGR" = "nodesource" ]; then
-  sudo npm install -g git+https://github.com/NVIDIA/NemoClaw.git
-else
-  npm install -g git+https://github.com/NVIDIA/NemoClaw.git
+# Clone first so we can pre-extract openclaw before npm install (GH-503).
+# npm install -g git+https://... does this internally but we can't hook
+# into its extraction pipeline, so we do it ourselves.
+NEMOCLAW_SRC="${HOME}/.nemoclaw/source"
+rm -rf "$NEMOCLAW_SRC"
+mkdir -p "$(dirname "$NEMOCLAW_SRC")"
+git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$NEMOCLAW_SRC"
+pre_extract_openclaw "$NEMOCLAW_SRC" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+# Use sudo for npm link when the global prefix requires it (e.g., nodesource),
+# but skip sudo if already root (e.g., Docker containers).
+SUDO=""
+if [ "$NODE_MGR" = "nodesource" ] && [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
 fi
+(cd "$NEMOCLAW_SRC" && npm install --ignore-scripts && cd nemoclaw && npm install --ignore-scripts && npm run build && cd .. && $SUDO npm link)
 
 if [ "$NEED_RESHIM" = true ]; then
   info "Reshimming asdf..."

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -69,7 +69,7 @@ exit 98
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-fallback-"));
     const fakeBin = path.join(tmp, "bin");
     const prefix = path.join(tmp, "prefix");
-    const npmLog = path.join(tmp, "npm.log");
+    const gitLog = path.join(tmp, "git.log");
     fs.mkdirSync(fakeBin);
     fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
 
@@ -80,8 +80,26 @@ if [ "$1" = "--version" ]; then
   echo "v22.14.0"
   exit 0
 fi
+if [ "$1" = "-e" ]; then
+  exit 1
+fi
 echo "unexpected node invocation: $*" >&2
 exit 99
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "git"),
+      `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GIT_LOG_PATH"
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0
 `,
     );
 
@@ -89,7 +107,6 @@ exit 99
       path.join(fakeBin, "npm"),
       `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$*" >> "$NPM_LOG_PATH"
 if [ "$1" = "--version" ]; then
   echo "10.9.2"
   exit 0
@@ -98,7 +115,16 @@ if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
   echo "$NPM_PREFIX"
   exit 0
 fi
-if [ "$1" = "install" ] && [ "$2" = "-g" ] && [ "$3" = "${GITHUB_INSTALL_URL}" ]; then
+if [ "$1" = "pack" ]; then
+  exit 1
+fi
+if [ "$1" = "install" ] && [[ "$*" == *"--ignore-scripts"* ]]; then
+  exit 0
+fi
+if [ "$1" = "run" ]; then
+  exit 0
+fi
+if [ "$1" = "link" ]; then
   cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
 #!/usr/bin/env bash
 if [ "$1" = "onboard" ]; then
@@ -127,12 +153,12 @@ exit 98
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
         NPM_PREFIX: prefix,
-        NPM_LOG_PATH: npmLog,
+        GIT_LOG_PATH: gitLog,
       },
     });
 
     assert.equal(result.status, 0);
-    assert.match(fs.readFileSync(npmLog, "utf-8"), new RegExp(`install -g ${GITHUB_INSTALL_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+    assert.match(fs.readFileSync(gitLog, "utf-8"), /clone.*NemoClaw\.git/);
   });
 
   it("prints the HTTPS GitHub remediation when the binary is missing", () => {
@@ -149,8 +175,25 @@ if [ "$1" = "--version" ]; then
   echo "v22.14.0"
   exit 0
 fi
+if [ "$1" = "-e" ]; then
+  exit 1
+fi
 echo "unexpected node invocation: $*" >&2
 exit 99
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "git"),
+      `#!/usr/bin/env bash
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0
 `,
     );
 
@@ -166,7 +209,16 @@ if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
   echo "$NPM_PREFIX"
   exit 0
 fi
-if [ "$1" = "install" ] && [ "$2" = "-g" ] && [ "$3" = "${GITHUB_INSTALL_URL}" ]; then
+if [ "$1" = "pack" ]; then
+  exit 1
+fi
+if [ "$1" = "install" ] && [[ "$*" == *"--ignore-scripts"* ]]; then
+  exit 0
+fi
+if [ "$1" = "run" ]; then
+  exit 0
+fi
+if [ "$1" = "link" ]; then
   exit 0
 fi
 echo "unexpected npm invocation: $*" >&2
@@ -286,7 +338,24 @@ if [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
   echo "v22.14.0"
   exit 0
 fi
+if [ "$1" = "-e" ]; then
+  exit 1
+fi
 exit 99
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "git"),
+      `#!/usr/bin/env bash
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0
 `,
     );
 
@@ -302,7 +371,16 @@ if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
   echo "$NPM_PREFIX"
   exit 0
 fi
-if [ "$1" = "install" ] && [ "$2" = "-g" ]; then
+if [ "$1" = "pack" ]; then
+  exit 1
+fi
+if [ "$1" = "install" ] && [[ "$*" == *"--ignore-scripts"* ]]; then
+  exit 0
+fi
+if [ "$1" = "run" ]; then
+  exit 0
+fi
+if [ "$1" = "link" ]; then
   cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
 #!/usr/bin/env bash
 if [ "$1" = "--version" ]; then
@@ -375,7 +453,24 @@ if [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
   echo "v22.14.0"
   exit 0
 fi
+if [ "$1" = "-e" ]; then
+  exit 1
+fi
 exit 99
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "git"),
+      `#!/usr/bin/env bash
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0
 `,
     );
 
@@ -391,7 +486,16 @@ if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
   echo "$NPM_PREFIX"
   exit 0
 fi
-if [ "$1" = "install" ] && [ "$2" = "-g" ] && [ "$3" = "${GITHUB_INSTALL_URL}" ]; then
+if [ "$1" = "pack" ]; then
+  exit 1
+fi
+if [ "$1" = "install" ] && [[ "$*" == *"--ignore-scripts"* ]]; then
+  exit 0
+fi
+if [ "$1" = "run" ]; then
+  exit 0
+fi
+if [ "$1" = "link" ]; then
   cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
 #!/usr/bin/env bash
 if [ "$1" = "onboard" ]; then


### PR DESCRIPTION
## Summary
- Pre-extract the `openclaw` dependency with system `tar` before `npm install` to bypass npm's broken tarball extraction
- Change the GitHub install path from `npm install -g git+...` to clone → pre-extract → `npm install --ignore-scripts && npm link`
- Add `--ignore-scripts` to all `npm install` calls to prevent `@whiskeysockets/baileys` postinstall crash
- Update installer test stubs for the new install flow

## Root Cause
The `openclaw` npm tarball (v2026.3.11) is missing directory entries for `extensions/`, `skills/`, and `dist/plugin-sdk/config/`. npm's tar extractor hard-fails with `ENOENT` because it doesn't create parent directories implicitly. System `tar` handles this correctly.

## Fix
Pre-extract openclaw into `node_modules/openclaw` using system `tar` **before** `npm install` runs. npm sees the dependency is already satisfied and skips the broken tarball download entirely.

For the GitHub install path, the installer now:
1. Clones the repo to `~/.nemoclaw/source`
2. Downloads the openclaw tarball via `npm pack`
3. Extracts it with system `tar` (handles missing dir entries)
4. Runs `npm install --ignore-scripts && npm link`

The pre-extraction is non-fatal — if it fails, the install continues and will succeed once the upstream tarball is fixed.

## Test plan
- [x] `npm test` passes (167/167)
- [x] Docker clean room: `node:22-bookworm` container, install from branch, `nemoclaw --help` exits 0
- [x] Post-install smoke: `nemoclaw --help` prints full usage
- [x] All `npm install` calls have `--ignore-scripts`

Fixes #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored installation flow to use local cloning and dependency linking instead of global installation
  * Added pre-extraction step for openclaw dependency to improve installation reliability and determinism
<!-- end of auto-generated comment: release notes by coderabbit.ai -->