### PR TITLE
feat(presets): add shrike-security preset for cognitive threat detection

### DIFF
--- a/nemoclaw-blueprint/policies/presets/shrike-security.yaml
+++ b/nemoclaw-blueprint/policies/presets/shrike-security.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Data flow: When activated with a SHRIKE_API_KEY, scanned content is
+# transmitted to api.shrikesecurity.com over TLS for threat analysis.
+# No data leaves the device without an API key configured.
+# See https://shrikesecurity.com/privacy for data handling policy.
+
+preset:
+  name: shrike-security
+  description: "Shrike Security — cognitive AI agent threat scanning (prompt injection, data exfiltration, OWASP LLM Top 10)"
+
+network_policies:
+  shrike_security:
+    name: shrike_security
+    endpoints:
+      - host: api.shrikesecurity.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: POST, path: "/agent/scan" }
+          - allow: { method: POST, path: "/agent/api/scan/specialized" }
+          - allow: { method: GET, path: "/agent/api/threatsense/**" }
+          - allow: { method: POST, path: "/agent/api/threatsense/**" }
+          - allow: { method: GET, path: "/agent/api/v1/approvals/**" }
+          - allow: { method: POST, path: "/agent/api/v1/approvals/**" }
+          - allow: { method: POST, path: "/agent/api/session/reset" }
+          - allow: { method: GET, path: "/health" }
+    binaries:
+      - { path: /usr/local/bin/node* }
+      - { path: /usr/local/bin/npx* }
+      - { path: /usr/bin/node* }
+      - { path: /usr/local/bin/shrike-sh }

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -10,7 +10,7 @@ describe("policies", () => {
   describe("listPresets", () => {
     it("returns all 9 presets", () => {
       const presets = policies.listPresets();
-      expect(presets.length).toBe(9);
+      expect(presets.length).toBe(10);
     });
 
     it("each preset has name and description", () => {
@@ -22,7 +22,7 @@ describe("policies", () => {
 
     it("returns expected preset names", () => {
       const names = policies.listPresets().map((p) => p.name).sort();
-      const expected = ["discord", "docker", "huggingface", "jira", "npm", "outlook", "pypi", "slack", "telegram"];
+      const expected = ["discord", "docker", "huggingface", "jira", "npm", "outlook", "pypi", "shrike-security", "slack", "telegram"];
       expect(names).toEqual(expected);
     });
   });


### PR DESCRIPTION
## Summary

- Add `shrike-security.yaml` network policy preset for [Shrike Security](https://shrikesecurity.com), a cognitive security layer for AI agents
- Restricts egress to `api.shrikesecurity.com:443` with path-scoped rules covering all 12 MCP security tools
- Binary-restricted to `node`/`npx` (MCP server transport) and `shrike-sh` (optional shell proxy)
- Updates `test/policies.test.js` for new preset count (9 → 10) and expected name list

Unlike static pattern matching, Shrike reasons about threats in real time — detecting prompt injection, multi-turn attack campaigns, data exfiltration, and novel threats through a 10-layer detection pipeline that includes session-aware correlation and LLM-powered analysis. It integrates with OpenClaw as an MCP skill (`npx shrike-mcp@1.0.1`) providing 12 security tools that agents invoke automatically during task execution.

### Privacy & data flow

This preset enables **optional** egress to Shrike's API for cognitive threat scanning. All traffic is TLS-encrypted. Shrike's MCP tools are opt-in — the agent user must configure a `SHRIKE_API_KEY` to activate scanning. Without the key, the preset adds the network policy allowance without any data transit.

- The preset YAML itself contains a data flow comment documenting this behavior
- See [shrikesecurity.com/privacy](https://shrikesecurity.com/privacy) for retention, cross-customer intelligence, GDPR/CCPA compliance, and data deletion

### Allowed endpoints

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/agent/scan` | Prompt and response scanning |
| POST | `/agent/api/scan/specialized` | SQL, file, command, web search, A2A, agent card scanning |
| GET/POST | `/agent/api/threatsense/**` | Threat intelligence patterns and bypass reporting |
| GET/POST | `/agent/api/v1/approvals/**` | Human-in-the-loop approval polling |
| POST | `/agent/api/session/reset` | Session correlation reset |
| GET | `/health` | Health check |

### Design decisions

- **Path-scoped rules** (not `/**`): Only scan, threat intel, and health endpoints are allowed. Dashboard, admin, and reporting APIs are excluded.
- **`tls: terminate`** (not `access: full`): Shrike is a security API with well-defined endpoints, not a package manager.
- **Binary restriction**: Only `node`/`npx` (MCP server) and `shrike-sh` (Go shell proxy). Other binaries cannot reach the API.

## Files changed

| File | Change |
|------|--------|
| `nemoclaw-blueprint/policies/presets/shrike-security.yaml` | New preset (8 path-scoped rules, data flow comment) |
| `test/policies.test.js` | Update count 9→10, add name to expected array |

## Test plan

- [x] Preset YAML passes schema validation (no rules at policy level, has network_policies, etc.)
- [x] `npx vitest run test/policies.test.js` passes with 10 presets
- [x] `python3 test/validate-blueprint.py` passes (unaffected)
- [ ] `openshell policy set` applies without error (requires sandbox)
- [ ] Agent can POST to `/agent/scan` and GET `/health`

## Related

- [shrike-mcp on npm](https://www.npmjs.com/package/shrike-mcp) — Apache-2.0, 12 MCP security tools
- NVIDIA Inception member

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shrike-security preset with network policies for Shrike Security API connectivity (TLS-encrypted endpoint access on port 443), including REST method and path-based access controls and binary execution whitelisting for Node/Npm utilities and system tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->