### PR TITLE
fix: install from latest release tag instead of main

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,31 @@ resolve_installer_version() {
 
 NEMOCLAW_VERSION="$(resolve_installer_version)"
 
+# Resolve which Git ref to install from.
+# Priority: NEMOCLAW_INSTALL_TAG env var > GitHub releases API > "main" fallback.
+resolve_release_tag() {
+  # Allow explicit override (for CI, pinning, or testing).
+  if [[ -n "${NEMOCLAW_INSTALL_TAG:-}" ]]; then
+    printf "%s" "$NEMOCLAW_INSTALL_TAG"
+    return 0
+  fi
+
+  # Query the GitHub releases API for the latest published release.
+  local response tag
+  response="$(curl -fsSL --max-time 10 \
+    https://api.github.com/repos/NVIDIA/NemoClaw/releases/latest 2>/dev/null)" || true
+  tag="$(printf '%s' "$response" \
+    | grep '"tag_name"' \
+    | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/' \
+    | head -1 || true)"
+
+  if [[ -n "$tag" && "$tag" =~ ^v[0-9] ]]; then
+    printf "%s" "$tag"
+  else
+    printf "main"
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Color / style — disabled when NO_COLOR is set or stdout is not a TTY.
 # Uses exact NVIDIA green #76B900 on truecolor terminals; 256-color otherwise.
@@ -132,6 +157,7 @@ usage() {
   printf "    NEMOCLAW_NON_INTERACTIVE=1    Same as --non-interactive\n"
   printf "    NEMOCLAW_SANDBOX_NAME         Sandbox name to create/use\n"
   printf "    NEMOCLAW_RECREATE_SANDBOX=1   Recreate an existing sandbox\n"
+  printf "    NEMOCLAW_INSTALL_TAG         Git ref to install (default: latest release)\n"
   printf "    NEMOCLAW_PROVIDER             cloud | ollama | nim | vllm\n"
   printf "    NEMOCLAW_MODEL                Inference model to configure\n"
   printf "    NEMOCLAW_POLICY_MODE          suggested | custom | skip\n"
@@ -453,13 +479,17 @@ install_nemoclaw() {
     spin "Linking NemoClaw CLI" npm link
   else
     info "Installing NemoClaw from GitHub…"
+    # Resolve the latest release tag so we never install raw main.
+    local release_ref
+    release_ref="$(resolve_release_tag)"
+    info "Resolved install ref: ${release_ref}"
     # Clone first so we can pre-extract openclaw before npm install (GH-503).
     # npm install -g git+https://... does this internally but we can't hook
     # into its extraction pipeline, so we do it ourselves.
     local nemoclaw_src="${HOME}/.nemoclaw/source"
     rm -rf "$nemoclaw_src"
     mkdir -p "$(dirname "$nemoclaw_src")"
-    spin "Cloning NemoClaw source" git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$nemoclaw_src"
+    spin "Cloning NemoClaw source" git clone --depth 1 --branch "$release_ref" https://github.com/NVIDIA/NemoClaw.git "$nemoclaw_src"
     spin "Preparing OpenClaw package" bash -c "$(declare -f info warn pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$nemoclaw_src" \
       || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
     spin "Installing NemoClaw dependencies" bash -c "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
@@ -610,4 +640,6 @@ main() {
   post_install_message
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]:-}" == "$0" ]] || { [[ -z "${BASH_SOURCE[0]:-}" ]] && { [[ "$0" == "bash" ]] || [[ "$0" == "-bash" ]]; }; }; then
+  main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -407,16 +407,42 @@ pre_extract_openclaw() {
   rm -rf "$tmpdir"
 }
 
+# ── Resolve release tag ──────────────────────────────────────────
+# Priority: NEMOCLAW_INSTALL_TAG env var > GitHub releases API > "main" fallback.
+resolve_release_tag() {
+  if [ -n "${NEMOCLAW_INSTALL_TAG:-}" ]; then
+    printf "%s" "$NEMOCLAW_INSTALL_TAG"
+    return 0
+  fi
+
+  local response tag
+  response="$(curl -fsSL --max-time 10 \
+    https://api.github.com/repos/NVIDIA/NemoClaw/releases/latest 2>/dev/null)" || true
+  tag="$(printf '%s' "$response" \
+    | grep '"tag_name"' \
+    | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/' \
+    | head -1 || true)"
+
+  if [ -n "$tag" ] && printf '%s' "$tag" | grep -qE '^v[0-9]'; then
+    printf "%s" "$tag"
+  else
+    printf "main"
+  fi
+}
+
 # ── Install NemoClaw CLI ─────────────────────────────────────────
 
 info "Installing nemoclaw CLI..."
+# Resolve the latest release tag so we never install raw main.
+NEMOCLAW_RELEASE_REF="$(resolve_release_tag)"
+info "Resolved install ref: ${NEMOCLAW_RELEASE_REF}"
 # Clone first so we can pre-extract openclaw before npm install (GH-503).
 # npm install -g git+https://... does this internally but we can't hook
 # into its extraction pipeline, so we do it ourselves.
 NEMOCLAW_SRC="${HOME}/.nemoclaw/source"
 rm -rf "$NEMOCLAW_SRC"
 mkdir -p "$(dirname "$NEMOCLAW_SRC")"
-git clone --depth 1 https://github.com/NVIDIA/NemoClaw.git "$NEMOCLAW_SRC"
+git clone --depth 1 --branch "$NEMOCLAW_RELEASE_REF" https://github.com/NVIDIA/NemoClaw.git "$NEMOCLAW_SRC"
 pre_extract_openclaw "$NEMOCLAW_SRC" || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
 # Use sudo for npm link only when the global prefix directory is not writable
 # by the current user (e.g., system-managed nodesource installs to /usr).

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -745,3 +745,775 @@ exit 0
     expect(`${result.stdout}${result.stderr}`).toMatch(/Created user-local shim/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Release-tag resolution — install.sh should clone the latest GitHub release
+// tag instead of defaulting to main.
+// ---------------------------------------------------------------------------
+
+describe("installer release-tag resolution", () => {
+  /**
+   * Helper: call resolve_release_tag() in isolation by sourcing install.sh.
+   * Requires the source guard so that main() doesn't run on source.
+   * `fakeBin` must contain a `curl` stub (and optionally `node`).
+   */
+  function callResolveReleaseTag(fakeBin, env = {}) {
+    return spawnSync(
+      "bash",
+      [
+        "-c",
+        `source "${INSTALLER}" 2>/dev/null; resolve_release_tag`,
+      ],
+      {
+        cwd: path.join(import.meta.dirname, ".."),
+        encoding: "utf-8",
+        env: {
+          HOME: os.tmpdir(),
+          PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+          ...env,
+        },
+      },
+    );
+  }
+
+  it("returns the tag_name from the GitHub releases API", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-tag-ok-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    // curl stub that returns a realistic GitHub releases/latest JSON snippet
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+cat <<'EOF'
+{
+  "tag_name": "v0.3.0",
+  "name": "NemoClaw v0.3.0"
+}
+EOF`,
+    );
+    writeExecutable(path.join(fakeBin, "node"), "#!/usr/bin/env bash\nexit 1");
+
+    const result = callResolveReleaseTag(fakeBin);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("v0.3.0");
+  });
+
+  it("falls back to 'main' when curl fails (network error)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-tag-neterr-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    // curl stub that fails
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+exit 1`,
+    );
+    writeExecutable(path.join(fakeBin, "node"), "#!/usr/bin/env bash\nexit 1");
+
+    const result = callResolveReleaseTag(fakeBin);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("main");
+  });
+
+  it("falls back to 'main' when API returns garbage JSON", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-tag-garbage-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    // curl stub that returns nonsense
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+echo "502 Bad Gateway"`,
+    );
+    writeExecutable(path.join(fakeBin, "node"), "#!/usr/bin/env bash\nexit 1");
+
+    const result = callResolveReleaseTag(fakeBin);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("main");
+  });
+
+  it("uses NEMOCLAW_INSTALL_TAG override without calling curl", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-tag-override-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    // curl stub that would fail — must NOT be called
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+echo "curl should not be called" >&2
+exit 99`,
+    );
+    writeExecutable(path.join(fakeBin, "node"), "#!/usr/bin/env bash\nexit 1");
+
+    const result = callResolveReleaseTag(fakeBin, {
+      NEMOCLAW_INSTALL_TAG: "v0.2.0",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("v0.2.0");
+  });
+
+  it("falls back to 'main' when tag_name has no 'v' prefix (e.g. 'release-1.0')", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-tag-noprefix-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+echo '{"tag_name":"release-1.0","name":"NemoClaw release-1.0"}'`,
+    );
+    writeExecutable(path.join(fakeBin, "node"), "#!/usr/bin/env bash\nexit 1");
+
+    const result = callResolveReleaseTag(fakeBin);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("main");
+  });
+
+  it("accepts partial semver tags like 'v1' or 'v1.2'", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-tag-partial-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+echo '{"tag_name":"v1.2","name":"NemoClaw v1.2"}'`,
+    );
+    writeExecutable(path.join(fakeBin, "node"), "#!/usr/bin/env bash\nexit 1");
+
+    const result = callResolveReleaseTag(fakeBin);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("v1.2");
+  });
+
+  it("falls back to 'main' when API returns empty JSON object", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-tag-empty-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+echo '{}'`,
+    );
+    writeExecutable(path.join(fakeBin, "node"), "#!/usr/bin/env bash\nexit 1");
+
+    const result = callResolveReleaseTag(fakeBin);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("main");
+  });
+
+  it("source-checkout path does NOT call resolve_release_tag / git clone", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-source-notag-"));
+    const fakeBin = path.join(tmp, "bin");
+    const prefix = path.join(tmp, "prefix");
+    const gitLog = path.join(tmp, "git.log");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+    writeNodeStub(fakeBin);
+    writeNpmStub(
+      fakeBin,
+      `if [ "$1" = "pack" ]; then exit 1; fi
+if [ "$1" = "install" ] || [ "$1" = "run" ]; then exit 0; fi
+if [ "$1" = "link" ]; then
+  cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
+#!/usr/bin/env bash
+if [ "$1" = "onboard" ] || [ "$1" = "--version" ]; then exit 0; fi
+exit 0
+EOS
+  chmod +x "$NPM_PREFIX/bin/nemoclaw"
+  exit 0
+fi`,
+    );
+
+    // curl stub that would fail — must NOT be called
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+echo "curl should not be called for source checkout" >&2
+exit 99`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "git"),
+      `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GIT_LOG_PATH"
+exit 0`,
+    );
+
+    // Write package.json that triggers source-checkout path
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({ name: "nemoclaw", version: "0.1.0", dependencies: { openclaw: "2026.3.11" } }, null, 2),
+    );
+    fs.mkdirSync(path.join(tmp, "nemoclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, "nemoclaw", "package.json"),
+      JSON.stringify({ name: "nemoclaw-plugin", version: "0.1.0" }, null, 2),
+    );
+
+    const result = spawnSync("bash", [INSTALLER], {
+      cwd: tmp,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NPM_PREFIX: prefix,
+        GIT_LOG_PATH: gitLog,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    // git should NOT have been called at all in the source-checkout path
+    expect(fs.existsSync(gitLog)).toBe(false);
+    // And curl for the releases API should NOT have been called
+    expect(`${result.stdout}${result.stderr}`).not.toMatch(/curl should not be called/);
+  });
+
+  it("full install: git clone receives --branch with the resolved release tag", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-tag-e2e-"));
+    const fakeBin = path.join(tmp, "bin");
+    const prefix = path.join(tmp, "prefix");
+    const gitLog = path.join(tmp, "git.log");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+    writeNodeStub(fakeBin);
+
+    // curl stub: returns a release tag for the API URL, passes through otherwise
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+for arg in "$@"; do
+  if [[ "$arg" == *"api.github.com/repos/NVIDIA/NemoClaw/releases/latest"* ]]; then
+    echo '{"tag_name":"v0.5.0","name":"NemoClaw v0.5.0"}'
+    exit 0
+  fi
+done
+# Fall through to real curl for anything else (e.g. nvm)
+/usr/bin/curl "$@"`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "git"),
+      `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GIT_LOG_PATH"
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.5.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.5.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0`,
+    );
+
+    writeNpmStub(
+      fakeBin,
+      `if [ "$1" = "pack" ]; then exit 1; fi
+if [ "$1" = "install" ] || [ "$1" = "run" ]; then exit 0; fi
+if [ "$1" = "link" ]; then
+  cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
+#!/usr/bin/env bash
+if [ "$1" = "onboard" ] || [ "$1" = "--version" ]; then exit 0; fi
+exit 0
+EOS
+  chmod +x "$NPM_PREFIX/bin/nemoclaw"
+  exit 0
+fi`,
+    );
+
+    const result = spawnSync("bash", [INSTALLER], {
+      cwd: tmp,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NPM_PREFIX: prefix,
+        GIT_LOG_PATH: gitLog,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const gitCalls = fs.readFileSync(gitLog, "utf-8");
+    expect(gitCalls).toMatch(/--branch v0\.5\.0/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure helper functions — sourced and tested in isolation.
+// ---------------------------------------------------------------------------
+
+describe("installer pure helpers", () => {
+  /**
+   * Helper: source install.sh and call a function, returning stdout.
+   */
+  function callInstallerFn(fnCall, env = {}) {
+    return spawnSync(
+      "bash",
+      ["-c", `source "${INSTALLER}" 2>/dev/null; ${fnCall}`],
+      {
+        cwd: path.join(import.meta.dirname, ".."),
+        encoding: "utf-8",
+        env: {
+          HOME: os.tmpdir(),
+          PATH: TEST_SYSTEM_PATH,
+          ...env,
+        },
+      },
+    );
+  }
+
+  // -- version_gte --
+
+  it("version_gte: equal versions return 0", () => {
+    const r = callInstallerFn('version_gte "1.2.3" "1.2.3" && echo yes || echo no');
+    expect(r.stdout.trim()).toBe("yes");
+  });
+
+  it("version_gte: higher major returns 0", () => {
+    const r = callInstallerFn('version_gte "2.0.0" "1.9.9" && echo yes || echo no');
+    expect(r.stdout.trim()).toBe("yes");
+  });
+
+  it("version_gte: lower major returns 1", () => {
+    const r = callInstallerFn('version_gte "0.17.0" "0.18.0" && echo yes || echo no');
+    expect(r.stdout.trim()).toBe("no");
+  });
+
+  it("version_gte: higher minor returns 0", () => {
+    const r = callInstallerFn('version_gte "0.19.0" "0.18.0" && echo yes || echo no');
+    expect(r.stdout.trim()).toBe("yes");
+  });
+
+  it("version_gte: higher patch returns 0", () => {
+    const r = callInstallerFn('version_gte "0.18.1" "0.18.0" && echo yes || echo no');
+    expect(r.stdout.trim()).toBe("yes");
+  });
+
+  it("version_gte: lower patch returns 1", () => {
+    const r = callInstallerFn('version_gte "0.18.0" "0.18.1" && echo yes || echo no');
+    expect(r.stdout.trim()).toBe("no");
+  });
+
+  // -- version_major --
+
+  it("version_major: strips v prefix", () => {
+    const r = callInstallerFn('version_major "v22.14.0"');
+    expect(r.stdout.trim()).toBe("22");
+  });
+
+  it("version_major: works without v prefix", () => {
+    const r = callInstallerFn('version_major "10.9.2"');
+    expect(r.stdout.trim()).toBe("10");
+  });
+
+  it("version_major: single digit", () => {
+    const r = callInstallerFn('version_major "v8"');
+    expect(r.stdout.trim()).toBe("8");
+  });
+
+  // -- resolve_installer_version --
+
+  it("resolve_installer_version: reads version from package.json", () => {
+    const r = callInstallerFn("resolve_installer_version");
+    // Should read from the repo's actual package.json
+    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("resolve_installer_version: falls back to DEFAULT when no package.json", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-ver-"));
+    // source from a directory with no package.json — SCRIPT_DIR will be wrong
+    const r = spawnSync(
+      "bash",
+      ["-c", `SCRIPT_DIR="${tmp}"; source "${INSTALLER}" 2>/dev/null; resolve_installer_version`],
+      {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: { HOME: tmp, PATH: TEST_SYSTEM_PATH },
+      },
+    );
+    expect(r.stdout.trim()).toBe("0.1.0");
+  });
+
+  // -- resolve_default_sandbox_name --
+
+  it("resolve_default_sandbox_name: returns 'my-assistant' with no registry", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sandbox-name-"));
+    const r = callInstallerFn("resolve_default_sandbox_name", { HOME: tmp });
+    expect(r.stdout.trim()).toBe("my-assistant");
+  });
+
+  it("resolve_default_sandbox_name: reads defaultSandbox from registry", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sandbox-name-reg-"));
+    const registryDir = path.join(tmp, ".nemoclaw");
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify({
+        defaultSandbox: "work-bot",
+        sandboxes: { "work-bot": {}, "test-bot": {} },
+      }),
+    );
+    const r = callInstallerFn("resolve_default_sandbox_name", {
+      HOME: tmp,
+      PATH: `${process.env.PATH}`,
+    });
+    expect(r.stdout.trim()).toBe("work-bot");
+  });
+
+  it("resolve_default_sandbox_name: honors NEMOCLAW_SANDBOX_NAME env var", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sandbox-name-env-"));
+    const r = callInstallerFn("resolve_default_sandbox_name", {
+      HOME: tmp,
+      NEMOCLAW_SANDBOX_NAME: "my-custom-name",
+    });
+    expect(r.stdout.trim()).toBe("my-custom-name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// main() flag parsing edge cases
+// ---------------------------------------------------------------------------
+
+describe("installer flag parsing", () => {
+  it("rejects unknown flags with usage + error", () => {
+    const result = spawnSync("bash", [INSTALLER, "--bogus"], {
+      cwd: path.join(import.meta.dirname, ".."),
+      encoding: "utf-8",
+    });
+
+    expect(result.status).not.toBe(0);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toMatch(/Unknown option: --bogus/);
+    expect(output).toMatch(/NemoClaw Installer/); // usage was printed
+  });
+
+  it("--help shows NEMOCLAW_INSTALL_TAG in environment section", () => {
+    const result = spawnSync("bash", [INSTALLER, "--help"], {
+      cwd: path.join(import.meta.dirname, ".."),
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/NEMOCLAW_INSTALL_TAG/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensure_supported_runtime — missing binary paths
+// ---------------------------------------------------------------------------
+
+describe("installer runtime checks (sourced)", () => {
+  /**
+   * Call ensure_supported_runtime() in isolation by sourcing install.sh.
+   * This avoids triggering install_nodejs() which would download real nvm.
+   */
+  function callEnsureSupportedRuntime(fakeBin, env = {}) {
+    return spawnSync(
+      "bash",
+      ["-c", `source "${INSTALLER}" 2>/dev/null; ensure_supported_runtime`],
+      {
+        cwd: path.join(import.meta.dirname, ".."),
+        encoding: "utf-8",
+        env: {
+          HOME: os.tmpdir(),
+          PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+          ...env,
+        },
+      },
+    );
+  }
+
+  it("fails with clear message when node is missing entirely", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-no-node-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    // npm exists but node does not
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+echo "10.9.2"`,
+    );
+
+    const result = callEnsureSupportedRuntime(fakeBin);
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/Node\.js was not found on PATH/);
+  });
+
+  it("fails with clear message when npm is missing entirely", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-no-npm-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "node"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "v22.14.0"; exit 0; fi
+exit 0`,
+    );
+
+    const result = callEnsureSupportedRuntime(fakeBin);
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/npm was not found on PATH/);
+  });
+
+  it("succeeds with acceptable Node.js 20 and npm 10", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-runtime-ok-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "node"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "v20.0.0"; exit 0; fi
+exit 0`,
+    );
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "10.0.0"; exit 0; fi
+exit 0`,
+    );
+
+    const result = callEnsureSupportedRuntime(fakeBin);
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/Runtime OK/);
+  });
+
+  it("rejects node that returns a non-numeric version", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-runtime-badver-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "node"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "nope"; exit 0; fi
+exit 0`,
+    );
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "10.9.2"; exit 0; fi
+exit 0`,
+    );
+
+    const result = callEnsureSupportedRuntime(fakeBin);
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/Could not determine Node\.js version/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scripts/install.sh (curl-pipe installer) release-tag resolution
+// ---------------------------------------------------------------------------
+
+describe("curl-pipe installer release-tag resolution", () => {
+  /**
+   * Build the full fakeBin environment needed to run scripts/install.sh.
+   * Unlike install.sh, this script also requires docker, openshell, and
+   * uname stubs because it runs everything top-to-bottom with no main().
+   */
+  function buildCurlPipeEnv(tmp, { curlStub, gitStub }) {
+    const fakeBin = path.join(tmp, "bin");
+    const prefix = path.join(tmp, "prefix");
+    const gitLog = path.join(tmp, "git.log");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+    writeExecutable(
+      path.join(fakeBin, "node"),
+      `#!/usr/bin/env bash
+if [ "$1" = "-v" ] || [ "$1" = "--version" ]; then echo "v22.14.0"; exit 0; fi
+if [ "$1" = "-e" ]; then exit 1; fi
+exit 99`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "--version" ]; then echo "10.9.2"; exit 0; fi
+if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then echo "$NPM_PREFIX"; exit 0; fi
+if [ "$1" = "pack" ]; then exit 1; fi
+if [ "$1" = "install" ] && [[ "$*" == *"--ignore-scripts"* ]]; then exit 0; fi
+if [ "$1" = "run" ]; then exit 0; fi
+if [ "$1" = "link" ]; then
+  cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
+#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "v0.5.0-test"; exit 0; fi
+exit 0
+EOS
+  chmod +x "$NPM_PREFIX/bin/nemoclaw"
+  exit 0
+fi
+echo "unexpected npm invocation: $*" >&2; exit 98`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "docker"),
+      `#!/usr/bin/env bash
+if [ "$1" = "info" ]; then exit 0; fi
+exit 0`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "openshell"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "openshell 0.0.9"; exit 0; fi
+exit 0`,
+    );
+
+    writeExecutable(path.join(fakeBin, "curl"), curlStub);
+    writeExecutable(path.join(fakeBin, "git"), gitStub);
+
+    return { fakeBin, prefix, gitLog };
+  }
+
+  it("git clone receives --branch with the resolved release tag", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-pipe-tag-e2e-"));
+    const { fakeBin, prefix, gitLog } = buildCurlPipeEnv(tmp, {
+      curlStub: `#!/usr/bin/env bash
+for arg in "$@"; do
+  if [[ "$arg" == *"api.github.com/repos/NVIDIA/NemoClaw/releases/latest"* ]]; then
+    echo '{"tag_name":"v0.5.0","name":"NemoClaw v0.5.0"}'
+    exit 0
+  fi
+done
+/usr/bin/curl "$@"`,
+      gitStub: `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GIT_LOG_PATH"
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.5.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.5.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0`,
+    });
+
+    const result = spawnSync("bash", [CURL_PIPE_INSTALLER], {
+      cwd: tmp,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NPM_PREFIX: prefix,
+        GIT_LOG_PATH: gitLog,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const gitCalls = fs.readFileSync(gitLog, "utf-8");
+    expect(gitCalls).toMatch(/--branch v0\.5\.0/);
+  });
+
+  it("falls back to 'main' when the GitHub API is unreachable", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-pipe-tag-fail-"));
+    const { fakeBin, prefix, gitLog } = buildCurlPipeEnv(tmp, {
+      curlStub: `#!/usr/bin/env bash
+for arg in "$@"; do
+  if [[ "$arg" == *"api.github.com"* ]]; then
+    exit 1
+  fi
+done
+/usr/bin/curl "$@"`,
+      gitStub: `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GIT_LOG_PATH"
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.1.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.1.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0`,
+    });
+
+    const result = spawnSync("bash", [CURL_PIPE_INSTALLER], {
+      cwd: tmp,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NPM_PREFIX: prefix,
+        GIT_LOG_PATH: gitLog,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const gitCalls = fs.readFileSync(gitLog, "utf-8");
+    expect(gitCalls).toMatch(/--branch main/);
+  });
+
+  it("uses NEMOCLAW_INSTALL_TAG override without calling the API", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-pipe-tag-override-"));
+    const { fakeBin, prefix, gitLog } = buildCurlPipeEnv(tmp, {
+      curlStub: `#!/usr/bin/env bash
+for arg in "$@"; do
+  if [[ "$arg" == *"api.github.com"* ]]; then
+    echo "curl should not hit the releases API" >&2
+    exit 99
+  fi
+done
+/usr/bin/curl "$@"`,
+      gitStub: `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GIT_LOG_PATH"
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw"
+  echo '{"name":"nemoclaw","version":"0.2.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.2.0"}' > "$target/nemoclaw/package.json"
+  exit 0
+fi
+exit 0`,
+    });
+
+    const result = spawnSync("bash", [CURL_PIPE_INSTALLER], {
+      cwd: tmp,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NPM_PREFIX: prefix,
+        GIT_LOG_PATH: gitLog,
+        NEMOCLAW_INSTALL_TAG: "v0.2.0",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const gitCalls = fs.readFileSync(gitLog, "utf-8");
+    expect(gitCalls).toMatch(/--branch v0\.2\.0/);
+    // Confirm the releases API was NOT called
+    expect(`${result.stdout}${result.stderr}`).not.toMatch(/curl should not hit the releases API/);
+  });
+});


### PR DESCRIPTION
## Problem

The vanity URL `www.nvidia.com/nemoclaw.sh` is an Akamai redirect hardcoded to `refs/heads/main/install.sh`:

```
HTTP/2 301
location: https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/install.sh
```

Every `curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash` clones and installs whatever is on `main` — which may be mid-development, broken, or untested. This makes controlled releases impossible.

## Solution

Both installers (`install.sh` and `scripts/install.sh`) now resolve the latest **published GitHub release tag** before cloning:

1. **`resolve_release_tag()`** — queries `api.github.com/repos/NVIDIA/NemoClaw/releases/latest`, extracts `tag_name`
2. **`git clone --branch <tag>`** — installs from the resolved tag, not `main`
3. **Safe fallback** — falls back to `main` only when the API is unreachable or returns garbage
4. **`NEMOCLAW_INSTALL_TAG`** env var — allows pinning a specific version for CI or testing

Also adds a `BASH_SOURCE` guard to `install.sh` so functions can be sourced and unit-tested in isolation (matching the existing pattern in `uninstall.sh`).

## Release workflow

Once this lands, every release just needs to create a GitHub release with a `vX.Y.Z` tag. No Akamai redirect change needed — `main` still serves the installer, but it always installs the latest tag.

## Tests

27 new tests (305 → 332 total), all TDD — written red first:

- **`resolve_release_tag()`**: API success, curl failure, garbage JSON, empty JSON, no-v-prefix rejection, partial semver acceptance, env var override
- **Source-checkout path**: verifies `resolve_release_tag` / git clone are NOT called
- **Full e2e** (both installers): `git clone` receives `--branch <tag>`
- **Pure helpers**: `version_gte()`, `version_major()`, `resolve_installer_version()`, `resolve_default_sandbox_name()` — previously untested
- **Runtime checks**: missing node, missing npm, acceptable versions, non-numeric version
- **Flag parsing**: unknown flag rejection, `NEMOCLAW_INSTALL_TAG` in `--help`

```
shellcheck install.sh           # clean
shellcheck scripts/install.sh   # clean
npx vitest run --project cli    # 332 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * NemoClaw installer now supports specifying a release version via the `NEMOCLAW_INSTALL_TAG` environment variable
  * Automatic detection and resolution of the latest available release from GitHub
  * Installation process now includes fallback mechanisms for improved reliability

* **Tests**
  * Added comprehensive test coverage for release tag resolution and installation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->