### PR TITLE
fix(docs): remove bare npm install that installs placeholder package

### DIFF
--- a/.agents/skills/docs/nemoclaw-reference/references/commands.md
+++ b/.agents/skills/docs/nemoclaw-reference/references/commands.md
@@ -1,6 +1,7 @@
 # Commands
 
-The `nemoclaw` CLI is the primary interface for managing NemoClaw sandboxes. It is installed when you run `npm install -g nemoclaw`.
+The `nemoclaw` CLI is the primary interface for managing NemoClaw sandboxes.
+It is installed automatically by the installer (`curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash`).
 
 ## `/nemoclaw` Slash Command
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -20,7 +20,8 @@ status: published
 
 # Commands
 
-The `nemoclaw` CLI is the primary interface for managing NemoClaw sandboxes. It is installed when you run `npm install -g nemoclaw`.
+The `nemoclaw` CLI is the primary interface for managing NemoClaw sandboxes.
+It is installed automatically by the [installer](../../README.md#install).
 
 ## `/nemoclaw` Slash Command
 


### PR DESCRIPTION
## Summary

- Remove `npm install -g nemoclaw` from docs, which resolves to a placeholder 0.1.0 package on npmjs.org and clobbers the real CLI installed from GitHub source
- Replace with reference to the official curl installer in both `docs/reference/commands.md` and the agent skills reference copy

## Context

The installer scripts (`scripts/install.sh`, `install.sh`) correctly use `npm install -g git+https://github.com/NVIDIA/NemoClaw.git`, and there's even a test asserting the bare form is never used (`install-preflight.test.js:284`). But the docs page told users to run the bare `npm install -g nemoclaw`, which pulls the placeholder from npmjs.org.

Fixes #737

## Test plan

- [x] `vitest run test/install-preflight.test.js` — 11/11 passing
- [ ] Verify rendered docs page no longer contains `npm install -g nemoclaw`

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated nemoclaw CLI installation instructions across documentation files to reflect automatic installation via the project's installer script, replacing the previous npm install method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->