### PR TITLE
docs: remove plugin wording from README stack description

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ NemoClaw installs the NVIDIA OpenShell runtime, then creates a sandboxed OpenCla
 
 | Component        | Role                                                                                      |
 |------------------|-------------------------------------------------------------------------------------------|
-| **Plugin**       | TypeScript CLI commands for launch, connect, status, and logs.                            |
+| **CLI layer**    | Host-side and in-chat command surfaces for onboarding, connect, status, logs, and service control. |
 | **Blueprint**    | Versioned Python artifact that orchestrates sandbox creation, policy, and inference setup. |
 | **Sandbox**      | Isolated OpenShell container running OpenClaw with policy-enforced egress and filesystem.  |
 | **Inference**    | Provider-routed model calls, routed through the OpenShell gateway, transparent to the agent. |


### PR DESCRIPTION
## Summary
- replace the README component table's plugin wording with CLI-layer language
- keep the section aligned with NemoClaw's reference-stack messaging

## Testing
- not run (docs-only change)

Fixes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation in the README to clarify the CLI layer and available command surfaces for system management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->