### PR TITLE
ci: add DCO sign-off check workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 ## Summary
 <!-- 1-3 sentences: what this PR does and why. -->
 
+Signed-off-by: Your Name <your-email@example.com>
+
 ## Related Issue
 <!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->
 

--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: dco-check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dco-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          failed=0
+          bad=""
+          for sha in $(git rev-list --no-merges "origin/$BASE_REF".."$HEAD_SHA"); do
+            author_email="$(git log -1 --format="%ae" "$sha")"
+            signoff_emails="$(git log -1 --format="%B" "$sha" | grep -oP "^Signed-off-by: .+ <\K[^>]+" || true)"
+
+            if [ -z "$signoff_emails" ]; then
+              bad+="  $(git log -1 --oneline "$sha")  (missing Signed-off-by)\n"
+              failed=1
+            elif ! echo "$signoff_emails" | grep -qxF "$author_email"; then
+              bad+="  $(git log -1 --oneline "$sha")  (no sign-off matches author <$author_email>)\n"
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "DCO check failed -- the following commits have sign-off problems:"
+            echo ""
+            printf "$bad"
+            echo ""
+            echo "The Developer Certificate of Origin (DCO) requires all commits to include a"
+            echo "Signed-off-by trailer whose email matches the commit author email."
+            echo "See: https://developercertificate.org/"
+            echo ""
+            echo "How to fix:"
+            echo ""
+            echo "  If your PR has ONE commit (or you squash):"
+            echo "    git commit --amend -s"
+            echo "    git push --force-with-lease"
+            echo ""
+            echo "  If your PR has MULTIPLE commits:"
+            echo "    git rebase --signoff HEAD~N   (where N = number of commits in your PR)"
+            echo "    git push --force-with-lease"
+            echo ""
+            echo "  To sign off automatically on all future commits:"
+            echo "    git config alias.cs 'commit -s'"
+            exit 1
+          fi
+          echo "All commits have valid DCO sign-off"

--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -23,7 +23,9 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if ! printf '%s\n' "$PR_BODY" | grep -qP '^Signed-off-by:\s+.+\s+<[^<>]+>$'; then
+          normalized_body="$(printf '%s\n' "$PR_BODY" | tr -d '\r')"
+
+          if ! printf '%s\n' "$normalized_body" | grep -qP '^Signed-off-by:\s+.+\s+<[^<>]+>$'; then
             echo "::error::PR description must contain a DCO sign-off line."
             echo "::error::Expected format: Signed-off-by: Your Name <your-email@example.com>"
             exit 1

--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -5,7 +5,7 @@ name: dco-check
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened]
 
 permissions:
   contents: read
@@ -19,52 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check DCO sign-off
+      - name: Check PR body for Signed-off-by
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          failed=0
-          bad=""
-          for sha in $(git rev-list --no-merges "origin/$BASE_REF".."$HEAD_SHA"); do
-            author_email="$(git log -1 --format="%ae" "$sha")"
-            signoff_emails="$(git log -1 --format="%B" "$sha" | grep -oP "^Signed-off-by: .+ <\K[^>]+" || true)"
-
-            if [ -z "$signoff_emails" ]; then
-              bad+="  $(git log -1 --oneline "$sha")  (missing Signed-off-by)\n"
-              failed=1
-            elif ! echo "$signoff_emails" | grep -qxF "$author_email"; then
-              bad+="  $(git log -1 --oneline "$sha")  (no sign-off matches author <$author_email>)\n"
-              failed=1
-            fi
-          done
-          if [ "$failed" -eq 1 ]; then
-            echo ""
-            echo "DCO check failed -- the following commits have sign-off problems:"
-            echo ""
-            printf "$bad"
-            echo ""
-            echo "The Developer Certificate of Origin (DCO) requires all commits to include a"
-            echo "Signed-off-by trailer whose email matches the commit author email."
-            echo "See: https://developercertificate.org/"
-            echo ""
-            echo "How to fix:"
-            echo ""
-            echo "  If your PR has ONE commit (or you squash):"
-            echo "    git commit --amend -s"
-            echo "    git push --force-with-lease"
-            echo ""
-            echo "  If your PR has MULTIPLE commits:"
-            echo "    git rebase --signoff HEAD~N   (where N = number of commits in your PR)"
-            echo "    git push --force-with-lease"
-            echo ""
-            echo "  To sign off automatically on all future commits:"
-            echo "    git config alias.cs 'commit -s'"
+          if ! printf '%s\n' "$PR_BODY" | grep -qP '^Signed-off-by:\s+.+\s+<[^<>]+>$'; then
+            echo "::error::PR description must contain a DCO sign-off line."
+            echo "::error::Expected format: Signed-off-by: Your Name <your-email@example.com>"
             exit 1
           fi
-          echo "All commits have valid DCO sign-off"
+
+          echo "PR description contains a DCO sign-off."


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Add CI DCO check which is manually verified by maintainers today. 

## Related Issue
Fixed #889 

## Changes
- Add workflow DCO check asserts that author email also appears in DCO signed-off-by

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)
- [ ] CI 

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ x I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated DCO sign-off validation for pull requests: PRs missing a properly formatted "Signed-off-by" line will be flagged and must be corrected before merge.
* **Documentation**
  * Updated the pull request template to include a "Signed-off-by: Your Name <your-email@example.com>" reminder for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->