### PR TITLE
ci: auto-create GitHub issue on nightly E2E failure

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -134,10 +134,6 @@ jobs:
           path: /tmp/nemoclaw-gpu-e2e-test.log
           if-no-files-found: ignore
 
-  # ── Failure notification ────────────────────────────────────────
-  # Creates or updates a GitHub issue when any E2E job fails.
-  # Skipped jobs (e.g. gpu-e2e when GPU_E2E_ENABLED is unset) do not
-  # trigger the notification — only actual failures do.
   notify-on-failure:
     runs-on: ubuntu-latest
     needs: [cloud-e2e, cloud-experimental-e2e, gpu-e2e]

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -8,6 +8,7 @@
 #   gpu-e2e                  Local Ollama inference on a GPU self-hosted runner.
 #                            Controlled by the GPU_E2E_ENABLED repository variable.
 #                            Set vars.GPU_E2E_ENABLED to "true" in repo settings to enable.
+#   notify-on-failure        Auto-creates a GitHub issue when any E2E job fails.
 #
 # Runs directly on the runner (not inside Docker) because OpenShell bootstraps
 # a K3s cluster inside a privileged Docker container — nesting would break networking.
@@ -132,3 +133,47 @@ jobs:
           name: gpu-e2e-test-log
           path: /tmp/nemoclaw-gpu-e2e-test.log
           if-no-files-found: ignore
+
+  # ── Failure notification ────────────────────────────────────────
+  # Creates or updates a GitHub issue when any E2E job fails.
+  # Skipped jobs (e.g. gpu-e2e when GPU_E2E_ENABLED is unset) do not
+  # trigger the notification — only actual failures do.
+  notify-on-failure:
+    runs-on: ubuntu-latest
+    needs: [cloud-e2e, cloud-experimental-e2e, gpu-e2e]
+    if: failure()
+    permissions:
+      issues: write
+    steps:
+      - name: Create or update failure issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = 'Nightly E2E failed';
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'CI/CD',
+              per_page: 100,
+            });
+            const match = existing.find(i => !i.pull_request && i.title.startsWith(title));
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again on ${new Date().toISOString().split('T')[0]}.\n\n**Run:** ${runUrl}\n**Artifacts:** Install log uploaded as \`install-log\` artifact.`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `${title} — ${new Date().toISOString().split('T')[0]}`,
+                body: `The nightly E2E pipeline failed.\n\n**Run:** ${runUrl}\n**Artifacts:** Install log uploaded as \`install-log\` artifact on the failed run.`,
+                labels: ['bug', 'CI/CD'],
+              });
+            }

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -137,7 +137,7 @@ jobs:
   notify-on-failure:
     runs-on: ubuntu-latest
     needs: [cloud-e2e, cloud-experimental-e2e, gpu-e2e]
-    if: failure()
+    if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
     permissions:
       issues: write
     steps:
@@ -162,14 +162,14 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: match.number,
-                body: `Failed again on ${new Date().toISOString().split('T')[0]}.\n\n**Run:** ${runUrl}\n**Artifacts:** Install log uploaded as \`install-log\` artifact.`,
+                body: `Failed again on ${new Date().toISOString().split('T')[0]}.\n\n**Run:** ${runUrl}\n**Artifacts:** Check the run artifacts for install/test logs (artifact names vary by job).`,
               });
             } else {
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: `${title} — ${new Date().toISOString().split('T')[0]}`,
-                body: `The nightly E2E pipeline failed.\n\n**Run:** ${runUrl}\n**Artifacts:** Install log uploaded as \`install-log\` artifact on the failed run.`,
+                body: `The nightly E2E pipeline failed.\n\n**Run:** ${runUrl}\n**Artifacts:** Check the run artifacts for install/test logs (artifact names vary by job).`,
                 labels: ['bug', 'CI/CD'],
               });
             }


### PR DESCRIPTION
## Summary

Adds automatic GitHub issue creation when the nightly E2E pipeline fails. If an open failure issue already exists, it adds a comment instead of creating a duplicate.

## Related Issue

None.

## Changes

- Add `notify-on-failure` job to `nightly-e2e.yaml`
- On failure: searches for an existing open issue with `CI/CD` label and "Nightly E2E failed" title
- If found: adds a comment with the new failure date and run link
- If not found: creates a new issue with run link and artifact reference
-`issues: write` permission scoped to only the notify job

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `make check` passes.
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)
- [x] YAML validated locally
- [x] Tested on fork by manually triggering a failing run — issue was created with correct title, labels, and run link

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).

### Code Changes

- [ ] `make format` applied (TypeScript and Python).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated notifications for nightly end-to-end failures: when the nightly run fails the system will either update an existing CI/CD issue or create a new dated bug+CI/CD issue, posting the failure timestamp, a direct link to the failed run, and a note referencing uploaded artifacts (e.g., install-log) to accelerate triage and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->