### PR TITLE
feat: add Dreamline spend governance preset

### DIFF
--- a/nemoclaw-blueprint/policies/presets/dreamline.yaml
+++ b/nemoclaw-blueprint/policies/presets/dreamline.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: dreamline
+  description: "Dreamline spend governance — on-chain blacklist and policy enforcement for agent payments"
+
+network_policies:
+  dreamline:
+    name: dreamline
+    endpoints:
+      - host: dreamline-backend.onrender.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: POST, path: "/proxy/pay" }
+          - allow: { method: POST, path: "/proxy/approve" }
+          - allow: { method: GET, path: "/proxy/status" }
+          - allow: { method: GET, path: "/health" }
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/curl }


### PR DESCRIPTION
Adds a network policy preset for Dreamline — an open-source spend governance layer for AI agents.

## What is Dreamline?

Dreamline adds financial guardrails to OpenClaw agents. Before any payment, the agent calls Dreamline's /proxy/pay endpoint which:

- Checks an on-chain blacklist stored in a BNB Chain smart contract
- Enforces per-agent policies (daily budget, per-tx limit, destination whitelist)
- Returns an EIP-712 signature on every approval, verifiable on any EVM chain

This complements NemoClaw's sandbox isolation — NemoClaw secures the runtime, Dreamline secures the wallet.

## What this preset does

Allows egress only to `dreamline-backend.onrender.com` on port 443, restricted to the specific endpoints needed:
- POST /proxy/pay — authorize a payment
- POST /proxy/approve — get EIP-712 signature
- GET /proxy/status — check agent status
- GET /health — health check

## Related

- Issue #920
- GitHub: https://github.com/aisatoshinext-arch/dreamline
- Live demo: https://dreamline-jade.vercel.app/landing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "dreamline" preset configuration for managing network policies and endpoint access, including TLS termination and HTTP route allowlisting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->