### PR TITLE
ci: exempt core maintainers from PR limit

### DIFF
--- a/.github/workflows/pr-limit.yaml
+++ b/.github/workflows/pr-limit.yaml
@@ -27,6 +27,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          # Core maintainers are exempt from the PR limit.
+          EXEMPT="ericksoa kjw3 jacobtomlinson cv"
+          for user in $EXEMPT; do
+            if [ "$AUTHOR" = "$user" ]; then
+              echo "Author $AUTHOR is a core maintainer — exempt from PR limit"
+              exit 0
+            fi
+          done
+
           OPEN_COUNT=$(gh pr list --repo "$REPO" --author "$AUTHOR" --state open --json number --jq 'length')
 
           echo "Author $AUTHOR has $OPEN_COUNT open PR(s)"


### PR DESCRIPTION
## Summary

Exempt core maintainers (ericksoa, kjw3, jacobtomlinson, cv) from the 10 open PR limit so they aren't blocked during active review/security work.

## Changes

Added an early-exit check in `.github/workflows/pr-limit.yaml` that skips the limit for listed maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request limit enforcement workflow to include exemptions for select users, allowing them to bypass the standard PR limit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->