### PR TITLE
fix(policy): add protocol/enforcement/tls to GitHub endpoints

### DIFF
--- a/nemoclaw-blueprint/policies/presets/github.yaml
+++ b/nemoclaw-blueprint/policies/presets/github.yaml
@@ -19,12 +19,56 @@ network_policies:
   github:
     name: github
     endpoints:
+      # git transport (clone, fetch, push) over smart HTTP.
+      # POST scoped to git-upload-pack / git-receive-pack only.
       - host: github.com
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**/git-upload-pack" }
+          - allow: { method: POST, path: "/**/git-receive-pack" }
+      # REST API: GET is unrestricted; writes scoped to PR/issue
+      # workflows and git ref/content operations. DELETE excluded to
+      # block destructive ops (repo deletion, branch force-delete,
+      # org membership changes).
       - host: api.github.com
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          # PR workflow
+          - allow: { method: POST, path: "/repos/*/*/pulls" }
+          - allow: { method: PATCH, path: "/repos/*/*/pulls/*" }
+          - allow: { method: PUT, path: "/repos/*/*/pulls/*/merge" }
+          - allow: { method: PUT, path: "/repos/*/*/pulls/*/update-branch" }
+          - allow: { method: POST, path: "/repos/*/*/pulls/*/reviews" }
+          - allow: { method: POST, path: "/repos/*/*/pulls/*/requested_reviewers" }
+          # Issues
+          - allow: { method: POST, path: "/repos/*/*/issues" }
+          - allow: { method: PATCH, path: "/repos/*/*/issues/*" }
+          - allow: { method: POST, path: "/repos/*/*/issues/*/comments" }
+          # Labels
+          - allow: { method: POST, path: "/repos/*/*/labels" }
+          - allow: { method: PATCH, path: "/repos/*/*/labels/*" }
+          # Milestones
+          - allow: { method: POST, path: "/repos/*/*/milestones" }
+          - allow: { method: PATCH, path: "/repos/*/*/milestones/*" }
+          # Releases
+          - allow: { method: POST, path: "/repos/*/*/releases" }
+          - allow: { method: PATCH, path: "/repos/*/*/releases/*" }
+          # Forks
+          - allow: { method: POST, path: "/repos/*/*/forks" }
+          # Branch creation and file commits via API
+          - allow: { method: POST, path: "/repos/*/*/git/refs" }
+          - allow: { method: PATCH, path: "/repos/*/*/git/refs/**" }
+          - allow: { method: PUT, path: "/repos/*/*/contents/**" }
+          # Manual workflow dispatch (gh workflow run)
+          - allow: { method: POST, path: "/repos/*/*/actions/workflows/*/dispatches" }
     binaries:
       - { path: /usr/bin/gh }
       - { path: /usr/bin/git }


### PR DESCRIPTION
## Summary

- Replace `access: full` on `github.com` and `api.github.com` with `protocol: rest`, `enforcement: enforce`, `tls: terminate`, and explicitly scoped method/path rules
- Splits git transport (github.com) from REST API (api.github.com) so each host has the minimum method set it actually needs
- Excludes DELETE entirely to block destructive ops (repo deletion, branch force-delete, org membership changes)

## Related Issue

Closes #1111

## Changes

The GitHub policy used `access: full` without `protocol: rest`, which means the proxy treats connections as L4-only — method/path rules cannot be evaluated, per-request logging is unavailable, and credential injection via SecretResolver won't work.

This fix adds the L7 inspection fields that every other REST endpoint in the policy already has, and replaces the `access: full` shorthand with explicit rules scoped to PR/issue/git workflows.

### github.com — git transport only
- `GET /**` — ref discovery (`git clone`, `git ls-remote`)
- `POST /**/git-upload-pack` — clone/fetch handshake
- `POST /**/git-receive-pack` — push handshake

### api.github.com — REST API
- `GET /**` — unrestricted reads
- PR workflow: create PRs, update PRs, request reviewers, submit reviews, merge PRs
- Issue workflow: create issues, update issues, comment on issues/PRs
- Git refs/contents: branch creation, ref updates, file commits via Contents API
- `POST /repos/*/*/actions/workflows/*/dispatches` — manual workflow dispatch (`gh workflow run`)
- DELETE excluded entirely

## Testing — workflow validation

Each common `gh` and `git` workflow was mapped against the rule set to confirm coverage. All standard agent operations are covered; destructive operations are explicitly blocked.

### git transport (github.com)

