### PR TITLE
fix(security): harden gateway auth defaults and restrict auto-pair

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ chat_origin = f'{parsed.scheme}://{parsed.netloc}' if parsed.scheme and parsed.n
 origins = ['http://127.0.0.1:18789']; \
 origins = list(dict.fromkeys(origins + [chat_origin])); \
 disable_device_auth = os.environ.get('NEMOCLAW_DISABLE_DEVICE_AUTH', '') == '1'; \
-allow_insecure = parsed.scheme != 'https'; \
+allow_insecure = parsed.scheme == 'http'; \
 providers = { \
     provider_key: { \
         'baseUrl': inference_base_url, \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ ARG CHAT_UI_URL=http://127.0.0.1:18789
 ARG NEMOCLAW_INFERENCE_BASE_URL=https://inference.local/v1
 ARG NEMOCLAW_INFERENCE_API=openai-completions
 ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=
+# Set to "1" to disable device-pairing auth (development/headless only).
+# Default: "0" (device auth enabled — secure by default).
+ARG NEMOCLAW_DISABLE_DEVICE_AUTH=0
 # Unique per build to ensure each image gets a fresh auth token.
 # Pass --build-arg NEMOCLAW_BUILD_ID=$(date +%s) to bust the cache.
 ARG NEMOCLAW_BUILD_ID=default
@@ -67,7 +70,8 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
     CHAT_UI_URL=${CHAT_UI_URL} \
     NEMOCLAW_INFERENCE_BASE_URL=${NEMOCLAW_INFERENCE_BASE_URL} \
     NEMOCLAW_INFERENCE_API=${NEMOCLAW_INFERENCE_API} \
-    NEMOCLAW_INFERENCE_COMPAT_B64=${NEMOCLAW_INFERENCE_COMPAT_B64}
+    NEMOCLAW_INFERENCE_COMPAT_B64=${NEMOCLAW_INFERENCE_COMPAT_B64} \
+    NEMOCLAW_DISABLE_DEVICE_AUTH=${NEMOCLAW_DISABLE_DEVICE_AUTH}
 
 WORKDIR /sandbox
 USER sandbox
@@ -91,6 +95,8 @@ parsed = urlparse(chat_ui_url); \
 chat_origin = f'{parsed.scheme}://{parsed.netloc}' if parsed.scheme and parsed.netloc else 'http://127.0.0.1:18789'; \
 origins = ['http://127.0.0.1:18789']; \
 origins = list(dict.fromkeys(origins + [chat_origin])); \
+disable_device_auth = os.environ.get('NEMOCLAW_DISABLE_DEVICE_AUTH', '') == '1'; \
+allow_insecure = parsed.scheme != 'https'; \
 providers = { \
     provider_key: { \
         'baseUrl': inference_base_url, \
@@ -106,8 +112,8 @@ config = { \
     'gateway': { \
         'mode': 'local', \
         'controlUi': { \
-            'allowInsecureAuth': True, \
-            'dangerouslyDisableDeviceAuth': True, \
+            'allowInsecureAuth': allow_insecure, \
+            'dangerouslyDisableDeviceAuth': disable_device_auth, \
             'allowedOrigins': origins, \
         }, \
         'trustedProxies': ['127.0.0.1', '::1'], \

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -915,6 +915,12 @@ function patchStagedDockerfile(
     /^ARG NEMOCLAW_BUILD_ID=.*$/m,
     `ARG NEMOCLAW_BUILD_ID=${buildId}`,
   );
+  // Onboard flow expects immediate dashboard access without device pairing,
+  // so disable device auth for images built during onboard (see #1217).
+  dockerfile = dockerfile.replace(
+    /^ARG NEMOCLAW_DISABLE_DEVICE_AUTH=.*$/m,
+    `ARG NEMOCLAW_DISABLE_DEVICE_AUTH=1`,
+  );
   fs.writeFileSync(dockerfilePath, dockerfile);
 }
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -154,6 +154,7 @@ OPENCLAW = os.environ.get('OPENCLAW_BIN', 'openclaw')
 DEADLINE = time.time() + 600
 QUIET_POLLS = 0
 APPROVED = 0
+HANDLED = set()  # Track rejected/approved requestIds to avoid reprocessing
 
 def run(*args):
     proc = subprocess.run(args, capture_output=True, text=True)
@@ -176,20 +177,26 @@ while time.time() < DEADLINE:
 
     if pending:
         QUIET_POLLS = 0
+        # SECURITY NOTE: clientId/clientMode are client-supplied and spoofable
+        # (the gateway stores connectParams.client.id verbatim). This allowlist
+        # is defense-in-depth, not a trust boundary. PR #690 adds one-shot exit,
+        # timeout reduction, and token cleanup for a more comprehensive fix.
         ALLOWED_CLIENTS = {'openclaw-control-ui'}
         ALLOWED_MODES = {'webchat'}
         for device in pending:
             if not isinstance(device, dict):
                 continue
+            request_id = device.get('requestId')
+            if not request_id or request_id in HANDLED:
+                continue
             client_id = device.get('clientId', '')
             client_mode = device.get('clientMode', '')
             if client_id not in ALLOWED_CLIENTS and client_mode not in ALLOWED_MODES:
+                HANDLED.add(request_id)
                 print(f'[auto-pair] rejected unknown client={client_id} mode={client_mode}')
                 continue
-            request_id = device.get('requestId')
-            if not request_id:
-                continue
             arc, aout, aerr = run(OPENCLAW, 'devices', 'approve', request_id, '--json')
+            HANDLED.add(request_id)
             if arc == 0:
                 APPROVED += 1
                 print(f'[auto-pair] approved request={request_id} client={client_id}')

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -10,8 +10,9 @@
 # The config hash is verified at startup to detect tampering.
 #
 # Optional env:
-#   NVIDIA_API_KEY   API key for NVIDIA-hosted inference
-#   CHAT_UI_URL      Browser origin that will access the forwarded dashboard
+#   NVIDIA_API_KEY                API key for NVIDIA-hosted inference
+#   CHAT_UI_URL                   Browser origin that will access the forwarded dashboard
+#   NEMOCLAW_DISABLE_DEVICE_AUTH  Set to "1" to skip device-pairing auth (development only)
 
 set -euo pipefail
 
@@ -175,14 +176,23 @@ while time.time() < DEADLINE:
 
     if pending:
         QUIET_POLLS = 0
+        ALLOWED_CLIENTS = {'openclaw-control-ui'}
+        ALLOWED_MODES = {'webchat'}
         for device in pending:
-            request_id = (device or {}).get('requestId')
+            if not isinstance(device, dict):
+                continue
+            client_id = device.get('clientId', '')
+            client_mode = device.get('clientMode', '')
+            if client_id not in ALLOWED_CLIENTS and client_mode not in ALLOWED_MODES:
+                print(f'[auto-pair] rejected unknown client={client_id} mode={client_mode}')
+                continue
+            request_id = device.get('requestId')
             if not request_id:
                 continue
             arc, aout, aerr = run(OPENCLAW, 'devices', 'approve', request_id, '--json')
             if arc == 0:
                 APPROVED += 1
-                print(f'[auto-pair] approved request={request_id}')
+                print(f'[auto-pair] approved request={request_id} client={client_id}')
             elif aout or aerr:
                 print(f'[auto-pair] approve failed request={request_id}: {(aerr or aout)[:400]}')
         time.sleep(1)

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -12,7 +12,9 @@
 # Optional env:
 #   NVIDIA_API_KEY                API key for NVIDIA-hosted inference
 #   CHAT_UI_URL                   Browser origin that will access the forwarded dashboard
-#   NEMOCLAW_DISABLE_DEVICE_AUTH  Set to "1" to skip device-pairing auth (development only)
+#   NEMOCLAW_DISABLE_DEVICE_AUTH  Build-time only. Set to "1" to skip device-pairing auth
+#                                 (development/headless). Has no runtime effect — openclaw.json
+#                                 is baked at image build and verified by hash at startup.
 
 set -euo pipefail
 
@@ -155,6 +157,12 @@ DEADLINE = time.time() + 600
 QUIET_POLLS = 0
 APPROVED = 0
 HANDLED = set()  # Track rejected/approved requestIds to avoid reprocessing
+# SECURITY NOTE: clientId/clientMode are client-supplied and spoofable
+# (the gateway stores connectParams.client.id verbatim). This allowlist
+# is defense-in-depth, not a trust boundary. PR #690 adds one-shot exit,
+# timeout reduction, and token cleanup for a more comprehensive fix.
+ALLOWED_CLIENTS = {'openclaw-control-ui'}
+ALLOWED_MODES = {'webchat'}
 
 def run(*args):
     proc = subprocess.run(args, capture_output=True, text=True)
@@ -177,12 +185,6 @@ while time.time() < DEADLINE:
 
     if pending:
         QUIET_POLLS = 0
-        # SECURITY NOTE: clientId/clientMode are client-supplied and spoofable
-        # (the gateway stores connectParams.client.id verbatim). This allowlist
-        # is defense-in-depth, not a trust boundary. PR #690 adds one-shot exit,
-        # timeout reduction, and token cleanup for a more comprehensive fix.
-        ALLOWED_CLIENTS = {'openclaw-control-ui'}
-        ALLOWED_MODES = {'webchat'}
         for device in pending:
             if not isinstance(device, dict):
                 continue

--- a/test/nemoclaw-start.test.js
+++ b/test/nemoclaw-start.test.js
@@ -59,3 +59,38 @@ describe("nemoclaw-start non-root fallback", () => {
     }
   });
 });
+
+describe("nemoclaw-start auto-pair client whitelisting (#117)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("defines ALLOWED_CLIENTS whitelist containing openclaw-control-ui", () => {
+    expect(src).toMatch(/ALLOWED_CLIENTS\s*=\s*\{.*'openclaw-control-ui'.*\}/);
+  });
+
+  it("defines ALLOWED_MODES whitelist containing webchat", () => {
+    expect(src).toMatch(/ALLOWED_MODES\s*=\s*\{.*'webchat'.*\}/);
+  });
+
+  it("rejects devices not in the whitelist", () => {
+    expect(src).toMatch(/client_id not in ALLOWED_CLIENTS and client_mode not in ALLOWED_MODES/);
+    expect(src).toMatch(/\[auto-pair\] rejected unknown client=/);
+  });
+
+  it("validates device is a dict before accessing fields", () => {
+    expect(src).toMatch(/if not isinstance\(device, dict\)/);
+  });
+
+  it("logs client identity on approval", () => {
+    expect(src).toMatch(/\[auto-pair\] approved request=\{request_id\} client=\{client_id\}/);
+  });
+
+  it("does not unconditionally approve all pending devices", () => {
+    // The old pattern: `(device or {}).get('requestId')` — approve everything
+    // Must NOT be present in the auto-pair block
+    expect(src).not.toMatch(/\(device or \{\}\)\.get\('requestId'\)/);
+  });
+
+  it("documents NEMOCLAW_DISABLE_DEVICE_AUTH in the script header", () => {
+    expect(src).toMatch(/NEMOCLAW_DISABLE_DEVICE_AUTH/);
+  });
+});

