### PR TITLE
fix(blueprint): add error handling for JSON.parse in state, config, and migration loaders

### DIFF
--- a/nemoclaw/src/blueprint/state.test.ts
+++ b/nemoclaw/src/blueprint/state.test.ts
@@ -57,6 +57,14 @@ describe("blueprint/state", () => {
       store.set(STATE_PATH, JSON.stringify(saved));
       expect(loadState()).toEqual(saved);
     });
+
+    it("returns blank state when file contains malformed JSON", () => {
+      store.set(STATE_PATH, "not valid json {{{");
+      const state = loadState();
+      expect(state.lastRunId).toBeNull();
+      expect(state.lastAction).toBeNull();
+      expect(state.updatedAt).toBeDefined();
+    });
   });
 
   describe("saveState", () => {

--- a/nemoclaw/src/blueprint/state.ts
+++ b/nemoclaw/src/blueprint/state.ts
@@ -50,7 +50,11 @@ export function loadState(): NemoClawState {
   if (!existsSync(path)) {
     return blankState();
   }
-  return JSON.parse(readFileSync(path, "utf-8")) as NemoClawState;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as NemoClawState;
+  } catch {
+    return blankState();
+  }
 }
 
 export function saveState(state: NemoClawState): void {

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -605,6 +605,16 @@ describe("commands/migration-state", () => {
       const loaded = loadSnapshotManifest("/snapshots/snap1");
       expect(loaded).toEqual(manifest);
     });
+
+    it("throws when snapshot.json contains malformed JSON", () => {
+      addFile("/snapshots/bad/snapshot.json", "not valid json");
+      expect(() => loadSnapshotManifest("/snapshots/bad")).toThrow();
+    });
+
+    it("throws when snapshot.json is an array instead of object", () => {
+      addFile("/snapshots/bad/snapshot.json", "[1, 2, 3]");
+      expect(() => loadSnapshotManifest("/snapshots/bad")).toThrow(/not a JSON object/);
+    });
   });
 
   describe("restoreSnapshotToHost", () => {

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -484,9 +484,12 @@ function writeSnapshotManifest(snapshotDir: string, manifest: SnapshotManifest):
 }
 
 function readSnapshotManifest(snapshotDir: string): SnapshotManifest {
-  return JSON.parse(
-    readFileSync(path.join(snapshotDir, "snapshot.json"), "utf-8"),
-  ) as SnapshotManifest;
+  const filePath = path.join(snapshotDir, "snapshot.json");
+  const parsed: unknown = JSON.parse(readFileSync(filePath, "utf-8"));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Snapshot manifest at ${filePath} is not a JSON object.`);
+  }
+  return parsed as SnapshotManifest;
 }
 
 function resolveConfigSourcePath(manifest: SnapshotManifest, snapshotDir: string): string {

--- a/nemoclaw/src/onboard/config.test.ts
+++ b/nemoclaw/src/onboard/config.test.ts
@@ -115,6 +115,12 @@ describe("onboard/config", () => {
       store.set(configPath, JSON.stringify(config));
       expect(loadOnboardConfig()).toEqual(config);
     });
+
+    it("returns null when config file contains malformed JSON", () => {
+      const configPath = `${process.env.HOME ?? "/tmp"}/.nemoclaw/config.json`;
+      store.set(configPath, "corrupt data here");
+      expect(loadOnboardConfig()).toBeNull();
+    });
   });
 
   describe("saveOnboardConfig", () => {

--- a/nemoclaw/src/onboard/config.ts
+++ b/nemoclaw/src/onboard/config.ts
@@ -71,7 +71,11 @@ export function loadOnboardConfig(): NemoClawOnboardConfig | null {
   if (!existsSync(path)) {
     return null;
   }
-  return JSON.parse(readFileSync(path, "utf-8")) as NemoClawOnboardConfig;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as NemoClawOnboardConfig;
+  } catch {
+    return null;
+  }
 }
 
 export function saveOnboardConfig(config: NemoClawOnboardConfig): void {


### PR DESCRIPTION
## Summary
- Add try-catch error handling around bare `JSON.parse` calls in `loadState()`, `loadOnboardConfig()`, and `readSnapshotManifest()`
- Follows the existing pattern established by `loadConfigDocument()` in `migration-state.ts` (lines 143-153)
- `loadState()` recovers silently (returns blank state) — state is machine-written ephemeral data, and the next `saveState()` call self-heals the file
- `loadOnboardConfig()` recovers silently (returns null) — allows re-onboarding
- `readSnapshotManifest()` throws a descriptive error with structural validation (matching `loadConfigDocument` pattern) — migration cannot proceed safely with corrupt data

Related to #553

## Test plan
- [x] `cd nemoclaw && npx vitest run` — 79 tests pass (4 new)
- [x] `npx tsc --noEmit` — no type errors
- [x] Added test for malformed JSON in `state.test.ts`
- [x] Added test for malformed JSON in `config.test.ts`
- [x] Added tests for malformed JSON and array input in `migration-state.test.ts`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>