### PR TITLE
fix: update debug for OpenShell CLI compat and macOS support

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -81,6 +81,7 @@ done
 
 TMPDIR_BASE="${TMPDIR:-/tmp}"
 COLLECT_DIR=$(mktemp -d "${TMPDIR_BASE}/nemoclaw-debug-XXXXXX")
+trap 'rm -rf "$COLLECT_DIR"' EXIT
 
 # Detect timeout binary (GNU coreutils; gtimeout on macOS via brew)
 TIMEOUT_BIN=""
@@ -262,10 +263,6 @@ if [ -n "$OUTPUT" ]; then
   warn "Known secrets are auto-redacted, but please review for any remaining sensitive data before sharing."
   info "Attach this file to your GitHub issue."
 fi
-
-# ── Cleanup ──────────────────────────────────────────────────────
-
-rm -rf "$COLLECT_DIR"
 
 echo ""
 info "Done. If filing a bug, run with --output and attach the tarball to your issue:"

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -165,7 +165,6 @@ collect "ps-cpu" sh -c 'ps -eo pid,ppid,cmd,%mem,%cpu --sort=-%cpu | head -30'
 
 if [ "$QUICK" = false ]; then
   collect "ps-mem" sh -c 'ps -eo pid,ppid,cmd,%mem,%cpu --sort=-%mem | head -30'
-  collect "ps-all" ps -ef
   collect "top" sh -c 'top -b -n 1 | head -50'
 fi
 
@@ -204,21 +203,21 @@ section "OpenShell"
 collect "openshell-status" openshell status
 collect "openshell-sandbox-list" openshell sandbox list
 collect "openshell-sandbox-get" openshell sandbox get "$SANDBOX_NAME"
-collect "openshell-sandbox-logs" openshell sandbox logs "$SANDBOX_NAME"
+collect "openshell-logs" openshell logs "$SANDBOX_NAME"
 
 if [ "$QUICK" = false ]; then
   collect "openshell-gateway-info" openshell gateway info
 fi
 
-# -- Sandbox internals (via openshell sandbox exec) --
+# -- Sandbox internals (via openshell sandbox connect) --
 
 if command -v openshell &>/dev/null && openshell sandbox list 2>/dev/null | grep -q "$SANDBOX_NAME"; then
   section "Sandbox Internals"
-  collect "sandbox-ps" openshell sandbox exec "$SANDBOX_NAME" -- ps -ef
-  collect "sandbox-free" openshell sandbox exec "$SANDBOX_NAME" -- free -m
+  collect "sandbox-ps" openshell sandbox connect "$SANDBOX_NAME" -- ps -ef
+  collect "sandbox-free" openshell sandbox connect "$SANDBOX_NAME" -- free -m
   if [ "$QUICK" = false ]; then
-    collect "sandbox-top" openshell sandbox exec "$SANDBOX_NAME" -- sh -c 'top -b -n 1 | head -50'
-    collect "sandbox-gateway-log" openshell sandbox exec "$SANDBOX_NAME" -- tail -200 /tmp/gateway.log
+    collect "sandbox-top" openshell sandbox connect "$SANDBOX_NAME" -- sh -c 'top -b -n 1 | head -50'
+    collect "sandbox-gateway-log" openshell sandbox connect "$SANDBOX_NAME" -- tail -200 /tmp/gateway.log
   fi
 fi
 
@@ -231,8 +230,8 @@ if [ "$QUICK" = false ]; then
   collect "ip-route" ip route
   collect "resolv-conf" cat /etc/resolv.conf
   collect "nslookup" nslookup integrate.api.nvidia.com
-  collect "curl-models" curl -I -s https://integrate.api.nvidia.com/v1/models
-  collect "lsof-net" lsof -i -P -n
+  collect "curl-models" sh -c 'code=$(curl -s -o /dev/null -w "%{http_code}" https://integrate.api.nvidia.com/v1/models); echo "HTTP $code"; if [ "$code" -ge 200 ] && [ "$code" -lt 500 ]; then echo "NIM API reachable"; else echo "NIM API unreachable"; exit 1; fi'
+  collect "lsof-net" sh -c 'lsof -i -P -n 2>/dev/null | head -50'
   collect "lsof-18789" lsof -i :18789
 fi
 

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -232,19 +232,31 @@ if [ "$QUICK" = false ]; then
   collect "openshell-gateway-info" openshell gateway info
 fi
 
