### PR TITLE
fix(security): build-arg code injection in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,12 @@ ARG CHAT_UI_URL=http://127.0.0.1:18789
 # Pass --build-arg NEMOCLAW_BUILD_ID=$(date +%s) to bust the cache.
 ARG NEMOCLAW_BUILD_ID=default
 
+# SECURITY: Promote build-args to env vars so the Python script reads them
+# via os.environ, never via string interpolation into Python source code.
+# Direct ARG interpolation into python3 -c is a code injection vector (C-2).
+ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
+    CHAT_UI_URL=${CHAT_UI_URL}
+
 WORKDIR /sandbox
 USER sandbox
 
@@ -94,8 +100,8 @@ USER sandbox
 RUN python3 -c "\
 import json, os, secrets; \
 from urllib.parse import urlparse; \
-model = '${NEMOCLAW_MODEL}'; \
-chat_ui_url = '${CHAT_UI_URL}'; \
+model = os.environ['NEMOCLAW_MODEL']; \
+chat_ui_url = os.environ['CHAT_UI_URL']; \
 parsed = urlparse(chat_ui_url); \
 chat_origin = f'{parsed.scheme}://{parsed.netloc}' if parsed.scheme and parsed.netloc else 'http://127.0.0.1:18789'; \
 origins = ['http://127.0.0.1:18789']; \

