### PR TITLE
fix: remove gcc and netcat from sandbox image (#807, #808)

### DIFF
--- a/docs/security/process-limits.md
+++ b/docs/security/process-limits.md
@@ -1,0 +1,64 @@
+# Process Limits
+
+## Fork Bomb Protection
+
+Without process limits, a prompt-injected agent can exhaust host resources
+by spawning processes recursively.
+
+### Defence Layers
+
+```mermaid
+graph TD
+    subgraph "Process Limit Enforcement"
+        A[Agent spawns processes] --> B{ulimit -u set?}
+        B -->|Yes| C[Kernel enforces RLIMIT_NPROC]
+        B -->|No / unlimited| D[nemoclaw-start sets ulimit -u 512]
+        D --> C
+        C --> E{Over limit?}
+        E -->|Yes| F[fork returns EAGAIN]
+        E -->|No| G[Process created]
+    end
+
+    subgraph "Container Level"
+        H[--pids-limit 512] --> I[cgroup pids.max]
+        I --> C
+    end
+
+    F --> J[Agent receives error]
+    J --> K[System stays responsive]
+```
+
+### Configuration
+
+The default process limit is 512 per sandbox. This is sufficient for normal
+agent operation (typically < 50 processes) whilst preventing fork bombs.
+
+| Setting | Where | Default |
+|---------|-------|---------|
+| `ulimit -u` | nemoclaw-start.sh | 512 (if unlimited) |
+| `--pids-limit` | Container runtime | 512 (via `docker update`) |
+| cgroup `pids.max` | Kernel | Set by container runtime |
+
+### How It Works
+
+1. **Container level (primary):** During onboarding, `nemoclaw onboard` calls
+   `docker update --pids-limit 512` after sandbox creation. This sets the
+   cgroup `pids.max` value, which the kernel enforces regardless of what
+   happens inside the container.
+
+2. **In-sandbox fallback:** `nemoclaw-start.sh` checks `ulimit -u` at
+   startup. If the value is `unlimited` (meaning the container runtime
+   didn't set a limit), it sets `ulimit -u 512` as a safety net.
+
+3. **Policy documentation:** The sandbox policy YAML documents that
+   OpenShell does not currently expose a `pids_limit` field, so the
+   limit must be enforced at the container runtime level.
+
+### Overriding the Default
+
+Set `NEMOCLAW_PIDS_LIMIT` before running `nemoclaw onboard` to change
+the default:
+
+```bash
+NEMOCLAW_PIDS_LIMIT=1024 nemoclaw onboard
+```

--- a/docs/security/sandbox-hardening.md
+++ b/docs/security/sandbox-hardening.md
@@ -1,0 +1,43 @@
+# Sandbox Image Hardening
+
+## Attack Surface Reduction
+
+The NemoClaw sandbox image is hardened by removing unnecessary tools that could
+be used by a compromised or prompt-injected agent.
+
+### Removed Packages
+
+| Package | Risk | Reference |
+|---------|------|-----------|
+| gcc, g++, cpp, make | Compile exploit code, LD_PRELOAD injection | [#807](https://github.com/NVIDIA/NemoClaw/issues/807) |
+| netcat-openbsd, netcat-traditional | Reverse shells, raw TCP exfiltration | [#808](https://github.com/NVIDIA/NemoClaw/issues/808) |
+
+### Defence Layers
+
+```mermaid
+graph TD
+    subgraph "Sandbox Image Hardening"
+        A[Base Image] -->|apt-get purge| B[No gcc/g++/make]
+        A -->|apt-get purge| C[No netcat]
+        B --> D[Cannot compile LD_PRELOAD libraries]
+        B --> E[Cannot compile exploit code]
+        C --> F[Cannot open reverse shells]
+        C --> G[Cannot exfiltrate via raw TCP]
+    end
+
+    subgraph "Existing Defences"
+        H[Landlock] --> I[Read-only /usr /etc /lib]
+        J[Seccomp] --> K[Blocked syscalls]
+        L[Network Proxy] --> M[Allowlisted egress only]
+    end
+
+    D --> N[Defence in Depth]
+    F --> N
+    H --> N
+    J --> N
+    L --> N
+```
+
+Even if one layer is bypassed, the others provide protection. Removing tools
+from the image means an attacker who escapes the proxy still cannot compile
+custom tooling or open raw TCP connections.

--- a/docs/security/sandbox-hardening.md
+++ b/docs/security/sandbox-hardening.md
@@ -1,20 +1,37 @@
+---
+title:
+  page: "Sandbox Image Hardening — Attack Surface Reduction"
+  nav: "Sandbox Hardening"
+description: "NemoClaw hardens the sandbox image by removing unnecessary tools that expand the attack surface."
+keywords: ["security", "sandbox", "hardening", "gcc", "netcat", "attack surface"]
+topics: ["security"]
+tags: ["hardening", "dockerfile", "defence-in-depth"]
+content:
+  type: reference
+  difficulty: technical_beginner
+  audience: ["operator", "contributor"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Sandbox Image Hardening
 
-## Attack Surface Reduction
+NemoClaw hardens the sandbox image by stripping unnecessary tools that a compromised or prompt-injected agent could use.
 
-The NemoClaw sandbox image is hardened by removing unnecessary tools that could
-be used by a compromised or prompt-injected agent.
-
-### Removed Packages
+## Removed Packages
 
 | Package | Risk | Reference |
 |---------|------|-----------|
 | gcc, g++, cpp, make | Compile exploit code, LD_PRELOAD injection | [#807](https://github.com/NVIDIA/NemoClaw/issues/807) |
 | netcat-openbsd, netcat-traditional | Reverse shells, raw TCP exfiltration | [#808](https://github.com/NVIDIA/NemoClaw/issues/808) |
 
-### Defence Layers
+## Defence Layers
 
-```mermaid
+```{mermaid}
 graph TD
     subgraph "Sandbox Image Hardening"
         A[Base Image] -->|apt-get purge| B[No gcc/g++/make]
@@ -38,6 +55,5 @@ graph TD
     L --> N
 ```
 
-Even if one layer is bypassed, the others provide protection. Removing tools
-from the image means an attacker who escapes the proxy still cannot compile
-custom tooling or open raw TCP connections.
+Even if one layer is bypassed, the others provide protection.
+Removing tools from the image means an attacker who escapes the proxy still cannot compile custom tooling or open raw TCP connections.

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -54,6 +54,10 @@ landlock:
 process:
   run_as_user: sandbox
   run_as_group: sandbox
+  # NOTE: Process count limits (fork bomb protection) must be enforced
+  # at the container runtime level. OpenShell does not currently expose
+  # a pids-limit field in the sandbox policy.
+  # Ref: https://github.com/NVIDIA/NemoClaw/issues/809
 
 network_policies:
   claude_code:

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -119,6 +119,15 @@ elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
   echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2
 fi
 
+# Fork bomb protection: set process limit if the container runtime
+# didn't set one. This is a safety net — the limit should ideally
+# be enforced at the container level via --pids-limit.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/809
+current_nproc=$(ulimit -u 2>/dev/null || echo "unlimited")
+if [ "$current_nproc" = "unlimited" ]; then
+  ulimit -u 512 2>/dev/null || true
+fi
+
 # Normalize the sandbox-create bootstrap wrapper. Onboard launches the
 # container as `env CHAT_UI_URL=... nemoclaw-start`, but this script is already
 # the ENTRYPOINT. If we treat that wrapper as a real command, the root path will

--- a/test/dockerfile-attack-surface.test.js
+++ b/test/dockerfile-attack-surface.test.js
@@ -3,11 +3,11 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const rootDockerfile = readFileSync(
-  resolve(__dirname, "..", "Dockerfile"),
+  resolve(import.meta.dirname, "..", "Dockerfile"),
   "utf8",
 );
 const testDockerfile = readFileSync(
-  resolve(__dirname, "Dockerfile.sandbox"),
+  resolve(import.meta.dirname, "Dockerfile.sandbox"),
   "utf8",
 );
 

--- a/test/dockerfile-attack-surface.test.js
+++ b/test/dockerfile-attack-surface.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const rootDockerfile = readFileSync(
+  resolve(__dirname, "..", "Dockerfile"),
+  "utf8",
+);
+const testDockerfile = readFileSync(
+  resolve(__dirname, "Dockerfile.sandbox"),
+  "utf8",
+);
+
+describe("Dockerfile attack-surface hardening", () => {
+  for (const [label, content] of [
+    ["Dockerfile", rootDockerfile],
+    ["test/Dockerfile.sandbox", testDockerfile],
+  ]) {
+    describe(label, () => {
+      it("purges gcc and compiler toolchain", () => {
+        // The purge command spans multiple lines via backslash continuations
+        expect(content).toMatch(/apt-get purge[^#]*gcc/s);
+        expect(content).toMatch(/apt-get purge[^#]*g\+\+/s);
+        expect(content).toMatch(/apt-get purge[^#]*make/s);
+      });
+
+      it("purges netcat variants", () => {
+        expect(content).toMatch(/apt-get purge[^#]*netcat-openbsd/s);
+        expect(content).toMatch(/apt-get purge[^#]*netcat-traditional/s);
+      });
+
+      it("does not install build-essential", () => {
+        expect(content).not.toMatch(/apt-get install.*build-essential/);
+      });
+    });
+  }
+});

--- a/test/process-limits.test.js
+++ b/test/process-limits.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const startScript = readFileSync(
+  resolve(__dirname, "..", "scripts", "nemoclaw-start.sh"),
+  "utf8",
+);
+
+const policyYaml = readFileSync(
+  resolve(
+    __dirname,
+    "..",
+    "nemoclaw-blueprint",
+    "policies",
+    "openclaw-sandbox.yaml",
+  ),
+  "utf8",
+);
+
+const onboardJs = readFileSync(
+  resolve(__dirname, "..", "bin", "lib", "onboard.js"),
+  "utf8",
+);
+
+describe("fork bomb protection (process limits)", () => {
+  describe("nemoclaw-start.sh", () => {
+    it("checks current ulimit -u value", () => {
+      expect(startScript).toContain("ulimit -u");
+    });
+
+    it("sets ulimit -u 512 when unlimited", () => {
+      expect(startScript).toMatch(/ulimit -u 512/);
+    });
+
+    it("only overrides when the current limit is unlimited", () => {
+      expect(startScript).toMatch(
+        /if \[ "\$current_nproc" = "unlimited" \]/,
+      );
+    });
+
+    it("references issue #809", () => {
+      expect(startScript).toContain(
+        "https://github.com/NVIDIA/NemoClaw/issues/809",
+      );
+    });
+  });
+
+  describe("sandbox policy YAML", () => {
+    it("documents that pids-limit must be set at container runtime level", () => {
+      expect(policyYaml).toContain("fork bomb protection");
+    });
+
+    it("references issue #809", () => {
+      expect(policyYaml).toContain(
+        "https://github.com/NVIDIA/NemoClaw/issues/809",
+      );
+    });
+  });
+
+  describe("onboard.js", () => {
+    it("applies docker update --pids-limit after sandbox creation", () => {
+      expect(onboardJs).toMatch(/docker update --pids-limit/);
+    });
+
+    it("uses NEMOCLAW_PIDS_LIMIT env var with 512 default", () => {
+      expect(onboardJs).toContain('NEMOCLAW_PIDS_LIMIT');
+      expect(onboardJs).toMatch(/\|\|\s*"512"/);
+    });
+  });
+});

--- a/test/process-limits.test.js
+++ b/test/process-limits.test.js
@@ -3,13 +3,13 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const startScript = readFileSync(
-  resolve(__dirname, "..", "scripts", "nemoclaw-start.sh"),
+  resolve(import.meta.dirname, "..", "scripts", "nemoclaw-start.sh"),
   "utf8",
 );
 
 const policyYaml = readFileSync(
   resolve(
-    __dirname,
+    import.meta.dirname,
     "..",
     "nemoclaw-blueprint",
     "policies",
@@ -19,7 +19,7 @@ const policyYaml = readFileSync(
 );
 
 const onboardJs = readFileSync(
-  resolve(__dirname, "..", "bin", "lib", "onboard.js"),
+  resolve(import.meta.dirname, "..", "bin", "lib", "onboard.js"),
   "utf8",
 );
 


### PR DESCRIPTION
## Summary

- Strip compiler toolchain (gcc, g++, cpp, make) and netcat from the sandbox image
- Applies to both production Dockerfile and test sandbox image
- Adds regression test to verify dangerous packages are purged

Closes #807, closes #808

## Defence layers

```mermaid
graph TD
    subgraph "Image Hardening"
        A[Base Image] -->|apt-get purge| B[No gcc/g++/make]
        A -->|apt-get purge| C[No netcat]
        B --> D[Cannot compile LD_PRELOAD libraries]
        C --> E[Cannot open reverse shells]
    end
    subgraph "Existing Defences"
        F[Landlock] --> G[Read-only /usr /etc]
        H[Network Proxy] --> I[Allowlisted egress]
    end
    D --> J[Defence in Depth]
    E --> J
    F --> J
    H --> J
```

## Test plan

- [ ] `npx vitest run test/dockerfile-attack-surface.test.js` passes
- [ ] `docker build -t nemoclaw-hardened .` succeeds
- [ ] Inside sandbox: `which gcc` returns not found
- [ ] Inside sandbox: `which nc` returns not found
- [ ] Existing functionality unaffected (node, python3, curl, git still present)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented fork-bomb protection using configurable process limits to prevent denial-of-service attacks in sandboxed environments.

* **Documentation**
  * Added comprehensive guides on process limits enforcement and fork-bomb protection mechanisms.
  * Added documentation detailing sandbox image hardening through removal of dangerous packages.

* **Tests**
  * Added validation tests for sandbox image hardening.
  * Added enforcement tests for process limit configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->