### PR TITLE
fix(onboard): pull default model when Ollama has no models installed

### DIFF
--- a/bin/lib/local-inference.js
+++ b/bin/lib/local-inference.js
@@ -104,15 +104,12 @@ function parseOllamaList(output) {
 
 function getOllamaModelOptions(runCapture) {
   const output = runCapture("ollama list 2>/dev/null", { ignoreError: true });
-  const parsed = parseOllamaList(output);
-  if (parsed.length > 0) {
-    return parsed;
-  }
-  return [DEFAULT_OLLAMA_MODEL];
+  return parseOllamaList(output);
 }
 
 function getDefaultOllamaModel(runCapture) {
   const models = getOllamaModelOptions(runCapture);
+  if (models.length === 0) return DEFAULT_OLLAMA_MODEL;
   return models.includes(DEFAULT_OLLAMA_MODEL) ? DEFAULT_OLLAMA_MODEL : models[0];
 }
 
@@ -134,6 +131,15 @@ function getOllamaProbeCommand(model, timeoutSeconds = 120, keepAlive = "15m") {
     keep_alive: keepAlive,
   });
   return `curl -sS --max-time ${timeoutSeconds} http://localhost:11434/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} 2>/dev/null`;
+}
+
+function hasOllamaModels(tagsOutput) {
+  try {
+    const data = JSON.parse(tagsOutput);
+    return Array.isArray(data.models) && data.models.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 function validateOllamaModel(model, runCapture) {
@@ -171,6 +177,7 @@ module.exports = {
   getOllamaModelOptions,
   getOllamaProbeCommand,
   getOllamaWarmupCommand,
+  hasOllamaModels,
   parseOllamaList,
   validateOllamaModel,
   validateLocalProvider,

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -11,10 +11,12 @@ const path = require("path");
 const { spawn, spawnSync } = require("child_process");
 const { ROOT, SCRIPTS, run, runCapture, shellQuote } = require("./runner");
 const {
+  DEFAULT_OLLAMA_MODEL,
   getDefaultOllamaModel,
   getLocalProviderBaseUrl,
   getOllamaModelOptions,
   getOllamaWarmupCommand,
+  hasOllamaModels,
   validateOllamaModel,
   validateLocalProvider,
 } = require("./local-inference");
@@ -211,20 +213,38 @@ async function promptCloudModel() {
 }
 
 async function promptOllamaModel() {
-  const options = getOllamaModelOptions(runCapture);
-  const defaultModel = getDefaultOllamaModel(runCapture);
-  const defaultIndex = Math.max(0, options.indexOf(defaultModel));
+  const installed = getOllamaModelOptions(runCapture);
+
+  if (installed.length === 0) {
+    console.log("");
+    console.log("  No local Ollama models found. A model must be pulled first.");
+    console.log("");
+    console.log("  Ollama models:");
+    console.log(`    1) ${DEFAULT_OLLAMA_MODEL}`);
+    console.log("");
+    const choice = await prompt("  Pull and use this model? [Y/n]: ");
+    if (choice && choice.toLowerCase() === "n") {
+      console.error("  Cannot continue without a model. Run 'ollama pull <model>' and try again.");
+      process.exit(1);
+    }
+    console.log(`  Pulling ${DEFAULT_OLLAMA_MODEL} (this may take a while)...`);
+    run(`ollama pull ${shellQuote(DEFAULT_OLLAMA_MODEL)}`);
+    return DEFAULT_OLLAMA_MODEL;
+  }
+
+  const defaultModel = installed.includes(DEFAULT_OLLAMA_MODEL) ? DEFAULT_OLLAMA_MODEL : installed[0];
+  const defaultIndex = Math.max(0, installed.indexOf(defaultModel));
 
   console.log("");
   console.log("  Ollama models:");
-  options.forEach((option, index) => {
+  installed.forEach((option, index) => {
     console.log(`    ${index + 1}) ${option}`);
   });
   console.log("");
 
   const choice = await prompt(`  Choose model [${defaultIndex + 1}]: `);
   const index = parseInt(choice || String(defaultIndex + 1), 10) - 1;
-  return options[index] || options[defaultIndex] || defaultModel;
+  return installed[index] || installed[defaultIndex] || defaultModel;
 }
 
 function isDockerRunning() {
@@ -650,7 +670,9 @@ async function setupNim(sandboxName, gpu) {
 
   // Detect local inference options
   const hasOllama = !!runCapture("command -v ollama", { ignoreError: true });
-  const ollamaRunning = !!runCapture("curl -sf http://localhost:11434/api/tags 2>/dev/null", { ignoreError: true });
+  const ollamaTagsResponse = runCapture("curl -sf http://localhost:11434/api/tags 2>/dev/null", { ignoreError: true });
+  const ollamaRunning = !!ollamaTagsResponse;
+  const ollamaHasModels = ollamaRunning && hasOllamaModels(ollamaTagsResponse);
   const vllmRunning = !!runCapture("curl -sf http://localhost:8000/v1/models 2>/dev/null", { ignoreError: true });
   const requestedProvider = isNonInteractive() ? getNonInteractiveProvider() : null;
   const requestedModel = isNonInteractive() ? getNonInteractiveModel(requestedProvider || "cloud") : null;
@@ -663,14 +685,15 @@ async function setupNim(sandboxName, gpu) {
     key: "cloud",
     label:
       "NVIDIA Endpoint API (build.nvidia.com)" +
-      (!ollamaRunning && !(EXPERIMENTAL && vllmRunning) ? " (recommended)" : ""),
+      (!ollamaHasModels && !(EXPERIMENTAL && vllmRunning) ? " (recommended)" : ""),
   });
   if (hasOllama || ollamaRunning) {
     options.push({
       key: "ollama",
       label:
         `Local Ollama (localhost:11434)${ollamaRunning ? " — running" : ""}` +
-        (ollamaRunning ? " (suggested)" : ""),
+        (ollamaRunning && !ollamaHasModels ? " (no models pulled)" : "") +
+        (ollamaHasModels ? " (suggested)" : ""),
     });
   }
   if (EXPERIMENTAL && vllmRunning) {

--- a/test/local-inference.test.js
+++ b/test/local-inference.test.js
@@ -13,6 +13,7 @@ import {
   getOllamaModelOptions,
   getOllamaProbeCommand,
   getOllamaWarmupCommand,
+  hasOllamaModels,
   parseOllamaList,
   validateOllamaModel,
   validateLocalProvider,
@@ -86,8 +87,8 @@ describe("local inference helpers", () => {
     ).toEqual(["nemotron-3-nano:30b", "qwen3:32b"]);
   });
 
-  it("falls back to the default ollama model when list output is empty", () => {
-    expect(getOllamaModelOptions(() => "")).toEqual([DEFAULT_OLLAMA_MODEL]);
+  it("returns an empty array when no ollama models are installed", () => {
+    expect(getOllamaModelOptions(() => "")).toEqual([]);
   });
 
   it("prefers the default ollama model when present", () => {
@@ -136,5 +137,23 @@ describe("local inference helpers", () => {
       () => JSON.stringify({ model: "nemotron-3-nano:30b", response: "hello", done: true }),
     );
     expect(result).toEqual({ ok: true });
+  });
+
+  it("detects models present in /api/tags response", () => {
+    expect(hasOllamaModels(JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] }))).toBe(true);
+  });
+
+  it("returns false when /api/tags response has an empty models array", () => {
+    expect(hasOllamaModels(JSON.stringify({ models: [] }))).toBe(false);
+  });
+
+  it("returns false when /api/tags response is not valid JSON", () => {
+    expect(hasOllamaModels("not json")).toBe(false);
+  });
+
+  it("returns false when /api/tags response is empty", () => {
+    expect(hasOllamaModels("")).toBe(false);
+    expect(hasOllamaModels(null)).toBe(false);
+    expect(hasOllamaModels(undefined)).toBe(false);
   });
 });

--- a/test/onboard-selection.test.js
+++ b/test/onboard-selection.test.js
@@ -84,4 +84,79 @@ const { setupNim } = require(${onboardPath});
     ).toBeTruthy();
     expect(payload.lines.some((line) => line.includes("Cloud models:"))).toBeTruthy();
   });
+
+  it("shows '(no models pulled)' and keeps cloud '(recommended)' when Ollama is running but has no models", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-nomodels-"));
+    const scriptPath = path.join(tmpDir, "no-models-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "credentials.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "registry.js"));
+    const script = String.raw`
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+
+let promptCalls = 0;
+const messages = [];
+const updates = [];
+
+credentials.prompt = async (message) => {
+  promptCalls += 1;
+  messages.push(message);
+  return "";
+};
+credentials.ensureApiKey = async () => {};
+runner.runCapture = (command) => {
+  if (command.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (command.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [] });
+  if (command.includes("ollama list")) return "";
+  if (command.includes("localhost:8000/v1/models")) return "";
+  return "";
+};
+registry.updateSandbox = (_name, update) => updates.push(update);
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  const originalLog = console.log;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim("no-models-test", null);
+    originalLog(JSON.stringify({ result, promptCalls, messages, updates, lines }));
+  } finally {
+    console.log = originalLog;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).not.toBe("");
+    const payload = JSON.parse(result.stdout.trim());
+    expect(payload.result.provider).toBe("nvidia-nim");
+    expect(
+      payload.lines.some((line) => line.includes("(recommended)"))
+    ).toBeTruthy();
+    expect(
+      payload.lines.some((line) => line.includes("no models pulled"))
+    ).toBeTruthy();
+    expect(
+      payload.lines.every((line) => !line.includes("(suggested)"))
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Previously, the onboarding wizard recommended Ollama as `(suggested)` as long as the daemon was running, even when no models were pulled locally. This led users into a dead end where setup would fail at the model validation step. 

Now the wizard detects an empty model list, shows `(no models pulled)` in the menu, and prompts the user to pull the
default model before continuing.

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

Fixes #710

## Changes
<!-- Bullet list of key changes. -->

- Add `hasOllamaModels()` to parse the `/api/tags` response and check whether any models are locally available.
- Keep cloud `(recommended)` and show `(no models pulled)` on the Ollama option when the daemon is running but the model list is empty.
- Rewrite `promptOllamaModel()` to detect an empty model list and offer to `ollama pull` the default model before continuing.
- Let `getOllamaModelOptions()` return an honest empty array so callers can distinguish "no models" from "has models".
- Add unit tests for `hasOllamaModels` and an onboard-selection test for the empty-models scenario.

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

### Verify

```bash
# node bin/nemoclaw.js onboard
.....
  [4/7] Configuring inference (NIM)
  ──────────────────────────────────────────────────

  Inference options:
    1) NVIDIA Endpoint API (build.nvidia.com) (recommended)
    2) Local Ollama (localhost:11434)

  Choose [1]: 2
  Starting Ollama...
  ✓ Using Ollama on localhost:11434

  No local Ollama models found. A model must be pulled first.

  Ollama models:
    1) nemotron-3-nano:30b

  Pull and use this model? [Y/n]: y
  Pulling nemotron-3-nano:30b (this may take a while)...
