### PR TITLE
fix: Check for git command existence in install_nemoclaw

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -444,6 +444,7 @@ pre_extract_openclaw() {
 }
 
 install_nemoclaw() {
+  command_exists git || error "git was not found on PATH."
   if [[ -f "./package.json" ]] && grep -q '"name": "nemoclaw"' ./package.json 2>/dev/null; then
     info "NemoClaw package.json found in current directory — installing from source…"
     spin "Preparing OpenClaw package" bash -c "$(declare -f info warn pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$(pwd)" \


### PR DESCRIPTION
## Summary
Ubuntu server 24.04.4 LTS minimal installation does not include git.  The install script assumes git to exist (not _entirely_ unreasonable) and terminates ungracefully:

```
Computing checksum with sha256sum
Checksums matched!
Now using node v22.22.1 (npm v10.9.4)
Creating default alias: default -> 22 (-> v22.22.1 *)
[INFO]  Node.js installed: v22.22.1
[INFO]  Runtime OK: Node.js v22.22.1, npm 10.9.4
[INFO]  Installing NemoClaw from GitHub…
main: line 281: git: command not found
```

## Changes

- Add a check to install_nemoclaw() to check for git.  FUTURE:  might be better to have a single prerequisites-check function.  You can decide.

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] Ran the update on my system that was producing the error above.  It now terminates gracefully.

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

_Not Applicable for this change_

- [ ] `make format` applied (TypeScript and Python).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes

_Not Applicable for this change_

- [ ] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now performs a pre-flight check that explicitly verifies Git is available on PATH and aborts with a clear error if missing.
  * Prevents the installer from proceeding without required tooling, reducing failed or partial installations and improving diagnostic messages for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->