### PR TITLE
feat(cli): add shell completion for bash, zsh, and fish

### DIFF
--- a/bin/lib/completion.js
+++ b/bin/lib/completion.js
@@ -6,7 +6,7 @@ const registry = require("./registry");
 const GLOBAL_COMMANDS = [
   "onboard", "list", "deploy", "setup-spark",
   "start", "stop", "status", "debug", "uninstall",
-  "help", "completion",
+  "help", "completion", "--help", "-h", "--version", "-v",
 ];
 
 const SANDBOX_ACTIONS = [
@@ -28,7 +28,13 @@ function bash() {
 
 _nemoclaw() {
   local cur prev words cword
-  _init_completion || return
+  if type _init_completion &>/dev/null; then
+    _init_completion || return
+  else
+    cur="\${COMP_WORDS[COMP_CWORD]}"
+    prev="\${COMP_WORDS[COMP_CWORD-1]}"
+    cword=$COMP_CWORD
+  fi
 
   local global_cmds="${GLOBAL_COMMANDS.join(" ")}"
   local sandbox_actions="${SANDBOX_ACTIONS.join(" ")}"
@@ -44,9 +50,7 @@ _nemoclaw() {
   if [[ $cword -eq 2 ]]; then
     # If first arg is a sandbox name, complete with actions
     case "$prev" in
-      onboard|list|start|stop|status|help|completion|uninstall)
-        return ;;
-      deploy)
+      onboard|list|deploy|setup-spark|start|stop|status|help|completion|uninstall|--help|-h|--version|-v)
         return ;;
       debug)
         COMPREPLY=($(compgen -W "--quick --output --help" -- "$cur"))
@@ -94,6 +98,10 @@ _nemoclaw() {
     'uninstall:Uninstall NemoClaw'
     'help:Show help'
     'completion:Generate shell completion script'
+    '--help:Show help'
+    '-h:Show help'
+    '--version:Show version'
+    '-v:Show version'
   )
 
   sandbox_actions=(
@@ -114,9 +122,7 @@ _nemoclaw() {
 
   if (( CURRENT == 3 )); then
     case "\${words[2]}" in
-      onboard|list|start|stop|status|help|completion|uninstall)
-        return ;;
-      deploy)
+      onboard|list|deploy|setup-spark|start|stop|status|help|completion|uninstall|--help|-h|--version|-v)
         return ;;
       debug)
         _arguments '--quick[Quick diagnostics]' '--output[Save to file]:file:_files' '--help[Show help]'
@@ -163,6 +169,10 @@ complete -c nemoclaw -n '__fish_use_subcommand' -a 'debug' -d 'Collect diagnosti
 complete -c nemoclaw -n '__fish_use_subcommand' -a 'uninstall' -d 'Uninstall NemoClaw'
 complete -c nemoclaw -n '__fish_use_subcommand' -a 'help' -d 'Show help'
 complete -c nemoclaw -n '__fish_use_subcommand' -a 'completion' -d 'Generate shell completion script'
+complete -c nemoclaw -n '__fish_use_subcommand' -l help -d 'Show help'
+complete -c nemoclaw -n '__fish_use_subcommand' -s h -d 'Show help'
+complete -c nemoclaw -n '__fish_use_subcommand' -l version -d 'Show version'
+complete -c nemoclaw -n '__fish_use_subcommand' -s v -d 'Show version'
 
 # Dynamic sandbox names
 complete -c nemoclaw -n '__fish_use_subcommand' -a '(nemoclaw completion --list-sandboxes 2>/dev/null)'
