### PR TITLE
fix(sandbox): make OpenClaw version configurable via build arg (fixes #739)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
     && chown -R sandbox:sandbox /sandbox/.openclaw /sandbox/.openclaw-data
 
 # Install OpenClaw CLI and PyYAML for blueprint runner (single layer)
-RUN npm install -g openclaw@2026.3.11 \
+ARG OPENCLAW_VERSION=2026.3.22
+RUN npm install -g openclaw@${OPENCLAW_VERSION} \
     && pip3 install --no-cache-dir --break-system-packages "pyyaml==6.0.3"
 
 # Copy built plugin and blueprint into the sandbox


### PR DESCRIPTION
Fixes #739 (part 1: pinned OpenClaw version)

## Problem

The Dockerfile hardcodes `openclaw@2026.3.11`, but OpenClaw 2026.3.22 is available with important fixes. Users cannot update OpenClaw inside the sandbox (`openclaw update` fails with EACCES due to read-only filesystem), forcing a full image rebuild with no easy way to change the version.

## Solution

Add `OPENCLAW_VERSION` build arg (default: `2026.3.22`) following the existing pattern of `NEMOCLAW_MODEL` and `CHAT_UI_URL`:

```dockerfile
ARG OPENCLAW_VERSION=2026.3.22
RUN npm install -g openclaw@${OPENCLAW_VERSION} ...
```

Users can now:
- Get the latest version by default on fresh builds
- Pin a specific version: `docker build --build-arg OPENCLAW_VERSION=2026.3.XX ...`
- Update without modifying the Dockerfile

## Scope

This PR only addresses part 1 of #739 (pinned version). Parts 2 (allowedOrigins) and 3 (trustedProxies) are separate concerns that could be addressed in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenClaw CLI to version 2026.3.22 in Docker build configuration. Version can now be customized via build-time argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->