### PR TITLE
fix: parse gateway inference section only (#1150)

### DIFF
--- a/src/lib/inference-config.ts
+++ b/src/lib/inference-config.ts
@@ -121,9 +121,9 @@ export function getOpenClawPrimaryModel(provider: string, model?: string): strin
 }
 
 export function parseGatewayInference(output: string | null | undefined): GatewayInference | null {
-  if (!output || /Not configured/i.test(output)) return null;
-  const provider = output.match(/Provider:\s*(.+)/);
-  const model = output.match(/Model:\s*(.+)/);
+  if (!output) return null;
+  const provider = output.match(/Gateway inference:[\s\S]*?Provider:\s*(.+)/);
+  const model = output.match(/Gateway inference:[\s\S]*?Model:\s*(.+)/);
   if (!provider && !model) return null;
   return {
     provider: provider ? provider[1].trim() : null,

--- a/src/lib/inference-config.ts
+++ b/src/lib/inference-config.ts
@@ -122,11 +122,28 @@ export function getOpenClawPrimaryModel(provider: string, model?: string): strin
 
 export function parseGatewayInference(output: string | null | undefined): GatewayInference | null {
   if (!output) return null;
-  const provider = output.match(/Gateway inference:[\s\S]*?Provider:\s*(.+)/);
-  const model = output.match(/Gateway inference:[\s\S]*?Model:\s*(.+)/);
+  // eslint-disable-next-line no-control-regex
+  const stripped = output.replace(/\u001b\[[0-9;]*m/g, "");
+  const lines = stripped.split("\n");
+  let inGateway = false;
+  let provider: string | null = null;
+  let model: string | null = null;
+  for (const line of lines) {
+    if (/^Gateway inference:\s*$/i.test(line)) {
+      inGateway = true;
+      continue;
+    }
+    if (inGateway && /^\S.*:$/.test(line)) {
+      break;
+    }
+    if (inGateway) {
+      const trimmed = line.trim();
+      const p = trimmed.match(/^Provider:\s*(.+)/);
+      const m = trimmed.match(/^Model:\s*(.+)/);
+      if (p) provider = p[1].trim();
+      if (m) model = m[1].trim();
+    }
+  }
   if (!provider && !model) return null;
-  return {
-    provider: provider ? provider[1].trim() : null,
-    model: model ? model[1].trim() : null,
-  };
+  return { provider, model };
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`nemoclaw list` and `nemoclaw status` show model and provider as "unknown" even when gateway inference is configured. The `parseGatewayInference` function matched "Not configured" from the System inference section of `openshell inference get` output, causing an early return before parsing the Gateway inference section.

## Related Issue
Fixes #1150

## Changes
  - `src/lib/inference-config.ts`: Replace single-pass regex with line-by-line parser that scopes to the `Gateway inference:` section only. Strip ANSI color codes before parsing. Detect section boundaries by matching unindented lines ending with `:`. Removes the `Not configured` early-return check that was falsely triggered by the System inference section.

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway inference parsing: more accurate extraction of Provider and Model from the designated inference section, ignores unrelated lines, strips formatting codes, and only returns no-result when both values are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->