@@ -201,7 +211,7 @@ function listSandboxNames() {
 }
 
 function run(args) {
-  if (args.includes("--list-sandboxes")) {
+  if (args[0] === "--list-sandboxes") {
     listSandboxNames();
     return;
   }

--- a/bin/lib/completion.js
+++ b/bin/lib/completion.js
@@ -30,7 +30,7 @@ function bash() {
   const globalCmds = GLOBAL_COMMANDS.join(" ");
   const sandboxActions = SANDBOX_ACTIONS.join(" ");
   const debugFlags = DEBUG_FLAGS.join(" ");
-  const noArgCmds = GLOBAL_COMMANDS.filter((c) => c !== "debug").join("|");
+  const noArgCmds = GLOBAL_COMMANDS.filter((c) => !["debug", "completion"].includes(c)).join("|");
 
   return `# nemoclaw bash completion
 # Add to ~/.bashrc:  eval "$(nemoclaw completion bash)"
@@ -60,6 +60,9 @@ _nemoclaw() {
   if [[ $cword -eq 2 ]]; then
     # If first arg is a sandbox name, complete with actions
     case "$prev" in
+      completion)
+        COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
+        return ;;
       ${noArgCmds})
         return ;;
       debug)
@@ -94,7 +97,7 @@ complete -F _nemoclaw nemoclaw
 // previously caused escaping bugs caught only by the linter.
 
 function zsh() {
-  const noArgCmds = GLOBAL_COMMANDS.filter((c) => c !== "debug").join("|");
+  const noArgCmds = GLOBAL_COMMANDS.filter((c) => !["debug", "completion"].includes(c)).join("|");
 
   return "#compdef nemoclaw\n"
     + "# nemoclaw zsh completion\n"
@@ -139,6 +142,9 @@ function zsh() {
     + "\n"
     + "  if (( CURRENT == 3 )); then\n"
     + '    case "${words[2]}" in\n'
+    + "      completion)\n"
+    + "        _values 'shell' bash zsh fish\n"
+    + "        return ;;\n"
     + "      " + noArgCmds + ")\n"
     + "        return ;;\n"
     + "      debug)\n"
@@ -168,7 +174,7 @@ function zsh() {
     + "  fi\n"
     + "}\n"
     + "\n"
-    + '_nemoclaw "$@"\n';
+    + "compdef _nemoclaw nemoclaw\n";
 }
 
 function fish() {
@@ -248,8 +254,12 @@ function run(args) {
       process.stdout.write(zsh());
     } else if (envShell.includes("fish")) {
       process.stdout.write(fish());
-    } else {
+    } else if (envShell.includes("bash")) {
       process.stdout.write(bash());
+    } else {
+      console.error(`  Unknown shell: ${envShell || "<unset>"}`);
+      console.error("  Supported: bash, zsh, fish");
+      process.exit(1);
     }
     return;
   }

--- a/bin/lib/completion.js
+++ b/bin/lib/completion.js
@@ -13,6 +13,10 @@ const SANDBOX_ACTIONS = [
   "connect", "status", "logs", "policy-add", "policy-list", "destroy",
 ];
 
+// Flags accepted by scripts/debug.sh — keep in sync or update the
+// "completion flags match debug.sh" test when debug.sh gains new flags.
+const DEBUG_FLAGS = ["--quick", "--sandbox", "--output", "--help"];
+
 function getSandboxNames() {
   try {
     const { sandboxes } = registry.listSandboxes();
@@ -23,6 +27,11 @@ function getSandboxNames() {
 }
 
 function bash() {
+  const globalCmds = GLOBAL_COMMANDS.join(" ");
+  const sandboxActions = SANDBOX_ACTIONS.join(" ");
+  const debugFlags = DEBUG_FLAGS.join(" ");
+  const noArgCmds = GLOBAL_COMMANDS.filter((c) => c !== "debug").join("|");
+
   return `# nemoclaw bash completion
 # Add to ~/.bashrc:  eval "$(nemoclaw completion bash)"
 
@@ -36,8 +45,8 @@ _nemoclaw() {
     cword=$COMP_CWORD
   fi
 
-  local global_cmds="${GLOBAL_COMMANDS.join(" ")}"
-  local sandbox_actions="${SANDBOX_ACTIONS.join(" ")}"
+  local global_cmds="${globalCmds}"
+  local sandbox_actions="${sandboxActions}"
 
   if [[ $cword -eq 1 ]]; then
     # Complete global commands + sandbox names
@@ -50,10 +59,10 @@ _nemoclaw() {
   if [[ $cword -eq 2 ]]; then
     # If first arg is a sandbox name, complete with actions
     case "$prev" in
-      onboard|list|deploy|setup-spark|start|stop|status|help|completion|uninstall|--help|-h|--version|-v)
+      ${noArgCmds})
         return ;;
       debug)
-        COMPREPLY=($(compgen -W "--quick --output --help" -- "$cur"))
+        COMPREPLY=($(compgen -W "${debugFlags}" -- "$cur"))
         return ;;
     esac
     # Assume sandbox name → offer actions
@@ -78,78 +87,92 @@ complete -F _nemoclaw nemoclaw
 `;
 }
 
+// The zsh completion script uses plain string concatenation instead of a single
+// template literal.  This avoids mixing JS interpolation (${expr}) with zsh
+// parameter expansion (${words[2]}, ${(f)...}) in the same string, which
+// previously caused escaping bugs caught only by the linter.
+
 function zsh() {
-  return `#compdef nemoclaw
-# nemoclaw zsh completion
-# Add to ~/.zshrc:  eval "$(nemoclaw completion zsh)"
+  const noArgCmds = GLOBAL_COMMANDS.filter((c) => c !== "debug").join("|");
 
-_nemoclaw() {
-  local -a global_cmds sandbox_actions sandboxes
-
-  global_cmds=(
-    'onboard:Configure inference endpoint and credentials'
-    'list:List all sandboxes'
-    'deploy:Deploy to a Brev VM'
-    'setup-spark:Set up on DGX Spark'
-    'start:Start auxiliary services'
-    'stop:Stop all services'
-    'status:Show sandbox list and service status'
-    'debug:Collect diagnostics for bug reports'
-    'uninstall:Uninstall NemoClaw'
-    'help:Show help'
-    'completion:Generate shell completion script'
-    '--help:Show help'
-    '-h:Show help'
-    '--version:Show version'
-    '-v:Show version'
-  )
-
-  sandbox_actions=(
-    'connect:Shell into a running sandbox'
-    'status:Sandbox health and NIM status'
-    'logs:Stream sandbox logs'
-    'policy-add:Add a network or filesystem policy preset'
-    'policy-list:List presets'
-    'destroy:Stop NIM and delete sandbox'
-  )
-
-  if (( CURRENT == 2 )); then
-    # Get sandbox names dynamically
-    sandboxes=(\${(f)"$(nemoclaw completion --list-sandboxes 2>/dev/null)"})
-    _describe 'command' global_cmds -- sandboxes
-    return
-  fi
-
-  if (( CURRENT == 3 )); then
-    case "\${words[2]}" in
-      onboard|list|deploy|setup-spark|start|stop|status|help|completion|uninstall|--help|-h|--version|-v)
-        return ;;
-      debug)
-        _arguments '--quick[Quick diagnostics]' '--output[Save to file]:file:_files' '--help[Show help]'
-        return ;;
-    esac
-    # Assume sandbox name → offer actions
-    _describe 'action' sandbox_actions
-    return
-  fi
-
-  if (( CURRENT == 4 )); then
-    case "\${words[3]}" in
-      logs)
-        _arguments '--follow[Follow log output]'
-        return ;;
-      destroy)
-        _arguments '--yes[Skip confirmation]' '--force[Skip confirmation]'
-        return ;;
-    esac
-  fi
-}
-
-_nemoclaw "$@"
-`;
+  return "#compdef nemoclaw\n"
+    + "# nemoclaw zsh completion\n"
+    + '# Add to ~/.zshrc:  eval "$(nemoclaw completion zsh)"\n'
+    + "\n"
+    + "_nemoclaw() {\n"
+    + "  local -a global_cmds sandbox_actions sandboxes\n"
+    + "\n"
+    + "  global_cmds=(\n"
+    + "    'onboard:Configure inference endpoint and credentials'\n"
+    + "    'list:List all sandboxes'\n"
+    + "    'deploy:Deploy to a Brev VM'\n"
+    + "    'setup-spark:Set up on DGX Spark'\n"
+    + "    'start:Start auxiliary services'\n"
+    + "    'stop:Stop all services'\n"
+    + "    'status:Show sandbox list and service status'\n"
+    + "    'debug:Collect diagnostics for bug reports'\n"
+    + "    'uninstall:Uninstall NemoClaw'\n"
+    + "    'help:Show help'\n"
+    + "    'completion:Generate shell completion script'\n"
+    + "    '--help:Show help'\n"
+    + "    '-h:Show help'\n"
+    + "    '--version:Show version'\n"
+    + "    '-v:Show version'\n"
+    + "  )\n"
+    + "\n"
+    + "  sandbox_actions=(\n"
+    + "    'connect:Shell into a running sandbox'\n"
+    + "    'status:Sandbox health and NIM status'\n"
+    + "    'logs:Stream sandbox logs'\n"
+    + "    'policy-add:Add a network or filesystem policy preset'\n"
+    + "    'policy-list:List presets'\n"
+    + "    'destroy:Stop NIM and delete sandbox'\n"
+    + "  )\n"
+    + "\n"
+    + "  if (( CURRENT == 2 )); then\n"
+    + "    # Get sandbox names dynamically\n"
+    + '    sandboxes=(${(f)"$(nemoclaw completion --list-sandboxes 2>/dev/null)"})\n'
+    + "    _describe 'command' global_cmds -- sandboxes\n"
+    + "    return\n"
+    + "  fi\n"
+    + "\n"
+    + "  if (( CURRENT == 3 )); then\n"
+    + '    case "${words[2]}" in\n'
+    + "      " + noArgCmds + ")\n"
+    + "        return ;;\n"
+    + "      debug)\n"
+    + "        _arguments"
+    + DEBUG_FLAGS.map((f) => {
+      const desc = { "--quick": "Quick diagnostics", "--sandbox": "Target sandbox", "--output": "Save to file", "--help": "Show help" }[f] || f;
+      const extra = f === "--output" ? ":file:_files" : f === "--sandbox" ? ":name: " : "";
+      return " '" + f + "[" + desc + "]" + extra + "'";
+    }).join("")
+    + "\n"
+    + "        return ;;\n"
+    + "    esac\n"
+    + "    # Assume sandbox name → offer actions\n"
+    + "    _describe 'action' sandbox_actions\n"
+    + "    return\n"
+    + "  fi\n"
+    + "\n"
+    + "  if (( CURRENT == 4 )); then\n"
+    + '    case "${words[3]}" in\n'
+    + "      logs)\n"
+    + "        _arguments '--follow[Follow log output]'\n"
+    + "        return ;;\n"
+    + "      destroy)\n"
+    + "        _arguments '--yes[Skip confirmation]' '--force[Skip confirmation]'\n"
+    + "        return ;;\n"
+    + "    esac\n"
+    + "  fi\n"
+    + "}\n"
+    + "\n"
+    + '_nemoclaw "$@"\n';
 }
 
 function fish() {
+  const debugFlags = DEBUG_FLAGS;
+
   return `# nemoclaw fish completion
 # Add to ~/.config/fish/completions/nemoclaw.fish
 # Or run:  nemoclaw completion fish | source
