### PR TITLE
fix: reduce auto-pair timeout and add skip/configure env vars

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -102,12 +102,14 @@ print(f'[auto-pair] watcher launched (timeout={timeout}s)')
 
 def run(*args):
     """Run a subprocess and return (returncode, stdout, stderr)."""
-    remaining = max(1, int(DEADLINE - time.time()))
+    remaining = DEADLINE - time.time()
+    if remaining <= 0:
+        return 124, '', 'watcher deadline exceeded'
     try:
         proc = subprocess.run(args, capture_output=True, text=True, timeout=remaining)
         return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
     except subprocess.TimeoutExpired:
-        return 124, '', f'subprocess timed out after {remaining}s'
+        return 124, '', f'subprocess timed out after {remaining:.0f}s'
 
 while time.time() < DEADLINE:
     rc, out, err = run('openclaw', 'devices', 'list', '--json')

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -8,6 +8,8 @@
 # Optional env:
 #   NVIDIA_API_KEY   API key for NVIDIA-hosted inference
 #   CHAT_UI_URL      Browser origin that will access the forwarded dashboard
+#   NEMOCLAW_SKIP_AUTO_PAIR     Set to 1/true/yes to disable auto-pair watcher
+#   NEMOCLAW_AUTO_PAIR_TIMEOUT  Auto-pair timeout in seconds (default: 120)
 
 set -euo pipefail
 
@@ -37,6 +39,7 @@ os.chmod(path, 0o600)
 PYAUTH
 }
 
+# Print the local and remote dashboard URLs, appending the auth token if present.
 print_dashboard_urls() {
   local token chat_ui_base local_url remote_url
 
@@ -66,19 +69,45 @@ PYTOKEN
   echo "[gateway] Remote UI: ${remote_url}"
 }
 
+# Launch a background watcher that auto-approves pending device-pair requests.
 start_auto_pair() {
-  nohup python3 - <<'PYAUTOPAIR' >>/tmp/gateway.log 2>&1 &
+  case "$(echo "${NEMOCLAW_SKIP_AUTO_PAIR:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes)
+      echo "[gateway] auto-pair watcher skipped (NEMOCLAW_SKIP_AUTO_PAIR is set)"
+      return
+      ;;
+  esac
+  local pair_timeout="${NEMOCLAW_AUTO_PAIR_TIMEOUT:-120}"
+  if ! [[ "$pair_timeout" =~ ^[0-9]+$ ]] || [ "$pair_timeout" -le 0 ]; then
+    pair_timeout=120
+  fi
+  export NEMOCLAW_AUTO_PAIR_TIMEOUT="$pair_timeout"
+  echo "[gateway] auto-pair watcher launching (timeout=${pair_timeout}s)"
+  nohup python3 - <<'PYAUTOPAIR' >> /tmp/gateway.log 2>&1 &
 import json
+import os
 import subprocess
 import time
 
-DEADLINE = time.time() + 600
+try:
+    timeout = int(os.environ.get('NEMOCLAW_AUTO_PAIR_TIMEOUT', '120'))
+    if timeout <= 0:
+        timeout = 120
+except ValueError:
+    timeout = 120
+DEADLINE = time.time() + timeout
 QUIET_POLLS = 0
 APPROVED = 0
+print(f'[auto-pair] watcher launched (timeout={timeout}s)')
 
 def run(*args):
-    proc = subprocess.run(args, capture_output=True, text=True)
-    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    """Run a subprocess and return (returncode, stdout, stderr)."""
+    remaining = max(1, int(DEADLINE - time.time()))
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=remaining)
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 124, '', f'subprocess timed out after {remaining}s'
 
 while time.time() < DEADLINE:
     rc, out, err = run('openclaw', 'devices', 'list', '--json')


### PR DESCRIPTION
## Summary

- Reduce default auto-pair watcher timeout from 5 minutes to 2 minutes
- Add `NEMOCLAW_AUTOPAIR_TIMEOUT` env var to configure timeout
- Add `NEMOCLAW_AUTOPAIR_SKIP` env var to skip auto-pair entirely
- Add subprocess timeout to watcher `run()` helper to prevent indefinite blocking
- Echo timeout value before nohup redirect for observability

> Continuation of closed #145.

Related to #430 — the indefinite blocking during sandbox startup is partly caused by the auto-pair watcher having no timeout; this adds configurable timeouts and a skip option

## Test plan

### Automated Tests
```
npm test -- --grep "auto-pair"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background auto-pair watcher can be disabled via an environment variable.
  * Auto-pair timeout duration is now configurable via an environment variable (default: 120s).

* **Improvements**
  * Watcher now enforces a global deadline so background jobs cannot exceed the configured timeout.
  * Subprocess invocations respect the remaining deadline and return explicit timeout results when exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->