### PR TITLE
fix(ci): base-image workflow fixes (ARG scoping, arm64, buildx)

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   build-and-push:
+    if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -64,3 +65,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Build and push the sandbox base image to GHCR.
+#
+# Triggers:
+#   - Push to main when Dockerfile.base changes (new apt pkgs, openclaw bump, etc.)
+#   - Manual dispatch for ad-hoc rebuilds
+#
+# The base image contains the expensive, rarely-changing layers (apt, gosu,
+# user setup, openclaw CLI). The production Dockerfile layers PR-specific
+# code on top via: FROM ghcr.io/nvidia/nemoclaw/sandbox-base:<tag>
+
+name: base-image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile.base"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: base-image
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nvidia/nemoclaw/sandbox-base
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.base
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-pin-check.yaml
+++ b/.github/workflows/docker-pin-check.yaml
@@ -25,4 +25,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check Dockerfile base-image pin
-        run: bash scripts/update-docker-pin.sh --check
+        run: |
+          bash scripts/update-docker-pin.sh --check
+          DOCKERFILE=Dockerfile.base bash scripts/update-docker-pin.sh --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -82,8 +82,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Pull base image from GHCR (fall back to local build)
+        run: |
+          if docker pull ghcr.io/nvidia/nemoclaw/sandbox-base:latest 2>/dev/null; then
+            echo "BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest" >> "$GITHUB_ENV"
+          else
+            echo "::warning::GHCR base image not available, building locally"
+            docker build -f Dockerfile.base -t nemoclaw-sandbox-base-local .
+            echo "BASE_IMAGE=nemoclaw-sandbox-base-local" >> "$GITHUB_ENV"
+          fi
+
       - name: Build production image
-        run: docker build -t nemoclaw-production .
+        run: docker build --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} -t nemoclaw-production .
 
       - name: Build sandbox test image (fixtures layered on production)
         run: docker build -f test/Dockerfile.sandbox --build-arg BASE_IMAGE=nemoclaw-production -t nemoclaw-sandbox-test .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -124,8 +124,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Pull base image from GHCR (fall back to local build)
+        run: |
+          if docker pull ghcr.io/nvidia/nemoclaw/sandbox-base:latest 2>/dev/null; then
+            echo "BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest" >> "$GITHUB_ENV"
+          else
+            echo "::warning::GHCR base image not available, building locally"
+            docker build -f Dockerfile.base -t nemoclaw-sandbox-base-local .
+            echo "BASE_IMAGE=nemoclaw-sandbox-base-local" >> "$GITHUB_ENV"
+          fi
+
       - name: Build production image on arm64
-        run: docker build -t nemoclaw-production-arm64 .
+        run: docker build --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} -t nemoclaw-production-arm64 .
 
       - name: Build sandbox test image on arm64
         run: docker build -f test/Dockerfile.sandbox --build-arg BASE_IMAGE=nemoclaw-production-arm64 -t nemoclaw-sandbox-test-arm64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@
 # For local builds without GHCR access, build the base first:
 #   docker build -f Dockerfile.base -t ghcr.io/nvidia/nemoclaw/sandbox-base:latest .
 
+# Global ARG — must be declared before the first FROM to be visible
+# to all FROM directives. Can be overridden via --build-arg.
+ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest
+
 # Stage 1: Build TypeScript plugin from source
 FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d AS builder
 COPY nemoclaw/package.json nemoclaw/tsconfig.json /opt/nemoclaw/
@@ -15,7 +19,6 @@ WORKDIR /opt/nemoclaw
 RUN npm install && npm run build
 
 # Stage 2: Runtime image — pull cached base from GHCR
-ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest
 FROM ${BASE_IMAGE}
 
 # Copy built plugin and blueprint into the sandbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,12 @@ FROM ${BASE_IMAGE}
 # Copy built plugin and blueprint into the sandbox
 COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
-COPY nemoclaw/package.json /opt/nemoclaw/
+COPY nemoclaw/package.json nemoclaw/package-lock.json /opt/nemoclaw/
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
 
 # Install runtime dependencies only (no devDependencies, no build step)
 WORKDIR /opt/nemoclaw
-RUN npm install --omit=dev
+RUN npm ci --omit=dev
 
 # Set up blueprint for local resolution
 RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 # NemoClaw sandbox image — OpenClaw + NemoClaw plugin inside OpenShell
+#
+# Layers PR-specific code (plugin, blueprint, config, startup script) on top
+# of the pre-built base image from GHCR. The base image contains all the
+# expensive, rarely-changing layers (apt, gosu, users, openclaw CLI).
+#
+# For local builds without GHCR access, build the base first:
+#   docker build -f Dockerfile.base -t ghcr.io/nvidia/nemoclaw/sandbox-base:latest .
 
 # Stage 1: Build TypeScript plugin from source
 FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d AS builder