pulling manifest 
pulling a70437c41b3b:   8% ▕███████                                                                                              ▏ 1.8 GB/ 24 GB  3.1 MB/s    2h0m
```

```bash

```bash
 npx vitest run test/local-inference.test.js

 RUN  v4.1.0 /Users/sevenc/code/ai/agent/NemoClaw

 ✓  cli  test/local-inference.test.js (22 tests) 4ms
   ✓ local inference helpers (22)
     ✓ returns the expected base URL for vllm-local 1ms
     ✓ returns the expected base URL for ollama-local 0ms
     ✓ returns the expected health check command for ollama-local 0ms
     ✓ returns the expected container reachability command for ollama-local 0ms
     ✓ validates a reachable local provider 0ms
     ✓ returns a clear error when ollama-local is unavailable 0ms
     ✓ returns a clear error when ollama-local is not reachable from containers 0ms
     ✓ returns a clear error when vllm-local is unavailable 0ms
     ✓ parses model names from ollama list output 0ms
     ✓ returns parsed ollama model options when available 0ms
     ✓ returns an empty array when no ollama models are installed 0ms
     ✓ prefers the default ollama model when present 0ms
     ✓ falls back to the first listed ollama model when the default is absent 0ms
     ✓ builds a background warmup command for ollama models 0ms
     ✓ builds a foreground probe command for ollama models 0ms
     ✓ fails ollama model validation when the probe times out or returns nothing 0ms
     ✓ fails ollama model validation when Ollama returns an error payload 0ms
     ✓ passes ollama model validation when the probe returns a normal payload 0ms
     ✓ detects models present in /api/tags response 0ms
     ✓ returns false when /api/tags response has an empty models array 0ms
     ✓ returns false when /api/tags response is not valid JSON 0ms
     ✓ returns false when /api/tags response is empty 0ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  22:46:27
   Duration  382ms (transform 30ms, setup 0ms, import 68ms, tests 4ms, environment 0ms)

 npx vitest run test/onboard-selection.test.js

 RUN  v4.1.0 /Users/sevenc/code/ai/agent/NemoClaw

 ✓  cli  test/onboard-selection.test.js (2 tests) 150ms
   ✓ onboard provider selection UX (2)
     ✓ prompts explicitly instead of silently auto-selecting detected Ollama 114ms
     ✓ shows '(no models pulled)' and keeps cloud '(recommended)' when Ollama is running but has no models 36ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  22:46:56
   Duration  709ms (transform 15ms, setup 0ms, import 34ms, tests 150ms, environment 0ms)
```
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model selection logic when no local Ollama models are installed
  * Improved Ollama provider detection to verify models are available

* **New Features**
  * Added prompts guiding users to pull models when none are detected locally
  * Enhanced provider recommendations based on actual model availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->