### PR TITLE
docs: add no-external-links policy to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,16 @@ We welcome contributions. Every PR requires maintainer review. To keep the revie
 > [!WARNING]
 > Accounts that repeatedly exceed this limit or submit automated bulk PRs may have their PRs closed or their access restricted.
 
+### No External Project Links
+
+Do not add links, references, or integrations pointing to third-party repositories, tools, or services in documentation, README files, or code. This applies to "awesome lists," community template collections, wrapper projects, and similar resources — regardless of popularity or utility.
+
+**Why:** External repositories are outside our control. They can change ownership, inject malicious content, or misrepresent an endorsement by NVIDIA. Keeping references within our own repo avoids these risks entirely.
+
+If you believe an external resource belongs in our docs, open an issue to discuss it with maintainers first.
+
+### Submitting a Pull Request
+
 Follow these steps to submit a pull request.
 
 1. Create a feature branch from `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,9 @@ We welcome contributions. Every PR requires maintainer review. To keep the revie
 
 ### No External Project Links
 
-Do not add links, references, or integrations pointing to third-party repositories, tools, or services in documentation, README files, or code. This applies to "awesome lists," community template collections, wrapper projects, and similar resources — regardless of popularity or utility.
+Do not add links to third-party code repositories, community collections, or unofficial resources in documentation, README files, or code. This includes "awesome lists," community template repositories, wrapper projects, and similar community-maintained resources — regardless of popularity or utility.
+
+Links to official documentation for tools we depend on (e.g., Node.js, Python, uv) and industry standards (e.g., Conventional Commits) are acceptable.
 
 **Why:** External repositories are outside our control. They can change ownership, inject malicious content, or misrepresent an endorsement by NVIDIA. Keeping references within our own repo avoids these risks entirely.
 


### PR DESCRIPTION
## Summary

- Adds a **No External Project Links** policy to `CONTRIBUTING.md` under the Pull Requests section
- Prohibits linking to third-party repos, "awesome lists," community template collections, and similar resources in docs, README, or code
- Explains the security rationale: external repos can change ownership, inject malicious content, or imply NVIDIA endorsement

## Context

Prompted by [PR #75](https://github.com/NVIDIA/NemoClaw/pull/75), which adds links to an external community template repo. This policy gives maintainers a clear, documented basis for declining such contributions.

## Test plan

- [ ] Review the new section in `CONTRIBUTING.md` for clarity and tone
- [ ] Confirm placement within the Pull Requests section reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarifies contribution guidelines: avoid adding links to third‑party/unofficial repositories, community collections, templates, or wrappers in documentation, READMEs, or code; links to official tool documentation and recognized standards remain allowed.
  * Requires opening an issue to discuss any proposed external resource with maintainers before including it; this guidance is positioned ahead of the pull‑request submission steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->