### PR TITLE
fix(install): add trap handler to spin() for clean Ctrl+C teardown

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,20 @@
 
 set -euo pipefail
 
+# Global cleanup state — ensures background processes are killed and temp files
+# are removed on any exit path (set -e, unhandled signal, unexpected error).
+_cleanup_pids=()
+_cleanup_files=()
+_global_cleanup() {
+  for pid in "${_cleanup_pids[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  for f in "${_cleanup_files[@]:-}"; do
+    rm -f "$f" 2>/dev/null || true
+  done
+}
+trap _global_cleanup EXIT
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 DEFAULT_NEMOCLAW_VERSION="0.1.0"
 TOTAL_STEPS=3
@@ -210,6 +224,10 @@ spin() {
   local pid=$! i=0
   local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
 
+  # Register with global cleanup so any exit path reaps the child and temp file.
+  _cleanup_pids+=("$pid")
+  _cleanup_files+=("$log")
+
   # Ensure Ctrl+C kills the background process and cleans up the temp file.
   trap 'kill "$pid" 2>/dev/null; rm -f "$log"; exit 130' INT TERM
 
@@ -226,6 +244,11 @@ spin() {
   else
     local status=$?
   fi
+
+  # Remove from global cleanup since we handled it here.
+  _cleanup_pids=("${_cleanup_pids[@]/$pid/}")
+  _cleanup_files=("${_cleanup_files[@]/$log/}")
+
   if [[ $status -eq 0 ]]; then
     printf "\r  ${C_GREEN}✓${C_RESET}  %s\n" "$msg"
   else

--- a/install.sh
+++ b/install.sh
@@ -210,10 +210,16 @@ spin() {
   local pid=$! i=0
   local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
 
+  # Ensure Ctrl+C kills the background process and cleans up the temp file.
+  trap 'kill "$pid" 2>/dev/null; rm -f "$log"; exit 130' INT TERM
+
   while kill -0 "$pid" 2>/dev/null; do
     printf "\r  ${C_GREEN}%s${C_RESET}  %s" "${frames[$((i++ % 10))]}" "$msg"
     sleep 0.08
   done
+
+  # Restore default signal handling after the background process exits.
+  trap - INT TERM
 
   if wait "$pid"; then
     local status=0

--- a/install.sh
+++ b/install.sh
@@ -245,10 +245,6 @@ spin() {
     local status=$?
   fi
 
-  # Remove from global cleanup since we handled it here.
-  _cleanup_pids=("${_cleanup_pids[@]/$pid/}")
-  _cleanup_files=("${_cleanup_files[@]/$log/}")
-
   if [[ $status -eq 0 ]]; then
     printf "\r  ${C_GREEN}✓${C_RESET}  %s\n" "$msg"
   else
@@ -257,6 +253,11 @@ spin() {
     printf "\n"
   fi
   rm -f "$log"
+
+  # Deregister only after cleanup actions are complete, so the global EXIT
+  # trap still covers this pid/log if a signal arrives before this point.
+  _cleanup_pids=("${_cleanup_pids[@]/$pid/}")
+  _cleanup_files=("${_cleanup_files[@]/$log/}")
   return $status
 }
 


### PR DESCRIPTION
## Summary

spin() runs background commands with a spinner but had no signal handler. Ctrl+C during installation orphaned the background process and leaked temp files. Added INT/TERM trap and global EXIT trap for defense-in-depth.

## Related Issue

Closes #1020

## Changes

- Added INT/TERM trap inside spin() that kills background PID and cleans temp file
- Added global _cleanup_pids/_cleanup_files arrays with EXIT trap
- spin() registers/deregisters from global arrays on entry/completion
- trap - restores defaults after normal process exit

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).

### Code Changes

- [x] Formatters applied.
- [x] No secrets, API keys, or credentials committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installation script now reliably tracks and cleans up background processes and temporary files on exit and interruptions, reducing leftover artifacts and improving installer robustness and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->