### PR TITLE
fix(onboard): increase gateway health-poll window and preserve state on first retry

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1926,9 +1926,11 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
   }
 
   // Retry gateway start with exponential backoff. On some hosts (Horde VMs,
-  // first-run environments) the embedded k3s needs more time than OpenShell's
-  // internal health-check window allows. Retrying after a clean destroy lets
-  // the second attempt benefit from cached images and cleaner cgroup state.
+  // first-run environments, Colima on macOS) the embedded k3s needs more time
+  // than OpenShell's internal health-check window allows.
+  //
+  // The first retry keeps the existing gateway (to preserve cached images and
+  // k3s state); only subsequent retries destroy and recreate.
   // See: https://github.com/NVIDIA/OpenShell/issues/433
   const retries = exitOnFailure ? 2 : 0;
   try {
@@ -1936,8 +1938,8 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
       () => {
         runOpenshell(["gateway", "start", ...gwArgs], { ignoreError: true, env: gatewayEnv });
 
-        const healthPollCount = envInt("NEMOCLAW_HEALTH_POLL_COUNT", 5);
-        const healthPollInterval = envInt("NEMOCLAW_HEALTH_POLL_INTERVAL", 2);
+        const healthPollCount = envInt("NEMOCLAW_HEALTH_POLL_COUNT", 30);
+        const healthPollInterval = envInt("NEMOCLAW_HEALTH_POLL_INTERVAL", 5);
         for (let i = 0; i < healthPollCount; i++) {
           const status = runCaptureOpenshell(["status"], { ignoreError: true });
           const namedInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], {
@@ -1947,7 +1949,12 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
           if (isGatewayHealthy(status, namedInfo, currentInfo)) {
             return; // success
           }
-          if (i < healthPollCount - 1) sleep(healthPollInterval);
+          if (i < healthPollCount - 1) {
+            if (i === 0) {
+              console.log("  Waiting for gateway to become healthy...");
+            }
+            sleep(healthPollInterval);
+          }
         }
 
         throw new Error("Gateway failed to start");
@@ -1960,7 +1967,10 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
           console.log(
             `  Gateway start attempt ${err.attemptNumber} failed. ${err.retriesLeft} retries left...`,
           );
-          if (err.retriesLeft > 0 && exitOnFailure) {
+          // First retry: keep the gateway to preserve cached images and k3s
+          // cluster state. Only destroy on subsequent retries when a cold
+          // restart is genuinely needed.
+          if (err.retriesLeft > 0 && exitOnFailure && err.attemptNumber > 1) {
             destroyGateway();
           }
         },

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1648,7 +1648,7 @@ async function ensureNamedCredential(envName, label, helpUrl = null) {
   return replaceNamedCredential(envName, label, helpUrl);
 }
 
-function waitForSandboxReady(sandboxName, attempts = 10, delaySeconds = 2) {
+function waitForSandboxReady(sandboxName, attempts = 15, delaySeconds = 4) {
   for (let i = 0; i < attempts; i += 1) {
     const podPhase = runCaptureOpenshell(
       [
@@ -3129,37 +3129,30 @@ async function _setupPolicies(sandboxName) {
       process.exit(1);
     }
 
-    if (answer.toLowerCase() === "list") {
-      // Let user pick
-      const picks = await prompt("  Enter preset names (comma-separated): ");
-      const selected = picks
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-      for (const name of selected) {
+    const presetsToApply =
+      answer.toLowerCase() === "list"
+        ? (await prompt("  Enter preset names (comma-separated): "))
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : suggestions;
+
+    for (const name of presetsToApply) {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
         try {
           policies.applyPreset(sandboxName, name);
+          break;
         } catch (err) {
           const message = err && err.message ? err.message : String(err);
           if (message.includes("Unimplemented")) {
             console.error("  OpenShell policy updates are not supported by this gateway build.");
             console.error("  This is a known issue tracked in NemoClaw #536.");
+            throw err;
           }
-          throw err;
-        }
-      }
-    } else {
-      // Apply suggested
-      for (const name of suggestions) {
-        try {
-          policies.applyPreset(sandboxName, name);
-        } catch (err) {
-          const message = err && err.message ? err.message : String(err);
-          if (message.includes("Unimplemented")) {
-            console.error("  OpenShell policy updates are not supported by this gateway build.");
-            console.error("  This is a known issue tracked in NemoClaw #536.");
+          if (!message.includes("sandbox not found") || attempt === 2) {
+            throw err;
           }
-          throw err;
+          sleep(2);
         }
       }
     }

--- a/bin/lib/policies.js
+++ b/bin/lib/policies.js
@@ -255,7 +255,12 @@ function applyPreset(sandboxName, presetName) {
   fs.writeFileSync(tmpFile, merged, { encoding: "utf-8", mode: 0o600 });
 
   try {
-    run(buildPolicySetCommand(tmpFile, sandboxName));
+    const result = run(buildPolicySetCommand(tmpFile, sandboxName), { ignoreError: true });
+    if (result.status !== 0) {
+      const stderr = (result.stderr || "").toString();
+      const errMsg = stderr || `exit code ${result.status}`;
+      throw new Error(errMsg);
+    }
 
     console.log(`  Applied preset: ${presetName}`);
   } finally {


### PR DESCRIPTION
## Summary

- Raise default gateway health-poll from `5 × 2 s = 10 s` to `30 × 5 s ≈ 2.5 min` (still overridable via `NEMOCLAW_HEALTH_POLL_COUNT` / `NEMOCLAW_HEALTH_POLL_INTERVAL`)
- Skip `destroyGateway()` on the first retry to preserve cached images and k3s cluster state; only destroy on subsequent retries
- Print a "Waiting for gateway to become healthy..." message during the poll so the user knows the process is not stuck

Refs: #446

## Root Cause

On first-run or resource-constrained environments the embedded k3s inside the OpenShell gateway can take 30–90 s to become fully healthy after `openshell gateway start` returns. The current 10 s health-poll window expires, triggering a retry that calls `destroyGateway()` — which removes Docker volumes and wipes cached images. The next attempt is therefore a cold start that is even slower, creating a timeout loop that never converges.

The code comment on line 1925 notes that retrying "lets the second attempt benefit from cached images", but `destroyGateway()` deletes those cached images, contradicting the stated intent.

## Changes

**`bin/lib/onboard.js`**
- Default `NEMOCLAW_HEALTH_POLL_COUNT`: `5` → `30`
- Default `NEMOCLAW_HEALTH_POLL_INTERVAL`: `2` → `5`
- `onFailedAttempt`: only call `destroyGateway()` when `attemptNumber > 1`
- Print status message on first poll iteration

## Testing

- Code-level analysis of the retry path; the env var override mechanism is unchanged
- Not verified on a natively supported platform (Linux / Apple Silicon) — tested through a Docker-wrapped openshell on macOS Intel + Colima where the gateway consistently needed > 10 s to become healthy
- Existing `test/gateway-cleanup.test.js` assertions still hold (`destroyGateway()` is still present in the function block, just conditionally gated)

## Test plan

- [ ] Verify on Linux (native Docker) that the happy path is unaffected (gateway starts in < 10 s, no extra wait)
- [ ] Verify on a slow first-run environment that the extended poll window avoids the destroy-rebuild loop
- [ ] Confirm `NEMOCLAW_HEALTH_POLL_COUNT=5 NEMOCLAW_HEALTH_POLL_INTERVAL=2` restores the old behavior

Signed-off-by: Tommy Lin <tommylin@signalpro.com.tw>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a one-time status message while waiting for the gateway to become healthy.
  * Unified interactive policy preset flow with per-preset retry (up to 3 attempts) for transient failures.
  * Clearer, explicit error reporting when applying policy presets fails.

* **Bug Fixes**
  * Increased readiness and startup polling windows for more robust startup on slow environments.
  * Improved startup recovery to preserve gateway state on the first retry attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->