### PR TITLE
fix(onboard): upgrade stale openshell during preflight (Fixes #1404)

### DIFF
--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -65,7 +65,7 @@ resolve_min_version() {
 
   if [[ -f "$blueprint" ]]; then
     local version
-    version="$(sed -nE 's/^[[:space:]]*min_openshell_version:[[:space:]]*"?(v?[0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' "$blueprint" | head -1)"
+    version="$(sed -nE 's/^[[:space:]]*min_openshell_version:[[:space:]]*"(v?[0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' "$blueprint" | head -1)"
     version="${version#v}"
     if [[ -n "$version" ]]; then
       printf "%s" "$version"

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -34,13 +37,47 @@ esac
 info "Detected $OS_LABEL ($ARCH_LABEL)"
 
 # Minimum version required for sandbox persistence across gateway restarts
-# (deterministic k3s node name + workspace PVC: NVIDIA/OpenShell#739, #488)
-MIN_VERSION="0.0.24"
+# (deterministic k3s node name + workspace PVC: NVIDIA/OpenShell#739, #488).
+DEFAULT_MIN_VERSION="0.0.24"
 # Maximum version validated for this NemoClaw release. Newer OpenShell builds
 # may change sandbox semantics; upgrade NemoClaw before upgrading past this.
 MAX_VERSION="0.0.26"
 # Pin fresh installs to this version instead of pulling "latest".
 PIN_VERSION="$MAX_VERSION"
+
+# When a blueprint declares a higher minimum, prefer that newer requirement.
+resolve_min_version() {
+  if [[ -n "${NEMOCLAW_MIN_OPENSHELL_VERSION:-}" ]]; then
+    printf "%s" "${NEMOCLAW_MIN_OPENSHELL_VERSION}"
+    return
+  fi
+
+  local blueprint="${REPO_ROOT}/nemoclaw-blueprint/blueprint.yaml"
+  local parser="${SCRIPT_DIR}/lib/openshell-version.js"
+  if [[ -f "$blueprint" && -f "$parser" && -n "$(command -v node || true)" ]]; then
+    local version
+    version="$(node "$parser" "$blueprint" 2>/dev/null || true)"
+    if [[ -n "$version" ]]; then
+      printf "%s" "$version"
+      return
+    fi
+  fi
+
+  if [[ -f "$blueprint" ]]; then
+    local version
+    version="$(sed -nE 's/^[[:space:]]*min_openshell_version:[[:space:]]*"?(v?[0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' "$blueprint" | head -1)"
+    version="${version#v}"
+    if [[ -n "$version" ]]; then
+      printf "%s" "$version"
+      return
+    fi
+  fi
+
+  # Keep a safe fallback for contexts that only have this script.
+  printf "%s" "$DEFAULT_MIN_VERSION"
+}
+
+MIN_VERSION="$(resolve_min_version)"
 
 version_gte() {
   # Returns 0 (true) if $1 >= $2 — portable, no sort -V (BSD compat)

--- a/scripts/lib/openshell-version.js
+++ b/scripts/lib/openshell-version.js
@@ -6,7 +6,7 @@ const path = require("path");
 
 const DEFAULT_MIN_OPENSHELL_VERSION = "0.0.24";
 const MIN_OPENSHELL_VERSION_PATTERN =
-  /^[\t ]*min_openshell_version:[\t ]*"?(v?[0-9]+\.[0-9]+\.[0-9]+)"?.*$/m;
+  /^[\t ]*min_openshell_version:[\t ]*"(v?[0-9]+\.[0-9]+\.[0-9]+)".*$/m;
 
 function parseMinimumOpenshellVersion(blueprintText = "") {
   const match = String(blueprintText ?? "").match(MIN_OPENSHELL_VERSION_PATTERN);

--- a/scripts/lib/openshell-version.js
+++ b/scripts/lib/openshell-version.js
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_MIN_OPENSHELL_VERSION = "0.0.24";
+const MIN_OPENSHELL_VERSION_PATTERN =
+  /^[\t ]*min_openshell_version:[\t ]*"?(v?[0-9]+\.[0-9]+\.[0-9]+)"?.*$/m;
+
+function parseMinimumOpenshellVersion(blueprintText = "") {
+  const match = String(blueprintText ?? "").match(MIN_OPENSHELL_VERSION_PATTERN);
+  return match?.[1]?.replace(/^v/i, "") || DEFAULT_MIN_OPENSHELL_VERSION;
+}
+
+function getMinimumOpenshellVersionFromFile(
+  blueprintPath = path.join(__dirname, "..", "..", "nemoclaw-blueprint", "blueprint.yaml"),
+) {
+  if (!fs.existsSync(blueprintPath)) {
+    return DEFAULT_MIN_OPENSHELL_VERSION;
+  }
+  return parseMinimumOpenshellVersion(fs.readFileSync(blueprintPath, "utf-8"));
+}
+
+if (require.main === module) {
+  process.stdout.write(getMinimumOpenshellVersionFromFile(process.argv[2]));
+}
+
+module.exports = {
+  DEFAULT_MIN_OPENSHELL_VERSION,
+  getMinimumOpenshellVersionFromFile,
+  parseMinimumOpenshellVersion,
+};

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -58,6 +58,12 @@ const nim = require("./nim");
 const onboardSession = require("./onboard-session");
 const policies = require("./policies");
 const tiers = require("./tiers");
+const {
+  DEFAULT_MIN_OPENSHELL_VERSION,
+  getMinimumOpenshellVersionFromFile,
+  parseMinimumOpenshellVersion,
+} = require("../../scripts/lib/openshell-version");
+const tiers = require("./tiers");
 const { ensureUsageNoticeConsent } = require("./usage-notice");
 const {
   assessHost,
@@ -479,13 +485,9 @@ function getBlueprintMaxOpenshellVersion(rootDir = ROOT) {
 }
 
 function getMinimumOpenshellVersion(blueprintText = null) {
-  if (blueprintText == null) {
-    return getBlueprintMinOpenshellVersion();
+    return getMinimumOpenshellVersionFromFile(path.join(ROOT, "nemoclaw-blueprint", "blueprint.yaml"));
   }
-  const match = String(blueprintText).match(
-    /^\s*min_openshell_version:\s*"?(?<version>v?[0-9]+\.[0-9]+\.[0-9]+)"?\s*$/m,
-  );
-  return normalizeVersion(match?.groups?.version || null);
+  return normalizeVersion(parseMinimumOpenshellVersion(String(blueprintText))) || DEFAULT_MIN_OPENSHELL_VERSION;
 }
 
 function shouldUpgradeOpenshell(installedVersion = null, minimumVersion = null) {
@@ -5409,6 +5411,7 @@ module.exports = {
   copyBuildContextDir,
   classifySandboxCreateFailure,
   createSandbox,
+  DEFAULT_MIN_OPENSHELL_VERSION,
   formatEnvAssignment,
   getFutureShellPathHint,
   getGatewayStartEnv,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -116,6 +116,8 @@ const OPENAI_ENDPOINT_URL = "https://api.openai.com/v1";
 const ANTHROPIC_ENDPOINT_URL = "https://api.anthropic.com";
 const GEMINI_ENDPOINT_URL = "https://generativelanguage.googleapis.com/v1beta/openai/";
 const BRAVE_SEARCH_HELP_URL = "https://brave.com/search/api/";
+const TROUBLESHOOTING_GUIDE_URL =
+  "https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html";
 
 const REMOTE_PROVIDER_CONFIG = {
   build: {
@@ -399,24 +401,47 @@ function getInstalledOpenshellVersion(versionOutput = null) {
 }
 
 /**
- * Compare two semver-like x.y.z strings. Returns true iff `left >= right`.
- * Non-numeric or missing components are treated as 0.
+ * Normalize a version-like value into x.y.z form.
+ * Trims whitespace, strips a leading "v", and extracts up to 3 numeric parts.
  */
-function versionGte(left = "0.0.0", right = "0.0.0") {
-  const lhs = String(left)
+function normalizeVersion(version = null) {
+  if (version == null) return null;
+  const raw = String(version).trim().replace(/^v/i, "");
+  if (!raw) return null;
+  const parts = raw
+    .split(/[^0-9]+/)
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((part) => Number.parseInt(part, 10))
+    .filter((part) => Number.isFinite(part));
+  if (parts.length === 0) return null;
+  while (parts.length < 3) parts.push(0);
+  return parts.join(".");
+}
+
+function compareVersions(left = "0.0.0", right = "0.0.0") {
+  const lhs = (normalizeVersion(left) || "0.0.0")
     .split(".")
     .map((part) => Number.parseInt(part, 10) || 0);
-  const rhs = String(right)
+  const rhs = (normalizeVersion(right) || "0.0.0")
     .split(".")
     .map((part) => Number.parseInt(part, 10) || 0);
   const length = Math.max(lhs.length, rhs.length);
   for (let index = 0; index < length; index += 1) {
     const a = lhs[index] || 0;
     const b = rhs[index] || 0;
-    if (a > b) return true;
-    if (a < b) return false;
+    if (a > b) return 1;
+    if (a < b) return -1;
   }
-  return true;
+  return 0;
+}
+
+/**
+ * Compare two semver-like x.y.z strings. Returns true iff `left >= right`.
+ * Non-numeric or missing components are treated as 0.
+ */
+function versionGte(left = "0.0.0", right = "0.0.0") {
+  return compareVersions(left, right) >= 0;
 }
 
 /**
@@ -453,6 +478,24 @@ function getBlueprintMaxOpenshellVersion(rootDir = ROOT) {
   return getBlueprintVersionField("max_openshell_version", rootDir);
 }
 
+function getMinimumOpenshellVersion(blueprintText = null) {
+  if (blueprintText == null) {
+    return getBlueprintMinOpenshellVersion();
+  }
+  const match = String(blueprintText).match(
+    /^\s*min_openshell_version:\s*"?(?<version>v?[0-9]+\.[0-9]+\.[0-9]+)"?\s*$/m,
+  );
+  return normalizeVersion(match?.groups?.version || null);
+}
+
+function shouldUpgradeOpenshell(installedVersion = null, minimumVersion = null) {
+  const normalizedMinimum = normalizeVersion(minimumVersion);
+  if (!normalizedMinimum) return false;
+  const normalizedInstalled = normalizeVersion(installedVersion);
+  if (!normalizedInstalled) return true;
+  return compareVersions(normalizedInstalled, normalizedMinimum) < 0;
+}
+
 function getStableGatewayImageRef(versionOutput = null) {
   const version = getInstalledOpenshellVersion(versionOutput);
   if (!version) return null;
@@ -464,7 +507,7 @@ function getOpenshellBinary() {
   const resolved = resolveOpenshell();
   if (!resolved) {
     console.error("  openshell CLI not found.");
-    console.error("  Install manually: https://github.com/NVIDIA/OpenShell/releases");
+    console.error(`  See: ${TROUBLESHOOTING_GUIDE_URL}`);
     process.exit(1);
   }
   OPENSHELL_BIN = resolved;
@@ -1693,10 +1736,14 @@ function getPortConflictServiceHints(platform = process.platform) {
   ];
 }
 
-function installOpenshell() {
+function installOpenshell(opts = {}) {
+  const env = { ...process.env };
+  if (opts.minimumVersion) {
+    env.NEMOCLAW_MIN_OPENSHELL_VERSION = opts.minimumVersion;
+  }
   const result = spawnSync("bash", [path.join(SCRIPTS, "install-openshell.sh")], {
     cwd: ROOT,
-    env: process.env,
+    env,
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",
     timeout: 300_000,
@@ -1851,44 +1898,28 @@ async function preflight() {
   // MIN_VERSION in install-openshell.sh handles the version gate; calling it
   // when openshell already exists is safe (it exits early if version is OK).
   let openshellInstall = { localBin: null, futureShellPathHint: null };
-  if (!isOpenshellInstalled()) {
+  const openshellInstalled = isOpenshellInstalled();
+  const requiredOpenshellVersion = getMinimumOpenshellVersion();
+  const installedOpenshellVersion = openshellInstalled ? getInstalledOpenshellVersion() : null;
+  if (!openshellInstalled) {
     console.log("  openshell CLI not found. Installing...");
-    openshellInstall = installOpenshell();
+    openshellInstall = installOpenshell({ minimumVersion: requiredOpenshellVersion });
     if (!openshellInstall.installed) {
       console.error("  Failed to install openshell CLI.");
-      console.error("  Install manually: https://github.com/NVIDIA/OpenShell/releases");
+      console.error(`  See: ${TROUBLESHOOTING_GUIDE_URL}`);
       process.exit(1);
     }
-  } else {
-    // Ensure the installed version meets the minimum required by install-openshell.sh.
-    // The script itself is idempotent — it exits early if the version is already sufficient.
-    const currentVersion = getInstalledOpenshellVersion();
-    if (!currentVersion) {
-      console.log("  openshell version could not be determined. Reinstalling...");
-      openshellInstall = installOpenshell();
-      if (!openshellInstall.installed) {
-        console.error("  Failed to reinstall openshell CLI.");
-        console.error("  Install manually: https://github.com/NVIDIA/OpenShell/releases");
-        process.exit(1);
-      }
-    } else {
-      const parts = currentVersion.split(".").map(Number);
-      const minParts = [0, 0, 24]; // must match MIN_VERSION in scripts/install-openshell.sh
-      const needsUpgrade =
-        parts[0] < minParts[0] ||
-        (parts[0] === minParts[0] && parts[1] < minParts[1]) ||
-        (parts[0] === minParts[0] && parts[1] === minParts[1] && parts[2] < minParts[2]);
-      if (needsUpgrade) {
-        console.log(
-          `  openshell ${currentVersion} is below minimum required version. Upgrading...`,
-        );
-        openshellInstall = installOpenshell();
-        if (!openshellInstall.installed) {
-          console.error("  Failed to upgrade openshell CLI.");
-          console.error("  Install manually: https://github.com/NVIDIA/OpenShell/releases");
-          process.exit(1);
-        }
-      }
+  } else if (shouldUpgradeOpenshell(installedOpenshellVersion, requiredOpenshellVersion)) {
+    console.log(
+      `  openshell CLI ${installedOpenshellVersion || "unknown"} is below required ${requiredOpenshellVersion}. Upgrading...`,
+    );
+    openshellInstall = installOpenshell({ minimumVersion: requiredOpenshellVersion });
+    if (!openshellInstall.installed) {
+      console.error(
+        `  Failed to upgrade openshell CLI to meet NemoClaw's minimum ${requiredOpenshellVersion}.`,
+      );
+      console.error(`  See: ${TROUBLESHOOTING_GUIDE_URL}`);
+      process.exit(1);
     }
   }
   const openshellVersionOutput = runCaptureOpenshell(["--version"], { ignoreError: true });
@@ -1897,21 +1928,21 @@ async function preflight() {
   // this check, users can complete a full onboard against an OpenShell that
   // pre-dates required CLI surface (e.g. `sandbox exec`, `--upload`) and hit
   // silent failures inside the sandbox at runtime. See #1317.
-  const installedOpenshellVersion = getInstalledOpenshellVersion(openshellVersionOutput);
+  const currentInstalledOpenshellVersion = getInstalledOpenshellVersion(openshellVersionOutput);
   const minOpenshellVersion = getBlueprintMinOpenshellVersion();
   if (
-    installedOpenshellVersion &&
+    currentInstalledOpenshellVersion &&
     minOpenshellVersion &&
-    !versionGte(installedOpenshellVersion, minOpenshellVersion)
+    !versionGte(currentInstalledOpenshellVersion, minOpenshellVersion)
   ) {
     console.error("");
     console.error(
-      `  ✗ openshell ${installedOpenshellVersion} is below the minimum required by this NemoClaw release.`,
+      `  ✗ openshell ${currentInstalledOpenshellVersion} is below the minimum required by this NemoClaw release.`,
     );
     console.error(`    blueprint.yaml min_openshell_version: ${minOpenshellVersion}`);
     console.error("");
-    console.error("    Upgrade openshell and retry:");
-    console.error("      https://github.com/NVIDIA/OpenShell/releases");
+    console.error("    Upgrade openshell and retry. See:");
+    console.error(`      ${TROUBLESHOOTING_GUIDE_URL}`);
     console.error(
       "    Or remove the existing binary so the installer can re-fetch a current build:",
     );
@@ -1926,19 +1957,19 @@ async function preflight() {
   // OpenShell releases.
   const maxOpenshellVersion = getBlueprintMaxOpenshellVersion();
   if (
-    installedOpenshellVersion &&
+    currentInstalledOpenshellVersion &&
     maxOpenshellVersion &&
-    !versionGte(maxOpenshellVersion, installedOpenshellVersion)
+    !versionGte(maxOpenshellVersion, currentInstalledOpenshellVersion)
   ) {
     console.error("");
     console.error(
-      `  ✗ openshell ${installedOpenshellVersion} is above the maximum supported by this NemoClaw release.`,
+      `  ✗ openshell ${currentInstalledOpenshellVersion} is above the maximum supported by this NemoClaw release.`,
     );
     console.error(`    blueprint.yaml max_openshell_version: ${maxOpenshellVersion}`);
     console.error("");
-    console.error("    Upgrade NemoClaw to a version that supports your OpenShell release,");
-    console.error("    or install a supported OpenShell version:");
-    console.error("      https://github.com/NVIDIA/OpenShell/releases");
+    console.error("    Upgrade NemoClaw to a version that supports your OpenShell release.");
+    console.error("    See:");
+    console.error(`      ${TROUBLESHOOTING_GUIDE_URL}`);
     console.error("");
     process.exit(1);
   }
@@ -5388,6 +5419,7 @@ module.exports = {
   getBlueprintMinOpenshellVersion,
   getBlueprintMaxOpenshellVersion,
   versionGte,
+  getMinimumOpenshellVersion,
   getRequestedModelHint,
   getRequestedProviderHint,
   getStableGatewayImageRef,
@@ -5418,6 +5450,7 @@ module.exports = {
   getDashboardForwardPort,
   getDashboardForwardStartCommand,
   getDashboardGuidanceLines,
+  shouldUpgradeOpenshell,
   startGatewayForRecovery,
   runCaptureOpenshell,
   setupInference,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -63,7 +63,6 @@ const {
   getMinimumOpenshellVersionFromFile,
   parseMinimumOpenshellVersion,
 } = require("../../scripts/lib/openshell-version");
-const tiers = require("./tiers");
 const { ensureUsageNoticeConsent } = require("./usage-notice");
 const {
   assessHost,
@@ -485,7 +484,10 @@ function getBlueprintMaxOpenshellVersion(rootDir = ROOT) {
 }
 
 function getMinimumOpenshellVersion(blueprintText = null) {
-    return getMinimumOpenshellVersionFromFile(path.join(ROOT, "nemoclaw-blueprint", "blueprint.yaml"));
+  if (blueprintText == null) {
+    return getMinimumOpenshellVersionFromFile(
+      path.join(ROOT, "nemoclaw-blueprint", "blueprint.yaml"),
+    );
   }
   return normalizeVersion(parseMinimumOpenshellVersion(String(blueprintText))) || DEFAULT_MIN_OPENSHELL_VERSION;
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -500,6 +500,38 @@ function shouldUpgradeOpenshell(installedVersion = null, minimumVersion = null) 
   return compareVersions(normalizedInstalled, normalizedMinimum) < 0;
 }
 
+function enforceOpenshellVersionConstraint(
+  currentVersion = null,
+  requiredVersion = null,
+  isSatisfied = null,
+  {
+    headline = "",
+    blueprintField = "",
+    guidanceLines = [],
+    showRemoveHint = false,
+  } = {},
+) {
+  if (!currentVersion || !requiredVersion || typeof isSatisfied !== "function") return;
+  if (isSatisfied(currentVersion, requiredVersion)) return;
+
+  console.error("");
+  console.error(headline);
+  console.error(`    blueprint.yaml ${blueprintField}: ${requiredVersion}`);
+  console.error("");
+  for (const line of guidanceLines) {
+    console.error(line);
+  }
+  console.error(`      ${TROUBLESHOOTING_GUIDE_URL}`);
+  if (showRemoveHint) {
+    console.error(
+      "    Or remove the existing binary so the installer can re-fetch a current build:",
+    );
+    console.error('      command -v openshell && rm -f "$(command -v openshell)"');
+  }
+  console.error("");
+  process.exit(1);
+}
+
 function getStableGatewayImageRef(versionOutput = null) {
   const version = getInstalledOpenshellVersion(versionOutput);
   if (!version) return null;
@@ -1934,49 +1966,36 @@ async function preflight() {
   // silent failures inside the sandbox at runtime. See #1317.
   const currentInstalledOpenshellVersion = getInstalledOpenshellVersion(openshellVersionOutput);
   const minOpenshellVersion = getBlueprintMinOpenshellVersion();
-  if (
-    currentInstalledOpenshellVersion &&
-    minOpenshellVersion &&
-    !versionGte(currentInstalledOpenshellVersion, minOpenshellVersion)
-  ) {
-    console.error("");
-    console.error(
-      `  ✗ openshell ${currentInstalledOpenshellVersion} is below the minimum required by this NemoClaw release.`,
-    );
-    console.error(`    blueprint.yaml min_openshell_version: ${minOpenshellVersion}`);
-    console.error("");
-    console.error("    Upgrade openshell and retry. See:");
-    console.error(`      ${TROUBLESHOOTING_GUIDE_URL}`);
-    console.error(
-      "    Or remove the existing binary so the installer can re-fetch a current build:",
-    );
-    console.error('      command -v openshell && rm -f "$(command -v openshell)"');
-    console.error("");
-    process.exit(1);
-  }
+  enforceOpenshellVersionConstraint(
+    currentInstalledOpenshellVersion,
+    minOpenshellVersion,
+    versionGte,
+    {
+      headline: `  ✗ openshell ${currentInstalledOpenshellVersion} is below the minimum required by this NemoClaw release.`,
+      blueprintField: "min_openshell_version",
+      guidanceLines: ["    Upgrade openshell and retry. See:"],
+      showRemoveHint: true,
+    },
+  );
   // Enforce nemoclaw-blueprint/blueprint.yaml's max_openshell_version. Newer
   // OpenShell releases may change sandbox semantics that this NemoClaw version
   // has not been validated against. Blocking early avoids silent runtime
   // breakage. Users should upgrade NemoClaw to pick up support for newer
   // OpenShell releases.
   const maxOpenshellVersion = getBlueprintMaxOpenshellVersion();
-  if (
-    currentInstalledOpenshellVersion &&
-    maxOpenshellVersion &&
-    !versionGte(maxOpenshellVersion, currentInstalledOpenshellVersion)
-  ) {
-    console.error("");
-    console.error(
-      `  ✗ openshell ${currentInstalledOpenshellVersion} is above the maximum supported by this NemoClaw release.`,
-    );
-    console.error(`    blueprint.yaml max_openshell_version: ${maxOpenshellVersion}`);
-    console.error("");
-    console.error("    Upgrade NemoClaw to a version that supports your OpenShell release.");
-    console.error("    See:");
-    console.error(`      ${TROUBLESHOOTING_GUIDE_URL}`);
-    console.error("");
-    process.exit(1);
-  }
+  enforceOpenshellVersionConstraint(
+    currentInstalledOpenshellVersion,
+    maxOpenshellVersion,
+    (currentVersion, supportedVersion) => versionGte(supportedVersion, currentVersion),
+    {
+      headline: `  ✗ openshell ${currentInstalledOpenshellVersion} is above the maximum supported by this NemoClaw release.`,
+      blueprintField: "max_openshell_version",
+      guidanceLines: [
+        "    Upgrade NemoClaw to a version that supports your OpenShell release.",
+        "    See:",
+      ],
+    },
+  );
   if (openshellInstall.futureShellPathHint) {
     console.log(
       `  Note: openshell was installed to ${openshellInstall.localBin} for this onboarding run.`,

--- a/test/install-openshell.test.js
+++ b/test/install-openshell.test.js
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const INSTALL_OPEN_SHELL = path.join(import.meta.dirname, "..", "scripts", "install-openshell.sh");
+const TEST_SYSTEM_PATH = "/usr/bin:/bin";
+
+function writeExecutable(target, contents) {
+  fs.writeFileSync(target, contents, { mode: 0o755 });
+}
+
+describe("install-openshell.sh", () => {
+  it("uses the blueprint minimum version when no override is provided", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-openshell-blueprint-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "openshell"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  echo "openshell 0.0.24"
+  exit 0
+fi
+exit 0
+`,
+    );
+
+    const result = spawnSync("bash", [INSTALL_OPEN_SHELL], {
+      cwd: path.join(import.meta.dirname, ".."),
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/openshell already installed: 0\.0\.24 \(>= 0\.0\.24\)/);
+  });
+
+  it("honors an explicit minimum-version override from the caller", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-openshell-override-"));
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "openshell"),
+      `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  echo "openshell 0.0.21"
+  exit 0
+fi
+exit 0
+`,
+    );
+
+    const result = spawnSync("bash", [INSTALL_OPEN_SHELL], {
+      cwd: path.join(import.meta.dirname, ".."),
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmp,
+        PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        NEMOCLAW_MIN_OPENSHELL_VERSION: "0.0.20",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/openshell already installed: 0\.0\.21 \(>= 0\.0\.20\)/);
+  });
+});

--- a/test/install-openshell.test.ts
+++ b/test/install-openshell.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -42,7 +43,9 @@ exit 0
     });
 
     expect(result.status).toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toMatch(/openshell already installed: 0\.0\.24 \(>= 0\.0\.24\)/);
+    expect(`${result.stdout}${result.stderr}`).toMatch(
+      /openshell already installed: 0\.0\.24 \(>= 0\.0\.24, <= 0\.0\.26\)/,
+    );
   });
 
   it("honors an explicit minimum-version override from the caller", () => {
@@ -73,6 +76,8 @@ exit 0
     });
 
     expect(result.status).toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toMatch(/openshell already installed: 0\.0\.21 \(>= 0\.0\.20\)/);
+    expect(`${result.stdout}${result.stderr}`).toMatch(
+      /openshell already installed: 0\.0\.21 \(>= 0\.0\.20, <= 0\.0\.26\)/,
+    );
   });
 });

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -27,6 +27,7 @@ import {
   getBlueprintMinOpenshellVersion,
   getBlueprintMaxOpenshellVersion,
   versionGte,
+  getMinimumOpenshellVersion,
   getRequestedModelHint,
   getRequestedProviderHint,
   getRequestedSandboxNameHint,
@@ -45,6 +46,7 @@ import {
   resolveDashboardForwardTarget,
   summarizeCurlFailure,
   summarizeProbeFailure,
+  shouldUpgradeOpenshell,
   shouldIncludeBuildContextPath,
   writeSandboxConfigSyncFile,
 } from "../dist/lib/onboard";
@@ -841,6 +843,13 @@ describe("onboard helpers", () => {
     expect(getInstalledOpenshellVersion("openshell 0.0.12")).toBe("0.0.12");
     expect(getInstalledOpenshellVersion("openshell 0.0.13-dev.8+gbbcaed2ea")).toBe("0.0.13");
     expect(getInstalledOpenshellVersion("bogus")).toBe(null);
+    expect(getMinimumOpenshellVersion('min_openshell_version: "0.1.0"\n')).toBe("0.1.0");
+    expect(getMinimumOpenshellVersion('min_openshell_version: "v0.1.0"\n')).toBe("0.1.0");
+    expect(shouldUpgradeOpenshell("0.0.21", "0.1.0")).toBe(true);
+    expect(shouldUpgradeOpenshell("v0.0.21", "0.1.0")).toBe(true);
+    expect(shouldUpgradeOpenshell("bogus", "0.1.0")).toBe(true);
+    expect(shouldUpgradeOpenshell("0.1.0", "0.1.0")).toBe(false);
+    expect(shouldUpgradeOpenshell("0.1.2", "0.1.0")).toBe(false);
     expect(getStableGatewayImageRef("openshell 0.0.12")).toBe(
       "ghcr.io/nvidia/openshell/cluster:0.0.12",
     );

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -23,6 +23,7 @@ import {
   getPortConflictServiceHints,
   getFutureShellPathHint,
   getSandboxInferenceConfig,
+  DEFAULT_MIN_OPENSHELL_VERSION,
   getInstalledOpenshellVersion,
   getBlueprintMinOpenshellVersion,
   getBlueprintMaxOpenshellVersion,
@@ -845,6 +846,12 @@ describe("onboard helpers", () => {
     expect(getInstalledOpenshellVersion("bogus")).toBe(null);
     expect(getMinimumOpenshellVersion('min_openshell_version: "0.1.0"\n')).toBe("0.1.0");
     expect(getMinimumOpenshellVersion('min_openshell_version: "v0.1.0"\n')).toBe("0.1.0");
+    expect(getMinimumOpenshellVersion("min_openshell_version: 0.2.0\n")).toBe(
+      DEFAULT_MIN_OPENSHELL_VERSION,
+    );
+    expect(getMinimumOpenshellVersion("name: no-version-here\n")).toBe(
+      DEFAULT_MIN_OPENSHELL_VERSION,
+    );
     expect(shouldUpgradeOpenshell("0.0.21", "0.1.0")).toBe(true);
     expect(shouldUpgradeOpenshell("v0.0.21", "0.1.0")).toBe(true);
     expect(shouldUpgradeOpenshell("bogus", "0.1.0")).toBe(true);


### PR DESCRIPTION
## Summary

Fixes #1404.

NemoClaw already declares a minimum supported OpenShell version in the blueprint, but onboarding only installed OpenShell when the CLI was missing. If an older CLI was already present, upgrading NemoClaw could leave that stale OpenShell binary in place and keep using it.

## Changes

- Updated `bin/lib/onboard.js` to:
  - read `min_openshell_version` from the blueprint
  - detect when the installed OpenShell CLI is below that minimum
  - run the existing OpenShell installer path during preflight when an upgrade is needed
- Added `scripts/lib/openshell-version.js` so onboarding and the installer resolve the minimum OpenShell version with the same parsing and fallback behavior.
- Updated `scripts/install-openshell.sh` to use that shared parser when available, with the existing shell fallback and env override path intact.
- Added coverage in `test/onboard.test.js` for the new minimum-version helpers.
- Added `test/install-openshell.test.js` to verify the shell installer honors the blueprint minimum and explicit override path without attempting a network download.

## Testing

- `npm run build:cli`
- `npm test -- test/onboard.test.js test/install-openshell.test.js`

## Evidence it works

- `test/onboard.test.js` now covers the version comparison path that decides whether OpenShell needs an upgrade.
- `test/install-openshell.test.js` verifies that the shell installer reads the blueprint minimum version and respects an explicit minimum-version override.
- I also ran the full `npm test` suite in this worktree. The branch-specific tests are green, but the broader suite still hit unrelated existing failures in:
  - `src/lib/preflight.test.ts`
  - `test/install-preflight.test.js`

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenShell installer now dynamically resolves the minimum required version from configuration files instead of using a hardcoded default.
  * Error messages now include links to a troubleshooting guide for additional support.

* **Refactor**
  * Improved version comparison logic for more robust version checking and upgrade decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->