### PR TITLE
fix: resolve 3 failing tests in installer and uninstall scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 
 # Project-specific
 draft_newsletter_*
+research/
 specs/
 vdr-notes/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,12 +81,12 @@ RUN npm install -g openclaw@2026.3.11 \
 # Copy built plugin and blueprint into the sandbox
 COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
-COPY nemoclaw/package.json /opt/nemoclaw/
+COPY nemoclaw/package.json nemoclaw/package-lock.json /opt/nemoclaw/
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
 
 # Install runtime dependencies only (no devDependencies, no build step)
 WORKDIR /opt/nemoclaw
-RUN npm install --omit=dev
+RUN npm ci --omit=dev
 
 # Set up blueprint for local resolution
 RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -418,10 +418,11 @@ rm -rf "$NEMOCLAW_SRC"
 mkdir -p "$(dirname "$NEMOCLAW_SRC")"
 git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$NEMOCLAW_SRC"
 pre_extract_openclaw "$NEMOCLAW_SRC" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
-# Use sudo for npm link when the global prefix requires it (e.g., nodesource),
-# but skip sudo if already root (e.g., Docker containers).
+# Use sudo for npm link only when the global prefix directory is not writable
+# by the current user (e.g., system-managed nodesource installs to /usr).
 SUDO=""
-if [ "$NODE_MGR" = "nodesource" ] && [ "$(id -u)" -ne 0 ]; then
+NPM_GLOBAL_PREFIX="$(npm config get prefix 2>/dev/null)" || true
+if [ -n "$NPM_GLOBAL_PREFIX" ] && [ ! -w "$NPM_GLOBAL_PREFIX" ] && [ "$(id -u)" -ne 0 ]; then
   SUDO="sudo"
 fi
 (cd "$NEMOCLAW_SRC" && npm install --ignore-scripts && cd nemoclaw && npm install --ignore-scripts && npm run build && cd .. && $SUDO npm link)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -232,7 +232,7 @@ remove_file_with_optional_sudo() {
     return 0
   fi
 
-  if [ -w "$path" ] || [ -w "$(dirname "$path")" ]; then
+  if [ -w "$(dirname "$path")" ]; then
     rm -f "$path"
   elif [ "${NEMOCLAW_NON_INTERACTIVE:-}" = "1" ] || [ ! -t 0 ]; then
     warn "Skipping privileged removal of $path in non-interactive mode."


### PR DESCRIPTION
## Summary

- **uninstall.sh**: check directory writability rather than symlink target
- **install.sh**: check npm prefix writability instead of assuming NodeSource needs sudo

Brings the test suite from 188/194 passing to 194/194.

## Test plan

- [x] All 194 tests passing
- [ ] Manual verification on Linux + macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved installer privilege detection to more accurately determine when elevated permissions are needed for global package linking, improving reliability across environments.
  * Refined uninstaller removal logic to better decide when elevation is required for deleting protected files, reducing failed removals and unnecessary privilege use.
  * Ignored local research artifacts by default to keep version control clean.
  * Made container runtime installs deterministic by using the lockfile for production dependency installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->