### PR TITLE
docs(cli): clarify OpenShell compatibility recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 If you use nvm or fnm to manage Node.js, the installer may not update your current shell's PATH.
 If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
 
+> **Version compatibility**
+>
+> Treat the OpenShell version installed or reused by the NemoClaw installer as part of the NemoClaw release.
+> Do not run `openshell self-update`, `npm update -g openshell`, `openshell gateway start --recreate`, or `openshell sandbox create` directly on a NemoClaw-managed deployment.
+> If you suspect the installed OpenShell version is incompatible, back up your workspace and rerun `nemoclaw onboard` so NemoClaw can reinstall and reconfigure the expected runtime.
+
 When the install completes, a summary confirms the running environment:
 
 ```text

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -734,7 +734,10 @@ function printOldLogsCompatibilityGuidance(installedVersion = null) {
   );
   console.error(`  NemoClaw expects \`openshell logs <name>\` and live streaming via \`--tail\`.`);
   console.error(
-    "  Upgrade OpenShell by rerunning `nemoclaw onboard`, or reinstall the OpenShell CLI and try again.",
+    "  Rerun `nemoclaw onboard` to reinstall the pinned OpenShell version for this NemoClaw setup.",
+  );
+  console.error(
+    "  Do not run `openshell self-update` or recreate NemoClaw-managed sandboxes directly with `openshell` commands.",
   );
 }
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -92,6 +92,12 @@ This is a build-time setting baked into the sandbox image, not a runtime knob.
 If you export `NEMOCLAW_DISABLE_DEVICE_AUTH` after onboarding finishes, it has no effect on an existing sandbox.
 :::
 
+:::{warning} OpenShell version compatibility
+Treat the OpenShell version installed or reused by NemoClaw as part of the NemoClaw release you installed.
+Do not run `openshell self-update`, `npm update -g openshell`, `openshell gateway start --recreate`, or `openshell sandbox create` directly for a NemoClaw-managed deployment.
+If you suspect an incompatible OpenShell upgrade, [back up your workspace](../workspace/backup-restore.md) and rerun `nemoclaw onboard` so NemoClaw can reinstall the expected runtime and rebuild the managed resources.
+:::
+
 When the install completes, a summary confirms the running environment:
 
 ```text

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -105,6 +105,19 @@ $ export PATH=~/.npm-global/bin:$PATH
 
 Add the `export` line to your `~/.bashrc` or `~/.zshrc` to make it permanent, then re-run the installer.
 
+### OpenShell was upgraded independently
+
+NemoClaw manages an OpenShell-based runtime and expects the OpenShell version that was installed or reused during `nemoclaw onboard`.
+If you run `openshell self-update`, `npm update -g openshell`, `openshell gateway start --recreate`, or `openshell sandbox create` directly, the recreated gateway or sandbox can drift away from the layout and behavior that NemoClaw configured.
+
+To recover:
+
+1. Back up your workspace files by following [Back Up and Restore](../workspace/backup-restore.md).
+2. Re-run `nemoclaw onboard` so NemoClaw can reinstall the expected OpenShell runtime and rebuild its managed resources.
+3. Restore workspace files if the sandbox had to be recreated.
+
+Avoid running standalone `openshell` lifecycle commands on a NemoClaw-managed deployment unless the NemoClaw documentation explicitly tells you to do so.
+
 ### Port already in use
 
 The NemoClaw gateway uses port `18789` by default.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -649,7 +649,8 @@ describe("CLI dispatch", () => {
 
     expect(r.code).toBe(1);
     expect(r.out.includes("too old or incompatible with `nemoclaw logs`")).toBeTruthy();
-    expect(r.out.includes("Upgrade OpenShell by rerunning `nemoclaw onboard`")).toBeTruthy();
+    expect(r.out.includes("reinstall the pinned OpenShell version")).toBeTruthy();
+    expect(r.out.includes("Do not run `openshell self-update`")).toBeTruthy();
   });
 
   it("connect does not pre-start a duplicate port forward", () => {


### PR DESCRIPTION
## Summary
- document that NemoClaw-managed deployments should not upgrade or recreate OpenShell resources independently
- add recovery guidance to README, quickstart, and troubleshooting
- update the CLI incompatibility hint and lock it with a CLI test

## Verification
- ./node_modules/.bin/vitest run test/cli.test.js
- npm run typecheck:cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OpenShell version compatibility guidance, recovery workflow, and explicit warnings not to run manual OpenShell/NPM lifecycle commands on NemoClaw-managed deployments.

* **Bug Fixes**
  * Clarified user-facing guidance for incompatible OpenShell instances: back up workspace and rerun nemo﻿claw onboard to restore the expected runtime.

* **Tests**
  * Updated CLI tests to expect the revised compatibility guidance text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->