### PR TITLE
fix(security): tighten snapshot manifest validation nits

### DIFF
--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -629,46 +629,65 @@ describe("commands/migration-state", () => {
 
     it("restores state directory from snapshot", () => {
       const logger = makeLogger();
-      const manifest: SnapshotManifest = {
-        version: 2,
-        createdAt: "2026-03-01T00:00:00.000Z",
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configPath: null,
-        hasExternalConfig: false,
-        externalRoots: [],
-        warnings: [],
-      };
-      addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
-      addDir("/snapshots/snap1/openclaw");
-      addFile("/snapshots/snap1/openclaw/openclaw.json", JSON.stringify({ restored: true }));
-      // Existing state dir to be archived
-      addDir("/home/user/.openclaw");
+      const origHome = process.env.HOME;
+      process.env.HOME = "/home/user";
+      try {
+        const manifest: SnapshotManifest = {
+          version: 2,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          homeDir: "/home/user",
+          stateDir: "/home/user/.openclaw",
+          configPath: null,
+          hasExternalConfig: false,
+          externalRoots: [],
+          warnings: [],
+        };
+        addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+        addDir("/snapshots/snap1/openclaw");
+        addFile("/snapshots/snap1/openclaw/openclaw.json", JSON.stringify({ restored: true }));
+        // Existing state dir to be archived
+        addDir("/home/user/.openclaw");
 
-      const result = restoreSnapshotToHost("/snapshots/snap1", logger);
-      expect(result).toBe(true);
-      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("restored"));
+        const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+        expect(result).toBe(true);
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("restored"));
+      } finally {
+        process.env.HOME = origHome;
+      }
     });
 
     it("restores external config when hasExternalConfig", () => {
       const logger = makeLogger();
-      const manifest: SnapshotManifest = {
-        version: 2,
-        createdAt: "2026-03-01T00:00:00.000Z",
-        homeDir: "/home/user",
-        stateDir: "/home/user/.openclaw",
-        configPath: "/etc/openclaw.json",
-        hasExternalConfig: true,
-        externalRoots: [],
-        warnings: [],
-      };
-      addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
-      addDir("/snapshots/snap1/openclaw");
-      addFile("/snapshots/snap1/config/openclaw.json", JSON.stringify({ external: true }));
+      const origHome = process.env.HOME;
+      const origConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.HOME = "/home/user";
+      process.env.OPENCLAW_CONFIG_PATH = "/etc/openclaw.json";
+      try {
+        const manifest: SnapshotManifest = {
+          version: 2,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          homeDir: "/home/user",
+          stateDir: "/home/user/.openclaw",
+          configPath: "/etc/openclaw.json",
+          hasExternalConfig: true,
+          externalRoots: [],
+          warnings: [],
+        };
+        addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+        addDir("/snapshots/snap1/openclaw");
+        addFile("/snapshots/snap1/config/openclaw.json", JSON.stringify({ external: true }));
 
-      const result = restoreSnapshotToHost("/snapshots/snap1", logger);
-      expect(result).toBe(true);
-      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("external config"));
+        const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+        expect(result).toBe(true);
+        expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("external config"));
+      } finally {
+        process.env.HOME = origHome;
+        if (origConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = origConfigPath;
+        }
+      }
     });
   });
 });

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -689,5 +689,179 @@ describe("commands/migration-state", () => {
         }
       }
     });
