### PR TITLE
fix(docs): inline quickstart content to fix GitHub rendering

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -20,19 +20,115 @@ status: published
 
 # Quickstart
 
-```{include} ../_includes/alpha-statement.md
-```
+:::{admonition} Alpha software
+NemoClaw is in alpha, available as an early preview since March 16, 2026.
+APIs, configuration schemas, and runtime behavior are subject to breaking changes between releases.
+Do not use this software in production environments.
+File issues and feedback through the GitHub repository as the project continues to stabilize.
+:::
 
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
+## Prerequisites
+
+Before getting started, check the prerequisites to ensure you have the necessary software and hardware to run NemoClaw.
+
+### Hardware
+
+| Resource | Minimum        | Recommended      |
+|----------|----------------|------------------|
+| CPU      | 4 vCPU         | 4+ vCPU          |
+| RAM      | 8 GB           | 16 GB            |
+| Disk     | 20 GB free     | 40 GB free       |
+
+The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon, k3s, and the OpenShell gateway run alongside the export pipeline, which buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer. If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
+
+### Software
+
+| Dependency | Version                          |
+|------------|----------------------------------|
+| Linux      | Ubuntu 22.04 LTS or later |
+| Node.js    | 22.16 or later |
+| npm        | 10 or later |
+| Container runtime | Supported runtime installed and running |
+| [OpenShell](https://github.com/NVIDIA/OpenShell) | Installed |
+
+### Container Runtimes
+
+| Platform | Supported runtimes | Notes |
+|----------|--------------------|-------|
+| Linux | Docker | Primary supported path. |
+| macOS (Apple Silicon) | Colima, Docker Desktop | Install Xcode Command Line Tools (`xcode-select --install`) and start the runtime before running the installer. |
+| macOS (Intel) | Podman | Not supported yet. Depends on OpenShell support for Podman on macOS. |
+| Windows WSL | Docker Desktop (WSL backend) | Supported target path. |
+| DGX Spark | Docker | Refer to the [DGX Spark setup guide](https://github.com/NVIDIA/NemoClaw/blob/main/spark-install.md) for cgroup v2 and Docker configuration. |
+
+## Install NemoClaw and Onboard OpenClaw Agent
+
+Download and run the installer script.
+The script installs Node.js if it is not already present, then runs the guided onboard wizard to create a sandbox, configure inference, and apply security policies.
+
 :::{note}
-NemoClaw creates a new OpenClaw instance during onboarding.
+NemoClaw creates a fresh OpenClaw instance inside the sandbox during the onboarding process.
 :::
 
-```{include} ../../README.md
-:start-after: <!-- start-quickstart-guide -->
-:end-before: <!-- end-quickstart-guide -->
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
+
+If you use nvm or fnm to manage Node.js, the installer may not update your current shell's PATH.
+If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
+
+When the install completes, a summary confirms the running environment:
+
+```text
+──────────────────────────────────────────────────
+Sandbox      my-assistant (Landlock + seccomp + netns)
+Model        nvidia/nemotron-3-super-120b-a12b (NVIDIA Endpoints)
+──────────────────────────────────────────────────
+Run:         nemoclaw my-assistant connect
+Status:      nemoclaw my-assistant status
+Logs:        nemoclaw my-assistant logs --follow
+──────────────────────────────────────────────────
+
+[INFO]  === Installation complete ===
+```
+
+## Chat with the Agent
+
+Connect to the sandbox, then chat with the agent through the TUI or the CLI.
+
+```bash
+nemoclaw my-assistant connect
+```
+
+In the sandbox shell, open the OpenClaw terminal UI and start a chat:
+
+```bash
+openclaw tui
+```
+
+Alternatively, send a single message and print the response:
+
+```bash
+openclaw agent --agent main --local -m "hello" --session-id test
+```
+
+## Uninstall
+
+To remove NemoClaw and all resources created during setup, run the uninstall script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash
+```
+
+| Flag               | Effect                                              |
+|--------------------|-----------------------------------------------------|
+| `--yes`            | Skip the confirmation prompt.                       |
+| `--keep-openshell` | Leave the `openshell` binary installed.              |
+| `--delete-models`  | Also remove NemoClaw-pulled Ollama models.           |
+
+For troubleshooting installation or onboarding issues, see the [Troubleshooting guide](../reference/troubleshooting.md).
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- Inlined quickstart content directly into `docs/get-started/quickstart.md` instead of using Sphinx `{include}` directives that render as raw markup on GitHub.
- Removed all `{include}` directives from the file (README.md quickstart and alpha-statement).

Closes #1181.

## Test plan

- [ ] Verify `docs/get-started/quickstart.md` renders correctly on GitHub (no raw directive markup visible).
- [ ] Verify `make docs` builds without warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart guide with comprehensive prerequisites (hardware requirements, software versions, supported container runtimes for Linux/macOS/Windows WSL/DGX Spark)
  * Expanded installation instructions with setup and configuration steps
  * Added usage instructions for agent connection and CLI tools
  * Added uninstall section with configuration options
  * Updated troubleshooting references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->