### PR TITLE
fix(ci): split docs preview into build + deploy workflows

### DIFF
--- a/.github/workflows/docs-preview-deploy.yaml
+++ b/.github/workflows/docs-preview-deploy.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Step 2 of 2: Deploy (or clean up) the docs preview built by docs-preview-pr.yaml.
+# Runs via workflow_run so it always has write access to gh-pages.
+
+name: Docs PR Preview Deploy
+
+on:
+  workflow_run:
+    workflows: ["Docs PR Preview"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-preview-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          echo "pr-number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+          if [ -f pr-action.txt ]; then
+            echo "action=$(cat pr-action.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "action=deploy" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download docs artifact
+        if: steps.meta.outputs.action != 'closed'
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-preview
+          path: docs-preview-html/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy preview
+        if: steps.meta.outputs.action != 'closed'
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./docs-preview-html/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: deploy
+          pr-number: ${{ steps.meta.outputs.pr-number }}
+
+      - name: Remove preview
+        if: steps.meta.outputs.action == 'closed'
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove
+          pr-number: ${{ steps.meta.outputs.pr-number }}

--- a/.github/workflows/docs-preview-deploy.yaml
+++ b/.github/workflows/docs-preview-deploy.yaml
@@ -61,6 +61,10 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout repository
+        if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true' || steps.meta.outputs.action == 'closed'
+        uses: actions/checkout@v4
+
       - name: Deploy preview
         if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true'
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/docs-preview-deploy.yaml
+++ b/.github/workflows/docs-preview-deploy.yaml
@@ -3,6 +3,8 @@
 
 # Step 2 of 2: Deploy (or clean up) the docs preview built by docs-preview-pr.yaml.
 # Runs via workflow_run so it always has write access to gh-pages.
+# Only deploys previews for same-repo PRs to prevent fork PRs from
+# publishing arbitrary content to the GitHub Pages domain.
 
 name: Docs PR Preview Deploy
 
@@ -38,9 +40,20 @@ jobs:
           else
             echo "action=deploy" >> "$GITHUB_OUTPUT"
           fi
+          if [ -f same-repo.txt ]; then
+            echo "same-repo=$(cat same-repo.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "same-repo=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip fork PRs
+        if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo != 'true'
+        run: |
+          echo "::notice::Skipping preview deploy for fork PR #${{ steps.meta.outputs.pr-number }}"
+          exit 0
 
       - name: Download docs artifact
-        if: steps.meta.outputs.action != 'closed'
+        if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true'
         uses: actions/download-artifact@v4
         with:
           name: docs-preview
@@ -49,7 +62,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy preview
-        if: steps.meta.outputs.action != 'closed'
+        if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true'
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./docs-preview-html/

--- a/.github/workflows/docs-preview-deploy.yaml
+++ b/.github/workflows/docs-preview-deploy.yaml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download PR metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs-preview-metadata
           run-id: ${{ github.event.workflow_run.id }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Download docs artifact
         if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs-preview
           path: docs-preview-html/
@@ -63,7 +63,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true' || steps.meta.outputs.action == 'closed'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deploy preview
         if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true'

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -33,15 +33,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install doc dependencies
         run: uv sync --group docs
@@ -56,7 +56,7 @@ jobs:
           touch docs/_build/html/.nojekyll
 
       - name: Upload preview artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-preview
           path: docs/_build/html/
@@ -72,7 +72,7 @@ jobs:
           fi
 
       - name: Upload PR metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-preview-metadata
           path: |
@@ -92,7 +92,7 @@ jobs:
           echo "closed" > pr-action.txt
 
       - name: Upload PR metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-preview-metadata
           path: |

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -63,13 +63,21 @@ jobs:
           retention-days: 1
 
       - name: Save PR metadata
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+            echo "true" > same-repo.txt
+          else
+            echo "false" > same-repo.txt
+          fi
 
       - name: Upload PR metadata
         uses: actions/upload-artifact@v4
         with:
           name: docs-preview-metadata
-          path: pr-number.txt
+          path: |
+            pr-number.txt
+            same-repo.txt
           retention-days: 1
 
   # On PR close, trigger the deploy workflow to clean up the preview.

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Step 1 of 2: Build docs on the PR and upload as an artifact.
+# Step 2 (deploy) runs in docs-preview-deploy.yaml via workflow_run,
+# which has write access to gh-pages regardless of PR origin.
+
 name: Docs PR Preview
 
 on:
@@ -13,17 +17,18 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/docs-preview-pr.yaml"
+      - ".github/workflows/docs-preview-deploy.yaml"
 
 concurrency:
   group: preview-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  preview:
+  build:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -31,34 +36,58 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        if: github.event.action != 'closed'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Install uv
-        if: github.event.action != 'closed'
         uses: astral-sh/setup-uv@v4
 
       - name: Install doc dependencies
-        if: github.event.action != 'closed'
         run: uv sync --group docs
 
       - name: Build documentation
-        if: github.event.action != 'closed'
         run: uv run --group docs sphinx-build -W -b html docs docs/_build/html
 
       - name: Clean build artifacts
-        if: github.event.action != 'closed'
         run: |
           find docs/_build -name .doctrees -prune -exec rm -rf {} \;
           find docs/_build -name .buildinfo -exec rm {} \;
           touch docs/_build/html/.nojekyll
 
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
         with:
-          source-dir: ./docs/_build/html/
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          action: auto
+          name: docs-preview
+          path: docs/_build/html/
+          retention-days: 1
+
+      - name: Save PR metadata
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-preview-metadata
+          path: pr-number.txt
+          retention-days: 1
+
+  # On PR close, trigger the deploy workflow to clean up the preview.
+  close:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Save PR metadata
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo "closed" > pr-action.txt
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-preview-metadata
+          path: |
+            pr-number.txt
+            pr-action.txt
+          retention-days: 1

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -60,7 +60,7 @@ jobs:
         with:
           name: docs-preview
           path: docs/_build/html/
-          retention-days: 1
+          retention-days: 3
 
       - name: Save PR metadata
         run: |
@@ -78,7 +78,7 @@ jobs:
           path: |
             pr-number.txt
             same-repo.txt
-          retention-days: 1
+          retention-days: 3
 
   # On PR close, trigger the deploy workflow to clean up the preview.
   close:
@@ -98,4 +98,4 @@ jobs:
           path: |
             pr-number.txt
             pr-action.txt
-          retention-days: 1
+          retention-days: 3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,7 +181,7 @@ repos:
 
       - id: pyright-check
         name: Pyright (nemoclaw-blueprint)
-        entry: bash -c 'cd nemoclaw-blueprint && uv run --with pyright pyright .'
+        entry: bash -c 'cd nemoclaw-blueprint && uv run --with pyright pyright'
         language: system
         pass_filenames: false
         always_run: true

--- a/nemoclaw-blueprint/Makefile
+++ b/nemoclaw-blueprint/Makefile
@@ -10,4 +10,4 @@ format:
 check:
 	ruff check .
 	ruff format --check .
-	uv run --extra dev --with pyright pyright .
+	uv run --extra dev --with pyright pyright

--- a/nemoclaw-blueprint/pyproject.toml
+++ b/nemoclaw-blueprint/pyproject.toml
@@ -44,6 +44,7 @@ ignore = [
 pythonVersion = "3.11"
 typeCheckingMode = "strict"
 include = ["orchestrator", "migrations"]
+exclude = ["**/test_*.py"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary

The docs preview deployment has been failing on every PR that touches docs — `github-actions[bot]` lacks push access to the `gh-pages` branch from `pull_request` events (403 permission denied).

Fix by splitting the single workflow into two:

1. **`docs-preview-pr.yaml`** (runs on `pull_request`) — builds docs and uploads as an artifact. Only needs `contents: read`.
2. **`docs-preview-deploy.yaml`** (new, runs on `workflow_run`) — downloads the artifact and deploys to `gh-pages`. Because `workflow_run` always executes in the base repo context, it gets a token with `contents: write`.

### Security: fork PRs are excluded

The deploy workflow only publishes previews for **same-repo PRs** (branches within NVIDIA/NemoClaw). Fork PRs still get the docs build check (verifying the build compiles), but their artifacts are never deployed to GitHub Pages. This prevents a malicious fork contributor from publishing arbitrary HTML under the `nvidia.github.io` domain.

### Also included

Two pre-existing CI fixes that were blocking pre-push hooks on main:
- Exclude `**/test_*.py` from pyright strict type-checking (pytest is untyped)
- Drop stray `.` arg from pyright hook entry (was scanning `.venv`)

## Test plan

- [ ] Merge this PR and verify the next docs-touching same-repo PR gets a working preview deployment
- [ ] Open a fork PR touching docs and verify the deploy workflow skips it with a notice
- [ ] Close a PR with a preview and verify the cleanup job removes it from `gh-pages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a gated CI workflow to publish and remove per-PR documentation previews after successful preview builds.
  * Split the PR docs pipeline into separate build and close jobs that upload preview artifacts and metadata for downstream deploy/cleanup.
  * Tightened workflow permissions and moved guards to job level for clearer execution control.
  * Adjusted pre-commit and type-checker settings to refine lint/type analysis and exclude test files from checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->