### PR TITLE
fix(onboard): surface openshell PATH guidance

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -250,6 +250,13 @@ function isOpenshellInstalled() {
   }
 }
 
+function getFutureShellPathHint(binDir, pathValue = process.env.PATH || "") {
+  if (String(pathValue).split(path.delimiter).includes(binDir)) {
+    return null;
+  }
+  return `export PATH="${binDir}:$PATH"`;
+}
+
 function installOpenshell() {
   const result = spawnSync("bash", [path.join(SCRIPTS, "install-openshell.sh")], {
     cwd: ROOT,
@@ -262,13 +269,21 @@ function installOpenshell() {
     if (output) {
       console.error(output);
     }
-    return false;
+    return { installed: false, localBin: null, futureShellPathHint: null };
   }
   const localBin = process.env.XDG_BIN_HOME || path.join(process.env.HOME || "", ".local", "bin");
-  if (fs.existsSync(path.join(localBin, "openshell")) && !process.env.PATH.split(path.delimiter).includes(localBin)) {
+  const openshellPath = path.join(localBin, "openshell");
+  const futureShellPathHint = fs.existsSync(openshellPath)
+    ? getFutureShellPathHint(localBin, process.env.PATH)
+    : null;
+  if (fs.existsSync(openshellPath) && futureShellPathHint) {
     process.env.PATH = `${localBin}${path.delimiter}${process.env.PATH}`;
   }
-  return isOpenshellInstalled();
+  return {
+    installed: isOpenshellInstalled(),
+    localBin,
+    futureShellPathHint,
+  };
 }
 
 function sleep(seconds) {
@@ -344,15 +359,22 @@ async function preflight() {
   }
 
   // OpenShell CLI
+  let openshellInstall = { localBin: null, futureShellPathHint: null };
   if (!isOpenshellInstalled()) {
     console.log("  openshell CLI not found. Installing...");
-    if (!installOpenshell()) {
+    openshellInstall = installOpenshell();
+    if (!openshellInstall.installed) {
       console.error("  Failed to install openshell CLI.");
       console.error("  Install manually: https://github.com/NVIDIA/OpenShell/releases");
       process.exit(1);
     }
   }
   console.log(`  ✓ openshell CLI: ${runCapture("openshell --version 2>/dev/null || echo unknown", { ignoreError: true })}`);
+  if (openshellInstall.futureShellPathHint) {
+    console.log(`  Note: openshell was installed to ${openshellInstall.localBin} for this onboarding run.`);
+    console.log(`  Future shells may still need: ${openshellInstall.futureShellPathHint}`);
+    console.log("  Add that export to your shell profile, or open a new terminal before running openshell directly.");
+  }
 
   // Clean up stale NemoClaw session before checking ports.
   // A previous onboard run may have left the gateway container and port
@@ -1052,6 +1074,7 @@ async function onboard(opts = {}) {
 
 module.exports = {
   buildSandboxConfigSyncScript,
+  getFutureShellPathHint,
   getInstalledOpenshellVersion,
   getStableGatewayImageRef,
   hasStaleGateway,

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -98,7 +98,8 @@ elif [ "${NEMOCLAW_NON_INTERACTIVE:-}" = "1" ] || [ ! -t 0 ]; then
   mkdir -p "$target_dir"
   install -m 755 "$tmpdir/openshell" "$target_dir/openshell"
   warn "Installed openshell to $target_dir/openshell (user-local path)"
-  warn "Ensure $target_dir is on PATH for future shells."
+  warn "For future shells, run: export PATH=\"$target_dir:\$PATH\""
+  warn "Add that export to your shell profile, or open a new shell before using openshell directly."
 else
   sudo install -m 755 "$tmpdir/openshell" "$target_dir/openshell"
 fi

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -7,6 +7,7 @@ const path = require("path");
 
 const {
   buildSandboxConfigSyncScript,
+  getFutureShellPathHint,
   getInstalledOpenshellVersion,
   getStableGatewayImageRef,
   writeSandboxConfigSyncFile,
@@ -44,6 +45,18 @@ describe("onboard helpers", () => {
     expect(getStableGatewayImageRef("openshell 0.0.12")).toBe("ghcr.io/nvidia/openshell/cluster:0.0.12");
     expect(getStableGatewayImageRef("openshell 0.0.13-dev.8+gbbcaed2ea")).toBe("ghcr.io/nvidia/openshell/cluster:0.0.13");
     expect(getStableGatewayImageRef("bogus")).toBe(null);
+  });
+
+  it("returns a future-shell PATH hint for user-local openshell installs", () => {
+    expect(getFutureShellPathHint("/home/test/.local/bin", "/usr/local/bin:/usr/bin")).toBe(
+      'export PATH="/home/test/.local/bin:$PATH"'
+    );
+  });
+
+  it("skips the future-shell PATH hint when the bin dir is already on PATH", () => {
+    expect(
+      getFutureShellPathHint("/home/test/.local/bin", "/home/test/.local/bin:/usr/local/bin:/usr/bin")
+    ).toBe(null);
   });
 
   it("writes sandbox sync scripts to a temp file for stdin redirection", () => {


### PR DESCRIPTION
## Summary

Surface explicit PATH guidance when `nemoclaw onboard` installs `openshell` into a user-local bin directory for the current run.

## Related Issue

Fixes #708.

## Changes

- add a small onboard helper that determines when a future-shell PATH hint is needed
- print a post-install note in onboard when `openshell` was installed into `XDG_BIN_HOME` or `~/.local/bin`
- upgrade `scripts/install-openshell.sh` from a generic warning to an exact `export PATH=...` remediation
- add unit coverage for the future-shell PATH hint helper

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [ ] `make check` passes.
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)
- [x] `npx vitest run test/onboard.test.js test/onboard-selection.test.js test/onboard-readiness.test.js`
- [x] `bash -n scripts/install-openshell.sh`
- [x] `test/onboard.test.js` fails before the helper implementation and passes after it.
- [ ] Full `npm test` is currently green on my machine. I still see pre-existing failures in `test/install-preflight.test.js` on a clean `main`-derived branch.

## Checklist

### General
- [x] I have read and followed the [contributing guide](../CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](../docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
- [ ] `make format` applied (TypeScript and Python).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
- [ ] Follows the [style guide](../docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding guidance with clearer PATH configuration instructions during openshell installation.
  * Enhanced post-installation feedback to guide users on updating shell profiles and terminal restarts.

* **Tests**
  * Added unit tests for shell path configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->