### PR TITLE
[fix] Add nemoclaw to $PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ secrets.json
 secrets.yaml
 service-account*.json
 token.json
+
+# IDEs
+.vscode/
+.idea/
+.cursor/

--- a/install.sh
+++ b/install.sh
@@ -382,6 +382,17 @@ ensure_nemoclaw_shim() {
   ln -sfn "$npm_bin/nemoclaw" "$shim_path"
   refresh_path
   info "Created user-local shim at $shim_path"
+
+  # Persist ~/.local/bin to the user's shell profile if not already present.
+  local profile
+  profile="$(detect_shell_profile)"
+  # shellcheck disable=SC2016
+  local path_line='export PATH="$HOME/.local/bin:$PATH"'
+  if [[ -f "$profile" ]] && ! grep -q '\.local/bin' "$profile"; then
+    printf '\n# Added by NemoClaw installer\n%s\n' "$path_line" >>"$profile"
+    info "Added ~/.local/bin to PATH in $profile"
+  fi
+
   return 0
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -310,6 +310,32 @@ remove_nemoclaw_cli() {
   elif [ -f "${NEMOCLAW_SHIM_DIR}/nemoclaw" ]; then
     warn "Leaving ${NEMOCLAW_SHIM_DIR}/nemoclaw in place because it is not an installer-managed shim."
   fi
+
+  # Remove the PATH entry added by the installer from all common shell profiles.
+  local profiles=(
+    "$HOME/.bashrc"
+    "$HOME/.zshrc"
+    "$HOME/.profile"
+    "$HOME/.config/fish/config.fish"
+    "$HOME/.tcshrc"
+    "$HOME/.cshrc"
+  )
+  for profile in "${profiles[@]}"; do
+    [[ -f "$profile" ]] || continue
+    if grep -q '^# Added by NemoClaw installer$' "$profile"; then
+      local backup="${profile}.nemoclaw.bak"
+      cp "$profile" "$backup"
+      # Delete the "# Added by NemoClaw installer" comment line and the
+      # immediately following export PATH line containing .local/bin.
+      awk '
+        /^# Added by NemoClaw installer$/ { skip=1; next }
+        skip && /export PATH=.*\.local\/bin/ { skip=0; next }
+        { skip=0; print }
+      ' "$backup" >"$profile"
+      rm -f "$backup"
+      info "Removed ~/.local/bin PATH entry from $profile"
+    fi
+  done
 }
 
 remove_docker_resources() {


### PR DESCRIPTION

Add `.local/bin` to $PATH if not already exists.
This is the same pattern used by fix_npm_permissions() for ~/.npm-global/bin

<!-- markdownlint-disable MD041 -->
## Summary

In install.sh, after creating the shim symlink, ensure_nemoclaw_shim() now appends export PATH="$HOME/.local/bin/nemoclaw:$PATH" to the detected shell profile (.zshrc, .bashrc, etc.) if ~/.local/bin isn't already mentioned there.

## Changes
install.sh

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Jibin Varghese <jibinv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now adds your ~/.local/bin to your shell profile so the command is available in new terminals and prints an informational message when it does.
  * Uninstaller now removes installer-added PATH entries from common shell profile files and logs which profiles were updated.
  * .gitignore updated to ignore common IDE workspace folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->