### PR TITLE
feat: add OpenRouter as inference provider

### DIFF
--- a/bin/lib/inference-config.js
+++ b/bin/lib/inference-config.js
@@ -51,6 +51,17 @@ function getProviderSelectionConfig(provider, model) {
         provider,
         providerLabel: "Local Ollama",
       };
+    case "openrouter":
+      return {
+        endpointType: "custom",
+        endpointUrl: INFERENCE_ROUTE_URL,
+        ncpPartner: null,
+        model: model || DEFAULT_CLOUD_MODEL,
+        profile: DEFAULT_ROUTE_PROFILE,
+        credentialEnv: DEFAULT_ROUTE_CREDENTIAL_ENV,
+        provider,
+        providerLabel: "OpenRouter",
+      };
     default:
       return null;
   }

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -28,7 +28,7 @@ const {
   isUnsupportedMacosRuntime,
   shouldPatchCoredns,
 } = require("./platform");
-const { prompt, ensureApiKey, getCredential } = require("./credentials");
+const { prompt, ensureApiKey, getCredential, saveCredential } = require("./credentials");
 const registry = require("./registry");
 const nim = require("./nim");
 const policies = require("./policies");
@@ -256,10 +256,10 @@ function getNonInteractiveProvider() {
   const providerKey = (process.env.NEMOCLAW_PROVIDER || "").trim().toLowerCase();
   if (!providerKey) return null;
 
-  const validProviders = new Set(["cloud", "ollama", "vllm", "nim"]);
+  const validProviders = new Set(["cloud", "ollama", "vllm", "nim", "openrouter"]);
   if (!validProviders.has(providerKey)) {
     console.error(`  Unsupported NEMOCLAW_PROVIDER: ${providerKey}`);
-    console.error("  Valid values: cloud, ollama, vllm, nim");
+    console.error("  Valid values: cloud, ollama, vllm, nim, openrouter");
     process.exit(1);
   }
 
@@ -589,6 +589,10 @@ async function setupNim(sandboxName, gpu) {
       "NVIDIA Endpoint API (build.nvidia.com)" +
       (!ollamaRunning && !(EXPERIMENTAL && vllmRunning) ? " (recommended)" : ""),
   });
