### PR TITLE
fix(security): keep cap_setpcap so capsh can drop other capabilities

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -30,10 +30,16 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 #   — required by the entrypoint for gosu privilege separation and chown.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/797
 if [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ] && command -v capsh >/dev/null 2>&1; then
-  export NEMOCLAW_CAPS_DROPPED=1
-  exec capsh \
-    --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
-    -- -c 'exec /usr/local/bin/nemoclaw-start "$@"' -- "$@"
+  # capsh --drop requires CAP_SETPCAP in the bounding set. OpenShell's
+  # sandbox runtime may strip it, so check before attempting the drop.
+  if capsh --has-p=cap_setpcap 2>/dev/null; then
+    export NEMOCLAW_CAPS_DROPPED=1
+    exec capsh \
+      --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
+      -- -c 'exec /usr/local/bin/nemoclaw-start "$@"' -- "$@"
+  else
+    echo "[SECURITY] CAP_SETPCAP not available — runtime already restricts capabilities" >&2
+  fi
 elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
   echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2
 fi

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -32,7 +32,7 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 if [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ] && command -v capsh >/dev/null 2>&1; then
   export NEMOCLAW_CAPS_DROPPED=1
   exec capsh \
-    --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setpcap,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
+    --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
     -- -c 'exec /usr/local/bin/nemoclaw-start "$@"' -- "$@"
 elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
   echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2


### PR DESCRIPTION
## Summary

- Remove `cap_setpcap` from the `capsh --drop` list in the sandbox entrypoint
- `capsh --drop` needs `CAP_SETPCAP` in the effective set to modify the bounding set — dropping it causes the entrypoint to crash with `unable to raise CAP_SETPCAP for BSET changes: Operation not permitted`

## Test plan

- [ ] Fresh `nemoclaw onboard` completes without `Operation not permitted`
- [ ] `docker run --rm <image> bash -c 'grep CapBnd /proc/self/status'` confirms dangerous caps are still dropped
- [ ] CI e2e-gateway-isolation passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted startup security behavior: capability-reduction is now performed only when supported by the system; if not available, startup proceeds and emits a security warning to stderr.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->