| Workflow | HTTP call | Rule | Status |
|---|---|---|---|
| `git clone` (ref discovery) | `GET /{o}/{r}.git/info/refs` | `GET /**` | ✅ |
| `git clone` (handshake) | `POST /{o}/{r}.git/git-upload-pack` | `POST /**/git-upload-pack` | ✅ |
| `git fetch` / `git pull` | `GET /info/refs` + `POST /git-upload-pack` | both | ✅ |
| `git push` | `GET /info/refs` + `POST /git-receive-pack` | both | ✅ |
| `git ls-remote` | `GET /info/refs` | `GET /**` | ✅ |

### gh CLI / REST API (api.github.com)

| Workflow | HTTP call | Rule | Status |
|---|---|---|---|
| `gh auth status`, `gh api user` | `GET /user` | `GET /**` | ✅ |
| `gh repo view` | `GET /repos/{o}/{r}` | `GET /**` | ✅ |
| `gh issue list` / `view` | `GET /repos/{o}/{r}/issues[/{n}]` | `GET /**` | ✅ |
| `gh issue create` | `POST /repos/{o}/{r}/issues` | `POST /repos/*/*/issues` | ✅ |
| `gh issue edit` / `gh issue close` | `PATCH /repos/{o}/{r}/issues/{n}` | `PATCH /repos/*/*/issues/*` | ✅ |
| `gh issue comment` | `POST /repos/{o}/{r}/issues/{n}/comments` | `POST /repos/*/*/issues/*/comments` | ✅ |
| `gh pr list` / `view` | `GET /repos/{o}/{r}/pulls[/{n}]` | `GET /**` | ✅ |
| `gh pr create` (branch) | `POST /repos/{o}/{r}/git/refs` | `POST /repos/*/*/git/refs` | ✅ |
| `gh pr create` (PR) | `POST /repos/{o}/{r}/pulls` | `POST /repos/*/*/pulls` | ✅ |
| `gh pr edit` / `gh pr close` | `PATCH /repos/{o}/{r}/pulls/{n}` | `PATCH /repos/*/*/pulls/*` | ✅ |
| `gh pr comment` | `POST /repos/{o}/{r}/issues/{n}/comments` (shared with issues) | `POST /repos/*/*/issues/*/comments` | ✅ |
| `gh pr review --approve/--request-changes` | `POST /repos/{o}/{r}/pulls/{n}/reviews` | `POST /repos/*/*/pulls/*/reviews` | ✅ |
| `gh pr review --request <user>` | `POST /repos/{o}/{r}/pulls/{n}/requested_reviewers` | `POST /repos/*/*/pulls/*/requested_reviewers` | ✅ |
| `gh pr merge` | `PUT /repos/{o}/{r}/pulls/{n}/merge` | `PUT /repos/*/*/pulls/*/merge` | ✅ |
| `gh release list` / `view` | `GET /repos/{o}/{r}/releases` | `GET /**` | ✅ |
| `gh run list` / `view` | `GET /repos/{o}/{r}/actions/runs` | `GET /**` | ✅ |
| `gh workflow run` | `POST /repos/{o}/{r}/actions/workflows/{id}/dispatches` | `POST /repos/*/*/actions/workflows/*/dispatches` | ✅ |
| File commit via Contents API | `PUT /repos/{o}/{r}/contents/{path}` | `PUT /repos/*/*/contents/**` | ✅ |
| Ref update via API | `PATCH /repos/{o}/{r}/git/refs/heads/{branch}` | `PATCH /repos/*/*/git/refs/**` | ✅ |

### Intentionally blocked (destructive / out-of-scope)

| Workflow | API call | Reason |
|---|---|---|
| `gh repo delete` | `DELETE /repos/{o}/{r}` | DELETE not allowed |
| `gh release delete` | `DELETE /repos/{o}/{r}/releases/{id}` | DELETE not allowed |
| Force-delete branch via API | `DELETE /repos/{o}/{r}/git/refs/heads/{b}` | DELETE not allowed |
| `gh repo create` | `POST /user/repos` | Not in allow list (avoids agent creating arbitrary repos) |
| Branch protection changes | `PUT /repos/{o}/{r}/branches/{b}/protection` | Admin-only, intentionally not exposed |

## Checklist

- [x] Conventional commit format
- [x] Scoped to issue, no unrelated changes
- [x] No secrets or credentials
- [x] gh/git workflow validation documented above

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Updates**
  * Tightened network access to GitHub endpoints: enforce REST-only traffic with TLS termination.
  * Restricted allowed HTTP methods to essential reads and explicitly permitted write actions.
  * Limited write operations to specific pull-request, review, issue and repository content/ref endpoints; broader or destructive methods are disallowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->