### PR TITLE
refactor: fixed terminology for build.nvidia.com endpoints

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Nightly full E2E: install → onboard → live inference against NVIDIA Cloud API.
+# Nightly full E2E: install → onboard → live inference against NVIDIA Endpoint API.
 # Runs directly on the runner (not inside Docker) because OpenShell bootstraps
 # a K3s cluster inside a privileged Docker container — nesting would break networking.
 #

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ When the install completes, a summary confirms the running environment:
 ```
 ──────────────────────────────────────────────────
 Sandbox      my-assistant (Landlock + seccomp + netns)
-Model        nvidia/nemotron-3-super-120b-a12b (NVIDIA Cloud API)
+Model        nvidia/nemotron-3-super-120b-a12b (NVIDIA Endpoint API)
 ──────────────────────────────────────────────────
 Run:         nemoclaw my-assistant connect
 Status:      nemoclaw my-assistant status
@@ -169,7 +169,7 @@ NemoClaw installs the NVIDIA OpenShell runtime and Nemotron models, then uses a 
 | **Plugin**       | TypeScript CLI commands for launch, connect, status, and logs.                            |
 | **Blueprint**    | Versioned Python artifact that orchestrates sandbox creation, policy, and inference setup. |
 | **Sandbox**      | Isolated OpenShell container running OpenClaw with policy-enforced egress and filesystem.  |
-| **Inference**    | NVIDIA cloud model calls, routed through the OpenShell gateway, transparent to the agent.  |
+| **Inference**    | NVIDIA Endpoint model calls, routed through the OpenShell gateway, transparent to the agent.  |
 
 The blueprint lifecycle follows four stages: resolve the artifact, verify its digest, plan the resources, and apply through the OpenShell CLI.
 
@@ -179,11 +179,11 @@ When something goes wrong, errors may originate from either NemoClaw or the Open
 
 ## Inference
 
-Inference requests from the agent never leave the sandbox directly. OpenShell intercepts every call and routes it to the NVIDIA cloud provider.
+Inference requests from the agent never leave the sandbox directly. OpenShell intercepts every call and routes it to the NVIDIA Endpoint provider.
 
 | Provider     | Model                               | Use Case                                       |
 |--------------|--------------------------------------|-------------------------------------------------|
-| NVIDIA cloud | `nvidia/nemotron-3-super-120b-a12b` | Production. Requires an NVIDIA API key.         |
+| NVIDIA Endpoint | `nvidia/nemotron-3-super-120b-a12b` | Production. Requires an NVIDIA API key.         |
 
 Get an API key from [build.nvidia.com](https://build.nvidia.com). The `nemoclaw onboard` command prompts for this key during setup.
 
@@ -230,7 +230,7 @@ Refer to the documentation for more information on NemoClaw.
 - [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html): Learn what NemoClaw does and how it fits together.
 - [How It Works](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html): Learn about the plugin, blueprint, and sandbox lifecycle.
 - [Architecture](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html): Learn about the plugin structure, blueprint lifecycle, and sandbox environment.
-- [Inference Profiles](https://docs.nvidia.com/nemoclaw/latest/reference/inference-profiles.html): Learn about the NVIDIA cloud inference configuration.
+- [Inference Profiles](https://docs.nvidia.com/nemoclaw/latest/reference/inference-profiles.html): Learn about the NVIDIA Endpoint inference configuration.
 - [Network Policies](https://docs.nvidia.com/nemoclaw/latest/reference/network-policies.html): Learn about egress control and policy customization.
 - [CLI Commands](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html): Learn about the full command reference.
 - [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html): Troubleshoot common issues and resolution steps.

--- a/bin/lib/inference-config.js
+++ b/bin/lib/inference-config.js
@@ -27,7 +27,7 @@ function getProviderSelectionConfig(provider, model) {
         profile: DEFAULT_ROUTE_PROFILE,
         credentialEnv: DEFAULT_ROUTE_CREDENTIAL_ENV,
         provider,
-        providerLabel: "NVIDIA Cloud API",
+        providerLabel: "NVIDIA Endpoint API",
       };
     case "vllm-local":
       return {

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -560,7 +560,7 @@ async function setupNim(sandboxName, gpu) {
   options.push({
     key: "cloud",
     label:
-      "NVIDIA Cloud API (build.nvidia.com)" +
+      "NVIDIA Endpoint API (build.nvidia.com)" +
       (!ollamaRunning && !(EXPERIMENTAL && vllmRunning) ? " (recommended)" : ""),
   });
   if (hasOllama || ollamaRunning) {
@@ -711,7 +711,7 @@ async function setupNim(sandboxName, gpu) {
       model = model || (await promptCloudModel()) || DEFAULT_CLOUD_MODEL;
     }
     model = model || requestedModel || DEFAULT_CLOUD_MODEL;
-    console.log(`  Using NVIDIA Cloud API with model: ${model}`);
+    console.log(`  Using NVIDIA Endpoint API with model: ${model}`);
   }
 
   registry.updateSandbox(sandboxName, { model, provider, nimContainer });
@@ -926,7 +926,7 @@ function printDashboard(sandboxName, model, provider) {
   const nimLabel = nimStat.running ? "running" : "not running";
 
   let providerLabel = provider;
-  if (provider === "nvidia-nim") providerLabel = "NVIDIA Cloud API";
+  if (provider === "nvidia-nim") providerLabel = "NVIDIA Endpoint API";
   else if (provider === "vllm-local") providerLabel = "Local vLLM";
   else if (provider === "ollama-local") providerLabel = "Local Ollama";
 

--- a/docs/about/how-it-works.md
+++ b/docs/about/how-it-works.md
@@ -113,7 +113,7 @@ After the sandbox starts, the agent runs inside it with all network, filesystem,
 
 Inference requests from the agent never leave the sandbox directly.
 OpenShell intercepts every inference call and routes it to the configured provider.
-NemoClaw routes inference to NVIDIA cloud, specifically Nemotron 3 Super 120B through [build.nvidia.com](https://build.nvidia.com). You can switch models at runtime without restarting the sandbox.
+NemoClaw routes inference to NVIDIA Endpoints, specifically Nemotron 3 Super 120B through [build.nvidia.com](https://build.nvidia.com). You can switch models at runtime without restarting the sandbox.
 
 ## Network and Filesystem Policy
 

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -44,7 +44,7 @@ NemoClaw provides the following benefits.
 | Benefit                    | Description                                                                                                            |
 |----------------------------|------------------------------------------------------------------------------------------------------------------------|
 | Sandboxed execution        | Every agent runs inside an OpenShell sandbox with Landlock, seccomp, and network namespace isolation. No access is granted by default. |
-| NVIDIA cloud inference     | Agent traffic routes through cloud-hosted Nemotron 3 Super 120B via [build.nvidia.com](https://build.nvidia.com), transparent to the agent.          |
+| NVIDIA Endpoint inference     | Agent traffic routes through cloud-hosted Nemotron 3 Super 120B via [build.nvidia.com](https://build.nvidia.com), transparent to the agent.          |
 | Declarative network policy | Egress rules are defined in YAML. Unknown hosts are blocked and surfaced to the operator for approval.                 |
 | Single CLI                 | The `nemoclaw` command orchestrates the full stack: gateway, sandbox, inference provider, and network policy.           |
 | Blueprint lifecycle        | Versioned blueprints handle sandbox creation, digest verification, and reproducible setup.                             |

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,7 +127,7 @@ CLI commands for launching, connecting, monitoring, and managing sandboxes.
 :link: reference/inference-profiles
 :link-type: doc
 
-NVIDIA cloud inference configuration and available models.
+NVIDIA endpoint inference configuration and available models.
 
 +++
 {bdg-secondary}`Reference`

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -96,7 +96,7 @@ Inference requests from the agent never leave the sandbox directly.
 OpenShell intercepts them and routes to the configured provider:
 
 ```text
