### PR TITLE
fix(blueprint): clawhub.ai and node egress in OpenShell policy

### DIFF
--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -72,13 +72,13 @@ The following endpoint groups are allowed by default:
   - GET, POST, PATCH, PUT, DELETE
 
 * - `clawhub`
-  - `clawhub.com:443`
-  - `/usr/local/bin/openclaw`
+  - `clawhub.ai:443`
+  - `/usr/local/bin/openclaw`, `/usr/local/bin/node`
   - GET, POST
 
 * - `openclaw_api`
   - `openclaw.ai:443`
-  - `/usr/local/bin/openclaw`
+  - `/usr/local/bin/openclaw`, `/usr/local/bin/node`
   - GET, POST
 
 * - `openclaw_docs`

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -101,14 +101,14 @@ network_policies:
 
   # ── OpenClaw "phone home" ────────────────────────────────────────────
   # Minimum viable set for OpenClaw to authenticate, discover plugins,
-  # and reach ClawHub. Binary-restricted to openclaw only.
+  # and reach ClawHub. Restricted to openclaw and node (skill flows run on Node).
   # Docs access is read-only (GET). ClawHub and openclaw.ai are
   # restricted to GET+POST (auth flows, plugin discovery).
 
   clawhub:
     name: clawhub
     endpoints:
-      - host: clawhub.com
+      - host: clawhub.ai
         port: 443
         protocol: rest
         enforcement: enforce
@@ -118,6 +118,7 @@ network_policies:
           - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }
 
   openclaw_api:
     name: openclaw_api
@@ -132,6 +133,7 @@ network_policies:
           - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }
 
   openclaw_docs:
     name: openclaw_docs


### PR DESCRIPTION
## Summary

- **ClawHub domain:** Updated the default OpenShell sandbox network policy so the ClawHub allowlist uses `clawhub.ai` instead of `clawhub.com`, matching the real host and preventing the proxy from blocking skill installs from the sandbox.
- **Binary allowlist:** Added `/usr/local/bin/node` to the `clawhub` and `openclaw_api` network policy groups alongside `openclaw`, so Node-based OpenClaw skill flows can reach those endpoints.
- **Docs:** Refreshed `docs/reference/network-policies.md` so the reference table matches the default policy.

## How to test

From the repository root (per [CONTRIBUTING](CONTRIBUTING.md)):

1. `make check`
2. `npm test`
3. `cd nemoclaw && npm test`

For a quick sanity check on this change, confirm `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` lists `host: clawhub.ai` under `clawhub` and that `binaries` includes `/usr/local/bin/node` for both `clawhub` and `openclaw_api`.

Fixes #507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated network policy reference documentation with current endpoint information and authorized executable configurations.

* **Chores**
  * Updated sandbox network security policies to enable Node.js support alongside existing authorized executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->