### PR TITLE
fix(docs): ignore HTML comments in doc link check

### DIFF
--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -224,6 +224,7 @@ extract_targets() {
   perl -CS -ne '
     if (/^\s*```/) { $in = !$in; next; }
     next if $in;
+    next if /^\s*<!--/ .. /-->\s*$/;
     while (/\!?\[[^\]]*\]\(([^)\s]+)(?:\s+["'"'"'][^)"'"'"']*["'"'"'])?\)/g) { print "$1\n"; }
     while (/<(https?:[^>\s]+)>/g) { print "$1\n"; }
   ' -- "$1"

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -220,14 +220,27 @@ collect_default_docs() {
   fi
 }
 
+strip_html_comments() {
+  perl -CS -0pe '
+    my $copy = $_;
+    $copy =~ s/```.*?```//gs;
+    my $comment = qr/<!--.*?-->/s;
+    my $stripped = $copy;
+    $stripped =~ s/$comment//g;
+    if ($stripped =~ /<!--|-->/) {
+      die "malformed HTML comment";
+    }
+    s/$comment//g;
+  ' -- "$1"
+}
+
 extract_targets() {
-  perl -CS -ne '
+  strip_html_comments "$1" | perl -CS -ne '
     if (/^\s*```/) { $in = !$in; next; }
     next if $in;
-    next if /^\s*<!--/ .. /-->\s*$/;
     while (/\!?\[[^\]]*\]\(([^)\s]+)(?:\s+["'"'"'][^)"'"'"']*["'"'"'])?\)/g) { print "$1\n"; }
     while (/<(https?:[^>\s]+)>/g) { print "$1\n"; }
-  ' -- "$1"
+  '
 }
 
 check_local_ref() {
@@ -369,6 +382,15 @@ run_links_check() {
       continue
     fi
     local target rc
+    local _targets_output _targets_err
+    _targets_err="$(mktemp)"
+    if ! _targets_output="$(extract_targets "$md" 2>"$_targets_err")"; then
+      echo "check-docs: [links] malformed HTML comment in $md: $(tr '\n' ' ' <"$_targets_err" | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')" >&2
+      rm -f "$_targets_err"
+      failures=1
+      continue
+    fi
+    rm -f "$_targets_err"
     while IFS= read -r target || [[ -n "$target" ]]; do
       [[ -z "$target" ]] && continue
       set +e
@@ -382,7 +404,7 @@ run_links_check() {
       else
         failures=1
       fi
-    done < <(extract_targets "$md")
+    done <<<"$_targets_output"
   done
 
   if [[ "$failures" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Ignore HTML comment blocks when extracting Markdown link targets in the documentation checker. This prevents false-positive “unreachable URL” failures in CI when a URL is intentionally commented out in a Markdown file.

## Changes

- Update `test/e2e/e2e-cloud-experimental/check-docs.sh`
- Skip content inside `<!-- ... -->` blocks during link extraction
- Preserve existing link validation behavior for normal Markdown content

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes

- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---

Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation link validation to skip HTML comment blocks and avoid false positives.
  * Detects and reports malformed HTML comments in Markdown files, marking the check as failed and skipping further processing for affected files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->