### PR TITLE
feat(onboard): print Control UI chat URLs with embedded gateway token

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -2137,6 +2137,68 @@ async function setupPolicies(sandboxName) {
 
 // ── Dashboard ────────────────────────────────────────────────────
 
+const CONTROL_UI_PORT = 18789;
+const CONTROL_UI_CHAT_PATH = "/chat?session=main";
+
+function findOpenclawJsonPath(dir) {
+  if (!fs.existsSync(dir)) return null;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      const found = findOpenclawJsonPath(p);
+      if (found) return found;
+    } else if (e.name === "openclaw.json") {
+      return p;
+    }
+  }
+  return null;
+}
+
+/**
+ * Pull gateway.auth.token from the sandbox image via openshell sandbox download
+ * so onboard can print copy-paste Control UI URLs with #token= (same idea as nemoclaw-start.sh).
+ */
+function fetchGatewayAuthTokenFromSandbox(sandboxName) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
+  try {
+    const destDir = `${tmpDir}${path.sep}`;
+    const result = runOpenshell(
+      ["sandbox", "download", sandboxName, "/sandbox/.openclaw/openclaw.json", destDir],
+      { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] }
+    );
+    if (result.status !== 0) return null;
+    const jsonPath = findOpenclawJsonPath(tmpDir);
+    if (!jsonPath) return null;
+    const cfg = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+    const token = cfg && cfg.gateway && cfg.gateway.auth && cfg.gateway.auth.token;
+    return typeof token === "string" && token.length > 0 ? token : null;
+  } catch {
+    return null;
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+function buildControlUiChatUrls(token) {
+  const hash = token ? `#token=${token}` : "";
+  const pathChat = `${CONTROL_UI_CHAT_PATH}${hash}`;
+  const bases = [
+    `http://127.0.0.1:${CONTROL_UI_PORT}`,
+    `http://localhost:${CONTROL_UI_PORT}`,
+  ];
+  const chatUi = (process.env.CHAT_UI_URL || "").trim().replace(/\/$/, "");
+  const urls = bases.map((b) => `${b}${pathChat}`);
+  if (chatUi && /^https?:\/\//i.test(chatUi) && !bases.includes(chatUi)) {
+    urls.push(`${chatUi}${pathChat}`);
+  }
+  return [...new Set(urls)];
+}
+
 function printDashboard(sandboxName, model, provider, nimContainer = null) {
   const nimStat = nimContainer ? nim.nimStatusByName(nimContainer) : nim.nimStatus(sandboxName);
   const nimLabel = nimStat.running ? "running" : "not running";
@@ -2151,6 +2213,8 @@ function printDashboard(sandboxName, model, provider, nimContainer = null) {
   else if (provider === "vllm-local") providerLabel = "Local vLLM";
   else if (provider === "ollama-local") providerLabel = "Local Ollama";
 
+  const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
+
   console.log("");
   console.log(`  ${"─".repeat(50)}`);
   // console.log(`  Dashboard    http://localhost:18789/`);
@@ -2159,6 +2223,18 @@ function printDashboard(sandboxName, model, provider, nimContainer = null) {
   console.log(`  NIM          ${nimLabel}`);
   console.log(`  ${"─".repeat(50)}`);
   console.log(`  Next:`);
+  if (token) {
+    note("  URLs below embed the gateway token — treat them like a password.");
+    console.log(`  Control UI:  copy one line into your browser (port ${CONTROL_UI_PORT} must be forwarded):`);
+    for (const u of buildControlUiChatUrls(token)) {
+      console.log(`    ${u}`);
+    }
+  } else {
+    note("  Could not read gateway token from the sandbox (download failed).");
+    console.log(`  Control UI:  http://127.0.0.1:${CONTROL_UI_PORT}${CONTROL_UI_CHAT_PATH}`);
+    console.log(`  Token:       nemoclaw ${sandboxName} connect  →  jq -r '.gateway.auth.token' /sandbox/.openclaw/openclaw.json`);
+    console.log(`               append  #token=<token>  to the URL, or see /tmp/gateway.log inside the sandbox.`);
+  }
   console.log(`  Run:         nemoclaw ${sandboxName} connect`);
   console.log(`  Status:      nemoclaw ${sandboxName} status`);
   console.log(`  Logs:        nemoclaw ${sandboxName} logs --follow`);


### PR DESCRIPTION
## Summary

After onboard completes, print clickable Control UI URLs that include the gateway auth token so users can copy-paste them directly into a browser (port-forwarded). When the token download fails, fall back to manual instructions.

## Related Issue

Related to #20 — this PR complements the remote dashboard access fix by providing token-embedded URLs that work over SSH port-forwarding. See also #114 which addresses the gateway binding side.

## Changes

- **`bin/lib/onboard.js`**:
  - Add `CONTROL_UI_PORT` / `CONTROL_UI_CHAT_PATH` constants
  - Add `findOpenclawJsonPath()` — recursive search for `openclaw.json` in download dir
  - Add `fetchGatewayAuthTokenFromSandbox()` — downloads `openclaw.json` from the sandbox to extract `gateway.auth.token`
  - Add `buildControlUiChatUrls()` — generates `http://127.0.0.1` and `http://localhost` URLs with `#token=` hash
  - Update `printDashboard()` — show Control UI URLs with embedded token, or fallback instructions

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Manual testing: onboard prints Control UI URLs when sandbox has a gateway token

## Checklist

### General
- [x] I have read the [CONTRIBUTING](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md) doc.
- [x] I have signed my commits (`git log --show-signature`).

### Code Changes
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting.
- [x] No secrets, API keys, or credentials committed.