### PR TITLE
fix(ci): lint only PR title since repo is squash-merge only

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -33,14 +31,7 @@ jobs:
       - name: Install dependencies
         run: npm install --ignore-scripts
 
-      - name: Lint commits
-        if: github.event.action != 'edited'
-        env:
-          FROM_SHA: ${{ github.event.pull_request.base.sha }}
-          TO_SHA: ${{ github.event.pull_request.head.sha }}
-        run: npx commitlint --from "$FROM_SHA" --to "$TO_SHA" --verbose
-
-      - name: Lint PR title (squash-merge path)
+      - name: Lint PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: printf '%s\n' "$PR_TITLE" | npx commitlint --verbose

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ On a fresh macOS machine, install the prerequisites in this order:
 3. Run the NemoClaw installer.
 
 This avoids the two most common first-run failures on macOS:
+
 - missing developer tools needed by the installer and Node.js toolchain
 - Docker connection errors when no supported container runtime is installed or running
 


### PR DESCRIPTION
## Summary

The repo uses squash-merge exclusively. Individual commit messages are
discarded at merge time — only the PR title becomes the commit on `main`
and drives changelog generation.

This PR removes the per-commit lint step from the `commit-lint` workflow
and keeps only the PR title check. Also drops `fetch-depth: 0` (no
longer needed) and fixes a pre-existing markdownlint MD032 in README.md.

**Context:** PR #913 has a commit created via GitHub's web-UI
"Apply suggestion" feature which doesn't follow conventional commit
format. Rather than special-casing those, this aligns the CI check with
what actually matters for the squash-merge workflow.

## Test plan

- [ ] `commit-lint` CI job passes on this PR
- [ ] PR #913 `commit-lint` job passes after this merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated commit linting workflow to validate pull request titles.
  * Minor documentation formatting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->