### PR TITLE
security: block likely secrets from persistent memory writes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,9 +118,19 @@ path = os.path.expanduser('~/.openclaw/openclaw.json'); \
 json.dump(config, open(path, 'w'), indent=2); \
 os.chmod(path, 0o600)"
 
-# Install NemoClaw plugin into OpenClaw
-RUN openclaw doctor --fix > /dev/null 2>&1 || true \
-    && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
+# Install NemoClaw plugin into OpenClaw.
+# OpenClaw installs extensions under the state directory. In the sandbox image,
+# ~/.openclaw/extensions is a symlink to /sandbox/.openclaw-data/extensions, and
+# the installer rejects symlinked install roots. Point the install at the real
+# state directory while still persisting plugin metadata into the canonical
+# openclaw.json before it is locked down.
+RUN mkdir -p /sandbox/.openclaw-data/extensions \
+    && OPENCLAW_STATE_DIR=/sandbox/.openclaw-data \
+       OPENCLAW_CONFIG_PATH=/sandbox/.openclaw/openclaw.json \
+       openclaw doctor --fix > /dev/null 2>&1 || true \
+    && OPENCLAW_STATE_DIR=/sandbox/.openclaw-data \
+       OPENCLAW_CONFIG_PATH=/sandbox/.openclaw/openclaw.json \
+       openclaw plugins install /opt/nemoclaw > /dev/null 2>&1
 
 # Lock openclaw.json via DAC: chown to root so the sandbox user cannot modify
 # it at runtime.  This works regardless of Landlock enforcement status.

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { handleSlashCommand } from "./commands/slash.js";
+import { evaluateMemorySecretGuard } from "./memory-secret-guard.js";
 import {
   describeOnboardEndpoint,
   describeOnboardProvider,
@@ -247,6 +248,28 @@ export default function register(api: OpenClawPluginApi): void {
   const onboardCfg = loadOnboardConfig();
   const providerCredentialEnv = onboardCfg?.credentialEnv ?? "NVIDIA_API_KEY";
   api.registerProvider(registeredProviderForConfig(onboardCfg, providerCredentialEnv));
+
+  api.on("before_tool_call", (event) => {
+    if (!event || typeof event !== "object") {
+      return;
+    }
+    const toolEvent = event as { toolName?: unknown; params?: unknown };
+    if (typeof toolEvent.toolName !== "string") {
+      return;
+    }
+    const toolParams =
+      typeof toolEvent.params === "object" &&
+      toolEvent.params !== null &&
+      !Array.isArray(toolEvent.params)
+        ? (toolEvent.params as Record<string, unknown>)
+        : {};
+    return evaluateMemorySecretGuard({
+      toolName: toolEvent.toolName,
+      toolParams,
+      config: api.config,
+      resolvePath: api.resolvePath,
+    });
+  });
 
   const bannerEndpoint = onboardCfg ? describeOnboardEndpoint(onboardCfg) : "build.nvidia.com";
   const bannerProvider = onboardCfg ? describeOnboardProvider(onboardCfg) : "NVIDIA Endpoints";

--- a/nemoclaw/src/memory-secret-guard.ts
+++ b/nemoclaw/src/memory-secret-guard.ts
@@ -40,7 +40,7 @@ const SECRET_RULES: SecretRule[] = [
   {
     id: "anthropic-api-key",
     label: "Anthropic API key",
-    pattern: /\bsk-ant-api03-[A-Za-z0-9_-]{20,}AA(?:[\s'"`;"]|$)/,
+    pattern: /(?<![A-Za-z0-9_-])sk-ant-api03-[A-Za-z0-9_-]{80,128}(?![A-Za-z0-9_-])/,
   },
   {
     id: "openai-api-key",

--- a/nemoclaw/src/memory-secret-guard.ts
+++ b/nemoclaw/src/memory-secret-guard.ts
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+type UnknownRecord = Record<string, unknown>;
+
+export type SecretMatch = {
+  ruleId: string;
+  label: string;
+};
+
+type SecretRule = {
+  id: string;
+  label: string;
+  pattern: RegExp;
+};
+
+const DEFAULT_WORKSPACE_DIR = "/sandbox/.openclaw/workspace";
+const MEMORY_INDEX_NAME = "MEMORY.md";
+const DAILY_MEMORY_DIR_NAME = "memory";
+
+const TEXT_KEYS = new Set([
+  "content",
+  "new_string",
+  "newString",
+  "new_str",
+  "newText",
+  "replacement",
+  "text",
+  "insert_text",
+  "insertText",
+]);
+
+const PATH_KEYS = ["file_path", "filePath", "path"];
+
+const WRITE_LIKE_TOOLS = new Set(["write", "edit", "multiedit", "notebookedit"]);
+
+const SECRET_RULES: SecretRule[] = [
+  {
+    id: "anthropic-api-key",
+    label: "Anthropic API key",
+    pattern: /\bsk-ant-api03-[A-Za-z0-9_-]{20,}AA(?:[\s'"`;"]|$)/,
+  },
+  {
+    id: "openai-api-key",
+    label: "OpenAI API key",
+    pattern:
+      /\b(?:sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20})(?:[\s'"`;"]|$)/,
+  },
+  {
+    id: "github-pat",
+    label: "GitHub token",
+    pattern: /\b(?:ghp_[0-9A-Za-z]{36}|github_pat_[0-9A-Za-z_]{20,}|gh[ousr]_[0-9A-Za-z]{36})\b/,
+  },
+  {
+    id: "aws-access-token",
+    label: "AWS access token",
+    pattern: /\b(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16}\b/,
+  },
+  {
+    id: "slack-bot-token",
+    label: "Slack bot token",
+    pattern: /\bxoxb-[0-9]{10,13}-[0-9]{10,13}[A-Za-z0-9-]*\b/,
+  },
+  {
+    id: "private-key",
+    label: "Private key",
+    pattern:
+      /-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S]{32,}?-----END[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----/i,
+  },
+];
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+}
+
+export function resolveWorkspaceDir(config: UnknownRecord): string {
+  const agents = asRecord(config["agents"]);
+  const defaults = asRecord(agents?.["defaults"]);
+  const workspaceDir = defaults?.["workspace"];
+  if (typeof workspaceDir === "string" && workspaceDir.trim()) {
+    return path.resolve(workspaceDir.trim());
+  }
+  return DEFAULT_WORKSPACE_DIR;
+}
+
+export function isProtectedMemoryPath(filePath: string, workspaceDir: string): boolean {
+  const resolvedPath = path.resolve(filePath);
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
+  const memoryIndexPath = path.join(resolvedWorkspaceDir, MEMORY_INDEX_NAME);
+  const dailyMemoryDir = path.join(resolvedWorkspaceDir, DAILY_MEMORY_DIR_NAME);
+  return (
+    resolvedPath === memoryIndexPath || resolvedPath.startsWith(`${dailyMemoryDir}${path.sep}`)
+  );
+}
+
+function resolveTargetPath(
+  params: UnknownRecord,
+  resolvePath: ((input: string) => string) | undefined,
+): string | null {
+  for (const key of PATH_KEYS) {
+    const value = params[key];
+    if (typeof value === "string" && value.trim()) {
+      return resolvePath ? resolvePath(value) : path.resolve(value);
+    }
+  }
+  return null;
+}
+
+function collectWritableText(value: unknown, depth = 0): string[] {
+  if (depth > 4 || value == null) {
+    return [];
+  }
+  if (typeof value === "string") {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectWritableText(item, depth + 1));
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return [];
+  }
+  const texts: string[] = [];
+  for (const [key, nestedValue] of Object.entries(record)) {
+    if (TEXT_KEYS.has(key) && typeof nestedValue === "string" && nestedValue.trim()) {
+      texts.push(nestedValue);
+      continue;
+    }
+    texts.push(...collectWritableText(nestedValue, depth + 1));
+  }
+  return texts;
+}
+
+export function scanForMemorySecrets(text: string): SecretMatch[] {
+  const matches: SecretMatch[] = [];
+  for (const rule of SECRET_RULES) {
+    if (rule.pattern.test(text)) {
+      matches.push({ ruleId: rule.id, label: rule.label });
+    }
+  }
+  return matches;
+}
+
+function uniqueLabels(matches: SecretMatch[]): string[] {
+  return [...new Set(matches.map((match) => match.label))];
+}
+
+function formatMemoryPath(filePath: string, workspaceDir: string): string {
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
+  const resolvedPath = path.resolve(filePath);
+  if (resolvedPath === path.join(resolvedWorkspaceDir, MEMORY_INDEX_NAME)) {
+    return MEMORY_INDEX_NAME;
+  }
+  const dailyDir = path.join(resolvedWorkspaceDir, DAILY_MEMORY_DIR_NAME);
+  if (resolvedPath.startsWith(`${dailyDir}${path.sep}`)) {
+    return path.join(DAILY_MEMORY_DIR_NAME, path.relative(dailyDir, resolvedPath));
+  }
+  return path.basename(resolvedPath);
+}
+
+export function evaluateMemorySecretGuard(params: {
+  toolName: string;
+  toolParams: UnknownRecord;
+  config: UnknownRecord;
+  resolvePath?: (input: string) => string;
+}): { block: true; blockReason: string } | undefined {
+  const toolName = params.toolName.trim().toLowerCase();
+  if (!WRITE_LIKE_TOOLS.has(toolName)) {
+    return undefined;
+  }
+
+  const targetPath = resolveTargetPath(params.toolParams, params.resolvePath);
+  if (!targetPath) {
+    return undefined;
+  }
+
+  const workspaceDir = resolveWorkspaceDir(params.config);
+  if (!isProtectedMemoryPath(targetPath, workspaceDir)) {
+    return undefined;
+  }
+
+  const textSegments = collectWritableText(params.toolParams);
+  if (textSegments.length === 0) {
+    return undefined;
+  }
+
+  const matches = uniqueLabels(textSegments.flatMap((segment) => scanForMemorySecrets(segment)));
+  if (matches.length === 0) {
+    return undefined;
+  }
+
+  const targetLabel = formatMemoryPath(targetPath, workspaceDir);
+  const joinedLabels = matches.join(", ");
+  return {
+    block: true,
+    blockReason:
+      `Refusing to write likely secrets (${joinedLabels}) into persistent memory file ${targetLabel}. ` +
+      "Remove the sensitive material or keep credentials in the host-side OpenShell provider path instead.",
+  };
+}

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -201,6 +201,29 @@ describe("memory secret guard", () => {
       blockReason: expect.stringContaining("Private key"),
     });
   });
+
+  it("blocks multiedit writes that add an Anthropic key to persistent memory", () => {
+    const anthropicKey = `sk-ant-api03-${"A".repeat(100)}`;
+
+    const result = evaluateMemorySecretGuard({
+      toolName: "multiedit",
+      toolParams: {
+        file_path: "/sandbox/.openclaw/workspace/memory/2026-04-01.md",
+        edits: [
+          {
+            old_string: "TODO",
+            new_string: `Remember this token: ${anthropicKey}`,
+          },
+        ],
+      },
+      config: {},
+    });
+
+    expect(result).toEqual({
+      block: true,
+      blockReason: expect.stringContaining("Anthropic API key"),
+    });
+  });
 });
 
 describe("getPluginConfig", () => {

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -12,6 +12,12 @@ vi.mock("./onboard/config.js", () => ({
 
 import register, { getPluginConfig } from "./index.js";
 import { loadOnboardConfig } from "./onboard/config.js";
+import {
+  evaluateMemorySecretGuard,
+  isProtectedMemoryPath,
+  resolveWorkspaceDir,
+  scanForMemorySecrets,
+} from "./memory-secret-guard.js";
 
 const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
 
@@ -54,6 +60,12 @@ describe("plugin registration", () => {
     expect(api.registerProvider).toHaveBeenCalledWith(expect.objectContaining({ id: "inference" }));
   });
 
+  it("registers a before_tool_call hook for persistent memory writes", () => {
+    const api = createMockApi();
+    register(api);
+    expect(api.on).toHaveBeenCalledWith("before_tool_call", expect.any(Function));
+  });
+
   it("does NOT register CLI commands", () => {
     const api = createMockApi();
     // registerCli should not exist on the API interface after removal
@@ -76,6 +88,118 @@ describe("plugin registration", () => {
     expect(providerArg.models?.chat).toEqual([
       expect.objectContaining({ id: "inference/nvidia/custom-model" }),
     ]);
+  });
+
+  it("blocks likely secrets from being written into persistent memory", () => {
+    const api = createMockApi();
+    register(api);
+
+    const hook = vi
+      .mocked(api.on)
+      .mock.calls.find(([hookName]) => hookName === "before_tool_call")?.[1];
+    expect(hook).toBeTypeOf("function");
+
+    const result = (hook as (event: unknown) => unknown)({
+      toolName: "Write",
+      params: {
+        file_path: "/sandbox/.openclaw/workspace/MEMORY.md",
+        content: "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      },
+    });
+
+    expect(result).toEqual({
+      block: true,
+      blockReason: expect.stringContaining("GitHub token"),
+    });
+  });
+});
+
+describe("memory secret guard", () => {
+  it("uses the default workspace path when no workspace is configured", () => {
+    expect(resolveWorkspaceDir({})).toBe("/sandbox/.openclaw/workspace");
+  });
+
+  it("uses the configured workspace path when one is provided", () => {
+    expect(
+      resolveWorkspaceDir({
+        agents: {
+          defaults: {
+            workspace: "/sandbox/custom-workspace",
+          },
+        },
+      }),
+    ).toBe("/sandbox/custom-workspace");
+  });
+
+  it("protects MEMORY.md and daily memory files only", () => {
+    expect(
+      isProtectedMemoryPath(
+        "/sandbox/.openclaw/workspace/MEMORY.md",
+        "/sandbox/.openclaw/workspace",
+      ),
+    ).toBe(true);
+    expect(
+      isProtectedMemoryPath(
+        "/sandbox/.openclaw/workspace/memory/2026-04-01.md",
+        "/sandbox/.openclaw/workspace",
+      ),
+    ).toBe(true);
+    expect(
+      isProtectedMemoryPath("/sandbox/.openclaw/workspace/USER.md", "/sandbox/.openclaw/workspace"),
+    ).toBe(false);
+    expect(isProtectedMemoryPath("/tmp/random.md", "/sandbox/.openclaw/workspace")).toBe(false);
+  });
+
+  it("detects high-confidence GitHub tokens", () => {
+    expect(scanForMemorySecrets("ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")).toEqual([
+      {
+        ruleId: "github-pat",
+        label: "GitHub token",
+      },
+    ]);
+  });
+
+  it("allows non-secret writes into MEMORY.md", () => {
+    expect(
+      evaluateMemorySecretGuard({
+        toolName: "write",
+        toolParams: {
+          file_path: "/sandbox/.openclaw/workspace/MEMORY.md",
+          content: "Remember to check the nightly build in the morning.",
+        },
+        config: {},
+      }),
+    ).toBeUndefined();
+  });
+
+  it("ignores writes outside persistent memory", () => {
+    expect(
+      evaluateMemorySecretGuard({
+        toolName: "write",
+        toolParams: {
+          file_path: "/sandbox/.openclaw/workspace/USER.md",
+          content: "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        },
+        config: {},
+      }),
+    ).toBeUndefined();
+  });
+
+  it("blocks edits that add a private key to daily memory", () => {
+    const result = evaluateMemorySecretGuard({
+      toolName: "edit",
+      toolParams: {
+        file_path: "/sandbox/.openclaw/workspace/memory/2026-04-01.md",
+        new_string:
+          "-----BEGIN PRIVATE KEY-----\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n-----END PRIVATE KEY-----",
+      },
+      config: {},
+    });
+
+    expect(result).toEqual({
+      block: true,
+      blockReason: expect.stringContaining("Private key"),
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add a `before_tool_call` guard that blocks high-confidence secrets from being written into persistent memory files
- limit the guard to `MEMORY.md` and `memory/*` so normal workspace edits are unaffected
- install the NemoClaw plugin through the real OpenClaw state directory during image build so the hook is actually loaded in sandbox images

## Why
Issue [NVIDIA/NemoClaw#1233](https://github.com/NVIDIA/NemoClaw/issues/1233) calls for persistent memory writes to reject likely secrets. The new guard keeps credentials out of the long-lived workspace memory surface without changing the normal edit flow elsewhere.

While validating the change in a rebuilt sandbox, the NemoClaw plugin install step was also found to be silently skipped because OpenClaw now rejects a symlinked extensions directory as an install root. This patch installs the plugin through the real state directory before `openclaw.json` is locked, so the new hook is present in clean images.

## Testing
- `cd nemoclaw && npm run check`
- `cd .. && npx vitest run --project plugin nemoclaw/src/register.test.ts`
- repeated the same checks in `/home/cluster2600/.nemoclaw/source` on `cluster2600@192.168.1.109`
- rebuilt the live `nemoclaw` sandbox from the updated remote source
- verified the rebuilt sandbox auto-loads the NemoClaw plugin and reports the typed `before_tool_call` hook
- verified the installed guard module blocks a GitHub token written to `MEMORY.md`

Addresses NVIDIA/NemoClaw#1233.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocks writes to persistent memory when content appears to contain credentials (API keys, tokens, private keys), with detectable reason provided.

* **Tests**
  * Added tests covering workspace resolution, protected-path matching, secret detection cases, and blocking behavior for protected memory writes.

* **Chores**
  * Adjusted build to control where extension data is written during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->