### PR TITLE
docs: add host-side config and state file locations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ Credentials stay on the host in `~/.nemoclaw/credentials.json`. The sandbox only
 
 Local Ollama is supported in the standard onboarding flow. Local vLLM remains experimental, and local host-routed inference on macOS still depends on OpenShell host-routing support in addition to the local service itself being reachable on the host.
 
+## Host-Side State and Config
+
+NemoClaw keeps its operator-facing state on the host rather than inside the sandbox.
+These are the main files new users usually need to locate:
+
+| Path | Purpose |
+|---|---|
+| `~/.nemoclaw/credentials.json` | Provider credentials saved during onboarding |
+| `~/.nemoclaw/sandboxes.json` | Registered sandbox metadata, including the default sandbox selection |
+| `~/.openclaw/openclaw.json` | Host OpenClaw configuration that NemoClaw snapshots or restores during migration flows |
+
+Common environment variables for optional services and local access include `TELEGRAM_BOT_TOKEN`, `ALLOWED_CHAT_IDS`, and `CHAT_UI_URL`.
+For normal sandbox setup and reconfiguration, prefer `nemoclaw onboard` over editing these files by hand.
+
 ---
 
 ## Protection Layers


### PR DESCRIPTION
## Summary
- add a README section that points users to the main host-side NemoClaw state files
- call out the optional service environment variables users are most likely to need
- steer reconfiguration back toward `nemoclaw onboard` instead of manual edits

## Testing
- not run (docs-only change)

Fixes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Host-Side State and Config" section explaining where NemoClaw stores operator configuration and state files on the host system.
  * Documented common environment variables for optional services and configuration.
  * Clarified recommended setup and reconfiguration procedures using the onboard command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->