@@ -188,6 +211,7 @@ complete -c nemoclaw -n "not __fish_use_subcommand; and not __fish_seen_subcomma
 
 # debug flags
 complete -c nemoclaw -n '__fish_seen_subcommand_from debug' -l quick -d 'Quick diagnostics'
+complete -c nemoclaw -n '__fish_seen_subcommand_from debug' -l sandbox -d 'Target sandbox' -r
 complete -c nemoclaw -n '__fish_seen_subcommand_from debug' -l output -d 'Save diagnostics to file' -r
 complete -c nemoclaw -n '__fish_seen_subcommand_from debug' -l help -d 'Show help'
 
@@ -248,4 +272,4 @@ function run(args) {
   }
 }
 
-module.exports = { run };
+module.exports = { run, DEBUG_FLAGS };

--- a/bin/lib/completion.js
+++ b/bin/lib/completion.js
@@ -58,7 +58,7 @@ _nemoclaw() {
   fi
 
   if [[ $cword -eq 3 ]]; then
-    local action="${words[2]}"
+    local action="\${words[2]}"
     case "$action" in
       logs)
         COMPREPLY=($(compgen -W "--follow" -- "$cur"))
@@ -139,7 +139,7 @@ _nemoclaw() {
   fi
 }
 
-_nemoclaw "\$@"
+_nemoclaw "$@"
 `;
 }
 

--- a/bin/lib/completion.js
+++ b/bin/lib/completion.js
@@ -42,6 +42,7 @@ _nemoclaw() {
   else
     cur="\${COMP_WORDS[COMP_CWORD]}"
     prev="\${COMP_WORDS[COMP_CWORD-1]}"
+    words=("\${COMP_WORDS[@]}")
     cword=$COMP_CWORD
   fi
 

--- a/bin/lib/completion.js
+++ b/bin/lib/completion.js
@@ -172,8 +172,6 @@ function zsh() {
 }
 
 function fish() {
-  const debugFlags = DEBUG_FLAGS;
-
   return `# nemoclaw fish completion
 # Add to ~/.config/fish/completions/nemoclaw.fish
 # Or run:  nemoclaw completion fish | source

