### PR TITLE
fix(status): query gateway for live inference provider/model (Fixes #806)

### DIFF
--- a/bin/lib/inference-config.js
+++ b/bin/lib/inference-config.js
@@ -118,6 +118,17 @@ function getOpenClawPrimaryModel(provider, model) {
   return resolvedModel ? `${MANAGED_PROVIDER_ID}/${resolvedModel}` : null;
 }
 
+function parseGatewayInference(output) {
+  if (!output || /Not configured/i.test(output)) return null;
+  const provider = output.match(/Provider:\s*(.+)/);
+  const model = output.match(/Model:\s*(.+)/);
+  if (!provider && !model) return null;
+  return {
+    provider: provider ? provider[1].trim() : null,
+    model: model ? model[1].trim() : null,
+  };
+}
+
 module.exports = {
   CLOUD_MODEL_OPTIONS,
   DEFAULT_CLOUD_MODEL,
@@ -128,4 +139,5 @@ module.exports = {
   MANAGED_PROVIDER_ID,
   getOpenClawPrimaryModel,
   getProviderSelectionConfig,
+  parseGatewayInference,
 };

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -20,7 +20,7 @@ const R = _useColor ? "\x1b[0m" : "";
 const _RD = _useColor ? "\x1b[1;31m" : "";
 const YW = _useColor ? "\x1b[1;33m" : "";
 
-const { ROOT, SCRIPTS, run, runCapture: _runCapture, runInteractive, shellQuote, validateName } = require("./lib/runner");
+const { ROOT, SCRIPTS, run, runCapture, runInteractive, shellQuote, validateName } = require("./lib/runner");
 const {
   ensureApiKey,
   ensureGithubToken,
@@ -30,6 +30,7 @@ const {
 const registry = require("./lib/registry");
 const nim = require("./lib/nim");
 const policies = require("./lib/policies");
+const { parseGatewayInference } = require("./lib/inference-config");
 
 // ── Global commands ──────────────────────────────────────────────
 
@@ -306,11 +307,14 @@ function sandboxConnect(sandboxName) {
 
 function sandboxStatus(sandboxName) {
   const sb = registry.getSandbox(sandboxName);
+  const live = parseGatewayInference(
+    runCapture("openshell inference get 2>/dev/null", { ignoreError: true })
+  );
   if (sb) {
     console.log("");
     console.log(`  Sandbox: ${sb.name}`);
-    console.log(`    Model:    ${sb.model || "unknown"}`);
-    console.log(`    Provider: ${sb.provider || "unknown"}`);
+    console.log(`    Model:    ${(live && live.model) || sb.model || "unknown"}`);
+    console.log(`    Provider: ${(live && live.provider) || sb.provider || "unknown"}`);
     console.log(`    GPU:      ${sb.gpuEnabled ? "yes" : "no"}`);
     console.log(`    Policies: ${(sb.policies || []).join(", ") || "none"}`);
   }

--- a/test/inference-config.test.js
+++ b/test/inference-config.test.js
@@ -13,6 +13,7 @@ import {
   MANAGED_PROVIDER_ID,
   getOpenClawPrimaryModel,
   getProviderSelectionConfig,
+  parseGatewayInference,
 } from "../bin/lib/inference-config";
 
 describe("inference selection config", () => {
@@ -144,5 +145,62 @@ describe("inference selection config", () => {
 
   it("builds a default OpenClaw primary model for non-ollama providers", () => {
     expect(getOpenClawPrimaryModel("nvidia-prod")).toBe(`${MANAGED_PROVIDER_ID}/nvidia/nemotron-3-super-120b-a12b`);
+  });
+});
+
+describe("parseGatewayInference", () => {
+  it("parses provider and model from openshell inference get output", () => {
+    const output = [
+      "Gateway inference:",
+      "",
+      "  Provider: nvidia-nim",
+      "  Model: nvidia/nemotron-3-super-120b-a12b",
+      "  Version: 2",
+    ].join("\n");
+    expect(parseGatewayInference(output)).toEqual({
+      provider: "nvidia-nim",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+    });
+  });
+
+  it("returns null for empty output", () => {
+    expect(parseGatewayInference("")).toBeNull();
+    expect(parseGatewayInference(null)).toBeNull();
+    expect(parseGatewayInference(undefined)).toBeNull();
+  });
+
+  it("returns null when inference is not configured", () => {
+    const output = "Gateway inference:\n\n  Not configured";
+    expect(parseGatewayInference(output)).toBeNull();
+  });
+
+  it("parses output with different provider/model combinations", () => {
+    const output = [
+      "Gateway inference:",
+      "",
+      "  Provider: ollama-local",
+      "  Model: qwen/qwen3.5-397b-a17b",
+      "  Version: 1",
+    ].join("\n");
+    expect(parseGatewayInference(output)).toEqual({
+      provider: "ollama-local",
+      model: "qwen/qwen3.5-397b-a17b",
+    });
+  });
+
+  it("handles output with only provider (no model line)", () => {
+    const output = "Gateway inference:\n\n  Provider: nvidia-nim";
+    expect(parseGatewayInference(output)).toEqual({
+      provider: "nvidia-nim",
+      model: null,
+    });
+  });
+
+  it("handles output with only model (no provider line)", () => {
+    const output = "Gateway inference:\n\n  Model: some/model";
+    expect(parseGatewayInference(output)).toEqual({
+      provider: null,
+      model: "some/model",
+    });
   });
 });


### PR DESCRIPTION
The bug was that nemoclaw <sandbox> status displayed model/provider from ~/.nemoclaw/sandboxes.json (written once during onboard). After running openshell inference set to switch models, the gateway updated but the NemoClaw registry was stale.

The fix adds parseGatewayInference() to inference-config.js -- a pure function that parses openshell inference get output. sandboxStatus() now queries the gateway live and prefers those values, falling back to registry data when the gateway is down. 6 unit tests cover the parser (normal output, empty, "Not configured", partial output, different providers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now queries live inference gateway details and prefers live Model/Provider values, falling back to stored settings or "unknown" when unavailable.
  * Added parsing of gateway output that extracts provider/model when present, or returns null for empty, missing, or "Not configured" outputs.

* **Tests**
  * Added comprehensive tests covering parsing and handling of multi-line, partial, empty, and "Not configured" gateway outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->