### PR TITLE
fix(security): pin NIM container images with sha256 digests

### DIFF
--- a/.github/workflows/docker-pin-check.yaml
+++ b/.github/workflows/docker-pin-check.yaml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Weekly check that the pinned Dockerfile base-image digest is still current.
-# Fails with an actionable message when a newer node:22-slim is available.
+# Weekly check that pinned container image digests are still current.
+# Fails with an actionable message when a newer image is available.
 
 name: docker-pin-check
 
@@ -28,3 +28,15 @@ jobs:
         run: |
           bash scripts/update-docker-pin.sh --check
           DOCKERFILE=Dockerfile.base bash scripts/update-docker-pin.sh --check
+
+      - name: Log in to nvcr.io
+        if: env.NVIDIA_API_KEY != ''
+        run: echo "$NVIDIA_API_KEY" | docker login nvcr.io --username '$oauthtoken' --password-stdin
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+
+      - name: Check NIM image pins
+        if: env.NVIDIA_API_KEY != ''
+        run: bash scripts/update-nim-pins.sh --check
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}

--- a/bin/lib/nim-images.json
+++ b/bin/lib/nim-images.json
@@ -2,7 +2,7 @@
   "models": [
     {
       "name": "nvidia/nemotron-3-super-120b-a12b",
-      "image": "nvcr.io/nim/nvidia/nemotron-3-super-120b-a12b:latest",
+      "image": "nvcr.io/nim/nvidia/nemotron-3-super-120b-a12b:latest@sha256:5bc19174d56df3efbdcc37b4fb0cb56aff66896c9a87667ceb2cb78053b3e743",
       "minGpuMemoryMB": 40960
     },
     {
@@ -12,12 +12,12 @@
     },
     {
       "name": "nvidia/llama-3.1-nemotron-70b-instruct",
-      "image": "nvcr.io/nim/nvidia/llama-3.1-nemotron-70b-instruct:latest",
+      "image": "nvcr.io/nim/nvidia/llama-3.1-nemotron-70b-instruct:latest@sha256:d0a77e5206ea97ac31d53ba689466cbaae0a668c6b06328d154360b61b486566",
       "minGpuMemoryMB": 81920
     },
     {
       "name": "nvidia/llama-3.3-nemotron-super-49b-v1",
-      "image": "nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1:latest",
+      "image": "nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1:latest@sha256:b5559886f370d2ec8dc6387ae36abdd95d69ce869c9872dd1f5897c560649801",
       "minGpuMemoryMB": 24576
     },
     {

--- a/scripts/update-nim-pins.sh
+++ b/scripts/update-nim-pins.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Updates the pinned sha256 digests for NIM container images in nim-images.json.
+# Queries nvcr.io for the current manifest digest of each image and rewrites
+# the image reference to include @sha256:<digest>.
+#
+# Requires: docker CLI authenticated to nvcr.io (docker login nvcr.io)
+#
+# Usage:
+#   scripts/update-nim-pins.sh            # update nim-images.json
+#   scripts/update-nim-pins.sh --check    # exit 0 if all pinned, 1 if any unpinned/stale
+
+set -euo pipefail
+
+case "${1:-}" in
+  "" | --check) ;;
+  *)
+    echo "Usage: scripts/update-nim-pins.sh [--check]" >&2
+    exit 2
+    ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+NIM_IMAGES="${REPO_ROOT}/bin/lib/nim-images.json"
+
+if [[ ! -f "$NIM_IMAGES" ]]; then
+  echo "ERROR: ${NIM_IMAGES} not found" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve the manifest digest for a single image:tag via docker manifest inspect
+# ---------------------------------------------------------------------------
+resolve_digest() {
+  local image_ref="$1"
+  local manifest digest
+
+  manifest=$(docker manifest inspect "$image_ref" 2>/dev/null) || {
+    echo ""
+    return
+  }
+
+  # Try single-arch manifest first (config.digest), then multi-arch (manifests[].digest for amd64)
+  digest=$(echo "$manifest" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if d.get('config', {}).get('digest'):
+        print(d['config']['digest'])
+    elif d.get('manifests'):
+        for m in d['manifests']:
+            if m.get('platform', {}).get('architecture') == 'amd64':
+                print(m['digest']); break
+except:
+    pass
+" 2>/dev/null)
+
+  echo "${digest:-}"
+}
+
+# ---------------------------------------------------------------------------
+# Extract the base image (without @sha256:...) from a full image reference
+# ---------------------------------------------------------------------------
+strip_digest() {
+  printf '%s' "${1%%@sha256:*}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+images=$(python3 -c "
+import json
+data = json.load(open('${NIM_IMAGES}'))
+for m in data['models']:
+    print(m['image'])
+")
+
+any_unpinned=0
+any_stale=0
+any_failed=0
+
+for full_ref in $images; do
+  base_ref=$(strip_digest "$full_ref")
+  current_digest=""
+
+  # Extract existing pinned digest if present
+  if [[ "$full_ref" == *"@sha256:"* ]]; then
+    current_digest="${full_ref##*@}"
+  fi
+
+  echo -n "  ${base_ref}: "
+
+  latest_digest=$(resolve_digest "$base_ref")
+
+  if [[ -z "$latest_digest" ]]; then
+    echo "SKIPPED (auth denied or image not found)"
+    any_failed=1
+    continue
+  fi
+
+  if [[ -z "$current_digest" ]]; then
+    echo "UNPINNED → ${latest_digest}"
+    any_unpinned=1
+  elif [[ "$current_digest" == "$latest_digest" ]]; then
+    echo "OK (${current_digest:0:19}...)"
+    continue
+  else
+    echo "STALE (${current_digest:0:19}... → ${latest_digest:0:19}...)"
+    any_stale=1
+  fi
+
+  if [[ "${1:-}" != "--check" ]]; then
+    # Update the image reference in nim-images.json
+    python3 -c "
+import json, sys
+data = json.load(open('${NIM_IMAGES}'))
+for m in data['models']:
+    stripped = m['image'].split('@')[0]
+    if stripped == '${base_ref}':
+        m['image'] = stripped + '@${latest_digest}'
+json.dump(data, open('${NIM_IMAGES}', 'w'), indent=2)
+print('')  # trailing newline
+" 2>/dev/null
+    # Ensure trailing newline
+    python3 -c "
+import pathlib
+p = pathlib.Path('${NIM_IMAGES}')
+t = p.read_text()
+if not t.endswith('\n'):
+    p.write_text(t + '\n')
+"
+  fi
+done
+
+if [[ "${1:-}" == "--check" ]]; then
+  if [[ $any_unpinned -ne 0 || $any_stale -ne 0 ]]; then
+    echo ""
+    echo "Some NIM images are unpinned or stale. Run:"
+    echo ""
+    echo "  scripts/update-nim-pins.sh"
+    echo ""
+    exit 1
+  fi
+  if [[ $any_failed -ne 0 ]]; then
+    echo ""
+    echo "WARNING: Some images could not be checked (auth denied). Ensure docker is logged in to nvcr.io."
+    # Don't fail CI for auth issues — the images we CAN check are pinned
+  fi
+  echo ""
+  echo "All checkable NIM images are pinned and up-to-date."
+  exit 0
+fi
+
+echo ""
+echo "Updated ${NIM_IMAGES} with current digests."
+if [[ $any_failed -ne 0 ]]; then
+  echo "WARNING: Some images were skipped due to auth/license issues. Accept licenses at https://ngc.nvidia.com and retry."
+fi

--- a/test/security-nim-image-pins.test.js
+++ b/test/security-nim-image-pins.test.js
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "module";
+import { describe, it, expect } from "vitest";
+
+const require = createRequire(import.meta.url);
+const nimImages = require("../bin/lib/nim-images.json");
+
+describe("NIM container image digest pinning", () => {
+  // TODO: remove this allowlist once NGC license acceptance is done for these images
+  const PENDING_LICENSE_ACCEPTANCE = new Set([
+    "nvcr.io/nim/nvidia/nemotron-3-nano:latest",
+    "nvcr.io/nim/meta/llama-3.1-8b-instruct:latest",
+  ]);
+
+  it("every NIM model image includes a @sha256: digest pin", () => {
+    const unpinned = nimImages.models
+      .filter((m) => !/@sha256:[a-f0-9]{64}/.test(m.image))
+      .filter((m) => !PENDING_LICENSE_ACCEPTANCE.has(m.image));
+
+    expect(
+      unpinned,
+      `Unpinned NIM images found:\n${unpinned.map((m) => `  ${m.image}`).join("\n")}\n\n` +
+        "Run: scripts/update-nim-pins.sh",
+    ).toEqual([]);
+  });
+
+  it("tracks images pending license acceptance", () => {
+    const stillPending = nimImages.models.filter((m) => PENDING_LICENSE_ACCEPTANCE.has(m.image));
+    if (stillPending.length === 0) {
+      throw new Error(
+        "All pending images are now pinned — remove PENDING_LICENSE_ACCEPTANCE allowlist",
+      );
+    }
+  });
+
+  it("all images reference nvcr.io", () => {
+    for (const m of nimImages.models) {
+      expect(m.image).toMatch(/^nvcr\.io\//);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

All 5 NIM model container images in `nim-images.json` used `:latest` tags without `@sha256:` digest pinning. These images are pulled and run with `--gpus all --shm-size 16g` — a substituted image would have full GPU access.

This PR pins 3 of 5 images with `@sha256:` digest pins. The remaining 2 (`nemotron-3-nano` and `meta/llama-3.1-8b-instruct`) require browser-based NGC license acceptance before their digests can be resolved.

## Changes

- **`bin/lib/nim-images.json`**: Add `@sha256:` digest pins to 3 images
- **`scripts/update-nim-pins.sh`**: New script to resolve and update NIM image digests from nvcr.io (follows `update-docker-pin.sh` pattern)
- **`.github/workflows/docker-pin-check.yaml`**: Extended weekly CI check to also verify NIM image pins (requires `NVIDIA_API_KEY` secret)
- **`test/security-nim-image-pins.test.js`**: Regression test ensuring all images have digest pins (allowlist for the 2 pending license acceptance)

## TODO

- [ ] Accept NGC licenses for remaining 2 images and pin them
- [ ] Configure `NVIDIA_API_KEY` repository secret for CI