### PR TITLE
fix: resolve openclaw.json permissions conflict and scope Dockerfile …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,22 @@ RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
         /sandbox/.openclaw-data/workspace \
         /sandbox/.openclaw-data/skills \
         /sandbox/.openclaw-data/hooks \
+        /sandbox/.openclaw-data/identity \
+        /sandbox/.openclaw-data/devices \
+        /sandbox/.openclaw-data/canvas \
+        /sandbox/.openclaw-data/cron \
     && mkdir -p /sandbox/.openclaw \
     && ln -s /sandbox/.openclaw-data/agents /sandbox/.openclaw/agents \
     && ln -s /sandbox/.openclaw-data/extensions /sandbox/.openclaw/extensions \
     && ln -s /sandbox/.openclaw-data/workspace /sandbox/.openclaw/workspace \
     && ln -s /sandbox/.openclaw-data/skills /sandbox/.openclaw/skills \
     && ln -s /sandbox/.openclaw-data/hooks /sandbox/.openclaw/hooks \
+    && ln -s /sandbox/.openclaw-data/identity /sandbox/.openclaw/identity \
+    && ln -s /sandbox/.openclaw-data/devices /sandbox/.openclaw/devices \
+    && ln -s /sandbox/.openclaw-data/canvas /sandbox/.openclaw/canvas \
+    && ln -s /sandbox/.openclaw-data/cron /sandbox/.openclaw/cron \
+    && touch /sandbox/.openclaw-data/update-check.json \
+    && ln -s /sandbox/.openclaw-data/update-check.json /sandbox/.openclaw/update-check.json \
     && chown -R sandbox:sandbox /sandbox/.openclaw /sandbox/.openclaw-data
 
 # Install OpenClaw CLI