+
+    it("rejects when homeDir is outside trusted root", () => {
+      const logger = makeLogger();
+      const origHome = process.env.HOME;
+      process.env.HOME = "/home/user";
+      try {
+        const manifest: SnapshotManifest = {
+          version: 2,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          homeDir: "/tmp/evil",
+          stateDir: "/tmp/evil/.openclaw",
+          configPath: null,
+          hasExternalConfig: false,
+          externalRoots: [],
+          warnings: [],
+        };
+        addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+        addDir("/snapshots/snap1/openclaw");
+
+        const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+        expect(result).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("homeDir is outside"));
+      } finally {
+        process.env.HOME = origHome;
+      }
+    });
+
+    it("rejects when stateDir is outside trusted root", () => {
+      const logger = makeLogger();
+      const origHome = process.env.HOME;
+      process.env.HOME = "/home/user";
+      try {
+        const manifest: SnapshotManifest = {
+          version: 2,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          homeDir: "/home/user",
+          stateDir: "/tmp/evil/.openclaw",
+          configPath: null,
+          hasExternalConfig: false,
+          externalRoots: [],
+          warnings: [],
+        };
+        addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+        addDir("/snapshots/snap1/openclaw");
+
+        const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+        expect(result).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("stateDir is outside"));
+      } finally {
+        process.env.HOME = origHome;
+      }
+    });
+
+    it("rejects when stateDir does not match OPENCLAW_STATE_DIR", () => {
+      const logger = makeLogger();
+      const origHome = process.env.HOME;
+      const origStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.HOME = "/home/user";
+      process.env.OPENCLAW_STATE_DIR = "/home/user/.custom-state";
+      try {
+        const manifest: SnapshotManifest = {
+          version: 2,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          homeDir: "/home/user",
+          stateDir: "/home/user/.openclaw",
+          configPath: null,
+          hasExternalConfig: false,
+          externalRoots: [],
+          warnings: [],
+        };
+        addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+        addDir("/snapshots/snap1/openclaw");
+
+        const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+        expect(result).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining("does not match OPENCLAW_STATE_DIR"),
+        );
+      } finally {
+        process.env.HOME = origHome;
+        if (origStateDir === undefined) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = origStateDir;
+        }
+      }
+    });
+
+    it("rejects when hasExternalConfig is true but configPath is null", () => {
+      const logger = makeLogger();
+      const origHome = process.env.HOME;
+      process.env.HOME = "/home/user";
+      try {
+        const manifest: SnapshotManifest = {
+          version: 2,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          homeDir: "/home/user",
+          stateDir: "/home/user/.openclaw",
+          configPath: null,
+          hasExternalConfig: true,
+          externalRoots: [],
+          warnings: [],
+        };
+        addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+        addDir("/snapshots/snap1/openclaw");
+
+        const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+        expect(result).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("configPath is missing"));
+      } finally {
+        process.env.HOME = origHome;
+      }
+    });
+
+    it("rejects when configPath is outside trusted root", () => {
+      const logger = makeLogger();
+      const origHome = process.env.HOME;
+      process.env.HOME = "/home/user";
+      try {
+        const manifest: SnapshotManifest = {
+          version: 2,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          homeDir: "/home/user",
+          stateDir: "/home/user/.openclaw",
+          configPath: "/tmp/evil/openclaw.json",
+          hasExternalConfig: true,
+          externalRoots: [],
+          warnings: [],
+        };
+        addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+        addDir("/snapshots/snap1/openclaw");
+
+        const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+        expect(result).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("configPath is outside"));
+      } finally {
+        process.env.HOME = origHome;
+      }
+    });
+
+    it("rejects when configPath does not match OPENCLAW_CONFIG_PATH", () => {
+      const logger = makeLogger();
+      const origHome = process.env.HOME;
+      const origConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.HOME = "/home/user";
+      process.env.OPENCLAW_CONFIG_PATH = "/home/user/my-config.json";
+      try {
+        const manifest: SnapshotManifest = {
+          version: 2,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          homeDir: "/home/user",
+          stateDir: "/home/user/.openclaw",
+          configPath: "/etc/openclaw.json",
+          hasExternalConfig: true,
+          externalRoots: [],
+          warnings: [],
+        };
+        addFile("/snapshots/snap1/snapshot.json", JSON.stringify(manifest));
+        addDir("/snapshots/snap1/openclaw");
+
+        const result = restoreSnapshotToHost("/snapshots/snap1", logger);
+        expect(result).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining("does not match OPENCLAW_CONFIG_PATH"),
+        );
+      } finally {
+        process.env.HOME = origHome;
+        if (origConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = origConfigPath;
+        }
+      }
+    });
   });
 });

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -652,7 +652,11 @@ describe("commands/migration-state", () => {
         expect(result).toBe(true);
         expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("restored"));
       } finally {
-        process.env.HOME = origHome;
+        if (origHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = origHome;
+        }
       }
     });
 
