### PR TITLE
fix: make gosu install architecture-aware (ARM64 support)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # gosu for privilege separation (gateway vs sandbox user).
 # Install from GitHub release with checksum verification instead of
 # Debian bookworm's ancient 1.14 (2020). Pinned to 1.19 (2025-09).
+# Architecture-aware: downloads the correct binary for amd64 or arm64.
 # hadolint ignore=DL4006
-RUN curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-amd64" \
-    && echo "52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0  /usr/local/bin/gosu" | sha256sum -c - \
+RUN GOSU_ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-${GOSU_ARCH}" \
+    && curl -fsSL -o /tmp/gosu-checksums.txt "https://github.com/tianon/gosu/releases/download/1.19/SHA256SUMS" \
+    && grep "gosu-${GOSU_ARCH}$" /tmp/gosu-checksums.txt | sha256sum -c - \
+    && rm /tmp/gosu-checksums.txt \
     && chmod +x /usr/local/bin/gosu \
     && gosu --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Architecture-aware: downloads the correct binary for amd64 or arm64.
 # hadolint ignore=DL4006
 RUN GOSU_ARCH="$(dpkg --print-architecture)" \
+    && case "$GOSU_ARCH" in \
+         amd64) GOSU_SHA256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0" ;; \
+         arm64) GOSU_SHA256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
+         *) echo "Unsupported gosu arch: $GOSU_ARCH" >&2; exit 1 ;; \
+       esac \
     && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-${GOSU_ARCH}" \
-    && curl -fsSL -o /tmp/gosu-checksums.txt "https://github.com/tianon/gosu/releases/download/1.19/SHA256SUMS" \
-    && grep "gosu-${GOSU_ARCH}$" /tmp/gosu-checksums.txt | sha256sum -c - \
-    && rm /tmp/gosu-checksums.txt \
+    && echo "${GOSU_SHA256}  /usr/local/bin/gosu" | sha256sum -c - \
     && chmod +x /usr/local/bin/gosu \
     && gosu --version
 


### PR DESCRIPTION
## Summary

The gosu binary URL in the Dockerfile is hardcoded to `gosu-amd64`, causing `exec format error` (exit code 126) when building on ARM64/aarch64 hosts (e.g. AWS Graviton `t4g` instances).

## Changes

- Use `dpkg --print-architecture` to download the correct gosu binary (`gosu-amd64` or `gosu-arm64`)
- Fetch `SHA256SUMS` from the gosu release instead of hardcoding the amd64 checksum, so verification works on any architecture

## Before (broken on ARM64)
```dockerfile
RUN curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-amd64" \
    && echo "52c8749d...  /usr/local/bin/gosu" | sha256sum -c - \
```

## After (works on both amd64 and arm64)
```dockerfile
RUN GOSU_ARCH="$(dpkg --print-architecture)" \
    && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-${GOSU_ARCH}" \
    && curl -fsSL -o /tmp/gosu-checksums.txt "https://github.com/tianon/gosu/releases/download/1.19/SHA256SUMS" \
    && grep "gosu-${GOSU_ARCH}$" /tmp/gosu-checksums.txt | sha256sum -c - \
```

## Testing

Tested on AWS EC2 `t4g.medium` (ARM64 Graviton): `nemoclaw onboard` completes successfully with `gosu-arm64`, sandbox reaches Ready state.

Introduced in #721.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build/install now detects CPU architecture and selects the appropriate helper binary automatically, improving cross-platform compatibility.
  * Downloads are verified against the corresponding upstream checksums at install time to ensure integrity.
  * The build fails explicitly on unsupported architectures and removes temporary verification artifacts after installation, improving reliability and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->