--- a/test/nemoclaw-start.test.js
+++ b/test/nemoclaw-start.test.js
@@ -90,6 +90,12 @@ describe("nemoclaw-start auto-pair client whitelisting (#117)", () => {
     expect(src).not.toMatch(/\(device or \{\}\)\.get\('requestId'\)/);
   });
 
+  it("tracks handled requests to avoid reprocessing rejected devices", () => {
+    expect(src).toMatch(/HANDLED\s*=\s*set\(\)/);
+    expect(src).toMatch(/request_id in HANDLED/);
+    expect(src).toMatch(/HANDLED\.add\(request_id\)/);
+  });
+
   it("documents NEMOCLAW_DISABLE_DEVICE_AUTH in the script header", () => {
     expect(src).toMatch(/NEMOCLAW_DISABLE_DEVICE_AUTH/);
   });

--- a/test/nemoclaw-start.test.js
+++ b/test/nemoclaw-start.test.js
@@ -96,7 +96,27 @@ describe("nemoclaw-start auto-pair client whitelisting (#117)", () => {
     expect(src).toMatch(/HANDLED\.add\(request_id\)/);
   });
 
-  it("documents NEMOCLAW_DISABLE_DEVICE_AUTH in the script header", () => {
-    expect(src).toMatch(/NEMOCLAW_DISABLE_DEVICE_AUTH/);
+  it("documents NEMOCLAW_DISABLE_DEVICE_AUTH as a build-time setting in the script header", () => {
+    // Must mention it's build-time only — setting at runtime has no effect
+    // because openclaw.json is baked and immutable
+    const header = src.split("set -euo pipefail")[0];
+    expect(header).toMatch(/NEMOCLAW_DISABLE_DEVICE_AUTH/);
+    expect(header).toMatch(/build[- ]time/i);
+  });
+
+  it("defines ALLOWED_CLIENTS and ALLOWED_MODES outside the poll loop", () => {
+    // These are constants — they should be defined once alongside HANDLED,
+    // not reconstructed inside the `if pending:` block every poll cycle
+    const autoPairBlock = src.match(/PYAUTOPAIR[\s\S]*?PYAUTOPAIR/);
+    expect(autoPairBlock).toBeTruthy();
+    const pyCode = autoPairBlock[0];
+
+    // ALLOWED_CLIENTS/ALLOWED_MODES should appear BEFORE the `while` loop,
+    // at the same level as HANDLED, APPROVED, etc.
+    const allowedClientsPos = pyCode.indexOf("ALLOWED_CLIENTS");
+    const whilePos = pyCode.indexOf("while time.time()");
+    expect(allowedClientsPos).toBeGreaterThan(-1);
+    expect(whilePos).toBeGreaterThan(-1);
+    expect(allowedClientsPos).toBeLessThan(whilePos);
   });
 });

