### PR TITLE
fix(test): convert assert.ok to vitest expect in policies.test.js

### DIFF
--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -127,15 +127,9 @@ describe("policies", () => {
       const packagePresets = ["pypi", "npm"];
       for (const name of packagePresets) {
         const content = policies.loadPreset(name);
-        assert.ok(content, `preset not found: ${name}`);
-        assert.ok(
-          !content.includes("tls: terminate"),
-          `${name} preset must not use tls: terminate (breaks CONNECT tunneling)`
-        );
-        assert.ok(
-          content.includes("access: full"),
-          `${name} preset must use access: full for package manager compatibility`
-        );
+        expect(content).toBeTruthy();
+        expect(content.includes("tls: terminate")).toBe(false);
+        expect(content.includes("access: full")).toBe(true);
       }
     });
 
@@ -148,15 +142,9 @@ describe("policies", () => {
       ];
       for (const { name, expectedBinary } of packagePresets) {
         const content = policies.loadPreset(name);
-        assert.ok(content, `preset not found: ${name}`);
-        assert.ok(
-          content.includes("binaries:"),
-          `${name} preset must include a binaries section`
-        );
-        assert.ok(
-          content.includes(expectedBinary),
-          `${name} preset binaries must include ${expectedBinary}`
-        );
+        expect(content).toBeTruthy();
+        expect(content.includes("binaries:")).toBe(true);
+        expect(content.includes(expectedBinary)).toBe(true);
       }
     });
   });


### PR DESCRIPTION
## Summary

PR #356 added tests using `node:assert` which is incompatible with the vitest runner. This breaks `test-unit` on main and every open PR.

Converts `assert.ok()` to vitest `expect().toBeTruthy()` / `expect().toBe()`.

## Test plan

- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for package manager preset schema validation to improve test robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->