### PR TITLE
docs(policy): fix openshell policy set CLI examples

### DIFF
--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -158,7 +158,7 @@ Available presets:
 To apply a preset to a running sandbox, pass it as a policy file:
 
 ```console
-$ openshell policy set --policy nemoclaw-blueprint/policies/presets/pypi.yaml my-sandbox
+$ openshell policy set --policy nemoclaw-blueprint/policies/presets/pypi.yaml my-assistant
 ```
 
 To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.

--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -123,7 +123,7 @@ Follow the same format as the baseline policy in `nemoclaw-blueprint/policies/op
 Use the OpenShell CLI to apply the policy update:
 
 ```console
-$ openshell policy set <policy-file>
+$ openshell policy set --policy <policy-file> <sandbox-name>
 ```
 
 The change takes effect immediately.
@@ -158,7 +158,7 @@ Available presets:
 To apply a preset to a running sandbox, pass it as a policy file:
 
 ```console
-$ openshell policy set nemoclaw-blueprint/policies/presets/pypi.yaml
+$ openshell policy set --policy nemoclaw-blueprint/policies/presets/pypi.yaml my-sandbox
 ```
 
 To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -83,7 +83,7 @@ Follow the same format as the baseline policy in `nemoclaw-blueprint/policies/op
 Use the OpenShell CLI to apply the policy update:
 
 ```console
-$ openshell policy set <policy-file>
+$ openshell policy set --policy <policy-file> <sandbox-name>
 ```
 
 The change takes effect immediately.
@@ -118,7 +118,7 @@ Available presets:
 To apply a preset to a running sandbox, pass it as a policy file:
 
 ```console
-$ openshell policy set nemoclaw-blueprint/policies/presets/pypi.yaml
+$ openshell policy set --policy nemoclaw-blueprint/policies/presets/pypi.yaml my-sandbox
 ```
 
 To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -118,7 +118,7 @@ Available presets:
 To apply a preset to a running sandbox, pass it as a policy file:
 
 ```console
-$ openshell policy set --policy nemoclaw-blueprint/policies/presets/pypi.yaml my-sandbox
+$ openshell policy set --policy nemoclaw-blueprint/policies/presets/pypi.yaml my-assistant
 ```
 
 To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.

--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -131,5 +131,5 @@ $ nemoclaw onboard
 Apply policy updates to a running sandbox without restarting:
 
 ```console
-$ openshell policy set <policy-file>
+$ openshell policy set --policy <policy-file> <sandbox-name>
 ```


### PR DESCRIPTION
## Summary

Updates all `openshell policy set` examples to match the current CLI: **`openshell policy set --policy <policy-file> <sandbox-name>`** (instead of the outdated `openshell policy set <policy-file>` form).

## Related Issue

N/A (documentation alignment with OpenShell CLI).

## Changes

- `README.md` — dynamic policy row in the network-policy table
- `docs/network-policy/customize-network-policy.md` — apply policy and preset examples
- `docs/reference/network-policies.md` — running-sandbox policy update example
- `.agents/skills/nemoclaw-manage-policy/SKILL.md` — same examples for agent workflows

## Type of Change

- [x] Doc only. Prose changes without code sample modifications.

## Checklist

- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [x] I have read and followed the [style guide](docs/CONTRIBUTING.md).
- [x] No secrets, API keys, or credentials committed.
- [x] Doc pages updated for any user-facing behavior changes.

Signed-off-by: Ruben Hagege <rhagege@nvidia.com>