### PR TITLE
fix(onboard): skip OLLAMA_HOST=0.0.0.0 on WSL2 to fix Docker routing

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -30,6 +30,7 @@ const {
 const {
   inferContainerRuntime,
   isUnsupportedMacosRuntime,
+  isWsl,
   shouldPatchCoredns,
 } = require("./platform");
 const { resolveOpenshell } = require("./resolve-openshell");
@@ -2192,7 +2193,11 @@ async function setupNim(gpu) {
     } else if (selected.key === "ollama") {
       if (!ollamaRunning) {
         console.log("  Starting Ollama...");
-        run("OLLAMA_HOST=0.0.0.0:11434 ollama serve > /dev/null 2>&1 &", { ignoreError: true });
+        // On WSL2, binding to 0.0.0.0 creates a dual-stack socket that Docker
+        // cannot reach via host-gateway. The default 127.0.0.1 binding works
+        // because WSL2 relays IPv4-only sockets to the Windows host.
+        const ollamaEnv = isWsl() ? "" : "OLLAMA_HOST=0.0.0.0:11434 ";
+        run(`${ollamaEnv}ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
         sleep(2);
       }
       console.log("  ✓ Using Ollama on localhost:11434");
@@ -2230,6 +2235,7 @@ async function setupNim(gpu) {
       }
       break;
     } else if (selected.key === "install-ollama") {
+      // macOS only — this option is gated by process.platform === "darwin" above
       console.log("  Installing Ollama via Homebrew...");
       run("brew install ollama", { ignoreError: true });
       console.log("  Starting Ollama...");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Ollama's Go runtime creates a dual-stack (AF_INET6) socket when given OLLAMA_HOST=0.0.0.0, but WSL2's port relay only forwards IPv4 sockets to the Windows host. Docker's host-gateway cannot reach the dual-stack socket, causing inference requests to fail with connection refused.

On WSL2, let Ollama bind to the default 127.0.0.1 instead, which creates an IPv4-only socket that the WSL2 relay forwards correctly.

Current support matrix on Windows / WSL Ollama inference path
```
┌─────────────────────┬──────────────────────┬─────────────────────────────────────────────────────┐
│ WSL Ollama          │ Windows Ollama       │ Result                                              │
├─────────────────────┼──────────────────────┼─────────────────────────────────────────────────────┤
│ running (systemd    │ -                    │ Works.                                              │
│ or manual)          │                      │ wslrelay forwards 127.0.0.1:11434 to Windows host,  │
│                     │                      │ gateway reaches it via host.openshell.internal.     │
├─────────────────────┼──────────────────────┼─────────────────────────────────────────────────────┤
│ installed, not      │ -                    │ Works with isWsl fix.                               │
│ running             │                      │ Onboard starts Ollama on 127.0.0.1 (default).       │
│                     │                      │ Without fix: Go binds dual-stack socket (*:11434),  │
│                     │                      │ wslrelay can't forward it (WSL#4851), gateway fails.│
├─────────────────────┼──────────────────────┼─────────────────────────────────────────────────────┤
│ not installed       │ installed / running  │ Ollama option doesn't show.                         │
│                     │                      │ hasOllama=false (binary not in WSL PATH),           │
│                     │                      │ ollamaRunning=false (WSL localhost can't reach      │
│                     │                      │ Windows 127.0.0.1).                                 │
├─────────────────────┼──────────────────────┼─────────────────────────────────────────────────────┤
│ running / started   │ running              │ Does not work.                                      │
│ by onboard          │                      │ Windows Ollama blocks wslrelay on port 11434.       │
│                     │                      │ Gateway hits Windows Ollama via host-gateway, but   │
│                     │                      │ model was pulled to WSL -> 404 model not found.     │
├─────────────────────┼──────────────────────┼─────────────────────────────────────────────────────┤
│ installed, not      │ running              │ Same as row 4.                                      │
│ running             │                      │                                                     │
└─────────────────────┴──────────────────────┴─────────────────────────────────────────────────────┘
```

## Related Issue
#336 #417 

## Changes
On WSL2, skip setting `OLLAMA_HOST=0.0.0.0:11434` when starting Ollama during onboard, letting it bind to the default `127.0.0.1` instead. Uses the existing `isWsl()` helper from `platform.js` to detect WSL2.

## Type of Change
<!-- Check the one that applies. -->
- [X] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [X] `npx prek run --all-files` passes (or equivalently `make check`).
- [X] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [X] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [X] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [X] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Ollama local startup so non-WSL systems explicitly set the host binding while WSL systems leave Ollama to use its default binding, preventing incorrect forced bindings during local startup.

* **Documentation**
  * Clarified that the Ollama installation option is macOS-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->