-# -- Sandbox internals (via openshell sandbox connect) --
+# -- Sandbox internals (via SSH using openshell ssh-config) --
 
 if command -v openshell &>/dev/null \
   && openshell sandbox list 2>/dev/null \
     | awk 'NF { if (tolower($1) == "name") next; print $1 }' \
     | grep -Fxq -- "$SANDBOX_NAME"; then
   section "Sandbox Internals"
-  collect "sandbox-ps" openshell sandbox connect "$SANDBOX_NAME" -- ps -ef
-  collect "sandbox-free" openshell sandbox connect "$SANDBOX_NAME" -- free -m
-  if [ "$QUICK" = false ]; then
-    collect "sandbox-top" openshell sandbox connect "$SANDBOX_NAME" -- sh -c 'top -b -n 1 | head -50'
-    collect "sandbox-gateway-log" openshell sandbox connect "$SANDBOX_NAME" -- tail -200 /tmp/gateway.log
+
+  # Build a temporary SSH config so we can run commands inside the sandbox.
+  # This follows the pattern from OpenShell's own demo.sh.
+  SANDBOX_SSH_CONFIG=$(mktemp "${TMPDIR_BASE}/nemoclaw-ssh-XXXXXX")
+  if openshell sandbox ssh-config "$SANDBOX_NAME" > "$SANDBOX_SSH_CONFIG" 2>/dev/null; then
+    SANDBOX_SSH_HOST="openshell-${SANDBOX_NAME}"
+    sandbox_ssh() { ssh -F "$SANDBOX_SSH_CONFIG" -o StrictHostKeyChecking=no -o ConnectTimeout=10 "$SANDBOX_SSH_HOST" "$@"; }
+
+    collect "sandbox-ps" sandbox_ssh ps -ef
+    collect "sandbox-free" sandbox_ssh free -m
+    if [ "$QUICK" = false ]; then
+      collect "sandbox-top" sandbox_ssh 'top -b -n 1 | head -50'
+      collect "sandbox-gateway-log" sandbox_ssh tail -200 /tmp/gateway.log
+    fi
+  else
+    warn "Could not generate SSH config for sandbox '${SANDBOX_NAME}', skipping internals"
   fi
+  rm -f "$SANDBOX_SSH_CONFIG"
 fi
 
 # -- Network (full mode only) --

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -245,13 +245,13 @@ if command -v openshell &>/dev/null \
   SANDBOX_SSH_CONFIG=$(mktemp "${TMPDIR_BASE}/nemoclaw-ssh-XXXXXX")
   if openshell sandbox ssh-config "$SANDBOX_NAME" > "$SANDBOX_SSH_CONFIG" 2>/dev/null; then
     SANDBOX_SSH_HOST="openshell-${SANDBOX_NAME}"
-    sandbox_ssh() { ssh -F "$SANDBOX_SSH_CONFIG" -o StrictHostKeyChecking=no -o ConnectTimeout=10 "$SANDBOX_SSH_HOST" "$@"; }
+    SANDBOX_SSH_OPTS=(-F "$SANDBOX_SSH_CONFIG" -o StrictHostKeyChecking=no -o ConnectTimeout=10)
 
-    collect "sandbox-ps" sandbox_ssh ps -ef
-    collect "sandbox-free" sandbox_ssh free -m
+    collect "sandbox-ps" ssh "${SANDBOX_SSH_OPTS[@]}" "$SANDBOX_SSH_HOST" ps -ef
+    collect "sandbox-free" ssh "${SANDBOX_SSH_OPTS[@]}" "$SANDBOX_SSH_HOST" free -m
     if [ "$QUICK" = false ]; then
