### PR TITLE
fix: require non-empty digest in blueprint verification; fail closed on missing or empty field

### DIFF
--- a/bin/lib/verify-digest.js
+++ b/bin/lib/verify-digest.js
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Blueprint digest verification — computes a SHA-256 digest over the blueprint
+// directory contents and compares it against the digest field in blueprint.yaml.
+// Fails closed: missing or empty digest fields are treated as verification failures.
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+const BLUEPRINT_DIR = path.join(__dirname, "..", "..", "nemoclaw-blueprint");
+const BLUEPRINT_YAML = path.join(BLUEPRINT_DIR, "blueprint.yaml");
+
+/**
+ * Recursively collect all files in a directory, sorted for deterministic hashing.
+ */
+function collectFiles(dirPath, prefix = "") {
+  const entries = fs.readdirSync(dirPath).sort();
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry);
+    const relativePath = prefix ? `${prefix}/${entry}` : entry;
+    const stat = fs.statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...collectFiles(fullPath, relativePath));
+    } else {
+      files.push(relativePath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Compute a deterministic SHA-256 digest over all files in the blueprint directory.
+ * The digest covers file paths and contents to detect any modification.
+ * blueprint.yaml itself is included but the digest field is zeroed before hashing
+ * to avoid a circular dependency.
+ */
+function computeBlueprintDigest() {
+  const files = collectFiles(BLUEPRINT_DIR);
+  const hash = crypto.createHash("sha256");
+
+  for (const file of files) {
+    hash.update(file);
+    let content = fs.readFileSync(path.join(BLUEPRINT_DIR, file));
+    // Zero the digest field in blueprint.yaml to avoid circular dependency
+    if (file === "blueprint.yaml") {
+      content = Buffer.from(
+        content.toString("utf-8").replace(/^digest:\s*"[^"]*"/m, 'digest: ""')
+      );
+    }
+    hash.update(content);
+  }
+
+  return hash.digest("hex");
+}
+
+/**
+ * Extract the digest field from blueprint.yaml.
+ */
+function readExpectedDigest() {
+  const content = fs.readFileSync(BLUEPRINT_YAML, "utf-8");
+  const match = content.match(/^digest:\s*"([^"]*)"/m);
+  return match ? match[1] : null;
+}
+
+/**
+ * Verify the blueprint directory against its declared digest.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.skipVerification - If true, skip verification (explicit opt-out)
+ * @returns {{ valid: boolean, reason?: string, expectedDigest: string|null, actualDigest: string }}
+ */
+function verifyBlueprintDigest(opts = {}) {
+  if (opts.skipVerification) {
+    return { valid: true, reason: "verification skipped (--skip-verification)", expectedDigest: null, actualDigest: "" };
+  }
+
+  const expectedDigest = readExpectedDigest();
+  const actualDigest = computeBlueprintDigest();
+
+  // Fail closed: missing or empty digest is a verification failure
+  if (!expectedDigest || expectedDigest.trim() === "") {
+    return {
+      valid: false,
+      reason: "digest field is missing or empty in blueprint.yaml — verification required",
+      expectedDigest: expectedDigest || "",
+      actualDigest,
+    };
+  }
+
+  if (expectedDigest !== actualDigest) {
+    return {
+      valid: false,
+      reason: `digest mismatch: expected ${expectedDigest}, got ${actualDigest}`,
+      expectedDigest,
+      actualDigest,
+    };
+  }
+
+  return { valid: true, expectedDigest, actualDigest };
+}
+
+module.exports = { verifyBlueprintDigest, computeBlueprintDigest, readExpectedDigest };

--- a/bin/lib/verify-digest.js
+++ b/bin/lib/verify-digest.js
@@ -77,8 +77,8 @@ function verifyBlueprintDigest(opts = {}) {
     return { valid: true, reason: "verification skipped (--skip-verification)", expectedDigest: null, actualDigest: "" };
   }
 
-  const expectedDigest = readExpectedDigest();
-  const actualDigest = computeBlueprintDigest();
+  const expectedDigest = module.exports.readExpectedDigest();
+  const actualDigest = module.exports.computeBlueprintDigest();
 
   // Fail closed: missing or empty digest is a verification failure
   if (!expectedDigest || expectedDigest.trim() === "") {

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -4,7 +4,7 @@
 version: "0.1.0"
 min_openshell_version: "0.1.0"
 min_openclaw_version: "2026.3.0"
-digest: ""  # Computed at release time
+digest: ""  # MUST be populated before release — run: node -e 'console.log(require("./bin/lib/verify-digest").computeBlueprintDigest())'
 
 profiles:
   - default

--- a/test/verify-digest.test.js
+++ b/test/verify-digest.test.js
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for blueprint digest verification — ensures fail-closed behavior
+// when digest is missing, empty, or mismatched.
+
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+
+const verifyDigestPath = path.join(import.meta.dirname, "..", "bin", "lib", "verify-digest");
+
+describe("blueprint digest verification", () => {
+  it("computeBlueprintDigest returns a 64-char hex string", () => {
+    const { computeBlueprintDigest } = require(verifyDigestPath);
+    const digest = computeBlueprintDigest();
+    expect(digest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("computeBlueprintDigest is deterministic", () => {
+    const { computeBlueprintDigest } = require(verifyDigestPath);
+    const d1 = computeBlueprintDigest();
+    const d2 = computeBlueprintDigest();
+    expect(d1).toBe(d2);
+  });
+
+  it("readExpectedDigest returns the digest field from blueprint.yaml", () => {
+    const { readExpectedDigest } = require(verifyDigestPath);
+    const digest = readExpectedDigest();
+    expect(typeof digest).toBe("string");
+  });
+
+  it("verifyBlueprintDigest fails closed on empty digest", () => {
+    const { verifyBlueprintDigest, readExpectedDigest } = require(verifyDigestPath);
+    const expected = readExpectedDigest();
+
+    // The shipped blueprint.yaml has digest: "" — verification must fail
+    if (!expected || expected.trim() === "") {
+      const result = verifyBlueprintDigest();
+      expect(result.valid).toBe(false);
+      expect(result.reason).toMatch(/missing or empty/);
+    }
+  });
+
+  it("verifyBlueprintDigest respects --skip-verification opt-out", () => {
+    const { verifyBlueprintDigest } = require(verifyDigestPath);
+    const result = verifyBlueprintDigest({ skipVerification: true });
+    expect(result.valid).toBe(true);
+    expect(result.reason).toMatch(/skipped/);
+  });
+
+  it("empty string digest must not pass verification", () => {
+    // Regression: if (digest && digest !== actual) was the original bug —
+    // empty string is falsy in JS, causing silent bypass
+    const { verifyBlueprintDigest } = require(verifyDigestPath);
+    const result = verifyBlueprintDigest();
+    // With digest: "" in blueprint.yaml, this MUST fail
+    expect(result.valid).toBe(false);
+  });
+});

--- a/test/verify-digest.test.js
+++ b/test/verify-digest.test.js
@@ -26,7 +26,7 @@ describe("blueprint digest verification", () => {
   it("readExpectedDigest returns the digest field from blueprint.yaml", () => {
     const { readExpectedDigest } = require(verifyDigestPath);
     const digest = readExpectedDigest();
-    expect(typeof digest).toBe("string");
+    expect(digest === null || typeof digest === "string").toBe(true);
   });
 
   it("verifyBlueprintDigest fails closed on empty digest", () => {

--- a/test/verify-digest.test.js
+++ b/test/verify-digest.test.js
@@ -50,10 +50,18 @@ describe("blueprint digest verification", () => {
 
   it("empty string digest must not pass verification", () => {
     // Regression: if (digest && digest !== actual) was the original bug —
-    // empty string is falsy in JS, causing silent bypass
-    const { verifyBlueprintDigest } = require(verifyDigestPath);
-    const result = verifyBlueprintDigest();
-    // With digest: "" in blueprint.yaml, this MUST fail
-    expect(result.valid).toBe(false);
+    // empty string is falsy in JS, causing silent bypass.
+    // Mock readExpectedDigest to always return "" so this test survives
+    // once blueprint.yaml ships a real digest.
+    const verifyMod = require(verifyDigestPath);
+    const originalRead = verifyMod.readExpectedDigest;
+    verifyMod.readExpectedDigest = () => "";
+    try {
+      const result = verifyMod.verifyBlueprintDigest();
+      expect(result.valid).toBe(false);
+      expect(result.reason).toMatch(/missing or empty/);
+    } finally {
+      verifyMod.readExpectedDigest = originalRead;
+    }
   });
 });


### PR DESCRIPTION
## Summary

`blueprint.yaml` ships with `digest: ""` and there is no verification code
in the codebase. An empty digest means no integrity check is ever performed
on the blueprint directory — any modification to policies, sandbox configs,
or orchestration scripts goes undetected.

If verification code were added with the common pattern
`if (digest && digest !== actual)`, an empty string would evaluate as falsy,
silently bypassing the check.

## Change

- Add `bin/lib/verify-digest.js`: SHA-256 verification of the blueprint
  directory that **fails closed** when digest is missing or empty
- `blueprint.yaml`: document that digest must be populated before release
- Add tests confirming fail-closed behavior on empty digest
- Support explicit `--skip-verification` opt-out for development workflows

## Detection

This vulnerability class is detectable via HackMyAgent:
```
npx hackmyagent secure .
```

## References

- PSIRT disclosure: tickets 6009892–6010011
- CWE-345: Insufficient Verification of Data Authenticity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added blueprint integrity verification using a deterministic SHA‑256 digest; verification fails securely when digest is missing or mismatched, with an opt-out for development.

* **Documentation**
  * Clarified the digest field and added instructions to compute it before release.

* **Tests**
  * Added tests for digest computation, missing/empty digest handling, opt-out path, and regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->