### PR TITLE
ci: add SPDX license header check to pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,19 @@
   },
   "lint-staged": {
     "nemoclaw/src/**/*.ts": [
+      "bash scripts/check-spdx-headers.sh",
       "sh -c 'cd nemoclaw && npx eslint --fix \"$@\"' _",
       "sh -c 'cd nemoclaw && npx prettier --write \"$@\"' _"
     ],
     "nemoclaw-blueprint/**/*.py": [
+      "bash scripts/check-spdx-headers.sh",
       "uvx ruff check --fix",
       "uvx ruff format"
     ],
-    "**/*.sh": "npx shellcheck",
+    "**/*.sh": [
+      "bash scripts/check-spdx-headers.sh",
+      "npx shellcheck"
+    ],
     ".husky/{pre-commit,pre-push,commit-msg}": "npx shellcheck"
   },
   "devDependencies": {

--- a/scripts/check-spdx-headers.sh
+++ b/scripts/check-spdx-headers.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks that all given files contain the required SPDX license headers.
+# Usage: check-spdx-headers.sh file1 file2 ...
+
+set -euo pipefail
+
+COPYRIGHT="SPDX-FileCopyrightText: Copyright (c)"
+LICENSE="SPDX-License-Identifier: Apache-2.0"
+
+failed=0
+for file in "$@"; do
+  if ! head -5 "$file" | grep -q "$COPYRIGHT"; then
+    echo "Missing SPDX-FileCopyrightText: $file"
+    failed=1
+  fi
+  if ! head -5 "$file" | grep -q "$LICENSE"; then
+    echo "Missing SPDX-License-Identifier: $file"
+    failed=1
+  fi
+done
+
+exit $failed

--- a/scripts/check-spdx-headers.sh
+++ b/scripts/check-spdx-headers.sh
@@ -12,11 +12,12 @@ LICENSE="SPDX-License-Identifier: Apache-2.0"
 
 failed=0
 for file in "$@"; do
-  if ! head -5 "$file" | grep -q "$COPYRIGHT"; then
+  file_head="$(head -n 5 -- "$file")"
+  if ! grep -Fq "$COPYRIGHT" <<< "$file_head"; then
     echo "Missing SPDX-FileCopyrightText: $file"
     failed=1
   fi
-  if ! head -5 "$file" | grep -q "$LICENSE"; then
+  if ! grep -Fq "$LICENSE" <<< "$file_head"; then
     echo "Missing SPDX-License-Identifier: $file"
     failed=1
   fi


### PR DESCRIPTION
## Summary
- Add `scripts/check-spdx-headers.sh` that verifies files contain `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers in the first 5 lines
- Wire into lint-staged for `.ts`, `.py`, and `.sh` files so missing headers block commits
- Modeled after the SPDX enforcement in [callisto](https://github.com/NVIDIA/callisto)

## Test plan
- [x] Script correctly passes files with SPDX headers
- [x] Script correctly fails files missing headers, reporting which header is missing
- [x] lint-staged runs the check on staged `.ts`, `.py`, and `.sh` files
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added SPDX license header validation to pre-commit checks for improved licensing compliance.
  * Introduced a new executable validation script that verifies required SPDX copyright and Apache-2.0 license identifiers.
  * Validation requires headers within the first five lines of files to pass.
  * Checks run automatically on staged changes (including TypeScript, Python, and shell scripts) before commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->