### PR TITLE
fix: degrade gracefully when port probe gets EPERM/EACCES (#544)

### DIFF
--- a/bin/lib/preflight.js
+++ b/bin/lib/preflight.js
@@ -18,6 +18,7 @@ const { runCapture } = require("./runner");
  *
  * Returns:
  *   { ok: true }
+ *   { ok: true, warning: string }           — probe blocked by EPERM/EACCES
  *   { ok: false, process: string, pid: number|null, reason: string }
  */
 async function checkPortAvailable(port, opts) {
@@ -71,6 +72,13 @@ async function checkPortAvailable(port, opts) {
           process: "unknown",
           pid: null,
           reason: `port ${p} is in use (EADDRINUSE)`,
+        });
+      } else if (err.code === "EPERM" || err.code === "EACCES") {
+        // Bind blocked by sandbox/seccomp/AppArmor policy — not a port
+        // conflict. Degrade gracefully and assume the port is available.
+        resolve({
+          ok: true,
+          warning: `port probe skipped: ${err.code} (${err.message})`,
         });
       } else {
         // Unexpected error — treat port as unavailable

--- a/test/preflight.test.js
+++ b/test/preflight.test.js
@@ -110,6 +110,57 @@ describe("checkPortAvailable", () => {
     assert.equal(typeof result.ok, "boolean");
   });
 
+  // Helper: monkey-patch net.createServer to emit a specific error code on listen.
+  function mockBindError(code, message) {
+    const origCreate = net.createServer;
+    net.createServer = function () {
+      const srv = origCreate.call(net);
+      srv.listen = function () {
+        process.nextTick(() => {
+          const err = new Error(message);
+          err.code = code;
+          srv.emit("error", err);
+        });
+        return srv;
+      };
+      return srv;
+    };
+    return origCreate;
+  }
+
+  it("degrades gracefully when bind is blocked by EPERM", async () => {
+    const restore = mockBindError("EPERM", "listen EPERM: operation not permitted 127.0.0.1");
+    try {
+      const result = await checkPortAvailable(9999, { skipLsof: true });
+      assert.equal(result.ok, true);
+      assert.ok(result.warning && result.warning.includes("EPERM"));
+    } finally {
+      net.createServer = restore;
+    }
+  });
+
+  it("degrades gracefully when bind is blocked by EACCES", async () => {
+    const restore = mockBindError("EACCES", "listen EACCES: permission denied 127.0.0.1");
+    try {
+      const result = await checkPortAvailable(9999, { skipLsof: true });
+      assert.equal(result.ok, true);
+      assert.ok(result.warning && result.warning.includes("EACCES"));
+    } finally {
+      net.createServer = restore;
+    }
+  });
+
+  it("treats unexpected bind errors as port unavailable", async () => {
+    const restore = mockBindError("ENOTFOUND", "getaddrinfo ENOTFOUND 127.0.0.1");
+    try {
+      const result = await checkPortAvailable(9999, { skipLsof: true });
+      assert.equal(result.ok, false);
+      assert.ok(result.reason.includes("port probe failed"));
+    } finally {
+      net.createServer = restore;
+    }
+  });
+
   it("checks gateway port 8080", async () => {
     const freePort = await new Promise((resolve) => {
       const srv = net.createServer();


### PR DESCRIPTION
Fixes #544.

## Summary

- Distinguish `EPERM`/`EACCES` from `EADDRINUSE` in the `checkPortAvailable()` net probe fallback
- Permission errors resolve as `{ ok: true, warning: "..." }` instead of falsely reporting the port as unavailable
- Add `mockBindError` test helper and 3 new tests: EPERM graceful degradation, EACCES graceful degradation, and unexpected error code catch-all

## Motivation

In restricted environments (sandboxes, containers with seccomp profiles, CI runners with network restrictions), the `net.createServer().listen()` bind probe can fail with `EPERM` even when the port is free. The current code treats all non-`EADDRINUSE` errors as "port unavailable," which kills onboarding with a false port conflict.

`EPERM` means "you're not allowed to probe," not "the port is taken." The fix distinguishes between the two so preflight degrades gracefully instead of blocking.

## Test plan

### Automated Tests
```
npm test -- --grep "checkPortAvailable"
```

12/12 tests pass. Cross-platform validation:

| Platform | Arch | OS | Node | Tests | Result |
|----------|------|----|------|-------|--------|
| **Linux (DGX Spark)** | aarch64 | Ubuntu 24.04 | 22.x | 12/12 | **PASS** |
| **macOS (Apple Silicon)** | arm64 | macOS 26.2 | 25.6.0 | 12/12 | **PASS** |
| **Windows/WSL2** | x86_64 | WSL2 kernel 6.6.87 | 22.22.1 | 12/12 | **PASS** |
| **Seccomp-restricted container** | aarch64 | node:22-slim | 22.x | live EPERM | **PASS** |

The seccomp test used a custom profile blocking the `bind()` syscall to produce a real kernel-level `EPERM`, confirming the fix works against actual restricted environments — not just mocked errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port checks now treat permission-related probe failures (permission denied) as non-fatal: they return a warning and allow startup to continue instead of reporting an unexpected failure.
* **Tests**
  * Added tests covering permission-related probe errors and unexpected probe failures to validate warning vs. error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->