### PR TITLE
chore: fix all markdownlint violations and enable remaining rules

### DIFF
--- a/.agents/skills/docs/nemoclaw-get-started/SKILL.md
+++ b/.agents/skills/docs/nemoclaw-get-started/SKILL.md
@@ -16,11 +16,11 @@ Follow these steps to get started with NemoClaw and your first sandboxed OpenCla
 
 > **Note:** NemoClaw currently requires a fresh installation of OpenClaw.
 
-### Prerequisites
+## Prerequisites
 
 Check the prerequisites before you start to ensure you have the necessary software and hardware to run NemoClaw.
 
-#### Hardware
+### Hardware
 
 | Resource | Minimum        | Recommended      |
 |----------|----------------|------------------|
@@ -67,7 +67,7 @@ If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.
 
 When the install completes, a summary confirms the running environment:
 
-```
+```text
 ──────────────────────────────────────────────────
 Sandbox      my-assistant (Landlock + seccomp + netns)
 Model        nvidia/nemotron-3-super-120b-a12b (NVIDIA Endpoint API)
@@ -139,10 +139,6 @@ For example, to skip the confirmation prompt:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash -s -- --yes
 ```
-
-### Troubleshooting
-
-If you run into issues during installation or onboarding, refer to the Troubleshooting guide (see the `nemoclaw-reference` skill) for common error messages and resolution steps.
 
 ## Related Skills
 

--- a/.agents/skills/docs/nemoclaw-overview/SKILL.md
+++ b/.agents/skills/docs/nemoclaw-overview/SKILL.md
@@ -69,7 +69,7 @@ Respect CLI boundaries
 Supply chain safety
 : Blueprint artifacts are immutable, versioned, and digest-verified before execution.
 
-> Full details in `references/how-it-works.md`.
+*Full details in `references/how-it-works.md`.*
 
 > **Alpha software:** NemoClaw is in alpha, available as an early preview since March 16, 2026.
 > APIs, configuration schemas, and runtime behavior are subject to breaking changes between releases.

--- a/.agents/skills/docs/nemoclaw-reference/references/commands.md
+++ b/.agents/skills/docs/nemoclaw-reference/references/commands.md
@@ -2,7 +2,7 @@
 
 The `nemoclaw` CLI is the primary interface for managing NemoClaw sandboxes. It is installed when you run `npm install -g nemoclaw`.
 
-### `/nemoclaw` Slash Command
+## `/nemoclaw` Slash Command
 
 The `/nemoclaw` slash command is available inside the OpenClaw chat interface for quick actions:
 
@@ -81,6 +81,10 @@ $ nemoclaw my-assistant logs [--follow]
 
 Stop the NIM container and delete the sandbox.
 This removes the sandbox from the registry.
+
+> **Warning:** Destroying a sandbox permanently deletes all files inside it, including
+> workspace files (see the `nemoclaw-workspace` skill) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes).
+> Back up your workspace first by following the instructions at Back Up and Restore (see the `nemoclaw-workspace` skill).
 
 ```console
 $ nemoclaw my-assistant destroy

--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -115,7 +115,7 @@ When creating a new page:
 
 After drafting all updates, present a summary to the user:
 
-```
+```markdown
 ## Doc Updates from Commits
 
 ### Updated pages

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 ## Summary
 <!-- 1-3 sentences: what this PR does and why. -->
 
@@ -23,6 +24,7 @@
 ## Checklist
 
 ### General
+
 - [ ] I have read and followed the [contributing guide](CONTRIBUTING.md).
 - [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)
 

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,9 +4,7 @@
 # markdownlint-cli2 configuration
 # https://github.com/DavidAnson/markdownlint-cli2
 #
-# All default rules are enabled unless listed below. Rules are either:
-#   - Permanently disabled (style preference or false positive)
-#   - Temporarily disabled (pending a follow-up --fix PR)
+# All default rules are enabled unless listed below.
 
 config:
   default: true
@@ -24,23 +22,6 @@ config:
   # not a plain title string. The default regex falsely matches it as an h1.
   MD025:
     front_matter_title: ""
