### PR TITLE
fix(cli): add sudo to lsof and kill hints in onboarding port check

### DIFF
--- a/.agents/skills/docs/nemoclaw-reference/references/commands.md
+++ b/.agents/skills/docs/nemoclaw-reference/references/commands.md
@@ -82,6 +82,10 @@ $ nemoclaw my-assistant logs [--follow]
 Stop the NIM container and delete the sandbox.
 This removes the sandbox from the registry.
 
+> **Warning:** Destroying a sandbox permanently deletes all files inside it, including
+> workspace files (see the `nemoclaw-workspace` skill) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes).
+> Back up your workspace first by following the instructions at Back Up and Restore (see the `nemoclaw-workspace` skill).
+
 ```console
 $ nemoclaw my-assistant destroy
 ```

--- a/.agents/skills/docs/nemoclaw-reference/references/troubleshooting.md
+++ b/.agents/skills/docs/nemoclaw-reference/references/troubleshooting.md
@@ -69,8 +69,8 @@ If another process is already bound to this port, onboarding fails.
 Identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```console
-$ lsof -i :18789
-$ kill <PID>
+$ sudo lsof -i :18789
+$ sudo kill <PID>
 ```
 
 If the process does not exit, use `kill -9 <PID>` to force-terminate it.

--- a/.agents/skills/docs/nemoclaw-workspace/SKILL.md
+++ b/.agents/skills/docs/nemoclaw-workspace/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: nemoclaw-workspace
+description: Hows to back up and restore OpenClaw workspace files before destructive operations. Also covers whats workspace files are, where they live, and how they persist across sandbox restarts. Use when agents.md, back restore workspace files, backup, identity.md, memory.md, nemoclaw, nemoclaw backup, nemoclaw restore.
+---
+
+# Nemoclaw Workspace
+
+How to back up and restore OpenClaw workspace files before destructive operations.
+
+## Context
+
+OpenClaw stores agent identity, behavior, and memory in a set of Markdown files inside the sandbox.
+These files live at `/sandbox/.openclaw/workspace/` and are read by the agent at the start of every session.
+
+## File Reference
+
+Each file controls a distinct aspect of the agent's behavior and memory.
+
+| File | Purpose | Upstream Docs |
+|---|---|---|
+| `SOUL.md` | Core personality, tone, and behavioral rules. | [SOUL template](https://docs.openclaw.ai/reference/templates/SOUL) |
+| `USER.md` | Preferences, context, and facts the agent learns about you. | [USER template](https://docs.openclaw.ai/reference/templates/USER) |
+| `IDENTITY.md` | Agent name, creature type, emoji, and self-presentation. | [IDENTITY template](https://docs.openclaw.ai/reference/templates/IDENTITY) |
+| `AGENTS.md` | Multi-agent coordination, memory conventions, and safety guidelines. | [AGENTS template](https://docs.openclaw.ai/reference/templates/AGENTS) |
+| `MEMORY.md` | Curated long-term memory distilled from daily notes. | — |
+| `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. | — |
+
+## Where They Live
+
+All workspace files reside inside the sandbox filesystem:
+
+```text
+/sandbox/.openclaw/workspace/
+├── AGENTS.md
+├── IDENTITY.md
+├── MEMORY.md
+├── SOUL.md
+├── USER.md
+└── memory/
+    ├── 2026-03-18.md
+    └── 2026-03-19.md
+```
+
+> **Note:** The workspace directory is hidden (`.openclaw`).
+> The files are not at `/sandbox/SOUL.md` — use the full path when downloading or uploading.
+
+## Persistence Behavior
+
+Understanding when these files persist and when they are lost is critical.
+
+| Event | Workspace files |
+|---|---|
+| Sandbox restart | **Preserved** — the sandbox PVC retains its data. |
+| `nemoclaw <name> destroy` | **Lost** — the sandbox and its PVC are deleted. |
+
+> **Warning:** Always back up your workspace files before running `nemoclaw <name> destroy`.
+> See Back Up and Restore (see the `nemoclaw-workspace` skill) for instructions.
+
+## Editing Workspace Files
+
+The agent reads these files at the start of every session.
+You can edit them in two ways:
+
+1. **Let the agent do it** — Ask your agent to update its persona, memory, or user context during a session.
+2. **Edit manually** — Use `openshell sandbox connect` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
+
+## Prerequisites
+
+- A running NemoClaw sandbox (for backup) or a freshly created sandbox (for restore).
+- The OpenShell CLI on your `PATH`.
+- The sandbox name (shown by `nemoclaw list`).
+
+Workspace files define your agent's personality, memory, and user context.
+They persist across sandbox restarts but are **permanently deleted** when you run `nemoclaw <name> destroy`.
+
+This guide covers manual backup with CLI commands and an automated script.
+
+## Step 1: When to Back Up
+
+- Before running `nemoclaw <name> destroy`.
+- Before major NemoClaw version upgrades.
+- Periodically, if you have invested time customizing your agent.
+
+## Step 2: Manual Backup
+
+Use `openshell sandbox download` to copy files from the sandbox to your host.
+
+```console
+$ SANDBOX=my-assistant
+$ BACKUP_DIR=~/.nemoclaw/backups/$(date +%Y%m%d-%H%M%S)
+$ mkdir -p "$BACKUP_DIR"
+
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/SOUL.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/USER.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/IDENTITY.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/AGENTS.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/MEMORY.md "$BACKUP_DIR/"
+$ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/memory/ "$BACKUP_DIR/memory/"
+```
+
+## Step 3: Manual Restore
+
+Use `openshell sandbox upload` to push files back into a sandbox.
+
+```console
+$ SANDBOX=my-assistant
+$ BACKUP_DIR=~/.nemoclaw/backups/20260320-120000  # pick a timestamp
+
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/SOUL.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/USER.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/IDENTITY.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/AGENTS.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/MEMORY.md" /sandbox/.openclaw/workspace/
+$ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/memory/" /sandbox/.openclaw/workspace/memory/
+```
+
+## Step 4: Using the Backup Script
+
+The repository includes a convenience script at `scripts/backup-workspace.sh`.
+
+### Backup
+
+```console
+$ ./scripts/backup-workspace.sh backup my-assistant
+Backing up workspace from sandbox 'my-assistant'...
+Backup saved to /home/user/.nemoclaw/backups/20260320-120000/ (6 items)
+```
+
+### Restore
+
+Restore from the most recent backup:
+
+```console
+$ ./scripts/backup-workspace.sh restore my-assistant
+```
+
+Restore from a specific timestamp:
+
+```console
+$ ./scripts/backup-workspace.sh restore my-assistant 20260320-120000
+```
+
+## Step 5: Verifying a Backup
+
+List backed-up files to confirm completeness:
+
+```console
+$ ls ~/.nemoclaw/backups/20260320-120000/
+AGENTS.md
+IDENTITY.md
+MEMORY.md
+SOUL.md
+USER.md
+memory/
+```
+
+## Step 6: Inspecting Files Inside the Sandbox
+
+Connect to the sandbox to list or view workspace files directly:
+
+```console
+$ openshell sandbox connect my-assistant
+$ ls -la /sandbox/.openclaw/workspace/
+```
+
+## Related Skills
+
+- `nemoclaw-reference` — Commands reference
+- `nemoclaw-monitor-sandbox` — Monitor Sandbox Activity

--- a/.agents/skills/docs/nemoclaw-workspace/references/workspace-files.md
+++ b/.agents/skills/docs/nemoclaw-workspace/references/workspace-files.md
@@ -1,0 +1,61 @@
+# Workspace Files
+
+OpenClaw stores agent identity, behavior, and memory in a set of Markdown files inside the sandbox.
+These files live at `/sandbox/.openclaw/workspace/` and are read by the agent at the start of every session.
+
+## File Reference
+
+Each file controls a distinct aspect of the agent's behavior and memory.
+
+| File | Purpose | Upstream Docs |
+|---|---|---|
+| `SOUL.md` | Core personality, tone, and behavioral rules. | [SOUL template](https://docs.openclaw.ai/reference/templates/SOUL) |
+| `USER.md` | Preferences, context, and facts the agent learns about you. | [USER template](https://docs.openclaw.ai/reference/templates/USER) |
+| `IDENTITY.md` | Agent name, creature type, emoji, and self-presentation. | [IDENTITY template](https://docs.openclaw.ai/reference/templates/IDENTITY) |
+| `AGENTS.md` | Multi-agent coordination, memory conventions, and safety guidelines. | [AGENTS template](https://docs.openclaw.ai/reference/templates/AGENTS) |
+| `MEMORY.md` | Curated long-term memory distilled from daily notes. | — |
+| `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. | — |
+
+## Where They Live
+
+All workspace files reside inside the sandbox filesystem:
+
+```text
+/sandbox/.openclaw/workspace/
+├── AGENTS.md
+├── IDENTITY.md
+├── MEMORY.md
+├── SOUL.md
+├── USER.md
+└── memory/
+    ├── 2026-03-18.md
+    └── 2026-03-19.md
+```
+
+> **Note:** The workspace directory is hidden (`.openclaw`).
+> The files are not at `/sandbox/SOUL.md` — use the full path when downloading or uploading.
+
+## Persistence Behavior
+
+Understanding when these files persist and when they are lost is critical.
+
+| Event | Workspace files |
+|---|---|
+| Sandbox restart | **Preserved** — the sandbox PVC retains its data. |
+| `nemoclaw <name> destroy` | **Lost** — the sandbox and its PVC are deleted. |
+
+> **Warning:** Always back up your workspace files before running `nemoclaw <name> destroy`.
+> See Back Up and Restore (see the `nemoclaw-workspace` skill) for instructions.
+
+## Editing Workspace Files
+
+The agent reads these files at the start of every session.
+You can edit them in two ways:
+
+1. **Let the agent do it** — Ask your agent to update its persona, memory, or user context during a session.
+2. **Edit manually** — Use `openshell sandbox connect` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
+
+## Next Steps
+
+- Back Up and Restore workspace files (see the `nemoclaw-workspace` skill)
+- Commands reference (see the `nemoclaw-reference` skill)

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -320,6 +320,31 @@ function getNonInteractiveModel(providerKey) {
   return model;
 }
 
+/**
+ * Build a human-readable hint for resolving a port conflict.
+ * Returned as a single string (may contain newlines).
+ */
+function formatPortConflictHint(port, portCheck) {
+  const lines = [];
+  if (portCheck.process && portCheck.process !== "unknown") {
+    lines.push(`     Blocked by: ${portCheck.process}${portCheck.pid ? ` (PID ${portCheck.pid})` : ""}`);
+    lines.push("");
+    lines.push("     To fix, stop the conflicting process:");
+    lines.push("");
+    if (portCheck.pid) {
+      lines.push(`       sudo kill ${portCheck.pid}`);
+    } else {
+      lines.push(`       sudo lsof -i :${port} -sTCP:LISTEN -P -n`);
+    }
+    lines.push("       # or, if it's a systemd service:");
+    lines.push("       systemctl --user stop openclaw-gateway.service");
+  } else {
+    lines.push(`     Could not identify the process using port ${port}.`);
+    lines.push(`     Run: sudo lsof -i :${port} -sTCP:LISTEN`);
+  }
+  return lines.join("\n");
+}
+
 // ── Step 1: Preflight ────────────────────────────────────────────
 
 async function preflight() {
@@ -378,22 +403,7 @@ async function preflight() {
       console.error(`  !! Port ${port} is not available.`);
       console.error(`     ${label} needs this port.`);
       console.error("");
-      if (portCheck.process && portCheck.process !== "unknown") {
-        console.error(`     Blocked by: ${portCheck.process}${portCheck.pid ? ` (PID ${portCheck.pid})` : ""}`);
-        console.error("");
-        console.error("     To fix, stop the conflicting process:");
-        console.error("");
-        if (portCheck.pid) {
-          console.error(`       sudo kill ${portCheck.pid}`);
-        } else {
-          console.error(`       lsof -i :${port} -sTCP:LISTEN -P -n`);
-        }
-        console.error("       # or, if it's a systemd service:");
-        console.error("       systemctl --user stop openclaw-gateway.service");
-      } else {
-        console.error(`     Could not identify the process using port ${port}.`);
-        console.error(`     Run: lsof -i :${port} -sTCP:LISTEN`);
-      }
+      console.error(formatPortConflictHint(port, portCheck));
       console.error("");
       console.error(`     Detail: ${portCheck.reason}`);
       process.exit(1);
@@ -1056,6 +1066,7 @@ async function onboard(opts = {}) {
 
 module.exports = {
   buildSandboxConfigSyncScript,
+  formatPortConflictHint,
   getInstalledOpenshellVersion,
   getStableGatewayImageRef,
   hasStaleGateway,

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -95,8 +95,8 @@ If another process is already bound to this port, onboarding fails.
 Identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```console
-$ lsof -i :18789
-$ kill <PID>
+$ sudo lsof -i :18789
+$ sudo kill <PID>
 ```
 
 If the process does not exit, use `kill -9 <PID>` to force-terminate it.

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -8,6 +8,7 @@ import path from "node:path";
 
 import {
   buildSandboxConfigSyncScript,
+  formatPortConflictHint,
   getInstalledOpenshellVersion,
   getStableGatewayImageRef,
   writeSandboxConfigSyncFile,
@@ -45,6 +46,30 @@ describe("onboard helpers", () => {
     expect(getStableGatewayImageRef("openshell 0.0.12")).toBe("ghcr.io/nvidia/openshell/cluster:0.0.12");
     expect(getStableGatewayImageRef("openshell 0.0.13-dev.8+gbbcaed2ea")).toBe("ghcr.io/nvidia/openshell/cluster:0.0.13");
     expect(getStableGatewayImageRef("bogus")).toBe(null);
+  });
+
+  it("suggests sudo lsof when process is unknown (fixes #726)", () => {
+    const hint = formatPortConflictHint(8080, {
+      process: "unknown",
+      pid: null,
+    });
+    expect(hint).toContain("sudo lsof -i :8080");
+  });
+
+  it("suggests sudo kill when process is known with PID", () => {
+    const hint = formatPortConflictHint(8080, {
+      process: "docker-pr",
+      pid: 190242,
+    });
+    expect(hint).toContain("sudo kill 190242");
+  });
+
+  it("suggests sudo lsof when process is known but PID is missing", () => {
+    const hint = formatPortConflictHint(8080, {
+      process: "docker-pr",
+      pid: null,
+    });
+    expect(hint).toContain("sudo lsof -i :8080");
   });
 
   it("writes sandbox sync scripts to a temp file for stdin redirection", () => {


### PR DESCRIPTION
## Summary

Non-root users cannot see root-owned listeners via `lsof`, so the port-conflict hints shown during onboarding silently fail. This PR adds `sudo` to the `lsof` and `kill` hints displayed to users, and updates the troubleshooting docs to match.

The programmatic `lsof` call in `preflight.js` is intentionally left without `sudo` — adding it there would trigger an interactive password prompt during onboarding, which is a worse UX. The current approach (try without sudo, fall through gracefully, then suggest the user run it manually with sudo) is the right tradeoff.

## Related Issue

Fixes #726

## Changes

- Extracted inline hint logic into a dedicated `formatPortConflictHint()` helper in `onboard.js` for testability
- Added `sudo` prefix to `lsof` and `kill` commands in the user-facing hints (both "unknown process" and "known process without PID" paths)
- Updated `docs/reference/troubleshooting.md` with `sudo` commands
- Regenerated `.agents/skills/docs/` via `docs-to-skills.py`
- Added 3 unit tests covering all hint branches

## Type of Change

- [x] Code change with doc updates.

## Testing

- [x] `npm test` passes.
- [x] 3 new tests added in `test/onboard.test.js` covering all `formatPortConflictHint()` branches: unknown process, known with PID, known without PID.

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).

### Code Changes
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [x] Doc pages updated for any user-facing behavior changes.

### Doc Changes
- [x] Cross-references and links verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for backing up and restoring workspace files
  * Added reference documentation describing workspace Markdown files and persistence behavior
  * Added warning callouts about permanent file deletion when destroying sandboxes

* **Bug Fixes**
  * Updated port conflict troubleshooting commands to use elevated privileges for improved reliability

* **Tests**
  * Added unit tests for port conflict error message formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->