### PR TITLE
fix(security): use mktemp for cloudflared download to prevent TOCTOU race

### DIFF
--- a/scripts/brev-setup.sh
+++ b/scripts/brev-setup.sh
@@ -106,9 +106,10 @@ if ! command -v cloudflared > /dev/null 2>&1; then
     aarch64|arm64) CF_ARCH="arm64" ;;
     *) fail "Unsupported architecture for cloudflared: $CF_ARCH" ;;
   esac
-  curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${CF_ARCH}" -o /tmp/cloudflared
-  sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
-  rm -f /tmp/cloudflared
+  tmpdir=$(mktemp -d)
+  curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${CF_ARCH}" -o "$tmpdir/cloudflared"
+  sudo install -m 755 "$tmpdir/cloudflared" /usr/local/bin/cloudflared
+  rm -rf "$tmpdir"
   info "cloudflared $(cloudflared --version 2>&1 | head -1) installed"
 else
   info "cloudflared already installed"
@@ -140,7 +141,7 @@ if command -v nvidia-smi > /dev/null 2>&1; then
       > /tmp/vllm-server.log 2>&1 &
     VLLM_PID=$!
     info "Waiting for vLLM to load model (this can take a few minutes)..."
-    for i in $(seq 1 120); do
+    for _ in $(seq 1 120); do
       if curl -s http://localhost:8000/v1/models > /dev/null 2>&1; then
         info "vLLM ready (PID $VLLM_PID)"
         break


### PR DESCRIPTION
## Summary

Replace hardcoded `/tmp/cloudflared` download path in `brev-setup.sh` with a `mktemp -d` based path to prevent TOCTOU race conditions where an attacker could replace the binary between download and `sudo install`.

## Test plan

- [x] All tests and pre-commit hooks pass
- [ ] Manual: `brev-setup.sh` downloads and installs cloudflared successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloudflared installer robustness by using isolated temporary storage during the installation process, preventing potential file path conflicts.
  * Enhanced vLLM startup initialization reliability through improved readiness detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->