### PR TITLE
ci: add SPDX license header check for source files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -146,3 +146,51 @@ jobs:
 
       - name: Run gateway isolation E2E tests
         run: NEMOCLAW_TEST_IMAGE=nemoclaw-production bash test/e2e-gateway-isolation.sh
+
+  check-spdx-headers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get changed source files
+        id: changed
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          # File types that must carry SPDX headers.
+          files=$(git diff --name-only --diff-filter=ACMRT "$base" -- \
+            '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs' '*.py' '*.sh' '*.yaml' '*.yml' \
+            || true)
+          # Exclude paths that are generated, vendored, or don't support comments.
+          filtered=""
+          for f in $files; do
+            case "$f" in
+              node_modules/*|dist/*|build/*|docs/*|nemoclaw/node_modules/*|.venv/*|_deps/*) continue ;;
+            esac
+            filtered="$filtered $f"
+          done
+          filtered="${filtered# }"
+          if [ -z "$filtered" ]; then
+            echo "No source files changed."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "$filtered"
+            echo "files<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$filtered" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check SPDX license headers
+        if: steps.changed.outputs.skip != 'true'
+        run: |
+          echo ""
+          echo "Expected header (comment style varies by language):"
+          echo "  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+          echo "  SPDX-License-Identifier: Apache-2.0"
+          echo ""
+          # shellcheck disable=SC2086
+          bash scripts/check-spdx-headers.sh ${{ steps.changed.outputs.files }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hooks `scripts/check-spdx-headers.sh` into the PR workflow so missing license headers get caught in CI. The script was already wired into prek pre-commit hooks with `--fix`, but contributors who skip local hooks could push files without headers and nobody would notice until review.

## Related Issue

Fixes #551

## Changes

- Add `check-spdx-headers` job to `.github/workflows/pr.yaml`
- Job diffs source files (`.ts`, `.js`, `.py`, `.sh`, `.yaml`, `.yml`) against PR base
- Excludes generated/vendored paths (`node_modules/`, `dist/`, `docs/`, `.venv/`)
- Runs in check-only mode (no `--fix`) — fails with file list + expected header on missing headers
- Skips cleanly when no matching source files are in the diff

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

Ran `check-spdx-headers.sh` locally against existing source files — all pass. Confirmed it correctly rejects a test file without the header (exits 1, prints filename).

## Checklist

### General

- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CI check to validate SPDX-style file headers in source contributions.
  * The check targets typical code files, ignores generated/build/vendor directories, and prints expected header text before running validation.
  * The validation is skipped automatically when no relevant files are changed to avoid unnecessary blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->