### PR TITLE
fix(ci): add setup-buildx-action to base-image workflow

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Problem

The `base-image` workflow [fails on push to main](https://github.com/NVIDIA/NemoClaw/actions/runs/23563926719/job/68610594591) with:

```
Cache export is not supported for the docker driver.
```

The job uses GHA cache (`cache-from`/`cache-to type=gha`), which requires the `docker-container` buildx driver. Without `setup-buildx-action`, buildx defaults to the `docker` driver, which doesn't support cache export.

## Fix

Add `docker/setup-buildx-action@v3` before the build step to create a builder with the `docker-container` driver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability by enhancing Docker image build initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->