### PR TITLE
fix(security): drop unnecessary Linux capabilities at container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates=20230311+deb12u1 \
         iproute2=6.1.0-3 \
         iptables=1.8.9-2 \
-        libcap2-bin=1:2.66-4 \
+        libcap2-bin=1:2.66-4+deb12u2+b2 \
     && rm -rf /var/lib/apt/lists/*
 
 # gosu for privilege separation (gateway vs sandbox user).

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git=1:2.39.5-0+deb12u3 \
         ca-certificates=20230311+deb12u1 \
         iproute2=6.1.0-3 \
+        libcap2-bin=1:2.66-4 \
     && rm -rf /var/lib/apt/lists/*
 
 # gosu for privilege separation (gateway vs sandbox user).

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -32,16 +32,10 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 if [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ] && command -v capsh >/dev/null 2>&1; then
   export NEMOCLAW_CAPS_DROPPED=1
   exec capsh \
-    --drop=cap_net_raw \
-    --drop=cap_dac_override \
-    --drop=cap_sys_chroot \
-    --drop=cap_fsetid \
-    --drop=cap_setpcap \
-    --drop=cap_setfcap \
-    --drop=cap_mknod \
-    --drop=cap_audit_write \
-    --drop=cap_net_bind_service \
+    --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setpcap,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
     -- -c 'exec /usr/local/bin/nemoclaw-start "$@"' -- "$@"
+elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
+  echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2
 fi
 
 # Filter out self-invocation: openshell sandbox create passes "nemoclaw-start"

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -19,6 +19,31 @@ set -euo pipefail
 # into commands executed by the entrypoint or auto-pair watcher.
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
+# ── Drop unnecessary Linux capabilities ──────────────────────────
+# CIS Docker Benchmark 5.3: containers should not run with default caps.
+# OpenShell manages the container runtime so we cannot pass --cap-drop=ALL
+# to docker run. Instead, drop dangerous capabilities from the bounding set
+# at startup using capsh. The bounding set limits what caps any child process
+# (gateway, sandbox, agent) can ever acquire.
+#
+# Kept: cap_chown, cap_setuid, cap_setgid, cap_fowner, cap_kill
+#   — required by the entrypoint for gosu privilege separation and chown.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/797
+if [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ] && command -v capsh >/dev/null 2>&1; then
+  export NEMOCLAW_CAPS_DROPPED=1
+  exec capsh \
+    --drop=cap_net_raw \
+    --drop=cap_dac_override \
+    --drop=cap_sys_chroot \
+    --drop=cap_fsetid \
+    --drop=cap_setpcap \
+    --drop=cap_setfcap \
+    --drop=cap_mknod \
+    --drop=cap_audit_write \
+    --drop=cap_net_bind_service \
+    -- -c 'exec /usr/local/bin/nemoclaw-start "$@"' -- "$@"
+fi
+
 # Filter out self-invocation: openshell sandbox create passes "nemoclaw-start"
 # as the command, but since this script is now the ENTRYPOINT, receiving our
 # own name as $1 would cause infinite recursion via the NEMOCLAW_CMD exec path.

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -192,7 +192,7 @@ fi
 info "12. Entrypoint drops dangerous capabilities from bounding set"
 # Run the entrypoint (which re-execs through capsh) and check CapBnd.
 # The entrypoint drops cap_net_raw (bit 13 = 0x2000) among others.
-# We read /proc/1/status CapBnd after the entrypoint has run.
+# We read /proc/self/status CapBnd after the entrypoint has run.
 OUT=$(docker run --rm "$IMAGE" bash -c '
   # We are inside the capsh-wrapped entrypoint. Read our bounding set.
   CAP_BND=$(grep "^CapBnd:" /proc/self/status | awk "{print \$2}")

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -177,6 +177,33 @@ else
   fail "sandbox CAN kill gateway processes: $OUT"
 fi
 
+# ── Test 11: Dangerous capabilities are dropped by entrypoint ────
+
+info "11. Entrypoint drops dangerous capabilities from bounding set"
+# Run the entrypoint (which re-execs through capsh) and check CapBnd.
+# The entrypoint drops cap_net_raw (bit 13 = 0x2000) among others.
+# We read /proc/1/status CapBnd after the entrypoint has run.
+OUT=$(docker run --rm "$IMAGE" bash -c '
+  # We are inside the capsh-wrapped entrypoint. Read our bounding set.
+  CAP_BND=$(grep "^CapBnd:" /proc/self/status | awk "{print \$2}")
+  echo "CapBnd=$CAP_BND"
+  # Check cap_net_raw (bit 13) is NOT set
+  BND_DEC=$((16#$CAP_BND))
+  NET_RAW_BIT=$((1 << 13))
+  if [ $((BND_DEC & NET_RAW_BIT)) -ne 0 ]; then
+    echo "DANGEROUS: cap_net_raw present"
+  else
+    echo "SAFE: cap_net_raw dropped"
+  fi
+' 2>&1)
+if echo "$OUT" | grep -q "SAFE: cap_net_raw dropped"; then
+  pass "entrypoint drops dangerous capabilities (cap_net_raw not in bounding set)"
+elif echo "$OUT" | grep -q "DANGEROUS"; then
+  fail "cap_net_raw still present after entrypoint: $OUT"
+else
+  fail "could not verify capability state: $OUT"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds `libcap2-bin` to the Dockerfile (provides `capsh`)
- Entrypoint (`nemoclaw-start.sh`) self-re-execs through `capsh` to drop 9 dangerous capabilities from the bounding set before any child processes launch: `cap_net_raw`, `cap_dac_override`, `cap_sys_chroot`, `cap_fsetid`, `cap_setpcap`, `cap_setfcap`, `cap_mknod`, `cap_audit_write`, `cap_net_bind_service`
- Keeps only the 5 capabilities required for gosu privilege separation: `cap_chown`, `cap_setuid`, `cap_setgid`, `cap_fowner`, `cap_kill`
- Adds e2e test verifying `cap_net_raw` is absent from the bounding set after entrypoint runs

Since OpenShell manages the container runtime (no `--cap-drop` flag on `openshell sandbox create`), the entrypoint handles capability dropping itself via `capsh`. This is defense-in-depth per CIS Docker Benchmark 5.3.

## Thanks

Thanks to @BenediktSchackenberg for the thorough issue write-up and CIS benchmark references, and to @h-network for pushing back on docs-only approaches and keeping the bar high for a proper enforcement fix.

Fixes #797

## Test plan

- [ ] `docker build` succeeds with new `libcap2-bin` package
- [ ] Container starts normally (entrypoint self-re-exec is transparent)
- [ ] `test/e2e-gateway-isolation.sh` test 11 passes — `cap_net_raw` absent from bounding set
- [ ] Existing tests 1–10 still pass (gosu, config integrity, symlinks, process isolation)
- [ ] Gateway and sandbox processes function correctly with reduced capability set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced application startup with reduced system-level privileges for improved security posture.

* **Tests**
  * Added verification test to ensure privilege restrictions are properly enforced at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->