### PR TITLE
fix(docker): use multi-arch gosu binary for DGX Spark ARM64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install from GitHub release with checksum verification instead of
 # Debian bookworm's ancient 1.14 (2020). Pinned to 1.19 (2025-09).
 # hadolint ignore=DL4006
-RUN curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-amd64" \
-    && echo "52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0  /usr/local/bin/gosu" | sha256sum -c - \
+RUN GOSU_ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-${GOSU_ARCH}" \
+    && curl -fsSL -o /tmp/gosu-sha256sums "https://github.com/tianon/gosu/releases/download/1.19/SHA256SUMS" \
+    && grep "gosu-${GOSU_ARCH}$" /tmp/gosu-sha256sums | sha256sum -c - \
+    && rm /tmp/gosu-sha256sums \
     && chmod +x /usr/local/bin/gosu \
     && gosu --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # hadolint ignore=DL4006
 RUN GOSU_ARCH="$(dpkg --print-architecture)" \
     && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-${GOSU_ARCH}" \
-    && curl -fsSL -o /tmp/gosu-sha256sums "https://github.com/tianon/gosu/releases/download/1.19/SHA256SUMS" \
-    && grep "gosu-${GOSU_ARCH}$" /tmp/gosu-sha256sums | sha256sum -c - \
-    && rm /tmp/gosu-sha256sums \
+    && case "${GOSU_ARCH}" in \
+         amd64) GOSU_SHA256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0" ;; \
+         arm64) GOSU_SHA256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
+         *) echo "Unsupported architecture: ${GOSU_ARCH}" >&2; exit 1 ;; \
+       esac \
+    && echo "${GOSU_SHA256}  /usr/local/bin/gosu" | sha256sum -c - \
     && chmod +x /usr/local/bin/gosu \
     && gosu --version
 


### PR DESCRIPTION
## Summary

Fix gosu binary architecture detection to support ARM64 platforms (DGX Spark GB10).

## Related Issue

Closes #877

## Changes

The Dockerfile hardcoded `gosu-amd64`, causing `Exec format error` on ARM64:

```
/bin/sh: 1: gosu: Exec format error
```

**Fix:** Use `dpkg --print-architecture` to select the correct binary at build time and verify the checksum dynamically from the upstream SHA256SUMS file.

| Before | After |
|--------|-------|
| Downloads `gosu-amd64` always | Downloads `gosu-${ARCH}` based on platform |
| Hardcoded amd64 checksum | Fetches + verifies from upstream SHA256SUMS |

## Testing

- Verified SHA256SUMS file contains checksums for both `gosu-amd64` and `gosu-arm64`
- amd64 checksum matches the previously hardcoded value (`52c8749d...`)
- `dpkg --print-architecture` returns `amd64` or `arm64` on respective platforms

## Checklist

- [x] Addresses a single issue
- [x] Maintains checksum verification (security)
- [x] No breaking changes for existing amd64 builds
- [x] Follows PR template format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container build now auto-detects system architecture and selects appropriate artifacts instead of a single hardcoded configuration.
  * Improved security with per-architecture checksum verification for downloaded build dependencies.
  * Builds on unsupported architectures now fail early with a clear error to avoid partial/invalid installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->