### PR TITLE
fix(onboard): increase endpoint probe timeout for large model inference

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -448,7 +448,7 @@ function hydrateCredentialEnv(envName) {
 }
 
 function getCurlTimingArgs() {
-  return ["--connect-timeout 5", "--max-time 20"];
+  return ["--connect-timeout 10", "--max-time 60"];
 }
 
 function buildProviderArgs(action, name, type, credentialEnv, baseUrl) {

--- a/test/credential-exposure.test.js
+++ b/test/credential-exposure.test.js
@@ -87,7 +87,7 @@ describe("credential exposure in process arguments", () => {
     const src = fs.readFileSync(ONBOARD_JS, "utf-8");
 
     expect(src).toMatch(/function getCurlTimingArgs\(\)/);
-    expect(src).toMatch(/--connect-timeout 5/);
-    expect(src).toMatch(/--max-time 20/);
+    expect(src).toMatch(/--connect-timeout 10/);
+    expect(src).toMatch(/--max-time 60/);
   });
 });


### PR DESCRIPTION
## Summary

- Increase `--connect-timeout` from 5s to 10s and `--max-time` from 20s to 60s in `getCurlTimingArgs()`
- The onboard endpoint probe sends a full inference request to validate the provider. 20s was too tight for `nvidia/nemotron-3-super-120b-a12b` on NVIDIA Endpoints, causing a curl timeout (exit 28) and non-interactive onboard failure.
- This probe was added in #648 (March 24) but has never passed in the nightly e2e — the e2e has been broken since March 23 for unrelated reasons, so this code path was never validated in CI.
- Only runs once during onboard, so the longer timeout has no UX impact.

## Test plan

- [ ] Nightly e2e `cloud-e2e` job passes the endpoint validation step (requires #1079 to also be merged for the Node.js install fix)
- [ ] Unit tests pass (`credential-exposure.test.js` updated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased network probe timeout values to improve reliability during network operations.

* **Tests**
  * Updated test assertions to reflect network probe timeout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->