### PR TITLE
chore(docs): add debug and uninstall to commands reference

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -180,3 +180,28 @@ After the fixes complete, the script prompts you to run `nemoclaw onboard` to co
 ```console
 $ sudo nemoclaw setup-spark
 ```
+
+### `nemoclaw debug`
+
+Collect diagnostics for bug reports.
+Gathers system info, Docker state, gateway logs, and sandbox status into a summary or tarball.
+
+```console
+$ nemoclaw debug [--quick]
+$ nemoclaw debug --output diagnostics.tar.gz
+```
+
+### `nemoclaw uninstall`
+
+Remove NemoClaw, destroying all sandboxes and the gateway.
+Runs the bundled `uninstall.sh` if available, otherwise downloads it from GitHub.
+
+```console
+$ nemoclaw uninstall [--yes] [--keep-openshell] [--delete-models]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Skip the confirmation prompt |
+| `--keep-openshell` | Leave the openshell binary installed |
+| `--delete-models` | Remove NemoClaw-pulled Ollama models |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -187,9 +187,14 @@ Collect diagnostics for bug reports.
 Gathers system info, Docker state, gateway logs, and sandbox status into a summary or tarball.
 
 ```console
-$ nemoclaw debug [--quick]
-$ nemoclaw debug --output diagnostics.tar.gz
+$ nemoclaw debug [--quick] [--sandbox NAME] [--output PATH]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--quick` | Collect minimal diagnostics only |
+| `--sandbox NAME` | Target a specific sandbox (default: auto-detect) |
+| `--output PATH` | Write diagnostics tarball to the given path |
 
 ### `nemoclaw uninstall`
 


### PR DESCRIPTION
## Summary

- Add `nemoclaw debug` and `nemoclaw uninstall` to `docs/reference/commands.md`
- Fixes the `check-docs.sh` CLI parity check which found 15 commands in `--help` but only 13 headings in the docs

## Test plan

- [ ] `check-docs.sh --only-cli` passes (verified locally: 15/15 parity)
- [ ] `cloud-experimental-e2e` Phase 5f passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CLI reference for `nemoclaw debug` describing diagnostics collection, `--quick`, `--sandbox`, and `--output` options.
  * Added CLI reference for `nemoclaw uninstall` describing removal behavior and flags `--yes`, `--keep-openshell`, and `--delete-models`, with flag descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->