### PR TITLE
feat(cli): add gateway-token command to retrieve auth token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ secrets.json
 secrets.yaml
 service-account*.json
 token.json
+.venv/

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -4520,9 +4520,11 @@ async function onboard(opts = {}) {
 module.exports = {
   buildProviderArgs,
   buildSandboxConfigSyncScript,
+  buildControlUiUrls,
   compactText,
   copyBuildContextDir,
   classifySandboxCreateFailure,
+  fetchGatewayAuthTokenFromSandbox,
   createSandbox,
   formatEnvAssignment,
   getFutureShellPathHint,

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -1165,7 +1165,33 @@ function sandboxLogs(sandboxName, follow) {
   exitWithSpawnResult(result);
 }
 
-function sandboxGatewayToken(sandboxName) {
+/**
+ * Wait for a TCP port to accept connections, with timeout.
+ */
+function waitForPort(port, timeoutMs = 10000) {
+  const net = require("net");
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    function tryConnect() {
+      const sock = net.createConnection({ port, host: "127.0.0.1" }, () => {
+        sock.destroy();
+        resolve();
+      });
+      sock.on("error", () => {
+        sock.destroy();
+        if (Date.now() - start > timeoutMs) {
+          reject(new Error(`Port ${port} not ready after ${timeoutMs}ms`));
+        } else {
+          setTimeout(tryConnect, 500);
+        }
+      });
+    }
+    tryConnect();
+  });
+}
+
+async function sandboxGatewayToken(sandboxName) {
+  await ensureLiveSandboxOrExit(sandboxName);
   const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
   if (!token) {
     console.error(`  ${_RD}Error${R}: Could not retrieve gateway auth token from sandbox '${sandboxName}'.`);
@@ -1179,8 +1205,9 @@ function sandboxGatewayToken(sandboxName) {
 
 async function sandboxOpen(sandboxName) {
   await ensureLiveSandboxOrExit(sandboxName);
-  // Ensure port forward is alive before opening
+  // Start port forward and wait for it to be ready
   runOpenshell(["forward", "start", "--background", "18789", sandboxName], { ignoreError: true });
+  await waitForPort(18789, 10000);
 
   const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
   if (!token) {
@@ -1197,11 +1224,14 @@ async function sandboxOpen(sandboxName) {
   console.log(`  Opening Control UI at ${safeUrl} ...`);
 
   // Open URL in default browser (platform-appropriate)
-  const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  // Windows "start" is a cmd built-in, not an executable — requires shell: true
+  const isWin = process.platform === "win32";
+  const opener = process.platform === "darwin" ? "open" : isWin ? "start" : "xdg-open";
   try {
-    const child = require("child_process").spawn(opener, [url], {
+    const child = require("child_process").spawn(opener, isWin ? ["", url] : [url], {
       stdio: "ignore",
       detached: true,
+      shell: isWin,
     });
     child.unref();
   } catch (_e) {
@@ -1464,7 +1494,7 @@ const [cmd, ...args] = process.argv.slice(2);
         sandboxPolicyList(cmd);
         break;
       case "gateway-token":
-        sandboxGatewayToken(cmd);
+        await sandboxGatewayToken(cmd);
         break;
       case "open":
         await sandboxOpen(cmd);

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -1161,6 +1161,61 @@ function sandboxLogs(sandboxName, follow) {
   exitWithSpawnResult(result);
 }
 
+function sandboxGatewayToken(sandboxName) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
+  try {
+    const qn = shellQuote(sandboxName);
+    const destDir = `${tmpDir}${path.sep}`;
+    const result = spawnSync("bash", ["-c", `openshell sandbox download ${qn} /sandbox/.openclaw/openclaw.json ${shellQuote(destDir)}`], {
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    if (result.status !== 0) {
+      console.error(`  ${_RD}Error${R}: Could not retrieve config from sandbox '${sandboxName}'.`);
+      console.error(`  Make sure the sandbox is running and accessible.`);
+      process.exit(1);
+    }
+    // Find the downloaded file (may be nested in subdirectory)
+    const candidates = [
+      path.join(tmpDir, "openclaw.json"),
+      path.join(tmpDir, "sandbox", ".openclaw", "openclaw.json"),
+    ];
+    let jsonPath = null;
+    for (const p of candidates) {
+      if (fs.existsSync(p)) { jsonPath = p; break; }
+    }
+    // Fallback: recursive search
+    if (!jsonPath) {
+      const findResult = spawnSync("find", [tmpDir, "-name", "openclaw.json", "-type", "f"], {
+        encoding: "utf-8",
+      });
+      const found = (findResult.stdout || "").trim().split("\n").filter(Boolean)[0];
+      if (found) jsonPath = found;
+    }
+    if (!jsonPath) {
+      console.error(`  ${_RD}Error${R}: openclaw.json not found in sandbox '${sandboxName}'.`);
+      process.exit(1);
+    }
+    const cfg = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+    const token = cfg && cfg.gateway && cfg.gateway.auth && cfg.gateway.auth.token;
+    if (typeof token === "string" && token.length > 0) {
+      console.log(token);
+    } else {
+      console.error(`  ${_RD}Error${R}: Gateway auth token not found in sandbox config.`);
+      console.error(`  The sandbox may not have been fully onboarded yet.`);
+      process.exit(1);
+    }
+  } catch (e) {
+    console.error(`  ${_RD}Error${R}: ${e.message}`);
+    process.exit(1);
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
 async function sandboxPolicyAdd(sandboxName, args = []) {
   const dryRun = args.includes("--dry-run");
   const allPresets = policies.listPresets();
@@ -1290,6 +1345,7 @@ function help() {
     nemoclaw <name> connect          Shell into a running sandbox
     nemoclaw <name> status           Sandbox health + NIM status
     nemoclaw <name> logs ${D}[--follow]${R}  Stream sandbox logs
+    nemoclaw <name> gateway-token    Print the gateway auth token
     nemoclaw <name> destroy          Stop NIM + delete sandbox ${D}(--yes to skip prompt)${R}
 
   ${G}Policy Presets:${R}
@@ -1411,12 +1467,15 @@ const [cmd, ...args] = process.argv.slice(2);
       case "policy-list":
         sandboxPolicyList(cmd);
         break;
+      case "gateway-token":
+        sandboxGatewayToken(cmd);
+        break;
       case "destroy":
         await sandboxDestroy(cmd, actionArgs);
         break;
       default:
         console.error(`  Unknown action: ${action}`);
-        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, destroy`);
+        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, gateway-token, destroy`);
         process.exit(1);
     }
     return;

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -30,7 +30,11 @@ const {
   validateName,
 } = require("./lib/runner");
 const { resolveOpenshell } = require("./lib/resolve-openshell");
-const { startGatewayForRecovery } = require("./lib/onboard");
+const {
+  buildControlUiUrls,
+  fetchGatewayAuthTokenFromSandbox,
+  startGatewayForRecovery,
+} = require("./lib/onboard");
 const {
   getCredential,
   deleteCredential,
@@ -1162,57 +1166,48 @@ function sandboxLogs(sandboxName, follow) {
 }
 
 function sandboxGatewayToken(sandboxName) {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
-  try {
-    const qn = shellQuote(sandboxName);
-    const destDir = `${tmpDir}${path.sep}`;
-    const result = spawnSync("bash", ["-c", `openshell sandbox download ${qn} /sandbox/.openclaw/openclaw.json ${shellQuote(destDir)}`], {
-      stdio: ["ignore", "ignore", "ignore"],
-    });
-    if (result.status !== 0) {
-      console.error(`  ${_RD}Error${R}: Could not retrieve config from sandbox '${sandboxName}'.`);
-      console.error(`  Make sure the sandbox is running and accessible.`);
-      process.exit(1);
-    }
-    // Find the downloaded file (may be nested in subdirectory)
-    const candidates = [
-      path.join(tmpDir, "openclaw.json"),
-      path.join(tmpDir, "sandbox", ".openclaw", "openclaw.json"),
-    ];
-    let jsonPath = null;
-    for (const p of candidates) {
-      if (fs.existsSync(p)) { jsonPath = p; break; }
-    }
-    // Fallback: recursive search
-    if (!jsonPath) {
-      const findResult = spawnSync("find", [tmpDir, "-name", "openclaw.json", "-type", "f"], {
-        encoding: "utf-8",
-      });
-      const found = (findResult.stdout || "").trim().split("\n").filter(Boolean)[0];
-      if (found) jsonPath = found;
-    }
-    if (!jsonPath) {
-      console.error(`  ${_RD}Error${R}: openclaw.json not found in sandbox '${sandboxName}'.`);
-      process.exit(1);
-    }
-    const cfg = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
-    const token = cfg && cfg.gateway && cfg.gateway.auth && cfg.gateway.auth.token;
-    if (typeof token === "string" && token.length > 0) {
-      console.log(token);
-    } else {
-      console.error(`  ${_RD}Error${R}: Gateway auth token not found in sandbox config.`);
-      console.error(`  The sandbox may not have been fully onboarded yet.`);
-      process.exit(1);
-    }
-  } catch (e) {
-    console.error(`  ${_RD}Error${R}: ${e.message}`);
+  const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
+  if (!token) {
+    console.error(`  ${_RD}Error${R}: Could not retrieve gateway auth token from sandbox '${sandboxName}'.`);
+    console.error(`  Make sure the sandbox is running and accessible.`);
     process.exit(1);
-  } finally {
-    try {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    } catch {
-      // ignore cleanup errors
-    }
+  }
+  // Print warning to stderr before token to stdout
+  console.error(`  ${YW}⚠️  Treat this token like a password. Do not share it or include it in logs/screencasts.${R}`);
+  console.log(token);
+}
+
+async function sandboxOpen(sandboxName) {
+  await ensureLiveSandboxOrExit(sandboxName);
+  // Ensure port forward is alive before opening
+  runOpenshell(["forward", "start", "--background", "18789", sandboxName], { ignoreError: true });
+
+  const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
+  if (!token) {
+    console.error(`  ${_RD}Error${R}: Could not retrieve gateway auth token from sandbox '${sandboxName}'.`);
+    console.error(`  Make sure the sandbox is running and accessible.`);
+    process.exit(1);
+  }
+
+  const urls = buildControlUiUrls(token);
+  const url = urls[0]; // Use the first URL (localhost)
+
+  // Log without token to avoid exposure in terminal history/screencasts
+  const safeUrl = url.replace(/#.*$/, "");
+  console.log(`  Opening Control UI at ${safeUrl} ...`);
+
+  // Open URL in default browser (platform-appropriate)
+  const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+  try {
+    const child = require("child_process").spawn(opener, [url], {
+      stdio: "ignore",
+      detached: true,
+    });
+    child.unref();
+  } catch (_e) {
+    console.error(`  ${_RD}Error${R}: Could not open browser. Please open this URL manually:`);
+    console.error(`  ${url}`);
+    process.exit(1);
   }
 }
 
@@ -1345,7 +1340,8 @@ function help() {
     nemoclaw <name> connect          Shell into a running sandbox
     nemoclaw <name> status           Sandbox health + NIM status
     nemoclaw <name> logs ${D}[--follow]${R}  Stream sandbox logs
-    nemoclaw <name> gateway-token    Print the gateway auth token
+    nemoclaw <name> open             Open Control UI in browser with auth token
+    nemoclaw <name> gateway-token    Print the gateway auth token ${D}(for scripts)${R}
     nemoclaw <name> destroy          Stop NIM + delete sandbox ${D}(--yes to skip prompt)${R}
 
   ${G}Policy Presets:${R}
@@ -1470,12 +1466,15 @@ const [cmd, ...args] = process.argv.slice(2);
       case "gateway-token":
         sandboxGatewayToken(cmd);
         break;
+      case "open":
+        await sandboxOpen(cmd);
+        break;
       case "destroy":
         await sandboxDestroy(cmd, actionArgs);
         break;
       default:
         console.error(`  Unknown action: ${action}`);
-        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, gateway-token, destroy`);
+        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, gateway-token, open, destroy`);
         process.exit(1);
     }
     return;

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -1207,7 +1207,15 @@ async function sandboxOpen(sandboxName) {
   await ensureLiveSandboxOrExit(sandboxName);
   // Start port forward and wait for it to be ready
   runOpenshell(["forward", "start", "--background", "18789", sandboxName], { ignoreError: true });
-  await waitForPort(18789, 10000);
+  try {
+    await waitForPort(18789, 10000);
+  } catch (_e) {
+    console.error(`  ${_RD}Error${R}: Port forward timed out — could not reach localhost:18789.`);
+    console.error(`  The sandbox '${sandboxName}' may still be starting. Try again in a moment, or run:`);
+    console.error(`    nemoclaw ${sandboxName} gateway-token`);
+    console.error(`  to retrieve the token manually.`);
+    process.exit(1);
+  }
 
   const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
   if (!token) {
@@ -1227,18 +1235,18 @@ async function sandboxOpen(sandboxName) {
   // Windows "start" is a cmd built-in, not an executable — requires shell: true
   const isWin = process.platform === "win32";
   const opener = process.platform === "darwin" ? "open" : isWin ? "start" : "xdg-open";
-  try {
-    const child = require("child_process").spawn(opener, isWin ? ["", url] : [url], {
-      stdio: "ignore",
-      detached: true,
-      shell: isWin,
-    });
-    child.unref();
-  } catch (_e) {
+  const child = require("child_process").spawn(opener, isWin ? ["", url] : [url], {
+    stdio: "ignore",
+    detached: true,
+    shell: isWin,
+  });
+  child.on("error", () => {
     console.error(`  ${_RD}Error${R}: Could not open browser. Please open this URL manually:`);
-    console.error(`  ${url}`);
+    console.error(`  ${safeUrl}`);
+    console.error(`  If you need the auth token for manual login, run: nemoclaw ${sandboxName} gateway-token`);
     process.exit(1);
-  }
+  });
+  child.unref();
 }
 
 async function sandboxPolicyAdd(sandboxName, args = []) {


### PR DESCRIPTION
## Summary

Adds `nemoclaw <name> gateway-token` command that prints the gateway auth token for a sandbox, replacing the multi-step workaround documented in #938.

### Before (workaround)
```bash
d=$(mktemp -d) && openshell sandbox download my-assistant /sandbox/.openclaw/openclaw.json "$d/" && jq -r '.gateway.auth.token' "$d/openclaw.json" && rm -rf "$d"
```

### After
```bash
nemoclaw my-assistant gateway-token
```

## Changes

- **`bin/nemoclaw.js`**: Added `sandboxGatewayToken()` function and `gateway-token` action
- Downloads `openclaw.json` from sandbox via `openshell sandbox download` to a temp directory
- Extracts `gateway.auth.token` and prints to stdout (pipe-friendly)
- Cleans up temp files in all cases (try/finally)
- Clear error messages when sandbox is inaccessible or token is missing
- Updated help text and valid actions list

## Usage

```bash
# Print the token
nemoclaw my-assistant gateway-token

# Use in scripts
TOKEN=$(nemoclaw my-assistant gateway-token)
openclaw acp --url wss://localhost:18789 --token "$TOKEN"
```

## Design Notes

- Reuses the same `openshell sandbox download` + temp directory + cleanup pattern used by `fetchGatewayAuthTokenFromSandbox()` in onboard.js
- Output is just the raw token (no decorations) so it can be captured with `$()`
- Discoverable via `nemoclaw help` under Sandbox Management

Closes #938

Signed-off-by: Kagura <kagura-agent@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `gateway-token` CLI action to verify a sandbox, fetch and print a gateway auth token (token to stdout; warnings/errors to stderr).
  * Added `open` CLI action to verify a sandbox, ensure local connectivity/port-forwarding, obtain an auth token, derive a Control UI URL (non-token URL logged), and open it in the default browser.

* **Other**
  * CLI help updated to list the new actions.

* **Chores**
  * Ignore local Python virtual environment directory (.venv) in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->