### PR TITLE
fix(policy): convert npm_registry from access: full to REST GET-only

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -151,13 +151,18 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/openclaw }
 
-  # npm registry — needed for `openclaw plugins install` and `npm install`
+  # npm registry — needed for `openclaw plugins install` and `npm install`.
+  # Read-only: agents only fetch packages, never publish.
   npm_registry:
     name: npm_registry
     endpoints:
       - host: registry.npmjs.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/npm }


### PR DESCRIPTION
## Summary

- Replace L4 pass-through (`access: full`) on `npm_registry` endpoint with L7-enforced REST policy restricted to `GET /**`
- Agents only fetch packages from the npm registry and never publish, so write methods are not needed
- Enables per-request rule evaluation, per-request logging, and SecretResolver credential injection

## Motivation

- Issue #1111 called out converting `npm_registry` alongside the GitHub endpoints
- Discussed and agreed upon during review of PR #1225 but deferred to keep that PR scoped
- CodeRabbit filed #1355 to track this follow-up

## Test plan

- [ ] Verify `openclaw plugins install` succeeds with GET-only policy
- [ ] Verify `npm install` inside sandbox completes normally
- [ ] Confirm write attempts (e.g. `npm publish`) are blocked by the policy

Closes #1355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Enforced REST/TLS access for the npm registry and terminated TLS at the gateway for stricter transport handling.
  * Replaced broad/full access with an allowlist limiting registry interactions to read-only package fetches (HTTP GET).
  * Updated registry policy description to clearly state enforced, read-only access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->