### PR TITLE
fix(security): stop passing NVIDIA_API_KEY into sandbox and command lines

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -533,10 +533,13 @@ async function createSandbox(gpu) {
 
   console.log(`  Creating sandbox '${sandboxName}' (this takes a few minutes on first run)...`);
   const chatUiUrl = process.env.CHAT_UI_URL || 'http://127.0.0.1:18789';
+  // Only pass non-sensitive env vars to the sandbox. NVIDIA_API_KEY is NOT
+  // needed inside the sandbox — inference is proxied through the OpenShell
+  // gateway which injects the stored credential server-side. The gateway
+  // also strips any Authorization headers sent by the sandbox client.
+  // See: crates/openshell-sandbox/src/proxy.rs (header stripping),
+  //      crates/openshell-router/src/backend.rs (server-side auth injection).
   const envArgs = [`CHAT_UI_URL=${shellQuote(chatUiUrl)}`];
-  if (process.env.NVIDIA_API_KEY) {
-    envArgs.push(`NVIDIA_API_KEY=${shellQuote(process.env.NVIDIA_API_KEY)}`);
-  }
   const discordToken = getCredential("DISCORD_BOT_TOKEN") || process.env.DISCORD_BOT_TOKEN;
   if (discordToken) {
     envArgs.push(`DISCORD_BOT_TOKEN=${shellQuote(discordToken)}`);
@@ -1067,6 +1070,11 @@ async function onboard(opts = {}) {
   const sandboxName = await createSandbox(gpu);
   const { model, provider } = await setupNim(sandboxName, gpu);
   await setupInference(sandboxName, model, provider);
+  // The key is now stored in openshell's provider config. Clear it from our
+  // process environment so new child processes don't inherit it. Note: this
+  // does NOT clear /proc/pid/environ (kernel snapshot is immutable after exec),
+  // but it prevents run()'s { ...process.env } from propagating the key.
+  delete process.env.NVIDIA_API_KEY;
   await setupOpenclaw(sandboxName, model, provider);
   await setupPolicies(sandboxName);
   printDashboard(sandboxName, model, provider);

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -96,8 +96,8 @@ async function setup() {
 }
 
 async function setupSpark() {
-  await ensureApiKey();
-  run(`sudo -E NVIDIA_API_KEY=${shellQuote(process.env.NVIDIA_API_KEY)} bash "${SCRIPTS}/setup-spark.sh"`);
+  // setup-spark.sh configures Docker cgroups — it does not use NVIDIA_API_KEY.
+  run(`sudo bash "${SCRIPTS}/setup-spark.sh"`);
 }
 
 async function deploy(instanceName) {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -133,10 +133,12 @@ fi
 info "Setting up inference providers..."
 
 # nvidia-nim (build.nvidia.com)
+# Use env-name-only form so openshell reads the value from the environment
+# internally — the literal key value never appears in the process argument list.
 upsert_provider \
   "nvidia-nim" \
   "openai" \
-  "NVIDIA_API_KEY=$NVIDIA_API_KEY" \
+  "NVIDIA_API_KEY" \
   "OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1"
 
 # vllm-local (if vLLM is installed or running)
@@ -193,9 +195,11 @@ rm -rf "$BUILD_CTX/nemoclaw/node_modules"
 # detect failures. The raw log is kept on failure for debugging.
 CREATE_LOG=$(mktemp /tmp/nemoclaw-create-XXXXXX.log)
 set +e
+# NVIDIA_API_KEY is NOT passed into the sandbox. Inference is proxied through
+# the OpenShell gateway which injects the stored credential server-side.
 openshell sandbox create --from "$BUILD_CTX/Dockerfile" --name "$SANDBOX_NAME" \
   --provider nvidia-nim \
-  -- env NVIDIA_API_KEY="$NVIDIA_API_KEY" >"$CREATE_LOG" 2>&1
+  >"$CREATE_LOG" 2>&1
 CREATE_RC=$?
 set -e
 rm -rf "$BUILD_CTX"

--- a/scripts/walkthrough.sh
+++ b/scripts/walkthrough.sh
@@ -72,9 +72,7 @@ if ! command -v tmux >/dev/null 2>&1; then
   echo ""
   echo "  Terminal 2 (Agent):"
   echo "    openshell sandbox connect nemoclaw"
-  echo '    export NVIDIA_API_KEY=<your-key>'
-  echo "    nemoclaw-start"
-  echo "    openclaw agent --agent main --local --session-id live"
+  echo "    nemoclaw-start openclaw agent --agent main --local --session-id live"
   exit 0
 fi
 
@@ -87,8 +85,10 @@ tmux kill-session -t "$SESSION" 2>/dev/null || true
 tmux new-session -d -s "$SESSION" -x 200 -y 50 "openshell term"
 
 # Split right pane for the agent
+# NVIDIA_API_KEY is not needed inside the sandbox — inference is proxied
+# through the OpenShell gateway which injects credentials server-side.
 tmux split-window -h -t "$SESSION" \
-  "openshell sandbox connect nemoclaw -- bash -c 'export NVIDIA_API_KEY=$NVIDIA_API_KEY && nemoclaw-start openclaw agent --agent main --local --session-id live'"
+  "openshell sandbox connect nemoclaw -- bash -c 'nemoclaw-start openclaw agent --agent main --local --session-id live'"
 
 # Even split
 tmux select-layout -t "$SESSION" even-horizontal

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -208,4 +208,72 @@ describe("runner helpers", () => {
       expect(!src.includes("execSync")).toBeTruthy();
     });
   });
+
+  describe("credential exposure guards (#429)", () => {
+    it("onboard createSandbox does not pass NVIDIA_API_KEY to sandbox env", () => {
+      const fs = require("fs");
+      const src = fs.readFileSync(path.join(__dirname, "..", "bin", "lib", "onboard.js"), "utf-8");
+      // Find the envArgs block in createSandbox — it should not contain NVIDIA_API_KEY
+      const envArgsMatch = src.match(/const envArgs = \[[\s\S]*?\];/);
+      expect(envArgsMatch).toBeTruthy();
+      expect(envArgsMatch[0].includes("NVIDIA_API_KEY")).toBe(false);
+    });
+
+    it("onboard clears NVIDIA_API_KEY from process.env after setupInference", () => {
+      const fs = require("fs");
+      const src = fs.readFileSync(path.join(__dirname, "..", "bin", "lib", "onboard.js"), "utf-8");
+      expect(src.includes("delete process.env.NVIDIA_API_KEY")).toBeTruthy();
+    });
+
+    it("setup.sh uses env-name-only form for nvidia-nim credential", () => {
+      const fs = require("fs");
+      const src = fs.readFileSync(path.join(__dirname, "..", "scripts", "setup.sh"), "utf-8");
+      // Should use "NVIDIA_API_KEY" (name only), not "NVIDIA_API_KEY=$NVIDIA_API_KEY" (value)
+      const lines = src.split("\n");
+      for (const line of lines) {
+        if (line.includes("upsert_provider") || line.includes("--credential")) continue;
+        if (line.trim().startsWith("#")) continue;
+        // Check credential argument lines passed to upsert_provider
+        if (line.includes('"NVIDIA_API_KEY=')) {
+          // Allow "NVIDIA_API_KEY" alone but not "NVIDIA_API_KEY=$..."
+          expect(line.includes("NVIDIA_API_KEY=$")).toBe(false);
+        }
+      }
+    });
+
+    it("setup.sh does not pass NVIDIA_API_KEY in sandbox create env args", () => {
+      const fs = require("fs");
+      const src = fs.readFileSync(path.join(__dirname, "..", "scripts", "setup.sh"), "utf-8");
+      // Find sandbox create command — should not have env NVIDIA_API_KEY
+      const createLines = src.split("\n").filter((l) => l.includes("sandbox create"));
+      for (const line of createLines) {
+        expect(line.includes("NVIDIA_API_KEY")).toBe(false);
+      }
+    });
+
+    it("setupSpark does not pass NVIDIA_API_KEY to sudo", () => {
+      const fs = require("fs");
+      const src = fs.readFileSync(path.join(__dirname, "..", "bin", "nemoclaw.js"), "utf-8");
+      // Find the run() call inside setupSpark — it should not contain the key
+      const sparkLines = src.split("\n").filter(
+        (l) => l.includes("setup-spark") && l.includes("run(")
+      );
+      for (const line of sparkLines) {
+        expect(line.includes("NVIDIA_API_KEY")).toBe(false);
+      }
+    });
+
+    it("walkthrough.sh does not embed NVIDIA_API_KEY in tmux or sandbox commands", () => {
+      const fs = require("fs");
+      const src = fs.readFileSync(path.join(__dirname, "..", "scripts", "walkthrough.sh"), "utf-8");
+      // Check only executable lines (tmux spawn, openshell connect) — not comments/docs
+      const cmdLines = src.split("\n").filter(
+        (l) => !l.trim().startsWith("#") && !l.trim().startsWith("echo") &&
+               (l.includes("tmux") || l.includes("openshell sandbox connect"))
+      );
+      for (const line of cmdLines) {
+        expect(line.includes("NVIDIA_API_KEY")).toBe(false);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #429. Lands independently of #617.

The OpenShell gateway proxies inference and injects stored credentials server-side — the raw NVIDIA_API_KEY was never needed inside the sandbox but was passed via env args, `setup.sh`, walkthrough commands, and the `setupSpark` sudo call, exposing it in `ps aux`, `/proc/pid/cmdline`, `docker inspect`, and k3s audit logs.

- Remove `NVIDIA_API_KEY` from `openshell sandbox create` env args (`onboard.js`, `setup.sh`)
- Use env-name-only `--credential NVIDIA_API_KEY` form in `setup.sh` (same pattern as #330)
- Remove key from `walkthrough.sh` tmux/connect commands
- Remove unnecessary key + `ensureApiKey()` from `setupSpark` (script never reads it)
- Clear key from `process.env` after `setupInference` handoff
- Add 6 regression tests for credential exposure

## What this does NOT fix

- `/proc/pid/environ` of the nemoclaw process itself — kernel snapshot is immutable after exec. `delete process.env` only prevents child process inheritance. True fix requires file-based credential loading (OpenShell provider model change).
- `--credential NVIDIA_API_KEY=<value>` in `onboard.js` `setupInference` — that's #330's scope.
- Messaging tokens in sandbox env — blocked on #617 merge.

## Why it works

Verified in OpenShell source:
- `proxy.rs:1068` — gateway strips all `Authorization` / `X-Api-Key` headers from sandbox requests
- `backend.rs:101` — gateway re-authenticates upstream using stored provider key
- `grpc.rs:3446` — inference provider credentials are NOT injected into sandbox env
- `nemoclaw-start.sh:19` — `write_auth_profile()` gracefully no-ops if key is absent

## Test plan

- [x] 225/225 tests pass (including 6 new regression tests)
- [ ] E2E: `nemoclaw onboard` completes, inference works through gateway without key in sandbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks to ensure sensitive credentials are not embedded or forwarded during agent setup and sandbox creation.

* **Chores**
  * Ceased forwarding the GPU/API credential into sandbox and setup commands and added post-setup cleanup to prevent propagation.
  * Updated walkthroughs and inline documentation to reflect gateway-side credential handling and simplified agent startup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->