### PR TITLE
fix: proper entrypoint, foreground sidecar, correct port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: [self-hosted, Linux, X64]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,5 +71,6 @@ os.chmod(path, 0o600)"
 RUN openclaw doctor --fix > /dev/null 2>&1 || true \
     && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
-ENTRYPOINT ["/bin/bash"]
-CMD []
+EXPOSE 3100
+
+ENTRYPOINT ["/usr/local/bin/nemoclaw-start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \
 COPY scripts/nemoclaw-start.sh /usr/local/bin/nemoclaw-start
 RUN chmod +x /usr/local/bin/nemoclaw-start
 
+# WOPR sidecar — provision + health endpoints for nemoclaw-platform
+COPY wopr/ /opt/wopr/
+
 WORKDIR /sandbox
 USER sandbox
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -183,8 +183,13 @@ echo "[gateway] openclaw gateway launched (pid $!)"
 start_auto_pair
 print_dashboard_urls
 
-# Start WOPR sidecar — /internal/health + /internal/provision for nemoclaw-platform
+# Start WOPR sidecar in foreground — keeps the container alive.
+# Serves /internal/health + /internal/provision for nemoclaw-platform.
 if [ -f /opt/wopr/sidecar.js ]; then
-  nohup node /opt/wopr/sidecar.js > /tmp/wopr-sidecar.log 2>&1 &
-  echo "[wopr-sidecar] launched (pid $!)"
+  echo "[wopr-sidecar] starting in foreground (port ${PORT:-3100})"
+  exec node /opt/wopr/sidecar.js
 fi
+
+# Fallback: keep container alive if no sidecar
+echo "[nemoclaw] no sidecar found, waiting..."
+exec tail -f /tmp/gateway.log

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -182,3 +182,9 @@ nohup openclaw gateway run > /tmp/gateway.log 2>&1 &
 echo "[gateway] openclaw gateway launched (pid $!)"
 start_auto_pair
 print_dashboard_urls
+
+# Start WOPR sidecar — /internal/health + /internal/provision for nemoclaw-platform
+if [ -f /opt/wopr/sidecar.js ]; then
+  nohup node /opt/wopr/sidecar.js > /tmp/wopr-sidecar.log 2>&1 &
+  echo "[wopr-sidecar] launched (pid $!)"
+fi

--- a/wopr/package.json
+++ b/wopr/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@wopr-network/nemoclaw-sidecar",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "WOPR provision sidecar for NemoClaw managed hosting"
+}

--- a/wopr/sidecar.js
+++ b/wopr/sidecar.js
@@ -14,7 +14,7 @@ import os from "node:os";
 
 const SECRET = process.env.WOPR_PROVISION_SECRET ?? "";
 const GATEWAY_URL = process.env.WOPR_GATEWAY_URL ?? "";
