### PR TITLE
fix(policy): scope sentry.io POST to SDK-specific paths

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -70,7 +70,8 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
+          - allow: { method: POST, path: "/api/*/envelope/" }
+          - allow: { method: POST, path: "/api/*/store/" }
     binaries:
       - { path: /usr/local/bin/claude }
 


### PR DESCRIPTION
## Summary
- Restricts sentry.io POST from `/**` to `/api/*/envelope/` and `/api/*/store/`
- Prevents potential data exfiltration via attacker-controlled Sentry projects
- The Sentry SDK only POSTs to these two path patterns

## Test plan
- [ ] Verify Sentry error reporting still works with scoped paths
- [ ] Confirm POST to arbitrary sentry.io paths is blocked

Fixes #1437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined API access controls to restrict POST operations to designated endpoints only, replacing the previous blanket access model. This security enhancement reduces the potential attack surface while preserving full GET request functionality across all endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->