### PR TITLE
fix: skip vitest pre-push hooks on docs-only changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -221,7 +221,7 @@ repos:
         entry: bash -c 'npx vitest run --project cli --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
         language: system
         pass_filenames: false
-        always_run: true
+        files: ^(bin/|test/)
         stages: [pre-push]
         priority: 20
 
@@ -230,7 +230,7 @@ repos:
         entry: bash -c 'npx vitest run --project plugin --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/plugin --coverage.include="nemoclaw/src/**/*.ts" --coverage.exclude="**/*.test.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"'
         language: system
         pass_filenames: false
-        always_run: true
+        files: ^nemoclaw/
         stages: [pre-push]
         priority: 20
 


### PR DESCRIPTION
## Description

Replace `always_run: true` with `files:` patterns on the two vitest coverage pre-push hooks so they only fire when relevant source files change:

- `vitest-cli-coverage`: `^(bin/|test/)`
- `vitest-plugin-coverage`: `^nemoclaw/`

CI is unaffected — it uses `--all-files` which always matches.

## Type of change

- [x] Code change without doc updates.

## Testing

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] Verified with `prek run --dry-run`:
  - docs-only pre-commit: all three vitest hooks **Skipped**
  - docs-only pre-push: all three vitest hooks **Skipped**
  - CI-style `--all-files --stage pre-push`: all three vitest hooks **Run**

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).

### Code Changes

- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized pre-commit hooks to run coverage checks more selectively based on changed files, improving development workflow efficiency and reducing unnecessary test executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->