### PR TITLE
fix: symlink telegram state into openclaw-data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,7 +176,11 @@ RUN openclaw doctor --fix > /dev/null 2>&1 || true \
 # The writable state lives in .openclaw-data, reached via the symlinks.
 # hadolint ignore=DL3002
 USER root
-RUN chown root:root /sandbox/.openclaw \
+RUN mkdir -p /sandbox/.openclaw-data/telegram \
+    && chown -R sandbox:sandbox /sandbox/.openclaw-data/telegram \
+    && rm -rf /sandbox/.openclaw/telegram \
+    && ln -sfn /sandbox/.openclaw-data/telegram /sandbox/.openclaw/telegram \
+    && chown root:root /sandbox/.openclaw \
     && rm -rf /root/.npm /sandbox/.npm \
     && find /sandbox/.openclaw -mindepth 1 -maxdepth 1 -exec chown -h root:root {} + \
     && chmod 755 /sandbox/.openclaw \

--- a/test/dockerfile-telegram-state.test.js
+++ b/test/dockerfile-telegram-state.test.js
@@ -15,16 +15,13 @@ describe("Dockerfile telegram state layout (#975)", () => {
   });
 
   it("symlinks .openclaw/telegram into .openclaw-data before locking .openclaw", () => {
-    expect(DOCKERFILE.includes("ln -sfn /sandbox/.openclaw-data/telegram /sandbox/.openclaw/telegram")).toBeTruthy();
-  });
+    const symlink = DOCKERFILE.indexOf("ln -sfn /sandbox/.openclaw-data/telegram /sandbox/.openclaw/telegram");
+    const lockStep = DOCKERFILE.indexOf("chown root:root /sandbox/.openclaw");
+    const cleanupBeforeSymlink = DOCKERFILE.indexOf("rm -rf /sandbox/.openclaw/telegram");
 
-  it("removes any existing .openclaw/telegram path before creating the symlink", () => {
-    const rm = DOCKERFILE.indexOf("rm -rf /sandbox/.openclaw/telegram");
-    const ln = DOCKERFILE.indexOf(
-      "ln -sfn /sandbox/.openclaw-data/telegram /sandbox/.openclaw/telegram",
-    );
-    expect(rm).toBeGreaterThanOrEqual(0);
-    expect(ln).toBeGreaterThanOrEqual(0);
-    expect(rm).toBeLessThan(ln);
+    expect(symlink).toBeGreaterThan(-1);
+    expect(lockStep).toBeGreaterThan(symlink);
+    expect(cleanupBeforeSymlink).toBeGreaterThan(-1);
+    expect(cleanupBeforeSymlink).toBeLessThan(symlink);
   });
 });

--- a/test/dockerfile-telegram-state.test.js
+++ b/test/dockerfile-telegram-state.test.js
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const DOCKERFILE = fs.readFileSync(path.join(ROOT, "Dockerfile"), "utf-8");
+
+describe("Dockerfile telegram state layout (#975)", () => {
+  it("precreates writable telegram state under .openclaw-data", () => {
+    expect(DOCKERFILE.includes("mkdir -p /sandbox/.openclaw-data/telegram")).toBeTruthy();
+    expect(DOCKERFILE.includes("chown -R sandbox:sandbox /sandbox/.openclaw-data/telegram")).toBeTruthy();
+  });
+
+  it("symlinks .openclaw/telegram into .openclaw-data before locking .openclaw", () => {
+    expect(DOCKERFILE.includes("ln -sfn /sandbox/.openclaw-data/telegram /sandbox/.openclaw/telegram")).toBeTruthy();
+  });
+
+  it("removes any existing .openclaw/telegram path before creating the symlink", () => {
+    const rm = DOCKERFILE.indexOf("rm -rf /sandbox/.openclaw/telegram");
+    const ln = DOCKERFILE.indexOf(
+      "ln -sfn /sandbox/.openclaw-data/telegram /sandbox/.openclaw/telegram",
+    );
+    expect(rm).toBeGreaterThanOrEqual(0);
+    expect(ln).toBeGreaterThanOrEqual(0);
+    expect(rm).toBeLessThan(ln);
+  });
+});


### PR DESCRIPTION
## Summary
- precreate writable Telegram channel state under `/sandbox/.openclaw-data/telegram`
- symlink `/sandbox/.openclaw/telegram` into `.openclaw-data` before locking `.openclaw`
- add a regression test that keeps the Dockerfile layout from drifting

Fixes #975.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests that verify the container’s Telegram state setup is present and applied in the correct order.

* **Chores**
  * Improved container setup for Telegram state: creates dedicated writable storage, ensures correct ownership and permissions, and replaces any legacy path to provide more reliable persistence and access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->