@@ -681,7 +685,11 @@ describe("commands/migration-state", () => {
         expect(result).toBe(true);
         expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("external config"));
       } finally {
-        process.env.HOME = origHome;
+        if (origHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = origHome;
+        }
         if (origConfigPath === undefined) {
           delete process.env.OPENCLAW_CONFIG_PATH;
         } else {
@@ -712,7 +720,11 @@ describe("commands/migration-state", () => {
         expect(result).toBe(false);
         expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("homeDir is outside"));
       } finally {
-        process.env.HOME = origHome;
+        if (origHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = origHome;
+        }
       }
     });
 
@@ -738,7 +750,11 @@ describe("commands/migration-state", () => {
         expect(result).toBe(false);
         expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("stateDir is outside"));
       } finally {
-        process.env.HOME = origHome;
+        if (origHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = origHome;
+        }
       }
     });
 
@@ -768,7 +784,11 @@ describe("commands/migration-state", () => {
           expect.stringContaining("does not match OPENCLAW_STATE_DIR"),
         );
       } finally {
-        process.env.HOME = origHome;
+        if (origHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = origHome;
+        }
         if (origStateDir === undefined) {
           delete process.env.OPENCLAW_STATE_DIR;
         } else {
@@ -799,7 +819,11 @@ describe("commands/migration-state", () => {
         expect(result).toBe(false);
         expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("configPath is missing"));
       } finally {
-        process.env.HOME = origHome;
+        if (origHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = origHome;
+        }
       }
     });
 
@@ -825,7 +849,11 @@ describe("commands/migration-state", () => {
         expect(result).toBe(false);
         expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("configPath is outside"));
       } finally {
-        process.env.HOME = origHome;
+        if (origHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = origHome;
+        }
       }
     });
 
