### PR TITLE
Dead plugin modules (4 TypeScript files ship in dist/ but are   unreachable at runtime)    

### DIFF
--- a/nemoclaw/package.json
+++ b/nemoclaw/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "nemoclaw-runner": "./dist/blueprint/runner.js"
+  },
   "openclaw": {
     "extensions": [
       "./dist/index.js"

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -447,4 +448,13 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
     default:
       throw new Error(`Unknown action '${String(action)}'. Use: plan, apply, status, rollback`);
   }
+}
+
+// Auto-invoke when run as a CLI binary (not when imported as a module).
+import { fileURLToPath } from "node:url";
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((e: unknown) => {
+    process.stderr.write((e instanceof Error ? e.message : String(e)) + "\n");
+    process.exit(1);
+  });
 }

--- a/nemoclaw/src/blueprint/snapshot.ts
+++ b/nemoclaw/src/blueprint/snapshot.ts
@@ -9,6 +9,9 @@
  *   - Restore: push snapshot contents into sandbox filesystem
  *   - Cutover: rename host config to archived, point OpenClaw at sandbox
  *   - Rollback: restore host config from snapshot
+ *
+ * TODO(#977): Wire into the `nemoclaw migrate` command alongside migration-state.ts.
+ *   These functions are tested and ready; they need a CLI entry point.
  */
 
 import type { Dirent } from "node:fs";

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * Migration state detection and snapshot bundling for the `nemoclaw migrate` flow.
+ *
+ * TODO(#977): Wire into the `nemoclaw migrate` command alongside snapshot.ts.
+ *   This module is tested and ready; it needs a CLI entry point.
+ */
+
 import {
   chmodSync,
   copyFileSync,


### PR DESCRIPTION
## Summary

`runner.ts`, `ssrf.ts`, `snapshot.ts`, and `migration-state.ts` all compile and ship in the npm package but are never reachable at runtime (#977). This PR fixes the two modules that have a natural CLI entry point and documents the other two for a follow-up migration command.

- **`runner.ts`** is the TypeScript port of the Python blueprint runner. It has a `main()` function designed for CLI use but was never exposed as a bin. This PR wires it in.
- **`ssrf.ts`** is now reachable transitively (imported by `runner.ts`).
- **`snapshot.ts`** and **`migration-state.ts`** implement the `nemoclaw migrate` flow. They are tested and ready, but need a future CLI subcommand to hook into; `TODO(#977)` comments added to mark this.

## Changes

- `nemoclaw/src/blueprint/runner.ts` — add `#!/usr/bin/env node` shebang and ESM main-module guard (`process.argv[1] === fileURLToPath(import.meta.url)`) so the compiled binary auto-invokes `main()` when run directly but is still importable as a module (tests unaffected)
- `nemoclaw/package.json` — add `"bin": { "nemoclaw-runner": "./dist/blueprint/runner.js" }` so the binary is installed when the package is installed
- `nemoclaw/src/blueprint/snapshot.ts` — add `TODO(#977)` comment pointing to the pending `nemoclaw migrate` entry point
- `nemoclaw/src/commands/migration-state.ts` — same

## Testing

```
cd nemoclaw && npm install --ignore-scripts && npm run build && cd ..
npm test
```

All 542 tests pass (2 pre-existing skips). Build is clean.

The shebang is preserved in compiled output (`dist/blueprint/runner.js`) and the main-module guard ensures `main()` runs when invoked as a CLI binary but not when imported by tests or other modules.

Fixes #977

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `nemoclaw-runner` CLI command, enabling direct command-line execution of the nemoclaw runner.

* **Chores**
  * Added documentation comments clarifying the purpose of migration state and snapshot functions for future CLI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->