### PR TITLE
fix(security): add verification for downloaded Ollama installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,25 @@ error() {
 }
 ok() { printf "  ${C_GREEN}✓${C_RESET}  %s\n" "$*"; }
 
+verify_downloaded_script() {
+  local file="$1" label="${2:-script}"
+  if [ ! -s "$file" ]; then
+    error "$label installer download is empty or missing"
+  fi
+  if ! head -1 "$file" | grep -qE '^#!.*(sh|bash)'; then
+    error "$label installer does not start with a shell shebang — possible download corruption"
+  fi
+  local hash
+  if command -v sha256sum >/dev/null 2>&1; then
+    hash="$(sha256sum "$file" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    hash="$(shasum -a 256 "$file" | awk '{print $1}')"
+  fi
+  if [ -n "${hash:-}" ]; then
+    info "$label installer SHA-256: $hash"
+  fi
+}
+
 resolve_default_sandbox_name() {
   local registry_file="${HOME}/.nemoclaw/sandboxes.json"
   local sandbox_name="${NEMOCLAW_SANDBOX_NAME:-}"
@@ -485,12 +504,11 @@ install_or_upgrade_ollama() {
       info "Ollama v${current} meets minimum requirement (>= v${OLLAMA_MIN_VERSION})"
     else
       info "Ollama v${current:-unknown} is below v${OLLAMA_MIN_VERSION} — upgrading…"
-      # Upstream URL is a rolling release so SHA-256 pinning isn't practical,
-      # but download-then-execute allows inspection and prevents partial-download execution.
       (
         tmpdir="$(mktemp -d)"
         trap 'rm -rf "$tmpdir"' EXIT
         curl -fsSL https://ollama.com/install.sh -o "$tmpdir/install_ollama.sh"
+        verify_downloaded_script "$tmpdir/install_ollama.sh" "Ollama"
         sh "$tmpdir/install_ollama.sh"
       )
       info "Ollama upgraded to $(get_ollama_version)"
@@ -499,12 +517,11 @@ install_or_upgrade_ollama() {
     # No ollama — only install if a GPU is present
     if detect_gpu; then
       info "GPU detected — installing Ollama…"
-      # Upstream URL is a rolling release so SHA-256 pinning isn't practical,
-      # but download-then-execute allows inspection and prevents partial-download execution.
       (
         tmpdir="$(mktemp -d)"
         trap 'rm -rf "$tmpdir"' EXIT
         curl -fsSL https://ollama.com/install.sh -o "$tmpdir/install_ollama.sh"
+        verify_downloaded_script "$tmpdir/install_ollama.sh" "Ollama"
         sh "$tmpdir/install_ollama.sh"
       )
       info "Ollama installed: v$(get_ollama_version)"


### PR DESCRIPTION
## Summary

- Add `verify_downloaded_script()` that validates downloaded installer scripts before execution (CWE-494, NVBUG 6009912)
- Checks: non-empty file, valid shell shebang (catches MITM truncation/corruption), logs SHA-256 hash for audit trail
- Applied to both Ollama install paths in `install.sh`
- SHA-256 pinning is not practical for Ollama's rolling-release URL, but shebang validation + hash logging provides defense-in-depth

## Test plan

- [ ] `install_or_upgrade_ollama` with GPU present — downloads, validates shebang, logs hash, installs
- [ ] Simulated empty download — rejected with clear error before execution
- [ ] Simulated non-shell download (e.g. HTML error page) — rejected at shebang check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced installation security with automatic verification of downloaded scripts to ensure they are valid and uncorrupted before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->