### PR TITLE
fix(install): ensure .openclaw-data ownership for sandbox user (fixes #692)

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -150,15 +150,20 @@ fix_openclaw_data_ownership() {
 
   # Fix ownership if the top-level data dir is not owned by us (common when
   # the entire tree was created as root during installation).
-  if find "$data_dir" -maxdepth 0 ! -user "$(id -u)" -print -quit 2>/dev/null | grep -q .; then
+  if find "$data_dir" -maxdepth 2 ! -user "$(id -u)" -print -quit 2>/dev/null | grep -q .; then
     chown -R "$(id -u):$(id -g)" "$data_dir" 2>/dev/null || true
     echo "[setup] fixed ownership on ${data_dir}"
   fi
 
   # Ensure the identity symlink exists (may be missing on native installs).
-  if [ ! -e "${openclaw_dir}/identity" ] && [ -d "${data_dir}/identity" ]; then
+  # Remove any broken symlinks first to prevent conflicts.
+  if [ ! -L "${openclaw_dir}/identity" ] && [ ! -e "${openclaw_dir}/identity" ] && [ -d "${data_dir}/identity" ]; then
     ln -sf "${data_dir}/identity" "${openclaw_dir}/identity" 2>/dev/null || true
     echo "[setup] created identity symlink"
+  elif [ -L "${openclaw_dir}/identity" ] && [ ! -e "${openclaw_dir}/identity" ]; then
+    rm -f "${openclaw_dir}/identity"
+    ln -sf "${data_dir}/identity" "${openclaw_dir}/identity" 2>/dev/null || true
+    echo "[setup] replaced broken identity symlink"
   fi
 }
 fix_openclaw_data_ownership

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -148,7 +148,8 @@ fix_openclaw_data_ownership() {
     mkdir -p "${data_dir}/${sub}" 2>/dev/null || true
   done
 
-  # Fix ownership if any files are not owned by us.
+  # Fix ownership if the top-level data dir is not owned by us (common when
+  # the entire tree was created as root during installation).
   if find "$data_dir" -maxdepth 0 ! -user "$(id -u)" -print -quit 2>/dev/null | grep -q .; then
     chown -R "$(id -u):$(id -g)" "$data_dir" 2>/dev/null || true
     echo "[setup] fixed ownership on ${data_dir}"

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -130,6 +130,38 @@ echo 'Setting up NemoClaw...'
 # openclaw doctor --fix and openclaw plugins install already ran at build time
 # (Dockerfile Step 28). At runtime they fail with EPERM against the locked
 # /sandbox/.openclaw directory and accomplish nothing.
+
+# Ensure writable state directories exist and are owned by the current user.
+# The Docker build (Dockerfile) sets this up correctly, but the native curl
+# installer may create these directories as root, causing EACCES when openclaw
+# tries to write device-auth.json or other state files.  Ref: #692
+fix_openclaw_data_ownership() {
+  local data_dir="${HOME}/.openclaw-data"
+  local openclaw_dir="${HOME}/.openclaw"
+
+  # Only act when the split layout (.openclaw-data + symlinks) is present.
+  [ -d "$data_dir" ] || return 0
+
+  # Create any missing writable subdirectories (mirrors Dockerfile setup).
+  local subdirs="agents/main/agent extensions workspace skills hooks identity devices canvas cron"
+  for sub in $subdirs; do
+    mkdir -p "${data_dir}/${sub}" 2>/dev/null || true
+  done
+
+  # Fix ownership if any files are not owned by us.
+  if find "$data_dir" -maxdepth 0 ! -user "$(id -u)" -print -quit 2>/dev/null | grep -q .; then
+    chown -R "$(id -u):$(id -g)" "$data_dir" 2>/dev/null || true
+    echo "[setup] fixed ownership on ${data_dir}"
+  fi
+
+  # Ensure the identity symlink exists (may be missing on native installs).
+  if [ ! -e "${openclaw_dir}/identity" ] && [ -d "${data_dir}/identity" ]; then
+    ln -sf "${data_dir}/identity" "${openclaw_dir}/identity" 2>/dev/null || true
+    echo "[setup] created identity symlink"
+  fi
+}
+fix_openclaw_data_ownership
+
 write_auth_profile
 
 if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then


### PR DESCRIPTION
## Problem

When NemoClaw is installed via the curl installer on Linux, the `.openclaw-data` directories (including `identity/`) may be created with root ownership. When openclaw subsequently runs as the `sandbox` user, it gets `EACCES: permission denied` trying to write `device-auth.json`.

```
gateway connect failed: Error: EACCES: permission denied, open '/sandbox/.openclaw/identity/device-auth.json'
```

The Docker path handles this correctly (Dockerfile line 52: `chown -R sandbox:sandbox`), but the native install path lacks an equivalent ownership fix.

## Fix

Add a `fix_openclaw_data_ownership()` function to `scripts/nemoclaw-start.sh` that runs before gateway startup:

1. Creates any missing writable subdirectories (mirrors the Dockerfile layout)
2. Fixes ownership if files are not owned by the current user
3. Creates the `identity` symlink if missing on native installs

This only activates when the split layout (`.openclaw-data` + symlinks) is present, so it's a no-op on setups that don't use this pattern.

## Testing

- Verified script passes `bash -n` syntax check
- The fix is defensive: it uses `|| true` for all operations so it won't break existing working setups
- Docker path is unaffected (ownership is already correct from Dockerfile)

Fixes #692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Startup now prepares and normalizes the app data directory to reduce initialization issues.
  * Adds ownership and permission handling to minimize startup failures from inaccessible files.
  * Ensures required writable subdirectories and a valid identity link are present before authentication, improving startup reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->