### PR TITLE
docs: document workspace file persistence and backup/restore

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,16 @@ Egress control, operator approval flow, and policy configuration.
 {bdg-secondary}`Reference`
 :::
 
+:::{grid-item-card} Workspace Files
+:link: workspace/workspace-files
+:link-type: doc
+
+Understand agent identity, memory, and configuration files that persist in the sandbox.
+
++++
+{bdg-secondary}`Concept`
+:::
+
 :::{grid-item-card} How-To Guides
 :link: inference/switch-inference-providers
 :link-type: doc
@@ -228,6 +238,14 @@ Set Up the Telegram Bridge <deployment/set-up-telegram-bridge>
 :hidden:
 
 Monitor Sandbox Activity <monitoring/monitor-sandbox-activity>
+```
+
+```{toctree}
+:caption: Workspace
+:hidden:
+
+Workspace Files <workspace/workspace-files>
+Back Up & Restore <workspace/backup-restore>
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -245,7 +245,7 @@ Monitor Sandbox Activity <monitoring/monitor-sandbox-activity>
 :hidden:
 
 Workspace Files <workspace/workspace-files>
-Back Up & Restore <workspace/backup-restore>
+Back Up and Restore <workspace/backup-restore>
 ```
 
 ```{toctree}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -104,6 +104,12 @@ $ nemoclaw my-assistant logs [--follow]
 Stop the NIM container and delete the sandbox.
 This removes the sandbox from the registry.
 
+:::{warning}
+Destroying a sandbox permanently deletes all files inside it, including
+[workspace files](../workspace/workspace-files.md) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes).
+Back up your workspace first — see [Back Up and Restore](../workspace/backup-restore.md).
+:::
+
 ```console
 $ nemoclaw my-assistant destroy
 ```

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -107,7 +107,7 @@ This removes the sandbox from the registry.
 :::{warning}
 Destroying a sandbox permanently deletes all files inside it, including
 [workspace files](../workspace/workspace-files.md) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes).
-Back up your workspace first — see [Back Up and Restore](../workspace/backup-restore.md).
+Back up your workspace first by following the instructions at [Back Up and Restore](../workspace/backup-restore.md).
 :::
 
 ```console

--- a/docs/workspace/backup-restore.md
+++ b/docs/workspace/backup-restore.md
@@ -1,0 +1,126 @@
+---
+title:
+  page: "Back Up and Restore Workspace Files"
+  nav: "Back Up & Restore"
+description: "How to back up and restore OpenClaw workspace files before destructive operations."
+keywords: ["nemoclaw backup", "nemoclaw restore", "workspace backup", "openshell sandbox download upload"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "sandboxing", "workspace", "backup", "nemoclaw"]
+content:
+  type: how_to
+  difficulty: technical_beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Back Up and Restore Workspace Files
+
+Workspace files define your agent's personality, memory, and user context.
+They persist across sandbox restarts but are **permanently deleted** when you run `nemoclaw <name> destroy`.
+
+This guide covers manual backup with CLI commands and an automated script.
+
+## Prerequisites
+
+- A running NemoClaw sandbox (for backup) or a freshly created sandbox (for restore).
+- The OpenShell CLI on your `PATH`.
+- The sandbox name (shown by `nemoclaw list`).
+
+## When to Back Up
+
+- Before running `nemoclaw <name> destroy`.
+- Before major NemoClaw version upgrades.
+- Periodically, if you have invested time customizing your agent.
+
+## Manual Backup
+
+Use `openshell sandbox download` to copy files from the sandbox to your host.
+
+```console
+$ SANDBOX=my-assistant
+$ BACKUP_DIR=~/.nemoclaw/backups/$(date +%Y%m%d-%H%M%S)
+$ mkdir -p "$BACKUP_DIR"
+
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/SOUL.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/USER.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/IDENTITY.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/AGENTS.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/MEMORY.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/memory/ "$BACKUP_DIR/memory/"
+```
+
+## Manual Restore
+
+Use `openshell sandbox upload` to push files back into a sandbox.
+
+```console
+$ SANDBOX=my-assistant
+$ BACKUP_DIR=~/.nemoclaw/backups/20260320-120000  # pick a timestamp
+
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/SOUL.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/USER.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/IDENTITY.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/AGENTS.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/MEMORY.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/memory/" /sandbox/.openclaw/workspace/memory/
+```
+
+## Using the Backup Script
+
+The repository includes a convenience script at `scripts/backup-workspace.sh`.
+
+### Backup
+
+```console
+$ ./scripts/backup-workspace.sh backup my-assistant
+Backing up workspace from sandbox 'my-assistant'...
+Backup saved to /home/user/.nemoclaw/backups/20260320-120000/ (6 items)
+```
+
+### Restore
+
+Restore from the most recent backup:
+
+```console
+$ ./scripts/backup-workspace.sh restore my-assistant
+```
+
+Restore from a specific timestamp:
+
+```console
+$ ./scripts/backup-workspace.sh restore my-assistant 20260320-120000
+```
+
+## Verifying a Backup
+
+List backed-up files to confirm completeness:
+
+```console
+$ ls ~/.nemoclaw/backups/20260320-120000/
+AGENTS.md
+IDENTITY.md
+MEMORY.md
+SOUL.md
+USER.md
+memory/
+```
+
+## Inspecting Files Inside the Sandbox
+
+Connect to the sandbox to list or view workspace files directly:
+
+```console
+$ openshell sandbox connect my-assistant
+$ ls -la /sandbox/.openclaw/workspace/
+```
+
+## Related Topics
+
+- [Workspace Files overview](workspace-files.md) — learn what each file does
+- [Commands reference](../reference/commands.md)
+- [Monitor Sandbox Activity](../monitoring/monitor-sandbox-activity.md)

--- a/docs/workspace/backup-restore.md
+++ b/docs/workspace/backup-restore.md
@@ -119,7 +119,7 @@ $ openshell sandbox connect my-assistant
 $ ls -la /sandbox/.openclaw/workspace/
 ```
 
