### PR TITLE
fix: resolve 3 failing tests in installer and uninstall scripts

### DIFF
--- a/research/results.tsv
+++ b/research/results.tsv
@@ -1,0 +1,3 @@
+experiment	track	description	tests_total	tests_pass	tests_fail	notes
+0	baseline	initial state — 194 tests, 188 pass, 6 fail	194	188	6	6 failures in installer preflight + uninstall CLI; 30 open issues; coverage: 93% lines, 98% functions, 87% branches
+1	track1	fix 3 remaining test failures: uninstall symlink rm, installer sudo heuristic	194	194	0	uninstall.sh: check dir writability not symlink target; scripts/install.sh: check npm prefix writability instead of assuming nodesource needs sudo

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -414,10 +414,11 @@ rm -rf "$NEMOCLAW_SRC"
 mkdir -p "$(dirname "$NEMOCLAW_SRC")"
 git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$NEMOCLAW_SRC"
 pre_extract_openclaw "$NEMOCLAW_SRC" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
-# Use sudo for npm link when the global prefix requires it (e.g., nodesource),
-# but skip sudo if already root (e.g., Docker containers).
+# Use sudo for npm link only when the global prefix directory is not writable
+# by the current user (e.g., system-managed nodesource installs to /usr).
 SUDO=""
-if [ "$NODE_MGR" = "nodesource" ] && [ "$(id -u)" -ne 0 ]; then
+NPM_GLOBAL_PREFIX="$(npm config get prefix 2>/dev/null)" || true
+if [ -n "$NPM_GLOBAL_PREFIX" ] && [ ! -w "$NPM_GLOBAL_PREFIX" ] && [ "$(id -u)" -ne 0 ]; then
   SUDO="sudo"
 fi
 (cd "$NEMOCLAW_SRC" && npm install --ignore-scripts && cd nemoclaw && npm install --ignore-scripts && npm run build && cd .. && $SUDO npm link)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -223,7 +223,7 @@ remove_file_with_optional_sudo() {
     return 0
   fi
 
-  if [ -w "$path" ] || [ -w "$(dirname "$path")" ]; then
+  if [ -w "$(dirname "$path")" ]; then
     rm -f "$path"
   elif [ "${NEMOCLAW_NON_INTERACTIVE:-}" = "1" ] || [ ! -t 0 ]; then
     warn "Skipping privileged removal of $path in non-interactive mode."


### PR DESCRIPTION
## Summary

- **uninstall.sh**: check directory writability rather than symlink target
- **install.sh**: check npm prefix writability instead of assuming NodeSource needs sudo

Brings the test suite from 188/194 passing to 194/194.

## Test plan

- [x] All 194 tests passing
- [ ] Manual verification on Linux + macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the installer's ability to determine when elevated permissions are needed during the installation process.
  * Refined the uninstaller's file removal logic to better handle different permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->