### PR TITLE
fix(blueprint): pin sandbox image tag and document digest field

### DIFF
--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -4,7 +4,13 @@
 version: "0.1.0"
 min_openshell_version: "0.1.0"
 min_openclaw_version: "2026.3.0"
-digest: ""  # Computed at release time
+# Supply-chain integrity: populate the digest after building/pulling the
+# pinned image so that the blueprint is tied to an exact manifest:
+#   docker pull ghcr.io/nvidia/openshell-community/sandboxes/openclaw:0.1.0
+#   docker inspect --format='{{index .RepoDigests 0}}' \
+#       ghcr.io/nvidia/openshell-community/sandboxes/openclaw:0.1.0
+# Then paste the sha256:... value below.
+digest: ""  # TODO: pin after first 0.1.0 image publish
 
 profiles:
   - default
@@ -18,7 +24,7 @@ description: |
 
 components:
   sandbox:
-    image: "ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest"
+    image: "ghcr.io/nvidia/openshell-community/sandboxes/openclaw:0.1.0"
     name: "openclaw"
     forward_ports:
       - 18789


### PR DESCRIPTION
## Summary
- Replaces mutable `:latest` tag with explicit `:0.1.0` version tag on the sandbox image in `blueprint.yaml`
- Documents how to populate the digest field for supply chain integrity using `docker inspect`

## Test plan
- [ ] Verify blueprint still loads correctly with the updated image reference
- [ ] Confirm onboarding works with the pinned image

Fixes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated sandbox image reference to use a pinned version (0.1.0) instead of the latest tag for improved stability and supply-chain integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->