### PR TITLE
docs: explain Linux Ollama bind requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ During onboarding, NemoClaw validates the selected provider and model before it 
 
 Credentials stay on the host in `~/.nemoclaw/credentials.json`. The sandbox only sees the routed `inference.local` endpoint, not your raw provider key.
 
-Local Ollama is supported in the standard onboarding flow. Local vLLM remains experimental, and local host-routed inference on macOS still depends on OpenShell host-routing support in addition to the local service itself being reachable on the host.
+Local Ollama is supported in the standard onboarding flow. On Linux Docker hosts, Ollama must listen on `0.0.0.0:11434` so sandboxes can reach `http://host.openshell.internal:11434`; a loopback-only `127.0.0.1:11434` bind will fail validation. Local vLLM remains experimental, and local host-routed inference on macOS still depends on OpenShell host-routing support in addition to the local service itself being reachable on the host.
 
 ---
 

--- a/docs/reference/inference-profiles.md
+++ b/docs/reference/inference-profiles.md
@@ -76,6 +76,14 @@ Ollama gets additional onboarding help:
 - it warms the model
 - it validates the model before continuing
 
+On Linux hosts that run NemoClaw with Docker, the sandbox reaches Ollama through `http://host.openshell.internal:11434`, not the host shell's `localhost` socket. If Ollama is already running, make sure it listens on `0.0.0.0:11434` instead of `127.0.0.1:11434`, for example:
+
+```bash
+OLLAMA_HOST=0.0.0.0:11434 ollama serve
+```
+
+If Ollama only binds loopback, NemoClaw can detect it on the host but the sandbox-side validation step will fail because containers cannot reach it.
+
 ## Experimental Local Providers
 
 The following local providers require `NEMOCLAW_EXPERIMENTAL=1`:

--- a/docs/reference/inference-profiles.md
+++ b/docs/reference/inference-profiles.md
@@ -76,13 +76,15 @@ Ollama gets additional onboarding help:
 - it warms the model
 - it validates the model before continuing
 
-On Linux hosts that run NemoClaw with Docker, the sandbox reaches Ollama through `http://host.openshell.internal:11434`, not the host shell's `localhost` socket. If Ollama is already running, make sure it listens on `0.0.0.0:11434` instead of `127.0.0.1:11434`, for example:
+On Linux hosts that run NemoClaw with Docker, the sandbox reaches Ollama through `http://host.openshell.internal:11434`, not the host shell's `localhost` socket.
+If Ollama is already running, make sure it listens on `0.0.0.0:11434` instead of `127.0.0.1:11434`.
+For example:
 
-```bash
-OLLAMA_HOST=0.0.0.0:11434 ollama serve
+```console
+$ OLLAMA_HOST=0.0.0.0:11434 ollama serve
 ```
 
-If Ollama only binds loopback, NemoClaw can detect it on the host but the sandbox-side validation step will fail because containers cannot reach it.
+If Ollama only binds loopback, NemoClaw can detect it on the host but the sandbox-side validation step fails because containers cannot reach it.
 
 ## Experimental Local Providers
 


### PR DESCRIPTION
## Summary
- document that Linux Docker sandboxes reach Ollama through `host.openshell.internal`
- call out the required `0.0.0.0:11434` bind for host Ollama services
- align the docs with the existing onboarding validation failure mode

Fixes #709.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Local Ollama inference setup and onboarding guidance for Linux/Docker hosts. Now clarifies that Ollama must bind to 0.0.0.0:11434 (reachable via host routing) so the sandbox can connect; loopback-only 127.0.0.1:11434 will fail onboarding validation. Includes explicit examples and troubleshooting notes for container network reachability and host-routing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->