### PR TITLE
fix(cli): stop auxiliary services on destroy

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -1165,6 +1165,9 @@ async function sandboxDestroy(sandboxName, args = []) {
     process.exit(deleteResult.status || 1);
   }
 
+  const { stopAll } = require("./lib/services");
+  stopAll({ sandboxName });
+
   const removed = registry.removeSandbox(sandboxName);
   if (
     (deleteResult.status === 0 || alreadyGone) &&

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -1167,6 +1167,8 @@ async function sandboxDestroy(sandboxName, args = []) {
 
   const { stopAll } = require("./lib/services");
   stopAll({ sandboxName });
+  const sandboxServiceDir = path.join(os.tmpdir(), `nemoclaw-services-${sandboxName}`);
+  fs.rmSync(sandboxServiceDir, { recursive: true, force: true });
 
   const removed = registry.removeSandbox(sandboxName);
   if (

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -549,6 +549,75 @@ describe("CLI dispatch", () => {
     expect(fs.readFileSync(bashLog, "utf8")).toContain("docker volume ls -q --filter");
   });
 
+  it("stops auxiliary services for the destroyed sandbox", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-destroy-services-"));
+    const localBin = path.join(home, "bin");
+    const registryDir = path.join(home, ".nemoclaw");
+    const openshellLog = path.join(home, "openshell.log");
+    const serviceDir = "/tmp/nemoclaw-services-alpha";
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify({
+        sandboxes: {
+          alpha: {
+            name: "alpha",
+            model: "test-model",
+            provider: "nvidia-prod",
+            gpuEnabled: false,
+            policies: [],
+          },
+          beta: {
+            name: "beta",
+            model: "test-model",
+            provider: "nvidia-prod",
+            gpuEnabled: false,
+            policies: [],
+          },
+        },
+        defaultSandbox: "alpha",
+      }),
+      { mode: 0o600 },
+    );
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/bin/sh",
+        `log_file=${JSON.stringify(openshellLog)}`,
+        'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+        '  printf "NAME STATUS\\nbeta Ready\\n" >> "$log_file"',
+        '  printf "NAME STATUS\\nbeta Ready\\n"',
+        "  exit 0",
+        "fi",
+        'printf \'%s\\n\' "$*" >> "$log_file"',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    fs.rmSync(serviceDir, { recursive: true, force: true });
+    fs.mkdirSync(serviceDir, { recursive: true });
+    fs.writeFileSync(path.join(serviceDir, "telegram-bridge.pid"), "999999\n");
+    fs.writeFileSync(path.join(serviceDir, "cloudflared.pid"), "999999\n");
+
+    try {
+      const r = runWithEnv("alpha destroy --yes", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.out).toContain("telegram-bridge was not running");
+      expect(r.out).toContain("cloudflared was not running");
+      expect(r.out).toContain("All services stopped.");
+      expect(fs.existsSync(path.join(serviceDir, "telegram-bridge.pid"))).toBe(false);
+      expect(fs.existsSync(path.join(serviceDir, "cloudflared.pid"))).toBe(false);
+    } finally {
+      fs.rmSync(serviceDir, { recursive: true, force: true });
+    }
+  });
+
   it("passes plain logs through without the tail flag", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-plain-"));
     const localBin = path.join(home, "bin");

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -553,16 +553,17 @@ describe("CLI dispatch", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-destroy-services-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
+    const sandboxName = `alpha-${Date.now()}-${process.pid}`;
     const openshellLog = path.join(home, "openshell.log");
-    const serviceDir = "/tmp/nemoclaw-services-alpha";
+    const serviceDir = path.join(os.tmpdir(), `nemoclaw-services-${sandboxName}`);
     fs.mkdirSync(localBin, { recursive: true });
     fs.mkdirSync(registryDir, { recursive: true });
     fs.writeFileSync(
       path.join(registryDir, "sandboxes.json"),
       JSON.stringify({
         sandboxes: {
-          alpha: {
-            name: "alpha",
+          [sandboxName]: {
+            name: sandboxName,
             model: "test-model",
             provider: "nvidia-prod",
             gpuEnabled: false,
@@ -576,7 +577,7 @@ describe("CLI dispatch", () => {
             policies: [],
           },
         },
-        defaultSandbox: "alpha",
+        defaultSandbox: sandboxName,
       }),
       { mode: 0o600 },
     );
@@ -602,7 +603,7 @@ describe("CLI dispatch", () => {
     fs.writeFileSync(path.join(serviceDir, "cloudflared.pid"), "999999\n");
 
     try {
-      const r = runWithEnv("alpha destroy --yes", {
+      const r = runWithEnv(`${sandboxName} destroy --yes`, {
         HOME: home,
         PATH: `${localBin}:${process.env.PATH || ""}`,
       });
@@ -611,8 +612,7 @@ describe("CLI dispatch", () => {
       expect(r.out).toContain("telegram-bridge was not running");
       expect(r.out).toContain("cloudflared was not running");
       expect(r.out).toContain("All services stopped.");
-      expect(fs.existsSync(path.join(serviceDir, "telegram-bridge.pid"))).toBe(false);
-      expect(fs.existsSync(path.join(serviceDir, "cloudflared.pid"))).toBe(false);
+      expect(fs.existsSync(serviceDir)).toBe(false);
     } finally {
       fs.rmSync(serviceDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
Destroying a sandbox currently removes it from OpenShell and the local registry but leaves sandbox-scoped auxiliary services behind.
This updates the destroy flow to stop those services as part of teardown and adds a regression test for stale service PID cleanup.

## Related Issue
Fixes #1405

## Changes
- stop sandbox-scoped auxiliary services during `sandboxDestroy()` after a successful delete or already-gone result
- add a regression test that seeds stale `telegram-bridge` and `cloudflared` PID files under `/tmp/nemoclaw-services-alpha`
- verify `alpha destroy --yes` removes those stale service PID files and reports service shutdown output

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

Targeted verification:
- [x] `npm run build:cli`
- [x] `npx vitest run test/cli.test.js -t "destroy"`
- [x] `npx eslint bin/nemoclaw.js test/cli.test.js`
- [x] `npx prettier --check bin/nemoclaw.js test/cli.test.js`

Notes:
- `npx prek run --all-files` is currently blocked in this environment by an existing missing `hadolint` binary and a missing `@typescript-eslint/eslint-plugin` dependency for `nemoclaw/eslint.config.mjs`.
- the repo's full `test-cli` hook currently reports unrelated failures in existing tests on the current base branch; the destroy-focused regression coverage added in this PR passes.

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes

- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
Signed-off-by: Alan Pena <alanpena91@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auxiliary services are now stopped and their sandbox-scoped temporary service data is removed when a sandbox is destroyed, preventing orphaned processes and leftover service files.

* **Tests**
  * Added CLI test coverage verifying auxiliary services are stopped, cleanup messages are shown, and the sandbox service directory is removed during destruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->