-      collect "sandbox-top" sandbox_ssh 'top -b -n 1 | head -50'
-      collect "sandbox-gateway-log" sandbox_ssh tail -200 /tmp/gateway.log
+      collect "sandbox-top" ssh "${SANDBOX_SSH_OPTS[@]}" "$SANDBOX_SSH_HOST" 'top -b -n 1 | head -50'
+      collect "sandbox-gateway-log" ssh "${SANDBOX_SSH_OPTS[@]}" "$SANDBOX_SSH_HOST" tail -200 /tmp/gateway.log
     fi
   else
     warn "Could not generate SSH config for sandbox '${SANDBOX_NAME}', skipping internals"

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -81,7 +81,12 @@ done
 
 TMPDIR_BASE="${TMPDIR:-/tmp}"
 COLLECT_DIR=$(mktemp -d "${TMPDIR_BASE}/nemoclaw-debug-XXXXXX")
-trap 'rm -rf "$COLLECT_DIR"' EXIT
+SANDBOX_SSH_CONFIG=""
+cleanup() {
+  rm -rf "$COLLECT_DIR"
+  [ -n "$SANDBOX_SSH_CONFIG" ] && rm -f "$SANDBOX_SSH_CONFIG"
+}
+trap cleanup EXIT
 
 # Platform detection
 IS_MACOS=false
@@ -256,7 +261,6 @@ if command -v openshell &>/dev/null \
   else
     warn "Could not generate SSH config for sandbox '${SANDBOX_NAME}', skipping internals"
   fi
-  rm -f "$SANDBOX_SSH_CONFIG"
 fi
 
 # -- Network (full mode only) --

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -83,6 +83,12 @@ TMPDIR_BASE="${TMPDIR:-/tmp}"
 COLLECT_DIR=$(mktemp -d "${TMPDIR_BASE}/nemoclaw-debug-XXXXXX")
 trap 'rm -rf "$COLLECT_DIR"' EXIT
 
+# Platform detection
+IS_MACOS=false
+if [ "$(uname -s)" = "Darwin" ]; then
+  IS_MACOS=true
+fi
+
 # Detect timeout binary (GNU coreutils; gtimeout on macOS via brew)
 TIMEOUT_BIN=""
 if command -v timeout >/dev/null 2>&1; then
@@ -156,7 +162,11 @@ section "System"
 collect "date" date
 collect "uname" uname -a
 collect "uptime" uptime
-collect "free" free -m
+if [ "$IS_MACOS" = true ]; then
+  collect "memory" sh -c 'echo "Physical: $(($(sysctl -n hw.memsize) / 1048576)) MB"; vm_stat'
+else
+  collect "free" free -m
+fi
 
 if [ "$QUICK" = false ]; then
   collect "df" df -h
@@ -165,11 +175,20 @@ fi
 # -- Processes --
 
 section "Processes"
-collect "ps-cpu" sh -c 'ps -eo pid,ppid,cmd,%mem,%cpu --sort=-%cpu | head -30'
+if [ "$IS_MACOS" = true ]; then
+  collect "ps-cpu" sh -c 'ps -eo pid,ppid,comm,%mem,%cpu | sort -k5 -rn | head -30'
+else
+  collect "ps-cpu" sh -c 'ps -eo pid,ppid,cmd,%mem,%cpu --sort=-%cpu | head -30'
+fi
 
 if [ "$QUICK" = false ]; then
-  collect "ps-mem" sh -c 'ps -eo pid,ppid,cmd,%mem,%cpu --sort=-%mem | head -30'
-  collect "top" sh -c 'top -b -n 1 | head -50'
+  if [ "$IS_MACOS" = true ]; then
+    collect "ps-mem" sh -c 'ps -eo pid,ppid,comm,%mem,%cpu | sort -k4 -rn | head -30'
+    collect "top" sh -c 'top -l 1 | head -50'
+  else
+    collect "ps-mem" sh -c 'ps -eo pid,ppid,cmd,%mem,%cpu --sort=-%mem | head -30'
+    collect "top" sh -c 'top -b -n 1 | head -50'
+  fi
 fi
 
 # -- GPU --
@@ -232,10 +251,17 @@ fi
 
 if [ "$QUICK" = false ]; then
   section "Network"
