### PR TITLE
fix(security): replace NodeSource setup script with direct apt repo config

### DIFF
--- a/scripts/brev-setup.sh
+++ b/scripts/brev-setup.sh
@@ -40,7 +40,7 @@ export DEBIAN_FRONTEND=noninteractive
 if ! command -v node >/dev/null 2>&1; then
   info "Installing Node.js..."
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
+    | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/nodesource.gpg
   echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
     | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
   sudo apt-get update -qq >/dev/null 2>&1

--- a/scripts/brev-setup.sh
+++ b/scripts/brev-setup.sh
@@ -39,7 +39,11 @@ export DEBIAN_FRONTEND=noninteractive
 # --- 0. Node.js (needed for services) ---
 if ! command -v node >/dev/null 2>&1; then
   info "Installing Node.js..."
-  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - >/dev/null 2>&1
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
+  echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+    | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+  sudo apt-get update -qq >/dev/null 2>&1
   sudo apt-get install -y -qq nodejs >/dev/null 2>&1
   info "Node.js $(node --version) installed"
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -236,7 +236,7 @@ install_node() {
       ;;
     nodesource)
       curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-        | sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
+        | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/nodesource.gpg
       echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
         | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
       sudo apt-get update -qq >/dev/null 2>&1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -235,7 +235,11 @@ install_node() {
       brew link --overwrite node@22 2>/dev/null || true
       ;;
     nodesource)
-      curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - >/dev/null 2>&1
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
+      echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+        | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+      sudo apt-get update -qq >/dev/null 2>&1
       sudo apt-get install -y -qq nodejs >/dev/null 2>&1
       ;;
     none)


### PR DESCRIPTION
## Summary

Replace `curl | sudo bash` of NodeSource's `setup_22.x` script with GPG key import + apt source configuration in both `scripts/brev-setup.sh` and `scripts/install.sh`.

This eliminates execution of a third-party shell script as root entirely. Instead, Node.js is installed via apt's built-in GPG signature verification — the same pattern already used for the NVIDIA Container Toolkit in `brev-setup.sh` (lines 61–65).

| File | What changed |
|------|-------------|
| `scripts/brev-setup.sh` | NodeSource `setup_22.x` → GPG key + apt source |
| `scripts/install.sh` | NodeSource `setup_22.x` → GPG key + apt source |

## Test plan

- [ ] Manual: `scripts/install.sh` on Linux with `NODE_MGR=nodesource` installs Node.js 22 correctly
- [ ] Manual: `scripts/brev-setup.sh` on fresh Brev VM installs Node.js correctly
- [ ] Verify `/usr/share/keyrings/nodesource.gpg` and `/etc/apt/sources.list.d/nodesource.list` are created
- [ ] Verify `node --version` reports v22.x after install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js 22.x installation flow in setup and installer scripts to use explicit package repository and key handling (signed APT entry and repo update) instead of invoking remote setup scripts, keeping the same installation outcome and checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->