### PR TITLE
fix(policies): guard extractPresetEntries against null/undefined input

### DIFF
--- a/bin/lib/policies.js
+++ b/bin/lib/policies.js
@@ -63,6 +63,7 @@ function getPresetEndpoints(content) {
  * `preset:` metadata header.
  */
 function extractPresetEntries(presetContent) {
+  if (!presetContent) return null;
   const npMatch = presetContent.match(/^network_policies:\n([\s\S]*)$/m);
   if (!npMatch) return null;
   return npMatch[1].trimEnd();

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -136,6 +136,121 @@ describe("policies", () => {
     });
   });
 
+  describe("extractPresetEntries", () => {
+    it("returns null for null input", () => {
+      expect(policies.extractPresetEntries(null)).toBe(null);
+    });
+
+    it("returns null for undefined input", () => {
+      expect(policies.extractPresetEntries(undefined)).toBe(null);
+    });
+
+    it("returns null for empty string", () => {
+      expect(policies.extractPresetEntries("")).toBe(null);
+    });
+
+    it("returns null when no network_policies section exists", () => {
+      const content = "preset:\n  name: test\n  description: test preset";
+      expect(policies.extractPresetEntries(content)).toBe(null);
+    });
+
+    it("extracts indented entries from network_policies section", () => {
+      const content = [
+        "preset:",
+        "  name: test",
+        "",
+        "network_policies:",
+        "  test_rule:",
+        "    name: test_rule",
+        "    endpoints:",
+        "      - host: example.com",
+        "        port: 443",
+      ].join("\n");
+      const entries = policies.extractPresetEntries(content);
+      expect(entries).toContain("test_rule:");
+      expect(entries).toContain("host: example.com");
+      expect(entries).toContain("port: 443");
+    });
+
+    it("strips trailing whitespace from extracted entries", () => {
+      const content = "network_policies:\n  rule:\n    name: rule\n\n\n";
+      const entries = policies.extractPresetEntries(content);
+      expect(entries).not.toMatch(/\n$/);
+    });
+
+    it("works on every real preset file", () => {
+      for (const p of policies.listPresets()) {
+        const content = policies.loadPreset(p.name);
+        const entries = policies.extractPresetEntries(content);
+        expect(entries).toBeTruthy();
+        expect(entries).toContain("endpoints:");
+      }
+    });
+
+    it("does not include preset metadata header", () => {
+      const content = [
+        "preset:",
+        "  name: test",
+        "  description: desc",
+        "",
+        "network_policies:",
+        "  rule:",
+        "    name: rule",
+      ].join("\n");
+      const entries = policies.extractPresetEntries(content);
+      expect(entries).not.toContain("preset:");
+      expect(entries).not.toContain("description:");
+    });
+  });
+
+  describe("parseCurrentPolicy", () => {
+    it("returns empty string for null input", () => {
+      expect(policies.parseCurrentPolicy(null)).toBe("");
+    });
+
+    it("returns empty string for undefined input", () => {
+      expect(policies.parseCurrentPolicy(undefined)).toBe("");
+    });
+
+    it("returns empty string for empty string input", () => {
+      expect(policies.parseCurrentPolicy("")).toBe("");
+    });
+
+    it("strips metadata header before --- separator", () => {
+      const raw = [
+        "Version: 3",
+        "Hash: abc123",
+        "Updated: 2026-03-26",
+        "---",
+        "version: 1",
+        "",
+        "network_policies:",
+        "  rule: {}",
+      ].join("\n");
+      const result = policies.parseCurrentPolicy(raw);
+      expect(result).toBe("version: 1\n\nnetwork_policies:\n  rule: {}");
+      expect(result).not.toContain("Hash:");
+      expect(result).not.toContain("Updated:");
+    });
+
+    it("returns raw content when no --- separator exists", () => {
+      const raw = "version: 1\nnetwork_policies:\n  rule: {}";
+      expect(policies.parseCurrentPolicy(raw)).toBe(raw);
+    });
+
+    it("trims whitespace around extracted YAML", () => {
+      const raw = "Header: value\n---\n  \nversion: 1\n  ";
+      const result = policies.parseCurrentPolicy(raw);
+      expect(result).toBe("version: 1");
+    });
+
+    it("handles --- appearing as first line", () => {
+      const raw = "---\nversion: 1\nnetwork_policies: {}";
+      const result = policies.parseCurrentPolicy(raw);
+      expect(result).toBe("version: 1\nnetwork_policies: {}");
+    });
+  });
+
   describe("mergePresetIntoPolicy", () => {
     const sampleEntries = "  - host: example.com\n    allow: true";
 


### PR DESCRIPTION
## Problem

`extractPresetEntries()` throws an unhandled `TypeError: Cannot read properties of null (reading 'match')` when called with `null` or `undefined`. The function is exported as part of the public module API but lacks the same defensive guard that its sibling `parseCurrentPolicy()` already implements.

The current call site in `applyPreset()` is protected indirectly — `loadPreset()` returns `null` and the caller bails before reaching `extractPresetEntries()` — but direct consumers of the exported function hit the crash:

const { extractPresetEntries } = require("./policies");
extractPresetEntries(null); // TypeError



Fix
Add an early-return null guard consistent with the existing [parseCurrentPolicy()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) pattern (line 79). One line, zero behavioral change for the happy path.

Tests
Added 15 regression tests for two exported pure functions that previously had zero direct test coverage:

[extractPresetEntries](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (8 tests): null, undefined, empty string, missing section, extraction correctness, trailing whitespace stripping, real preset integration, metadata exclusion
[parseCurrentPolicy](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (7 tests): null, undefined, empty string, metadata stripping, no-separator passthrough, whitespace trimming, edge-case separator position
All 37 policy tests pass. Full suite: 615 pass, 2 pre-existing failures in install-preflight.test.js (unrelated).