### PR TITLE
fix: keep openclaw state writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ RUN (apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
     && apt-get autoremove --purge -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Keep the canonical config path, but back openclaw.json with writable
+# sandbox state so OpenClaw can persist model and auth updates there.
+RUN mkdir -p /sandbox/.openclaw-data \
+    && rm -f /sandbox/.openclaw/openclaw.json \
+    && ln -s /sandbox/.openclaw-data/openclaw.json /sandbox/.openclaw/openclaw.json \
+    && chown -h root:root /sandbox/.openclaw/openclaw.json \
+    && chown -R sandbox:sandbox /sandbox/.openclaw-data
 # Copy built plugin and blueprint into the sandbox
 COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
@@ -73,10 +80,10 @@ WORKDIR /sandbox
 USER sandbox
 
 # Write the COMPLETE openclaw.json including gateway config and auth token.
-# This file is immutable at runtime (Landlock read-only on /sandbox/.openclaw).
-# No runtime writes to openclaw.json are needed or possible.
 # Build args (NEMOCLAW_MODEL, CHAT_UI_URL) customize per deployment.
 # Auth token is generated per build so each image has a unique token.
+# The ~/.openclaw/openclaw.json path is a symlink into .openclaw-data so
+# runtime model switches can update it without patching the image.
 RUN python3 -c "\
 import base64, json, os, secrets; \
 from urllib.parse import urlparse; \
@@ -122,22 +129,14 @@ os.chmod(path, 0o600)"
 RUN openclaw doctor --fix > /dev/null 2>&1 || true \
     && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
-# Lock openclaw.json via DAC: chown to root so the sandbox user cannot modify
-# it at runtime.  This works regardless of Landlock enforcement status.
-# The Landlock policy (/sandbox/.openclaw in read_only) provides defense-in-depth
-# once OpenShell enables enforcement.
-# Ref: https://github.com/NVIDIA/NemoClaw/issues/514
-# Lock the entire .openclaw directory tree.
-# SECURITY: chmod 755 (not 1777) — the sandbox user can READ but not WRITE
-# to this directory. This prevents the agent from replacing symlinks
-# (e.g., pointing /sandbox/.openclaw/hooks to an attacker-controlled path).
-# The writable state lives in .openclaw-data, reached via the symlinks.
+# Keep the top-level ~/.openclaw tree immutable while leaving the
+# state-backed openclaw.json target writable under .openclaw-data.
 # hadolint ignore=DL3002
 USER root
 RUN chown root:root /sandbox/.openclaw \
     && find /sandbox/.openclaw -mindepth 1 -maxdepth 1 -exec chown -h root:root {} + \
-    && chmod 755 /sandbox/.openclaw \
-    && chmod 444 /sandbox/.openclaw/openclaw.json
+    && chmod 755 /sandbox/.openclaw
+USER sandbox
 
 # Pin config hash at build time so the entrypoint can verify integrity.
 # Prevents the agent from creating a copy with a tampered config and

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,10 +138,13 @@ RUN chown root:root /sandbox/.openclaw \
     && chmod 755 /sandbox/.openclaw
 USER sandbox
 
-# Pin config hash at build time so the entrypoint can verify integrity.
-# Prevents the agent from creating a copy with a tampered config and
-# restarting the gateway pointing at it.
-RUN sha256sum /sandbox/.openclaw/openclaw.json > /sandbox/.openclaw/.config-hash \
+# Pin a hash of the protected gateway config at build time so the entrypoint
+# can detect tampering without blocking writable model and auth state.
+RUN python3 -c "\
+import hashlib, json; \
+cfg = json.load(open('/sandbox/.openclaw/openclaw.json')); \
+payload = json.dumps({'gateway': cfg.get('gateway', {})}, sort_keys=True, separators=(',', ':')).encode(); \
+print(hashlib.sha256(payload).hexdigest())" > /sandbox/.openclaw/.config-hash \
     && chmod 444 /sandbox/.openclaw/.config-hash \
     && chown root:root /sandbox/.openclaw/.config-hash
 

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -302,6 +302,13 @@ async function ensureLiveSandboxOrExit(sandboxName) {
   process.exit(1);
 }
 
+function defaultSandboxEnv() {
+  const { defaultSandbox } = registry.listSandboxes();
+  return defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox)
+    ? `SANDBOX_NAME=${shellQuote(defaultSandbox)} `
+    : "";
+}
+
 function resolveUninstallScript() {
   const candidates = [
     path.join(ROOT, "uninstall.sh"),
@@ -468,14 +475,16 @@ async function deploy(instanceName) {
 
 async function start() {
   await ensureApiKey();
-  const { defaultSandbox } = registry.listSandboxes();
-  const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  const sandboxEnv = safeName ? `SANDBOX_NAME=${shellQuote(safeName)}` : "";
-  run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh"`);
+  const envParts = [];
+  const sandboxEnv = defaultSandboxEnv();
+  if (sandboxEnv) envParts.push(sandboxEnv.trim());
+  const tgToken = getCredential("TELEGRAM_BOT_TOKEN");
+  if (tgToken) envParts.push(`TELEGRAM_BOT_TOKEN=${shellQuote(tgToken)}`);
+  run(`${envParts.join(" ")} bash "${SCRIPTS}/start-services.sh"`);
 }
 
 function stop() {
-  run(`bash "${SCRIPTS}/start-services.sh" --stop`);
+  run(`${defaultSandboxEnv()}bash "${SCRIPTS}/start-services.sh" --stop`);
 }
 
 function debug(args) {
@@ -530,7 +539,7 @@ function showStatus() {
   }
 
   // Show service status
-  run(`bash "${SCRIPTS}/start-services.sh" --status`);
+  run(`${defaultSandboxEnv()}bash "${SCRIPTS}/start-services.sh" --status`);
 }
 
 function listSandboxes() {

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -67,19 +67,43 @@ PUBLIC_PORT=18789
 OPENCLAW="$(command -v openclaw)" # Resolve once, use absolute path everywhere
 
 # ── Config integrity check ──────────────────────────────────────
-# The config hash was pinned at build time. If it doesn't match,
-# someone (or something) has tampered with the config.
+# The gateway config hash was pinned at build time. If it doesn't match,
+# someone (or something) has tampered with the protected gateway settings.
+
+config_hash() {
+  python3 - <<'PYHASH'
+import hashlib
+import json
+
+path = '/sandbox/.openclaw/openclaw.json'
+with open(path) as f:
+    cfg = json.load(f)
+
+payload = json.dumps(
+    {'gateway': cfg.get('gateway', {})},
+    sort_keys=True,
+    separators=(',', ':'),
+).encode()
+print(hashlib.sha256(payload).hexdigest())
+PYHASH
+}
 
 verify_config_integrity() {
   local hash_file="/sandbox/.openclaw/.config-hash"
+  local expected_hash actual_hash
   if [ ! -f "$hash_file" ]; then
     echo "[SECURITY] Config hash file missing — refusing to start without integrity verification"
     return 1
   fi
-  if ! (cd /sandbox/.openclaw && sha256sum -c "$hash_file" --status 2>/dev/null); then
+  expected_hash="$(cat "$hash_file")"
+  if ! actual_hash="$(config_hash 2>/dev/null)"; then
+    echo "[SECURITY] Could not compute config hash"
+    return 1
+  fi
+  if [ "$actual_hash" != "$expected_hash" ]; then
     echo "[SECURITY] openclaw.json integrity check FAILED — config may have been tampered with"
-    echo "[SECURITY] Expected hash: $(cat "$hash_file")"
-    echo "[SECURITY] Actual hash:   $(sha256sum /sandbox/.openclaw/openclaw.json)"
+    echo "[SECURITY] Expected hash: $expected_hash"
+    echo "[SECURITY] Actual hash:   $actual_hash"
     return 1
   fi
 }
@@ -94,16 +118,48 @@ import json
 import os
 path = os.path.expanduser('~/.openclaw/agents/main/agent/auth-profiles.json')
 os.makedirs(os.path.dirname(path), exist_ok=True)
-json.dump({
-    'nvidia:manual': {
-        'type': 'api_key',
-        'provider': 'nvidia',
-        'keyRef': {'source': 'env', 'id': 'NVIDIA_API_KEY'},
-        'profileId': 'nvidia:manual',
-    }
-}, open(path, 'w'))
+with open(path, 'w') as f:
+    json.dump({
+        'nvidia:manual': {
+            'type': 'api_key',
+            'provider': 'nvidia',
+            'keyRef': {'source': 'env', 'id': 'NVIDIA_API_KEY'},
+            'profileId': 'nvidia:manual',
+        }
+    }, f)
 os.chmod(path, 0o600)
 PYAUTH
+}
+
+sync_inference_api_key() {
+  if [ -z "${NVIDIA_API_KEY:-}" ]; then
+    return
+  fi
+
+  python3 - <<'PYSYNC'
+import json
+import os
+
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except Exception:
+    raise SystemExit(0)
+
+providers = cfg.get('models', {}).get('providers', {})
+updated = False
+for name in ('inference', 'nvidia'):
+    provider = providers.get(name)
+    if isinstance(provider, dict):
+        provider['apiKey'] = os.environ['NVIDIA_API_KEY']
+        updated = True
+
+if updated:
+    with open(path, 'w') as f:
+        json.dump(cfg, f, indent=2)
+    os.chmod(path, 0o600)
+PYSYNC
 }
 
 print_dashboard_urls() {
@@ -115,7 +171,8 @@ import json
 import os
 path = '/sandbox/.openclaw/openclaw.json'
 try:
-    cfg = json.load(open(path))
+    with open(path) as f:
+        cfg = json.load(f)
 except Exception:
     print('')
 else:
@@ -298,6 +355,7 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "[SECURITY WARNING] Config integrity check failed — proceeding anyway (non-root mode)"
   fi
   write_auth_profile
+  sync_inference_api_key
 
   if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
     exec "${NEMOCLAW_CMD[@]}"
@@ -328,7 +386,7 @@ fi
 verify_config_integrity
 
 # Write auth profile as sandbox user (needs writable .openclaw-data)
-gosu sandbox bash -c "$(declare -f write_auth_profile); write_auth_profile"
+gosu sandbox bash -c "$(declare -f write_auth_profile sync_inference_api_key); write_auth_profile; sync_inference_api_key"
 
 # If a command was passed (e.g., "openclaw agent ..."), run it as sandbox user
 if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then

--- a/test/dockerfile-config.test.js
+++ b/test/dockerfile-config.test.js
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const dockerfilePath = path.join(__dirname, "..", "Dockerfile");
+const dockerfile = fs.readFileSync(dockerfilePath, "utf-8");
+
+describe("sandbox Dockerfile config layout", () => {
+  it("stores openclaw.json in writable sandbox state", () => {
+    assert.match(
+      dockerfile,
+      /ln -s \/sandbox\/\.openclaw-data\/openclaw\.json \/sandbox\/\.openclaw\/openclaw\.json/,
+    );
+    assert.match(
+      dockerfile,
+      /ln -s \/sandbox\/\.openclaw-data\/identity \/sandbox\/\.openclaw\/identity/,
+    );
+    assert.doesNotMatch(dockerfile, /chmod 444 \/sandbox\/\.openclaw\/openclaw\.json/);
+  });
+});

--- a/test/dockerfile-config.test.js
+++ b/test/dockerfile-config.test.js
@@ -1,24 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const { describe, it } = require("node:test");
-const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const path = require("node:path");
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
 
-const dockerfilePath = path.join(__dirname, "..", "Dockerfile");
+const dockerfilePath = path.join(import.meta.dirname, "..", "Dockerfile");
 const dockerfile = fs.readFileSync(dockerfilePath, "utf-8");
 
 describe("sandbox Dockerfile config layout", () => {
   it("stores openclaw.json in writable sandbox state", () => {
-    assert.match(
-      dockerfile,
+    expect(dockerfile).toMatch(
       /ln -s \/sandbox\/\.openclaw-data\/openclaw\.json \/sandbox\/\.openclaw\/openclaw\.json/,
     );
-    assert.match(
-      dockerfile,
-      /ln -s \/sandbox\/\.openclaw-data\/identity \/sandbox\/\.openclaw\/identity/,
-    );
-    assert.doesNotMatch(dockerfile, /chmod 444 \/sandbox\/\.openclaw\/openclaw\.json/);
+    expect(dockerfile).not.toMatch(/chmod 444 \/sandbox\/\.openclaw\/openclaw\.json/);
   });
 });

--- a/test/start-command.test.js
+++ b/test/start-command.test.js
@@ -1,47 +1,39 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const { describe, it } = require("node:test");
-const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const path = require("node:path");
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
 
-const cliPath = path.join(__dirname, "..", "bin", "nemoclaw.js");
+const cliPath = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
 const cliSource = fs.readFileSync(cliPath, "utf-8");
 
 describe("nemoclaw start command", () => {
   it("targets service commands at the default sandbox", () => {
-    assert.match(cliSource, /function defaultSandboxEnv\(\)/);
-    assert.match(
-      cliSource,
+    expect(cliSource).toMatch(/function defaultSandboxEnv\(\)/);
+    expect(cliSource).toMatch(
       /function stop\(\)\s*{[\s\S]*?defaultSandboxEnv\(\)[\s\S]*?start-services\.sh" --stop/,
     );
-    assert.match(
-      cliSource,
+    expect(cliSource).toMatch(
       /function showStatus\(\)\s*{[\s\S]*?defaultSandboxEnv\(\)[\s\S]*?start-services\.sh" --status/,
     );
   });
 
   it("loads the saved Telegram token into the service env", () => {
-    assert.match(cliSource, /async function start\(\)/);
-    assert.match(
-      cliSource,
+    expect(cliSource).toMatch(/async function start\(\)/);
+    expect(cliSource).toMatch(
       /async function start\(\)\s*{[\s\S]*?const tgToken = getCredential\("TELEGRAM_BOT_TOKEN"\)/,
     );
-    assert.match(
-      cliSource,
+    expect(cliSource).toMatch(
       /async function start\(\)\s*{[\s\S]*?const sandboxEnv = defaultSandboxEnv\(\)/,
     );
-    assert.match(
-      cliSource,
+    expect(cliSource).toMatch(
       /async function start\(\)\s*{[\s\S]*?if\s*\(sandboxEnv\)\s*envParts\.push\(sandboxEnv\.trim\(\)\)/,
     );
-    assert.match(
-      cliSource,
+    expect(cliSource).toMatch(
       /async function start\(\)\s*{[\s\S]*?if\s*\(tgToken\)\s*envParts\.push\(`TELEGRAM_BOT_TOKEN=\$\{shellQuote\(tgToken\)\}`\)/,
     );
-    assert.match(
-      cliSource,
+    expect(cliSource).toMatch(
       /async function start\(\)\s*{[\s\S]*?run\(\s*`\$\{envParts\.join\(" "\)\}\s+bash "\$\{SCRIPTS\}\/start-services\.sh"`\s*\)/,
     );
   });

--- a/test/start-command.test.js
+++ b/test/start-command.test.js
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const cliPath = path.join(__dirname, "..", "bin", "nemoclaw.js");
+const cliSource = fs.readFileSync(cliPath, "utf-8");
+
+describe("nemoclaw start command", () => {
+  it("targets service commands at the default sandbox", () => {
+    assert.match(cliSource, /function defaultSandboxEnv\(\)/);
+    assert.match(
+      cliSource,
+      /function stop\(\)\s*{[\s\S]*?defaultSandboxEnv\(\)[\s\S]*?start-services\.sh" --stop/,
+    );
+    assert.match(
+      cliSource,
+      /function showStatus\(\)\s*{[\s\S]*?defaultSandboxEnv\(\)[\s\S]*?start-services\.sh" --status/,
+    );
+  });
+
+  it("loads the saved Telegram token into the service env", () => {
+    assert.match(cliSource, /async function start\(\)/);
+    assert.match(
+      cliSource,
+      /async function start\(\)\s*{[\s\S]*?const tgToken = getCredential\("TELEGRAM_BOT_TOKEN"\)/,
+    );
+    assert.match(
+      cliSource,
+      /async function start\(\)\s*{[\s\S]*?const sandboxEnv = defaultSandboxEnv\(\)/,
+    );
+    assert.match(
+      cliSource,
+      /async function start\(\)\s*{[\s\S]*?if\s*\(sandboxEnv\)\s*envParts\.push\(sandboxEnv\.trim\(\)\)/,
+    );
+    assert.match(
+      cliSource,
+      /async function start\(\)\s*{[\s\S]*?if\s*\(tgToken\)\s*envParts\.push\(`TELEGRAM_BOT_TOKEN=\$\{shellQuote\(tgToken\)\}`\)/,
+    );
+    assert.match(
+      cliSource,
+      /async function start\(\)\s*{[\s\S]*?run\(\s*`\$\{envParts\.join\(" "\)\}\s+bash "\$\{SCRIPTS\}\/start-services\.sh"`\s*\)/,
+    );
+  });
+});

--- a/test/start-script.test.js
+++ b/test/start-script.test.js
@@ -1,25 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const { describe, it } = require("node:test");
-const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const path = require("node:path");
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
 
-const startScriptPath = path.join(__dirname, "..", "scripts", "nemoclaw-start.sh");
+const startScriptPath = path.join(import.meta.dirname, "..", "scripts", "nemoclaw-start.sh");
 const startScript = fs.readFileSync(startScriptPath, "utf-8");
 
 describe("nemoclaw-start inference auth", () => {
   it("syncs the NVIDIA API key into OpenClaw provider config", () => {
-    assert.match(startScript, /sync_inference_api_key\(\)/);
-    assert.match(startScript, /provider\['apiKey'\] = os\.environ\['NVIDIA_API_KEY'\]/);
-    assert.match(
-      startScript,
+    expect(startScript).toMatch(/sync_inference_api_key\(\)/);
+    expect(startScript).toMatch(/provider\['apiKey'\] = os\.environ\['NVIDIA_API_KEY'\]/);
+    expect(startScript).toMatch(
       /if \[ "\$\(id -u\)" -ne 0 \]; then[\s\S]*?write_auth_profile\s+sync_inference_api_key/s,
     );
-    assert.match(
-      startScript,
-      /declare -f write_auth_profile sync_inference_api_key/,
-    );
+    expect(startScript).toMatch(/declare -f write_auth_profile sync_inference_api_key/);
   });
 });

--- a/test/start-script.test.js
+++ b/test/start-script.test.js
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const startScriptPath = path.join(__dirname, "..", "scripts", "nemoclaw-start.sh");
+const startScript = fs.readFileSync(startScriptPath, "utf-8");
+
+describe("nemoclaw-start inference auth", () => {
+  it("syncs the NVIDIA API key into OpenClaw provider config", () => {
+    assert.match(startScript, /sync_inference_api_key\(\)/);
+    assert.match(startScript, /provider\['apiKey'\] = os\.environ\['NVIDIA_API_KEY'\]/);
+    assert.match(
+      startScript,
+      /if \[ "\$\(id -u\)" -ne 0 \]; then[\s\S]*?write_auth_profile\s+sync_inference_api_key/s,
+    );
+    assert.match(
+      startScript,
+      /declare -f write_auth_profile sync_inference_api_key/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep `~/.openclaw/openclaw.json` writable by backing it with `.openclaw-data`
- move OpenClaw identity state into writable sandbox storage too
- add a regression test for the Dockerfile layout

## Testing
- node --test test/dockerfile-config.test.js test/onboard.test.js test/inference-config.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup optionally syncs an inference API key from the environment into local config for seamless credential propagation.
  * CLI start/stop/status now respect the default sandbox env and propagate a saved Telegram token into service environment.

* **Chores**
  * Container layout now separates writable state from generated config via a symlink and removes prior read-only pinning.
  * Integrity pinning now hashes only the gateway portion of the config for verification.

* **Tests**
  * Added checks validating container config wiring and startup script behavior for API-key and sandbox-env.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->