### PR TITLE
chore: add shared hook config and improve Husky scripts

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,8 +1,10 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
-# shellcheck source=scripts/husky-env.sh
+# shellcheck disable=SC1091
 . "$REPO_ROOT/scripts/husky-env.sh"
 
 if [ -x ./node_modules/.bin/commitlint ]; then

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,18 @@
 #!/bin/sh
-npx --no -- commitlint --edit "$1"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+if [ -z "${NVM_DIR:-}" ]; then
+  NVM_DIR="$HOME/.nvm"
+fi
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+fi
+
+if [ -x ./node_modules/.bin/commitlint ]; then
+  ./node_modules/.bin/commitlint --edit "$1"
+else
+  npx --no -- commitlint --edit "$1"
+fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,14 +2,8 @@
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
-
-if [ -z "${NVM_DIR:-}" ]; then
-  NVM_DIR="$HOME/.nvm"
-fi
-if [ -s "$NVM_DIR/nvm.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$NVM_DIR/nvm.sh"
-fi
+# shellcheck source=scripts/husky-env.sh
+. "$REPO_ROOT/scripts/husky-env.sh"
 
 if [ -x ./node_modules/.bin/commitlint ]; then
   ./node_modules/.bin/commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,14 +3,8 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
-
-if [ -z "${NVM_DIR:-}" ]; then
-  NVM_DIR="$HOME/.nvm"
-fi
-if [ -s "$NVM_DIR/nvm.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$NVM_DIR/nvm.sh"
-fi
+# shellcheck source=scripts/husky-env.sh
+. "$REPO_ROOT/scripts/husky-env.sh"
 
 if [ -x ./node_modules/.bin/lint-staged ]; then
   ./node_modules/.bin/lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,11 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
-# shellcheck source=scripts/husky-env.sh
+# shellcheck disable=SC1091
 . "$REPO_ROOT/scripts/husky-env.sh"
 
 if [ -x ./node_modules/.bin/lint-staged ]; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,26 @@
 #!/bin/sh
 set -e
-npx --no -- lint-staged
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+if [ -z "${NVM_DIR:-}" ]; then
+  NVM_DIR="$HOME/.nvm"
+fi
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+fi
+
+if [ -x ./node_modules/.bin/lint-staged ]; then
+  ./node_modules/.bin/lint-staged
+else
+  npx --no -- lint-staged
+fi
+
 cd nemoclaw
-npx vitest run
+if [ -x ./node_modules/.bin/vitest ]; then
+  ./node_modules/.bin/vitest run
+else
+  npx vitest run
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,12 +1,59 @@
 #!/bin/sh
-# Type checking — catches errors before wasting a CI round-trip.
+# Type checking and shared hooks before push — avoids a wasted CI round-trip.
+set -e
 
-# TypeScript
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+# GUI Git / minimal PATH often lacks nvm/npm — load nvm when present so npx works as fallback.
+if [ -z "${NVM_DIR:-}" ]; then
+  NVM_DIR="$HOME/.nvm"
+fi
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+fi
+
 echo "pre-push: checking TypeScript types..."
-(cd nemoclaw && npx tsc --noEmit) || exit 1
+cd nemoclaw
+if [ -x ./node_modules/.bin/tsc ]; then
+  ./node_modules/.bin/tsc --noEmit
+elif command -v npx >/dev/null 2>&1; then
+  npx tsc --noEmit
+else
+  echo "pre-push: tsc not found — run: cd nemoclaw && npm install" >&2
+  exit 1
+fi
+cd "$REPO_ROOT"
 
 # Pyright (Python) — skip if uv is not installed
 if command -v uv >/dev/null 2>&1; then
   echo "pre-push: checking Python types..."
   (cd nemoclaw-blueprint && uv run --with pyright pyright .) || exit 1
+fi
+
+# pre-commit: same hooks as .pre-commit-config.yaml — optional if not installed locally.
+# Falls back to prek if present (same config file).
+if command -v pre-commit >/dev/null 2>&1; then
+  echo "pre-push: running pre-commit on outgoing commits..."
+  if git rev-parse @{u} >/dev/null 2>&1; then
+    FROM=$(git merge-base HEAD @{u})
+    pre-commit run --from-ref "$FROM" --to-ref HEAD
+  elif git rev-parse HEAD~1 >/dev/null 2>&1; then
+    pre-commit run --from-ref HEAD~1 --to-ref HEAD
+  else
+    pre-commit run --all-files
+  fi
+elif command -v prek >/dev/null 2>&1; then
+  echo "pre-push: running prek on outgoing commits..."
+  if git rev-parse @{u} >/dev/null 2>&1; then
+    FROM=$(git merge-base HEAD @{u})
+    prek run --from-ref "$FROM" --to-ref HEAD
+  elif git rev-parse HEAD~1 >/dev/null 2>&1; then
+    prek run --from-ref HEAD~1 --to-ref HEAD
+  else
+    prek run --all-files
+  fi
+else
+  echo "pre-push: pre-commit not in PATH — skipping shared hooks (pip install pre-commit && pre-commit install). Optional: install prek for the same config without Python." >&2
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,10 +1,13 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Type checking and shared hooks before push — avoids a wasted CI round-trip.
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
-# shellcheck source=scripts/husky-env.sh
+# shellcheck disable=SC1091
 . "$REPO_ROOT/scripts/husky-env.sh"
 
 echo "pre-push: checking TypeScript types..."
@@ -29,8 +32,8 @@ fi
 # Falls back to pre-commit if prek is absent (same config file).
 if command -v prek >/dev/null 2>&1; then
   echo "pre-push: running prek on outgoing commits..."
-  if git rev-parse @{u} >/dev/null 2>&1; then
-    FROM=$(git merge-base HEAD @{u})
+  if git rev-parse '@{u}' >/dev/null 2>&1; then
+    FROM=$(git merge-base HEAD '@{u}')
     prek run --from-ref "$FROM" --to-ref HEAD
   elif git rev-parse HEAD~1 >/dev/null 2>&1; then
     prek run --from-ref HEAD~1 --to-ref HEAD
@@ -39,8 +42,8 @@ if command -v prek >/dev/null 2>&1; then
   fi
 elif command -v pre-commit >/dev/null 2>&1; then
   echo "pre-push: running pre-commit on outgoing commits..."
-  if git rev-parse @{u} >/dev/null 2>&1; then
-    FROM=$(git merge-base HEAD @{u})
+  if git rev-parse '@{u}' >/dev/null 2>&1; then
+    FROM=$(git merge-base HEAD '@{u}')
     pre-commit run --from-ref "$FROM" --to-ref HEAD
   elif git rev-parse HEAD~1 >/dev/null 2>&1; then
     pre-commit run --from-ref HEAD~1 --to-ref HEAD

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -32,19 +32,9 @@ if command -v uv >/dev/null 2>&1; then
   (cd nemoclaw-blueprint && uv run --with pyright pyright .) || exit 1
 fi
 
-# pre-commit: same hooks as .pre-commit-config.yaml — optional if not installed locally.
-# Falls back to prek if present (same config file).
-if command -v pre-commit >/dev/null 2>&1; then
-  echo "pre-push: running pre-commit on outgoing commits..."
-  if git rev-parse @{u} >/dev/null 2>&1; then
-    FROM=$(git merge-base HEAD @{u})
-    pre-commit run --from-ref "$FROM" --to-ref HEAD
-  elif git rev-parse HEAD~1 >/dev/null 2>&1; then
-    pre-commit run --from-ref HEAD~1 --to-ref HEAD
-  else
-    pre-commit run --all-files
-  fi
-elif command -v prek >/dev/null 2>&1; then
+# prek: same hooks as .pre-commit-config.yaml — optional if not installed locally.
+# Falls back to pre-commit if prek is absent (same config file).
+if command -v prek >/dev/null 2>&1; then
   echo "pre-push: running prek on outgoing commits..."
   if git rev-parse @{u} >/dev/null 2>&1; then
     FROM=$(git merge-base HEAD @{u})
@@ -54,6 +44,16 @@ elif command -v prek >/dev/null 2>&1; then
   else
     prek run --all-files
   fi
+elif command -v pre-commit >/dev/null 2>&1; then
+  echo "pre-push: running pre-commit on outgoing commits..."
+  if git rev-parse @{u} >/dev/null 2>&1; then
+    FROM=$(git merge-base HEAD @{u})
+    pre-commit run --from-ref "$FROM" --to-ref HEAD
+  elif git rev-parse HEAD~1 >/dev/null 2>&1; then
+    pre-commit run --from-ref HEAD~1 --to-ref HEAD
+  else
+    pre-commit run --all-files
+  fi
 else
-  echo "pre-push: pre-commit not in PATH — skipping shared hooks (pip install pre-commit && pre-commit install). Optional: install prek for the same config without Python." >&2
+  echo "pre-push: prek not in PATH — skipping shared hooks (brew install prek | uv tool install prek | pip install prek). Alternative: pip install pre-commit." >&2
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,15 +4,8 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
-
-# GUI Git / minimal PATH often lacks nvm/npm — load nvm when present so npx works as fallback.
-if [ -z "${NVM_DIR:-}" ]; then
-  NVM_DIR="$HOME/.nvm"
-fi
-if [ -s "$NVM_DIR/nvm.sh" ]; then
-  # shellcheck source=/dev/null
-  . "$NVM_DIR/nvm.sh"
-fi
+# shellcheck source=scripts/husky-env.sh
+. "$REPO_ROOT/scripts/husky-env.sh"
 
 echo "pre-push: checking TypeScript types..."
 cd nemoclaw

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,23 @@
-# NemoClaw — pre-commit hook configuration
-# See https://pre-commit.com
+# NemoClaw — prek / pre-commit hook configuration (same file; prek is recommended)
+# prek: https://github.com/j178/prek — single binary, no Python required for the runner
 #
-# Local setup:
-#   pip install pre-commit
-#   pre-commit install
-#   pre-commit run --all-files
+# Local (prek):
+#   brew install prek | uv tool install prek | pip install prek
+#   curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/latest/download/prek-installer.sh | sh
+#   prek install
+#   prek run --all-files
 #
-# CI / diff-only runs (e.g. pull requests):
+# Alternative — Python pre-commit (reads this file too): https://pre-commit.com
+#   pip install pre-commit && pre-commit install && pre-commit run --all-files
+#
+# CI / diff-only runs:
+#   prek run --from-ref <base> --to-ref HEAD
 #   pre-commit run --from-ref <base> --to-ref HEAD
 #
-# Optional: [prek](https://github.com/j178/prek) reads this same file and can run hooks without a
-# Python install — useful if you prefer a single binary. Command shape matches pre-commit.
-#
-# Husky (see .husky/pre-commit) runs lint-staged + Vitest on commit; pre-commit adds repo-wide
+# Husky (see .husky/pre-commit) runs lint-staged + Vitest on commit; this file adds repo-wide
 # checks (shell, Docker, ruff, eslint in nemoclaw/, SPDX, gitleaks, etc.).
 #
-# Priority groups (honoured by prek; ignored by stock pre-commit):
+# Priority groups (prek: same priority may run in parallel; stock pre-commit ignores priority):
 #   0  — General file fixers (whitespace, EOF, line endings)
 #   5  — Shell / Python / TS formatters (shfmt, ruff format, prettier)
 #   6  — Fixes that should follow formatters (ruff check --fix, eslint --fix)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,144 @@
+# NemoClaw — pre-commit hook configuration
+# See https://pre-commit.com
+#
+# Local setup:
+#   pip install pre-commit
+#   pre-commit install
+#   pre-commit run --all-files
+#
+# CI / diff-only runs (e.g. pull requests):
+#   pre-commit run --from-ref <base> --to-ref HEAD
+#
+# Optional: [prek](https://github.com/j178/prek) reads this same file and can run hooks without a
+# Python install — useful if you prefer a single binary. Command shape matches pre-commit.
+#
+# Husky (see .husky/pre-commit) runs lint-staged + Vitest on commit; pre-commit adds repo-wide
+# checks (shell, Docker, ruff, eslint in nemoclaw/, SPDX, gitleaks, etc.).
+#
+# Priority groups (honoured by prek; ignored by stock pre-commit):
+#   0  — General file fixers (whitespace, EOF, line endings)
+#   5  — Shell / Python / TS formatters (shfmt, ruff format, prettier)
+#   6  — Fixes that should follow formatters (ruff check --fix, eslint --fix)
+#  10  — Linters and read-only checks
+
+exclude: ^(nemoclaw/dist/|nemoclaw/node_modules/|docs/_build/|\.venv/|uv\.lock$)
+
+repos:
+  # ── Priority 0: general file fixers ───────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        priority: 0
+      - id: end-of-file-fixer
+        priority: 0
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+        priority: 0
+
+  # ── Priority 5: formatters ────────────────────────────────────────────────
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.12.0-2
+    hooks:
+      - id: shfmt
+        args:
+          - -w
+          - -i
+          - "2"
+          - -ci
+          - -bn
+        priority: 5
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
+    hooks:
+      - id: ruff-format
+        files: ^(nemoclaw-blueprint/.*\.py|scripts/.*\.py)$
+        priority: 5
+      - id: ruff
+        args: [--fix]
+        files: ^(nemoclaw-blueprint/.*\.py|scripts/.*\.py)$
+        priority: 6
+
+  - repo: local
+    hooks:
+      - id: nemoclaw-prettier
+        name: Prettier (nemoclaw TypeScript)
+        entry: bash -c 'root="$(git rev-parse --show-toplevel)" && cd "$root/nemoclaw" && files=() && for f in "$@"; do files+=("${f#nemoclaw/}"); done && npx prettier --write "${files[@]}"' --
+        language: system
+        files: ^nemoclaw/.*\.ts$
+        pass_filenames: true
+        priority: 5
+
+  # ── Priority 6: auto-fix after formatting ─────────────────────────────────
+  - repo: local
+    hooks:
+      - id: nemoclaw-eslint
+        name: ESLint (nemoclaw TypeScript)
+        entry: bash -c 'root="$(git rev-parse --show-toplevel)" && cd "$root/nemoclaw" && files=() && for f in "$@"; do files+=("${f#nemoclaw/}"); done && npx eslint --fix "${files[@]}"' --
+        language: system
+        files: ^nemoclaw/.*\.ts$
+        pass_filenames: true
+        priority: 6
+
+  # ── Priority 10: linters and validation ─────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+        priority: 10
+      - id: check-added-large-files
+        args: ["--maxkb=2000"]
+        priority: 10
+      - id: check-case-conflict
+        priority: 10
+      - id: check-yaml
+        priority: 10
+      - id: check-toml
+        priority: 10
+      - id: check-json
+        priority: 10
+      - id: detect-private-key
+        priority: 10
+      - id: check-executables-have-shebangs
+        priority: 10
+      - id: check-shebang-scripts-are-executable
+        priority: 10
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        args:
+          - --severity=warning
+          - --exclude=SC1091
+        priority: 10
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint
+        priority: 10
+
+  - repo: local
+    hooks:
+      - id: spdx-headers
+        name: SPDX license headers
+        entry: bash scripts/check-spdx-headers.sh
+        language: system
+        files: ^(nemoclaw/src/.*\.ts|nemoclaw-blueprint/.*\.py|.*\.sh|\.husky/.*)$
+        pass_filenames: true
+        priority: 10
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        name: gitleaks (secret scan)
+        priority: 10
+
+default_language_version:
+  python: python3
+
+fail_fast: false
+minimum_pre_commit_version: "3.0.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,25 @@ These are the primary `make` and `npm` targets for day-to-day development:
 | `cd nemoclaw && npm test` | Run plugin unit tests (Vitest) |
 | `make docs` | Build documentation (Sphinx/MyST) |
 | `make docs-live` | Serve docs locally with auto-rebuild |
+| `pre-commit run --all-files` | Optional: run shared hooks from `.pre-commit-config.yaml` — see below |
+
+### Optional: pre-commit
+
+The repository includes [`.pre-commit-config.yaml`](.pre-commit-config.yaml) for the [`pre-commit`](https://pre-commit.com/) framework. It **complements** [Husky](.husky/pre-commit), which runs lint-staged and Vitest when you commit.
+
+Install and run from the repository root:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files   # good check before opening a PR, or after broad edits
+```
+
+`make check` remains the primary documented linter entry point. For pull requests, CI or local runs can scope checks with `pre-commit run --from-ref <base> --to-ref HEAD`.
+
+[prek](https://prek.j178.dev/) is an optional alternative runner that uses the same config file without installing Python; install it separately if you prefer that workflow.
+
+If `pre-commit` is on your `PATH`, [.husky/pre-push](.husky/pre-push) also runs it on the commits you are about to push (merge-base with `@{u}`, or the last commit if no upstream is set). Husky scripts prefer `node_modules/.bin` so type checks and lint-staged work when `npx` is missing from the environment (for example some GUI Git clients).
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,25 +57,24 @@ These are the primary `make` and `npm` targets for day-to-day development:
 | `cd nemoclaw && npm test` | Run plugin unit tests (Vitest) |
 | `make docs` | Build documentation (Sphinx/MyST) |
 | `make docs-live` | Serve docs locally with auto-rebuild |
-| `pre-commit run --all-files` | Optional: run shared hooks from `.pre-commit-config.yaml` — see below |
+| `prek run --all-files` | Optional: run shared hooks from `.pre-commit-config.yaml` — see below |
 
-### Optional: pre-commit
+### Optional: prek (pre-commit–compatible)
 
-The repository includes [`.pre-commit-config.yaml`](.pre-commit-config.yaml) for the [`pre-commit`](https://pre-commit.com/) framework. It **complements** [Husky](.husky/pre-commit), which runs lint-staged and Vitest when you commit.
+The repository includes [`.pre-commit-config.yaml`](.pre-commit-config.yaml) for [prek](https://prek.j178.dev/) (recommended) and the Python [`pre-commit`](https://pre-commit.com/) runner — same file, either tool. This **complements** [Husky](.husky/pre-commit), which runs lint-staged and Vitest when you commit.
 
-Install and run from the repository root:
+Install **prek** (pick one): `brew install prek`, `uv tool install prek`, `pip install prek`, or the [standalone installer](https://prek.j178.dev/installation/). From the repository root:
 
 ```bash
-pip install pre-commit
-pre-commit install
-pre-commit run --all-files   # good check before opening a PR, or after broad edits
+prek install
+prek run --all-files   # good check before opening a PR, or after broad edits
 ```
 
-`make check` remains the primary documented linter entry point. For pull requests, CI or local runs can scope checks with `pre-commit run --from-ref <base> --to-ref HEAD`.
+`make check` remains the primary documented linter entry point. For scoped runs: `prek run --from-ref <base> --to-ref HEAD` (same flags work with `pre-commit` if you use that instead).
 
-[prek](https://prek.j178.dev/) is an optional alternative runner that uses the same config file without installing Python; install it separately if you prefer that workflow.
+If **prek** is not available, install [`pre-commit`](https://pre-commit.com/) and use `pre-commit install` / `pre-commit run --all-files` with the same config file.
 
-If `pre-commit` is on your `PATH`, [.husky/pre-push](.husky/pre-push) also runs it on the commits you are about to push (merge-base with `@{u}`, or the last commit if no upstream is set). Husky scripts prefer `node_modules/.bin` so type checks and lint-staged work when `npx` is missing from the environment (for example some GUI Git clients).
+If **prek** (or **pre-commit**) is on your `PATH`, [.husky/pre-push](.husky/pre-push) also runs it on the commits you are about to push (merge-base with `@{u}`, or the last commit if no upstream is set). Husky scripts prefer `node_modules/.bin` so type checks and lint-staged work when `npx` is missing from the environment (for example some GUI Git clients).
 
 ## Project Structure
 

--- a/scripts/husky-env.sh
+++ b/scripts/husky-env.sh
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sourced by .husky/* hooks. Git GUI / non-login shells often omit PATH entries where Node lives,
+# which breaks bin stubs that use `#!/usr/bin/env node` (tsc, vitest, lint-staged, etc.).
+
+PATH="/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:$PATH"
+export PATH
+
+if [ -z "${NVM_DIR:-}" ]; then
+  NVM_DIR="$HOME/.nvm"
+fi
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+fi
+
+if command -v fnm >/dev/null 2>&1; then
+  eval "$(fnm env)" || true
+fi

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -9,23 +9,26 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-info()  { echo -e "${GREEN}[install]${NC} $1"; }
-warn()  { echo -e "${YELLOW}[install]${NC} $1"; }
-fail()  { echo -e "${RED}[install]${NC} $1"; exit 1; }
+info() { echo -e "${GREEN}[install]${NC} $1"; }
+warn() { echo -e "${YELLOW}[install]${NC} $1"; }
+fail() {
+  echo -e "${RED}[install]${NC} $1"
+  exit 1
+}
 
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
 case "$OS" in
   Darwin) OS_LABEL="macOS" ;;
-  Linux)  OS_LABEL="Linux" ;;
-  *)      fail "Unsupported OS: $OS" ;;
+  Linux) OS_LABEL="Linux" ;;
+  *) fail "Unsupported OS: $OS" ;;
 esac
 
 case "$ARCH" in
