### PR TITLE
security: redact secret patterns from CLI log and error output

### DIFF
--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -14,25 +14,24 @@ if (dockerHost) {
 }
 
 // Redact known secret patterns from command strings for logging and error output.
-// Patterns are created inside the function to avoid shared /g lastIndex state.
+// Handles unquoted (KEY=val), double-quoted (KEY="val"), and single-quoted (KEY='val') forms.
 function redactSecrets(str) {
-  const patterns = [
-    /NVIDIA_API_KEY=[^\s"']*/g,
-    /nvapi-[A-Za-z0-9_-]+/g,
-    /GITHUB_TOKEN=[^\s"']*/g,
-    /TELEGRAM_BOT_TOKEN=[^\s"']*/g,
-    /OPENAI_API_KEY=[^\s"']*/g,
-    /SLACK_BOT_TOKEN=[^\s"']*/g,
-    /DISCORD_BOT_TOKEN=[^\s"']*/g,
+  const keyedSecrets = [
+    "NVIDIA_API_KEY",
+    "GITHUB_TOKEN",
+    "TELEGRAM_BOT_TOKEN",
+    "OPENAI_API_KEY",
+    "SLACK_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
   ];
   let result = str;
-  for (const pattern of patterns) {
-    result = result.replace(pattern, (match) => {
-      const eqIdx = match.indexOf("=");
-      if (eqIdx > 0) return match.slice(0, eqIdx + 1) + "***";
-      return match.slice(0, 8) + "***";
-    });
+  for (const key of keyedSecrets) {
+    // Match KEY="quoted" or KEY='quoted' or KEY=unquoted
+    const pattern = new RegExp(`${key}=(?:"[^"]*"|'[^']*'|[^\\s"']*)`, "g");
+    result = result.replace(pattern, `${key}=***`);
   }
+  // Bare nvapi- tokens (e.g., in Bearer headers)
+  result = result.replace(/nvapi-[A-Za-z0-9_-]+/g, (match) => match.slice(0, 8) + "***");
   return result;
 }
 
@@ -84,6 +83,9 @@ function runCapture(cmd, opts = {}) {
     }
     if (err.stderr) {
       err.stderr = redactSecrets(err.stderr);
+    }
+    if (err.stdout) {
+      err.stdout = redactSecrets(err.stdout);
     }
     throw err;
   }

--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -24,7 +24,7 @@ function redactSecrets(str) {
     "SLACK_BOT_TOKEN",
     "DISCORD_BOT_TOKEN",
   ];
-  let result = str;
+  let result = String(str ?? "");
   for (const key of keyedSecrets) {
     // Match KEY="quoted" or KEY='quoted' or KEY=unquoted
     const pattern = new RegExp(`${key}=(?:"[^"]*"|'[^']*'|[^\\s"']*)`, "g");

--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -13,6 +13,29 @@ if (dockerHost) {
   process.env.DOCKER_HOST = dockerHost.dockerHost;
 }
 
+// Redact known secret patterns from command strings for logging and error output.
+// Patterns are created inside the function to avoid shared /g lastIndex state.
+function redactSecrets(str) {
+  const patterns = [
+    /NVIDIA_API_KEY=[^\s"']*/g,
+    /nvapi-[A-Za-z0-9_-]+/g,
+    /GITHUB_TOKEN=[^\s"']*/g,
+    /TELEGRAM_BOT_TOKEN=[^\s"']*/g,
+    /OPENAI_API_KEY=[^\s"']*/g,
+    /SLACK_BOT_TOKEN=[^\s"']*/g,
+    /DISCORD_BOT_TOKEN=[^\s"']*/g,
+  ];
+  let result = str;
+  for (const pattern of patterns) {
+    result = result.replace(pattern, (match) => {
+      const eqIdx = match.indexOf("=");
+      if (eqIdx > 0) return match.slice(0, eqIdx + 1) + "***";
+      return match.slice(0, 8) + "***";
+    });
+  }
+  return result;
+}
+
 function run(cmd, opts = {}) {
   const stdio = opts.stdio ?? ["ignore", "inherit", "inherit"];
   const result = spawnSync("bash", ["-c", cmd], {
@@ -22,7 +45,7 @@ function run(cmd, opts = {}) {
     env: { ...process.env, ...opts.env },
   });
   if (result.status !== 0 && !opts.ignoreError) {
-    console.error(`  Command failed (exit ${result.status}): ${cmd.slice(0, 80)}`);
+    console.error(`  Command failed (exit ${result.status}): ${redactSecrets(cmd.slice(0, 80))}`);
     process.exit(result.status || 1);
   }
   return result;
@@ -37,7 +60,7 @@ function runInteractive(cmd, opts = {}) {
     env: { ...process.env, ...opts.env },
   });
   if (result.status !== 0 && !opts.ignoreError) {
-    console.error(`  Command failed (exit ${result.status}): ${cmd.slice(0, 80)}`);
+    console.error(`  Command failed (exit ${result.status}): ${redactSecrets(cmd.slice(0, 80))}`);
     process.exit(result.status || 1);
   }
   return result;
@@ -54,6 +77,14 @@ function runCapture(cmd, opts = {}) {
     }).trim();
   } catch (err) {
     if (opts.ignoreError) return "";
+    // Redact secrets from the error message so callers that log the
+    // thrown error don't accidentally leak credentials.
+    if (err.message) {
+      err.message = redactSecrets(err.message);
+    }
+    if (err.stderr) {
+      err.stderr = redactSecrets(err.stderr);
+    }
     throw err;
   }
 }
@@ -85,4 +116,4 @@ function validateName(name, label = "name") {
   return name;
 }
 
-module.exports = { ROOT, SCRIPTS, run, runCapture, runInteractive, shellQuote, validateName };
+module.exports = { ROOT, SCRIPTS, run, runCapture, runInteractive, shellQuote, validateName, redactSecrets };

--- a/test/runner-redact.test.js
+++ b/test/runner-redact.test.js
@@ -84,6 +84,11 @@ describe("redactSecrets", () => {
     expect(redactSecrets("")).toBe("");
   });
 
+  it("handles null and undefined without throwing", () => {
+    expect(redactSecrets(null)).toBe("");
+    expect(redactSecrets(undefined)).toBe("");
+  });
+
   it("produces identical results on consecutive calls", () => {
     const input = "NVIDIA_API_KEY=nvapi-test123";
     const r1 = redactSecrets(input);

--- a/test/runner-redact.test.js
+++ b/test/runner-redact.test.js
@@ -68,6 +68,18 @@ describe("redactSecrets", () => {
     expect(result).toContain("GITHUB_TOKEN=***");
   });
 
+  it("redacts double-quoted secret values", () => {
+    const result = redactSecrets('GITHUB_TOKEN="ghp_secretValue123"');
+    expect(result).not.toContain("ghp_secretValue123");
+    expect(result).toBe("GITHUB_TOKEN=***");
+  });
+
+  it("redacts single-quoted secret values", () => {
+    const result = redactSecrets("NVIDIA_API_KEY='nvapi-secretValue123'");
+    expect(result).not.toContain("nvapi-secretValue123");
+    expect(result).toBe("NVIDIA_API_KEY=***");
+  });
+
   it("handles empty string", () => {
     expect(redactSecrets("")).toBe("");
   });

--- a/test/runner-redact.test.js
+++ b/test/runner-redact.test.js
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const require = createRequire(import.meta.url);
+const { redactSecrets } = require("../bin/lib/runner");
+
+describe("redactSecrets", () => {
+  it("redacts NVIDIA_API_KEY=value", () => {
+    const input = 'openshell provider create --credential "NVIDIA_API_KEY=nvapi-abc123XYZ"';
+    const result = redactSecrets(input);
+    expect(result).not.toContain("nvapi-abc123XYZ");
+    expect(result).toContain("NVIDIA_API_KEY=***");
+  });
+
+  it("redacts bare nvapi- tokens", () => {
+    const input = "Bearer nvapi-SomeSecretToken123";
+    const result = redactSecrets(input);
+    expect(result).not.toContain("nvapi-SomeSecretToken123");
+    expect(result).toContain("nvapi-So***");
+  });
+
+  it("redacts GITHUB_TOKEN=value", () => {
+    const result = redactSecrets("GITHUB_TOKEN=ghp_1234567890abcdef");
+    expect(result).not.toContain("ghp_1234567890abcdef");
+    expect(result).toContain("GITHUB_TOKEN=***");
+  });
+
+  it("redacts TELEGRAM_BOT_TOKEN=value", () => {
+    const result = redactSecrets("TELEGRAM_BOT_TOKEN=123456:ABC-DEF");
+    expect(result).not.toContain("123456:ABC-DEF");
+    expect(result).toContain("TELEGRAM_BOT_TOKEN=***");
+  });
+
+  it("redacts OPENAI_API_KEY=value", () => {
+    const result = redactSecrets("OPENAI_API_KEY=sk-proj-abc123");
+    expect(result).not.toContain("sk-proj-abc123");
+    expect(result).toContain("OPENAI_API_KEY=***");
+  });
+
+  it("redacts SLACK_BOT_TOKEN=value", () => {
+    const result = redactSecrets("SLACK_BOT_TOKEN=xoxb-1234");
+    expect(result).not.toContain("xoxb-1234");
+    expect(result).toContain("SLACK_BOT_TOKEN=***");
+  });
+
+  it("redacts DISCORD_BOT_TOKEN=value", () => {
+    const result = redactSecrets("DISCORD_BOT_TOKEN=MTk4NjIy");
+    expect(result).not.toContain("MTk4NjIy");
+    expect(result).toContain("DISCORD_BOT_TOKEN=***");
+  });
+
+  it("returns input unchanged when no secrets present", () => {
+    const input = "openshell sandbox create --name my-assistant";
+    expect(redactSecrets(input)).toBe(input);
+  });
+
+  it("redacts multiple different secrets in one string", () => {
+    const input = 'NVIDIA_API_KEY=nvapi-secret GITHUB_TOKEN=ghp_token123';
+    const result = redactSecrets(input);
+    expect(result).not.toContain("nvapi-secret");
+    expect(result).not.toContain("ghp_token123");
+    expect(result).toContain("NVIDIA_API_KEY=***");
+    expect(result).toContain("GITHUB_TOKEN=***");
+  });
+
+  it("handles empty string", () => {
+    expect(redactSecrets("")).toBe("");
+  });
+
+  it("produces identical results on consecutive calls", () => {
+    const input = "NVIDIA_API_KEY=nvapi-test123";
+    const r1 = redactSecrets(input);
+    const r2 = redactSecrets(input);
+    expect(r1).toBe(r2);
+    expect(r1).not.toContain("nvapi-test123");
+  });
+
+  it("run() error output redacts secrets (integration)", () => {
+    // Spawn a child that requires runner.js and calls run() with a command
+    // that will fail, then captures stderr to verify redaction.
+    const runnerPath = path.join(import.meta.dirname, "..", "bin", "lib", "runner");
+    const script = `
+      const { run } = require(${JSON.stringify(runnerPath)});
+      // Override process.exit so the child doesn't exit before we capture output
+      process.exit = () => {};
+      run("false NVIDIA_API_KEY=nvapi-realSecretValue123");
+    `;
+    const result = spawnSync("node", ["-e", script], {
+      cwd: path.join(import.meta.dirname, ".."),
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    expect(result.stderr).toContain("NVIDIA_API_KEY=***");
+    expect(result.stderr).not.toContain("nvapi-realSecretValue123");
+  });
+});


### PR DESCRIPTION
## Summary

Add a `redactSecrets()` helper to `bin/lib/runner.js` that masks known secret patterns in all CLI error output, preventing accidental credential leakage when commands fail.

### Patterns redacted
`NVIDIA_API_KEY`, `GITHUB_TOKEN`, `TELEGRAM_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `OPENAI_API_KEY`, and bare `nvapi-` tokens.

### Applied to
- `run()` and `runInteractive()` — error messages via `console.error`
- `runCapture()` — thrown error `.message` and `.stderr` fields

Regex patterns are created inside the function on each call to avoid the well-known `/g` `lastIndex` state leak across calls.

## Test plan

- [x] 12 Vitest tests (11 unit + 1 integration), all passing
- [x] Unit: each secret pattern individually, no-op for clean strings, multiple secrets, empty input, consecutive-call consistency
- [x] Integration: spawns a child process that calls `run()` with a secret in a failing command, asserts stderr contains `NVIDIA_API_KEY=***` and does NOT contain the real value

## Files changed (2)

| File | Change |
|---|---|
| `bin/lib/runner.js` | Add `redactSecrets()`, apply to `run()`/`runInteractive()` error output and `runCapture()` thrown errors, export function |
| `test/runner-redact.test.js` | **New** — 12 tests covering all patterns and integration wiring |

Closes #664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes a redaction utility to sanitize secret-like values before they appear in logs or error output.
* **Bug Fixes**
  * Credentials and bearer-style tokens are now redacted from error messages and command output to avoid leaking secrets.
* **Tests**
  * Added tests validating redaction across various formats, quoted values, repeated calls, and integration with failing commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->