### PR TITLE
feat(security): add tamper-evident audit chain logger

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "nemoclaw-user-reference"
-description: "Describes how NemoClaw combines a CLI plugin with a versioned blueprint to move OpenClaw into a controlled sandbox. Use when looking up NemoClaw architecture, plugin structure, or blueprint design. Lists all slash commands and standalone NemoClaw CLI commands. Use when looking up a command, checking command syntax, or browsing the CLI reference. Documents baseline network policy, filesystem rules, and operator approval flow. Use when reviewing default network policies, understanding egress controls, or looking up the approval flow. Diagnoses and resolves common NemoClaw installation, onboarding, and runtime issues. Use when troubleshooting errors, debugging sandbox problems, or resolving setup failures."
+description: "Describes how NemoClaw combines a CLI plugin with a versioned blueprint to move OpenClaw into a controlled sandbox. Use when looking up NemoClaw architecture, plugin structure, or blueprint design. References for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities. Lists all slash commands and standalone NemoClaw CLI commands. Use when looking up a command, checking command syntax, or browsing the CLI reference. Documents baseline network policy, filesystem rules, and operator approval flow. Use when reviewing default network policies, understanding egress controls, or looking up the approval flow. Diagnoses and resolves common NemoClaw installation, onboarding, and runtime issues. Use when troubleshooting errors, debugging sandbox problems, or resolving setup failures."
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -13,6 +13,7 @@ Describes how NemoClaw combines a CLI plugin with a versioned blueprint to move 
 ## Reference
 
 - [NemoClaw Architecture: Plugin, Blueprint, and Sandbox Structure](references/architecture.md)
+- [NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log](references/audit-chain.md)
 - [NemoClaw CLI Commands Reference](references/commands.md)
 - [NemoClaw Network Policies: Baseline Rules and Operator Approval](references/network-policies.md)
 - [NemoClaw Troubleshooting Guide](references/troubleshooting.md)

--- a/.agents/skills/nemoclaw-user-reference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "nemoclaw-user-reference"
-description: "Describes how NemoClaw combines a CLI plugin with a versioned blueprint to move OpenClaw into a controlled sandbox. Use when looking up NemoClaw architecture, plugin structure, or blueprint design. References for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities. Lists all slash commands and standalone NemoClaw CLI commands. Use when looking up a command, checking command syntax, or browsing the CLI reference. Documents baseline network policy, filesystem rules, and operator approval flow. Use when reviewing default network policies, understanding egress controls, or looking up the approval flow. Diagnoses and resolves common NemoClaw installation, onboarding, and runtime issues. Use when troubleshooting errors, debugging sandbox problems, or resolving setup failures."
+description: "Describes how NemoClaw combines a CLI plugin with a versioned blueprint to move OpenClaw into a controlled sandbox. Use when looking up NemoClaw architecture, plugin structure, or blueprint design. References for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities. Use when looking up audit chain entry format, hash chaining behavior, or the verify/export/tail API. Lists all slash commands and standalone NemoClaw CLI commands. Use when looking up a command, checking command syntax, or browsing the CLI reference. Documents baseline network policy, filesystem rules, and operator approval flow. Use when reviewing default network policies, understanding egress controls, or looking up the approval flow. Diagnoses and resolves common NemoClaw installation, onboarding, and runtime issues. Use when troubleshooting errors, debugging sandbox problems, or resolving setup failures."
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -13,7 +13,7 @@ Describes how NemoClaw combines a CLI plugin with a versioned blueprint to move 
 ## Reference
 
 - [NemoClaw Architecture: Plugin, Blueprint, and Sandbox Structure](references/architecture.md)
-- [NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log](references/audit-chain.md)
+- [NemoClaw Audit Chain: Tamper-Evident Hash-Chained Audit Log](references/audit-chain.md)
 - [NemoClaw CLI Commands Reference](references/commands.md)
 - [NemoClaw Network Policies: Baseline Rules and Operator Approval](references/network-policies.md)
 - [NemoClaw Troubleshooting Guide](references/troubleshooting.md)

--- a/.agents/skills/nemoclaw-user-reference/references/audit-chain.md
+++ b/.agents/skills/nemoclaw-user-reference/references/audit-chain.md
@@ -1,23 +1,5 @@
----
-title:
-  page: "NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log"
-  nav: "Audit Chain"
-description: "Reference for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities."
-keywords: ["nemoclaw audit chain", "hash chain", "tamper detection", "audit log"]
-topics: ["generative_ai", "ai_agents"]
-tags: ["openclaw", "openshell", "security", "audit", "integrity"]
-content:
-  type: reference
-  difficulty: intermediate
-  audience: ["developer", "engineer"]
-status: published
----
-
-<!--
-  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-  SPDX-License-Identifier: Apache-2.0
--->
-
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 # NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log
 
 The audit chain module writes tamper-evident log entries in JSONL format.

--- a/.agents/skills/nemoclaw-user-reference/references/audit-chain.md
+++ b/.agents/skills/nemoclaw-user-reference/references/audit-chain.md
@@ -1,6 +1,6 @@
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-# NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log
+# NemoClaw Audit Chain: Tamper-Evident Hash-Chained Audit Log
 
 The audit chain module writes tamper-evident log entries in JSONL format.
 
