### PR TITLE
docs(network-policy): fix incorrect CLI usage for presets and dynamic policy updates

### DIFF
--- a/.agents/skills/nemoclaw-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-manage-policy/SKILL.md
@@ -114,13 +114,14 @@ Dynamic changes apply a policy update to a running sandbox without restarting it
 
 Create a YAML file with the endpoints to add.
 Follow the same format as the baseline policy in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`.
+The file must include the mandatory `version` field (e.g., `version: 1`) to be accepted by the OpenShell parser.
 
 ### Apply the Policy
 
 Use the OpenShell CLI to apply the policy update:
 
 ```console
-$ openshell policy set <policy-file>
+$ openshell policy set --policy <policy-file> <name>
 ```
 
 The change takes effect immediately.
@@ -150,13 +151,28 @@ Available presets:
 | `slack` | Slack API and webhooks |
 | `telegram` | Telegram Bot API |
 
-To apply a preset to a running sandbox, pass it as a policy file:
+To apply a preset to a running sandbox:
 
 ```console
-$ openshell policy set nemoclaw-blueprint/policies/presets/pypi.yaml
+$ nemoclaw <name> policy-add <preset>
+```
+
+For example, to add PyPI access to a running sandbox:
+
+```console
+$ nemoclaw my-assistant policy-add pypi
+```
+
+To list which presets are applied to a sandbox:
+
+```console
+$ nemoclaw <name> policy-list
 ```
 
 To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.
+
+> **Note:** The `openshell policy set --policy <file> <name>` command operates on raw policy files and does not accept the `preset:` metadata block used in preset YAML files.
+> Use `nemoclaw <name> policy-add` for presets.
 
 ## Related Skills
 

--- a/.agents/skills/nemoclaw-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-manage-policy/SKILL.md
@@ -154,14 +154,7 @@ Available presets:
 To apply a preset to a running sandbox:
 
 ```console
-$ nemoclaw <name> policy-add <preset>
-```
-
-For example, to add PyPI access to a running sandbox:
-
-```console
-$ nemoclaw my-assistant policy-add pypi
-```
+$ nemoclaw <name> policy-add
 
 To list which presets are applied to a sandbox:
 

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -75,13 +75,14 @@ Dynamic changes apply a policy update to a running sandbox without restarting it
 
 Create a YAML file with the endpoints to add.
 Follow the same format as the baseline policy in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`.
+The file must include the mandatory `version` field (e.g., `version: 1`) to be accepted by the OpenShell parser.
 
 ### Apply the Policy
 
 Use the OpenShell CLI to apply the policy update:
 
 ```console
-$ openshell policy set <policy-file>
+$ openshell policy set --policy <policy-file> <name>
 ```
 
 The change takes effect immediately.
@@ -111,13 +112,30 @@ Available presets:
 | `slack` | Slack API and webhooks |
 | `telegram` | Telegram Bot API |
 
-To apply a preset to a running sandbox, pass it as a policy file:
+To apply a preset to a running sandbox:
 
 ```console
-$ openshell policy set nemoclaw-blueprint/policies/presets/pypi.yaml
+$ nemoclaw <name> policy-add <preset>
+```
+
+For example, to add PyPI access to a running sandbox:
+
+```console
+$ nemoclaw my-assistant policy-add pypi
+```
+
+To list which presets are applied to a sandbox:
+
+```console
+$ nemoclaw <name> policy-list
 ```
 
 To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.
+
+:::{note}
+The `openshell policy set --policy <file> <name>` command operates on raw policy files and does not accept the `preset:` metadata block used in preset YAML files.
+Use `nemoclaw <name> policy-add` for presets.
+:::
 
 ## Related Topics
 

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -115,10 +115,10 @@ Available presets:
 To apply a preset to a running sandbox:
 
 ```console
-$ nemoclaw <name> policy-add <preset>
+$ nemoclaw <name> policy-add
 ```
 
-For example, to add PyPI access to a running sandbox:
+For example, to add PyPI access to a running sandbox, run the command and select 'pypi' at the prompt:
 
 ```console
 $ nemoclaw my-assistant policy-add pypi


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
The preset application instructions in `docs/network-policy/customize-network-policy.md` show incorrect CLI commands for applying dynamic policy updates and presets.
Following the current instructions produces parse errors from the OpenShell CLI.
This PR corrects the command syntax, adds the missing `version` field requirement for custom policies, and replaces the broken preset workflow with the correct `nemoclaw <name> policy-add` command.

## Changes
<!-- Bullet list of key changes. -->

- Fix openshell policy set <policy-file> -> `openshell policy set --policy <policy-file> <name>` (missing flag and positional argument).
- Add note that custom policy YAML files must include the mandatory version field (e.g., `version: 1`).
- Replace broken openshell policy set <preset.yaml> instructions with `nemoclaw <name> policy-add <preset>`.
- Add concrete example: nemoclaw my-assistant policy-add pypi.
- Add nemoclaw <name> policy-list usage.
- Add admonition explaining why openshell policy set rejects preset files (the preset: metadata block is NemoClaw-specific, not part of the OpenShell policy schema).

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [x] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

Reproduced on a live NemoClaw sandbox (Ubuntu 24.04, DigitalOcean s-4vcpu-8gb)

<img width="1902" height="614" alt="image" src="https://github.com/user-attachments/assets/d936e0fa-35c4-4f80-a28c-1644e450d5c3" />


## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [x] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Require a top-level `version` field in dynamic YAML policy files.
  * Update OpenShell CLI syntax to use `openshell policy set --policy <file> <name>`, adding an explicit sandbox/name parameter.
  * Replace applying preset YAML directly with NemoClaw preset subcommands: `nemoclaw <name> policy-add <preset>` and `nemoclaw <name> policy-list`.
  * Clarify that preset YAMLs containing `preset:` must be applied via NemoClaw commands (example: `pypi`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->