### PR TITLE
fix(scripts): force IPv4 DNS on WSL2 to prevent bridge ETIMEDOUT

### DIFF
--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -132,6 +132,15 @@ do_start() {
 
   command -v node >/dev/null || fail "node not found. Install Node.js first."
 
+  # WSL2 ships with broken IPv6 routing. Node.js resolves dual-stack DNS results
+  # and tries IPv6 first (ENETUNREACH) then IPv4 (ETIMEDOUT), causing bridge
+  # connections to api.telegram.org and gateway.discord.gg to fail from the host.
+  # Force IPv4-first DNS result ordering for all bridge Node.js processes.
+  if [ -n "${WSL_DISTRO_NAME:-}" ] || [ -n "${WSL_INTEROP:-}" ] || grep -qi microsoft /proc/version 2>/dev/null; then
+    export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--dns-result-order=ipv4first"
+    info "WSL2 detected — setting --dns-result-order=ipv4first for Node.js bridge processes"
+  fi
+
   # Verify sandbox is running
   if command -v openshell >/dev/null 2>&1; then
     if ! openshell sandbox list 2>&1 | grep -q "Ready"; then


### PR DESCRIPTION
## Problem

On Windows WSL2 + Docker Desktop, `nemoclaw start` launches the Telegram bridge but the bridge process exits within seconds. `nemoclaw status` then shows it as stopped even though it was just started.

**Root cause:** WSL2 ships with broken IPv6 routing. Node.js resolves dual-stack DNS records and tries IPv6 addresses first. The IPv6 attempt returns `ENETUNREACH` and the IPv4 attempt times out with `ETIMEDOUT`:

```
AggregateError [ETIMEDOUT]:
  Error: connect ETIMEDOUT 149.154.166.110:443
  Error: connect ENETUNREACH 2001:67c:4e8:f004::9:443
```

This affects `api.telegram.org` and would affect `gateway.discord.gg` for any host-side bridge. `curl` is unaffected because it uses a CONNECT tunnel, not the Node.js `http.Agent` path.

## Fix

Detect WSL2 via the standard environment variables (`WSL_DISTRO_NAME`, `WSL_INTEROP`) and the `/proc/version` marker. When WSL2 is detected, export `NODE_OPTIONS=--dns-result-order=ipv4first` before launching bridge processes so Node.js uses IPv4 DNS results exclusively.

This is a safe, additive change — it does not affect Linux, macOS, or cloud VM deployments. The `--dns-result-order=ipv4first` flag has been available since Node.js 17.

## Testing

- Non-WSL2 systems: unaffected — the `if` block does not execute
- WSL2: `NODE_OPTIONS` is set before `nohup node telegram-bridge.js` — bridge connects to `api.telegram.org` via IPv4 immediately

Fixes #1065.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS resolution handling for WSL2 environments to enhance connectivity and service reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->