### PR TITLE
docs: add nemoclaw debug command to CLI reference and troubleshooting

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -194,7 +194,8 @@ $ nemoclaw status
 ### `nemoclaw debug`
 
 Collect diagnostic information for bug reports.
-The command gathers system, GPU, Docker, OpenShell, and sandbox internals into a single report with secrets automatically redacted.
+The command gathers system, GPU, Docker, OpenShell, and sandbox internals into a single report with known secret patterns automatically redacted.
+Review the output for any remaining sensitive data before sharing.
 
 ```console
 $ nemoclaw debug [--quick] [--sandbox NAME] [--output PATH]

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -191,6 +191,33 @@ Show the sandbox list and the status of auxiliary services.
 $ nemoclaw status
 ```
 
+### `nemoclaw debug`
+
+Collect diagnostic information for bug reports.
+The command gathers system, GPU, Docker, OpenShell, and sandbox internals into a single report with secrets automatically redacted.
+
+```console
+$ nemoclaw debug [--quick] [--sandbox NAME] [--output PATH]
+```
+
+| Flag | Description |
+|---|---|
+| `--quick` | Collect minimal diagnostics only (skips disk, memory-sorted process lists, GPU monitoring, network, and kernel sections). |
+| `--sandbox NAME` | Target a specific sandbox. Defaults to `$NEMOCLAW_SANDBOX` or auto-detects the first sandbox. |
+| `--output PATH` | Write a compressed tarball to `PATH` for attaching to GitHub issues. |
+
+To save a tarball for a bug report:
+
+```console
+$ nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz
+```
+
+The script can also run without a local clone:
+
+```console
+$ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/main/scripts/debug.sh | bash -s -- --quick
+```
+
 ### `nemoclaw setup-spark`
 
 Set up NemoClaw on DGX Spark.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -204,7 +204,7 @@ $ nemoclaw debug [--quick] [--sandbox NAME] [--output PATH]
 | Flag | Description |
 |---|---|
 | `--quick` | Collect minimal diagnostics only (skips disk, memory-sorted process lists, GPU monitoring, network, and kernel sections). |
-| `--sandbox NAME` | Target a specific sandbox. Defaults to `$NEMOCLAW_SANDBOX` or auto-detects the first sandbox. |
+| `--sandbox NAME` | Target a specific sandbox (defaults to `$NEMOCLAW_SANDBOX` or auto-detects the first). |
 | `--output PATH` | Write a compressed tarball to `PATH` for attaching to GitHub issues. |
 
 To save a tarball for a bug report:
@@ -229,22 +229,6 @@ After the fixes complete, the script prompts you to run `nemoclaw onboard` to co
 ```console
 $ sudo nemoclaw setup-spark
 ```
-
-### `nemoclaw debug`
-
-Collect diagnostics for bug reports.
-Gathers system info, Docker state, gateway logs, and sandbox status into a summary or tarball.
-Use `--sandbox <name>` to target a specific sandbox, `--quick` for a smaller snapshot, or `--output <path>` to save a tarball that you can attach to an issue.
-
-```console
-$ nemoclaw debug [--quick] [--sandbox NAME] [--output PATH]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--quick` | Collect minimal diagnostics only |
-| `--sandbox NAME` | Target a specific sandbox (default: auto-detect) |
-| `--output PATH` | Write diagnostics tarball to the given path |
 
 ### `nemoclaw uninstall`
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -24,6 +24,14 @@ status: published
 
 This page covers common issues you may encounter when installing, onboarding, or running NemoClaw, along with their resolution steps.
 
+:::{admonition} Collect diagnostics first
+:class: tip
+
+Run `nemoclaw debug` to collect system, GPU, Docker, OpenShell, and sandbox diagnostics into a single redacted report.
+Use `nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz` to save a tarball you can attach to a [GitHub issue](https://github.com/NVIDIA/NemoClaw/issues/new).
+See the [debug command reference](commands.md#nemoclaw-debug) for all flags.
+:::
+
 :::{admonition} Get Help
 :class: tip
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -27,7 +27,8 @@ This page covers common issues you may encounter when installing, onboarding, or
 :::{admonition} Collect diagnostics first
 :class: tip
 
-Run `nemoclaw debug` to collect system, GPU, Docker, OpenShell, and sandbox diagnostics into a single redacted report.
+Run `nemoclaw debug` to collect system, GPU, Docker, OpenShell, and sandbox diagnostics into a single report with known secret patterns redacted.
+Review the output for any remaining sensitive data before sharing.
 Use `nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz` to save a tarball you can attach to a [GitHub issue](https://github.com/NVIDIA/NemoClaw/issues/new).
 See the [debug command reference](commands.md#nemoclaw-debug) for all flags.
 :::


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [x] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new `nemoclaw debug` command guide describing generating a single, consolidated diagnostics report with automatic redaction, flags for quick runs, sandbox scoping, and outputting a compressed report.
  * Updated troubleshooting guidance to recommend running the debug command, reviewing/redacting any remaining sensitive data, optionally saving the tarball for issue attachments, and including a remote-run example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->