### PR TITLE
feat(ci): add ephemeral Brev E2E test infrastructure

### DIFF
--- a/.github/workflows/e2e-brev.yaml
+++ b/.github/workflows/e2e-brev.yaml
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: e2e-brev
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test"
+        required: true
+        default: "main"
+      pr_number:
+        description: "PR number (for status reporting, optional)"
+        required: false
+        default: ""
+      test_suite:
+        description: "Test suite to run"
+        required: true
+        default: "full"
+        type: choice
+        options:
+          - full
+          - credential-sanitization
+          - all
+      keep_alive:
+        description: "Keep Brev instance alive after tests (for SSH debugging)"
+        required: false
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+      pr_number:
+        required: false
+        type: string
+        default: ""
+      test_suite:
+        required: false
+        type: string
+        default: "full"
+      keep_alive:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      BREV_API_TOKEN:
+        required: true
+      NVIDIA_API_KEY:
+        required: true
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: e2e-brev-${{ inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-brev:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Create check run (pending)
+        if: inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_SHA=$(gh pr view ${{ inputs.pr_number }} --json headRefOid -q .headRefOid)
+          CHECK_RUN_ID=$(gh api repos/${{ github.repository }}/check-runs \
+            -f name="Brev E2E (${{ inputs.test_suite }})" \
+            -f head_sha="$PR_SHA" \
+            -f status="in_progress" \
+            -f "output[title]=Running on ephemeral Brev instance" \
+            -f "output[summary]=Tests in progress..." \
+            --jq '.id')
+          echo "CHECK_RUN_ID=$CHECK_RUN_ID" >> "$GITHUB_ENV"
+          echo "PR_SHA=$PR_SHA" >> "$GITHUB_ENV"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Brev CLI
+        run: |
+          # Pin to v0.6.310 — v0.6.322 removed --cpu flag and defaults to GPU instances
+          curl -fsSL -o /tmp/brev.tar.gz "https://github.com/brevdev/brev-cli/releases/download/v0.6.310/brev-cli_0.6.310_linux_amd64.tar.gz"
+          tar -xzf /tmp/brev.tar.gz -C /usr/local/bin brev
+          chmod +x /usr/local/bin/brev
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run ephemeral Brev E2E
+        env:
+          BREV_API_TOKEN: ${{ secrets.BREV_API_TOKEN }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+          INSTANCE_NAME: e2e-pr-${{ inputs.pr_number || github.run_id }}
+          TEST_SUITE: ${{ inputs.test_suite }}
+          KEEP_ALIVE: ${{ inputs.keep_alive }}
+        run: npx vitest run --project e2e-brev --reporter=verbose
+
+      - name: Update check run (completed)
+        if: always() && inputs.pr_number != '' && env.CHECK_RUN_ID != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CONCLUSION=${{ job.status == 'success' && 'success' || 'failure' }}
+          gh api repos/${{ github.repository }}/check-runs/${{ env.CHECK_RUN_ID }} \
+            -X PATCH \
+            -f status="completed" \
+            -f conclusion="$CONCLUSION" \
+            -f "output[title]=Brev E2E (${{ inputs.test_suite }}): ${CONCLUSION}" \
+            -f "output[summary]=See workflow run for details."
+
+      - name: Post PR comment
+        if: always() && inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            EMOJI="✅"
+            STATUS="PASSED"
+          else
+            EMOJI="❌"
+            STATUS="FAILED"
+          fi
+          INSTANCE="e2e-pr-${{ inputs.pr_number || github.run_id }}"
+          BODY="${EMOJI} **Brev E2E** (${{ inputs.test_suite }}): **${STATUS}** on branch \`${{ inputs.branch }}\` — [See logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          if [ "${{ inputs.keep_alive }}" = "true" ]; then
+            BODY="${BODY}
+
+          > **Instance \`${INSTANCE}\` is still running.** To SSH in:
+          > \`\`\`
+          > brev refresh && ssh ${INSTANCE}
+          > \`\`\`
+          > When done, delete it: \`brev delete ${INSTANCE}\`"
+          fi
+          gh pr comment ${{ inputs.pr_number }} --repo ${{ github.repository }} --body "$BODY"
+
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-brev-logs
+          path: /tmp/brev-e2e-*.log
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 
 # Project-specific
 draft_newsletter_*
+specs/
 vdr-notes/
 
 # Security: secrets, credentials, and keys

--- a/test/e2e/brev-e2e.test.js
+++ b/test/e2e/brev-e2e.test.js
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Ephemeral Brev E2E test suite.
+ *
+ * Creates a fresh Brev instance, bootstraps it, runs E2E tests remotely,
+ * then tears it down. Intended to be run from CI via:
+ *
+ *   npx vitest run --project e2e-brev
+ *
+ * Required env vars:
+ *   BREV_API_TOKEN   — Brev refresh token for headless auth
+ *   NVIDIA_API_KEY   — passed to VM for inference config during onboarding
+ *   GITHUB_TOKEN     — passed to VM for OpenShell binary download
+ *   INSTANCE_NAME    — Brev instance name (e.g. pr-156-test)
+ *
+ * Optional env vars:
+ *   TEST_SUITE       — which test to run: full (default), credential-sanitization, all
+ *   BREV_CPU         — CPU spec (default: 4x16)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync, execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const BREV_CPU = process.env.BREV_CPU || "4x16";
+const INSTANCE_NAME = process.env.INSTANCE_NAME;
+const TEST_SUITE = process.env.TEST_SUITE || "full";
+const REPO_DIR = path.resolve(import.meta.dirname, "../..");
+
+let remoteDir;
+let instanceCreated = false;
+
+// --- helpers ----------------------------------------------------------------
+
+function brev(...args) {
+  return execFileSync("brev", args, {
+    encoding: "utf-8",
+    timeout: 60_000,
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+function ssh(cmd, { timeout = 120_000 } = {}) {
+  // Use single quotes to prevent local shell expansion of remote commands
+  const escaped = cmd.replace(/'/g, "'\\''");
+  return execSync(
+    `ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR "${INSTANCE_NAME}" '${escaped}'`,
+    { encoding: "utf-8", timeout, stdio: ["pipe", "pipe", "pipe"] },
+  ).trim();
+}
+
+function shellEscape(value) {
+  return value.replace(/'/g, "'\\''");
+}
+
+/** Run a command on the remote VM with secrets passed via stdin (not CLI args). */
+function sshWithSecrets(cmd, { timeout = 600_000 } = {}) {
+  const secretPreamble = [
+    `export NVIDIA_API_KEY='${shellEscape(process.env.NVIDIA_API_KEY)}'`,
+    `export GITHUB_TOKEN='${shellEscape(process.env.GITHUB_TOKEN)}'`,
+    `export NEMOCLAW_NON_INTERACTIVE=1`,
+    `export NEMOCLAW_SANDBOX_NAME=e2e-test`,
+  ].join("\n");
+
+  // Pipe secrets via stdin so they don't appear in ps/process listings
+  return execSync(
+    `ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR "${INSTANCE_NAME}" 'eval "$(cat)" && ${cmd.replace(/'/g, "'\\''")}'`,
+    {
+      encoding: "utf-8",
+      timeout,
+      input: secretPreamble,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  ).trim();
+}
+
+function waitForSsh(maxAttempts = 60, intervalMs = 5_000) {
+  for (let i = 1; i <= maxAttempts; i++) {
+    try {
+      ssh("echo ok", { timeout: 10_000 });
+      return;
+    } catch {
+      if (i === maxAttempts) throw new Error(`SSH not ready after ${maxAttempts} attempts`);
+      if (i % 5 === 0) {
+        try { brev("refresh"); } catch { /* ignore */ }
+      }
+      execSync(`sleep ${intervalMs / 1000}`);
+    }
+  }
+}
+
+function runRemoteTest(scriptPath) {
+  const cmd = [
+    `cd ${remoteDir}`,
+    `export npm_config_prefix=$HOME/.local`,
+    `export PATH=$HOME/.local/bin:$PATH`,
+    `bash ${scriptPath}`,
+  ].join(" && ");
+
+  return sshWithSecrets(cmd, { timeout: 600_000 });
+}
+
+// --- suite ------------------------------------------------------------------
+
+const REQUIRED_VARS = ["BREV_API_TOKEN", "NVIDIA_API_KEY", "GITHUB_TOKEN", "INSTANCE_NAME"];
+const hasRequiredVars = REQUIRED_VARS.every((key) => process.env[key]);
+
+describe.runIf(hasRequiredVars)("Brev E2E", () => {
+  beforeAll(() => {
+
+    // Authenticate with Brev
+    mkdirSync(path.join(homedir(), ".brev"), { recursive: true });
+    writeFileSync(
+      path.join(homedir(), ".brev", "onboarding_step.json"),
+      '{"step":1,"hasRunBrevShell":true,"hasRunBrevOpen":true}',
+    );
+    brev("login", "--token", process.env.BREV_API_TOKEN);
+
+    // Create instance
+    brev("create", INSTANCE_NAME, "--cpu", BREV_CPU, "--detached");
+    instanceCreated = true;
+
+    // Wait for SSH
+    try { brev("refresh"); } catch { /* ignore */ }
+    waitForSsh();
+
+    // Sync code
+    const remoteHome = ssh("echo $HOME");
+    remoteDir = `${remoteHome}/nemoclaw`;
+    ssh(`mkdir -p ${remoteDir}`);
+    execSync(
+      `rsync -az --delete --exclude node_modules --exclude .git --exclude dist --exclude .venv "${REPO_DIR}/" "${INSTANCE_NAME}:${remoteDir}/"`,
+      { encoding: "utf-8", timeout: 120_000 },
+    );
+
+    // Bootstrap VM
+    sshWithSecrets(`cd ${remoteDir} && bash scripts/brev-setup.sh`, { timeout: 900_000 });
+  }, 1_200_000); // 20 min — instance creation + bootstrap can be slow
+
+  afterAll(() => {
+    if (!instanceCreated) return;
+    if (process.env.KEEP_ALIVE === "true") {
+      console.log(`\n  Instance "${INSTANCE_NAME}" kept alive for debugging.`);
+      console.log(`  To connect: brev refresh && ssh ${INSTANCE_NAME}`);
+      console.log(`  To delete:  brev delete ${INSTANCE_NAME}\n`);
+      return;
+    }
+    try {
+      brev("delete", INSTANCE_NAME);
+    } catch {
+      // Best-effort cleanup — instance may already be gone
+    }
+  });
+
+  it.runIf(TEST_SUITE === "full" || TEST_SUITE === "all")(
+    "full E2E suite passes on remote VM",
+    () => {
+      const output = runRemoteTest("test/e2e/test-full-e2e.sh");
+      expect(output).toContain("PASS");
+      expect(output).not.toMatch(/FAIL:/);
+    },
+    600_000,
+  );
+
+  it.runIf(TEST_SUITE === "credential-sanitization" || TEST_SUITE === "all")(
+    "credential sanitization suite passes on remote VM",
+    () => {
+      const output = runRemoteTest("test/e2e/test-credential-sanitization.sh");
+      expect(output).toContain("PASS");
+      expect(output).not.toMatch(/FAIL:/);
+    },
+    600_000,
+  );
+});

