### PR TITLE
fix(onboard): skip gateway destroy on stale detection to preserve metadata

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1905,8 +1905,12 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
     return;
   }
 
+  // When a stale gateway is detected (metadata exists but container is gone,
+  // e.g. after a Docker/Colima restart), skip the destroy — `gateway start`
+  // can recover the container without wiping metadata and mTLS certs.
+  // The retry loop below will destroy only if start genuinely fails.
   if (hasStaleGateway(gwInfo)) {
-    runOpenshell(["gateway", "destroy", "-g", GATEWAY_NAME], { ignoreError: true });
+    console.log("  Stale gateway detected — attempting restart without destroy...");
   }
 
   const gwArgs = ["--name", GATEWAY_NAME];

--- a/test/gateway-cleanup.test.js
+++ b/test/gateway-cleanup.test.js
@@ -25,12 +25,10 @@ describe("gateway cleanup: Docker volumes removed on failure (#17)", () => {
     expect(startGwBlock).toBeTruthy();
 
     // Current behavior:
-    // 1. stale gateway metadata is destroyed directly before start, if present
-    // 2. destroyGateway() runs inside the retry loop on each failed attempt
+    // 1. stale gateway is detected but NOT destroyed upfront — gateway start
+    //    can recover the container without wiping metadata/certs
+    // 2. destroyGateway() runs inside the retry loop only on genuine failure
     expect(startGwBlock[0].includes("if (hasStaleGateway(gwInfo))")).toBe(true);
-    expect(
-      startGwBlock[0].includes('runOpenshell(["gateway", "destroy", "-g", GATEWAY_NAME]'),
-    ).toBe(true);
     expect(startGwBlock[0]).toContain("destroyGateway()");
   });
 


### PR DESCRIPTION
## Problem

When `nemoclaw onboard` detects a "stale" gateway (metadata exists but the
container is gone — e.g. after a Docker/Colima restart), it calls
`openshell gateway destroy` before attempting `gateway start`.  This wipes
`metadata.json`, `active_gateway`, and mTLS certs, forcing a full
re-onboard even though `gateway start` alone can recover the container.

**Root cause:** `startGatewayWithOptions()` at `bin/lib/onboard.js:1908`
unconditionally destroys on `hasStaleGateway()` — but "stale" here only
means the container is gone, not that the metadata is corrupt.

## Solution

Replace the upfront `gateway destroy` with an informational log message.
The existing retry loop (`onFailedAttempt` at line 1968) already calls
`destroyGateway()` on genuine start failures after the first attempt, so
corrupted state is still handled.

### Before
```
stale detected → destroy → start (metadata gone, must re-onboard)
```

### After
```
stale detected → start (metadata preserved, gateway recovers)
         ↓ if start fails
    retry loop → destroy → start (fallback still works)
```

## Test plan

- [x] Updated `test/gateway-cleanup.test.js` to match new behavior
- [x] `test/onboard-readiness.test.js` `hasStaleGateway` tests unchanged and passing
- [ ] Manual: stop Colima, restart, run `nemoclaw onboard` — gateway recovers without wiping metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced gateway restart behavior to prioritize recovery attempts over immediate destruction when encountering stale instances, improving system stability and reducing unnecessary service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->