### PR TITLE
fix(install): upgrade Node.js via nvm when system version is below minimum

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -448,7 +448,7 @@ function hydrateCredentialEnv(envName) {
 }
 
 function getCurlTimingArgs() {
-  return ["--connect-timeout 5", "--max-time 20"];
+  return ["--connect-timeout 10", "--max-time 60"];
 }
 
 function buildProviderArgs(action, name, type, credentialEnv, baseUrl) {

--- a/install.sh
+++ b/install.sh
@@ -262,8 +262,11 @@ version_gte() {
 # Ensure nvm environment is loaded in the current shell.
 # Skip if node is already on PATH — sourcing nvm.sh can reset PATH and
 # override the caller's node/npm (e.g. in test environments with stubs).
+# Pass --force to load nvm even when node is on PATH (needed when upgrading).
 ensure_nvm_loaded() {
-  command -v node &>/dev/null && return 0
+  if [[ "${1:-}" != "--force" ]]; then
+    command -v node &>/dev/null && return 0
+  fi
   if [[ -z "${NVM_DIR:-}" ]]; then
     export NVM_DIR="$HOME/.nvm"
   fi
@@ -362,11 +365,16 @@ ensure_supported_runtime() {
 # ---------------------------------------------------------------------------
 install_nodejs() {
   if command_exists node; then
-    info "Node.js found: $(node --version)"
-    return
+    local current_version
+    current_version="$(node --version 2>/dev/null || true)"
+    if version_gte "${current_version#v}" "$MIN_NODE_VERSION"; then
+      info "Node.js found: ${current_version}"
+      return
+    fi
+    warn "Node.js ${current_version} found but NemoClaw requires >=${MIN_NODE_VERSION} — upgrading via nvm…"
+  else
+    info "Node.js not found — installing via nvm…"
   fi
-
-  info "Node.js not found — installing via nvm…"
   # IMPORTANT: update NVM_SHA256 when changing NVM_VERSION
   local NVM_VERSION="v0.40.4"
   local NVM_SHA256="4b7412c49960c7d31e8df72da90c1fb5b8cccb419ac99537b737028d497aba4f"
@@ -393,9 +401,9 @@ install_nodejs() {
   info "nvm installer integrity verified"
   spin "Installing nvm..." bash "$nvm_tmp"
   rm -f "$nvm_tmp"
-  ensure_nvm_loaded
+  ensure_nvm_loaded --force
   spin "Installing Node.js 22..." bash -c ". \"$NVM_DIR/nvm.sh\" && nvm install 22 --no-progress"
-  ensure_nvm_loaded
+  ensure_nvm_loaded --force
   nvm use 22 --silent
   info "Node.js installed: $(node --version)"
 }

--- a/install.sh
+++ b/install.sh
@@ -438,7 +438,7 @@ install_nodejs() {
   spin "Installing Node.js 22..." bash -c ". \"$NVM_DIR/nvm.sh\" && nvm install 22 --no-progress"
   ensure_nvm_loaded --force
   nvm use 22 --silent
-  nvm alias default 22 --silent 2>/dev/null || true
+  nvm alias default 22 2>/dev/null || true
   info "Node.js installed: $(node --version)"
 }
 
@@ -600,6 +600,7 @@ install_nemoclaw() {
 verify_nemoclaw() {
   if command_exists nemoclaw; then
     NEMOCLAW_READY_NOW=true
+    ensure_nemoclaw_shim || true
     info "Verified: nemoclaw is available at $(command -v nemoclaw)"
     return 0
   fi

--- a/install.sh
+++ b/install.sh
@@ -395,13 +395,16 @@ ensure_supported_runtime() {
 # ---------------------------------------------------------------------------
 install_nodejs() {
   if command_exists node; then
-    local current_version
+    local current_version current_npm_major
     current_version="$(node --version 2>/dev/null || true)"
-    if version_gte "${current_version#v}" "$MIN_NODE_VERSION"; then
+    current_npm_major="$(version_major "$(npm --version 2>/dev/null || echo 0)")"
+    if version_gte "${current_version#v}" "$MIN_NODE_VERSION" \
+      && [[ "$current_npm_major" =~ ^[0-9]+$ ]] \
+      && ((current_npm_major >= MIN_NPM_MAJOR)); then
       info "Node.js found: ${current_version}"
       return
     fi
-    warn "Node.js ${current_version} found but NemoClaw requires >=${MIN_NODE_VERSION} — upgrading via nvm…"
+    warn "Node.js ${current_version}, npm major ${current_npm_major:-unknown} found but NemoClaw requires Node.js >=${MIN_NODE_VERSION} and npm >=${MIN_NPM_MAJOR} — upgrading via nvm…"
   else
     info "Node.js not found — installing via nvm…"
   fi

--- a/install.sh
+++ b/install.sh
@@ -438,6 +438,7 @@ install_nodejs() {
   spin "Installing Node.js 22..." bash -c ". \"$NVM_DIR/nvm.sh\" && nvm install 22 --no-progress"
   ensure_nvm_loaded --force
   nvm use 22 --silent
+  nvm alias default 22 --silent 2>/dev/null || true
   info "Node.js installed: $(node --version)"
 }
 

--- a/test/credential-exposure.test.js
+++ b/test/credential-exposure.test.js
@@ -87,7 +87,7 @@ describe("credential exposure in process arguments", () => {
     const src = fs.readFileSync(ONBOARD_JS, "utf-8");
 
     expect(src).toMatch(/function getCurlTimingArgs\(\)/);
-    expect(src).toMatch(/--connect-timeout 5/);
-    expect(src).toMatch(/--max-time 20/);
+    expect(src).toMatch(/--connect-timeout 10/);
+    expect(src).toMatch(/--max-time 60/);
   });
 });

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -59,7 +59,7 @@ echo "unexpected npm invocation: $*" >&2; exit 98`,
 // ---------------------------------------------------------------------------
 
 describe("installer runtime preflight", () => {
-  it("fails fast with a clear message on unsupported Node.js and npm", () => {
+  it("attempts nvm upgrade when system Node.js is below minimum version", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-preflight-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -88,6 +88,14 @@ exit 98
 `,
     );
 
+    // Fake curl that fails — prevents real nvm download and keeps the test fast.
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+exit 1
+`,
+    );
+
     const result = spawnSync("bash", [INSTALLER], {
       cwd: path.join(import.meta.dirname, ".."),
       encoding: "utf-8",
@@ -100,10 +108,9 @@ exit 98
 
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status).not.toBe(0);
-    expect(output).toMatch(/Unsupported runtime detected/);
-    expect(output).toMatch(/Node\.js >=22\.16\.0 and npm >=10/);
-    expect(output).toMatch(/v18\.19\.1/);
-    expect(output).toMatch(/9\.8\.1/);
+    expect(output).toMatch(/v18\.19\.1 found but NemoClaw requires >=22\.16\.0/);
+    expect(output).toMatch(/upgrading via nvm/);
+    expect(output).toMatch(/Failed to download nvm installer/);
   });
 
   it("uses the HTTPS GitHub fallback when not installing from a repo checkout", () => {

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -108,7 +108,7 @@ exit 1
 
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status).not.toBe(0);
-    expect(output).toMatch(/v18\.19\.1 found but NemoClaw requires >=22\.16\.0/);
+    expect(output).toMatch(/v18\.19\.1.*found but NemoClaw requires/);
     expect(output).toMatch(/upgrading via nvm/);
     expect(output).toMatch(/Failed to download nvm installer/);
   });


### PR DESCRIPTION
## Summary

- `install_nodejs()` returned early when any Node.js was found on PATH, even if the version was below `MIN_NODE_VERSION` (22.16.0). Now checks the version and falls through to the nvm upgrade path when too old.
- `ensure_nvm_loaded()` skipped sourcing `nvm.sh` when any `node` was on PATH, preventing newly-installed Node 22 from being activated. Added `--force` flag used by the install path.

Fixes #1078

## Test plan

- [ ] Nightly e2e passes on `ubuntu-24.04` runner (Node 20 pre-installed)
- [ ] Fresh install (no Node) still works
- [ ] Install with Node >=22.16.0 still short-circuits correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Installer: better Node/npm detection comparing both Node and npm minimums, warns when inadequate and proceeds to upgrade via nvm; forces environment loader during upgrades; best-effort default Node aliasing after install.
  * Tool shim: creates/updates a user-local shim when the tool is already present.
  * Network probes: increased curl connect and total timeouts for endpoint/model checks.

* **Tests**
  * Updated preflight and probe tests to reflect nvm-upgrade flow, failure messaging, and new curl timeout values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->