### PR TITLE
feat(cli): add --json output for list, status, and policy-list commands

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -253,9 +253,21 @@ function uninstall(args) {
   exitWithSpawnResult(result);
 }
 
-function showStatus() {
+function showStatus({ json = false } = {}) {
   // Show sandbox registry
   const { sandboxes, defaultSandbox } = registry.listSandboxes();
+
+  if (json) {
+    console.log(JSON.stringify({
+      sandboxes: sandboxes.map((sb) => ({
+        name: sb.name,
+        default: sb.name === defaultSandbox,
+        model: sb.model || null,
+      })),
+    }));
+    return;
+  }
+
   if (sandboxes.length > 0) {
     console.log("");
     console.log("  Sandboxes:");
@@ -271,8 +283,23 @@ function showStatus() {
   run(`bash "${SCRIPTS}/start-services.sh" --status`);
 }
 
-function listSandboxes() {
+function listSandboxes({ json = false } = {}) {
   const { sandboxes, defaultSandbox } = registry.listSandboxes();
+
+  if (json) {
+    console.log(JSON.stringify({
+      sandboxes: sandboxes.map((sb) => ({
+        name: sb.name,
+        default: sb.name === defaultSandbox,
+        model: sb.model || null,
+        provider: sb.provider || null,
+        gpuEnabled: sb.gpuEnabled || false,
+        policies: sb.policies || [],
+      })),
+    }));
+    return;
+  }
+
   if (sandboxes.length === 0) {
     console.log("");
     console.log("  No sandboxes registered. Run `nemoclaw onboard` to get started.");
@@ -305,11 +332,29 @@ function sandboxConnect(sandboxName) {
   runInteractive(`openshell sandbox connect ${qn}`);
 }
 
-function sandboxStatus(sandboxName) {
+function sandboxStatus(sandboxName, { json = false } = {}) {
   const sb = registry.getSandbox(sandboxName);
   const live = parseGatewayInference(
     runCapture("openshell inference get 2>/dev/null", { ignoreError: true })
   );
+  const nimStat = sb && sb.nimContainer ? nim.nimStatusByName(sb.nimContainer) : nim.nimStatus(sandboxName);
+
+  if (json) {
+    console.log(JSON.stringify({
+      name: sandboxName,
+      model: (live && live.model) || (sb && sb.model) || null,
+      provider: (live && live.provider) || (sb && sb.provider) || null,
+      gpuEnabled: (sb && sb.gpuEnabled) || false,
+      policies: (sb && sb.policies) || [],
+      nim: {
+        running: nimStat.running,
+        container: nimStat.container || null,
+        healthy: nimStat.healthy || false,
+      },
+    }));
+    return;
+  }
+
   if (sb) {
     console.log("");
     console.log(`  Sandbox: ${sb.name}`);
@@ -323,7 +368,6 @@ function sandboxStatus(sandboxName) {
   run(`openshell sandbox get ${shellQuote(sandboxName)} 2>/dev/null || true`, { ignoreError: true });
 
   // NIM health
-  const nimStat = sb && sb.nimContainer ? nim.nimStatusByName(sb.nimContainer) : nim.nimStatus(sandboxName);
   console.log(`    NIM:      ${nimStat.running ? `running (${nimStat.container})` : "not running"}`);
   if (nimStat.running) {
     console.log(`    Healthy:  ${nimStat.healthy ? "yes" : "no"}`);
@@ -358,9 +402,21 @@ async function sandboxPolicyAdd(sandboxName) {
   policies.applyPreset(sandboxName, answer);
 }
 
-function sandboxPolicyList(sandboxName) {
+function sandboxPolicyList(sandboxName, { json = false } = {}) {
   const allPresets = policies.listPresets();
   const applied = policies.getAppliedPresets(sandboxName);
+
+  if (json) {
+    console.log(JSON.stringify({
+      sandbox: sandboxName,
+      presets: allPresets.map((p) => ({
+        name: p.name,
+        description: p.description,
+        applied: applied.includes(p.name),
+      })),
+    }));
+    return;
+  }
 
   console.log("");
   console.log(`  Policy presets for sandbox '${sandboxName}':`);
@@ -465,10 +521,10 @@ const [cmd, ...args] = process.argv.slice(2);
       case "deploy":      await deploy(args[0]); break;
       case "start":       await start(); break;
       case "stop":        stop(); break;
-      case "status":      showStatus(); break;
+      case "status":      showStatus({ json: args.includes("--json") }); break;
       case "debug":       debug(args); break;
       case "uninstall":   uninstall(args); break;
-      case "list":        listSandboxes(); break;
+      case "list":        listSandboxes({ json: args.includes("--json") }); break;
       case "--version":
       case "-v": {
         const pkg = require(path.join(__dirname, "..", "package.json"));
@@ -489,10 +545,10 @@ const [cmd, ...args] = process.argv.slice(2);
 
     switch (action) {
       case "connect":     sandboxConnect(cmd); break;
-      case "status":      sandboxStatus(cmd); break;
+      case "status":      sandboxStatus(cmd, { json: actionArgs.includes("--json") }); break;
       case "logs":        sandboxLogs(cmd, actionArgs.includes("--follow")); break;
       case "policy-add":  await sandboxPolicyAdd(cmd); break;
-      case "policy-list": sandboxPolicyList(cmd); break;
+      case "policy-list": sandboxPolicyList(cmd, { json: actionArgs.includes("--json") }); break;
       case "destroy":     await sandboxDestroy(cmd, actionArgs); break;
       default:
         console.error(`  Unknown action: ${action}`);

--- a/test/json-output.test.js
+++ b/test/json-output.test.js
@@ -69,11 +69,14 @@ describe("--json output", () => {
 
   it("list --json outputs empty array when no sandboxes", () => {
     const emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-json-empty-"));
-    const r = run("list --json", emptyHome);
-    expect(r.code).toBe(0);
-    const data = JSON.parse(r.out);
-    expect(data.sandboxes).toEqual([]);
-    fs.rmSync(emptyHome, { recursive: true, force: true });
+    try {
+      const r = run("list --json", emptyHome);
+      expect(r.code).toBe(0);
+      const data = JSON.parse(r.out);
+      expect(data.sandboxes).toEqual([]);
+    } finally {
+      fs.rmSync(emptyHome, { recursive: true, force: true });
+    }
   });
 
   it("status --json outputs valid JSON with sandbox array", () => {

--- a/test/json-output.test.js
+++ b/test/json-output.test.js
@@ -84,4 +84,28 @@ describe("--json output", () => {
     expect(data.sandboxes[0].name).toBe("my-assistant");
     expect(data.sandboxes[0].default).toBe(true);
   });
+
+  it("<name> status --json outputs valid JSON with sandbox details", () => {
+    const r = run("my-assistant status --json", tmpHome);
+    expect(r.code).toBe(0);
+    const data = JSON.parse(r.out);
+    expect(data.name).toBe("my-assistant");
+    expect(data.model).toBe("nvidia/nemotron-3-super-120b-a12b");
+    expect(data.provider).toBe("nvidia-prod");
+    expect(data.gpuEnabled).toBe(false);
+    expect(data.policies).toEqual(["pypi", "npm-registry"]);
+    expect(data.nim).toMatchObject({ running: false });
+  });
+
+  it("<name> policy-list --json outputs valid JSON with presets", () => {
+    const r = run("my-assistant policy-list --json", tmpHome);
+    expect(r.code).toBe(0);
+    const data = JSON.parse(r.out);
+    expect(data.sandbox).toBe("my-assistant");
+    expect(data.presets).toBeInstanceOf(Array);
+    expect(data.presets.length).toBeGreaterThan(0);
+    const pypi = data.presets.find((p) => p.name === "pypi");
+    expect(pypi).toBeDefined();
+    expect(pypi.applied).toBe(true);
+  });
 });

--- a/test/json-output.test.js
+++ b/test/json-output.test.js
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
+
+function run(args, home) {
+  try {
+    const out = execSync(`${JSON.stringify(process.execPath)} "${CLI}" ${args}`, {
+      encoding: "utf-8",
+      timeout: 10000,
+      env: { ...process.env, HOME: home },
+    });
+    return { code: 0, out };
+  } catch (err) {
+    return { code: err.status, out: (err.stdout || "") + (err.stderr || "") };
+  }
+}
+
+describe("--json output", () => {
+  let tmpHome;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-json-test-"));
+    const nemoclawDir = path.join(tmpHome, ".nemoclaw");
+    fs.mkdirSync(nemoclawDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nemoclawDir, "sandboxes.json"),
+      JSON.stringify({
+        defaultSandbox: "my-assistant",
+        sandboxes: {
+          "my-assistant": {
+            name: "my-assistant",
+            createdAt: "2026-03-25T00:00:00.000Z",
+            model: "nvidia/nemotron-3-super-120b-a12b",
+            provider: "nvidia-prod",
+            gpuEnabled: false,
+            policies: ["pypi", "npm-registry"],
+          },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("list --json outputs valid JSON with sandbox array", () => {
+    const r = run("list --json", tmpHome);
+    expect(r.code).toBe(0);
+    const data = JSON.parse(r.out);
+    expect(data.sandboxes).toBeInstanceOf(Array);
+    expect(data.sandboxes).toHaveLength(1);
+    expect(data.sandboxes[0]).toMatchObject({
+      name: "my-assistant",
+      default: true,
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      provider: "nvidia-prod",
+      gpuEnabled: false,
+      policies: ["pypi", "npm-registry"],
+    });
+  });
+
+  it("list --json outputs empty array when no sandboxes", () => {
+    const emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-json-empty-"));
+    const r = run("list --json", emptyHome);
+    expect(r.code).toBe(0);
+    const data = JSON.parse(r.out);
+    expect(data.sandboxes).toEqual([]);
+    fs.rmSync(emptyHome, { recursive: true, force: true });
+  });
+
+  it("status --json outputs valid JSON with sandbox array", () => {
+    const r = run("status --json", tmpHome);
+    expect(r.code).toBe(0);
+    const data = JSON.parse(r.out);
+    expect(data.sandboxes).toBeInstanceOf(Array);
+    expect(data.sandboxes[0].name).toBe("my-assistant");
+    expect(data.sandboxes[0].default).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--json` flag to `nemoclaw list`, `nemoclaw status`, `nemoclaw <name> status`, and `nemoclaw <name> policy-list`
- JSON output is machine-readable for scripting and automation
- Human-readable output remains the default

### Example

```console
$ nemoclaw list --json
{"sandboxes":[{"name":"my-assistant","default":true,"model":"nvidia/nemotron-3-super-120b-a12b","provider":"nvidia-prod","gpuEnabled":false,"policies":["pypi","npm-registry"]}]}
```

Fixes #753

## Test plan

- [x] All pre-commit and pre-push hooks pass
- [x] 3 new tests validate JSON shape and exit behavior
- [x] All 528 existing tests pass (34 test files, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--json` flag to CLI commands (global `status`, `list`, and sandbox-scoped operations) to output structured JSON for sandboxes, health/NIM status, and policy preset lists.

* **Tests**
  * Added tests verifying JSON output structure, fields, and behavior for list, status, sandbox-specific status, and policy-list commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->