### PR TITLE
fix(install): keep nemoclaw available after install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ exec_installer_from_ref() {
 
   if has_payload_marker "$payload_script"; then
     verify_downloaded_script "$payload_script" "versioned installer"
-    NEMOCLAW_INSTALL_REF="$ref" NEMOCLAW_INSTALL_TAG="$ref" NEMOCLAW_REPO_ROOT="$source_root" \
+    NEMOCLAW_INSTALL_REF="$ref" NEMOCLAW_INSTALL_TAG="$ref" NEMOCLAW_BOOTSTRAP_PAYLOAD=1 \
       bash "$payload_script" "$@"
     return
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -373,7 +373,6 @@ MIN_NODE_VERSION="22.16.0"
 MIN_NPM_MAJOR=10
 RUNTIME_REQUIREMENT_MSG="NemoClaw requires Node.js >=${MIN_NODE_VERSION} and npm >=${MIN_NPM_MAJOR}."
 NEMOCLAW_SHIM_DIR="${HOME}/.local/bin"
-ORIGINAL_PATH="${PATH:-}"
 NEMOCLAW_READY_NOW=false
 NEMOCLAW_RECOVERY_PROFILE=""
 NEMOCLAW_RECOVERY_EXPORT_DIR=""
@@ -454,7 +453,7 @@ refresh_path() {
 }
 
 ensure_nemoclaw_shim() {
-  local npm_bin shim_path
+  local npm_bin shim_path node_path node_dir cli_path
   npm_bin="$(npm config get prefix 2>/dev/null)/bin" || true
   shim_path="${NEMOCLAW_SHIM_DIR}/nemoclaw"
 
@@ -462,12 +461,24 @@ ensure_nemoclaw_shim() {
     return 1
   fi
 
-  if [[ ":$ORIGINAL_PATH:" == *":$npm_bin:"* ]] || [[ ":$ORIGINAL_PATH:" == *":$NEMOCLAW_SHIM_DIR:"* ]]; then
-    return 0
+  node_path="$(command -v node 2>/dev/null || true)"
+  if [[ -z "$node_path" || ! -x "$node_path" ]]; then
+    return 1
   fi
 
+  cli_path="$npm_bin/nemoclaw"
+  if [[ -z "$cli_path" || ! -x "$cli_path" ]]; then
+    return 1
+  fi
+  node_dir="$(dirname "$node_path")"
+
   mkdir -p "$NEMOCLAW_SHIM_DIR"
-  ln -sfn "$npm_bin/nemoclaw" "$shim_path"
+  cat >"$shim_path" <<EOF
+#!/usr/bin/env bash
+export PATH="$node_dir:\$PATH"
+exec "$cli_path" "\$@"
+EOF
+  chmod +x "$shim_path"
   refresh_path
   ensure_local_bin_in_profile
   info "Created user-local shim at $shim_path"
@@ -815,12 +826,26 @@ resolve_openclaw_version() {
   fi
 }
 
+is_source_checkout() {
+  local repo_root="$1"
+  local package_json="${repo_root}/package.json"
+
+  [[ -f "$package_json" ]] || return 1
+  grep -q '"name"[[:space:]]*:[[:space:]]*"nemoclaw"' "$package_json" 2>/dev/null || return 1
+
+  if [[ -n "${NEMOCLAW_REPO_ROOT:-}" || -d "${repo_root}/.git" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 install_nemoclaw() {
   command_exists git || error "git was not found on PATH."
   local repo_root package_json
   repo_root="$(resolve_repo_root)"
   package_json="${repo_root}/package.json"
-  if [[ -f "$package_json" ]] && grep -q '"name"[[:space:]]*:[[:space:]]*"nemoclaw"' "$package_json" 2>/dev/null; then
+  if is_source_checkout "$repo_root"; then
     info "NemoClaw package.json found in the selected source checkout — installing from source…"
     NEMOCLAW_SOURCE_ROOT="$repo_root"
     spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$NEMOCLAW_SOURCE_ROOT" \
@@ -830,6 +855,9 @@ install_nemoclaw() {
     spin "Building NemoClaw plugin" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\"/nemoclaw && npm install --ignore-scripts && npm run build"
     spin "Linking NemoClaw CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link"
   else
+    if [[ -f "$package_json" ]]; then
+      info "Installer payload is not a persistent source checkout — installing from GitHub…"
+    fi
     info "Installing NemoClaw from GitHub…"
     # Resolve the latest release tag so we never install raw main.
     local release_ref

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -833,6 +833,10 @@ is_source_checkout() {
   [[ -f "$package_json" ]] || return 1
   grep -q '"name"[[:space:]]*:[[:space:]]*"nemoclaw"' "$package_json" 2>/dev/null || return 1
 
+  if [[ "${NEMOCLAW_BOOTSTRAP_PAYLOAD:-}" == "1" ]]; then
+    return 1
+  fi
+
   if [[ -n "${NEMOCLAW_REPO_ROOT:-}" || -d "${repo_root}/.git" ]]; then
     return 0
   fi

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -409,6 +409,7 @@ exit 98
     const prefix = path.join(tmp, "prefix");
     const npmLog = path.join(tmp, "npm.log");
     fs.mkdirSync(fakeBin);
+    fs.mkdirSync(path.join(tmp, ".git"));
     fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
 
     writeNodeStub(fakeBin);
@@ -809,7 +810,8 @@ exit 0
 
     const shimPath = path.join(tmp, ".local", "bin", "nemoclaw");
     expect(result.status).toBe(0);
-    expect(fs.readlinkSync(shimPath)).toBe(path.join(prefix, "bin", "nemoclaw"));
+    expect(fs.readFileSync(shimPath, "utf-8")).toContain(`export PATH="${fakeBin}:$PATH"`);
+    expect(fs.readFileSync(shimPath, "utf-8")).toContain(path.join(prefix, "bin", "nemoclaw"));
     expect(`${result.stdout}${result.stderr}`).toMatch(/Created user-local shim/);
   });
 
@@ -1287,6 +1289,51 @@ describe("installer pure helpers", () => {
   it("resolve_openclaw_version: falls back to Dockerfile.base when package.json omits it", () => {
     const r = callInstallerFn('resolve_openclaw_version "$PWD"');
     expect(r.stdout.trim()).toBe("2026.3.11");
+  });
+
+  it("is_source_checkout: rejects a payload-like checkout without git metadata", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-checkout-"));
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
+    );
+    const r = spawnSync(
+      "bash",
+      [
+        "-c",
+        `source "${INSTALLER}" 2>/dev/null; is_source_checkout "${tmp}" && echo yes || echo no`,
+      ],
+      {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: { HOME: tmp, PATH: TEST_SYSTEM_PATH },
+      },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("no");
+  });
+
+  it("is_source_checkout: accepts an explicit source checkout with git metadata", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-checkout-git-"));
+    fs.mkdirSync(path.join(tmp, ".git"));
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
+    );
+    const r = spawnSync(
+      "bash",
+      [
+        "-c",
+        `source "${INSTALLER}" 2>/dev/null; is_source_checkout "${tmp}" && echo yes || echo no`,
+      ],
+      {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: { HOME: tmp, PATH: TEST_SYSTEM_PATH },
+      },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("yes");
   });
 
   it("resolve_installer_version: falls back to package.json when git tags are unavailable", () => {

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -1336,6 +1336,29 @@ describe("installer pure helpers", () => {
     expect(r.stdout.trim()).toBe("yes");
   });
 
+  it("is_source_checkout: rejects bootstrap payload clones even when git metadata exists", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-checkout-bootstrap-"));
+    fs.mkdirSync(path.join(tmp, ".git"));
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
+    );
+    const r = spawnSync(
+      "bash",
+      [
+        "-c",
+        `source "${INSTALLER}" 2>/dev/null; is_source_checkout "${tmp}" && echo yes || echo no`,
+      ],
+      {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: { HOME: tmp, PATH: TEST_SYSTEM_PATH, NEMOCLAW_BOOTSTRAP_PAYLOAD: "1" },
+      },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("no");
+  });
+
   it("resolve_installer_version: falls back to package.json when git tags are unavailable", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resolve-ver-pkg-"));
     fs.mkdirSync(path.join(tmp, ".git"));
@@ -1822,7 +1845,8 @@ EOS
 #!/usr/bin/env bash
 set -euo pipefail
 # NEMOCLAW_VERSIONED_INSTALLER_PAYLOAD=1
-node "$NEMOCLAW_REPO_ROOT/bin/lib/usage-notice.js"
+repo_root="\${NEMOCLAW_REPO_ROOT:-$(cd "$(dirname "\${BASH_SOURCE[0]}")/.." && pwd)}"
+node "$repo_root/bin/lib/usage-notice.js"
 EOS
   chmod +x "$target/scripts/install.sh"
   exit 0

--- a/test/uninstall.test.js
+++ b/test/uninstall.test.js
@@ -151,6 +151,35 @@ describe("uninstall helpers", () => {
     expect(fs.existsSync(shimPath)).toBe(false);
   });
 
+  it("preserves a wrapper-like shim when extra content is appended", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-wrapper-extra-"));
+    const shimDir = path.join(tmp, ".local", "bin");
+    const shimPath = path.join(shimDir, "nemoclaw");
+
+    fs.mkdirSync(shimDir, { recursive: true });
+    fs.writeFileSync(
+      shimPath,
+      [
+        "#!/usr/bin/env bash",
+        'export PATH="/tmp/node-bin:$PATH"',
+        'exec "/tmp/prefix/bin/nemoclaw" "$@"',
+        "echo user-extra",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync("bash", ["-c", `source "${UNINSTALL_SCRIPT}"; remove_nemoclaw_cli`], {
+      cwd: path.join(import.meta.dirname, ".."),
+      encoding: "utf-8",
+      env: createFakeNpmEnv(tmp),
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(shimPath)).toBe(true);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/not an installer-managed shim/);
+  });
+
   it("removes the onboard session file as part of NemoClaw state cleanup", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-session-"));
     const stateDir = path.join(tmp, ".nemoclaw");

--- a/test/uninstall.test.js
+++ b/test/uninstall.test.js
@@ -124,6 +124,33 @@ describe("uninstall helpers", () => {
     expect(`${result.stdout}${result.stderr}`).toMatch(/not an installer-managed shim/);
   });
 
+  it("removes an installer-managed nemoclaw wrapper file in the shim directory", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-wrapper-"));
+    const shimDir = path.join(tmp, ".local", "bin");
+    const shimPath = path.join(shimDir, "nemoclaw");
+
+    fs.mkdirSync(shimDir, { recursive: true });
+    fs.writeFileSync(
+      shimPath,
+      [
+        "#!/usr/bin/env bash",
+        'export PATH="/tmp/node-bin:$PATH"',
+        'exec "/tmp/prefix/bin/nemoclaw" "$@"',
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync("bash", ["-c", `source "${UNINSTALL_SCRIPT}"; remove_nemoclaw_cli`], {
+      cwd: path.join(import.meta.dirname, ".."),
+      encoding: "utf-8",
+      env: createFakeNpmEnv(tmp),
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(shimPath)).toBe(false);
+  });
+
   it("removes the onboard session file as part of NemoClaw state cleanup", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-session-"));
     const stateDir = path.join(tmp, ".nemoclaw");

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -326,6 +326,24 @@ remove_nemoclaw_alias_from_profile() {
   done
 }
 
+is_installer_managed_nemoclaw_shim() {
+  local shim_path="$1"
+  [ -f "$shim_path" ] || return 1
+
+  local contents=""
+  contents="$(cat "$shim_path" 2>/dev/null || true)"
+  local path_line="export PATH=\""
+  local path_suffix=":\$PATH\""
+  local exec_line="exec \""
+  local exec_suffix="/nemoclaw\" \"\$@\""
+  case "$contents" in
+    '#!/usr/bin/env bash'*$'\n'"$path_line"*"$path_suffix"$'\n'"$exec_line"*"$exec_suffix"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 remove_nemoclaw_cli() {
   if command -v npm >/dev/null 2>&1; then
     npm unlink -g nemoclaw >/dev/null 2>&1 || true
@@ -339,6 +357,8 @@ remove_nemoclaw_cli() {
   fi
 
   if [ -L "${NEMOCLAW_SHIM_DIR}/nemoclaw" ]; then
+    remove_path "${NEMOCLAW_SHIM_DIR}/nemoclaw"
+  elif is_installer_managed_nemoclaw_shim "${NEMOCLAW_SHIM_DIR}/nemoclaw"; then
     remove_path "${NEMOCLAW_SHIM_DIR}/nemoclaw"
   elif [ -f "${NEMOCLAW_SHIM_DIR}/nemoclaw" ]; then
     warn "Leaving ${NEMOCLAW_SHIM_DIR}/nemoclaw in place because it is not an installer-managed shim."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -337,7 +337,7 @@ is_installer_managed_nemoclaw_shim() {
   local exec_line="exec \""
   local exec_suffix="/nemoclaw\" \"\$@\""
   case "$contents" in
-    '#!/usr/bin/env bash'*$'\n'"$path_line"*"$path_suffix"$'\n'"$exec_line"*"$exec_suffix"*)
+    '#!/usr/bin/env bash'$'\n'"$path_line"*"$path_suffix"$'\n'"$exec_line"*"$exec_suffix")
       return 0
       ;;
   esac


### PR DESCRIPTION
## Summary
Fixes a CLI install regression where `nemoclaw` was reported as installed but the command was broken after install completed.

This changes the installer so:
- user shells get a stable `~/.local/bin/nemoclaw` wrapper
- the wrapper prepends the resolved Node bin to `PATH` before execing the installed CLI
- bootstrap `curl | bash` installs no longer `npm link` a temporary cloned checkout
- bootstrap payload clones are treated as ephemeral, not as persistent source checkouts

## Root Cause
There were two installer-side problems:

1. The thin bootstrap `install.sh` cloned the selected ref into a temporary directory and then executed `scripts/install.sh` from that clone. The payload installer treated that temp clone as a source checkout and ran `npm link`, which created a global package symlink into the temp directory. Once the bootstrap temp directory was cleaned up, `nemoclaw` was broken.

2. Even when the CLI binary existed, future shells could still fail to run it because the shebang relied on `node` being on `PATH`. On hosts using `nvm`, sourcing `nvm.sh` was not sufficient to guarantee that a Node version was active in later shells.

## Related Issues
Related: #569, #989, #1429

Notes:
- `#569` is the closest installer/runtime-path issue.
- `#989` and `#1429` track the developer-doc path that requires `npm link`.
- This PR does not update docs, so it does not close `#989` or `#1429`.

## Related Prior Work
This overlaps with earlier installer investigation/work in:
- `#485` by @afurm
- `#517` by @MilanKiele

Those PRs helped surface the same general npm/prefix/PATH fragility from adjacent angles.

## What Changed
- `install.sh`
  - marks bootstrap payload execution as ephemeral via `NEMOCLAW_BOOTSTRAP_PAYLOAD=1`
- `scripts/install.sh`
  - adds a stable `~/.local/bin/nemoclaw` wrapper
  - wrapper exports the resolved Node bin onto `PATH` and execs the installed `nemoclaw`
  - `is_source_checkout()` now rejects bootstrap payload clones
- `test/install-preflight.test.js`
  - adds coverage for source checkout detection and bootstrap payload handling
  - updates shim expectations to match the wrapper behavior

## Supported Paths
This PR fixes the fully supported installer paths:
- `curl | bash`
- repo checkout + `./install.sh`

Developer repo usage remains:
- `git clone`
- `npm install`
- `npm link`
- `nemoclaw onboard`

Plain `npm install` alone is not treated as a supported CLI install path.

## Validation
Local:
- `npm test -- test/install-preflight.test.js`

Live:
- `brev-cpu` `kj-nemoclaw-cpu-test`
  - repo checkout + `./install.sh --non-interactive`
  - raw GitHub bootstrap installer equivalent to `curl | bash`
  - verified fresh-shell `command -v nemoclaw` and `nemoclaw --version`
- `spark` `spark-d8c8`
  - reproduced broken pre-fix binary state
  - repo checkout + `./install.sh --non-interactive`
  - verified fresh-shell `command -v nemoclaw` and `nemoclaw --version`

## Notes
I only live-tested non-interactive installs on this branch. Interactive install behavior was not live-retested here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Improved installer reliability and shim creation so the CLI runs correctly even when Node is outside PATH.
  * Installer better distinguishes source checkouts vs non-persistent payload installs and emits clearer informational messages.
  * Uninstaller now recognizes and removes installer-generated wrapper shims while preserving unrelated user files.

* **Tests**
  * Added and updated tests covering shim behavior, uninstall handling, and installation-type detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->