### PR TITLE
fix(cli): map --follow to --tail for openshell logs streaming

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -665,7 +665,7 @@ async function sandboxStatus(sandboxName) {
 
 function sandboxLogs(sandboxName, follow) {
   const args = ["logs", sandboxName];
-  if (follow) args.push("--follow");
+  if (follow) args.push("--tail");
   runOpenshell(args);
 }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -104,7 +104,7 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("nemoclaw debug")).toBeTruthy();
   });
 
-  it("passes --follow through to openshell logs", () => {
+  it("maps --follow to openshell --tail flag", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -144,7 +144,7 @@ describe("CLI dispatch", () => {
     });
 
     expect(r.code).toBe(0);
-    expect(fs.readFileSync(markerFile, "utf8")).toContain("logs alpha --follow");
+    expect(fs.readFileSync(markerFile, "utf8")).toContain("logs alpha --tail");
   });
 
   it("connect does not pre-start a duplicate port forward", () => {


### PR DESCRIPTION
## Summary

- `nemoclaw <name> logs --follow` passes `--follow` to openshell, but openshell expects `--tail` for live log streaming
- Map the user-facing `--follow` flag to `--tail` internally, keeping the CLI interface unchanged
- Update the test to verify the correct flag reaches openshell

This restores the fix from #436 (credit: @paritoshd-nv) which was inadvertently lost during a refactor.

## Reproduction (before fix)

```bash
$ nemoclaw my-assistant logs --follow
error: unexpected argument '--follow' found
  Command failed (exit 2): openshell logs my-assistant --follow
```

## Test plan

- [x] `npm test` — 675 passed, 3 skipped
- [x] Manual: `nemoclaw my-assistant logs --follow` streams live logs (DGX Spark, openshell 0.0.12)
- [x] Manual: `nemoclaw my-assistant logs` (without --follow) still works

Fixes #1146

Signed-off-by: senthilr-nv <senthilr@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed log-follow functionality by correcting the CLI argument translation used when retrieving live sandbox logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->