### PR TITLE
fix: correct broken CLI reference link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Run these on the host to set up, connect to, and manage sandboxes.
 | `openshell term`                     | Launch the OpenShell TUI for monitoring and approvals. |
 | `nemoclaw start` / `stop` / `status` | Manage auxiliary services (Telegram bridge, tunnel).   |
 
-See the full [CLI reference](https://docs.nvidia.com/nemoclaw/latest/reference/commands.md) for all commands, flags, and options.
+See the full [CLI reference](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html) for all commands, flags, and options.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #712 (partially — the broken external link).

The CLI reference link on line 244 pointed to `commands.md` which returns HTTP 404. Changed to `commands.html` which is the correct URL (and already used on line 257).

## Changes

- `README.md`: `commands.md` → `commands.html` (1 line)

## Note on other links in #712

The `CONTRIBUTING.md` and `docs/CONTRIBUTING.md` links in the PR template are relative paths that resolve correctly — both files exist in the repo. The issue reporter may have encountered GitHub's context-dependent relative link resolution (e.g., links in the PR creation form don't resolve against the repo root).