### PR TITLE
feat(presets): add SidClaw agent governance preset

### DIFF
--- a/nemoclaw-blueprint/policies/presets/sidclaw.yaml
+++ b/nemoclaw-blueprint/policies/presets/sidclaw.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: sidclaw
+  description: "SidClaw agent governance — policy evaluation, human approval, audit trails"
+
+network_policies:
+  sidclaw:
+    name: sidclaw
+    endpoints:
+      - host: api.sidclaw.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: POST, path: "/api/v1/evaluate" }
+          - allow: { method: GET, path: "/api/v1/approvals/**" }
+          - allow: { method: POST, path: "/api/v1/approvals/*/approve" }
+          - allow: { method: POST, path: "/api/v1/approvals/*/deny" }
+          - allow: { method: POST, path: "/api/v1/traces/*/outcome" }
+          - allow: { method: GET, path: "/api/v1/agents/**" }
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/python3 }

--- a/nemoclaw-blueprint/policies/presets/sidclaw.yaml
+++ b/nemoclaw-blueprint/policies/presets/sidclaw.yaml
@@ -17,10 +17,10 @@ network_policies:
         rules:
           - allow: { method: POST, path: "/api/v1/evaluate" }
           - allow: { method: GET, path: "/api/v1/approvals/**" }
-          - allow: { method: POST, path: "/api/v1/approvals/*/approve" }
-          - allow: { method: POST, path: "/api/v1/approvals/*/deny" }
           - allow: { method: POST, path: "/api/v1/traces/*/outcome" }
           - allow: { method: GET, path: "/api/v1/agents/**" }
+    # Both runtimes needed: @sidclaw/sdk (TypeScript) and sidclaw (Python).
+    # If your agent uses only one, override with a narrower binaries list.
     binaries:
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/python3 }

--- a/nemoclaw-blueprint/policies/presets/sidclaw.yaml
+++ b/nemoclaw-blueprint/policies/presets/sidclaw.yaml
@@ -19,8 +19,8 @@ network_policies:
           - allow: { method: GET, path: "/api/v1/approvals/**" }
           - allow: { method: POST, path: "/api/v1/traces/*/outcome" }
           - allow: { method: GET, path: "/api/v1/agents/**" }
-    # Both runtimes needed: @sidclaw/sdk (TypeScript) and sidclaw (Python).
-    # If your agent uses only one, override with a narrower binaries list.
+    # Only the SidClaw-specific binaries — not generic interpreters.
+    # The MCP proxy (@sidclaw/sdk) and the Python CLI (sidclaw).
     binaries:
-      - { path: /usr/local/bin/node }
-      - { path: /usr/bin/python3 }
+      - { path: /usr/local/bin/sidclaw* }
+      - { path: /usr/local/bin/sidclaw-mcp-proxy }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -96,9 +96,9 @@ selectFromList(items, options)
 
 describe("policies", () => {
   describe("listPresets", () => {
-    it("returns all 11 presets", () => {
+    it("returns all 12 presets", () => {
       const presets = policies.listPresets();
-      expect(presets.length).toBe(11);
+      expect(presets.length).toBe(12);
     });
 
     it("each preset has name and description", () => {
@@ -123,6 +123,7 @@ describe("policies", () => {
         "npm",
         "outlook",
         "pypi",
+        "sidclaw",
         "slack",
         "telegram",
       ];


### PR DESCRIPTION
## Summary

Adds a network policy preset for [SidClaw](https://sidclaw.com), an agent governance platform that adds policy evaluation, human-in-the-loop approval, and hash-chain audit trails to tools running inside NemoClaw sandboxes.

NemoClaw secures the sandbox (network, filesystem, process). SidClaw governs what happens inside it (policy, approval, audit).

## What this preset enables

The `sidclaw` preset allows the sandbox to reach the SidClaw API (`api.sidclaw.com:443`) for:

- **Policy evaluation** — `POST /api/v1/evaluate` — every tool call checked against governance policies
- **Approval polling** — `GET /api/v1/approvals/**` — wait for human approval on high-risk actions
- **Outcome recording** — `POST /api/v1/traces/*/outcome` — tamper-proof audit trail
- **Agent identity** — `GET /api/v1/agents/**` — resolve agent permissions

## Usage

Add `sidclaw` to your blueprint's preset list, then use the SidClaw SDK:

```typescript
import { governNemoClawTools } from '@sidclaw/sdk/nemoclaw';

const governed = governNemoClawTools(client, tools, {
  sandboxName: 'my-sandbox',
  dataClassification: { send_email: 'confidential' },
});
```

```python
from sidclaw.middleware.nemoclaw import govern_nemoclaw_tools

governed = govern_nemoclaw_tools(client, tools, config)
```

## Links

- npm: [@sidclaw/sdk](https://www.npmjs.com/package/@sidclaw/sdk) (v0.1.5)
- PyPI: [sidclaw](https://pypi.org/project/sidclaw/) (v0.1.2)
- Docs: [NemoClaw Integration Guide](https://docs.sidclaw.com/docs/integrations/nemoclaw)
- Example: [nemoclaw-governed](https://github.com/sidclawhq/platform/tree/main/examples/nemoclaw-governed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "sidclaw" policy preset with governance features including policy evaluation, human approval workflows, and comprehensive audit trails
  * Configured secure network communications with TLS encryption for API endpoints
  * Restricted executable access to authorized SidClaw-specific binaries only
<!-- end of auto-generated comment: release notes by coderabbit.ai -->