### PR TITLE
fix(cli): validate metadata.gatewayName type in normalizeSession

### DIFF
--- a/src/lib/onboard-session.test.ts
+++ b/src/lib/onboard-session.test.ts
@@ -172,6 +172,17 @@ describe("onboard session", () => {
     expect(loaded.metadata.token).toBeUndefined();
   });
 
+  it("drops non-string gatewayName during normalization", () => {
+    fs.mkdirSync(path.dirname(session.SESSION_FILE), { recursive: true });
+    fs.writeFileSync(
+      session.SESSION_FILE,
+      JSON.stringify({ version: 1, metadata: { gatewayName: 123 } }),
+    );
+    const loaded = session.loadSession();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.metadata.gatewayName).toBe("nemoclaw");
+  });
+
   it("returns null for corrupt session data", () => {
     fs.mkdirSync(path.dirname(session.SESSION_FILE), { recursive: true });
     fs.writeFileSync(session.SESSION_FILE, "not-json");

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -253,7 +253,9 @@ export function normalizeSession(data: unknown): Session | null {
     failure: sanitizeFailure(d.failure as Record<string, unknown> | null),
     metadata: isObject(d.metadata)
       ? ({
-          gatewayName: (d.metadata as Record<string, unknown>).gatewayName,
+          gatewayName: typeof (d.metadata as Record<string, unknown>).gatewayName === "string"
+            ? (d.metadata as Record<string, unknown>).gatewayName
+            : "nemoclaw",
           fromDockerfile: (d.metadata as Record<string, unknown>).fromDockerfile || null,
         } as SessionMetadata)
       : undefined,


### PR DESCRIPTION
## Summary

- Add `typeof` check for `gatewayName` in `normalizeSession` so non-string values are dropped

## Related Issue

Closes #1283

## Changes

In `src/lib/onboard-session.ts`, `normalizeSession` copies `metadata.gatewayName` without checking its type. A persisted payload like `{ "metadata": { "gatewayName": 123 } }` would pass through and `loadSession()` would return a Session where `metadata.gatewayName` is not a string.

Added `typeof ... === "string"` check. When gatewayName is not a string, metadata falls back to undefined and the default "nemoclaw" is used.

Added regression test for numeric gatewayName.

## Testing

- Existing session load/save tests pass
- New test: numeric gatewayName → drops to default

## Checklist

- [x] Conventional commit format
- [x] Scoped to issue, no unrelated changes
- [x] No secrets or credentials

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session normalization now enforces that gateway names are strings; invalid or non-string values are replaced with the default "nemoclaw", preventing corrupted persisted sessions and improving session reliability.

* **Tests**
  * Added test coverage to verify session normalization behavior when a persisted gateway name is non-string, ensuring future regressions are caught.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->