### PR TITLE
fix(installer): resolve usage notice helper for piped installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -241,7 +241,11 @@ usage() {
 
 show_usage_notice() {
   local source_root="${NEMOCLAW_SOURCE_ROOT:-$SCRIPT_DIR}"
-  local -a notice_cmd=(node "${source_root}/bin/lib/usage-notice.js")
+  local notice_script="${source_root}/bin/lib/usage-notice.js"
+  if [[ ! -f "$notice_script" ]]; then
+    notice_script="${SCRIPT_DIR}/bin/lib/usage-notice.js"
+  fi
+  local -a notice_cmd=(node "$notice_script")
   if [ "${NON_INTERACTIVE:-}" = "1" ]; then
     notice_cmd+=(--non-interactive)
     if [ "${ACCEPT_THIRD_PARTY_SOFTWARE:-}" = "1" ]; then

--- a/install.sh
+++ b/install.sh
@@ -240,7 +240,8 @@ usage() {
 }
 
 show_usage_notice() {
-  local -a notice_cmd=(node "${SCRIPT_DIR}/bin/lib/usage-notice.js")
+  local source_root="${NEMOCLAW_SOURCE_ROOT:-$SCRIPT_DIR}"
+  local -a notice_cmd=(node "${source_root}/bin/lib/usage-notice.js")
   if [ "${NON_INTERACTIVE:-}" = "1" ]; then
     notice_cmd+=(--non-interactive)
     if [ "${ACCEPT_THIRD_PARTY_SOFTWARE:-}" = "1" ]; then
@@ -327,6 +328,7 @@ ORIGINAL_PATH="${PATH:-}"
 NEMOCLAW_READY_NOW=false
 NEMOCLAW_RECOVERY_PROFILE=""
 NEMOCLAW_RECOVERY_EXPORT_DIR=""
+NEMOCLAW_SOURCE_ROOT="$SCRIPT_DIR"
 ONBOARD_RAN=false
 
 # Compare two semver strings (major.minor.patch). Returns 0 if $1 >= $2.
@@ -768,6 +770,7 @@ install_nemoclaw() {
   command_exists git || error "git was not found on PATH."
   if [[ -f "./package.json" ]] && grep -q '"name": "nemoclaw"' ./package.json 2>/dev/null; then
     info "NemoClaw package.json found in current directory — installing from source…"
+    NEMOCLAW_SOURCE_ROOT="$(pwd)"
     spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$(pwd)" \
       || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
     spin "Installing NemoClaw dependencies" npm install --ignore-scripts
@@ -786,6 +789,7 @@ install_nemoclaw() {
     local nemoclaw_src="${HOME}/.nemoclaw/source"
     rm -rf "$nemoclaw_src"
     mkdir -p "$(dirname "$nemoclaw_src")"
+    NEMOCLAW_SOURCE_ROOT="$nemoclaw_src"
     spin "Cloning NemoClaw source" git clone --depth 1 --branch "$release_ref" https://github.com/NVIDIA/NemoClaw.git "$nemoclaw_src"
     # Fetch version tags into the shallow clone so `git describe --tags
     # --match "v*"` works at runtime (the shallow clone only has the

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -1630,4 +1630,44 @@ exit 0`,
     // Confirm the releases API was NOT called
     expect(`${result.stdout}${result.stderr}`).not.toMatch(/curl should not hit the releases API/);
   });
+
+  it("resolves the usage notice helper from the cloned source during piped installs", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-pipe-usage-notice-"));
+    const { fakeBin, prefix } = buildCurlPipeEnv(tmp, {
+      curlStub: `#!/usr/bin/env bash
+/usr/bin/curl "$@"`,
+      gitStub: `#!/usr/bin/env bash
+if [ "$1" = "clone" ]; then
+  target="\${@: -1}"
+  mkdir -p "$target/nemoclaw" "$target/bin/lib"
+  echo '{"name":"nemoclaw","version":"0.5.0","dependencies":{"openclaw":"2026.3.11"}}' > "$target/package.json"
+  echo '{"name":"nemoclaw-plugin","version":"0.5.0"}' > "$target/nemoclaw/package.json"
+  cat > "$target/bin/lib/usage-notice.js" <<'EOS'
+#!/usr/bin/env node
+process.exit(0)
+EOS
+  chmod +x "$target/bin/lib/usage-notice.js"
+  exit 0
+fi
+exit 0`,
+    });
+
+    const installerInput = fs.readFileSync(CURL_PIPE_INSTALLER, "utf-8");
+    const result = spawnSync("bash", [], {
+      cwd: tmp,
+      input: installerInput,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        NPM_PREFIX: prefix,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).not.toMatch(/Cannot find module .*usage-notice\.js/);
+  });
 });


### PR DESCRIPTION
## Summary
- resolve the installer usage-notice helper from the actual NemoClaw source root instead of the shell invocation directory
- set `NEMOCLAW_SOURCE_ROOT` consistently for both source-checkout and GitHub-clone installs
- add a regression test for the `curl | bash` install path so piped installs keep working on Spark and other hosts

## Problem
`curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash` could fail before onboarding with:

```text
Error: Cannot find module '/home/.../bin/lib/usage-notice.js'
```

The installer was resolving the notice helper relative to `SCRIPT_DIR`, which is wrong for piped installs. The helper needs to come from the installed/cloned NemoClaw source tree.

## Validation
- `npm run build:cli`
- `npx vitest run test/install-preflight.test.js -t "resolves the usage notice helper from the cloned source during piped installs|requires explicit terms acceptance in non-interactive install mode|passes the acceptance flag through to non-interactive onboard"`
- `npx eslint test/install-preflight.test.js`

## Issues
- fixes the Spark installer regression introduced by the third-party software notice flow
- Fixes #1373
- Fixes #1381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation resource resolution across different setup scenarios.
  
* **Tests**
  * Added validation tests for installer behavior across installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->