### PR TITLE
[feat] docs(security): clarify PSIRT reporting path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ Use the [NVIDIA public PGP key](https://www.nvidia.com/en-us/security/pgp-key) t
 
 GitHub supports [private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configuring-private-vulnerability-reporting-for-a-repository) for repositories that enable it.
 This repository does not currently show **Report a vulnerability** in the **Security** tab.
-Use the [NVIDIA Vulnerability Disclosure Program](https://www.nvidia.com/en-us/security/report-vulnerability/) or email [psirt@nvidia.com](mailto:psirt@nvidia.com) instead.
+Report the issue directly to NVIDIA PSIRT through the [NVIDIA Vulnerability Disclosure Program](https://www.nvidia.com/en-us/security/report-vulnerability/) or by emailing [psirt@nvidia.com](mailto:psirt@nvidia.com).
 
 ## What to Include
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,8 +23,9 @@ Use the [NVIDIA public PGP key](https://www.nvidia.com/en-us/security/pgp-key) t
 
 ### GitHub Private Vulnerability Reporting
 
-You can use [GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configuring-private-vulnerability-reporting-for-a-repository) to submit a report directly on this repository.
-Navigate to the **Security** tab and select **Report a vulnerability**.
+GitHub supports [private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configuring-private-vulnerability-reporting-for-a-repository) for repositories that enable it.
+If this repository shows **Report a vulnerability** in the **Security** tab, you can use that flow to submit a private report.
+If the button is not available, use the [NVIDIA Vulnerability Disclosure Program](https://www.nvidia.com/en-us/security/report-vulnerability/) or email [psirt@nvidia.com](mailto:psirt@nvidia.com) instead.
 
 ## What to Include
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,8 +24,8 @@ Use the [NVIDIA public PGP key](https://www.nvidia.com/en-us/security/pgp-key) t
 ### GitHub Private Vulnerability Reporting
 
 GitHub supports [private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configuring-private-vulnerability-reporting-for-a-repository) for repositories that enable it.
-If this repository shows **Report a vulnerability** in the **Security** tab, you can use that flow to submit a private report.
-If the button is not available, use the [NVIDIA Vulnerability Disclosure Program](https://www.nvidia.com/en-us/security/report-vulnerability/) or email [psirt@nvidia.com](mailto:psirt@nvidia.com) instead.
+This repository does not currently show **Report a vulnerability** in the **Security** tab.
+Use the [NVIDIA Vulnerability Disclosure Program](https://www.nvidia.com/en-us/security/report-vulnerability/) or email [psirt@nvidia.com](mailto:psirt@nvidia.com) instead.
 
 ## What to Include
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Updates `SECURITY.md` so it no longer instructs NemoClaw reporters to use a GitHub **Report a vulnerability** flow that is not currently available on the repository Security page.
The revised guidance tells users to report NemoClaw vulnerabilities directly to NVIDIA PSIRT through the NVIDIA Vulnerability Disclosure Program or `psirt@nvidia.com`.

## Related Issue

None.

## Changes

- Replaced the unconditional GitHub private vulnerability reporting instructions in `SECURITY.md`
- Stated that this repository does not currently show **Report a vulnerability** in the **Security** tab
- Directed NemoClaw vulnerability reports to NVIDIA PSIRT through the NVIDIA Vulnerability Disclosure Program or `psirt@nvidia.com`

## Type of Change

- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)
- [x] `npx markdownlint-cli2 SECURITY.md` passes.

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [x] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [x] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: 13ernkastel <LennonCMJ@live.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security vulnerability reporting instructions to direct users to contact NVIDIA PSIRT via the Vulnerability Disclosure Program or email instead of GitHub's private reporting feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->