-Agent (sandbox)  ──▶  OpenShell gateway  ──▶  NVIDIA cloud (build.nvidia.com)
+Agent (sandbox)  ──▶  OpenShell gateway  ──▶  NVIDIA Endpoint (build.nvidia.com)
 ```
 
 Refer to [Inference Profiles](../reference/inference-profiles.md) for provider configuration details.

--- a/docs/reference/inference-profiles.md
+++ b/docs/reference/inference-profiles.md
@@ -1,9 +1,9 @@
 ---
 title:
-  page: "NemoClaw Inference Profiles — NVIDIA Cloud"
+  page: "NemoClaw Inference Profiles — NVIDIA Endpoint"
   nav: "Inference Profiles"
-description: "Configuration reference for NVIDIA cloud inference profiles."
-keywords: ["nemoclaw inference profiles", "nemoclaw nvidia cloud provider"]
+description: "Configuration reference for NVIDIA Endpoint inference profiles."
+keywords: ["nemoclaw inference profiles", "nemoclaw nvidia endpoint provider"]
 topics: ["generative_ai", "ai_agents"]
 tags: ["openclaw", "openshell", "inference_routing", "llms"]
 content:
@@ -29,7 +29,7 @@ Inference requests are routed transparently through the OpenShell gateway.
 
 | Profile | Provider | Model | Endpoint | Use Case |
 |---|---|---|---|---|
-| `default` | NVIDIA cloud | `nvidia/nemotron-3-super-120b-a12b` | `integrate.api.nvidia.com` | Production. Requires an NVIDIA API key. |
+| `default` | NVIDIA Endpoint | `nvidia/nemotron-3-super-120b-a12b` | `integrate.api.nvidia.com` | Production. Requires an NVIDIA API key. |
 
 ## Available Models
 
@@ -45,7 +45,7 @@ The `nvidia-nim` provider registers the following models from [build.nvidia.com]
 The default profile uses Nemotron 3 Super 120B.
 You can switch to any model in the catalog at runtime.
 
-## `default` -- NVIDIA Cloud
+## `default` -- NVIDIA Endpoint
 
 The default profile routes inference to NVIDIA's hosted API through [build.nvidia.com](https://build.nvidia.com).
 

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -240,7 +240,7 @@ export default function register(api: OpenClawPluginApi): void {
   api.registerProvider(registeredProviderForConfig(onboardCfg, providerCredentialEnv));
 
   const bannerEndpoint = onboardCfg ? describeOnboardEndpoint(onboardCfg) : "build.nvidia.com";
-  const bannerProvider = onboardCfg ? describeOnboardProvider(onboardCfg) : "NVIDIA Cloud API";
+  const bannerProvider = onboardCfg ? describeOnboardProvider(onboardCfg) : "NVIDIA Endpoint API";
   const bannerModel = onboardCfg?.model ?? "nvidia/nemotron-3-super-120b-a12b";
 
   api.logger.info("");

--- a/nemoclaw/src/onboard/config.ts
+++ b/nemoclaw/src/onboard/config.ts
@@ -35,7 +35,7 @@ export function describeOnboardProvider(config: NemoClawOnboardConfig): string {
 
   switch (config.endpointType) {
     case "build":
-      return "NVIDIA Cloud API";
+      return "NVIDIA Endpoint API";
     case "ollama":
       return "Local Ollama";
     case "vllm":

--- a/test/e2e/test-full-e2e.sh
+++ b/test/e2e/test-full-e2e.sh
@@ -2,7 +2,7 @@
 # Full E2E: install → onboard → verify inference (REAL services, no mocks)
 #
 # Proves the COMPLETE user journey including real inference against
-# the NVIDIA Cloud API. Runs install.sh --non-interactive which handles
+# the NVIDIA Endpoint API. Runs install.sh --non-interactive which handles
 # Node.js, openshell, NemoClaw, and onboard setup automatically.
 #
 # Prerequisites:
@@ -14,7 +14,7 @@
 #   NEMOCLAW_NON_INTERACTIVE=1   — required (enables non-interactive install + onboard)
 #   NEMOCLAW_SANDBOX_NAME        — sandbox name (default: e2e-nightly)
 #   NEMOCLAW_RECREATE_SANDBOX=1  — recreate sandbox if it exists from a previous run
-#   NVIDIA_API_KEY               — required for NVIDIA Cloud API inference
+#   NVIDIA_API_KEY               — required for NVIDIA Endpoint API inference
 #
 # Usage:
 #   NEMOCLAW_NON_INTERACTIVE=1 NVIDIA_API_KEY=nvapi-... bash test/e2e/test-full-e2e.sh
@@ -221,7 +221,7 @@ fi
 # ══════════════════════════════════════════════════════════════════
 section "Phase 4: Live inference"
 
-# ── Test 4a: Direct NVIDIA Cloud API ──
+# ── Test 4a: Direct NVIDIA Endpoint API ──
 info "[LIVE] Direct API test → integrate.api.nvidia.com..."
 api_response=$(curl -s --max-time 30 \
   -X POST https://integrate.api.nvidia.com/v1/chat/completions \
@@ -271,7 +271,7 @@ if [ -n "$sandbox_response" ]; then
   sandbox_content=$(echo "$sandbox_response" | parse_chat_content 2>/dev/null) || true
   if echo "$sandbox_content" | grep -qi "PONG"; then
     pass "[LIVE] Sandbox inference: model responded with PONG through sandbox"
-    info "Full path proven: user → sandbox → openshell gateway → NVIDIA Cloud API → response"
+    info "Full path proven: user → sandbox → openshell gateway → NVIDIA Endpoint API → response"
   else
     fail "[LIVE] Sandbox inference: expected PONG, got: ${sandbox_content:0:200}"
   fi

--- a/test/inference-config.test.js
+++ b/test/inference-config.test.js
@@ -52,7 +52,7 @@ describe("inference selection config", () => {
       profile: DEFAULT_ROUTE_PROFILE,
       credentialEnv: DEFAULT_ROUTE_CREDENTIAL_ENV,
       provider: "nvidia-nim",
-      providerLabel: "NVIDIA Cloud API",
+      providerLabel: "NVIDIA Endpoint API",
     });
   });
 


### PR DESCRIPTION
## Summary

Aligns user-facing wording with build.nvidia.com / hosted inference naming by replacing “NVIDIA Cloud API” / “NVIDIA cloud” with “NVIDIA Endpoint API” / “NVIDIA Endpoint” (and related phrases) in the CLI, plugin defaults, README, reference docs, workflow comments, and tests. No change to inference URLs, providers, or behavior—terminology and labels only.

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes

- CLI / runtime labels: providerLabel and onboard/dashboard copy in bin/lib/inference-config.js, bin/lib/onboard.js; default banner strings in nemoclaw/src/index.ts and describeOnboardProvider in nemoclaw/src/onboard/config.ts.
- Docs: README inference section and glossary; docs/about/overview.md, docs/about/how-it-works.md, docs/index.md, docs/reference/architecture.md, docs/reference/inference-profiles.md (title, frontmatter, tables, diagram text).
- Automation / tests: Comment and log strings in .github/workflows/nightly-e2e.yaml, test/e2e/test-full-e2e.sh; expectation in test/inference-config.test.js for providerLabel.

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [X] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [X] `make check` passes.
- [X] `npm test` passes.
- [X] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General
- [X] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [X] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [X] `make format` applied (TypeScript and Python).
- [X] Tests added or updated for new or changed behavior.
- [X] No secrets, API keys, or credentials committed.
- [X] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [X] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [X] New pages include SPDX license header and frontmatter, if creating a new page.
- [X] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized terminology: updated all references from "NVIDIA Cloud API" to "NVIDIA Endpoint API" across documentation, user-facing labels, configuration text, and reference materials to reflect current provider naming conventions.

* **Chores**
  * Updated test suite and internal references to align with revised NVIDIA provider terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->