--- a/bin/lib/completion.js
+++ b/bin/lib/completion.js
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const registry = require("./registry");
+
+const GLOBAL_COMMANDS = [
+  "onboard", "list", "deploy", "setup-spark",
+  "start", "stop", "status", "debug", "uninstall",
+  "help", "completion",
+];
+
+const SANDBOX_ACTIONS = [
+  "connect", "status", "logs", "policy-add", "policy-list", "destroy",
+];
+
+function getSandboxNames() {
+  try {
+    const { sandboxes } = registry.listSandboxes();
+    return sandboxes.map((s) => s.name);
+  } catch {
+    return [];
+  }
+}
+
+function bash() {
+  return `# nemoclaw bash completion
+# Add to ~/.bashrc:  eval "$(nemoclaw completion bash)"
+
+_nemoclaw() {
+  local cur prev words cword
+  _init_completion || return
+
+  local global_cmds="${GLOBAL_COMMANDS.join(" ")}"
+  local sandbox_actions="${SANDBOX_ACTIONS.join(" ")}"
+
+  if [[ $cword -eq 1 ]]; then
+    # Complete global commands + sandbox names
+    local sandboxes
+    sandboxes="$(nemoclaw completion --list-sandboxes 2>/dev/null)"
+    COMPREPLY=($(compgen -W "$global_cmds $sandboxes" -- "$cur"))
+    return
+  fi
+
+  if [[ $cword -eq 2 ]]; then
+    # If first arg is a sandbox name, complete with actions
+    case "$prev" in
+      onboard|list|start|stop|status|help|completion|uninstall)
+        return ;;
+      deploy)
+        return ;;
+      debug)
+        COMPREPLY=($(compgen -W "--quick --output --help" -- "$cur"))
+        return ;;
+    esac
+    # Assume sandbox name → offer actions
+    COMPREPLY=($(compgen -W "$sandbox_actions" -- "$cur"))
+    return
+  fi
+
+  if [[ $cword -eq 3 ]]; then
+    local action="${words[2]}"
+    case "$action" in
+      logs)
+        COMPREPLY=($(compgen -W "--follow" -- "$cur"))
+        return ;;
+      destroy)
+        COMPREPLY=($(compgen -W "--yes --force" -- "$cur"))
+        return ;;
+    esac
+  fi
+}
+
+complete -F _nemoclaw nemoclaw
+`;
+}
+
+function zsh() {
+  return `#compdef nemoclaw
+# nemoclaw zsh completion
+# Add to ~/.zshrc:  eval "$(nemoclaw completion zsh)"
+
+_nemoclaw() {
+  local -a global_cmds sandbox_actions sandboxes
+
+  global_cmds=(
+    'onboard:Configure inference endpoint and credentials'
+    'list:List all sandboxes'
+    'deploy:Deploy to a Brev VM'
+    'setup-spark:Set up on DGX Spark'
+    'start:Start auxiliary services'
+    'stop:Stop all services'
+    'status:Show sandbox list and service status'
+    'debug:Collect diagnostics for bug reports'
+    'uninstall:Uninstall NemoClaw'
+    'help:Show help'
+    'completion:Generate shell completion script'
+  )
+
+  sandbox_actions=(
+    'connect:Shell into a running sandbox'
+    'status:Sandbox health and NIM status'
+    'logs:Stream sandbox logs'
+    'policy-add:Add a network or filesystem policy preset'
+    'policy-list:List presets'
+    'destroy:Stop NIM and delete sandbox'
+  )
+
+  if (( CURRENT == 2 )); then
+    # Get sandbox names dynamically
+    sandboxes=(\${(f)"$(nemoclaw completion --list-sandboxes 2>/dev/null)"})
+    _describe 'command' global_cmds -- sandboxes
+    return
+  fi
+
+  if (( CURRENT == 3 )); then
+    case "\${words[2]}" in
+      onboard|list|start|stop|status|help|completion|uninstall)
+        return ;;
+      deploy)
+        return ;;
+      debug)
+        _arguments '--quick[Quick diagnostics]' '--output[Save to file]:file:_files' '--help[Show help]'
+        return ;;
+    esac
+    # Assume sandbox name → offer actions
+    _describe 'action' sandbox_actions
+    return
+  fi
+
+  if (( CURRENT == 4 )); then
+    case "\${words[3]}" in
+      logs)
+        _arguments '--follow[Follow log output]'
+        return ;;
+      destroy)
+        _arguments '--yes[Skip confirmation]' '--force[Skip confirmation]'
+        return ;;
+    esac
+  fi
+}
+
+_nemoclaw "\$@"
+`;
+}
+
+function fish() {
+  return `# nemoclaw fish completion
+# Add to ~/.config/fish/completions/nemoclaw.fish
+# Or run:  nemoclaw completion fish | source
+
+# Disable file completions by default
+complete -c nemoclaw -f
+
+# Global commands
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'onboard' -d 'Configure inference endpoint and credentials'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'list' -d 'List all sandboxes'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'deploy' -d 'Deploy to a Brev VM'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'setup-spark' -d 'Set up on DGX Spark'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'start' -d 'Start auxiliary services'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'stop' -d 'Stop all services'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'status' -d 'Show sandbox list and service status'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'debug' -d 'Collect diagnostics for bug reports'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'uninstall' -d 'Uninstall NemoClaw'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'help' -d 'Show help'
+complete -c nemoclaw -n '__fish_use_subcommand' -a 'completion' -d 'Generate shell completion script'
+
+# Dynamic sandbox names
+complete -c nemoclaw -n '__fish_use_subcommand' -a '(nemoclaw completion --list-sandboxes 2>/dev/null)'
+
+# Sandbox actions (when first arg is not a global command)
+set -l global_cmds onboard list deploy setup-spark start stop status debug uninstall help completion
+complete -c nemoclaw -n "not __fish_use_subcommand; and not __fish_seen_subcommand_from $global_cmds" -a 'connect' -d 'Shell into sandbox'
+complete -c nemoclaw -n "not __fish_use_subcommand; and not __fish_seen_subcommand_from $global_cmds" -a 'status' -d 'Sandbox health and NIM status'
+complete -c nemoclaw -n "not __fish_use_subcommand; and not __fish_seen_subcommand_from $global_cmds" -a 'logs' -d 'Stream sandbox logs'
+complete -c nemoclaw -n "not __fish_use_subcommand; and not __fish_seen_subcommand_from $global_cmds" -a 'policy-add' -d 'Add a policy preset'
+complete -c nemoclaw -n "not __fish_use_subcommand; and not __fish_seen_subcommand_from $global_cmds" -a 'policy-list' -d 'List presets'
+complete -c nemoclaw -n "not __fish_use_subcommand; and not __fish_seen_subcommand_from $global_cmds" -a 'destroy' -d 'Stop NIM and delete sandbox'
+
+# debug flags
+complete -c nemoclaw -n '__fish_seen_subcommand_from debug' -l quick -d 'Quick diagnostics'
+complete -c nemoclaw -n '__fish_seen_subcommand_from debug' -l output -d 'Save diagnostics to file' -r
+complete -c nemoclaw -n '__fish_seen_subcommand_from debug' -l help -d 'Show help'
+
+# logs flags
+complete -c nemoclaw -n '__fish_seen_subcommand_from logs' -l follow -d 'Follow log output'
+
+# destroy flags
+complete -c nemoclaw -n '__fish_seen_subcommand_from destroy' -l yes -d 'Skip confirmation'
+complete -c nemoclaw -n '__fish_seen_subcommand_from destroy' -l force -d 'Skip confirmation'
+
+# completion subcommands
+complete -c nemoclaw -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish' -d 'Shell type'
+`;
+}
+
+function listSandboxNames() {
+  const names = getSandboxNames();
+  if (names.length > 0) {
+    console.log(names.join("\n"));
+  }
+}
+
+function run(args) {
+  if (args.includes("--list-sandboxes")) {
+    listSandboxNames();
+    return;
+  }
+
+  const shell = args[0];
+
+  if (!shell) {
+    // Auto-detect from SHELL env
+    const envShell = process.env.SHELL || "";
+    if (envShell.includes("zsh")) {
+      process.stdout.write(zsh());
+    } else if (envShell.includes("fish")) {
+      process.stdout.write(fish());
+    } else {
+      process.stdout.write(bash());
+    }
+    return;
+  }
+
+  switch (shell) {
+    case "bash":
+      process.stdout.write(bash());
+      break;
+    case "zsh":
+      process.stdout.write(zsh());
+      break;
+    case "fish":
+      process.stdout.write(fish());
+      break;
+    default:
+      console.error(`  Unknown shell: ${shell}`);
+      console.error("  Supported: bash, zsh, fish");
+      process.exit(1);
+  }
+}
+
+module.exports = { run };

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -36,7 +36,7 @@ const policies = require("./lib/policies");
 const GLOBAL_COMMANDS = new Set([
   "onboard", "list", "deploy", "setup", "setup-spark",
   "start", "stop", "status", "debug", "uninstall",
-  "help", "--help", "-h", "--version", "-v",
+  "completion", "help", "--help", "-h", "--version", "-v",
 ]);
 
 const REMOTE_UNINSTALL_URL = "https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh";