-
-  # --- Temporarily disabled — pending follow-up --fix PR ---
-  # Auto-fixable:
-  MD005: false  # list-indent
-  MD007: false  # ul-indent
-  MD009: false  # no-trailing-spaces
-  MD010: false  # no-hard-tabs
-  MD012: false  # no-multiple-blanks
-  MD022: false  # blanks-around-headings
-  MD031: false  # blanks-around-fences
-  MD032: false  # blanks-around-lists
-  MD034: false  # no-bare-urls
-  # Manual fix needed:
-  MD001: false  # heading-increment
-  MD028: false  # no-blanks-blockquote
-  MD040: false  # fenced-code-language
-  MD041: false  # first-line-heading
 
 ignores:
   - "node_modules/**"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,7 +63,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting GitHub_Conduct@nvidia.com. All complaints will be reviewed and
+reported by contacting <GitHub_Conduct@nvidia.com>. All complaints will be reviewed and
 investigated and will result in a response that is deemed necessary and appropriate
 to the circumstances. The project team is obligated to maintain confidentiality with
 regard to the reporter of an incident. Further details of specific enforcement policies
@@ -76,9 +76,9 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+<https://www.contributor-covenant.org/faq>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ The generated `.agents/skills/docs/` directory is committed to the repo but is e
 
 Each skill directory contains:
 
-```
+```text
 .agents/skills/docs/<skill-name>/
 ├── SKILL.md              # Frontmatter + procedures + related skills
 └── references/           # Detailed concept and reference content (loaded on demand)
@@ -173,7 +173,7 @@ Follow these steps to submit a pull request.
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/). All commit messages must follow the format:
 
-```
+```text
 <type>(<scope>): <description>
 
 [optional body]
@@ -194,7 +194,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/). 
 
 **Examples:**
 
-```
+```text
 feat(cli): add --profile flag to nemoclaw onboard
 fix(blueprint): handle missing API key gracefully
 docs: update quickstart for new install wizard

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.
 
 When the install completes, a summary confirms the running environment:
 
-```
+```text
 ──────────────────────────────────────────────────
 Sandbox      my-assistant (Landlock + seccomp + netns)
 Model        nvidia/nemotron-3-super-120b-a12b (NVIDIA Endpoint API)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 ## Security
 
 NVIDIA is dedicated to the security and trust of our software products and services, including all source code repositories managed through our organization.
@@ -7,18 +8,19 @@ If you need to report a security issue, please use the appropriate contact point
 ## Reporting Potential Security Vulnerability in an NVIDIA Product
 
 To report a potential security vulnerability in any NVIDIA product:
