### PR TITLE
fix(ci): build base image for amd64 and arm64

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -60,11 +60,15 @@ jobs:
             type=raw,value=latest
             type=sha,prefix=,format=short
 
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.base
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -59,9 +62,6 @@ jobs:
           tags: |
             type=raw,value=latest
             type=sha,prefix=,format=short
-
-      - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary

- Add QEMU setup and `platforms: linux/amd64,linux/arm64` to the base-image workflow
- arm64 users were hitting `no matching manifest for linux/arm64/v8` during sandbox creation because the GHCR base image only had an amd64 manifest

## Test plan

- [ ] Workflow dispatch on this branch builds and pushes both architectures
- [ ] `docker manifest inspect ghcr.io/nvidia/nemoclaw/sandbox-base:latest` shows both amd64 and arm64
- [ ] arm64 user can complete `nemoclaw onboard` without manifest error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the CI/CD pipeline to build and publish multi-architecture Docker images supporting both AMD64 and ARM64 processor architectures, expanding deployment platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->