### PR TITLE
fix: use npm ci with package-lock.json in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,12 +81,12 @@ RUN npm install -g openclaw@2026.3.11 \
 # Copy built plugin and blueprint into the sandbox
 COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
-COPY nemoclaw/package.json /opt/nemoclaw/
+COPY nemoclaw/package.json nemoclaw/package-lock.json /opt/nemoclaw/
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
 
 # Install runtime dependencies only (no devDependencies, no build step)
 WORKDIR /opt/nemoclaw
-RUN npm install --omit=dev
+RUN npm ci --omit=dev
 
 # Set up blueprint for local resolution
 RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \


### PR DESCRIPTION
## Summary

- Copy `package-lock.json` alongside `package.json` into the Docker image
- Replace `npm install --omit=dev` with `npm ci --omit=dev` for deterministic, reproducible builds

Supersedes #640 with a signed commit.

Co-authored-by: Praveen Singh <pr4veensingh@proton.me>

## Test plan

- [x] `hadolint` passes
- [x] All pre-commit and pre-push hooks pass
- [x] `npm ci --omit=dev` installs correctly with lockfile present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to improve consistency and reproducibility of application deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->