### PR TITLE
Revert "fix(security): deny Tailscale socket and binary access in sandbox policy"

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -17,22 +17,6 @@ version: 1
 
 filesystem_policy:
   include_workdir: true
-  deny:
-    # Block Tailscale CLI, daemon binaries, and daemon sockets to prevent the agent from
-    # establishing direct network connections that bypass the sandbox proxy
-    # (CWE-284, NVBUG 6012377). Deny takes precedence over the broad
-    # read_only /usr grant per OpenShell Landlock semantics.
-    - /var/run/tailscale
-    - /run/tailscale           # /var/run is often a symlink to /run
-    - /usr/bin/tailscale
-    - /usr/sbin/tailscale
-    - /usr/local/bin/tailscale
-    - /usr/bin/tailscaled
-    - /usr/sbin/tailscaled
-    - /usr/local/bin/tailscaled
-    - /usr/local/sbin/tailscaled
-    - /var/run/tailscale/tailscaled.sock
-    - /run/tailscale/tailscaled.sock
   read_only:
     - /usr
     - /lib

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -18,19 +18,6 @@ const BASE_POLICY_PATH = new URL(
   import.meta.url,
 );
 const REQUIRED_PROFILE_FIELDS = ["provider_type", "endpoint"] as const;
-const TAILSCALE_DENY_PATHS = [
-  "/var/run/tailscale",
-  "/run/tailscale",
-  "/usr/bin/tailscale",
-  "/usr/sbin/tailscale",
-  "/usr/local/bin/tailscale",
-  "/usr/bin/tailscaled",
-  "/usr/sbin/tailscaled",
-  "/usr/local/bin/tailscaled",
-  "/usr/local/sbin/tailscaled",
-  "/var/run/tailscale/tailscaled.sock",
-  "/run/tailscale/tailscaled.sock",
-] as const;
 
 const bp = YAML.parse(readFileSync(BLUEPRINT_PATH, "utf-8")) as Record<string, unknown>;
 const declared = Array.isArray(bp?.profiles) ? (bp.profiles as string[]) : [];
@@ -95,18 +82,5 @@ describe("base sandbox policy", () => {
 
   it("has 'network_policies'", () => {
     expect("network_policies" in policy).toBe(true);
-  });
-
-  it("keeps Tailscale deny paths alongside the broad /usr read_only grant", () => {
-    const filesystemPolicy = policy.filesystem_policy as
-      | { deny?: string[]; read_only?: string[] }
-      | undefined;
-    const deny = Array.isArray(filesystemPolicy?.deny) ? filesystemPolicy.deny : [];
-    const readOnly = Array.isArray(filesystemPolicy?.read_only)
-      ? filesystemPolicy.read_only
-      : [];
-
-    expect(readOnly).toContain("/usr");
-    expect(deny).toEqual(expect.arrayContaining(TAILSCALE_DENY_PATHS));
   });
 });


### PR DESCRIPTION
Reverts NVIDIA/NemoClaw#1142 for now.

Closes #1153 

This needs to hold until newer openshell is enforced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed filesystem policy restrictions that were blocking Tailscale CLI/daemon binaries and runtime socket access in the sandbox environment.

* **Tests**
  * Updated test suite to align with modified sandbox policy validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->