### PR TITLE
fix: prevent file descriptor leak in acquireOnboardLock

### DIFF
--- a/bin/lib/onboard-session.js
+++ b/bin/lib/onboard-session.js
@@ -227,9 +227,7 @@ function acquireOnboardLock(command = null) {
 
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      const fd = fs.openSync(LOCK_FILE, "wx", 0o600);
-      fs.writeFileSync(fd, payload);
-      fs.closeSync(fd);
+      fs.writeFileSync(LOCK_FILE, payload, { flag: "wx", mode: 0o600 });
       return { acquired: true, lockFile: LOCK_FILE, stale: false };
     } catch (error) {
       if (error?.code !== "EEXIST") {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Replace manual fd lifecycle (`openSync`/`writeFileSync`/`closeSync`) in `acquireOnboardLock` with a single `writeFileSync` call. If the write threw (e.g. `ENOSPC`), the catch block re-threw because the error code is not `EEXIST`, bypassing `closeSync` and leaking the descriptor. Repeated failures accumulate leaked fds until the process crashes with `EMFILE`.

*Please note that npm test and prek linters currently fail due to pre-existing issues on main (131 unrelated test failures, and pre-existing shellcheck/shebang/Vitest plugin failures on Windows). These changes should introduce zero new failures, and the relevant onboard-session tests pass successfully.*

## Changes
<!-- Bullet list of key changes. -->

- Removed manual `fs.openSync` / `fs.closeSync` fd management in `bin/lib/onboard-session.js`
- Replaced with `fs.writeFileSync(LOCK_FILE, payload, { flag: "wx", mode: 0o600 })` which lets Node.js manage the fd internally, guaranteeing cleanup regardless of write outcome


## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized internal lock file handling for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->