### PR TITLE
fix: replace exec() with execFile() in logs command to prevent command injection

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -327,8 +327,13 @@ function sandboxStatus(sandboxName) {
 }
 
 function sandboxLogs(sandboxName, follow) {
-  const followFlag = follow ? " --tail" : "";
-  run(`openshell logs ${shellQuote(sandboxName)}${followFlag}`);
+  // Use spawnSync with array args to avoid shell interpretation
+  const args = ["logs", sandboxName];
+  if (follow) args.push("--tail");
+  spawnSync("openshell", args, {
+    stdio: "inherit",
+    cwd: ROOT,
+  });
 }
 
 async function sandboxPolicyAdd(sandboxName) {

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -330,10 +330,11 @@ function sandboxLogs(sandboxName, follow) {
   // Use spawnSync with array args to avoid shell interpretation
   const args = ["logs", sandboxName];
   if (follow) args.push("--tail");
-  spawnSync("openshell", args, {
+  const result = spawnSync("openshell", args, {
     stdio: "inherit",
     cwd: ROOT,
   });
+  exitWithSpawnResult(result);
 }
 
 async function sandboxPolicyAdd(sandboxName) {

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -201,6 +201,35 @@ describe("runner helpers", () => {
       }
     });
 
+    it("sandboxLogs does not pass sandbox name through bash -c", () => {
+      const src = fs.readFileSync(path.join(import.meta.dirname, "..", "bin", "nemoclaw.js"), "utf-8");
+      const fn = src.match(/function sandboxLogs\([\s\S]*?\n\}/);
+      expect(fn).toBeTruthy();
+      const body = fn[0];
+      expect(body).not.toMatch(/run\s*\(\s*`[^`]*\$\{/);
+      expect(body).toMatch(/spawnSync\s*\(\s*"openshell"/);
+    });
+
+    it("sandboxLogs rejects shell metacharacters in sandbox name (e2e)", () => {
+      const canaryDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-logs-canary-"));
+      const canary = path.join(canaryDir, "executed");
+      try {
+        const result = spawnSync("node", [
+          path.join(import.meta.dirname, "..", "bin", "nemoclaw.js"),
+          `test; touch ${canary}`,
+          "logs",
+        ], {
+          encoding: "utf-8",
+          timeout: 10000,
+          cwd: path.join(import.meta.dirname, ".."),
+        });
+        expect(result.status).not.toBe(0);
+        expect(fs.existsSync(canary)).toBe(false);
+      } finally {
+        fs.rmSync(canaryDir, { recursive: true, force: true });
+      }
+    });
+
     it("telegram bridge validates SANDBOX_NAME on startup", () => {
 
       const src = fs.readFileSync(path.join(import.meta.dirname, "..", "scripts", "telegram-bridge.js"), "utf-8");

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -206,7 +206,11 @@ describe("runner helpers", () => {
       const fn = src.match(/function sandboxLogs\([\s\S]*?\n\}/);
       expect(fn).toBeTruthy();
       const body = fn[0];
-      expect(body).not.toMatch(/run\s*\(\s*`[^`]*\$\{/);
+      // Must not use bash -c, shell: true, or any run() variant
+      expect(body).not.toMatch(/spawnSync\s*\(\s*"bash"\s*,\s*\[\s*"-c"/);
+      expect(body).not.toMatch(/shell\s*:\s*true/);
+      expect(body).not.toMatch(/\brun(?:Capture|Interactive)?\s*\(/);
+      // Should use spawnSync with array args targeting openshell directly
       expect(body).toMatch(/spawnSync\s*\(\s*"openshell"/);
     });
 


### PR DESCRIPTION
## Summary

`sandboxLogs()` passes the sandbox name through `run()` which uses
`spawnSync("bash", ["-c", cmd])` for command execution. Same root cause
as the `sandboxStatus` fix — two independent call sites with the same
vulnerable pattern.

## Change

Replace `run()` bash -c call with direct `spawnSync("openshell", [...args])`
in `sandboxLogs`. This removes shell interpretation from the code path
that handles sandbox names.

## Detection

This vulnerability class is detectable via HackMyAgent:
```
npx hackmyagent secure .
```

## References

- PSIRT disclosure: tickets 6009892–6010011
- CWE-78: Improper Neutralization of Special Elements used in an OS Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logs command now safely handles sandbox names containing special characters, preventing unintended command execution and ensuring reliable exit behavior.

* **Tests**
  * Added regression and end-to-end tests to verify the logs command rejects malicious sandbox names and does not perform unintended file-system actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->