### PR TITLE
workflow: add doc preview PR workflow

### DIFF
--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -53,6 +53,7 @@ jobs:
         run: |
           find docs/_build -name .doctrees -prune -exec rm -rf {} \;
           find docs/_build -name .buildinfo -exec rm {} \;
+          touch docs/_build/html/.nojekyll
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Docs PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/docs-preview-pr.yaml"
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        if: github.event.action != 'closed'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        if: github.event.action != 'closed'
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install doc dependencies
+        if: github.event.action != 'closed'
+        run: uv sync --group docs
+
+      - name: Build documentation
+        if: github.event.action != 'closed'
+        run: uv run --group docs sphinx-build -W -b html docs docs/_build/html
+
+      - name: Clean build artifacts
+        if: github.event.action != 'closed'
+        run: |
+          find docs/_build -name .doctrees -prune -exec rm -rf {} \;
+          find docs/_build -name .buildinfo -exec rm {} \;
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./docs/_build/html/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -20,7 +20,6 @@ status: published
 
 # Overview
 
-test2
 NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants.
 It incorporates policy-based privacy and security guardrails, giving users control over their agents’ behavior and data handling.
 This enables self-evolving claws to run more safely in clouds, on prem, RTX PCs and DGX Spark.

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -20,7 +20,7 @@ status: published
 
 # Overview
 
-test
+test2
 NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants.
 It incorporates policy-based privacy and security guardrails, giving users control over their agents’ behavior and data handling.
 This enables self-evolving claws to run more safely in clouds, on prem, RTX PCs and DGX Spark.

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -20,6 +20,7 @@ status: published
 
 # Overview
 
+test
 NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants.
 It incorporates policy-based privacy and security guardrails, giving users control over their agents’ behavior and data handling.
 This enables self-evolving claws to run more safely in clouds, on prem, RTX PCs and DGX Spark.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated documentation preview generation for pull requests: doc changes are built, validated (treating warnings as errors), and deployed as live PR previews for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `make check` passes.
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General
- [ ] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] `make format` applied (TypeScript and Python).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.
