### PR TITLE
Pin OpenShell gateway image to installed release

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -90,7 +90,7 @@ function shellQuote(value) {
 }
 
 function getStableGatewayImageRef(versionOutput = null) {
-  const output = versionOutput || runCapture("openshell -V", { ignoreError: true });
+  const output = String(versionOutput ?? runCapture("openshell -V", { ignoreError: true })).trim();
   const match = output.match(/openshell\s+([0-9]+\.[0-9]+\.[0-9]+)/i);
   if (!match) return null;
   return `ghcr.io/nvidia/openshell/cluster:${match[1]}`;

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -89,6 +89,13 @@ function shellQuote(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`;
 }
 
+function getStableGatewayImageRef(versionOutput = null) {
+  const output = versionOutput || runCapture("openshell -V", { ignoreError: true });
+  const match = output.match(/openshell\s+([0-9]+\.[0-9]+\.[0-9]+)/i);
+  if (!match) return null;
+  return `ghcr.io/nvidia/openshell/cluster:${match[1]}`;
+}
+
 function pythonLiteralJson(value) {
   return JSON.stringify(JSON.stringify(value));
 }
@@ -373,8 +380,17 @@ async function startGateway(gpu) {
   // sandbox itself does not need direct GPU access. Passing --gpu causes
   // FailedPrecondition errors when the gateway's k3s device plugin cannot
   // allocate GPUs. See: https://build.nvidia.com/spark/nemoclaw/instructions
+  const gatewayEnv = {};
+  const stableGatewayImage = getStableGatewayImageRef();
+  if (stableGatewayImage) {
+    gatewayEnv.OPENSHELL_CLUSTER_IMAGE = stableGatewayImage;
+    console.log(`  Using pinned OpenShell gateway image: ${stableGatewayImage}`);
+  }
 
-  run(`openshell gateway start ${gwArgs.join(" ")}`, { ignoreError: false });
+  run(`openshell gateway start ${gwArgs.join(" ")}`, {
+    ignoreError: false,
+    env: gatewayEnv,
+  });
 
   // Verify health
   for (let i = 0; i < 5; i++) {
@@ -964,4 +980,11 @@ async function onboard(opts = {}) {
   printDashboard(sandboxName, model, provider);
 }
 
-module.exports = { buildSandboxConfigSyncScript, hasStaleGateway, isSandboxReady, onboard, setupNim };
+module.exports = {
+  buildSandboxConfigSyncScript,
+  getStableGatewayImageRef,
+  hasStaleGateway,
+  isSandboxReady,
+  onboard,
+  setupNim,
+};

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -89,11 +89,17 @@ function shellQuote(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`;
 }
 
-function getStableGatewayImageRef(versionOutput = null) {
+function getInstalledOpenshellVersion(versionOutput = null) {
   const output = String(versionOutput ?? runCapture("openshell -V", { ignoreError: true })).trim();
   const match = output.match(/openshell\s+([0-9]+\.[0-9]+\.[0-9]+)/i);
   if (!match) return null;
-  return `ghcr.io/nvidia/openshell/cluster:${match[1]}`;
+  return match[1];
+}
+
+function getStableGatewayImageRef(versionOutput = null) {
+  const version = getInstalledOpenshellVersion(versionOutput);
+  if (!version) return null;
+  return `ghcr.io/nvidia/openshell/cluster:${version}`;
 }
 
 function pythonLiteralJson(value) {
@@ -381,9 +387,13 @@ async function startGateway(gpu) {
   // FailedPrecondition errors when the gateway's k3s device plugin cannot
   // allocate GPUs. See: https://build.nvidia.com/spark/nemoclaw/instructions
   const gatewayEnv = {};
-  const stableGatewayImage = getStableGatewayImageRef();
-  if (stableGatewayImage) {
+  const openshellVersion = getInstalledOpenshellVersion();
+  const stableGatewayImage = openshellVersion
+    ? `ghcr.io/nvidia/openshell/cluster:${openshellVersion}`
+    : null;
+  if (stableGatewayImage && openshellVersion) {
     gatewayEnv.OPENSHELL_CLUSTER_IMAGE = stableGatewayImage;
+    gatewayEnv.IMAGE_TAG = openshellVersion;
     console.log(`  Using pinned OpenShell gateway image: ${stableGatewayImage}`);
   }
 
@@ -982,6 +992,7 @@ async function onboard(opts = {}) {
 
 module.exports = {
   buildSandboxConfigSyncScript,
+  getInstalledOpenshellVersion,
   getStableGatewayImageRef,
   hasStaleGateway,
   isSandboxReady,

--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -16,10 +16,10 @@ if (dockerHost) {
 function run(cmd, opts = {}) {
   const stdio = opts.stdio ?? ["ignore", "inherit", "inherit"];
   const result = spawnSync("bash", ["-c", cmd], {
+    ...opts,
     stdio,
     cwd: ROOT,
     env: { ...process.env, ...opts.env },
-    ...opts,
   });
   if (result.status !== 0 && !opts.ignoreError) {
     console.error(`  Command failed (exit ${result.status}): ${cmd.slice(0, 80)}`);
@@ -31,10 +31,10 @@ function run(cmd, opts = {}) {
 function runInteractive(cmd, opts = {}) {
   const stdio = opts.stdio ?? "inherit";
   const result = spawnSync("bash", ["-c", cmd], {
+    ...opts,
     stdio,
     cwd: ROOT,
     env: { ...process.env, ...opts.env },
-    ...opts,
   });
   if (result.status !== 0 && !opts.ignoreError) {
     console.error(`  Command failed (exit ${result.status}): ${cmd.slice(0, 80)}`);
@@ -46,11 +46,11 @@ function runInteractive(cmd, opts = {}) {
 function runCapture(cmd, opts = {}) {
   try {
     return execSync(cmd, {
+      ...opts,
       encoding: "utf-8",
       cwd: ROOT,
       env: { ...process.env, ...opts.env },
       stdio: ["pipe", "pipe", "pipe"],
-      ...opts,
     }).trim();
   } catch (err) {
     if (opts.ignoreError) return "";

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -93,9 +93,13 @@ SANDBOX_NAME="${1:-nemoclaw}"
 info "Using sandbox name: ${SANDBOX_NAME}"
 
 OPEN_SHELL_VERSION_RAW="$(openshell -V 2>/dev/null || true)"
-if [[ "$OPEN_SHELL_VERSION_RAW" =~ openshell[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+OPEN_SHELL_VERSION_LOWER="${OPEN_SHELL_VERSION_RAW,,}"
+if [[ "$OPEN_SHELL_VERSION_LOWER" =~ openshell[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
   export OPENSHELL_CLUSTER_IMAGE="ghcr.io/nvidia/openshell/cluster:${BASH_REMATCH[1]}"
   info "Using pinned OpenShell gateway image: ${OPENSHELL_CLUSTER_IMAGE}"
+elif [[ -n "$OPEN_SHELL_VERSION_RAW" ]]; then
+  warn "Could not parse openshell version from 'openshell -V': ${OPEN_SHELL_VERSION_RAW}"
+  warn "Skipping OpenShell gateway image pinning."
 fi
 
 # 1. Gateway — always start fresh to avoid stale state

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -95,6 +95,7 @@ info "Using sandbox name: ${SANDBOX_NAME}"
 OPEN_SHELL_VERSION_RAW="$(openshell -V 2>/dev/null || true)"
 OPEN_SHELL_VERSION_LOWER="${OPEN_SHELL_VERSION_RAW,,}"
 if [[ "$OPEN_SHELL_VERSION_LOWER" =~ openshell[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+  export IMAGE_TAG="${BASH_REMATCH[1]}"
   export OPENSHELL_CLUSTER_IMAGE="ghcr.io/nvidia/openshell/cluster:${BASH_REMATCH[1]}"
   info "Using pinned OpenShell gateway image: ${OPENSHELL_CLUSTER_IMAGE}"
 elif [[ -n "$OPEN_SHELL_VERSION_RAW" ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -92,6 +92,12 @@ fi
 SANDBOX_NAME="${1:-nemoclaw}"
 info "Using sandbox name: ${SANDBOX_NAME}"
 
+OPEN_SHELL_VERSION_RAW="$(openshell -V 2>/dev/null || true)"
+if [[ "$OPEN_SHELL_VERSION_RAW" =~ openshell[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+  export OPENSHELL_CLUSTER_IMAGE="ghcr.io/nvidia/openshell/cluster:${BASH_REMATCH[1]}"
+  info "Using pinned OpenShell gateway image: ${OPENSHELL_CLUSTER_IMAGE}"
+fi
+
 # 1. Gateway — always start fresh to avoid stale state
 info "Starting OpenShell gateway..."
 openshell gateway destroy -g nemoclaw > /dev/null 2>&1 || true

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -4,7 +4,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 
-const { buildSandboxConfigSyncScript } = require("../bin/lib/onboard");
+const { buildSandboxConfigSyncScript, getStableGatewayImageRef } = require("../bin/lib/onboard");
 
 describe("onboard helpers", () => {
   it("builds a sandbox sync script that writes config and updates the selected model", () => {
@@ -27,5 +27,14 @@ describe("onboard helpers", () => {
     assert.match(script, /json\.loads\("\{\\\"baseUrl\\\":\\\"https:\/\/inference\.local\/v1\\\",\\\"apiKey\\\":\\\"unused\\\"/);
     assert.match(script, /inference\/nemotron-3-nano:30b/);
     assert.match(script, /^exit$/m);
+  });
+
+  it("pins the gateway image to the installed OpenShell release version", () => {
+    assert.equal(
+      getStableGatewayImageRef("openshell 0.0.12"),
+      "ghcr.io/nvidia/openshell/cluster:0.0.12"
+    );
+    assert.equal(getStableGatewayImageRef("openshell 0.0.13-dev.8+gbbcaed2ea"), "ghcr.io/nvidia/openshell/cluster:0.0.13");
+    assert.equal(getStableGatewayImageRef("bogus"), null);
   });
 });

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -4,7 +4,11 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 
-const { buildSandboxConfigSyncScript, getStableGatewayImageRef } = require("../bin/lib/onboard");
+const {
+  buildSandboxConfigSyncScript,
+  getInstalledOpenshellVersion,
+  getStableGatewayImageRef,
+} = require("../bin/lib/onboard");
 
 describe("onboard helpers", () => {
   it("builds a sandbox sync script that writes config and updates the selected model", () => {
@@ -30,6 +34,9 @@ describe("onboard helpers", () => {
   });
 
   it("pins the gateway image to the installed OpenShell release version", () => {
+    assert.equal(getInstalledOpenshellVersion("openshell 0.0.12"), "0.0.12");
+    assert.equal(getInstalledOpenshellVersion("openshell 0.0.13-dev.8+gbbcaed2ea"), "0.0.13");
+    assert.equal(getInstalledOpenshellVersion("bogus"), null);
     assert.equal(
       getStableGatewayImageRef("openshell 0.0.12"),
       "ghcr.io/nvidia/openshell/cluster:0.0.12"

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -52,4 +52,27 @@ describe("runner helpers", () => {
     assert.deepEqual(calls[0][2].stdio, ["ignore", "inherit", "inherit"]);
     assert.equal(calls[1][2].stdio, "inherit");
   });
+
+  it("preserves process env when opts.env is provided", () => {
+    const calls = [];
+    const originalSpawnSync = childProcess.spawnSync;
+    childProcess.spawnSync = (...args) => {
+      calls.push(args);
+      return { status: 0 };
+    };
+
+    try {
+      delete require.cache[require.resolve(runnerPath)];
+      const { run } = require(runnerPath);
+      process.env.PATH = "/usr/local/bin:/usr/bin";
+      run("echo test", { env: { OPENSHELL_CLUSTER_IMAGE: "ghcr.io/nvidia/openshell/cluster:0.0.12" } });
+    } finally {
+      childProcess.spawnSync = originalSpawnSync;
+      delete require.cache[require.resolve(runnerPath)];
+    }
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][2].env.OPENSHELL_CLUSTER_IMAGE, "ghcr.io/nvidia/openshell/cluster:0.0.12");
+    assert.equal(calls[0][2].env.PATH, "/usr/local/bin:/usr/bin");
+  });
 });

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -56,6 +56,7 @@ describe("runner helpers", () => {
   it("preserves process env when opts.env is provided", () => {
     const calls = [];
     const originalSpawnSync = childProcess.spawnSync;
+    const originalPath = process.env.PATH;
     childProcess.spawnSync = (...args) => {
       calls.push(args);
       return { status: 0 };
@@ -67,6 +68,11 @@ describe("runner helpers", () => {
       process.env.PATH = "/usr/local/bin:/usr/bin";
       run("echo test", { env: { OPENSHELL_CLUSTER_IMAGE: "ghcr.io/nvidia/openshell/cluster:0.0.12" } });
     } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
       childProcess.spawnSync = originalSpawnSync;
       delete require.cache[require.resolve(runnerPath)];
     }


### PR DESCRIPTION
## Summary
- pin the OpenShell gateway image to the installed CLI release instead of drifting to `ghcr.io/nvidia/openshell/cluster:dev`
- apply the same pin in both `nemoclaw onboard` and `scripts/setup.sh`
- add regression coverage for the version-to-image mapping

## Why
Fresh host setups were bootstrapping a dev gateway image even when the installed CLI was `openshell 0.0.12`. On macOS this led to a mixed version pair where `policy get` worked but `policy set` returned `Unimplemented`, blocking onboarding at step 7/7.

## Testing
- `node --test test/onboard.test.js test/install-preflight.test.js`
- live repro on macOS showed `openshell 0.0.12` paired with gateway server `0.0.13-dev.8+...`
- confirmed `openshell policy set` fails against the dev gateway but the stable image tag `ghcr.io/nvidia/openshell/cluster:0.0.12` exists

Fixes #536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway startup now detects the installed OpenShell CLI version and, when a stable semantic version is found, pins and uses the matching cluster image for more consistent deployments; a log indicates when pinning is applied and a warning is emitted if detection fails.

* **Bug Fixes**
  * Command runner and gateway startup now reliably honor explicitly provided environment values while preserving existing environment entries.

* **Tests**
  * Added tests for version detection, prerelease normalization, image mapping, unrecognized inputs, and environment-preservation during runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->