-  collect "ss" ss -ltnp
-  collect "ip-addr" ip addr
-  collect "ip-route" ip route
-  collect "resolv-conf" cat /etc/resolv.conf
+  if [ "$IS_MACOS" = true ]; then
+    collect "listening" sh -c 'netstat -anp tcp | grep LISTEN'
+    collect "ifconfig" ifconfig
+    collect "routes" netstat -rn
+    collect "dns-config" scutil --dns
+  else
+    collect "ss" ss -ltnp
+    collect "ip-addr" ip addr
+    collect "ip-route" ip route
+    collect "resolv-conf" cat /etc/resolv.conf
+  fi
   collect "nslookup" nslookup integrate.api.nvidia.com
   collect "curl-models" sh -c 'code=$(curl -s -o /dev/null -w "%{http_code}" https://integrate.api.nvidia.com/v1/models); echo "HTTP $code"; if [ "$code" -ge 200 ] && [ "$code" -lt 500 ]; then echo "NIM API reachable"; else echo "NIM API unreachable"; exit 1; fi'
   collect "lsof-net" sh -c 'lsof -i -P -n 2>/dev/null | head -50'
@@ -246,14 +272,23 @@ fi
 
 if [ "$QUICK" = false ]; then
   section "Kernel / IO"
-  collect "vmstat" vmstat 1 5
-  collect "iostat" iostat -xz 1 5
+  if [ "$IS_MACOS" = true ]; then
+    collect "vmstat" vm_stat
+    collect "iostat" iostat -c 5 -w 1
+  else
+    collect "vmstat" vmstat 1 5
+    collect "iostat" iostat -xz 1 5
+  fi
 fi
 
 # -- dmesg (always, last 100 lines) --
 
 section "Kernel Messages"
