### PR TITLE
fix(onboard): skip CoreDNS patching on WSL2 to fix sandbox DNS

### DIFF
--- a/bin/lib/platform.js
+++ b/bin/lib/platform.js
@@ -35,10 +35,12 @@ function isUnsupportedMacosRuntime(runtime, opts = {}) {
   return platform === "darwin" && runtime === "podman";
 }
 
-function shouldPatchCoredns(runtime) {
-  // k3s-inside-Docker has broken DNS forwarding on all platforms
-  // (systemd-resolved, Docker Desktop DNS, Colima DNS).
-  // Always patch CoreDNS to use a non-loopback upstream.
+function shouldPatchCoredns(runtime, opts = {}) {
+  // k3s CoreDNS defaults to a loopback DNS that pods can't reach.
+  // Patch it to use a real upstream on most Docker-based runtimes.
+  // On WSL2, the host DNS is not routable from k3s pods - skip the
+  // patch and let setup-dns-proxy.sh handle resolution instead.
+  if (isWsl(opts)) return false;
   return runtime !== "unknown";
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
On WSL2 + Docker Desktop, fix-coredns.sh picks up the host DNS from /etc/resolv.conf which is not routable from k3s pods. This breaks CoreDNS and all DNS resolution inside the gateway - sandbox web tools fail with getaddrinfo EAI_AGAIN, and cloud inference onboarding fails because openshell inference set cannot verify the endpoint (e.g. integrate.api.nvidia.com).

## Related Issue
#414 +  Cloud inference onboarding failure regression was reported offline and was reproducible

## Changes
Skip CoreDNS patching on WSL2 and rely on setup-dns-proxy.sh to handle sandbox DNS resolution instead.

## Type of Change
<!-- Check the one that applies. -->
- [X] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [X] `npx prek run --all-files` passes (or equivalently `make check`).
- [X] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)
- Cloud inference onboarding -> openclaw tui 
- Connect to sandbox -> run `node -e "fetch('https://wttr.in/SanFrancisco?format=3').then(r => r.text()).then(t => console.log('OK', t)).catch(e => console.log('FAIL', e.code, e.cause))"` with following rule added to policy 
```
  weather:
    name: weather
    endpoints:
      - host: wttr.in
        port: 443
        access: full
      - host: api.open-meteo.com
        port: 443
        access: full
    binaries:
      - { path: /usr/local/bin/node }
```

## Checklist

### General

- [X] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [X] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [X] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CoreDNS patching behavior for Windows Subsystem for Linux (WSL) environments to prevent unnecessary modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->