--- a/test/security-c2-dockerfile-injection.test.js
+++ b/test/security-c2-dockerfile-injection.test.js
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Security regression test: C-2 — CHAT_UI_URL Python code injection in Dockerfile.
+//
+// The vulnerable pattern interpolates Docker build-args directly into a
+// python3 -c source string. A single-quote in the value closes the Python
+// string literal and allows arbitrary code execution at image build time.
+//
+// The fixed pattern reads values via os.environ (data, not source code).
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const DOCKERFILE = path.join(__dirname, "..", "Dockerfile");
+
+function runPython(src, env = {}) {
+  return spawnSync("python3", ["-c", src], {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+    timeout: 5000,
+  });
+}
+
+// Simulate what Docker ARG substitution produces (the VULNERABLE pattern)
+function vulnerableSource(chatUiUrlValue) {
+  return (
+    "import json, os, secrets; " +
+    "from urllib.parse import urlparse; " +
+    `chat_ui_url = '${chatUiUrlValue}'; ` +
+    "parsed = urlparse(chat_ui_url); " +
+    "print(repr(chat_ui_url))"
+  );
+}
+
+// Simulate the FIXED pattern (env var, no source interpolation)
+function fixedSource() {
+  return (
+    "import json, os, secrets; " +
+    "from urllib.parse import urlparse; " +
+    "chat_ui_url = os.environ['CHAT_UI_URL']; " +
+    "parsed = urlparse(chat_ui_url); " +
+    "print(repr(chat_ui_url))"
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. PoC — vulnerable pattern allows code injection
+// ═══════════════════════════════════════════════════════════════════
+describe("C-2 PoC: vulnerable pattern (ARG interpolation into python3 -c)", () => {
+  it("benign URL works in the vulnerable pattern (baseline)", () => {
+    const src = vulnerableSource("http://127.0.0.1:18789");
+    const result = runPython(src);
+    assert.equal(result.status, 0, `python3 exit ${result.status}: ${result.stderr}`);
+    assert.ok(result.stdout.includes("127.0.0.1"));
+  });
+
+  it("single-quote in URL causes SyntaxError", () => {
+    const src = vulnerableSource("http://x'.evil.com");
+    const result = runPython(src);
+    assert.notEqual(result.status, 0, "Expected non-zero exit (SyntaxError)");
+    assert.ok(result.stderr.includes("SyntaxError"));
+  });
+
+  it("injection payload writes canary file — arbitrary Python executes", () => {
+    const canary = path.join(os.tmpdir(), `nemoclaw-c2-poc-${Date.now()}`);
+    try {
+      const payload = `http://x'; open('${canary}','w').write('PWNED') #`;
+      const src = vulnerableSource(payload);
+      runPython(src);
+
+      assert.ok(
+        fs.existsSync(canary),
+        "Canary file must exist — injection payload executed arbitrary Python",
+      );
+      assert.equal(fs.readFileSync(canary, "utf-8"), "PWNED");
+    } finally {
+      try { fs.unlinkSync(canary); } catch { /* cleanup */ }
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. Fix verification — env var pattern treats all payloads as data
+// ═══════════════════════════════════════════════════════════════════
+describe("C-2 fix: env var pattern (os.environ) is safe", () => {
+  it("benign URL works through env var", () => {
+    const result = runPython(fixedSource(), { CHAT_UI_URL: "http://127.0.0.1:18789" });
+    assert.equal(result.status, 0);
+    assert.ok(result.stdout.includes("127.0.0.1"));
+  });
+
+  it("single-quote in URL is treated as data, not a code boundary", () => {
+    const result = runPython(fixedSource(), { CHAT_UI_URL: "http://x'.evil.com" });
+    assert.equal(result.status, 0, `Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes("x'.evil.com"));
+  });
+
+  it("injection payload does NOT execute — URL is inert data", () => {
+    const canary = path.join(os.tmpdir(), `nemoclaw-c2-fixed-${Date.now()}`);
+    try {
+      const payload = `http://x'; open('${canary}','w').write('PWNED') #`;
+      const result = runPython(fixedSource(), { CHAT_UI_URL: payload });
+
+      assert.equal(result.status, 0);
+      assert.equal(
+        fs.existsSync(canary),
+        false,
+        "Canary file must NOT exist — injection payload must not execute",
+      );
+    } finally {
+      try { fs.unlinkSync(canary); } catch { /* cleanup */ }
+    }
+  });
+
+  it("semicolons and import statements in URL are literal data", () => {
+    const dangerous = "http://x; import subprocess; subprocess.run(['id'])";
+    const result = runPython(fixedSource(), { CHAT_UI_URL: dangerous });
+    // The URL is treated as data — urlparse may or may not raise, but
+    // the key property is that no code injection occurs. Check stdout or stderr
+    // does NOT contain evidence of os.system/subprocess execution.
+    const combined = result.stdout + result.stderr;
+    assert.ok(
+      !combined.includes("uid="),
+      "No command execution output should appear — URL is inert data",
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 3. Dockerfile regression guard — source must use the fixed pattern
+// ═══════════════════════════════════════════════════════════════════
+describe("C-2 regression: Dockerfile must not interpolate build-args into Python source", () => {
+  it("Dockerfile does not interpolate CHAT_UI_URL into a Python string literal", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    const vulnerablePattern = /'\$\{CHAT_UI_URL\}'/;
+    const lines = src.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (vulnerablePattern.test(lines[i])) {
+        assert.fail(
+          `Dockerfile:${i + 1} interpolates CHAT_UI_URL into a Python string literal.\n` +
+          `  Line: ${lines[i].trim()}\n` +
+          `  Fix: use os.environ['CHAT_UI_URL'] instead.`,
+        );
+      }
+    }
+  });
+
+  it("Dockerfile does not interpolate NEMOCLAW_MODEL into a Python string literal", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    const vulnerablePattern = /'\$\{NEMOCLAW_MODEL\}'/;
+    const lines = src.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (vulnerablePattern.test(lines[i])) {
+        assert.fail(
+          `Dockerfile:${i + 1} interpolates NEMOCLAW_MODEL into a Python string literal.\n` +
+          `  Line: ${lines[i].trim()}\n` +
+          `  Fix: use os.environ['NEMOCLAW_MODEL'] instead.`,
+        );
+      }
+    }
+  });
+
+  it("Dockerfile promotes CHAT_UI_URL to ENV before the RUN layer", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    // ENV may span multiple lines via backslash continuation
+    assert.ok(
+      /^ENV\s[\s\S]*?CHAT_UI_URL/m.test(src),
+      "Dockerfile must have ENV instruction that promotes CHAT_UI_URL from ARG to env var",
+    );
+  });
+
+  it("Python script uses os.environ to read CHAT_UI_URL", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    const hasEnvRead =
+      src.includes("os.environ['CHAT_UI_URL']") ||
+      src.includes('os.environ["CHAT_UI_URL"]') ||
+      src.includes("os.environ.get('CHAT_UI_URL'") ||
+      src.includes('os.environ.get("CHAT_UI_URL"');
+    assert.ok(hasEnvRead, "Python script must read CHAT_UI_URL via os.environ");
+  });
+});

--- a/test/security-c2-dockerfile-injection.test.js
+++ b/test/security-c2-dockerfile-injection.test.js
@@ -140,40 +140,81 @@ describe("C-2 fix: env var pattern (os.environ) is safe", () => {
 describe("C-2 regression: Dockerfile must not interpolate build-args into Python source", () => {
   it("Dockerfile does not interpolate CHAT_UI_URL into a Python string literal", () => {
     const src = fs.readFileSync(DOCKERFILE, "utf-8");
-    const vulnerablePattern = /'\$\{CHAT_UI_URL\}'/;
+    const vulnerablePattern = /\$\{CHAT_UI_URL\}/;
     const lines = src.split("\n");
+    let inPythonRunBlock = false;
     for (let i = 0; i < lines.length; i++) {
-      if (vulnerablePattern.test(lines[i])) {
+      const line = lines[i];
+      if (/^\s*RUN\b.*python3\s+-c\b/.test(line)) {
+        inPythonRunBlock = true;
+      }
+      if (inPythonRunBlock && vulnerablePattern.test(line)) {
         assert.fail(
           `Dockerfile:${i + 1} interpolates CHAT_UI_URL into a Python string literal.\n` +
-          `  Line: ${lines[i].trim()}\n` +
+          `  Line: ${line.trim()}\n` +
           `  Fix: use os.environ['CHAT_UI_URL'] instead.`,
         );
+      }
+      if (inPythonRunBlock && !/\\\s*$/.test(line)) {
+        inPythonRunBlock = false;
       }
     }
   });
 
   it("Dockerfile does not interpolate NEMOCLAW_MODEL into a Python string literal", () => {
     const src = fs.readFileSync(DOCKERFILE, "utf-8");
-    const vulnerablePattern = /'\$\{NEMOCLAW_MODEL\}'/;
+    const vulnerablePattern = /\$\{NEMOCLAW_MODEL\}/;
     const lines = src.split("\n");
+    let inPythonRunBlock = false;
     for (let i = 0; i < lines.length; i++) {
-      if (vulnerablePattern.test(lines[i])) {
+      const line = lines[i];
+      if (/^\s*RUN\b.*python3\s+-c\b/.test(line)) {
+        inPythonRunBlock = true;
+      }
+      if (inPythonRunBlock && vulnerablePattern.test(line)) {
         assert.fail(
           `Dockerfile:${i + 1} interpolates NEMOCLAW_MODEL into a Python string literal.\n` +
-          `  Line: ${lines[i].trim()}\n` +
+          `  Line: ${line.trim()}\n` +
           `  Fix: use os.environ['NEMOCLAW_MODEL'] instead.`,
         );
+      }
+      if (inPythonRunBlock && !/\\\s*$/.test(line)) {
+        inPythonRunBlock = false;
       }
     }
   });
 
   it("Dockerfile promotes CHAT_UI_URL to ENV before the RUN layer", () => {
     const src = fs.readFileSync(DOCKERFILE, "utf-8");
-    // ENV may span multiple lines via backslash continuation
+    const lines = src.split("\n");
+    let chatUiUrlPromoted = false;
+    let inEnvBlock = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Detect start of an ENV instruction
+      if (/^\s*ENV\b/.test(line)) {
+        inEnvBlock = true;
+      }
+      // Check if CHAT_UI_URL is set in the current ENV block (same line or continuation)
+      if (inEnvBlock && /CHAT_UI_URL[=\s]/.test(line)) {
+        chatUiUrlPromoted = true;
+      }
+      // ENV block ends when the line does NOT end with a backslash continuation
+      if (inEnvBlock && !/\\\s*$/.test(line)) {
+        inEnvBlock = false;
+      }
+      // Verify promotion happened before the python3 -c RUN layer
+      if (/^\s*RUN\b.*python3\s+-c\b/.test(line)) {
+        assert.ok(
+          chatUiUrlPromoted,
+          `Dockerfile:${i + 1} has a python3 -c RUN layer but CHAT_UI_URL was not promoted via ENV before it`,
+        );
+        return; // Found the RUN layer and verified — done
+      }
+    }
     assert.ok(
-      /^ENV\s[\s\S]*?CHAT_UI_URL/m.test(src),
-      "Dockerfile must have ENV instruction that promotes CHAT_UI_URL from ARG to env var",
+      chatUiUrlPromoted,
+      "Dockerfile must have ENV instruction that promotes CHAT_UI_URL from ARG to env var before the python3 -c RUN layer",
     );
   });
 


### PR DESCRIPTION
## Summary

Docker build-args `CHAT_UI_URL` and `NEMOCLAW_MODEL` were interpolated directly into a `python3 -c "..."` source string. A single-quote in the value closes the Python string literal and allows arbitrary code execution at image build time.

**PoC**: `CHAT_UI_URL="http://x'; open('/tmp/pwned','w').write('PWNED') #"` writes an arbitrary file during `docker build`.

### Fix

Promote build-args to `ENV`, read via `os.environ['CHAT_UI_URL']` in Python. Values become data, never source code.

### Changes

| File | Change |
|------|--------|
| `Dockerfile` | Add `ENV` promotion; replace `'${CHAT_UI_URL}'` with `os.environ['CHAT_UI_URL']` |
| `test/security-c2-dockerfile-injection.test.js` | 11 tests: PoC, fix verification, regression guards |

## Test plan

- [x] 11 tests pass (`node --test test/security-c2-dockerfile-injection.test.js`)
- [x] PoC proves canary file written via vulnerable pattern
- [x] Fix proves injection payload is inert data
- [x] Regression guards scan Dockerfile to prevent revert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container configuration now promotes build-time settings to runtime environment variables so the app reads config from the environment during build/execution.

* **Tests**
  * Added security regression tests to validate safer handling of externally supplied configuration and guard against injection vectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->