@@ -7,86 +14,19 @@ COPY nemoclaw/src/ /opt/nemoclaw/src/
 WORKDIR /opt/nemoclaw
 RUN npm install && npm run build
 
-# Stage 2: Runtime image
-FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3=3.11.2-1+b1 \
-        python3-pip=23.0.1+dfsg-1 \
-        python3-venv=3.11.2-1+b1 \
-        curl=7.88.1-10+deb12u14 \
-        git=1:2.39.5-0+deb12u3 \
-        ca-certificates=20230311+deb12u1 \
-        iproute2=6.1.0-3 \
-        iptables=1.8.9-2 \
-    && rm -rf /var/lib/apt/lists/*
-
-# gosu for privilege separation (gateway vs sandbox user).
-# Install from GitHub release with checksum verification instead of
-# Debian bookworm's ancient 1.14 (2020). Pinned to 1.19 (2025-09).
-# hadolint ignore=DL4006
-RUN arch="$(dpkg --print-architecture)" \
-    && case "$arch" in \
-        amd64) gosu_asset="gosu-amd64"; gosu_sha256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0" ;; \
-        arm64) gosu_asset="gosu-arm64"; gosu_sha256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
-        *) echo "Unsupported architecture for gosu: $arch" >&2; exit 1 ;; \
-    esac \
-    && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
-    && echo "${gosu_sha256}  /usr/local/bin/gosu" | sha256sum -c - \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu --version
-
-# Create sandbox user (matches OpenShell convention) and gateway user.
-# The gateway runs as 'gateway' so the 'sandbox' user (agent) cannot
-# kill it or restart it with a tampered HOME/config.
-RUN groupadd -r gateway && useradd -r -g gateway -d /sandbox -s /usr/sbin/nologin gateway \
-    && groupadd -r sandbox && useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox \
-    && mkdir -p /sandbox/.nemoclaw \
-    && chown -R sandbox:sandbox /sandbox
-
-# Split .openclaw into immutable config dir + writable state dir.
-# The policy makes /sandbox/.openclaw read-only via Landlock, so the agent
-# cannot modify openclaw.json, auth tokens, or CORS settings.  Writable
-# state (agents, plugins, etc.) lives in .openclaw-data, reached via symlinks.
-# Ref: https://github.com/NVIDIA/NemoClaw/issues/514
-RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
-        /sandbox/.openclaw-data/extensions \
-        /sandbox/.openclaw-data/workspace \
-        /sandbox/.openclaw-data/skills \
-        /sandbox/.openclaw-data/hooks \
-        /sandbox/.openclaw-data/identity \
-        /sandbox/.openclaw-data/devices \
-        /sandbox/.openclaw-data/canvas \
-        /sandbox/.openclaw-data/cron \
-    && mkdir -p /sandbox/.openclaw \
-    && ln -s /sandbox/.openclaw-data/agents /sandbox/.openclaw/agents \
-    && ln -s /sandbox/.openclaw-data/extensions /sandbox/.openclaw/extensions \
-    && ln -s /sandbox/.openclaw-data/workspace /sandbox/.openclaw/workspace \
-    && ln -s /sandbox/.openclaw-data/skills /sandbox/.openclaw/skills \
-    && ln -s /sandbox/.openclaw-data/hooks /sandbox/.openclaw/hooks \
-    && ln -s /sandbox/.openclaw-data/identity /sandbox/.openclaw/identity \
-    && ln -s /sandbox/.openclaw-data/devices /sandbox/.openclaw/devices \
-    && ln -s /sandbox/.openclaw-data/canvas /sandbox/.openclaw/canvas \
-    && ln -s /sandbox/.openclaw-data/cron /sandbox/.openclaw/cron \
-    && touch /sandbox/.openclaw-data/update-check.json \
-    && ln -s /sandbox/.openclaw-data/update-check.json /sandbox/.openclaw/update-check.json \
-    && chown -R sandbox:sandbox /sandbox/.openclaw /sandbox/.openclaw-data
-
-# Install OpenClaw CLI + PyYAML for inline Python scripts in e2e tests
-RUN npm install -g openclaw@2026.3.11 \
-    && pip3 install --no-cache-dir --break-system-packages "pyyaml==6.0.3"
+# Stage 2: Runtime image — pull cached base from GHCR
+ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest
+FROM ${BASE_IMAGE}
 
 # Copy built plugin and blueprint into the sandbox
 COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
-COPY nemoclaw/package.json nemoclaw/package-lock.json /opt/nemoclaw/
+COPY nemoclaw/package.json /opt/nemoclaw/
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
 
 # Install runtime dependencies only (no devDependencies, no build step)
 WORKDIR /opt/nemoclaw
-RUN npm ci --omit=dev
+RUN npm install --omit=dev
 
 # Set up blueprint for local resolution
 RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,7 +15,7 @@
 #   node:22-slim        — pinned by sha256 digest, checked weekly by
 #                          docker-pin-check.yaml
 #   apt packages        — pinned to exact Debian bookworm versions
-#   gosu 1.19           — pinned release + sha256 checksum verification
+#   gosu 1.19           — pinned release + per-arch sha256 checksum
 #   gateway/sandbox     — OS users and groups; names and UIDs are a
 #     users               stable contract with OpenShell
 #   .openclaw dirs      — directory structure + symlinks are dictated by
@@ -60,14 +60,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git=1:2.39.5-0+deb12u3 \
         ca-certificates=20230311+deb12u1 \
         iproute2=6.1.0-3 \
+        iptables=1.8.9-2 \
     && rm -rf /var/lib/apt/lists/*
 
 # gosu for privilege separation (gateway vs sandbox user).
 # Install from GitHub release with checksum verification instead of
 # Debian bookworm's ancient 1.14 (2020). Pinned to 1.19 (2025-09).
 # hadolint ignore=DL4006
-RUN curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-amd64" \
-    && echo "52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0  /usr/local/bin/gosu" | sha256sum -c - \
+RUN arch="$(dpkg --print-architecture)" \
+    && case "$arch" in \
+        amd64) gosu_asset="gosu-amd64"; gosu_sha256="52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0" ;; \
+        arm64) gosu_asset="gosu-arm64"; gosu_sha256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
+        *) echo "Unsupported architecture for gosu: $arch" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
+    && echo "${gosu_sha256}  /usr/local/bin/gosu" | sha256sum -c - \
     && chmod +x /usr/local/bin/gosu \
     && gosu --version
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,7 +6,47 @@
 # Built on main merges and pushed to GHCR. The production Dockerfile
 # layers PR-specific code (plugin, blueprint, config) on top.
 #
-# Rebuild triggers: changes to this file, or OpenClaw CLI version bump.
+# ── Why these layers are safe to cache ──────────────────────────────────
+#
+# Everything in this file is either pinned to an exact version or is
+# structural (users, directories, symlinks) that doesn't depend on
+# NemoClaw application code. Specifically:
+#
+#   node:22-slim        — pinned by sha256 digest, checked weekly by
+#                          docker-pin-check.yaml
+#   apt packages        — pinned to exact Debian bookworm versions
+#   gosu 1.19           — pinned release + sha256 checksum verification
+#   gateway/sandbox     — OS users and groups; names and UIDs are a
+#     users               stable contract with OpenShell
+#   .openclaw dirs      — directory structure + symlinks are dictated by
+#     + symlinks          the OpenClaw CLI layout; new dirs are additive
+#                          (add them here and rebuild)
+#   openclaw CLI        — pinned to exact npm version (e.g., 2026.3.11)
+#   pyyaml              — pinned to exact pip version (6.0.3)
+#
+# Nothing here references NemoClaw plugin source, blueprint files,
+# startup scripts, or build-time config (model, provider, auth token).
+# Those all live in the production Dockerfile's thin top layers.
+#
+# ── When to rebuild ─────────────────────────────────────────────────────
+#
+# The base-image.yaml workflow rebuilds automatically on main merges that
+# touch this file. You need to edit this file (triggering a rebuild) when:
+#
+#   1. OpenClaw CLI version bump    — change the openclaw@version below
+#   2. New apt package needed       — add it to the apt-get install list
+#   3. gosu upgrade                 — update URL, checksum, and version
+#   4. node:22-slim digest rotated  — update-docker-pin.sh updates both
+#                                      Dockerfile and Dockerfile.base
+#   5. New .openclaw subdirectory   — add mkdir + symlink below
+#   6. PyYAML or other pip dep bump — change the version below
+#
+# For ad-hoc rebuilds (e.g., security patch), use workflow_dispatch on
+# the base-image workflow.
+#
+# Expected rebuild frequency: every few weeks to months, driven mostly
+# by OpenClaw CLI version bumps or the weekly docker-pin-check.
+# ────────────────────────────────────────────────────────────────────────
 
 FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,73 @@
+# NemoClaw sandbox base image — expensive, rarely-changing layers.
+#
+# Contains: node:22-slim, apt packages, gosu, user/group setup,
+# .openclaw directory structure, OpenClaw CLI, and PyYAML.
+#
+# Built on main merges and pushed to GHCR. The production Dockerfile
+# layers PR-specific code (plugin, blueprint, config) on top.
+#
+# Rebuild triggers: changes to this file, or OpenClaw CLI version bump.
+
+FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9ed5bfaf3d
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3=3.11.2-1+b1 \
+        python3-pip=23.0.1+dfsg-1 \
+        python3-venv=3.11.2-1+b1 \
+        curl=7.88.1-10+deb12u14 \
+        git=1:2.39.5-0+deb12u3 \
+        ca-certificates=20230311+deb12u1 \
+        iproute2=6.1.0-3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# gosu for privilege separation (gateway vs sandbox user).
+# Install from GitHub release with checksum verification instead of
+# Debian bookworm's ancient 1.14 (2020). Pinned to 1.19 (2025-09).
+# hadolint ignore=DL4006
+RUN curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-amd64" \
+    && echo "52c8749d0142edd234e9d6bd5237dff2d81e71f43537e2f4f66f75dd4b243dd0  /usr/local/bin/gosu" | sha256sum -c - \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu --version
+
+# Create sandbox user (matches OpenShell convention) and gateway user.
+# The gateway runs as 'gateway' so the 'sandbox' user (agent) cannot
+# kill it or restart it with a tampered HOME/config.
+RUN groupadd -r gateway && useradd -r -g gateway -d /sandbox -s /usr/sbin/nologin gateway \
+    && groupadd -r sandbox && useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox \
+    && mkdir -p /sandbox/.nemoclaw \
+    && chown -R sandbox:sandbox /sandbox
+
+# Split .openclaw into immutable config dir + writable state dir.
+# The policy makes /sandbox/.openclaw read-only via Landlock, so the agent
+# cannot modify openclaw.json, auth tokens, or CORS settings.  Writable
+# state (agents, plugins, etc.) lives in .openclaw-data, reached via symlinks.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/514
+RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
+        /sandbox/.openclaw-data/extensions \
+        /sandbox/.openclaw-data/workspace \
+        /sandbox/.openclaw-data/skills \
+        /sandbox/.openclaw-data/hooks \
+        /sandbox/.openclaw-data/identity \
+        /sandbox/.openclaw-data/devices \
+        /sandbox/.openclaw-data/canvas \
+        /sandbox/.openclaw-data/cron \
+    && mkdir -p /sandbox/.openclaw \
+    && ln -s /sandbox/.openclaw-data/agents /sandbox/.openclaw/agents \
+    && ln -s /sandbox/.openclaw-data/extensions /sandbox/.openclaw/extensions \
+    && ln -s /sandbox/.openclaw-data/workspace /sandbox/.openclaw/workspace \
+    && ln -s /sandbox/.openclaw-data/skills /sandbox/.openclaw/skills \
+    && ln -s /sandbox/.openclaw-data/hooks /sandbox/.openclaw/hooks \
+    && ln -s /sandbox/.openclaw-data/identity /sandbox/.openclaw/identity \
+    && ln -s /sandbox/.openclaw-data/devices /sandbox/.openclaw/devices \
+    && ln -s /sandbox/.openclaw-data/canvas /sandbox/.openclaw/canvas \
+    && ln -s /sandbox/.openclaw-data/cron /sandbox/.openclaw/cron \
+    && touch /sandbox/.openclaw-data/update-check.json \
+    && ln -s /sandbox/.openclaw-data/update-check.json /sandbox/.openclaw/update-check.json \
+    && chown -R sandbox:sandbox /sandbox/.openclaw /sandbox/.openclaw-data
+
+# Install OpenClaw CLI + PyYAML for inline Python scripts in e2e tests.
+# When bumping the openclaw version, rebuild this base image.
+RUN npm install -g openclaw@2026.3.11 \
+    && pip3 install --no-cache-dir --break-system-packages "pyyaml==6.0.3"


### PR DESCRIPTION
Follow-up fixes for #914:

1. **ARG scoping** — `ARG BASE_IMAGE` must be before the first `FROM` to be a global arg visible to all stages
2. **arm64 job** — was missing the GHCR base pull + `--build-arg BASE_IMAGE` override
3. **buildx driver** — GHA cache (`cache-to: type=gha`) requires `docker/setup-buildx-action` to create a docker-container builder

After merge, re-run the `base-image` workflow via dispatch to publish `ghcr.io/nvidia/nemoclaw/sandbox-base:latest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build performance through implementation of a cached base image layer
  * Enhanced CI/CD workflow for faster, more efficient builds and deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->