### PR TITLE
fix: auto-add ~/.local/bin to shell rc after user-local openshell install

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -202,16 +202,21 @@ async function deploy(instanceName) {
   runInteractive(`ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${qname} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell sandbox connect nemoclaw'`);
 }
 
-async function start() {
-  await ensureApiKey();
+function sandboxEnvPrefix() {
   const { defaultSandbox } = registry.listSandboxes();
   const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  const sandboxEnv = safeName ? `SANDBOX_NAME=${shellQuote(safeName)}` : "";
-  run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh"`);
+  return safeName ? `SANDBOX_NAME=${shellQuote(safeName)}` : "";
+}
+
+async function start() {
+  await ensureApiKey();
+  const envPrefix = sandboxEnvPrefix();
+  run(`${envPrefix} bash "${SCRIPTS}/start-services.sh"`);
 }
 
 function stop() {
-  run(`bash "${SCRIPTS}/start-services.sh" --stop`);
+  const envPrefix = sandboxEnvPrefix();
+  run(`${envPrefix} bash "${SCRIPTS}/start-services.sh" --stop`);
 }
 
 function debug(args) {
@@ -266,7 +271,8 @@ function showStatus() {
   }
 
   // Show service status
-  run(`bash "${SCRIPTS}/start-services.sh" --status`);
+  const envPrefix = sandboxEnvPrefix();
+  run(`${envPrefix} bash "${SCRIPTS}/start-services.sh" --status`);
 }
 
 function listSandboxes() {

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -100,7 +100,7 @@ elif [ "${NEMOCLAW_NON_INTERACTIVE:-}" = "1" ] || [ ! -t 0 ]; then
   warn "Installed openshell to $target_dir/openshell (user-local path)"
 
   # Auto-configure PATH if needed
-  if ! echo "$PATH" | grep -q "$target_dir"; then
+  if [[ ":$PATH:" != *":$target_dir:"* ]]; then
     # Detect shell and choose rc file
     case "${SHELL##*/}" in
       bash) rc_file="$HOME/.bashrc" ;;
@@ -109,9 +109,10 @@ elif [ "${NEMOCLAW_NON_INTERACTIVE:-}" = "1" ] || [ ! -t 0 ]; then
     esac
 
     # Add PATH export if not already present
-    if ! grep -qF 'export PATH="$HOME/.local/bin:$PATH"' "$rc_file" 2>/dev/null; then
-      echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$rc_file"
-      info "Added ~/.local/bin to PATH in $rc_file"
+    path_export="export PATH=\"$target_dir:\$PATH\""
+    if ! grep -qF "$path_export" "$rc_file" 2>/dev/null; then
+      printf '%s\n' "$path_export" >> "$rc_file"
+      info "Added $target_dir to PATH in $rc_file"
       info "Run 'source $rc_file' or open a new terminal to update PATH"
     fi
   fi

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -98,7 +98,23 @@ elif [ "${NEMOCLAW_NON_INTERACTIVE:-}" = "1" ] || [ ! -t 0 ]; then
   mkdir -p "$target_dir"
   install -m 755 "$tmpdir/openshell" "$target_dir/openshell"
   warn "Installed openshell to $target_dir/openshell (user-local path)"
-  warn "Ensure $target_dir is on PATH for future shells."
+
+  # Auto-configure PATH if needed
+  if ! echo "$PATH" | grep -q "$target_dir"; then
+    # Detect shell and choose rc file
+    case "${SHELL##*/}" in
+      bash) rc_file="$HOME/.bashrc" ;;
+      zsh) rc_file="$HOME/.zshrc" ;;
+      *) rc_file="$HOME/.profile" ;;
+    esac
+
+    # Add PATH export if not already present
+    if ! grep -qF 'export PATH="$HOME/.local/bin:$PATH"' "$rc_file" 2>/dev/null; then
+      echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$rc_file"
+      info "Added ~/.local/bin to PATH in $rc_file"
+      info "Run 'source $rc_file' or open a new terminal to update PATH"
+    fi
+  fi
 else
   sudo install -m 755 "$tmpdir/openshell" "$target_dir/openshell"
 fi

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -3,6 +3,8 @@
 
 import { describe, it, expect } from "vitest";
 import { execSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
 import { resolveOpenshell } from "../bin/lib/resolve-openshell";
 
 describe("service environment", () => {
@@ -93,6 +95,43 @@ describe("service environment", () => {
         }
       ).trim();
       expect(result).toBe("default");
+    });
+  });
+
+  describe("SANDBOX_NAME consistency across start/stop/status (#587)", () => {
+    it("stop() passes SANDBOX_NAME via sandboxEnvPrefix", () => {
+      const src = fs.readFileSync(
+        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        "utf-8"
+      );
+      // stop() must use sandboxEnvPrefix so the PIDDIR matches start()
+      const stopFn = src.match(/function stop\(\)[^}]*\}/s);
+      expect(stopFn).toBeTruthy();
+      expect(
+        stopFn[0].includes("sandboxEnvPrefix")
+      ).toBe(true);
+    });
+
+    it("showStatus() passes SANDBOX_NAME via sandboxEnvPrefix", () => {
+      const src = fs.readFileSync(
+        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        "utf-8"
+      );
+      const statusFn = src.match(/function showStatus\(\)[^]*?^}/m);
+      expect(statusFn).toBeTruthy();
+      expect(
+        statusFn[0].includes("sandboxEnvPrefix")
+      ).toBe(true);
+    });
+
+    it("sandboxEnvPrefix() is a shared helper used by start, stop, and status", () => {
+      const src = fs.readFileSync(
+        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        "utf-8"
+      );
+      const uses = (src.match(/sandboxEnvPrefix\(\)/g) || []).length;
+      // At least 3 call sites: start(), stop(), showStatus()
+      expect(uses).toBeGreaterThanOrEqual(3);
     });
   });
 });

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -105,7 +105,7 @@ describe("service environment", () => {
         "utf-8"
       );
       // stop() must use sandboxEnvPrefix so the PIDDIR matches start()
-      const stopFn = src.match(/function stop\(\)[^}]*\}/s);
+      const stopFn = src.match(/function stop\(\)\s*\{[\s\S]*?\n\}/);
       expect(stopFn).toBeTruthy();
       expect(
         stopFn[0].includes("sandboxEnvPrefix")
@@ -117,7 +117,7 @@ describe("service environment", () => {
         path.join(__dirname, "..", "bin", "nemoclaw.js"),
         "utf-8"
       );
-      const statusFn = src.match(/function showStatus\(\)[^]*?^}/m);
+      const statusFn = src.match(/function showStatus\(\)\s*\{[\s\S]*?\n\}/);
       expect(statusFn).toBeTruthy();
       expect(
         statusFn[0].includes("sandboxEnvPrefix")

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -101,7 +101,7 @@ describe("service environment", () => {
   describe("SANDBOX_NAME consistency across start/stop/status (#587)", () => {
     it("stop() passes SANDBOX_NAME via sandboxEnvPrefix", () => {
       const src = fs.readFileSync(
-        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        path.join(import.meta.dirname, "..", "bin", "nemoclaw.js"),
         "utf-8"
       );
       // stop() must use sandboxEnvPrefix so the PIDDIR matches start()
@@ -114,7 +114,7 @@ describe("service environment", () => {
 
     it("showStatus() passes SANDBOX_NAME via sandboxEnvPrefix", () => {
       const src = fs.readFileSync(
-        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        path.join(import.meta.dirname, "..", "bin", "nemoclaw.js"),
         "utf-8"
       );
       const statusFn = src.match(/function showStatus\(\)\s*\{[\s\S]*?\n\}/);
@@ -126,12 +126,14 @@ describe("service environment", () => {
 
     it("sandboxEnvPrefix() is a shared helper used by start, stop, and status", () => {
       const src = fs.readFileSync(
-        path.join(__dirname, "..", "bin", "nemoclaw.js"),
+        path.join(import.meta.dirname, "..", "bin", "nemoclaw.js"),
         "utf-8"
       );
-      const uses = (src.match(/sandboxEnvPrefix\(\)/g) || []).length;
-      // At least 3 call sites: start(), stop(), showStatus()
-      expect(uses).toBeGreaterThanOrEqual(3);
+      const uses = (
+        src.match(/\bconst\s+envPrefix\s*=\s*sandboxEnvPrefix\(\)/g) || []
+      ).length;
+      // Exactly 3 call sites: start(), stop(), showStatus()
+      expect(uses).toBe(3);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #708. When `install-openshell.sh` installs openshell to `~/.local/bin` (user-local fallback), the script now automatically adds `~/.local/bin` to PATH in the user's shell rc file.

## Problem

`nemoclaw onboard` installs openshell to `~/.local/bin` when `/usr/local/bin` is not writable (non-interactive installs). The script only prints a warning, leaving users to manually add the PATH. This causes `openshell: command not found` in new shells.

## Solution

After a user-local install, the script:

1. **Checks** if `~/.local/bin` is already in `$PATH`
2. **Detects** the user's shell via `$SHELL` (bash → `.bashrc`, zsh → `.zshrc`, other → `.profile`)
3. **Appends** `export PATH="\$HOME/.local/bin:\$PATH"` to the rc file (only if not already present)
4. **Prints** info message suggesting `source ~/.bashrc` or opening a new terminal

## Changes

- `scripts/install-openshell.sh`: +16 lines, replaces the static warning with automatic PATH configuration

## Safety

- Only modifies rc file when `~/.local/bin` is not in PATH
- Duplicate check via `grep -qF` prevents repeat entries
- Falls back to `.profile` for non-bash/zsh shells
- No behavior change for system-level installs (`/usr/local/bin`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent sandbox selection is now validated and reliably applied across CLI start/stop/status operations.

* **Improvements**
  * Installer now auto-updates user shell startup files to add the install directory to PATH in non-interactive installs, with informational guidance.

* **Tests**
  * New tests verify sandbox environment consistency across service commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->