@@ -427,6 +427,9 @@ function help() {
     nemoclaw debug [--quick]         Collect diagnostics for bug reports
     nemoclaw debug --output FILE     Save diagnostics tarball for GitHub issues
 
+  ${G}Shell Completion:${R}
+    nemoclaw completion [bash|zsh|fish]  Generate shell completion script
+
   Cleanup:
     nemoclaw uninstall [flags]       Run uninstall.sh (local first, curl fallback)
 
@@ -464,6 +467,7 @@ const [cmd, ...args] = process.argv.slice(2);
       case "status":      showStatus(); break;
       case "debug":       debug(args); break;
       case "uninstall":   uninstall(args); break;
+      case "completion":  require("./lib/completion").run(args); break;
       case "list":        listSandboxes(); break;
       case "--version":
       case "-v": {

--- a/test/completion.test.js
+++ b/test/completion.test.js
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { execSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
@@ -69,5 +70,31 @@ describe("completion command", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("completion");
     expect(r.out).toContain("Shell Completion");
+  });
+
+  it("completion flags match debug.sh", () => {
+    // Parse the flags that debug.sh actually accepts from its case statement,
+    // so completion stays in sync when debug.sh gains new flags.
+    const debugSh = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "scripts", "debug.sh"),
+      "utf-8",
+    );
+    // Match case patterns like "    --sandbox)", "    --output | -o)"
+    const casePatterns = debugSh.match(/^\s+--[^\n]+\)/gm) || [];
+    const debugShFlags = casePatterns
+      .map((m) => m.trim().replace(/\)$/, "").split(/\s*\|\s*/))
+      .flat()
+      .map((f) => f.trim())
+      .filter((f) => f.startsWith("--"));
+
+    // eslint-disable-next-line -- CJS require for the exported constant
+    const { DEBUG_FLAGS } = require("../bin/lib/completion.js");
+
+    for (const flag of debugShFlags) {
+      expect(
+        DEBUG_FLAGS,
+        `debug.sh accepts ${flag} but completion.js DEBUG_FLAGS is missing it`,
+      ).toContain(flag);
+    }
   });
 });

