### PR TITLE
fix(test): handle dict-format sandbox registry in E2E survival test

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -7,6 +7,8 @@
 #   cloud-experimental-e2e   Experimental cloud inference test (main script skips embedded
 #                            check-docs + final cleanup; follow-up steps run check-docs,
 #                            skip/05-network-policy.sh, then cleanup.sh --verify with if: always()).
+#   sandbox-survival-e2e     Sandbox survival across gateway restarts (onboard, inference,
+#                            gateway stop/start, verify sandbox + workspace + inference).
 #   gpu-e2e                  Local Ollama inference on a GPU self-hosted runner.
 #                            Controlled by the GPU_E2E_ENABLED repository variable.
 #                            Set vars.GPU_E2E_ENABLED to "true" in repo settings to enable.
@@ -161,6 +163,33 @@ jobs:
           path: /tmp/nemoclaw-e2e-cloud-experimental-install.log
           if-no-files-found: ignore
 
+  # ── Sandbox survival (gateway restart recovery) ──────────────
+  sandbox-survival-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run sandbox survival E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-survival"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-sandbox-survival.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandbox-survival-install-log
+          path: /tmp/nemoclaw-e2e-install.log
+          if-no-files-found: ignore
+
   # ── GPU E2E (Ollama local inference) ──────────────────────────
   # Enable by setting repository variable GPU_E2E_ENABLED=true
   # (Settings → Secrets and variables → Actions → Variables)
@@ -213,8 +242,8 @@ jobs:
 
   notify-on-failure:
     runs-on: ubuntu-latest
-    needs: [cloud-e2e, cloud-experimental-e2e, gpu-e2e]
-    if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
+    needs: [cloud-e2e, cloud-experimental-e2e, sandbox-survival-e2e, gpu-e2e]
+    if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.sandbox-survival-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
     permissions:
       issues: write
     steps:

--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -100,8 +100,11 @@ registry_has() {
   [ -f "$REGISTRY" ] && python3 - "$REGISTRY" "$name" <<'PY'
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as fh:
-    sandboxes = json.load(fh).get("sandboxes", [])
-sys.exit(0 if any(sb.get("name") == sys.argv[2] for sb in sandboxes) else 1)
+    sandboxes = json.load(fh).get("sandboxes", {})
+if isinstance(sandboxes, dict):
+    sys.exit(0 if sys.argv[2] in sandboxes else 1)
+else:
+    sys.exit(0 if any(sb.get("name") == sys.argv[2] for sb in sandboxes) else 1)
 PY
 }
 


### PR DESCRIPTION
## Summary

- Fix `registry_has()` in `test-sandbox-survival.sh` — the sandbox registry format changed from an array to a dict, causing `'str' object has no attribute 'get'` and a false FAIL on the registry check after onboard
- Add `sandbox-survival-e2e` as a parallel job in the nightly E2E pipeline so gateway restart recovery is tested every night

## Test plan

- [x] Pre-commit hooks pass (shellcheck, shfmt, yaml check, gitleaks)
- [x] Verified registry fix during manual E2E sandbox survival run — all phases pass through live inference after gateway restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end sandbox checks to handle different sandbox data formats, increasing robustness of sandbox-related tests.
  * Added a new nightly sandbox-survival end-to-end job that runs the survival test and uploads install logs on failure; notification workflow now includes this job's failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->