### PR TITLE
fix: replace predictable temp filenames with mkdtempSync

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -54,6 +54,13 @@ const nim = require("./nim");
 const onboardSession = require("./onboard-session");
 const policies = require("./policies");
 const { checkPortAvailable, ensureSwap, getMemoryInfo } = require("./preflight");
+
+/**
+ * Create a temp file inside a directory with a cryptographically random name.
+ * Uses fs.mkdtempSync (OS-level mkdtemp) to avoid predictable filenames that
+ * could be exploited via symlink attacks on shared /tmp.
+ * Ref: https://github.com/NVIDIA/NemoClaw/issues/1093
+ */
 function secureTempFile(prefix, ext = "") {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
   return path.join(dir, `${prefix}${ext}`);
@@ -952,9 +959,8 @@ function isOpenclawReady(sandboxName) {
   return Boolean(fetchGatewayAuthTokenFromSandbox(sandboxName));
 }
 
-function writeSandboxConfigSyncFile(script, tmpDir = os.tmpdir()) {
-  const dir = fs.mkdtempSync(path.join(tmpDir, "nemoclaw-sync-"));
-  const scriptFile = path.join(dir, "sync.sh");
+function writeSandboxConfigSyncFile(script) {
+  const scriptFile = secureTempFile("nemoclaw-sync", ".sh");
   fs.writeFileSync(scriptFile, `${script}\n`, { mode: 0o600 });
   return scriptFile;
 }

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -499,6 +499,7 @@ describe("onboard helpers", () => {
         expect(stat.mode & 0o777).toBe(0o600);
       }
     } finally {
+      // mirrors cleanupTempDir() — inline guard to safely remove mkdtemp directory
       const parentDir = path.dirname(scriptFile);
       if (parentDir !== os.tmpdir() && path.basename(parentDir).startsWith("nemoclaw-sync-")) {
         fs.rmSync(parentDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Six functions in `bin/lib/onboard.js` create temporary files using `Date.now()` and `Math.random().toString(36)`, both of which are predictable. A local attacker can win a TOCTOU race to pre-create a symlink at the predicted path in `/tmp`, enabling:

1. **Data exfiltration** — redirect curl output (API responses with model data) to an attacker-controlled location
2. **Script injection** — via `writeSandboxConfigSyncFile`, inject a malicious script that gets piped into `openshell sandbox connect`

## Changes

**`bin/lib/onboard.js`:**
- Added `secureTempFile(prefix, ext)` helper that uses `fs.mkdtempSync()` (OS-level `mkdtemp` syscall with cryptographically random suffix)
- Replaced all 6 predictable temp file constructions:
  - `probeOpenAiLikeEndpoint` (line ~667)
  - `probeAnthropicEndpoint` (line ~711)
  - `fetchNvidiaEndpointModels` (line ~857)
  - `fetchOpenAiLikeModels` (line ~911)
  - `fetchAnthropicModels` (line ~947)
  - `writeSandboxConfigSyncFile` (line ~527)

**`test/onboard.test.js`:**
- Updated the sync file test to validate the new mkdtemp-based path structure instead of the old predictable pattern

## Why this approach

The file already uses `fs.mkdtempSync()` securely in two other places (lines 1781 and 2710), making this fix consistent with existing code patterns rather than introducing new dependencies.

The remaining `Date.now()` usage in `patchStagedDockerfile` is a build identifier written into the Dockerfile, not a temp filename — left unchanged.

Fixes #1093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved temporary-file handling: sync scripts and downloaded responses are now written to securely named temp subdirectories and cleaned up at the directory level to reduce leftover artifacts.

* **Tests**
  * Updated tests to validate new temp-file placement and naming pattern, exact script contents, and tightened directory-level cleanup checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Benedikt Schackenberg <6381261+BenediktSchackenberg@users.noreply.github.com>
