### PR TITLE
fix(onboard): print dashboard URL with auth token on completion

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1050,6 +1050,31 @@ async function setupPolicies(sandboxName) {
 
 // ── Dashboard ────────────────────────────────────────────────────
 
+function getDashboardUrl(sandboxName) {
+  // Retrieve the auth token from inside the sandbox so we can print a
+  // ready-to-use dashboard URL.  `openclaw dashboard --no-open` prints
+  // "Dashboard URL: http://127.0.0.1:18789/#token=<hex>" to stdout.
+  //
+  // We connect via openshell's ssh-proxy (the same mechanism used by
+  // `openshell sandbox connect`) so no separate SSH config setup is needed.
+  try {
+    const openshellBin = runCapture("command -v openshell", { ignoreError: true }).trim();
+    if (!openshellBin) return "http://127.0.0.1:18789/";
+    const proxyCmd = `${openshellBin} ssh-proxy --gateway-name nemoclaw --name ${shellQuote(sandboxName)}`;
+    const out = runCapture(
+      `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR` +
+      ` -o "ProxyCommand=${proxyCmd}"` +
+      ` sandbox@${shellQuote(sandboxName)} 'openclaw dashboard --no-open 2>/dev/null'`,
+      { ignoreError: true }
+    );
+    const match = String(out).match(/Dashboard URL:\s*(http\S+)/);
+    if (match) return match[1];
+  } catch (_) {
+    // fall through — token retrieval is best-effort
+  }
+  return "http://127.0.0.1:18789/";
+}
+
 function printDashboard(sandboxName, model, provider) {
   const nimStat = nim.nimStatus(sandboxName);
   const nimLabel = nimStat.running ? "running" : "not running";
@@ -1059,12 +1084,14 @@ function printDashboard(sandboxName, model, provider) {
   else if (provider === "vllm-local") providerLabel = "Local vLLM";
   else if (provider === "ollama-local") providerLabel = "Local Ollama";
 
+  const dashboardUrl = getDashboardUrl(sandboxName);
+
   console.log("");
   console.log(`  ${"─".repeat(50)}`);
-  // console.log(`  Dashboard    http://localhost:18789/`);
   console.log(`  Sandbox      ${sandboxName} (Landlock + seccomp + netns)`);
   console.log(`  Model        ${model} (${providerLabel})`);
   console.log(`  NIM          ${nimLabel}`);
+  console.log(`  Dashboard    ${dashboardUrl}`);
   console.log(`  ${"─".repeat(50)}`);
   console.log(`  Next:`);
   console.log(`  Run:         nemoclaw ${sandboxName} connect`);


### PR DESCRIPTION
## Problem

After `nemoclaw onboard` completes, the summary prints the sandbox name and next steps but never shows the dashboard URL or its auth token. Users who navigate to `http://127.0.0.1:18789/` hit a login prompt with no token in sight, creating a circular experience.

Reported in #53.

## Solution

Add `getDashboardUrl()` which SSHes into the sandbox via `openshell ssh-proxy` (the same channel used by `nemoclaw <name> connect`) and runs `openclaw dashboard --no-open` to retrieve the token. The complete `http://127.0.0.1:18789/#token=<hex>` URL is then printed in the onboarding summary.

Falls back silently to the bare URL if token retrieval fails, so the onboarding flow is never blocked.

## Test plan

- [ ] Run `nemoclaw onboard` end-to-end — confirm the summary prints a `Dashboard` line with a `#token=` fragment
- [ ] Copy the URL into a browser — confirm it opens the dashboard without an extra login step
- [ ] Kill the openshell gateway mid-retrieval — confirm onboarding still completes (fallback URL printed)

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard URL is now displayed during the onboarding process, providing easier access to the dashboard.
  * Added fallback mechanism to ensure the dashboard link remains accessible when certain services are unavailable or restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->