### PR TITLE
feat(env): add configurable port overrides via .env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# NemoClaw port configuration — copy to .env and edit as needed.
+# Ports must be integers in range 1024–65535.
+# Run scripts/check-ports.sh to find port conflicts
+
+NEMOCLAW_DASHBOARD_PORT=18789
+NEMOCLAW_GATEWAY_PORT=8080
+NEMOCLAW_OLLAMA_PORT=11434
+NEMOCLAW_VLLM_PORT=8000

--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ NemoClaw uses four network ports. All are configurable via environment variables
 
 To use non-default ports, set the environment variables before running `nemoclaw onboard`:
 
-```bash
-export NEMOCLAW_GATEWAY_PORT=9080
-export NEMOCLAW_VLLM_PORT=9000
-nemoclaw onboard
+```console
+$ export NEMOCLAW_GATEWAY_PORT=9080
+$ export NEMOCLAW_VLLM_PORT=9000
+$ nemoclaw onboard
 ```
 
 Or create a `.env` file at the project root (see `.env.example`). For personal overrides that should never be committed, use `.env.local` — it is loaded after `.env` and takes precedence.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,37 @@ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uni
 
 ---
 
+## Port Configuration
+
+NemoClaw uses four network ports. All are configurable via environment variables or a `.env` file at the project root (copy `.env.example` to get started).
+
+| Port | Default | Env var | Purpose | Conflict risk |
+|------|---------|---------|---------|---------------|
+| Dashboard | 18789 | `NEMOCLAW_DASHBOARD_PORT` | OpenClaw web UI, forwarded from sandbox to host | Low |
+| Gateway | 8080 | `NEMOCLAW_GATEWAY_PORT` | OpenShell gateway signal channel | **High** — Jenkins, Tomcat, K8s dashboard |
+| vLLM/NIM | 8000 | `NEMOCLAW_VLLM_PORT` | Local vLLM or NIM inference endpoint | **High** — Django, PHP dev server |
+| Ollama | 11434 | `NEMOCLAW_OLLAMA_PORT` | Local Ollama inference endpoint | Low |
+
+To use non-default ports, set the environment variables before running `nemoclaw onboard`:
+
+```bash
+export NEMOCLAW_GATEWAY_PORT=9080
+export NEMOCLAW_VLLM_PORT=9000
+nemoclaw onboard
+```
+
+Or create a `.env` file at the project root (see `.env.example`). For personal overrides that should never be committed, use `.env.local` — it is loaded after `.env` and takes precedence.
+
+> **ℹ️ Note**
+>
+> Changing the dashboard port requires rebuilding the sandbox image because the CORS origin is baked in at build time. Re-run `nemoclaw onboard` after changing `NEMOCLAW_DASHBOARD_PORT`.
+
+> **⚠️ Network exposure**
+>
+> When using local inference (Ollama or vLLM), the inference service binds to `0.0.0.0` so that containers can reach it via `host.openshell.internal`. This means the service is reachable from your local network, not just localhost. This is required for the sandbox architecture but should be considered in shared or untrusted network environments.
+
+---
+
 ## How It Works
 
 NemoClaw installs the NVIDIA OpenShell runtime and Nemotron models, then uses a versioned blueprint to create a sandboxed environment where every network request, file access, and inference call is governed by declarative policy. The `nemoclaw` CLI orchestrates the full stack: OpenShell gateway, sandbox, inference provider, and network policy.

--- a/bin/lib/env.js
+++ b/bin/lib/env.js
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lightweight .env loader — reads .env files from the project root and populates
+// process.env. Existing environment variables are never overwritten, so shell
+// exports always take precedence over file values.
+//
+// Supports:
+//   - Multiple files (loaded in order; first file's values win over later files)
+//   - Comments (#) and blank lines
+//   - KEY=VALUE, KEY="VALUE", KEY='VALUE'
+//   - Inline comments after unquoted values
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const CWD = process.cwd();
+
+/**
+ * Walk up from a directory looking for a .git marker to find the repo root.
+ * @param {string} start - Directory to begin searching from.
+ * @returns {string|null} Absolute path to the git root, or null if not found.
+ */
+function findGitRoot(start) {
+  let dir = start;
+  while (true) {
+    try {
+      fs.statSync(path.join(dir, ".git"));
+      return dir;
+    } catch {
+      const parent = path.dirname(dir);
+      if (parent === dir) return null;
+      dir = parent;
+    }
+  }
+}
+
+const GIT_ROOT = findGitRoot(CWD);
+
+/**
+ * Parse a .env file and populate process.env with its values.
+ * Existing environment variables are never overwritten.
+ * @param {string} filePath - Absolute path to the .env file.
+ */
+function parseEnvFile(filePath) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return; // file doesn't exist or isn't readable — skip silently
+  }
+
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const eqIndex = line.indexOf("=");
+    if (eqIndex === -1) continue;
+
+    const key = line.slice(0, eqIndex).trim();
+    if (!key) continue;
+
+    let value = line.slice(eqIndex + 1).trim();
+
+    // Strip surrounding quotes first so that `#` inside quoted values is
+    // preserved (e.g. KEY="val#ue" or KEY="value" # comment).
+    if (
+      (value.startsWith('"') && value.includes('"', 1)) ||
+      (value.startsWith("'") && value.includes("'", 1))
+    ) {
+      const quote = value[0];
+      const closeIdx = value.indexOf(quote, 1);
+      value = value.slice(1, closeIdx);
+    } else {
+      // Unquoted value — strip inline comments
+      const hashIndex = value.indexOf(" #");
+      if (hashIndex !== -1) {
+        value = value.slice(0, hashIndex).trim();
+      }
+    }
+
+    // Never overwrite existing env vars
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+// Collect unique directories to search for .env files.  The git repo root and
+// CWD are checked in addition to the __dirname-relative ROOT so that a user's
+// .env.local (which is gitignored and therefore not synced into the sandbox
+// source directory) is still picked up on a fresh install.
+const SEARCH_DIRS = [...new Set([ROOT, GIT_ROOT, CWD].filter(Boolean))];
+
+// Load .env files in priority order — first file wins for any given key
+// because we never overwrite once set.
+const ENV_FILES = [".env.local", ".env"];
+
+for (const file of ENV_FILES) {
+  for (const dir of SEARCH_DIRS) {
+    parseEnvFile(path.join(dir, file));
+  }
+}
+
+module.exports = { parseEnvFile, findGitRoot };

--- a/bin/lib/local-inference.js
+++ b/bin/lib/local-inference.js
@@ -1,45 +1,50 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+const { VLLM_PORT, OLLAMA_PORT } = require("./ports");
 const { shellQuote } = require("./runner");
 
 const HOST_GATEWAY_URL = "http://host.openshell.internal";
 const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
 const DEFAULT_OLLAMA_MODEL = "nemotron-3-nano:30b";
 
+/** Return the base URL a sandbox uses to reach a local inference provider. */
 function getLocalProviderBaseUrl(provider) {
   switch (provider) {
     case "vllm-local":
-      return `${HOST_GATEWAY_URL}:8000/v1`;
+      return `${HOST_GATEWAY_URL}:${VLLM_PORT}/v1`;
     case "ollama-local":
-      return `${HOST_GATEWAY_URL}:11434/v1`;
+      return `${HOST_GATEWAY_URL}:${OLLAMA_PORT}/v1`;
     default:
       return null;
   }
 }
 
+/** Return a curl command to check if a local provider is responding on localhost. */
 function getLocalProviderHealthCheck(provider) {
   switch (provider) {
     case "vllm-local":
-      return "curl -sf http://localhost:8000/v1/models 2>/dev/null";
+      return `curl -sf http://localhost:${VLLM_PORT}/v1/models 2>/dev/null`;
     case "ollama-local":
-      return "curl -sf http://localhost:11434/api/tags 2>/dev/null";
+      return `curl -sf http://localhost:${OLLAMA_PORT}/api/tags 2>/dev/null`;
     default:
       return null;
   }
 }
 
+/** Return a docker curl command to verify a provider is reachable from containers. */
 function getLocalProviderContainerReachabilityCheck(provider) {
   switch (provider) {
     case "vllm-local":
-      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`;
+      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:${VLLM_PORT}/v1/models 2>/dev/null`;
     case "ollama-local":
-      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`;
+      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:${OLLAMA_PORT}/api/tags 2>/dev/null`;
     default:
       return null;
   }
 }
 
