### PR TITLE
 fix(onboard): fall back to provider update when nvidia-nim already exists (Fixes #447)

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -845,10 +845,11 @@ async function setupInference(sandboxName, model, provider) {
   step(5, 7, "Setting up inference provider");
 
   if (provider === "nvidia-nim") {
-    // Create nvidia-nim provider
     run(
       `openshell provider create --name nvidia-nim --type openai ` +
       `--credential ${shellQuote("NVIDIA_API_KEY")} ` +
+      `--config "OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1" 2>&1 || ` +
+      `openshell provider update nvidia-nim --credential ${shellQuote("NVIDIA_API_KEY")} ` +
       `--config "OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1" 2>&1 || true`,
       { ignoreError: true }
     );


### PR DESCRIPTION
## SUmmary 

After nemoclaw onboard, the NVIDIA API key is saved to ~/.nemoclaw/credentials.json but silently fails to register in the OpenShell gateway when the nvidia-nim provider already exists (e.g. from a previous partial onboard attempt). The openshell provider create command exits non-zero because the provider exists, and unlike vllm-local and ollama-local there was no fallback to openshell provider update. Users see a working install but inference never responds.

Fixes #447

## Changes
bin/lib/onboard.js: Added || openshell provider update fallback to the nvidia-nim provider setup, matching the existing pattern used by vllm-local and ollama-local.

## Testing
npm test -- all 307 tests pass (27 test files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced NVIDIA NIM provider setup process with improved error handling and automatic recovery mechanisms. When initial provider configuration attempts fail, the system now automatically retries using alternative setup methods to ensure successful onboarding and seamless provider integration. This improvement enhances overall reliability and reduces the need for manual troubleshooting during provider setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->