### PR TITLE
fix(test): use sed instead of hardcoded line count in PATH isolation test

### DIFF
--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -126,7 +126,7 @@ fi
 
 info "7. Entrypoint locks PATH to system directories"
 # Run the entrypoint preamble (up to the PATH export) and verify the result
-OUT=$(run_as_root "bash -c 'source <(head -21 /usr/local/bin/nemoclaw-start) 2>/dev/null; echo \$PATH'")
+OUT=$(run_as_root "bash -c 'source <(sed -n \"1,/^export PATH=/p\" /usr/local/bin/nemoclaw-start) 2>/dev/null; echo \$PATH'")
 if echo "$OUT" | grep -q "^/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin$"; then
   pass "PATH is locked to system directories"
 else


### PR DESCRIPTION
## Summary

- Replace `head -21` with `sed -n "1,/^export PATH=/p"` in the gateway isolation E2E test
- The hardcoded line count broke after #830 added `ulimit` lines to `nemoclaw-start.sh`, pushing the `export PATH=` line from 21 to 30
- Using `sed` dynamically finds the PATH export regardless of future changes to the entrypoint preamble

## Test plan

- [x] All pre-commit and pre-push hooks pass (including shellcheck)
- [ ] `test-e2e-gateway-isolation` CI job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test verification logic for PATH isolation checks to be more precise.

---

**Note:** This release contains internal test infrastructure improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->