### PR TITLE
fix(ci): checkout before artifact download in docs preview deploy

### DIFF
--- a/.github/workflows/docs-preview-deploy.yaml
+++ b/.github/workflows/docs-preview-deploy.yaml
@@ -24,6 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Checkout first so subsequent artifact downloads are not clobbered.
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Download PR metadata
         uses: actions/download-artifact@v8
         with:
@@ -60,10 +64,6 @@ jobs:
           path: docs-preview-html/
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout repository
-        if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true' || steps.meta.outputs.action == 'closed'
-        uses: actions/checkout@v6
 
       - name: Deploy preview
         if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true'


### PR DESCRIPTION
## Summary

The docs preview deploy workflow (`docs-preview-deploy.yaml`) fails on every PR that touches docs:

```
The directory you're trying to deploy named docs-preview-html/ doesn't exist.
```

The `actions/checkout` step was running *after* the artifact download, clobbering `docs-preview-html/` when it cloned the repo into the workspace. Moved checkout to the first step so artifact downloads write into the already-checked-out workspace.

Introduced in #717 when the docs workflow was split into build + deploy.

## Test plan

- [ ] Merge this PR, then push a docs change to any open PR — verify the deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow reliability by performing the repository checkout unconditionally at the start of deployment runs, simplifying checkout logic and reducing conditional branching during preview deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->