### PR TITLE
fix(scripts): redirect all operational log messages to stderr

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -73,13 +73,13 @@ OPENCLAW="$(command -v openclaw)" # Resolve once, use absolute path everywhere
 verify_config_integrity() {
   local hash_file="/sandbox/.openclaw/.config-hash"
   if [ ! -f "$hash_file" ]; then
-    echo "[SECURITY] Config hash file missing — refusing to start without integrity verification"
+    echo "[SECURITY] Config hash file missing — refusing to start without integrity verification" >&2
     return 1
   fi
   if ! (cd /sandbox/.openclaw && sha256sum -c "$hash_file" --status 2>/dev/null); then
-    echo "[SECURITY] openclaw.json integrity check FAILED — config may have been tampered with"
-    echo "[SECURITY] Expected hash: $(cat "$hash_file")"
-    echo "[SECURITY] Actual hash:   $(sha256sum /sandbox/.openclaw/openclaw.json)"
+    echo "[SECURITY] openclaw.json integrity check FAILED — config may have been tampered with" >&2
+    echo "[SECURITY] Expected hash: $(cat "$hash_file")" >&2
+    echo "[SECURITY] Actual hash:   $(sha256sum /sandbox/.openclaw/openclaw.json)" >&2
     return 1
   fi
 }
@@ -131,8 +131,8 @@ PYTOKEN
     remote_url="${remote_url}#token=${token}"
   fi
 
-  echo "[gateway] Local UI: ${local_url}"
-  echo "[gateway] Remote UI: ${remote_url}"
+  echo "[gateway] Local UI: ${local_url}" >&2
+  echo "[gateway] Remote UI: ${remote_url}" >&2
 }
 
 start_auto_pair() {
@@ -202,7 +202,7 @@ while time.time() < DEADLINE:
 else:
     print(f'[auto-pair] watcher timed out approvals={APPROVED}')
 PYAUTOPAIR
-  echo "[gateway] auto-pair watcher launched (pid $!)"
+  echo "[gateway] auto-pair watcher launched (pid $!)" >&2
 }
 
 # ── Proxy environment ────────────────────────────────────────────
@@ -283,7 +283,7 @@ fi
 
 # ── Main ─────────────────────────────────────────────────────────
 
-echo 'Setting up NemoClaw...'
+echo 'Setting up NemoClaw...' >&2
 [ -f .env ] && chmod 600 .env
 
 # ── Non-root fallback ──────────────────────────────────────────
@@ -292,10 +292,10 @@ echo 'Setting up NemoClaw...'
 # separation and run everything as the current user (sandbox).
 # Gateway process isolation is not available in this mode.
 if [ "$(id -u)" -ne 0 ]; then
-  echo "[gateway] Running as non-root (uid=$(id -u)) — privilege separation disabled"
+  echo "[gateway] Running as non-root (uid=$(id -u)) — privilege separation disabled" >&2
   export HOME=/sandbox
   if ! verify_config_integrity; then
-    echo "[SECURITY] Config integrity check failed — refusing to start (non-root mode)"
+    echo "[SECURITY] Config integrity check failed — refusing to start (non-root mode)" >&2
     exit 1
   fi
   write_auth_profile
@@ -316,7 +316,7 @@ if [ "$(id -u)" -ne 0 ]; then
   # Start gateway in background, auto-pair, then wait
   nohup "$OPENCLAW" gateway run >/tmp/gateway.log 2>&1 &
   GATEWAY_PID=$!
-  echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)"
+  echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)" >&2
   start_auto_pair
   print_dashboard_urls
   wait "$GATEWAY_PID"
@@ -354,7 +354,7 @@ for entry in /sandbox/.openclaw/*; do
   target="$(readlink -f "$entry" 2>/dev/null || true)"
   expected="/sandbox/.openclaw-data/$name"
   if [ "$target" != "$expected" ]; then
-    echo "[SECURITY] Symlink $entry points to unexpected target: $target (expected $expected)"
+    echo "[SECURITY] Symlink $entry points to unexpected target: $target (expected $expected)" >&2
     exit 1
   fi
 done
@@ -365,7 +365,7 @@ done
 # the agent cannot restart the gateway with a tampered config.
 nohup gosu gateway "$OPENCLAW" gateway run >/tmp/gateway.log 2>&1 &
 GATEWAY_PID=$!
-echo "[gateway] openclaw gateway launched as 'gateway' user (pid $GATEWAY_PID)"
+echo "[gateway] openclaw gateway launched as 'gateway' user (pid $GATEWAY_PID)" >&2
 
 start_auto_pair
 print_dashboard_urls

--- a/test/nemoclaw-start.test.js
+++ b/test/nemoclaw-start.test.js
@@ -35,4 +35,29 @@ describe("nemoclaw-start non-root fallback", () => {
     const calls = src.match(/verify_config_integrity/g) || [];
     expect(calls.length).toBeGreaterThanOrEqual(3); // definition + 2 call sites
   });
+
+  it("sends startup diagnostics to stderr so they do not leak into bridge output (#1064)", () => {
+    const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+    expect(src).toContain("echo 'Setting up NemoClaw...' >&2");
+
+    const nonRootBlock = src.match(/if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)^fi$/m);
+    expect(nonRootBlock).toBeTruthy();
+    const block = nonRootBlock[1];
+
+    const echoLines = block.match(/^\s*echo\s+.+$/gm) || [];
+    expect(echoLines.length).toBeGreaterThan(0);
+    for (const line of echoLines) {
+      expect(line).toContain(">&2");
+    }
+
+    const dashboardFn = src.match(/print_dashboard_urls\(\) \{([\s\S]*?)^\}/m);
+    expect(dashboardFn).toBeTruthy();
+    const dashboardBody = dashboardFn[1];
+    const dashboardEchoes = dashboardBody.match(/^\s*echo\s+.+$/gm) || [];
+    expect(dashboardEchoes.length).toBeGreaterThan(0);
+    for (const line of dashboardEchoes) {
+      expect(line).toContain(">&2");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

All echo statements in nemoclaw-start.sh wrote to stdout, causing gateway and security log messages to leak into application output. The Telegram bridge captures stdout, so setup messages were prepended to every chat response.

## Related Issue

Closes #1064

## Changes

- Redirected all [gateway] operational messages to stderr
- Redirected all [SECURITY] messages to stderr
- Redirected 'Setting up NemoClaw...' to stderr
- Only exec'd process output now appears on stdout

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).

### Code Changes

- [x] Formatters applied.
- [x] No secrets, API keys, or credentials committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Redirected startup, status, and diagnostic/security messages to stderr so they no longer mix with normal program output, improving clarity for users and tooling.

* **Tests**
  * Added automated tests to verify diagnostic and startup messages are emitted to stderr, preventing interference with piped or machine-readable output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->