### PR TITLE
fix(security): deny Tailscale socket and binary access in sandbox policy

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -17,6 +17,18 @@ version: 1
 
 filesystem_policy:
   include_workdir: true
+  deny:
+    # Block Tailscale CLI and daemon sockets to prevent the agent from
+    # establishing direct network connections that bypass the sandbox
+    # proxy (CWE-284, NVBUG 6012377). Deny takes precedence over the
+    # broad read_only /usr grant per OpenShell Landlock semantics.
+    - /var/run/tailscale
+    - /run/tailscale           # /var/run is often a symlink to /run
+    - /usr/bin/tailscale
+    - /usr/sbin/tailscale
+    - /usr/local/bin/tailscale
+    - /var/run/tailscale/tailscaled.sock
+    - /run/tailscale/tailscaled.sock
   read_only:
     - /usr
     - /lib

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -18,15 +18,19 @@ version: 1
 filesystem_policy:
   include_workdir: true
   deny:
-    # Block Tailscale CLI and daemon sockets to prevent the agent from
-    # establishing direct network connections that bypass the sandbox
-    # proxy (CWE-284, NVBUG 6012377). Deny takes precedence over the
-    # broad read_only /usr grant per OpenShell Landlock semantics.
+    # Block Tailscale CLI, daemon binaries, and daemon sockets to prevent the agent from
+    # establishing direct network connections that bypass the sandbox proxy
+    # (CWE-284, NVBUG 6012377). Deny takes precedence over the broad
+    # read_only /usr grant per OpenShell Landlock semantics.
     - /var/run/tailscale
     - /run/tailscale           # /var/run is often a symlink to /run
     - /usr/bin/tailscale
     - /usr/sbin/tailscale
     - /usr/local/bin/tailscale
+    - /usr/bin/tailscaled
+    - /usr/sbin/tailscaled
+    - /usr/local/bin/tailscaled
+    - /usr/local/sbin/tailscaled
     - /var/run/tailscale/tailscaled.sock
     - /run/tailscale/tailscaled.sock
   read_only:

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -18,6 +18,19 @@ const BASE_POLICY_PATH = new URL(
   import.meta.url,
 );
 const REQUIRED_PROFILE_FIELDS = ["provider_type", "endpoint"] as const;
+const TAILSCALE_DENY_PATHS = [
+  "/var/run/tailscale",
+  "/run/tailscale",
+  "/usr/bin/tailscale",
+  "/usr/sbin/tailscale",
+  "/usr/local/bin/tailscale",
+  "/usr/bin/tailscaled",
+  "/usr/sbin/tailscaled",
+  "/usr/local/bin/tailscaled",
+  "/usr/local/sbin/tailscaled",
+  "/var/run/tailscale/tailscaled.sock",
+  "/run/tailscale/tailscaled.sock",
+] as const;
 
 const bp = YAML.parse(readFileSync(BLUEPRINT_PATH, "utf-8")) as Record<string, unknown>;
 const declared = Array.isArray(bp?.profiles) ? (bp.profiles as string[]) : [];
@@ -82,5 +95,18 @@ describe("base sandbox policy", () => {
 
   it("has 'network_policies'", () => {
     expect("network_policies" in policy).toBe(true);
+  });
+
+  it("keeps Tailscale deny paths alongside the broad /usr read_only grant", () => {
+    const filesystemPolicy = policy.filesystem_policy as
+      | { deny?: string[]; read_only?: string[] }
+      | undefined;
+    const deny = Array.isArray(filesystemPolicy?.deny) ? filesystemPolicy.deny : [];
+    const readOnly = Array.isArray(filesystemPolicy?.read_only)
+      ? filesystemPolicy.read_only
+      : [];
+
+    expect(readOnly).toContain("/usr");
+    expect(deny).toEqual(expect.arrayContaining(TAILSCALE_DENY_PATHS));
   });
 });


### PR DESCRIPTION
## Summary

- Add Landlock `deny` rules for `/var/run/tailscale`, `/usr/bin/tailscale`, and `/usr/sbin/tailscale` (CWE-284, NVBUG 6012377)
- The current `read_only: /usr` grant allows the agent to invoke the Tailscale CLI (if installed on the host image) to establish direct network connections that bypass the sandbox proxy
- `deny` rules take precedence over `read_only`, blocking execution even with the broad `/usr` grant

## Test plan

- [ ] Sandbox with Tailscale installed — `tailscale status` from within sandbox fails with permission denied
- [ ] Sandbox without Tailscale — no behavioral change
- [ ] Other `/usr` binaries (node, git, etc.) still accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox filesystem policy now explicitly blocks Tailscale-related binaries and socket paths, reducing access to those files within the sandbox.
* **Tests**
  * Added validation to ensure the sandbox policy includes the new deny entries and preserves existing read-only paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->