### PR TITLE
fix(security): warn on plaintext credential storage

### DIFF
--- a/bin/lib/credentials.js
+++ b/bin/lib/credentials.js
@@ -23,7 +23,25 @@ function normalizeCredentialValue(value) {
   return value.replace(/\r/g, "").trim();
 }
 
+let _credWarningShown = false;
+
+function warnPlaintextStorage() {
+  if (_credWarningShown) return;
+  if (process.env.NEMOCLAW_SUPPRESS_CREDENTIAL_WARNING === "1") return;
+  _credWarningShown = true;
+  console.warn(
+    "  \u26a0 Credentials stored as plaintext JSON at " + CREDS_FILE + " (mode 0600).\n" +
+    "    For sensitive deployments, set credentials via environment variables instead.\n" +
+    "    Suppress this warning: NEMOCLAW_SUPPRESS_CREDENTIAL_WARNING=1"
+  );
+}
+
+function getCredentialBackend() {
+  return "file";
+}
+
 function saveCredential(key, value) {
+  warnPlaintextStorage();
   fs.mkdirSync(CREDS_DIR, { recursive: true, mode: 0o700 });
   const creds = loadCredentials();
   creds[key] = normalizeCredentialValue(value);
@@ -262,6 +280,7 @@ module.exports = {
   normalizeCredentialValue,
   saveCredential,
   getCredential,
+  getCredentialBackend,
   prompt,
   ensureApiKey,
   ensureGithubToken,


### PR DESCRIPTION
## Summary

- Add one-time warning when `saveCredential()` writes plaintext JSON (CWE-522, NVBUG 6002816)
- Warning advises using environment variables for sensitive deployments
- Suppressible via `NEMOCLAW_SUPPRESS_CREDENTIAL_WARNING=1` (CI/automation friendly)
- Adds `getCredentialBackend()` stub returning `"file"` as extension point for future keychain support
- File permissions (0600/0700) already hardened in PR #864

## Test plan

- [ ] `nemoclaw onboard` — first `saveCredential` call shows plaintext warning once
- [ ] Second credential save in same session — no duplicate warning
- [ ] `NEMOCLAW_SUPPRESS_CREDENTIAL_WARNING=1 nemoclaw onboard` — no warning
- [ ] `getCredentialBackend()` returns `"file"`
- [ ] Existing credential tests pass (10 total)

Signed-off-by: Facundo Fernandez <facu.tha@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a one-time warning when credentials are saved to disk to alert users about plaintext storage. The warning can be suppressed via an environment variable if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->