### PR TITLE
fix(security): validate snapshot manifest paths before filesystem write

### DIFF
--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -666,6 +666,29 @@ export function restoreSnapshotToHost(snapshotDir: string, logger: PluginLogger)
     return false;
   }
 
+  // SECURITY (C-4): Validate that write targets are within the expected home
+  // directory tree. A tampered snapshot.json with stateDir or configPath pointing
+  // outside homeDir would cause arbitrary filesystem writes.
+  const allowedRoot = manifest.homeDir;
+
+  if (!isWithinRoot(manifest.stateDir, allowedRoot)) {
+    logger.error(
+      `Snapshot manifest stateDir is outside the expected home directory. ` +
+        `Refusing to restore. stateDir=${manifest.stateDir}, allowedRoot=${allowedRoot}`,
+    );
+    return false;
+  }
+
+  if (manifest.hasExternalConfig && manifest.configPath !== null) {
+    if (!isWithinRoot(manifest.configPath, allowedRoot)) {
+      logger.error(
+        `Snapshot manifest configPath is outside the expected home directory. ` +
+          `Refusing to restore. configPath=${manifest.configPath}, allowedRoot=${allowedRoot}`,
+      );
+      return false;
+    }
+  }
+
   try {
     if (existsSync(manifest.stateDir)) {
       const archiveName = `${manifest.stateDir}.nemoclaw-archived-${String(Date.now())}`;

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -666,24 +666,71 @@ export function restoreSnapshotToHost(snapshotDir: string, logger: PluginLogger)
     return false;
   }
 
-  // SECURITY (C-4): Validate that write targets are within the expected home
-  // directory tree. A tampered snapshot.json with stateDir or configPath pointing
-  // outside homeDir would cause arbitrary filesystem writes.
-  const allowedRoot = manifest.homeDir;
+  // SECURITY (C-4): Validate that write targets are within a trusted root.
+  // Use the host's actual home directory — NOT manifest.homeDir which is
+  // attacker-controlled data from the snapshot JSON.
+  const trustedRoot = resolveHostHome();
 
-  if (!isWithinRoot(manifest.stateDir, allowedRoot)) {
+  // Validate manifest.homeDir itself is within trusted root
+  if (typeof manifest.homeDir !== "string" || !isWithinRoot(manifest.homeDir, trustedRoot)) {
     logger.error(
-      `Snapshot manifest stateDir is outside the expected home directory. ` +
-        `Refusing to restore. stateDir=${manifest.stateDir}, allowedRoot=${allowedRoot}`,
+      `Snapshot manifest homeDir is outside the trusted host root. ` +
+        `Refusing to restore. homeDir=${String(manifest.homeDir)}, trustedRoot=${trustedRoot}`,
+    );
+    return false;
+  }
+
+  // Validate stateDir type and containment
+  if (typeof manifest.stateDir !== "string") {
+    logger.error(
+      `Snapshot manifest stateDir is not a string. Refusing to restore.`,
+    );
+    return false;
+  }
+
+  // Support OPENCLAW_STATE_DIR env override: when set, require exact match
+  const envStateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (envStateDir) {
+    const resolvedEnvStateDir = resolveUserPath(envStateDir);
+    if (normalizeHostPath(manifest.stateDir) !== normalizeHostPath(resolvedEnvStateDir)) {
+      logger.error(
+        `Snapshot manifest stateDir does not match OPENCLAW_STATE_DIR. ` +
+          `Refusing to restore. stateDir=${manifest.stateDir}, expected=${resolvedEnvStateDir}`,
+      );
+      return false;
+    }
+  } else if (!isWithinRoot(manifest.stateDir, trustedRoot)) {
+    logger.error(
+      `Snapshot manifest stateDir is outside the trusted host root. ` +
+        `Refusing to restore. stateDir=${manifest.stateDir}, trustedRoot=${trustedRoot}`,
     );
     return false;
   }
 
   if (manifest.hasExternalConfig && manifest.configPath !== null) {
-    if (!isWithinRoot(manifest.configPath, allowedRoot)) {
+    // Validate configPath type
+    if (typeof manifest.configPath !== "string") {
       logger.error(
-        `Snapshot manifest configPath is outside the expected home directory. ` +
-          `Refusing to restore. configPath=${manifest.configPath}, allowedRoot=${allowedRoot}`,
+        `Snapshot manifest configPath is not a string. Refusing to restore.`,
+      );
+      return false;
+    }
+
+    // Support OPENCLAW_CONFIG_PATH env override: when set, require exact match
+    const envConfigPath = process.env.OPENCLAW_CONFIG_PATH?.trim();
+    if (envConfigPath) {
+      const resolvedEnvConfigPath = resolveUserPath(envConfigPath);
+      if (normalizeHostPath(manifest.configPath) !== normalizeHostPath(resolvedEnvConfigPath)) {
+        logger.error(
+          `Snapshot manifest configPath does not match OPENCLAW_CONFIG_PATH. ` +
+            `Refusing to restore. configPath=${manifest.configPath}, expected=${resolvedEnvConfigPath}`,
+        );
+        return false;
+      }
+    } else if (!isWithinRoot(manifest.configPath, trustedRoot)) {
+      logger.error(
+        `Snapshot manifest configPath is outside the trusted host root. ` +
+          `Refusing to restore. configPath=${manifest.configPath}, trustedRoot=${trustedRoot}`,
       );
       return false;
     }

--- a/test/security-c4-manifest-traversal.test.js
+++ b/test/security-c4-manifest-traversal.test.js
@@ -1,0 +1,385 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Security regression test: C-4 — Snapshot manifest path traversal.
+//
+// restoreSnapshotToHost() reads manifest.stateDir and manifest.configPath
+// from snapshot.json and uses them as filesystem write targets. Without
+// validation, a tampered manifest can cause writes outside ~/.nemoclaw/.
+//
+// The fix validates both fields are within manifest.homeDir before any write.
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+// ═══════════════════════════════════════════════════════════════════
+// Helpers — simulate restoreSnapshotToHost's vulnerable vs fixed logic
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * isWithinRoot — same logic as migration-state.ts:120-125
+ */
+function isWithinRoot(candidatePath, rootPath) {
+  const candidate = path.resolve(candidatePath);
+  const root = path.resolve(rootPath);
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+/**
+ * copyDirectory — minimal recursive copy matching migration-state.ts:476
+ */
+function copyDirectory(src, dest) {
+  fs.cpSync(src, dest, { recursive: true });
+}
+
+/**
+ * Build a minimal snapshot directory with a tampered manifest.
+ */
+function buildSnapshotDir(parentDir, manifest) {
+  const snapshotDir = path.join(parentDir, "snapshot");
+  fs.mkdirSync(path.join(snapshotDir, "openclaw"), { recursive: true });
+  fs.writeFileSync(
+    path.join(snapshotDir, "openclaw", "sentinel.txt"),
+    "attacker-controlled-content",
+  );
+  fs.mkdirSync(path.join(snapshotDir, "config"), { recursive: true });
+  fs.writeFileSync(
+    path.join(snapshotDir, "config", "openclaw.json"),
+    JSON.stringify({ model: "attacker-model" }),
+  );
+  fs.writeFileSync(
+    path.join(snapshotDir, "snapshot.json"),
+    JSON.stringify(manifest, null, 2),
+  );
+  return snapshotDir;
+}
+
+/**
+ * Simulate restoreSnapshotToHost WITHOUT the fix (vulnerable).
+ * Returns { result, errors, written }.
+ */
+function restoreVulnerable(snapshotDir) {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(snapshotDir, "snapshot.json"), "utf-8"),
+  );
+  const snapshotStateDir = path.join(snapshotDir, "openclaw");
+  const errors = [];
+  let written = false;
+
+  try {
+    // No validation — directly writes to manifest.stateDir
+    fs.mkdirSync(path.dirname(manifest.stateDir), { recursive: true });
+    copyDirectory(snapshotStateDir, manifest.stateDir);
+    written = true;
+
+    if (manifest.hasExternalConfig && manifest.configPath) {
+      const configSrc = path.join(snapshotDir, "config", "openclaw.json");
+      fs.mkdirSync(path.dirname(manifest.configPath), { recursive: true });
+      fs.copyFileSync(configSrc, manifest.configPath);
+    }
+    return { result: true, errors, written };
+  } catch (err) {
+    errors.push(err.message);
+    return { result: false, errors, written };
+  }
+}
+
+/**
+ * Simulate restoreSnapshotToHost WITH the fix (validates paths).
+ * Returns { result, errors, written }.
+ */
+function restoreFixed(snapshotDir) {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(snapshotDir, "snapshot.json"), "utf-8"),
+  );
+  const snapshotStateDir = path.join(snapshotDir, "openclaw");
+  const errors = [];
+  let written = false;
+
+  // FIX: validate write targets are within homeDir
+  if (!isWithinRoot(manifest.stateDir, manifest.homeDir)) {
+    errors.push(
+      `Snapshot manifest stateDir is outside the expected home directory. ` +
+        `stateDir=${manifest.stateDir}, allowedRoot=${manifest.homeDir}`,
+    );
+    return { result: false, errors, written };
+  }
+
+  if (manifest.hasExternalConfig && manifest.configPath !== null) {
+    if (!isWithinRoot(manifest.configPath, manifest.homeDir)) {
+      errors.push(
+        `Snapshot manifest configPath is outside the expected home directory. ` +
+          `configPath=${manifest.configPath}, allowedRoot=${manifest.homeDir}`,
+      );
+      return { result: false, errors, written };
+    }
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(manifest.stateDir), { recursive: true });
+    copyDirectory(snapshotStateDir, manifest.stateDir);
+    written = true;
+
+    if (manifest.hasExternalConfig && manifest.configPath) {
+      const configSrc = path.join(snapshotDir, "config", "openclaw.json");
+      fs.mkdirSync(path.dirname(manifest.configPath), { recursive: true });
+      fs.copyFileSync(configSrc, manifest.configPath);
+    }
+    return { result: true, errors, written };
+  } catch (err) {
+    errors.push(err.message);
+    return { result: false, errors, written };
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. PoC — vulnerable code writes to traversal target
+// ═══════════════════════════════════════════════════════════════════
+describe("C-4 PoC: vulnerable restoreSnapshotToHost allows path traversal", () => {
+  it("tampered stateDir outside homeDir — vulnerable code writes the file", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-c4-poc-"));
+    try {
+      const homeDir = path.join(workDir, "home", "victim");
+      const traversalTarget = path.join(workDir, "evil-payload");
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const snapshotDir = buildSnapshotDir(workDir, {
+        version: 2,
+        createdAt: "2026-03-22T00:00:00.000Z",
+        homeDir,
+        stateDir: traversalTarget, // TAMPERED: outside homeDir
+        configPath: null,
+        hasExternalConfig: false,
+        externalRoots: [],
+        warnings: [],
+      });
+
+      const { result, written } = restoreVulnerable(snapshotDir);
+
+      // Vulnerable code writes to the traversal target
+      assert.ok(result, "vulnerable code should succeed (no validation)");
+      assert.ok(written, "vulnerable code writes to disk");
+      assert.ok(
+        fs.existsSync(path.join(traversalTarget, "sentinel.txt")),
+        "sentinel.txt must exist at traversal target — proves arbitrary write",
+      );
+      assert.equal(
+        fs.readFileSync(path.join(traversalTarget, "sentinel.txt"), "utf-8"),
+        "attacker-controlled-content",
+      );
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("tampered configPath outside homeDir — vulnerable code writes the file", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-c4-cfg-"));
+    try {
+      const homeDir = path.join(workDir, "home", "victim");
+      const legitimateStateDir = path.join(homeDir, ".openclaw");
+      const evilConfigPath = path.join(workDir, "evil-config.json");
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const snapshotDir = buildSnapshotDir(workDir, {
+        version: 2,
+        createdAt: "2026-03-22T00:00:00.000Z",
+        homeDir,
+        stateDir: legitimateStateDir,
+        configPath: evilConfigPath, // TAMPERED: outside homeDir
+        hasExternalConfig: true,
+        externalRoots: [],
+        warnings: [],
+      });
+
+      const { result } = restoreVulnerable(snapshotDir);
+
+      assert.ok(result, "vulnerable code should succeed");
+      assert.ok(
+        fs.existsSync(evilConfigPath),
+        "config written to traversal target — proves arbitrary file write",
+      );
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. Fix verification — fixed code rejects traversal
+// ═══════════════════════════════════════════════════════════════════
+describe("C-4 fix: restoreSnapshotToHost rejects path traversal", () => {
+  it("tampered stateDir outside homeDir is rejected", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-c4-fix-"));
+    try {
+      const homeDir = path.join(workDir, "home", "victim");
+      const traversalTarget = path.join(workDir, "evil-payload");
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const snapshotDir = buildSnapshotDir(workDir, {
+        version: 2,
+        createdAt: "2026-03-22T00:00:00.000Z",
+        homeDir,
+        stateDir: traversalTarget,
+        configPath: null,
+        hasExternalConfig: false,
+        externalRoots: [],
+        warnings: [],
+      });
+
+      const { result, errors, written } = restoreFixed(snapshotDir);
+
+      assert.equal(result, false, "fixed code must reject traversal");
+      assert.equal(written, false, "no files must be written");
+      assert.ok(!fs.existsSync(traversalTarget), "traversal target must not be created");
+      assert.ok(errors[0].includes("outside the expected home directory"));
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("tampered configPath outside homeDir is rejected", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-c4-fcfg-"));
+    try {
+      const homeDir = path.join(workDir, "home", "victim");
+      const legitimateStateDir = path.join(homeDir, ".openclaw");
+      const evilConfigPath = path.join(workDir, "evil-config.json");
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const snapshotDir = buildSnapshotDir(workDir, {
+        version: 2,
+        createdAt: "2026-03-22T00:00:00.000Z",
+        homeDir,
+        stateDir: legitimateStateDir,
+        configPath: evilConfigPath,
+        hasExternalConfig: true,
+        externalRoots: [],
+        warnings: [],
+      });
+
+      const { result, errors } = restoreFixed(snapshotDir);
+
+      assert.equal(result, false, "fixed code must reject configPath traversal");
+      assert.ok(!fs.existsSync(evilConfigPath), "evil config must not be written");
+      assert.ok(errors[0].includes("outside the expected home directory"));
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("sibling path (not a child of homeDir) is also rejected", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-c4-sib-"));
+    try {
+      const homeDir = path.join(workDir, "home");
+      const siblingDir = path.join(workDir, "not-home");
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const snapshotDir = buildSnapshotDir(workDir, {
+        version: 2,
+        createdAt: "2026-03-22T00:00:00.000Z",
+        homeDir,
+        stateDir: siblingDir,
+        configPath: null,
+        hasExternalConfig: false,
+        externalRoots: [],
+        warnings: [],
+      });
+
+      const { result } = restoreFixed(snapshotDir);
+      assert.equal(result, false, "sibling path must be rejected");
+      assert.ok(!fs.existsSync(siblingDir));
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("legitimate stateDir within homeDir succeeds", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-c4-ok-"));
+    try {
+      const homeDir = path.join(workDir, "home", "victim");
+      const legitimateStateDir = path.join(homeDir, ".openclaw");
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const snapshotDir = buildSnapshotDir(workDir, {
+        version: 2,
+        createdAt: "2026-03-22T00:00:00.000Z",
+        homeDir,
+        stateDir: legitimateStateDir,
+        configPath: null,
+        hasExternalConfig: false,
+        externalRoots: [],
+        warnings: [],
+      });
+
+      const { result, errors, written } = restoreFixed(snapshotDir);
+
+      assert.equal(result, true, "legitimate path must succeed");
+      assert.equal(errors.length, 0);
+      assert.ok(written);
+      assert.ok(fs.existsSync(path.join(legitimateStateDir, "sentinel.txt")));
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("legitimate configPath within homeDir succeeds", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-c4-cfgok-"));
+    try {
+      const homeDir = path.join(workDir, "home", "victim");
+      const legitimateStateDir = path.join(homeDir, ".openclaw");
+      const legitimateConfigPath = path.join(homeDir, ".config", "openclaw.json");
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const snapshotDir = buildSnapshotDir(workDir, {
+        version: 2,
+        createdAt: "2026-03-22T00:00:00.000Z",
+        homeDir,
+        stateDir: legitimateStateDir,
+        configPath: legitimateConfigPath,
+        hasExternalConfig: true,
+        externalRoots: [],
+        warnings: [],
+      });
+
+      const { result, errors } = restoreFixed(snapshotDir);
+
+      assert.equal(result, true, "legitimate config path must succeed");
+      assert.equal(errors.length, 0);
+      assert.ok(fs.existsSync(legitimateConfigPath));
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// 3. Regression guard — migration-state.ts must contain the validation
+// ═══════════════════════════════════════════════════════════════════
+describe("C-4 regression: migration-state.ts contains path validation", () => {
+  it("restoreSnapshotToHost calls isWithinRoot for stateDir", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "..", "nemoclaw", "src", "commands", "migration-state.ts"),
+      "utf-8",
+    );
+    assert.ok(
+      src.includes("isWithinRoot(manifest.stateDir"),
+      "restoreSnapshotToHost must validate manifest.stateDir with isWithinRoot",
+    );
+  });
+
+  it("restoreSnapshotToHost calls isWithinRoot for configPath", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "..", "nemoclaw", "src", "commands", "migration-state.ts"),
+      "utf-8",
+    );
+    assert.ok(
+      src.includes("isWithinRoot(manifest.configPath"),
+      "restoreSnapshotToHost must validate manifest.configPath with isWithinRoot",
+    );
+  });
+});

--- a/test/security-c4-manifest-traversal.test.js
+++ b/test/security-c4-manifest-traversal.test.js
@@ -22,11 +22,23 @@ const path = require("node:path");
 // ═══════════════════════════════════════════════════════════════════
 
 /**
+ * normalizeHostPath — mirrors migration-state.ts:115-118
+ * On Windows, lowercases the resolved path for case-insensitive comparison.
+ */
+function normalizeHostPath(p) {
+  const resolved = path.resolve(p);
+  if (process.platform === "win32") {
+    return resolved.toLowerCase();
+  }
+  return resolved;
+}
+
+/**
  * isWithinRoot — same logic as migration-state.ts:120-125
  */
 function isWithinRoot(candidatePath, rootPath) {
-  const candidate = path.resolve(candidatePath);
-  const root = path.resolve(rootPath);
+  const candidate = normalizeHostPath(candidatePath);
+  const root = normalizeHostPath(rootPath);
   const relative = path.relative(root, candidate);
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
@@ -92,30 +104,53 @@ function restoreVulnerable(snapshotDir) {
 
 /**
  * Simulate restoreSnapshotToHost WITH the fix (validates paths).
+ * Uses a trusted root instead of manifest.homeDir.
  * Returns { result, errors, written }.
+ * @param {string} snapshotDir
+ * @param {string} [trustedRoot] - trusted host root (defaults to os.homedir())
  */
-function restoreFixed(snapshotDir) {
+function restoreFixed(snapshotDir, trustedRoot) {
   const manifest = JSON.parse(
     fs.readFileSync(path.join(snapshotDir, "snapshot.json"), "utf-8"),
   );
   const snapshotStateDir = path.join(snapshotDir, "openclaw");
   const errors = [];
   let written = false;
+  const root = trustedRoot || os.homedir();
 
-  // FIX: validate write targets are within homeDir
-  if (!isWithinRoot(manifest.stateDir, manifest.homeDir)) {
+  // FIX: validate manifest.homeDir is within trusted root
+  if (typeof manifest.homeDir !== "string" || !isWithinRoot(manifest.homeDir, root)) {
     errors.push(
-      `Snapshot manifest stateDir is outside the expected home directory. ` +
-        `stateDir=${manifest.stateDir}, allowedRoot=${manifest.homeDir}`,
+      `Snapshot manifest homeDir is outside the trusted host root. ` +
+        `homeDir=${String(manifest.homeDir)}, trustedRoot=${root}`,
+    );
+    return { result: false, errors, written };
+  }
+
+  // FIX: validate stateDir type and containment
+  if (typeof manifest.stateDir !== "string") {
+    errors.push(`Snapshot manifest stateDir is not a string.`);
+    return { result: false, errors, written };
+  }
+
+  if (!isWithinRoot(manifest.stateDir, root)) {
+    errors.push(
+      `Snapshot manifest stateDir is outside the trusted host root. ` +
+        `stateDir=${manifest.stateDir}, trustedRoot=${root}`,
     );
     return { result: false, errors, written };
   }
 
   if (manifest.hasExternalConfig && manifest.configPath !== null) {
-    if (!isWithinRoot(manifest.configPath, manifest.homeDir)) {
+    if (typeof manifest.configPath !== "string") {
+      errors.push(`Snapshot manifest configPath is not a string.`);
+      return { result: false, errors, written };
+    }
+
+    if (!isWithinRoot(manifest.configPath, root)) {
       errors.push(
-        `Snapshot manifest configPath is outside the expected home directory. ` +
-          `configPath=${manifest.configPath}, allowedRoot=${manifest.homeDir}`,
+        `Snapshot manifest configPath is outside the trusted host root. ` +
+          `configPath=${manifest.configPath}, trustedRoot=${root}`,
       );
       return { result: false, errors, written };
     }
@@ -232,12 +267,13 @@ describe("C-4 fix: restoreSnapshotToHost rejects path traversal", () => {
         warnings: [],
       });
 
-      const { result, errors, written } = restoreFixed(snapshotDir);
+      // Pass homeDir as trustedRoot to simulate resolveHostHome()
+      const { result, errors, written } = restoreFixed(snapshotDir, homeDir);
 
       assert.equal(result, false, "fixed code must reject traversal");
       assert.equal(written, false, "no files must be written");
       assert.ok(!fs.existsSync(traversalTarget), "traversal target must not be created");
-      assert.ok(errors[0].includes("outside the expected home directory"));
+      assert.ok(errors[0].includes("outside the trusted host root"));
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -262,11 +298,11 @@ describe("C-4 fix: restoreSnapshotToHost rejects path traversal", () => {
         warnings: [],
       });
 
-      const { result, errors } = restoreFixed(snapshotDir);
+      const { result, errors } = restoreFixed(snapshotDir, homeDir);
 
       assert.equal(result, false, "fixed code must reject configPath traversal");
       assert.ok(!fs.existsSync(evilConfigPath), "evil config must not be written");
-      assert.ok(errors[0].includes("outside the expected home directory"));
+      assert.ok(errors[0].includes("outside the trusted host root"));
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -290,9 +326,39 @@ describe("C-4 fix: restoreSnapshotToHost rejects path traversal", () => {
         warnings: [],
       });
 
-      const { result } = restoreFixed(snapshotDir);
+      const { result } = restoreFixed(snapshotDir, homeDir);
       assert.equal(result, false, "sibling path must be rejected");
       assert.ok(!fs.existsSync(siblingDir));
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("tampered homeDir set to / is rejected based on trusted host root", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-c4-root-"));
+    try {
+      const trustedRoot = path.join(workDir, "home", "victim");
+      fs.mkdirSync(trustedRoot, { recursive: true });
+
+      const snapshotDir = buildSnapshotDir(workDir, {
+        version: 2,
+        createdAt: "2026-03-22T00:00:00.000Z",
+        homeDir: "/", // TAMPERED: set to filesystem root
+        stateDir: "/tmp/evil",
+        configPath: null,
+        hasExternalConfig: false,
+        externalRoots: [],
+        warnings: [],
+      });
+
+      const { result, errors, written } = restoreFixed(snapshotDir, trustedRoot);
+
+      assert.equal(result, false, "homeDir=/ must be rejected");
+      assert.equal(written, false, "no files must be written");
+      assert.ok(
+        errors[0].includes("homeDir is outside the trusted host root"),
+        `expected homeDir rejection, got: ${errors[0]}`,
+      );
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -316,7 +382,8 @@ describe("C-4 fix: restoreSnapshotToHost rejects path traversal", () => {
         warnings: [],
       });
 
-      const { result, errors, written } = restoreFixed(snapshotDir);
+      // trustedRoot = homeDir (simulates resolveHostHome() returning this dir)
+      const { result, errors, written } = restoreFixed(snapshotDir, homeDir);
 
       assert.equal(result, true, "legitimate path must succeed");
       assert.equal(errors.length, 0);
@@ -346,7 +413,7 @@ describe("C-4 fix: restoreSnapshotToHost rejects path traversal", () => {
         warnings: [],
       });
 
-      const { result, errors } = restoreFixed(snapshotDir);
+      const { result, errors } = restoreFixed(snapshotDir, homeDir);
 
       assert.equal(result, true, "legitimate config path must succeed");
       assert.equal(errors.length, 0);


### PR DESCRIPTION
## Summary

`restoreSnapshotToHost()` in `migration-state.ts` reads `manifest.stateDir` and `manifest.configPath` from `snapshot.json` via `JSON.parse` with no path validation, then uses them as write targets for `renameSync`, `mkdirSync`, `copyDirectory`, and `copyFileSync`. A tampered `snapshot.json` can cause writes to arbitrary locations on the host filesystem.

**PoC**: Setting `stateDir: "/tmp/evil-payload"` in `snapshot.json` causes snapshot content to be written to `/tmp/evil-payload/` — completely outside `~/.nemoclaw/`.

### Fix

Validate both `manifest.stateDir` and `manifest.configPath` are within `manifest.homeDir` using the existing `isWithinRoot()` helper before any filesystem mutation.

### Changes

| File | Change |
|------|--------|
| `nemoclaw/src/commands/migration-state.ts` | Add `isWithinRoot()` validation in `restoreSnapshotToHost()` |
| `test/security-c4-manifest-traversal.test.js` | 9 tests: PoC, fix rejection, legitimate paths |

## Test plan

- [x] 9 tests pass (`node --test test/security-c4-manifest-traversal.test.js`)
- [x] PoC proves write to traversal target with vulnerable code
- [x] Fix rejects stateDir, configPath, and sibling-path traversals
- [x] Legitimate paths within homeDir still succeed
- [x] Regression guards verify `isWithinRoot` calls in source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened snapshot restore security to prevent unauthorized filesystem writes and path traversal by validating manifest paths against a trusted host root, enforcing exact environment overrides when present, and rejecting unsafe restores with clear error logs.

* **Tests**
  * Added a security regression suite that verifies traversal is blocked, confirms legitimate restores still succeed, and asserts failures emit meaningful error messages when paths lie outside the trusted host root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->