-  x86_64|amd64) ARCH_LABEL="x86_64" ;;
-  aarch64|arm64) ARCH_LABEL="aarch64" ;;
-  *)             fail "Unsupported architecture: $ARCH" ;;
+  x86_64 | amd64) ARCH_LABEL="x86_64" ;;
+  aarch64 | arm64) ARCH_LABEL="aarch64" ;;
+  *) fail "Unsupported architecture: $ARCH" ;;
 esac
 
 info "Detected $OS_LABEL ($ARCH_LABEL)"
@@ -36,16 +39,18 @@ MIN_VERSION="0.0.7"
 version_gte() {
   # Returns 0 (true) if $1 >= $2 — portable, no sort -V (BSD compat)
   local IFS=.
-  local -a a=($1) b=($2)
+  local -a a b
+  read -r -a a <<< "$1"
+  read -r -a b <<< "$2"
   for i in 0 1 2; do
     local ai=${a[$i]:-0} bi=${b[$i]:-0}
-    if (( ai > bi )); then return 0; fi
-    if (( ai < bi )); then return 1; fi
+    if ((ai > bi)); then return 0; fi
+    if ((ai < bi)); then return 1; fi
   done
   return 0
 }
 
-if command -v openshell > /dev/null 2>&1; then
+if command -v openshell >/dev/null 2>&1; then
   INSTALLED_VERSION="$(openshell --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo '0.0.0')"
   if version_gte "$INSTALLED_VERSION" "$MIN_VERSION"; then
     info "openshell already installed: $INSTALLED_VERSION (>= $MIN_VERSION)"
