### PR TITLE
fix: pass sandbox name to start-services.sh in stop and status

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -185,7 +185,10 @@ async function start() {
 }
 
 function stop() {
-  run(`bash "${SCRIPTS}/start-services.sh" --stop`);
+  const { defaultSandbox } = registry.listSandboxes();
+  const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
+  const sandboxEnv = safeName ? `SANDBOX_NAME="${safeName}"` : "";
+  run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh" --stop`);
 }
 
 function debug(args) {
@@ -240,7 +243,9 @@ function showStatus() {
   }
 
   // Show service status
-  run(`bash "${SCRIPTS}/start-services.sh" --status`);
+  const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
+  const sandboxEnv = safeName ? `SANDBOX_NAME="${safeName}"` : "";
+  run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh" --status`);
 }
 
 function listSandboxes() {

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -32,6 +32,11 @@ function shellQuote(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`;
 }
 
+function buildSandboxEnvPrefix(defaultSandbox) {
+  const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
+  return safeName ? `SANDBOX_NAME="${safeName}"` : "";
+}
+
 function resolveUninstallScript() {
   const candidates = [
     path.join(ROOT, "uninstall.sh"),
@@ -179,15 +184,13 @@ async function deploy(instanceName) {
 async function start() {
   await ensureApiKey();
   const { defaultSandbox } = registry.listSandboxes();
-  const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  const sandboxEnv = safeName ? `SANDBOX_NAME="${safeName}"` : "";
+  const sandboxEnv = buildSandboxEnvPrefix(defaultSandbox);
   run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh"`);
 }
 
 function stop() {
   const { defaultSandbox } = registry.listSandboxes();
-  const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  const sandboxEnv = safeName ? `SANDBOX_NAME="${safeName}"` : "";
+  const sandboxEnv = buildSandboxEnvPrefix(defaultSandbox);
   run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh" --stop`);
 }
 
@@ -243,8 +246,7 @@ function showStatus() {
   }
 
   // Show service status
-  const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  const sandboxEnv = safeName ? `SANDBOX_NAME="${safeName}"` : "";
+  const sandboxEnv = buildSandboxEnvPrefix(defaultSandbox);
   run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh" --status`);
 }
 


### PR DESCRIPTION
## Summary

- `nemoclaw stop` and `nemoclaw status` always looked in `/tmp/nemoclaw-services-default/` for PID files, regardless of the actual sandbox name.
- `nemoclaw start` correctly passes `SANDBOX_NAME` from the registry to `start-services.sh`, but `stop()` and `showStatus()` did not.
- When the registered default sandbox is named anything other than `"default"`, `nemoclaw stop` reports the bridge as not running (and skips stopping it) and `nemoclaw status` shows it as stopped even though the bridge is alive.

## Root cause

`start-services.sh` computes `PIDDIR="/tmp/nemoclaw-services-${SANDBOX_NAME}"`. If `SANDBOX_NAME` is unset, it defaults to `"default"`. `stop()` and `showStatus()` in `nemoclaw.js` did not set `SANDBOX_NAME`, so they always defaulted to `/tmp/nemoclaw-services-default/`, creating a mismatch with the directory `start()` had written the PID files to.

## Fix

Apply the same registry-lookup and `SANDBOX_NAME` env prefix that `start()` already uses to both `stop()` and `showStatus()`:

```js
const { defaultSandbox } = registry.listSandboxes();
const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
const sandboxEnv = safeName ? `SANDBOX_NAME="${safeName}"` : "";
run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh" --stop`);
```

`showStatus()` already destructured `defaultSandbox` from `registry.listSandboxes()` for the sandbox list display, so the fix there is just two additional lines before the `run()` call.

Fixes #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * stop and status commands now consistently retrieve and validate the default sandbox before running service control operations, and apply a sanitized sandbox environment prefix when relevant to prevent invalid sandbox names from affecting execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->