### PR TITLE
fix: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docs-preview-deploy.yaml
+++ b/.github/workflows/docs-preview-deploy.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Deploy preview
         if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true'
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1
         with:
           source-dir: ./docs-preview-html/
           preview-branch: gh-pages
@@ -78,7 +78,7 @@ jobs:
 
       - name: Post preview comment
         if: steps.meta.outputs.action != 'closed' && steps.meta.outputs.same-repo == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405  # v2
         with:
           header: pr-preview
           number: ${{ steps.meta.outputs.pr-number }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Remove preview
         if: steps.meta.outputs.action == 'closed'
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1
         with:
           preview-branch: gh-pages
           umbrella-dir: pr-preview
@@ -99,7 +99,7 @@ jobs:
 
       - name: Remove preview comment
         if: steps.meta.outputs.action == 'closed'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405  # v2
         with:
           header: pr-preview
           number: ${{ steps.meta.outputs.pr-number }}


### PR DESCRIPTION
## Summary

- Pin `rossjrw/pr-preview-action@v1` to `ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9`
- Pin `marocchino/sticky-pull-request-comment@v2` to `773744901bac0e8cbb5a0dc842800d45e9b2b405`
- Add `.github/dependabot.yml` for automated GitHub Actions updates

Mutable tags (`@v1`, `@v2`) can be moved to point at any commit. If either action's repo is compromised, the attacker gains the workflow's `contents: write` and `pull-requests: write` permissions. Pinning to SHAs eliminates this supply chain risk.

Fixes #578

## Test plan

- [x] All pre-commit and pre-push hooks pass
- [ ] Verify docs preview still deploys on a test PR touching `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency management for GitHub Actions with weekly update checks to maintain current tool versions
  * Enhanced workflow reliability and traceability by pinning GitHub Actions to specific commit hashes instead of floating version tags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->