### PR TITLE
fix(install): always show source hint to cover stale hash on upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -423,22 +423,15 @@ ensure_nemoclaw_shim() {
   return 0
 }
 
-# Detect whether the installer had to extend PATH beyond what the user's
-# original shell had.  When running via `curl | bash`, PATH changes made
-# inside the script do not survive the script's exit, so the parent shell
-# still cannot resolve `nemoclaw`.
+# Detect whether the parent shell likely needs a reload after install.
+# When running via `curl | bash`, the installer executes in a subprocess.
+# Even when the bin directory is already in PATH, the parent shell may have
+# stale bash hash-table entries pointing to a previously deleted binary
+# (e.g. upgrade/reinstall after `rm $(which nemoclaw)`).  Sourcing the
+# shell profile reassigns PATH which clears the hash table, so we always
+# recommend it when the installer verified nemoclaw in the subprocess.
 needs_shell_reload() {
   [[ "$NEMOCLAW_READY_NOW" != true ]] && return 1
-
-  local npm_bin
-  npm_bin="$(npm config get prefix 2>/dev/null)/bin" || true
-
-  if [[ ":$ORIGINAL_PATH:" == *":$NEMOCLAW_SHIM_DIR:"* ]]; then
-    return 1
-  fi
-  if [[ -n "$npm_bin" && ":$ORIGINAL_PATH:" == *":$npm_bin:"* ]]; then
-    return 1
-  fi
   return 0
 }
 

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -772,7 +772,7 @@ exit 0
     expect(`${result.stdout}${result.stderr}`).toMatch(/Created user-local shim/);
   });
 
-  it("does not print PATH recovery instructions when nemoclaw is already usable in this shell", () => {
+  it("shows source hint even when bin dir is already in PATH (stale hash protection)", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-ready-shell-"));
     const fakeBin = path.join(tmp, "bin");
     const prefix = path.join(tmp, "prefix");
@@ -889,7 +889,9 @@ exit 0
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status).toBe(0);
     expect(output).not.toMatch(/current shell cannot resolve 'nemoclaw'/);
-    expect(output).not.toMatch(/source .*\.bashrc|source .*\.zshrc|source .*\.profile/);
+    // Always show source hint — the parent shell may have stale hash-table
+    // entries after an upgrade/reinstall even when the dir is in PATH.
+    expect(output).toMatch(/\$ source /);
   });
 
   it("shows shell reload hint when PATH was extended by the installer", () => {


### PR DESCRIPTION
## Summary

- Follow-up to #1228 — fixes the edge case where `needs_shell_reload()` skipped the `source` hint on upgrade/reinstall because the bin directory was already in `ORIGINAL_PATH`
- On upgrade, the parent shell's bash hash table may still point to a deleted old binary path, causing `nemoclaw: command not found` even though `~/.local/bin` is on PATH
- Fix: always show the `source <profile>` hint when the installer verifies nemoclaw in its subprocess — sourcing reassigns PATH which clears the stale hash table

## Root cause

`verify_nemoclaw()` runs `command -v nemoclaw` inside the installer subprocess (which has a fresh hash table) and sets `NEMOCLAW_READY_NOW=true`. Then `needs_shell_reload()` returned early with "no reload needed" when the bin directory was in `ORIGINAL_PATH`. But the **parent shell** still has a stale `hash` entry from the previous installation pointing to the now-deleted binary.

Reported by @hulynn in https://github.com/NVIDIA/NemoClaw/issues/1177#issuecomment-4176410621.

## Changes

- `install.sh`: simplified `needs_shell_reload()` to always return true when `NEMOCLAW_READY_NOW` is set — the extra `source` line is harmless and covers both fresh installs and upgrades
- `test/install-preflight.test.js`: updated the "bin dir already in PATH" test to expect the source hint instead of asserting its absence

## Test plan

- [x] `npm test` — all 907 tests pass
- [x] `make check` — all pre-commit hooks pass
- [ ] Manual: fresh install on Ubuntu VM via `curl | bash` — source hint shown
- [ ] Manual: upgrade scenario (`rm $(which nemoclaw)` then reinstall) — source hint shown

Closes https://github.com/NVIDIA/NemoClaw/issues/1177

Signed-off-by: Aaron Erickson <ericksoa@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now consistently recommends reloading your shell after installation to ensure newly installed commands are properly recognized and available in your environment, providing more reliable command resolution across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->