### PR TITLE
docs: add macOS first-run prerequisites to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ The sandbox image is approximately 2.4 GB compressed. During image push, the Doc
 | macOS | Podman | Not supported yet. NemoClaw currently depends on OpenShell support for Podman on macOS. |
 | Windows WSL | Docker Desktop (WSL backend) | Supported target path |
 
+#### macOS first-run checklist
+
+On a fresh macOS machine, install the prerequisites in this order:
+
+1. Install Xcode Command Line Tools:
+
+   ```bash
+   xcode-select --install
+   ```
+
+2. Install and start a supported container runtime:
+   - Docker Desktop
+   - Colima
+3. Run the NemoClaw installer.
+
+This avoids the two most common first-run failures on macOS:
+- missing developer tools needed by the installer and Node.js toolchain
+- Docker connection errors when no supported container runtime is installed or running
+
 > **💡 Tip**
 >
 > For DGX Spark, follow the [DGX Spark setup guide](https://github.com/NVIDIA/NemoClaw/blob/main/spark-install.md). It covers Spark-specific prerequisites, such as cgroup v2 and Docker configuration, before running the standard installer.


### PR DESCRIPTION
## Summary\n- add macOS first-run prerequisites to the quick start\n- document Xcode Command Line Tools, container runtime expectations, and recommended setup order\n- capture common first-run failures before the install steps\n\n## Linked issue\n- closes #814\n\nReplacement for auto-closed #905 after the contributor open-PR limit was hit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a macOS first-run checklist under Prerequisites to guide initial environment setup
  * Checklist outlines required steps: install Xcode Command Line Tools, set up a supported container runtime (Docker Desktop or Colima), then run the installer
  * Highlights common first-run issues to avoid: missing developer tools and Docker connection errors when no runtime is installed or running

<!-- end of auto-generated comment: release notes by coderabbit.ai -->