### PR TITLE
fix(security): reject unsafe HOME fallback in credential storage

### DIFF
--- a/bin/lib/credentials.js
+++ b/bin/lib/credentials.js
@@ -10,11 +10,28 @@ const { execFileSync } = require("child_process");
 const UNSAFE_HOME_PATHS = new Set(["/tmp", "/var/tmp", "/dev/shm", "/"]);
 
 function resolveHomeDir() {
-  const home = process.env.HOME || os.homedir();
-  if (!home || UNSAFE_HOME_PATHS.has(home)) {
+  const raw = process.env.HOME || os.homedir();
+  if (!raw) {
     throw new Error(
       "Cannot determine safe home directory for credential storage. " +
-      "HOME resolves to '" + (home || "") + "' which is world-readable. " +
+      "Set the HOME environment variable to a user-owned directory."
+    );
+  }
+  const home = path.resolve(raw);
+  try {
+    const real = fs.realpathSync(home);
+    if (UNSAFE_HOME_PATHS.has(real)) {
+      throw new Error(
+        "Cannot store credentials: HOME resolves to '" + real + "' which is world-readable. " +
+        "Set the HOME environment variable to a user-owned directory."
+      );
+    }
+  } catch (e) {
+    if (e.code !== "ENOENT") throw e;
+  }
+  if (UNSAFE_HOME_PATHS.has(home)) {
+    throw new Error(
+      "Cannot store credentials: HOME resolves to '" + home + "' which is world-readable. " +
       "Set the HOME environment variable to a user-owned directory."
     );
   }
@@ -53,9 +70,11 @@ function saveCredential(key, value) {
   const dir = getCredsDir();
   const file = getCredsFile();
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(dir, 0o700);
   const creds = loadCredentials();
   creds[key] = normalizeCredentialValue(value);
   fs.writeFileSync(file, JSON.stringify(creds, null, 2), { mode: 0o600 });
+  fs.chmodSync(file, 0o600);
 }
 
 function getCredential(key) {

--- a/bin/lib/credentials.js
+++ b/bin/lib/credentials.js
@@ -3,16 +3,42 @@
 
 const fs = require("fs");
 const path = require("path");
+const os = require("os");
 const readline = require("readline");
 const { execFileSync } = require("child_process");
 
-const CREDS_DIR = path.join(process.env.HOME || "/tmp", ".nemoclaw");
-const CREDS_FILE = path.join(CREDS_DIR, "credentials.json");
+const UNSAFE_HOME_PATHS = new Set(["/tmp", "/var/tmp", "/dev/shm", "/"]);
+
+function resolveHomeDir() {
+  const home = process.env.HOME || os.homedir();
+  if (!home || UNSAFE_HOME_PATHS.has(home)) {
+    throw new Error(
+      "Cannot determine safe home directory for credential storage. " +
+      "HOME resolves to '" + (home || "") + "' which is world-readable. " +
+      "Set the HOME environment variable to a user-owned directory."
+    );
+  }
+  return home;
+}
+
+let _credsDir = null;
+let _credsFile = null;
+
+function getCredsDir() {
+  if (!_credsDir) _credsDir = path.join(resolveHomeDir(), ".nemoclaw");
+  return _credsDir;
+}
+
+function getCredsFile() {
+  if (!_credsFile) _credsFile = path.join(getCredsDir(), "credentials.json");
+  return _credsFile;
+}
 
 function loadCredentials() {
   try {
-    if (fs.existsSync(CREDS_FILE)) {
-      return JSON.parse(fs.readFileSync(CREDS_FILE, "utf-8"));
+    const file = getCredsFile();
+    if (fs.existsSync(file)) {
+      return JSON.parse(fs.readFileSync(file, "utf-8"));
     }
   } catch { /* ignored */ }
   return {};
@@ -24,10 +50,12 @@ function normalizeCredentialValue(value) {
 }
 
 function saveCredential(key, value) {
-  fs.mkdirSync(CREDS_DIR, { recursive: true, mode: 0o700 });
+  const dir = getCredsDir();
+  const file = getCredsFile();
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const creds = loadCredentials();
   creds[key] = normalizeCredentialValue(value);
-  fs.writeFileSync(CREDS_FILE, JSON.stringify(creds, null, 2), { mode: 0o600 });
+  fs.writeFileSync(file, JSON.stringify(creds, null, 2), { mode: 0o600 });
 }
 
 function getCredential(key) {
@@ -255,9 +283,7 @@ async function ensureGithubToken() {
   console.log("");
 }
 
-module.exports = {
-  CREDS_DIR,
-  CREDS_FILE,
+const exports_ = {
   loadCredentials,
   normalizeCredentialValue,
   saveCredential,
@@ -267,3 +293,8 @@ module.exports = {
   ensureGithubToken,
   isRepoPrivate,
 };
+
+Object.defineProperty(exports_, "CREDS_DIR", { get: getCredsDir, enumerable: true });
+Object.defineProperty(exports_, "CREDS_FILE", { get: getCredsFile, enumerable: true });
+
+module.exports = exports_;


### PR DESCRIPTION
## Summary

- When `HOME` is unset, `credentials.js` falls back to `/tmp`, making `credentials.json` world-readable (CWE-522, NVBUG 6002816)
- Replaces eager module-level `const CREDS_DIR = path.join(process.env.HOME || "/tmp", ...)` with lazy getters that validate at access time
- Rejects `/tmp`, `/var/tmp`, `/dev/shm`, and `/` as credential storage locations
- Reads degrade gracefully (return empty `{}`); writes throw a clear error; module import never crashes

## Test plan

- [ ] `NVIDIA_API_KEY` in env + `HOME` unset → `getCredential("NVIDIA_API_KEY")` returns the env value (no file access)
- [ ] `HOME` unset, no env var → `getCredential()` returns `null` (no crash)
- [ ] `HOME=/tmp` → `saveCredential()` throws with actionable error message
- [ ] `HOME=/Users/x` (normal) → credentials saved/loaded as before, mode 0600
- [ ] External code importing `CREDS_DIR` / `CREDS_FILE` gets lazily resolved values via property getters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential storage security by validating and rejecting unsafe home-directory locations to avoid saving credentials to world-readable paths.
  * Enforced explicit filesystem permissions on credential directories and files (restricting access to the owner).
  * Made credential path resolution lazy and more robust, resolving and caching a validated home directory before producing credential paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->