### PR TITLE
fix(telegram): force IPv4 DNS on Jetson to prevent happy eyeballs timeout

### DIFF
--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -2,6 +2,23 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Jetson Tegra kernels have a non-functional IPv6 stack. Node.js v22 happy
+// eyeballs (autoSelectFamily) tries IPv6 even when dns.setDefaultResultOrder
+// is set to 'ipv4first', causing all outbound HTTPS requests to fail with
+// ETIMEDOUT. Force IPv4 at the DNS layer which is the only reliable fix.
+// See: https://github.com/nodejs/node/issues/52216
+const dns = require("dns");
+const fs = require("fs");
+if (fs.existsSync("/etc/nv_tegra_release")) {
+  const _lookup = dns.lookup;
+  dns.lookup = function (hostname, options, callback) {
+    if (typeof options === "function") { callback = options; options = {}; }
+    if (typeof options === "number") options = { family: options };
+    options = Object.assign({}, options, { family: 4 });
+    return _lookup.call(dns, hostname, options, callback);
+  };
+}
+
 /**
  * Telegram → NemoClaw bridge.
  *


### PR DESCRIPTION
## Summary

Force IPv4 DNS resolution in `telegram-bridge.js` on Jetson platforms to fix immediate crash on startup.

## Problem

Node.js v22 enables the [happy eyeballs algorithm](https://datatracker.ietf.org/doc/html/rfc8305) (`autoSelectFamily`) by default. On Jetson Tegra kernels (5.15), IPv6 is non-functional — the kernel lacks proper IPv6 connectivity, returning `ENETUNREACH` for any IPv6 connection attempt.

The happy eyeballs implementation ignores `dns.setDefaultResultOrder('ipv4first')` and tries all address families regardless of DNS ordering ([nodejs/node#52216](https://github.com/nodejs/node/issues/52216)). The failed IPv6 attempt (`ENETUNREACH`) causes the entire connection to fail with `ETIMEDOUT`, crashing the bridge on startup:

```
AggregateError [ETIMEDOUT]:
  Error: connect ETIMEDOUT 149.154.166.110:443
  Error: connect ENETUNREACH 2001:67c:4e8:f004::9:443
```

## Changes

- `scripts/telegram-bridge.js`: Override `dns.lookup` to force `family: 4` (IPv4 only), guarded by `/etc/nv_tegra_release` detection so non-Jetson platforms are unaffected.

## Why dns.lookup override instead of simpler alternatives

| Approach | Works? | Why not |
|----------|--------|---------|
| `dns.setDefaultResultOrder('ipv4first')` | No | `autoSelectFamily` ignores DNS result ordering |
| `net.setDefaultAutoSelectFamily(false)` | No | Does not affect `undici`/`fetch()` |
| `--no-network-family-autoselection` CLI flag | No | Same — does not affect `undici` |
| **`dns.lookup` override with `family: 4`** | **Yes** | Prevents IPv6 addresses from reaching the connection layer entirely |

## Test plan

Tested on Jetson Orin NX (L4T R36.4.3, kernel 5.15.148-tegra, Node.js v22.13.1):

- [x] Without fix: bridge crashes immediately with `ETIMEDOUT` + `ENETUNREACH`
- [x] With `setDefaultResultOrder('ipv4first')` only: still crashes
- [x] With `dns.lookup` override (this PR): bridge starts and operates normally
- [x] Fix is guarded by `/etc/nv_tegra_release` — no behavior change on non-Jetson platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures IPv4 DNS resolution on Jetson Tegra devices so outbound connections (e.g., the Telegram bridge) reliably use IPv4 when needed, improving connectivity and startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: brianyang <brianyang@signalpro.com.tw>