### PR TITLE
fix(install): ensure p-retry resolves for npm install -g from source

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,16 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc -p jsconfig.json",
     "typecheck:cli": "tsc -p tsconfig.cli.json",
-    "prepare": "if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; elif [ -d node_modules/@j178/prek ]; then echo \"ERROR: prek package found but binary not in PATH\" && exit 1; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
+    "prepare": "if [ ! -d node_modules/p-retry ]; then echo 'Installing production dependencies…' && npm install --omit=dev --ignore-scripts 2>/dev/null || true; fi && if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; elif [ -d node_modules/@j178/prek ]; then echo \"ERROR: prek package found but binary not in PATH\" && exit 1; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {
     "openclaw": "2026.3.11",
     "p-retry": "^4.6.2"
   },
+  "bundleDependencies": [
+    "p-retry"
+  ],
   "files": [
     "bin/",
     "nemoclaw/dist/",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc -p jsconfig.json",
     "typecheck:cli": "tsc -p tsconfig.cli.json",
-    "prepare": "if [ ! -d node_modules/p-retry ]; then echo 'Installing production dependencies…' && npm install --omit=dev --ignore-scripts 2>/dev/null || true; fi && if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; elif [ -d node_modules/@j178/prek ]; then echo \"ERROR: prek package found but binary not in PATH\" && exit 1; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
+    "prepare": "npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; elif [ -d node_modules/@j178/prek ]; then echo \"ERROR: prek package found but binary not in PATH\" && exit 1; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Bootstrap production deps in the `prepare` lifecycle script when `node_modules/p-retry` is missing — covers `npm install -g .` and `npm link` from a fresh clone
- Add `bundleDependencies` for `p-retry` so tarball-based installs (`npm pack`, `npm publish`) physically bundle it

## Root Cause

`npm install -g .` from a fresh clone creates a symlink (equivalent to `npm link`) and does **not** install dependencies — only `added 1 package` (the symlink itself). The binary then runs from the local directory where `node_modules` doesn't exist, so `require('p-retry')` fails with `MODULE_NOT_FOUND`.

The installer script (`install.sh`) was unaffected because it already runs `npm install --ignore-scripts` before `npm link`. This only broke the manual `git clone && npm install -g .` path.

Regression from #1051.

## Test plan

- [ ] `npm test` — 632 tests pass, no regressions
- [ ] Fresh clone → `npm install -g .` → `nemoclaw --help` no longer crashes
- [ ] Existing `install.sh` path unchanged (already runs `npm install` first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved package prepare/install flow to more reliably install production dependencies before setup steps, reducing failures during installation.
  * Ensured a key retry dependency is bundled with releases so it’s included in distributed packages and works consistently for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->