### PR TITLE
fix: lock gateway config via Landlock filesystem policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,28 +65,45 @@ RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \
 COPY scripts/nemoclaw-start.sh /usr/local/bin/nemoclaw-start
 RUN chmod +x /usr/local/bin/nemoclaw-start
 
+# Build args for config that varies per deployment.
+# nemoclaw onboard passes these at image build time.
+ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b
+ARG CHAT_UI_URL=http://127.0.0.1:18789
+# Unique per build to ensure each image gets a fresh auth token.
+# Pass --build-arg NEMOCLAW_BUILD_ID=$(date +%s) to bust the cache.
+ARG NEMOCLAW_BUILD_ID=default
+
 WORKDIR /sandbox
 USER sandbox
 
 # Write the COMPLETE openclaw.json including gateway config and auth token.
 # This file is immutable at runtime (Landlock read-only on /sandbox/.openclaw).
 # No runtime writes to openclaw.json are needed or possible.
+# Build args (NEMOCLAW_MODEL, CHAT_UI_URL) customize per deployment.
+# Auth token is generated per build so each image has a unique token.
 RUN python3 -c "\
 import json, os, secrets; \
+from urllib.parse import urlparse; \
+model = '${NEMOCLAW_MODEL}'; \
+chat_ui_url = '${CHAT_UI_URL}'; \
+parsed = urlparse(chat_ui_url); \
+chat_origin = f'{parsed.scheme}://{parsed.netloc}' if parsed.scheme and parsed.netloc else 'http://127.0.0.1:18789'; \
+origins = ['http://127.0.0.1:18789']; \
+origins = list(dict.fromkeys(origins + [chat_origin])); \
 config = { \
-    'agents': {'defaults': {'model': {'primary': 'nvidia/nemotron-3-super-120b-a12b'}}}, \
+    'agents': {'defaults': {'model': {'primary': model}}}, \
     'models': {'mode': 'merge', 'providers': {'nvidia': { \
         'baseUrl': 'https://inference.local/v1', \
         'apiKey': 'openshell-managed', \
         'api': 'openai-completions', \
-        'models': [{'id': 'nemotron-3-super-120b-a12b', 'name': 'NVIDIA Nemotron 3 Super 120B', 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
+        'models': [{'id': model.split('/')[-1], 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
     }}}, \
     'gateway': { \
         'mode': 'local', \
         'controlUi': { \
             'allowInsecureAuth': True, \
             'dangerouslyDisableDeviceAuth': True, \
-            'allowedOrigins': ['http://127.0.0.1:18789'], \
+            'allowedOrigins': origins, \
         }, \
         'trustedProxies': ['127.0.0.1', '::1'], \
         'auth': {'token': secrets.token_hex(32)} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN openclaw doctor --fix > /dev/null 2>&1 || true \
 # once OpenShell enables enforcement.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/514
 USER root
-RUN chown root:root /sandbox/.openclaw /sandbox/.openclaw/openclaw.json \
+RUN chown -h root:root /sandbox/.openclaw /sandbox/.openclaw/* \
     && chmod 1777 /sandbox/.openclaw \
     && chmod 444 /sandbox/.openclaw/openclaw.json
 USER sandbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,5 +100,15 @@ os.chmod(path, 0o600)"
 RUN openclaw doctor --fix > /dev/null 2>&1 || true \
     && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
+# Lock openclaw.json via DAC: chown to root so the sandbox user cannot modify
+# it at runtime.  This works regardless of Landlock enforcement status.
+# The Landlock policy (/sandbox/.openclaw in read_only) provides defense-in-depth
+# once OpenShell enables enforcement.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/514
+USER root
+RUN chown root:root /sandbox/.openclaw/openclaw.json \
+    && chmod 444 /sandbox/.openclaw/openclaw.json
+USER sandbox
+
 ENTRYPOINT ["/bin/bash"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN openclaw doctor --fix > /dev/null 2>&1 || true \
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/514
 USER root
 RUN chown root:root /sandbox/.openclaw /sandbox/.openclaw/openclaw.json \
-    && chmod 755 /sandbox/.openclaw \
+    && chmod 1777 /sandbox/.openclaw \
     && chmod 444 /sandbox/.openclaw/openclaw.json
 USER sandbox
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,8 @@ RUN openclaw doctor --fix > /dev/null 2>&1 || true \
 # once OpenShell enables enforcement.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/514
 USER root
-RUN chown root:root /sandbox/.openclaw/openclaw.json \
+RUN chown root:root /sandbox/.openclaw /sandbox/.openclaw/openclaw.json \
+    && chmod 755 /sandbox/.openclaw \
     && chmod 444 /sandbox/.openclaw/openclaw.json
 USER sandbox
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Create sandbox user (matches OpenShell convention)
 RUN groupadd -r sandbox && useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox \
-    && mkdir -p /sandbox/.openclaw /sandbox/.nemoclaw \
+    && mkdir -p /sandbox/.nemoclaw \
     && chown -R sandbox:sandbox /sandbox
+
+# Split .openclaw into immutable config dir + writable state dir.
+# The policy makes /sandbox/.openclaw read-only via Landlock, so the agent
+# cannot modify openclaw.json, auth tokens, or CORS settings.  Writable
+# state (agents, plugins, etc.) lives in .openclaw-data, reached via symlinks.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/514
+RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
+        /sandbox/.openclaw-data/extensions \
+        /sandbox/.openclaw-data/workspace \
+        /sandbox/.openclaw-data/skills \
+        /sandbox/.openclaw-data/hooks \
+    && mkdir -p /sandbox/.openclaw \
+    && ln -s /sandbox/.openclaw-data/agents /sandbox/.openclaw/agents \
+    && ln -s /sandbox/.openclaw-data/extensions /sandbox/.openclaw/extensions \
+    && ln -s /sandbox/.openclaw-data/workspace /sandbox/.openclaw/workspace \
+    && ln -s /sandbox/.openclaw-data/skills /sandbox/.openclaw/skills \
+    && ln -s /sandbox/.openclaw-data/hooks /sandbox/.openclaw/hooks \
+    && chown -R sandbox:sandbox /sandbox/.openclaw /sandbox/.openclaw-data
 
 # Install OpenClaw CLI
 RUN npm install -g openclaw@2026.3.11
@@ -50,15 +68,11 @@ RUN chmod +x /usr/local/bin/nemoclaw-start
 WORKDIR /sandbox
 USER sandbox
 
-# Pre-create OpenClaw directories
-RUN mkdir -p /sandbox/.openclaw/agents/main/agent \
-    && chmod 700 /sandbox/.openclaw
-
-# Write openclaw.json: set nvidia as default provider, route through
-# inference.local (OpenShell gateway proxy). No API key needed here —
-# openshell injects credentials via the provider configuration.
+# Write the COMPLETE openclaw.json including gateway config and auth token.
+# This file is immutable at runtime (Landlock read-only on /sandbox/.openclaw).
+# No runtime writes to openclaw.json are needed or possible.
 RUN python3 -c "\
-import json, os; \
+import json, os, secrets; \
 config = { \
     'agents': {'defaults': {'model': {'primary': 'nvidia/nemotron-3-super-120b-a12b'}}}, \
     'models': {'mode': 'merge', 'providers': {'nvidia': { \
@@ -66,7 +80,17 @@ config = { \
         'apiKey': 'openshell-managed', \
         'api': 'openai-completions', \
         'models': [{'id': 'nemotron-3-super-120b-a12b', 'name': 'NVIDIA Nemotron 3 Super 120B', 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
-    }}} \
+    }}}, \
+    'gateway': { \
+        'mode': 'local', \
+        'controlUi': { \
+            'allowInsecureAuth': True, \
+            'dangerouslyDisableDeviceAuth': True, \
+            'allowedOrigins': ['http://127.0.0.1:18789'], \
+        }, \
+        'trustedProxies': ['127.0.0.1', '::1'], \
+        'auth': {'token': secrets.token_hex(32)} \
+    } \
 }; \
 path = os.path.expanduser('~/.openclaw/openclaw.json'); \
 json.dump(config, open(path, 'w'), indent=2); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,8 @@ RUN openclaw doctor --fix > /dev/null 2>&1 || true \
 # once OpenShell enables enforcement.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/514
 USER root
-RUN chown -h root:root /sandbox/.openclaw /sandbox/.openclaw/* \
+RUN chown root:root /sandbox/.openclaw \
+    && find /sandbox/.openclaw -mindepth 1 -maxdepth 1 -exec chown -h root:root {} + \
     && chmod 1777 /sandbox/.openclaw \
     && chmod 444 /sandbox/.openclaw/openclaw.json
 USER sandbox

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -25,10 +25,16 @@ filesystem_policy:
     - /app
     - /etc
     - /var/log
+    - /sandbox/.openclaw            # Immutable gateway config — prevents agent
+                                    # from tampering with auth tokens or CORS.
+                                    # Writable state (agents, plugins) lives in
+                                    # /sandbox/.openclaw-data via symlinks.
+                                    # Ref: https://github.com/NVIDIA/NemoClaw/issues/514
   read_write:
     - /sandbox
     - /tmp
     - /dev/null
+    - /sandbox/.openclaw-data       # Writable agent/plugin state (symlinked from .openclaw)
 
 landlock:
   compatibility: best_effort

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -15,48 +15,6 @@ NEMOCLAW_CMD=("$@")
 CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:18789}"
 PUBLIC_PORT=18789
 
-fix_openclaw_config() {
-  python3 - <<'PYCFG'
-import json
-import os
-from urllib.parse import urlparse
-
-home = os.environ.get('HOME', '/sandbox')
-config_path = os.path.join(home, '.openclaw', 'openclaw.json')
-os.makedirs(os.path.dirname(config_path), exist_ok=True)
-
-cfg = {}
-if os.path.exists(config_path):
-    with open(config_path) as f:
-        cfg = json.load(f)
-
-default_model = os.environ.get('NEMOCLAW_MODEL')
-if default_model:
-    cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = default_model
-
-chat_ui_url = os.environ.get('CHAT_UI_URL', 'http://127.0.0.1:18789')
-parsed = urlparse(chat_ui_url)
-chat_origin = f"{parsed.scheme}://{parsed.netloc}" if parsed.scheme and parsed.netloc else 'http://127.0.0.1:18789'
-local_origin = f'http://127.0.0.1:{os.environ.get("PUBLIC_PORT", "18789")}'
-origins = [local_origin]
-if chat_origin not in origins:
-    origins.append(chat_origin)
-
-gateway = cfg.setdefault('gateway', {})
-gateway['mode'] = 'local'
-gateway['controlUi'] = {
-    'allowInsecureAuth': True,
-    'dangerouslyDisableDeviceAuth': True,
-    'allowedOrigins': origins,
-}
-gateway['trustedProxies'] = ['127.0.0.1', '::1']
-
-with open(config_path, 'w') as f:
-    json.dump(cfg, f, indent=2)
-os.chmod(config_path, 0o600)
-PYCFG
-}
-
 write_auth_profile() {
   if [ -z "${NVIDIA_API_KEY:-}" ]; then
     return
@@ -171,8 +129,6 @@ PYAUTOPAIR
 echo 'Setting up NemoClaw...'
 openclaw doctor --fix > /dev/null 2>&1 || true
 write_auth_profile
-export CHAT_UI_URL PUBLIC_PORT
-fix_openclaw_config
 openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
 if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then


### PR DESCRIPTION
## Summary

Prevents the sandboxed AI agent from modifying gateway security settings (`openclaw.json`) at runtime. All configuration — including gateway mode, CORS origins, trusted proxies, and auth token — is now pre-baked at Docker build time and made immutable via filesystem permissions.

Closes #514. Supersedes the approach in #515.

## How it works

**Pre-baked config:** The complete `openclaw.json` is written at Docker build time with a per-build auth token (`secrets.token_hex(32)`). The runtime `fix_openclaw_config()` function is removed — no runtime writes to the config are needed.

**Immutable config file:** After all build-time writes complete, the config file is set to `root:root 444`. The sandbox process (running as `sandbox` user) cannot modify it.

**Protected directory:** The parent directory uses sticky bit permissions (`root:root 1777`, same semantics as `/tmp`). The sandbox user can create and manage their own files but cannot delete root-owned files.

**Writable agent state:** Runtime state (plugins, agent profiles, etc.) is relocated to `/sandbox/.openclaw-data/` via symlinks baked into the image. Writes through symlinks resolve to the writable target directory.

**Filesystem policy (defense-in-depth):** `/sandbox/.openclaw` is added to the Landlock `read_only` list for additional enforcement when available.

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Restructure `.openclaw` with symlinks to `.openclaw-data`; pre-bake complete config with gateway section + auth token; `root:root 1777` on directory, `root:root 444` on config |
| `scripts/nemoclaw-start.sh` | Remove `fix_openclaw_config()` — no runtime config writes |
| `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` | Add `/sandbox/.openclaw` to `read_only`, `/sandbox/.openclaw-data` to `read_write` |

## Test results

11/11 tests pass across both Docker and OpenShell sandbox environments:

| Category | Tests | Result |
|----------|-------|--------|
| Build and structure | Image builds, permissions correct, symlinks resolve | PASS |
| Config immutability | Write, chmod, chown, delete all blocked | PASS |
| Runtime functionality | Gateway starts (HTTP 200), symlink writes work, auth profiles writable | PASS |
| Sandbox lifecycle | Re-creation preserves protections | PASS |

Full test plan in `test/test-plan-514-config-lock.md`.

## Defense-in-depth hardening

Additional hardening tracked in #516:
- Landlock enforcement (currently `best_effort`)
- Tool policy deny lists for write/edit/exec
- Re-evaluate `allowInsecureAuth` and `dangerouslyDisableDeviceAuth` defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Transitioned configuration initialization from runtime startup to build phase, enabling faster container startup cycles.
- Enhanced security posture through immutable configuration files and refined filesystem permission controls.
- Streamlined startup sequence by eliminating redundant runtime configuration modification steps.
- Improved sandbox isolation with reorganized filesystem layout separating immutable configuration from writable state directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->