### PR TITLE
fix: handle unbound BASH_SOURCE when install.sh is piped via curl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 DEFAULT_NEMOCLAW_VERSION="0.1.0"
 TOTAL_STEPS=3
 


### PR DESCRIPTION
## Summary

`curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash` fails with `BASH_SOURCE[0]: unbound variable` because `BASH_SOURCE` is empty when piped and `set -u` treats it as unbound.

Fix: `${BASH_SOURCE[0]:-$0}` falls back to `$0` when `BASH_SOURCE` is unset.

Regression from #470.

Closes #655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation script reliability across different shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->