### PR TITLE
fix(onboard): avoid piped sandbox connect sync in step 6

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -6,6 +6,7 @@
 // NEMOCLAW_NON_INTERACTIVE=1 env var for CI/CD pipelines.
 
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { ROOT, SCRIPTS, run, runCapture } = require("./runner");
 const {
@@ -163,6 +164,12 @@ PYCFG
 openclaw models set ${shellQuote(primaryModel)} > /dev/null 2>&1 || true
 exit
 `.trim();
+}
+
+function writeSandboxConfigSyncFile(script, tmpDir = os.tmpdir(), now = Date.now()) {
+  const scriptFile = path.join(tmpDir, `nemoclaw-sync-${now}.sh`);
+  fs.writeFileSync(scriptFile, `${script}\n`, { mode: 0o600 });
+  return scriptFile;
 }
 
 async function promptCloudModel() {
@@ -826,9 +833,14 @@ async function setupOpenclaw(sandboxName, model, provider) {
       onboardedAt: new Date().toISOString(),
     };
     const script = buildSandboxConfigSyncScript(sandboxConfig);
-    run(`cat <<'EOF_NEMOCLAW_SYNC' | openshell sandbox connect "${sandboxName}"
-${script}
-EOF_NEMOCLAW_SYNC`, { stdio: ["ignore", "ignore", "inherit"] });
+    const scriptFile = writeSandboxConfigSyncFile(script);
+    try {
+      run(`openshell sandbox connect "${sandboxName}" < ${shellQuote(scriptFile)}`, {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+    } finally {
+      fs.unlinkSync(scriptFile);
+    }
   }
 
   console.log("  ✓ OpenClaw gateway launched inside sandbox");
@@ -998,4 +1010,5 @@ module.exports = {
   isSandboxReady,
   onboard,
   setupNim,
+  writeSandboxConfigSyncFile,
 };

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 
@@ -8,6 +11,7 @@ const {
   buildSandboxConfigSyncScript,
   getInstalledOpenshellVersion,
   getStableGatewayImageRef,
+  writeSandboxConfigSyncFile,
 } = require("../bin/lib/onboard");
 
 describe("onboard helpers", () => {
@@ -43,5 +47,16 @@ describe("onboard helpers", () => {
     );
     assert.equal(getStableGatewayImageRef("openshell 0.0.13-dev.8+gbbcaed2ea"), "ghcr.io/nvidia/openshell/cluster:0.0.13");
     assert.equal(getStableGatewayImageRef("bogus"), null);
+  });
+
+  it("writes sandbox sync scripts to a temp file for stdin redirection", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-test-"));
+    try {
+      const scriptFile = writeSandboxConfigSyncFile("echo test", tmpDir, 1234);
+      assert.equal(scriptFile, path.join(tmpDir, "nemoclaw-sync-1234.sh"));
+      assert.equal(fs.readFileSync(scriptFile, "utf8"), "echo test\n");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- replace the piped heredoc sandbox sync path in step 6 with a temp-file stdin redirect
- keep the generated sync script unchanged
- add regression coverage for the temp-file helper

Fixes #580

## Testing
- `node --test test/onboard.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced sandbox connection script handling with improved temporary file management and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->