### PR TITLE
fix: pass Discord and Slack bot tokens via env vars into sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ config = { \
             'models': [{'id': model, 'name': model, 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 131072, 'maxTokens': 4096}] \
         } \
     }}, \
+    'channels': {'defaults': {'configWrites': False}}, \
     'gateway': { \
         'mode': 'local', \
         'controlUi': { \

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ When the agent tries to reach an unlisted host, OpenShell blocks the request and
 ## Configuring Sandbox Policy
 
 The sandbox policy is defined in a declarative YAML file and enforced by the OpenShell runtime.
-NemoClaw ships a strict baseline in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` that denies all network egress except explicitly listed endpoints.
+NemoClaw ships a strict baseline in [`nemoclaw-blueprint/policies/openclaw-sandbox.yaml`](https://github.com/NVIDIA/NemoClaw/blob/main/nemoclaw-blueprint/policies/openclaw-sandbox.yaml) that denies all network egress except explicitly listed endpoints.
 
 Operators can customize the policy in two ways:
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Operators can customize the policy in two ways:
 
 NemoClaw includes preset policy files for common integrations such as PyPI, Docker Hub, Slack, and Jira in `nemoclaw-blueprint/policies/presets/`. Apply a preset as-is or use it as a starting template.
 
+NemoClaw is an open project — we are still determining which presets to ship by default. If you have suggestions, please open an [issue](https://github.com/NVIDIA/NemoClaw/issues) or [discussion](https://github.com/NVIDIA/NemoClaw/discussions).
+
 When the agent attempts to reach an endpoint not covered by the policy, OpenShell blocks the request and surfaces it in the TUI (`openshell term`) for the operator to approve or deny in real time. Approved endpoints persist for the current session only.
 
 For step-by-step instructions, see [Customize Network Policy](https://docs.nvidia.com/nemoclaw/latest/network-policy/customize-network-policy.html). For the underlying enforcement details, see the OpenShell [Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) and [Sandbox Policies](https://docs.nvidia.com/openshell/latest/sandboxes/policies.html) documentation.

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -451,6 +451,14 @@ async function createSandbox(gpu) {
   if (process.env.NVIDIA_API_KEY) {
     envArgs.push(`NVIDIA_API_KEY=${process.env.NVIDIA_API_KEY}`);
   }
+  const discordToken = getCredential("DISCORD_BOT_TOKEN") || process.env.DISCORD_BOT_TOKEN;
+  if (discordToken) {
+    envArgs.push(`DISCORD_BOT_TOKEN=${shellQuote(discordToken)}`);
+  }
+  const slackToken = getCredential("SLACK_BOT_TOKEN") || process.env.SLACK_BOT_TOKEN;
+  if (slackToken) {
+    envArgs.push(`SLACK_BOT_TOKEN=${shellQuote(slackToken)}`);
+  }
 
   // Run without piping through awk — the pipe masked non-zero exit codes
   // from openshell because bash returns the status of the last pipeline

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -157,6 +157,10 @@ async function deploy(instanceName) {
   if (ghToken) envLines.push(`GITHUB_TOKEN=${ghToken}`);
   const tgToken = getCredential("TELEGRAM_BOT_TOKEN");
   if (tgToken) envLines.push(`TELEGRAM_BOT_TOKEN=${tgToken}`);
+  const discordToken = getCredential("DISCORD_BOT_TOKEN");
+  if (discordToken) envLines.push(`DISCORD_BOT_TOKEN=${discordToken}`);
+  const slackToken = getCredential("SLACK_BOT_TOKEN");
+  if (slackToken) envLines.push(`SLACK_BOT_TOKEN=${slackToken}`);
   const envTmp = path.join(os.tmpdir(), `nemoclaw-env-${Date.now()}`);
   fs.writeFileSync(envTmp, envLines.join("\n") + "\n", { mode: 0o600 });
   run(`scp -q -o StrictHostKeyChecking=no -o LogLevel=ERROR "${envTmp}" ${name}:/home/ubuntu/nemoclaw/.env`);

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -158,7 +158,7 @@ network_policies:
       - { path: /usr/local/bin/npm }
 
   # ── Messaging — pre-allowed for agent notifications ────────────
-  # Telegram Bot API is open by default so the agent can send
+  # Telegram and Discord are open by default so the agent can send
   # notifications and respond to chats without triggering approval.
   telegram:
     name: telegram
@@ -171,3 +171,30 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/bot*/**" }
           - allow: { method: POST, path: "/bot*/**" }
+
+  discord:
+    name: discord
+    endpoints:
+      - host: discord.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: gateway.discord.gg
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: cdn.discordapp.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }


### PR DESCRIPTION
## Summary
- Pass `DISCORD_BOT_TOKEN` and `SLACK_BOT_TOKEN` as env vars into the sandbox at creation time
- Forward both tokens in the Brev/VM deploy path
- Disable `channels.defaults.configWrites` in the build-time `openclaw.json` to prevent channel plugins from writing to the immutable config
- Add Discord endpoints (`discord.com`, `gateway.discord.gg`, `cdn.discordapp.com`) to the default baseline sandbox policy

## Context
PR #588 made `openclaw.json` immutable to prevent agent tampering with gateway auth tokens. Community users reported that OpenClaw's Discord integration fails because it tries to write the bot token to the now-immutable config.

OpenClaw already supports reading `DISCORD_BOT_TOKEN` from an environment variable and auto-enables the Discord channel when present. This PR passes the token through at sandbox creation time — the same pattern already used for `NVIDIA_API_KEY` and `TELEGRAM_BOT_TOKEN`.

Closes #599
Closes #606

## Test plan
- [x] Unit tests pass (187/187)
- [x] Full E2E pass (17/17) — install, onboard, sandbox verification, live inference, cleanup
- [ ] Set `DISCORD_BOT_TOKEN` env var, run onboard, verify token is available inside sandbox
- [ ] Verify no EPERM errors in gateway logs from configWrites
- [ ] Verify `openclaw.json` remains immutable (root:root, 444)