### PR TITLE
fix(test): replace fragile PATH source test with static assertion

### DIFF
--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -125,12 +125,17 @@ fi
 # ── Test 7: Entrypoint PATH is locked to system dirs ─────────────
 
 info "7. Entrypoint locks PATH to system directories"
-# Run the entrypoint preamble (up to the PATH export) and verify the result
-OUT=$(run_as_root "bash -c 'source <(grep -m1 -A0 \"^export PATH=\" /usr/local/bin/nemoclaw-start) 2>/dev/null; echo \$PATH'")
-if echo "$OUT" | grep -q "^/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin$"; then
-  pass "PATH is locked to system directories"
+# Verify the entrypoint contains exactly one PATH export with the expected
+# value. Previous approaches sourced partial scripts using hardcoded line
+# counts or grep, which broke when the preamble changed (#830). Checking
+# the file content directly is stable and tests the security property:
+# PATH must be locked before any user-controlled code runs.
+EXPECTED="export PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\""
+COUNT=$(run_as_root "grep -cF '${EXPECTED}' /usr/local/bin/nemoclaw-start")
+if [ "$COUNT" = "1" ]; then
+  pass "PATH is locked to system directories (exactly 1 export)"
 else
-  fail "PATH not locked as expected: $OUT"
+  fail "expected exactly 1 PATH export, found $COUNT"
 fi
 
 # ── Test 8: openclaw resolves to expected absolute path ──────────


### PR DESCRIPTION
## Summary

- Replace the gateway isolation PATH test that sourced partial entrypoint scripts with a static file content check
- Previous approaches used `head -21` (broke after #830 added ulimit lines) and `grep -m1` (fragile — sources a single line without context)
- New test uses `grep -cF` to verify the entrypoint contains exactly one `export PATH=` with the expected locked-down value

Supersedes #942.

## Why this is better

The old tests tried to *execute* parts of the entrypoint and check PATH. That couples the test to the script's line count and structure. The new test checks the security property directly: does the entrypoint contain the hardened PATH export? This won't break when lines are added, removed, or reordered.

## Test plan

- [x] All pre-commit and pre-push hooks pass (including shellcheck)
- [ ] `test-e2e-gateway-isolation` CI job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced PATH-hardening validation with improved static file inspection and more accurate failure reporting.

---

**Note:** This release contains internal testing infrastructure improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->