### PR TITLE
fix(security): pin Dockerfile base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # NemoClaw sandbox image — OpenClaw + NemoClaw plugin inside OpenShell
 
 # Stage 1: Build TypeScript plugin from source
-FROM node:22-slim AS builder
+FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d AS builder
 COPY nemoclaw/package.json nemoclaw/tsconfig.json /opt/nemoclaw/
 COPY nemoclaw/src/ /opt/nemoclaw/src/
 WORKDIR /opt/nemoclaw
 RUN npm install && npm run build
 
 # Stage 2: Runtime image
-FROM node:22-slim
+FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary

Pin both `FROM node:22-slim` lines in the Dockerfile to a specific sha256 digest for supply chain integrity.

Before: `FROM node:22-slim` (mutable tag)
After: `FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d`

## Test plan

- [x] 219/219 unit tests pass
- [ ] `nemoclaw onboard` builds sandbox image successfully with pinned digest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration to pin base image digests, ensuring consistent and reproducible container builds across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->