### PR TITLE
fix(installer): hide unresolved placeholder version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -56,6 +56,14 @@ resolve_installer_version() {
 
 NEMOCLAW_VERSION="$(resolve_installer_version)"
 
+installer_version_for_display() {
+  if [[ -z "${NEMOCLAW_VERSION:-}" || "${NEMOCLAW_VERSION}" == "${DEFAULT_NEMOCLAW_VERSION}" ]]; then
+    printf ""
+    return
+  fi
+  printf "  v%s" "$NEMOCLAW_VERSION"
+}
+
 # Resolve which Git ref to install from.
 # Priority: NEMOCLAW_INSTALL_TAG env var > "latest" tag.
 resolve_release_tag() {
@@ -147,6 +155,8 @@ step() {
 }
 
 print_banner() {
+  local version_suffix
+  version_suffix="$(installer_version_for_display)"
   printf "\n"
   # ANSI Shadow ASCII art — hand-crafted, no figlet dependency
   printf "  ${C_GREEN}${C_BOLD} ███╗   ██╗███████╗███╗   ███╗ ██████╗  ██████╗██╗      █████╗ ██╗    ██╗${C_RESET}\n"
@@ -156,7 +166,7 @@ print_banner() {
   printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
   printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
   printf "\n"
-  printf "  ${C_DIM}Launch OpenClaw in an OpenShell sandbox.  v%s${C_RESET}\n" "$NEMOCLAW_VERSION"
+  printf "  ${C_DIM}Launch OpenClaw in an OpenShell sandbox.%s${C_RESET}\n" "$version_suffix"
   printf "\n"
 }
 
@@ -210,8 +220,10 @@ print_done() {
 }
 
 usage() {
+  local version_suffix
+  version_suffix="$(installer_version_for_display)"
   printf "\n"
-  printf "  ${C_BOLD}NemoClaw Installer${C_RESET}  ${C_DIM}v%s${C_RESET}\n\n" "$NEMOCLAW_VERSION"
+  printf "  ${C_BOLD}NemoClaw Installer${C_RESET}${C_DIM}%s${C_RESET}\n\n" "$version_suffix"
   printf "  ${C_DIM}Usage:${C_RESET}\n"
   printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash\n"
   printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
@@ -934,7 +946,7 @@ main() {
       --non-interactive) NON_INTERACTIVE=1 ;;
       --yes-i-accept-third-party-software) ACCEPT_THIRD_PARTY_SOFTWARE=1 ;;
       --version | -v)
-        printf "nemoclaw-installer v%s\n" "$NEMOCLAW_VERSION"
+        printf "nemoclaw-installer%s\n" "$(installer_version_for_display)"
         exit 0
         ;;
       --help | -h)

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -1312,7 +1312,9 @@ describe("installer pure helpers", () => {
   });
 
   it("installer_version_for_display: hides the placeholder default", () => {
-    const r = callInstallerFn('NEMOCLAW_VERSION="$DEFAULT_NEMOCLAW_VERSION"; installer_version_for_display');
+    const r = callInstallerFn(
+      'NEMOCLAW_VERSION="$DEFAULT_NEMOCLAW_VERSION"; installer_version_for_display',
+    );
     expect(r.status).toBe(0);
     expect(r.stdout).toBe("");
   });

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -355,7 +355,9 @@ exit 98
     });
 
     expect(result.status).toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toMatch(/nemoclaw-installer v\d+\.\d+\.\d+/);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output.trim()).toMatch(/^nemoclaw-installer(?: v\d+\.\d+\.\d+(?:-.+)?)?$/);
+    expect(output).not.toMatch(/0\.1\.0/);
   });
 
   it("-v exits 0 and prints the version number", () => {
@@ -365,7 +367,35 @@ exit 98
     });
 
     expect(result.status).toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toMatch(/nemoclaw-installer v\d+\.\d+\.\d+/);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output.trim()).toMatch(/^nemoclaw-installer(?: v\d+\.\d+\.\d+(?:-.+)?)?$/);
+    expect(output).not.toMatch(/0\.1\.0/);
+  });
+
+  it("piped --help does not show the placeholder installer version", () => {
+    const result = spawnSync("bash", ["-s", "--", "--help"], {
+      cwd: os.tmpdir(),
+      encoding: "utf-8",
+      input: fs.readFileSync(INSTALLER, "utf-8"),
+    });
+
+    expect(result.status).toBe(0);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toMatch(/NemoClaw Installer/);
+    expect(output).not.toMatch(/0\.1\.0/);
+  });
+
+  it("piped --version omits the placeholder installer version", () => {
+    const result = spawnSync("bash", ["-s", "--", "--version"], {
+      cwd: os.tmpdir(),
+      encoding: "utf-8",
+      input: fs.readFileSync(INSTALLER, "utf-8"),
+    });
+
+    expect(result.status).toBe(0);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output.trim()).toBe("nemoclaw-installer");
+    expect(output).not.toMatch(/0\.1\.0/);
   });
 
   it("uses npm install + npm link for a source checkout (no -g)", () => {
@@ -1279,6 +1309,18 @@ describe("installer pure helpers", () => {
       },
     );
     expect(r.stdout.trim()).toBe("0.1.0");
+  });
+
+  it("installer_version_for_display: hides the placeholder default", () => {
+    const r = callInstallerFn('NEMOCLAW_VERSION="$DEFAULT_NEMOCLAW_VERSION"; installer_version_for_display');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("installer_version_for_display: formats real versions for display", () => {
+    const r = callInstallerFn('NEMOCLAW_VERSION="0.0.21"; installer_version_for_display');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("  v0.0.21");
   });
 
   // -- resolve_default_sandbox_name --


### PR DESCRIPTION
## Summary
- stop showing the stale placeholder installer version `v0.1.0` in user-facing output
- keep showing a real installer version when it can actually be resolved from git/package metadata
- add regression coverage for piped `bash -s -- --help` and `--version` flows

## Why
`install.sh` resolves `NEMOCLAW_VERSION` before a piped install has cloned NemoClaw, so the old fallback `0.1.0` could leak into the banner, help, and version output even when the installer was about to install some other real release. That placeholder should never be shown to users.

## Validation
- `npm install --include=dev`
- `npx vitest run test/install-preflight.test.js -t "piped --help does not show the placeholder installer version|piped --version omits the placeholder installer version|installer_version_for_display: hides the placeholder default|installer_version_for_display: formats real versions for display|--version exits 0 and prints the version number|-v exits 0 and prints the version number|--help exits 0 and shows install usage"`
- `npx eslint test/install-preflight.test.js`
- `shellcheck install.sh`

## Note
The full local pre-push hook stack in this clean worktree is currently blocked by unrelated existing failures in `src/lib/version.test.ts` and `src/lib/preflight.test.ts`. This PR keeps scope to the installer display bug and relies on CI for the full matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer version display now conditionally hides placeholder versions and only shows a real version suffix where appropriate (banner, help, and version output).

* **Tests**
  * Added and tightened tests covering version-display behavior across CLI usage and direct installer execution, including unit and end-to-end checks to ensure placeholder versions never appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->