### PR TITLE
chore: harden .gitignore with security-sensitive file patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,25 @@ docs/_build/
 coverage/
 vdr-notes/
 draft_newsletter_*
+
+# Security: prevent accidental commit of secrets and credentials
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+*.keystore
+.npmrc
+.netrc
+*_rsa
+*_ed25519
+*_ecdsa
+credentials.json
+
+# Security: prevent accidental commit of disclosure drafts
+DRAFT-*.md
+
+# Claude Code worktrees and local state
+.claude/


### PR DESCRIPTION
## Summary

Add exclusions for credential files, private keys, environment files, and other sensitive patterns that should never be committed.

### Patterns added

| Pattern | Purpose |
|---------|---------|
| `.env` / `.env.*` | Environment variable files with secrets |
| `*.pem` / `*.key` / `*.p12` / `*.pfx` | TLS/SSL key material |
| `*.jks` / `*.keystore` | Java keystores |
| `.npmrc` / `.netrc` | Package registry and network credentials |
| `*_rsa` / `*_ed25519` / `*_ecdsa` | SSH private keys |
| `credentials.json` | NemoClaw credential store |
| `DRAFT-*.md` | Security disclosure drafts |
| `.claude/` | Claude Code worktrees and local agent state |

### Context

A comprehensive git history audit (399 commits, all branches, reflog, stashes, GitHub Actions logs) confirmed **no secrets were ever committed**. However the current `.gitignore` has no exclusions for these sensitive file types, increasing the probability of a future accidental commit as the contributor base grows.

## Test plan

- [x] Verified no tracked files match the new patterns
- [x] `git status` shows no unintended changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude sensitive files and credentials from version control, including environment variables, certificates, API keys, and local development artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->