### PR TITLE
fix(policy): add protocol/enforcement/tls to statsig and sentry endpoints

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -57,11 +57,17 @@ network_policies:
           - allow: { method: POST, path: "/**" }
       - host: statsig.anthropic.com
         port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
       - host: sentry.io
         port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }


### PR DESCRIPTION
## Summary

- Add missing `protocol: rest`, `enforcement: enforce`, and `tls: terminate` to `statsig.anthropic.com` and `sentry.io` endpoints in `openclaw-sandbox.yaml`

## Related Issue

Closes #1214

## Changes

Both endpoints define GET/POST method rules, but without `protocol: rest` the proxy treats them as L4-only connections — the rules are never evaluated and any HTTP method is allowed through.

The fix adds the same three fields that `api.anthropic.com` (the adjacent endpoint in the same policy group) already has:

```yaml
protocol: rest
enforcement: enforce
tls: terminate
```

No new endpoints, no rule changes — just enabling L7 inspection on two endpoints that already have rules written for it.

## Testing

- Verified the YAML structure matches the working `api.anthropic.com` endpoint pattern
- No schema changes — `protocol`, `enforcement`, and `tls` are existing fields used across the policy file

## Checklist

- [x] Conventional commit format
- [x] Scoped to issue, no unrelated changes
- [x] No secrets or credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policy configurations for external service endpoints, including enhanced security enforcement and TLS termination settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->