### PR TITLE
docs: rename strict policy tier to default

### DIFF
--- a/docs/about/how-it-works.md
+++ b/docs/about/how-it-works.md
@@ -44,7 +44,7 @@ flowchart TB
     subgraph Sandbox["OpenShell Sandbox"]
         AGENT[OpenClaw agent]
         INF[NVIDIA inference, routed]
-        NET[strict network policy]
+        NET[default network policy]
         FS[filesystem isolation]
 
         AGENT --- INF

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -32,7 +32,7 @@ By combining powerful open source models with built-in safety measures, NemoClaw
 
 | Capability              | Description                                                                                                                                          |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Sandbox OpenClaw        | Creates an OpenShell sandbox pre-configured for OpenClaw, with strict filesystem and network policies applied from the first boot.                   |
+| Sandbox OpenClaw        | Creates an OpenShell sandbox pre-configured for OpenClaw, with filesystem and network policies applied from the first boot.                   |
 | Route inference         | Configures OpenShell inference routing so agent traffic flows through cloud-hosted Nemotron 3 Super 120B via [build.nvidia.com](https://build.nvidia.com). |
 | Manage the lifecycle    | Handles blueprint versioning, digest verification, and sandbox setup.                                                                                |
 

--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -20,7 +20,7 @@ status: published
 
 # Network Policies
 
-NemoClaw runs with a strict-by-default network policy.
+NemoClaw runs with a deny-by-default network policy.
 The sandbox can only reach endpoints that are explicitly allowed.
 Any request to an unlisted destination is intercepted by OpenShell, and the operator is prompted to approve or deny it in real time through the TUI.
 

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -7,7 +7,7 @@
 # via `openshell policy set`. Static fields are effectively creation-locked.
 #
 # Policy tiers (future):
-#   strict  — this file. Minimum for onboard + basic agent operation.
+#   default — this file. Minimum for onboard + basic agent operation.
 #   relaxed — adds third-party model providers, broader web access.
 #
 # To add endpoints: update this file and re-run `nemoclaw onboard`

--- a/scripts/walkthrough.sh
+++ b/scripts/walkthrough.sh
@@ -8,7 +8,7 @@
 #   LEFT:  OpenClaw agent (chat)
 #   RIGHT: OpenShell TUI (monitor + approve network egress)
 #
-# The agent runs inside a sandboxed environment with a strict network
+# The agent runs inside a sandboxed environment with a controlled network
 # policy. When it tries to access a service not in the allow list,
 # the TUI prompts the operator to approve or deny the request.
 #


### PR DESCRIPTION
## Summary
- Renames the `strict` policy tier to `default` in the YAML comment block
- Follows up on feedback from @krmurph on PR #602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated sandbox policy tier wording from "strict" to "default" across configuration and explanatory docs.
  * Revised network posture phrasing from "strict-by-default" to "deny-by-default" in network policy reference.
  * Updated descriptive text and flowchart labels to reflect the new wording in walkthroughs and overview pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->