### PR TITLE
fix(security): make .openclaw symlinks immutable after validation

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -359,6 +359,19 @@ for entry in /sandbox/.openclaw/*; do
   fi
 done
 
+# Lock .openclaw directory after symlink validation: set the immutable flag
+# so symlinks cannot be swapped at runtime even if DAC or Landlock are
+# bypassed. chattr requires cap_linux_immutable which the entrypoint has
+# as root; the sandbox user cannot remove the flag.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/1019
+if command -v chattr >/dev/null 2>&1; then
+  chattr +i /sandbox/.openclaw 2>/dev/null || true
+  for entry in /sandbox/.openclaw/*; do
+    [ -L "$entry" ] || continue
+    chattr +i "$entry" 2>/dev/null || true
+  done
+fi
+
 # Start the gateway as the 'gateway' user.
 # SECURITY: The sandbox user cannot kill this process because it runs
 # under a different UID. The fake-HOME attack no longer works because


### PR DESCRIPTION
## Summary

The symlink validation loop in `nemoclaw-start.sh` verifies that all symlinks in `/sandbox/.openclaw/` point to their expected `/sandbox/.openclaw-data/` targets, but this check runs only once at boot. After validation completes (line 360), the gateway starts on the next line (line 366), leaving a TOCTOU window where symlinks could theoretically be swapped.

This adds defense-in-depth by setting the immutable flag (`chattr +i`) on both the `/sandbox/.openclaw` directory and its validated symlinks immediately after the validation loop passes.

## Changes

- Added `chattr +i` on `/sandbox/.openclaw` directory and all symlinks after the validation loop
- Guarded behind `command -v chattr` check — degrades gracefully if not available
- All `chattr` calls use `|| true` to avoid failures on filesystems that don't support immutable flags

## Security Analysis

| Layer | Protection | Status |
|-------|-----------|--------|
| DAC (chmod/chown) | Directory owned by root:root, mode 755 | Already in place (Dockerfile) |
| Landlock | `/sandbox/.openclaw` in read-only policy | `best_effort` — not enforced on older kernels |
| **Immutable flag** | `chattr +i` prevents modification even by root | **Added by this PR** |

The immutable flag cannot be removed by the sandbox user (requires `CAP_LINUX_IMMUTABLE`), closing the TOCTOU window even if DAC or Landlock are bypassed.

## Test Plan

- [x] Full test suite: 650/653 passed (3 pre-existing failures in `service-env.test.js`)
- [x] Verified graceful degradation when `chattr` is unavailable
- [x] Confirmed `chattr` guard (`command -v`) prevents errors in minimal containers

Closes #1019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added additional sandbox hardening: verification of internal links followed by an optional immutability step to protect those links from runtime modification, improving integrity and reducing risk of unauthorized changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>