### PR TITLE
fix(onboard): retry gateway start with exponential backoff

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1653,8 +1653,8 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
       console.error("  Stale state removed. Please rerun: nemoclaw onboard");
       console.error("");
       console.error("  Troubleshooting:");
-      console.error("    openshell doctor logs --name nemoclaw");
-      console.error("    openshell doctor check --name nemoclaw");
+      console.error("    openshell doctor logs -g nemoclaw");
+      console.error("    openshell doctor check");
       process.exit(1);
     }
     throw new Error("Gateway failed to start");

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1623,18 +1623,16 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
   const retries = exitOnFailure ? 2 : 0;
   try {
     await pRetry(() => {
-      const startResult = runOpenshell(["gateway", "start", ...gwArgs], { ignoreError: true, env: gatewayEnv });
+      runOpenshell(["gateway", "start", ...gwArgs], { ignoreError: true, env: gatewayEnv });
 
-      if (startResult.status === 0) {
-        for (let i = 0; i < 5; i++) {
-          const status = runCaptureOpenshell(["status"], { ignoreError: true });
-          const namedInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], { ignoreError: true });
-          const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
-          if (isGatewayHealthy(status, namedInfo, currentInfo)) {
-            return; // success
-          }
-          if (i < 4) sleep(2);
+      for (let i = 0; i < 5; i++) {
+        const status = runCaptureOpenshell(["status"], { ignoreError: true });
+        const namedInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], { ignoreError: true });
+        const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
+        if (isGatewayHealthy(status, namedInfo, currentInfo)) {
+          return; // success
         }
+        if (i < 4) sleep(2);
       }
 
       if (exitOnFailure) {

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1653,7 +1653,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
       console.error("  Stale state removed. Please rerun: nemoclaw onboard");
       console.error("");
       console.error("  Troubleshooting:");
-      console.error("    openshell doctor logs -g nemoclaw");
+      console.error("    openshell doctor logs --name nemoclaw");
       console.error("    openshell doctor check");
       process.exit(1);
     }

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1619,7 +1619,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
   // internal health-check window allows. Retrying after a clean destroy lets
   // the second attempt benefit from cached images and cleaner cgroup state.
   // See: https://github.com/NVIDIA/OpenShell/issues/433
-  const MAX_GATEWAY_ATTEMPTS = 3;
+  const MAX_GATEWAY_ATTEMPTS = exitOnFailure ? 3 : 1;
   const GATEWAY_RETRY_DELAYS = [10, 30]; // seconds before 2nd, 3rd attempt
   let gatewayStarted = false;
 
@@ -1643,7 +1643,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
           healthy = true;
           break;
         }
-        sleep(2);
+        if (i < 4) sleep(2);
       }
       if (healthy) {
         gatewayStarted = true;

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1637,7 +1637,9 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
         }
       }
 
-      destroyGateway();
+      if (exitOnFailure) {
+        destroyGateway();
+      }
       throw new Error("Gateway failed to start");
     }, {
       retries,

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1614,36 +1614,61 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
     console.log(`  Using pinned OpenShell gateway image: ${gatewayEnv.OPENSHELL_CLUSTER_IMAGE}`);
   }
 
-  const startResult = runOpenshell(["gateway", "start", ...gwArgs], { ignoreError: true, env: gatewayEnv });
-  if (startResult.status !== 0) {
-    console.error("  Gateway failed to start. Cleaning up stale state...");
+  // Retry gateway start with exponential backoff. On some hosts (Horde VMs,
+  // first-run environments) the embedded k3s needs more time than OpenShell's
+  // internal health-check window allows. Retrying after a clean destroy lets
+  // the second attempt benefit from cached images and cleaner cgroup state.
+  // See: https://github.com/NVIDIA/OpenShell/issues/433
+  const MAX_GATEWAY_ATTEMPTS = 3;
+  const GATEWAY_RETRY_DELAYS = [10, 30]; // seconds before 2nd, 3rd attempt
+  let gatewayStarted = false;
+
+  for (let attempt = 0; attempt < MAX_GATEWAY_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      const delay = GATEWAY_RETRY_DELAYS[attempt - 1];
+      console.log(`  Retrying gateway start in ${delay}s (attempt ${attempt + 1}/${MAX_GATEWAY_ATTEMPTS})...`);
+      sleep(delay);
+    }
+
+    const startResult = runOpenshell(["gateway", "start", ...gwArgs], { ignoreError: true, env: gatewayEnv });
+
+    if (startResult.status === 0) {
+      // Gateway start command succeeded — verify health
+      let healthy = false;
+      for (let i = 0; i < 5; i++) {
+        const status = runCaptureOpenshell(["status"], { ignoreError: true });
+        const namedInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], { ignoreError: true });
+        const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
+        if (isGatewayHealthy(status, namedInfo, currentInfo)) {
+          healthy = true;
+          break;
+        }
+        sleep(2);
+      }
+      if (healthy) {
+        gatewayStarted = true;
+        break;
+      }
+    }
+
+    // This attempt failed — clean up before retry or final exit
     destroyGateway();
