### PR TITLE
feat: add cargo, go, apt, and ghcr policy presets

### DIFF
--- a/nemoclaw-blueprint/policies/presets/apt.yaml
+++ b/nemoclaw-blueprint/policies/presets/apt.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: apt
+  description: "Debian and Ubuntu package repositories"
+
+network_policies:
+  apt_repositories:
+    name: apt_repositories
+    endpoints:
+      - host: archive.ubuntu.com
+        port: 443
+        access: full
+      - host: security.ubuntu.com
+        port: 443
+        access: full
+      - host: deb.debian.org
+        port: 443
+        access: full
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/bin/apt-get }
+      - { path: /usr/bin/apt }

--- a/nemoclaw-blueprint/policies/presets/cargo.yaml
+++ b/nemoclaw-blueprint/policies/presets/cargo.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: cargo
+  description: "Rust Cargo registry access"
+
+network_policies:
+  cargo_registry:
+    name: cargo_registry
+    endpoints:
+      - host: crates.io
+        port: 443
+        access: full
+      - host: static.crates.io
+        port: 443
+        access: full
+      - host: index.crates.io
+        port: 443
+        access: full
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/cargo/bin/cargo }

--- a/nemoclaw-blueprint/policies/presets/ghcr.yaml
+++ b/nemoclaw-blueprint/policies/presets/ghcr.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: ghcr
+  description: "GitHub Container Registry access"
+
+network_policies:
+  ghcr_registry:
+    name: ghcr_registry
+    endpoints:
+      - host: ghcr.io
+        port: 443
+        access: full
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/bin/docker }

--- a/nemoclaw-blueprint/policies/presets/go.yaml
+++ b/nemoclaw-blueprint/policies/presets/go.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: go
+  description: "Go module proxy and checksum database"
+
+network_policies:
+  go_proxy:
+    name: go_proxy
+    endpoints:
+      - host: proxy.golang.org
+        port: 443
+        access: full
+      - host: sum.golang.org
+        port: 443
+        access: full
+      # Module archives are served from Google Cloud Storage
+      - host: storage.googleapis.com
+        port: 443
+        access: full
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/go/bin/go }

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -7,9 +7,11 @@ import policies from "../bin/lib/policies";
 
 describe("policies", () => {
   describe("listPresets", () => {
-    it("returns all 9 presets", () => {
+    const expected = ["apt", "cargo", "discord", "docker", "ghcr", "go", "huggingface", "jira", "npm", "outlook", "pypi", "slack", "telegram"];
+
+    it("returns all presets", () => {
       const presets = policies.listPresets();
-      expect(presets.length).toBe(9);
+      expect(presets.length).toBe(expected.length);
     });
 
     it("each preset has name and description", () => {
@@ -21,7 +23,6 @@ describe("policies", () => {
 
     it("returns expected preset names", () => {
       const names = policies.listPresets().map((p) => p.name).sort();
-      const expected = ["discord", "docker", "huggingface", "jira", "npm", "outlook", "pypi", "slack", "telegram"];
       expect(names).toEqual(expected);
     });
   });
@@ -118,6 +119,38 @@ describe("policies", () => {
         const content = policies.loadPreset(p.name);
         expect(content.includes("network_policies:")).toBeTruthy();
       }
+    });
+  });
+
+  describe("new preset endpoints", () => {
+    it("cargo preset has crates.io endpoints", () => {
+      const content = policies.loadPreset("cargo");
+      const hosts = policies.getPresetEndpoints(content);
+      expect(hosts.includes("crates.io")).toBeTruthy();
+      expect(hosts.includes("static.crates.io")).toBeTruthy();
+      expect(hosts.includes("index.crates.io")).toBeTruthy();
+    });
+
+    it("go preset has proxy and sum endpoints", () => {
+      const content = policies.loadPreset("go");
+      const hosts = policies.getPresetEndpoints(content);
+      expect(hosts.includes("proxy.golang.org")).toBeTruthy();
+      expect(hosts.includes("sum.golang.org")).toBeTruthy();
+      expect(hosts.includes("storage.googleapis.com")).toBeTruthy();
+    });
+
+    it("apt preset has ubuntu and debian endpoints", () => {
+      const content = policies.loadPreset("apt");
+      const hosts = policies.getPresetEndpoints(content);
+      expect(hosts.includes("archive.ubuntu.com")).toBeTruthy();
+      expect(hosts.includes("security.ubuntu.com")).toBeTruthy();
+      expect(hosts.includes("deb.debian.org")).toBeTruthy();
+    });
+
+    it("ghcr preset has registry endpoint", () => {
+      const content = policies.loadPreset("ghcr");
+      const hosts = policies.getPresetEndpoints(content);
+      expect(hosts.includes("ghcr.io")).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add 4 new network policy presets for package ecosystems with no existing coverage: **Cargo** (Rust), **Go modules**, **apt** (Debian/Ubuntu), and **GHCR** (GitHub Container Registry)
- Each preset uses `access: full` with binary restrictions, consistent with the upstream direction for package manager presets (see #356)
- Update preset count assertion and add endpoint validation tests for all 4 new presets

Related to #19 — expanding preset coverage so additional package managers work inside the sandbox out of the box

## Motivation

The sandbox ships with presets for npm, PyPI, Docker Hub, and a few messaging services, but developers using Rust, Go, Debian-based system packages, or GitHub Container Registry have no preset available. These 4 presets cover the most common gaps.

> Continuation of closed #141.

## Test plan

### Automated Tests
```
npm test -- --grep "policy presets"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four new network policy presets: APT (Debian/Ubuntu), Cargo (Rust), GHCR (GitHub Container Registry), and Go (module proxy/checksum DB) to simplify trusted network access for common package managers and container workflows.

* **Tests**
  * Extended test coverage to validate the expanded preset set and their endpoint declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->