-collect "dmesg" sh -c 'dmesg | tail -100'
+if [ "$IS_MACOS" = true ]; then
+  collect "system-log" sh -c 'log show --last 5m --predicate "eventType == logEvent" --style compact 2>/dev/null | tail -100'
+else
+  collect "dmesg" sh -c 'dmesg | tail -100'
+fi
 
 # ── Produce tarball if requested ─────────────────────────────────
 

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -134,7 +134,10 @@ collect() {
 
 if [ -z "$SANDBOX_NAME" ]; then
   if command -v openshell &>/dev/null; then
-    SANDBOX_NAME=$(openshell sandbox list 2>/dev/null | head -1 | awk '{print $1}' || true)
+    SANDBOX_NAME=$(
+      openshell sandbox list 2>/dev/null \
+        | awk 'NF { if (tolower($1) == "name") next; print $1; exit }'
+    ) || true
   fi
   SANDBOX_NAME="${SANDBOX_NAME:-default}"
 fi
@@ -211,7 +214,10 @@ fi
 
 # -- Sandbox internals (via openshell sandbox connect) --
 
-if command -v openshell &>/dev/null && openshell sandbox list 2>/dev/null | grep -q "$SANDBOX_NAME"; then
+if command -v openshell &>/dev/null \
+  && openshell sandbox list 2>/dev/null \
+    | awk 'NF { if (tolower($1) == "name") next; print $1 }' \
+    | grep -Fxq -- "$SANDBOX_NAME"; then
   section "Sandbox Internals"
   collect "sandbox-ps" openshell sandbox connect "$SANDBOX_NAME" -- ps -ef
   collect "sandbox-free" openshell sandbox connect "$SANDBOX_NAME" -- free -m
@@ -259,11 +265,7 @@ fi
 
 # ── Cleanup ──────────────────────────────────────────────────────
 
-if [ -z "$OUTPUT" ]; then
-  rm -rf "$COLLECT_DIR"
-else
-  info "Raw files kept in ${COLLECT_DIR}"
-fi
+rm -rf "$COLLECT_DIR"
 
 echo ""
 info "Done. If filing a bug, run with --output and attach the tarball to your issue:"

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -84,7 +84,9 @@ COLLECT_DIR=$(mktemp -d "${TMPDIR_BASE}/nemoclaw-debug-XXXXXX")
 SANDBOX_SSH_CONFIG=""
 cleanup() {
   rm -rf "$COLLECT_DIR"
-  [ -n "$SANDBOX_SSH_CONFIG" ] && rm -f "$SANDBOX_SSH_CONFIG"
+  if [ -n "$SANDBOX_SSH_CONFIG" ]; then
+    rm -f "$SANDBOX_SSH_CONFIG"
+  fi
 }
 trap cleanup EXIT
 
@@ -168,6 +170,7 @@ collect "date" date
 collect "uname" uname -a
 collect "uptime" uptime
 if [ "$IS_MACOS" = true ]; then
+  # shellcheck disable=SC2016
   collect "memory" sh -c 'echo "Physical: $(($(sysctl -n hw.memsize) / 1048576)) MB"; vm_stat'
 else
   collect "free" free -m
@@ -279,6 +282,7 @@ if [ "$QUICK" = false ]; then
     collect "resolv-conf" cat /etc/resolv.conf
   fi
   collect "nslookup" nslookup integrate.api.nvidia.com
+  # shellcheck disable=SC2016
   collect "curl-models" sh -c 'code=$(curl -s -o /dev/null -w "%{http_code}" https://integrate.api.nvidia.com/v1/models); echo "HTTP $code"; if [ "$code" -ge 200 ] && [ "$code" -lt 500 ]; then echo "NIM API reachable"; else echo "NIM API unreachable"; exit 1; fi'
   collect "lsof-net" sh -c 'lsof -i -P -n 2>/dev/null | head -50'
   collect "lsof-18789" lsof -i :18789


### PR DESCRIPTION
## Summary

### OpenShell CLI compatibility (#541)
- Replace `openshell sandbox logs` with `openshell logs` — the current CLI has no `sandbox logs` subcommand
- Replace `openshell sandbox exec` with `openshell sandbox connect ... --` for in-sandbox diagnostics
- Fix network probe: switch from `curl -I` (HEAD → 405) to GET with status code check; treat any 2xx–4xx as "reachable"
- Reduce output noise: drop redundant full `ps -ef` dump, limit `lsof` to 50 lines

### First-class macOS support (#546)
- Add platform detection (`uname -s` → `IS_MACOS` flag)
- Replace Linux-only collectors with macOS-native equivalents:
  - `free -m` → `vm_stat` + `sysctl hw.memsize`
  - `ps --sort=` → `ps | sort` (macOS ps lacks `--sort`)
  - `top -b -n 1` → `top -l 1`
  - `ss -ltnp` → `netstat -anp tcp | grep LISTEN`
  - `ip addr` → `ifconfig`
  - `ip route` → `netstat -rn`
  - `/etc/resolv.conf` → `scutil --dns`
  - `vmstat` → `vm_stat`
  - `iostat -xz` → `iostat -c -w` (macOS flags)
  - `dmesg` → `log show --last 5m`

### CodeRabbit fixes
- Skip header row when parsing `openshell sandbox list` output
- Use exact matching (`grep -Fxq`) for sandbox name lookup
- Add EXIT trap for guaranteed temp dir cleanup
- Always clean up raw diagnostics (even after tarball creation)

## Test plan

- [x] All 11 existing CLI tests pass
- [x] macOS collectors verified on a real Mac (memory, ps, top, netstat, scutil, vm_stat, iostat, log show)
- [ ] Re-run `nemoclaw debug` on Spark and confirm sandbox-internals section succeeds
- [ ] Re-run `nemoclaw debug` on Brev and confirm no more `unrecognized subcommand` errors
- [ ] Verify network probe shows "NIM API reachable" instead of noisy 405

Closes #541
Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit macOS-compatible diagnostic probes and adjusted system/network/process collectors
  * Switched sandbox internals collection to run over generated SSH config for better compatibility

* **Bug Fixes**
  * Always cleans up temporary diagnostic directories on exit
  * Improved sandbox detection and log retrieval paths

* **Chores**
  * Renamed and standardized collected log artifact and capped output sizes for readability
  * Updated network reachability probe to report reachable/unreachable by HTTP status
<!-- end of auto-generated comment: release notes by coderabbit.ai -->