### PR TITLE
fix(security): block CGNAT IPs in SSRF validation

### DIFF
--- a/nemoclaw/src/blueprint/ssrf.test.ts
+++ b/nemoclaw/src/blueprint/ssrf.test.ts
@@ -35,6 +35,9 @@ describe("isPrivateIp", () => {
     "::ffff:10.0.0.1", // IPv4-mapped IPv6 — private 10/8
     "::ffff:192.168.1.1", // IPv4-mapped IPv6 — private 192.168/16
     "::ffff:172.16.0.1", // IPv4-mapped IPv6 — private 172.16/12
+    "100.64.0.1", // RFC 6598 CGNAT
+    "100.127.255.254", // RFC 6598 CGNAT upper bound
+    "::ffff:100.64.0.1", // IPv4-mapped IPv6 — CGNAT
   ])("detects private IP: %s", (ip) => {
     expect(isPrivateIp(ip)).toBe(true);
   });

--- a/nemoclaw/src/blueprint/ssrf.ts
+++ b/nemoclaw/src/blueprint/ssrf.ts
@@ -15,6 +15,7 @@ const PRIVATE_NETWORKS: CidrRange[] = [
   cidr("172.16.0.0", 12),
   cidr("192.168.0.0", 16),
   cidr("169.254.0.0", 16),
+  cidr("100.64.0.0", 10), // RFC 6598 CGNAT (shared address space)
   cidr6("::1", 128),
   cidr6("fd00::", 8),
 ];


### PR DESCRIPTION
## Summary

- Add RFC 6598 CGNAT range (`100.64.0.0/10`) to `PRIVATE_NETWORKS` blocklist in `isPrivateIp()` (CWE-918, NVBUG 6012151)
- Without this, endpoints resolving to CGNAT addresses bypass the SSRF filter and can reach carrier-grade NAT infrastructure or Tailscale/WireGuard networks
- Tests added for `100.64.0.1`, `100.127.255.254`, and IPv4-mapped `::ffff:100.64.0.1`

## Test plan

- [ ] `isPrivateIp("100.64.0.1")` returns `true`
- [ ] `isPrivateIp("100.127.255.254")` returns `true`
- [ ] `isPrivateIp("::ffff:100.64.0.1")` returns `true` (IPv4-mapped)
- [ ] `isPrivateIp("100.63.255.255")` returns `false` (just below CGNAT range)
- [ ] Existing SSRF tests still pass (43 total)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced private IP address detection to include CGNAT address ranges, ensuring endpoint URLs resolving to these addresses are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->