### PR TITLE
fix: pass credentials via environment variable instead of CLI arguments

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -38,6 +38,26 @@ const USE_COLOR = !process.env.NO_COLOR && !!process.stdout.isTTY;
 const DIM = USE_COLOR ? "\x1b[2m" : "";
 const RESET = USE_COLOR ? "\x1b[0m" : "";
 
+/**
+ * Run an openshell command without shell interpretation.
+ * Uses spawnSync with an argument array instead of bash -c, preventing
+ * credential values or other arguments from appearing in shell command strings.
+ */
+function runOpenshell(args, opts = {}) {
+  const result = spawnSync("openshell", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    cwd: ROOT,
+    env: { ...process.env, ...opts.env },
+  });
+  if (result.status !== 0 && !opts.ignoreError) {
+    const stderr = result.stderr ? result.stderr.toString().trim() : "";
+    console.error(`  openshell command failed (exit ${result.status}): openshell ${args[0]} ${args[1] || ""}`);
+    if (stderr) console.error(`  ${stderr}`);
+    process.exit(result.status || 1);
+  }
+  return result;
+}
+
 // Non-interactive mode: set by --non-interactive flag or env var.
 // When active, all prompts use env var overrides or sensible defaults.
 let NON_INTERACTIVE = false;
@@ -845,15 +865,15 @@ async function setupInference(sandboxName, model, provider) {
   step(5, 7, "Setting up inference provider");
 
   if (provider === "nvidia-nim") {
-    // Create nvidia-nim provider
-    run(
-      `openshell provider create --name nvidia-nim --type openai ` +
-      `--credential ${shellQuote("NVIDIA_API_KEY")} ` +
-      `--config "OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1" 2>&1 || true`,
+    // Create nvidia-nim provider — pass credential via env, not CLI args
+    runOpenshell(
+      ["provider", "create", "--name", "nvidia-nim", "--type", "openai",
+       "--credential", "NVIDIA_API_KEY",
+       "--config", `OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1`],
       { ignoreError: true }
     );
-    run(
-      `openshell inference set --no-verify --provider nvidia-nim --model ${shellQuote(model)} 2>/dev/null || true`,
+    runOpenshell(
+      ["inference", "set", "--no-verify", "--provider", "nvidia-nim", "--model", model],
       { ignoreError: true }
     );
   } else if (provider === "vllm-local") {
@@ -863,18 +883,23 @@ async function setupInference(sandboxName, model, provider) {
       process.exit(1);
     }
     const baseUrl = getLocalProviderBaseUrl(provider);
-    run(
-      `OPENAI_API_KEY=dummy ` +
-      `openshell provider create --name vllm-local --type openai ` +
-      `--credential "OPENAI_API_KEY" ` +
-      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || ` +
-      `OPENAI_API_KEY=dummy ` +
-      `openshell provider update vllm-local --credential "OPENAI_API_KEY" ` +
-      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || true`,
-      { ignoreError: true }
+    // Pass credential value via env instead of shell command string
+    const vllmEnv = { OPENAI_API_KEY: "dummy" };
+    runOpenshell(
+      ["provider", "create", "--name", "vllm-local", "--type", "openai",
+       "--credential", "OPENAI_API_KEY",
+       "--config", `OPENAI_BASE_URL=${baseUrl}`],
+      { ignoreError: true, env: vllmEnv }
     );
-    run(
-      `openshell inference set --no-verify --provider vllm-local --model ${shellQuote(model)} 2>/dev/null || true`,
+    // Fall back to update if create fails (already exists)
+    runOpenshell(
+      ["provider", "update", "vllm-local",
+       "--credential", "OPENAI_API_KEY",
+       "--config", `OPENAI_BASE_URL=${baseUrl}`],
+      { ignoreError: true, env: vllmEnv }
+    );
+    runOpenshell(
+      ["inference", "set", "--no-verify", "--provider", "vllm-local", "--model", model],
       { ignoreError: true }
     );
   } else if (provider === "ollama-local") {
@@ -885,18 +910,22 @@ async function setupInference(sandboxName, model, provider) {
       process.exit(1);
     }
     const baseUrl = getLocalProviderBaseUrl(provider);
-    run(
-      `OPENAI_API_KEY=ollama ` +
-      `openshell provider create --name ollama-local --type openai ` +
-      `--credential "OPENAI_API_KEY" ` +
-      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || ` +
-      `OPENAI_API_KEY=ollama ` +
-      `openshell provider update ollama-local --credential "OPENAI_API_KEY" ` +
-      `--config "OPENAI_BASE_URL=${baseUrl}" 2>&1 || true`,
-      { ignoreError: true }
+    // Pass credential value via env instead of shell command string
+    const ollamaEnv = { OPENAI_API_KEY: "ollama" };
+    runOpenshell(
+      ["provider", "create", "--name", "ollama-local", "--type", "openai",
+       "--credential", "OPENAI_API_KEY",
+       "--config", `OPENAI_BASE_URL=${baseUrl}`],
+      { ignoreError: true, env: ollamaEnv }
     );
-    run(
-      `openshell inference set --no-verify --provider ollama-local --model ${shellQuote(model)} 2>/dev/null || true`,
+    runOpenshell(
+      ["provider", "update", "ollama-local",
+       "--credential", "OPENAI_API_KEY",
+       "--config", `OPENAI_BASE_URL=${baseUrl}`],
+      { ignoreError: true, env: ollamaEnv }
+    );
+    runOpenshell(
+      ["inference", "set", "--no-verify", "--provider", "ollama-local", "--model", model],
       { ignoreError: true }
     );
     console.log(`  Priming Ollama model: ${model}`);

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -106,10 +106,10 @@ function hasStaleGateway(gwInfoOutput) {
   return typeof gwInfoOutput === "string" && gwInfoOutput.length > 0 && gwInfoOutput.includes("nemoclaw");
 }
 
-function streamSandboxCreate(command) {
-  const child = spawn("bash", ["-lc", command], {
+function streamSandboxCreate(args, opts = {}) {
+  const child = spawn("openshell", args, {
     cwd: ROOT,
-    env: process.env,
+    env: { ...process.env, ...opts.env },
     stdio: ["ignore", "pipe", "pipe"],
   });
 
@@ -574,26 +574,40 @@ async function createSandbox(gpu) {
   // --gpu is intentionally omitted. See comment in startGateway().
 
   console.log(`  Creating sandbox '${sandboxName}' (this takes a few minutes on first run)...`);
-  const chatUiUrl = process.env.CHAT_UI_URL || 'http://127.0.0.1:18789';
-  const envArgs = [`CHAT_UI_URL=${shellQuote(chatUiUrl)}`];
+
+  // Pass credentials via subprocess environment, not CLI arguments.
+  // CLI arguments are visible in `ps aux` and /proc/PID/cmdline.
+  const sandboxEnv = {};
+  sandboxEnv.CHAT_UI_URL = process.env.CHAT_UI_URL || 'http://127.0.0.1:18789';
   if (process.env.NVIDIA_API_KEY) {
-    envArgs.push(`NVIDIA_API_KEY=${shellQuote(process.env.NVIDIA_API_KEY)}`);
+    sandboxEnv.NVIDIA_API_KEY = process.env.NVIDIA_API_KEY;
   }
   const discordToken = getCredential("DISCORD_BOT_TOKEN") || process.env.DISCORD_BOT_TOKEN;
   if (discordToken) {
-    envArgs.push(`DISCORD_BOT_TOKEN=${shellQuote(discordToken)}`);
+    sandboxEnv.DISCORD_BOT_TOKEN = discordToken;
   }
   const slackToken = getCredential("SLACK_BOT_TOKEN") || process.env.SLACK_BOT_TOKEN;
   if (slackToken) {
-    envArgs.push(`SLACK_BOT_TOKEN=${shellQuote(slackToken)}`);
+    sandboxEnv.SLACK_BOT_TOKEN = slackToken;
   }
 
-  // Run without piping through awk — the pipe masked non-zero exit codes
-  // from openshell because bash returns the status of the last pipeline
-  // command (awk, always 0) unless pipefail is set. Removing the pipe
-  // lets the real exit code flow through to run().
+  // Build env forwarding args for the sandbox entrypoint.
+  // Only pass env var NAMES (not values) so they are read from the environment.
+  const envNames = Object.keys(sandboxEnv);
+  const envForwardArgs = [];
+  for (const name of envNames) {
+    envForwardArgs.push(`${name}=\${${name}}`);
+  }
+
   const createResult = await streamSandboxCreate(
-    `openshell sandbox create ${createArgs.join(" ")} -- env ${envArgs.join(" ")} nemoclaw-start 2>&1`
+    [
+      "sandbox", "create",
+      "--from", `${buildCtx}/Dockerfile`,
+      "--name", sandboxName,
+      "--policy", basePolicyPath,
+      "--", "env", ...envForwardArgs, "nemoclaw-start",
+    ],
+    { env: sandboxEnv }
   );
 
   // Clean up build context regardless of outcome

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -879,16 +879,26 @@ async function setupInference(sandboxName, model, provider) {
   step(5, 7, "Setting up inference provider");
 
   if (provider === "nvidia-nim") {
-    // Create nvidia-nim provider — pass credential via env, not CLI args
-    runOpenshell(
+    // Create nvidia-nim provider — pass credential via env, not CLI args.
+    // Try create first; fall back to update only if create fails (already exists).
+    const createResult = runOpenshell(
       ["provider", "create", "--name", "nvidia-nim", "--type", "openai",
        "--credential", "NVIDIA_API_KEY",
        "--config", `OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1`],
       { ignoreError: true }
     );
+    if (createResult.status !== 0) {
+      runOpenshell(
+        ["provider", "update", "nvidia-nim",
+         "--credential", "NVIDIA_API_KEY",
+         "--config", `OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1`],
+        { ignoreError: false }
+      );
+    }
+    // inference set must succeed — do not ignore errors
     runOpenshell(
       ["inference", "set", "--no-verify", "--provider", "nvidia-nim", "--model", model],
-      { ignoreError: true }
+      { ignoreError: false }
     );
   } else if (provider === "vllm-local") {
     const validation = validateLocalProvider(provider, runCapture);
@@ -899,22 +909,24 @@ async function setupInference(sandboxName, model, provider) {
     const baseUrl = getLocalProviderBaseUrl(provider);
     // Pass credential value via env instead of shell command string
     const vllmEnv = { OPENAI_API_KEY: "dummy" };
-    runOpenshell(
+    const createResult = runOpenshell(
       ["provider", "create", "--name", "vllm-local", "--type", "openai",
        "--credential", "OPENAI_API_KEY",
        "--config", `OPENAI_BASE_URL=${baseUrl}`],
       { ignoreError: true, env: vllmEnv }
     );
-    // Fall back to update if create fails (already exists)
-    runOpenshell(
-      ["provider", "update", "vllm-local",
-       "--credential", "OPENAI_API_KEY",
-       "--config", `OPENAI_BASE_URL=${baseUrl}`],
-      { ignoreError: true, env: vllmEnv }
-    );
+    // Fall back to update only if create fails (provider already exists)
+    if (createResult.status !== 0) {
+      runOpenshell(
+        ["provider", "update", "vllm-local",
+         "--credential", "OPENAI_API_KEY",
+         "--config", `OPENAI_BASE_URL=${baseUrl}`],
+        { ignoreError: false, env: vllmEnv }
+      );
+    }
     runOpenshell(
       ["inference", "set", "--no-verify", "--provider", "vllm-local", "--model", model],
-      { ignoreError: true }
+      { ignoreError: false }
     );
   } else if (provider === "ollama-local") {
     const validation = validateLocalProvider(provider, runCapture);
@@ -926,21 +938,23 @@ async function setupInference(sandboxName, model, provider) {
     const baseUrl = getLocalProviderBaseUrl(provider);
     // Pass credential value via env instead of shell command string
     const ollamaEnv = { OPENAI_API_KEY: "ollama" };
-    runOpenshell(
+    const createResult = runOpenshell(
       ["provider", "create", "--name", "ollama-local", "--type", "openai",
        "--credential", "OPENAI_API_KEY",
        "--config", `OPENAI_BASE_URL=${baseUrl}`],
       { ignoreError: true, env: ollamaEnv }
     );
-    runOpenshell(
-      ["provider", "update", "ollama-local",
-       "--credential", "OPENAI_API_KEY",
-       "--config", `OPENAI_BASE_URL=${baseUrl}`],
-      { ignoreError: true, env: ollamaEnv }
-    );
+    if (createResult.status !== 0) {
+      runOpenshell(
+        ["provider", "update", "ollama-local",
+         "--credential", "OPENAI_API_KEY",
+         "--config", `OPENAI_BASE_URL=${baseUrl}`],
+        { ignoreError: false, env: ollamaEnv }
+      );
+    }
     runOpenshell(
       ["inference", "set", "--no-verify", "--provider", "ollama-local", "--model", model],
-      { ignoreError: true }
+      { ignoreError: false }
     );
     console.log(`  Priming Ollama model: ${model}`);
     run(getOllamaWarmupCommand(model), { ignoreError: true });

--- a/test/credential-exposure.test.js
+++ b/test/credential-exposure.test.js
@@ -63,23 +63,41 @@ describe("credential exposure in process arguments", () => {
     expect(violations).toEqual([]);
   });
 
+  it("setupInference uses runOpenshell (no bash -c) for credential commands", () => {
+    const src = fs.readFileSync(ONBOARD_JS, "utf-8");
+    const fn = src.match(/async function setupInference\([\s\S]*?\n\}/);
+    expect(fn).toBeTruthy();
+    const body = fn[0];
+    // Must not use run() with template-literal interpolation for openshell calls
+    expect(body).not.toMatch(/\brun\s*\(\s*\n?\s*`[^`]*openshell/);
+    // Should use runOpenshell with array args
+    expect(body).toMatch(/runOpenshell\s*\(/);
+  });
+
   it("onboard.js --credential flags pass env var names only", () => {
     const src = fs.readFileSync(ONBOARD_JS, "utf-8");
 
     // Find all --credential arguments and verify they contain only a key name
-    // (no "=" sign in the credential value)
+    // (no "=" sign in the credential value).
+    // Matches both shell-string patterns and array-element patterns:
+    //   --credential "NVIDIA_API_KEY"     (shell string)
+    //   "--credential", "NVIDIA_API_KEY"  (array element)
+    //   --credential ${shellQuote("...")} (shellQuote wrapper)
     const credentialArgs = src.match(/--credential\s+"([^"]+)"/g) || [];
     const credentialShellQuote =
       src.match(/--credential\s+\$\{shellQuote\("([^"]+)"\)\}/g) || [];
+    const credentialArrayArgs =
+      src.match(/"--credential",\s*"([^"]+)"/g) || [];
 
-    const allArgs = [...credentialArgs, ...credentialShellQuote];
+    const allArgs = [...credentialArgs, ...credentialShellQuote, ...credentialArrayArgs];
     expect(allArgs.length).toBeGreaterThan(0);
 
     for (const arg of allArgs) {
       // Extract the credential value from the match
       const valueMatch =
         arg.match(/--credential\s+"([^"]+)"/) ||
-        arg.match(/--credential\s+\$\{shellQuote\("([^"]+)"\)\}/);
+        arg.match(/--credential\s+\$\{shellQuote\("([^"]+)"\)\}/) ||
+        arg.match(/"--credential",\s*"([^"]+)"/);
       if (valueMatch) {
         expect(valueMatch[1]).not.toContain("=");
       }

--- a/test/credential-exposure.test.js
+++ b/test/credential-exposure.test.js
@@ -68,10 +68,25 @@ describe("credential exposure in process arguments", () => {
     const fn = src.match(/async function setupInference\([\s\S]*?\n\}/);
     expect(fn).toBeTruthy();
     const body = fn[0];
-    // Must not use run() with template-literal interpolation for openshell calls
-    expect(body).not.toMatch(/\brun\s*\(\s*\n?\s*`[^`]*openshell/);
+    // Must not use run() in any form (template literal or quoted string) for openshell
+    expect(body).not.toMatch(/\brun\s*\(\s*[`"'][^`"']*openshell/);
+    expect(body).not.toMatch(/\brun(?:Capture|Interactive)?\s*\([^)]*openshell/);
     // Should use runOpenshell with array args
     expect(body).toMatch(/runOpenshell\s*\(/);
+  });
+
+  it("createSandbox does not interpolate credentials into command strings", () => {
+    const src = fs.readFileSync(ONBOARD_JS, "utf-8");
+    const fn = src.match(/async function createSandbox\([\s\S]*?\n\}/);
+    expect(fn).toBeTruthy();
+    const body = fn[0];
+    // Must not interpolate credential values (process.env.NVIDIA_API_KEY, etc.)
+    // into shell command strings
+    expect(body).not.toMatch(/\$\{shellQuote\(process\.env\.NVIDIA_API_KEY\)\}/);
+    expect(body).not.toMatch(/\$\{shellQuote\(discordToken\)\}/);
+    expect(body).not.toMatch(/\$\{shellQuote\(slackToken\)\}/);
+    // streamSandboxCreate should receive an array, not a command string
+    expect(body).not.toMatch(/streamSandboxCreate\s*\(\s*\n?\s*`/);
   });
 
   it("onboard.js --credential flags pass env var names only", () => {


### PR DESCRIPTION
## Summary

`setupInference()` in `onboard.js` passes credential-related commands through
`run()` which uses `spawnSync("bash", ["-c", cmd])`. While the existing code
correctly passes only env var names (not values) to `--credential` flags, the
`run()` wrapper puts the entire command string in the process argument list
visible via `ps aux`.

For local providers (vllm, ollama), credential values like `OPENAI_API_KEY=dummy`
appear inline in the shell command string.

## Change

Add a `runOpenshell()` helper that uses `spawnSync` with an argument array,
and convert all `setupInference` openshell calls to use it. Credential values
are passed only via the subprocess environment, never in the command string.

## Detection

This vulnerability class is detectable via HackMyAgent:
```
npx hackmyagent secure .
```

## References

- PSIRT disclosure: tickets 6009892–6010011
- CWE-214: Invocation of Process Using Visible Sensitive Information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented embedding secrets into shell command strings during onboarding and sandbox setup; credentials are forwarded securely via environment variables.
  * Improved error handling so critical setup failures no longer get silently ignored.

* **Improvements**
  * More robust provider setup with create-then-fallback behavior for local providers and clearer success/failure signaling.

* **Tests**
  * Added regression tests ensuring secure invocation patterns and no credential exposure in command construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->