### PR TITLE
test: add comprehensive unit tests and raise coverage thresholds

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 #!/bin/sh
+set -e
 npx --no -- lint-staged
-cd nemoclaw && npx vitest run
+cd nemoclaw
+npx vitest run

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 #!/bin/sh
 npx --no -- lint-staged
+cd nemoclaw && npx vitest run

--- a/ci/coverage-threshold.json
+++ b/ci/coverage-threshold.json
@@ -1,6 +1,6 @@
 {
-  "lines": 6,
-  "functions": 2,
-  "branches": 5,
-  "statements": 6
+  "lines": 93,
+  "functions": 98,
+  "branches": 87,
+  "statements": 94
 }

--- a/nemoclaw/eslint.config.mjs
+++ b/nemoclaw/eslint.config.mjs
@@ -34,6 +34,8 @@ export default [
     rules: {
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/unbound-method": "off",
     },
   },
   prettier,

--- a/nemoclaw/src/blueprint/state.test.ts
+++ b/nemoclaw/src/blueprint/state.test.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { loadState, saveState, clearState, type NemoClawState } from "./state.js";
+
+const store = new Map<string, string>();
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...original,
+    existsSync: (p: string) => store.has(p),
+    mkdirSync: vi.fn(),
+    readFileSync: (p: string) => {
+      const content = store.get(p);
+      if (content === undefined) throw new Error(`ENOENT: ${p}`);
+      return content;
+    },
+    writeFileSync: (p: string, data: string) => {
+      store.set(p, data);
+    },
+  };
+});
+
+const STATE_PATH = `${process.env.HOME ?? "/tmp"}/.nemoclaw/state/nemoclaw.json`;
+
+describe("blueprint/state", () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  describe("loadState", () => {
+    it("returns blank state when no file exists", () => {
+      const state = loadState();
+      expect(state.lastRunId).toBeNull();
+      expect(state.lastAction).toBeNull();
+      expect(state.blueprintVersion).toBeNull();
+      expect(state.sandboxName).toBeNull();
+      expect(state.migrationSnapshot).toBeNull();
+      expect(state.hostBackupPath).toBeNull();
+      expect(state.createdAt).toBeNull();
+      expect(state.updatedAt).toBeDefined();
+    });
+
+    it("returns parsed state when file exists", () => {
+      const saved: NemoClawState = {
+        lastRunId: "run-1",
+        lastAction: "deploy",
+        blueprintVersion: "1.0.0",
+        sandboxName: "sb",
+        migrationSnapshot: null,
+        hostBackupPath: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T12:00:00.000Z",
+      };
+      store.set(STATE_PATH, JSON.stringify(saved));
+      expect(loadState()).toEqual(saved);
+    });
+  });
+
+  describe("saveState", () => {
+    it("writes state and sets updatedAt", () => {
+      const state = loadState();
+      state.lastAction = "deploy";
+      saveState(state);
+      const loaded = loadState();
+      expect(loaded.lastAction).toBe("deploy");
+      expect(loaded.updatedAt).toBeDefined();
+    });
+
+    it("sets createdAt on first save", () => {
+      const state = loadState();
+      expect(state.createdAt).toBeNull();
+      saveState(state);
+      const loaded = loadState();
+      expect(loaded.createdAt).toBeDefined();
+      expect(loaded.createdAt).toBe(loaded.updatedAt);
+    });
+
+    it("preserves existing createdAt", () => {
+      const state = loadState();
+      state.createdAt = "2026-01-01T00:00:00.000Z";
+      saveState(state);
+      const loaded = loadState();
+      expect(loaded.createdAt).toBe("2026-01-01T00:00:00.000Z");
+    });
+  });
+
+  describe("clearState", () => {
+    it("resets state to blank when file exists", () => {
+      const state = loadState();
+      state.lastAction = "deploy";
+      state.lastRunId = "run-1";
+      saveState(state);
+      clearState();
+      const loaded = loadState();
+      expect(loaded.lastAction).toBeNull();
+      expect(loaded.lastRunId).toBeNull();
+    });
+
+    it("does nothing when no file exists", () => {
+      expect(() => clearState()).not.toThrow();
+    });
+  });
+});

