### PR TITLE
ci: add markdownlint-cli2 to prek checks

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# markdownlint-cli2 configuration
+# https://github.com/DavidAnson/markdownlint-cli2
+#
+# All default rules are enabled unless listed below. Rules are either:
+#   - Permanently disabled (style preference or false positive)
+#   - Temporarily disabled (pending a follow-up --fix PR)
+
+config:
+  default: true
+
+  # --- Permanently disabled (style preferences) ---
+  MD004: false  # ul-style — mixed */- is fine
+  MD013: false  # line-length — 80-char limit too strict for docs prose
+  MD014: false  # commands-show-output — $ prefix in code blocks is intentional
+  MD024: false  # no-duplicate-heading — duplicate names in different sections are fine
+  MD033: false  # no-inline-html — HTML in markdown is common on GitHub
+  MD060: false  # table-column-style — table pipe spacing is cosmetic
+
+  # --- Permanently disabled (false positives) ---
+  # Front matter uses a complex `title:` object (with page/nav sub-keys),
+  # not a plain title string. The default regex falsely matches it as an h1.
+  MD025:
+    front_matter_title: ""
+
+  # --- Temporarily disabled — pending follow-up --fix PR ---
+  # Auto-fixable:
+  MD005: false  # list-indent
+  MD007: false  # ul-indent
+  MD009: false  # no-trailing-spaces
+  MD010: false  # no-hard-tabs
+  MD012: false  # no-multiple-blanks
+  MD022: false  # blanks-around-headings
+  MD031: false  # blanks-around-fences
+  MD032: false  # blanks-around-lists
+  MD034: false  # no-bare-urls
+  # Manual fix needed:
+  MD001: false  # heading-increment
+  MD028: false  # no-blanks-blockquote
+  MD040: false  # fenced-code-language
+  MD041: false  # first-line-heading
+
+ignores:
+  - "node_modules/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,6 +160,12 @@ repos:
         name: gitleaks (secret scan)
         priority: 10
 
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.0
+    hooks:
+      - id: markdownlint-cli2
+        priority: 10
+
   # ── Priority 20: project-level checks (pre-commit) ─────────────────────────
   - repo: local
     hooks:

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -91,6 +91,7 @@ vi.mock("node:fs", async (importOriginal) => {
     unlinkSync: vi.fn((p: string) => {
       store.delete(p);
     }),
+    chmodSync: vi.fn(),
   };
 });
 


### PR DESCRIPTION
## Summary
- Adds `markdownlint-cli2` as a prek pre-commit hook at priority 10
- Adds `.markdownlint-cli2.yaml` with rule configuration:
  - **Permanently disabled**: style-preference rules (line length, inline HTML, table formatting, `$` command prefixes, etc.) and false positives (front matter `title:` misdetected as h1)
  - **Temporarily disabled**: valid rules with existing violations, pending a follow-up `--fix` PR
  - **Enabled**: all remaining default rules — new markdown files get full coverage immediately
- Fixes 4 broken tests in `migration-state.test.ts` caused by a missing `chmodSync` mock (added in #647 but not mocked in the test)

## Test plan
- [x] `npx prek run markdownlint-cli2 --all-files` passes with zero violations
- [x] `vitest run --project plugin` passes (41/41 tests)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added markdown linting configuration to enforce documentation standards.
  * Integrated markdown linting into the development workflow via pre-commit hooks.
  * Updated test infrastructure for file system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->