### PR TITLE
fix(policies): deduplicate preset entries on re-apply to prevent inva…

### DIFF
--- a/bin/lib/policies.js
+++ b/bin/lib/policies.js
@@ -94,9 +94,68 @@ function buildPolicyGetCommand(sandboxName) {
 }
 
 /**
+ * Extract top-level mapping key names from a network_policies block.
+ * Keys are 2-space-indented identifiers followed by a colon, e.g. "  telegram_bot:".
+ */
+function extractPolicyKeyNames(text) {
+  const keys = [];
+  for (const m of text.matchAll(/^ {2}([a-zA-Z_][\w-]*):/gm)) {
+    keys.push(m[1]);
+  }
+  return keys;
+}
+
+/**
+ * Remove entries from the network_policies block whose key names appear in
+ * `keysToRemove`. Only operates within the `network_policies:` section so
+ * identically named keys in other top-level sections are not affected.
+ * Each entry starts at a 2-space-indented key line and extends to just before
+ * the next 2-space-indented key or the next top-level (non-indented) key.
+ */
+function stripPolicyKeys(policyText, keysToRemove) {
+  if (!keysToRemove.length) return policyText;
+  const removeSet = new Set(keysToRemove);
+  const lines = policyText.split("\n");
+  const result = [];
+  let inNetworkPolicies = false;
+  let skipping = false;
+
+  for (const line of lines) {
+    // Track when we enter/leave the network_policies section
+    if (/^network_policies\s*:/.test(line)) {
+      inNetworkPolicies = true;
+      result.push(line);
+      continue;
+    }
+    // Any other top-level key exits the section (and ends any skip)
+    if (/^\S/.test(line)) {
+      inNetworkPolicies = false;
+      skipping = false;
+    }
+
+    if (inNetworkPolicies) {
+      const keyMatch = line.match(/^ {2}([a-zA-Z_][\w-]*):/);
+      if (keyMatch) {
+        skipping = removeSet.has(keyMatch[1]);
+        if (skipping) continue;
+      }
+    }
+
+    if (!skipping) {
+      result.push(line);
+    }
+  }
+  return result.join("\n");
+}
+
+/**
  * Merge preset entries into existing policy YAML. Handles versionless policies
  * by ensuring the merged result has a version header when the current policy
  * has content but no version field. Pure function for testing.
+ *
+ * When a preset entry's key already exists in the current policy, the old
+ * entry is replaced (update semantics) so re-applying a preset picks up
+ * any changes without creating duplicate mapping keys.
  *
  * @param {string} currentPolicy - Existing policy YAML (may be versionless)
  * @param {string} presetEntries - Indented network_policies entries from preset
@@ -110,9 +169,14 @@ function mergePresetIntoPolicy(currentPolicy, presetEntries) {
     return "version: 1\n\nnetwork_policies:\n" + presetEntries;
   }
 
+  // Strip existing entries whose keys overlap with the incoming preset
+  // so re-applying a preset replaces rather than duplicates.
+  const incomingKeys = extractPolicyKeyNames(presetEntries);
+  const deduped = stripPolicyKeys(currentPolicy, incomingKeys);
+
   let merged;
-  if (/^network_policies\s*:/m.test(currentPolicy)) {
-    const lines = currentPolicy.split("\n");
+  if (/^network_policies\s*:/m.test(deduped)) {
+    const lines = deduped.split("\n");
     const result = [];
     let inNetworkPolicies = false;
     let inserted = false;
@@ -220,6 +284,8 @@ module.exports = {
   loadPreset,
   getPresetEndpoints,
   extractPresetEntries,
+  extractPolicyKeyNames,
+  stripPolicyKeys,
   parseCurrentPolicy,
   buildPolicySetCommand,
   buildPolicyGetCommand,

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -169,6 +169,84 @@ describe("policies", () => {
       expect(merged.startsWith("version: 1\n\nnetwork_policies:")).toBe(true);
       expect(merged).toContain("example.com");
     });
+
+    it("does not create duplicate keys when the same preset is applied twice", () => {
+      const telegramEntries = policies.extractPresetEntries(
+        policies.loadPreset("telegram"),
+      );
+      const base = "version: 1\n\nnetwork_policies:\n" + telegramEntries;
+      const merged = policies.mergePresetIntoPolicy(base, telegramEntries);
+
+      const keyCount = (merged.match(/telegram_bot:/g) || []).length;
+      expect(keyCount).toBe(1);
+    });
+
+    it("replaces stale entry when preset is re-applied (update semantics)", () => {
+      const stale =
+        "version: 1\n\nnetwork_policies:\n" +
+        "  telegram_bot:\n" +
+        "    name: telegram_bot\n" +
+        "    endpoints:\n" +
+        "      - host: old.stale.example.com\n" +
+        "        port: 443\n";
+      const telegramEntries = policies.extractPresetEntries(
+        policies.loadPreset("telegram"),
+      );
+      const merged = policies.mergePresetIntoPolicy(stale, telegramEntries);
+
+      expect(merged).not.toContain("old.stale.example.com");
+      expect(merged).toContain("api.telegram.org");
+      expect((merged.match(/telegram_bot:/g) || []).length).toBe(1);
+    });
+
+    it("preserves unrelated entries when deduplicating", () => {
+      const telegramEntries = policies.extractPresetEntries(
+        policies.loadPreset("telegram"),
+      );
+      const existing =
+        "version: 1\n\nnetwork_policies:\n" +
+        "  github:\n" +
+        "    name: github\n" +
+        "    endpoints:\n" +
+        "      - host: github.com\n" +
+        "        port: 443\n" +
+        "  telegram_bot:\n" +
+        "    name: telegram_bot\n" +
+        "    endpoints:\n" +
+        "      - host: api.telegram.org\n" +
+        "        port: 443\n";
+      const merged = policies.mergePresetIntoPolicy(existing, telegramEntries);
+
+      expect(merged).toContain("github:");
+      expect(merged).toContain("api.telegram.org");
+      expect((merged.match(/telegram_bot:/g) || []).length).toBe(1);
+    });
+
+    it("does not strip same-named keys outside network_policies", () => {
+      const telegramEntries = policies.extractPresetEntries(
+        policies.loadPreset("telegram"),
+      );
+      // Contrived policy where a non-network_policies section has a key
+      // matching the preset entry name ("telegram_bot").
+      const existing =
+        "version: 1\n\n" +
+        "other_section:\n" +
+        "  telegram_bot:\n" +
+        "    some_setting: true\n\n" +
+        "network_policies:\n" +
+        "  telegram_bot:\n" +
+        "    name: telegram_bot\n" +
+        "    endpoints:\n" +
+        "      - host: api.telegram.org\n" +
+        "        port: 443\n";
+      const merged = policies.mergePresetIntoPolicy(existing, telegramEntries);
+
+      // The key inside other_section must survive
+      expect(merged).toContain("other_section:");
+      expect(merged).toContain("some_setting: true");
+      // The network_policies entry is replaced (not duplicated)
+      expect((merged.match(/telegram_bot:/g) || []).length).toBe(2);
+    });
   });
 
   describe("preset YAML schema", () => {


### PR DESCRIPTION
## Summary

Prevent `policy-add` from generating invalid YAML when a preset is applied more than once. The previous merge path appended preset entries into `network_policies` without removing existing keys, which could produce duplicate mapping keys; this change gives repeated preset application update semantics by replacing overlapping entries before insertion.

## Related Issue

Fixes #1010

## Changes

* add `extractPolicyKeyNames()` to identify top-level policy keys contributed by an incoming preset within `network_policies`
* add `stripPolicyKeys()` to remove overlapping existing entries before merging the updated preset content
* update `mergePresetIntoPolicy()` so re-applying a preset replaces prior entries instead of appending duplicate keys
* preserve the existing lightweight text-based merge approach and avoid introducing new YAML parsing dependencies
* maintain compatibility with the current preset file structure and indentation conventions used in the repository

## Type of Change

* [x] Code change for a new feature, bug fix, or refactor.
* [ ] Code change with doc updates.
* [ ] Doc only. Prose changes without code sample modifications.
* [ ] Doc only. Includes code sample changes.

## Testing

* [ ] `npx prek run --all-files` passes (or equivalently `make check`).
* [ ] `npm test` passes.
* [ ] `make docs` builds without warnings. (for doc-only changes)

Additional validation:

* [ ] Verified re-applying the same preset no longer produces duplicate YAML mapping keys
* [ ] Confirmed merged output remains syntactically valid YAML
* [ ] Confirmed updated preset entries replace prior values as intended
* [ ] Confirmed existing one-time preset application behavior remains unchanged

## Checklist

### General

* [ ] I have read and followed the [[contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
* [ ] I have read and followed the [[style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

* [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
* [ ] Tests added or updated for new or changed behavior.
* [x] No secrets, API keys, or credentials committed.
* [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes

* [ ] Follows the [[style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
* [ ] New pages include SPDX license header and frontmatter, if creating a new page.
* [ ] Cross-references and links verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reapplying presets in policy files now replaces matching entries under network_policies instead of creating duplicates, preserves unrelated sections, and keeps same-named keys outside network_policies intact.

* **Tests**
  * Added tests verifying deduplication when re-merging presets, replacement of stale entries, scoping to network_policies, and preservation of same-named keys in other sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->