-## Related Topics
+## Next Steps
 
 - [Workspace Files overview](workspace-files.md) — learn what each file does
 - [Commands reference](../reference/commands.md)

--- a/docs/workspace/workspace-files.md
+++ b/docs/workspace/workspace-files.md
@@ -1,0 +1,85 @@
+---
+title:
+  page: "Workspace Files"
+  nav: "Workspace Files"
+description: "What workspace files are, where they live, and how they persist across sandbox restarts."
+keywords: ["nemoclaw workspace files", "soul.md", "user.md", "identity.md", "agents.md", "memory.md", "sandbox persistence"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "sandboxing", "workspace", "persistence", "nemoclaw"]
+content:
+  type: concept
+  difficulty: technical_beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Workspace Files
+
+OpenClaw stores agent identity, behavior, and memory in a set of Markdown files inside the sandbox.
+These files live at `/sandbox/.openclaw/workspace/` and are read by the agent at the start of every session.
+
+## File Reference
+
+Each file controls a distinct aspect of the agent's behavior and memory.
+
+| File | Purpose | Upstream Docs |
+|---|---|---|
+| `SOUL.md` | Core personality, tone, and behavioral rules. | [SOUL template](https://docs.openclaw.ai/reference/templates/SOUL) |
+| `USER.md` | Preferences, context, and facts the agent learns about you. | [USER template](https://docs.openclaw.ai/reference/templates/USER) |
+| `IDENTITY.md` | Agent name, creature type, emoji, and self-presentation. | [IDENTITY template](https://docs.openclaw.ai/reference/templates/IDENTITY) |
+| `AGENTS.md` | Multi-agent coordination, memory conventions, and safety guidelines. | [AGENTS template](https://docs.openclaw.ai/reference/templates/AGENTS) |
+| `MEMORY.md` | Curated long-term memory distilled from daily notes. | — |
+| `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. | — |
+
+## Where They Live
+
+All workspace files reside inside the sandbox filesystem:
+
+```text
+/sandbox/.openclaw/workspace/
+├── AGENTS.md
+├── IDENTITY.md
+├── MEMORY.md
+├── SOUL.md
+├── USER.md
+└── memory/
+    ├── 2026-03-18.md
+    └── 2026-03-19.md
+```
+
+:::{note}
+The workspace directory is hidden (`.openclaw`).
+The files are not at `/sandbox/SOUL.md` — use the full path when downloading or uploading.
+:::
+
+## Persistence Behavior
+
+Understanding when these files persist and when they are lost is critical.
+
+| Event | Workspace files |
+|---|---|
+| Sandbox restart | **Preserved** — the sandbox PVC retains its data. |
+| `nemoclaw <name> destroy` | **Lost** — the sandbox and its PVC are deleted. |
+
+:::{warning}
+Always back up your workspace files before running `nemoclaw <name> destroy`.
+See [Back Up and Restore](backup-restore.md) for instructions.
+:::
+
+## Editing Workspace Files
+
+The agent reads these files at the start of every session.
+You can edit them in two ways:
+
+1. **Let the agent do it** — Ask your agent to update its persona, memory, or user context during a session.
+2. **Edit manually** — Use `openshell sandbox connect` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
+
+## Related Topics
+
+- [Back Up and Restore workspace files](backup-restore.md)
+- [Commands reference](../reference/commands.md)

--- a/docs/workspace/workspace-files.md
+++ b/docs/workspace/workspace-files.md
@@ -79,7 +79,7 @@ You can edit them in two ways:
 1. **Let the agent do it** — Ask your agent to update its persona, memory, or user context during a session.
 2. **Edit manually** — Use `openshell sandbox connect` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
 
-## Related Topics
+## Next Steps
 
 - [Back Up and Restore workspace files](backup-restore.md)
 - [Commands reference](../reference/commands.md)

--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+WORKSPACE_PATH="/sandbox/.openclaw/workspace"
+BACKUP_BASE="${HOME}/.nemoclaw/backups"
+FILES=(SOUL.md USER.md IDENTITY.md AGENTS.md MEMORY.md)
+DIRS=(memory)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}[backup]${NC} $1"; }
+warn() { echo -e "${YELLOW}[backup]${NC} $1"; }
+fail() { echo -e "${RED}[backup]${NC} $1" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage:
+  $(basename "$0") backup  <sandbox-name>
+  $(basename "$0") restore <sandbox-name> [timestamp]
+
+Commands:
+  backup   Download workspace files from a sandbox to a timestamped local backup.
+  restore  Upload workspace files from a local backup into a sandbox.
+           If no timestamp is given, the most recent backup is used.
+
+Backup location: ${BACKUP_BASE}/<timestamp>/
+EOF
+    exit 1
+}
+
+do_backup() {
+    local sandbox="$1"
+    local ts
+    ts="$(date +%Y%m%d-%H%M%S)"
+    local dest="${BACKUP_BASE}/${ts}"
+
+    mkdir -p "$BACKUP_BASE"
+    chmod 0700 "${HOME}/.nemoclaw" "$BACKUP_BASE" 2>/dev/null || true
+    mkdir -p "$dest"
+    chmod 0700 "$dest"
+
+    info "Backing up workspace from sandbox '${sandbox}'..."
+
+    local count=0
+    for f in "${FILES[@]}"; do
+        if openshell sandbox download "$sandbox" "${WORKSPACE_PATH}/${f}" "${dest}/"; then
+            count=$((count + 1))
+        else
+            warn "Skipped ${f} (not found or download failed)"
+        fi
+    done
+
+    for d in "${DIRS[@]}"; do
+        if openshell sandbox download "$sandbox" "${WORKSPACE_PATH}/${d}/" "${dest}/${d}/"; then
+            count=$((count + 1))
+        else
+            warn "Skipped ${d}/ (not found or download failed)"
+        fi
+    done
+
+    if [ "$count" -eq 0 ]; then
+        fail "No files were backed up. Check that the sandbox '${sandbox}' exists and has workspace files."
+    fi
+
+    info "Backup saved to ${dest}/ (${count} items)"
+}
+
+do_restore() {
+    local sandbox="$1"
+    local ts="${2:-}"
+
+    if [ -z "$ts" ]; then
+        ts="$(ls -1 "$BACKUP_BASE" 2>/dev/null | sort -r | head -n1)"
+        [ -n "$ts" ] || fail "No backups found in ${BACKUP_BASE}/"
+        info "Using most recent backup: ${ts}"
+    fi
+
+    local src="${BACKUP_BASE}/${ts}"
+    [ -d "$src" ] || fail "Backup directory not found: ${src}"
+
+    info "Restoring workspace to sandbox '${sandbox}' from ${src}..."
+
+    local count=0
+    for f in "${FILES[@]}"; do
+        if [ -f "${src}/${f}" ]; then
+            if openshell sandbox upload "$sandbox" "${src}/${f}" "${WORKSPACE_PATH}/"; then
+                count=$((count + 1))
+            else
+                warn "Failed to restore ${f}"
+            fi
+        fi
+    done
+
+    for d in "${DIRS[@]}"; do
+        if [ -d "${src}/${d}" ]; then
+            if openshell sandbox upload "$sandbox" "${src}/${d}/" "${WORKSPACE_PATH}/${d}/"; then
+                count=$((count + 1))
+            else
+                warn "Failed to restore ${d}/"
+            fi
+        fi
+    done
+
+    if [ "$count" -eq 0 ]; then
+        fail "No files were restored. Check that the sandbox '${sandbox}' is running."
+    fi
+
+    info "Restored ${count} items to sandbox '${sandbox}'."
+}
+
+# --- Main ---
+
+[ $# -ge 2 ] || usage
+command -v openshell >/dev/null 2>&1 || fail "'openshell' is required but not found in PATH."
+
+action="$1"
+sandbox="$2"
+shift 2
+
+case "$action" in
+    backup)  do_backup "$sandbox" ;;
+    restore) do_restore "$sandbox" "$@" ;;
+    *)       usage ;;
+esac

--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -41,7 +41,8 @@ do_backup() {
     local dest="${BACKUP_BASE}/${ts}"
 
     mkdir -p "$BACKUP_BASE"
-    chmod 0700 "${HOME}/.nemoclaw" "$BACKUP_BASE" 2>/dev/null || true
+    chmod 0700 "${HOME}/.nemoclaw" "$BACKUP_BASE" || \
+        fail "Failed to set secure permissions on ${HOME}/.nemoclaw — check directory ownership."
     mkdir -p "$dest"
     chmod 0700 "$dest"
 


### PR DESCRIPTION
## Summary

Combines the best of #456 and #476 to fully address #434 — documenting workspace file persistence and providing backup/restore guidance.

**New files:**
- `docs/workspace/workspace-files.md` — Concept page covering all six workspace files (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, `memory/`) with links to upstream OpenClaw template docs
- `docs/workspace/backup-restore.md` — How-to guide for manual and scripted backup/restore
- `scripts/backup-workspace.sh` — Convenience script for automated backup and restore

**Modified files:**
- `docs/reference/commands.md` — Added data-loss warning to the `nemoclaw <name> destroy` section
- `docs/index.md` — Added Workspace section to navigation and Explore grid

## What this fixes over #456 and #476

| Source | Issue | Fix |
|--------|-------|-----|
| #476 | References nonexistent `openshell sandbox shell` | Uses `openshell sandbox connect` |
| #476 | References nonexistent `openshell sandbox restart` | Removed (command doesn't exist) |
| #476 | Script suppresses all errors with `2>/dev/null` | Errors are visible for debugging |
| #456 | Only covers 3 of 6 workspace files | Covers all 6 |
| #456 | Upload command uses wrong argument form | Uses directory path as dest |
| #456 | miyoungc review comments unaddressed | Incorporated upstream doc links |

Closes #434
Supersedes #456 and #476

## Test plan

- [x] Verify Sphinx docs build passes (`make docs-strict`)
- [x] Verify upstream OpenClaw template links resolve (SOUL, USER, IDENTITY, AGENTS — MEMORY returns 404 and is intentionally omitted)
- [x] Test `scripts/backup-workspace.sh backup <name>` against a running sandbox
- [x] Test `scripts/backup-workspace.sh restore <name>` against a fresh sandbox
- [x] Confirm grid card renders on docs landing page
- [x] Confirm Workspace section appears in sidebar navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backup/restore helper (CLI) to save and restore workspace files.

* **Documentation**
  * New "Workspace Files" overview describing persistent workspace files and editing workflows.
  * New "Back Up and Restore" guide with prerequisites, manual and scripted backup/restore steps, verification, and examples.
  * Added a prominent warning to the destroy command that it permanently deletes workspace files.
  * Added a "Workspace Files" card to the landing page and updated navigation to surface these docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->