### PR TITLE
fix: fall back to non-root mode when gosu is blocked by no-new-privileges

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -24,7 +24,7 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 # own name as $1 would cause infinite recursion via the NEMOCLAW_CMD exec path.
 # Only strip from $1 — later args with this name are legitimate user arguments.
 case "${1:-}" in
-nemoclaw-start | /usr/local/bin/nemoclaw-start) shift ;;
+  nemoclaw-start | /usr/local/bin/nemoclaw-start) shift ;;
 esac
 NEMOCLAW_CMD=("$@")
 CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:18789}"

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -103,7 +103,12 @@ PYTOKEN
 start_auto_pair() {
   # Run auto-pair as sandbox user (it talks to the gateway via CLI)
   # SECURITY: Pass resolved openclaw path to prevent PATH hijacking
-  OPENCLAW_BIN="$OPENCLAW" nohup gosu sandbox python3 - <<'PYAUTOPAIR' >>/tmp/auto-pair.log 2>&1 &
+  # When running as non-root, skip gosu (we're already the sandbox user)
+  local run_prefix=""
+  if [ "$(id -u)" -eq 0 ]; then
+    run_prefix="gosu sandbox"
+  fi
+  OPENCLAW_BIN="$OPENCLAW" nohup $run_prefix python3 - <<'PYAUTOPAIR' >>/tmp/auto-pair.log 2>&1 &
 import json
 import os
 import subprocess

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -24,7 +24,7 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 # own name as $1 would cause infinite recursion via the NEMOCLAW_CMD exec path.
 # Only strip from $1 — later args with this name are legitimate user arguments.
 case "${1:-}" in
-  nemoclaw-start | /usr/local/bin/nemoclaw-start) shift ;;
+nemoclaw-start | /usr/local/bin/nemoclaw-start) shift ;;
 esac
 NEMOCLAW_CMD=("$@")
 CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:18789}"
@@ -169,6 +169,32 @@ PYAUTOPAIR
 
 echo 'Setting up NemoClaw...'
 [ -f .env ] && chmod 600 .env
+
+# ── Non-root fallback ──────────────────────────────────────────
+# OpenShell runs containers with --security-opt=no-new-privileges, which
+# blocks gosu's setuid syscall. When we're not root, skip privilege
+# separation and run everything as the current user (sandbox).
+# Gateway process isolation is not available in this mode.
+if [ "$(id -u)" -ne 0 ]; then
+  echo "[gateway] Running as non-root (uid=$(id -u)) — privilege separation disabled"
+  verify_config_integrity || true
+  write_auth_profile
+
+  if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
+    exec "${NEMOCLAW_CMD[@]}"
+  fi
+
+  # Start gateway in background, auto-pair, then wait
+  "$OPENCLAW" gateway run &
+  GATEWAY_PID=$!
+  echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)"
+  start_auto_pair
+  print_dashboard_urls
+  wait "$GATEWAY_PID"
+  exit $?
+fi
+
+# ── Root path (full privilege separation via gosu) ─────────────
 
 # Verify config integrity before starting anything
 verify_config_integrity

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -104,11 +104,11 @@ start_auto_pair() {
   # Run auto-pair as sandbox user (it talks to the gateway via CLI)
   # SECURITY: Pass resolved openclaw path to prevent PATH hijacking
   # When running as non-root, skip gosu (we're already the sandbox user)
-  local run_prefix=""
+  local run_prefix=()
   if [ "$(id -u)" -eq 0 ]; then
-    run_prefix="gosu sandbox"
+    run_prefix=(gosu sandbox)
   fi
-  OPENCLAW_BIN="$OPENCLAW" nohup $run_prefix python3 - <<'PYAUTOPAIR' >>/tmp/auto-pair.log 2>&1 &
+  OPENCLAW_BIN="$OPENCLAW" nohup "${run_prefix[@]}" python3 - <<'PYAUTOPAIR' >>/tmp/auto-pair.log 2>&1 &
 import json
 import os
 import subprocess

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -182,7 +182,10 @@ echo 'Setting up NemoClaw...'
 # Gateway process isolation is not available in this mode.
 if [ "$(id -u)" -ne 0 ]; then
   echo "[gateway] Running as non-root (uid=$(id -u)) — privilege separation disabled"
-  verify_config_integrity || true
+  export HOME=/sandbox
+  if ! verify_config_integrity; then
+    echo "[SECURITY WARNING] Config integrity check failed — proceeding anyway (non-root mode)"
+  fi
   write_auth_profile
 
   if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Detect non-root at entrypoint startup and skip gosu privilege separation
- Fixes `"failed switching to 'sandbox': operation not permitted"` when OpenShell runs containers with `--security-opt=no-new-privileges`
- Gateway isolation (separate gateway user) still works when running as root (standalone Docker, Brev direct)

Regression from #721.

## Test plan

- [ ] `nemoclaw onboard` succeeds on Brev one-click deployment
- [ ] `nemoclaw onboard` succeeds on local Docker (root entrypoint path)
- [ ] Gateway isolation e2e tests pass (root path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now reliably handles both root and non-root environments to avoid permission issues.
  * Gateway can start and run in the background without elevated privileges; startup waits for the gateway and exits with its status.
  * Configuration integrity checks are tolerant in non-root mode, and dashboard URLs are consistently printed on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->