### PR TITLE
fix: make ulimit best-effort, fix PATH test regression

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 # Harden: limit process count to prevent fork bombs (ref: #809)
-ulimit -Hu 512 || {
-  echo "[SECURITY] Failed to set hard nproc limit" >&2
-  exit 1
-}
-ulimit -Su 512 || {
-  echo "[SECURITY] Failed to set soft nproc limit" >&2
-  exit 1
-}
+# Best-effort: some container runtimes (e.g., brev) restrict ulimit
+# modification, returning "Invalid argument". Warn but don't block startup.
+if ! ulimit -Hu 512 2>/dev/null; then
+  echo "[SECURITY] Could not set hard nproc limit (container runtime may restrict ulimit)" >&2
+fi
+if ! ulimit -Su 512 2>/dev/null; then
+  echo "[SECURITY] Could not set soft nproc limit (container runtime may restrict ulimit)" >&2
+fi
 
 # SECURITY: Lock down PATH so the agent cannot inject malicious binaries
 # into commands executed by the entrypoint or auto-pair watcher.

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -125,8 +125,8 @@ fi
 # ── Test 7: Entrypoint PATH is locked to system dirs ─────────────
 
 info "7. Entrypoint locks PATH to system directories"
-# Run the entrypoint preamble (up to the PATH export) and verify the result
-OUT=$(run_as_root "bash -c 'source <(grep -m1 -A0 \"^export PATH=\" /usr/local/bin/nemoclaw-start) 2>/dev/null; echo \$PATH'")
+# Walk the entrypoint line-by-line, eval each line, stop after the PATH export.
+OUT=$(run_as_root "bash -c 'while IFS= read -r line; do eval \"\$line\" 2>/dev/null; case \"\$line\" in \"export PATH=\"*) break;; esac; done < /usr/local/bin/nemoclaw-start; echo \$PATH'")
 if echo "$OUT" | grep -q "^/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin$"; then
   pass "PATH is locked to system directories"
 else

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -125,8 +125,9 @@ fi
 # ── Test 7: Entrypoint PATH is locked to system dirs ─────────────
 
 info "7. Entrypoint locks PATH to system directories"
-# Walk the entrypoint line-by-line, eval each line, stop after the PATH export.
-OUT=$(run_as_root "bash -c 'while IFS= read -r line; do eval \"\$line\" 2>/dev/null; case \"\$line\" in \"export PATH=\"*) break;; esac; done < /usr/local/bin/nemoclaw-start; echo \$PATH'")
+# Run a real command through the entrypoint to test the actual PATH a
+# sandboxed process receives — no eval hacks or grep extraction.
+OUT=$(docker run --rm "$IMAGE" bash -c 'echo "$PATH"' 2>&1)
 if echo "$OUT" | grep -q "^/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin$"; then
   pass "PATH is locked to system directories"
 else

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -125,9 +125,8 @@ fi
 # ── Test 7: Entrypoint PATH is locked to system dirs ─────────────
 
 info "7. Entrypoint locks PATH to system directories"
-# Run a real command through the entrypoint to test the actual PATH a
-# sandboxed process receives — no eval hacks or grep extraction.
-OUT=$(docker run --rm "$IMAGE" bash -c 'echo "$PATH"' 2>&1)
+# Walk the entrypoint line-by-line, eval each line, stop after the PATH export.
+OUT=$(run_as_root "bash -c 'while IFS= read -r line; do eval \"\$line\" 2>/dev/null; case \"\$line\" in \"export PATH=\"*) break;; esac; done < /usr/local/bin/nemoclaw-start; echo \$PATH'")
 if echo "$OUT" | grep -q "^/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin$"; then
   pass "PATH is locked to system directories"
 else

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -125,8 +125,8 @@ fi
 # ── Test 7: Entrypoint PATH is locked to system dirs ─────────────
 
 info "7. Entrypoint locks PATH to system directories"
-# Walk the entrypoint line-by-line, eval each line, stop after the PATH export.
-OUT=$(run_as_root "bash -c 'while IFS= read -r line; do eval \"\$line\" 2>/dev/null; case \"\$line\" in \"export PATH=\"*) break;; esac; done < /usr/local/bin/nemoclaw-start; echo \$PATH'")
+# Walk the entrypoint line-by-line, eval only export lines, stop after PATH.
+OUT=$(run_as_root "bash -c 'while IFS= read -r line; do case \"\$line\" in export\\ *) eval \"\$line\" 2>/dev/null;; esac; case \"\$line\" in \"export PATH=\"*) break;; esac; done < /usr/local/bin/nemoclaw-start; echo \$PATH'")
 if echo "$OUT" | grep -q "^/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin$"; then
   pass "PATH is locked to system directories"
 else


### PR DESCRIPTION
## Summary
- **ulimit hardening now best-effort**: `ulimit -Hu/-Su 512` fatally exited on container runtimes (e.g., brev) that reject limit modification with "Invalid argument", breaking sandbox bootstrap. Now warns and continues.
- **PATH test walks script line-by-line**: Replaces the broken grep extraction with a `while read` loop that evals each line and stops at `export PATH=`. No hardcoded line numbers, no grep, won't break when lines are added above PATH.

## Test plan
- [ ] Verify brev bootstrap no longer crashes on ulimit
- [ ] Run e2e-gateway-isolation.sh — test 7 (PATH lock) passes
- [ ] Verify ulimit warning appears in stderr on restricted runtimes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Startup is more resilient in containerized environments: resource-limit adjustments are now best-effort. Failures to tighten limits no longer abort startup and instead emit security warnings.

* **Tests**
  * Startup verification updated to read and evaluate the entrypoint's exported PATH lines in order, ensuring the runtime receives the expected system-directory-only PATH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->