### PR TITLE
fix(onboard): pre-select suggested policy presets in visual display

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -2571,7 +2571,7 @@ async function _setupPolicies(sandboxName) {
     console.log("");
     console.log("  Available policy presets:");
     allPresets.forEach((p) => {
-      const marker = applied.includes(p.name) ? "●" : "○";
+      const marker = applied.includes(p.name) || suggestions.includes(p.name) ? "●" : "○";
       const suggested = suggestions.includes(p.name) ? " (suggested)" : "";
       console.log(`    ${marker} ${p.name} — ${p.description}${suggested}`);
     });


### PR DESCRIPTION
## Summary

Fixes #706

Suggested policy presets (e.g. `npm`, `pypi`) now display with a filled `●` bullet instead of an empty `○`, matching the prompt behavior that applies them by default.

## Details

**Before** (all presets show `○`):
```
○ npm — npm and Yarn registry access (suggested)
○ pypi — Python Package Index (PyPI) access (suggested)
```

**After** (suggested presets show `●`):
```
● npm — npm and Yarn registry access (suggested)
● pypi — Python Package Index (PyPI) access (suggested)
```

One-line change in `bin/lib/onboard.js`: include `suggestions` array in the marker condition alongside `applied`.

## Test plan

- [x] Verified `npm test` — no new test failures
- [ ] Visual: run `nemoclaw onboard`, observe step 7 — suggested presets should show `●`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policy preset suggestions now display as selected in the interactive listing before being officially applied. This change improves visual feedback, making it clearer to users which presets are recommended for their configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Temrjan <x.temrjan@gmail.com>
