### PR TITLE
fix: validate and quote instance name in deploy shell commands

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -105,7 +105,17 @@ async function deploy(instanceName) {
   if (isRepoPrivate("NVIDIA/OpenShell")) {
     await ensureGithubToken();
   }
-  const name = instanceName;
+  const name = instanceName.trim();
+
+  // Validate: same RFC 1123 subdomain rules used for sandbox names — lowercase
+  // alphanumeric and hyphens, must start and end with alphanumeric.
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(name) || name.length > 253) {
+    console.error(`  Invalid instance name: '${name}'`);
+    console.error("  Names must be lowercase, contain only letters, numbers, and hyphens,");
+    console.error("  and must start and end with a letter or number (max 253 chars).");
+    process.exit(1);
+  }
+
   const gpu = process.env.NEMOCLAW_GPU || "a2-highgpu-1g:nvidia-tesla-a100:1";
 
   console.log("");
@@ -127,7 +137,7 @@ async function deploy(instanceName) {
 
   if (!exists) {
     console.log(`  Creating Brev instance '${name}' (${gpu})...`);
-    run(`brev create ${name} --gpu "${gpu}"`);
+    run(`brev create "${name}" --gpu "${gpu}"`);
   } else {
     console.log(`  Brev instance '${name}' already exists.`);
   }
@@ -137,7 +147,7 @@ async function deploy(instanceName) {
   console.log("  Waiting for SSH...");
   for (let i = 0; i < 60; i++) {
     try {
-      execSync(`ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no ${name} 'echo ok' 2>/dev/null`, { encoding: "utf-8", stdio: "pipe" });
+      execSync(`ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no "${name}" 'echo ok' 2>/dev/null`, { encoding: "utf-8", stdio: "pipe" });
       break;
     } catch {
       if (i === 59) {
@@ -149,8 +159,8 @@ async function deploy(instanceName) {
   }
 
   console.log("  Syncing NemoClaw to VM...");
-  run(`ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'mkdir -p /home/ubuntu/nemoclaw'`);
-  run(`rsync -az --delete --exclude node_modules --exclude .git --exclude src -e "ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR" "${ROOT}/scripts" "${ROOT}/Dockerfile" "${ROOT}/nemoclaw" "${ROOT}/nemoclaw-blueprint" "${ROOT}/bin" "${ROOT}/package.json" ${name}:/home/ubuntu/nemoclaw/`);
+  run(`ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR "${name}" 'mkdir -p /home/ubuntu/nemoclaw'`);
+  run(`rsync -az --delete --exclude node_modules --exclude .git --exclude src -e "ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR" "${ROOT}/scripts" "${ROOT}/Dockerfile" "${ROOT}/nemoclaw" "${ROOT}/nemoclaw-blueprint" "${ROOT}/bin" "${ROOT}/package.json" "${name}":/home/ubuntu/nemoclaw/`);
 
   const envLines = [`NVIDIA_API_KEY=${process.env.NVIDIA_API_KEY}`];
   const ghToken = process.env.GITHUB_TOKEN;
@@ -159,21 +169,21 @@ async function deploy(instanceName) {
   if (tgToken) envLines.push(`TELEGRAM_BOT_TOKEN=${tgToken}`);
   const envTmp = path.join(os.tmpdir(), `nemoclaw-env-${Date.now()}`);
   fs.writeFileSync(envTmp, envLines.join("\n") + "\n", { mode: 0o600 });
-  run(`scp -q -o StrictHostKeyChecking=no -o LogLevel=ERROR "${envTmp}" ${name}:/home/ubuntu/nemoclaw/.env`);
+  run(`scp -q -o StrictHostKeyChecking=no -o LogLevel=ERROR "${envTmp}" "${name}":/home/ubuntu/nemoclaw/.env`);
   fs.unlinkSync(envTmp);
 
   console.log("  Running setup...");
-  runInteractive(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && bash scripts/brev-setup.sh'`);
+  runInteractive(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR "${name}" 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && bash scripts/brev-setup.sh'`);
 
   if (tgToken) {
     console.log("  Starting services...");
-    run(`ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && bash scripts/start-services.sh'`);
+    run(`ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR "${name}" 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && bash scripts/start-services.sh'`);
   }
 
   console.log("");
   console.log("  Connecting to sandbox...");
   console.log("");
-  runInteractive(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${name} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell sandbox connect nemoclaw'`);
+  runInteractive(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR "${name}" 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell sandbox connect nemoclaw'`);
 }
 
 async function start() {

--- a/test/deploy-instance-name.test.js
+++ b/test/deploy-instance-name.test.js
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verify that deploy() validates and quotes the instance name in shell
+// commands to prevent command injection.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..");
+const source = fs.readFileSync(path.join(ROOT, "bin/nemoclaw.js"), "utf-8");
+
+describe("deploy instance name hardening", () => {
+  it("validates instance name with RFC 1123 regex", () => {
+    assert.ok(
+      source.includes("[a-z0-9-]") && source.includes("deploy"),
+      "deploy() must validate the instance name against RFC 1123 subdomain rules"
+    );
+  });
+
+  it("rejects names longer than 253 characters", () => {
+    assert.ok(
+      source.includes("253"),
+      "deploy() must enforce a 253-character limit on instance names"
+    );
+  });
+
+  it("does not interpolate unquoted instance name in ssh commands", () => {
+    // Extract lines inside deploy() that call ssh/scp/rsync with the instance name.
+    // After the fix, every ${name} in a shell string must be wrapped in double quotes.
+    const deployMatch = source.match(/async function deploy\([\s\S]*?\n\}/);
+    assert.ok(deployMatch, "Could not find deploy() function");
+    const deployBody = deployMatch[0];
+
+    // Find all shell-interpolated ${name} occurrences (skip console.log/error lines)
+    const lines = deployBody.split("\n");
+    for (const line of lines) {
+      if (line.includes("${name}") && !line.match(/console\.(log|error)/)) {
+        // In shell command strings, ${name} must be inside double quotes: "${name}"
+        const unquoted = line.match(/[^"]\$\{name\}[^"]/);
+        assert.ok(
+          !unquoted,
+          `Unquoted \${name} in shell command: ${line.trim()}`
+        );
+      }
+    }
+  });
+
+  it("quotes instance name in brev create", () => {
+    assert.ok(
+      source.includes('brev create "${name}"'),
+      'brev create must quote the instance name: brev create "${name}"'
+    );
+  });
+
+  it("quotes instance name in rsync destination", () => {
+    assert.ok(
+      source.includes('"${name}":/home/ubuntu/nemoclaw/'),
+      'rsync destination must quote the instance name: "${name}":/path'
+    );
+  });
+
+  it("quotes instance name in scp destination", () => {
+    assert.ok(
+      source.includes('"${name}":/home/ubuntu/nemoclaw/.env'),
+      'scp destination must quote the instance name: "${name}":/path'
+    );
+  });
+});


### PR DESCRIPTION
Continuation of the hardening started in #170 — extends RFC 1123 validation and double-quoting to the `deploy()` function.

## Summary

- Add RFC 1123 subdomain validation for instance names in `deploy()` (same regex as sandbox names from #170)
- Double-quote all 7 unquoted `${name}` interpolations in ssh, scp, and rsync shell commands
- Add 6 static-analysis regression tests (same pattern as `setup-sandbox-name.test.js`)

## Motivation

The `deploy()` function interpolates the user-supplied instance name into shell commands (`ssh`, `scp`, `rsync`, `brev create`) without quoting. A crafted instance name could inject arbitrary shell commands.

## Test plan

### Automated Tests
```
npm test -- --grep "deploy"
```

All 6 new tests pass. 177/177 total tests run; 3 pre-existing failures in `installer runtime preflight` (unrelated, present on main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Instance names are now validated with stricter requirements: lowercase letters, numbers, and hyphens only, with a maximum length of 253 characters
  * Invalid instance names now generate descriptive error messages
  * Improved handling of special characters in deployment commands

* **Tests**
  * Added comprehensive test suite for instance name validation and command execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->