### PR TITLE
fix: replace exec() with execFile() in status command to prevent command injection

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -314,8 +314,11 @@ function sandboxStatus(sandboxName) {
     console.log(`    Policies: ${(sb.policies || []).join(", ") || "none"}`);
   }
 
-  // openshell info
-  run(`openshell sandbox get ${shellQuote(sandboxName)} 2>/dev/null || true`, { ignoreError: true });
+  // openshell info — use spawnSync with array args to avoid shell interpretation
+  spawnSync("openshell", ["sandbox", "get", sandboxName], {
+    stdio: ["ignore", "inherit", "inherit"],
+    cwd: ROOT,
+  });
 
   // NIM health
   const nimStat = nim.nimStatus(sandboxName);

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -201,6 +201,37 @@ describe("runner helpers", () => {
       }
     });
 
+    it("sandboxStatus does not pass sandbox name through bash -c", () => {
+      const src = fs.readFileSync(path.join(import.meta.dirname, "..", "bin", "nemoclaw.js"), "utf-8");
+      const fn = src.match(/function sandboxStatus\([\s\S]*?\n\}/);
+      expect(fn).toBeTruthy();
+      const body = fn[0];
+      // Must not use run() with template-literal sandbox name interpolation
+      expect(body).not.toMatch(/run\s*\(\s*`[^`]*\$\{/);
+      // Should use spawnSync with array args
+      expect(body).toMatch(/spawnSync\s*\(\s*"openshell"/);
+    });
+
+    it("sandboxStatus rejects shell metacharacters in sandbox name (e2e)", () => {
+      const canaryDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-status-canary-"));
+      const canary = path.join(canaryDir, "executed");
+      try {
+        const result = spawnSync("node", [
+          path.join(import.meta.dirname, "..", "bin", "nemoclaw.js"),
+          `test; touch ${canary}`,
+          "status",
+        ], {
+          encoding: "utf-8",
+          timeout: 10000,
+          cwd: path.join(import.meta.dirname, ".."),
+        });
+        expect(result.status).not.toBe(0);
+        expect(fs.existsSync(canary)).toBe(false);
+      } finally {
+        fs.rmSync(canaryDir, { recursive: true, force: true });
+      }
+    });
+
     it("telegram bridge validates SANDBOX_NAME on startup", () => {
 
       const src = fs.readFileSync(path.join(import.meta.dirname, "..", "scripts", "telegram-bridge.js"), "utf-8");

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -210,17 +210,26 @@ describe("runner helpers", () => {
       expect(body).not.toMatch(/spawnSync\s*\(\s*"bash"\s*,\s*\[\s*"-c"/);
       expect(body).not.toMatch(/shell\s*:\s*true/);
       expect(body).not.toMatch(/\brun(?:Capture|Interactive)?\s*\(/);
-      // Should use spawnSync with array args targeting openshell directly
-      expect(body).toMatch(/spawnSync\s*\(\s*"openshell"/);
+      // Should use spawnSync with array args passing sandboxName as a discrete element
+      expect(body).toMatch(/spawnSync\s*\(\s*"openshell"\s*,\s*\[/);
+      expect(body).toMatch(/sandboxName/);
     });
 
     it("sandboxStatus rejects shell metacharacters in sandbox name (e2e)", () => {
+      // Seed a registry entry so the CLI reaches sandboxStatus()
+      // (without a matching sandbox, the CLI exits at the lookup before our code path)
+      const registryPath = path.join(import.meta.dirname, "..", "bin", "lib", "registry");
+      const { registerSandbox, removeSandbox } = require(registryPath);
+      const fakeName = "canary-test-sb";
+      registerSandbox(fakeName, { model: "test", provider: "test" });
+
       const canaryDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-status-canary-"));
       const canary = path.join(canaryDir, "executed");
       try {
+        // Even with a valid sandbox, metacharacters in argv must not execute
         const result = spawnSync("node", [
           path.join(import.meta.dirname, "..", "bin", "nemoclaw.js"),
-          `test; touch ${canary}`,
+          `${fakeName}; touch ${canary}`,
           "status",
         ], {
           encoding: "utf-8",
@@ -231,6 +240,7 @@ describe("runner helpers", () => {
         expect(fs.existsSync(canary)).toBe(false);
       } finally {
         fs.rmSync(canaryDir, { recursive: true, force: true });
+        removeSandbox(fakeName);
       }
     });
 

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -206,9 +206,11 @@ describe("runner helpers", () => {
       const fn = src.match(/function sandboxStatus\([\s\S]*?\n\}/);
       expect(fn).toBeTruthy();
       const body = fn[0];
-      // Must not use run() with template-literal sandbox name interpolation
-      expect(body).not.toMatch(/run\s*\(\s*`[^`]*\$\{/);
-      // Should use spawnSync with array args
+      // Must not use bash -c, shell: true, or any run() variant
+      expect(body).not.toMatch(/spawnSync\s*\(\s*"bash"\s*,\s*\[\s*"-c"/);
+      expect(body).not.toMatch(/shell\s*:\s*true/);
+      expect(body).not.toMatch(/\brun(?:Capture|Interactive)?\s*\(/);
+      // Should use spawnSync with array args targeting openshell directly
       expect(body).toMatch(/spawnSync\s*\(\s*"openshell"/);
     });
 


### PR DESCRIPTION
## Summary

`sandboxStatus()` passes the sandbox name through `run()` which uses
`spawnSync("bash", ["-c", cmd])` for command execution. While `shellQuote()`
and `validateName()` provide defense-in-depth, the proper fix eliminates
shell interpretation entirely by using `spawnSync` with an argument array.

## Change

Replace `run()` bash -c call with direct `spawnSync("openshell", [...args])`
in `sandboxStatus`. This removes shell interpretation from the code path
that handles sandbox names.

## Detection

This vulnerability class is detectable via HackMyAgent:
```
npx hackmyagent secure .
```

## References

- PSIRT disclosure: tickets 6009892–6010011
- CWE-78: Improper Neutralization of Special Elements used in an OS Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer execution of the sandbox status command to prevent shell metacharacters from affecting the host and improve stability when checking sandbox state.

* **Tests**
  * Added regression and end-to-end tests ensuring the status command handles malicious input safely and produces no unintended side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->