### PR TITLE
feat(preset): add PATCH method to Outlook preset for Graph API updates

### DIFF
--- a/nemoclaw-blueprint/policies/presets/outlook.yaml
+++ b/nemoclaw-blueprint/policies/presets/outlook.yaml
@@ -17,6 +17,7 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+          - allow: { method: PATCH, path: "/**" }
       - host: login.microsoftonline.com
         port: 443
         protocol: rest

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -607,6 +607,14 @@ describe("policies", () => {
       }
     });
 
+    it("outlook preset allows PATCH on graph.microsoft.com", () => {
+      // Microsoft Graph API uses PATCH for common email and calendar operations:
+      // marking messages as read, updating drafts, modifying calendar events.
+      const content = policies.loadPreset("outlook");
+      const graphSection = content.split("host: graph.microsoft.com")[1]?.split("- host:")[0] ?? "";
+      expect(graphSection).toContain("method: PATCH");
+    });
+
     it("messaging WebSocket presets keep tls: skip on gateway endpoints", () => {
       const cases = [
         { preset: "discord", pattern: /host:\s*gateway\.discord\.gg[\s\S]*?tls:\s*skip/ },


### PR DESCRIPTION
## Summary

Add PATCH method support to the `graph.microsoft.com` endpoint in the Outlook network policy preset.

Microsoft Graph API uses PATCH for standard email and calendar operations — marking messages as read, flagging for follow-up, and updating drafts. The current preset only allows GET and POST, which blocks these workflows inside sandboxes.

Fixes #1477

## Changes

- `nemoclaw-blueprint/policies/presets/outlook.yaml`: Add `allow: { method: PATCH, path: "/**" }` to `graph.microsoft.com` (1 line)
- `test/policies.test.js`: Add regression test asserting PATCH is allowed on graph.microsoft.com in the Outlook preset (8 lines)

## Scope

- Only `graph.microsoft.com` — the other endpoints in the preset do not need PATCH
- No PUT (Graph API uses PATCH, not PUT, for updates)
- No wildcards — explicit method rule follows the principle of least privilege

## Testing

- All 964 tests pass (`npx vitest run`)
- New test fails against the unmodified preset, passes after the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network policy now permits HTTP PATCH requests to the Microsoft Graph endpoint, enabling additional operations against that service.
* **Tests**
  * Added test coverage to verify PATCH request support for the Outlook preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Steven Obiajulu <steven@usejunior.com>