### PR TITLE
chore(docker, openclaw): Updating openclaw to 2026.3.13 as per https:…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
     && chown -R sandbox:sandbox /sandbox/.openclaw /sandbox/.openclaw-data
 
 # Install OpenClaw CLI + PyYAML for inline Python scripts in e2e tests
-RUN npm install -g openclaw@2026.3.11 \
+RUN npm install -g openclaw@2026.3.13 \
     && pip3 install --no-cache-dir --break-system-packages "pyyaml==6.0.3"
 
 # Copy built plugin and blueprint into the sandbox

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "openclaw": "2026.3.11"
+        "openclaw": "2026.3.13"
       },
       "bin": {
         "nemoclaw": "bin/nemoclaw.js"
@@ -10117,8 +10117,8 @@
       }
     },
     "node_modules/openclaw": {
-      "version": "2026.3.11",
-      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.3.11.tgz",
+      "version": "2026.3.13",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.3.13.tgz",
       "integrity": "sha512-bxwiBmHPakwfpY5tqC9lrV5TCu5PKf0c1bHNc3nhrb+pqKcPEWV4zOjDVFLQUHr98ihgWA+3pacy4b3LQ8wduQ==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {
-    "openclaw": "2026.3.11"
+    "openclaw": "2026.3.13"
   },
   "files": [
     "bin/",

--- a/test/Dockerfile.sandbox
+++ b/test/Dockerfile.sandbox
@@ -26,7 +26,7 @@ RUN mkdir -p /sandbox/.openclaw/workspace /sandbox/.openclaw/extensions /sandbox
         '{' \
         '  "wizard": {' \
         '    "lastRunAt": "2026-03-14T00:00:00.000Z",' \
-        '    "lastRunVersion": "2026.3.11",' \
+        '    "lastRunVersion": "2026.3.13",' \
         '    "lastRunCommand": "doctor",' \
         '    "lastRunMode": "local"' \
         '  },' \
@@ -36,7 +36,7 @@ RUN mkdir -p /sandbox/.openclaw/workspace /sandbox/.openclaw/extensions /sandbox
         '    "restart": true' \
         '  },' \
         '  "meta": {' \
-        '    "lastTouchedVersion": "2026.3.11",' \
+        '    "lastTouchedVersion": "2026.3.13",' \
         '    "lastTouchedAt": "2026-03-14T00:00:00.000Z"' \
         '  }' \
         '}' > /sandbox/.openclaw/openclaw.json \
@@ -73,7 +73,7 @@ RUN mkdir -p /sandbox/openclaw-state/extensions /sandbox/openclaw-state/skills /
         '    }' \
         '  },' \
         '  "meta": {' \
-        '    "lastTouchedVersion": "2026.3.11",' \
+        '    "lastTouchedVersion": "2026.3.13",' \
         '    "lastTouchedAt": "2026-03-14T00:00:00.000Z"' \
         '  }' \
         '}' > /sandbox/config/openclaw.json \

--- a/test/e2e-test.sh
+++ b/test/e2e-test.sh
@@ -253,7 +253,7 @@ if node --input-type=module -e "
   // Verify restoration
   const restored = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
   const version = (restored.meta || {}).lastTouchedVersion;
-  if (version !== '2026.3.11') throw new Error('Restored config wrong: ' + JSON.stringify(restored));
+  if (version !== '2026.3.13') throw new Error('Restored config wrong: ' + JSON.stringify(restored));
   if ('corrupted' in restored) throw new Error('Config still corrupted after rollback');
   console.log('Restored config: ' + JSON.stringify(restored));
 "; then

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -28,7 +28,7 @@ function writeNodeStub(fakeBin) {
 if [ "$1" = "--version" ] || [ "$1" = "-v" ]; then echo "v22.14.0"; exit 0; fi
 if [ "$1" = "-e" ]; then
   if [[ "$2" == *"dependencies.openclaw"* ]]; then
-    echo "2026.3.11"
+    echo "2026.3.13"
     exit 0
   fi
   exit 0
@@ -135,7 +135,7 @@ printf '%s\\n' "$*" >> "$GIT_LOG_PATH"
 if [ "$1" = "clone" ]; then
   target="\${@: -1}"
   mkdir -p "$target/nemoclaw"
-  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.13"}}' > "$target/package.json"
   echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
   exit 0
 fi
@@ -229,7 +229,7 @@ exit 99
 if [ "$1" = "clone" ]; then
   target="\${@: -1}"
   mkdir -p "$target/nemoclaw"
-  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.13"}}' > "$target/package.json"
   echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
   exit 0
 fi
@@ -391,7 +391,7 @@ exit 99
 if [ "$1" = "clone" ]; then
   target="\${@: -1}"
   mkdir -p "$target/nemoclaw"
-  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.13"}}' > "$target/package.json"
   echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
   exit 0
 fi
@@ -530,7 +530,7 @@ exit 0
 if [ "$1" = "pack" ]; then
   tmpdir="$4"
   mkdir -p "$tmpdir/package"
-  tar -czf "$tmpdir/openclaw-2026.3.11.tgz" -C "$tmpdir" package
+  tar -czf "$tmpdir/openclaw-2026.3.13.tgz" -C "$tmpdir" package
   exit 0
 fi
 if [ "$1" = "install" ]; then exit 0; fi
@@ -594,7 +594,7 @@ fi`,
 if [ "$1" = "clone" ]; then
   target="\${@: -1}"
   mkdir -p "$target/nemoclaw"
-  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.13"}}' > "$target/package.json"
   echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
   exit 0
 fi
@@ -657,7 +657,7 @@ exit 99
 if [ "$1" = "clone" ]; then
   target="\${@: -1}"
   mkdir -p "$target/nemoclaw"
-  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.13"}}' > "$target/package.json"
   echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
   exit 0
 fi


### PR DESCRIPTION
…//github.com/NVIDIA/NemoClaw/issues/328

To fix the issues mentioned in https://github.com/NVIDIA/NemoClaw/issues/328, the openclaw is getting updated

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [ ] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the OpenClaw CLI version from 2026.3.11 to 2026.3.13 across build/runtime images, test suites, sandbox metadata, and verification flows. Tests and sandbox artifacts were updated to match the new CLI version. No functional changes to application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->