### PR TITLE
fix(onboard): restore remote dashboard forward

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1885,9 +1885,7 @@ async function createSandbox(gpu, model, provider, preferredInferenceApi = null,
   // Release any stale forward on port 18789 before claiming it for the new sandbox.
   // A previous onboard run may have left the port forwarded to a different sandbox,
   // which would silently prevent the new sandbox's dashboard from being reachable.
-  runOpenshell(["forward", "stop", "18789"], { ignoreError: true });
-  // Forward dashboard port to the new sandbox
-  runOpenshell(["forward", "start", "--background", "18789", sandboxName], { ignoreError: true });
+  ensureDashboardForward(sandboxName, chatUiUrl);
 
   // Register only after confirmed ready — prevents phantom entries
   registry.registerSandbox({
@@ -2687,6 +2685,28 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
 const CONTROL_UI_PORT = 18789;
 const CONTROL_UI_PATH = "/";
 
+function resolveDashboardForwardTarget(chatUiUrl) {
+  const rawUrl = String(chatUiUrl || "").trim();
+  const localHosts = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+
+  if (!rawUrl) return String(CONTROL_UI_PORT);
+
+  try {
+    const { hostname } = new URL(rawUrl);
+    return localHosts.has(hostname) ? String(CONTROL_UI_PORT) : `0.0.0.0:${CONTROL_UI_PORT}`;
+  } catch {
+    return /(?:^|\/\/)(?:localhost|127\.0\.0\.1|\[?::1\]?)(?::\d+)?(?:\/|$)/i.test(rawUrl)
+      ? String(CONTROL_UI_PORT)
+      : `0.0.0.0:${CONTROL_UI_PORT}`;
+  }
+}
+
+function ensureDashboardForward(sandboxName, chatUiUrl) {
+  const forwardTarget = resolveDashboardForwardTarget(chatUiUrl);
+  runOpenshell(["forward", "stop", String(CONTROL_UI_PORT)], { ignoreError: true });
+  runOpenshell(["forward", "start", "--background", forwardTarget, sandboxName], { ignoreError: true });
+}
+
 function findOpenclawJsonPath(dir) {
   if (!fs.existsSync(dir)) return null;
   const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -3080,6 +3100,7 @@ module.exports = {
   getInstalledOpenshellVersion,
   getRequestedModelHint,
   getRequestedProviderHint,
+  resolveDashboardForwardTarget,
   getStableGatewayImageRef,
   getResumeConfigConflicts,
   isGatewayHealthy,

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -2685,17 +2685,21 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
 const CONTROL_UI_PORT = 18789;
 const CONTROL_UI_PATH = "/";
 
+function isLoopbackHostname(hostname) {
+  const normalized = String(hostname || "").replace(/^\[|\]$/g, "").toLowerCase();
+  return normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/.test(normalized);
+}
+
 function resolveDashboardForwardTarget(chatUiUrl) {
   const rawUrl = String(chatUiUrl || "").trim();
-  const localHosts = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
 
   if (!rawUrl) return String(CONTROL_UI_PORT);
 
   try {
     const { hostname } = new URL(rawUrl);
-    return localHosts.has(hostname) ? String(CONTROL_UI_PORT) : `0.0.0.0:${CONTROL_UI_PORT}`;
+    return isLoopbackHostname(hostname) ? String(CONTROL_UI_PORT) : `0.0.0.0:${CONTROL_UI_PORT}`;
   } catch {
-    return /(?:^|\/\/)(?:localhost|127\.0\.0\.1|\[?::1\]?)(?::\d+)?(?:\/|$)/i.test(rawUrl)
+    return /(?:^|\/\/)(?:localhost|127(?:\.\d{1,3}){3}|\[?::1\]?)(?::\d+)?(?:\/|$)/i.test(rawUrl)
       ? String(CONTROL_UI_PORT)
       : `0.0.0.0:${CONTROL_UI_PORT}`;
   }

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -22,7 +22,7 @@ const YW = _useColor ? "\x1b[1;33m" : "";
 
 const { ROOT, SCRIPTS, run, runCapture: _runCapture, runInteractive, shellQuote, validateName } = require("./lib/runner");
 const { resolveOpenshell } = require("./lib/resolve-openshell");
-const { startGatewayForRecovery } = require("./lib/onboard");
+const { resolveDashboardForwardTarget, startGatewayForRecovery } = require("./lib/onboard");
 const {
   ensureApiKey,
   ensureGithubToken,
@@ -570,6 +570,11 @@ function listSandboxes() {
 
 async function sandboxConnect(sandboxName) {
   await ensureLiveSandboxOrExit(sandboxName);
+  // Ensure port forward is alive before connecting
+  const chatUiUrl = process.env.CHAT_UI_URL || "http://127.0.0.1:18789";
+  const forwardTarget = resolveDashboardForwardTarget(chatUiUrl);
+  runOpenshell(["forward", "stop", "18789"], { ignoreError: true });
+  runOpenshell(["forward", "start", "--background", forwardTarget, sandboxName], { ignoreError: true });
   const result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {
     stdio: "inherit",
     cwd: ROOT,

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -30,6 +30,20 @@ import {
   writeSandboxConfigSyncFile,
 } from "../bin/lib/onboard";
 
+describe("resolveDashboardForwardTarget", () => {
+  it("keeps loopback chat UI URLs bound to loopback", () => {
+    expect(resolveDashboardForwardTarget("http://127.0.0.1:18789")).toBe("18789");
+    expect(resolveDashboardForwardTarget("http://127.42.0.9:18789")).toBe("18789");
+    expect(resolveDashboardForwardTarget("http://localhost:18789")).toBe("18789");
+    expect(resolveDashboardForwardTarget("http://[::1]:18789")).toBe("18789");
+  });
+
+  it("uses a public bind target for non-loopback chat UI URLs", () => {
+    expect(resolveDashboardForwardTarget("https://chat.example.com")).toBe("0.0.0.0:18789");
+    expect(resolveDashboardForwardTarget("http://10.0.0.25:18789")).toBe("0.0.0.0:18789");
+  });
+});
+
 describe("onboard helpers", () => {
   it("classifies sandbox create timeout failures and tracks upload progress", () => {
     expect(
@@ -483,19 +497,6 @@ const { setupInference } = require(${onboardPath});
 })().catch((error) => {
   console.error(error);
   process.exit(1);
-});
-
-describe("resolveDashboardForwardTarget", () => {
-  it("keeps localhost chat UI URLs bound to loopback", () => {
-    expect(resolveDashboardForwardTarget("http://127.0.0.1:18789")).toBe("18789");
-    expect(resolveDashboardForwardTarget("http://localhost:18789")).toBe("18789");
-    expect(resolveDashboardForwardTarget("http://[::1]:18789")).toBe("18789");
-  });
-
-  it("uses a public bind target for remote chat UI URLs", () => {
-    expect(resolveDashboardForwardTarget("https://chat.example.com")).toBe("0.0.0.0:18789");
-    expect(resolveDashboardForwardTarget("http://10.0.0.25:18789")).toBe("0.0.0.0:18789");
-  });
 });
 `;
     fs.writeFileSync(scriptPath, script);

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -25,6 +25,7 @@ import {
   isGatewayHealthy,
   patchStagedDockerfile,
   printSandboxCreateRecoveryHints,
+  resolveDashboardForwardTarget,
   shouldIncludeBuildContextPath,
   writeSandboxConfigSyncFile,
 } from "../bin/lib/onboard";
@@ -482,6 +483,19 @@ const { setupInference } = require(${onboardPath});
 })().catch((error) => {
   console.error(error);
   process.exit(1);
+});
+
+describe("resolveDashboardForwardTarget", () => {
+  it("keeps localhost chat UI URLs bound to loopback", () => {
+    expect(resolveDashboardForwardTarget("http://127.0.0.1:18789")).toBe("18789");
+    expect(resolveDashboardForwardTarget("http://localhost:18789")).toBe("18789");
+    expect(resolveDashboardForwardTarget("http://[::1]:18789")).toBe("18789");
+  });
+
+  it("uses a public bind target for remote chat UI URLs", () => {
+    expect(resolveDashboardForwardTarget("https://chat.example.com")).toBe("0.0.0.0:18789");
+    expect(resolveDashboardForwardTarget("http://10.0.0.25:18789")).toBe("0.0.0.0:18789");
+  });
 });
 `;
     fs.writeFileSync(scriptPath, script);


### PR DESCRIPTION
## Summary
- restore the dashboard forward when onboard keeps an existing sandbox
- bind the forward to `0.0.0.0:18789` when `CHAT_UI_URL` points at a non-local host
- add helper coverage for local vs remote forward targets

Closes #957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized dashboard forwarding: resolves loopback vs non-loopback UI URLs and selects the appropriate bind target; recreates forwards reliably when sandboxes are created or connected.

* **Bug Fixes**
  * Stops stale dashboard forwards and consistently starts the correct forward to prevent port-binding conflicts.

* **Tests**
  * Added tests verifying loopback vs non-loopback forwarding target resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->