### PR TITLE
fix(nim): resolve host port dynamically in nimStatusByName()

### DIFF
--- a/bin/lib/nim.js
+++ b/bin/lib/nim.js
@@ -198,7 +198,14 @@ function nimStatusByName(name) {
 
     let healthy = false;
     if (state === "running") {
-      const health = runCapture(`curl -sf http://localhost:8000/v1/models 2>/dev/null`, {
+      // Resolve the host port dynamically instead of assuming 8000.
+      // The container always listens on 8000 internally, but the host
+      // mapping is configurable via startNimContainer(... port).
+      const hostPort = runCapture(
+        `docker inspect --format '{{(index (index .NetworkSettings.Ports "8000/tcp") 0).HostPort}}' ${shellQuote(name)} 2>/dev/null`,
+        { ignoreError: true }
+      ) || "8000";
+      const health = runCapture(`curl -sf http://localhost:${Number(hostPort)}/v1/models 2>/dev/null`, {
         ignoreError: true,
       });
       healthy = !!health;

--- a/bin/lib/nim.js
+++ b/bin/lib/nim.js
@@ -201,11 +201,12 @@ function nimStatusByName(name) {
       // Resolve the host port dynamically instead of assuming 8000.
       // The container always listens on 8000 internally, but the host
       // mapping is configurable via startNimContainer(... port).
-      const hostPort = runCapture(
+      const rawHostPort = runCapture(
         `docker inspect --format '{{(index (index .NetworkSettings.Ports "8000/tcp") 0).HostPort}}' ${shellQuote(name)} 2>/dev/null`,
         { ignoreError: true }
-      ) || "8000";
-      const health = runCapture(`curl -sf http://localhost:${Number(hostPort)}/v1/models 2>/dev/null`, {
+      );
+      const hostPort = /^\d+$/.test(rawHostPort) ? Number(rawHostPort) : 8000;
+      const health = runCapture(`curl -sf http://localhost:${hostPort}/v1/models 2>/dev/null`, {
         ignoreError: true,
       });
       healthy = !!health;


### PR DESCRIPTION
## Summary

nimStatusByName() hardcoded port 8000 for health checks, but the host port is configurable. Containers on custom ports always reported unhealthy. Now uses docker inspect to resolve the actual host port mapping.

## Related Issue

Closes #1016

## Changes

- Use docker inspect to read the actual host port from NetworkSettings.Ports
- Validate port is numeric via regex, fall back to 8000 for unexpected output
- Existing callers are unchanged (nimStatus, nimStatusByName)

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).

### Code Changes

- [x] Formatters applied.
- [x] No secrets, API keys, or credentials committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health check to correctly detect service status regardless of Docker container port configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->