### PR TITLE
fix(install): update SCRIPT_DIR after clone and guard usage-notice

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -240,6 +240,11 @@ usage() {
 }
 
 show_usage_notice() {
+  if [[ ! -f "${SCRIPT_DIR}/bin/lib/usage-notice.js" ]]; then
+    # usage-notice.js may not exist when the cloned release tag predates the
+    # feature.  Skip gracefully so the installer can still complete.
+    return 0
+  fi
   local -a notice_cmd=(node "${SCRIPT_DIR}/bin/lib/usage-notice.js")
   if [ "${NON_INTERACTIVE:-}" = "1" ]; then
     notice_cmd+=(--non-interactive)
@@ -774,6 +779,7 @@ install_nemoclaw() {
     spin "Building NemoClaw CLI modules" npm run --if-present build:cli
     spin "Building NemoClaw plugin" bash -c 'cd nemoclaw && npm install --ignore-scripts && npm run build'
     spin "Linking NemoClaw CLI" npm link
+    SCRIPT_DIR="$(pwd)"
   else
     info "Installing NemoClaw from GitHub…"
     # Resolve the latest release tag so we never install raw main.
@@ -801,6 +807,7 @@ install_nemoclaw() {
     spin "Building NemoClaw CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"
     spin "Building NemoClaw plugin" bash -c "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
     spin "Linking NemoClaw CLI" bash -c "cd \"$nemoclaw_src\" && npm link"
+    SCRIPT_DIR="$nemoclaw_src"
   fi
 
   refresh_path


### PR DESCRIPTION
## Summary

- Update `SCRIPT_DIR` to the cloned source directory after the link step in both local-source and GitHub-clone install paths
- Guard `show_usage_notice()` against `usage-notice.js` not existing in the cloned source

## Root Cause

When piped via `curl | bash`, `BASH_SOURCE[0]` is empty and `$0` is `bash`, so:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
```

resolves to the user's cwd (e.g. `/home/u`), not the NemoClaw source. After cloning to `~/.nemoclaw/source`, `SCRIPT_DIR` was never updated, so `show_usage_notice()` looked for `usage-notice.js` in the wrong directory.

Additionally, the `latest` tag currently points to `b999c0e` which predates the `usage-notice.js` addition in #1290. Even with the correct `SCRIPT_DIR`, the file won't exist until the tag is moved forward.

## Test plan

Tested in Docker (Ubuntu 24.04, clean install, piped via `cat install.sh | bash`):

- [x] **Unpatched**: `Cannot find module '/home/testuser/bin/lib/usage-notice.js'` (wrong path)
- [x] **SCRIPT_DIR fix only**: Correct path but file missing due to stale `latest` tag
- [x] **Both fixes**: Installer completes through to `nemoclaw onboard` successfully

Closes #1373
Closes #1381

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability by ensuring script paths correctly resolve to their source locations during both local and GitHub-based installations.
  * Enhanced installation robustness with better handling of potentially missing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->