--- a/test/completion.test.js
+++ b/test/completion.test.js
@@ -88,7 +88,6 @@ describe("completion command", () => {
       .map((f) => f.trim())
       .filter((f) => f.startsWith("--"));
 
-    // eslint-disable-next-line -- CJS require for the exported constant
     const { DEBUG_FLAGS } = require("../bin/lib/completion.js");
 
     for (const flag of debugShFlags) {

--- a/test/completion.test.js
+++ b/test/completion.test.js
@@ -35,6 +35,7 @@ describe("completion command", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("#compdef nemoclaw");
     expect(r.out).toContain("_nemoclaw");
+    expect(r.out).toContain("compdef _nemoclaw nemoclaw");
     expect(r.out).toContain("onboard");
   });
 
@@ -46,10 +47,14 @@ describe("completion command", () => {
   });
 
   it("completion with no arg auto-detects shell", () => {
-    const r = run("completion");
-    expect(r.code).toBe(0);
-    // Should output some completion script regardless of shell
-    expect(r.out.length).toBeGreaterThan(100);
+    // Force SHELL so auto-detect works regardless of CI environment
+    const out = execSync(`node "${CLI}" completion`, {
+      encoding: "utf-8",
+      timeout: 10000,
+      env: { ...process.env, HOME: "/tmp/nemoclaw-completion-test-" + Date.now(), SHELL: "/bin/bash" },
+    });
+    expect(out.length).toBeGreaterThan(100);
+    expect(out).toContain("_nemoclaw");
   });
 
   it("completion with unknown shell exits 1", () => {

--- a/test/completion.test.js
+++ b/test/completion.test.js
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { execSync } from "node:child_process";
+import path from "node:path";
+
+const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
+
+function run(args) {
+  try {
+    const out = execSync(`node "${CLI}" ${args}`, {
+      encoding: "utf-8",
+      timeout: 10000,
+      env: { ...process.env, HOME: "/tmp/nemoclaw-completion-test-" + Date.now() },
+    });
+    return { code: 0, out };
+  } catch (err) {
+    return { code: err.status, out: (err.stdout || "") + (err.stderr || "") };
+  }
+}
+
+describe("completion command", () => {
+  it("completion bash outputs valid bash completion", () => {
+    const r = run("completion bash");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("_nemoclaw");
+    expect(r.out).toContain("complete -F _nemoclaw nemoclaw");
+    expect(r.out).toContain("onboard");
+  });
+
+  it("completion zsh outputs valid zsh completion", () => {
+    const r = run("completion zsh");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("#compdef nemoclaw");
+    expect(r.out).toContain("_nemoclaw");
+    expect(r.out).toContain("onboard");
+  });
+
+  it("completion fish outputs valid fish completion", () => {
+    const r = run("completion fish");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("complete -c nemoclaw");
+    expect(r.out).toContain("onboard");
+  });
+
+  it("completion with no arg auto-detects shell", () => {
+    const r = run("completion");
+    expect(r.code).toBe(0);
+    // Should output some completion script regardless of shell
+    expect(r.out.length).toBeGreaterThan(100);
+  });
+
+  it("completion with unknown shell exits 1", () => {
+    const r = run("completion powershell");
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("Unknown shell");
+    expect(r.out).toContain("Supported: bash, zsh, fish");
+  });
+
+  it("completion --list-sandboxes exits 0", () => {
+    const r = run("completion --list-sandboxes");
+    expect(r.code).toBe(0);
+    // With empty HOME, no sandboxes expected — just no error
+  });
+
+  it("help mentions completion command", () => {
+    const r = run("help");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("completion");
+    expect(r.out).toContain("Shell Completion");
+  });
+});

--- a/test/completion.test.js
+++ b/test/completion.test.js
@@ -80,7 +80,8 @@ describe("completion command", () => {
       "utf-8",
     );
     // Match case patterns like "    --sandbox)", "    --output | -o)"
-    const casePatterns = debugSh.match(/^\s+--[^\n]+\)/gm) || [];
+    // Only match lines where ) follows flags (with optional | short alias)
+    const casePatterns = debugSh.match(/^\s+--[\w-]+(?:\s*\|\s*-\w+)?\)/gm) || [];
     const debugShFlags = casePatterns
       .map((m) => m.trim().replace(/\)$/, "").split(/\s*\|\s*/))
       .flat()


### PR DESCRIPTION
## Summary

Add a `nemoclaw completion [bash|zsh|fish]` subcommand that generates shell completion scripts. Auto-detects the current shell when run without arguments.

Fixes #155

## Changes

- `bin/lib/completion.js` — generates bash, zsh, and fish completion scripts
- `bin/nemoclaw.js` — registers `completion` as a global command
- `test/completion.test.js` — 7 test cases

## Details

Completions cover:
- Global commands (onboard, list, deploy, etc.)
- Dynamic sandbox names from the registry
- Sandbox-scoped actions (connect, status, logs, etc.)
- Per-command flags (--follow, --yes, --quick, --output)

Hidden `--list-sandboxes` flag is used internally by completion scripts for dynamic sandbox name completion at tab-time.

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.

## Testing

- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.

```
# Usage
eval "$(nemoclaw completion bash)"   # bash
eval "$(nemoclaw completion zsh)"    # zsh
nemoclaw completion fish | source    # fish
nemoclaw completion                  # auto-detect
```

## Checklist

### General
- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).

### Code Changes
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shell completion for bash, zsh, and fish via `nemoclaw completion [bash|zsh|fish]`; omitting the shell auto-detects it. Completions include global commands, sandbox names, actions, and relevant flags. Adds a mode to list sandbox names for integration.
  * Help updated to document "Shell Completion".

* **Tests**
  * Added automated tests validating completion output, list-sandboxes mode, unknown-shell handling, and help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->