+  options.push({
+    key: "openrouter",
+    label: "OpenRouter (openrouter.ai)",
+  });
   if (hasOllama || ollamaRunning) {
     options.push({
       key: "ollama",
@@ -720,6 +724,40 @@ async function setupNim(sandboxName, gpu) {
       console.log("  ✓ Using existing vLLM on localhost:8000");
       provider = "vllm-local";
       model = "vllm-local";
+    } else if (selected.key === "openrouter") {
+      provider = "openrouter";
+      if (isNonInteractive()) {
+        if (!process.env.OPENROUTER_API_KEY) {
+          console.error("  OPENROUTER_API_KEY is required for OpenRouter in non-interactive mode.");
+          console.error("  Set it via: OPENROUTER_API_KEY=sk-or-v1-... nemoclaw onboard --non-interactive");
+          process.exit(1);
+        }
+        model = requestedModel || DEFAULT_CLOUD_MODEL;
+      } else {
+        let orKey = getCredential("OPENROUTER_API_KEY");
+        if (!orKey) {
+          console.log("");
+          console.log("  ┌─────────────────────────────────────────────────────────────────┐");
+          console.log("  │  OpenRouter API Key required                                    │");
+          console.log("  │                                                                 │");
+          console.log("  │  1. Go to https://openrouter.ai/keys                            │");
+          console.log("  │  2. Sign in to your OpenRouter account                          │");
+          console.log("  │  3. Create a new API key                                        │");
+          console.log("  │  4. Paste the key below (starts with sk-or-v1-)                 │");
+          console.log("  └─────────────────────────────────────────────────────────────────┘");
+          console.log("");
+          orKey = await prompt("  OpenRouter API Key: ");
+          if (!orKey) {
+            console.error("  API key is required.");
+            process.exit(1);
+          }
+          saveCredential("OPENROUTER_API_KEY", orKey);
+        }
+        process.env.OPENROUTER_API_KEY = orKey;
+        model = await promptCloudModel();
+      }
+      model = model || DEFAULT_CLOUD_MODEL;
+      console.log(`  Using OpenRouter with model: ${model}`);
     }
     // else: cloud — fall through to default below
   }
@@ -808,6 +846,19 @@ async function setupInference(sandboxName, model, provider) {
       console.error(`  ${probe.message}`);
       process.exit(1);
     }
+  } else if (provider === "openrouter") {
+    run(
+      `openshell provider create --name openrouter --type openai ` +
+      `--credential "OPENROUTER_API_KEY=${process.env.OPENROUTER_API_KEY}" ` +
+      `--config "OPENAI_BASE_URL=https://openrouter.ai/api/v1" 2>&1 || ` +
+      `openshell provider update openrouter --credential "OPENROUTER_API_KEY=${process.env.OPENROUTER_API_KEY}" ` +
+      `--config "OPENAI_BASE_URL=https://openrouter.ai/api/v1" 2>&1 || true`,
+      { ignoreError: true }
+    );
+    run(
+      `openshell inference set --no-verify --provider openrouter --model ${model} 2>/dev/null || true`,
+      { ignoreError: true }
+    );
   }
 
   registry.updateSandbox(sandboxName, { model, provider });
@@ -955,6 +1006,7 @@ function printDashboard(sandboxName, model, provider) {
   if (provider === "nvidia-nim") providerLabel = "NVIDIA Endpoint API";
   else if (provider === "vllm-local") providerLabel = "Local vLLM";
   else if (provider === "ollama-local") providerLabel = "Local Ollama";
+  else if (provider === "openrouter") providerLabel = "OpenRouter";
 
   console.log("");
   console.log(`  ${"─".repeat(50)}`);

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -11,6 +11,7 @@ profiles:
   - ncp
   - nim-local
   - vllm
+  - openrouter
 
 description: |
   NemoClaw blueprint: orchestrates OpenClaw sandbox creation, migration,
@@ -53,6 +54,13 @@ components:
         model: "nvidia/nemotron-3-nano-30b-a3b"
         credential_env: "OPENAI_API_KEY"
         credential_default: "dummy"
+
+      openrouter:
+        provider_type: "openai"
+        provider_name: "openrouter"
+        endpoint: "https://openrouter.ai/api/v1"
+        model: ""
+        credential_env: "OPENROUTER_API_KEY"
 
   policy:
     base: "sandboxes/openclaw/policy.yaml"

--- a/nemoclaw/src/onboard/config.ts
+++ b/nemoclaw/src/onboard/config.ts
@@ -6,7 +6,14 @@ import { join } from "node:path";
 
 const CONFIG_DIR = join(process.env.HOME ?? "/tmp", ".nemoclaw");
 
-export type EndpointType = "build" | "ncp" | "nim-local" | "vllm" | "ollama" | "custom";
+export type EndpointType =
+  | "build"
+  | "ncp"
+  | "nim-local"
+  | "vllm"
+  | "ollama"
+  | "openrouter"
+  | "custom";
 
 export interface NemoClawOnboardConfig {
   endpointType: EndpointType;
@@ -44,6 +51,8 @@ export function describeOnboardProvider(config: NemoClawOnboardConfig): string {
       return "Local NIM";
     case "ncp":
       return "NVIDIA Cloud Partner";
+    case "openrouter":
+      return "OpenRouter";
     case "custom":
       return "Managed Inference Route";
     default:

--- a/test/inference-config.test.js
+++ b/test/inference-config.test.js
@@ -56,6 +56,25 @@ describe("inference selection config", () => {
     });
   });
 
+  it("maps openrouter to the sandbox inference route", () => {
+    assert.deepEqual(getProviderSelectionConfig("openrouter", "anthropic/claude-sonnet-4"), {
+      endpointType: "custom",
+      endpointUrl: INFERENCE_ROUTE_URL,
+      ncpPartner: null,
+      model: "anthropic/claude-sonnet-4",
+      profile: DEFAULT_ROUTE_PROFILE,
+      credentialEnv: DEFAULT_ROUTE_CREDENTIAL_ENV,
+      provider: "openrouter",
+      providerLabel: "OpenRouter",
+    });
+  });
+
+  it("uses default cloud model when openrouter model is not specified", () => {
+    const config = getProviderSelectionConfig("openrouter");
+    assert.equal(config.model, "nvidia/nemotron-3-super-120b-a12b");
+    assert.equal(config.providerLabel, "OpenRouter");
+  });
+
   it("builds a qualified OpenClaw primary model for ollama-local", () => {
     assert.equal(
       getOpenClawPrimaryModel("ollama-local", "nemotron-3-nano:30b"),


### PR DESCRIPTION
## Summary

- Adds OpenRouter (openrouter.ai) as a first-class inference provider in the onboarding wizard alongside NVIDIA Build, Ollama, vLLM, and NIM
- Supports both interactive (API key prompt with credential storage) and non-interactive (`OPENROUTER_API_KEY` env var) setup flows
- Registers OpenRouter as an OpenAI-compatible provider in the sandbox via `openshell provider create/update`
- Adds `openrouter` inference profile to `blueprint.yaml` and provider selection config with tests

## Test plan

- [ ] Run `npm test` — all tests pass including new OpenRouter inference config tests
- [ ] Run `nemoclaw onboard` interactively and select OpenRouter — verify API key prompt and credential storage
- [ ] Run `NEMOCLAW_PROVIDER=openrouter OPENROUTER_API_KEY=sk-or-... nemoclaw onboard --non-interactive` — verify non-interactive flow
- [ ] Verify inference routes correctly through `openrouter.ai/api/v1` inside the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter as a new inference provider option with integrated credential management and model selection during onboarding.

* **Tests**
  * Added test coverage for OpenRouter provider configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->