### PR TITLE
fix: verify pod readiness before applying sandbox policies (#297)

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1115,8 +1115,11 @@ async function ensureNamedCredential(envName, label, helpUrl = null) {
 
 function waitForSandboxReady(sandboxName, attempts = 10, delaySeconds = 2) {
   for (let i = 0; i < attempts; i += 1) {
-    const exists = runCaptureOpenshell(["sandbox", "get", sandboxName], { ignoreError: true });
-    if (exists) return true;
+    const podPhase = runCaptureOpenshell(
+      ["doctor", "exec", "--", "kubectl", "-n", "openshell", "get", "pod", sandboxName, "-o", "jsonpath={.status.phase}"],
+      { ignoreError: true }
+    );
+    if (podPhase === "Running") return true;
     sleep(delaySeconds);
   }
   return false;
@@ -2057,6 +2060,11 @@ async function setupPolicies(sandboxName) {
     if (answer.toLowerCase() === "n") {
       console.log("  Skipping policy presets.");
       return;
+    }
+
+    if (!waitForSandboxReady(sandboxName)) {
+      console.error(`  Sandbox '${sandboxName}' was not ready for policy application.`);
+      process.exit(1);
     }
 
     if (answer.toLowerCase() === "list") {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes step 7 "sandbox not found" errors during onboarding (#297). The gateway can track a sandbox entry before the underlying k3s pod is actually running - a race condition that surfaces on slower machines or first-time runs when image pulls are cold.

## Related Issue
https://github.com/NVIDIA/NemoClaw/issues/297

## Changes
- `waitForSandboxReady` now checks the k3s pod phase via `openshell doctor exec -- kubectl get pod` instead of relying on `openshell sandbox get`, which can return stale gateway metadata for pods that aren't actually running
- Add `waitForSandboxReady` call to the interactive policy application path (step 7) - only the non-interactive path had it previously

## Type of Change
<!-- Check the one that applies. -->
- [X] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [X] `npx prek run --all-files` passes (or equivalently `make check`).
- [X] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [X] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [X] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [X] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sandbox readiness checks during onboarding to ensure proper initialization before applying policies, preventing potential failures in the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->