### PR TITLE
fix: add fork bomb protection via process limits

### DIFF
--- a/docs/security/process-limits.md
+++ b/docs/security/process-limits.md
@@ -1,13 +1,30 @@
+---
+title:
+  page: "Process Limits — Fork Bomb Protection"
+  nav: "Process Limits"
+description: "Fork bomb protection via cgroup pids.max and ulimit enforcement."
+keywords: ["security", "fork bomb", "process limits", "pids-limit", "ulimit"]
+topics: ["security"]
+tags: ["hardening", "sandbox", "process-limits"]
+content:
+  type: reference
+  difficulty: technical_beginner
+  audience: ["operator", "contributor"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Process Limits
 
-## Fork Bomb Protection
+Without process limits, a prompt-injected agent can exhaust host resources by spawning processes recursively.
 
-Without process limits, a prompt-injected agent can exhaust host resources
-by spawning processes recursively.
+## Defence Layers
 
-### Defence Layers
-
-```mermaid
+```{mermaid}
 graph TD
     subgraph "Process Limit Enforcement"
         A[Agent spawns processes] --> B{ulimit -u set?}
@@ -28,10 +45,10 @@ graph TD
     J --> K[System stays responsive]
 ```
 
-### Configuration
+## Configuration
 
-The default process limit is 512 per sandbox. This is sufficient for normal
-agent operation (typically < 50 processes) whilst preventing fork bombs.
+NemoClaw enforces a default process limit of 512 per sandbox.
+This is sufficient for normal agent operation (typically < 50 processes) whilst preventing fork bombs.
 
 | Setting | Where | Default |
 |---------|-------|---------|
@@ -39,26 +56,22 @@ agent operation (typically < 50 processes) whilst preventing fork bombs.
 | `--pids-limit` | Container runtime | 512 (via `docker update`) |
 | cgroup `pids.max` | Kernel | Set by container runtime |
 
-### How It Works
+## How It Works
 
-1. **Container level (primary):** During onboarding, `nemoclaw onboard` calls
-   `docker update --pids-limit 512` after sandbox creation. This sets the
-   cgroup `pids.max` value, which the kernel enforces regardless of what
-   happens inside the container.
+1. **Container level (primary):** During onboarding, `nemoclaw onboard` calls `docker update --pids-limit 512` after sandbox creation.
+This sets the cgroup `pids.max` value, which the kernel enforces regardless of what happens inside the container.
 
-2. **In-sandbox fallback:** `nemoclaw-start.sh` checks `ulimit -u` at
-   startup. If the value is `unlimited` (meaning the container runtime
-   didn't set a limit), it sets `ulimit -u 512` as a safety net.
+2. **In-sandbox fallback:** `nemoclaw-start.sh` checks `ulimit -u` at startup.
+If the value is `unlimited` (meaning the container runtime did not set a limit), it sets `ulimit -u 512` as a safety net.
 
-3. **Policy documentation:** The sandbox policy YAML documents that
-   OpenShell does not currently expose a `pids_limit` field, so the
-   limit must be enforced at the container runtime level.
+3. **Policy documentation:** The sandbox policy YAML documents that OpenShell does not currently expose a `pids_limit` field.
+The limit must therefore be enforced at the container runtime level.
 
-### Overriding the Default
+## Overriding the Default
 
-Set `NEMOCLAW_PIDS_LIMIT` before running `nemoclaw onboard` to change
-the default:
+Set `NEMOCLAW_PIDS_LIMIT` before running `nemoclaw onboard` to change the default.
+The value must be a positive integer; non-numeric values are silently replaced with the default (512).
 
-```bash
-NEMOCLAW_PIDS_LIMIT=1024 nemoclaw onboard
+```console
+$ NEMOCLAW_PIDS_LIMIT=1024 nemoclaw onboard
 ```

--- a/docs/security/process-limits.md
+++ b/docs/security/process-limits.md
@@ -1,0 +1,64 @@
+# Process Limits
+
+## Fork Bomb Protection
+
+Without process limits, a prompt-injected agent can exhaust host resources
+by spawning processes recursively.
+
+### Defence Layers
+
+```mermaid
+graph TD
+    subgraph "Process Limit Enforcement"
+        A[Agent spawns processes] --> B{ulimit -u set?}
+        B -->|Yes| C[Kernel enforces RLIMIT_NPROC]
+        B -->|No / unlimited| D[nemoclaw-start sets ulimit -u 512]
+        D --> C
+        C --> E{Over limit?}
+        E -->|Yes| F[fork returns EAGAIN]
+        E -->|No| G[Process created]
+    end
+
+    subgraph "Container Level"
+        H[--pids-limit 512] --> I[cgroup pids.max]
+        I --> C
+    end
+
+    F --> J[Agent receives error]
+    J --> K[System stays responsive]
+```
+
+### Configuration
+
+The default process limit is 512 per sandbox. This is sufficient for normal
+agent operation (typically < 50 processes) whilst preventing fork bombs.
+
+| Setting | Where | Default |
+|---------|-------|---------|
+| `ulimit -u` | nemoclaw-start.sh | 512 (if unlimited) |
+| `--pids-limit` | Container runtime | 512 (via `docker update`) |
+| cgroup `pids.max` | Kernel | Set by container runtime |
+
+### How It Works
+
+1. **Container level (primary):** During onboarding, `nemoclaw onboard` calls
+   `docker update --pids-limit 512` after sandbox creation. This sets the
+   cgroup `pids.max` value, which the kernel enforces regardless of what
+   happens inside the container.
+
+2. **In-sandbox fallback:** `nemoclaw-start.sh` checks `ulimit -u` at
+   startup. If the value is `unlimited` (meaning the container runtime
+   didn't set a limit), it sets `ulimit -u 512` as a safety net.
+
+3. **Policy documentation:** The sandbox policy YAML documents that
+   OpenShell does not currently expose a `pids_limit` field, so the
+   limit must be enforced at the container runtime level.
+
+### Overriding the Default
+
+Set `NEMOCLAW_PIDS_LIMIT` before running `nemoclaw onboard` to change
+the default:
+
+```bash
+NEMOCLAW_PIDS_LIMIT=1024 nemoclaw onboard
+```

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -54,6 +54,10 @@ landlock:
 process:
   run_as_user: sandbox
   run_as_group: sandbox
+  # NOTE: Process count limits (fork bomb protection) must be enforced
+  # at the container runtime level. OpenShell does not currently expose
+  # a pids-limit field in the sandbox policy.
+  # Ref: https://github.com/NVIDIA/NemoClaw/issues/809
 
 network_policies:
   claude_code:

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -119,6 +119,15 @@ elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
   echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2
 fi
 
+# Fork bomb protection: set process limit if the container runtime
+# didn't set one. This is a safety net — the limit should ideally
+# be enforced at the container level via --pids-limit.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/809
+current_nproc=$(ulimit -u 2>/dev/null || echo "unlimited")
+if [ "$current_nproc" = "unlimited" ]; then
+  ulimit -u 512 2>/dev/null || true
+fi
+
 # Normalize the sandbox-create bootstrap wrapper. Onboard launches the
 # container as `env CHAT_UI_URL=... nemoclaw-start`, but this script is already
 # the ENTRYPOINT. If we treat that wrapper as a real command, the root path will

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2804,7 +2804,8 @@ async function createSandbox(
   // This sets a cgroup pids.max of 512 — enough for normal agent operation
   // but low enough to prevent a prompt-injected fork bomb from exhausting
   // the host.  Ref: https://github.com/NVIDIA/NemoClaw/issues/809
-  const pidsLimit = process.env.NEMOCLAW_PIDS_LIMIT || "512";
+  const rawPidsLimit = process.env.NEMOCLAW_PIDS_LIMIT || "512";
+  const pidsLimit = /^\d+$/.test(rawPidsLimit) ? rawPidsLimit : "512";
   const dockerUpdate = runCapture(
     `docker update --pids-limit ${pidsLimit} "${sandboxName}" 2>&1`,
     { ignoreError: true }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2799,6 +2799,23 @@ async function createSandbox(
   // which would silently prevent the new sandbox's dashboard from being reachable.
   ensureDashboardForward(sandboxName, chatUiUrl);
 
+  // Fork bomb protection: OpenShell does not expose a pids-limit field in
+  // the sandbox policy, so we apply it post-creation via `docker update`.
+  // This sets a cgroup pids.max of 512 — enough for normal agent operation
+  // but low enough to prevent a prompt-injected fork bomb from exhausting
+  // the host.  Ref: https://github.com/NVIDIA/NemoClaw/issues/809
+  const pidsLimit = process.env.NEMOCLAW_PIDS_LIMIT || "512";
+  const dockerUpdate = runCapture(
+    `docker update --pids-limit ${pidsLimit} "${sandboxName}" 2>&1`,
+    { ignoreError: true }
+  );
+  if (dockerUpdate && !dockerUpdate.includes("Error")) {
+    console.log(`  ✓ Process limit set (--pids-limit ${pidsLimit})`);
+  } else {
+    console.log(`  ⓘ Could not set --pids-limit (container runtime may not support it)`);
+    console.log("    The in-sandbox ulimit fallback in nemoclaw-start.sh will apply.");
+  }
+
   // Register only after confirmed ready — prevents phantom entries
   registry.registerSandbox({
     name: sandboxName,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2805,7 +2805,7 @@ async function createSandbox(
   // but low enough to prevent a prompt-injected fork bomb from exhausting
   // the host.  Ref: https://github.com/NVIDIA/NemoClaw/issues/809
   const rawPidsLimit = process.env.NEMOCLAW_PIDS_LIMIT || "512";
-  const pidsLimit = /^\d+$/.test(rawPidsLimit) ? rawPidsLimit : "512";
+  const pidsLimit = /^[1-9][0-9]*$/.test(rawPidsLimit) ? rawPidsLimit : "512";
   const dockerUpdate = runCapture(
     `docker update --pids-limit ${pidsLimit} "${sandboxName}" 2>&1`,
     { ignoreError: true }

--- a/test/process-limits.test.js
+++ b/test/process-limits.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const startScript = readFileSync(
+  resolve(__dirname, "..", "scripts", "nemoclaw-start.sh"),
+  "utf8",
+);
+
+const policyYaml = readFileSync(
+  resolve(
+    __dirname,
+    "..",
+    "nemoclaw-blueprint",
+    "policies",
+    "openclaw-sandbox.yaml",
+  ),
+  "utf8",
+);
+
+const onboardJs = readFileSync(
+  resolve(__dirname, "..", "bin", "lib", "onboard.js"),
+  "utf8",
+);
+
+describe("fork bomb protection (process limits)", () => {
+  describe("nemoclaw-start.sh", () => {
+    it("checks current ulimit -u value", () => {
+      expect(startScript).toContain("ulimit -u");
+    });
+
+    it("sets ulimit -u 512 when unlimited", () => {
+      expect(startScript).toMatch(/ulimit -u 512/);
+    });
+
+    it("only overrides when the current limit is unlimited", () => {
+      expect(startScript).toMatch(
+        /if \[ "\$current_nproc" = "unlimited" \]/,
+      );
+    });
+
+    it("references issue #809", () => {
+      expect(startScript).toContain(
+        "https://github.com/NVIDIA/NemoClaw/issues/809",
+      );
+    });
+  });
+
+  describe("sandbox policy YAML", () => {
+    it("documents that pids-limit must be set at container runtime level", () => {
+      expect(policyYaml).toContain("fork bomb protection");
+    });
+
+    it("references issue #809", () => {
+      expect(policyYaml).toContain(
+        "https://github.com/NVIDIA/NemoClaw/issues/809",
+      );
+    });
+  });
+
+  describe("onboard.js", () => {
+    it("applies docker update --pids-limit after sandbox creation", () => {
+      expect(onboardJs).toMatch(/docker update --pids-limit/);
+    });
+
+    it("uses NEMOCLAW_PIDS_LIMIT env var with 512 default", () => {
+      expect(onboardJs).toContain('NEMOCLAW_PIDS_LIMIT');
+      expect(onboardJs).toMatch(/\|\|\s*"512"/);
+    });
+  });
+});

--- a/test/process-limits.test.js
+++ b/test/process-limits.test.js
@@ -3,13 +3,13 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const startScript = readFileSync(
-  resolve(__dirname, "..", "scripts", "nemoclaw-start.sh"),
+  resolve(import.meta.dirname, "..", "scripts", "nemoclaw-start.sh"),
   "utf8",
 );
 
 const policyYaml = readFileSync(
   resolve(
-    __dirname,
+    import.meta.dirname,
     "..",
     "nemoclaw-blueprint",
     "policies",
@@ -19,7 +19,7 @@ const policyYaml = readFileSync(
 );
 
 const onboardJs = readFileSync(
-  resolve(__dirname, "..", "bin", "lib", "onboard.js"),
+  resolve(import.meta.dirname, "..", "bin", "lib", "onboard.js"),
   "utf8",
 );
 


### PR DESCRIPTION
## Summary

Closes #809.

Without process limits, a prompt-injected agent can exhaust host resources by spawning processes recursively (fork bomb). This PR adds three layers of defence:

- **Container level:** `docker update --pids-limit 512` applied post-creation in `onboard.js`
- **In-sandbox fallback:** `ulimit -u 512` set in `nemoclaw-start.sh` when the current limit is unlimited
- **Documentation:** Comment in the sandbox policy YAML noting that OpenShell does not currently expose a `pids_limit` field

### Defence layers

```mermaid
graph TD
    subgraph "Process Limit Enforcement"
        A[Agent spawns processes] --> B{ulimit -u set?}
        B -->|Yes| C[Kernel enforces RLIMIT_NPROC]
        B -->|No / unlimited| D[nemoclaw-start sets ulimit -u 512]
        D --> C
        C --> E{Over limit?}
        E -->|Yes| F[fork returns EAGAIN]
        E -->|No| G[Process created]
    end

    subgraph "Container Level"
        H[--pids-limit 512] --> I[cgroup pids.max]
        I --> C
    end

    F --> J[Agent receives error]
    J --> K[System stays responsive]
```

### Changes

| File | Change |
|------|--------|
| `scripts/nemoclaw-start.sh` | Set `ulimit -u 512` when current limit is unlimited |
| `bin/lib/onboard.js` | Apply `docker update --pids-limit` after sandbox creation |
| `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` | Document limitation in process section |
| `docs/security/process-limits.md` | Full documentation with mermaid diagram |
| `test/process-limits.test.js` | Vitest assertions for all three components |

### Configuration

The default limit of 512 processes is configurable via `NEMOCLAW_PIDS_LIMIT` environment variable at onboard time.

## Test plan

- [x] `npx vitest run test/process-limits.test.js` — 8/8 tests pass
- [ ] Run `nemoclaw onboard` on a test host and verify `docker inspect` shows `PidsLimit: 512`
- [ ] Verify `ulimit -u` inside the sandbox returns 512
- [ ] Verify fork bomb (`:(){ :|:& };:`) is contained and doesn't affect the host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layered fork‑bomb protection: onboarding applies a container-level process limit (default 512, overridable via environment variable) with an in‑sandbox startup fallback enforcing a per-user process limit.

* **Documentation**
  * New security guide describing the two‑layer model, defaults, override behavior, and system behavior when limits are exceeded; notes that runtime enforcement is required.

* **Tests**
  * Added tests validating presence and configuration of the protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->