### PR TITLE
fix: harden sandbox image — remove gcc/netcat, add process limits, drop capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ RUN npm install && npm run build
 # Stage 2: Runtime image — pull cached base from GHCR
 FROM ${BASE_IMAGE}
 
+# Harden: remove unnecessary build tools and network probes from base image (#830)
+RUN apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
+        netcat-openbsd netcat-traditional ncat 2>/dev/null || true \
+    && apt-get autoremove --purge -y \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy built plugin and blueprint into the sandbox
 COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,4 +149,4 @@ RUN sha256sum /sandbox/.openclaw/openclaw.json > /sandbox/.openclaw/.config-hash
 # Entrypoint runs as root to start the gateway as the gateway user,
 # then drops to sandbox for agent commands. See nemoclaw-start.sh.
 ENTRYPOINT ["/usr/local/bin/nemoclaw-start"]
-CMD []
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN npm install && npm run build
 FROM ${BASE_IMAGE}
 
 # Harden: remove unnecessary build tools and network probes from base image (#830)
-RUN apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
-        netcat-openbsd netcat-traditional ncat 2>/dev/null || true \
+RUN (apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
+        netcat-openbsd netcat-traditional ncat 2>/dev/null || true) \
     && apt-get autoremove --purge -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/deployment/sandbox-hardening.md
+++ b/docs/deployment/sandbox-hardening.md
@@ -30,7 +30,6 @@ what is strictly required:
 ```bash
 docker run --rm \
   --cap-drop=ALL \
-  --cap-add=NET_BIND_SERVICE \
   --ulimit nproc=512:512 \
   nemoclaw-sandbox
 ```

--- a/docs/deployment/sandbox-hardening.md
+++ b/docs/deployment/sandbox-hardening.md
@@ -1,3 +1,23 @@
+---
+title:
+  page: "Sandbox Image Hardening"
+  nav: "Sandbox Hardening"
+description: "Security hardening measures applied to the NemoClaw sandbox container image."
+keywords: ["nemoclaw sandbox hardening", "container security", "docker capabilities", "process limits"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["nemoclaw", "sandboxing", "security"]
+content:
+  type: reference
+  difficulty: technical_beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # Sandbox Image Hardening
 
 The NemoClaw sandbox image applies several security measures to reduce attack
@@ -27,11 +47,11 @@ Adjust the value via the `--ulimit nproc=512:512` flag if launching with
 When running the sandbox container, drop all Linux capabilities and re-add only
 what is strictly required:
 
-```bash
-docker run --rm \
-  --cap-drop=ALL \
-  --ulimit nproc=512:512 \
-  nemoclaw-sandbox
+```console
+$ docker run --rm \
+    --cap-drop=ALL \
+    --ulimit nproc=512:512 \
+    nemoclaw-sandbox
 ```
 
 ### Docker Compose Example

--- a/docs/deployment/sandbox-hardening.md
+++ b/docs/deployment/sandbox-hardening.md
@@ -1,0 +1,69 @@
+# Sandbox Image Hardening
+
+The NemoClaw sandbox image applies several security measures to reduce attack
+surface and limit the blast radius of untrusted workloads.
+
+## Removed Unnecessary Tools
+
+Build toolchains (`gcc`, `g++`, `make`) and network probes (`netcat`) are
+explicitly purged from the runtime image. These tools are not needed at runtime
+and would unnecessarily widen the attack surface.
+
+If you need a compiler during build, use the existing multi-stage build
+(the `builder` stage has full Node.js tooling) and copy only artifacts into the
+runtime stage.
+
+## Process Limits
+
+The container ENTRYPOINT sets `ulimit -u 512` to cap the number of processes
+a sandbox user can spawn. This mitigates fork-bomb attacks. The startup script
+(`nemoclaw-start.sh`) applies the same limit.
+
+Adjust the value via the `--ulimit nproc=512:512` flag if launching with
+`docker run` directly.
+
+## Dropping Linux Capabilities
+
+When running the sandbox container, drop all Linux capabilities and re-add only
+what is strictly required:
+
+```bash
+docker run --rm \
+  --cap-drop=ALL \
+  --cap-add=NET_BIND_SERVICE \
+  --ulimit nproc=512:512 \
+  nemoclaw-sandbox
+```
+
+### Docker Compose Example
+
+```yaml
+services:
+  nemoclaw-sandbox:
+    image: nemoclaw-sandbox:latest
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    ulimits:
+      nproc:
+        soft: 512
+        hard: 512
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m
+```
+
+> **Note:** The `Dockerfile` itself cannot enforce `--cap-drop` — that is a
+> runtime concern controlled by the container orchestrator. Always configure
+> capability dropping in your `docker run` flags, Compose file, or Kubernetes
+> `securityContext`.
+
+## References
+
+- [#807](https://github.com/NVIDIA/NemoClaw/issues/807) — gcc in sandbox image
+- [#808](https://github.com/NVIDIA/NemoClaw/issues/808) — netcat in sandbox image
+- [#809](https://github.com/NVIDIA/NemoClaw/issues/809) — No process limit
+- [#797](https://github.com/NVIDIA/NemoClaw/issues/797) — Drop Linux capabilities

--- a/docs/index.md
+++ b/docs/index.md
@@ -231,6 +231,7 @@ Customize the Network Policy <network-policy/customize-network-policy>
 
 Deploy to a Remote GPU Instance <deployment/deploy-to-remote-gpu>
 Set Up the Telegram Bridge <deployment/set-up-telegram-bridge>
+Sandbox Hardening <deployment/sandbox-hardening>
 ```
 
 ```{toctree}

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -15,6 +15,10 @@
 
 set -euo pipefail
 
+# Harden: limit process count to prevent fork bombs (ref: #809)
+ulimit -Hu 512 2>/dev/null || true
+ulimit -Su 512 2>/dev/null || true
+
 # SECURITY: Lock down PATH so the agent cannot inject malicious binaries
 # into commands executed by the entrypoint or auto-pair watcher.
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -16,8 +16,8 @@
 set -euo pipefail
 
 # Harden: limit process count to prevent fork bombs (ref: #809)
-ulimit -Hu 512 2>/dev/null || true
-ulimit -Su 512 2>/dev/null || true
+ulimit -Hu 512 || { echo "[SECURITY] Failed to set hard nproc limit" >&2; exit 1; }
+ulimit -Su 512 || { echo "[SECURITY] Failed to set soft nproc limit" >&2; exit 1; }
 
 # SECURITY: Lock down PATH so the agent cannot inject malicious binaries
 # into commands executed by the entrypoint or auto-pair watcher.


### PR DESCRIPTION
Hardens the sandbox image: removes gcc/g++/make/netcat from runtime, adds ulimit -u 512 for fork bomb protection, adds docs for cap-drop=ALL. Fixes #807, #808, #809.

Note: #797 (capability dropping) is documented in the hardening guide but not enforced at container level — that needs a runtime/compose-level fix.

AI-assisted: Built with Claude, reviewed by human.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a sandbox hardening guide with deployment examples for image optimization, process limits, capability drops, read-only filesystems, and tmpfs usage.

* **Chores**
  * Reduced runtime image contents by removing build and network tooling.
  * Enforced a 512-process limit at container startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->