### PR TITLE
docs: add sandbox policy configurability section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ NemoClaw includes preset policy files for common integrations such as PyPI, Dock
 
 When the agent attempts to reach an endpoint not covered by the policy, OpenShell blocks the request and surfaces it in the TUI (`openshell term`) for the operator to approve or deny in real time. Approved endpoints persist for the current session only.
 
-For the full policy schema and customization guide, see the OpenShell [Policy Schema](https://github.com/NVIDIA/OpenShell/blob/main/docs/reference/policy-schema.md) and [Sandbox Policies](https://github.com/NVIDIA/OpenShell/blob/main/docs/sandboxes/policies.md) documentation.
+For step-by-step instructions, see [Customize Network Policy](https://docs.nvidia.com/nemoclaw/latest/network-policy/customize-network-policy.html). For the underlying enforcement details, see the OpenShell [Policy Schema](https://github.com/NVIDIA/OpenShell/blob/main/docs/reference/policy-schema.md) and [Sandbox Policies](https://github.com/NVIDIA/OpenShell/blob/main/docs/sandboxes/policies.md) documentation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ NemoClaw includes preset policy files for common integrations such as PyPI, Dock
 
 When the agent attempts to reach an endpoint not covered by the policy, OpenShell blocks the request and surfaces it in the TUI (`openshell term`) for the operator to approve or deny in real time. Approved endpoints persist for the current session only.
 
-For step-by-step instructions, see [Customize Network Policy](https://docs.nvidia.com/nemoclaw/latest/network-policy/customize-network-policy.html). For the underlying enforcement details, see the OpenShell [Policy Schema](https://github.com/NVIDIA/OpenShell/blob/main/docs/reference/policy-schema.md) and [Sandbox Policies](https://github.com/NVIDIA/OpenShell/blob/main/docs/sandboxes/policies.md) documentation.
+For step-by-step instructions, see [Customize Network Policy](https://docs.nvidia.com/nemoclaw/latest/network-policy/customize-network-policy.html). For the underlying enforcement details, see the OpenShell [Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) and [Sandbox Policies](https://docs.nvidia.com/openshell/latest/sandboxes/policies.html) documentation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,26 @@ When the agent tries to reach an unlisted host, OpenShell blocks the request and
 
 ---
 
+## Configuring Sandbox Policy
+
+The sandbox policy is defined in a declarative YAML file and enforced by the OpenShell runtime.
+NemoClaw ships a strict baseline in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` that denies all network egress except explicitly listed endpoints.
+
+Operators can customize the policy in two ways:
+
+| Method | How | Scope |
+|--------|-----|-------|
+| **Static** | Edit `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`. | Persists across restarts. |
+| **Dynamic** | Run `openshell policy set <policy-file>` on a running sandbox. | Session only; resets on restart. |
+
+NemoClaw includes preset policy files for common integrations such as PyPI, Docker Hub, Slack, and Jira in `nemoclaw-blueprint/policies/presets/`. Apply a preset as-is or use it as a starting template.
+
+When the agent attempts to reach an endpoint not covered by the policy, OpenShell blocks the request and surfaces it in the TUI (`openshell term`) for the operator to approve or deny in real time. Approved endpoints persist for the current session only.
+
+For the full policy schema and customization guide, see the OpenShell [Policy Schema](https://github.com/NVIDIA/OpenShell/blob/main/docs/reference/policy-schema.md) and [Sandbox Policies](https://github.com/NVIDIA/OpenShell/blob/main/docs/sandboxes/policies.md) documentation.
+
+---
+
 ## Key Commands
 
 ### Host commands (`nemoclaw`)

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -124,4 +124,4 @@ To include a preset in the baseline, merge its entries into `openclaw-sandbox.ya
 - [Approve or Deny Agent Network Requests](approve-network-requests.md) for real-time operator approval.
 - [Network Policies](../reference/network-policies.md) for the full baseline policy reference.
 - OpenShell [Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) for the full YAML policy schema reference.
-- OpenShell [Sandbox Policies](https://github.com/NVIDIA/OpenShell/blob/main/docs/sandboxes/policies.md) for applying, iterating, and debugging policies at the OpenShell layer.
+- OpenShell [Sandbox Policies](https://docs.nvidia.com/openshell/latest/sandboxes/policies.html) for applying, iterating, and debugging policies at the OpenShell layer.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -123,5 +123,5 @@ To include a preset in the baseline, merge its entries into `openclaw-sandbox.ya
 
 - [Approve or Deny Agent Network Requests](approve-network-requests.md) for real-time operator approval.
 - [Network Policies](../reference/network-policies.md) for the full baseline policy reference.
-- OpenShell [Policy Schema](https://github.com/NVIDIA/OpenShell/blob/main/docs/reference/policy-schema.md) for the full YAML policy schema reference.
+- OpenShell [Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) for the full YAML policy schema reference.
 - OpenShell [Sandbox Policies](https://github.com/NVIDIA/OpenShell/blob/main/docs/sandboxes/policies.md) for applying, iterating, and debugging policies at the OpenShell layer.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -21,7 +21,9 @@ status: published
 # Customize the Sandbox Network Policy
 
 Add, remove, or modify the endpoints that the sandbox is allowed to reach.
-NemoClaw supports both static policy changes that persist across restarts and dynamic updates to a running sandbox.
+
+The sandbox policy is defined in a declarative YAML file in the NemoClaw repository and enforced at runtime by [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell).
+NemoClaw supports both static policy changes that persist across restarts and dynamic updates applied to a running sandbox through the OpenShell CLI.
 
 ## Prerequisites
 
@@ -90,7 +92,36 @@ Dynamic changes apply only to the current session.
 When the sandbox stops, the running policy resets to the baseline defined in the policy file.
 To make changes permanent, update the static policy file and re-run setup.
 
+## Policy Presets
+
+NemoClaw ships preset policy files for common integrations in `nemoclaw-blueprint/policies/presets/`.
+Apply a preset as-is or use it as a starting template for a custom policy.
+
+Available presets:
+
+| Preset | Endpoints |
+|--------|-----------|
+| `discord` | Discord webhook API |
+| `docker` | Docker Hub, NVIDIA container registry |
+| `huggingface` | Hugging Face model registry |
+| `jira` | Atlassian Jira API |
+| `npm` | npm and Yarn registries |
+| `outlook` | Microsoft 365 and Outlook |
+| `pypi` | Python Package Index |
+| `slack` | Slack API and webhooks |
+| `telegram` | Telegram Bot API |
+
+To apply a preset to a running sandbox, pass it as a policy file:
+
+```console
+$ openshell policy set nemoclaw-blueprint/policies/presets/pypi.yaml
+```
+
+To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.
+
 ## Related Topics
 
 - [Approve or Deny Agent Network Requests](approve-network-requests.md) for real-time operator approval.
 - [Network Policies](../reference/network-policies.md) for the full baseline policy reference.
+- OpenShell [Policy Schema](https://github.com/NVIDIA/OpenShell/blob/main/docs/reference/policy-schema.md) for the full YAML policy schema reference.
+- OpenShell [Sandbox Policies](https://github.com/NVIDIA/OpenShell/blob/main/docs/sandboxes/policies.md) for applying, iterating, and debugging policies at the OpenShell layer.


### PR DESCRIPTION
## Summary
- Adds a new "Configuring Sandbox Policy" section to the README between Protection Layers and Key Commands
- Explains that sandbox policy is declarative YAML enforced by the OpenShell runtime
- Documents static (edit + re-onboard) and dynamic (`openshell policy set`) customization paths
- Mentions preset policy files and the operator approval flow
- Links to OpenShell's Policy Schema and Sandbox Policies documentation

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm OpenShell doc links resolve to the correct pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded sandbox policy configuration guide with instructions for static and dynamic policy updates.
  * Added Policy Presets section featuring available YAML templates and example commands for applying presets to running sandboxes.
  * Included references to policy schema and additional sandbox policy documentation resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->