### PR TITLE
fix(onboard): prevent API key plaintext exposure in retry prompt

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -572,16 +572,18 @@ async function promptValidationRecovery(label, recovery, credentialEnv = null, h
       .trim()
       .toLowerCase();
     // Guard against the user accidentally pasting an API key at this prompt.
-    // Tokens don't contain spaces; human sentences do — add !choice.includes(" ") to
-    // avoid false-positives on long typed sentences (e.g. 52-char help request).
-    if (
-      choice.startsWith("nvapi-") ||
-      choice.startsWith("ghp_") ||
-      (!choice.includes(" ") && choice.length > 40)
-    ) {
+    // Tokens don't contain spaces; human sentences do — the no-space + length check
+    // avoids false-positives on long typed sentences.
+    const API_KEY_PREFIXES = ["nvapi-", "ghp_", "gcm-", "sk-", "gpt-", "gemini-", "nvcf-"];
+    const looksLikeToken =
+      API_KEY_PREFIXES.some((p) => choice.startsWith(p)) ||
+      (!choice.includes(" ") && choice.length > 40) ||
+      // Regex fallback: base64-safe token pattern (20+ chars, no spaces, mixed alphanum)
+      /^[A-Za-z0-9_\-\.]{20,}$/.test(choice);
+    const validator = credentialEnv === "NVIDIA_API_KEY" ? validateNvidiaApiKeyValue : null;
+    if (looksLikeToken) {
       console.log("  ⚠️  That looks like an API key — do not paste credentials here.");
       console.log("  Treating as 'retry'. You will be prompted to enter the key securely.");
-      const validator = credentialEnv === "NVIDIA_API_KEY" ? validateNvidiaApiKeyValue : null;
       await replaceNamedCredential(credentialEnv, `${label} API key`, helpUrl, validator);
       return "credential";
     }
@@ -594,7 +596,6 @@ async function promptValidationRecovery(label, recovery, credentialEnv = null, h
       exitOnboardFromPrompt();
     }
     if (choice === "" || choice === "retry") {
-      const validator = credentialEnv === "NVIDIA_API_KEY" ? validateNvidiaApiKeyValue : null;
       await replaceNamedCredential(credentialEnv, `${label} API key`, helpUrl, validator);
       return "credential";
     }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -563,9 +563,22 @@ async function promptValidationRecovery(label, recovery, credentialEnv = null, h
     console.log(
       `  ${label} authorization failed. Re-enter the API key or choose a different provider/model.`,
     );
-    const choice = (await prompt("  Type 'retry', 'back', or 'exit' [retry]: ", { secret: true }))
+    console.log("  ⚠️  Do NOT paste your API key here — use the options below:");
+    const choice = (
+      await prompt("  Options: retry (re-enter key), back (change provider), exit [retry]: ", {
+        secret: true,
+      })
+    )
       .trim()
       .toLowerCase();
+    // Guard against the user accidentally pasting an API key at this prompt.
+    if (choice.startsWith("nvapi-") || choice.startsWith("ghp_") || choice.length > 40) {
+      console.log("  ⚠️  That looks like an API key — do not paste credentials here.");
+      console.log("  Treating as 'retry'. You will be prompted to enter the key securely.");
+      const validator = credentialEnv === "NVIDIA_API_KEY" ? validateNvidiaApiKeyValue : null;
+      await replaceNamedCredential(credentialEnv, `${label} API key`, helpUrl, validator);
+      return "credential";
+    }
     if (choice === "back") {
       console.log("  Returning to provider selection.");
       console.log("");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -572,7 +572,13 @@ async function promptValidationRecovery(label, recovery, credentialEnv = null, h
       .trim()
       .toLowerCase();
     // Guard against the user accidentally pasting an API key at this prompt.
-    if (choice.startsWith("nvapi-") || choice.startsWith("ghp_") || choice.length > 40) {
+    // Tokens don't contain spaces; human sentences do — add !choice.includes(" ") to
+    // avoid false-positives on long typed sentences (e.g. 52-char help request).
+    if (
+      choice.startsWith("nvapi-") ||
+      choice.startsWith("ghp_") ||
+      (!choice.includes(" ") && choice.length > 40)
+    ) {
       console.log("  ⚠️  That looks like an API key — do not paste credentials here.");
       console.log("  Treating as 'retry'. You will be prompted to enter the key securely.");
       const validator = credentialEnv === "NVIDIA_API_KEY" ? validateNvidiaApiKeyValue : null;

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -96,4 +96,19 @@ describe("credential exposure in process arguments", () => {
     expect(probeSrc).toMatch(/"--connect-timeout", "10"/);
     expect(probeSrc).toMatch(/"--max-time", "60"/);
   });
+
+  it("api-key paste-guard in credential recovery prompt uses space-aware heuristic", () => {
+    const src = fs.readFileSync(ONBOARD_JS, "utf-8");
+
+    // The guard must check for nvapi-/ghp_ prefixes AND a no-space+length check.
+    // It must NOT use a bare choice.length > 40 (false-positives on typed sentences).
+    expect(src).toMatch(/choice\.startsWith\("nvapi-"\)/);
+    expect(src).toMatch(/choice\.startsWith\("ghp_"\)/);
+    // Space-aware length check: !choice.includes(" ") && choice.length > 40
+    expect(src).toMatch(
+      /!choice\.includes\(" "\).*choice\.length > 40|choice\.length > 40.*!choice\.includes\(" "\)/,
+    );
+    // Must NOT use bare choice.length > 40 without the space guard
+    expect(src).not.toMatch(/\(choice\.length > 40\)/);
+  });
 });

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -106,13 +106,13 @@ describe("credential exposure in process arguments", () => {
     expect(src).toMatch(/"ghp_"/);
     // Space-aware length check must be present
     expect(src).toMatch(/!choice\.includes\(" "\).*choice\.length > 40/);
-    // Regex fallback for base64-safe tokens must be present
-    expect(src).toMatch(/\/\^\[A-Za-z0-9/);
-    // Validator must be hoisted (defined once, not inside both branches)
+    // Regex fallback for base64-safe tokens must be present (full shape)
+    expect(src).toMatch(/\/\^\[A-Za-z0-9_\\-\\.\]\{20,\}\$\/\.test\(choice\)/);
+    // Validator must be hoisted (defined exactly once, not inside both branches)
     const validatorCount = (
       src.match(/const validator = credentialEnv === "NVIDIA_API_KEY"/g) || []
     ).length;
-    expect(validatorCount).toBeLessThanOrEqual(1);
+    expect(validatorCount).toBe(1);
     // looksLikeToken variable must exist
     expect(src).toMatch(/looksLikeToken/);
   });

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -97,18 +97,23 @@ describe("credential exposure in process arguments", () => {
     expect(probeSrc).toMatch(/"--max-time", "60"/);
   });
 
-  it("api-key paste-guard in credential recovery prompt uses space-aware heuristic", () => {
+  it("api-key paste-guard uses extensible prefix list and regex fallback", () => {
     const src = fs.readFileSync(ONBOARD_JS, "utf-8");
 
-    // The guard must check for nvapi-/ghp_ prefixes AND a no-space+length check.
-    // It must NOT use a bare choice.length > 40 (false-positives on typed sentences).
-    expect(src).toMatch(/choice\.startsWith\("nvapi-"\)/);
-    expect(src).toMatch(/choice\.startsWith\("ghp_"\)/);
-    // Space-aware length check: !choice.includes(" ") && choice.length > 40
-    expect(src).toMatch(
-      /!choice\.includes\(" "\).*choice\.length > 40|choice\.length > 40.*!choice\.includes\(" "\)/,
-    );
-    // Must NOT use bare choice.length > 40 without the space guard
-    expect(src).not.toMatch(/\(choice\.length > 40\)/);
+    // Known prefix list must include at least NVIDIA and GitHub prefixes
+    expect(src).toMatch(/API_KEY_PREFIXES/);
+    expect(src).toMatch(/"nvapi-"/);
+    expect(src).toMatch(/"ghp_"/);
+    // Space-aware length check must be present
+    expect(src).toMatch(/!choice\.includes\(" "\).*choice\.length > 40/);
+    // Regex fallback for base64-safe tokens must be present
+    expect(src).toMatch(/\/\^\[A-Za-z0-9/);
+    // Validator must be hoisted (defined once, not inside both branches)
+    const validatorCount = (
+      src.match(/const validator = credentialEnv === "NVIDIA_API_KEY"/g) || []
+    ).length;
+    expect(validatorCount).toBeLessThanOrEqual(1);
+    // looksLikeToken variable must exist
+    expect(src).toMatch(/looksLikeToken/);
   });
 });

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -9,6 +9,11 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
+const CREDENTIAL_RETRY_PROMPT =
+  "  Options: retry (re-enter key), back (change provider), exit [retry]: ";
+const CREDENTIAL_RETRY_PROMPT_RE =
+  /Options: retry \(re-enter key\), back \(change provider\), exit \[retry\]: /;
+
 function writeOpenAiStyleAuthRetryCurl(fakeBin, goodToken, models = ["gpt-5.4"]) {
   fs.writeFileSync(
     path.join(fakeBin, "curl"),
@@ -2180,19 +2185,87 @@ const { setupNim } = require(${onboardPath});
       payload.messages.filter((message) => /Choose model \[1\]/.test(message)).length,
       1,
     );
-    assert.ok(
-      payload.messages.some((message) =>
-        /Type 'retry', 'back', or 'exit' \[retry\]: /.test(message),
-      ),
-    );
-    const retryPrompt = payload.prompts.find((entry) =>
-      /Type 'retry', 'back', or 'exit' \[retry\]: /.test(entry.message),
-    );
+    assert.ok(payload.messages.some((message) => CREDENTIAL_RETRY_PROMPT_RE.test(message)));
+    const retryPrompt = payload.prompts.find((entry) => CREDENTIAL_RETRY_PROMPT_RE.test(entry.message));
     assert.deepEqual(retryPrompt, {
-      message: "  Type 'retry', 'back', or 'exit' [retry]: ",
+      message: CREDENTIAL_RETRY_PROMPT,
       secret: true,
     });
     assert.ok(payload.messages.some((message) => /NVIDIA Endpoints API key: /.test(message)));
+  });
+
+  it("treats a pasted NVIDIA API key at the retry prompt as retry and re-prompts securely", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-nvidia-paste-guard-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "nvidia-paste-guard-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    writeOpenAiStyleAuthRetryCurl(fakeBin, "nvapi-good", ["nim/meta/llama-3.1-70b-instruct"]);
+
+    const script = String.raw`
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+
+const answers = ["1", "", "nvapi-fake-key-value", "nvapi-good", ""];
+const messages = [];
+
+credentials.prompt = async (message) => {
+  messages.push(message);
+  return answers.shift() || "";
+};
+runner.runCapture = () => "";
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  process.env.NVIDIA_API_KEY = "nvapi-bad";
+  const originalLog = console.log;
+  const originalError = console.error;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  console.error = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim(null);
+    originalLog(JSON.stringify({ result, messages, lines, key: process.env.NVIDIA_API_KEY }));
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.equal(payload.result.provider, "nvidia-prod");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
+    assert.equal(payload.key, "nvapi-good");
+    assert.ok(payload.lines.some((line) => line.includes("That looks like an API key")));
+    assert.ok(payload.lines.some((line) => line.includes("Treating as 'retry'")));
+    assert.ok(payload.messages.some((message) => CREDENTIAL_RETRY_PROMPT_RE.test(message)));
+    assert.ok(payload.messages.some((message) => /NVIDIA Endpoints API key: /.test(message)));
+    assert.equal(payload.messages.filter((message) => /Choose \[/.test(message)).length, 1);
+    assert.equal(
+      payload.messages.filter((message) => /Choose model \[1\]/.test(message)).length,
+      1,
+    );
   });
 
   it("lets users re-enter an OpenAI API key after authorization failure", () => {
@@ -2260,11 +2333,7 @@ const { setupNim } = require(${onboardPath});
     assert.equal(payload.result.preferredInferenceApi, "openai-responses");
     assert.equal(payload.key, "sk-good");
     assert.ok(payload.lines.some((line) => line.includes("OpenAI authorization failed")));
-    assert.ok(
-      payload.messages.some((message) =>
-        /Type 'retry', 'back', or 'exit' \[retry\]: /.test(message),
-      ),
-    );
+    assert.ok(payload.messages.some((message) => CREDENTIAL_RETRY_PROMPT_RE.test(message)));
     assert.ok(payload.messages.some((message) => /OpenAI API key: /.test(message)));
     assert.equal(payload.messages.filter((message) => /Choose \[/.test(message)).length, 1);
     assert.equal(
@@ -2338,11 +2407,7 @@ const { setupNim } = require(${onboardPath});
     assert.equal(payload.result.preferredInferenceApi, "anthropic-messages");
     assert.equal(payload.key, "anthropic-good");
     assert.ok(payload.lines.some((line) => line.includes("Anthropic authorization failed")));
-    assert.ok(
-      payload.messages.some((message) =>
-        /Type 'retry', 'back', or 'exit' \[retry\]: /.test(message),
-      ),
-    );
+    assert.ok(payload.messages.some((message) => CREDENTIAL_RETRY_PROMPT_RE.test(message)));
     assert.ok(payload.messages.some((message) => /Anthropic API key: /.test(message)));
     assert.equal(payload.messages.filter((message) => /Choose \[/.test(message)).length, 1);
     assert.equal(
@@ -2416,11 +2481,7 @@ const { setupNim } = require(${onboardPath});
     assert.equal(payload.result.preferredInferenceApi, "openai-completions");
     assert.equal(payload.key, "gemini-good");
     assert.ok(payload.lines.some((line) => line.includes("Google Gemini authorization failed")));
-    assert.ok(
-      payload.messages.some((message) =>
-        /Type 'retry', 'back', or 'exit' \[retry\]: /.test(message),
-      ),
-    );
+    assert.ok(payload.messages.some((message) => CREDENTIAL_RETRY_PROMPT_RE.test(message)));
     assert.ok(payload.messages.some((message) => /Google Gemini API key: /.test(message)));
     assert.equal(payload.messages.filter((message) => /Choose \[/.test(message)).length, 1);
     assert.equal(
@@ -2501,11 +2562,7 @@ const { setupNim } = require(${onboardPath});
         line.includes("Other OpenAI-compatible endpoint authorization failed"),
       ),
     );
-    assert.ok(
-      payload.messages.some((message) =>
-        /Type 'retry', 'back', or 'exit' \[retry\]: /.test(message),
-      ),
-    );
+    assert.ok(payload.messages.some((message) => CREDENTIAL_RETRY_PROMPT_RE.test(message)));
     assert.ok(
       payload.messages.some((message) =>
         /Other OpenAI-compatible endpoint API key: /.test(message),
@@ -2595,11 +2652,7 @@ const { setupNim } = require(${onboardPath});
         line.includes("Other Anthropic-compatible endpoint authorization failed"),
       ),
     );
-    assert.ok(
-      payload.messages.some((message) =>
-        /Type 'retry', 'back', or 'exit' \[retry\]: /.test(message),
-      ),
-    );
+    assert.ok(payload.messages.some((message) => CREDENTIAL_RETRY_PROMPT_RE.test(message)));
     assert.ok(
       payload.messages.some((message) =>
         /Other Anthropic-compatible endpoint API key: /.test(message),


### PR DESCRIPTION
## Summary

Fixes #1251.

After an invalid API key during NVIDIA Endpoints onboarding, the CLI showed:
```
Type 'retry', 'back', or 'exit' [retry]:
```
Users interpreted this as a place to re-enter their key and pasted it in plaintext (visible in terminal history).

## Changes

1. **Visible warning** — adds `⚠️ Do NOT paste your API key here` before the prompt
2. **Clearer prompt text** — `Options: retry (re-enter key), back (change provider), exit`
3. **Accidental paste guard** — detects if the user pastes a credential-shaped string (`nvapi-`, `ghp_`, or >40 chars), warns them, and redirects to the secure `replaceNamedCredential` flow

## Before / After

**Before:**
```
NVIDIA authorization failed. Re-enter the API key or choose a different provider/model.
  Type 'retry', 'back', or 'exit' [retry]: nvapi-abc123...   ← key pasted here in plaintext
```

**After:**
```
NVIDIA authorization failed. Re-enter the API key or choose a different provider/model.
  ⚠️  Do NOT paste your API key here — use the options below:
  Options: retry (re-enter key), back (change provider), exit [retry]:
```

Signed-off-by: Benedikt Schackenberg <6381261+BenediktSchackenberg@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified the credential-recovery prompt wording for clearer option presentation.
  * Improved detection of accidental API-key pastes (checks common prefixes, long space-free inputs, and token-like patterns) and forces secure credential re-entry when triggered.

* **Tests**
  * Added a regression test to ensure the paste-detection heuristic is space-aware, prefix-aware, and stable across branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->