### PR TITLE
fix(telegram): check res.ok for Markdown fallback in sendMessage

### DIFF
--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -79,20 +79,16 @@ async function sendMessage(chatId, text, replyTo) {
   }
   for (const chunk of chunks) {
     // tgApi() resolves even on API errors ({ok: false}), so .catch()
-    // never fires for Markdown parse failures. Check res.ok explicitly.
-    let res = await tgApi("sendMessage", {
+    // never fires for Markdown parse failures. Check explicitly for
+    // Telegram's "can't parse entities" error before retrying plain.
+    const res = await tgApi("sendMessage", {
       chat_id: chatId,
       text: chunk,
       reply_to_message_id: replyTo,
       parse_mode: "Markdown",
-    }).catch((e) => ({ ok: false, description: e.message }));
-    if (!res.ok) {
-      // Retry without Markdown (unbalanced formatting from LLM output)
-      res = await tgApi("sendMessage", {
-        chat_id: chatId,
-        text: chunk,
-        reply_to_message_id: replyTo,
-      }).catch((e) => ({ ok: false, description: e.message }));
+    });
+    if (res.error_code === 400 && /can't parse entities/i.test(res.description || "")) {
+      await tgApi("sendMessage", { chat_id: chatId, text: chunk, reply_to_message_id: replyTo });
     }
   }
 }

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -78,15 +78,22 @@ async function sendMessage(chatId, text, replyTo) {
     chunks.push(text.slice(i, i + 4000));
   }
   for (const chunk of chunks) {
-    await tgApi("sendMessage", {
+    // tgApi() resolves even on API errors ({ok: false}), so .catch()
+    // never fires for Markdown parse failures. Check res.ok explicitly.
+    let res = await tgApi("sendMessage", {
       chat_id: chatId,
       text: chunk,
       reply_to_message_id: replyTo,
       parse_mode: "Markdown",
-    }).catch(() =>
-      // Retry without markdown if it fails (unbalanced formatting)
-      tgApi("sendMessage", { chat_id: chatId, text: chunk, reply_to_message_id: replyTo }),
-    );
+    }).catch((e) => ({ ok: false, description: e.message }));
+    if (!res.ok) {
+      // Retry without Markdown (unbalanced formatting from LLM output)
+      res = await tgApi("sendMessage", {
+        chat_id: chatId,
+        text: chunk,
+        reply_to_message_id: replyTo,
+      }).catch((e) => ({ ok: false, description: e.message }));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fix silent message loss when LLM output contains invalid Markdown.

## Problem

`tgApi()` resolves with `{ok: false}` on Telegram API errors instead of rejecting the promise. The existing `.catch()` fallback for Markdown parse failures therefore **never triggers**, causing messages to be silently dropped with no error logged.

This affects all Telegram bridge users whenever the LLM outputs unbalanced Markdown entities (`*`, `_`, etc.), which is common with local models. Telegram returns:

```json
{"ok": false, "error_code": 400, "description": "Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 1883"}
```

But since `tgApi()` resolves (not rejects), `.catch()` is skipped and the plain-text retry never executes.

## Changes

- `scripts/telegram-bridge.js`: Check `res.ok` explicitly instead of relying on `.catch()` for the Markdown-to-plain-text fallback.

## Test plan

- [x] Send message triggering LLM response with broken Markdown (unmatched `*`)
- [x] Before fix: message silently lost, no error in logs
- [x] After fix: Markdown attempt fails → automatic plain-text retry → message delivered
- [x] Normal messages with valid Markdown still render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message resend behavior for formatting errors: when a message fails due to Markdown parsing, it is now retried automatically as plain text. Other delivery failures no longer trigger automatic retries, reducing duplicate attempts and improving overall messaging reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: brianyang <brianyang@signalpro.com.tw>