### PR TITLE
fix(security): stop piping curl output directly to sudo bash

### DIFF
--- a/scripts/brev-setup.sh
+++ b/scripts/brev-setup.sh
@@ -40,12 +40,21 @@ export DEBIAN_FRONTEND=noninteractive
 # --- 0. Node.js (needed for services) ---
 if ! command -v node >/dev/null 2>&1; then
   info "Installing Node.js..."
-  # Upstream URL is a rolling release so SHA-256 pinning isn't practical,
-  # but download-then-execute allows inspection and prevents partial-download execution.
+  NODESOURCE_URL="https://deb.nodesource.com/setup_22.x"
+  NODESOURCE_SHA256="575583bbac2fccc0b5edd0dbc03e222d9f9dc8d724da996d22754d6411104fd1"
   (
     tmpdir="$(mktemp -d)"
     trap 'rm -rf "$tmpdir"' EXIT
-    curl -fsSL https://deb.nodesource.com/setup_22.x -o "$tmpdir/setup_node.sh"
+    curl -fsSL "$NODESOURCE_URL" -o "$tmpdir/setup_node.sh"
+    if command -v sha256sum >/dev/null 2>&1; then
+      echo "$NODESOURCE_SHA256  $tmpdir/setup_node.sh" | sha256sum -c - >/dev/null \
+        || fail "NodeSource installer checksum mismatch — expected $NODESOURCE_SHA256"
+    elif command -v shasum >/dev/null 2>&1; then
+      echo "$NODESOURCE_SHA256  $tmpdir/setup_node.sh" | shasum -a 256 -c - >/dev/null \
+        || fail "NodeSource installer checksum mismatch — expected $NODESOURCE_SHA256"
+    else
+      fail "No SHA-256 verification tool found (need sha256sum or shasum)"
+    fi
     sudo -E bash "$tmpdir/setup_node.sh" >/dev/null 2>&1
   )
   sudo apt-get install -y -qq nodejs >/dev/null 2>&1


### PR DESCRIPTION
## Summary

- `brev-setup.sh` pipes `curl` output directly to `sudo -E bash -`, executing arbitrary remote code as root without inspection (CWE-250, NVBUG 6002888)
- Replaces with download-to-tempfile then `sudo -E bash "$tmpfile"` — the script is auditable on disk before root execution
- Temp file cleaned up after execution
- Other `sudo apt-get` and `sudo install` calls are left as-is (they legitimately need root for system package management)

## Test plan

- [ ] Run `brev-setup.sh` on a fresh Brev VM without Node.js — Node.js installs successfully
- [ ] Temp file is removed after execution (`ls /tmp/tmp.*` shows no leftover)
- [ ] If `curl` fails (e.g. no network), `set -e` exits before `sudo bash` runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the installer process to run from a downloaded temporary file instead of streaming, reducing risk during setup.
  * Added checksum verification for the downloaded installer to guard against tampering.
  * Ensured temporary installer artifacts are reliably removed on exit to improve cleanup and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->