### PR TITLE
fix: correct Telegram bridge status detection (fixes #587)

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -202,16 +202,21 @@ async function deploy(instanceName) {
   runInteractive(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${qname} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell sandbox connect nemoclaw'`);
 }
 
-async function start() {
-  await ensureApiKey();
+function sandboxEnvPrefix() {
   const { defaultSandbox } = registry.listSandboxes();
   const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  const sandboxEnv = safeName ? `SANDBOX_NAME=${shellQuote(safeName)}` : "";
-  run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh"`);
+  return safeName ? `SANDBOX_NAME=${shellQuote(safeName)}` : "";
+}
+
+async function start() {
+  await ensureApiKey();
+  const envPrefix = sandboxEnvPrefix();
+  run(`${envPrefix} bash "${SCRIPTS}/start-services.sh"`);
 }
 
 function stop() {
-  run(`bash "${SCRIPTS}/start-services.sh" --stop`);
+  const envPrefix = sandboxEnvPrefix();
+  run(`${envPrefix} bash "${SCRIPTS}/start-services.sh" --stop`);
 }
 
 function debug(args) {
@@ -266,7 +271,8 @@ function showStatus() {
   }
 
   // Show service status
-  run(`bash "${SCRIPTS}/start-services.sh" --status`);
+  const envPrefix = sandboxEnvPrefix();
+  run(`${envPrefix} bash "${SCRIPTS}/start-services.sh" --status`);
 }
 
 function listSandboxes() {

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -3,6 +3,8 @@
 
 import { describe, it, expect } from "vitest";
 import { execSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
 import { resolveOpenshell } from "../bin/lib/resolve-openshell";
 
 describe("service environment", () => {
@@ -93,6 +95,43 @@ describe("service environment", () => {
         }
       ).trim();
       expect(result).toBe("default");
+    });
+  });
+
+  describe("SANDBOX_NAME consistency across start/stop/status (#587)", () => {
+    it("stop() passes SANDBOX_NAME via sandboxEnvPrefix", () => {
+      const src = fs.readFileSync(
+        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        "utf-8"
+      );
+      // stop() must use sandboxEnvPrefix so the PIDDIR matches start()
+      const stopFn = src.match(/function stop\(\)[^}]*\}/s);
+      expect(stopFn).toBeTruthy();
+      expect(
+        stopFn[0].includes("sandboxEnvPrefix")
+      ).toBe(true);
+    });
+
+    it("showStatus() passes SANDBOX_NAME via sandboxEnvPrefix", () => {
+      const src = fs.readFileSync(
+        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        "utf-8"
+      );
+      const statusFn = src.match(/function showStatus\(\)[^]*?^}/m);
+      expect(statusFn).toBeTruthy();
+      expect(
+        statusFn[0].includes("sandboxEnvPrefix")
+      ).toBe(true);
+    });
+
+    it("sandboxEnvPrefix() is a shared helper used by start, stop, and status", () => {
+      const src = fs.readFileSync(
+        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        "utf-8"
+      );
+      const uses = (src.match(/sandboxEnvPrefix\(\)/g) || []).length;
+      // At least 3 call sites: start(), stop(), showStatus()
+      expect(uses).toBeGreaterThanOrEqual(3);
     });
   });
 });

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -105,7 +105,7 @@ describe("service environment", () => {
         "utf-8"
       );
       // stop() must use sandboxEnvPrefix so the PIDDIR matches start()
-      const stopFn = src.match(/function stop\(\)[^}]*\}/s);
+      const stopFn = src.match(/function stop\(\)\s*\{[\s\S]*?\n\}/);
       expect(stopFn).toBeTruthy();
       expect(
         stopFn[0].includes("sandboxEnvPrefix")
@@ -117,7 +117,7 @@ describe("service environment", () => {
         path.join(__dirname, "..", "bin", "nemoclaw.js"),
         "utf-8"
       );
-      const statusFn = src.match(/function showStatus\(\)[^]*?^}/m);
+      const statusFn = src.match(/function showStatus\(\)\s*\{[\s\S]*?\n\}/);
       expect(statusFn).toBeTruthy();
       expect(
         statusFn[0].includes("sandboxEnvPrefix")


### PR DESCRIPTION
## Problem

`nemoclaw start` launches the Telegram bridge correctly, but `nemoclaw status` reports it as stopped and `nemoclaw stop` says it's not running (even though the process is alive).

## Root Cause

In `bin/nemoclaw.js`:
- **`start()`** resolves the sandbox name from the registry and passes `SANDBOX_NAME=<name>` to `start-services.sh`, which saves the PID file in `/tmp/nemoclaw-services-<name>/`.
- **`stop()`** called `start-services.sh --stop` **without** passing `SANDBOX_NAME`, so the shell script defaulted to `"default"` and looked in `/tmp/nemoclaw-services-default/` — a different directory.
- **`showStatus()`** had the same problem — no `SANDBOX_NAME` passed, so it always checked the wrong PID directory.

This meant the PID file written by `start` was invisible to both `status` and `stop`.

## Fix

Extract a shared `sandboxEnvPrefix()` helper that resolves the default sandbox name from the registry (same logic `start()` already had), and use it in all three functions: `start()`, `stop()`, and `showStatus()`.

## Changes

- **`bin/nemoclaw.js`**: Extract `sandboxEnvPrefix()`, apply it to `stop()` and `showStatus()`
- **`test/service-env.test.js`**: Add regression tests verifying `stop()` and `showStatus()` use the shared helper, preventing future drift

## Testing

All 189 existing tests pass (1 pre-existing unrelated failure in `install-preflight.test.js`). 3 new regression tests added.

Fixes #587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Service management (start/stop/status) now consistently applies an optional sandbox environment prefix so operations target the intended sandbox reliably.

* **Tests**
  * Added static tests to ensure sandbox environment variables are propagated consistently across service start, stop and status operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->