### PR TITLE
fix(policy): update HuggingFace preset to router.huggingface.co

### DIFF
--- a/nemoclaw-blueprint/policies/presets/huggingface.yaml
+++ b/nemoclaw-blueprint/policies/presets/huggingface.yaml
@@ -24,7 +24,7 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
-      - host: api-inference.huggingface.co
+      - host: router.huggingface.co
         port: 443
         protocol: rest
         enforcement: enforce


### PR DESCRIPTION
## Summary
- Updates the HuggingFace policy preset from the deprecated `api-inference.huggingface.co` endpoint to `router.huggingface.co`
- The old endpoint returns HTTP 410 (Gone), breaking HuggingFace inference from sandboxes

## Test plan
- [ ] Apply huggingface preset and verify inference calls route to `router.huggingface.co`
- [ ] Confirm the old endpoint is no longer referenced in any preset files

Fixes #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the network endpoint used for HuggingFace Inference API access to route requests through the new host, preserving existing access patterns and security settings to maintain uninterrupted connectivity and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: dknos <rneebo@gmail.com>