### PR TITLE
feat(presets): add shrike-security preset

### DIFF
--- a/nemoclaw-blueprint/policies/presets/shrike-security.yaml
+++ b/nemoclaw-blueprint/policies/presets/shrike-security.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Data flow: When activated with a SHRIKE_API_KEY, scanned content is
+# transmitted to api.shrikesecurity.com over TLS for threat analysis.
+# No data leaves the device without an API key configured.
+# See https://shrikesecurity.com/privacy for data handling policy.
+
+preset:
+  name: shrike-security
+  description: "Shrike Security — cognitive AI agent threat scanning (prompt injection, data exfiltration, OWASP LLM Top 10)"
+
+network_policies:
+  shrike_security:
+    name: shrike_security
+    endpoints:
+      - host: api.shrikesecurity.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: POST, path: "/agent/scan" }
+          - allow: { method: POST, path: "/agent/api/scan/specialized" }
+          - allow: { method: GET, path: "/agent/api/threatsense/**" }
+          - allow: { method: POST, path: "/agent/api/threatsense/**" }
+          - allow: { method: GET, path: "/agent/api/v1/approvals/**" }
+          - allow: { method: POST, path: "/agent/api/v1/approvals/**" }
+          - allow: { method: POST, path: "/agent/api/session/reset" }
+          - allow: { method: GET, path: "/health" }
+    binaries:
+      - { path: /usr/local/bin/node* }
+      - { path: /usr/local/bin/npx* }
+      - { path: /usr/bin/node* }
+      - { path: /usr/local/bin/shrike-sh }

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -10,7 +10,7 @@ describe("policies", () => {
   describe("listPresets", () => {
     it("returns all 9 presets", () => {
       const presets = policies.listPresets();
-      expect(presets.length).toBe(9);
+      expect(presets.length).toBe(10);
     });
 
     it("each preset has name and description", () => {
@@ -22,7 +22,7 @@ describe("policies", () => {
 
     it("returns expected preset names", () => {
       const names = policies.listPresets().map((p) => p.name).sort();
-      const expected = ["discord", "docker", "huggingface", "jira", "npm", "outlook", "pypi", "slack", "telegram"];
+      const expected = ["discord", "docker", "huggingface", "jira", "npm", "outlook", "pypi", "shrike-security", "slack", "telegram"];
       expect(names).toEqual(expected);
     });
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add `shrike-security.yaml` network policy preset for [Shrike Security](https://shrikesecurity.com), a content-scanning service for AI agents. The preset allows sandboxed agents to reach `api.shrikesecurity.com:443` for prompt, response, SQL, file, and command scanning via 12 MCP security tools (`npx shrike-mcp@1.0.1`).

Egress is opt-in — the agent user must configure a `SHRIKE_API_KEY` to activate scanning. Without the key, no data leaves the device. The preset YAML contains a data flow comment documenting this behavior.

## Related Issue

N/A — new integration. [Shrike MCP server](https://www.npmjs.com/package/shrike-mcp) (Apache-2.0). NVIDIA Inception member.

## Changes

| File | Change |
|------|--------|
| `nemoclaw-blueprint/policies/presets/shrike-security.yaml` | New preset — 8 path-scoped egress rules, binary-restricted to `node`/`npx`/`shrike-sh`, `tls: terminate` |
| `test/policies.test.js` | Update preset count 9→10, add `"shrike-security"` to expected name array |

### Allowed endpoints

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/agent/scan` | Prompt and response scanning |
| POST | `/agent/api/scan/specialized` | SQL, file, command, web search scanning |
| GET/POST | `/agent/api/threatsense/**` | Threat intelligence patterns |
| GET/POST | `/agent/api/v1/approvals/**` | Human-in-the-loop approval polling |
| POST | `/agent/api/session/reset` | Session correlation reset |
| GET | `/health` | Health check |

### Design decisions

- **Path-scoped rules** (not `/**`): only scan, threat intel, and health endpoints are allowed. Dashboard, admin, and reporting APIs are excluded.
- **`tls: terminate`** (not `access: full`): Shrike is a security API with well-defined endpoints, not a package manager.
- **Binary restriction**: only `node`/`npx` (MCP server) and `shrike-sh` (Go shell proxy) can use this policy.

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).

### Code Changes

- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Shrike Security network policy preset that configures secure communication with Shrike Security API endpoints. The preset enables access to specific routes for agent scanning operations, threat-sensing capabilities, approval workflows, session management, and health monitoring. Designated binary executables are permitted for policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->