### PR TITLE
feat: add Rabbit R1 device pairing command

### DIFF
--- a/bin/lib/credentials.js
+++ b/bin/lib/credentials.js
@@ -32,21 +32,17 @@ function getCredential(key) {
 }
 
 function prompt(question) {
-  return new Promise((resolve) => {
-    const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
-    rl.question(question, (answer) => {
-      rl.close();
-      if (!process.stdin.isTTY) {
-        if (typeof process.stdin.pause === "function") {
-          process.stdin.pause();
-        }
-        if (typeof process.stdin.unref === "function") {
-          process.stdin.unref();
-        }
-      }
-      resolve(answer.trim());
-    });
+  // Use bash `read` instead of Node.js readline to avoid readline hanging
+  // after heavy spawnSync/execSync usage (gateway start, preflight checks).
+  // Node.js readline's internal terminal mode management can get corrupted
+  // when many synchronous child processes have run before the first prompt.
+  const { spawnSync } = require("child_process");
+  process.stderr.write(question);
+  const result = spawnSync("bash", ["-c", 'read -r line && printf "%s" "$line"'], {
+    stdio: ["inherit", "pipe", "inherit"],
+    encoding: "utf-8",
   });
+  return Promise.resolve((result.stdout || "").trim());
 }
 
 async function ensureApiKey() {

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -28,7 +28,7 @@ const {
   isUnsupportedMacosRuntime,
   shouldPatchCoredns,
 } = require("./platform");
-const { prompt, ensureApiKey, getCredential } = require("./credentials");
+const { prompt, ensureApiKey, getCredential, saveCredential } = require("./credentials");
 const registry = require("./registry");
 const nim = require("./nim");
 const policies = require("./policies");
@@ -473,10 +473,9 @@ async function createSandbox(gpu) {
   const os = require("os");
   const buildCtx = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-"));
   fs.copyFileSync(path.join(ROOT, "Dockerfile"), path.join(buildCtx, "Dockerfile"));
-  run(`cp -r "${path.join(ROOT, "nemoclaw")}" "${buildCtx}/nemoclaw"`);
+  run(`rsync -a --exclude node_modules --exclude src "${path.join(ROOT, "nemoclaw")}/" "${buildCtx}/nemoclaw/"`);
   run(`cp -r "${path.join(ROOT, "nemoclaw-blueprint")}" "${buildCtx}/nemoclaw-blueprint"`);
   run(`cp -r "${path.join(ROOT, "scripts")}" "${buildCtx}/scripts"`);
-  run(`rm -rf "${buildCtx}/nemoclaw/node_modules"`, { ignoreError: true });
 
   // Create sandbox (use -- echo to avoid dropping into interactive shell)
   // Pass the base policy so sandbox starts in proxy mode (required for policy updates later)

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -339,6 +339,11 @@ function sandboxPolicyList(sandboxName) {
   console.log("");
 }
 
+function sandboxR1Connect(sandboxName, actionArgs) {
+  const tunnelFlag = actionArgs.includes("--tunnel") ? " --tunnel" : "";
+  runInteractive(`bash "${SCRIPTS}/r1-connect.sh" --sandbox "${sandboxName}"${tunnelFlag}`);
+}
+
 function sandboxDestroy(sandboxName) {
   console.log(`  Stopping NIM for '${sandboxName}'...`);
   nim.stopNimContainer(sandboxName);
@@ -371,6 +376,10 @@ function help() {
   Policy Presets:
     nemoclaw <name> policy-add       Add a policy preset to a sandbox
     nemoclaw <name> policy-list      List presets (● = applied)
+
+  Devices:
+    nemoclaw <name> r1-connect       Pair a Rabbit R1 to the sandbox gateway
+    nemoclaw <name> r1-connect --tunnel  Same, but via cloudflared (remote access)
 
   Deploy:
     nemoclaw deploy <instance>       Deploy to a Brev VM and start services
@@ -438,10 +447,11 @@ const [cmd, ...args] = process.argv.slice(2);
       case "logs":        sandboxLogs(cmd, actionArgs.includes("--follow")); break;
       case "policy-add":  await sandboxPolicyAdd(cmd); break;
       case "policy-list": sandboxPolicyList(cmd); break;
+      case "r1-connect":  sandboxR1Connect(cmd, actionArgs); break;
       case "destroy":     sandboxDestroy(cmd); break;
       default:
         console.error(`  Unknown action: ${action}`);
-        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, destroy`);
+        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, r1-connect, destroy`);
         process.exit(1);
     }
     return;

--- a/scripts/r1-connect.sh
+++ b/scripts/r1-connect.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configure the OpenClaw gateway inside a NemoClaw sandbox for Rabbit R1
+# device pairing over LAN.
+#
+# This is the NemoClaw-adapted version of the upstream r1-openclaw.sh script.
+# Instead of running openclaw commands directly on the host, it runs them
+# inside the OpenShell sandbox via SSH and re-binds the port forward to
+# 0.0.0.0 so the R1 can reach the gateway on the local network.
+#
+# Usage:
+#   ./scripts/r1-connect.sh                       # use default sandbox
+#   ./scripts/r1-connect.sh --sandbox my-assistant # use named sandbox
+#   ./scripts/r1-connect.sh --tunnel               # use cloudflared for remote access
+
+set -euo pipefail
+
+# ── Helpers ──────────────────────────────────────────────────────
+info()  { printf '\033[1;34m[r1]\033[0m  %s\n' "$*"; }
+warn()  { printf '\033[1;33m[r1]\033[0m  %s\n' "$*"; }
+error() { printf '\033[1;31m[r1]\033[0m  %s\n' "$*"; exit 1; }
+
+command_exists() { command -v "$1" &>/dev/null; }
+
+DASHBOARD_PORT="${DASHBOARD_PORT:-18789}"
+SANDBOX_NAME=""
+USE_TUNNEL=false
+OUTPUT_DIR="${OUTPUT_DIR:-.}"
+
+# ── Parse flags ──────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sandbox)
+      SANDBOX_NAME="${2:?--sandbox requires a name}"
+      shift 2
+      ;;
+    --tunnel)
+      USE_TUNNEL=true
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+# ── Resolve sandbox name from NemoClaw registry ─────────────────
+if [ -z "$SANDBOX_NAME" ]; then
+  REGISTRY="$HOME/.nemoclaw/sandboxes.json"
+  if [ -f "$REGISTRY" ]; then
+    # Read defaultSandbox, fall back to first key
+    SANDBOX_NAME=$(node -e "
+      const r = require('$REGISTRY');
+      console.log(r.defaultSandbox || Object.keys(r.sandboxes || {})[0] || '');
+    " 2>/dev/null || true)
+  fi
+  if [ -z "$SANDBOX_NAME" ]; then
+    error "No sandbox found. Run 'nemoclaw onboard' first, or pass --sandbox <name>."
+  fi
+fi
+
+info "Using sandbox: $SANDBOX_NAME"
+
+# ── Verify sandbox is running ────────────────────────────────────
+command_exists openshell || error "openshell CLI not found. Is OpenShell installed?"
+
+SANDBOX_LIST=$(openshell sandbox list 2>&1 || true)
+if ! echo "$SANDBOX_LIST" | grep -q "$SANDBOX_NAME"; then
+  error "Sandbox '$SANDBOX_NAME' not found. Run 'nemoclaw onboard' first."
+fi
+
+# ── Set up SSH to sandbox ────────────────────────────────────────
+SSH_CONF=$(mktemp /tmp/nemoclaw-r1-ssh-XXXXXX.conf)
+openshell sandbox ssh-config "$SANDBOX_NAME" > "$SSH_CONF" 2>/dev/null
+SSH_HOST="openshell-${SANDBOX_NAME}"
+
+sandbox_exec() {
+  ssh -T -o StrictHostKeyChecking=no -o LogLevel=ERROR -F "$SSH_CONF" "$SSH_HOST" "$@"
+}
+
+cleanup() {
+  rm -f "$SSH_CONF"
+}
+trap cleanup EXIT
+
+# Verify SSH connectivity
+if ! sandbox_exec "echo ok" &>/dev/null; then
+  error "Cannot SSH into sandbox '$SANDBOX_NAME'. Is it in Ready state?"
+fi
+
+info "SSH connection to sandbox verified"
+
+# ── Confirm with user ───────────────────────────────────────────
+echo ""
+echo "This script will configure the OpenClaw gateway for R1 access:"
+echo ""
+echo "  1. Bind gateway to all network interfaces (0.0.0.0)"
+echo "     This allows connections from other devices on your local network."
+echo ""
+echo "     WARNING: This is intended for home networks only."
+echo "     Do not run on cloud instances where your IP is publicly accessible."
+echo ""
+echo "  2. Enable token authentication"
+echo "     Requires a secret token to connect, preventing unauthorized access."
+echo ""
+echo "  3. Generate/reuse an authentication token"
+echo "     A secure random token will be created (or existing one reused)."
+echo ""
+echo "  4. Re-bind the port forward on 0.0.0.0:$DASHBOARD_PORT"
+echo "     So the R1 can reach the gateway over the local network."
+echo ""
+read -p "Do you want to proceed with these changes? [y/N] " confirm < /dev/tty
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  echo "Aborted."
+  exit 0
+fi
+echo ""
+
+# ── Configure gateway inside sandbox ─────────────────────────────
+info "Configuring OpenClaw gateway inside sandbox..."
+
+# Check for existing token, reuse if present
+EXISTING_TOKEN=$(sandbox_exec "openclaw config get gateway.auth.token 2>/dev/null" || echo "")
+EXISTING_TOKEN=$(echo "$EXISTING_TOKEN" | tr -d '[:space:]')
+
+if [ -n "$EXISTING_TOKEN" ] && [ "$EXISTING_TOKEN" != "null" ] && [ "$EXISTING_TOKEN" != "undefined" ]; then
+  TOKEN="$EXISTING_TOKEN"
+  info "Reusing existing auth token"
+else
+  TOKEN=$(openssl rand -hex 32)
+  info "Generated new auth token"
+fi
+
+# Apply gateway config inside the sandbox
+sandbox_exec "openclaw config set gateway.bind lan"
+sandbox_exec "openclaw config set gateway.auth.mode token"
+sandbox_exec "openclaw config set gateway.auth.token '$TOKEN'"
+sandbox_exec "openclaw config set gateway.controlUi.allowInsecureAuth true"
+
+info "Restarting gateway inside sandbox..."
+sandbox_exec "openclaw gateway restart" 2>/dev/null || true
+
+# Give the gateway a moment to come back up
+sleep 3
+
+# Verify gateway is running
+if sandbox_exec "openclaw gateway status" &>/dev/null; then
+  info "Gateway restarted successfully"
+else
+  warn "Gateway may still be starting — continuing anyway"
+fi
+
+# ── Re-bind port forward to 0.0.0.0 ─────────────────────────────
+info "Re-binding port forward to 0.0.0.0:$DASHBOARD_PORT..."
+
+openshell forward stop "$DASHBOARD_PORT" 2>/dev/null || true
+
+# Wait for the port to be released — the previous forward may take a moment to
+# close the listening socket.  Also kill any leftover process on the port.
+for _attempt in 1 2 3; do
+  if ! lsof -i ":${DASHBOARD_PORT}" -sTCP:LISTEN -t &>/dev/null; then
+    break
+  fi
+  # Force-kill whatever is still holding the port
+  lsof -i ":${DASHBOARD_PORT}" -sTCP:LISTEN -t 2>/dev/null | xargs kill 2>/dev/null || true
+  sleep 1
+done
+
+openshell forward start --background "0.0.0.0:${DASHBOARD_PORT}" "$SANDBOX_NAME"
+
+info "Port forward active on 0.0.0.0:$DASHBOARD_PORT"
+
+# ── Detect host LAN IPs ─────────────────────────────────────────
+get_lan_ips() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    ifconfig | grep 'inet ' | awk '{print $2}' | \
+      grep -v '^127\.' | grep -v '^169\.254\.'
+  else
+    ip -4 addr show 2>/dev/null | \
+      grep -oP '(?<=inet\s)\d+(\.\d+){3}' | \
+      grep -v '^127\.' | grep -v '^169\.254\.' | grep -v '^172\.17\.'
+  fi
+}
+
+# ── Handle tunnel mode ───────────────────────────────────────────
+TUNNEL_URL=""
+TUNNEL_PID=""
+
+if [ "$USE_TUNNEL" = true ]; then
+  if ! command_exists cloudflared; then
+    warn "cloudflared not found. Install it or use LAN mode (without --tunnel)."
+    warn "On macOS: brew install cloudflared"
+    warn "Falling back to LAN mode."
+    USE_TUNNEL=false
+  else
+    info "Starting cloudflared tunnel to localhost:$DASHBOARD_PORT..."
+    TUNNEL_LOG=$(mktemp /tmp/nemoclaw-r1-tunnel-XXXXXX.log)
+    nohup cloudflared tunnel --url "http://localhost:$DASHBOARD_PORT" > "$TUNNEL_LOG" 2>&1 &
+    TUNNEL_PID=$!
+
+    # Wait for tunnel URL
+    for _ in $(seq 1 20); do
+      TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -1 || true)
+      if [ -n "$TUNNEL_URL" ]; then
+        break
+      fi
+      sleep 1
+    done
+
+    if [ -n "$TUNNEL_URL" ]; then
+      info "Tunnel active: $TUNNEL_URL"
+    else
+      warn "Tunnel URL not detected within 20s. Check $TUNNEL_LOG"
+      USE_TUNNEL=false
+    fi
+  fi
+fi
+
+# ── Build QR payload ─────────────────────────────────────────────
+IPS=$(get_lan_ips | while read -r ip; do echo "\"$ip\""; done | paste -sd ',' -)
+if [ -z "$IPS" ] && [ "$USE_TUNNEL" = false ]; then
+  error "No LAN IP addresses detected (ifconfig/ip command may be missing)."
+fi
+
+if [ "$USE_TUNNEL" = true ] && [ -n "$TUNNEL_URL" ]; then
+  # Extract hostname from tunnel URL for the QR payload
+  TUNNEL_HOST=$(echo "$TUNNEL_URL" | sed 's|https://||')
+  JSON_PAYLOAD="{\"type\":\"clawdbot-gateway\",\"version\":1,\"ips\":[\"$TUNNEL_HOST\"],\"port\":443,\"token\":\"$TOKEN\",\"protocol\":\"wss\"}"
+else
+  JSON_PAYLOAD="{\"type\":\"clawdbot-gateway\",\"version\":1,\"ips\":[$IPS],\"port\":$DASHBOARD_PORT,\"token\":\"$TOKEN\",\"protocol\":\"ws\"}"
+fi
+
+# ── Display connection info ──────────────────────────────────────
+echo ""
+echo "  ┌─────────────────────────────────────────────────────┐"
+echo "  │  NemoClaw + Rabbit R1                                │"
+echo "  │                                                      │"
+printf "  │  Sandbox:  %-42s│\n" "$SANDBOX_NAME"
+printf "  │  Port:     %-42s│\n" "$DASHBOARD_PORT"
+echo "  │  Auth:     token                                     │"
+echo "  │                                                      │"
+
+if [ "$USE_TUNNEL" = true ] && [ -n "$TUNNEL_URL" ]; then
+  printf "  │  Tunnel:   %-42s│\n" "$TUNNEL_URL"
+fi
+
+echo "  │  LAN IPs:                                            │"
+get_lan_ips | while read -r ip; do
+  printf "  │    %-49s│\n" "ws://$ip:$DASHBOARD_PORT"
+done
+
+echo "  │                                                      │"
+echo "  └─────────────────────────────────────────────────────┘"
+echo ""
+
+echo "Token: $TOKEN"
+echo ""
+
+# ── Generate QR code ─────────────────────────────────────────────
+info "QR Code (scan with your R1):"
+echo ""
+npx --yes qrcode "$JSON_PAYLOAD" --small < /dev/null
+
+OUTPUT_FILE="$OUTPUT_DIR/r1-gateway-connection.png"
+info "Saving QR code to: $OUTPUT_FILE"
+npx --yes qrcode "$JSON_PAYLOAD" -o "$OUTPUT_FILE" < /dev/null 2>/dev/null
+echo ""
+
+# ── Wait for R1 and auto-approve ─────────────────────────────────
+info "Waiting for Rabbit R1 to connect (timeout: 5 minutes)..."
+TIMEOUT=300
+ELAPSED=0
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  PENDING=$(sandbox_exec "openclaw devices list --json 2>/dev/null" | \
+    node -e "
+      let d='';
+      process.stdin.on('data',c=>d+=c);
+      process.stdin.on('end',()=>{
+        try {
+          const data=JSON.parse(d);
+          const pending=data.pending||[];
+          const r1=pending.find(p=>(p.displayName||'').includes('Rabbit R1'));
+          if(r1&&r1.requestId) console.log(r1.requestId);
+        } catch {}
+      });
+    " 2>/dev/null || true)
+
+  if [ -n "$PENDING" ]; then
+    info "Found Rabbit R1 device, approving..."
+    sandbox_exec "openclaw devices approve '$PENDING'" 2>/dev/null
+    info "Device approved successfully!"
+
+    echo ""
+    echo "  ✓ Your Rabbit R1 is now connected to OpenClaw"
+    echo "    running inside NemoClaw sandbox '$SANDBOX_NAME'."
+    echo ""
+    echo "  To monitor network egress approvals:"
+    echo "    openshell term"
+    echo ""
+
+    # Clean up tunnel on exit if running
+    if [ -n "$TUNNEL_PID" ]; then
+      echo "  Tunnel is still running (PID $TUNNEL_PID)."
+      echo "  Press Ctrl+C to stop, or kill $TUNNEL_PID when done."
+      echo ""
+      wait "$TUNNEL_PID" 2>/dev/null || true
+    fi
+    exit 0
+  fi
+
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+
+warn "Timeout: No Rabbit R1 device found within 5 minutes."
+warn "Make sure your R1 scanned the QR code and is on the same network."
+
+if [ -n "$TUNNEL_PID" ]; then
+  kill "$TUNNEL_PID" 2>/dev/null || true
+fi
+exit 1


### PR DESCRIPTION
## Summary

- Adds `nemoclaw <name> r1-connect` command that configures the OpenClaw gateway inside a sandbox for Rabbit R1 device pairing over LAN or cloudflared tunnel
- Includes `scripts/r1-connect.sh` which handles SSH into the sandbox, gateway configuration (bind to LAN, token auth), port forwarding rebind, QR code generation, and auto-approval of pending R1 devices
- Refactors `prompt()` helper in credentials.js to use bash `read` instead of Node.js readline, fixing terminal hangs after heavy spawnSync usage
- Switches sandbox build context copy from `cp -r` + `rm -rf` to `rsync --exclude` for efficiency

## Test plan

- [ ] Run `nemoclaw <sandbox> r1-connect` with a running sandbox and verify gateway is configured for LAN access
- [ ] Run `nemoclaw <sandbox> r1-connect --tunnel` and verify cloudflared tunnel is established
- [ ] Verify QR code is generated and scannable by R1 device
- [ ] Verify auto-approval of pending R1 device connection
- [ ] Run existing tests with `npm test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `r1-connect` command to configure Rabbit R1 device pairing within sandboxes over LAN.
  * Support for optional tunnel configuration for remote connectivity.
  * Automatic QR code generation for streamlined device pairing.
  * Device auto-approval upon detection in sandbox.

* **Improvements**
  * Optimized sandbox build context handling for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->