### PR TITLE
fix: unify vitest hooks and standardize pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,8 +83,8 @@ repos:
 
   - repo: local
     hooks:
-      - id: nemoclaw-prettier
-        name: Prettier (nemoclaw TypeScript)
+      - id: prettier-plugin
+        name: Prettier (plugin)
         entry: bash -c 'root="$(git rev-parse --show-toplevel)" && cd "$root/nemoclaw" && files=() && for f in "$@"; do files+=("${f#nemoclaw/}"); done && npx prettier --write "${files[@]}"' --
         language: system
         files: ^nemoclaw/.*\.ts$
@@ -94,8 +94,8 @@ repos:
   # ── Priority 6: auto-fix after formatting ─────────────────────────────────
   - repo: local
     hooks:
-      - id: nemoclaw-eslint
-        name: ESLint (nemoclaw TypeScript)
+      - id: eslint-plugin
+        name: ESLint (plugin)
         entry: bash -c 'root="$(git rev-parse --show-toplevel)" && cd "$root/nemoclaw" && files=() && for f in "$@"; do files+=("${f#nemoclaw/}"); done && npx eslint --fix "${files[@]}"' --
         language: system
         files: ^nemoclaw/.*\.ts$
@@ -104,8 +104,8 @@ repos:
 
   - repo: local
     hooks:
-      - id: eslint-js
-        name: ESLint (JavaScript)
+      - id: eslint-cli
+        name: ESLint (CLI)
         entry: npx eslint --fix
         language: system
         files: ^(bin|test|scripts|docs/_ext)/.*\.js$
@@ -177,8 +177,8 @@ repos:
   # ── pre-push hooks ─────────────────────────────────────────────────────────
   - repo: local
     hooks:
-      - id: tsc-check
-        name: TypeScript type check (tsc --noEmit)
+      - id: tsc-plugin
+        name: TypeScript (plugin)
         entry: bash -c 'cd nemoclaw && npx tsc --noEmit --incremental'
         language: system
         pass_filenames: false
@@ -186,8 +186,8 @@ repos:
         stages: [pre-push]
         priority: 10
 
-      - id: tsc-check-js
-        name: TypeScript type check (JavaScript)
+      - id: tsc-js
+        name: TypeScript (JS config)
         entry: npx tsc -p jsconfig.json
         language: system
         pass_filenames: false
@@ -195,8 +195,8 @@ repos:
         stages: [pre-push]
         priority: 10
 
-      - id: tsc-check-cli
-        name: TypeScript type check (CLI)
+      - id: tsc-cli
+        name: TypeScript (CLI)
         entry: npx tsc -p tsconfig.cli.json
         language: system
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -217,7 +217,7 @@ repos:
   - repo: local
     hooks:
       - id: test-cli
-        name: Vitest (CLI test + coverage ratchet)
+        name: Test (CLI)
         entry: bash -c 'npx vitest run --project cli --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
         language: system
         pass_filenames: false
@@ -225,7 +225,7 @@ repos:
         priority: 20
 
       - id: test-plugin
-        name: Vitest (plugin test + coverage ratchet)
+        name: Test (plugin)
         entry: bash -c 'npx vitest run --project plugin --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/plugin --coverage.include="nemoclaw/src/**/*.ts" --coverage.exclude="**/*.test.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"'
         language: system
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -193,7 +193,7 @@ repos:
         entry: bash -c 'cd nemoclaw && npx tsc --noEmit --incremental'
         language: system
         pass_filenames: false
-        always_run: true
+        files: ^nemoclaw/
         stages: [pre-push]
         priority: 10
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -209,7 +209,7 @@ repos:
   - repo: local
     hooks:
       - id: test-cli
-        name: Vitest (CLI coverage + ratchet)
+        name: Vitest (CLI test + coverage ratchet)
         entry: bash -c 'npx vitest run --project cli --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
         language: system
         pass_filenames: false
@@ -217,7 +217,7 @@ repos:
         priority: 20
 
       - id: test-plugin
-        name: Vitest (plugin coverage + ratchet)
+        name: Vitest (plugin test + coverage ratchet)
         entry: bash -c 'npx vitest run --project plugin --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/plugin --coverage.include="nemoclaw/src/**/*.ts" --coverage.exclude="**/*.test.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"'
         language: system
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -208,7 +208,7 @@ repos:
   # ── Priority 20: project-level checks (coverage + ratchet) ─────────────────
   - repo: local
     hooks:
-      - id: vitest-cli-coverage
+      - id: test-cli
         name: Vitest (CLI coverage + ratchet)
         entry: bash -c 'npx vitest run --project cli --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
         language: system
@@ -216,7 +216,7 @@ repos:
         files: ^(bin/|test/)
         priority: 20
 
-      - id: vitest-plugin-coverage
+      - id: test-plugin
         name: Vitest (plugin coverage + ratchet)
         entry: bash -c 'npx vitest run --project plugin --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/plugin --coverage.include="nemoclaw/src/**/*.ts" --coverage.exclude="**/*.test.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"'
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -165,17 +165,6 @@ repos:
       - id: markdownlint-cli2
         priority: 10
 
-  # ── Priority 20: project-level checks (pre-commit) ─────────────────────────
-  - repo: local
-    hooks:
-      - id: vitest-plugin
-        name: Vitest (plugin project)
-        entry: bash -c 'root="$(git rev-parse --show-toplevel)" && cd "$root" && exec ./node_modules/.bin/vitest run --project plugin'
-        language: system
-        pass_filenames: false
-        files: ^nemoclaw/
-        priority: 20
-
   # ── commit-msg hooks ────────────────────────────────────────────────────────
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.24.0
@@ -216,22 +205,23 @@ repos:
         stages: [pre-push]
         priority: 10
 
+  # ── Priority 20: project-level checks (coverage + ratchet) ─────────────────
+  - repo: local
+    hooks:
       - id: vitest-cli-coverage
-        name: Vitest (CLI coverage)
+        name: Vitest (CLI coverage + ratchet)
         entry: bash -c 'npx vitest run --project cli --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
         language: system
         pass_filenames: false
         files: ^(bin/|test/)
-        stages: [pre-push]
         priority: 20
 
       - id: vitest-plugin-coverage
-        name: Vitest (plugin coverage)
+        name: Vitest (plugin coverage + ratchet)
         entry: bash -c 'npx vitest run --project plugin --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/plugin --coverage.include="nemoclaw/src/**/*.ts" --coverage.exclude="**/*.test.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"'
         language: system
         pass_filenames: false
         files: ^nemoclaw/
-        stages: [pre-push]
         priority: 20
 
 default_language_version:


### PR DESCRIPTION
## Description

Three improvements to `.pre-commit-config.yaml`:

1. **Run coverage + ratchet everywhere**: Remove the standalone `vitest-plugin` pre-commit hook (ran tests without coverage) and drop the `stages: [pre-push]` restriction from both vitest coverage hooks. Coverage and ratchet checks now run on every commit and push.

2. **Skip `tsc-check` on docs-only changes**: Replace `always_run: true` with `files: ^nemoclaw/` on the `tsc-check` pre-push hook (same pattern as #1199).

3. **Standardize hook ids and names**: Rename all local hooks to follow the `thing` / `thing-cli` / `thing-plugin` convention:
   - `prettier-plugin`, `eslint-plugin`, `eslint-cli`
   - `tsc-plugin`, `tsc-js`, `tsc-cli`
   - `test-cli`, `test-plugin`

CI is unaffected — it uses `--all-files` which always matches.

## Type of change

- [x] Code change without doc updates.

## Testing

- [x] `npx prek run --all-files` passes.
- [x] Verified with `prek run --dry-run`:

| Scenario | Vitest CLI | Vitest Plugin | tsc-plugin |
|---|---|---|---|
| docs-only pre-commit | Skipped | Skipped | n/a |
| docs-only pre-push | Skipped | Skipped | Skipped |
| plugin change pre-commit | Skipped | **Run** | n/a |
| plugin change pre-push | Skipped | **Run** | **Run** |
| CLI change pre-commit | **Run** | Skipped | n/a |
| CLI change pre-push | **Run** | Skipped | Skipped |
| CI-style `--all-files` | **Run** | **Run** | **Run** |

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).

### Code Changes

- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling and pre-commit/pre-push hook configuration.
  * Renamed local linting and formatting hooks for clarity.
  * Replaced project-level test/coverage hooks and adjusted when coverage runs.
  * Changed type-check hooks so plugin checks run only for relevant code while CLI checks keep pre-push behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->