### PR TITLE
fix: remove Telegram Bot API from default sandbox network policy

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -157,20 +157,11 @@ network_policies:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/npm }
 
-  # ── Messaging — pre-allowed for agent notifications ────────────
-  # Telegram and Discord are open by default so the agent can send
-  # notifications and respond to chats without triggering approval.
-  telegram:
-    name: telegram
-    endpoints:
-      - host: api.telegram.org
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/bot*/**" }
-          - allow: { method: POST, path: "/bot*/**" }
+  # ── Messaging — opt-in only ──────────────────────────────────────
+  # Telegram is NOT included in the base policy. To enable Telegram
+  # Bot API access, apply the telegram preset:
+  #   nemoclaw <sandbox> policy-add  →  select "telegram"
+  # See: nemoclaw-blueprint/policies/presets/telegram.yaml
 
   discord:
     name: discord

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -87,6 +87,24 @@ describe("policies", () => {
     });
   });
 
+  describe("base policy security", () => {
+    it("base policy must not include telegram (exfiltration risk)", () => {
+      const fs = require("fs");
+      const basePolicyPath = path.join(
+        import.meta.dirname, "..", "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"
+      );
+      const content = fs.readFileSync(basePolicyPath, "utf-8");
+      expect(content).not.toMatch(/^\s+telegram:\s*$/m);
+      expect(content).not.toMatch(/host:\s*api\.telegram\.org/);
+    });
+
+    it("telegram preset exists as opt-in alternative", () => {
+      const content = policies.loadPreset("telegram");
+      expect(content).toBeTruthy();
+      expect(content).toContain("api.telegram.org");
+    });
+  });
+
   describe("buildPolicyGetCommand", () => {
     it("shell-quotes sandbox name", () => {
       const cmd = policies.buildPolicyGetCommand("my-assistant");


### PR DESCRIPTION
## Summary

`api.telegram.org` is pre-allowed in the default sandbox network policy
with unrestricted `GET` and `POST /bot*/**` access. This provides any
sandboxed agent with an out-of-box data exfiltration channel via the
Telegram Bot API (`POST /bot<token>/sendDocument`) without user approval
or notification.

## Change

Remove `api.telegram.org` from the base policy. Telegram integration
should be an explicit user opt-in via the existing telegram preset:

```
nemoclaw <sandbox> policy-add  →  select "telegram"
```

The preset at `nemoclaw-blueprint/policies/presets/telegram.yaml` is
unchanged and available for users who need Telegram Bot API access.

## Detection

This vulnerability class is detectable via HackMyAgent:
```
npx hackmyagent secure .
```

## References

- PSIRT disclosure: tickets 6009892–6010011
- CWE-200: Exposure of Sensitive Information to an Unauthorized Actor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved Telegram access configuration to optional preset instead of including it in base policy

* **Tests**
  * Added tests to verify Telegram policy configuration and preset availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->