### PR TITLE
fix(onboard): exclude .venv and caches from sandbox build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@ node_modules
 *.pyc
 __pycache__
 .pytest_cache
+.venv
+.env
+.env.*

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -542,6 +542,11 @@ async function createSandbox(gpu) {
   run(`cp -r "${path.join(ROOT, "nemoclaw-blueprint")}" "${buildCtx}/nemoclaw-blueprint"`);
   run(`cp -r "${path.join(ROOT, "scripts")}" "${buildCtx}/scripts"`);
   run(`rm -rf "${buildCtx}/nemoclaw/node_modules"`, { ignoreError: true });
+  // Exclude Python virtual environments, caches, and secrets from build context (#774)
+  for (const dir of [".venv", "__pycache__", ".pytest_cache"]) {
+    run(`rm -rf "${buildCtx}/nemoclaw-blueprint/${dir}"`, { ignoreError: true });
+  }
+  run(`find "${buildCtx}/nemoclaw-blueprint" -maxdepth 1 -name ".env" -o -name ".env.*" | xargs rm -f 2>/dev/null`, { ignoreError: true });
 
   // Create sandbox (use -- echo to avoid dropping into interactive shell)
   // Pass the base policy so sandbox starts in proxy mode (required for policy updates later)

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -546,7 +546,10 @@ async function createSandbox(gpu) {
   for (const dir of [".venv", "__pycache__", ".pytest_cache"]) {
     run(`rm -rf "${buildCtx}/nemoclaw-blueprint/${dir}"`, { ignoreError: true });
   }
-  run(`find "${buildCtx}/nemoclaw-blueprint" -maxdepth 1 -name ".env" -o -name ".env.*" | xargs rm -f 2>/dev/null`, { ignoreError: true });
+  run(
+    `find "${buildCtx}/nemoclaw-blueprint" -maxdepth 1 \\( -name ".env" -o -name ".env.*" \\) -print0 | xargs -0 rm -rf -- 2>/dev/null`,
+    { ignoreError: true }
+  );
 
   // Create sandbox (use -- echo to avoid dropping into interactive shell)
   // Pass the base policy so sandbox starts in proxy mode (required for policy updates later)


### PR DESCRIPTION
## Summary

Fixes #774

- Add cleanup of `.venv`, `__pycache__`, `.pytest_cache`, and `.env*` files from the staged build context after `cp -r`, following the existing `node_modules` cleanup pattern (line 544)
- Add `.venv`, `.env`, `.env.*` to `.dockerignore` as defense-in-depth for direct `docker build` invocations

## Details

The staging step in `createSandbox()` copies the entire `nemoclaw-blueprint/` tree into a temp build context via `cp -r`. If a developer has a `.venv` directory (from running `uv sync`, `pytest`, etc.), it gets baked into the sandbox image, causing:

1. **Build failures** — packaging can choke on `.venv` contents
2. **Security risk** — `.venv` and `.env` files may contain secrets that should not be in image layers

## Test plan

- [x] Verified `npm test` (vitest) — no new test failures introduced (1 pre-existing Windows PATH separator failure on `main`)
- [ ] Manual: create `.venv/` and `.env` in `nemoclaw-blueprint/`, run `nemoclaw onboard`, verify they are excluded from build context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Changes

* **Chores**
  * Excluded virtual environment and environment files from Docker build context to reduce build time and artifact size.
  * Cleaned sandbox staging by removing Python caches and top-level env files to produce cleaner, more consistent build sandboxes and smaller deliverables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->