### PR TITLE
fix: redirect non-root startup diagnostics to stderr

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -292,10 +292,10 @@ echo 'Setting up NemoClaw...'
 # separation and run everything as the current user (sandbox).
 # Gateway process isolation is not available in this mode.
 if [ "$(id -u)" -ne 0 ]; then
-  echo "[gateway] Running as non-root (uid=$(id -u)) — privilege separation disabled"
+  echo "[gateway] Running as non-root (uid=$(id -u)) — privilege separation disabled" >&2
   export HOME=/sandbox
   if ! verify_config_integrity; then
-    echo "[SECURITY] Config integrity check failed — refusing to start (non-root mode)"
+    echo "[SECURITY] Config integrity check failed — refusing to start (non-root mode)" >&2
     exit 1
   fi
   write_auth_profile
@@ -316,9 +316,9 @@ if [ "$(id -u)" -ne 0 ]; then
   # Start gateway in background, auto-pair, then wait
   nohup "$OPENCLAW" gateway run >/tmp/gateway.log 2>&1 &
   GATEWAY_PID=$!
-  echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)"
+  echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)" >&2
   start_auto_pair
-  print_dashboard_urls
+  print_dashboard_urls >&2
   wait "$GATEWAY_PID"
   exit $?
 fi

--- a/test/nemoclaw-start.test.js
+++ b/test/nemoclaw-start.test.js
@@ -35,4 +35,23 @@ describe("nemoclaw-start non-root fallback", () => {
     const calls = src.match(/verify_config_integrity/g) || [];
     expect(calls.length).toBeGreaterThanOrEqual(3); // definition + 2 call sites
   });
+
+  it("sends non-root startup diagnostics to stderr, not stdout (#1064)", () => {
+    const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+    // Extract the non-root block (between the if and fi)
+    const nonRootBlock = src.match(/if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)^fi$/m);
+    expect(nonRootBlock).toBeTruthy();
+    const block = nonRootBlock[1];
+
+    // Every echo in the non-root block should redirect to stderr
+    const echoLines = block.match(/^\s*echo\s+".+".*$/gm) || [];
+    expect(echoLines.length).toBeGreaterThan(0);
+    for (const line of echoLines) {
+      expect(line).toContain(">&2");
+    }
+
+    // print_dashboard_urls call should also redirect to stderr
+    expect(block).toContain("print_dashboard_urls >&2");
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Prevent non-root gateway startup diagnostics from leaking into Telegram agent responses. In the non-root execution path, `nemoclaw-start.sh` was emitting operational status lines to stdout, which the Telegram bridge treated as response content; this change redirects those diagnostics to stderr while preserving their visibility for operators.

## Related Issue

Fixes #1064

## Changes

* redirect non-root startup status messages from stdout to stderr in `scripts/nemoclaw-start.sh`
* route `print_dashboard_urls` to stderr in the same non-root path so dashboard information remains visible without polluting Telegram responses
* preserve the root / `gosu` path unchanged, since the reported leakage occurs only in non-root mode

## Type of Change

* [x] Code change for a new feature, bug fix, or refactor.
* [ ] Code change with doc updates.
* [ ] Doc only. Prose changes without code sample modifications.
* [ ] Doc only. Includes code sample changes.

## Testing

* [ ] `npx prek run --all-files` passes (or equivalently `make check`).
* [ ] `npm test` passes.
* [ ] `make docs` builds without warnings. (for doc-only changes)

Additional validation:

* [ ] Verified the non-root startup path no longer emits informational banner lines to stdout
* [ ] Confirmed diagnostics remain visible on stderr for operator troubleshooting
* [ ] Confirmed the root / `gosu` path is unchanged

## Checklist

### General

* [ ] I have read and followed the [[contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
* [ ] I have read and followed the [[style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

* [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
* [ ] Tests added or updated for new or changed behavior.
* [x] No secrets, API keys, or credentials committed.
* [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes

* [ ] Follows the [[style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
* [ ] New pages include SPDX license header and frontmatter, if creating a new page.
* [ ] Cross-references and links verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup diagnostic messages now emit to stderr during non-root execution.

* **Tests**
  * Added a test verifying diagnostic output is redirected to stderr in the non-root startup path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->