### PR TITLE
fix: upgrade openshell when installed version is below minimum

### DIFF
--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -46,7 +46,7 @@ version_gte() {
 }
 
 if command -v openshell > /dev/null 2>&1; then
-  INSTALLED_VERSION="$(openshell --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo '0.0.0')"
+  INSTALLED_VERSION="$(openshell --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo '0.0.0')"
   if version_gte "$INSTALLED_VERSION" "$MIN_VERSION"; then
     info "openshell already installed: $INSTALLED_VERSION (>= $MIN_VERSION)"
     exit 0

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -34,8 +34,15 @@ info "Detected $OS_LABEL ($ARCH_LABEL)"
 MIN_VERSION="0.0.7"
 
 version_gte() {
-  # Returns 0 (true) if $1 >= $2 using sort -V
-  [ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -1)" = "$2" ]
+  # Returns 0 (true) if $1 >= $2 — portable, no sort -V (BSD compat)
+  local IFS=.
+  local -a a=($1) b=($2)
+  for i in 0 1 2; do
+    local ai=${a[$i]:-0} bi=${b[$i]:-0}
+    if (( ai > bi )); then return 0; fi
+    if (( ai < bi )); then return 1; fi
+  done
+  return 0
 }
 
 if command -v openshell > /dev/null 2>&1; then

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -30,9 +30,21 @@ esac
 
 info "Detected $OS_LABEL ($ARCH_LABEL)"
 
+# Minimum version required for cgroup v2 fix (NVIDIA/OpenShell#329)
+MIN_VERSION="0.0.7"
+
+version_gte() {
+  # Returns 0 (true) if $1 >= $2 using sort -V
+  [ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -1)" = "$2" ]
+}
+
 if command -v openshell > /dev/null 2>&1; then
-  info "openshell already installed: $(openshell --version 2>&1 || echo 'unknown')"
-  exit 0
+  INSTALLED_VERSION="$(openshell --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo '0.0.0')"
+  if version_gte "$INSTALLED_VERSION" "$MIN_VERSION"; then
+    info "openshell already installed: $INSTALLED_VERSION (>= $MIN_VERSION)"
+    exit 0
+  fi
+  warn "openshell $INSTALLED_VERSION is below minimum $MIN_VERSION — upgrading..."
 fi
 
 info "Installing openshell CLI..."


### PR DESCRIPTION
## Summary

The install script previously skipped openshell installation if any version was already present. Users on 0.0.6 would never get upgraded and hit the cgroup v2 gateway crash fixed in 0.0.7 ([NVIDIA/OpenShell#329](https://github.com/NVIDIA/OpenShell/pull/329)).

Now checks the installed version against a minimum (0.0.7) and upgrades automatically if too old.

## Changes

`scripts/install-openshell.sh` — replace the early `exit 0` with a version check using `sort -V`. If installed version is below 0.0.7, proceeds with the download/install flow instead of exiting.

Closes #136

## Test plan
- [x] `npm test` — all tests pass
- [x] With openshell 0.0.6 installed: script upgrades to latest
- [x] With openshell 0.0.13 installed: script exits early (no download)
- [x] With no openshell installed: script installs latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now checks the existing openshell version, warns if it’s below the minimum required, and proceeds with an upgrade when needed. If the installed version meets the minimum, installation exits without changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->