### PR TITLE
feat(blueprint): add GoldRush blockchain data network policy preset

### DIFF
--- a/nemoclaw-blueprint/policies/presets/goldrush.yaml
+++ b/nemoclaw-blueprint/policies/presets/goldrush.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: goldrush
+  description: "GoldRush blockchain data API, streaming, and x402 access"
+
+network_policies:
+  goldrush:
+    name: goldrush
+    endpoints:
+      - host: api.covalenthq.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: streaming.goldrush.dev
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: streaming.goldrushdata.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: x402.goldrush.dev
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }


### PR DESCRIPTION
## Summary

- Adds a `goldrush.yaml` network policy preset so sandboxed agents can reach GoldRush blockchain data endpoints
- Covers four hosts: REST API (`api.covalenthq.com`), Streaming API (`streaming.goldrush.dev`, `streaming.goldrushdata.com`), and x402 pay-per-request proxy (`x402.goldrush.dev`)

## Context

[GoldRush](https://goldrush.dev) provides unified blockchain data across 100+ chains (balances, transactions, NFTs, token prices, DEX data). It's available as:

- **MCP server** (`@covalenthq/goldrush-mcp-server`) — auto-discovered by OpenClaw
- **Agent skills** (`covalenthq/goldrush-agent-skills`) — installable via `npx skills add`

Without this preset, sandboxed NemoClaw agents using GoldRush tools are blocked by network policy. This preset follows the same pattern as existing presets (Discord, Slack, HuggingFace, etc.).

## Test plan

- [ ] Verify YAML validates against the policy schema
- [ ] Confirm sandboxed agent can reach `api.covalenthq.com` with the preset enabled
- [ ] Confirm sandboxed agent can establish WebSocket to `streaming.goldrush.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GoldRush blockchain data API preset configuration enabling secure TLS-encrypted streaming and data access. The preset provides HTTP operation support across multiple endpoints with x402 protocol compatibility for flexible blockchain data integration and real-time data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->