### PR TITLE
docs: use CUDA base image for GPU smoke test in spark-install

### DIFF
--- a/spark-install.md
+++ b/spark-install.md
@@ -54,7 +54,7 @@ Use this to run inference locally on the DGX Spark's GPU instead of routing to c
 ### 1. Verify the NVIDIA Container Runtime
 
 ```bash
-docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi
+docker run --rm --runtime=nvidia --gpus all nvidia/cuda:12.8.0-base-ubuntu24.04 nvidia-smi
 ```
 
 If this fails, configure the NVIDIA runtime and restart Docker:


### PR DESCRIPTION
## Summary

- Replace `ubuntu` with `nvidia/cuda:12.8.0-base-ubuntu24.04` in the GPU verification command

## Related Issue

Closes #1166

## Changes

The GPU smoke test in `spark-install.md` uses the `ubuntu` Docker image, which does not include `nvidia-smi`. The command always fails even when GPUs are correctly configured, making it useless as a validation step.

Switched to `nvidia/cuda:12.8.0-base-ubuntu24.04` which includes `nvidia-smi` and correctly validates GPU access through the NVIDIA container runtime.

## Testing

- Verified `nvidia/cuda:12.8.0-base-ubuntu24.04` exists on Docker Hub
- Standard NVIDIA GPU validation image used in NVIDIA documentation

## Checklist

- [x] Conventional commit format
- [x] Scoped to issue, no unrelated changes
- [x] No secrets or credentials

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified NVIDIA container runtime verification instructions to specify an explicit CUDA base image version for clearer, more consistent GPU-enabled container setup. The verification step and GPU check remain intact, improving reproducibility of the documented workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->