--- a/nemoclaw/src/blueprint/state.test.ts
+++ b/nemoclaw/src/blueprint/state.test.ts
@@ -7,7 +7,7 @@ import { loadState, saveState, clearState, type NemoClawState } from "./state.js
 const store = new Map<string, string>();
 
 vi.mock("node:fs", async (importOriginal) => {
-  const original = await importOriginal<typeof import("node:fs")>();
+  const original = await importOriginal();
   return {
     ...original,
     existsSync: (p: string) => store.has(p),
@@ -100,7 +100,9 @@ describe("blueprint/state", () => {
     });
 
     it("does nothing when no file exists", () => {
-      expect(() => clearState()).not.toThrow();
+      expect(() => {
+        clearState();
+      }).not.toThrow();
     });
   });
 });

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -1,0 +1,666 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import path from "node:path";
+import type { PluginLogger } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// fs mock — thin in-memory store keyed by absolute path
+// ---------------------------------------------------------------------------
+
+interface FsEntry {
+  type: "file" | "dir" | "symlink";
+  content?: string;
+}
+
+const store = new Map<string, FsEntry>();
+
+function addDir(p: string): void {
+  store.set(p, { type: "dir" });
+}
+
+function addFile(p: string, content: string): void {
+  store.set(p, { type: "file", content });
+}
+
+function addSymlink(p: string): void {
+  store.set(p, { type: "symlink" });
+}
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...original,
+    existsSync: (p: string) => store.has(p),
+    mkdirSync: vi.fn((p: string) => {
+      addDir(p);
+    }),
+    readFileSync: (p: string) => {
+      const entry = store.get(p);
+      if (!entry || entry.type !== "file") throw new Error(`ENOENT: ${p}`);
+      return entry.content!;
+    },
+    writeFileSync: vi.fn((p: string, data: string) => {
+      store.set(p, { type: "file", content: data });
+    }),
+    copyFileSync: vi.fn((src: string, dest: string) => {
+      const entry = store.get(src);
+      if (!entry) throw new Error(`ENOENT: ${src}`);
+      store.set(dest, { ...entry });
+    }),
+    cpSync: vi.fn((src: string, dest: string) => {
+      // Shallow copy: copy all entries whose path starts with src
+      for (const [k, v] of store) {
+        if (k === src || k.startsWith(src + "/")) {
+          const relative = k.slice(src.length);
+          store.set(dest + relative, { ...v });
+        }
+      }
+    }),
+    rmSync: vi.fn(),
+    renameSync: vi.fn((oldPath: string, newPath: string) => {
+      for (const [k, v] of store) {
+        if (k === oldPath || k.startsWith(oldPath + "/")) {
+          const relative = k.slice(oldPath.length);
+          store.set(newPath + relative, v);
+          store.delete(k);
+        }
+      }
+    }),
+    lstatSync: (p: string) => {
+      const entry = store.get(p);
+      if (!entry) throw new Error(`ENOENT: ${p}`);
+      return {
+        isSymbolicLink: () => entry.type === "symlink",
+        isDirectory: () => entry.type === "dir",
+        isFile: () => entry.type === "file",
+      };
+    },
+    readdirSync: (p: string) => {
+      const prefix = p.endsWith("/") ? p : p + "/";
+      const entries = new Set<string>();
+      for (const k of store.keys()) {
+        if (k.startsWith(prefix)) {
+          const rest = k.slice(prefix.length);
+          const firstSegment = rest.split("/")[0];
+          if (firstSegment) entries.add(firstSegment);
+        }
+      }
+      return [...entries].sort();
+    },
+    unlinkSync: vi.fn((p: string) => {
+      store.delete(p);
+    }),
+  };
+});
+
+// Mock tar to avoid real archive creation
+vi.mock("tar", () => ({
+  create: vi.fn(async () => {}),
+}));
+
+import {
+  detectHostOpenClaw,
+  createSnapshotBundle,
+  cleanupSnapshotBundle,
+  createArchiveFromDirectory,
+  loadSnapshotManifest,
+  restoreSnapshotToHost,
+  type HostOpenClawState,
+  type SnapshotManifest,
+} from "./migration-state.js";
+
+function makeLogger(): PluginLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe("commands/migration-state", () => {
+  beforeEach(() => {
+    store.clear();
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // detectHostOpenClaw
+  // -------------------------------------------------------------------------
+
+  describe("detectHostOpenClaw", () => {
+    it("returns exists=false when no state dir or config", () => {
+      const env = { HOME: "/home/user" };
+      const result = detectHostOpenClaw(env);
+      expect(result.exists).toBe(false);
+      expect(result.stateDir).toBeNull();
+      expect(result.configPath).toBeNull();
+    });
+
+    it("detects existing state directory", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({ version: 1 }));
+      const result = detectHostOpenClaw(env);
+      expect(result.exists).toBe(true);
+      expect(result.stateDir).toBe("/home/user/.openclaw");
+      expect(result.configPath).toBe("/home/user/.openclaw/openclaw.json");
+      expect(result.homeDir).toBe("/home/user");
+    });
+
+    it("respects OPENCLAW_HOME override", () => {
+      const env = { HOME: "/home/user", OPENCLAW_HOME: "/custom/home" };
+      addDir("/custom/home/.openclaw");
+      const result = detectHostOpenClaw(env);
+      expect(result.exists).toBe(true);
+      expect(result.homeDir).toBe("/custom/home");
+      expect(result.stateDir).toBe("/custom/home/.openclaw");
+    });
+
+    it("resolves OPENCLAW_HOME=~ to HOME", () => {
+      const env = { HOME: "/home/user", OPENCLAW_HOME: "~" };
+      addDir("/home/user/.openclaw");
+      const result = detectHostOpenClaw(env);
+      expect(result.homeDir).toBe("/home/user");
+    });
+
+    it("resolves OPENCLAW_HOME=~/subdir", () => {
+      const env = { HOME: "/home/user", OPENCLAW_HOME: "~/subdir" };
+      addDir("/home/user/subdir/.openclaw");
+      const result = detectHostOpenClaw(env);
+      expect(result.homeDir).toBe("/home/user/subdir");
+    });
+
+    it("respects OPENCLAW_STATE_DIR override", () => {
+      const env = { HOME: "/home/user", OPENCLAW_STATE_DIR: "/custom/state" };
+      addDir("/custom/state");
+      addFile("/custom/state/openclaw.json", JSON.stringify({}));
+      const result = detectHostOpenClaw(env);
+      expect(result.stateDir).toBe("/custom/state");
+    });
+
+    it("respects OPENCLAW_CONFIG_PATH override", () => {
+      const env = { HOME: "/home/user", OPENCLAW_CONFIG_PATH: "/etc/openclaw.json" };
+      addDir("/home/user/.openclaw");
+      addFile("/etc/openclaw.json", JSON.stringify({}));
+      const result = detectHostOpenClaw(env);
+      expect(result.configPath).toBe("/etc/openclaw.json");
+      expect(result.hasExternalConfig).toBe(true);
+    });
+
+    it("reports error when state dir missing but config exists", () => {
+      const env = { HOME: "/home/user" };
+      addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({}));
+      const result = detectHostOpenClaw(env);
+      expect(result.exists).toBe(true);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain("does not exist");
+    });
+
+    it("reports error when config is invalid JSON", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile("/home/user/.openclaw/openclaw.json", "not valid json");
+      const result = detectHostOpenClaw(env);
+      expect(result.errors.some((e) => e.includes("Failed to parse"))).toBe(true);
+    });
+
+    it("reports error when config is an array", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile("/home/user/.openclaw/openclaw.json", "[1, 2, 3]");
+      const result = detectHostOpenClaw(env);
+      expect(result.errors.some((e) => e.includes("not a JSON object"))).toBe(true);
+    });
+
+    it("detects extensions, skills, and hooks dirs when present", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addDir("/home/user/.openclaw/extensions");
+      addDir("/home/user/.openclaw/skills");
+      addDir("/home/user/.openclaw/hooks");
+      const result = detectHostOpenClaw(env);
+      expect(result.extensionsDir).toBe("/home/user/.openclaw/extensions");
+      expect(result.skillsDir).toBe("/home/user/.openclaw/skills");
+      expect(result.hooksDir).toBe("/home/user/.openclaw/hooks");
+    });
+
+    it("returns null for missing optional dirs", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      const result = detectHostOpenClaw(env);
+      expect(result.extensionsDir).toBeNull();
+      expect(result.skillsDir).toBeNull();
+      expect(result.hooksDir).toBeNull();
+    });
+
+    it("detects workspace from config", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          agents: { defaults: { workspace: "/home/user/my-workspace" } },
+        }),
+      );
+      addDir("/home/user/my-workspace");
+      const result = detectHostOpenClaw(env);
+      expect(result.workspaceDir).toBe("/home/user/my-workspace");
+    });
+
+    it("uses default workspace path when not configured", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({}));
+      addDir("/home/user/.openclaw/workspace");
+      const result = detectHostOpenClaw(env);
+      expect(result.workspaceDir).toBe("/home/user/.openclaw/workspace");
+    });
+
+    it("uses profiled workspace path with OPENCLAW_PROFILE", () => {
+      const env = { HOME: "/home/user", OPENCLAW_PROFILE: "dev" };
+      addDir("/home/user/.openclaw");
+      addDir("/home/user/.openclaw/workspace-dev");
+      const result = detectHostOpenClaw(env);
+      expect(result.workspaceDir).toBe("/home/user/.openclaw/workspace-dev");
+    });
+
+    it("collects external roots from agent list workspaces", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          agents: {
+            list: [
+              { id: "agent-1", workspace: "/external/ws1" },
+              { id: "agent-2", agentDir: "/external/agentdir" },
+            ],
+          },
+        }),
+      );
+      addDir("/external/ws1");
+      addDir("/external/agentdir");
+      const result = detectHostOpenClaw(env);
+      expect(result.externalRoots.length).toBe(2);
+      expect(result.externalRoots.some((r) => r.kind === "workspace")).toBe(true);
+      expect(result.externalRoots.some((r) => r.kind === "agentDir")).toBe(true);
+    });
+
+    it("collects external roots from skills.load.extraDirs", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          skills: { load: { extraDirs: ["/external/skills1"] } },
+        }),
+      );
+      addDir("/external/skills1");
+      const result = detectHostOpenClaw(env);
+      expect(result.externalRoots.some((r) => r.kind === "skillsExtraDir")).toBe(true);
+    });
+
+    it("warns about symlinks in workspace", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addDir("/home/user/.openclaw/workspace");
+      addSymlink("/home/user/.openclaw/workspace/link");
+      const result = detectHostOpenClaw(env);
+      expect(result.warnings.some((w) => w.includes("symlink"))).toBe(true);
+    });
+
+    it("reports error for missing required external root", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          agents: { list: [{ id: "a1", workspace: "/missing/ws" }] },
+        }),
+      );
+      // Don't add /missing/ws to store
+      const result = detectHostOpenClaw(env);
+      expect(result.errors.some((e) => e.includes("missing"))).toBe(true);
+    });
+
+    it("reports error when external root is not a directory", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          agents: { list: [{ id: "a1", workspace: "/external/notdir" }] },
+        }),
+      );
+      addFile("/external/notdir", "not a dir");
+      const result = detectHostOpenClaw(env);
+      expect(result.errors.some((e) => e.includes("not a directory"))).toBe(true);
+    });
+
+    it("warns about symlinks in external roots", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          agents: { list: [{ id: "a1", workspace: "/external/ws" }] },
+        }),
+      );
+      addDir("/external/ws");
+      addSymlink("/external/ws/link");
+      const result = detectHostOpenClaw(env);
+      expect(result.warnings.some((w) => w.includes("symlink"))).toBe(true);
+    });
+
+    it("deduplicates roots that resolve to the same path", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          agents: {
+            defaults: { workspace: "/external/ws" },
+            list: [{ id: "a1", workspace: "/external/ws" }],
+          },
+        }),
+      );
+      addDir("/external/ws");
+      const result = detectHostOpenClaw(env);
+      const wsRoots = result.externalRoots.filter((r) => r.sourcePath === "/external/ws");
+      expect(wsRoots.length).toBe(1);
+      // But it should have two bindings
+      expect(wsRoots[0].bindings.length).toBe(2);
+    });
+
+    it("skips agent list entries that are not objects", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          agents: { list: [null, "string", 42] },
+        }),
+      );
+      const result = detectHostOpenClaw(env);
+      // Should not throw, no external roots from invalid entries
+      expect(result.exists).toBe(true);
+    });
+
+    it("skips extraDirs entries that are not strings", () => {
+      const env = { HOME: "/home/user" };
+      addDir("/home/user/.openclaw");
+      addFile(
+        "/home/user/.openclaw/openclaw.json",
+        JSON.stringify({
+          skills: { load: { extraDirs: [null, 42, ""] } },
+        }),
+      );
+      const result = detectHostOpenClaw(env);
+      expect(result.exists).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createSnapshotBundle
+  // -------------------------------------------------------------------------
+
+  describe("createSnapshotBundle", () => {
+    it("returns null when stateDir is missing", () => {
+      const logger = makeLogger();
+      const hostState: HostOpenClawState = {
+        exists: false,
+        homeDir: "/home/user",
+        stateDir: null,
+        configDir: null,
+        configPath: null,
+        workspaceDir: null,
+        extensionsDir: null,
+        skillsDir: null,
+        hooksDir: null,
+        externalRoots: [],
+        warnings: [],
+        errors: [],
+        hasExternalConfig: false,
+      };
+      expect(createSnapshotBundle(hostState, logger, { persist: false })).toBeNull();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("creates a snapshot bundle for a basic host state", () => {
+      const logger = makeLogger();
+      addDir("/home/user/.openclaw");
+      addFile("/home/user/.openclaw/openclaw.json", JSON.stringify({ version: 1 }));
+
+      const hostState: HostOpenClawState = {
+        exists: true,
+        homeDir: "/home/user",
+        stateDir: "/home/user/.openclaw",
+        configDir: "/home/user/.openclaw",
+        configPath: "/home/user/.openclaw/openclaw.json",
+        workspaceDir: null,
+        extensionsDir: null,
+        skillsDir: null,
+        hooksDir: null,
+        externalRoots: [],
+        warnings: [],
+        errors: [],
+        hasExternalConfig: false,
+      };
+
+      const bundle = createSnapshotBundle(hostState, logger, { persist: true });
+      expect(bundle).not.toBeNull();
+      expect(bundle!.manifest.version).toBe(2);
+      expect(bundle!.manifest.homeDir).toBe("/home/user");
+      expect(bundle!.temporary).toBe(false);
+    });
+
+    it("snapshots external config when hasExternalConfig", () => {
+      const logger = makeLogger();
+      addDir("/home/user/.openclaw");
+      addFile("/etc/openclaw.json", JSON.stringify({ external: true }));
+
+      const hostState: HostOpenClawState = {
+        exists: true,
+        homeDir: "/home/user",
+        stateDir: "/home/user/.openclaw",
+        configDir: "/home/user/.openclaw",
+        configPath: "/etc/openclaw.json",
+        workspaceDir: null,
+        extensionsDir: null,
+        skillsDir: null,
+        hooksDir: null,
+        externalRoots: [],
+        warnings: [],
+        errors: [],
+        hasExternalConfig: true,
+      };
+
+      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      expect(bundle).not.toBeNull();
+      expect(bundle!.manifest.hasExternalConfig).toBe(true);
+      expect(bundle!.temporary).toBe(true);
+    });
+
+    it("snapshots external roots", () => {
+      const logger = makeLogger();
+      addDir("/home/user/.openclaw");
+      addDir("/external/ws");
+
+      const hostState: HostOpenClawState = {
+        exists: true,
+        homeDir: "/home/user",
+        stateDir: "/home/user/.openclaw",
+        configDir: "/home/user/.openclaw",
+        configPath: null,
+        workspaceDir: null,
+        extensionsDir: null,
+        skillsDir: null,
+        hooksDir: null,
+        externalRoots: [
+          {
+            id: "workspaces-ws",
+            kind: "workspace",
+            label: "ws",
+            sourcePath: "/external/ws",
+            snapshotRelativePath: "external/workspaces-ws",
+            sandboxPath: "/sandbox/.nemoclaw/migration/workspaces/workspaces-ws",
+            symlinkPaths: [],
+            bindings: [{ configPath: "agents.list[0].workspace" }],
+          },
+        ],
+        warnings: [],
+        errors: [],
+        hasExternalConfig: false,
+      };
+
+      const bundle = createSnapshotBundle(hostState, logger, { persist: false });
+      expect(bundle).not.toBeNull();
+      expect(bundle!.manifest.externalRoots.length).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // cleanupSnapshotBundle
+  // -------------------------------------------------------------------------
+
+  describe("cleanupSnapshotBundle", () => {
+    it("removes temporary snapshot directory", async () => {
+      const fs = await import("node:fs");
+      vi.mocked(fs.rmSync).mockClear();
+      cleanupSnapshotBundle({
+        snapshotDir: "/tmp/snapshot",
+        snapshotPath: "/tmp/snapshot/snapshot.json",
+        preparedStateDir: "/tmp/snapshot/sandbox-bundle/openclaw",
+        archivesDir: "/tmp/snapshot/sandbox-bundle/archives",
+        manifest: {} as SnapshotManifest,
+        temporary: true,
+      });
+      expect(fs.rmSync).toHaveBeenCalledWith("/tmp/snapshot", { recursive: true, force: true });
+    });
+
+    it("does not remove persistent snapshot directory", async () => {
+      const fs = await import("node:fs");
+      vi.mocked(fs.rmSync).mockClear();
+      cleanupSnapshotBundle({
+        snapshotDir: "/tmp/snapshot",
+        snapshotPath: "/tmp/snapshot/snapshot.json",
+        preparedStateDir: "/tmp/snapshot/sandbox-bundle/openclaw",
+        archivesDir: "/tmp/snapshot/sandbox-bundle/archives",
+        manifest: {} as SnapshotManifest,
+        temporary: false,
+      });
+      expect(fs.rmSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createArchiveFromDirectory
+  // -------------------------------------------------------------------------
+
+  describe("createArchiveFromDirectory", () => {
+    it("calls tar.create with correct options", async () => {
+      const { create } = await import("tar");
+      await createArchiveFromDirectory("/src", "/dest/archive.tar");
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: "/src",
+          file: "/dest/archive.tar",
+          portable: true,
+          follow: false,
+          noMtime: true,
+        }),
+        ["."],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // loadSnapshotManifest / restoreSnapshotToHost
+  // -------------------------------------------------------------------------
+
+  describe("loadSnapshotManifest", () => {
+    it("reads and parses snapshot.json", () => {
+      const manifest: SnapshotManifest = {
+        version: 2,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        homeDir: "/home/user",
+        stateDir: "/home/user/.openclaw",
+        configPath: null,
+        hasExternalConfig: false,
+        externalRoots: [],
+        warnings: [],
+      };
+      addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+      const loaded = loadSnapshotManifest("/snapshots/snap1");
+      expect(loaded).toEqual(manifest);
+    });
+  });
+
+  describe("restoreSnapshotToHost", () => {
+    it("returns false when snapshot openclaw dir is missing", () => {
+      const logger = makeLogger();
+      const manifest: SnapshotManifest = {
+        version: 2,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        homeDir: "/home/user",
+        stateDir: "/home/user/.openclaw",
+        configPath: null,
+        hasExternalConfig: false,
+        externalRoots: [],
+        warnings: [],
+      };
+      addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+      // Don't add /snapshots/snap1/openclaw
+      const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+      expect(result).toBe(false);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("restores state directory from snapshot", () => {
+      const logger = makeLogger();
+      const manifest: SnapshotManifest = {
+        version: 2,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        homeDir: "/home/user",
+        stateDir: "/home/user/.openclaw",
+        configPath: null,
+        hasExternalConfig: false,
+        externalRoots: [],
+        warnings: [],
+      };
+      addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+      addDir("/snapshots/snap1/openclaw");
+      addFile("/snapshots/snap1/openclaw/openclaw.json", JSON.stringify({ restored: true }));
+      // Existing state dir to be archived
+      addDir("/home/user/.openclaw");
+
+      const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+      expect(result).toBe(true);
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("restored"));
+    });
+
+    it("restores external config when hasExternalConfig", () => {
+      const logger = makeLogger();
+      const manifest: SnapshotManifest = {
+        version: 2,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        homeDir: "/home/user",
+        stateDir: "/home/user/.openclaw",
+        configPath: "/etc/openclaw.json",
+        hasExternalConfig: true,
+        externalRoots: [],
+        warnings: [],
+      };
+      addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+      addDir("/snapshots/snap1/openclaw");
+      addFile("/snapshots/snap1/config/openclaw.json", JSON.stringify({ external: true }));
+
+      const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+      expect(result).toBe(true);
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("external config"));
+    });
+  });
+});

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import path from "node:path";
 import type { PluginLogger } from "../index.js";
 
 // ---------------------------------------------------------------------------
@@ -29,7 +28,7 @@ function addSymlink(p: string): void {
 }
 
 vi.mock("node:fs", async (importOriginal) => {
-  const original = await importOriginal<typeof import("node:fs")>();
+  const original = await importOriginal();
   return {
     ...original,
     existsSync: (p: string) => store.has(p),
@@ -39,7 +38,7 @@ vi.mock("node:fs", async (importOriginal) => {
     readFileSync: (p: string) => {
       const entry = store.get(p);
       if (!entry || entry.type !== "file") throw new Error(`ENOENT: ${p}`);
-      return entry.content!;
+      return entry.content ?? "";
     },
     writeFileSync: vi.fn((p: string, data: string) => {
       store.set(p, { type: "file", content: data });
@@ -451,10 +450,13 @@ describe("commands/migration-state", () => {
       };
 
       const bundle = createSnapshotBundle(hostState, logger, { persist: true });
-      expect(bundle).not.toBeNull();
-      expect(bundle!.manifest.version).toBe(2);
-      expect(bundle!.manifest.homeDir).toBe("/home/user");
-      expect(bundle!.temporary).toBe(false);
+      if (bundle === null) {
+        expect.unreachable("bundle should not be null");
+        return;
+      }
+      expect(bundle.manifest.version).toBe(2);
+      expect(bundle.manifest.homeDir).toBe("/home/user");
+      expect(bundle.temporary).toBe(false);
     });
 
     it("snapshots external config when hasExternalConfig", () => {
@@ -479,9 +481,12 @@ describe("commands/migration-state", () => {
       };
 
       const bundle = createSnapshotBundle(hostState, logger, { persist: false });
-      expect(bundle).not.toBeNull();
-      expect(bundle!.manifest.hasExternalConfig).toBe(true);
-      expect(bundle!.temporary).toBe(true);
+      if (bundle === null) {
+        expect.unreachable("bundle should not be null");
+        return;
+      }
+      expect(bundle.manifest.hasExternalConfig).toBe(true);
+      expect(bundle.temporary).toBe(true);
     });
 
     it("snapshots external roots", () => {
@@ -517,8 +522,11 @@ describe("commands/migration-state", () => {
       };
 
       const bundle = createSnapshotBundle(hostState, logger, { persist: false });
-      expect(bundle).not.toBeNull();
-      expect(bundle!.manifest.externalRoots.length).toBe(1);
+      if (bundle === null) {
+        expect.unreachable("bundle should not be null");
+        return;
+      }
+      expect(bundle.manifest.externalRoots.length).toBe(1);
     });
   });
 

--- a/nemoclaw/src/commands/slash.test.ts
+++ b/nemoclaw/src/commands/slash.test.ts
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PluginCommandContext, OpenClawPluginApi } from "../index.js";
+import type { NemoClawState } from "../blueprint/state.js";
+import type { NemoClawOnboardConfig } from "../onboard/config.js";
+
+vi.mock("../blueprint/state.js", () => ({
+  loadState: vi.fn(),
+}));
+
+vi.mock("../onboard/config.js", () => ({
+  loadOnboardConfig: vi.fn(),
+  describeOnboardEndpoint: vi.fn(),
+  describeOnboardProvider: vi.fn(),
+}));
+
+import { handleSlashCommand } from "./slash.js";
+import { loadState } from "../blueprint/state.js";
+import {
+  loadOnboardConfig,
+  describeOnboardEndpoint,
+  describeOnboardProvider,
+} from "../onboard/config.js";
+
+const mockedLoadState = vi.mocked(loadState);
+const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
+const mockedDescribeOnboardEndpoint = vi.mocked(describeOnboardEndpoint);
+const mockedDescribeOnboardProvider = vi.mocked(describeOnboardProvider);
+
+function makeCtx(args?: string): PluginCommandContext {
+  return {
+    channel: "test-channel",
+    isAuthorizedSender: true,
+    args,
+    commandBody: `/nemoclaw${args ? ` ${args}` : ""}`,
+    config: {},
+  };
+}
+
+function makeApi(): OpenClawPluginApi {
+  return {
+    id: "nemoclaw",
+    name: "NemoClaw",
+    config: {},
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    registerCommand: vi.fn(),
+    registerProvider: vi.fn(),
+    registerService: vi.fn(),
+    resolvePath: vi.fn((p: string) => p),
+    on: vi.fn(),
+  };
+}
+
+function blankState(): NemoClawState {
+  return {
+    lastRunId: null,
+    lastAction: null,
+    blueprintVersion: null,
+    sandboxName: null,
+    migrationSnapshot: null,
+    hostBackupPath: null,
+    createdAt: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe("commands/slash", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedLoadState.mockReturnValue(blankState());
+    mockedLoadOnboardConfig.mockReturnValue(null);
+  });
+
+  // -------------------------------------------------------------------------
+  // help (default)
+  // -------------------------------------------------------------------------
+
+  describe("help", () => {
+    it("returns help text for empty args", () => {
+      const result = handleSlashCommand(makeCtx(), makeApi());
+      expect(result.text).toContain("NemoClaw");
+      expect(result.text).toContain("Subcommands:");
+      expect(result.text).toContain("status");
+      expect(result.text).toContain("eject");
+      expect(result.text).toContain("onboard");
+    });
+
+    it("returns help text for unknown subcommand", () => {
+      const result = handleSlashCommand(makeCtx("unknown"), makeApi());
+      expect(result.text).toContain("Subcommands:");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // status
+  // -------------------------------------------------------------------------
+
+  describe("status", () => {
+    it("reports no operations when state is blank", () => {
+      const result = handleSlashCommand(makeCtx("status"), makeApi());
+      expect(result.text).toContain("No operations performed yet");
+    });
+
+    it("reports state when last action exists", () => {
+      mockedLoadState.mockReturnValue({
+        lastRunId: "run-123",
+        lastAction: "deploy",
+        blueprintVersion: "1.0.0",
+        sandboxName: "test-sandbox",
+        migrationSnapshot: null,
+        hostBackupPath: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      });
+      const result = handleSlashCommand(makeCtx("status"), makeApi());
+      expect(result.text).toContain("Last action: deploy");
+      expect(result.text).toContain("Blueprint: 1.0.0");
+      expect(result.text).toContain("Run ID: run-123");
+      expect(result.text).toContain("Sandbox: test-sandbox");
+    });
+
+    it("includes rollback snapshot when present", () => {
+      mockedLoadState.mockReturnValue({
+        lastRunId: "run-456",
+        lastAction: "migrate",
+        blueprintVersion: "2.0.0",
+        sandboxName: "sb",
+        migrationSnapshot: "/snapshots/snap-001",
+        hostBackupPath: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      });
+      const result = handleSlashCommand(makeCtx("status"), makeApi());
+      expect(result.text).toContain("Rollback snapshot: /snapshots/snap-001");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // eject
+  // -------------------------------------------------------------------------
+
+  describe("eject", () => {
+    it("reports nothing to eject when state is blank", () => {
+      const result = handleSlashCommand(makeCtx("eject"), makeApi());
+      expect(result.text).toContain("No NemoClaw deployment found");
+    });
+
+    it("reports manual rollback required when no snapshot exists", () => {
+      mockedLoadState.mockReturnValue({
+        lastRunId: "run-1",
+        lastAction: "deploy",
+        blueprintVersion: "1.0.0",
+        sandboxName: "sb",
+        migrationSnapshot: null,
+        hostBackupPath: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      });
+      const result = handleSlashCommand(makeCtx("eject"), makeApi());
+      expect(result.text).toContain("Manual rollback required");
+    });
+
+    it("shows eject instructions when migration snapshot exists", () => {
+      mockedLoadState.mockReturnValue({
+        lastRunId: "run-1",
+        lastAction: "migrate",
+        blueprintVersion: "1.0.0",
+        sandboxName: "sb",
+        migrationSnapshot: "/snapshots/snap-001",
+        hostBackupPath: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      });
+      const result = handleSlashCommand(makeCtx("eject"), makeApi());
+      expect(result.text).toContain("Eject from NemoClaw");
+      expect(result.text).toContain("nemoclaw <name> destroy");
+      expect(result.text).toContain("Snapshot: /snapshots/snap-001");
+    });
+
+    it("uses hostBackupPath when migrationSnapshot is absent", () => {
+      mockedLoadState.mockReturnValue({
+        lastRunId: "run-1",
+        lastAction: "deploy",
+        blueprintVersion: "1.0.0",
+        sandboxName: "sb",
+        migrationSnapshot: null,
+        hostBackupPath: "/backups/backup-001",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      });
+      const result = handleSlashCommand(makeCtx("eject"), makeApi());
+      expect(result.text).toContain("Snapshot: /backups/backup-001");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // onboard
+  // -------------------------------------------------------------------------
+
+  describe("onboard", () => {
+    it("shows setup instructions when no config exists", () => {
+      const result = handleSlashCommand(makeCtx("onboard"), makeApi());
+      expect(result.text).toContain("No configuration found");
+      expect(result.text).toContain("nemoclaw onboard");
+    });
+
+    it("shows onboard status when config exists", () => {
+      const config = {
+        endpointType: "build" as const,
+        endpointUrl: "https://api.build.nvidia.com/v1",
+        ncpPartner: null,
+        model: "nvidia/nemotron-3-super-120b-a12b",
+        profile: "default",
+        credentialEnv: "NVIDIA_API_KEY",
+        onboardedAt: "2026-03-01T00:00:00.000Z",
+      };
+      mockedLoadOnboardConfig.mockReturnValue(config);
+      mockedDescribeOnboardEndpoint.mockReturnValue("build (https://api.build.nvidia.com/v1)");
+      mockedDescribeOnboardProvider.mockReturnValue("NVIDIA Endpoint API");
+      const result = handleSlashCommand(makeCtx("onboard"), makeApi());
+      expect(result.text).toContain("NemoClaw Onboard Status");
+      expect(result.text).toContain("NVIDIA Endpoint API");
+      expect(result.text).toContain("nvidia/nemotron-3-super-120b-a12b");
+      expect(result.text).toContain("NVIDIA_API_KEY");
+    });
+
+    it("includes NCP partner when set", () => {
+      const config: NemoClawOnboardConfig = {
+        endpointType: "ncp",
+        endpointUrl: "https://partner.example.com/v1",
+        ncpPartner: "PartnerCo",
+        model: "nvidia/nemotron-3-super-120b-a12b",
+        profile: "default",
+        credentialEnv: "NVIDIA_API_KEY",
+        onboardedAt: "2026-03-01T00:00:00.000Z",
+      };
+      mockedLoadOnboardConfig.mockReturnValue(config);
+      mockedDescribeOnboardEndpoint.mockReturnValue("ncp (https://partner.example.com/v1)");
+      mockedDescribeOnboardProvider.mockReturnValue("NVIDIA Cloud Partner");
+      const result = handleSlashCommand(makeCtx("onboard"), makeApi());
+      expect(result.text).toContain("NCP Partner: PartnerCo");
+    });
+  });
+});

--- a/nemoclaw/src/onboard/config.test.ts
+++ b/nemoclaw/src/onboard/config.test.ts
@@ -17,7 +17,7 @@ import {
 const store = new Map<string, string>();
 
 vi.mock("node:fs", async (importOriginal) => {
-  const original = await importOriginal<typeof import("node:fs")>();
+  const original = await importOriginal();
   return {
     ...original,
     existsSync: (p: string) => store.has(p),
@@ -61,9 +61,7 @@ describe("onboard/config", () => {
   describe("describeOnboardEndpoint", () => {
     it("returns managed route description for inference.local", () => {
       const config = makeConfig({ endpointUrl: "https://inference.local/v1" });
-      expect(describeOnboardEndpoint(config)).toBe(
-        "Managed Inference Route (inference.local)",
-      );
+      expect(describeOnboardEndpoint(config)).toBe("Managed Inference Route (inference.local)");
     });
 
     it("returns type and URL for other endpoints", () => {
@@ -71,9 +69,7 @@ describe("onboard/config", () => {
         endpointType: "ollama",
         endpointUrl: "http://localhost:11434/v1",
       });
-      expect(describeOnboardEndpoint(config)).toBe(
-        "ollama (http://localhost:11434/v1)",
-      );
+      expect(describeOnboardEndpoint(config)).toBe("ollama (http://localhost:11434/v1)");
     });
   });
 
@@ -140,7 +136,9 @@ describe("onboard/config", () => {
     });
 
     it("does not throw when no config file exists", () => {
-      expect(() => clearOnboardConfig()).not.toThrow();
+      expect(() => {
+        clearOnboardConfig();
+      }).not.toThrow();
     });
   });
 });

--- a/nemoclaw/src/onboard/config.test.ts
+++ b/nemoclaw/src/onboard/config.test.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  describeOnboardEndpoint,
+  describeOnboardProvider,
+  loadOnboardConfig,
+  saveOnboardConfig,
+  clearOnboardConfig,
+  type NemoClawOnboardConfig,
+  type EndpointType,
+} from "./config.js";
+
+// Mock node:fs so tests don't touch the real filesystem.
+// The config module uses: existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync.
+const store = new Map<string, string>();
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...original,
+    existsSync: (p: string) => store.has(p),
+    mkdirSync: vi.fn(),
+    readFileSync: (p: string) => {
+      const content = store.get(p);
+      if (content === undefined) throw new Error(`ENOENT: ${p}`);
+      return content;
+    },
+    writeFileSync: (p: string, data: string) => {
+      store.set(p, data);
+    },
+    unlinkSync: (p: string) => {
+      store.delete(p);
+    },
+  };
+});
+
+function makeConfig(overrides: Partial<NemoClawOnboardConfig> = {}): NemoClawOnboardConfig {
+  return {
+    endpointType: "build",
+    endpointUrl: "https://api.build.nvidia.com/v1",
+    ncpPartner: null,
+    model: "nvidia/nemotron-3-super-120b-a12b",
+    profile: "default",
+    credentialEnv: "NVIDIA_API_KEY",
+    onboardedAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("onboard/config", () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  // -------------------------------------------------------------------------
+  // describeOnboardEndpoint
+  // -------------------------------------------------------------------------
+
+  describe("describeOnboardEndpoint", () => {
+    it("returns managed route description for inference.local", () => {
+      const config = makeConfig({ endpointUrl: "https://inference.local/v1" });
+      expect(describeOnboardEndpoint(config)).toBe(
+        "Managed Inference Route (inference.local)",
+      );
+    });
+
+    it("returns type and URL for other endpoints", () => {
+      const config = makeConfig({
+        endpointType: "ollama",
+        endpointUrl: "http://localhost:11434/v1",
+      });
+      expect(describeOnboardEndpoint(config)).toBe(
+        "ollama (http://localhost:11434/v1)",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // describeOnboardProvider
+  // -------------------------------------------------------------------------
+
+  describe("describeOnboardProvider", () => {
+    it("returns providerLabel when set", () => {
+      const config = makeConfig({ providerLabel: "My Custom Provider" });
+      expect(describeOnboardProvider(config)).toBe("My Custom Provider");
+    });
+
+    const endpointCases: [EndpointType, string][] = [
+      ["build", "NVIDIA Endpoint API"],
+      ["ollama", "Local Ollama"],
+      ["vllm", "Local vLLM"],
+      ["nim-local", "Local NIM"],
+      ["ncp", "NVIDIA Cloud Partner"],
+      ["custom", "Managed Inference Route"],
+    ];
+
+    for (const [endpointType, expected] of endpointCases) {
+      it(`returns "${expected}" for endpoint type "${endpointType}"`, () => {
+        const config = makeConfig({ endpointType, providerLabel: undefined });
+        expect(describeOnboardProvider(config)).toBe(expected);
+      });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // loadOnboardConfig / saveOnboardConfig / clearOnboardConfig
+  // -------------------------------------------------------------------------
+
+  describe("loadOnboardConfig", () => {
+    it("returns null when no config file exists", () => {
+      expect(loadOnboardConfig()).toBeNull();
+    });
+
+    it("returns parsed config when file exists", () => {
+      const config = makeConfig();
+      const configPath = `${process.env.HOME ?? "/tmp"}/.nemoclaw/config.json`;
+      store.set(configPath, JSON.stringify(config));
+      expect(loadOnboardConfig()).toEqual(config);
+    });
+  });
+
+  describe("saveOnboardConfig", () => {
+    it("writes config and can be loaded back", () => {
+      const config = makeConfig({ model: "nvidia/test-model" });
+      saveOnboardConfig(config);
+      const loaded = loadOnboardConfig();
+      expect(loaded).toEqual(config);
+    });
+  });
+
+  describe("clearOnboardConfig", () => {
+    it("removes existing config file", () => {
+      const config = makeConfig();
+      saveOnboardConfig(config);
+      expect(loadOnboardConfig()).not.toBeNull();
+      clearOnboardConfig();
+      expect(loadOnboardConfig()).toBeNull();
+    });
+
+    it("does not throw when no config file exists", () => {
+      expect(() => clearOnboardConfig()).not.toThrow();
+    });
+  });
+});

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi } from "vitest";
-import register from "./index.js";
+import register, { getPluginConfig } from "./index.js";
 import type { OpenClawPluginApi } from "./index.js";
 
 function createMockApi(): OpenClawPluginApi {
@@ -43,5 +43,75 @@ describe("plugin registration", () => {
     const api = createMockApi();
     // registerCli should not exist on the API interface after removal
     expect("registerCli" in api).toBe(false);
+  });
+
+  it("registers custom model when onboard config has a model", () => {
+    const api = createMockApi();
+    // Seed a config file so loadOnboardConfig returns a model
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const configPath = path.join(process.env.HOME ?? "/tmp", ".nemoclaw", "config.json");
+    const original = fs.existsSync(configPath) ? fs.readFileSync(configPath, "utf-8") : null;
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        endpointType: "build",
+        endpointUrl: "https://api.build.nvidia.com/v1",
+        ncpPartner: null,
+        model: "nvidia/custom-model",
+        profile: "default",
+        credentialEnv: "NVIDIA_API_KEY",
+        onboardedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    );
+    try {
+      register(api);
+      const providerArg = vi.mocked(api.registerProvider).mock.calls[0][0];
+      expect(providerArg.models?.chat).toEqual([
+        expect.objectContaining({ id: "inference/nvidia/custom-model" }),
+      ]);
+    } finally {
+      if (original !== null) {
+        fs.writeFileSync(configPath, original);
+      } else {
+        try { fs.unlinkSync(configPath); } catch { /* ignore */ }
+      }
+    }
+  });
+});
+
+describe("getPluginConfig", () => {
+  it("returns defaults when pluginConfig is undefined", () => {
+    const api = createMockApi();
+    api.pluginConfig = undefined;
+    const config = getPluginConfig(api);
+    expect(config.blueprintVersion).toBe("latest");
+    expect(config.blueprintRegistry).toBe("ghcr.io/nvidia/nemoclaw-blueprint");
+    expect(config.sandboxName).toBe("openclaw");
+    expect(config.inferenceProvider).toBe("nvidia");
+  });
+
+  it("returns defaults when pluginConfig has non-string values", () => {
+    const api = createMockApi();
+    api.pluginConfig = { blueprintVersion: 42, sandboxName: true };
+    const config = getPluginConfig(api);
+    expect(config.blueprintVersion).toBe("latest");
+    expect(config.sandboxName).toBe("openclaw");
+  });
+
+  it("uses string values from pluginConfig", () => {
+    const api = createMockApi();
+    api.pluginConfig = {
+      blueprintVersion: "2.0.0",
+      blueprintRegistry: "ghcr.io/custom/registry",
+      sandboxName: "custom-sandbox",
+      inferenceProvider: "openai",
+    };
+    const config = getPluginConfig(api);
+    expect(config.blueprintVersion).toBe("2.0.0");
+    expect(config.blueprintRegistry).toBe("ghcr.io/custom/registry");
+    expect(config.sandboxName).toBe("custom-sandbox");
+    expect(config.inferenceProvider).toBe("openai");
   });
 });

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -1,9 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, vi } from "vitest";
-import register, { getPluginConfig } from "./index.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { OpenClawPluginApi } from "./index.js";
+
+vi.mock("./onboard/config.js", () => ({
+  loadOnboardConfig: vi.fn(),
+  describeOnboardEndpoint: vi.fn(() => "build.nvidia.com"),
+  describeOnboardProvider: vi.fn(() => "NVIDIA Endpoint API"),
+}));
+
+import register, { getPluginConfig } from "./index.js";
+import { loadOnboardConfig } from "./onboard/config.js";
+
+const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
 
 function createMockApi(): OpenClawPluginApi {
   return {
@@ -27,6 +37,11 @@ function createMockApi(): OpenClawPluginApi {
 }
 
 describe("plugin registration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedLoadOnboardConfig.mockReturnValue(null);
+  });
+
   it("registers a slash command", () => {
     const api = createMockApi();
     register(api);
@@ -46,38 +61,21 @@ describe("plugin registration", () => {
   });
 
   it("registers custom model when onboard config has a model", () => {
+    mockedLoadOnboardConfig.mockReturnValue({
+      endpointType: "build",
+      endpointUrl: "https://api.build.nvidia.com/v1",
+      ncpPartner: null,
+      model: "nvidia/custom-model",
+      profile: "default",
+      credentialEnv: "NVIDIA_API_KEY",
+      onboardedAt: "2026-03-01T00:00:00.000Z",
+    });
     const api = createMockApi();
-    // Seed a config file so loadOnboardConfig returns a model
-    const fs = require("node:fs");
-    const path = require("node:path");
-    const configPath = path.join(process.env.HOME ?? "/tmp", ".nemoclaw", "config.json");
-    const original = fs.existsSync(configPath) ? fs.readFileSync(configPath, "utf-8") : null;
-    fs.mkdirSync(path.dirname(configPath), { recursive: true });
-    fs.writeFileSync(
-      configPath,
-      JSON.stringify({
-        endpointType: "build",
-        endpointUrl: "https://api.build.nvidia.com/v1",
-        ncpPartner: null,
-        model: "nvidia/custom-model",
-        profile: "default",
-        credentialEnv: "NVIDIA_API_KEY",
-        onboardedAt: "2026-03-01T00:00:00.000Z",
-      }),
-    );
-    try {
-      register(api);
-      const providerArg = vi.mocked(api.registerProvider).mock.calls[0][0];
-      expect(providerArg.models?.chat).toEqual([
-        expect.objectContaining({ id: "inference/nvidia/custom-model" }),
-      ]);
-    } finally {
-      if (original !== null) {
-        fs.writeFileSync(configPath, original);
-      } else {
-        try { fs.unlinkSync(configPath); } catch { /* ignore */ }
-      }
-    }
+    register(api);
+    const providerArg = vi.mocked(api.registerProvider).mock.calls[0][0];
+    expect(providerArg.models?.chat).toEqual([
+      expect.objectContaining({ id: "inference/nvidia/custom-model" }),
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add unit tests for all plugin modules: `onboard/config`, `commands/slash`, `blueprint/state`, `commands/migration-state`, and expand `register.test.ts` with `getPluginConfig` and custom model coverage
- Raise coverage thresholds from single digits (6%/2%/5%/6%) to 94%/98%/87%/93% (statements/functions/branches/lines)
- Total test count goes from 3 to 75

## Test plan
- [x] `npx vitest run --coverage` passes with all 75 tests green
- [x] Coverage meets new thresholds: 94% statements, 98% functions, 87% branches, 93% lines
- [x] CI coverage ratchet check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive test suites covering state management, migration snapshotting/restoration, slash command behavior, onboard config persistence, and plugin registration.

* **Chores**
  * Raised minimum code coverage thresholds significantly for lines, functions, branches, and statements.
  * Updated pre-commit hook to run the test suite during commit validation.
  * Relaxed two ESLint rules for test files to reduce noisy warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->