### PR TITLE
fix(policy): allow real sandbox clients in docker preset (Fixes #1406)

### DIFF
--- a/nemoclaw-blueprint/policies/presets/docker.yaml
+++ b/nemoclaw-blueprint/policies/presets/docker.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: docker
+  description: "Docker Hub and NVIDIA container registry access"
+
+network_policies:
+  docker_registries:
+    name: docker_registries
+    endpoints:
+      - host: registry-1.docker.io
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: auth.docker.io
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: nvcr.io
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: authn.nvidia.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/node* }
+      - { path: /usr/bin/node* }
+      - { path: /usr/local/bin/curl* }
+      - { path: /usr/bin/curl* }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -96,9 +96,9 @@ selectFromList(items, options)
 
 describe("policies", () => {
   describe("listPresets", () => {
-    it("returns all 11 presets", () => {
+    it("returns all 12 presets", () => {
       const presets = policies.listPresets();
-      expect(presets.length).toBe(11);
+      expect(presets.length).toBe(12);
     });
 
     it("each preset has name and description", () => {
@@ -117,6 +117,7 @@ describe("policies", () => {
         "brave",
         "brew",
         "discord",
+        "docker",
         "github",
         "huggingface",
         "jira",
@@ -619,6 +620,16 @@ describe("policies", () => {
         expect(content.includes("binaries:")).toBe(true);
         expect(content.includes(expectedBinary)).toBe(true);
       }
+    });
+
+    it("docker preset targets clients that exist inside the sandbox", () => {
+      const content = policies.loadPreset("docker");
+      expect(content).toBeTruthy();
+      expect(content.includes("/usr/bin/docker")).toBe(false);
+      expect(content.includes("/usr/local/bin/node")).toBe(true);
+      expect(content.includes("/usr/bin/node")).toBe(true);
+      expect(content.includes("/usr/local/bin/curl")).toBe(true);
+      expect(content.includes("/usr/bin/curl")).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #1406.

The `docker` policy preset only allowed `/usr/bin/docker`, but the sandbox image does not ship a Docker CLI there. That made the preset effectively unusable because no real sandbox client could match the binary filter and reach Docker Hub or `nvcr.io`.

## Changes

- Updated `nemoclaw-blueprint/policies/presets/docker.yaml` to allow the clients that actually exist in the sandbox image:
  - Node (`/usr/local/bin/node*`, `/usr/bin/node*`)
  - curl (`/usr/local/bin/curl*`, `/usr/bin/curl*`)
- Added a regression check in `test/policies.test.js` to make sure the preset no longer points at `/usr/bin/docker` and still includes all four real sandbox client paths.

## Testing

- `npm run build:cli`
- `npm test -- test/policies.test.js`

## Evidence it works

- `test/policies.test.js` passes with the updated preset and confirms the Docker policy now targets binaries that exist in the sandbox image.
- I also ran the full `npm test` suite in this worktree. The Docker preset change did not introduce any policy-test regressions, but the broader suite still hit unrelated existing failures in:
  - `test/security-c2-dockerfile-injection.test.js`
  - `src/lib/preflight.test.ts`
  - `test/install-preflight.test.js`

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Docker preset policy providing predefined access to Docker Hub and NVIDIA container registries (HTTPS, TLS terminate) with allow rules for registry requests and an allowlist permitting node and curl executables.

* **Tests**
  * Updated tests to include the new Docker preset and validate its presence and expected contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->