### PR TITLE
docs(troubleshooting): add reconnect steps after host reboot

### DIFF
--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -143,6 +143,56 @@ $ colima status
 
 ## Runtime
 
+### Reconnect after a host reboot
+
+After a host reboot, the container runtime, OpenShell gateway, and sandbox may not be running.
+Follow these steps to reconnect.
+
+1. Start the container runtime.
+
+   - **Linux:** start Docker if it is not already running (`sudo systemctl start docker`)
+   - **macOS:** open Docker Desktop or start Colima (`colima start`)
+
+1. Check sandbox state.
+
+   ```console
+   $ openshell sandbox list
+   ```
+
+   If the sandbox shows `Ready`, skip to step 4.
+
+1. Restart the gateway (if needed).
+
+   If the sandbox is not listed or the command fails, restart the OpenShell gateway:
+
+   ```console
+   $ openshell gateway start --name nemoclaw
+   ```
+
+   Wait a few seconds, then re-check with `openshell sandbox list`.
+
+1. Reconnect.
+
+   ```console
+   $ nemoclaw <name> connect
+   ```
+
+1. Start auxiliary services (if needed).
+
+   If you use the Telegram bridge or cloudflared tunnel, start them again:
+
+   ```console
+   $ nemoclaw start
+   ```
+
+:::{admonition} If the sandbox does not recover
+:class: warning
+
+If the sandbox remains missing after restarting the gateway, run `nemoclaw onboard` to recreate it.
+The wizard prompts for confirmation before destroying an existing sandbox. If you confirm, it **destroys and recreates** the sandbox — workspace files (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
+Back up your workspace first by following the instructions at [Back Up and Restore](../workspace/backup-restore.md).
+:::
+
 ### Sandbox shows as stopped
 
 The sandbox may have been stopped or deleted.


### PR DESCRIPTION
## Summary
- Add troubleshooting section documenting the full recovery sequence after a host reboot
- Steps: start container runtime, check sandbox state, restart gateway if needed, reconnect, restart auxiliary services
- Warn that `nemoclaw onboard` is destructive (destroys workspace files) and should only be used as a last resort

Closes #469

## Related
- #910 — follow-up feature request for a `nemoclaw reconnect` command to automate this sequence
- PR #904 — previous docs attempt by @WuKongAI-CMU (closed due to PR limit)

 ## Acknowledgment
   Credit to @RitikKadyan whose PR #474 first tackled this issue. This PR builds on that work with additional steps (gateway restart) and a data loss warning. Ritik is included as a co-author on the commit.

## Test plan
- [ ] Verify rendered docs render correctly on the docs site
- [ ] Confirm command sequence works on a real reboot scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting section for reconnecting after a host reboot with step-by-step instructions for container restart, sandbox verification, and client reconnection.
  * Included warning about potential data loss when using recovery commands for persistent sandbox issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->