### PR TITLE
fix(security): shell-quote sandboxName in exec and DNS proxy commands

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -2187,7 +2187,7 @@ async function createSandbox(
   console.log("  Waiting for NemoClaw dashboard to become ready...");
   for (let i = 0; i < 15; i++) {
     const readyMatch = runCapture(
-      `openshell sandbox exec ${sandboxName} curl -sf http://localhost:18789/ 2>/dev/null || echo "no"`,
+      `openshell sandbox exec ${shellQuote(sandboxName)} curl -sf http://localhost:18789/ 2>/dev/null || echo "no"`,
       { ignoreError: true },
     );
     if (readyMatch && !readyMatch.includes("no")) {
@@ -2216,7 +2216,7 @@ async function createSandbox(
   // sandbox namespace can resolve hostnames (fixes #626).
   console.log("  Setting up sandbox DNS proxy...");
   run(
-    `bash "${path.join(SCRIPTS, "setup-dns-proxy.sh")}" ${GATEWAY_NAME} "${sandboxName}" 2>&1 || true`,
+    `bash "${path.join(SCRIPTS, "setup-dns-proxy.sh")}" ${shellQuote(GATEWAY_NAME)} ${shellQuote(sandboxName)} 2>&1 || true`,
     { ignoreError: true },
   );
 

--- a/test/shellquote-sandbox.test.js
+++ b/test/shellquote-sandbox.test.js
@@ -1,0 +1,37 @@
+// Verify shellQuote is applied to sandboxName in shell commands
+import fs from "fs";
+import path from "path";
+import { describe, it, expect } from "vitest";
+
+describe("sandboxName shell quoting in onboard.js", () => {
+  const src = fs.readFileSync(
+    path.join(import.meta.dirname, "..", "bin", "lib", "onboard.js"),
+    "utf-8",
+  );
+
+  it("quotes sandboxName in openshell sandbox exec command", () => {
+    expect(src).toMatch(/openshell sandbox exec \$\{shellQuote\(sandboxName\)\}/);
+  });
+
+  it("quotes sandboxName in setup-dns-proxy.sh command", () => {
+    expect(src).toMatch(
+      /setup-dns-proxy\.sh.*\$\{shellQuote\(GATEWAY_NAME\)\}.*\$\{shellQuote\(sandboxName\)\}/,
+    );
+  });
+
+  it("does not have unquoted sandboxName in runCapture or run calls", () => {
+    const lines = src.split("\n");
+    const violations = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (
+        (line.includes("run(") || line.includes("runCapture(")) &&
+        line.includes("${sandboxName}") &&
+        !line.includes("shellQuote(sandboxName)")
+      ) {
+        violations.push(`Line ${i + 1}: ${line.trim()}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/test/shellquote-sandbox.test.js
+++ b/test/shellquote-sandbox.test.js
@@ -20,16 +20,19 @@ describe("sandboxName shell quoting in onboard.js", () => {
   });
 
   it("does not have unquoted sandboxName in runCapture or run calls", () => {
-    const lines = src.split("\n");
+    // Match run()/runCapture() calls that span multiple lines and contain
+    // template literals, so multiline invocations are not missed.
+    const callPattern = /\b(run|runCapture)\s*\(\s*`([^`]*)`/g;
     const violations = [];
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
+    let match;
+    while ((match = callPattern.exec(src)) !== null) {
+      const template = match[2];
       if (
-        (line.includes("run(") || line.includes("runCapture(")) &&
-        line.includes("${sandboxName}") &&
-        !line.includes("shellQuote(sandboxName)")
+        template.includes("${sandboxName}") &&
+        !template.includes("shellQuote(sandboxName)")
       ) {
-        violations.push(`Line ${i + 1}: ${line.trim()}`);
+        const line = src.slice(0, match.index).split("\n").length;
+        violations.push(`Line ${line}: ${match[0].slice(0, 120).trim()}`);
       }
     }
     expect(violations).toEqual([]);

--- a/test/shellquote-sandbox.test.js
+++ b/test/shellquote-sandbox.test.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Verify shellQuote is applied to sandboxName in shell commands
 import fs from "fs";
 import path from "path";


### PR DESCRIPTION
## Summary

- Wrap `sandboxName` with `shellQuote()` in the dashboard readiness check (`openshell sandbox exec`)
- Wrap both `GATEWAY_NAME` and `sandboxName` with `shellQuote()` in the DNS proxy setup command
- Add regression test that scans `onboard.js` for any unquoted `sandboxName` in `run()`/`runCapture()` calls

## Problem

`sandboxName` is interpolated into shell command strings passed to `run()`/`runCapture()` (which execute via `bash -c`) without `shellQuote()`. The same file imports and uses `shellQuote()` for other user-controlled values (lines 460, 1438, 3005) but omits it here.

Without quoting:
```
openshell sandbox exec test; rm -rf / curl ...
```

With quoting:
```
openshell sandbox exec 'test; rm -rf /' curl ...
```

## Test plan

- [x] 3 regression tests pass (vitest): quoted exec, quoted DNS proxy, no-unquoted-sandboxName scan
- [x] Verified `shellQuote()` output in Docker (node:22-slim) for semicolon, subshell, and pipe injection payloads
- [x] All 46 policy + security tests pass

Closes #1391

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding commands now correctly quote sandbox and gateway identifiers, preventing failures when names contain spaces or special characters and avoiding command parsing issues.

* **Tests**
  * Added tests that verify onboarding shell commands include required quoting for sandbox and gateway identifiers to guard against injection and parsing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->