### PR TITLE
docs(troubleshooting): explain reconnect flow after host reboot

### DIFF
--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -148,6 +148,33 @@ $ colima status
 The sandbox may have been stopped or deleted.
 Run `nemoclaw onboard` to recreate the sandbox from the same blueprint and policy definitions.
 
+### Reconnect after a host reboot
+
+After the host reboots, start your container runtime first:
+
+- Linux: start Docker if it is not already running
+- macOS: start Docker Desktop or Colima before reconnecting
+
+Then check the underlying sandbox state on the host:
+
+```console
+$ openshell sandbox list
+```
+
+If your sandbox is listed and shows `Ready`, reconnect normally:
+
+```console
+$ nemoclaw <name> connect
+```
+
+If you use auxiliary services such as the Telegram bridge or tunnel, start them again after the host comes back:
+
+```console
+$ nemoclaw start
+```
+
+If the sandbox is missing, or it does not recover to `Ready` after the container runtime starts, run `nemoclaw onboard` to recreate it.
+
 ### Status shows "not running" inside the sandbox
 
 This is expected behavior.


### PR DESCRIPTION
## Summary\n- document what happens to NemoClaw sessions after the host reboots\n- explain the reconnect path and the commands needed to resume work\n- add troubleshooting guidance for the common post-reboot failure mode\n\n## Linked issue\n- closes #469\n\nReplacement for auto-closed #904 after the contributor open-PR limit was hit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added troubleshooting guidance for reconnecting after a host reboot, including steps to restart the container runtime, validate sandbox state, and reconnect or reinitialize as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->