### PR TITLE
fix(security): replace method wildcards with explicit GET+POST in baseline policy

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -53,15 +53,18 @@ network_policies:
         enforcement: enforce
         tls: terminate
         rules:
-          - allow: { method: "*", path: "/**" }
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
       - host: statsig.anthropic.com
         port: 443
         rules:
-          - allow: { method: "*", path: "/**" }
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
       - host: sentry.io
         port: 443
         rules:
-          - allow: { method: "*", path: "/**" }
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/claude }
 
@@ -74,14 +77,16 @@ network_policies:
         enforcement: enforce
         tls: terminate
         rules:
-          - allow: { method: "*", path: "/**" }
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
       - host: inference-api.nvidia.com
         port: 443
         protocol: rest
         enforcement: enforce
         tls: terminate
         rules:
-          - allow: { method: "*", path: "/**" }
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/claude }
       - { path: /usr/local/bin/openclaw }

--- a/test/security-method-wildcards.test.js
+++ b/test/security-method-wildcards.test.js
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const BASELINE = path.join(import.meta.dirname, "..", "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
+
+describe("method wildcards: baseline policy", () => {
+  it("no endpoint uses method: \"*\" wildcard", () => {
+    // method: "*" permits DELETE, PUT, PATCH which inference APIs do not
+    // require. All endpoints should use explicit method rules (GET, POST).
+    const yaml = fs.readFileSync(BASELINE, "utf-8");
+    const lines = yaml.split("\n");
+    const violations = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (/method:\s*["']\*["']/.test(line)) {
+        violations.push({ line: i + 1, content: line.trim() });
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Replace `method: "*"` with explicit `GET` and `POST` rules on all inference provider endpoints in the baseline sandbox policy. The wildcard permits DELETE, PUT, and PATCH methods that these APIs do not require, increasing the attack surface if an agent or plugin is compromised.

## Changes

- `api.anthropic.com`: `method: "*"` → `GET` + `POST`
- `statsig.anthropic.com`: `method: "*"` → `GET` + `POST`
- `sentry.io`: `method: "*"` → `GET` + `POST`
- `integrate.api.nvidia.com`: `method: "*"` → `GET` + `POST`
- `inference-api.nvidia.com`: `method: "*"` → `GET` + `POST`

Inference calls use POST (completions, messages, token counting) and GET (model listing, health checks, usage). No other HTTP methods are required. No functional change.

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] Added `test/security-method-wildcards.test.js` — validates no `method: "*"` wildcards exist in baseline policy
- [x] `npx prek run --all-files` passes.
- [x] `npm test` passes.

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).

### Code Changes

- [x] Formatters applied.
- [x] Tests added for new behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes. *(N/A — no user-facing behavior change)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced network access control policies to restrict specified services to explicit HTTP methods (GET and POST) instead of allowing all methods, reducing attack surface.

* **Tests**
  * Added automated validation to ensure network policies comply with security standards by preventing overly permissive method configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->