@@ -95,14 +95,14 @@ Returns `{ valid: true, entries: 0 }` for empty or nonexistent files.
 Read entries with `seq >= since`, up to `limit`.
 When `limit` is omitted or zero, all matching entries are returned.
 
-Malformed lines are silently skipped.
+Skips malformed lines.
 
 ### `tailEntries(path: string, n?: number): AuditEntry[]`
 
 Return the last `n` entries from the audit file.
 Defaults to 50 when `n` is omitted or non-positive.
 
-Malformed lines are silently skipped.
+Skips malformed lines.
 
 ### `AuditEntry`
 
@@ -130,4 +130,4 @@ interface VerifyResult {
 
 ## Next Steps
 
-- See {doc}`/reference/architecture` for how security modules integrate into the NemoClaw plugin.
+- See NemoClaw Architecture: Plugin, Blueprint, and Sandbox Structure (see the `nemoclaw-user-reference` skill) for how security modules integrate into the NemoClaw plugin.

--- a/.github/workflows/e2e-brev.yaml
+++ b/.github/workflows/e2e-brev.yaml
@@ -115,11 +115,13 @@ jobs:
           BRANCH=$(gh pr view ${{ inputs.pr_number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)
           echo "Resolved PR #${{ inputs.pr_number }} → branch: $BRANCH"
           echo "RESOLVED_BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          # Use the PR head ref for checkout so fork PRs work too.
+          echo "PR_REF=refs/pull/${{ inputs.pr_number }}/head" >> "$GITHUB_ENV"
 
       - name: Checkout target branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ env.RESOLVED_BRANCH || inputs.branch || 'main' }}
+          ref: ${{ env.PR_REF || inputs.branch || 'main' }}
 
       - name: Create check run (pending)
         if: inputs.pr_number != ''

--- a/docs/index.md
+++ b/docs/index.md
@@ -355,6 +355,7 @@ Monitor Sandbox Activity <monitoring/monitor-sandbox-activity>
 :hidden:
 
 Architecture <reference/architecture>
+Audit Chain <reference/audit-chain>
 Commands <reference/commands>
 Network Policies <reference/network-policies>
 Troubleshooting <reference/troubleshooting>

--- a/docs/reference/audit-chain.md
+++ b/docs/reference/audit-chain.md
@@ -1,6 +1,6 @@
 ---
 title:
-  page: "Audit Chain — Tamper-Evident Hash-Chained Audit Log"
+  page: "NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log"
   nav: "Audit Chain"
 description: "Reference for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities."
 keywords: ["nemoclaw audit chain", "hash chain", "tamper detection", "audit log"]
@@ -18,7 +18,7 @@ status: published
   SPDX-License-Identifier: Apache-2.0
 -->
 
-# Audit Chain
+# NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log
 
 The audit chain module writes tamper-evident log entries in JSONL format.
 

--- a/docs/reference/audit-chain.md
+++ b/docs/reference/audit-chain.md
@@ -1,0 +1,152 @@
+---
+title:
+  page: "Audit Chain — Tamper-Evident Hash-Chained Audit Log"
+  nav: "Audit Chain"
+description: "Reference for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities."
+keywords: ["nemoclaw audit chain", "hash chain", "tamper detection", "audit log"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "security", "audit", "integrity"]
+content:
+  type: reference
+  difficulty: intermediate
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Audit Chain
+
+The audit chain module writes tamper-evident log entries in JSONL format.
+
+Each entry includes a SHA-256 hash of the previous entry, forming a hash chain that makes any modification or reordering detectable.
+
+## How Hash Chaining Works
+
+Every audit entry contains two hash fields.
+
+1. **`entry_hash`** is the SHA-256 digest of all other fields in the entry (seq, chain_id, prev_hash, type, time, data).
+   The logger computes this by JSON-serializing those fields and hashing the result.
+2. **`prev_hash`** is the `entry_hash` of the immediately preceding entry.
+   The first entry in a chain has an empty `prev_hash`.
+
+To verify integrity, a reader recomputes each `entry_hash` from the stored fields and confirms that each `prev_hash` matches the preceding entry.
+If any entry has been modified, deleted, or reordered, the hashes will not match.
+
+The `chain_id` is a random 24-character hex string generated when the logger creates a new file.
+It remains constant across all entries in a single chain.
+It persists when the logger resumes from an existing file.
+
+## Entry Structure
+
+Each line in the audit file is a JSON object with the following fields.
+
+| Field | Type | Description |
+|---|---|---|
+| `seq` | number | Monotonically increasing sequence number, starting at 1 |
+| `chain_id` | string | Random hex identifier for this chain instance |
+| `prev_hash` | string | `entry_hash` of the previous entry, or empty string for the first entry |
+| `entry_hash` | string | SHA-256 digest of the payload, formatted as `sha256:<64 hex chars>` |
+| `type` | string | Event type label (for example, `"tool.call"` or `"policy.decision"`) |
+| `time` | string | ISO 8601 timestamp in UTC |
+| `data` | unknown | Arbitrary JSON-serializable payload |
+
+Example entry:
+
+```json
+{
+  "seq": 1,
+  "chain_id": "a1b2c3d4e5f6a1b2c3d4e5f6",
+  "prev_hash": "",
+  "entry_hash": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  "type": "tool.call",
+  "time": "2026-03-25T12:00:00.000Z",
+  "data": { "action": "file_write", "target": "/tmp/output.txt" }
+}
+```
+
+## API
+
+The module exports the following from `nemoclaw/src/security/audit-chain.ts`.
+
+### `AuditLogger`
+
+Class that manages an append-only hash-chained audit file.
+
+```typescript
+import { AuditLogger } from "./security/audit-chain.js";
+
+const logger = new AuditLogger("/path/to/audit.jsonl");
+logger.log("tool.call", { action: "file_write", target: "/tmp/out.txt" });
+```
+
+The constructor creates parent directories if they do not exist.
+If the file already contains entries, the logger resumes the chain from the last entry.
+
+#### `log(type: string, data: unknown): void`
+
+Append a new entry to the audit file.
+The `type` parameter is a non-empty string label for the event.
+The `data` parameter is any JSON-serializable value.
+
+### `verifyChain(path: string): VerifyResult`
+
+Verify the integrity of an audit chain file.
+Returns a `VerifyResult` indicating whether all hashes are correct, all `prev_hash` links are intact, sequence numbers are contiguous (1, 2, 3, ...), and all entries share the same `chain_id`.
+
+```typescript
+import { verifyChain } from "./security/audit-chain.js";
+
+const result = verifyChain("/path/to/audit.jsonl");
+if (!result.valid) {
+  console.error("Chain tampered:", result.error);
+}
+```
+
+Returns `{ valid: true, entries: 0 }` for empty or nonexistent files.
+
+### `exportEntries(path: string, since: number, limit?: number): AuditEntry[]`
+
+Read entries with `seq >= since`, up to `limit`.
+When `limit` is omitted or zero, all matching entries are returned.
+
+Malformed lines are silently skipped.
+
+### `tailEntries(path: string, n?: number): AuditEntry[]`
+
+Return the last `n` entries from the audit file.
+Defaults to 50 when `n` is omitted or non-positive.
+
+Malformed lines are silently skipped.
+
+### `AuditEntry`
+
+```typescript
+interface AuditEntry {
+  readonly seq: number;
+  readonly chain_id: string;
+  readonly prev_hash: string;
+  readonly entry_hash: string;
+  readonly type: string;
+  readonly time: string;
+  readonly data: unknown;
+}
+```
+
+### `VerifyResult`
+
+```typescript
+interface VerifyResult {
+  readonly valid: boolean;
+  readonly entries: number;
+  readonly error?: string;
+}
+```
+
+## Next Steps
+
+- Review the injection scanner in {doc}`/reference/injection-scanner` to understand how NemoClaw detects prompt injection in agent tool calls.
+- See {doc}`/reference/architecture` for how security modules integrate into the NemoClaw plugin.

--- a/docs/reference/audit-chain.md
+++ b/docs/reference/audit-chain.md
@@ -1,8 +1,10 @@
 ---
 title:
-  page: "NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log"
+  page: "NemoClaw Audit Chain: Tamper-Evident Hash-Chained Audit Log"
   nav: "Audit Chain"
-description: "Reference for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities."
+description:
+  main: "Reference for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities."
+  agent: "References for the tamper-evident audit chain module that writes SHA-256 hash-chained JSONL entries and provides verify, export, and tail utilities. Use when looking up audit chain entry format, hash chaining behavior, or the verify/export/tail API."
 keywords: ["nemoclaw audit chain", "hash chain", "tamper detection", "audit log"]
 topics: ["generative_ai", "ai_agents"]
 tags: ["openclaw", "openshell", "security", "audit", "integrity"]
@@ -18,7 +20,7 @@ status: published
   SPDX-License-Identifier: Apache-2.0
 -->
 
-# NemoClaw Audit Chain — Tamper-Evident Hash-Chained Audit Log
+# NemoClaw Audit Chain: Tamper-Evident Hash-Chained Audit Log
 
 The audit chain module writes tamper-evident log entries in JSONL format.
 
@@ -113,14 +115,14 @@ Returns `{ valid: true, entries: 0 }` for empty or nonexistent files.
 Read entries with `seq >= since`, up to `limit`.
 When `limit` is omitted or zero, all matching entries are returned.
 
-Malformed lines are silently skipped.
+Skips malformed lines.
 
 ### `tailEntries(path: string, n?: number): AuditEntry[]`
 
 Return the last `n` entries from the audit file.
 Defaults to 50 when `n` is omitted or non-positive.
 
-Malformed lines are silently skipped.
+Skips malformed lines.
 
 ### `AuditEntry`
 
@@ -148,4 +150,4 @@ interface VerifyResult {
 
 ## Next Steps
 
-- See {doc}`/reference/architecture` for how security modules integrate into the NemoClaw plugin.
+- See [NemoClaw Architecture: Plugin, Blueprint, and Sandbox Structure](architecture.md) for how security modules integrate into the NemoClaw plugin.

--- a/nemoclaw/src/security/audit-chain.test.ts
+++ b/nemoclaw/src/security/audit-chain.test.ts
@@ -1,0 +1,579 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  AuditLogger,
+  verifyChain,
+  exportEntries,
+  tailEntries,
+  type AuditEntry,
+} from "./audit-chain.js";
+
+// ── Test helpers ─────────────────────────────────────────────
+
+let tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "audit-chain-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+/** Read all entries from an audit file. */
+function readEntries(path: string): AuditEntry[] {
+  const content = readFileSync(path, "utf-8");
+  return content
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line) as AuditEntry);
+}
+
+// ── AuditLogger ──────────────────────────────────────────────
+
+describe("AuditLogger", () => {
+  it("starts a new chain at seq 1 with empty prev_hash", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("test.action", { key: "value" });
+
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].seq).toBe(1);
+    expect(entries[0].prev_hash).toBe("");
+  });
+
+  it("links entry hashes across entries", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("first", { n: 1 });
+    logger.log("second", { n: 2 });
+
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(2);
+    expect(entries[1].prev_hash).toBe(entries[0].entry_hash);
+  });
+
+  it("increments sequence numbers", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", {});
+    logger.log("b", {});
+    logger.log("c", {});
+
+    const entries = readEntries(path);
+    expect(entries.map((e) => e.seq)).toEqual([1, 2, 3]);
+  });
+
+  it("uses a consistent chain_id across entries", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", {});
+    logger.log("b", {});
+
+    const entries = readEntries(path);
+    expect(entries[0].chain_id).toBe(entries[1].chain_id);
+    // chain_id is 24 hex chars (12 random bytes)
+    expect(entries[0].chain_id).toMatch(/^[0-9a-f]{24}$/);
+  });
+
+  it("resumes chain from an existing file", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+
+    const logger1 = new AuditLogger(path);
+    logger1.log("first", { n: 1 });
+    const entriesBefore = readEntries(path);
+
+    const logger2 = new AuditLogger(path);
+    logger2.log("second", { n: 2 });
+
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(2);
+    expect(entries[1].seq).toBe(2);
+    expect(entries[1].prev_hash).toBe(entriesBefore[0].entry_hash);
+    expect(entries[1].chain_id).toBe(entries[0].chain_id);
+  });
+
+  it("stores the data payload correctly", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    const payload = { action: "file_write", target: "/tmp/test.txt", size: 42 };
+    logger.log("tool.call", payload);
+
+    const entries = readEntries(path);
+    expect(entries[0].data).toEqual(payload);
+    expect(entries[0].type).toBe("tool.call");
+  });
+
+  it("produces entry_hash in sha256:<64 hex chars> format", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("test", { x: 1 });
+
+    const entries = readEntries(path);
+    expect(entries[0].entry_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("stores an ISO 8601 timestamp", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("test", {});
+
+    const entries = readEntries(path);
+    const parsed = new Date(entries[0].time);
+    expect(parsed.getTime()).not.toBeNaN();
+  });
+
+  it("throws on empty path", () => {
+    expect(() => new AuditLogger("")).toThrow("non-empty file path");
+  });
+
+  it("throws on empty type", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    expect(() => {
+      logger.log("", {});
+    }).toThrow("non-empty type string");
+  });
+
+  it("handles single-char data", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("t", "x");
+
+    const entries = readEntries(path);
+    expect(entries[0].data).toBe("x");
+    expect(entries[0].type).toBe("t");
+  });
+
+  it("handles extremely large data payload", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    const bigData = { blob: "A".repeat(100_000) };
+    logger.log("big", bigData);
+
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(1);
+    expect((entries[0].data as { blob: string }).blob.length).toBe(100_000);
+  });
+});
+
+// ── verifyChain ──────────────────────────────────────────────
+
+describe("verifyChain", () => {
+  it("returns valid for a correct chain", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", { n: 1 });
+    logger.log("b", { n: 2 });
+    logger.log("c", { n: 3 });
+
+    const result = verifyChain(path);
+    expect(result.valid).toBe(true);
+    expect(result.entries).toBe(3);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("detects tampered data", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", { n: 1 });
+    logger.log("b", { n: 2 });
+
+    // Tamper with the data field of the first entry.
+    const content = readFileSync(path, "utf-8");
+    const lines = content.split("\n").filter((l) => l.trim() !== "");
+    const entry = JSON.parse(lines[0]) as AuditEntry;
+    const tampered = { ...entry, data: { n: 999 } };
+    lines[0] = JSON.stringify(tampered);
+    writeFileSync(path, lines.join("\n") + "\n", "utf-8");
+
+    const result = verifyChain(path);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/entry_hash mismatch/);
+  });
+
+  it("detects broken prev_hash link", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", { n: 1 });
+    logger.log("b", { n: 2 });
+
+    // Replace the second entry's prev_hash with a bogus value.
+    const content = readFileSync(path, "utf-8");
+    const lines = content.split("\n").filter((l) => l.trim() !== "");
+    const entry = JSON.parse(lines[1]) as AuditEntry;
+    const broken = {
+      ...entry,
+      prev_hash: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    };
+    lines[1] = JSON.stringify(broken);
+    writeFileSync(path, lines.join("\n") + "\n", "utf-8");
+
+    const result = verifyChain(path);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/prev_hash mismatch/);
+  });
+
+  it("returns valid for an empty file", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    writeFileSync(path, "", "utf-8");
+
+    const result = verifyChain(path);
+    expect(result.valid).toBe(true);
+    expect(result.entries).toBe(0);
+  });
+
+  it("returns valid for a nonexistent file", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "does-not-exist.jsonl");
+
+    const result = verifyChain(path);
+    expect(result.valid).toBe(true);
+    expect(result.entries).toBe(0);
+  });
+
+  it("handles malformed JSONL line", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    writeFileSync(path, "not valid json\n", "utf-8");
+
+    const result = verifyChain(path);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/malformed JSON at line 1/);
+  });
+
+  it("returns valid for exactly 1 entry", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("single", { only: true });
+
+    const result = verifyChain(path);
+    expect(result.valid).toBe(true);
+    expect(result.entries).toBe(1);
+  });
+
+  it("returns error for empty path", () => {
+    const result = verifyChain("");
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/path is required/);
+  });
+
+  it("detects block-deletion attack (entries removed and chain re-linked)", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    for (let i = 1; i <= 5; i++) {
+      logger.log("entry", { i });
+    }
+
+    // Read all 5 entries.
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(5);
+
+    // Delete entries 2 and 3. Re-link entry 4's prev_hash to entry 1's hash.
+    const entry4 = { ...entries[3], prev_hash: entries[0].entry_hash };
+    // Recompute entry 4's entry_hash to match the new prev_hash.
+    const payload4 = {
+      seq: entry4.seq,
+      chain_id: entry4.chain_id,
+      prev_hash: entry4.prev_hash,
+      type: entry4.type,
+      time: entry4.time,
+      data: entry4.data,
+    };
+    const recomputedHash = `sha256:${createHash("sha256").update(JSON.stringify(payload4), "utf-8").digest("hex")}`;
+    entry4.entry_hash = recomputedHash;
+
+    // Also re-link entry 5's prev_hash to the recomputed entry 4 hash.
+    const entry5 = { ...entries[4], prev_hash: recomputedHash };
+    const payload5 = {
+      seq: entry5.seq,
+      chain_id: entry5.chain_id,
+      prev_hash: entry5.prev_hash,
+      type: entry5.type,
+      time: entry5.time,
+      data: entry5.data,
+    };
+    entry5.entry_hash = `sha256:${createHash("sha256").update(JSON.stringify(payload5), "utf-8").digest("hex")}`;
+
+    // Write the tampered chain: entries 1, 4 (re-linked), 5 (re-linked).
+    const tampered = [entries[0], entry4, entry5].map((e) => JSON.stringify(e)).join("\n") + "\n";
+    writeFileSync(path, tampered, "utf-8");
+
+    // verifyChain should detect the sequence gap (seq jumps from 1 to 4).
+    const result = verifyChain(path);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/sequence gap/);
+  });
+
+  it("detects direct entry_hash replacement (hash changed but not data)", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", { n: 1 });
+
+    const entries = readEntries(path);
+    const tampered = {
+      ...entries[0],
+      entry_hash: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    };
+    writeFileSync(path, JSON.stringify(tampered) + "\n", "utf-8");
+
+    const result = verifyChain(path);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/entry_hash mismatch/);
+  });
+
+  it("detects chain_id splice (entry from different chain inserted)", () => {
+    const dir = makeTempDir();
+
+    // Create two separate chains.
+    const pathA = join(dir, "chain-a.jsonl");
+    const pathB = join(dir, "chain-b.jsonl");
+    const loggerA = new AuditLogger(pathA);
+    const loggerB = new AuditLogger(pathB);
+    loggerA.log("a1", { source: "A" });
+    loggerA.log("a2", { source: "A" });
+    loggerB.log("b1", { source: "B" });
+
+    const entriesA = readEntries(pathA);
+    const entriesB = readEntries(pathB);
+
+    // Splice: replace entry 2 of chain A with entry 1 from chain B,
+    // adjusting seq and prev_hash to look plausible but keeping chain_id from B.
+    const spliced = {
+      ...entriesB[0],
+      seq: 2,
+      prev_hash: entriesA[0].entry_hash,
+    };
+    const splicedPayload = {
+      seq: spliced.seq,
+      chain_id: spliced.chain_id,
+      prev_hash: spliced.prev_hash,
+      type: spliced.type,
+      time: spliced.time,
+      data: spliced.data,
+    };
+    spliced.entry_hash = `sha256:${createHash("sha256").update(JSON.stringify(splicedPayload), "utf-8").digest("hex")}`;
+
+    const targetPath = join(dir, "spliced.jsonl");
+    writeFileSync(
+      targetPath,
+      JSON.stringify(entriesA[0]) + "\n" + JSON.stringify(spliced) + "\n",
+      "utf-8",
+    );
+
+    const result = verifyChain(targetPath);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/chain_id mismatch/);
+  });
+});
+
+// ── exportEntries ────────────────────────────────────────────
+
+describe("exportEntries", () => {
+  it("filters by since (sequence number)", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", {});
+    logger.log("b", {});
+    logger.log("c", {});
+
+    const entries = exportEntries(path, 2);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].seq).toBe(2);
+    expect(entries[1].seq).toBe(3);
+  });
+
+  it("respects limit", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", {});
+    logger.log("b", {});
+    logger.log("c", {});
+
+    const entries = exportEntries(path, 1, 2);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].seq).toBe(1);
+    expect(entries[1].seq).toBe(2);
+  });
+
+  it("returns all matching entries when limit is 0", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", {});
+    logger.log("b", {});
+
+    const entries = exportEntries(path, 1, 0);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("returns empty array for nonexistent file", () => {
+    const dir = makeTempDir();
+    const entries = exportEntries(join(dir, "missing.jsonl"), 1);
+    expect(entries).toEqual([]);
+  });
+
+  it("skips malformed lines", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", {});
+
+    // Append a malformed line followed by a valid entry.
+    const logger2 = new AuditLogger(path);
+    logger2.log("b", {});
+    const contentAfter = readFileSync(path, "utf-8");
+    const lines = contentAfter.split("\n").filter((l) => l.trim() !== "");
+    // Insert malformed line between entries.
+    const newContent = lines[0] + "\n{bad json\n" + lines[1] + "\n";
+    writeFileSync(path, newContent, "utf-8");
+
+    const entries = exportEntries(path, 1);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("throws on empty path", () => {
+    expect(() => exportEntries("", 1)).toThrow("non-empty file path");
+  });
+
+  it("throws on non-finite since", () => {
+    expect(() => exportEntries("/tmp/test", NaN)).toThrow("finite number");
+  });
+});
+
+// ── tailEntries ──────────────────────────────────────────────
+
+describe("tailEntries", () => {
+  it("returns last N entries", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    for (let i = 1; i <= 10; i++) {
+      logger.log("entry", { i });
+    }
+
+    const entries = tailEntries(path, 3);
+    expect(entries).toHaveLength(3);
+    expect(entries[0].seq).toBe(8);
+    expect(entries[1].seq).toBe(9);
+    expect(entries[2].seq).toBe(10);
+  });
+
+  it("returns all entries if fewer than N", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", {});
+    logger.log("b", {});
+
+    const entries = tailEntries(path, 100);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("defaults to 50 when n is omitted", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    for (let i = 1; i <= 60; i++) {
+      logger.log("entry", { i });
+    }
+
+    const entries = tailEntries(path);
+    expect(entries).toHaveLength(50);
+    expect(entries[0].seq).toBe(11);
+    expect(entries[49].seq).toBe(60);
+  });
+
+  it("defaults to 50 when n is 0", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    for (let i = 1; i <= 60; i++) {
+      logger.log("entry", { i });
+    }
+
+    const entries = tailEntries(path, 0);
+    expect(entries).toHaveLength(50);
+  });
+
+  it("returns empty array for nonexistent file", () => {
+    const dir = makeTempDir();
+    const entries = tailEntries(join(dir, "missing.jsonl"), 10);
+    expect(entries).toEqual([]);
+  });
+
+  it("skips malformed lines", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+    logger.log("a", {});
+    logger.log("b", {});
+
+    const content = readFileSync(path, "utf-8");
+    // Insert a malformed line in the middle.
+    const lines = content.split("\n").filter((l) => l.trim() !== "");
+    writeFileSync(path, lines[0] + "\n{broken\n" + lines[1] + "\n", "utf-8");
+
+    const entries = tailEntries(path, 10);
+    expect(entries).toHaveLength(2);
+  });
+
+  it("throws on empty path", () => {
+    expect(() => tailEntries("")).toThrow("non-empty file path");
+  });
+});
+
+// ── Rapid sequential writes ──────────────────────────────────
+
+describe("rapid sequential writes", () => {
+  it("handles rapid sequential writes without data loss", () => {
+    const dir = makeTempDir();
+    const path = join(dir, "audit.jsonl");
+    const logger = new AuditLogger(path);
+
+    for (let i = 0; i < 100; i++) {
+      logger.log("rapid", { i });
+    }
+
+    const entries = readEntries(path);
+    expect(entries).toHaveLength(100);
+    expect(entries[99].seq).toBe(100);
+
+    // Verify the entire chain is valid.
+    const result = verifyChain(path);
+    expect(result.valid).toBe(true);
+    expect(result.entries).toBe(100);
+  });
+});