+  }
+
+  if (!gatewayStarted) {
     if (exitOnFailure) {
+      console.error(`  Gateway failed to start after ${MAX_GATEWAY_ATTEMPTS} attempts.`);
       console.error("  Stale state removed. Please rerun: nemoclaw onboard");
+      console.error("");
+      console.error("  Troubleshooting:");
+      console.error("    openshell doctor logs --name nemoclaw");
+      console.error("    openshell doctor check --name nemoclaw");
       process.exit(1);
     }
     throw new Error("Gateway failed to start");
   }
 
-  for (let i = 0; i < 5; i++) {
-    const status = runCaptureOpenshell(["status"], { ignoreError: true });
-    const namedInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], { ignoreError: true });
-    const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
-    if (isGatewayHealthy(status, namedInfo, currentInfo)) {
-      console.log("  ✓ Gateway is healthy");
-      break;
-    }
-    if (i === 4) {
-      console.error("  Gateway health check failed. Cleaning up stale state...");
-      destroyGateway();
-      if (exitOnFailure) {
-        console.error("  Stale state removed. Please rerun: nemoclaw onboard");
-        process.exit(1);
-      }
-      throw new Error("Gateway failed to start");
-    }
-    sleep(2);
-  }
+  console.log("  ✓ Gateway is healthy");
 
   // CoreDNS fix — always run. k3s-inside-Docker has broken DNS on all platforms.
   const runtime = getContainerRuntime();

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1635,9 +1635,6 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
         if (i < 4) sleep(2);
       }
 
