### PR TITLE
fix(sandbox): add python -> python3 symlink in base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -65,7 +65,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcap2-bin=1:2.66-4+deb12u2+b2 \
         procps=2:4.0.2-3 \
         openssh-sftp-server=1:9.2p1-2+deb12u9 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # Create python -> python3 symlink so scripts using the bare `python`
+    # command work inside the sandbox without additional setup. (#1452)
+    && ln -s /usr/bin/python3 /usr/local/bin/python
 
 # gosu for privilege separation (gateway vs sandbox user).
 # Install from GitHub release with checksum verification instead of


### PR DESCRIPTION
## Summary

Partially fixes #1452.

The sandbox base image installs `python3` but has no `python` binary. Scripts using the bare `python` command (shebangs, subprocess calls, AI-generated code) fail with `python: command not found`. This is the specific trigger described in #1452 that causes tool call failures, which in turn can lead to agent hallucination.

## Change

Adds `ln -s /usr/bin/python3 /usr/local/bin/python` in the base image `apt-get` layer so `python` resolves to `python3` without any user action.

## Scope

This PR addresses the sandbox-side trigger. The broader agent hallucination behaviour on tool failure is an OpenClaw agent loop issue outside the scope of NemoClaw.

Signed-off-by: Benedikt Schackenberg <6381261+BenediktSchackenberg@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the runtime image so tools and scripts invoking the standard `python` command work out of the box. A system-level adjustment ensures `python` resolves to the installed Python 3 executable, improving compatibility and reducing setup friction for Python-based workflows and tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->