### PR TITLE
fix(test): restore port-resolution assertions in nimStatusByName tests

### DIFF
--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -217,6 +217,9 @@ describe("nim", () => {
 
           expect(st).toMatchObject({ running: true, healthy: true, container: "foo", state: "running" });
           expect(commands.some((cmd: string) => cmd.includes("docker port"))).toBe(true);
+          expect(commands.some((cmd: string) => cmd.includes("http://localhost:9000/v1/models"))).toBe(
+            true,
+          );
         } finally {
           restore();
         }
@@ -234,7 +237,12 @@ describe("nim", () => {
 
       try {
         const st = nimModule.nimStatusByName("foo");
+        const commands = runCapture.mock.calls.map(([cmd]: [string]) => cmd);
+
         expect(st).toMatchObject({ running: true, healthy: true, container: "foo", state: "running" });
+        expect(commands.some((cmd: string) => cmd.includes("http://localhost:8000/v1/models"))).toBe(
+          true,
+        );
       } finally {
         restore();
       }
@@ -249,8 +257,12 @@ describe("nim", () => {
 
       try {
         const st = nimModule.nimStatusByName("foo");
+        const commands = runCapture.mock.calls.map(([cmd]: [string]) => cmd);
+
         expect(st).toMatchObject({ running: false, healthy: false, container: "foo", state: "exited" });
         expect(runCapture.mock.calls).toHaveLength(1);
+        expect(commands.some((cmd: string) => cmd.includes("docker port"))).toBe(false);
+        expect(commands.some((cmd: string) => cmd.includes("curl"))).toBe(false);
       } finally {
         restore();
       }


### PR DESCRIPTION
## Summary
- Restores port-resolution assertions that were dropped during the TypeScript migration
- Ensures nimStatusByName correctly resolves inference endpoint ports

## Test plan
- [ ] Run the restored tests and verify they pass
- [ ] Confirm assertions match the expected port-resolution behavior

Fixes #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test assertions for NIM health check functionality to improve verification of system behavior across various configurations and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->