-      if (exitOnFailure) {
-        destroyGateway();
-      }
       throw new Error("Gateway failed to start");
     }, {
       retries,
@@ -1645,12 +1642,15 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
       factor: 3,
       onFailedAttempt: (err) => {
         console.log(`  Gateway start attempt ${err.attemptNumber} failed. ${err.retriesLeft} retries left...`);
+        if (err.retriesLeft > 0 && exitOnFailure) {
+          destroyGateway();
+        }
       },
     });
   } catch {
     if (exitOnFailure) {
       console.error(`  Gateway failed to start after ${retries + 1} attempts.`);
-      console.error("  Stale state removed. Please rerun: nemoclaw onboard");
+      console.error("  Gateway state preserved for diagnostics.");
       console.error("");
       console.error("  Troubleshooting:");
       console.error("    openshell doctor logs --name nemoclaw");

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -9,6 +9,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { spawn, spawnSync } = require("child_process");
+const pRetry = require("p-retry");
 const { ROOT, SCRIPTS, run, runCapture, shellQuote } = require("./runner");
 const {
   getDefaultOllamaModel,
@@ -1619,45 +1620,36 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
   // internal health-check window allows. Retrying after a clean destroy lets
   // the second attempt benefit from cached images and cleaner cgroup state.
   // See: https://github.com/NVIDIA/OpenShell/issues/433
-  const MAX_GATEWAY_ATTEMPTS = exitOnFailure ? 3 : 1;
-  const GATEWAY_RETRY_DELAYS = [10, 30]; // seconds before 2nd, 3rd attempt
-  let gatewayStarted = false;
+  const retries = exitOnFailure ? 2 : 0;
+  try {
+    await pRetry(() => {
+      const startResult = runOpenshell(["gateway", "start", ...gwArgs], { ignoreError: true, env: gatewayEnv });
 
-  for (let attempt = 0; attempt < MAX_GATEWAY_ATTEMPTS; attempt++) {
-    if (attempt > 0) {
-      const delay = GATEWAY_RETRY_DELAYS[attempt - 1];
-      console.log(`  Retrying gateway start in ${delay}s (attempt ${attempt + 1}/${MAX_GATEWAY_ATTEMPTS})...`);
-      sleep(delay);
-    }
-
-    const startResult = runOpenshell(["gateway", "start", ...gwArgs], { ignoreError: true, env: gatewayEnv });
-
-    if (startResult.status === 0) {
-      // Gateway start command succeeded — verify health
-      let healthy = false;
-      for (let i = 0; i < 5; i++) {
-        const status = runCaptureOpenshell(["status"], { ignoreError: true });
-        const namedInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], { ignoreError: true });
-        const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
-        if (isGatewayHealthy(status, namedInfo, currentInfo)) {
-          healthy = true;
-          break;
+      if (startResult.status === 0) {
+        for (let i = 0; i < 5; i++) {
+          const status = runCaptureOpenshell(["status"], { ignoreError: true });
+          const namedInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], { ignoreError: true });
+          const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
+          if (isGatewayHealthy(status, namedInfo, currentInfo)) {
+            return; // success
+          }
+          if (i < 4) sleep(2);
         }
-        if (i < 4) sleep(2);
       }
-      if (healthy) {
-        gatewayStarted = true;
-        break;
-      }
-    }
 
-    // This attempt failed — clean up before retry or final exit
-    destroyGateway();
-  }
-
-  if (!gatewayStarted) {
+      destroyGateway();
+      throw new Error("Gateway failed to start");
+    }, {
+      retries,
+      minTimeout: 10_000,
+      factor: 3,
+      onFailedAttempt: (err) => {
+        console.log(`  Gateway start attempt ${err.attemptNumber} failed. ${err.retriesLeft} retries left...`);
+      },
+    });
+  } catch {
     if (exitOnFailure) {
-      console.error(`  Gateway failed to start after ${MAX_GATEWAY_ATTEMPTS} attempts.`);
+      console.error(`  Gateway failed to start after ${retries + 1} attempts.`);
       console.error("  Stale state removed. Please rerun: nemoclaw onboard");
       console.error("");
       console.error("  Troubleshooting:");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "openclaw": "2026.3.11"
+        "openclaw": "2026.3.11",
+        "p-retry": "^4.6.2"
       },
       "bin": {
         "nemoclaw": "bin/nemoclaw.js"
@@ -28,7 +29,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.16.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -947,6 +948,14 @@
         "scripts/actions/documentation"
       ]
     },
+    "node_modules/@buape/carbon/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@buape/carbon/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
@@ -1338,6 +1347,14 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
+    },
+    "node_modules/@discordjs/voice/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prepublishOnly": "cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {
-    "openclaw": "2026.3.11"
+    "openclaw": "2026.3.11",
+    "p-retry": "^4.6.2"
   },
   "files": [
     "bin/",
@@ -42,8 +43,8 @@
     "@j178/prek": "^0.3.6",
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.0",
-    "execa": "^9.6.1",
     "eslint": "^10.1.0",
+    "execa": "^9.6.1",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.0"

--- a/test/gateway-cleanup.test.js
+++ b/test/gateway-cleanup.test.js
@@ -28,12 +28,10 @@ describe("gateway cleanup: Docker volumes removed on failure (#17)", () => {
 
     // Current behavior:
     // 1. stale gateway metadata is destroyed directly before start, if present
-    // 2. destroyGateway() runs after start failure
-    // 3. destroyGateway() runs after health check failure
+    // 2. destroyGateway() runs inside the retry loop on each failed attempt
     expect(startGwBlock[0].includes('if (hasStaleGateway(gwInfo))')).toBe(true);
     expect(startGwBlock[0].includes('runOpenshell(["gateway", "destroy", "-g", GATEWAY_NAME]')).toBe(true);
-    const destroyCalls = (startGwBlock[0].match(/destroyGateway\(\)/g) || []).length;
-    expect(destroyCalls).toBeGreaterThanOrEqual(2);
+    expect(startGwBlock[0]).toContain("destroyGateway()");
   });
 
   it("uninstall.sh: includes Docker volume cleanup", () => {


### PR DESCRIPTION
## Summary

- Retry `openshell gateway start` up to 3 times with exponential backoff during onboard, using `p-retry`
- Each failed attempt gets a clean `destroyGateway()` (including Docker volume cleanup) before retry
- Recovery path (`nemoclaw status`) remains single-attempt to keep CLI responsiveness
- Final failure message now includes `openshell doctor` troubleshooting commands

Fixes #1050

## Root Cause

On first-run environments (Horde VMs, fresh Ubuntu 24.04), the embedded k3s inside the OpenShell gateway can exceed the gateway's internal health-check timeout during initialization. The first attempt fails, but a second attempt typically succeeds because container images are cached and cgroup state is cleaner. Previously, NemoClaw made a single attempt and gave up immediately.

Upstream tracking: https://github.com/NVIDIA/OpenShell/issues/433

## Changes

**`bin/lib/onboard.js`** — Replace single-shot gateway start with `p-retry` (3 attempts, exponential backoff). Only the onboard path retries; the recovery path (`startGatewayForRecovery`) stays single-attempt.

**`package.json`** — Add `p-retry@^4.6.2` as a direct dependency (v4 is CJS-compatible).

**`test/gateway-cleanup.test.js`** — Update pattern-matching test to reflect that `destroyGateway()` now lives inside the retry callback.

## Testing

- `npm test` — all unit tests pass including cli.test.js (recovery path timing preserved)
- Manual: on macOS the retry path is not exercised (gateway starts on first attempt), confirming no regression for the happy path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Startup now automatically retries with exponential backoff, performs repeated health checks before declaring success, logs progress during attempts, and prints a single clear "Gateway is healthy" on success.
  * On final failure, messaging is consolidated with concise troubleshooting guidance; transient cleanup runs between retry attempts.

* **Chores**
  * Added a retry helper dependency to improve startup reliability.

* **Tests**
  * Updated gateway startup tests to reflect the new retry and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->