### PR TITLE
fix(cli): validate deploy instance names before setup prompts

### DIFF
--- a/src/lib/deploy.test.ts
+++ b/src/lib/deploy.test.ts
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { validateName } from "../../dist/lib/runner";
 import {
   buildDeployEnvLines,
+  executeDeploy,
   findBrevInstanceStatus,
   inferDeployProvider,
   isBrevInstanceFailed,
@@ -142,5 +144,38 @@ describe("Brev status helpers", () => {
         shell_status: "NOT READY",
       }),
     ).toBe(false);
+  });
+});
+
+describe("executeDeploy", () => {
+  it("exits before reading credentials when instance name is invalid (#575)", async () => {
+    const getCredential = vi.fn(() => "should-not-use");
+    const error = vi.fn();
+    const exit = vi.fn((code: number) => {
+      throw new Error(`exit:${code}`);
+    }) as (code: number) => never;
+
+    await expect(
+      executeDeploy({
+        instanceName: "foo;bar",
+        env: {},
+        rootDir: "/tmp",
+        getCredential,
+        validateName,
+        shellQuote: (value: string) => `'${value}'`,
+        run: vi.fn(),
+        runInteractive: vi.fn(),
+        execFileSync: vi.fn(() => ""),
+        spawnSync: vi.fn(() => ({ status: 0 })),
+        log: vi.fn(),
+        error,
+        stdoutWrite: vi.fn(),
+        exit,
+      }),
+    ).rejects.toThrow("exit:1");
+
+    expect(getCredential).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalled();
+    expect(String(error.mock.calls[0]?.[0])).toMatch(/Invalid instance name/);
   });
 });

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -238,7 +238,14 @@ export async function executeDeploy(opts: DeployExecutionOptions): Promise<void>
     );
   }
 
-  const name = validateName(instanceName, "instance name");
+  let name: string;
+  try {
+    name = validateName(instanceName, "instance name");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    error(`  ${message}`);
+    return exit(1);
+  }
   const qname = shellQuote(name);
   const gpu = env.NEMOCLAW_GPU || "a2-highgpu-1g:nvidia-tesla-a100:1";
   const brevProvider = String(env.NEMOCLAW_BREV_PROVIDER || "gcp").trim().toLowerCase();
@@ -248,7 +255,14 @@ export async function executeDeploy(opts: DeployExecutionOptions): Promise<void>
   const skipStartServices = ["1", "true"].includes(
     String(env.NEMOCLAW_DEPLOY_NO_START_SERVICES || "").toLowerCase(),
   );
-  const sandboxName = validateName(env.NEMOCLAW_SANDBOX_NAME || "my-assistant", "sandbox name");
+  let sandboxName: string;
+  try {
+    sandboxName = validateName(env.NEMOCLAW_SANDBOX_NAME || "my-assistant", "sandbox name");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    error(`  ${message}`);
+    return exit(1);
+  }
   const credentials: DeployCredentials = {
     NVIDIA_API_KEY: getCredential("NVIDIA_API_KEY"),
     OPENAI_API_KEY: getCredential("OPENAI_API_KEY"),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -63,6 +63,20 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("Unknown command")).toBeTruthy();
   });
 
+  it("deploy rejects invalid instance names before credential prompts (#575)", () => {
+    const r = run('deploy "foo;bar"');
+    expect(r.code).toBe(1);
+    expect(r.out).toMatch(/Invalid instance name/);
+    expect(r.out).not.toContain("NVIDIA API Key required");
+  });
+
+  it("deploy rejects command-substitution instance names (#575)", () => {
+    const r = run("deploy '$(id)'");
+    expect(r.code).toBe(1);
+    expect(r.out).toMatch(/Invalid instance name/);
+    expect(r.out).not.toContain("NVIDIA API Key required");
+  });
+
   it("list exits 0", () => {
     const r = run("list");
     expect(r.code).toBe(0);


### PR DESCRIPTION
Fixes #575.

## Summary
Validate `nemoclaw deploy <instance-name>` input before credential/setup steps.
This fails fast on malformed names and prevents API key prompt for invalid input.

## Changes
- Validate `instanceName` at start of `deploy()` in `bin/nemoclaw.js`
- Exit with clear error when name is invalid
- Add CLI regression tests in `test/cli.test.js` for:
  - `foo;bar`
  - `$(id)`

## Testing
- [x] `node --test --test-name-pattern "deploy rejects" test/cli.test.js`
- [x] Manual check: invalid name is rejected immediately
- [x] Manual check: valid name proceeds past validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment now validates instance names immediately, rejects invalid names with a clear error message, and exits early without prompting for credentials.

* **Tests**
  * Added CLI tests ensuring malformed instance names (including shell metacharacters) fail early, emit the expected error, and do not trigger credential prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->