+/** Validate that a local provider is responding on both localhost and from containers. */
 function validateLocalProvider(provider, runCapture) {
   const command = getLocalProviderHealthCheck(provider);
   if (!command) {
@@ -52,12 +57,12 @@ function validateLocalProvider(provider, runCapture) {
       case "vllm-local":
         return {
           ok: false,
-          message: "Local vLLM was selected, but nothing is responding on http://localhost:8000.",
+          message: `Local vLLM was selected, but nothing is responding on http://localhost:${VLLM_PORT}.`,
         };
       case "ollama-local":
         return {
           ok: false,
-          message: "Local Ollama was selected, but nothing is responding on http://localhost:11434.",
+          message: `Local Ollama was selected, but nothing is responding on http://localhost:${OLLAMA_PORT}.`,
         };
       default:
         return { ok: false, message: "The selected local inference provider is unavailable." };
@@ -79,19 +84,20 @@ function validateLocalProvider(provider, runCapture) {
       return {
         ok: false,
         message:
-          "Local vLLM is responding on localhost, but containers cannot reach http://host.openshell.internal:8000. Ensure the server is reachable from containers, not only from the host shell.",
+          `Local vLLM is responding on localhost, but containers cannot reach http://host.openshell.internal:${VLLM_PORT}. Ensure the server is reachable from containers, not only from the host shell.`,
       };
     case "ollama-local":
       return {
         ok: false,
         message:
-          "Local Ollama is responding on localhost, but containers cannot reach http://host.openshell.internal:11434. Ensure Ollama listens on 0.0.0.0:11434 instead of 127.0.0.1 so sandboxes can reach it.",
+          `Local Ollama is responding on localhost, but containers cannot reach http://host.openshell.internal:${OLLAMA_PORT}. Ensure Ollama listens on 0.0.0.0:${OLLAMA_PORT} instead of 127.0.0.1 so sandboxes can reach it.`,
       };
     default:
       return { ok: false, message: "The selected local inference provider is unavailable from containers." };
   }
 }
 
+/** Parse `ollama list` output into an array of model name strings. */
 function parseOllamaList(output) {
   return String(output || "")
     .split(/\r?\n/)
@@ -102,6 +108,7 @@ function parseOllamaList(output) {
     .filter(Boolean);
 }
 
+/** Return available Ollama models, falling back to the default if none are listed. */
 function getOllamaModelOptions(runCapture) {
   const output = runCapture("ollama list 2>/dev/null", { ignoreError: true });
   const parsed = parseOllamaList(output);
@@ -111,11 +118,13 @@ function getOllamaModelOptions(runCapture) {
   return [DEFAULT_OLLAMA_MODEL];
 }
 
+/** Return the preferred Ollama model, or the first available one. */
 function getDefaultOllamaModel(runCapture) {
   const models = getOllamaModelOptions(runCapture);
   return models.includes(DEFAULT_OLLAMA_MODEL) ? DEFAULT_OLLAMA_MODEL : models[0];
 }
 
+/** Build a background curl command that warms up an Ollama model. */
 function getOllamaWarmupCommand(model, keepAlive = "15m") {
   const payload = JSON.stringify({
     model,
@@ -123,9 +132,10 @@ function getOllamaWarmupCommand(model, keepAlive = "15m") {
     stream: false,
     keep_alive: keepAlive,
   });
-  return `nohup curl -s http://localhost:11434/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} >/dev/null 2>&1 &`;
+  return `nohup curl -s http://localhost:${OLLAMA_PORT}/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} >/dev/null 2>&1 &`;
 }
 
+/** Build a foreground curl command that probes an Ollama model with a timeout. */
 function getOllamaProbeCommand(model, timeoutSeconds = 120, keepAlive = "15m") {
   const payload = JSON.stringify({
     model,
@@ -133,9 +143,10 @@ function getOllamaProbeCommand(model, timeoutSeconds = 120, keepAlive = "15m") {
     stream: false,
     keep_alive: keepAlive,
   });
-  return `curl -sS --max-time ${timeoutSeconds} http://localhost:11434/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} 2>/dev/null`;
+  return `curl -sS --max-time ${timeoutSeconds} http://localhost:${OLLAMA_PORT}/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} 2>/dev/null`;
 }
 
+/** Probe an Ollama model and return { ok, message } indicating whether it responded. */
 function validateOllamaModel(model, runCapture) {
   const output = runCapture(getOllamaProbeCommand(model), { ignoreError: true });
   if (!output) {

--- a/bin/lib/nim.js
+++ b/bin/lib/nim.js
@@ -4,17 +4,21 @@
 // NIM container management — pull, start, stop, health-check NIM images.
 
 const { run, runCapture, shellQuote } = require("./runner");
+const { VLLM_PORT } = require("./ports");
 const nimImages = require("./nim-images.json");
 
+/** Return the Docker container name for a NIM instance tied to a sandbox. */
 function containerName(sandboxName) {
   return `nemoclaw-nim-${sandboxName}`;
 }
 
+/** Look up the Docker image for a model name; returns null if unknown. */
 function getImageForModel(modelName) {
   const entry = nimImages.models.find((m) => m.name === modelName);
   return entry ? entry.image : null;
 }
 
+/** Return all available NIM models with their image and memory requirements. */
 function listModels() {
   return nimImages.models.map((m) => ({
     name: m.name,
@@ -23,6 +27,7 @@ function listModels() {
   }));
 }
 
+/** Detect GPU hardware and return type, count, and memory; null if none found. */
 function detectGpu() {
   // Try NVIDIA first — query VRAM
   try {
@@ -114,6 +119,7 @@ function detectGpu() {
   return null;
 }
 
+/** Pull the Docker image for the given NIM model. Exits on unknown model. */
 function pullNimImage(model) {
   const image = getImageForModel(model);
   if (!image) {
@@ -125,7 +131,8 @@ function pullNimImage(model) {
   return image;
 }
 
-function startNimContainer(sandboxName, model, port = 8000) {
+/** Start a NIM container for the given sandbox and model, mapped to the configured port. */
+function startNimContainer(sandboxName, model, port = VLLM_PORT) {
   const name = containerName(sandboxName);
   const image = getImageForModel(model);
   if (!image) {
@@ -139,12 +146,14 @@ function startNimContainer(sandboxName, model, port = 8000) {
 
   console.log(`  Starting NIM container: ${name}`);
   run(
+    // Right-hand :8000 is the NIM image's internal port — fixed by the image, not configurable.
     `docker run -d --gpus all -p ${Number(port)}:8000 --name ${qn} --shm-size 16g ${shellQuote(image)}`
   );
   return name;
 }
 
-function waitForNimHealth(port = 8000, timeout = 300) {
+/** Poll the NIM health endpoint until it responds or the timeout (seconds) elapses. */
+function waitForNimHealth(port = VLLM_PORT, timeout = 300) {
   const start = Date.now();
   const interval = 5000;
   const safePort = Number(port);
@@ -167,6 +176,7 @@ function waitForNimHealth(port = 8000, timeout = 300) {
   return false;
 }
 
+/** Stop and remove the NIM container for a sandbox. */
 function stopNimContainer(sandboxName) {
   const name = containerName(sandboxName);
   const qn = shellQuote(name);
@@ -175,8 +185,10 @@ function stopNimContainer(sandboxName) {
   run(`docker rm ${qn} 2>/dev/null || true`, { ignoreError: true });
 }
 
-function nimStatus(sandboxName) {
+/** Check NIM container state and health for a sandbox. */
+function nimStatus(sandboxName, port = VLLM_PORT) {
   const name = containerName(sandboxName);
+  const safePort = Number(port);
   try {
     const state = runCapture(
       `docker inspect --format '{{.State.Status}}' ${shellQuote(name)} 2>/dev/null`,
@@ -186,7 +198,7 @@ function nimStatus(sandboxName) {
 
     let healthy = false;
     if (state === "running") {
-      const health = runCapture(`curl -sf http://localhost:8000/v1/models 2>/dev/null`, {
+      const health = runCapture(`curl -sf http://localhost:${safePort}/v1/models 2>/dev/null`, {
         ignoreError: true,
       });
       healthy = !!health;

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -10,6 +10,7 @@ const os = require("os");
 const path = require("path");
 const { spawn, spawnSync } = require("child_process");
 const { ROOT, SCRIPTS, run, runCapture, shellQuote } = require("./runner");
+const { DASHBOARD_PORT, GATEWAY_PORT, VLLM_PORT, OLLAMA_PORT } = require("./ports");
 const {
   getDefaultOllamaModel,
   getLocalProviderBaseUrl,
@@ -325,6 +326,16 @@ function getNonInteractiveModel(providerKey) {
 async function preflight() {
   step(1, 7, "Preflight checks");
 
+  // Bootstrap .env from .env.example on first run so port defaults are
+  // discoverable and editable.  This doesn't affect the current process
+  // (ports.js is already loaded), but ensures .env exists for future runs.
+  const envFile = path.join(ROOT, ".env");
+  const envExample = path.join(ROOT, ".env.example");
+  if (!fs.existsSync(envFile) && fs.existsSync(envExample)) {
+    fs.copyFileSync(envExample, envFile);
+    console.log("  ✓ Created .env from .env.example");
+  }
+
   // Docker
   if (!isDockerRunning()) {
     console.error("  Docker is not running. Please start Docker and try again.");
@@ -361,17 +372,17 @@ async function preflight() {
   const gwInfo = runCapture("openshell gateway info -g nemoclaw 2>/dev/null", { ignoreError: true });
   if (hasStaleGateway(gwInfo)) {
     console.log("  Cleaning up previous NemoClaw session...");
-    run("openshell forward stop 18789 2>/dev/null || true", { ignoreError: true });
+    run(`openshell forward stop ${DASHBOARD_PORT} 2>/dev/null || true`, { ignoreError: true });
     run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });
     console.log("  ✓ Previous session cleaned up");
   }
 
-  // Required ports — gateway (8080) and dashboard (18789)
+  // Required ports — gateway and dashboard
   const requiredPorts = [
-    { port: 8080, label: "OpenShell gateway" },
-    { port: 18789, label: "NemoClaw dashboard" },
+    { port: GATEWAY_PORT, label: "OpenShell gateway", envVar: "NEMOCLAW_GATEWAY_PORT" },
+    { port: DASHBOARD_PORT, label: "NemoClaw dashboard", envVar: "NEMOCLAW_DASHBOARD_PORT" },
   ];
-  for (const { port, label } of requiredPorts) {
+  for (const { port, label, envVar } of requiredPorts) {
     const portCheck = await checkPortAvailable(port);
     if (!portCheck.ok) {
       console.error("");
@@ -381,7 +392,7 @@ async function preflight() {
       if (portCheck.process && portCheck.process !== "unknown") {
         console.error(`     Blocked by: ${portCheck.process}${portCheck.pid ? ` (PID ${portCheck.pid})` : ""}`);
         console.error("");
-        console.error("     To fix, stop the conflicting process:");
+        console.error("     To fix, either stop the conflicting process:");
         console.error("");
         if (portCheck.pid) {
           console.error(`       sudo kill ${portCheck.pid}`);
@@ -394,6 +405,9 @@ async function preflight() {
         console.error(`     Could not identify the process using port ${port}.`);
         console.error(`     Run: lsof -i :${port} -sTCP:LISTEN`);
       }
+      console.error("");
+      console.error(`     Or use a different port by adding to .env.local:`);
+      console.error(`       echo '${envVar}=<port>' >> .env.local`);
       console.error("");
       console.error(`     Detail: ${portCheck.reason}`);
       process.exit(1);
@@ -423,7 +437,7 @@ async function startGateway(gpu) {
   // Destroy old gateway
   run("openshell gateway destroy -g nemoclaw 2>/dev/null || true", { ignoreError: true });
 
-  const gwArgs = ["--name", "nemoclaw"];
+  const gwArgs = ["--name", "nemoclaw", "--port", String(GATEWAY_PORT)];
   // Do NOT pass --gpu here. On DGX Spark (and most GPU hosts), inference is
   // routed through a host-side provider (Ollama, vLLM, or cloud API) — the
   // sandbox itself does not need direct GPU access. Passing --gpu causes
@@ -524,16 +538,33 @@ async function createSandbox(gpu) {
   // Create sandbox (use -- echo to avoid dropping into interactive shell)
   // Pass the base policy so sandbox starts in proxy mode (required for policy updates later)
   const basePolicyPath = path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
+  const chatUiUrl = process.env.CHAT_UI_URL || `http://127.0.0.1:${DASHBOARD_PORT}`;
   const createArgs = [
     `--from "${buildCtx}/Dockerfile"`,
     `--name "${sandboxName}"`,
     `--policy "${basePolicyPath}"`,
   ];
+  // --build-arg is not supported by the openshell sandbox create CLI, so
+  // patch the Dockerfile copy to bake the configured dashboard URL into the
+  // ARG default. This ensures openclaw.json gets the correct CORS origin at
+  // build time when the user overrides DASHBOARD_PORT.
+  const dockerfilePath = path.join(buildCtx, "Dockerfile");
+  const dockerfileContent = fs.readFileSync(dockerfilePath, "utf-8");
+  fs.writeFileSync(
+    dockerfilePath,
+    dockerfileContent.replace(
+      /^ARG CHAT_UI_URL=.*/m,
+      `ARG CHAT_UI_URL=${chatUiUrl}`
+    )
+  );
   // --gpu is intentionally omitted. See comment in startGateway().
 
   console.log(`  Creating sandbox '${sandboxName}' (this takes a few minutes on first run)...`);
-  const chatUiUrl = process.env.CHAT_UI_URL || 'http://127.0.0.1:18789';
-  const envArgs = [`CHAT_UI_URL=${shellQuote(chatUiUrl)}`];
+  const envArgs = [
+    `CHAT_UI_URL=${shellQuote(chatUiUrl)}`,
+    `NEMOCLAW_DASHBOARD_PORT=${DASHBOARD_PORT}`,
+    `PUBLIC_PORT=${DASHBOARD_PORT}`,
+  ];
   if (process.env.NVIDIA_API_KEY) {
     envArgs.push(`NVIDIA_API_KEY=${shellQuote(process.env.NVIDIA_API_KEY)}`);
   }
@@ -600,12 +631,12 @@ async function createSandbox(gpu) {
     process.exit(1);
   }
 
-  // Release any stale forward on port 18789 before claiming it for the new sandbox.
+  // Release any stale forward on the dashboard port before claiming it for the new sandbox.
   // A previous onboard run may have left the port forwarded to a different sandbox,
   // which would silently prevent the new sandbox's dashboard from being reachable.
-  run(`openshell forward stop 18789 2>/dev/null || true`, { ignoreError: true });
+  run(`openshell forward stop ${DASHBOARD_PORT} 2>/dev/null || true`, { ignoreError: true });
   // Forward dashboard port to the new sandbox
-  run(`openshell forward start --background 18789 "${sandboxName}"`, { ignoreError: true });
+  run(`openshell forward start --background ${DASHBOARD_PORT} "${sandboxName}"`, { ignoreError: true });
 
   // Register only after confirmed ready — prevents phantom entries
   registry.registerSandbox({
@@ -628,8 +659,8 @@ async function setupNim(sandboxName, gpu) {
 
   // Detect local inference options
   const hasOllama = !!runCapture("command -v ollama", { ignoreError: true });
-  const ollamaRunning = !!runCapture("curl -sf http://localhost:11434/api/tags 2>/dev/null", { ignoreError: true });
-  const vllmRunning = !!runCapture("curl -sf http://localhost:8000/v1/models 2>/dev/null", { ignoreError: true });
+  const ollamaRunning = !!runCapture(`curl -sf http://localhost:${OLLAMA_PORT}/api/tags 2>/dev/null`, { ignoreError: true });
+  const vllmRunning = !!runCapture(`curl -sf http://localhost:${VLLM_PORT}/v1/models 2>/dev/null`, { ignoreError: true });
   const requestedProvider = isNonInteractive() ? getNonInteractiveProvider() : null;
   const requestedModel = isNonInteractive() ? getNonInteractiveModel(requestedProvider || "cloud") : null;
   // Build options list — only show local options with NEMOCLAW_EXPERIMENTAL=1
@@ -647,14 +678,14 @@ async function setupNim(sandboxName, gpu) {
     options.push({
       key: "ollama",
       label:
-        `Local Ollama (localhost:11434)${ollamaRunning ? " — running" : ""}` +
+        `Local Ollama (localhost:${OLLAMA_PORT})${ollamaRunning ? " — running" : ""}` +
         (ollamaRunning ? " (suggested)" : ""),
     });
   }
   if (EXPERIMENTAL && vllmRunning) {
     options.push({
       key: "vllm",
-      label: "Existing vLLM instance (localhost:8000) — running [experimental] (suggested)",
+      label: `Existing vLLM instance (localhost:${VLLM_PORT}) — running [experimental] (suggested)`,
     });
   }
 
@@ -745,33 +776,55 @@ async function setupNim(sandboxName, gpu) {
         }
       }
     } else if (selected.key === "ollama") {
-      if (!ollamaRunning) {
+      let ready = ollamaRunning;
+      if (!ready) {
         console.log("  Starting Ollama...");
-        run("OLLAMA_HOST=0.0.0.0:11434 ollama serve > /dev/null 2>&1 &", { ignoreError: true });
-        sleep(2);
+        run(`OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
+        for (let i = 0; i < 10; i++) {
+          sleep(1);
+          if (runCapture(`curl -sf http://localhost:${OLLAMA_PORT}/api/tags 2>/dev/null`, { ignoreError: true })) {
+            ready = true;
+            break;
+          }
+        }
       }
-      console.log("  ✓ Using Ollama on localhost:11434");
-      provider = "ollama-local";
-      if (isNonInteractive()) {
-        model = requestedModel || getDefaultOllamaModel(runCapture);
+      if (ready) {
+        console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT}`);
+        provider = "ollama-local";
+        if (isNonInteractive()) {
+          model = requestedModel || getDefaultOllamaModel(runCapture);
+        } else {
+          model = await promptOllamaModel();
+        }
       } else {
-        model = await promptOllamaModel();
+        console.error(`  Ollama did not become ready on port ${OLLAMA_PORT}. Falling back to cloud API.`);
       }
     } else if (selected.key === "install-ollama") {
       console.log("  Installing Ollama via Homebrew...");
       run("brew install ollama", { ignoreError: true });
       console.log("  Starting Ollama...");
-      run("OLLAMA_HOST=0.0.0.0:11434 ollama serve > /dev/null 2>&1 &", { ignoreError: true });
-        sleep(2);
-      console.log("  ✓ Using Ollama on localhost:11434");
-      provider = "ollama-local";
-      if (isNonInteractive()) {
-        model = requestedModel || getDefaultOllamaModel(runCapture);
+      run(`OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
+      let ready = false;
+      for (let i = 0; i < 10; i++) {
+        sleep(1);
+        if (runCapture(`curl -sf http://localhost:${OLLAMA_PORT}/api/tags 2>/dev/null`, { ignoreError: true })) {
+          ready = true;
+          break;
+        }
+      }
+      if (ready) {
+        console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT}`);
+        provider = "ollama-local";
+        if (isNonInteractive()) {
+          model = requestedModel || getDefaultOllamaModel(runCapture);
+        } else {
+          model = await promptOllamaModel();
+        }
       } else {
-        model = await promptOllamaModel();
+        console.error(`  Ollama did not become ready on port ${OLLAMA_PORT}. Falling back to cloud API.`);
       }
     } else if (selected.key === "vllm") {
-      console.log("  ✓ Using existing vLLM on localhost:8000");
+      console.log(`  ✓ Using existing vLLM on localhost:${VLLM_PORT}`);
       provider = "vllm-local";
       model = "vllm-local";
     }
@@ -792,6 +845,23 @@ async function setupNim(sandboxName, gpu) {
     }
     model = model || requestedModel || DEFAULT_CLOUD_MODEL;
     console.log(`  Using NVIDIA Endpoint API with model: ${model}`);
+  }
+
+  // Warn (don't block) if the selected inference port is occupied by another process.
+  // Only check for vllm-local when we did NOT start NIM ourselves (nimContainer is
+  // set when we launched a NIM container).  For ollama-local we always start or
+  // adopt the service, so the port being in use is expected — skip the warning.
+  if (provider === "vllm-local" && !nimContainer) {
+    const vllmCheck = await checkPortAvailable(VLLM_PORT);
+    if (!vllmCheck.ok) {
+      const who = vllmCheck.process !== "unknown"
+        ? ` by ${vllmCheck.process}${vllmCheck.pid ? ` (PID ${vllmCheck.pid})` : ""}`
+        : "";
+      console.log("");
+      console.log(`  ⚠  Port ${VLLM_PORT} is in use${who}.`);
+      console.log(`     vLLM/NIM inference needs this port. If this is your inference server, you're fine.`);
+      console.log(`     Otherwise, stop the conflicting process or set NEMOCLAW_VLLM_PORT to a different port.`);
+    }
   }
 
   registry.updateSandbox(sandboxName, { model, provider, nimContainer });

--- a/bin/lib/ports.js
+++ b/bin/lib/ports.js
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Central port configuration — single source of truth for all configurable ports.
+// Override via environment variables or a .env file at the project root.
+
+/**
+ * Read a port number from an environment variable with validation.
+ * @param {string} envVar - Environment variable name to read.
+ * @param {number} fallback - Default port when the variable is unset.
+ * @returns {number} Validated port number between 1024 and 65535.
+ * @throws {Error} If the value is not a valid port in the allowed range.
+ */
+function parsePort(envVar, fallback) {
+  const raw = process.env[envVar];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed < 1024 || parsed > 65535) {
+    throw new Error(
+      `Invalid port: ${envVar}="${raw}" — must be an integer between 1024 and 65535`
+    );
+  }
+  return parsed;
+}
+
+// Dashboard port supports legacy env var fallback chain:
+//   NEMOCLAW_DASHBOARD_PORT → DASHBOARD_PORT → PUBLIC_PORT → 18789
+const DASHBOARD_PORT = parsePort(
+  "NEMOCLAW_DASHBOARD_PORT",
+  parsePort("DASHBOARD_PORT", parsePort("PUBLIC_PORT", 18789))
+);
+
+module.exports = {
+  DASHBOARD_PORT,
+  GATEWAY_PORT: parsePort("NEMOCLAW_GATEWAY_PORT", 8080),
+  VLLM_PORT: parsePort("NEMOCLAW_VLLM_PORT", 8000),
+  OLLAMA_PORT: parsePort("NEMOCLAW_OLLAMA_PORT", 11434),
+};

--- a/bin/lib/preflight.js
+++ b/bin/lib/preflight.js
@@ -5,6 +5,7 @@
 
 const net = require("net");
 const { runCapture } = require("./runner");
+const { DASHBOARD_PORT } = require("./ports");
 
 /**
  * Check whether a TCP port is available for listening.
@@ -21,7 +22,7 @@ const { runCapture } = require("./runner");
  *   { ok: false, process: string, pid: number|null, reason: string }
  */
 async function checkPortAvailable(port, opts) {
-  const p = port || 18789;
+  const p = port || DASHBOARD_PORT;
   const o = opts || {};
 
   // ── lsof path ──────────────────────────────────────────────────

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -7,6 +7,9 @@ const path = require("path");
 const fs = require("fs");
 const os = require("os");
 
+// Load .env files before any module reads process.env (e.g. ports.js)
+require("./lib/env");
+
 // ---------------------------------------------------------------------------
 // Color / style — respects NO_COLOR and non-TTY environments.
 // Uses exact NVIDIA green #76B900 on truecolor terminals; 256-color otherwise.
@@ -30,6 +33,7 @@ const {
 const registry = require("./lib/registry");
 const nim = require("./lib/nim");
 const policies = require("./lib/policies");
+const { DASHBOARD_PORT } = require("./lib/ports");
 
 // ── Global commands ──────────────────────────────────────────────
 
@@ -299,7 +303,7 @@ function listSandboxes() {
 function sandboxConnect(sandboxName) {
   const qn = shellQuote(sandboxName);
   // Ensure port forward is alive before connecting
-  run(`openshell forward start --background 18789 ${qn} 2>/dev/null || true`, { ignoreError: true });
+  run(`openshell forward start --background ${DASHBOARD_PORT} ${qn} 2>/dev/null || true`, { ignoreError: true });
   runInteractive(`openshell sandbox connect ${qn}`);
 }
 

--- a/docs/reference/port-configuration.md
+++ b/docs/reference/port-configuration.md
@@ -1,0 +1,118 @@
+---
+title:
+  page: "NemoClaw Port Configuration"
+  nav: "Port Configuration"
+description: "Configure NemoClaw network ports using environment variables or a .env file."
+keywords: ["nemoclaw ports", "nemoclaw port configuration", "nemoclaw port conflict"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "configuration", "nemoclaw"]
+content:
+  type: reference
+  difficulty: technical_beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# NemoClaw Port Configuration
+
+NemoClaw uses four network ports.
+All ports are configurable through environment variables or a `.env` file at the project root.
+
+## Default Ports
+
+| Port | Default | Environment variable | Purpose |
+|------|---------|----------------------|---------|
+| Dashboard | 18789 | `NEMOCLAW_DASHBOARD_PORT` | OpenClaw web UI, forwarded from sandbox to host |
+| Gateway | 8080 | `NEMOCLAW_GATEWAY_PORT` | OpenShell gateway API |
+| vLLM/NIM | 8000 | `NEMOCLAW_VLLM_PORT` | Local vLLM or NIM inference server |
+| Ollama | 11434 | `NEMOCLAW_OLLAMA_PORT` | Local Ollama inference server |
+
+## Configure Ports with a .env File
+
+Copy the example file and edit it to set your preferred ports.
+
+```console
+$ cp .env.example .env
+```
+
+The `.env.example` file contains all four port variables with their defaults:
+
+```bash
+NEMOCLAW_DASHBOARD_PORT=18789
+NEMOCLAW_GATEWAY_PORT=8080
+NEMOCLAW_VLLM_PORT=8000
+NEMOCLAW_OLLAMA_PORT=11434
+```
+
+Edit `.env` to change any port.
+Ports must be integers in the range 1024 to 65535.
+The `.env` file is gitignored and not committed to the repository.
+
+## Configure Ports with Environment Variables
+
+Export the variables directly in your shell instead of using a `.env` file.
+
+```console
+$ export NEMOCLAW_DASHBOARD_PORT=28789
+$ export NEMOCLAW_VLLM_PORT=9000
+$ nemoclaw onboard
+```
+
+Shell exports take precedence over `.env` file values.
+
+## Dashboard Port Fallback Chain
+
+The dashboard port checks multiple variables for backward compatibility.
+The first defined value wins:
+
+1. `NEMOCLAW_DASHBOARD_PORT`
+2. `DASHBOARD_PORT`
+3. `PUBLIC_PORT`
+4. `18789` (default)
+
+## Check for Port Conflicts
+
+Run the port checker script before onboarding to detect conflicts.
+
+```console
+$ scripts/check-ports.sh
+```
+
+The script reads your `.env` and `.env.local` files (if present) to resolve the configured ports, then checks each one.
+If a port is in use, the output shows the process name and PID holding it.
+
+```text
+Checking NemoClaw ports...
+
+  ok        18789 (dashboard)
+  CONFLICT  8080 (gateway) — in use by nginx (PID 1234)
+  ok        8000 (vllm/nim)
+  ok        11434 (ollama)
+
+1 port conflict(s) found.
+Set NEMOCLAW_*_PORT env vars or edit .env to use different ports.
+```
+
+You can also pass custom ports as arguments to check additional ports.
+
+```console
+$ scripts/check-ports.sh 9000 9080
+```
+
+The onboarding preflight also checks for port conflicts automatically.
+
+:::{note}
+Ports 8080 and 8000 are common conflict sources.
+Port 8080 is used by many web servers and proxies.
+Port 8000 is used by development servers and other inference tools.
+:::
+
+## Next Steps
+
+- [Troubleshooting](troubleshooting.md) for resolving port and onboarding issues.
+- [CLI Commands](commands.md) for the full command reference.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -90,17 +90,29 @@ Add the `export` line to your `~/.bashrc` or `~/.zshrc` to make it permanent, th
 
 ### Port already in use
 
-The NemoClaw gateway uses port `18789` by default.
-If another process is already bound to this port, onboarding fails.
-Identify the conflicting process, verify it is safe to stop, and terminate it:
+NemoClaw uses four ports (see the [Port Configuration](../../README.md#port-configuration) section in the README).
+If another process is bound to one of these ports, you see an error identifying the conflicting process during onboarding.
+
+To resolve, either stop the conflicting process:
 
 ```console
-$ lsof -i :18789
+$ lsof -i :8080
 $ kill <PID>
 ```
 
-If the process does not exit, use `kill -9 <PID>` to force-terminate it.
-Then retry onboarding.
+Or use a different port by setting the corresponding environment variable before onboarding:
+
+```console
+$ export NEMOCLAW_GATEWAY_PORT=9080
+$ nemoclaw onboard
+```
+
+| Default port | Env var | Common conflicts |
+|-------------|---------|-----------------|
+| 8080 | `NEMOCLAW_GATEWAY_PORT` | Jenkins, Tomcat, K8s dashboard |
+| 8000 | `NEMOCLAW_VLLM_PORT` | Django, PHP dev server |
+| 18789 | `NEMOCLAW_DASHBOARD_PORT` | Uncommon |
+| 11434 | `NEMOCLAW_OLLAMA_PORT` | Uncommon |
 
 ## Onboarding
 

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -20,7 +20,7 @@ components:
   sandbox:
     image: "ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest"
     name: "openclaw"
-    forward_ports:
+    forward_ports:  # Override at runtime via NEMOCLAW_DASHBOARD_PORT
       - 18789
 
   inference:
@@ -42,14 +42,14 @@ components:
       nim-local:
         provider_type: "openai"
         provider_name: "nim-local"
-        endpoint: "http://nim-service.local:8000/v1"
+        endpoint: "http://nim-service.local:8000/v1"  # Port overridden by NEMOCLAW_VLLM_PORT via runner.py
         model: "nvidia/nemotron-3-super-120b-a12b"
         credential_env: "NIM_API_KEY"
 
       vllm:
         provider_type: "openai"
         provider_name: "vllm-local"
-        endpoint: "http://localhost:8000/v1"
+        endpoint: "http://localhost:8000/v1"  # Port overridden by NEMOCLAW_VLLM_PORT via runner.py
         model: "nvidia/nemotron-3-nano-30b-a3b"
         credential_env: "OPENAI_API_KEY"
         credential_default: "dummy"
@@ -61,5 +61,5 @@ components:
         name: nim_service
         endpoints:
           - host: "nim-service.local"
-            port: 8000
+            port: 8000  # Overridden by NEMOCLAW_VLLM_PORT via runner.py
             protocol: rest

--- a/nemoclaw-blueprint/orchestrator/runner.py
+++ b/nemoclaw-blueprint/orchestrator/runner.py
@@ -17,6 +17,7 @@ Protocol:
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -29,27 +30,84 @@ import yaml
 
 
 def log(msg: str) -> None:
+    """Print a message to stdout with immediate flush."""
     print(msg, flush=True)
 
 
 def progress(pct: int, label: str) -> None:
+    """Emit a PROGRESS:<pct>:<label> line for the TS plugin to parse."""
     print(f"PROGRESS:{pct}:{label}", flush=True)
 
 
 def emit_run_id() -> str:
+    """Generate a unique run ID and print it as a RUN_ID:<id> line."""
     rid = f"nc-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}"
     print(f"RUN_ID:{rid}", flush=True)
     return rid
 
 
 def load_blueprint() -> dict[str, Any]:
+    """Load blueprint.yaml from NEMOCLAW_BLUEPRINT_PATH and apply port overrides."""
     blueprint_path = Path(os.environ.get("NEMOCLAW_BLUEPRINT_PATH", "."))
     bp_file = blueprint_path / "blueprint.yaml"
     if not bp_file.exists():
         log(f"ERROR: blueprint.yaml not found at {bp_file}")
         sys.exit(1)
     with bp_file.open() as f:
-        return yaml.safe_load(f)
+        bp = yaml.safe_load(f)
+    _apply_port_overrides(bp)
+    return bp
+
+
+def _parse_port_env(env_var: str) -> int | None:
+    """Read and validate a port from an environment variable.
+
+    Returns the port as an int, or None if the variable is unset/empty.
+    Exits with a clear error for invalid values (matching ports.js behavior).
+    """
+    raw = os.environ.get(env_var, "")
+    if not raw:
+        return None
+    try:
+        port = int(raw)
+    except ValueError:
+        log(f'ERROR: {env_var}="{raw}" is not a valid port number')
+        sys.exit(1)
+    if port < 1024 or port > 65535:
+        log(f"ERROR: {env_var}={port} — must be between 1024 and 65535")
+        sys.exit(1)
+    return port
+
+
+def _apply_port_overrides(bp: dict[str, Any]) -> None:
+    """Override hardcoded ports from NEMOCLAW_*_PORT env vars.
+
+    Keeps blueprint.yaml as a readable reference of defaults while allowing
+    runtime configuration without editing YAML.
+    """
+    components = bp.setdefault("components", {})
+
+    # Dashboard / forward port
+    dashboard_port = _parse_port_env("NEMOCLAW_DASHBOARD_PORT")
+    if dashboard_port:
+        sandbox = components.setdefault("sandbox", {})
+        sandbox["forward_ports"] = [dashboard_port]
+
+    # vLLM / NIM inference port
+    vllm_port = _parse_port_env("NEMOCLAW_VLLM_PORT")
+    if vllm_port:
+        profiles = components.get("inference", {}).get("profiles", {})
+        for key in ("nim-local", "vllm"):
+            if key in profiles:
+                old_endpoint = profiles[key].get("endpoint", "")
+                # Replace the port in endpoint URL (matches any numeric port)
+                profiles[key]["endpoint"] = re.sub(r":\d+(/|$)", f":{vllm_port}\\1", old_endpoint)
+
+        # Policy addition: nim_service port
+        additions = components.get("policy", {}).get("additions", {})
+        nim_svc = additions.get("nim_service", {})
+        for ep in nim_svc.get("endpoints", []):
+            ep["port"] = vllm_port
 
 
 def run_cmd(
@@ -310,6 +368,7 @@ def action_rollback(rid: str) -> None:
 
 
 def main() -> None:
+    """Parse CLI arguments and dispatch to the requested action."""
     parser = argparse.ArgumentParser(description="NemoClaw Blueprint Runner")
     parser.add_argument("action", choices=["plan", "apply", "status", "rollback"])
     parser.add_argument("--profile", default="default")

--- a/package-lock.json
+++ b/package-lock.json
@@ -891,14 +891,6 @@
         "scripts/actions/documentation"
       ]
     },
-    "node_modules/@buape/carbon/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@buape/carbon/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
@@ -1290,14 +1282,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/voice/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",

--- a/scripts/brev-setup.sh
+++ b/scripts/brev-setup.sh
@@ -27,6 +27,12 @@ fail() { echo -e "${RED}[brev]${NC} $1"; exit 1; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Load port overrides if present
+# shellcheck source=/dev/null
+[ -f "${SCRIPT_DIR}/../.env" ] && set -a && . "${SCRIPT_DIR}/../.env" && set +a
+# shellcheck source=/dev/null
+[ -f "${SCRIPT_DIR}/../.env.local" ] && set -a && . "${SCRIPT_DIR}/../.env.local" && set +a
+
 [ -n "${NVIDIA_API_KEY:-}" ] || fail "NVIDIA_API_KEY not set"
 
 # Suppress needrestart noise from apt (Scanning processes, No services need...)
@@ -129,19 +135,20 @@ if command -v nvidia-smi > /dev/null 2>&1; then
   fi
 
   # Start vLLM if not already running
-  if curl -s http://localhost:8000/v1/models > /dev/null 2>&1; then
-    info "vLLM already running on :8000"
+  VLLM_PORT="${NEMOCLAW_VLLM_PORT:-8000}"
+  if curl -s "http://localhost:${VLLM_PORT}/v1/models" > /dev/null 2>&1; then
+    info "vLLM already running on :${VLLM_PORT}"
   elif python3 -c "import vllm" 2>/dev/null; then
     info "Starting vLLM with $VLLM_MODEL..."
     nohup python3 -m vllm.entrypoints.openai.api_server \
       --model "$VLLM_MODEL" \
-      --port 8000 \
+      --port "$VLLM_PORT" \
       --host 0.0.0.0 \
       > /tmp/vllm-server.log 2>&1 &
     VLLM_PID=$!
     info "Waiting for vLLM to load model (this can take a few minutes)..."
-    for i in $(seq 1 120); do
-      if curl -s http://localhost:8000/v1/models > /dev/null 2>&1; then
+    for _i in $(seq 1 120); do
+      if curl -s "http://localhost:${VLLM_PORT}/v1/models" > /dev/null 2>&1; then
         info "vLLM ready (PID $VLLM_PID)"
         break
       fi

--- a/scripts/check-ports.sh
+++ b/scripts/check-ports.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# check-ports.sh — Check whether NemoClaw ports are available.
+#
+# Reads configured ports from .env (if present), falls back to defaults.
+# Pass custom ports as arguments to check additional ports.
+#
+# Usage:
+#   scripts/check-ports.sh            # check configured/default ports
+#   scripts/check-ports.sh 9000 9080  # check custom ports
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Load .env ────────────────────────────────────────────────────────
+load_env() {
+  local env_file="$1"
+  [[ -f "$env_file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Trim leading/trailing whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    # Skip blank lines and full-line comments
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    [[ "$line" == *=* ]] || continue
+    local key="${line%%=*}"
+    local val="${line#*=}"
+    # Handle quoted values (preserve # inside quotes), then strip inline comments on unquoted
+    if [[ "$val" == \"*\"* ]]; then
+      val="${val#\"}" ; val="${val%%\"*}"
+    elif [[ "$val" == \'*\'* ]]; then
+      val="${val#\'}" ; val="${val%%\'*}"
+    else
+      val="${val%%[[:space:]]\#*}"
+    fi
+    # Only set if not already in environment
+    if [[ -z "${!key+x}" ]]; then
+      export "$key=$val"
+    fi
+  done < "$env_file"
+}
+
+load_env "$PROJECT_ROOT/.env.local"
+load_env "$PROJECT_ROOT/.env"
+
+# ── Resolve ports ────────────────────────────────────────────────────
+DASHBOARD_PORT="${NEMOCLAW_DASHBOARD_PORT:-${DASHBOARD_PORT:-${PUBLIC_PORT:-18789}}}"
+GATEWAY_PORT="${NEMOCLAW_GATEWAY_PORT:-8080}"
+VLLM_PORT="${NEMOCLAW_VLLM_PORT:-8000}"
+OLLAMA_PORT="${NEMOCLAW_OLLAMA_PORT:-11434}"
+
+# ── Validate ports ──────────────────────────────────────────────────
+validate_port() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "Error: $name is not a valid integer: '$value'" >&2
+    exit 1
+  fi
+  if (( value < 1024 || value > 65535 )); then
+    echo "Error: $name=$value is out of range (must be 1024–65535)" >&2
+    exit 1
+  fi
+}
+
+validate_port "DASHBOARD_PORT" "$DASHBOARD_PORT"
+validate_port "GATEWAY_PORT" "$GATEWAY_PORT"
+validate_port "VLLM_PORT" "$VLLM_PORT"
+validate_port "OLLAMA_PORT" "$OLLAMA_PORT"
+
+# ── Ensure lsof is available ────────────────────────────────────────
+if ! command -v lsof >/dev/null 2>&1; then
+  echo "Error: lsof is required but not found in PATH" >&2
+  exit 1
+fi
+
+# ── Check a single port ─────────────────────────────────────────────
+conflicts=0
+
+check_port() {
+  local port="$1"
+  local label="${2:-}"
+  local prefix="$port"
+  [[ -n "$label" ]] && prefix="$port ($label)"
+
+  if lsof -iTCP:"$port" -sTCP:LISTEN -nP >/dev/null 2>&1; then
+    local proc
+    proc="$(lsof -iTCP:"$port" -sTCP:LISTEN -nP 2>/dev/null | awk 'NR==2 {print $1 " (PID " $2 ")"}')"
+    echo "  CONFLICT  $prefix — in use by $proc"
+    conflicts=$((conflicts + 1))
+    return 1
+  else
+    echo "  ok        $prefix"
+    return 0
+  fi
+}
+
+# ── Run checks ───────────────────────────────────────────────────────
+echo "Checking NemoClaw ports..."
+echo ""
+
+check_port "$DASHBOARD_PORT" "dashboard" || true
+check_port "$GATEWAY_PORT" "gateway" || true
+check_port "$VLLM_PORT" "vllm/nim" || true
+check_port "$OLLAMA_PORT" "ollama" || true
+
+if [[ $# -gt 0 ]]; then
+  echo ""
+  echo "Custom ports:"
+  for p in "$@"; do
+    check_port "$p" || true
+  done
+fi
+
+echo ""
+if [[ $conflicts -gt 0 ]]; then
+  echo "$conflicts port conflict(s) found."
+  echo "Set NEMOCLAW_*_PORT env vars or edit .env to use different ports."
+  exit 1
+else
+  echo "All ports available."
+fi

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -26,6 +26,12 @@ RED='\033[0;31m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+[ -f "${SCRIPT_DIR}/../.env" ] && set -a && . "${SCRIPT_DIR}/../.env" && set +a
+# shellcheck source=/dev/null
+[ -f "${SCRIPT_DIR}/../.env.local" ] && set -a && . "${SCRIPT_DIR}/../.env.local" && set +a
+
 info()    { echo -e "${GREEN}[debug]${NC} $1"; }
 warn()    { echo -e "${YELLOW}[debug]${NC} $1"; }
 fail()    { echo -e "${RED}[debug]${NC} $1"; exit 1; }
@@ -285,7 +291,7 @@ if [ "$QUICK" = false ]; then
   # shellcheck disable=SC2016
   collect "curl-models" sh -c 'code=$(curl -s -o /dev/null -w "%{http_code}" https://integrate.api.nvidia.com/v1/models); echo "HTTP $code"; if [ "$code" -ge 200 ] && [ "$code" -lt 500 ]; then echo "NIM API reachable"; else echo "NIM API unreachable"; exit 1; fi'
   collect "lsof-net" sh -c 'lsof -i -P -n 2>/dev/null | head -50'
-  collect "lsof-18789" lsof -i :18789
+  collect "lsof-dashboard" lsof -i :"${NEMOCLAW_DASHBOARD_PORT:-18789}"
 fi
 
 # -- Kernel / IO (full mode only) --

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -206,8 +206,8 @@ get_local_provider_base_url() {
   local provider="${1:-}"
 
   case "$provider" in
-    vllm-local) printf 'http://host.openshell.internal:8000/v1\n' ;;
-    ollama-local) printf 'http://host.openshell.internal:11434/v1\n' ;;
+    vllm-local) printf 'http://host.openshell.internal:%s/v1\n' "${NEMOCLAW_VLLM_PORT:-8000}" ;;
+    ollama-local) printf 'http://host.openshell.internal:%s/v1\n' "${NEMOCLAW_OLLAMA_PORT:-11434}" ;;
     *) return 1 ;;
   esac
 }
@@ -217,10 +217,10 @@ check_local_provider_health() {
 
   case "$provider" in
     vllm-local)
-      curl -sf http://localhost:8000/v1/models > /dev/null 2>&1
+      curl -sf "http://localhost:${NEMOCLAW_VLLM_PORT:-8000}/v1/models" > /dev/null 2>&1
       ;;
     ollama-local)
-      curl -sf http://localhost:11434/api/tags > /dev/null 2>&1
+      curl -sf "http://localhost:${NEMOCLAW_OLLAMA_PORT:-11434}/api/tags" > /dev/null 2>&1
       ;;
     *)
       return 1

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -11,9 +11,15 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+[ -f "${SCRIPT_DIR}/../.env" ] && set -a && . "${SCRIPT_DIR}/../.env" && set +a
+# shellcheck source=/dev/null
+[ -f "${SCRIPT_DIR}/../.env.local" ] && set -a && . "${SCRIPT_DIR}/../.env.local" && set +a
+
 NEMOCLAW_CMD=("$@")
-CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:18789}"
-PUBLIC_PORT=18789
+PUBLIC_PORT="${NEMOCLAW_DASHBOARD_PORT:-${PUBLIC_PORT:-18789}}"
+CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:${PUBLIC_PORT}}"
 
 write_auth_profile() {
   if [ -z "${NVIDIA_API_KEY:-}" ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,6 +31,11 @@ NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load port overrides if present (.env.local takes precedence)
+[ -f "${REPO_DIR}/.env" ] && set -a && . "${REPO_DIR}/.env" && set +a
+[ -f "${REPO_DIR}/.env.local" ] && set -a && . "${REPO_DIR}/.env.local" && set +a
+
 # shellcheck source=./lib/runtime.sh
 . "$SCRIPT_DIR/lib/runtime.sh"
 
@@ -106,7 +111,7 @@ fi
 # 1. Gateway — always start fresh to avoid stale state
 info "Starting OpenShell gateway..."
 openshell gateway destroy -g nemoclaw > /dev/null 2>&1 || true
-GATEWAY_ARGS=(--name nemoclaw)
+GATEWAY_ARGS=(--name nemoclaw --port "${NEMOCLAW_GATEWAY_PORT:-8080}")
 command -v nvidia-smi > /dev/null 2>&1 && GATEWAY_ARGS+=(--gpu)
 openshell gateway start "${GATEWAY_ARGS[@]}" 2>&1 | grep -E "Gateway|✓|Error|error" || true
 
@@ -156,7 +161,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
     # Start Ollama service if not running
     if ! check_local_provider_health "ollama-local"; then
       info "Starting Ollama service..."
-      OLLAMA_HOST=0.0.0.0:11434 ollama serve > /dev/null 2>&1 &
+      OLLAMA_HOST="0.0.0.0:${NEMOCLAW_OLLAMA_PORT:-11434}" ollama serve > /dev/null 2>&1 &
       sleep 2
     fi
     OLLAMA_LOCAL_BASE_URL="$(get_local_provider_base_url "ollama-local")"

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -16,7 +16,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-DASHBOARD_PORT="${DASHBOARD_PORT:-18789}"
+
+# Load port overrides if present (.env.local takes precedence)
+[ -f "${REPO_DIR}/.env" ] && set -a && . "${REPO_DIR}/.env" && set +a
+[ -f "${REPO_DIR}/.env.local" ] && set -a && . "${REPO_DIR}/.env.local" && set +a
+
+DASHBOARD_PORT="${NEMOCLAW_DASHBOARD_PORT:-${DASHBOARD_PORT:-18789}}"
 
 # ── Parse flags ──────────────────────────────────────────────────
 SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}"

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -18,7 +18,6 @@
 
 const https = require("https");
 const { execFileSync, spawn } = require("child_process");
-const crypto = require("crypto");
 const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
 const { shellQuote, validateName } = require("../bin/lib/runner");
 

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Double onboard: verify that consecutive `nemoclaw onboard` runs recover
 # automatically from stale state (gateway, port forward, registry entries)
 # left behind by a previous run.
@@ -51,7 +54,7 @@ if command -v nemoclaw > /dev/null 2>&1; then
 fi
 openshell sandbox delete "$SANDBOX_A" 2>/dev/null || true
 openshell sandbox delete "$SANDBOX_B" 2>/dev/null || true
-openshell forward stop 18789 2>/dev/null || true
+openshell forward stop "${NEMOCLAW_DASHBOARD_PORT:-18789}" 2>/dev/null || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 pass "Pre-cleanup complete"
 
@@ -156,13 +159,13 @@ echo "$output2" | grep -q "Cleaning up previous NemoClaw session" \
   && pass "Stale session cleanup fired on second onboard" \
   || fail "Stale session cleanup did NOT fire (regression: #397)"
 
-echo "$output2" | grep -q "Port 8080 is not available" \
-  && fail "Port 8080 conflict detected (regression: #21)" \
-  || pass "No port 8080 conflict"
+echo "$output2" | grep -q "Port ${NEMOCLAW_GATEWAY_PORT:-8080} is not available" \
+  && fail "Port ${NEMOCLAW_GATEWAY_PORT:-8080} conflict detected (regression: #21)" \
+  || pass "No port ${NEMOCLAW_GATEWAY_PORT:-8080} conflict"
 
-echo "$output2" | grep -q "Port 18789 is not available" \
-  && fail "Port 18789 conflict detected" \
-  || pass "No port 18789 conflict"
+echo "$output2" | grep -q "Port ${NEMOCLAW_DASHBOARD_PORT:-18789} is not available" \
+  && fail "Port ${NEMOCLAW_DASHBOARD_PORT:-18789} conflict detected" \
+  || pass "No port ${NEMOCLAW_DASHBOARD_PORT:-18789} conflict"
 
 echo "$output2" | grep -q "Sandbox '${SANDBOX_A}' created" \
   && pass "Sandbox '$SANDBOX_A' recreated" \
@@ -197,13 +200,13 @@ echo "$output3" | grep -q "Cleaning up previous NemoClaw session" \
   && pass "Stale session cleanup fired on third onboard" \
   || fail "Stale session cleanup did NOT fire on third onboard"
 
-echo "$output3" | grep -q "Port 8080 is not available" \
-  && fail "Port 8080 conflict on third onboard (regression)" \
-  || pass "No port 8080 conflict on third onboard"
+echo "$output3" | grep -q "Port ${NEMOCLAW_GATEWAY_PORT:-8080} is not available" \
+  && fail "Port ${NEMOCLAW_GATEWAY_PORT:-8080} conflict on third onboard (regression)" \
+  || pass "No port ${NEMOCLAW_GATEWAY_PORT:-8080} conflict on third onboard"
 
-echo "$output3" | grep -q "Port 18789 is not available" \
-  && fail "Port 18789 conflict on third onboard" \
-  || pass "No port 18789 conflict on third onboard"
+echo "$output3" | grep -q "Port ${NEMOCLAW_DASHBOARD_PORT:-18789} is not available" \
+  && fail "Port ${NEMOCLAW_DASHBOARD_PORT:-18789} conflict on third onboard" \
+  || pass "No port ${NEMOCLAW_DASHBOARD_PORT:-18789} conflict on third onboard"
 
 echo "$output3" | grep -q "Sandbox '${SANDBOX_B}' created" \
   && pass "Sandbox '$SANDBOX_B' created" \
@@ -218,7 +221,7 @@ nemoclaw "$SANDBOX_A" destroy 2>/dev/null || true
 nemoclaw "$SANDBOX_B" destroy 2>/dev/null || true
 openshell sandbox delete "$SANDBOX_A" 2>/dev/null || true
 openshell sandbox delete "$SANDBOX_B" 2>/dev/null || true
-openshell forward stop 18789 2>/dev/null || true
+openshell forward stop "${NEMOCLAW_DASHBOARD_PORT:-18789}" 2>/dev/null || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 
 openshell sandbox get "$SANDBOX_A" > /dev/null 2>&1 \

--- a/test/env.test.js
+++ b/test/env.test.js
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { parseEnvFile, findGitRoot } = require("../bin/lib/env");
+
+describe("parseEnvFile", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-env-test-"));
+  });
+
+  afterEach(() => {
+    // Clean up any env vars we set during tests
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("NEMOCLAW_TEST_ENV_")) {
+        delete process.env[key];
+      }
+    }
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("parses KEY=VALUE lines into process.env", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), "NEMOCLAW_TEST_ENV_A=hello\n");
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_A, "hello");
+  });
+
+  it("strips surrounding double quotes", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), 'NEMOCLAW_TEST_ENV_B="quoted"\n');
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_B, "quoted");
+  });
+
+  it("strips surrounding single quotes", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), "NEMOCLAW_TEST_ENV_C='single'\n");
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_C, "single");
+  });
+
+  it("strips inline comments after unquoted values", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), "NEMOCLAW_TEST_ENV_D=val # comment\n");
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_D, "val");
+  });
+
+  it("skips blank lines and comments", () => {
+    fs.writeFileSync(
+      path.join(tmp, ".env"),
+      "# this is a comment\n\nNEMOCLAW_TEST_ENV_E=yes\n\n# another\n",
+    );
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_E, "yes");
+  });
+
+  it("skips lines without an equals sign", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), "no-equals-here\nNEMOCLAW_TEST_ENV_F=ok\n");
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_F, "ok");
+  });
+
+  it("never overwrites existing env vars", () => {
+    process.env.NEMOCLAW_TEST_ENV_G = "original";
+    fs.writeFileSync(path.join(tmp, ".env"), "NEMOCLAW_TEST_ENV_G=overwritten\n");
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_G, "original");
+  });
+
+  it("first file wins when loading multiple files", () => {
+    fs.writeFileSync(path.join(tmp, "first"), "NEMOCLAW_TEST_ENV_H=first\n");
+    fs.writeFileSync(path.join(tmp, "second"), "NEMOCLAW_TEST_ENV_H=second\n");
+    parseEnvFile(path.join(tmp, "first"));
+    parseEnvFile(path.join(tmp, "second"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_H, "first");
+  });
+
+  it("silently skips missing files", () => {
+    assert.doesNotThrow(() => {
+      parseEnvFile(path.join(tmp, "nonexistent"));
+    });
+  });
+
+  it("handles empty values", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), "NEMOCLAW_TEST_ENV_I=\n");
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_I, "");
+  });
+
+  it("preserves # inside double-quoted values", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), 'NEMOCLAW_TEST_ENV_J="val#ue"\n');
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_J, "val#ue");
+  });
+
+  it("preserves # inside single-quoted values", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), "NEMOCLAW_TEST_ENV_K='val#ue'\n");
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_K, "val#ue");
+  });
+
+  it("strips inline comment after quoted value", () => {
+    fs.writeFileSync(path.join(tmp, ".env"), 'NEMOCLAW_TEST_ENV_L="value" # comment\n');
+    parseEnvFile(path.join(tmp, ".env"));
+    assert.equal(process.env.NEMOCLAW_TEST_ENV_L, "value");
+  });
+});
+
+describe("findGitRoot", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gitroot-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("finds .git directory in current dir", () => {
+    fs.mkdirSync(path.join(tmp, ".git"));
+    assert.equal(findGitRoot(tmp), tmp);
+  });
+
+  it("walks up to find .git in parent", () => {
+    fs.mkdirSync(path.join(tmp, ".git"));
+    const nested = path.join(tmp, "a", "b", "c");
+    fs.mkdirSync(nested, { recursive: true });
+    assert.equal(findGitRoot(nested), tmp);
+  });
+
+  it("returns null when no .git found", () => {
+    assert.equal(findGitRoot(tmp), null);
+  });
+});

--- a/test/local-inference.test.js
+++ b/test/local-inference.test.js
@@ -18,33 +18,34 @@ const {
   validateOllamaModel,
   validateLocalProvider,
 } = require("../bin/lib/local-inference");
+const { VLLM_PORT, OLLAMA_PORT } = require("../bin/lib/ports");
 
 describe("local inference helpers", () => {
   it("returns the expected base URL for vllm-local", () => {
     assert.equal(
       getLocalProviderBaseUrl("vllm-local"),
-      "http://host.openshell.internal:8000/v1",
+      `http://host.openshell.internal:${VLLM_PORT}/v1`,
     );
   });
 
   it("returns the expected base URL for ollama-local", () => {
     assert.equal(
       getLocalProviderBaseUrl("ollama-local"),
-      "http://host.openshell.internal:11434/v1",
+      `http://host.openshell.internal:${OLLAMA_PORT}/v1`,
     );
   });
 
   it("returns the expected health check command for ollama-local", () => {
     assert.equal(
       getLocalProviderHealthCheck("ollama-local"),
-      "curl -sf http://localhost:11434/api/tags 2>/dev/null",
+      `curl -sf http://localhost:${OLLAMA_PORT}/api/tags 2>/dev/null`,
     );
   });
 
   it("returns the expected container reachability command for ollama-local", () => {
     assert.equal(
       getLocalProviderContainerReachabilityCheck("ollama-local"),
-      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`,
+      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:${OLLAMA_PORT}/api/tags 2>/dev/null`,
     );
   });
 
@@ -61,7 +62,7 @@ describe("local inference helpers", () => {
   it("returns a clear error when ollama-local is unavailable", () => {
     const result = validateLocalProvider("ollama-local", () => "");
     assert.equal(result.ok, false);
-    assert.match(result.message, /http:\/\/localhost:11434/);
+    assert.match(result.message, new RegExp(`http://localhost:${OLLAMA_PORT}`));
   });
 
   it("returns a clear error when ollama-local is not reachable from containers", () => {
@@ -71,14 +72,14 @@ describe("local inference helpers", () => {
       return callCount === 1 ? '{"models":[]}' : "";
     });
     assert.equal(result.ok, false);
-    assert.match(result.message, /host\.openshell\.internal:11434/);
-    assert.match(result.message, /0\.0\.0\.0:11434/);
+    assert.match(result.message, new RegExp(`host\\.openshell\\.internal:${OLLAMA_PORT}`));
+    assert.match(result.message, new RegExp(`0\\.0\\.0\\.0:${OLLAMA_PORT}`));
   });
 
   it("returns a clear error when vllm-local is unavailable", () => {
     const result = validateLocalProvider("vllm-local", () => "");
     assert.equal(result.ok, false);
-    assert.match(result.message, /http:\/\/localhost:8000/);
+    assert.match(result.message, new RegExp(`http://localhost:${VLLM_PORT}`));
   });
 
   it("parses model names from ollama list output", () => {
@@ -121,14 +122,14 @@ describe("local inference helpers", () => {
 
   it("builds a background warmup command for ollama models", () => {
     const command = getOllamaWarmupCommand("nemotron-3-nano:30b");
-    assert.match(command, /^nohup curl -s http:\/\/localhost:11434\/api\/generate /);
+    assert.match(command, new RegExp(`^nohup curl -s http://localhost:${OLLAMA_PORT}/api/generate `));
     assert.match(command, /"model":"nemotron-3-nano:30b"/);
     assert.match(command, /"keep_alive":"15m"/);
   });
 
   it("builds a foreground probe command for ollama models", () => {
     const command = getOllamaProbeCommand("nemotron-3-nano:30b");
-    assert.match(command, /^curl -sS --max-time 120 http:\/\/localhost:11434\/api\/generate /);
+    assert.match(command, new RegExp(`^curl -sS --max-time 120 http://localhost:${OLLAMA_PORT}/api/generate `));
     assert.match(command, /"model":"nemotron-3-nano:30b"/);
   });
 

--- a/test/onboard-readiness.test.js
+++ b/test/onboard-readiness.test.js
@@ -4,8 +4,10 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 
+require("../bin/lib/env");
 const { buildPolicySetCommand, buildPolicyGetCommand } = require("../bin/lib/policies");
 const { hasStaleGateway, isSandboxReady } = require("../bin/lib/onboard");
+const { GATEWAY_PORT } = require("../bin/lib/ports");
 
 describe("sandbox readiness parsing", () => {
   it("detects Ready sandbox", () => {
@@ -135,7 +137,7 @@ describe("stale gateway detection", () => {
       "Gateway Info",
       "",
       "  Gateway: nemoclaw",
-      "  Gateway endpoint: https://127.0.0.1:8080",
+      `  Gateway endpoint: https://127.0.0.1:${GATEWAY_PORT}`,
     ].join("\n");
     assert.ok(hasStaleGateway(output));
   });
@@ -144,7 +146,7 @@ describe("stale gateway detection", () => {
     const output =
       "\x1b[1m\x1b[36mGateway Info\x1b[39m\x1b[0m\n\n" +
       "  \x1b[2mGateway:\x1b[0m nemoclaw\n" +
-      "  \x1b[2mGateway endpoint:\x1b[0m https://127.0.0.1:8080";
+      `  \x1b[2mGateway endpoint:\x1b[0m https://127.0.0.1:${GATEWAY_PORT}`;
     assert.ok(hasStaleGateway(output));
   });
 
@@ -168,7 +170,7 @@ describe("stale gateway detection", () => {
       "Gateway Info",
       "",
       "  Gateway: my-other-gateway",
-      "  Gateway endpoint: https://127.0.0.1:8080",
+      `  Gateway endpoint: https://127.0.0.1:${GATEWAY_PORT}`,
     ].join("\n");
     assert.ok(!hasStaleGateway(output));
   });

--- a/test/onboard-selection.test.js
+++ b/test/onboard-selection.test.js
@@ -17,10 +17,12 @@ describe("onboard provider selection UX", () => {
     const credentialsPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "credentials.js"));
     const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
     const registryPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "registry.js"));
+    const portsPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "ports.js"));
     const script = String.raw`
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 const registry = require(${registryPath});
+const { VLLM_PORT, OLLAMA_PORT } = require(${portsPath});
 
 let promptCalls = 0;
 const messages = [];
@@ -34,9 +36,9 @@ credentials.prompt = async (message) => {
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
   if (command.includes("command -v ollama")) return "/usr/bin/ollama";
-  if (command.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
+  if (command.includes("localhost:" + OLLAMA_PORT + "/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
   if (command.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now\\nqwen3:32b  def  20 GB  now";
-  if (command.includes("localhost:8000/v1/models")) return "";
+  if (command.includes("localhost:" + VLLM_PORT + "/v1/models")) return "";
   return "";
 };
 registry.updateSandbox = (_name, update) => updates.push(update);

--- a/test/preflight.test.js
+++ b/test/preflight.test.js
@@ -6,6 +6,7 @@ const assert = require("node:assert/strict");
 
 const net = require("net");
 const { checkPortAvailable } = require("../bin/lib/preflight");
+const { DASHBOARD_PORT } = require("../bin/lib/ports");
 
 describe("checkPortAvailable", () => {
   it("falls through to net probe when lsof output is empty", async () => {
@@ -104,7 +105,7 @@ describe("checkPortAvailable", () => {
     assert.equal(result.ok, true);
   });
 
-  it("defaults to port 18789 when no args given", async () => {
+  it(`defaults to port ${DASHBOARD_PORT} when no args given`, async () => {
     // Should not throw — just verify it returns a valid result object
     const result = await checkPortAvailable();
     assert.equal(typeof result.ok, "boolean");

--- a/test/runtime-shell.test.js
+++ b/test/runtime-shell.test.js
@@ -119,13 +119,13 @@ describe("shell runtime helpers", () => {
   it("returns the vllm-local base URL", () => {
     const result = runShell(`source "${RUNTIME_SH}"; get_local_provider_base_url vllm-local`);
     assert.equal(result.status, 0);
-    assert.equal(result.stdout.trim(), "http://host.openshell.internal:8000/v1");
+    assert.equal(result.stdout.trim(), `http://host.openshell.internal:${process.env.NEMOCLAW_VLLM_PORT || "8000"}/v1`);
   });
 
   it("returns the ollama-local base URL", () => {
     const result = runShell(`source "${RUNTIME_SH}"; get_local_provider_base_url ollama-local`);
     assert.equal(result.status, 0);
-    assert.equal(result.stdout.trim(), "http://host.openshell.internal:11434/v1");
+    assert.equal(result.stdout.trim(), `http://host.openshell.internal:${process.env.NEMOCLAW_OLLAMA_PORT || "11434"}/v1`);
   });
 
   it("rejects unknown local providers", () => {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -106,6 +106,36 @@ print_bye() {
 }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Load .env so custom port overrides are visible ──────────────────
+_load_env() {
+  local env_file="$1"
+  [[ -f "$env_file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Trim leading/trailing whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    # Skip blank lines and full-line comments
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    [[ "$line" == *=* ]] || continue
+    local key="${line%%=*}"
+    local val="${line#*=}"
+    # Handle quoted values (preserve # inside quotes), then strip inline comments on unquoted
+    if [[ "$val" == \"*\"* ]]; then
+      val="${val#\"}" ; val="${val%%\"*}"
+    elif [[ "$val" == \'*\'* ]]; then
+      val="${val#\'}" ; val="${val%%\'*}"
+    else
+      val="${val%%[[:space:]]\#*}"
+    fi
+    if [[ -z "${!key+x}" ]]; then
+      export "$key=$val"
+    fi
+  done < "$env_file"
+}
+_load_env "$SCRIPT_DIR/.env.local"
+_load_env "$SCRIPT_DIR/.env"
+
 NEMOCLAW_STATE_DIR="${HOME}/.nemoclaw"
 OPENSHELL_CONFIG_DIR="${HOME}/.config/openshell"
 NEMOCLAW_CONFIG_DIR="${HOME}/.config/nemoclaw"
@@ -253,7 +283,7 @@ stop_openshell_forward_processes() {
   while IFS= read -r pid; do
     [ -n "$pid" ] || continue
     pids+=("$pid")
-  done < <(pgrep -f 'openshell.*forward.*18789' 2>/dev/null || true)
+  done < <(pgrep -f "openshell.*forward.*${NEMOCLAW_DASHBOARD_PORT:-18789}" 2>/dev/null || true)
 
   if [ "${#pids[@]}" -eq 0 ]; then
     info "No local OpenShell forward processes found"


### PR DESCRIPTION
## Summary

- Add configurable port overrides (`GATEWAY_PORT`, `DASHBOARD_PORT`, `OLLAMA_PORT`, `VLLM_PORT`) via `.env` / `.env.local` files
- Introduce `bin/lib/env.js` (env loader with git-root + CWD search) and `bin/lib/ports.js` (central port config)
- Replace all hardcoded ports across 30 files (JS, shell scripts, blueprint YAML, Python orchestrator, tests)
- Add port-conflict detection in `preflight()` with `.env.local` override guidance
- Add `scripts/check-ports.sh` diagnostic utility, `docs/reference/port-configuration.md`, and `test/env.test.js`

## Bug fixes included

1. **`bin/lib/env.js`** — `.env.local` not found on fresh installs (only searched `__dirname`; now also searches git root and CWD)
2. **`bin/lib/onboard.js`** — No `.env` bootstrapped on fresh clone; unhelpful port-conflict error (now copies `.env.example` → `.env` and shows `.env.local` override instructions)
3. **Shell scripts** (`nemoclaw-start.sh`, `debug.sh`, `brev-setup.sh`, etc.) — `.env` never loaded, so port overrides had no effect
4. **`scripts/telegram-bridge.js`** — Removed unused `crypto` import
5. **`test/onboard-readiness.test.js`** — Hardcoded port 8080; now reads from ports config
6. **`bin/lib/env.js` / `scripts/check-ports.sh` / `uninstall.sh`** — Inline comment stripping corrupted quoted values containing `#` (fixed parse order per CodeRabbit review)
7. **`bin/lib/onboard.js`** — Custom dashboard port not reaching build-time Dockerfile ARG (now patches Dockerfile copy before build)
8. **`bin/lib/onboard.js`** — Ollama startup accepted without health verification (now retries with curl probe)

## CodeRabbit review status

All actionable findings from [PR #639](https://github.com/NVIDIA/NemoClaw/pull/639) are addressed. One documented first-run edge case remains (ports resolved at module load before `.env.example` copy — defaults match, so behavior is identical).

## Test plan

- [ ] `npm test` — 311 tests (81 TS + 230 JS), all passing (5 pre-existing upstream failures in `install-preflight.test.js`)
- [ ] `node --test test/env.test.js test/preflight.test.js test/onboard-readiness.test.js` — 46/46 port-config tests pass
- [ ] `node bin/nemoclaw.js --version` / `--help` — CLI smoke test
- [ ] Verify Dockerfile preserves `os.environ` security fix (C-2)
- [ ] Pre-commit hooks pass: SPDX headers, shellcheck, ruff, commitlint
- [ ] Pre-push hooks pass: TypeScript + Python type checks

Supersedes #639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable ports for Dashboard, Gateway, vLLM/NIM, and Ollama services via environment variables (NEMOCLAW_DASHBOARD_PORT, NEMOCLAW_GATEWAY_PORT, NEMOCLAW_VLLM_PORT, NEMOCLAW_OLLAMA_PORT).
  * .env and .env.local file support for persistent port configuration.
  * Port conflict detection utility to identify conflicting services.

* **Documentation**
  * Added port configuration reference guide with defaults and environment variable mappings.
  * Updated troubleshooting guide with port conflict resolution steps.

* **Tests**
  * Added environment variable and port configuration tests.
  * Updated existing tests to use configurable ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->