### PR TITLE
fix: use sudo -n for lsof retry in preflight to avoid password prompt

### DIFF
--- a/bin/lib/preflight.js
+++ b/bin/lib/preflight.js
@@ -101,7 +101,7 @@ async function checkPortAvailable(port, opts) {
       // through to the net probe (which can only detect EADDRINUSE but not
       // the owning process).
       if (dataLines.length === 0 && !o.lsofOutput) {
-        const sudoOut = runCapture(`sudo lsof -i :${p} -sTCP:LISTEN -P -n 2>/dev/null`, {
+        const sudoOut = runCapture(`sudo -n lsof -i :${p} -sTCP:LISTEN -P -n 2>/dev/null`, {
           ignoreError: true,
         });
         if (typeof sudoOut === "string") {


### PR DESCRIPTION
## Problem

The port-availability preflight check in `checkPortAvailable` retries with `sudo lsof` to detect root-owned listeners when unprivileged `lsof` returns empty output. Without `-n` (non-interactive mode), `sudo` blocks on a `Password:` prompt, stalling non-interactive installs:

- `curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash`
- `nemoclaw onboard --non-interactive`
- `NEMOCLAW_NON_INTERACTIVE=1`
- CI pipelines

## Fix

Use `sudo -n` so it fails immediately when passwordless sudo is unavailable, falling through to the TCP bind probe instead of hanging.

This is the only `sudo` call in the codebase that should degrade gracefully — the other `sudo` calls (swap creation) intentionally require elevated privileges to succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preflight setup process by enabling non-interactive mode for privilege elevation checks, preventing unexpected password prompts during port availability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->