--- a/nemoclaw/src/security/audit-chain.ts
+++ b/nemoclaw/src/security/audit-chain.ts
@@ -345,7 +345,6 @@ function readTailState(path: string): TailState {
       entry = JSON.parse(line) as AuditEntry;
     } catch {
       // Skip malformed lines and continue with the last successfully parsed entry.
-      console.error(`readTailState: skipping malformed line in ${path}`);
       continue;
     }
     lastSeq = entry.seq;

--- a/nemoclaw/src/security/audit-chain.ts
+++ b/nemoclaw/src/security/audit-chain.ts
@@ -1,0 +1,357 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tamper-evident audit chain logger.
+ *
+ * Each log entry includes a SHA-256 hash of its payload and the hash of the
+ * previous entry, forming a hash chain. Any modification to an entry or its
+ * ordering is detectable by verifying the chain.
+ *
+ * Entry format (one JSON object per line):
+ *   { seq, chain_id, prev_hash, entry_hash, type, time, data }
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+// ── Public types ─────────────────────────────────────────────
+
+/** A single audit log entry as persisted in JSONL. */
+export interface AuditEntry {
+  readonly seq: number;
+  readonly chain_id: string;
+  readonly prev_hash: string;
+  readonly entry_hash: string;
+  readonly type: string;
+  readonly time: string;
+  readonly data: unknown;
+}
+
+/** Result returned by `verifyChain`. */
+export interface VerifyResult {
+  readonly valid: boolean;
+  readonly entries: number;
+  readonly error?: string;
+}
+
+// ── Internal types ───────────────────────────────────────────
+
+/** Payload used to compute the entry hash (all fields except entry_hash). */
+interface LogPayload {
+  seq: number;
+  chain_id: string;
+  prev_hash: string;
+  type: string;
+  time: string;
+  data: unknown;
+}
+
+// ── AuditLogger class ────────────────────────────────────────
+
+/**
+ * Append-only audit logger that writes hash-chained JSONL entries.
+ *
+ * Construct with a file path. The logger creates parent directories as
+ * needed and resumes the chain if the file already contains entries.
+ */
+export class AuditLogger {
+  private readonly path: string;
+  private seq: number;
+  private prevHash: string;
+  private readonly chainId: string;
+
+  constructor(path: string) {
+    if (!path || typeof path !== "string") {
+      throw new Error("AuditLogger requires a non-empty file path");
+    }
+
+    const dir = dirname(path);
+    mkdirSync(dir, { recursive: true });
+
+    const tail = readTailState(path);
+    this.path = path;
+    this.seq = tail.seq;
+    this.prevHash = tail.prevHash;
+    this.chainId = tail.chainId || randomChainId();
+  }
+
+  /** Append a new audit entry. */
+  log(type: string, data: unknown): void {
+    if (!type || typeof type !== "string") {
+      throw new Error("log() requires a non-empty type string");
+    }
+
+    const nextSeq = this.seq + 1;
+    const now = new Date().toISOString();
+
+    const payload: LogPayload = {
+      seq: nextSeq,
+      chain_id: this.chainId,
+      prev_hash: this.prevHash,
+      type,
+      time: now,
+      data,
+    };
+
+    const entryHash = computeEntryHash(payload);
+
+    const entry: AuditEntry = {
+      seq: nextSeq,
+      chain_id: this.chainId,
+      prev_hash: this.prevHash,
+      entry_hash: entryHash,
+      type,
+      time: now,
+      data,
+    };
+
+    appendFileSync(this.path, JSON.stringify(entry) + "\n", "utf-8");
+    this.seq = nextSeq;
+    this.prevHash = entryHash;
+  }
+}
+
+// ── Standalone functions ─────────────────────────────────────
+
+/**
+ * Verify the integrity of an audit chain file.
+ *
+ * Reads every JSONL line, recomputes each entry hash, and confirms that
+ * `prev_hash` links form an unbroken chain. Returns a result object
+ * indicating whether the chain is valid.
+ *
+ * Returns `{ valid: true, entries: 0 }` for empty or nonexistent files.
+ */
+export function verifyChain(path: string): VerifyResult {
+  if (!path || typeof path !== "string") {
+    return { valid: false, entries: 0, error: "path is required" };
+  }
+
+  if (!existsSync(path)) {
+    return { valid: true, entries: 0 };
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(path, "utf-8");
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { valid: false, entries: 0, error: `failed to read file: ${message}` };
+  }
+
+  const lines = content.split("\n").filter((line) => line.trim() !== "");
+  if (lines.length === 0) {
+    return { valid: true, entries: 0 };
+  }
+
+  let lastHash = "";
+  let count = 0;
+  let expectedSeq = 1;
+  let chainId = "";
+
+  for (let i = 0; i < lines.length; i++) {
+    let entry: AuditEntry;
+    try {
+      entry = JSON.parse(lines[i]) as AuditEntry;
+    } catch {
+      return {
+        valid: false,
+        entries: count,
+        error: `malformed JSON at line ${String(i + 1)}`,
+      };
+    }
+
+    // Verify sequence numbers are contiguous (1, 2, 3, ...).
+    if (entry.seq !== expectedSeq) {
+      return {
+        valid: false,
+        entries: count,
+        error: `sequence gap at seq ${String(entry.seq)}: expected ${String(expectedSeq)}`,
+      };
+    }
+
+    // Verify chain_id is consistent across all entries.
+    if (i === 0) {
+      chainId = entry.chain_id;
+    } else if (entry.chain_id !== chainId) {
+      return {
+        valid: false,
+        entries: count,
+        error: `chain_id mismatch at seq ${String(entry.seq)}: expected "${chainId}", got "${entry.chain_id}"`,
+      };
+    }
+
+    // Verify prev_hash links to the previous entry's entry_hash.
+    if (entry.prev_hash !== lastHash) {
+      return {
+        valid: false,
+        entries: count,
+        error: `prev_hash mismatch at seq ${String(entry.seq)} (line ${String(i + 1)})`,
+      };
+    }
+
+    // Reconstruct the payload (all fields except entry_hash) and recompute.
+    const payload: LogPayload = {
+      seq: entry.seq,
+      chain_id: entry.chain_id,
+      prev_hash: entry.prev_hash,
+      type: entry.type,
+      time: entry.time,
+      data: entry.data,
+    };
+
+    const expectedHash = computeEntryHash(payload);
+    if (entry.entry_hash !== expectedHash) {
+      return {
+        valid: false,
+        entries: count,
+        error: `entry_hash mismatch at seq ${String(entry.seq)} (line ${String(i + 1)})`,
+      };
+    }
+
+    lastHash = entry.entry_hash;
+    count++;
+    expectedSeq++;
+  }
+
+  return { valid: true, entries: count };
+}
+
+/**
+ * Export audit entries with `seq >= since`, up to `limit`.
+ *
+ * If `limit` is 0 or omitted, all matching entries are returned.
+ * Malformed lines are silently skipped.
+ */
+export function exportEntries(path: string, since: number, limit?: number): AuditEntry[] {
+  if (!path || typeof path !== "string") {
+    throw new Error("exportEntries requires a non-empty file path");
+  }
+  if (typeof since !== "number" || !Number.isFinite(since)) {
+    throw new Error("since must be a finite number");
+  }
+
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  const content = readFileSync(path, "utf-8");
+  const lines = content.split("\n").filter((line) => line.trim() !== "");
+  const result: AuditEntry[] = [];
+  const effectiveLimit = limit != null && limit > 0 ? limit : 0;
+
+  for (const line of lines) {
+    let entry: AuditEntry;
+    try {
+      entry = JSON.parse(line) as AuditEntry;
+    } catch {
+      // Skip malformed lines.
+      continue;
+    }
+
+    if (entry.seq < since) {
+      continue;
+    }
+
+    result.push(entry);
+
+    if (effectiveLimit > 0 && result.length >= effectiveLimit) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Return the last `n` entries from an audit file.
+ *
+ * Defaults to 50 when `n` is omitted or non-positive.
+ * Malformed lines are silently skipped.
+ */
+export function tailEntries(path: string, n?: number): AuditEntry[] {
+  if (!path || typeof path !== "string") {
+    throw new Error("tailEntries requires a non-empty file path");
+  }
+
+  const effectiveN = n != null && n > 0 ? n : 50;
+
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  const content = readFileSync(path, "utf-8");
+  const lines = content.split("\n").filter((line) => line.trim() !== "");
+  const entries: AuditEntry[] = [];
+
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line) as AuditEntry);
+    } catch {
+      // Skip malformed lines.
+      continue;
+    }
+  }
+
+  if (entries.length <= effectiveN) {
+    return entries;
+  }
+
+  return entries.slice(entries.length - effectiveN);
+}
+
+// ── Internal helpers ─────────────────────────────────────────
+
+/** Compute the SHA-256 hash of a log payload. */
+// NOTE: Hash computation uses JSON.stringify which preserves insertion-order
+// key ordering within a single Node.js runtime. Cross-runtime verification
+// (e.g., Go, Python) requires a canonical JSON serialization (RFC 8785).
+// This module's verification is only guaranteed within Node.js environments.
+function computeEntryHash(payload: LogPayload): string {
+  const json = JSON.stringify(payload);
+  const hash = createHash("sha256").update(json, "utf-8").digest("hex");
+  return `sha256:${hash}`;
+}
+
+/** Generate a random 24-character hex chain ID (12 random bytes). */
+function randomChainId(): string {
+  return randomBytes(12).toString("hex");
+}
+
+interface TailState {
+  seq: number;
+  prevHash: string;
+  chainId: string;
+}
+
+/** Read the last entry's state from an existing audit file. */
+function readTailState(path: string): TailState {
+  if (!existsSync(path)) {
+    return { seq: 0, prevHash: "", chainId: "" };
+  }
+
+  const content = readFileSync(path, "utf-8");
+  const lines = content.split("\n").filter((line) => line.trim() !== "");
+
+  let lastSeq = 0;
+  let lastHash = "";
+  let lastChainId = "";
+
+  for (const line of lines) {
+    let entry: AuditEntry;
+    try {
+      entry = JSON.parse(line) as AuditEntry;
+    } catch {
+      // Skip malformed lines and continue with the last successfully parsed entry.
+      console.error(`readTailState: skipping malformed line in ${path}`);
+      continue;
+    }
+    lastSeq = entry.seq;
+    lastHash = entry.entry_hash;
+    lastChainId = entry.chain_id;
+  }
+
+  return { seq: lastSeq, prevHash: lastHash, chainId: lastChainId };
+}


### PR DESCRIPTION
Closes #891

## What this does

Adds a tamper-evident audit logger under `nemoclaw/src/security/`. It writes JSONL entries where each entry includes a SHA-256 hash of the previous one — modifying or deleting any entry breaks the chain downstream.

Comes with `verifyChain()` to validate an entire log file, plus `exportEntries()` and `tailEntries()` for querying.

Three new files, no changes to existing NemoClaw code.

## How the chain works

Each entry has: `seq` (monotonic), `chain_id` (random hex per instance), `prev_hash`, `entry_hash`, `type`, `time`, `data`. The logger resumes from an existing file by reading the last entry for continuation state.

`verifyChain` catches: modified data, broken hash links, sequence gaps (block deletion), and chain_id mismatches (splice attacks).

## Test plan

- [x] 38 tests passing (`npx vitest run src/security/audit-chain.test.ts`)
- [x] `tsc --noEmit` clean
- [x] All pre-commit hooks pass
- [x] Tamper scenarios: modified data, broken prev_hash, deleted entries, chain splicing
- [x] Edge cases: malformed JSONL lines, empty files, single-entry chains, 100-entry stress test

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>