@@ -59,13 +64,13 @@ info "Installing openshell CLI..."
 case "$OS" in
   Darwin)
     case "$ARCH_LABEL" in
-      x86_64)  ASSET="openshell-x86_64-apple-darwin.tar.gz" ;;
+      x86_64) ASSET="openshell-x86_64-apple-darwin.tar.gz" ;;
       aarch64) ASSET="openshell-aarch64-apple-darwin.tar.gz" ;;
     esac
     ;;
   Linux)
     case "$ARCH_LABEL" in
-      x86_64)  ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
+      x86_64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
       aarch64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
     esac
     ;;
@@ -74,7 +79,7 @@ esac
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
-if command -v gh > /dev/null 2>&1; then
+if command -v gh >/dev/null 2>&1; then
   GH_TOKEN="${GITHUB_TOKEN:-}" gh release download --repo NVIDIA/OpenShell \
     --pattern "$ASSET" --dir "$tmpdir"
 else


### PR DESCRIPTION
## Summary

Adds a repo-wide .pre-commit-config.yaml (shell, Docker, ruff, nemoclaw ESLint/Prettier, SPDX script, gitleaks, hygiene hooks) and documents prek as the recommended runner with pre-commit as an alternative.
Hardens Husky (shared scripts/husky-env.sh, SPDX on hook scripts, shellcheck-safe @{u} quoting) and fixes SC2206 in scripts/install-openshell.sh.
Goal: consistent checks locally and a clear path for CI later.

## Changes

- Add .pre-commit-config.yaml with priority groups (prek), excludes, and local nemoclaw TS hooks.
- Update CONTRIBUTING.md: optional prek / pre-commit, table row, pre-push behavior.
- Add scripts/husky-env.sh and source it from .husky/pre-commit, .husky/pre-push, .husky/commit-msg (PATH + nvm/fnm for GUI Git).
- .husky/*: SPDX headers, SC1091 / @{u} fixes for shellcheck.
- scripts/install-openshell.sh: shellcheck-safe version compare (read -a), mode/exec as needed.


## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [x] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `make check` passes.
- [x] `npm test` passes.
- [] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] `make format` applied (TypeScript and Python).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [x] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

## How to verify
- pip install pre-commit && pre-commit run --all-files
  (or: prek install && prek run --all-files)
- git push (exercises pre-push if prek/pre-commit on PATH)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Git hooks and development tooling to streamline code quality checks and improve the developer workflow.
  * Updated development configuration and documentation to simplify local environment setup and contribution processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->