+
 - Web: [Security Vulnerability Submission Form](https://www.nvidia.com/object/submit-security-vulnerability.html)
-- E-Mail: psirt@nvidia.com
-    - We encourage you to use the following PGP key for secure email communication: [NVIDIA public PGP Key for communication](https://www.nvidia.com/en-us/security/pgp-key)
-    - Please include the following information:
-   	 - Product/Driver name and version/branch that contains the vulnerability
-     - Type of vulnerability (code execution, denial of service, buffer overflow, etc.)
-   	 - Instructions to reproduce the vulnerability
-   	 - Proof-of-concept or exploit code
-   	 - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
+- E-Mail: <psirt@nvidia.com>
+  - We encourage you to use the following PGP key for secure email communication: [NVIDIA public PGP Key for communication](https://www.nvidia.com/en-us/security/pgp-key)
+  - Please include the following information:
+  - Product/Driver name and version/branch that contains the vulnerability
+  - Type of vulnerability (code execution, denial of service, buffer overflow, etc.)
+  - Instructions to reproduce the vulnerability
+  - Proof-of-concept or exploit code
+  - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
 
 While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
 
 ## NVIDIA Product Security
 
-For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security
+For all security-related concerns, please visit NVIDIA's Product Security portal at <https://www.nvidia.com/en-us/security>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -90,7 +90,8 @@ make docs-live
 - Docs use [MyST Markdown](https://myst-parser.readthedocs.io/), a Sphinx-compatible superset of CommonMark.
 - Every page starts with YAML frontmatter (title, description, topics, tags, content type).
 - Include the SPDX license header after frontmatter:
-  ```
+
+  ```html
   <!--
     SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     SPDX-License-Identifier: Apache-2.0
@@ -153,9 +154,11 @@ These patterns are common in LLM-generated text and erode trust with technical r
 - One sentence per line in the source file (makes diffs readable).
 - Use `code` formatting for CLI commands, file paths, flags, parameter names, and values.
 - Use code blocks with the `console` language for CLI examples. Prefix commands with `$`:
+
   ```console
   $ nemoclaw onboard
   ```
+
 - Use tables for structured comparisons. Keep tables simple (no nested formatting).
 - Use MyST admonitions (`:::{tip}`, `:::{note}`, `:::{warning}`) for callouts, not bold text.
 - Avoid nested admonitions.
@@ -187,13 +190,13 @@ Use these consistently:
 3. Build locally with `make docs` and verify the output.
 4. Open a PR with `docs:` as the conventional commit type.
 
-```
+```text
 docs: update quickstart for new onboard wizard
 ```
 
 If your doc change accompanies a code change, include both in the same PR and use the code change's commit type:
 
-```
+```text
 feat(cli): add policy-add command
 ```
 

--- a/docs/_includes/alpha-statement.md
+++ b/docs/_includes/alpha-statement.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 :::{admonition} Alpha software
 NemoClaw is in alpha, available as an early preview since March 16, 2026.
 APIs, configuration schemas, and runtime behavior are subject to breaking changes between releases.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -34,7 +34,7 @@ NemoClaw currently requires a fresh installation of OpenClaw.
 :end-before: <!-- end-quickstart-guide -->
 ```
 
-### Next Steps
+## Next Steps
 
 - [Switch inference providers](../inference/switch-inference-providers.md) to use a different model or endpoint.
 - [Approve or deny network requests](../network-policy/approve-network-requests.md) when the agent tries to reach external hosts.
@@ -42,6 +42,6 @@ NemoClaw currently requires a fresh installation of OpenClaw.
 - [Deploy to a remote GPU instance](../deployment/deploy-to-remote-gpu.md) for always-on operation.
 - [Monitor sandbox activity](../monitoring/monitor-sandbox-activity.md) through the OpenShell TUI.
 
-### Troubleshooting
+## Troubleshooting
 
 If you run into issues during installation or onboarding, refer to the [Troubleshooting guide](../reference/troubleshooting.md) for common error messages and resolution steps.

--- a/docs/monitoring/monitor-sandbox-activity.md
+++ b/docs/monitoring/monitor-sandbox-activity.md
@@ -57,7 +57,6 @@ To follow the log output in real time:
 $ nemoclaw <name> logs -f
 ```
 
-
 ## Monitor Network Activity in the TUI
 
 Open the OpenShell terminal UI for a live view of sandbox network activity and egress requests:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -22,7 +22,7 @@ status: published
 
 The `nemoclaw` CLI is the primary interface for managing NemoClaw sandboxes. It is installed when you run `npm install -g nemoclaw`.
 
-### `/nemoclaw` Slash Command
+## `/nemoclaw` Slash Command
 
 The `/nemoclaw` slash command is available inside the OpenClaw chat interface for quick actions:
 

--- a/scripts/docs-to-skills.py
+++ b/scripts/docs-to-skills.py
@@ -58,6 +58,50 @@ from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
+# Heading normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_heading_levels(text: str) -> str:
+    """Ensure markdown headings increment by at most one level at a time.
+
+    After resolving includes the document may contain heading-level gaps
+    (e.g. ``# Title`` followed by ``### Sub`` with no intervening ``##``).
+    This function promotes headings so the nesting never skips a level,
+    preserving the relative depth of sibling and child headings.
+    """
+    lines = text.split("\n")
+    heading_re = re.compile(r"^(#{1,6})\s")
+    # First pass: collect all heading levels in order.
+    heading_levels: list[tuple[int, int]] = []  # (line_index, level)
+    for i, line in enumerate(lines):
+        m = heading_re.match(line)
+        if m:
+            heading_levels.append((i, len(m.group(1))))
+
+    if not heading_levels:
+        return text
+
+    # Second pass: compute the minimum level each heading should have
+    # so that no heading exceeds its predecessor by more than 1.
+    max_allowed = 0
+    remap: dict[int, int] = {}  # line_index -> new_level
+    for idx, level in heading_levels:
+        new_level = min(level, max_allowed + 1)
+        remap[idx] = new_level
+        max_allowed = new_level
+
+    # Third pass: rewrite headings.
+    for idx, new_level in remap.items():
+        m = heading_re.match(lines[idx])
+        if m:
+            old_prefix = m.group(1)
+            lines[idx] = "#" * new_level + lines[idx][len(old_prefix) :]
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Frontmatter / doc parsing
 # ---------------------------------------------------------------------------
 
@@ -917,7 +961,7 @@ def generate_skill(
                 cut = _safe_truncation_point(body_lines, 60)
                 trimmed = "\n".join(body_lines[:cut])
                 ref_name = cp.path.stem + ".md"
-                trimmed += f"\n\n> Full details in `references/{ref_name}`."
+                trimmed += f"\n\n*Full details in `references/{ref_name}`.*"
                 lines.append(trimmed)
             else:
                 lines.append(body)
@@ -1020,13 +1064,13 @@ def generate_skill(
             lines.append(entry)
         lines.append("")
 
-    skill_md = "\n".join(lines)
+    skill_md = normalize_heading_levels("\n".join(lines))
 
     # --- Build reference files ---
     ref_files: dict[str, str] = {}
     for rp in reference_pages + context_pages:
         ref_name = rp.path.stem + ".md"
-        body = _clean(rp.body, rp)
+        body = normalize_heading_levels(_clean(rp.body, rp))
         ref_files[ref_name] = body
 
     # --- Write output ---
@@ -1044,13 +1088,13 @@ def generate_skill(
         return summary
 
     skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text(skill_md.rstrip("\n") + "\n", encoding="utf-8")
 
     if ref_files:
         refs_dir = skill_dir / "references"
         refs_dir.mkdir(exist_ok=True)
         for fname, content in ref_files.items():
-            (refs_dir / fname).write_text(content, encoding="utf-8")
+            (refs_dir / fname).write_text(content.rstrip("\n") + "\n", encoding="utf-8")
 
     return summary
 

--- a/spark-install.md
+++ b/spark-install.md
@@ -22,7 +22,7 @@ DGX Spark ships **Ubuntu 24.04 + Docker 28.x** but no k8s/k3s. OpenShell embeds 
 
 ### 1. Docker permissions
 
-```
+```text
 Error in the hyper legacy client: client error (Connect)
   Permission denied (os error 13)
 ```
@@ -32,7 +32,7 @@ Error in the hyper legacy client: client error (Connect)
 
 ### 2. cgroup v2 incompatibility
 
-```
+```text
 K8s namespace not ready
 openat2 /sys/fs/cgroup/kubepods/pids.max: no
 Failed to start ContainerManager: failed to initialize top level QOS containers
@@ -48,16 +48,20 @@ These should already be on your Spark:
 
 - **Docker** (pre-installed, v28.x)
 - **Node.js 22** — if not installed:
+
   ```bash
   curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
   sudo apt-get install -y nodejs
   ```
+
 - **OpenShell CLI**:
+
   ```bash
   ARCH=$(uname -m)  # aarch64 on Spark
   curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/latest/download/openshell-linux-${ARCH}" -o /usr/local/bin/openshell
   chmod +x /usr/local/bin/openshell
   ```
+
 - **NVIDIA API Key** from [build.nvidia.com](https://build.nvidia.com) — prompted on first run
 
 ## Manual Setup (if setup-spark doesn't work)
@@ -123,7 +127,7 @@ openshell term
 
 ## Architecture Notes
 
-```
+```text
 DGX Spark (Ubuntu 24.04, cgroup v2)
   └── Docker (28.x, cgroupns=host)
        └── OpenShell gateway container


### PR DESCRIPTION
## Summary
- Applies `markdownlint-cli2 --fix` for auto-fixable rules and manually fixes the rest
- Removes the "temporarily disabled" section from `.markdownlint-cli2.yaml` — all valid rules are now enforced
- Fixes `docs-to-skills.py` to produce lint-clean output:
  - Normalizes heading levels so generated skill files never skip levels (e.g. h1 → h3)
  - Ensures files end with a trailing newline (MD047)
  - Uses italic text instead of blockquotes for truncation notes to avoid MD028 conflicts with admonition blockquotes

## Test plan
- [x] `npx prek run --all-files` passes (all hooks green)
- [x] `npx prek run markdownlint-cli2 --all-files` passes with zero violations
- [x] Vitest passes (41/41 tests)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation structure and heading hierarchy across guides and references for better readability.
  * Added prominent warning clarifying that destroying a sandbox permanently deletes all workspace files, with guidance to back up first.
  * Enhanced code block formatting and consistency across documentation and examples.

* **Chores**
  * Updated markdown linting configuration to enforce stricter formatting standards.
  * Improved URL and contact information formatting in contribution and security docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->