### PR TITLE
fix(cli): guard classifyGatewayStatus against "Not connected"

### DIFF
--- a/src/lib/runtime-recovery.test.ts
+++ b/src/lib/runtime-recovery.test.ts
@@ -74,6 +74,9 @@ describe("runtime recovery helpers", () => {
     expect(classifyGatewayStatus("Gateway: nemoclaw\nStatus: Disconnected").state).toBe(
       "inactive",
     );
+    expect(classifyGatewayStatus("Gateway: nemoclaw\nStatus: Not connected").state).toBe(
+      "inactive",
+    );
   });
 
   it("only attempts gateway recovery when sandbox access is unavailable and gateway is down", () => {

--- a/src/lib/runtime-recovery.ts
+++ b/src/lib/runtime-recovery.ts
@@ -61,7 +61,7 @@ export function classifyGatewayStatus(output = ""): StateClassification {
   if (!clean) {
     return { state: "inactive", reason: "empty" };
   }
-  if (/\bConnected\b/i.test(clean) && !/\bDisconnected\b/i.test(clean)) {
+  if (/\bConnected\b/i.test(clean) && !/\bDisconnected\b/i.test(clean) && !/\bNot connected\b/i.test(clean)) {
     return { state: "connected", reason: "ok" };
   }
   if (


### PR DESCRIPTION
## Summary

- Add "Not connected" guard to `classifyGatewayStatus` regex so it correctly returns `inactive` instead of `connected`

## Related Issue

Closes #1279

## Changes

The regex `/\bConnected\b/i` matches "Status: Not connected" because "Connected" is a word boundary match and the existing `Disconnected` guard doesn't catch "Not connected". Added `/\bNot connected\b/i` exclusion to the condition.

Before: `"Status: Not connected"` → `connected`
After: `"Status: Not connected"` → `inactive`

Added regression test.

## Testing

- Existing test for "Connected" → connected still passes
- Existing test for "Disconnected" → inactive still passes
- New test for "Not connected" → inactive

## Checklist

- [x] Conventional commit format
- [x] Scoped to issue, no unrelated changes
- [x] No secrets or credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway status detection to correctly identify disconnected gateways, preventing misclassification of gateways displaying "Not connected" status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->