### PR TITLE
docs(deploy): add Brev first-run quick start

### DIFF
--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -23,6 +23,19 @@ status: published
 Run NemoClaw on a remote GPU instance through [Brev](https://brev.nvidia.com).
 The deploy command provisions the VM, installs dependencies, and connects you to a running sandbox.
 
+## Quick Start
+
+If your Brev instance is already up and you want to try NemoClaw immediately, start with the sandbox chat flow:
+
+```console
+$ nemoclaw my-assistant connect
+$ openclaw tui
+```
+
+This gets you into the sandbox shell first and opens the OpenClaw chat UI right away.
+
+If you are connecting from your local machine and still need to provision the remote VM, use `nemoclaw deploy <instance-name>` as described below.
+
 ## Prerequisites
 
 - The [Brev CLI](https://brev.nvidia.com) installed and authenticated.


### PR DESCRIPTION
## Summary
- add a first-run quick start near the top of the remote GPU deployment guide
- make the first user action on an already-provisioned Brev instance `nemoclaw my-assistant connect` followed by `openclaw tui`
- keep the full deploy and monitoring instructions in the rest of the page

## Testing
- not run (docs-only change)

Fixes #805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Quick Start section to deployment documentation for immediate setup guidance
  * Clarified prerequisites for users with existing instances
  * Provided deployment instructions for users requiring VM provisioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->