--- a/test/security-c2-dockerfile-injection.test.js
+++ b/test/security-c2-dockerfile-injection.test.js
@@ -324,10 +324,12 @@ describe("Gateway auth hardening: Dockerfile must not hardcode insecure auth def
     expect(src).toMatch(/'dangerouslyDisableDeviceAuth':\s*disable_device_auth/);
   });
 
-  it("allowInsecureAuth is derived from URL scheme", () => {
+  it("allowInsecureAuth is derived from URL scheme (explicit http allowlist)", () => {
     const src = fs.readFileSync(DOCKERFILE, "utf-8");
-    // Must derive insecure auth from the parsed URL scheme
-    expect(src).toMatch(/allow_insecure\s*=\s*parsed\.scheme\s*!=\s*'https'/);
+    // Must use explicit 'http' allowlist — not `!= 'https'` which would allow
+    // insecure auth for malformed or unknown schemes (CodeRabbit review on #123)
+    expect(src).toMatch(/allow_insecure\s*=\s*parsed\.scheme\s*==\s*'http'/);
+    expect(src).not.toMatch(/allow_insecure\s*=\s*parsed\.scheme\s*!=\s*'https'/);
     // And use the derived variable in the config dict
     expect(src).toMatch(/'allowInsecureAuth':\s*allow_insecure/);
   });

--- a/test/security-c2-dockerfile-injection.test.js
+++ b/test/security-c2-dockerfile-injection.test.js
@@ -299,3 +299,69 @@ describe("C-2 regression: Dockerfile must not interpolate build-args into Python
     expect(hasEnvRead).toBeTruthy();
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════
+// 4. Gateway auth hardening — no hardcoded insecure defaults (#117)
+// ═══════════════════════════════════════════════════════════════════
+describe("Gateway auth hardening: Dockerfile must not hardcode insecure auth defaults", () => {
+  it("dangerouslyDisableDeviceAuth is not hardcoded to True", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    // Must not contain a literal `'dangerouslyDisableDeviceAuth': True`
+    expect(src).not.toMatch(/'dangerouslyDisableDeviceAuth':\s*True/);
+  });
+
+  it("allowInsecureAuth is not hardcoded to True", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    // Must not contain a literal `'allowInsecureAuth': True`
+    expect(src).not.toMatch(/'allowInsecureAuth':\s*True/);
+  });
+
+  it("dangerouslyDisableDeviceAuth is derived from NEMOCLAW_DISABLE_DEVICE_AUTH env var", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    // The Python config generation must read the env var
+    expect(src).toMatch(/os\.environ\.get\(['"]NEMOCLAW_DISABLE_DEVICE_AUTH['"]/);
+    // And use the derived variable in the config dict
+    expect(src).toMatch(/'dangerouslyDisableDeviceAuth':\s*disable_device_auth/);
+  });
+
+  it("allowInsecureAuth is derived from URL scheme", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    // Must derive insecure auth from the parsed URL scheme
+    expect(src).toMatch(/allow_insecure\s*=\s*parsed\.scheme\s*!=\s*'https'/);
+    // And use the derived variable in the config dict
+    expect(src).toMatch(/'allowInsecureAuth':\s*allow_insecure/);
+  });
+
+  it("NEMOCLAW_DISABLE_DEVICE_AUTH defaults to '0' (secure by default)", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    expect(src).toMatch(/ARG\s+NEMOCLAW_DISABLE_DEVICE_AUTH=0/);
+  });
+
+  it("NEMOCLAW_DISABLE_DEVICE_AUTH is promoted to ENV before the Python RUN layer", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+    const lines = src.split("\n");
+    let promoted = false;
+    let inEnvBlock = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (/^\s*FROM\b/.test(line)) {
+        promoted = false;
+        inEnvBlock = false;
+      }
+      if (/^\s*ENV\b/.test(line)) {
+        inEnvBlock = true;
+      }
+      if (inEnvBlock && /NEMOCLAW_DISABLE_DEVICE_AUTH[=\s]/.test(line)) {
+        promoted = true;
+      }
+      if (inEnvBlock && !/\\\s*$/.test(line)) {
+        inEnvBlock = false;
+      }
+      if (/^\s*RUN\b.*python3\s+-c\b/.test(line)) {
+        expect(promoted).toBeTruthy();
+        return;
+      }
+    }
+    expect(promoted).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #117 — Insecure authentication configuration in gateway setup.

> **Supersedes PR #123**, which targeted the correct security issues but patched code paths that have since moved. Recommend closing #123 in favor of this PR.

---

## Background 

NemoClaw runs an AI assistant inside a locked-down sandbox. The **gateway** is the front door to that sandbox, and the **Control UI** is a web dashboard users open in their browser to interact with the assistant.

There were three security problems with that front door:

### Problem 1: Device auth was permanently disabled 🔓

The config had `dangerouslyDisableDeviceAuth: True` hardcoded. This meant any device could connect to the gateway without proving its identity. It was added as a temporary workaround (commit `5fb629f`) and never reverted. While the sandbox network isolation mitigates this today, it becomes dangerous if combined with LAN-bind changes or cloudflared tunnels in remote deployments — resulting in an unauthenticated, publicly reachable dashboard.

**Fix:** Default to `false` (device auth enabled). Developers who genuinely need it disabled for headless/dev environments can set `NEMOCLAW_DISABLE_DEVICE_AUTH=1` as a build arg.

### Problem 2: Insecure auth was always allowed, even over HTTPS 🌐

`allowInsecureAuth: True` was hardcoded, meaning insecure (non-HTTPS) authentication was permitted regardless of deployment context. For local development on `http://127.0.0.1` this is fine, but for production/remote deployments over `https://` it defeats the purpose of TLS.

**Fix:** Derive it from the `CHAT_UI_URL` scheme. If the URL is `http://` → allow insecure auth (local dev). If `https://` → block it (production).

### Problem 3: The auto-pair bouncer let everyone in 🚪

The `start_auto_pair` watcher automatically approved *every* pending device pairing request with zero validation. A rogue or unexpected client type could pair with the gateway unchallenged.

**Fix:** Only approve devices with recognized `clientId` (`openclaw-control-ui`) or `clientMode` (`webchat`). Unknown clients are rejected and logged.

---

## Why this PR exists (instead of merging #123)

PR #123 (opened Mar 17) correctly identified all three issues and proposed the right fixes. However, since then, commit `0f8eedd` ("make openclaw.json immutable at runtime, move config to build time") moved the gateway `controlUi` configuration from `scripts/nemoclaw-start.sh` into the **Dockerfile**. The config is now baked at image build time and verified via SHA-256 hash at startup.

PR #123's changes to the start script's Python config block would patch dead code — that block no longer exists. This PR applies the same security logic where the code actually lives now:

| Issue | PR #123 patched | This PR patches |
|-------|----------------|----------------|
| `dangerouslyDisableDeviceAuth` | `scripts/nemoclaw-start.sh` (removed) | `Dockerfile` (build-time config) |
| `allowInsecureAuth` | `scripts/nemoclaw-start.sh` (removed) | `Dockerfile` (build-time config) |
| Auto-pair whitelisting | `scripts/nemoclaw-start.sh` ✅ | `scripts/nemoclaw-start.sh` ✅ |

---

## Changes

### `Dockerfile` (+8/-2)
- `dangerouslyDisableDeviceAuth` → derived from `NEMOCLAW_DISABLE_DEVICE_AUTH` env var (default `0` = secure)
- `allowInsecureAuth` → derived from `CHAT_UI_URL` scheme (`false` when `https://`)
- New `ARG NEMOCLAW_DISABLE_DEVICE_AUTH=0` with `ENV` promotion (follows existing C-2 safe pattern — no ARG interpolation into Python source)

### `scripts/nemoclaw-start.sh` (+12/-4)
- Auto-pair only approves `ALLOWED_CLIENTS = {'openclaw-control-ui'}` and `ALLOWED_MODES = {'webchat'}`
- Validates `isinstance(device, dict)` before field access
- Rejects unknown clients with `[auto-pair] rejected unknown client=... mode=...` log
- Logs `client=` on approval for audit trail
- Documents `NEMOCLAW_DISABLE_DEVICE_AUTH` in script header

### `test/security-c2-dockerfile-injection.test.js` (+6 tests)
- No hardcoded `True` for `dangerouslyDisableDeviceAuth`
- No hardcoded `True` for `allowInsecureAuth`
- Env var derivation for both settings
- `ARG` defaults to `0`
- `ENV` promotion before `RUN` layer

### `test/nemoclaw-start.test.js` (+7 tests)
- Whitelist definitions (`ALLOWED_CLIENTS`, `ALLOWED_MODES`)
- Rejection logic for unknown clients
- Dict type validation
- Client identity in approval logs
- No unconditional approval pattern
- `NEMOCLAW_DISABLE_DEVICE_AUTH` documented

---

## Why no Brev E2E test

These changes are **deterministic config values and simple conditional logic**, not runtime behavior with environmental ambiguity:

1. **Dockerfile config** — Two Python booleans evaluated at build time: `os.environ.get(...) == '1'` and `parsed.scheme != 'https'`. If the source is correct, the output is correct.
2. **Auto-pair whitelisting** — Python set membership check. No shell interpretation, no SSH pipeline, no quoting edge cases.

This is fundamentally different from something like the telegram bridge injection fix, where you *must* send real payloads through a real shell on a real sandbox to prove metacharacters don't get interpreted. Our changes have no gap between "looks right in source" and "works right at runtime." The 13 source-pattern tests provide sufficient confidence.

If deeper verification is desired in the future, a **build-time unit test** that runs the Dockerfile's Python snippet and asserts the JSON output would be the appropriate next step — a regular CI test, not a Brev instance.

---

## Test plan

- [x] All 752 tests pass (739 existing + 13 new)
- [x] `shellcheck` ✅
- [x] `hadolint` ✅
- [x] `shfmt` / `prettier` ✅
- [x] `gitleaks` ✅
- [ ] Default onboarding: gateway starts with device auth enabled, Control UI pairing works via auto-pair
- [ ] `NEMOCLAW_DISABLE_DEVICE_AUTH=1` build: device auth is disabled (backward-compatible escape hatch)
- [ ] `CHAT_UI_URL=https://...` build: `allowInsecureAuth` is `false`
- [ ] `CHAT_UI_URL=http://127.0.0.1:18789` (default): `allowInsecureAuth` is `true`
- [ ] Unknown device type connecting to gateway: auto-pair rejects and logs
- [ ] `openclaw-control-ui` / `webchat` devices: auto-pair approves as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Device authentication can be toggled at build time; UI insecure-auth is allowed only when the control UI URL uses http.
* **Bug Fixes**
  * Auto-pair processing now validates inputs, rejects unknown client/mode, logs identifiers, and deduplicates requests to avoid repeated approvals/rejections.
* **Tests**
  * Added tests for auto-pair validation, logging, de-duplication, and configurable auth behavior.
* **Chores**
  * Sandbox/setup flow now enforces the build-time device-auth setting for images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->