### PR TITLE
fix(install): make prek optional in prepare script (fixes #731)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "vitest run",
-    "prepare": "if [ -d .git ]; then prek install; fi",
+    "prepare": "if [ -d .git ] && command -v prek >/dev/null 2>&1; then prek install; fi",
     "prepublishOnly": "cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "vitest run",
-    "prepare": "if [ -d .git ] && command -v prek >/dev/null 2>&1; then prek install; fi",
+    "prepare": "if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; elif [ -d node_modules/@j178/prek ]; then echo \"ERROR: prek package found but binary not in PATH\" && exit 1; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #731

## Problem

The `prepare` script in `package.json` unconditionally runs `prek install` to set up git hooks. Since `prek` is a devDependency (`@j178/prek`), it's not installed when:

- End users clone the repo and run `npm install` without `--include=dev`
- The installer runs `npm install --ignore-scripts` then later triggers `prepare`
- Users deploy from a git checkout directory

This causes `npm error code 127` (`sh: 1: prek: not found`) and blocks installation.

## Solution

Guard the `prek` invocation with `command -v prek` so the prepare hook only runs when prek is actually available:

```diff
- "prepare": "if [ -d .git ]; then prek install; fi"
+ "prepare": "if [ -d .git ] && command -v prek >/dev/null 2>&1; then prek install; fi"
```

Developers with devDependencies installed get hooks as before. End-user installs skip hook setup gracefully.

## One-line change

Only `package.json` is modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved install/setup script to verify the required CLI tool is available before running setup.
  * Now emits a clear error if the project expects the tool but it’s not accessible, preventing silent failures.
  * If the tool is not present at all, the hook/setup step is skipped with an informative message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->