-const PORT = parseInt(process.env.WOPR_SIDECAR_PORT ?? "3001", 10);
+const PORT = parseInt(process.env.PORT ?? process.env.WOPR_SIDECAR_PORT ?? "3100", 10);
 const OPENCLAW_CONFIG_PATH = path.join(os.homedir(), ".openclaw", "openclaw.json");
 
 function assertSecret(req) {

--- a/wopr/sidecar.js
+++ b/wopr/sidecar.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// WOPR NemoClaw sidecar — exposes /internal/health and /internal/provision
+// so nemoclaw-platform can use the same provision contract as paperclip-platform.
+//
+// Env vars:
+//   WOPR_PROVISION_SECRET  — shared secret for auth
+//   WOPR_GATEWAY_URL       — WOPR inference gateway base URL (e.g. https://gateway.wopr.bot/v1)
+//   PORT                   — sidecar port (default: 3001)
+
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const SECRET = process.env.WOPR_PROVISION_SECRET ?? "";
+const GATEWAY_URL = process.env.WOPR_GATEWAY_URL ?? "";
+const PORT = parseInt(process.env.WOPR_SIDECAR_PORT ?? "3001", 10);
+const OPENCLAW_CONFIG_PATH = path.join(os.homedir(), ".openclaw", "openclaw.json");
+
+function assertSecret(req) {
+  const auth = req.headers["authorization"] ?? "";
+  if (!auth.startsWith("Bearer ")) return false;
+  return auth.slice("Bearer ".length).trim() === SECRET;
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeJson(filePath, obj) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(obj, null, 2), { mode: 0o600 });
+}
+
+function isGatewayUp() {
+  try {
+    const logPath = "/tmp/gateway.log";
+    if (!fs.existsSync(logPath)) return false;
+    const tail = fs.readFileSync(logPath, "utf8").slice(-4096);
+    // openclaw gateway prints "Listening" or "Gateway running" when ready
+    return /listening|gateway running|started/i.test(tail);
+  } catch {
+    return false;
+  }
+}
+
+function provision(body) {
+  const { tenantId, tenantName, gatewayUrl, apiKey, budgetCents } = body;
+
+  if (!tenantId || !tenantName) {
+    throw new Error("Missing required fields: tenantId, tenantName");
+  }
+
+  const effectiveGateway = gatewayUrl || GATEWAY_URL;
+  if (!effectiveGateway) {
+    throw new Error("No gateway URL provided and WOPR_GATEWAY_URL not set");
+  }
+
+  // Point NemoClaw at WOPR's inference gateway instead of NVIDIA's
+  const cfg = readJson(OPENCLAW_CONFIG_PATH);
+
+  cfg.agents ??= {};
+  cfg.agents.defaults ??= {};
+  cfg.agents.defaults.model ??= {};
+  cfg.agents.defaults.model.primary = "nvidia/nemotron-3-super-120b-a12b";
+
+  cfg.models ??= {};
+  cfg.models.mode = "merge";
+  cfg.models.providers ??= {};
+  cfg.models.providers["wopr-gateway"] = {
+    baseUrl: effectiveGateway,
+    apiKey: apiKey ?? "wopr-managed",
+    api: "openai-completions",
+    models: [
+      {
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "Nemotron 3 Super 120B (via WOPR)",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 4096,
+      },
+    ],
+  };
+
+  // Set WOPR gateway as the active provider
+  cfg.agents.defaults.model.primary = "nvidia/nemotron-3-super-120b-a12b";
+  cfg.gateway ??= {};
+  cfg.gateway.inferenceProvider = "wopr-gateway";
+
+  // Store tenant metadata for reference
+  cfg._wopr = { tenantId, tenantName, budgetCents: budgetCents ?? 0, provisionedAt: new Date().toISOString() };
+
+  writeJson(OPENCLAW_CONFIG_PATH, cfg);
+
+  // Derive a stable tenantEntityId and slug from tenantId
+  const tenantSlug = tenantName.toLowerCase().replace(/[^a-z0-9]/g, "-").replace(/-+/g, "-").slice(0, 32);
+  const tenantEntityId = `e:${tenantId}`;
+
+  return { tenantEntityId, tenantSlug };
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+
+  // Health check — no auth required
+  if (req.method === "GET" && url.pathname === "/internal/health") {
+    const up = isGatewayUp();
+    res.writeHead(up ? 200 : 503, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: up, gateway: up ? "running" : "starting" }));
+    return;
+  }
+
+  // Provision — auth required
+  if (req.method === "POST" && url.pathname === "/internal/provision") {
+    if (!assertSecret(req)) {
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => {
+      try {
+        const parsed = JSON.parse(body);
+        const result = provision(parsed);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, ...result }));
+      } catch (err) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "Not found" }));
+});
+
+server.listen(PORT, "0.0.0.0", () => {
+  console.log(`[wopr-sidecar] listening on :${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Dockerfile: `ENTRYPOINT ["/bin/bash"]` → `ENTRYPOINT ["/usr/local/bin/nemoclaw-start"]` — container was exiting immediately with code 0 because bash had no TTY
- nemoclaw-start.sh: run WOPR sidecar in foreground via `exec` (keeps container alive) instead of `nohup` background
- sidecar.js: read `PORT` env var (fleet.ts sets 3100) instead of `WOPR_SIDECAR_PORT` defaulting to 3001 — port mismatch caused health checks to fail

## Test plan
- [x] Container should start and stay running (exit code != 0 restart loop)
- [x] Sidecar listens on PORT (3100) matching fleet health check
- [ ] `/internal/health` returns 200 after gateway starts
- [ ] `/internal/provision` accepts provision payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)