--- a/test/e2e/test-full-e2e.sh
+++ b/test/e2e/test-full-e2e.sh
@@ -86,7 +86,7 @@ SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-nightly}"
 section "Phase 0: Pre-cleanup"
 info "Destroying any leftover sandbox/gateway from previous runs..."
 if command -v nemoclaw >/dev/null 2>&1; then
-  nemoclaw "$SANDBOX_NAME" destroy 2>/dev/null || true
+  nemoclaw "$SANDBOX_NAME" destroy --yes 2>/dev/null || true
 fi
 if command -v openshell >/dev/null 2>&1; then
   openshell sandbox delete "$SANDBOX_NAME" 2>/dev/null || true
@@ -338,7 +338,7 @@ fi
 # ══════════════════════════════════════════════════════════════════
 section "Phase 6: Cleanup"
 
-nemoclaw "$SANDBOX_NAME" destroy 2>&1 | tail -3 || true
+nemoclaw "$SANDBOX_NAME" destroy --yes 2>&1 | tail -3 || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 
 list_after=$(nemoclaw list 2>&1)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,13 +10,21 @@ export default defineConfig({
         test: {
           name: "cli",
           include: ["test/**/*.test.js"],
-          exclude: ["**/node_modules/**", "**/.claude/**"],
+          exclude: ["**/node_modules/**", "**/.claude/**", "test/e2e/**"],
         },
       },
       {
         test: {
           name: "plugin",
           include: ["nemoclaw/src/**/*.test.ts"],
+        },
+      },
+      {
+        test: {
+          name: "e2e-brev",
+          include: ["test/e2e/brev-e2e.test.js"],
+          // Only run when explicitly targeted: npx vitest run --project e2e-brev
+          enabled: !!process.env.BREV_API_TOKEN,
         },
       },
     ],