@@ -91,13 +101,21 @@ chat_origin = f'{parsed.scheme}://{parsed.netloc}' if parsed.scheme and parsed.n
 origins = ['http://127.0.0.1:18789']; \
 origins = list(dict.fromkeys(origins + [chat_origin])); \
 config = { \
-    'agents': {'defaults': {'model': {'primary': model}}}, \
-    'models': {'mode': 'merge', 'providers': {'nvidia': { \
-        'baseUrl': 'https://inference.local/v1', \
-        'apiKey': 'openshell-managed', \
-        'api': 'openai-completions', \
-        'models': [{'id': model.split('/')[-1], 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
-    }}}, \
+    'agents': {'defaults': {'model': {'primary': f'inference/{model}'}}}, \
+    'models': {'mode': 'merge', 'providers': { \
+        'nvidia': { \
+            'baseUrl': 'https://inference.local/v1', \
+            'apiKey': 'openshell-managed', # pragma: allowlist secret \
+            'api': 'openai-completions', \
+            'models': [{'id': model.split('/')[-1], 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
+        }, \
+        'inference': { \
+            'baseUrl': 'https://inference.local/v1', \
+            'apiKey': 'unused', # pragma: allowlist secret \
+            'api': 'openai-completions', \
+            'models': [{'id': model, 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
+        } \
+    }}, \
     'gateway': { \
         'mode': 'local', \
         'controlUi': { \

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -103,50 +103,17 @@ function buildSandboxConfigSyncScript(selectionConfig) {
         ? "vllm-local"
         : "nvidia-nim";
   const primaryModel = getOpenClawPrimaryModel(providerType, selectionConfig.model);
-  const providerKey = "inference";
-  const providerConfig = {
-    baseUrl: selectionConfig.endpointUrl,
-    apiKey: "unused",
-    api: "openai-completions",
-    models: [
-      {
-        id: selectionConfig.model,
-        name: selectionConfig.model,
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 131072,
-        maxTokens: 4096,
-      },
-    ],
-  };
+  // openclaw.json is immutable (root:root 444, Landlock read-only) — never
+  // write to it at runtime.  The inference provider and default model are baked
+  // at image build time.  We only write the NemoClaw selection config (writable
+  // ~/.nemoclaw/) and override the active model via `openclaw models set`,
+  // which writes to the agent-level config in ~/.openclaw-data/ (writable).
   return `
 set -euo pipefail
-mkdir -p ~/.nemoclaw ~/.openclaw
+mkdir -p ~/.nemoclaw
 cat > ~/.nemoclaw/config.json <<'EOF_NEMOCLAW_CFG'
 ${JSON.stringify(selectionConfig, null, 2)}
 EOF_NEMOCLAW_CFG
-python3 - <<'PYCFG'
-import json
-import os
-
-cfg_path = os.path.expanduser('~/.openclaw/openclaw.json')
-cfg = {}
-if os.path.exists(cfg_path):
-    with open(cfg_path) as f:
-        cfg = json.load(f)
-
-cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = ${JSON.stringify(primaryModel)}
-models_cfg = cfg.setdefault('models', {})
-models_cfg.setdefault('mode', 'merge')
-providers_cfg = models_cfg.setdefault('providers', {})
-providers_cfg[${JSON.stringify(providerKey)}] = json.loads(${pythonLiteralJson(providerConfig)})
-
-with open(cfg_path, 'w') as f:
-    json.dump(cfg, f, indent=2)
-
-os.chmod(cfg_path, 0o600)
-PYCFG
 openclaw models set ${shellQuote(primaryModel)} > /dev/null 2>&1 || true
 exit
 `.trim();

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -127,9 +127,10 @@ PYAUTOPAIR
 }
 
 echo 'Setting up NemoClaw...'
-openclaw doctor --fix > /dev/null 2>&1 || true
+# openclaw doctor --fix and openclaw plugins install already ran at build time
+# (Dockerfile Step 28). At runtime they fail with EPERM against the locked
+# /sandbox/.openclaw directory and accomplish nothing.
 write_auth_profile
-openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
 if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
   exec "${NEMOCLAW_CMD[@]}"

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -7,7 +7,7 @@ const assert = require("node:assert/strict");
 const { buildSandboxConfigSyncScript } = require("../bin/lib/onboard");
 
 describe("onboard helpers", () => {
-  it("builds a sandbox sync script that writes config and updates the selected model", () => {
+  it("builds a sandbox sync script that writes config and sets the model", () => {
     const script = buildSandboxConfigSyncScript({
       endpointType: "custom",
       endpointUrl: "https://inference.local/v1",
@@ -18,14 +18,17 @@ describe("onboard helpers", () => {
       onboardedAt: "2026-03-18T12:00:00.000Z",
     });
 
+    // Writes NemoClaw selection config to writable ~/.nemoclaw/
     assert.match(script, /cat > ~\/\.nemoclaw\/config\.json/);
     assert.match(script, /"model": "nemotron-3-nano:30b"/);
     assert.match(script, /"credentialEnv": "OPENAI_API_KEY"/);
+
+    // Sets the active model via openclaw CLI (writes to agent config, not openclaw.json)
     assert.match(script, /openclaw models set 'inference\/nemotron-3-nano:30b'/);
-    assert.match(script, /cfg\.setdefault\('agents', \{\}\)\.setdefault\('defaults', \{\}\)\.setdefault\('model', \{\}\)\['primary'\]/);
-    assert.match(script, /providers_cfg\["inference"\]/);
-    assert.match(script, /json\.loads\("\{\\\"baseUrl\\\":\\\"https:\/\/inference\.local\/v1\\\",\\\"apiKey\\\":\\\"unused\\\"/);
-    assert.match(script, /inference\/nemotron-3-nano:30b/);
+
+    // Must NOT write to openclaw.json — it is immutable (root:root 444)
+    assert.doesNotMatch(script, /openclaw\.json/);
+
     assert.match(script, /^exit$/m);
   });
 });


### PR DESCRIPTION
…lockdown

- Bake both 'nvidia' and 'inference' providers into openclaw.json at image build time; remove runtime Python config-patching from buildSandboxConfigSyncScript (writes to locked root:root 444 file)
- Use `openclaw models set` for runtime model selection (writes to writable agent config in .openclaw-data/)
- Add identity/, devices/, canvas/, cron/ to .openclaw-data symlinks so the gateway can write device-auth.json at runtime
- Remove dead `openclaw doctor --fix` and `openclaw plugins install` calls from nemoclaw-start.sh (already ran at build time, fail with EPERM at runtime)

Caused-by: 2d3f84e (fix: lock gateway config via Landlock filesystem policy) Fixes #514

## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [x] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `make check` passes.
- [x] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [x] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] `make format` applied (TypeScript and Python).
- [x] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple model providers in configuration.

* **Improvements**
  * Simplified runtime initialization by moving configuration steps to build time, reducing startup overhead.
  * Model selection now handled via command-line interface for better consistency.

* **Tests**
  * Updated test cases to reflect new configuration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->