### PR TITLE
ci(hooks): add root-level vitest to pre-push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -216,6 +216,15 @@ repos:
         stages: [pre-push]
         priority: 10
 
+      - id: vitest-root
+        name: Vitest (unit tests)
+        entry: npx vitest run --project cli
+        language: system
+        pass_filenames: false
+        files: ^(bin|test|scripts)/
+        stages: [pre-push]
+        priority: 20
+
 default_language_version:
   python: python3
 


### PR DESCRIPTION
## Summary

Root-level unit tests (`test/*.test.js`) were only caught by CI's `test-unit` job, never by local pre-push hooks. This meant test failures could be pushed and only discovered in CI.

Adds a `vitest-root` pre-push hook that runs `npx vitest run --project cli` when files in `bin/`, `test/`, or `scripts/` change. Matches what CI's `test-unit` job runs.

## Changes

**`.pre-commit-config.yaml`** — Add `vitest-root` hook at priority 20 (same as existing `vitest-plugin`), stage `pre-push`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development workflow by adding automated unit test validation during the push process for improved code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->