### PR DESCRIPTION
## How to use

After merge, any maintainer can trigger a full-stack E2E test against any branch:

1. Go to **Actions → "e2e-brev" → "Run workflow"**
2. Enter the **branch name**, optionally a **PR number**, pick a **test suite**, and leave **keep_alive** as `true`
3. Tests run on a fresh Brev CPU instance (~15-20 min)
4. A comment is posted on the PR with results and SSH access:

> ✅ **Brev E2E** (full): **PASSED** on branch `feat/my-pr` — [See logs](...)
>
> **Instance `e2e-pr-813` is still running.** To SSH in:
> ```
> brev refresh && ssh e2e-pr-813
> ```
> When done, delete it: `brev delete e2e-pr-813`

Set **keep_alive** to `false` to auto-delete the instance after tests complete.

### SSH access setup

To SSH into a kept-alive instance, you need to be in the NemoClaw Brev org:

1. **Join the org**: [NemoClaw Brev Org Invite](https://brev.nvidia.com/invite?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHBpcmF0aW9uIjoxNzc0OTk1ODI3LCJvcmdJZCI6Im9yZy0zQk1YTlFNZVFVT29yY2N6aHYzUlg2em5QQ2EiLCJ1c2VySWQiOiJ1c2VyLTJ3cmx6U2MyRzhwaEV2VVdYQ3owaEhvNklZNSJ9.cLGFaNMv1nsXXRprsxTCVeD12pPnX-4cZJXZbJVjT9c&orgID=org-3BMXNQMeQUOorcczhv3RX6znPCa)
2. **Install Brev CLI**: `brew install brev` (or see [docs](https://docs.nvidia.com/brev/))
3. **Login**: `brev login`
4. **Connect**: `brev refresh && ssh <instance-name>`

---

## Summary

- Vitest-based E2E test suite that provisions an ephemeral Brev CPU instance, bootstraps NemoClaw (Node.js, Docker, OpenShell, gateway, sandbox), runs tests remotely, and optionally keeps the instance alive for SSH debugging
- GitHub Actions workflow (`e2e-brev`) triggered via `workflow_dispatch` or `workflow_call`
- Results reported to PRs via check runs and comments with SSH instructions

## Motivation

Security-critical PRs (e.g., #156) need testing against the real OpenShell + sandbox stack, which the existing Docker sandbox E2E and nightly cloud E2E cannot provide.

## Files changed

| File | Change |
|------|--------|
| `test/e2e/brev-e2e.test.js` | **New** — vitest E2E test: create instance, bootstrap, run tests, cleanup |
| `.github/workflows/e2e-brev.yaml` | **New** — workflow with dispatch inputs, PR reporting, keep_alive option |
| `vitest.config.ts` | **Modified** — added `e2e-brev` project, excluded E2E from CLI test project |
| `test/e2e/test-full-e2e.sh` | **Modified** — pass `--yes` to destroy, shfmt formatting |
| `.gitignore` | **Modified** — added `specs/` |

## Required secrets (must be configured before first run)

### `BREV_API_TOKEN`

```bash
# 1. Login interactively (opens browser)
brev login

# 2. Extract the refresh token
python3 -c "import json; print(json.load(open('$HOME/.brev/credentials.json'))['refresh_token'])"

# 3. Add to GitHub secrets
gh secret set BREV_API_TOKEN --repo NVIDIA/NemoClaw --body "<token>"
```

**Note**: Brev refresh tokens expire in ~24 hours. The secret needs periodic refresh.

### `NVIDIA_API_KEY`

Already exists. Must start with `nvapi-`.

## Validated end-to-end

All 6 phases passed on an ephemeral Brev instance triggered from GitHub Actions ([fork run](https://github.com/jyaunches/NemoClaw/actions)):

| Phase | Result |
|-------|--------|
| Phase 0: Pre-cleanup | ✅ |
| Phase 1: Prerequisites (Docker, API key, network) | ✅ |
| Phase 2: Install (install.sh, nemoclaw, openshell) | ✅ |
| Phase 3: Sandbox verification (list, status, inference, policies) | ✅ |
| Phase 4: Live inference (direct API + sandbox-to-API) | ✅ |
| Phase 5: CLI operations (logs) | ✅ |
| Phase 6: Cleanup (destroy sandbox) | ✅ |
| Instance teardown (brev delete) | ✅ |

## Known limitations

- **Brev refresh tokens expire (~24 hours)** — `BREV_API_TOKEN` needs periodic refresh
- **vLLM installs unnecessarily on CPU boxes** — `brev-setup.sh` wastes ~3 min (separate fix)
- **Brev CLI pinned to v0.6.310** — v0.6.322 removed `--cpu` flag

## Next steps (after this PR merges)

1. **Long-lived Brev auth token** — refresh token expires daily. Investigate service account tokens with longer TTL.
2. **`/test-brev` PR comment trigger** — `issue_comment` workflow so maintainers can type `/test-brev` on a PR instead of using the Actions UI. Requires the workflow file on `main` first.
3. **Credential sanitization test suite** — `test/e2e/test-credential-sanitization.sh` exercising real `createSnapshotBundle()` from `migration-state.ts`. The dropdown option is wired but no script exists yet.
4. **Nightly integration** — add job in `nightly-e2e.yaml` calling `e2e-brev.yaml` via `workflow_call`.
5. **Skip vLLM on CPU boxes** — fix `brev-setup.sh` GPU detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)