### PR TITLE
ci: post Vitest coverage report on pull requests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,6 +60,9 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -80,6 +83,12 @@ jobs:
 
       - name: Run all unit tests with coverage
         run: npx vitest run --coverage
+
+      - name: Report Vitest coverage (PR comment + job summary)
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          vite-config-path: vitest.config.ts
 
       - name: Check coverage ratchet
         run: bash scripts/check-coverage-ratchet.sh

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Coverage reporters required by davelosert/vitest-coverage-report-action (json-summary + json).
+// reportOnFailure allows CI to publish a coverage comment when tests fail (see pr.yaml).
+// Include only the TypeScript plugin sources so totals match ci/coverage-threshold.json (ratchet).
 
 import { defineConfig } from "vitest/config";
 
@@ -24,7 +28,8 @@ export default defineConfig({
       provider: "v8",
       include: ["nemoclaw/src/**/*.ts"],
       exclude: ["**/*.test.ts"],
-      reporter: ["text", "json-summary"],
+      reporter: ["text", "json-summary", "json"],
+      reportOnFailure: true,
     },
   },
 });


### PR DESCRIPTION
## Summary

Integrates [davelosert/vitest-coverage-report-action](https://github.com/marketplace/actions/vitest-coverage-report) into the existing `test-unit` job so each PR gets a **job summary** and an optional **PR comment** with Vitest coverage (summary + file-level detail when `coverage-final.json` is present).

The `test-unit` job now requests `pull-requests: write` for that comment. Vitest config adds the `json` coverage reporter and `reportOnFailure: true` so the report step can still run when tests fail (paired with `if: always()` on the action).

## Related Issue

Loosely related to [#554](https://github.com/NVIDIA/NemoClaw/issues/554) — that issue tracks adding a **coverage ratchet** and broader coverage gates; this PR does not change the ratchet logic but improves **visibility** of the same Vitest coverage data in CI (complements the existing `scripts/check-coverage-ratchet.sh` step).

## Changes

- `.github/workflows/pr.yaml`: grant `pull-requests: write` on `test-unit`; run `davelosert/vitest-coverage-report-action@v2` after `npx vitest run --coverage`.
- `vitest.config.ts`: document reporters; add `json` reporter and `reportOnFailure: true` for the action (ratchet still uses `coverage-summary.json` as before).

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes

- [ ] Follows the [style guide](docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test coverage visibility by publishing coverage reports directly in pull requests as comments and job summaries.
  * Updated coverage reporting configuration to capture results even when tests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->