### PR TITLE
fix: make openclaw.json immutable at runtime, move config to build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,13 +105,13 @@ config = { \
     'models': {'mode': 'merge', 'providers': { \
         'nvidia': { \
             'baseUrl': 'https://inference.local/v1', \
-            'apiKey': 'openshell-managed', # pragma: allowlist secret \
+            'apiKey': 'openshell-managed', \
             'api': 'openai-completions', \
             'models': [{'id': model.split('/')[-1], 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
         }, \
         'inference': { \
             'baseUrl': 'https://inference.local/v1', \
-            'apiKey': 'unused', # pragma: allowlist secret \
+            'apiKey': 'unused', \
             'api': 'openai-completions', \
             'models': [{'id': model, 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
         } \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,22 @@ RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
         /sandbox/.openclaw-data/workspace \
         /sandbox/.openclaw-data/skills \
         /sandbox/.openclaw-data/hooks \
+        /sandbox/.openclaw-data/identity \
+        /sandbox/.openclaw-data/devices \
+        /sandbox/.openclaw-data/canvas \
+        /sandbox/.openclaw-data/cron \
     && mkdir -p /sandbox/.openclaw \
     && ln -s /sandbox/.openclaw-data/agents /sandbox/.openclaw/agents \
     && ln -s /sandbox/.openclaw-data/extensions /sandbox/.openclaw/extensions \
     && ln -s /sandbox/.openclaw-data/workspace /sandbox/.openclaw/workspace \
     && ln -s /sandbox/.openclaw-data/skills /sandbox/.openclaw/skills \
     && ln -s /sandbox/.openclaw-data/hooks /sandbox/.openclaw/hooks \
+    && ln -s /sandbox/.openclaw-data/identity /sandbox/.openclaw/identity \
+    && ln -s /sandbox/.openclaw-data/devices /sandbox/.openclaw/devices \
+    && ln -s /sandbox/.openclaw-data/canvas /sandbox/.openclaw/canvas \
+    && ln -s /sandbox/.openclaw-data/cron /sandbox/.openclaw/cron \
+    && touch /sandbox/.openclaw-data/update-check.json \
+    && ln -s /sandbox/.openclaw-data/update-check.json /sandbox/.openclaw/update-check.json \
     && chown -R sandbox:sandbox /sandbox/.openclaw /sandbox/.openclaw-data
 
 # Install OpenClaw CLI
@@ -91,13 +101,21 @@ chat_origin = f'{parsed.scheme}://{parsed.netloc}' if parsed.scheme and parsed.n
 origins = ['http://127.0.0.1:18789']; \
 origins = list(dict.fromkeys(origins + [chat_origin])); \
 config = { \
-    'agents': {'defaults': {'model': {'primary': model}}}, \
-    'models': {'mode': 'merge', 'providers': {'nvidia': { \
-        'baseUrl': 'https://inference.local/v1', \
-        'apiKey': 'openshell-managed', \
-        'api': 'openai-completions', \
-        'models': [{'id': model.split('/')[-1], 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
-    }}}, \
+    'agents': {'defaults': {'model': {'primary': f'inference/{model}'}}}, \
+    'models': {'mode': 'merge', 'providers': { \
+        'nvidia': { \
+            'baseUrl': 'https://inference.local/v1', \
+            'apiKey': 'openshell-managed', # pragma: allowlist secret \
+            'api': 'openai-completions', \
+            'models': [{'id': model.split('/')[-1], 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
+        }, \
+        'inference': { \
+            'baseUrl': 'https://inference.local/v1', \
+            'apiKey': 'unused', # pragma: allowlist secret \
+            'api': 'openai-completions', \
+            'models': [{'id': model, 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
+        } \
+    }}, \
     'gateway': { \
         'mode': 'local', \
         'controlUi': { \

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -116,50 +116,17 @@ function buildSandboxConfigSyncScript(selectionConfig) {
         ? "vllm-local"
         : "nvidia-nim";
   const primaryModel = getOpenClawPrimaryModel(providerType, selectionConfig.model);
-  const providerKey = "inference";
-  const providerConfig = {
-    baseUrl: selectionConfig.endpointUrl,
-    apiKey: "unused",
-    api: "openai-completions",
-    models: [
-      {
-        id: selectionConfig.model,
-        name: selectionConfig.model,
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 131072,
-        maxTokens: 4096,
-      },
-    ],
-  };
+  // openclaw.json is immutable (root:root 444, Landlock read-only) — never
+  // write to it at runtime.  The inference provider and default model are baked
+  // at image build time.  We only write the NemoClaw selection config (writable
+  // ~/.nemoclaw/) and override the active model via `openclaw models set`,
+  // which writes to the agent-level config in ~/.openclaw-data/ (writable).
   return `
 set -euo pipefail
-mkdir -p ~/.nemoclaw ~/.openclaw
+mkdir -p ~/.nemoclaw
 cat > ~/.nemoclaw/config.json <<'EOF_NEMOCLAW_CFG'
 ${JSON.stringify(selectionConfig, null, 2)}
 EOF_NEMOCLAW_CFG
-python3 - <<'PYCFG'
-import json
-import os
-
-cfg_path = os.path.expanduser('~/.openclaw/openclaw.json')
-cfg = {}
-if os.path.exists(cfg_path):
-    with open(cfg_path) as f:
-        cfg = json.load(f)
-
-cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = ${JSON.stringify(primaryModel)}
-models_cfg = cfg.setdefault('models', {})
-models_cfg.setdefault('mode', 'merge')
-providers_cfg = models_cfg.setdefault('providers', {})
-providers_cfg[${JSON.stringify(providerKey)}] = json.loads(${pythonLiteralJson(providerConfig)})
-
-with open(cfg_path, 'w') as f:
-    json.dump(cfg, f, indent=2)
-
-os.chmod(cfg_path, 0o600)
-PYCFG
 openclaw models set ${shellQuote(primaryModel)} > /dev/null 2>&1 || true
 exit
 `.trim();

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -19,8 +19,6 @@ const {
 const {
   CLOUD_MODEL_OPTIONS,
   DEFAULT_CLOUD_MODEL,
-  DEFAULT_OLLAMA_MODEL,
-  getOpenClawPrimaryModel,
   getProviderSelectionConfig,
 } = require("./inference-config");
 const {
@@ -102,32 +100,17 @@ function getStableGatewayImageRef(versionOutput = null) {
   return `ghcr.io/nvidia/openshell/cluster:${version}`;
 }
 
-function pythonLiteralJson(value) {
-  return JSON.stringify(JSON.stringify(value));
-}
-
 function buildSandboxConfigSyncScript(selectionConfig) {
-  const providerType =
-    selectionConfig.profile === "inference-local"
-      ? selectionConfig.model === DEFAULT_OLLAMA_MODEL
-        ? "ollama-local"
-        : "nvidia-nim"
-      : selectionConfig.endpointType === "vllm"
-        ? "vllm-local"
-        : "nvidia-nim";
-  const primaryModel = getOpenClawPrimaryModel(providerType, selectionConfig.model);
   // openclaw.json is immutable (root:root 444, Landlock read-only) — never
-  // write to it at runtime.  The inference provider and default model are baked
-  // at image build time.  We only write the NemoClaw selection config (writable
-  // ~/.nemoclaw/) and override the active model via `openclaw models set`,
-  // which writes to the agent-level config in ~/.openclaw-data/ (writable).
+  // write to it at runtime.  Model routing is handled by the host-side
+  // gateway (`openshell inference set` in Step 5), not from inside the
+  // sandbox.  We only write the NemoClaw selection config (~/.nemoclaw/).
   return `
 set -euo pipefail
 mkdir -p ~/.nemoclaw
 cat > ~/.nemoclaw/config.json <<'EOF_NEMOCLAW_CFG'
 ${JSON.stringify(selectionConfig, null, 2)}
 EOF_NEMOCLAW_CFG
-openclaw models set ${shellQuote(primaryModel)} > /dev/null 2>&1 || true
 exit
 `.trim();
 }

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -127,9 +127,10 @@ PYAUTOPAIR
 }
 
 echo 'Setting up NemoClaw...'
-openclaw doctor --fix > /dev/null 2>&1 || true
+# openclaw doctor --fix and openclaw plugins install already ran at build time
+# (Dockerfile Step 28). At runtime they fail with EPERM against the locked
+# /sandbox/.openclaw directory and accomplish nothing.
 write_auth_profile
-openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
 if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
   exec "${NEMOCLAW_CMD[@]}"

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -11,7 +11,7 @@ const {
 } = require("../bin/lib/onboard");
 
 describe("onboard helpers", () => {
-  it("builds a sandbox sync script that writes config and sets the model", () => {
+  it("builds a sandbox sync script that only writes nemoclaw config", () => {
     const script = buildSandboxConfigSyncScript({
       endpointType: "custom",
       endpointUrl: "https://inference.local/v1",
@@ -27,11 +27,10 @@ describe("onboard helpers", () => {
     assert.match(script, /"model": "nemotron-3-nano:30b"/);
     assert.match(script, /"credentialEnv": "OPENAI_API_KEY"/);
 
-    // Sets the active model via openclaw CLI (writes to agent config, not openclaw.json)
-    assert.match(script, /openclaw models set 'inference\/nemotron-3-nano:30b'/);
-
-    // Must NOT write to openclaw.json — it is immutable (root:root 444)
+    // Must NOT modify openclaw config from inside the sandbox — model routing
+    // is handled by the host-side gateway (openshell inference set)
     assert.doesNotMatch(script, /openclaw\.json/);
+    assert.doesNotMatch(script, /openclaw models set/);
 
     assert.match(script, /^exit$/m);
   });

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -11,7 +11,7 @@ const {
 } = require("../bin/lib/onboard");
 
 describe("onboard helpers", () => {
-  it("builds a sandbox sync script that writes config and updates the selected model", () => {
+  it("builds a sandbox sync script that writes config and sets the model", () => {
     const script = buildSandboxConfigSyncScript({
       endpointType: "custom",
       endpointUrl: "https://inference.local/v1",
@@ -22,14 +22,17 @@ describe("onboard helpers", () => {
       onboardedAt: "2026-03-18T12:00:00.000Z",
     });
 
+    // Writes NemoClaw selection config to writable ~/.nemoclaw/
     assert.match(script, /cat > ~\/\.nemoclaw\/config\.json/);
     assert.match(script, /"model": "nemotron-3-nano:30b"/);
     assert.match(script, /"credentialEnv": "OPENAI_API_KEY"/);
+
+    // Sets the active model via openclaw CLI (writes to agent config, not openclaw.json)
     assert.match(script, /openclaw models set 'inference\/nemotron-3-nano:30b'/);
-    assert.match(script, /cfg\.setdefault\('agents', \{\}\)\.setdefault\('defaults', \{\}\)\.setdefault\('model', \{\}\)\['primary'\]/);
-    assert.match(script, /providers_cfg\["inference"\]/);
-    assert.match(script, /json\.loads\("\{\\\"baseUrl\\\":\\\"https:\/\/inference\.local\/v1\\\",\\\"apiKey\\\":\\\"unused\\\"/);
-    assert.match(script, /inference\/nemotron-3-nano:30b/);
+
+    // Must NOT write to openclaw.json — it is immutable (root:root 444)
+    assert.doesNotMatch(script, /openclaw\.json/);
+
     assert.match(script, /^exit$/m);
   });
 


### PR DESCRIPTION
## Summary

Makes `openclaw.json` fully immutable at runtime by moving all configuration to build time and removing all runtime config modification from inside the sandbox. Model routing is handled by the host-side gateway (`openshell inference set`), not from inside the sandbox.

- Bake both `nvidia` and `inference` providers into `openclaw.json` at Docker build time
- Remove runtime Python config-patching from `buildSandboxConfigSyncScript` (was writing to locked `root:root 444` file)
- Remove `openclaw models set` from sync script — it also writes to `openclaw.json`, which is correctly locked. Model selection happens from the host via `openshell inference set` (Step 5 of onboard)
- Add `identity/`, `devices/`, `canvas/`, `cron/`, `update-check.json` to `.openclaw-data` symlinks so the gateway can write device-auth.json at runtime
- Remove dead `openclaw doctor --fix` and `openclaw plugins install` calls from `nemoclaw-start.sh` (already ran at build time, fail with EPERM at runtime)
- Fix `# pragma: allowlist secret` comments that broke inline Python in Dockerfile (DanTup's finding on #570)
- Clean up dead code: `pythonLiteralJson`, unused `getOpenClawPrimaryModel`/`DEFAULT_OLLAMA_MODEL` imports

Caused-by: 2d3f84e (fix: lock gateway config via Landlock filesystem policy)
Fixes #580
Follow-up to #514
Supersedes #570 (cherry-picked + pragma fix + removed `openclaw models set`)

## Design

The sandbox should never modify its own configuration — that's giving the prisoner keys to his own cell. The OpenShell security model enforces this via:

1. **Landlock** — `/sandbox/.openclaw` is read-only in the filesystem policy
2. **DAC** — `openclaw.json` is `root:root 444`
3. **Host-side routing** — `openshell inference set` configures the gateway's privacy router from outside; the sandbox just calls `https://inference.local/v1` and the gateway handles model routing, credential injection, and request rewriting

The sync script (Step 6) now only writes NemoClaw's own selection config to `~/.nemoclaw/config.json` (writable). All model/provider config lives at the gateway layer.

## Test results

### Automated
- [x] `npm test` — 173/173 pass

### Docker build
- [x] Build succeeds (pragma comment fix unblocks the inline Python)
- [x] Both providers (`nvidia`, `inference`) baked into `openclaw.json`
- [x] `openclaw.json` is `root:root 444`
- [x] All 10 symlinks present (agents, extensions, workspace, skills, hooks, identity, devices, canvas, cron, update-check.json)
- [x] Writable dirs confirmed: identity, devices, canvas, cron

### Security verification
- [x] `echo >> ~/.openclaw/openclaw.json` fails with permission denied from inside sandbox
- [x] `openclaw models set` fails with EACCES from inside sandbox (writes to `openclaw.json`)
- [x] `openclaw.json` hash unchanged after onboard (no runtime writes)

### Host-side model routing
- [x] `openshell inference set` switches model from host without sandbox involvement
- [x] Switched model routes correctly inside sandbox (gateway rewrites requests)
- [x] Second model switch works dynamically (no sandbox restart needed)
- [x] Brand-new model (not in Dockerfile or onboard picker) works without image rebuild
- [x] Full onboard with non-default model selection completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured initialization and model configuration to occur at Docker build time rather than runtime startup, reducing startup overhead.
  * Simplified the application startup entrypoint by removing redundant initialization steps.
  * Updated model routing configuration defaults and provider mapping structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->