### PR TITLE
docs: replace "strict baseline" with "default" for policy language

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Local inference options such as Ollama and vLLM are still experimental. On macOS
 
 ## Protection Layers
 
-The sandbox starts with a strict baseline policy that controls network egress and filesystem access:
+The sandbox starts with a default policy that controls network egress and filesystem access:
 
 | Layer      | What it protects                                    | When it applies             |
 |------------|-----------------------------------------------------|-----------------------------|

--- a/docs/about/how-it-works.md
+++ b/docs/about/how-it-works.md
@@ -117,7 +117,7 @@ NemoClaw routes inference to NVIDIA Endpoints, specifically Nemotron 3 Super 120
 
 ## Network and Filesystem Policy
 
-The sandbox starts with a strict baseline policy defined in `openclaw-sandbox.yaml`.
+The sandbox starts with a default policy defined in `openclaw-sandbox.yaml`.
 This policy controls which network endpoints the agent can reach and which filesystem paths it can access.
 
 - For network, only endpoints listed in the policy are allowed.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -60,7 +60,7 @@ nemoclaw-blueprint/
 ├── orchestrator/
 │   └── runner.py                   CLI runner — plan / apply / status
 ├── policies/
-│   └── openclaw-sandbox.yaml       Strict baseline network + filesystem policy
+│   └── openclaw-sandbox.yaml       Default network + filesystem policy
 ```
 
 ### Blueprint Lifecycle

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Strict baseline policy for the OpenClaw sandbox.
+# Default policy for the OpenClaw sandbox.
 # Principle: deny by default, allow only what's needed for core functionality.
 # Dynamic updates (network_policies, inference) can be applied post-creation
 # via `openshell policy set`. Static fields are effectively creation-locked.


### PR DESCRIPTION
## Summary
- Replaces "strict baseline" with "default" across all references to the sandbox policy
- Affects README, how-it-works, architecture docs, and the policy YAML comment
- Follows feedback from @naderkhalil on PR #594

## Changed files
- `README.md`
- `docs/about/how-it-works.md`
- `docs/reference/architecture.md`
- `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sandbox policy terminology from "strict baseline policy" to "default policy" across documentation and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->