### PR TITLE
fix(cli): pass SANDBOX_NAME to service stop/status

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -468,14 +468,19 @@ async function deploy(instanceName) {
 
 async function start() {
   await ensureApiKey();
+  const sandboxEnv = getServicesSandboxEnvPrefix();
+  run(`${sandboxEnv}bash "${SCRIPTS}/start-services.sh"`);
+}
+
+function getServicesSandboxEnvPrefix() {
   const { defaultSandbox } = registry.listSandboxes();
   const safeName = defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  const sandboxEnv = safeName ? `SANDBOX_NAME=${shellQuote(safeName)}` : "";
-  run(`${sandboxEnv} bash "${SCRIPTS}/start-services.sh"`);
+  return safeName ? `SANDBOX_NAME=${shellQuote(safeName)} ` : "";
 }
 
 function stop() {
-  run(`bash "${SCRIPTS}/start-services.sh" --stop`);
+  const sandboxEnv = getServicesSandboxEnvPrefix();
+  run(`${sandboxEnv}bash "${SCRIPTS}/start-services.sh" --stop`);
 }
 
 function debug(args) {
@@ -533,7 +538,8 @@ function showStatus() {
   }
 
   // Show service status
-  run(`bash "${SCRIPTS}/start-services.sh" --status`);
+  const sandboxEnv = getServicesSandboxEnvPrefix();
+  run(`${sandboxEnv}bash "${SCRIPTS}/start-services.sh" --status`);
 }
 
 function listSandboxes() {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -26,6 +26,55 @@ function runWithEnv(args, env = {}, timeout = 10000) {
   }
 }
 
+function createServiceCommandHarness(defaultSandbox = "test-slack1") {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-services-"));
+  const localBin = path.join(home, "bin");
+  const registryDir = path.join(home, ".nemoclaw");
+  const markerFile = path.join(home, "bash-commands");
+  fs.mkdirSync(localBin, { recursive: true });
+  fs.mkdirSync(registryDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(registryDir, "sandboxes.json"),
+    JSON.stringify({
+      sandboxes: {
+        [defaultSandbox]: {
+          name: defaultSandbox,
+          model: "test-model",
+          provider: "nvidia-prod",
+          gpuEnabled: false,
+          policies: [],
+        },
+      },
+      defaultSandbox,
+    }),
+    { mode: 0o600 }
+  );
+  fs.writeFileSync(
+    path.join(localBin, "bash"),
+    [
+      "#!/bin/sh",
+      `marker_file=${JSON.stringify(markerFile)}`,
+      "printf '%s\\n' \"$2\" >> \"$marker_file\"",
+      "exit 0",
+    ].join("\n"),
+    { mode: 0o755 }
+  );
+  fs.writeFileSync(
+    path.join(localBin, "openshell"),
+    "#!/bin/sh\nexit 0\n",
+    { mode: 0o755 }
+  );
+  return {
+    home,
+    localBin,
+    markerFile,
+    env: {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    },
+  };
+}
+
 describe("CLI dispatch", () => {
   it("help exits 0 and shows sections", () => {
     const r = run("help");
@@ -102,6 +151,41 @@ describe("CLI dispatch", () => {
     expect(r.code).toBe(0);
     expect(r.out.includes("Troubleshooting")).toBeTruthy();
     expect(r.out.includes("nemoclaw debug")).toBeTruthy();
+  });
+
+  it("start passes the default sandbox name to start-services.sh", () => {
+    const harness = createServiceCommandHarness();
+    const r = runWithEnv("start", {
+      ...harness.env,
+      NVIDIA_API_KEY: "nvapi-test",
+    });
+
+    expect(r.code).toBe(0);
+    const command = fs.readFileSync(harness.markerFile, "utf8").trim();
+    expect(command).toContain("SANDBOX_NAME='test-slack1' bash");
+    expect(command).toContain("start-services.sh");
+  });
+
+  it("stop passes the default sandbox name to start-services.sh", () => {
+    const harness = createServiceCommandHarness();
+    const r = runWithEnv("stop", harness.env);
+
+    expect(r.code).toBe(0);
+    const command = fs.readFileSync(harness.markerFile, "utf8").trim();
+    expect(command).toContain("SANDBOX_NAME='test-slack1' bash");
+    expect(command).toContain("start-services.sh");
+    expect(command).toContain("--stop");
+  });
+
+  it("status passes the default sandbox name to start-services.sh", () => {
+    const harness = createServiceCommandHarness();
+    const r = runWithEnv("status", harness.env);
+
+    expect(r.code).toBe(0);
+    const command = fs.readFileSync(harness.markerFile, "utf8").trim();
+    expect(command).toContain("SANDBOX_NAME='test-slack1' bash");
+    expect(command).toContain("start-services.sh");
+    expect(command).toContain("--status");
   });
 
   it("passes --follow through to openshell logs", () => {


### PR DESCRIPTION
## Summary
- extract a shared helper for resolving the services sandbox env prefix
- pass the default sandbox name to `start-services.sh` for `start`, `stop`, and `status`
- add CLI regression tests covering all three commands

Fixes #1375.

## Testing
- `npx vitest run test/cli.test.js -t "(start|stop|status) passes the default sandbox name to start-services.sh"`

## Notes
- This matches the issue root cause directly: `stop()` and `showStatus()` were previously invoking `start-services.sh` without `SANDBOX_NAME`, which caused them to look in `/tmp/nemoclaw-services-default/` instead of the active sandbox PID directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced validation of sandbox configuration in service-management commands (start, stop, status) with improved environment variable handling.

* **Tests**
  * Added comprehensive test coverage for sandbox configuration validation and command execution verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->