### PR TITLE
refactor(install): show post-install message last for visibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -529,7 +529,7 @@ run_onboard() {
   fi
 }
 
-# 6. Post-install message
+# 6. Post-install message (printed last — after onboarding — so PATH hints stay visible)
 # ---------------------------------------------------------------------------
 post_install_message() {
   # Only show shell reload instructions when Node was installed via a
@@ -598,7 +598,6 @@ main() {
   # install_or_upgrade_ollama
   install_nemoclaw
   verify_nemoclaw
-  post_install_message
 
   step 3 "Onboarding"
   if command_exists nemoclaw; then
@@ -608,6 +607,7 @@ main() {
   fi
 
   print_done
+  post_install_message
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- Move `post_install_message()` call after onboarding so PATH hints stay visible to the user

Squash-merge of #847 with a signed commit (original PR from fork lacked verified signatures).

Co-authored-by: Hagege Ruben <20857346+HagegeR@users.noreply.github.com>

## Test plan
- [x] Run `install.sh` and verify post-install message appears after onboarding completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the installation sequence to display post-installation messaging after the onboarding process completes rather than during earlier setup steps, ensuring users receive information at a more appropriate point in their setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->