@@ -855,7 +883,11 @@ describe("commands/migration-state", () => {
           expect.stringContaining("does not match OPENCLAW_CONFIG_PATH"),
         );
       } finally {
-        process.env.HOME = origHome;
+        if (origHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = origHome;
+        }
         if (origConfigPath === undefined) {
           delete process.env.OPENCLAW_CONFIG_PATH;
         } else {

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -675,7 +675,7 @@ export function restoreSnapshotToHost(snapshotDir: string, logger: PluginLogger)
   if (typeof manifest.homeDir !== "string" || !isWithinRoot(manifest.homeDir, trustedRoot)) {
     logger.error(
       `Snapshot manifest homeDir is outside the trusted host root. ` +
-        `Refusing to restore. homeDir=${String(manifest.homeDir)}, trustedRoot=${trustedRoot}`,
+        `Refusing to restore. homeDir=${manifest.homeDir}, trustedRoot=${trustedRoot}`,
     );
     return false;
   }
@@ -707,11 +707,12 @@ export function restoreSnapshotToHost(snapshotDir: string, logger: PluginLogger)
     return false;
   }
 
-  if (manifest.hasExternalConfig && manifest.configPath !== null) {
-    // Validate configPath type
-    if (typeof manifest.configPath !== "string") {
+  if (manifest.hasExternalConfig) {
+    // Validate configPath type — fail closed when hasExternalConfig is true
+    // but configPath is null/empty (partial restore would silently skip config).
+    if (typeof manifest.configPath !== "string" || !manifest.configPath.trim()) {
       logger.error(
-        `Snapshot manifest configPath is not a string. Refusing to restore.`,
+        `Snapshot manifest has hasExternalConfig=true but configPath is missing or empty. Refusing to restore.`,
       );
       return false;
     }

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -682,9 +682,7 @@ export function restoreSnapshotToHost(snapshotDir: string, logger: PluginLogger)
 
   // Validate stateDir type and containment
   if (typeof manifest.stateDir !== "string") {
-    logger.error(
-      `Snapshot manifest stateDir is not a string. Refusing to restore.`,
-    );
+    logger.error(`Snapshot manifest stateDir is not a string. Refusing to restore.`);
     return false;
   }
 

--- a/test/security-c4-manifest-traversal.test.js
+++ b/test/security-c4-manifest-traversal.test.js
@@ -141,9 +141,11 @@ function restoreFixed(snapshotDir, trustedRoot) {
     return { result: false, errors, written };
   }
 
-  if (manifest.hasExternalConfig && manifest.configPath !== null) {
-    if (typeof manifest.configPath !== "string") {
-      errors.push(`Snapshot manifest configPath is not a string.`);
+  if (manifest.hasExternalConfig) {
+    if (typeof manifest.configPath !== "string" || !manifest.configPath.trim()) {
+      errors.push(
+        `Snapshot manifest has hasExternalConfig=true but configPath is missing or empty.`,
+      );
       return { result: false, errors, written };
     }
 
@@ -428,25 +430,47 @@ describe("C-4 fix: restoreSnapshotToHost rejects path traversal", () => {
 // 3. Regression guard — migration-state.ts must contain the validation
 // ═══════════════════════════════════════════════════════════════════
 describe("C-4 regression: migration-state.ts contains path validation", () => {
-  it("restoreSnapshotToHost calls isWithinRoot for stateDir", () => {
+  /** Extract the restoreSnapshotToHost function body from the source. */
+  function getRestoreFnBody() {
     const src = fs.readFileSync(
       path.join(__dirname, "..", "nemoclaw", "src", "commands", "migration-state.ts"),
       "utf-8",
     );
+    const fnStart = src.indexOf("function restoreSnapshotToHost");
+    assert.ok(fnStart !== -1, "restoreSnapshotToHost must exist in migration-state.ts");
+    return src.slice(fnStart);
+  }
+
+  it("restoreSnapshotToHost calls isWithinRoot on manifest.stateDir", () => {
+    const fnBody = getRestoreFnBody();
     assert.ok(
-      src.includes("isWithinRoot(manifest.stateDir"),
-      "restoreSnapshotToHost must validate manifest.stateDir with isWithinRoot",
+      /isWithinRoot\s*\(\s*manifest\.stateDir/.test(fnBody),
+      "restoreSnapshotToHost must call isWithinRoot on manifest.stateDir",
     );
   });
 
-  it("restoreSnapshotToHost calls isWithinRoot for configPath", () => {
-    const src = fs.readFileSync(
-      path.join(__dirname, "..", "nemoclaw", "src", "commands", "migration-state.ts"),
-      "utf-8",
-    );
+  it("restoreSnapshotToHost calls isWithinRoot on manifest.configPath", () => {
+    const fnBody = getRestoreFnBody();
     assert.ok(
-      src.includes("isWithinRoot(manifest.configPath"),
-      "restoreSnapshotToHost must validate manifest.configPath with isWithinRoot",
+      /isWithinRoot\s*\(\s*manifest\.configPath/.test(fnBody),
+      "restoreSnapshotToHost must call isWithinRoot on manifest.configPath",
+    );
+  });
+
+  it("restoreSnapshotToHost validates manifest.homeDir against trusted root", () => {
+    const fnBody = getRestoreFnBody();
+    assert.ok(
+      /isWithinRoot\s*\(\s*manifest\.homeDir/.test(fnBody),
+      "restoreSnapshotToHost must call isWithinRoot on manifest.homeDir",
+    );
+  });
+
+  it("restoreSnapshotToHost fails closed when hasExternalConfig is true with missing configPath", () => {
+    const fnBody = getRestoreFnBody();
+    assert.ok(
+      /manifest\.hasExternalConfig\b/.test(fnBody) &&
+        /typeof\s+manifest\.configPath\s*!==\s*["']string["']/.test(fnBody),
+      "restoreSnapshotToHost must type-check manifest.configPath when hasExternalConfig is true",
     );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #612. Fixes the lint error blocking CI and tightens two validation gaps identified during review.

Credit to @gn00295120 for the original path traversal fix.

## Changes

- **Lint fix**: Remove unnecessary `String()` wrapper on `manifest.homeDir` in error message (line 678)
- **Fail closed**: Reject manifests where `hasExternalConfig: true` but `configPath` is null or empty, instead of silently returning success after partial restore
- **Stronger regression guards**: Replace `src.includes("isWithinRoot")` with regex patterns scoped to the `restoreSnapshotToHost` function body

Closes #646

## Test plan
- [x] `npx eslint 'src/**/*.ts'` — lint passes
- [x] `node --test test/security-c4-manifest-traversal.test.js` — all tests pass
- [x] `npm test` — 217/217 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter restore validation: external config is rejected when its path is missing, empty/whitespace, or outside the trusted root; clearer error messages when validation fails.
* **Refactor**
  * Simplified logging for restore operations to produce clearer path output.
* **Tests**
  * Expanded manifest path/security checks and hardened tests by isolating/restoring environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->