### PR TITLE
feat: multi-user NemoClaw — Slack/WhatsApp bridges, per-user sandboxes

### DIFF
--- a/.agents/skills/add-claw/SKILL.md
+++ b/.agents/skills/add-claw/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: add-claw
+description: Register a new NemoClaw user, create their sandbox, and bring it up on the current DGX multi-user deployment. Use when asked to add a claw, create a claw, provision a new user sandbox, or onboard a Slack user into the current NemoClaw deployment.
+---
+
+# Add Claw
+
+This skill creates a new user claw on the current DGX-hosted multi-user NemoClaw deployment.
+
+Required arguments:
+
+1. Slack user ID
+2. Display name
+3. Claw name
+4. GitHub handle
+
+Validate before running:
+
+- Slack user ID must match `^U[A-Z0-9]+$`
+- claw name must match `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
+- display name and GitHub handle must be non-empty
+
+If validation fails, stop and show:
+
+```text
+Usage: add-claw <slack_id> <display_name> <claw_name> <github_handle>
+Example: add-claw U12345ABC "Jane Doe" jane-claw janedoe
+```
+
+Run from the repo root:
+
+```bash
+node bin/nemoclaw.js user-add --non-interactive \
+  --slack-id "<slack_id>" \
+  --display-name "<display_name>" \
+  --claw-name "<claw_name>" \
+  --github-user "<github_handle>"
+```
+
+Then run full bring-up:
+
+```bash
+bash scripts/nemoclaw-resilience.sh \
+  --sandbox "<claw_name>" \
+  --cred-dir "persist/users/<slack_id>/credentials" \
+  --github-user "<github_handle>" \
+  --slack-user-id "<slack_id>"
+```
+
+Notes:
+
+- The Slack bridge now reloads user registry state per message, so no bridge restart is required after add.
+- Report failures immediately and stop at the failing step.
+- Summarize:
+  - user registered
+  - sandbox created
+  - resilience run completed or failed
+  - any warnings

--- a/.agents/skills/delete-claw/SKILL.md
+++ b/.agents/skills/delete-claw/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: delete-claw
+description: Fully purge a NemoClaw user from the current DGX multi-user deployment by deleting their sandbox, registry entry, and persist data. Use when asked to delete a claw, remove a claw, purge a user sandbox, or deprovision a Slack user from the current deployment.
+---
+
+# Delete Claw
+
+This skill performs a full purge for a claw on the current DGX-hosted multi-user NemoClaw deployment.
+
+Required argument:
+
+1. Claw name
+
+Validate before running:
+
+- claw name must match `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
+- the claw must exist in `node bin/nemoclaw.js user-list`
+
+If validation fails, stop and show:
+
+```text
+Usage: delete-claw <claw_name>
+Example: delete-claw alice-claw
+```
+
+Before destruction, confirm with the user that this will remove:
+
+- the sandbox
+- the user registry entry
+- all persist data for that user
+
+Run from the repo root:
+
+```bash
+node bin/nemoclaw.js user-purge --sandbox "<claw_name>"
+```
+
+Notes:
+
+- The Slack bridge now reloads user registry state per message, so no bridge restart is required after delete.
+- This is destructive. Do not continue without explicit confirmation.
+- Summarize:
+  - sandbox destroyed
+  - registry entry removed
+  - persist data removed
+  - any warnings

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,39 @@ RUN (apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
     && apt-get autoremove --purge -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Claude Code CLI (pin version for reproducible builds)
+RUN npm install -g @anthropic-ai/claude-code@2.1.81
+
+# Install GitHub CLI (gh)
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -sL "https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_linux_${ARCH}.tar.gz" \
+    | tar xz -C /tmp && cp /tmp/gh_*/bin/gh /usr/local/bin/gh && rm -rf /tmp/gh_*
+
+# Install gog CLI (Google OAuth helper for headless environments)
+RUN ARCH=$(dpkg --print-architecture) && \
+    GOG_ARCH=$([ "$ARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
+    curl -sL "https://github.com/steipete/gogcli/releases/download/v0.12.0/gogcli_0.12.0_linux_${GOG_ARCH}.tar.gz" \
+    | tar xz -C /tmp && cp /tmp/gog /usr/local/bin/gog && chmod +x /usr/local/bin/gog && rm -f /tmp/gog
+
+# Install xurl (X/Twitter API CLI)
+RUN ARCH=$(dpkg --print-architecture) && \
+    XURL_ARCH=$([ "$ARCH" = "arm64" ] && echo "arm64" || echo "x86_64") && \
+    curl -sL "https://github.com/xdevplatform/xurl/releases/download/v1.0.3/xurl_Linux_${XURL_ARCH}.tar.gz" \
+    | tar xz -C /tmp && cp /tmp/xurl /usr/local/bin/xurl && chmod +x /usr/local/bin/xurl && rm -f /tmp/xurl
+
+# Install JDK and Gradle (always use Gradle for Java projects, never Maven)
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends default-jdk-headless unzip \
+    && GRADLE_VERSION=8.13 \
+    && curl -fsSL "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -o /tmp/gradle.zip \
+    && unzip -q /tmp/gradle.zip -d /opt \
+    && ln -sf "/opt/gradle-${GRADLE_VERSION}/bin/gradle" /usr/local/bin/gradle \
+    && rm -f /tmp/gradle.zip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install PyYAML for blueprint runner
+RUN pip3 install --break-system-packages pyyaml
+
 # Copy built plugin and blueprint into the sandbox
 COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
@@ -54,7 +87,6 @@ ARG CHAT_UI_URL=http://127.0.0.1:18789
 ARG NEMOCLAW_INFERENCE_BASE_URL=https://inference.local/v1
 ARG NEMOCLAW_INFERENCE_API=openai-completions
 ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=
-ARG NEMOCLAW_WEB_CONFIG_B64=e30=
 # Set to "1" to disable device-pairing auth (development/headless only).
 # Default: "0" (device auth enabled — secure by default).
 ARG NEMOCLAW_DISABLE_DEVICE_AUTH=0
@@ -72,15 +104,19 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
     NEMOCLAW_INFERENCE_BASE_URL=${NEMOCLAW_INFERENCE_BASE_URL} \
     NEMOCLAW_INFERENCE_API=${NEMOCLAW_INFERENCE_API} \
     NEMOCLAW_INFERENCE_COMPAT_B64=${NEMOCLAW_INFERENCE_COMPAT_B64} \
-    NEMOCLAW_WEB_CONFIG_B64=${NEMOCLAW_WEB_CONFIG_B64} \
     NEMOCLAW_DISABLE_DEVICE_AUTH=${NEMOCLAW_DISABLE_DEVICE_AUTH}
 
 WORKDIR /sandbox
 USER sandbox
 
+# Pre-create OpenClaw directories
+RUN mkdir -p /sandbox/.openclaw/agents/main/agent \
+    && chmod 700 /sandbox/.openclaw
+
 # Write the COMPLETE openclaw.json including gateway config and auth token.
+# Claude Sonnet 4.6 as default, nvidia as fallback.
+# ANTHROPIC_API_KEY is injected at runtime from Claude credentials.
 # This file is immutable at runtime (Landlock read-only on /sandbox/.openclaw).
-# No runtime writes to openclaw.json are needed or possible.
 # Build args (NEMOCLAW_MODEL, CHAT_UI_URL) customize per deployment.
 # Auth token is generated per build so each image has a unique token.
 RUN python3 -c "\
@@ -93,7 +129,6 @@ primary_model_ref = os.environ['NEMOCLAW_PRIMARY_MODEL_REF']; \
 inference_base_url = os.environ['NEMOCLAW_INFERENCE_BASE_URL']; \
 inference_api = os.environ['NEMOCLAW_INFERENCE_API']; \
 inference_compat = json.loads(base64.b64decode(os.environ['NEMOCLAW_INFERENCE_COMPAT_B64']).decode('utf-8')); \
-web_config = json.loads(base64.b64decode(os.environ.get('NEMOCLAW_WEB_CONFIG_B64', 'e30=') or 'e30=').decode('utf-8')); \
 parsed = urlparse(chat_ui_url); \
 chat_origin = f'{parsed.scheme}://{parsed.netloc}' if parsed.scheme and parsed.netloc else 'http://127.0.0.1:18789'; \
 origins = ['http://127.0.0.1:18789']; \
@@ -109,8 +144,15 @@ providers = { \
     } \
 }; \
 config = { \
-    'agents': {'defaults': {'model': {'primary': primary_model_ref}}}, \
-    'models': {'mode': 'merge', 'providers': providers}, \
+    'agents': {'defaults': {'model': {'primary': 'anthropic/claude-sonnet-4-6'}}}, \
+    'models': {'mode': 'merge', 'providers': {**providers, \
+        'anthropic': { \
+            'baseUrl': 'https://api.anthropic.com/v1', \
+            'apiKey': 'injected-at-runtime', \
+            'api': 'anthropic-messages', \
+            'models': [{'id': 'claude-sonnet-4-6', 'name': 'Claude Sonnet 4.6', 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 200000, 'maxTokens': 64000}] \
+        } \
+    }}, \
     'channels': {'defaults': {'configWrites': False}}, \
     'gateway': { \
         'mode': 'local', \
@@ -123,20 +165,6 @@ config = { \
         'auth': {'token': secrets.token_hex(32)} \
     } \
 }; \
-config.update({ \
-    'tools': { \
-        'web': { \
-            'search': { \
-                'enabled': True, \
-                'provider': 'brave', \
-                **({'apiKey': web_config.get('apiKey', '')} if web_config.get('apiKey', '') else {}) \
-            }, \
-            'fetch': { \
-                'enabled': bool(web_config.get('fetchEnabled', True)) \
-            } \
-        } \
-    } \
-} if web_config.get('provider') == 'brave' else {}); \
 path = os.path.expanduser('~/.openclaw/openclaw.json'); \
 json.dump(config, open(path, 'w'), indent=2); \
 os.chmod(path, 0o600)"

--- a/bin/lib/credential-setup.js
+++ b/bin/lib/credential-setup.js
@@ -1,0 +1,628 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Self-service credential and personality setup via Slack DM.
+// Handles !setup commands: saves credentials to persist dir, injects into sandbox.
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+const { resolveOpenshell } = require("./resolve-openshell");
+const userRegistry = require("./user-registry");
+
+const OPENSHELL = resolveOpenshell();
+const REPO_DIR = path.resolve(__dirname, "../..");
+
+function resolvePath(relPath) {
+  if (relPath.startsWith("/")) return relPath;
+  return path.join(REPO_DIR, relPath);
+}
+
+function sshCmd(sandbox, cmd) {
+  const confPath = `/tmp/ssh-config-${sandbox}`;
+  // Ensure we have a fresh SSH config
+  try {
+    const cfg = execSync(`"${OPENSHELL}" sandbox ssh-config "${sandbox}"`, { encoding: "utf-8" });
+    fs.writeFileSync(confPath, cfg);
+  } catch {
+    throw new Error(`Cannot reach sandbox '${sandbox}'. Is it running?`);
+  }
+  return execSync(
+    `ssh -F "${confPath}" -o StrictHostKeyChecking=no -o ConnectTimeout=10 "openshell-${sandbox}" ${JSON.stringify(cmd)}`,
+    { encoding: "utf-8", timeout: 30000 }
+  );
+}
+
+function sshPipe(sandbox, data, remoteCmd) {
+  const confPath = `/tmp/ssh-config-${sandbox}`;
+  const { execFileSync } = require("child_process");
+  try {
+    const cfg = execSync(`"${OPENSHELL}" sandbox ssh-config "${sandbox}"`, { encoding: "utf-8" });
+    fs.writeFileSync(confPath, cfg);
+  } catch {
+    throw new Error(`Cannot reach sandbox '${sandbox}'.`);
+  }
+  execFileSync("ssh", ["-F", confPath, "-o", "StrictHostKeyChecking=no", `openshell-${sandbox}`, remoteCmd], {
+    input: data,
+    timeout: 30000,
+  });
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Try to set up heartbeat cron for a user if they have a HEARTBEAT.md.
+ * Non-fatal — silently skips if prerequisites aren't met.
+ */
+function trySetupHeartbeatCron(user) {
+  try {
+    const scriptPath = path.join(REPO_DIR, "scripts", "setup-heartbeat-cron.sh");
+    if (!fs.existsSync(scriptPath)) return null;
+    const result = execSync(
+      `bash "${scriptPath}" "${user.sandboxName}" --slack-user-id "${user.slackUserId}"`,
+      { encoding: "utf-8", timeout: 60000, env: { ...process.env, SSH_CONF: `/tmp/ssh-config-${user.sandboxName}` } }
+    );
+    if (result.includes("created")) {
+      return "\nHeartbeat cron job auto-configured (every 30m).";
+    }
+  } catch {}
+  return null;
+}
+
+// ── Setup handlers ──────────────────────────────────────────────
+
+function setupGithub(user, token) {
+  token = token.trim();
+  if (!token.startsWith("ghp_") && !token.startsWith("gho_") && !token.startsWith("github_pat_")) {
+    return "Invalid GitHub token. Expected a token starting with `ghp_`, `gho_`, or `github_pat_`.";
+  }
+
+  const credDir = resolvePath(user.credentialsDir);
+  fs.mkdirSync(credDir, { recursive: true, mode: 0o700 });
+
+  // Save gh-hosts.yml
+  const ghUser = user.githubUser || "user";
+  const hostsYml = `github.com:\n  oauth_token: ${token}\n  user: ${ghUser}\n  git_protocol: https\n`;
+  const hostsPath = path.join(credDir, "gh-hosts.yml");
+  fs.writeFileSync(hostsPath, hostsYml, { mode: 0o600 });
+
+  // Inject into sandbox
+  const b64 = Buffer.from(hostsYml).toString("base64");
+  sshPipe(user.sandboxName, b64 + "\n",
+    "mkdir -p /sandbox/.config/gh && base64 -d | tee /sandbox/.config/gh/hosts.yml > /dev/null && chmod 600 /sandbox/.config/gh/hosts.yml");
+
+  // Set git config
+  if (user.githubUser) {
+    sshCmd(user.sandboxName,
+      `git config --global user.name '${user.githubUser}' && git config --global user.email '${user.githubUser}@users.noreply.github.com'`);
+  }
+
+  return `GitHub token saved and injected into sandbox \`${user.sandboxName}\`.` +
+    (user.githubUser ? `\nGit config set to \`${user.githubUser}\`.` : "");
+}
+
+function setupClaude(user, jsonStr) {
+  jsonStr = jsonStr.trim();
+  // Accept either raw JSON or a code block
+  jsonStr = jsonStr.replace(/^```(?:json)?\s*/m, "").replace(/\s*```$/m, "");
+
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    return "Invalid JSON. Paste the contents of your `~/.claude/.credentials.json` file.";
+  }
+
+  const credDir = resolvePath(user.credentialsDir);
+  fs.mkdirSync(credDir, { recursive: true, mode: 0o700 });
+
+  const credPath = path.join(credDir, "claude-credentials.json");
+  fs.writeFileSync(credPath, JSON.stringify(parsed, null, 2), { mode: 0o600 });
+
+  // Inject into sandbox
+  const b64 = Buffer.from(JSON.stringify(parsed)).toString("base64");
+  sshCmd(user.sandboxName, "mkdir -p /sandbox/.claude");
+  sshPipe(user.sandboxName, b64 + "\n",
+    "base64 -d > /sandbox/.claude/.credentials.json && chmod 600 /sandbox/.claude/.credentials.json");
+
+  // Patch ANTHROPIC_API_KEY in openclaw config
+  const accessToken = (parsed.claudeAiOauth || {}).accessToken || "";
+  if (accessToken) {
+    try {
+      sshCmd(user.sandboxName,
+        `grep -q ANTHROPIC_API_KEY /sandbox/.env 2>/dev/null && sed -i 's|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${accessToken}|' /sandbox/.env || echo 'ANTHROPIC_API_KEY=${accessToken}' >> /sandbox/.env; chmod 600 /sandbox/.env`);
+    } catch {}
+    try {
+      const patchScript = `
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+if os.path.exists(path):
+    cfg = json.load(open(path))
+    p = cfg.get('models',{}).get('providers',{}).get('anthropic',{})
+    if p:
+        p['apiKey'] = '${accessToken}'
+    cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = 'anthropic/claude-sonnet-4-6'
+    json.dump(cfg, open(path, 'w'), indent=2)
+    os.chmod(path, 0o600)
+`;
+      const scriptB64 = Buffer.from(patchScript).toString("base64");
+      sshPipe(user.sandboxName, scriptB64 + "\n", "base64 -d | python3");
+    } catch {}
+  }
+
+  return `Claude credentials saved and injected into sandbox \`${user.sandboxName}\`.\n` +
+    "Anthropic runtime config was updated from the new Claude OAuth access token and reset to the Claude primary model.";
+}
+
+function setupClaudeToken(user, token) {
+  token = token.trim();
+  token = token.replace(/^```\s*/m, "").replace(/\s*```$/m, "").trim();
+
+  if (!token.startsWith("sk-ant-oat")) {
+    return "Invalid Claude token. Expected the long-lived token produced by `claude setup-token`.\n" +
+      "It should start with `sk-ant-oat`.";
+  }
+
+  const credDir = resolvePath(user.credentialsDir);
+  fs.mkdirSync(credDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(credDir, "claude-oauth-token.txt"), token, { mode: 0o600 });
+  try {
+    fs.rmSync(path.join(credDir, "claude-credentials.json"), { force: true });
+  } catch {}
+
+  try {
+    sshCmd(user.sandboxName,
+      `grep -q CLAUDE_CODE_OAUTH_TOKEN /sandbox/.env 2>/dev/null && sed -i 's|^CLAUDE_CODE_OAUTH_TOKEN=.*|CLAUDE_CODE_OAUTH_TOKEN=${token}|' /sandbox/.env || echo 'CLAUDE_CODE_OAUTH_TOKEN=${token}' >> /sandbox/.env; chmod 600 /sandbox/.env`);
+    sshCmd(user.sandboxName,
+      `grep -q ANTHROPIC_API_KEY /sandbox/.env 2>/dev/null && sed -i 's|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${token}|' /sandbox/.env || echo 'ANTHROPIC_API_KEY=${token}' >> /sandbox/.env; chmod 600 /sandbox/.env`);
+    sshCmd(user.sandboxName, "rm -f /sandbox/.claude/.credentials.json");
+  } catch {}
+
+  try {
+    const patchScript = `
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+if os.path.exists(path):
+    cfg = json.load(open(path))
+    p = cfg.get('models',{}).get('providers',{}).get('anthropic',{})
+    if p:
+        p['apiKey'] = '${token}'
+    cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = 'anthropic/claude-sonnet-4-6'
+    json.dump(cfg, open(path, 'w'), indent=2)
+    os.chmod(path, 0o600)
+`;
+    const scriptB64 = Buffer.from(patchScript).toString("base64");
+    sshPipe(user.sandboxName, scriptB64 + "\n", "base64 -d | python3");
+  } catch {}
+
+  return `Claude long-lived token saved and injected into sandbox \`${user.sandboxName}\`.\n` +
+    "This token came from `claude setup-token`, is now the preferred per-user Claude auth source, and reset the sandbox back to the Claude primary model.";
+}
+
+function setupGoogle(user, b64Data) {
+  b64Data = b64Data.trim();
+  // Accept code blocks
+  b64Data = b64Data.replace(/^```\s*/m, "").replace(/\s*```$/m, "");
+
+  if (!b64Data) {
+    return "Please provide your gogcli credentials as a base64-encoded tar archive.\n" +
+      "On your machine, run:\n```\ncd ~/.config/gogcli && tar czf - . | base64\n```\n" +
+      "Then paste the output after `!setup google `.";
+  }
+
+  // Validate it's base64
+  try {
+    Buffer.from(b64Data.slice(0, 100), "base64");
+  } catch {
+    return "That doesn't look like valid base64. Run `cd ~/.config/gogcli && tar czf - . | base64` and paste the full output.";
+  }
+
+  const credDir = resolvePath(user.credentialsDir);
+  const gogDir = path.join(credDir, "gogcli");
+  fs.mkdirSync(gogDir, { recursive: true, mode: 0o700 });
+
+  // Save the base64 data to decode locally
+  const tarData = Buffer.from(b64Data, "base64");
+  execSync(`tar xzf - -C ${JSON.stringify(gogDir)}`, { input: tarData, timeout: 10000 });
+  execSync(`chmod -R 700 ${JSON.stringify(gogDir)}`);
+
+  // Inject into sandbox
+  sshPipe(user.sandboxName, b64Data + "\n",
+    "mkdir -p /sandbox/.config/gogcli && base64 -d | tar xzf - -C /sandbox/.config/gogcli && chmod -R 700 /sandbox/.config/gogcli");
+
+  let msg = `Google (gogcli) credentials saved and injected into sandbox \`${user.sandboxName}\`.`;
+  const hb = trySetupHeartbeatCron(user);
+  if (hb) msg += hb;
+  return msg;
+}
+
+function setupPersonality(user, content) {
+  content = content.trim();
+  if (!content) {
+    return "Please provide your personality text after the command.\n" +
+      "Example: `!setup personality You are a helpful coding assistant named Alice. You are friendly and concise.`";
+  }
+
+  const workspaceDir = resolvePath(user.personalityDir);
+  fs.mkdirSync(workspaceDir, { recursive: true });
+
+  // Save SOUL.md locally
+  fs.writeFileSync(path.join(workspaceDir, "SOUL.md"), content);
+
+  // Inject into sandbox
+  const b64 = Buffer.from(content).toString("base64");
+  sshPipe(user.sandboxName, b64 + "\n",
+    "base64 -d > /sandbox/.openclaw/workspace/SOUL.md");
+
+  return `Agent personality (SOUL.md) updated in sandbox \`${user.sandboxName}\`.`;
+}
+
+function setupHeartbeat(user, content) {
+  content = content.trim();
+  if (!content) {
+    return "Please provide your heartbeat instructions after the command.\n" +
+      "This controls what your agent checks periodically (email, calendar, etc.).\n" +
+      "Example: `!setup heartbeat Check my Gmail for urgent emails. Check my Google Calendar for meetings in the next 2 hours. Send a summary to Slack.`";
+  }
+
+  const workspaceDir = resolvePath(user.personalityDir);
+  fs.mkdirSync(workspaceDir, { recursive: true });
+
+  // Save HEARTBEAT.md locally
+  fs.writeFileSync(path.join(workspaceDir, "HEARTBEAT.md"), content);
+
+  // Inject into sandbox
+  const b64 = Buffer.from(content).toString("base64");
+  sshPipe(user.sandboxName, b64 + "\n",
+    "base64 -d > /sandbox/.openclaw/workspace/HEARTBEAT.md");
+
+  let msg = `Heartbeat instructions (HEARTBEAT.md) updated in sandbox \`${user.sandboxName}\`.`;
+  const hb = trySetupHeartbeatCron(user);
+  if (hb) msg += hb;
+  return msg;
+}
+
+function setupIdentity(user, content) {
+  content = content.trim();
+  if (!content) {
+    return "Please provide your agent identity/name after the command.\n" +
+      "Example: `!setup identity You are Alice, a personal AI assistant.`";
+  }
+
+  const workspaceDir = resolvePath(user.personalityDir);
+  fs.mkdirSync(workspaceDir, { recursive: true });
+
+  fs.writeFileSync(path.join(workspaceDir, "IDENTITY.md"), content);
+
+  const b64 = Buffer.from(content).toString("base64");
+  sshPipe(user.sandboxName, b64 + "\n",
+    "base64 -d > /sandbox/.openclaw/workspace/IDENTITY.md");
+
+  return `Agent identity (IDENTITY.md) updated in sandbox \`${user.sandboxName}\`.`;
+}
+
+function setupUser(user, content) {
+  content = content.trim();
+  if (!content) {
+    return "Please provide context about yourself after the command.\n" +
+      "This helps your agent understand who you are.\n" +
+      "Example: `!setup user I'm Alice, a backend engineer at Acme Corp. I work on the payments service in Go.`";
+  }
+
+  const workspaceDir = resolvePath(user.personalityDir);
+  fs.mkdirSync(workspaceDir, { recursive: true });
+
+  fs.writeFileSync(path.join(workspaceDir, "USER.md"), content);
+
+  const b64 = Buffer.from(content).toString("base64");
+  sshPipe(user.sandboxName, b64 + "\n",
+    "base64 -d > /sandbox/.openclaw/workspace/USER.md");
+
+  return `User context (USER.md) updated in sandbox \`${user.sandboxName}\`.`;
+}
+
+function setupFreshrelease(user, key) {
+  key = key.trim();
+  // Accept code blocks
+  key = key.replace(/^```\s*/m, "").replace(/\s*```$/m, "").trim();
+
+  if (!key) {
+    return "Please provide your Freshrelease API key after the command.\n" +
+      "Example: `!setup freshrelease <your-api-key>`\n" +
+      "Get one from: Freshrelease → Profile → API Key";
+  }
+
+  // Persist to credentials dir
+  const credDir = resolvePath(user.credentialsDir);
+  fs.mkdirSync(credDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(credDir, "freshrelease-api-key.txt"), key, { mode: 0o600 });
+
+  // Patch Claude settings.json on the sandbox to add/update the Freshrelease MCP server
+  // Use sshPipe + base64 to avoid shell escaping issues with multi-line Python
+  const patchScript = `
+import json, os, sys
+path = '/sandbox/.claude/settings.json'
+if not os.path.exists(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    json.dump({}, open(path, 'w'), indent=4)
+cfg = json.load(open(path))
+mcp = cfg.setdefault('mcpServers', {})
+mcp['freshrelease'] = {
+    'command': '/usr/local/bin/freshrelease-mcp',
+    'args': [],
+    'env': {
+        'FRESHRELEASE_DOMAIN': 'freshworks.freshrelease.com',
+        'FRESHRELEASE_API_KEY': '${key}'
+    }
+}
+json.dump(cfg, open(path, 'w'), indent=4)
+os.chmod(path, 0o600)
+`;
+  const scriptB64 = Buffer.from(patchScript).toString("base64");
+  sshPipe(user.sandboxName, scriptB64 + "\n",
+    "base64 -d | python3");
+
+  return `Freshrelease API key saved and MCP server configured in sandbox \`${user.sandboxName}\`.\n` +
+    "This does not configure Claude auth. Use `!setup claude` separately.";
+}
+
+function setupWebhook(user, url) {
+  url = url.trim();
+  if (!url.startsWith("https://hooks.slack.com/")) {
+    return "Invalid webhook URL. Expected a URL starting with `https://hooks.slack.com/`.";
+  }
+
+  // Persist to credentials dir
+  const credDir = resolvePath(user.credentialsDir);
+  fs.mkdirSync(credDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(credDir, "slack-webhook-url.txt"), url, { mode: 0o600 });
+
+  // Inject into sandbox .env
+  sshCmd(user.sandboxName,
+    `grep -q SLACK_WEBHOOK_URL /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_WEBHOOK_URL=.*|SLACK_WEBHOOK_URL=${url}|' /sandbox/.env || echo 'SLACK_WEBHOOK_URL=${url}' >> /sandbox/.env; chmod 600 /sandbox/.env`);
+
+  let msg = `Slack webhook URL saved and injected into sandbox \`${user.sandboxName}\`.\n` +
+    "Heartbeat notifications will use this webhook as a fallback if bot DM delivery fails.";
+  const hb = trySetupHeartbeatCron(user);
+  if (hb) msg += hb;
+  return msg;
+}
+
+function setupTimezone(user, tz) {
+  tz = tz.trim();
+  if (!tz) {
+    const current = user.timezone || "UTC";
+    return `Your current timezone is \`${current}\`.\n` +
+      "To change it, provide an IANA timezone name:\n" +
+      "Example: `!setup timezone America/Los_Angeles`\n" +
+      "Common values: `America/New_York`, `America/Chicago`, `America/Los_Angeles`, `Asia/Kolkata`, `Europe/London`, `UTC`";
+  }
+
+  // Basic validation: must look like Area/City or UTC
+  if (tz !== "UTC" && !/^[A-Z][a-z]+\/[A-Z][a-z_]+/.test(tz)) {
+    return `Invalid timezone: \`${tz}\`.\n` +
+      "Use IANA format like `America/Los_Angeles`, `Asia/Kolkata`, or `UTC`.";
+  }
+
+  // Save to user registry
+  userRegistry.updateUser(user.slackUserId, { timezone: tz });
+
+  return `Timezone set to \`${tz}\` for ${user.slackDisplayName}.`;
+}
+
+function setupWhatsApp(user, number) {
+  // Slack auto-links phone numbers: <tel:+15551234567|+15551234567> — extract the raw number
+  number = number.trim().replace(/<tel:([^|>]+)\|?[^>]*>/g, "$1").replace(/<[^>]+>/g, "").trim();
+  if (!number) {
+    const credDir = resolvePath(user.credentialsDir);
+    const waFile = path.join(credDir, "whatsapp-number.txt");
+    const current = fs.existsSync(waFile) ? fs.readFileSync(waFile, "utf-8").trim() : "not set";
+    return `Your WhatsApp number: \`${current}\`\n` +
+      "To set/change: `!setup whatsapp +1XXXXXXXXXX`\n" +
+      "Use E.164 format (country code + number, no spaces/dashes).";
+  }
+
+  // Normalize: strip everything except + and digits
+  const cleaned = number.replace(/[^+0-9]/g, "");
+  if (!/^\+?[1-9][0-9]{6,14}$/.test(cleaned)) {
+    return `Invalid phone number: \`${number}\`.\nUse E.164 format: \`+1XXXXXXXXXX\` (country code + number).`;
+  }
+
+  const credDir = resolvePath(user.credentialsDir);
+  fs.mkdirSync(credDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(credDir, "whatsapp-number.txt"), cleaned, { mode: 0o600 });
+
+  return `WhatsApp number set to \`${cleaned}\` for ${user.slackDisplayName}.\n` +
+    "You'll receive notification forwarding on WhatsApp (emoji-prefixed messages).\n" +
+    "To chat with your claw via WhatsApp, DM the bot's WhatsApp number.";
+}
+
+function setupStatus(user) {
+  const credDir = resolvePath(user.credentialsDir);
+  const workspaceDir = resolvePath(user.personalityDir);
+
+  const checks = {
+    "Claude credentials": fs.existsSync(path.join(credDir, "claude-credentials.json")),
+    "Claude Teams token": fs.existsSync(path.join(credDir, "claude-oauth-token.txt")),
+    "GitHub token": fs.existsSync(path.join(credDir, "gh-hosts.yml")),
+    "Google OAuth (gogcli)": fs.existsSync(path.join(credDir, "gogcli", "config.json")),
+    "Freshrelease API key": fs.existsSync(path.join(credDir, "freshrelease-api-key.txt")),
+    "WhatsApp number": fs.existsSync(path.join(credDir, "whatsapp-number.txt")),
+    "Personality (SOUL.md)": fs.existsSync(path.join(workspaceDir, "SOUL.md")),
+    "Identity (IDENTITY.md)": fs.existsSync(path.join(workspaceDir, "IDENTITY.md")),
+    "Heartbeat (HEARTBEAT.md)": fs.existsSync(path.join(workspaceDir, "HEARTBEAT.md")),
+    "User context (USER.md)": fs.existsSync(path.join(workspaceDir, "USER.md")),
+  };
+
+  let sandboxStatus = "unknown";
+  try {
+    const out = execSync("openshell sandbox list 2>&1", { encoding: "utf-8" });
+    if (out.includes(user.sandboxName) && out.includes("Ready")) {
+      sandboxStatus = "Ready";
+    } else if (out.includes(user.sandboxName)) {
+      sandboxStatus = "Not Ready";
+    } else {
+      sandboxStatus = "Not Found";
+    }
+  } catch {
+    sandboxStatus = "cannot check";
+  }
+
+  const lines = [
+    `*Setup status for ${user.slackDisplayName}*`,
+    `Sandbox: \`${user.sandboxName}\` (${sandboxStatus})`,
+    `Timezone: \`${user.timezone || "UTC"}\``,
+    "",
+  ];
+
+  for (const [name, ok] of Object.entries(checks)) {
+    lines.push(`${ok ? ":white_check_mark:" : ":x:"} ${name}`);
+  }
+
+  lines.push("");
+  lines.push("_Credentials: DM me `!setup help` for commands._");
+
+  return lines.join("\n");
+}
+
+function setupHelp() {
+  return `*Developer Self-Service Tool Setup*
+
+*Credentials* (send via DM only — your message will be deleted after processing):
+• \`!setup github <token>\` — GitHub personal access token (ghp_...)
+• \`!setup claude-token <token>\` — Recommended for Claude Teams users, especially on macOS. Run \`claude setup-token\` on your machine and paste the long-lived token
+• \`!setup freshrelease <key>\` — Freshrelease API key for ticket management MCP
+• \`!setup webhook <url>\` — Slack incoming webhook URL (optional override)
+• \`!setup claude <json>\` — Secondary option for users whose Claude Code install stores OAuth JSON on disk. In practice this is mainly Linux users with \`~/.claude/.credentials.json\`
+• \`!setup google <base64>\` — Google OAuth credentials
+  _Run on your machine:_ \`cd ~/.config/gogcli && tar czf - . | base64\`
+
+*Personalization* (safe to send in DM or channel):
+• \`!setup personality <text>\` — Set your agent's personality (SOUL.md)
+• \`!setup identity <text>\` — Set your agent's name/role (IDENTITY.md)
+• \`!setup user <text>\` — Tell your agent about yourself (USER.md)
+• \`!setup heartbeat <text>\` — Configure periodic checks (HEARTBEAT.md)
+• \`!setup timezone <tz>\` — Set your timezone (e.g. \`America/Los_Angeles\`, \`Asia/Kolkata\`, \`UTC\`)
+
+*Status:*
+• \`!setup status\` — Check which credentials and files are configured
+
+*Notifications:*
+Heartbeat notifications (email/calendar alerts) are sent as DMs from this bot by default — no setup needed.
+Use \`!setup webhook\` only if you want notifications posted to a specific channel instead.
+
+*Claude Teams Note:*
+Most MacBook users should use \`!setup claude-token <token>\` after running \`claude setup-token\`.
+Use \`!setup claude <json>\` only if your machine actually has \`~/.claude/.credentials.json\` available, which is more common on Linux.
+
+_All credential messages are deleted immediately after processing for security._`;
+}
+
+// ── Main dispatch ───────────────────────────────────────────────
+
+const CREDENTIAL_COMMANDS = new Set(["github", "claude", "claude-token", "google", "webhook", "freshrelease", "whatsapp"]);
+
+/**
+ * Handle a !setup command.
+ * @param {object} user - User registry entry
+ * @param {string} text - Full message text after "!setup "
+ * @returns {{ response: string, deleteMessage: boolean }}
+ */
+function handleSetup(user, text) {
+  const spaceIdx = text.indexOf(" ");
+  const subcommand = spaceIdx === -1 ? text : text.slice(0, spaceIdx);
+  const arg = spaceIdx === -1 ? "" : text.slice(spaceIdx + 1);
+
+  let response;
+  let deleteMessage = false;
+
+  try {
+    switch (subcommand.toLowerCase()) {
+      case "github":
+        response = setupGithub(user, arg);
+        deleteMessage = true;
+        break;
+      case "claude":
+        response = setupClaude(user, arg);
+        deleteMessage = true;
+        break;
+      case "claude-token":
+        response = setupClaudeToken(user, arg);
+        deleteMessage = true;
+        break;
+      case "google":
+        response = setupGoogle(user, arg);
+        deleteMessage = true;
+        break;
+      case "webhook":
+        response = setupWebhook(user, arg);
+        deleteMessage = true;
+        break;
+      case "freshrelease":
+        response = setupFreshrelease(user, arg);
+        deleteMessage = true;
+        break;
+      case "personality":
+        response = setupPersonality(user, arg);
+        break;
+      case "identity":
+        response = setupIdentity(user, arg);
+        break;
+      case "user":
+        response = setupUser(user, arg);
+        break;
+      case "heartbeat":
+        response = setupHeartbeat(user, arg);
+        break;
+      case "timezone":
+        response = setupTimezone(user, arg);
+        break;
+      case "whatsapp":
+        response = setupWhatsApp(user, arg);
+        deleteMessage = true;
+        break;
+      case "status":
+        response = setupStatus(user);
+        break;
+      case "help":
+        response = setupHelp();
+        break;
+      default:
+        response = `Unknown setup command: \`${subcommand}\`. Run \`!setup help\` for available commands.`;
+        break;
+    }
+  } catch (err) {
+    response = `Setup failed: ${err.message}`;
+    // Still delete credential messages even on error
+    deleteMessage = CREDENTIAL_COMMANDS.has(subcommand.toLowerCase());
+  }
+
+  return { response, deleteMessage };
+}
+
+/**
+ * Normalize text: strip invisible Unicode chars (zero-width spaces, BOM, etc.)
+ * and collapse whitespace. Mobile keyboards (especially on Android/iOS) often
+ * insert these, causing exact string matches to fail.
+ */
+function normalizeText(text) {
+  return text
+    .replace(/[\u200B-\u200D\uFEFF\u00AD\u2060\u180E]/g, "") // zero-width / invisible chars
+    .replace(/\u00A0/g, " ") // non-breaking space → regular space
+    .replace(/\s+/g, " ")    // collapse whitespace
+    .trim();
+}
+
+/**
+ * Check if text is a !setup command.
+ */
+function isSetupCommand(text) {
+  return normalizeText(text).toLowerCase().startsWith("!setup");
+}
+
+module.exports = {
+  handleSetup,
+  isSetupCommand,
+  normalizeText,
+  setupHelp,
+};

--- a/bin/lib/user-registry.js
+++ b/bin/lib/user-registry.js
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Multi-user registry at ~/.nemoclaw/users.json
+
+const fs = require("fs");
+const path = require("path");
+
+const REGISTRY_FILE = path.join(process.env.HOME || "/tmp", ".nemoclaw", "users.json");
+
+function normalizeRoles(roles) {
+  const raw = Array.isArray(roles)
+    ? roles
+    : typeof roles === "string" && roles.trim()
+      ? roles.split(",")
+      : [];
+  const normalized = raw
+    .map((role) => String(role).trim().toLowerCase())
+    .filter(Boolean);
+  if (!normalized.includes("user")) normalized.unshift("user");
+  return [...new Set(normalized)];
+}
+
+function hydrateUser(slackUserId, entry = {}) {
+  return {
+    slackUserId: entry.slackUserId || slackUserId,
+    slackDisplayName: entry.slackDisplayName || "",
+    sandboxName: entry.sandboxName,
+    githubUser: entry.githubUser || "",
+    createdAt: entry.createdAt || new Date().toISOString(),
+    personalityDir: entry.personalityDir || `persist/users/${slackUserId}/workspace`,
+    credentialsDir: entry.credentialsDir || `persist/users/${slackUserId}/credentials`,
+    enabled: entry.enabled !== undefined ? entry.enabled : true,
+    timezone: entry.timezone || "UTC",
+    roles: normalizeRoles(entry.roles),
+  };
+}
+
+function load() {
+  try {
+    if (fs.existsSync(REGISTRY_FILE)) {
+      const data = JSON.parse(fs.readFileSync(REGISTRY_FILE, "utf-8"));
+      if (data && data.users && typeof data.users === "object") {
+        for (const [slackUserId, entry] of Object.entries(data.users)) {
+          data.users[slackUserId] = hydrateUser(slackUserId, entry);
+        }
+      }
+      return data;
+    }
+  } catch {}
+  return { users: {}, defaultUser: null, deletedUsers: [] };
+}
+
+function save(data) {
+  const dir = path.dirname(REGISTRY_FILE);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(REGISTRY_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
+}
+
+function getUser(slackUserId) {
+  const data = load();
+  return data.users[slackUserId] || null;
+}
+
+function getUserBySandbox(sandboxName) {
+  const data = load();
+  return Object.values(data.users).find((u) => u.sandboxName === sandboxName) || null;
+}
+
+function getDefault() {
+  const data = load();
+  if (data.defaultUser && data.users[data.defaultUser]) {
+    return data.defaultUser;
+  }
+  const ids = Object.keys(data.users);
+  return ids.length > 0 ? ids[0] : null;
+}
+
+function registerUser(entry) {
+  const data = load();
+  data.users[entry.slackUserId] = hydrateUser(entry.slackUserId, entry);
+  if (!data.defaultUser) {
+    data.defaultUser = entry.slackUserId;
+  }
+  save(data);
+}
+
+function updateUser(slackUserId, updates) {
+  const data = load();
+  if (!data.users[slackUserId]) return false;
+  data.users[slackUserId] = hydrateUser(slackUserId, {
+    ...data.users[slackUserId],
+    ...updates,
+  });
+  save(data);
+  return true;
+}
+
+function removeUser(slackUserId) {
+  const data = load();
+  if (!data.users[slackUserId]) return false;
+  // Track deleted users so the bridge can silently ignore them
+  if (!data.deletedUsers) data.deletedUsers = [];
+  if (!data.deletedUsers.includes(slackUserId)) {
+    data.deletedUsers.push(slackUserId);
+  }
+  delete data.users[slackUserId];
+  if (data.defaultUser === slackUserId) {
+    const remaining = Object.keys(data.users);
+    data.defaultUser = remaining.length > 0 ? remaining[0] : null;
+  }
+  save(data);
+  return true;
+}
+
+function isDeletedUser(slackUserId) {
+  const data = load();
+  return (data.deletedUsers || []).includes(slackUserId);
+}
+
+function listUsers() {
+  const data = load();
+  return {
+    users: Object.values(data.users),
+    defaultUser: data.defaultUser,
+  };
+}
+
+function setDefault(slackUserId) {
+  const data = load();
+  if (!data.users[slackUserId]) return false;
+  data.defaultUser = slackUserId;
+  save(data);
+  return true;
+}
+
+module.exports = {
+  load,
+  save,
+  getUser,
+  getUserBySandbox,
+  getDefault,
+  registerUser,
+  updateUser,
+  removeUser,
+  isDeletedUser,
+  listUsers,
+  setDefault,
+  normalizeRoles,
+};

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const { execFileSync, spawnSync } = require("child_process");
+const { execFileSync, execSync, spawnSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
@@ -23,6 +23,7 @@ const YW = _useColor ? "\x1b[1;33m" : "";
 
 const {
   ROOT,
+  SCRIPTS,
   run,
   runCapture: _runCapture,
   runInteractive,
@@ -30,9 +31,15 @@ const {
   validateName,
 } = require("./lib/runner");
 const { resolveOpenshell } = require("./lib/resolve-openshell");
-const { startGatewayForRecovery } = require("./lib/onboard");
-const { getCredential } = require("./lib/credentials");
+const { startGatewayForRecovery, pruneStaleSandboxEntry } = require("./lib/onboard");
+const {
+  ensureApiKey,
+  ensureGithubToken,
+  getCredential,
+  isRepoPrivate,
+} = require("./lib/credentials");
 const registry = require("./lib/registry");
+const userReg = require("./lib/user-registry");
 const nim = require("./lib/nim");
 const policies = require("./lib/policies");
 const { parseGatewayInference } = require("./lib/inference-config");
@@ -40,7 +47,6 @@ const { getVersion } = require("./lib/version");
 const onboardSession = require("./lib/onboard-session");
 const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
 const { NOTICE_ACCEPT_ENV, NOTICE_ACCEPT_FLAG } = require("./lib/usage-notice");
-const { executeDeploy } = require("../dist/lib/deploy");
 
 // ── Global commands ──────────────────────────────────────────────
 
@@ -55,6 +61,15 @@ const GLOBAL_COMMANDS = new Set([
   "status",
   "debug",
   "uninstall",
+  "user-add",
+  "user-remove",
+  "user-purge",
+  "user-list",
+  "user-status",
+  "user-enable",
+  "user-disable",
+  "user-grant-admin",
+  "user-revoke-admin",
   "help",
   "--help",
   "-h",
@@ -168,167 +183,6 @@ function getInstalledOpenshellVersion() {
 function stripAnsi(value = "") {
   // eslint-disable-next-line no-control-regex
   return String(value).replace(/\x1b\[[0-9;]*m/g, "");
-}
-
-// ── Sandbox process health (OpenClaw gateway inside the sandbox) ─────────
-
-/**
- * Run a command inside the sandbox via SSH and return { status, stdout, stderr }.
- * Returns null if SSH config cannot be obtained.
- */
-function executeSandboxCommand(sandboxName, command) {
-  const sshConfigResult = captureOpenshell(["sandbox", "ssh-config", sandboxName], {
-    ignoreError: true,
-  });
-  if (sshConfigResult.status !== 0) return null;
-
-  const tmpFile = path.join(os.tmpdir(), `nemoclaw-ssh-${process.pid}-${Date.now()}.conf`);
-  fs.writeFileSync(tmpFile, sshConfigResult.output, { mode: 0o600 });
-  try {
-    const result = spawnSync(
-      "ssh",
-      [
-        "-F",
-        tmpFile,
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
-        "-o",
-        "ConnectTimeout=5",
-        "-o",
-        "LogLevel=ERROR",
-        `openshell-${sandboxName}`,
-        command,
-      ],
-      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], timeout: 15000 },
-    );
-    return {
-      status: result.status ?? 1,
-      stdout: (result.stdout || "").trim(),
-      stderr: (result.stderr || "").trim(),
-    };
-  } catch {
-    return null;
-  } finally {
-    try {
-      fs.unlinkSync(tmpFile);
-    } catch {
-      /* ignore */
-    }
-  }
-}
-
-/**
- * Check whether the OpenClaw gateway process is running inside the sandbox.
- * Uses the gateway's HTTP endpoint (port 18789) as the source of truth,
- * since the gateway runs as a separate user and pgrep may not see it.
- * Returns true (running), false (stopped), or null (cannot determine).
- */
-function isSandboxGatewayRunning(sandboxName) {
-  const result = executeSandboxCommand(
-    sandboxName,
-    "curl -sf --max-time 3 http://127.0.0.1:18789/ > /dev/null 2>&1 && echo RUNNING || echo STOPPED",
-  );
-  if (!result) return null;
-  if (result.stdout === "RUNNING") return true;
-  if (result.stdout === "STOPPED") return false;
-  return null;
-}
-
-/**
- * Restart the OpenClaw gateway process inside the sandbox after a pod restart.
- * Cleans stale lock/temp files, sources proxy config, and launches the gateway
- * in the background. Returns true on success.
- */
-function recoverSandboxProcesses(sandboxName) {
-  // The recovery script runs as the sandbox user (non-root). This matches
-  // the non-root fallback path in nemoclaw-start.sh — no privilege
-  // separation, but the gateway runs and inference works.
-  const script = [
-    // Source proxy config (written to .bashrc by nemoclaw-start on first boot)
-    "[ -f ~/.bashrc ] && . ~/.bashrc 2>/dev/null;",
-    // Re-check liveness before touching anything — another caller may have
-    // already recovered the gateway between our initial check and now (TOCTOU).
-    "if curl -sf --max-time 3 http://127.0.0.1:18789/ > /dev/null 2>&1; then echo ALREADY_RUNNING; exit 0; fi;",
-    // Clean stale lock files from the previous run (gateway checks these)
-    "rm -rf /tmp/openclaw-*/gateway.*.lock 2>/dev/null;",
-    // Clean stale temp files from the previous run
-    "rm -f /tmp/gateway.log /tmp/auto-pair.log;",
-    "touch /tmp/gateway.log; chmod 600 /tmp/gateway.log;",
-    "touch /tmp/auto-pair.log; chmod 600 /tmp/auto-pair.log;",
-    // Resolve and start gateway
-    'OPENCLAW="$(command -v openclaw)";',
-    'if [ -z "$OPENCLAW" ]; then echo OPENCLAW_MISSING; exit 1; fi;',
-    'nohup "$OPENCLAW" gateway run > /tmp/gateway.log 2>&1 &',
-    "GPID=$!; sleep 2;",
-    // Verify the gateway actually started (didn't crash immediately)
-    'if kill -0 "$GPID" 2>/dev/null; then echo "GATEWAY_PID=$GPID"; else echo GATEWAY_FAILED; cat /tmp/gateway.log 2>/dev/null | tail -5; fi',
-  ].join(" ");
-
-  const result = executeSandboxCommand(sandboxName, script);
-  if (!result) return false;
-  return (
-    result.status === 0 &&
-    (result.stdout.includes("GATEWAY_PID=") || result.stdout.includes("ALREADY_RUNNING"))
-  );
-}
-
-/**
- * Re-establish the dashboard port forward (18789) to the sandbox.
- */
-function ensureSandboxPortForward(sandboxName) {
-  runOpenshell(["forward", "stop", DASHBOARD_FORWARD_PORT], { ignoreError: true });
-  runOpenshell(["forward", "start", "--background", DASHBOARD_FORWARD_PORT, sandboxName], {
-    ignoreError: true,
-  });
-}
-
-/**
- * Detect and recover from a sandbox that survived a gateway restart but
- * whose OpenClaw processes are not running. Returns an object describing
- * the outcome: { checked, wasRunning, recovered }.
- */
-function checkAndRecoverSandboxProcesses(sandboxName, { quiet = false } = {}) {
-  const running = isSandboxGatewayRunning(sandboxName);
-  if (running === null) {
-    return { checked: false, wasRunning: null, recovered: false };
-  }
-  if (running) {
-    return { checked: true, wasRunning: true, recovered: false };
-  }
-
-  // Gateway not running — attempt recovery
-  if (!quiet) {
-    console.log("");
-    console.log("  OpenClaw gateway is not running inside the sandbox (sandbox likely restarted).");
-    console.log("  Recovering...");
-  }
-
-  const recovered = recoverSandboxProcesses(sandboxName);
-  if (recovered) {
-    // Wait for gateway to bind its HTTP port before declaring success
-    spawnSync("sleep", ["3"]);
-    if (isSandboxGatewayRunning(sandboxName) !== true) {
-      // Gateway process started but HTTP endpoint never came up
-      if (!quiet) {
-        console.error("  Gateway process started but is not responding.");
-        console.error("  Check /tmp/gateway.log inside the sandbox for details.");
-      }
-      return { checked: true, wasRunning: false, recovered: false };
-    }
-    ensureSandboxPortForward(sandboxName);
-    if (!quiet) {
-      console.log(`  ${G}✓${R} OpenClaw gateway restarted inside sandbox.`);
-      console.log(`  ${G}✓${R} Dashboard port forward re-established.`);
-    }
-  } else if (!quiet) {
-    console.error("  Could not restart OpenClaw gateway automatically.");
-    console.error("  Connect to the sandbox and run manually:");
-    console.error("    nohup openclaw gateway run > /tmp/gateway.log 2>&1 &");
-  }
-
-  return { checked: true, wasRunning: false, recovered };
 }
 
 function buildRecoveredSandboxEntry(name, metadata = {}) {
@@ -802,33 +656,139 @@ async function setup(args = []) {
   await onboard(args);
 }
 
-async function setupSpark(args = []) {
-  console.log("");
-  console.log("  ⚠  `nemoclaw setup-spark` is deprecated.");
-  console.log("  Current OpenShell releases handle the old DGX Spark cgroup issue themselves.");
-  console.log("  Use `nemoclaw onboard` instead.");
-  console.log("");
-  await onboard(args);
+async function setupSpark() {
+  // setup-spark.sh configures Docker cgroups — it does not use NVIDIA_API_KEY.
+  run(`sudo bash "${SCRIPTS}/setup-spark.sh"`);
 }
 
+// eslint-disable-next-line complexity
 async function deploy(instanceName) {
-  await executeDeploy({
-    instanceName,
-    env: process.env,
-    rootDir: ROOT,
-    getCredential,
-    validateName,
-    shellQuote,
-    run,
-    runInteractive,
-    execFileSync: (file, args, opts = {}) =>
-      String(execFileSync(file, args, { encoding: "utf-8", ...opts })),
-    spawnSync,
-    log: console.log,
-    error: console.error,
-    stdoutWrite: (message) => process.stdout.write(message),
-    exit: (code) => process.exit(code),
-  });
+  if (!instanceName) {
+    console.error("  Usage: nemoclaw deploy <instance-name>");
+    console.error("");
+    console.error("  Examples:");
+    console.error("    nemoclaw deploy my-gpu-box");
+    console.error("    nemoclaw deploy nemoclaw-prod");
+    console.error("    nemoclaw deploy nemoclaw-test");
+    process.exit(1);
+  }
+  await ensureApiKey();
+  if (isRepoPrivate("NVIDIA/OpenShell")) {
+    await ensureGithubToken();
+  }
+  validateName(instanceName, "instance name");
+  const name = instanceName;
+  const qname = shellQuote(name);
+  const gpu = process.env.NEMOCLAW_GPU || "a2-highgpu-1g:nvidia-tesla-a100:1";
+
+  console.log("");
+  console.log(`  Deploying NemoClaw to Brev instance: ${name}`);
+  console.log("");
+
+  try {
+    execFileSync("which", ["brev"], { stdio: "ignore" });
+  } catch {
+    console.error("brev CLI not found. Install: https://brev.nvidia.com");
+    process.exit(1);
+  }
+
+  let exists = false;
+  try {
+    const out = execFileSync("brev", ["ls"], { encoding: "utf-8" });
+    exists = out.includes(name);
+  } catch (err) {
+    if (err.stdout && err.stdout.includes(name)) exists = true;
+    if (err.stderr && err.stderr.includes(name)) exists = true;
+  }
+
+  if (!exists) {
+    console.log(`  Creating Brev instance '${name}' (${gpu})...`);
+    run(`brev create ${qname} --gpu ${shellQuote(gpu)}`);
+  } else {
+    console.log(`  Brev instance '${name}' already exists.`);
+  }
+
+  run(`brev refresh`, { ignoreError: true });
+
+  process.stdout.write(`  Waiting for SSH `);
+  for (let i = 0; i < 60; i++) {
+    try {
+      execFileSync(
+        "ssh",
+        ["-o", "ConnectTimeout=5", "-o", "StrictHostKeyChecking=no", name, "echo", "ok"],
+        { encoding: "utf-8", stdio: "ignore" },
+      );
+      process.stdout.write(` ${G}✓${R}\n`);
+      break;
+    } catch {
+      if (i === 59) {
+        process.stdout.write("\n");
+        console.error(`  Timed out waiting for SSH to ${name}`);
+        process.exit(1);
+      }
+      process.stdout.write(".");
+      spawnSync("sleep", ["3"]);
+    }
+  }
+
+  console.log("  Syncing NemoClaw to VM...");
+  run(
+    `ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${qname} 'mkdir -p /home/ubuntu/nemoclaw'`,
+  );
+  run(
+    `rsync -az --delete --exclude node_modules --exclude .git --exclude src -e "ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR" "${ROOT}/scripts" "${ROOT}/Dockerfile" "${ROOT}/nemoclaw" "${ROOT}/nemoclaw-blueprint" "${ROOT}/bin" "${ROOT}/package.json" ${qname}:/home/ubuntu/nemoclaw/`,
+  );
+
+  const envLines = [`NVIDIA_API_KEY=${shellQuote(process.env.NVIDIA_API_KEY || "")}`];
+  const ghToken = process.env.GITHUB_TOKEN;
+  if (ghToken) envLines.push(`GITHUB_TOKEN=${shellQuote(ghToken)}`);
+  const tgToken = getCredential("TELEGRAM_BOT_TOKEN");
+  if (tgToken) envLines.push(`TELEGRAM_BOT_TOKEN=${shellQuote(tgToken)}`);
+  const discordToken = getCredential("DISCORD_BOT_TOKEN");
+  if (discordToken) envLines.push(`DISCORD_BOT_TOKEN=${shellQuote(discordToken)}`);
+  const slackToken = getCredential("SLACK_BOT_TOKEN");
+  if (slackToken) envLines.push(`SLACK_BOT_TOKEN=${shellQuote(slackToken)}`);
+  const envDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-env-"));
+  const envTmp = path.join(envDir, "env");
+  fs.writeFileSync(envTmp, envLines.join("\n") + "\n", { mode: 0o600 });
+  try {
+    run(
+      `scp -q -o StrictHostKeyChecking=no -o LogLevel=ERROR ${shellQuote(envTmp)} ${qname}:/home/ubuntu/nemoclaw/.env`,
+    );
+    run(
+      `ssh -q -o StrictHostKeyChecking=no -o LogLevel=ERROR ${qname} 'chmod 600 /home/ubuntu/nemoclaw/.env'`,
+    );
+  } finally {
+    try {
+      fs.unlinkSync(envTmp);
+    } catch {
+      /* ignored */
+    }
+    try {
+      fs.rmdirSync(envDir);
+    } catch {
+      /* ignored */
+    }
+  }
+
+  console.log("  Running setup...");
+  runInteractive(
+    `ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${qname} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && bash scripts/brev-setup.sh'`,
+  );
+
+  if (tgToken) {
+    console.log("  Starting services...");
+    run(
+      `ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${qname} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && bash scripts/start-services.sh'`,
+    );
+  }
+
+  console.log("");
+  console.log("  Connecting to sandbox...");
+  console.log("");
+  runInteractive(
+    `ssh -t -o StrictHostKeyChecking=no -o LogLevel=ERROR ${qname} 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell sandbox connect nemoclaw'`,
+  );
 }
 
 async function start() {
@@ -976,6 +936,13 @@ async function listSandboxes() {
     return;
   }
 
+  // Build user-to-sandbox lookup
+  const { users } = userReg.listUsers();
+  const sandboxUserMap = {};
+  for (const u of users) {
+    sandboxUserMap[u.sandboxName] = u.slackDisplayName || u.slackUserId;
+  }
+
   // Query live gateway inference once; prefer it over stale registry values.
   const live = parseGatewayInference(
     captureOpenshell(["inference", "get"], { ignoreError: true }).output,
@@ -995,15 +962,447 @@ async function listSandboxes() {
   console.log("  Sandboxes:");
   for (const sb of sandboxes) {
     const def = sb.name === defaultSandbox ? " *" : "";
+    const owner = sandboxUserMap[sb.name] || "-";
     const model = (live && live.model) || sb.model || "unknown";
     const provider = (live && live.provider) || sb.provider || "unknown";
     const gpu = sb.gpuEnabled ? "GPU" : "CPU";
     const presets = sb.policies && sb.policies.length > 0 ? sb.policies.join(", ") : "none";
-    console.log(`    ${sb.name}${def}`);
-    console.log(`      model: ${model}  provider: ${provider}  ${gpu}  policies: ${presets}`);
+    console.log(`    ${owner.padEnd(12)} ${sb.name}${def}`);
+    console.log(`${"".padEnd(17)}model: ${model}  provider: ${provider}  ${gpu}  policies: ${presets}`);
   }
   console.log("");
   console.log("  * = default sandbox");
+  console.log("");
+}
+
+// ── User lifecycle commands ──────────────────────────────────────
+
+async function userAdd(args = []) {
+  const { prompt: askPrompt } = require("./lib/credentials");
+  const applyDefaultPolicies = async (sandboxNameForPolicies) => {
+    const defaultPresets = ["npm", "pypi", "slack"];
+    const allPresets = policies.listPresets();
+    const knownNames = new Set(allPresets.map((p) => p.name));
+
+    console.log("");
+    console.log("  Available policy presets:");
+    allPresets.forEach((p) => {
+      const suggested = defaultPresets.includes(p.name) ? " (default)" : "";
+      console.log(`    ○ ${p.name} — ${p.description}${suggested}`);
+    });
+    console.log("");
+
+    let selectedPresets = defaultPresets;
+    if (nonInteractive) {
+      console.log(`  [non-interactive] Applying default presets: ${defaultPresets.join(", ")}`);
+    } else {
+      const presetAnswer = await askPrompt(`  Apply default presets (${defaultPresets.join(", ")})? [Y/n/list]: `);
+
+      if (presetAnswer.toLowerCase() === "n") {
+        selectedPresets = [];
+        console.log("  Skipping policy presets.");
+      } else if (presetAnswer.toLowerCase() === "list") {
+        const picks = await askPrompt("  Enter preset names (comma-separated): ");
+        selectedPresets = picks.split(",").map((s) => s.trim()).filter(Boolean);
+        const invalid = selectedPresets.filter((n) => !knownNames.has(n));
+        if (invalid.length > 0) {
+          console.error(`  Unknown preset(s): ${invalid.join(", ")} — skipping those.`);
+          selectedPresets = selectedPresets.filter((n) => knownNames.has(n));
+        }
+      }
+    }
+
+    for (const preset of selectedPresets) {
+      try {
+        policies.applyPreset(sandboxNameForPolicies, preset);
+      } catch (err) {
+        console.error(`  Warning: failed to apply preset '${preset}': ${err.message}`);
+      }
+    }
+    if (selectedPresets.length > 0) {
+      console.log(`  Applied presets: ${selectedPresets.join(", ")}`);
+    }
+  };
+
+  // Parse --non-interactive mode with named args
+  const nonInteractive = args.includes("--non-interactive");
+  const argAdmin = args.includes("--admin");
+  let argSlackId, argDisplayName, argClawName, argGithubUser;
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--slack-id":      argSlackId = args[++i]; break;
+      case "--display-name":  argDisplayName = args[++i]; break;
+      case "--claw-name":     argClawName = args[++i]; break;
+      case "--github-user":   argGithubUser = args[++i]; break;
+    }
+  }
+
+  if (nonInteractive && (!argSlackId || !argDisplayName || !argClawName)) {
+    console.error("  Usage: nemoclaw user-add --non-interactive --slack-id <ID> --display-name <NAME> --claw-name <NAME> [--github-user <USER>] [--admin]");
+    process.exit(1);
+  }
+
+  console.log("");
+  console.log("  NemoClaw — Register a new user");
+  console.log("");
+
+  const slackUserId = nonInteractive ? argSlackId : await askPrompt("  Slack user ID (e.g. U09R681EPQ9): ");
+  if (!slackUserId || !/^U[A-Z0-9]+$/.test(slackUserId)) {
+    console.error("  Invalid Slack user ID. Must start with U followed by alphanumeric characters.");
+    process.exit(1);
+  }
+
+  const existing = userReg.getUser(slackUserId);
+  if (existing) {
+    console.error(`  User ${slackUserId} already registered (sandbox: ${existing.sandboxName}).`);
+    console.error("  Run 'nemoclaw user-remove " + slackUserId + "' first to re-register.");
+    process.exit(1);
+  }
+
+  const slackDisplayName = nonInteractive ? argDisplayName : await askPrompt("  Slack display name: ");
+  const sandboxName = nonInteractive ? argClawName : await askPrompt("  Sandbox name (e.g. alice-claw): ");
+  if (!sandboxName || !/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(sandboxName)) {
+    console.error("  Invalid sandbox name. Use lowercase letters, numbers, and hyphens.");
+    process.exit(1);
+  }
+
+  const githubUser = nonInteractive ? (argGithubUser || "") : await askPrompt("  GitHub username (optional, press Enter to skip): ");
+
+  // Check if sandbox exists or needs to be created
+  let sbExists = registry.getSandbox(sandboxName);
+  const liveExists = pruneStaleSandboxEntry(sandboxName);
+  sbExists = registry.getSandbox(sandboxName);
+  if (!sbExists && liveExists) {
+    registry.registerSandbox({
+      name: sandboxName,
+      model: "anthropic/claude-sonnet-4-6",
+      provider: "openshell",
+      gpuEnabled: false,
+      policies: [],
+    });
+    sbExists = registry.getSandbox(sandboxName);
+    console.log(`  Found existing live sandbox '${sandboxName}'. Adopting it into the local registry.`);
+    await applyDefaultPolicies(sandboxName);
+  }
+
+  if (!sbExists) {
+    const create = nonInteractive ? "y" : await askPrompt(`  Sandbox '${sandboxName}' not registered. Create it? [Y/n]: `);
+    if (create.toLowerCase() !== "n") {
+      console.log(`  Creating sandbox '${sandboxName}' (this may take a few minutes on first run)...`);
+
+      // Stage build context (same as onboard flow)
+      const { mkdtempSync } = require("fs");
+      const buildCtx = mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-"));
+      fs.copyFileSync(path.join(ROOT, "Dockerfile"), path.join(buildCtx, "Dockerfile"));
+      execFileSync("cp", ["-r", path.join(ROOT, "nemoclaw"), path.join(buildCtx, "nemoclaw")], { stdio: "inherit" });
+      execFileSync("cp", ["-r", path.join(ROOT, "nemoclaw-blueprint"), path.join(buildCtx, "nemoclaw-blueprint")], { stdio: "inherit" });
+      execFileSync("cp", ["-r", path.join(ROOT, "scripts"), path.join(buildCtx, "scripts")], { stdio: "inherit" });
+      execFileSync("rm", ["-rf", path.join(buildCtx, "nemoclaw", "node_modules")], { stdio: "ignore" });
+
+      const basePolicyPath = path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
+      const envArgs = [];
+      if (process.env.NVIDIA_API_KEY) envArgs.push(`NVIDIA_API_KEY=${process.env.NVIDIA_API_KEY}`);
+
+      try {
+        execFileSync(
+          "openshell",
+          ["sandbox", "create", "--from", path.join(buildCtx, "Dockerfile"), "--name", sandboxName, "--policy", basePolicyPath, "--", "env", ...envArgs, "nemoclaw-start"],
+          { stdio: "inherit", timeout: 300000 }
+        );
+      } catch (err) {
+        console.error(`  Failed to create sandbox: ${err.message}`);
+        execFileSync("rm", ["-rf", buildCtx], { stdio: "ignore" });
+        process.exit(1);
+      }
+      execFileSync("rm", ["-rf", buildCtx], { stdio: "ignore" });
+
+      registry.registerSandbox({
+        name: sandboxName,
+        model: "anthropic/claude-sonnet-4-6",
+        provider: "openshell",
+        gpuEnabled: false,
+        policies: [],
+      });
+      console.log(`  Sandbox '${sandboxName}' created and registered.`);
+      await applyDefaultPolicies(sandboxName);
+    }
+  }
+
+  // Create per-user persist directories
+  const persistBase = `persist/users/${slackUserId}`;
+  const credDir = `${persistBase}/credentials`;
+  const workspaceDir = `${persistBase}/workspace`;
+  fs.mkdirSync(path.join(ROOT, credDir), { recursive: true, mode: 0o700 });
+  fs.mkdirSync(path.join(ROOT, workspaceDir), { recursive: true });
+
+  // Copy default personality files if workspace is empty
+  const defaultWorkspace = path.join(ROOT, "persist", "workspace");
+  const userWorkspace = path.join(ROOT, workspaceDir);
+  if (fs.existsSync(defaultWorkspace)) {
+    const files = ["SOUL.md", "IDENTITY.md", "USER.md", "TOOLS.md", "HEARTBEAT.md", "AGENTS.md", "BOOTSTRAP.md"];
+    for (const f of files) {
+      const src = path.join(defaultWorkspace, f);
+      const dst = path.join(userWorkspace, f);
+      if (fs.existsSync(src) && !fs.existsSync(dst)) {
+        fs.copyFileSync(src, dst);
+      }
+    }
+    console.log("  Default personality files copied to user workspace.");
+  }
+
+  // Register user
+  userReg.registerUser({
+    slackUserId,
+    slackDisplayName,
+    sandboxName,
+    githubUser,
+    personalityDir: workspaceDir,
+    credentialsDir: credDir,
+    enabled: true,
+    roles: argAdmin ? ["user", "admin"] : ["user"],
+  });
+
+  const roles = userReg.getUser(slackUserId)?.roles || ["user"];
+
+  console.log("");
+  console.log(`  User registered:`);
+  console.log(`    Slack ID:    ${slackUserId}`);
+  console.log(`    Name:        ${slackDisplayName}`);
+  console.log(`    Sandbox:     ${sandboxName}`);
+  console.log(`    GitHub:      ${githubUser || "(none)"}`);
+  console.log(`    Roles:       ${roles.join(", ")}`);
+  console.log(`    Credentials: ${credDir}`);
+  console.log(`    Workspace:   ${workspaceDir}`);
+  console.log("");
+  console.log("  Next steps:");
+  console.log(`    1. Place credentials in ${credDir}/`);
+  console.log("       (claude-credentials.json, gh-hosts.yml, gogcli/)");
+  console.log(`    2. Customize personality in ${workspaceDir}/`);
+  console.log(`    3. Run: scripts/inject-user-credentials.sh ${sandboxName} ${credDir}` + (githubUser ? ` --github-user ${githubUser}` : ""));
+  console.log("");
+}
+
+function userRemove(slackUserId) {
+  if (!slackUserId) {
+    console.error("  Usage: nemoclaw user-remove <slack-user-id>");
+    process.exit(1);
+  }
+
+  const user = userReg.getUser(slackUserId);
+  if (!user) {
+    console.error(`  User ${slackUserId} not found in registry.`);
+    process.exit(1);
+  }
+
+  console.log("");
+  console.log(`  Removing user: ${user.slackDisplayName} (${slackUserId})`);
+  console.log(`    Sandbox: ${user.sandboxName}`);
+
+  userReg.removeUser(slackUserId);
+  console.log(`  User removed from registry.`);
+  console.log("");
+  console.log("  Note: Sandbox and persist files were NOT deleted.");
+  console.log(`  To also destroy the sandbox: nemoclaw ${user.sandboxName} destroy`);
+  console.log(`  To delete user data: rm -rf persist/users/${slackUserId}`);
+  console.log("");
+}
+
+function userPurge(args = []) {
+  // Parse arguments: --sandbox <name> or --slack-id <id>
+  let sandboxName, slackUserId;
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--sandbox":  sandboxName = args[++i]; break;
+      case "--slack-id": slackUserId = args[++i]; break;
+    }
+  }
+
+  if (!sandboxName && !slackUserId) {
+    console.error("  Usage: nemoclaw user-purge --sandbox <claw-name>");
+    console.error("         nemoclaw user-purge --slack-id <slack-user-id>");
+    process.exit(1);
+  }
+
+  // Resolve user from whichever identifier was given
+  let user;
+  if (slackUserId) {
+    user = userReg.getUser(slackUserId);
+  } else {
+    user = userReg.getUserBySandbox(sandboxName);
+  }
+
+  if (!user) {
+    // Even without a registry entry, allow purging by sandbox name
+    if (sandboxName) {
+      console.log("");
+      console.log(`  No user found for sandbox '${sandboxName}'. Destroying sandbox only.`);
+      const sb = registry.getSandbox(sandboxName);
+      if (sb) {
+        sandboxDestroy(sandboxName);
+        console.log(`  Sandbox '${sandboxName}' destroyed.`);
+      } else {
+        // Try openshell directly in case it exists but isn't registered
+        try {
+          execFileSync("openshell", ["sandbox", "delete", sandboxName], { stdio: "inherit" });
+          console.log(`  Sandbox '${sandboxName}' deleted via openshell.`);
+        } catch {
+          console.log(`  Sandbox '${sandboxName}' not found in openshell either.`);
+        }
+      }
+      console.log("");
+      return;
+    }
+    console.error(`  User ${slackUserId} not found in registry.`);
+    process.exit(1);
+  }
+
+  slackUserId = user.slackUserId;
+  sandboxName = user.sandboxName;
+
+  console.log("");
+  console.log(`  Purging user: ${user.slackDisplayName} (${slackUserId})`);
+  console.log(`    Sandbox:   ${sandboxName}`);
+  console.log("");
+
+  // Step 1: Destroy sandbox (NIM + openshell + sandbox registry)
+  const sb = registry.getSandbox(sandboxName);
+  if (sb) {
+    console.log("  [1/3] Destroying sandbox...");
+    sandboxDestroy(sandboxName);
+  } else {
+    console.log("  [1/3] Sandbox not in registry, attempting openshell delete...");
+    try {
+      execFileSync("openshell", ["sandbox", "delete", sandboxName], { stdio: "inherit" });
+    } catch {
+      console.log(`         Sandbox '${sandboxName}' not found — skipping.`);
+    }
+  }
+
+  // Step 2: Remove from user registry
+  console.log("  [2/3] Removing from user registry...");
+  userReg.removeUser(slackUserId);
+
+  // Step 3: Delete persist data
+  const persistDir = path.join(ROOT, "persist", "users", slackUserId);
+  console.log("  [3/3] Deleting persist data...");
+  if (fs.existsSync(persistDir)) {
+    fs.rmSync(persistDir, { recursive: true, force: true });
+    console.log(`         Removed ${persistDir}`);
+  } else {
+    console.log("         No persist directory found — skipping.");
+  }
+
+  console.log("");
+  console.log(`  User '${user.slackDisplayName}' (${slackUserId}) fully purged.`);
+  console.log("  Note: Restart the Slack bridge to stop routing messages for this user.");
+  console.log("");
+}
+
+function userList() {
+  const { users, defaultUser } = userReg.listUsers();
+  if (users.length === 0) {
+    console.log("");
+    console.log("  No users registered. Run 'nemoclaw user-add' to get started.");
+    console.log("");
+    return;
+  }
+
+  console.log("");
+  console.log("  Registered Users:");
+  for (const u of users) {
+    const def = u.slackUserId === defaultUser ? " *" : "";
+    const status = u.enabled ? "enabled" : "disabled";
+    console.log(`    ${u.slackDisplayName || u.slackUserId}${def}`);
+    console.log(`      slack: ${u.slackUserId}  sandbox: ${u.sandboxName}  github: ${u.githubUser || "-"}  ${status}  roles: ${(u.roles || ["user"]).join(",")}`);
+  }
+  console.log("");
+  console.log("  * = default user");
+  console.log("");
+}
+
+function userStatus(slackUserId) {
+  if (!slackUserId) {
+    console.error("  Usage: nemoclaw user-status <slack-user-id>");
+    process.exit(1);
+  }
+
+  const user = userReg.getUser(slackUserId);
+  if (!user) {
+    console.error(`  User ${slackUserId} not found in registry.`);
+    process.exit(1);
+  }
+
+  console.log("");
+  console.log(`  User: ${user.slackDisplayName} (${slackUserId})`);
+  console.log(`    Sandbox:     ${user.sandboxName}`);
+  console.log(`    GitHub:      ${user.githubUser || "-"}`);
+  console.log(`    Enabled:     ${user.enabled}`);
+  console.log(`    Roles:       ${(user.roles || ["user"]).join(", ")}`);
+  console.log(`    Credentials: ${user.credentialsDir}`);
+  console.log(`    Workspace:   ${user.personalityDir}`);
+  console.log(`    Created:     ${user.createdAt}`);
+
+  // Check sandbox health
+  try {
+    const out = execFileSync("openshell", ["sandbox", "list"], { encoding: "utf-8" });
+    if (out.includes(user.sandboxName)) {
+      const ready = out.includes(`${user.sandboxName}`) && out.includes("Ready");
+      console.log(`    Sandbox:     ${ready ? "Ready" : "Not Ready"}`);
+    } else {
+      console.log("    Sandbox:     Not found (not created?)");
+    }
+  } catch {
+    console.log("    Sandbox:     (cannot check — openshell not available)");
+  }
+  console.log("");
+}
+
+function userSetEnabled(slackUserId, enabled) {
+  if (!slackUserId) {
+    console.error(`  Usage: nemoclaw ${enabled ? "user-enable" : "user-disable"} <slack-user-id>`);
+    process.exit(1);
+  }
+
+  const user = userReg.getUser(slackUserId);
+  if (!user) {
+    console.error(`  User ${slackUserId} not found in registry.`);
+    process.exit(1);
+  }
+
+  if (!userReg.updateUser(slackUserId, { enabled })) {
+    console.error(`  Failed to update ${slackUserId}.`);
+    process.exit(1);
+  }
+
+  console.log("");
+  console.log(`  User ${user.slackDisplayName || slackUserId} is now ${enabled ? "enabled" : "disabled"}.`);
+  console.log("");
+}
+
+function userSetAdmin(slackUserId, grantAdmin) {
+  if (!slackUserId) {
+    console.error(`  Usage: nemoclaw ${grantAdmin ? "user-grant-admin" : "user-revoke-admin"} <slack-user-id>`);
+    process.exit(1);
+  }
+
+  const user = userReg.getUser(slackUserId);
+  if (!user) {
+    console.error(`  User ${slackUserId} not found in registry.`);
+    process.exit(1);
+  }
+
+  const roles = new Set(user.roles || ["user"]);
+  roles.add("user");
+  if (grantAdmin) roles.add("admin");
+  else roles.delete("admin");
+
+  if (!userReg.updateUser(slackUserId, { roles: [...roles] })) {
+    console.error(`  Failed to update ${slackUserId}.`);
+    process.exit(1);
+  }
+
+  console.log("");
+  console.log(`  User ${user.slackDisplayName || slackUserId} roles: ${[...roles].join(", ")}`);
   console.log("");
 }
 
@@ -1011,7 +1410,6 @@ async function listSandboxes() {
 
 async function sandboxConnect(sandboxName) {
   await ensureLiveSandboxOrExit(sandboxName);
-  checkAndRecoverSandboxProcesses(sandboxName);
   const result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {
     stdio: "inherit",
     cwd: ROOT,
@@ -1099,28 +1497,6 @@ async function sandboxStatus(sandboxName) {
       console.log(lookup.output);
     }
     printGatewayLifecycleHint(lookup.output, sandboxName, console.log);
-  }
-
-  // OpenClaw process health inside the sandbox
-  if (lookup.state === "present") {
-    const processCheck = checkAndRecoverSandboxProcesses(sandboxName, { quiet: true });
-    if (processCheck.checked) {
-      if (processCheck.wasRunning) {
-        console.log(`    OpenClaw: ${G}running${R}`);
-      } else if (processCheck.recovered) {
-        console.log(`    OpenClaw: ${G}recovered${R} (gateway restarted after sandbox restart)`);
-      } else {
-        console.log(`    OpenClaw: ${_RD}not running${R}`);
-        console.log("");
-        console.log("  The sandbox is alive but the OpenClaw gateway process is not running.");
-        console.log("  This typically happens after a gateway restart (e.g., laptop close/open).");
-        console.log("");
-        console.log("  To recover, run:");
-        console.log(`    ${D}nemoclaw ${sandboxName} connect${R}  (auto-recovers on connect)`);
-        console.log("  Or manually inside the sandbox:");
-        console.log(`    ${D}nohup openclaw gateway run > /tmp/gateway.log 2>&1 &${R}`);
-      }
-    }
   }
 
   // NIM health
@@ -1263,6 +1639,7 @@ function help() {
   ${G}Getting Started:${R}
     ${B}nemoclaw onboard${R}                 Configure inference endpoint and credentials
                                     ${D}(non-interactive: ${NOTICE_ACCEPT_FLAG} or ${NOTICE_ACCEPT_ENV}=1)${R}
+    nemoclaw setup-spark             Set up on DGX Spark ${D}(fixes cgroup v2 + Docker)${R}
 
   ${G}Sandbox Management:${R}
     ${B}nemoclaw list${R}                    List all sandboxes
@@ -1275,10 +1652,20 @@ function help() {
     nemoclaw <name> policy-add       Add a network or filesystem policy preset
     nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
-  ${G}Compatibility Commands:${R}
-    nemoclaw setup                   Deprecated alias for ${B}nemoclaw onboard${R}
-    nemoclaw setup-spark             Deprecated alias for ${B}nemoclaw onboard${R}
-    nemoclaw deploy <instance>       Deprecated Brev-specific bootstrap path
+  ${G}Multi-User:${R}
+    nemoclaw user-add                Register a new user (interactive wizard)
+    nemoclaw user-remove <slack-id>  Remove a user from registry (keeps sandbox/data)
+    nemoclaw user-purge --sandbox <name>  Destroy sandbox + registry + persist data
+    nemoclaw user-purge --slack-id <id>   Same, by Slack user ID
+    nemoclaw user-list               List all registered users
+    nemoclaw user-status <slack-id>  Show user details and sandbox health
+    nemoclaw user-enable <slack-id>  Enable a registered user in the Slack bridge
+    nemoclaw user-disable <slack-id> Disable a registered user in the Slack bridge
+    nemoclaw user-grant-admin <id>   Grant admin role to a registered user
+    nemoclaw user-revoke-admin <id>  Revoke admin role from a registered user
+
+  ${G}Deploy:${R}
+    nemoclaw deploy <instance>       Deploy to a Brev VM and start services
 
   ${G}Services:${R}
     nemoclaw start                   Start auxiliary services ${D}(Telegram, tunnel)${R}
@@ -1325,7 +1712,7 @@ const [cmd, ...args] = process.argv.slice(2);
         await setup(args);
         break;
       case "setup-spark":
-        await setupSpark(args);
+        await setupSpark();
         break;
       case "deploy":
         await deploy(args[0]);
@@ -1347,6 +1734,33 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       case "list":
         await listSandboxes();
+        break;
+      case "user-add":
+        await userAdd(args);
+        break;
+      case "user-remove":
+        userRemove(args[0]);
+        break;
+      case "user-purge":
+        userPurge(args);
+        break;
+      case "user-list":
+        userList();
+        break;
+      case "user-status":
+        userStatus(args[0]);
+        break;
+      case "user-enable":
+        userSetEnabled(args[0], true);
+        break;
+      case "user-disable":
+        userSetEnabled(args[0], false);
+        break;
+      case "user-grant-admin":
+        userSetAdmin(args[0], true);
+        break;
+      case "user-revoke-admin":
+        userSetAdmin(args[0], false);
         break;
       case "--version":
       case "-v": {

--- a/docs/multi-user-architecture.svg
+++ b/docs/multi-user-architecture.svg
@@ -1,0 +1,199 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 780" font-family="Inter, -apple-system, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#059669"/>
+    </marker>
+    <linearGradient id="headerGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <filter id="shadow" x="-4%" y="-4%" width="108%" height="112%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="920" height="780" rx="12" fill="#f8fafc"/>
+
+  <!-- Title -->
+  <rect x="0" y="0" width="920" height="48" rx="12" fill="url(#headerGrad)"/>
+  <rect x="0" y="24" width="920" height="24" fill="url(#headerGrad)"/>
+  <text x="460" y="31" text-anchor="middle" fill="white" font-size="16" font-weight="600">Multi-User NemoClaw — Service Architecture</text>
+
+  <!-- ===== SLACK LAYER ===== -->
+  <text x="40" y="82" fill="#475569" font-size="11" font-weight="600" letter-spacing="1">SLACK</text>
+
+  <!-- Slack App -->
+  <rect x="350" y="66" width="220" height="44" rx="8" fill="#4A154B" filter="url(#shadow)"/>
+  <text x="460" y="84" text-anchor="middle" fill="white" font-weight="600" font-size="13">Slack App</text>
+  <text x="460" y="100" text-anchor="middle" fill="#e2b8e4" font-size="10">Socket Mode  ·  1 bot token</text>
+
+  <!-- User icons -->
+  <g fill="#7c3aed" font-size="10">
+    <rect x="170" y="72" width="80" height="32" rx="6" fill="#ede9fe"/>
+    <text x="210" y="93" text-anchor="middle" fill="#6d28d9">Users (8)</text>
+    <line x1="250" y1="88" x2="350" y2="88" stroke="#7c3aed" stroke-width="1.5" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+  </g>
+
+  <!-- Arrow Slack → Bridge -->
+  <line x1="460" y1="110" x2="460" y2="148" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- ===== DGX SPARK HOST ===== -->
+  <rect x="20" y="130" width="880" height="120" rx="10" fill="none" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="40" y="147" fill="#475569" font-size="11" font-weight="600" letter-spacing="1">DGX SPARK HOST</text>
+
+  <!-- Bridge (outside cluster) -->
+  <rect x="310" y="152" width="300" height="56" rx="8" fill="#0ea5e9" filter="url(#shadow)"/>
+  <text x="460" y="175" text-anchor="middle" fill="white" font-weight="600">slack-bridge-multi.js</text>
+  <text x="460" y="191" text-anchor="middle" fill="#bae6fd" font-size="10">Route by slackUserId · RBAC · Admin cmds · Queue</text>
+
+  <!-- Registries -->
+  <rect x="670" y="156" width="200" height="48" rx="8" fill="#fef3c7" stroke="#f59e0b" stroke-width="1" filter="url(#shadow)"/>
+  <text x="770" y="176" text-anchor="middle" fill="#92400e" font-weight="600" font-size="12">users.json</text>
+  <text x="770" y="191" text-anchor="middle" fill="#a16207" font-size="10">sandboxes.json</text>
+  <line x1="610" y1="180" x2="670" y2="180" stroke="#f59e0b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- CLI -->
+  <rect x="48" y="156" width="200" height="48" rx="8" fill="#dbeafe" stroke="#3b82f6" stroke-width="1" filter="url(#shadow)"/>
+  <text x="148" y="176" text-anchor="middle" fill="#1e3a5f" font-weight="600" font-size="12">nemoclaw CLI</text>
+  <text x="148" y="191" text-anchor="middle" fill="#3b82f6" font-size="10">user-add · purge · list · status</text>
+  <line x1="248" y1="180" x2="310" y2="180" stroke="#3b82f6" stroke-width="1" stroke-dasharray="4,3"/>
+
+  <!-- ===== K3S CLUSTER ===== -->
+  <rect x="30" y="260" width="860" height="210" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="2"/>
+  <!-- K3s label with icon -->
+  <rect x="42" y="268" width="120" height="22" rx="4" fill="#16a34a"/>
+  <text x="102" y="283" text-anchor="middle" fill="white" font-size="11" font-weight="600">K3s Cluster</text>
+  <!-- Namespace label -->
+  <text x="180" y="283" fill="#15803d" font-size="10" font-weight="500">namespace: openshell</text>
+
+  <!-- SSH fan-out lines from bridge into cluster -->
+  <line x1="370" y1="208" x2="150" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="460" y1="208" x2="460" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="550" y1="208" x2="770" y2="300" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="245" y="260" fill="#64748b" font-size="10" transform="rotate(-18,245,260)">SSH proxy</text>
+  <text x="470" y="260" fill="#64748b" font-size="10">SSH proxy</text>
+  <text x="665" y="260" fill="#64748b" font-size="10" transform="rotate(18,665,260)">SSH proxy</text>
+
+  <!-- Pod 1 -->
+  <rect x="48" y="300" width="200" height="70" rx="8" fill="#10b981" filter="url(#shadow)"/>
+  <rect x="48" y="300" width="200" height="22" rx="8" fill="#059669"/>
+  <rect x="48" y="314" width="200" height="8" fill="#059669"/>
+  <text x="148" y="316" text-anchor="middle" fill="white" font-size="10" font-weight="600">POD</text>
+  <text x="148" y="342" text-anchor="middle" fill="white" font-weight="600">veyonce-claw</text>
+  <text x="148" y="358" text-anchor="middle" fill="#a7f3d0" font-size="10">Claude Sonnet 4.6 · admin</text>
+
+  <!-- Pod 2 -->
+  <rect x="360" y="300" width="200" height="70" rx="8" fill="#10b981" filter="url(#shadow)"/>
+  <rect x="360" y="300" width="200" height="22" rx="8" fill="#059669"/>
+  <rect x="360" y="314" width="200" height="8" fill="#059669"/>
+  <text x="460" y="316" text-anchor="middle" fill="white" font-size="10" font-weight="600">POD</text>
+  <text x="460" y="342" text-anchor="middle" fill="white" font-weight="600">aditya-claw</text>
+  <text x="460" y="358" text-anchor="middle" fill="#a7f3d0" font-size="10">OpenShell sandbox</text>
+
+  <!-- Pod N -->
+  <rect x="672" y="300" width="200" height="70" rx="8" fill="#10b981" filter="url(#shadow)"/>
+  <rect x="672" y="300" width="200" height="22" rx="8" fill="#059669"/>
+  <rect x="672" y="314" width="200" height="8" fill="#059669"/>
+  <text x="772" y="316" text-anchor="middle" fill="white" font-size="10" font-weight="600">POD</text>
+  <text x="772" y="342" text-anchor="middle" fill="white" font-weight="600">nirmal-claw</text>
+  <text x="772" y="358" text-anchor="middle" fill="#a7f3d0" font-size="10">OpenShell sandbox</text>
+
+  <!-- Ellipsis between pods -->
+  <text x="600" y="342" text-anchor="middle" fill="#16a34a" font-size="22" font-weight="600">···</text>
+
+  <!-- Network policy badges on pods -->
+  <rect x="60" y="374" width="74" height="16" rx="3" fill="#bbf7d0" stroke="#16a34a" stroke-width="0.5"/>
+  <text x="97" y="385" text-anchor="middle" fill="#166534" font-size="8" font-weight="500">net policy</text>
+  <rect x="372" y="374" width="74" height="16" rx="3" fill="#bbf7d0" stroke="#16a34a" stroke-width="0.5"/>
+  <text x="409" y="385" text-anchor="middle" fill="#166534" font-size="8" font-weight="500">net policy</text>
+  <rect x="684" y="374" width="74" height="16" rx="3" fill="#bbf7d0" stroke="#16a34a" stroke-width="0.5"/>
+  <text x="721" y="385" text-anchor="middle" fill="#166534" font-size="8" font-weight="500">net policy</text>
+
+  <!-- Controller pod -->
+  <rect x="48" y="404" width="220" height="42" rx="6" fill="#dcfce7" stroke="#16a34a" stroke-width="1"/>
+  <text x="158" y="422" text-anchor="middle" fill="#166534" font-weight="600" font-size="11">agent-sandbox-controller</text>
+  <text x="158" y="436" text-anchor="middle" fill="#15803d" font-size="9">pod lifecycle · SSH proxy · policy</text>
+
+  <!-- openshell-0 pod -->
+  <rect x="300" y="404" width="180" height="42" rx="6" fill="#dcfce7" stroke="#16a34a" stroke-width="1"/>
+  <text x="390" y="422" text-anchor="middle" fill="#166534" font-weight="600" font-size="11">openshell-0</text>
+  <text x="390" y="436" text-anchor="middle" fill="#15803d" font-size="9">gateway · dashboard</text>
+
+  <!-- Per-user persist (outside cluster, on host) -->
+  <rect x="48" y="488" width="200" height="48" rx="6" fill="#fef9c3" stroke="#eab308" stroke-width="1"/>
+  <text x="148" y="506" text-anchor="middle" fill="#854d0e" font-size="11" font-weight="600">persist/users/U0AN.../</text>
+  <text x="148" y="522" text-anchor="middle" fill="#a16207" font-size="10">credentials/ · workspace/ · .env</text>
+
+  <rect x="360" y="488" width="200" height="48" rx="6" fill="#fef9c3" stroke="#eab308" stroke-width="1"/>
+  <text x="460" y="506" text-anchor="middle" fill="#854d0e" font-size="11" font-weight="600">persist/users/U09E.../</text>
+  <text x="460" y="522" text-anchor="middle" fill="#a16207" font-size="10">credentials/ · workspace/ · .env</text>
+
+  <rect x="672" y="488" width="200" height="48" rx="6" fill="#fef9c3" stroke="#eab308" stroke-width="1"/>
+  <text x="772" y="506" text-anchor="middle" fill="#854d0e" font-size="11" font-weight="600">persist/users/U0AP.../</text>
+  <text x="772" y="522" text-anchor="middle" fill="#a16207" font-size="10">credentials/ · workspace/ · .env</text>
+
+  <!-- inject arrows from persist into pods -->
+  <line x1="148" y1="488" x2="148" y2="394" stroke="#059669" stroke-width="1" marker-end="url(#arrow-green)" stroke-dasharray="3,2"/>
+  <line x1="460" y1="488" x2="460" y2="394" stroke="#059669" stroke-width="1" marker-end="url(#arrow-green)" stroke-dasharray="3,2"/>
+  <line x1="772" y1="488" x2="772" y2="394" stroke="#059669" stroke-width="1" marker-end="url(#arrow-green)" stroke-dasharray="3,2"/>
+  <text x="500" y="480" fill="#059669" font-size="9">SSH inject</text>
+
+  <!-- ===== AUTOMATION LAYER ===== -->
+  <text x="40" y="562" fill="#475569" font-size="11" font-weight="600" letter-spacing="1">AUTOMATION (HOST)</text>
+
+  <rect x="40" y="574" width="200" height="48" rx="8" fill="#e0e7ff" stroke="#6366f1" stroke-width="1" filter="url(#shadow)"/>
+  <text x="140" y="594" text-anchor="middle" fill="#3730a3" font-weight="600" font-size="11">refresh-credentials.sh</text>
+  <text x="140" y="610" text-anchor="middle" fill="#6366f1" font-size="9">cron 15 min · OAuth · gateway</text>
+
+  <rect x="265" y="574" width="200" height="48" rx="8" fill="#e0e7ff" stroke="#6366f1" stroke-width="1" filter="url(#shadow)"/>
+  <text x="365" y="594" text-anchor="middle" fill="#3730a3" font-weight="600" font-size="11">nemoclaw-resilience.sh</text>
+  <text x="365" y="610" text-anchor="middle" fill="#6366f1" font-size="9">--all · full bring-up sequence</text>
+
+  <rect x="490" y="574" width="200" height="48" rx="8" fill="#e0e7ff" stroke="#6366f1" stroke-width="1" filter="url(#shadow)"/>
+  <text x="590" y="594" text-anchor="middle" fill="#3730a3" font-weight="600" font-size="11">watchdog-bridge.sh</text>
+  <text x="590" y="610" text-anchor="middle" fill="#6366f1" font-size="9">cron 2 min · restart + lock cleanup</text>
+
+  <rect x="715" y="574" width="200" height="48" rx="8" fill="#e0e7ff" stroke="#6366f1" stroke-width="1" filter="url(#shadow)"/>
+  <text x="815" y="594" text-anchor="middle" fill="#3730a3" font-weight="600" font-size="11">start-services.sh</text>
+  <text x="815" y="610" text-anchor="middle" fill="#6366f1" font-size="9">auto-detect multi-user · PID</text>
+
+  <!-- ===== SECURITY LAYER ===== -->
+  <text x="40" y="652" fill="#475569" font-size="11" font-weight="600" letter-spacing="1">SECURITY</text>
+
+  <rect x="40" y="664" width="190" height="44" rx="8" fill="#fce7f3" stroke="#ec4899" stroke-width="1"/>
+  <text x="135" y="683" text-anchor="middle" fill="#9d174d" font-weight="600" font-size="11">Credential Isolation</text>
+  <text x="135" y="698" text-anchor="middle" fill="#be185d" font-size="9">mode 700 · per-user dirs</text>
+
+  <rect x="255" y="664" width="150" height="44" rx="8" fill="#fce7f3" stroke="#ec4899" stroke-width="1"/>
+  <text x="330" y="683" text-anchor="middle" fill="#9d174d" font-weight="600" font-size="11">RBAC</text>
+  <text x="330" y="698" text-anchor="middle" fill="#be185d" font-size="9">admin · user roles</text>
+
+  <rect x="430" y="664" width="190" height="44" rx="8" fill="#fce7f3" stroke="#ec4899" stroke-width="1"/>
+  <text x="525" y="683" text-anchor="middle" fill="#9d174d" font-weight="600" font-size="11">K8s Network Policy</text>
+  <text x="525" y="698" text-anchor="middle" fill="#be185d" font-size="9">per-pod · merge-policy.py</text>
+
+  <rect x="645" y="664" width="170" height="44" rx="8" fill="#fce7f3" stroke="#ec4899" stroke-width="1"/>
+  <text x="730" y="683" text-anchor="middle" fill="#9d174d" font-weight="600" font-size="11">Audit Log</text>
+  <text x="730" y="698" text-anchor="middle" fill="#be185d" font-size="9">admin-actions.log · JSON</text>
+
+  <!-- ===== LEGEND ===== -->
+  <rect x="40" y="726" width="840" height="40" rx="8" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"/>
+  <line x1="60" y1="748" x2="90" y2="748" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="96" y="752" fill="#475569" font-size="10">Data flow</text>
+  <line x1="160" y1="748" x2="190" y2="748" stroke="#059669" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arrow-green)"/>
+  <text x="196" y="752" fill="#475569" font-size="10">Cred inject</text>
+  <line x1="260" y1="748" x2="290" y2="748" stroke="#64748b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="296" y="752" fill="#475569" font-size="10">Lookup</text>
+  <text x="370" y="752" fill="#475569" font-size="10">
+    <tspan fill="#4A154B" font-weight="600">Purple</tspan>=Slack
+    <tspan dx="6" fill="#0ea5e9" font-weight="600">Blue</tspan>=Bridge
+    <tspan dx="6" fill="#16a34a" font-weight="600">Green</tspan>=K3s/Pods
+    <tspan dx="6" fill="#854d0e" font-weight="600">Yellow</tspan>=Persist
+    <tspan dx="6" fill="#6366f1" font-weight="600">Indigo</tspan>=Cron
+    <tspan dx="6" fill="#9d174d" font-weight="600">Pink</tspan>=Security
+  </text>
+</svg>

--- a/docs/reference/inference-profiles.md
+++ b/docs/reference/inference-profiles.md
@@ -1,0 +1,100 @@
+---
+title:
+  page: "NemoClaw Inference Profiles"
+  nav: "Inference Profiles"
+description:
+  main: "Configuration reference for NemoClaw routed inference providers."
+  agent: "Documents configuration options for NemoClaw routed inference providers. Use when configuring inference profiles, looking up provider routing settings, or reviewing available LLM providers."
+keywords: ["nemoclaw inference profiles", "nemoclaw provider routing"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "inference_routing", "llms"]
+content:
+  type: reference
+  difficulty: intermediate
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Inference Profiles
+
+NemoClaw configures inference through the OpenShell gateway.
+The agent inside the sandbox talks to `inference.local`, and OpenShell routes that traffic to the provider you selected during onboarding.
+
+## Routed Provider Model
+
+NemoClaw keeps provider credentials on the host.
+The sandbox does not receive your raw OpenAI, Anthropic, Gemini, or NVIDIA API key.
+
+At onboard time, NemoClaw configures:
+
+- an OpenShell provider
+- an OpenShell inference route
+- the baked OpenClaw model reference inside the sandbox
+
+That means the sandbox knows which model family to use, while OpenShell owns the actual provider credential and upstream endpoint.
+
+## Supported Providers
+
+The following non-experimental provider paths are available through `nemoclaw onboard`.
+
+| Provider | Endpoint Type | Notes |
+|---|---|---|
+| NVIDIA Endpoints | OpenAI-compatible | Hosted models on `integrate.api.nvidia.com` |
+| OpenAI | Native OpenAI-compatible | Uses OpenAI model IDs |
+| Other OpenAI-compatible endpoint | Custom OpenAI-compatible | For compatible proxies and gateways |
+| Anthropic | Native Anthropic | Uses `anthropic-messages` |
+| Other Anthropic-compatible endpoint | Custom Anthropic-compatible | For Claude proxies and compatible gateways |
+| Google Gemini | OpenAI-compatible | Uses Google's OpenAI-compatible endpoint |
+
+## Validation During Onboarding
+
+NemoClaw validates the selected provider and model before it creates the sandbox.
+
+- OpenAI-compatible providers:
+  NemoClaw tries `/responses` first, then `/chat/completions`.
+- Anthropic-compatible providers:
+  NemoClaw tries `/v1/messages`.
+- NVIDIA Endpoints manual model entry:
+  NemoClaw also validates the model name against `https://integrate.api.nvidia.com/v1/models`.
+- Compatible endpoint flows:
+  NemoClaw validates by sending a real inference request, because many proxies do not expose a reliable `/models` endpoint.
+
+If validation fails, the wizard does not continue to sandbox creation.
+
+## Local Ollama
+
+Local Ollama is available in the standard onboarding flow when Ollama is installed or running on the host.
+It uses the same routed `inference.local` pattern, but the upstream runtime runs locally instead of in the cloud.
+
+Ollama gets additional onboarding help:
+
+- if no models are installed, NemoClaw offers starter models
+- it pulls the selected model
+- it warms the model
+- it validates the model before continuing
+
+On Linux hosts that run NemoClaw with Docker, the sandbox reaches Ollama through `http://host.openshell.internal:11434`, not the host shell's `localhost` socket.
+If Ollama is already running, make sure it listens on `0.0.0.0:11434` instead of `127.0.0.1:11434`.
+Run the following command to start Ollama with that bind address.
+
+```console
+$ OLLAMA_HOST=0.0.0.0:11434 ollama serve
+```
+
+If Ollama only binds loopback, NemoClaw can detect it on the host, but the sandbox-side validation step fails because containers cannot reach it.
+
+## Experimental Local Providers
+
+The following local providers require `NEMOCLAW_EXPERIMENTAL=1`:
+
+- Local NVIDIA NIM (requires a NIM-capable GPU)
+- Local vLLM (must already be running on `localhost:8000`)
+
+## Runtime Switching
+
+For runtime switching guidance, refer to [Switch Inference Models](../inference/switch-inference-providers.md).

--- a/multi-user-nemoclaw.md
+++ b/multi-user-nemoclaw.md
@@ -1,0 +1,238 @@
+# Multi-User NemoClaw
+
+## Overview
+
+Run multiple always-on assistants — each dedicated to one user — inside isolated OpenShell sandboxes, all managed through Slack and WhatsApp. A central bridge routes messages by user ID, and per-user credential isolation ensures no cross-user data leakage.
+
+**Status:** Production — 8 users across 8 sandboxes on DGX Spark (128 GB RAM).
+
+---
+
+## Architecture
+
+<p align="center">
+  <img src="docs/multi-user-architecture.svg" alt="Multi-User NemoClaw Service Architecture" width="100%" />
+</p>
+
+<details>
+<summary>Text version (for terminals)</summary>
+
+```
+Slack App (Socket Mode, 1 bot)       WhatsApp (Baileys, 1 session)
+    │                                     │
+    ▼                                     ▼
+slack-bridge-multi.js               whatsapp-bridge-multi.js
+    │                                     │
+    ├── SSH proxy ─┐                      │
+    ├── SSH proxy ─┤   K3s cluster  (namespace: openshell)
+    └── SSH proxy ─┤   ┌──────────────────────────────────────────┐
+                   │   │  [pod] veyonce-claw    (net policy)     │
+                   │   │  [pod] aditya-claw     (net policy)     │
+                   │   │  [pod] ...                               │
+                   │   │  [pod] nirmal-claw     (net policy)     │
+                   │   │  [pod] agent-sandbox-controller          │
+                   │   │  [pod] openshell-0 (gateway/dashboard)  │
+                   │   └──────────────────────────────────────────┘
+
+Host services:  yahoo-mail.py · watchdog-bridge.sh · forward-slack-to-whatsapp.sh
+Automation:     refresh-credentials.sh (15 min) · nemoclaw-resilience.sh --all
+Security:       mode 700 credentials · RBAC · K8s network policy · audit log
+```
+</details>
+
+### Design Decisions
+
+- **One Slack app** with Socket Mode handles all users (no per-user bot tokens)
+- **One WhatsApp session** (Baileys) — users register via `!setup whatsapp +number`
+- **Per-message routing**: bridge looks up user ID in registry → resolves sandbox
+- **Fire-and-poll SSH**: agent launched in background, polled via short SSH calls (survives proxy drops)
+- **Per-user message queue**: serializes agent runs per sandbox (OpenClaw lane lock constraint)
+- **Orphaned result recovery**: pending runs persisted to disk, delivered on bridge restart
+- **Single Node.js process** per bridge regardless of user count
+
+---
+
+## Inference
+
+| Priority | Provider | Model | Where | Used For |
+|----------|----------|-------|-------|----------|
+| **Primary** | NVIDIA NIM | Llama 3.3 70B Instruct | Gateway (`inference.local`) | All agent reasoning |
+| **Claude Code** | Anthropic | Claude Sonnet 4.6 | Direct API | Code migrations, PRs, complex tool use |
+| **Fallback 1** | NVIDIA NIM | Llama 3.3 70B | Gateway | Rate limit fallback |
+| **Fallback 2** | Ollama | DeepSeek R1 70B | Local (not yet routable from sandbox) | Future fallback |
+| **Fallback 3** | Ollama | Qwen3 Coder 30B | Local (not yet routable) | Future fallback |
+| **Fallback 4** | Ollama | GPT-oss | Local (not yet routable) | Future fallback |
+
+Rate limit detection triggers automatic fallback: Anthropic → NVIDIA → Ollama chain with 60s cooldown.
+
+---
+
+## Messaging Channels
+
+### Slack (`scripts/slack-bridge-multi.js`)
+
+- Socket Mode, single bot token
+- Admin commands: `!show-claws`, `!add-claw`, `!delete-claw`, `!admins`, `!admin-audit`
+- Self-service: `!setup help/github/whatsapp/personality/timezone/status`
+- Host-side commands: `!yahoo inbox/send/search`, `!wa send`
+- Markdown table → Slack native table block conversion
+- Clickable links extracted below tables as context blocks
+- Debug logging (`[debug:sessionId]`) for troubleshooting
+
+### WhatsApp (`scripts/whatsapp-bridge-multi.js`)
+
+- Baileys (WhatsApp Web) running on host (sandbox proxy blocks WebSocket)
+- Two-way: users message the bot's WhatsApp number → routed to their claw → response sent back
+- Supports all `!` commands (setup, yahoo, wa, admin, help)
+- LID JID resolution for linked device format
+- Users register via Slack: `!setup whatsapp +1XXXXXXXXXX`
+- Notification forwarding: emoji-prefixed bot responses auto-forwarded to WhatsApp
+
+### Yahoo Mail (`scripts/yahoo-mail.py`)
+
+- Runs on host (IMAP port 993 blocked by sandbox proxy)
+- Bridge commands: `!yahoo inbox`, `!yahoo read <id>`, `!yahoo send`, `!yahoo search`
+- Cron check every 4 hours with Slack + WhatsApp notification
+- Per-user credentials in `persist/users/<id>/credentials/yahoo-creds.env`
+
+---
+
+## Freshrelease Integration
+
+Direct REST API from sandbox (no Claude Code MCP — saves 2 API calls per query):
+
+- **Endpoint**: `https://freshworks.freshrelease.com/{PROJECT_KEY}/issues`
+- **Auth**: `Authorization: Token <key>` + `Accept: application/json`
+- **User resolution**: `?include=owner,reporter` returns `users` array with `{id, name, email}`
+- **API key**: injected into sandbox `.env` as `FRESHRELEASE_API_KEY`
+- **Network policy**: `freshworks.yaml` preset with `python3.*` binary glob for httpx support
+- **Known projects**: FRESHID, BILLING, SEARCH, EMAIL
+
+---
+
+## User Registry
+
+### `~/.nemoclaw/users.json`
+
+```json
+{
+  "users": {
+    "U0AN4K44ZQB": {
+      "slackUserId": "U0AN4K44ZQB",
+      "slackDisplayName": "vamsee",
+      "sandboxName": "veyonce-claw",
+      "githubUser": "lakamsani",
+      "enabled": true,
+      "timezone": "America/Los_Angeles",
+      "roles": ["user", "admin"]
+    }
+  },
+  "defaultUser": "U0AN4K44ZQB",
+  "deletedUsers": []
+}
+```
+
+---
+
+## Per-User Credential Storage
+
+```
+persist/users/<slack-user-id>/
+  .env                              # User-specific env vars
+  credentials/                      # Mode 700
+    claude-oauth-token.txt          # Long-lived Teams token
+    claude-credentials.json         # OAuth session for claude --print
+    claude-settings.json            # Claude Code settings
+    gh-hosts.yml                    # GitHub token
+    gogcli/                         # Google OAuth (all services)
+    freshrelease-api-key.txt        # Freshrelease REST API key
+    yahoo-creds.env                 # Yahoo IMAP credentials
+    whatsapp-number.txt             # WhatsApp phone number
+    whatsapp-auth/                  # Baileys session (if applicable)
+  workspace/                        # Personality customization
+    SOUL.md / IDENTITY.md / USER.md / TOOLS.md
+    HEARTBEAT.md / AGENTS.md / MEMORY.md
+```
+
+---
+
+## CLI Commands
+
+```
+nemoclaw user-add                         Interactive wizard (or --non-interactive)
+nemoclaw user-remove <slack-id>           Remove from registry (keeps sandbox/data)
+nemoclaw user-purge --sandbox <name>      Destroy sandbox + registry + persist data
+nemoclaw user-list                        List all registered users
+nemoclaw user-status <slack-id>           Show user details and sandbox health
+nemoclaw user-enable/disable <slack-id>   Enable/disable in bridges
+nemoclaw user-grant-admin <slack-id>      Grant admin role
+nemoclaw user-revoke-admin <slack-id>     Revoke admin role
+```
+
+---
+
+## Automation (Cron)
+
+| Schedule | Script | Purpose |
+|----------|--------|---------|
+| Every 2 min | `watchdog-bridge.sh` | Restart Slack/WhatsApp bridges if dead, fix root-owned files via kubectl, clean stale session locks |
+| Every 15 min | `refresh-all-credentials.sh` | Re-inject all user credentials, restart gateway if config changed |
+| Every 2 hours | `backup-all-workspaces.sh` | Backup workspace files from all sandboxes |
+| Every 4 hours | `check-yahoo-unread.sh` | Check Yahoo unread, notify via Slack + WhatsApp |
+| Every 5 min | `forward-slack-to-whatsapp.sh` | Forward emoji-prefixed Slack bot DMs to WhatsApp |
+
+---
+
+## Security
+
+- **Credential isolation**: Mode 700 per-user directories, no cross-user access
+- **SSH tunneling**: Credentials injected via SSH, never committed to git
+- **RBAC**: Admin commands restricted by role in user registry
+- **Network policies**: Per-sandbox, binary-scoped, protocol-inspected (REST with method/path rules)
+- **Inference routing**: NVIDIA NIM via gateway (`inference.local`), agent never sees API keys
+- **Rate limit handling**: Auto-detect + 60s cooldown + NVIDIA/Ollama fallback chain
+- **Token management**: `.credentials.json` written from long-lived token on every refresh (not deleted)
+- **Output filtering**: Internal errors (`[tools]`, `[agent/]`, `PermissionError`, `Traceback`) stripped from user-facing responses
+- **Deleted user tracking**: Silent ignores prevent access after removal
+- **Audit trail**: Admin actions logged as JSON lines
+
+---
+
+## Capacity (DGX Spark)
+
+| Metric | Value |
+|--------|-------|
+| RAM per idle sandbox | ~512 MB |
+| RAM per active sandbox | ~2 GB |
+| Host RAM | 128 GB |
+| Comfortable capacity | 50+ sandboxes |
+| Current deployment | 8 users / 8 sandboxes |
+| Slack bridge | Single Node.js process |
+| WhatsApp bridge | Single Node.js process |
+| Installed dev tools | JDK 17, Gradle 8.13 (all sandboxes) |
+
+---
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `bin/nemoclaw.js` | CLI: user-add/remove/purge/list/status/enable/disable/grant/revoke |
+| `bin/lib/user-registry.js` | User metadata, lifecycle, deleted-user tracking |
+| `bin/lib/registry.js` | Sandbox tracking, atomic locking |
+| `bin/lib/credential-setup.js` | `!setup` command handling (github/claude/whatsapp/freshrelease/etc.) |
+| `scripts/slack-bridge-multi.js` | Multi-user Slack routing, RBAC, admin commands, table formatting, rate limit fallback |
+| `scripts/whatsapp-bridge-multi.js` | Multi-user WhatsApp routing, `!` commands, LID resolution |
+| `scripts/whatsapp-bridge.js` | WhatsApp CLI (send/inbox/contacts) for host-side use |
+| `scripts/yahoo-mail.py` | Yahoo IMAP/SMTP CLI with HTTP CONNECT proxy support |
+| `scripts/inject-user-credentials.sh` | Per-user credential setup (SSH-based) |
+| `scripts/refresh-credentials.sh` | Cron: re-inject credentials + gateway health |
+| `scripts/nemoclaw-resilience.sh` | Full bring-up (`--all` for all users), JDK/Gradle install |
+| `scripts/start-services.sh` | Start Slack + WhatsApp bridges (auto-detect multi-user) |
+| `scripts/watchdog-bridge.sh` | Cron: restart bridges, fix ownership, clean locks |
+| `scripts/check-yahoo-unread.sh` | Cron: Yahoo unread check + notification |
+| `scripts/forward-slack-to-whatsapp.sh` | Cron: forward emoji-prefixed Slack DMs to WhatsApp |
+| `scripts/notify.sh` | Shared notification helper (Slack + WhatsApp) |
+| `persist/users/<id>/` | Per-user credentials + workspace |
+| `persist/audit/admin-actions.log` | Admin action audit trail (JSON lines) |
+| `persist/pending-slack-runs.json` | Orphaned run recovery tracker |

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -72,7 +72,10 @@ network_policies:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/node }
       - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
+      - { path: /usr/local/bin/openclaw }
 
   nvidia:
     name: nvidia
@@ -94,7 +97,9 @@ network_policies:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
     binaries:
+      - { path: /usr/local/bin/node }
       - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
       - { path: /usr/local/bin/openclaw }
 
   github:
@@ -108,7 +113,11 @@ network_policies:
         access: full
     binaries:
       - { path: /usr/bin/gh }
+      - { path: /usr/local/bin/gh }
+      - { path: /sandbox/.local/bin/gh }
       - { path: /usr/bin/git }
+      - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
 
   # ── OpenClaw "phone home" ────────────────────────────────────────────
   # Minimum viable set for OpenClaw to authenticate, discover plugins,
@@ -167,9 +176,12 @@ network_policies:
         port: 443
         access: full
     binaries:
+      - { path: /usr/local/bin/node }
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/npm }
       - { path: /usr/local/bin/node }
+      - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
 
   # ── Messaging — pre-allowed for OpenClaw agent notifications ────
   # Restricted to node processes to prevent arbitrary data exfiltration

--- a/nemoclaw-blueprint/policies/presets/freshworks.yaml
+++ b/nemoclaw-blueprint/policies/presets/freshworks.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: freshworks
+  description: "FreshWorks Freshrelease API access for ticket management MCP"
+
+network_policies:
+  freshworks:
+    name: freshworks
+    endpoints:
+      - host: freshworks.freshrelease.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: PUT, path: "/**" }
+          - allow: { method: PATCH, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
+      - { path: /usr/local/bin/openclaw }
+      - { path: /root/.local/bin/uvx }
+      - { path: /root/.local/bin/uv }
+      - { path: /usr/bin/python3 }
+      - { path: /usr/bin/python3.* }
+      - { path: /usr/local/bin/python3* }
+      - { path: /usr/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/google.yaml
+++ b/nemoclaw-blueprint/policies/presets/google.yaml
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: google
+  description: "Google Workspace APIs (Drive, Calendar, Gmail, Sheets, Docs, Slides, Tasks, Contacts)"
+
+network_policies:
+  google:
+    name: google
+    endpoints:
+      # OAuth — needs GET+POST for token exchange
+      - host: accounts.google.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: oauth2.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      # Read-write APIs (gog needs GET, POST, PUT, PATCH, DELETE for full CRUD)
+      - host: www.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: PUT, path: "/**" }
+          - allow: { method: PATCH, path: "/**" }
+          - allow: { method: DELETE, path: "/**" }
+      - host: gmail.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: PUT, path: "/**" }
+          - allow: { method: PATCH, path: "/**" }
+          - allow: { method: DELETE, path: "/**" }
+      - host: calendar-json.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: PUT, path: "/**" }
+          - allow: { method: PATCH, path: "/**" }
+          - allow: { method: DELETE, path: "/**" }
+      - host: drive.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: PUT, path: "/**" }
+          - allow: { method: PATCH, path: "/**" }
+          - allow: { method: DELETE, path: "/**" }
+      - host: tasks.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: PUT, path: "/**" }
+          - allow: { method: PATCH, path: "/**" }
+          - allow: { method: DELETE, path: "/**" }
+      - host: people.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      # Read-only APIs
+      - host: sheets.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: PUT, path: "/**" }
+      - host: docs.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: slides.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
+      - { path: /usr/local/bin/gog }
+      - { path: /sandbox/.local/bin/gog }
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/jira.yaml
+++ b/nemoclaw-blueprint/policies/presets/jira.yaml
@@ -3,28 +3,13 @@
 
 preset:
   name: jira
-  description: "Jira and Atlassian Cloud access"
+  description: "Jira and Atlassian Cloud access (scoped to Atlassian APIs, not wildcard)"
 
 network_policies:
   atlassian:
     name: atlassian
     endpoints:
-      - host: "*.atlassian.net"
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
-      - host: auth.atlassian.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
+      # Atlassian REST API (covers Jira, Confluence, etc.)
       - host: api.atlassian.com
         port: 443
         protocol: rest
@@ -33,5 +18,23 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+      # Auth
+      - host: auth.atlassian.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      # Instance-specific access — add your org's subdomain here:
+      # - host: your-org.atlassian.net
+      #   port: 443
+      #   protocol: rest
+      #   enforcement: enforce
+      #   tls: terminate
+      #   rules:
+      #     - allow: { method: GET, path: "/**" }
+      #     - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/node }

--- a/nemoclaw-blueprint/policies/presets/npm.yaml
+++ b/nemoclaw-blueprint/policies/presets/npm.yaml
@@ -3,7 +3,7 @@
 
 preset:
   name: npm
-  description: "npm and Yarn registry access"
+  description: "npm and Yarn registry access (read-only — install, not publish)"
 
 network_policies:
   npm_yarn:
@@ -11,10 +11,18 @@ network_policies:
     endpoints:
       - host: registry.npmjs.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
       - host: registry.yarnpkg.com
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
     binaries:
       - { path: /usr/local/bin/npm* }
       - { path: /usr/local/bin/npx* }
@@ -22,3 +30,4 @@ network_policies:
       - { path: /usr/local/bin/yarn* }
       - { path: /usr/bin/npm* }
       - { path: /usr/bin/node* }
+      - { path: /usr/local/bin/openclaw }

--- a/nemoclaw-blueprint/policies/presets/ollama.yaml
+++ b/nemoclaw-blueprint/policies/presets/ollama.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: ollama
+  description: "Local Ollama inference (host.docker.internal:11434)"
+
+network_policies:
+  ollama:
+    name: ollama
+    endpoints:
+      - host: host.docker.internal
+        port: 11435
+        access: full
+      - host: host.openshell.internal
+        port: 11435
+        access: full
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
+      - { path: /usr/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/pypi.yaml
+++ b/nemoclaw-blueprint/policies/presets/pypi.yaml
@@ -3,7 +3,7 @@
 
 preset:
   name: pypi
-  description: "Python Package Index (PyPI) access"
+  description: "Python Package Index (PyPI) access (read-only — install, not publish)"
 
 network_policies:
   pypi:
@@ -11,10 +11,18 @@ network_policies:
     endpoints:
       - host: pypi.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
       - host: files.pythonhosted.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
     binaries:
       - { path: /usr/bin/python3* }
       - { path: /usr/bin/pip* }

--- a/nemoclaw-blueprint/policies/presets/whatsapp.yaml
+++ b/nemoclaw-blueprint/policies/presets/whatsapp.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: whatsapp
+  description: "WhatsApp Web connectivity for OpenClaw channel"
+
+network_policies:
+  whatsapp:
+    name: whatsapp
+    endpoints:
+      - host: web.whatsapp.com
+        port: 443
+        access: full
+      - host: w1.web.whatsapp.com
+        port: 443
+        access: full
+      - host: w2.web.whatsapp.com
+        port: 443
+        access: full
+      - host: w3.web.whatsapp.com
+        port: 443
+        access: full
+      - host: mmg.whatsapp.net
+        port: 443
+        access: full
+      - host: pps.whatsapp.net
+        port: 443
+        access: full
+      - host: static.whatsapp.net
+        port: 443
+        access: full
+      - host: media.whatsapp.com
+        port: 443
+        access: full
+      - host: dit.whatsapp.net
+        port: 443
+        access: full
+      - host: graph.facebook.com
+        port: 443
+        access: full
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }

--- a/nemoclaw-blueprint/policies/presets/xcurl.yaml
+++ b/nemoclaw-blueprint/policies/presets/xcurl.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: xcurl
+  description: "X/Twitter API access for xcurl skill"
+
+network_policies:
+  xcurl:
+    name: xcurl
+    binaries:
+      - { path: /usr/bin/curl }
+      - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
+    endpoints:
+      - host: api.x.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: DELETE, path: "/**" }
+      - host: api.twitter.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+          - allow: { method: DELETE, path: "/**" }
+      - host: upload.twitter.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/yahoo.yaml
+++ b/nemoclaw-blueprint/policies/presets/yahoo.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: yahoo
+  description: "Yahoo Mail IMAP/SMTP access"
+
+network_policies:
+  yahoo:
+    name: yahoo
+    endpoints:
+      - host: imap.mail.yahoo.com
+        port: 993
+        access: full
+      - host: smtp.mail.yahoo.com
+        port: 465
+        access: full
+    binaries:
+      - { path: /usr/bin/python3 }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/local/bin/claude }
+      - { path: /sandbox/.local/bin/claude }
+      - { path: /usr/local/bin/openclaw }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepublishOnly": "cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {
+    "@slack/bolt": "^4.2.0",
     "p-retry": "^4.6.2",
     "yaml": "^2.8.3"
   },

--- a/scripts/backup-all-workspaces.sh
+++ b/scripts/backup-all-workspaces.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Backup workspace files for all registered users.
+# Falls back to single-sandbox backup if no users.json exists.
+#
+# Usage: ./scripts/backup-all-workspaces.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a; . "$REPO_DIR/.env"; set +a
+fi
+
+USERS_FILE="$HOME/.nemoclaw/users.json"
+
+if [ -f "$USERS_FILE" ] && python3 -c "import json; d=json.load(open('$USERS_FILE')); exit(0 if len(d.get('users',{})) > 0 else 1)" 2>/dev/null; then
+  # Multi-user mode: iterate over all enabled users
+  USER_IDS=$(python3 -c "import json; d=json.load(open('$USERS_FILE')); [print(uid) for uid, u in d.get('users',{}).items() if u.get('enabled', True)]")
+
+  for uid in $USER_IDS; do
+    SANDBOX=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid']['sandboxName'])")
+    WORKSPACE_DIR=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid'].get('personalityDir','persist/workspace'))")
+    NAME=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid'].get('slackDisplayName','$uid'))")
+
+    # Resolve relative path
+    if [[ "$WORKSPACE_DIR" != /* ]]; then
+      WORKSPACE_DIR="$REPO_DIR/$WORKSPACE_DIR"
+    fi
+
+    mkdir -p "$WORKSPACE_DIR"
+
+    echo "[backup-all] Backing up workspace for $NAME → $WORKSPACE_DIR ($(date))"
+
+    # Generate SSH config
+    openshell sandbox ssh-config "$SANDBOX" > "/tmp/ssh-config-${SANDBOX}" 2>/dev/null || {
+      echo "[backup-all] Cannot get SSH config for $SANDBOX — skipping"
+      continue
+    }
+
+    ssh -F "/tmp/ssh-config-${SANDBOX}" -o StrictHostKeyChecking=no "openshell-${SANDBOX}" \
+      'cd /sandbox/.openclaw/workspace && tar czf - \
+        SOUL.md IDENTITY.md USER.md TOOLS.md HEARTBEAT.md AGENTS.md BOOTSTRAP.md \
+        .openclaw memory 2>/dev/null || true' \
+      | tar xzf - -C "$WORKSPACE_DIR" 2>/dev/null || {
+      echo "[backup-all] Backup failed for $NAME ($SANDBOX) — continuing..."
+    }
+
+    # Backup GOG OAuth tokens from sandbox to per-user credentials dir
+    CRED_DIR=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid'].get('credentialsDir',''))" 2>/dev/null)
+    if [ -n "$CRED_DIR" ]; then
+      [[ "$CRED_DIR" != /* ]] && CRED_DIR="$REPO_DIR/$CRED_DIR"
+      GOG_BACKUP_DIR="$CRED_DIR/gogcli"
+      mkdir -p "$GOG_BACKUP_DIR/keyring"
+      ssh -F "/tmp/ssh-config-${SANDBOX}" -o StrictHostKeyChecking=no "openshell-${SANDBOX}" \
+        'cd /sandbox/.config/gogcli && tar czf - . 2>/dev/null || true' \
+        | tar xzf - -C "$GOG_BACKUP_DIR" 2>/dev/null && {
+        echo "[backup-all] GOG tokens backed up for $NAME"
+      } || true
+    fi
+  done
+else
+  # Legacy single-user mode
+  "$SCRIPT_DIR/nemoclaw-backup-workspace.sh"
+fi

--- a/scripts/brev-setup.sh
+++ b/scripts/brev-setup.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Brev VM bootstrap — installs prerequisites then runs nemoclaw onboard.
+#
+# Run on a fresh Brev VM:
+#   export NVIDIA_API_KEY=nvapi-...
+#   ./scripts/brev-setup.sh
+#
+# What it does:
+#   1. Installs Docker (if missing)
+#   2. Installs NVIDIA Container Toolkit (if GPU present)
+#   3. Installs openshell CLI from GitHub release (binary, no Rust build)
+#   4. Installs nemoclaw CLI and runs nemoclaw onboard
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+_ts() { date '+%H:%M:%S'; }
+info() { echo -e "${GREEN}[$(_ts) brev]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(_ts) brev]${NC} $1"; }
+fail() {
+  echo -e "${RED}[$(_ts) brev]${NC} $1"
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+[ -n "${NVIDIA_API_KEY:-}" ] || fail "NVIDIA_API_KEY not set"
+
+# Suppress needrestart noise from apt (Scanning processes, No services need...)
+export NEEDRESTART_MODE=a
+export DEBIAN_FRONTEND=noninteractive
+
+# --- 0. Node.js (needed for services) ---
+if ! command -v node >/dev/null 2>&1; then
+  info "Installing Node.js..."
+  NODESOURCE_URL="https://deb.nodesource.com/setup_22.x"
+  NODESOURCE_SHA256="575583bbac2fccc0b5edd0dbc03e222d9f9dc8d724da996d22754d6411104fd1"
+  (
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    curl -fsSL "$NODESOURCE_URL" -o "$tmpdir/setup_node.sh"
+    if command -v sha256sum >/dev/null 2>&1; then
+      echo "$NODESOURCE_SHA256  $tmpdir/setup_node.sh" | sha256sum -c - >/dev/null \
+        || fail "NodeSource installer checksum mismatch — expected $NODESOURCE_SHA256"
+    elif command -v shasum >/dev/null 2>&1; then
+      echo "$NODESOURCE_SHA256  $tmpdir/setup_node.sh" | shasum -a 256 -c - >/dev/null \
+        || fail "NodeSource installer checksum mismatch — expected $NODESOURCE_SHA256"
+    else
+      fail "No SHA-256 verification tool found (need sha256sum or shasum)"
+    fi
+    sudo -E bash "$tmpdir/setup_node.sh" >/dev/null 2>&1
+  )
+  sudo apt-get install -y -qq nodejs >/dev/null 2>&1
+  info "Node.js $(node --version) installed"
+else
+  info "Node.js already installed: $(node --version)"
+fi
+
+# --- 1. Docker ---
+if ! command -v docker >/dev/null 2>&1; then
+  info "Installing Docker..."
+  sudo apt-get update -qq >/dev/null 2>&1
+  sudo apt-get install -y -qq docker.io >/dev/null 2>&1
+  sudo usermod -aG docker "$(whoami)"
+  info "Docker installed"
+else
+  info "Docker already installed"
+fi
+
+# --- 2. NVIDIA Container Toolkit (if GPU present) ---
+if command -v nvidia-smi >/dev/null 2>&1; then
+  if ! dpkg -s nvidia-container-toolkit >/dev/null 2>&1; then
+    info "Installing NVIDIA Container Toolkit..."
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+      | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+      | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+      | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list >/dev/null
+    sudo apt-get update -qq >/dev/null 2>&1
+    sudo apt-get install -y -qq nvidia-container-toolkit >/dev/null 2>&1
+    sudo nvidia-ctk runtime configure --runtime=docker >/dev/null 2>&1
+    sudo systemctl restart docker
+    info "NVIDIA Container Toolkit installed"
+  else
+    info "NVIDIA Container Toolkit already installed"
+  fi
+fi
+
+# --- 3. openshell CLI (binary release, not pip) ---
+if ! command -v openshell >/dev/null 2>&1; then
+  info "Installing openshell CLI from GitHub release..."
+  if ! command -v gh >/dev/null 2>&1; then
+    sudo apt-get update -qq >/dev/null 2>&1
+    sudo apt-get install -y -qq gh >/dev/null 2>&1
+  fi
+  ARCH="$(uname -m)"
+  case "$ARCH" in
+    x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
+    aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
+    *) fail "Unsupported architecture: $ARCH" ;;
+  esac
+  tmpdir="$(mktemp -d)"
+  GH_TOKEN="${GITHUB_TOKEN:-}" gh release download --repo NVIDIA/OpenShell \
+    --pattern "$ASSET" --dir "$tmpdir"
+  tar xzf "$tmpdir/$ASSET" -C "$tmpdir"
+  sudo install -m 755 "$tmpdir/openshell" /usr/local/bin/openshell
+  rm -rf "$tmpdir"
+  info "openshell $(openshell --version) installed"
+else
+  info "openshell already installed: $(openshell --version)"
+fi
+
+# --- 3b. cloudflared (for public tunnel) ---
+if ! command -v cloudflared >/dev/null 2>&1; then
+  info "Installing cloudflared..."
+  CF_ARCH="$(uname -m)"
+  case "$CF_ARCH" in
+    x86_64 | amd64) CF_ARCH="amd64" ;;
+    aarch64 | arm64) CF_ARCH="arm64" ;;
+    *) fail "Unsupported architecture for cloudflared: $CF_ARCH" ;;
+  esac
+  tmpdir=$(mktemp -d)
+  curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${CF_ARCH}" -o "$tmpdir/cloudflared"
+  sudo install -m 755 "$tmpdir/cloudflared" /usr/local/bin/cloudflared
+  rm -rf "$tmpdir"
+  info "cloudflared $(cloudflared --version 2>&1 | head -1) installed"
+else
+  info "cloudflared already installed"
+fi
+
+# --- 4. vLLM (local inference, if GPU present) ---
+VLLM_MODEL="nvidia/nemotron-3-nano-30b-a3b"
+if [ "${SKIP_VLLM:-}" = "1" ]; then
+  info "Skipping vLLM install (SKIP_VLLM=1)"
+elif command -v nvidia-smi >/dev/null 2>&1; then
+  if ! python3 -c "import vllm" 2>/dev/null; then
+    info "Installing vLLM..."
+    if ! command -v pip3 >/dev/null 2>&1; then
+      sudo apt-get install -y -qq python3-pip >/dev/null 2>&1
+    fi
+    pip3 install --break-system-packages vllm 2>/dev/null || pip3 install vllm
+    info "vLLM installed"
+  else
+    info "vLLM already installed"
+  fi
+
+  # Start vLLM if not already running
+  if curl -s http://localhost:8000/v1/models >/dev/null 2>&1; then
+    info "vLLM already running on :8000"
+  elif python3 -c "import vllm" 2>/dev/null; then
+    info "Starting vLLM with $VLLM_MODEL..."
+    nohup python3 -m vllm.entrypoints.openai.api_server \
+      --model "$VLLM_MODEL" \
+      --port 8000 \
+      --host 0.0.0.0 \
+      >/tmp/vllm-server.log 2>&1 &
+    VLLM_PID=$!
+    info "Waiting for vLLM to load model (this can take a few minutes)..."
+    for _ in $(seq 1 120); do
+      if curl -s http://localhost:8000/v1/models >/dev/null 2>&1; then
+        info "vLLM ready (PID $VLLM_PID)"
+        break
+      fi
+      if ! kill -0 "$VLLM_PID" 2>/dev/null; then
+        warn "vLLM exited. Check /tmp/vllm-server.log"
+        break
+      fi
+      sleep 2
+    done
+  fi
+fi
+
+# --- 5. Install nemoclaw CLI and run onboard ---
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info "Installing nemoclaw CLI..."
+export npm_config_prefix="$HOME/.local"
+export PATH="$HOME/.local/bin:$PATH"
+(cd "$REPO_DIR/nemoclaw" && npm install && npm run build) >/dev/null 2>&1
+(cd "$REPO_DIR" && npm install --ignore-scripts && npm link) >/dev/null 2>&1
+info "nemoclaw $(nemoclaw --version) installed"
+
+# Use sg docker to ensure docker group is active (usermod -aG doesn't
+# take effect in the current session without re-login)
+
+# CHAT_UI_URL tells onboard which browser origin to allow in the gateway
+# config.  On Brev, the launchable config should set this to the public URL
+# (e.g. https://openclaw0-<id>.brevlab.com).  Without it the dashboard
+# rejects remote browsers with "origin not allowed".
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/795
+if [ -n "${CHAT_UI_URL:-}" ]; then
+  export CHAT_UI_URL
+  info "CHAT_UI_URL=${CHAT_UI_URL}"
+elif [ -z "${DISPLAY:-}" ] && [ ! -e /tmp/.X11-unix ]; then
+  warn "CHAT_UI_URL is not set.  Remote browser access will fail with"
+  warn "'origin not allowed' unless you set CHAT_UI_URL to the public URL"
+  warn "of this instance (e.g. https://openclaw0-<id>.brevlab.com)."
+fi
+
+info "Running nemoclaw onboard..."
+export NVIDIA_API_KEY
+exec sg docker -c "nemoclaw onboard --non-interactive"

--- a/scripts/check-yahoo-unread.sh
+++ b/scripts/check-yahoo-unread.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Check Yahoo unread emails and notify via Slack if any important ones found.
+# Designed to run from cron alongside the heartbeat.
+#
+# Usage: check-yahoo-unread.sh <slack-user-id>
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SLACK_USER_ID="${1:-}"
+if [ -z "$SLACK_USER_ID" ]; then
+  echo "Usage: check-yahoo-unread.sh <slack-user-id>" >&2
+  exit 1
+fi
+
+# Source .env for Slack tokens
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$REPO_DIR/.env"
+  set +a
+fi
+
+CREDS_FILE="$REPO_DIR/persist/users/$SLACK_USER_ID/credentials/yahoo-creds.env"
+if [ ! -f "$CREDS_FILE" ]; then
+  exit 0  # No Yahoo credentials — skip silently
+fi
+
+# Load Yahoo credentials
+set -a
+# shellcheck source=/dev/null
+. "$CREDS_FILE"
+set +a
+
+# Check unread count
+UNREAD_OUTPUT=$(python3 "$SCRIPT_DIR/yahoo-mail.py" inbox --count 5 --unread 2>&1) || true
+
+if echo "$UNREAD_OUTPUT" | grep -q "No messages found"; then
+  exit 0
+fi
+
+# Count unread messages (subtract header + separator lines)
+UNREAD_COUNT=$(echo "$UNREAD_OUTPUT" | tail -n +3 | grep -c "." || true)
+
+if [ "$UNREAD_COUNT" -eq 0 ]; then
+  exit 0
+fi
+
+# Format notification
+SUMMARY=$(echo "$UNREAD_OUTPUT" | tail -n +3 | head -5 | while IFS= read -r line; do
+  # Extract subject from the fixed-width output
+  subj=$(echo "$line" | sed 's/^.\{60\}//' | xargs)
+  from=$(echo "$line" | cut -c9-38 | xargs)
+  [ -n "$subj" ] && echo "• $from: $subj"
+done)
+
+if [ -z "$SUMMARY" ]; then
+  exit 0
+fi
+
+MESSAGE="📧 *Yahoo Mail* — $UNREAD_COUNT unread:
+$SUMMARY"
+
+# Send via Slack + WhatsApp
+"$SCRIPT_DIR/notify.sh" "$SLACK_USER_ID" "$MESSAGE"

--- a/scripts/forward-slack-to-whatsapp.sh
+++ b/scripts/forward-slack-to-whatsapp.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Forward emoji-prefixed Slack bot DMs to WhatsApp.
+# Runs on host cron every 5 minutes. Reads recent bot messages from
+# each user's DM channel and forwards new ones to WhatsApp.
+#
+# Usage: forward-slack-to-whatsapp.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+STATE_FILE="/tmp/nemoclaw-wa-forward-state.json"
+
+# Source .env
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$REPO_DIR/.env"
+  set +a
+fi
+
+[ -n "${SLACK_BOT_TOKEN:-}" ] || exit 0
+
+# Initialize state file
+[ -f "$STATE_FILE" ] || echo '{}' > "$STATE_FILE"
+
+# Get bot user ID
+BOT_USER_ID=$(/usr/bin/curl -s -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  "https://slack.com/api/auth.test" | python3 -c "import sys,json; print(json.load(sys.stdin).get('user_id',''))" 2>/dev/null)
+
+[ -n "$BOT_USER_ID" ] || exit 0
+
+# Load user registry
+USERS_FILE="$HOME/.nemoclaw/users.json"
+[ -f "$USERS_FILE" ] || exit 0
+
+# For each user with a WhatsApp number
+python3 -c "
+import json, os, sys, subprocess, time
+
+repo = '$REPO_DIR'
+bot_token = '$SLACK_BOT_TOKEN'
+bot_user_id = '$BOT_USER_ID'
+state_file = '$STATE_FILE'
+
+users = json.load(open('$USERS_FILE')).get('users', {})
+state = json.load(open(state_file))
+
+for slack_id, user in users.items():
+    if not user.get('enabled', True):
+        continue
+
+    wa_file = os.path.join(repo, 'persist', 'users', slack_id, 'credentials', 'whatsapp-number.txt')
+    if not os.path.exists(wa_file):
+        continue
+    wa_number = open(wa_file).read().strip()
+    if not wa_number:
+        continue
+
+    # Open DM channel with user
+    import urllib.request, urllib.parse
+    headers = {'Authorization': f'Bearer {bot_token}', 'Content-Type': 'application/json'}
+    req = urllib.request.Request(
+        'https://slack.com/api/conversations.open',
+        data=json.dumps({'users': slack_id}).encode(),
+        headers=headers
+    )
+    try:
+        resp = json.loads(urllib.request.urlopen(req, timeout=10).read())
+        dm_channel = resp.get('channel', {}).get('id', '')
+    except:
+        continue
+    if not dm_channel:
+        continue
+
+    # Get recent messages from bot in this DM (last 5 minutes)
+    last_ts = state.get(slack_id, '0')
+    req = urllib.request.Request(
+        f'https://slack.com/api/conversations.history?channel={dm_channel}&limit=10&oldest={last_ts}',
+        headers=headers
+    )
+    try:
+        resp = json.loads(urllib.request.urlopen(req, timeout=10).read())
+        messages = resp.get('messages', [])
+    except:
+        continue
+
+    # Filter: only bot messages with emoji prefix
+    # Match both Unicode emoji and Slack :emoji: notation
+    emoji_re = __import__('re').compile(r'^(:[a-z_]+:|[\U0001F4E7\U0001F4C5\U000023F0\U0001F514\U000026A0\U00002757\U0001F6A8\U0001F4CC\U0001F4CB\U00002705\U0001F198\U0001F534\U0001F7E1\U0001F7E2])')
+
+    max_ts = last_ts
+    for msg in reversed(messages):
+        ts = msg.get('ts', '0')
+        if float(ts) <= float(last_ts):
+            continue
+        if ts > max_ts:
+            max_ts = ts
+
+        # Only forward bot's own messages
+        if msg.get('user') != bot_user_id and msg.get('bot_id') is None:
+            continue
+
+        text = msg.get('text', '')
+        if not text or not emoji_re.match(text):
+            continue
+
+        # Convert Slack emoji to Unicode and strip mrkdwn for WhatsApp
+        import re as _re
+        slack_emoji = {
+            ':clipboard:': '\U0001F4CB', ':email:': '\U0001F4E7', ':calendar:': '\U0001F4C5',
+            ':alarm_clock:': '\U000023F0', ':bell:': '\U0001F514', ':warning:': '\U000026A0',
+            ':exclamation:': '\U00002757', ':rotating_light:': '\U0001F6A8', ':pushpin:': '\U0001F4CC',
+            ':white_check_mark:': '\U00002705', ':sos:': '\U0001F198', ':red_circle:': '\U0001F534',
+            ':large_yellow_circle:': '\U0001F7E1', ':large_green_circle:': '\U0001F7E2',
+            ':memo:': '\U0001F4DD', ':mailbox:': '\U0001F4EB',
+        }
+        plain = text
+        for k, v in slack_emoji.items():
+            plain = plain.replace(k, v)
+        # Strip remaining :emoji: notation
+        plain = _re.sub(r':[a-z_]+:', '', plain)
+        plain = plain.replace('*', '').strip()
+        if len(plain) < 5:
+            continue
+
+        # Send to WhatsApp
+        try:
+            env = dict(os.environ)
+            env['SLACK_USER_ID'] = slack_id
+            subprocess.run(
+                ['node', os.path.join(repo, 'scripts', 'whatsapp-bridge.js'), 'send', wa_number, plain],
+                env=env, timeout=30, capture_output=True
+            )
+            print(f'[wa-forward] Forwarded to {wa_number} for {user.get(\"slackDisplayName\", slack_id)}')
+        except:
+            pass
+
+    if max_ts != last_ts:
+        state[slack_id] = max_ts
+
+json.dump(state, open(state_file, 'w'))
+" 2>/dev/null

--- a/scripts/inject-credentials.sh
+++ b/scripts/inject-credentials.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copy credentials from host into the NemoClaw sandbox.
+# Re-run after sandbox restarts or token refreshes.
+#
+# Usage:
+#   ./scripts/inject-credentials.sh [sandbox-name]
+
+set -euo pipefail
+
+SANDBOX="${1:-${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-my-assistant}}}"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[inject]${NC} $1"; }
+warn()  { echo -e "${YELLOW}[inject]${NC} $1"; }
+fail()  { echo -e "${RED}[inject]${NC} $1"; exit 1; }
+
+ssh_cmd() {
+  ssh -o StrictHostKeyChecking=no "openshell-${SANDBOX}" "$@"
+}
+
+scp_to() {
+  local src="$1" dst="$2"
+  scp -o StrictHostKeyChecking=no "$src" "openshell-${SANDBOX}:${dst}"
+}
+
+# Ensure target directories exist
+ssh_cmd 'mkdir -p /sandbox/.claude /sandbox/.config/gh'
+
+# ── Claude Code credentials ──────────────────────────────────────
+if [ -f "$HOME/.claude/.credentials.json" ]; then
+  scp_to "$HOME/.claude/.credentials.json" "/sandbox/.claude/.credentials.json"
+  ssh_cmd 'chmod 600 /sandbox/.claude/.credentials.json'
+  info "Claude credentials copied"
+else
+  warn "No Claude credentials found at ~/.claude/.credentials.json"
+fi
+
+if [ -f "$HOME/.claude/settings.json" ]; then
+  scp_to "$HOME/.claude/settings.json" "/sandbox/.claude/settings.json"
+  info "Claude settings copied"
+else
+  warn "No Claude settings found at ~/.claude/settings.json"
+fi
+
+# ── Claude MCP auth cache ────────────────────────────────────────
+if [ -f "$HOME/.claude/mcp-needs-auth-cache.json" ]; then
+  scp_to "$HOME/.claude/mcp-needs-auth-cache.json" "/sandbox/.claude/mcp-needs-auth-cache.json"
+  info "Claude MCP auth cache copied"
+else
+  warn "No MCP auth cache found — Google/Slack MCP tools may need re-auth"
+fi
+
+# ── GitHub token ─────────────────────────────────────────────────
+GH_TOKEN="${GH_TOKEN:-}"
+if [ -z "$GH_TOKEN" ] && command -v gh > /dev/null 2>&1; then
+  GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+fi
+
+if [ -n "$GH_TOKEN" ]; then
+  ssh_cmd "cat > /sandbox/.config/gh/hosts.yml" <<EOF
+github.com:
+  oauth_token: ${GH_TOKEN}
+  user: lakamsani
+  git_protocol: https
+EOF
+  ssh_cmd 'chmod 600 /sandbox/.config/gh/hosts.yml'
+  info "GitHub token injected"
+else
+  warn "No GH_TOKEN found — set GH_TOKEN or run 'gh auth login' first"
+fi
+
+# ── Google service account credential ─────────────────────────────
+GOOGLE_SA_PATH="${GOOGLE_APPLICATION_CREDENTIALS:-$HOME/lakmsani-gmail-service-account.json}"
+if [ -f "$GOOGLE_SA_PATH" ]; then
+  ssh_cmd 'mkdir -p /sandbox/.config/gcloud'
+  scp_to "$GOOGLE_SA_PATH" "/sandbox/.config/gcloud/service-account.json"
+  ssh_cmd 'chmod 600 /sandbox/.config/gcloud/service-account.json'
+  ssh_cmd "echo 'export GOOGLE_APPLICATION_CREDENTIALS=/sandbox/.config/gcloud/service-account.json' >> /sandbox/.bashrc"
+  info "Google service account credential copied"
+else
+  warn "No Google service account found at $GOOGLE_SA_PATH"
+fi
+
+# ── gog CLI (Google OAuth) credentials ───────────────────────────
+if [ -d "$HOME/.config/gogcli" ]; then
+  ssh_cmd 'mkdir -p /sandbox/.config/gogcli'
+  for f in config.json credentials.json; do
+    if [ -f "$HOME/.config/gogcli/$f" ]; then
+      scp_to "$HOME/.config/gogcli/$f" "/sandbox/.config/gogcli/$f"
+    fi
+  done
+  # Copy keyring and tokens directories
+  for d in keyring tokens; do
+    if [ -d "$HOME/.config/gogcli/$d" ]; then
+      ssh_cmd "mkdir -p /sandbox/.config/gogcli/$d"
+      for f in "$HOME/.config/gogcli/$d"/*; do
+        [ -f "$f" ] && scp_to "$f" "/sandbox/.config/gogcli/$d/$(basename "$f")"
+      done
+    fi
+  done
+  ssh_cmd 'chmod -R 700 /sandbox/.config/gogcli'
+  info "gog OAuth credentials copied"
+else
+  warn "No gog config found at ~/.config/gogcli — Google OAuth tools won't work"
+fi
+
+# ── gog keyring password (for headless/heartbeat use) ────────────
+GOG_KEYRING_PW="${GOG_KEYRING_PASSWORD:-nemoclaw}"
+ssh_cmd "grep -q GOG_KEYRING_PASSWORD /sandbox/.env 2>/dev/null && sed -i 's|^GOG_KEYRING_PASSWORD=.*|GOG_KEYRING_PASSWORD=${GOG_KEYRING_PW}|' /sandbox/.env || echo 'GOG_KEYRING_PASSWORD=${GOG_KEYRING_PW}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+info "GOG_KEYRING_PASSWORD injected into /sandbox/.env"
+
+# ── Git config ───────────────────────────────────────────────────
+ssh_cmd 'git config --global user.name "lakamsani" && git config --global user.email "lakamsani@users.noreply.github.com"'
+info "Git config set"
+
+echo ""
+info "Credential injection complete for sandbox '${SANDBOX}'"
+info "Verify with:"
+info "  ssh openshell-${SANDBOX} 'claude --version'"
+info "  ssh openshell-${SANDBOX} 'gh auth status'"
+info "  ssh openshell-${SANDBOX} 'gog auth status'"

--- a/scripts/inject-user-credentials.sh
+++ b/scripts/inject-user-credentials.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copy per-user credentials from host into a NemoClaw sandbox.
+# Parameterized version of inject-credentials.sh for multi-user support.
+#
+# Usage:
+#   ./scripts/inject-user-credentials.sh <sandbox-name> <cred-dir> [--github-user <user>] [--slack-user-id <id>]
+#
+# Example:
+#   ./scripts/inject-user-credentials.sh veyonce-claw persist/users/U09R681EPQ9/credentials --github-user lakamsani --slack-user-id U09R681EPQ9
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a; . "$REPO_DIR/.env"; set +a
+fi
+
+SANDBOX="${1:?Usage: inject-user-credentials.sh <sandbox-name> <cred-dir> [--github-user <user>]}"
+CRED_DIR="${2:?Usage: inject-user-credentials.sh <sandbox-name> <cred-dir>}"
+shift 2
+
+# Resolve relative cred dir to absolute
+if [[ "$CRED_DIR" != /* ]]; then
+  CRED_DIR="$REPO_DIR/$CRED_DIR"
+fi
+
+GITHUB_USER=""
+GITHUB_EMAIL=""
+SLACK_USER_ID=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --github-user) GITHUB_USER="${2:?--github-user requires a value}"; shift 2 ;;
+    --github-email) GITHUB_EMAIL="${2:?--github-email requires a value}"; shift 2 ;;
+    --slack-user-id) SLACK_USER_ID="${2:?--slack-user-id requires a value}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# Default email from github user
+if [ -n "$GITHUB_USER" ] && [ -z "$GITHUB_EMAIL" ]; then
+  GITHUB_EMAIL="${GITHUB_USER}@users.noreply.github.com"
+fi
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[inject]${NC} $1"; }
+warn()  { echo -e "${YELLOW}[inject]${NC} $1"; }
+fail()  { echo -e "${RED}[inject]${NC} $1"; exit 1; }
+
+SSH_CONF="/tmp/ssh-config-${SANDBOX}"
+openshell sandbox ssh-config "$SANDBOX" > "$SSH_CONF" 2>/dev/null || fail "Cannot get SSH config for $SANDBOX"
+
+ssh_cmd() {
+  ssh -F "$SSH_CONF" -o StrictHostKeyChecking=no "openshell-${SANDBOX}" "$@"
+}
+
+patch_claude_runtime() {
+  local anthropic_key="${1:-}"
+  local script
+  script=$(cat <<'PYSCRIPT'
+import base64, json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+if not os.path.exists(path):
+    raise SystemExit(0)
+key = base64.b64decode(os.environ.get('ANTHROPIC_KEY_B64', '')).decode() if os.environ.get('ANTHROPIC_KEY_B64') else ''
+cfg = json.load(open(path))
+providers = cfg.setdefault('models', {}).setdefault('providers', {})
+anthropic = providers.get('anthropic')
+if isinstance(anthropic, dict) and key:
+    anthropic['apiKey'] = key
+cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = 'anthropic/claude-sonnet-4-6'
+json.dump(cfg, open(path, 'w'), indent=2)
+os.chmod(path, 0o600)
+PYSCRIPT
+)
+  local b64_script
+  local b64_key
+  b64_script="$(printf '%s' "$script" | base64 -w0)"
+  b64_key="$(printf '%s' "$anthropic_key" | base64 -w0)"
+  ssh_cmd "ANTHROPIC_KEY_B64='$b64_key' base64 -d <<< '$b64_script' | python3" 2>/dev/null
+}
+
+# Ensure target directories exist
+ssh_cmd 'mkdir -p /sandbox/.claude /sandbox/.config/gh'
+
+# ── Claude long-lived Teams token (preferred when present) ──────
+if [ -f "$CRED_DIR/claude-oauth-token.txt" ]; then
+  CLAUDE_OAUTH_TOKEN="$(cat "$CRED_DIR/claude-oauth-token.txt")"
+  ssh_cmd "grep -q CLAUDE_CODE_OAUTH_TOKEN /sandbox/.env 2>/dev/null && sed -i 's|^CLAUDE_CODE_OAUTH_TOKEN=.*|CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_OAUTH_TOKEN}|' /sandbox/.env || echo 'CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_OAUTH_TOKEN}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+  ssh_cmd "grep -q ANTHROPIC_API_KEY /sandbox/.env 2>/dev/null && sed -i 's|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${CLAUDE_OAUTH_TOKEN}|' /sandbox/.env || echo 'ANTHROPIC_API_KEY=${CLAUDE_OAUTH_TOKEN}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+  # Also write .credentials.json so claude --print works (it reads this, not .env)
+  ssh_cmd "python3 -c \"
+import json, os
+creds = {
+    'claudeAiOauth': {
+        'accessToken': '${CLAUDE_OAUTH_TOKEN}',
+        'refreshToken': '',
+        'expiresAt': 9999999999999,
+        'scopes': ['user:inference', 'user:mcp_servers', 'user:profile', 'user:sessions:claude_code'],
+        'subscriptionType': 'team',
+        'rateLimitTier': 'default_claude_max_5x'
+    }
+}
+os.makedirs('/sandbox/.claude', exist_ok=True)
+json.dump(creds, open('/sandbox/.claude/.credentials.json', 'w'), indent=2)
+os.chmod('/sandbox/.claude/.credentials.json', 0o600)
+\"" 2>/dev/null
+  patch_claude_runtime "$CLAUDE_OAUTH_TOKEN"
+  info "Claude long-lived token injected (per-user, .env + .credentials.json)"
+fi
+
+# ── Claude Code credentials (fallback if no long-lived token) ────
+if [ ! -f "$CRED_DIR/claude-oauth-token.txt" ] && [ -f "$CRED_DIR/claude-credentials.json" ]; then
+  base64 "$CRED_DIR/claude-credentials.json" | ssh_cmd 'base64 -d > /sandbox/.claude/.credentials.json && chmod 600 /sandbox/.claude/.credentials.json'
+  CLAUDE_ACCESS_TOKEN="$(python3 -c "import json; d=json.load(open('$CRED_DIR/claude-credentials.json')); print(d.get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null || true)"
+  if [ -n "$CLAUDE_ACCESS_TOKEN" ]; then
+    ssh_cmd "grep -q ANTHROPIC_API_KEY /sandbox/.env 2>/dev/null && sed -i 's|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${CLAUDE_ACCESS_TOKEN}|' /sandbox/.env || echo 'ANTHROPIC_API_KEY=${CLAUDE_ACCESS_TOKEN}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+    patch_claude_runtime "$CLAUDE_ACCESS_TOKEN"
+  fi
+  info "Claude credentials.json injected (per-user)"
+elif [ ! -f "$CRED_DIR/claude-oauth-token.txt" ]; then
+  warn "No per-user Claude credentials found"
+fi
+
+# Claude settings
+if [ -f "$CRED_DIR/claude-settings.json" ]; then
+  base64 "$CRED_DIR/claude-settings.json" | ssh_cmd 'base64 -d > /sandbox/.claude/settings.json'
+  info "Claude settings injected (per-user)"
+fi
+
+# ── Freshrelease API key (injected into sandbox .env for direct curl access) ──
+if [ -f "$CRED_DIR/freshrelease-api-key.txt" ]; then
+  FR_KEY="$(cat "$CRED_DIR/freshrelease-api-key.txt" | tr -d '[:space:]')"
+  ssh_cmd "grep -q FRESHRELEASE_API_KEY /sandbox/.env 2>/dev/null && sed -i 's|^FRESHRELEASE_API_KEY=.*|FRESHRELEASE_API_KEY=${FR_KEY}|' /sandbox/.env || echo 'FRESHRELEASE_API_KEY=${FR_KEY}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+  # Also remove any leftover MCP config from claude settings
+  ssh_cmd "python3 -c \"
+import json, os
+path = '/sandbox/.claude/settings.json'
+if not os.path.exists(path): exit(0)
+cfg = json.load(open(path))
+mcp = cfg.get('mcpServers', {})
+if 'freshrelease' in mcp:
+    del mcp['freshrelease']
+    json.dump(cfg, open(path, 'w'), indent=4)
+    os.chmod(path, 0o600)
+\"" 2>/dev/null
+  info "Freshrelease API key injected into .env (direct REST access)"
+fi
+
+# ── Claude MCP auth cache ────────────────────────────────────────
+if [ -f "$CRED_DIR/mcp-needs-auth-cache.json" ]; then
+  base64 "$CRED_DIR/mcp-needs-auth-cache.json" | ssh_cmd 'base64 -d > /sandbox/.claude/mcp-needs-auth-cache.json && chmod 600 /sandbox/.claude/mcp-needs-auth-cache.json'
+  info "Claude MCP auth cache injected (per-user)"
+fi
+
+# ── Claude credentials.json (OAuth session for claude --print) ───
+if [ -f "$CRED_DIR/claude-credentials.json" ]; then
+  base64 "$CRED_DIR/claude-credentials.json" | ssh_cmd 'base64 -d > /sandbox/.claude/.credentials.json && chmod 600 /sandbox/.claude/.credentials.json'
+  info "Claude credentials.json injected (per-user)"
+fi
+
+# ── GitHub token (per-user only — no host fallback) ──────────────
+if [ -f "$CRED_DIR/gh-hosts.yml" ]; then
+  base64 "$CRED_DIR/gh-hosts.yml" | ssh_cmd 'mkdir -p /sandbox/.config/gh && base64 -d > /sandbox/.config/gh/hosts.yml && chmod 600 /sandbox/.config/gh/hosts.yml'
+  info "GitHub token injected (from user credentials)"
+fi
+
+# ── Google service account ───────────────────────────────────────
+GOOGLE_SA_PATH="$CRED_DIR/service-account.json"
+if [ ! -f "$GOOGLE_SA_PATH" ]; then
+  GOOGLE_SA_PATH="${GOOGLE_APPLICATION_CREDENTIALS:-$HOME/lakmsani-gmail-service-account.json}"
+fi
+if [ -f "$GOOGLE_SA_PATH" ]; then
+  ssh_cmd 'mkdir -p /sandbox/.config/gcloud'
+  base64 "$GOOGLE_SA_PATH" | ssh_cmd 'base64 -d > /sandbox/.config/gcloud/service-account.json && chmod 600 /sandbox/.config/gcloud/service-account.json'
+  info "Google service account injected"
+fi
+
+# ── gog CLI (Google OAuth) credentials (per-user only — no host fallback) ──
+GOG_DIR="$CRED_DIR/gogcli"
+if [ -d "$GOG_DIR" ]; then
+  cd "$GOG_DIR" && tar czf - . | ssh_cmd 'mkdir -p /sandbox/.config/gogcli && tar xzf - -C /sandbox/.config/gogcli && chmod -R 700 /sandbox/.config/gogcli'
+  cd "$REPO_DIR"
+  info "gog OAuth credentials injected"
+fi
+
+# ── User-specific .env values ────────────────────────────────────
+# GOG keyring password (per-user only)
+if [ -f "$CRED_DIR/../.env" ]; then
+  GOG_KEYRING_PW=""
+  set -a; . "$CRED_DIR/../.env"; set +a
+  GOG_KEYRING_PW="${GOG_KEYRING_PASSWORD:-}"
+  if [ -n "$GOG_KEYRING_PW" ]; then
+    ssh_cmd "grep -q GOG_KEYRING_PASSWORD /sandbox/.env 2>/dev/null && sed -i 's|^GOG_KEYRING_PASSWORD=.*|GOG_KEYRING_PASSWORD=${GOG_KEYRING_PW}|' /sandbox/.env || echo 'GOG_KEYRING_PASSWORD=${GOG_KEYRING_PW}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+    info "GOG_KEYRING_PASSWORD injected"
+  fi
+fi
+
+# Slack webhook URL (per-user only — no host fallback)
+if [ -f "$CRED_DIR/slack-webhook-url.txt" ]; then
+  USER_SLACK_WEBHOOK="$(cat "$CRED_DIR/slack-webhook-url.txt")"
+  ssh_cmd "grep -q SLACK_WEBHOOK_URL /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_WEBHOOK_URL=.*|SLACK_WEBHOOK_URL=${USER_SLACK_WEBHOOK}|' /sandbox/.env || echo 'SLACK_WEBHOOK_URL=${USER_SLACK_WEBHOOK}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+  info "Slack webhook URL injected (from user credentials)"
+fi
+
+# Slack bot token (for DM-based heartbeat notifications — preferred over webhook)
+if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+  ssh_cmd "grep -q SLACK_BOT_TOKEN /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_BOT_TOKEN=.*|SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}|' /sandbox/.env || echo 'SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+  info "Slack bot token injected"
+fi
+
+# Slack user ID (so heartbeat can DM the right user)
+if [ -n "$SLACK_USER_ID" ]; then
+  ssh_cmd "grep -q SLACK_USER_ID /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_USER_ID=.*|SLACK_USER_ID=${SLACK_USER_ID}|' /sandbox/.env || echo 'SLACK_USER_ID=${SLACK_USER_ID}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+  info "Slack user ID injected ($SLACK_USER_ID)"
+fi
+
+# slack-notify helper script (DM via bot token, fallback to webhook)
+NOTIFY_SCRIPT="$SCRIPT_DIR/slack-notify.sh"
+if [ -f "$NOTIFY_SCRIPT" ]; then
+  base64 "$NOTIFY_SCRIPT" | ssh_cmd 'mkdir -p /sandbox/.local/bin && base64 -d > /sandbox/.local/bin/slack-notify && chmod +x /sandbox/.local/bin/slack-notify'
+  info "slack-notify helper installed"
+fi
+
+# ── xurl (X/Twitter) (per-user only — no host fallback) ──────────
+if [ -f "$CRED_DIR/xurl-binary" ]; then
+  base64 "$CRED_DIR/xurl-binary" | ssh_cmd 'mkdir -p /sandbox/.local/bin && base64 -d > /sandbox/.local/bin/xurl && chmod +x /sandbox/.local/bin/xurl'
+  info "xurl binary injected (from user credentials)"
+fi
+
+if [ -f "$CRED_DIR/twitter-creds.txt" ]; then
+  set -a; . "$CRED_DIR/twitter-creds.txt"; set +a
+  ssh_cmd "export PATH='/sandbox/.local/bin:\$PATH' && \
+    python3 -c \"import os; f=os.path.expanduser('~/.xurl'); os.path.exists(f) and os.remove(f)\" 2>/dev/null; \
+    xurl auth apps add nemoclaw --client-id '${X_API_KEY}' --client-secret '${X_API_KEY_SECRET}' 2>/dev/null; \
+    xurl auth oauth1 --consumer-key '${X_API_KEY}' --consumer-secret '${X_API_KEY_SECRET}' --access-token '${X_ACCESS_TOKEN}' --token-secret '${X_ACCESS_TOKEN_SECRET}' 2>/dev/null; \
+    xurl auth app --bearer-token '${X_BEARER_TOKEN}' 2>/dev/null; \
+    xurl auth default default 2>/dev/null" 2>&1 | grep -v '^\[' || true
+  info "xurl (X/Twitter) credentials configured (from user credentials)"
+fi
+
+# ── Git config ───────────────────────────────────────────────────
+if [ -n "$GITHUB_USER" ]; then
+  ssh_cmd "git config --global user.name '${GITHUB_USER}' && git config --global user.email '${GITHUB_EMAIL}'" 2>/dev/null
+  info "Git config set (user: $GITHUB_USER)"
+fi
+
+# ── uv / uvx (Python package runner) ─────────────────────────────
+if ! ssh_cmd 'test -x /root/.local/bin/uvx'; then
+  ssh_cmd 'curl -LsSf https://astral.sh/uv/install.sh | sh' 2>/dev/null && info "uv/uvx installed" || warn "uv/uvx install failed"
+else
+  info "uv/uvx already present"
+fi
+
+# ── Shell profile ────────────────────────────────────────────────
+ssh_cmd 'cat > /sandbox/.bashrc << "BASHRC"
+# NemoClaw sandbox shell profile
+export PATH="/sandbox/.local/bin:$PATH"
+if [ -f /sandbox/.env ]; then set -a; . /sandbox/.env; set +a; fi
+BASHRC
+chmod 644 /sandbox/.bashrc'
+info "Shell profile created"
+
+echo ""
+info "Credential injection complete for sandbox '${SANDBOX}'"

--- a/scripts/merge-policy.py
+++ b/scripts/merge-policy.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Merge a base sandbox policy with one or more preset YAML files.
+# Usage: merge-policy.py base.yaml [preset1.yaml preset2.yaml ...] > merged.yaml
+
+import sys
+import yaml
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: merge-policy.py base.yaml [preset1.yaml ...]", file=sys.stderr)
+        sys.exit(1)
+
+    with open(sys.argv[1]) as f:
+        base = yaml.safe_load(f)
+
+    for preset_path in sys.argv[2:]:
+        with open(preset_path) as f:
+            preset = yaml.safe_load(f)
+        for name, policy in (preset.get("network_policies") or {}).items():
+            base.setdefault("network_policies", {})[name] = policy
+
+    yaml.dump(base, sys.stdout, default_flow_style=False, sort_keys=False)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nemoclaw-backup-workspace.sh
+++ b/scripts/nemoclaw-backup-workspace.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Download workspace personality files from sandbox to host persist/ dir.
+# Run before rebuilds or on a cron for continuous backup.
+#
+# Usage: ./scripts/nemoclaw-backup-workspace.sh [sandbox-name]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a; . "$REPO_DIR/.env"; set +a
+fi
+
+SANDBOX="${1:-${NEMOCLAW_SANDBOX:-veyonce-claw}}"
+PERSIST_DIR="$REPO_DIR/persist/workspace"
+
+mkdir -p "$PERSIST_DIR"
+
+# Generate SSH config
+openshell sandbox ssh-config "$SANDBOX" > "/tmp/ssh-config-${SANDBOX}" 2>/dev/null
+
+# Download workspace files via tar over SSH
+ssh -F "/tmp/ssh-config-${SANDBOX}" -o StrictHostKeyChecking=no "openshell-${SANDBOX}" \
+  'cd /sandbox/.openclaw/workspace && tar czf - \
+    SOUL.md IDENTITY.md USER.md TOOLS.md HEARTBEAT.md AGENTS.md BOOTSTRAP.md \
+    .openclaw memory 2>/dev/null || true' \
+  | tar xzf - -C "$PERSIST_DIR" 2>/dev/null
+
+echo "[backup] Workspace downloaded to $PERSIST_DIR ($(date))"

--- a/scripts/nemoclaw-resilience.sh
+++ b/scripts/nemoclaw-resilience.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Full bring-up script for NemoClaw after sandbox restart or host reboot.
+# Idempotent — safe to run whether sandbox is already up or not.
+#
+# Sequence: sandbox wait → policy → credentials → workspace → services
+#
+# Usage:
+#   ./scripts/nemoclaw-resilience.sh
+#   ./scripts/nemoclaw-resilience.sh --sandbox veyonce-claw
+#   ./scripts/nemoclaw-resilience.sh --all                    # All registered users
+#   ./scripts/nemoclaw-resilience.sh --sandbox X --cred-dir persist/users/U.../credentials --github-user alice
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Source .env
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a; . "$REPO_DIR/.env"; set +a
+fi
+
+SANDBOX="${NEMOCLAW_SANDBOX:-veyonce-claw}"
+CRED_DIR=""
+GITHUB_USER=""
+SLACK_USER_ID=""
+ALL_USERS=false
+
+# Parse args
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sandbox) SANDBOX="${2:?--sandbox requires a name}"; shift 2 ;;
+    --cred-dir) CRED_DIR="${2:?--cred-dir requires a path}"; shift 2 ;;
+    --github-user) GITHUB_USER="${2:?--github-user requires a name}"; shift 2 ;;
+    --slack-user-id) SLACK_USER_ID="${2:?--slack-user-id requires a value}"; shift 2 ;;
+    --all) ALL_USERS=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+# ── --all mode: iterate over all registered users ─────────────────
+if [ "$ALL_USERS" = "true" ]; then
+  USERS_FILE="$HOME/.nemoclaw/users.json"
+  if [ ! -f "$USERS_FILE" ]; then
+    echo "[resilience] No users.json found at $USERS_FILE"
+    exit 1
+  fi
+
+  USER_IDS=$(python3 -c "import json; d=json.load(open('$USERS_FILE')); [print(uid) for uid, u in d.get('users',{}).items() if u.get('enabled', True)]")
+
+  for uid in $USER_IDS; do
+    USER_SANDBOX=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid']['sandboxName'])")
+    USER_CRED_DIR=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid']['credentialsDir'])")
+    USER_GITHUB=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid'].get('githubUser',''))")
+    USER_NAME=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid'].get('slackDisplayName','$uid'))")
+
+    echo ""
+    echo "================================================================"
+    echo "[resilience] Bringing up user: $USER_NAME ($uid) → $USER_SANDBOX"
+    echo "================================================================"
+
+    GITHUB_FLAG=""
+    [ -n "$USER_GITHUB" ] && GITHUB_FLAG="--github-user $USER_GITHUB"
+
+    "$0" --sandbox "$USER_SANDBOX" --cred-dir "$USER_CRED_DIR" --slack-user-id "$uid" $GITHUB_FLAG || {
+      echo "[resilience] FAILED for user $USER_NAME ($USER_SANDBOX) — continuing..."
+    }
+  done
+
+  echo ""
+  echo "[resilience] All users processed."
+  exit 0
+fi
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[resilience]${NC} $1"; }
+warn()  { echo -e "${YELLOW}[resilience]${NC} $1"; }
+fail()  { echo -e "${RED}[resilience]${NC} $1"; exit 1; }
+
+# ── Step 1: Wait for sandbox to be Ready ─────────────────────────
+info "Waiting for sandbox '$SANDBOX' to be Ready..."
+READY=false
+for i in $(seq 1 36); do
+  if openshell sandbox list 2>&1 | grep -q "${SANDBOX}.*Ready"; then
+    READY=true
+    break
+  fi
+  sleep 5
+done
+
+if [ "$READY" != "true" ]; then
+  fail "Sandbox '$SANDBOX' not in Ready state after 3 minutes. Is it created?"
+fi
+info "Sandbox '$SANDBOX' is Ready"
+
+# ── Step 2: Generate SSH config ──────────────────────────────────
+SSH_CONF="/tmp/ssh-config-${SANDBOX}"
+openshell sandbox ssh-config "$SANDBOX" > "$SSH_CONF" 2>/dev/null
+info "SSH config generated"
+
+ssh_cmd() {
+  ssh -F "$SSH_CONF" -o StrictHostKeyChecking=no "openshell-${SANDBOX}" "$@"
+}
+
+# ── Step 3: Apply merged network policy ──────────────────────────
+POLICY_DIR="$REPO_DIR/nemoclaw-blueprint/policies"
+PRESETS=()
+for preset in google.yaml xcurl.yaml slack.yaml npm.yaml pypi.yaml freshworks.yaml; do
+  [ -f "$POLICY_DIR/presets/$preset" ] && PRESETS+=("$POLICY_DIR/presets/$preset")
+done
+
+python3 "$SCRIPT_DIR/merge-policy.py" \
+  "$POLICY_DIR/openclaw-sandbox.yaml" \
+  "${PRESETS[@]}" \
+  > /tmp/nemoclaw-merged-policy.yaml
+
+openshell policy set --policy /tmp/nemoclaw-merged-policy.yaml "$SANDBOX" 2>&1 | tail -1
+info "Network policy applied"
+
+# ── Step 3b: Install dev tools (JDK + Gradle) if missing ────────
+docker exec openshell-cluster-nemoclaw kubectl exec -n openshell "$SANDBOX" -- sh -c '
+  if ! command -v gradle >/dev/null 2>&1; then
+    apt-get update -qq 2>/dev/null
+    apt-get install -y -qq default-jdk-headless unzip 2>/dev/null
+    cd /tmp
+    curl -fsSL https://services.gradle.org/distributions/gradle-8.13-bin.zip -o gradle.zip 2>/dev/null
+    unzip -q gradle.zip -d /opt 2>/dev/null
+    ln -sf /opt/gradle-8.13/bin/gradle /usr/local/bin/gradle
+    rm -f gradle.zip
+  fi
+' 2>/dev/null || true
+info "Dev tools checked (JDK + Gradle)"
+
+# ── Step 4: Inject credentials ───────────────────────────────────
+if [ -n "$CRED_DIR" ]; then
+  # Multi-user mode: use per-user credential injection script
+  GITHUB_FLAG=""
+  [ -n "$GITHUB_USER" ] && GITHUB_FLAG="--github-user $GITHUB_USER"
+  SLACK_FLAG=""
+  [ -n "$SLACK_USER_ID" ] && SLACK_FLAG="--slack-user-id $SLACK_USER_ID"
+  "$SCRIPT_DIR/inject-user-credentials.sh" "$SANDBOX" "$CRED_DIR" $GITHUB_FLAG $SLACK_FLAG
+  info "Per-user credentials injected via inject-user-credentials.sh"
+
+  # Extract ANTHROPIC_API_KEY for openclaw config from per-user credentials
+  if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    if [ -n "$CRED_DIR" ] && [[ "$CRED_DIR" == /* ]]; then
+      CRED_ABS="$CRED_DIR"
+    else
+      CRED_ABS="$REPO_DIR/$CRED_DIR"
+    fi
+    if [ -f "$CRED_ABS/claude-oauth-token.txt" ]; then
+      ANTHROPIC_API_KEY="$(cat "$CRED_ABS/claude-oauth-token.txt")"
+    elif [ -f "$CRED_ABS/claude-credentials.json" ]; then
+      ANTHROPIC_API_KEY="$(python3 -c "import json; d=json.load(open('$CRED_ABS/claude-credentials.json')); print(d.get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null || true)"
+    fi
+  fi
+else
+  # Legacy single-user mode is no longer configured for shared Claude OAuth.
+  warn "No per-user credential directory provided. Shared Claude fallback is disabled."
+
+  # Claude MCP auth cache
+  if [ -f "$HOME/.claude/mcp-needs-auth-cache.json" ]; then
+    base64 "$HOME/.claude/mcp-needs-auth-cache.json" | ssh_cmd 'base64 -d > /sandbox/.claude/mcp-needs-auth-cache.json && chmod 600 /sandbox/.claude/mcp-needs-auth-cache.json'
+    info "Claude MCP auth cache injected"
+  fi
+
+  # Claude settings
+  if [ -f "$HOME/.claude/settings.json" ]; then
+    base64 "$HOME/.claude/settings.json" | ssh_cmd 'base64 -d > /sandbox/.claude/settings.json'
+    info "Claude settings injected"
+  fi
+
+  # GitHub token
+  GH_TOKEN="${GH_TOKEN:-}"
+  if [ -z "$GH_TOKEN" ] && command -v gh > /dev/null 2>&1; then
+    GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+  fi
+  if [ -n "$GH_TOKEN" ]; then
+    ssh_cmd "mkdir -p /sandbox/.config/gh && cat > /sandbox/.config/gh/hosts.yml" <<GHEOF
+github.com:
+  oauth_token: ${GH_TOKEN}
+  user: lakamsani
+  git_protocol: https
+GHEOF
+    ssh_cmd 'chmod 600 /sandbox/.config/gh/hosts.yml'
+    info "GitHub token injected"
+  else
+    warn "No GitHub token available"
+  fi
+
+  # Google service account
+  GOOGLE_SA_PATH="${GOOGLE_APPLICATION_CREDENTIALS:-$HOME/lakmsani-gmail-service-account.json}"
+  if [ -f "$GOOGLE_SA_PATH" ]; then
+    ssh_cmd 'mkdir -p /sandbox/.config/gcloud'
+    base64 "$GOOGLE_SA_PATH" | ssh_cmd 'base64 -d > /sandbox/.config/gcloud/service-account.json && chmod 600 /sandbox/.config/gcloud/service-account.json'
+    info "Google service account injected"
+  fi
+
+  # gog OAuth credentials
+  if [ -d "$HOME/.config/gogcli" ]; then
+    cd "$HOME/.config/gogcli" && tar czf - . | ssh_cmd 'mkdir -p /sandbox/.config/gogcli && tar xzf - -C /sandbox/.config/gogcli && chmod -R 700 /sandbox/.config/gogcli'
+    cd "$REPO_DIR"
+    info "gog OAuth credentials injected"
+  fi
+
+  # xurl config (X/Twitter)
+  XURL_BIN="$REPO_DIR/persist/xurl-linux-arm64"
+  if [ -f "$XURL_BIN" ]; then
+    base64 "$XURL_BIN" | ssh_cmd 'mkdir -p /sandbox/.local/bin && base64 -d > /sandbox/.local/bin/xurl && chmod +x /sandbox/.local/bin/xurl'
+    info "xurl binary injected"
+  fi
+
+  TWITTER_CREDS="${TWITTER_CREDS_PATH:-$HOME/twitter-claw.txt}"
+  if [ -f "$TWITTER_CREDS" ]; then
+    set -a; . "$TWITTER_CREDS"; set +a
+    ssh_cmd "export PATH='/sandbox/.local/bin:\$PATH' && \
+      python3 -c \"import os; f=os.path.expanduser('~/.xurl'); os.path.exists(f) and os.remove(f)\" 2>/dev/null; \
+      xurl auth apps add nemoclaw --client-id '${X_API_KEY}' --client-secret '${X_API_KEY_SECRET}' 2>/dev/null; \
+      xurl auth oauth1 --consumer-key '${X_API_KEY}' --consumer-secret '${X_API_KEY_SECRET}' --access-token '${X_ACCESS_TOKEN}' --token-secret '${X_ACCESS_TOKEN_SECRET}' 2>/dev/null; \
+      xurl auth app --bearer-token '${X_BEARER_TOKEN}' 2>/dev/null; \
+      xurl auth default default 2>/dev/null" 2>&1 | grep -v '^\[' || true
+    info "xurl (X/Twitter) credentials configured"
+  else
+    warn "No twitter credentials at $TWITTER_CREDS"
+  fi
+
+  # Git config
+  ssh_cmd 'git config --global user.name "lakamsani" && git config --global user.email "lakamsani@users.noreply.github.com"' 2>/dev/null
+  info "Git config set"
+
+  # Slack webhook URL (fallback for heartbeat)
+  if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+    ssh_cmd "grep -q SLACK_WEBHOOK_URL /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_WEBHOOK_URL=.*|SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}|' /sandbox/.env || echo 'SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}' >> /sandbox/.env"
+    ssh_cmd 'chmod 600 /sandbox/.env'
+    info "Slack webhook URL injected"
+  fi
+
+  # Slack bot token + user ID (for DM-based heartbeat notifications)
+  if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+    ssh_cmd "grep -q SLACK_BOT_TOKEN /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_BOT_TOKEN=.*|SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}|' /sandbox/.env || echo 'SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+    info "Slack bot token injected"
+  fi
+  if [ -n "$SLACK_USER_ID" ]; then
+    ssh_cmd "grep -q SLACK_USER_ID /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_USER_ID=.*|SLACK_USER_ID=${SLACK_USER_ID}|' /sandbox/.env || echo 'SLACK_USER_ID=${SLACK_USER_ID}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+    info "Slack user ID injected ($SLACK_USER_ID)"
+  fi
+
+  # slack-notify helper script
+  NOTIFY_SCRIPT="$SCRIPT_DIR/slack-notify.sh"
+  if [ -f "$NOTIFY_SCRIPT" ]; then
+    base64 "$NOTIFY_SCRIPT" | ssh_cmd 'mkdir -p /sandbox/.local/bin && base64 -d > /sandbox/.local/bin/slack-notify && chmod +x /sandbox/.local/bin/slack-notify'
+    info "slack-notify helper installed"
+  fi
+
+  # GOG_KEYRING_PASSWORD
+  GOG_KEYRING_PW="${GOG_KEYRING_PASSWORD:-nemoclaw}"
+  ssh_cmd "grep -q GOG_KEYRING_PASSWORD /sandbox/.env 2>/dev/null && sed -i 's|^GOG_KEYRING_PASSWORD=.*|GOG_KEYRING_PASSWORD=${GOG_KEYRING_PW}|' /sandbox/.env || echo 'GOG_KEYRING_PASSWORD=${GOG_KEYRING_PW}' >> /sandbox/.env; chmod 600 /sandbox/.env"
+  info "GOG_KEYRING_PASSWORD injected"
+
+  # Shell profile (.bashrc)
+  ssh_cmd 'cat > /sandbox/.bashrc << "BASHRC"
+# NemoClaw sandbox shell profile
+export PATH="/sandbox/.local/bin:$PATH"
+if [ -f /sandbox/.env ]; then set -a; . /sandbox/.env; set +a; fi
+BASHRC
+chmod 644 /sandbox/.bashrc'
+  info "Shell profile (.bashrc) created"
+fi
+
+# ── Step 5a: Patch OpenClaw config with Anthropic (if API key available) ──
+GATEWAY_TOKEN="${GATEWAY_AUTH_TOKEN:?GATEWAY_AUTH_TOKEN must be set}"
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  ssh_cmd "python3 -c \"
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(path))
+providers = cfg.setdefault('models', {}).setdefault('providers', {})
+if 'anthropic' not in providers:
+    providers['anthropic'] = {'baseUrl': 'https://api.anthropic.com/v1', 'api': 'anthropic-messages', 'models': [{'id': 'claude-sonnet-4-6', 'name': 'Claude Sonnet 4.6', 'reasoning': False, 'input': ['text'], 'cost': {'input': 0, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0}, 'contextWindow': 200000, 'maxTokens': 64000}]}
+providers['anthropic']['apiKey'] = '${ANTHROPIC_API_KEY}'
+cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = 'anthropic/claude-sonnet-4-6'
+json.dump(cfg, open(path, 'w'), indent=2)
+os.chmod(path, 0o600)
+
+# Write auth profiles
+profiles = {}
+profiles['anthropic:manual'] = {'type': 'api_key', 'provider': 'anthropic', 'keyRef': {'source': 'env', 'id': 'ANTHROPIC_API_KEY'}, 'profileId': 'anthropic:manual'}
+apath = os.path.expanduser('~/.openclaw/agents/main/agent/auth-profiles.json')
+os.makedirs(os.path.dirname(apath), exist_ok=True)
+json.dump(profiles, open(apath, 'w'))
+os.chmod(apath, 0o600)
+\"" 2>/dev/null
+  info "OpenClaw config patched (anthropic/claude-sonnet-4-6)"
+else
+  warn "No ANTHROPIC_API_KEY — OpenClaw will use default Nemotron model"
+fi
+
+# ── Step 5b: Gateway auth, device pairing, and start (always runs) ──
+# Patch gateway auth token + controlUi settings
+ssh_cmd "python3 -c \"
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(path))
+gw = cfg.setdefault('gateway', {})
+gw['auth'] = {'mode': 'token', 'token': '${GATEWAY_TOKEN}'}
+gw['controlUi'] = {'allowInsecureAuth': True, 'dangerouslyDisableDeviceAuth': True, 'allowedOrigins': ['http://127.0.0.1:18789', 'http://localhost:18789']}
+json.dump(cfg, open(path, 'w'), indent=2)
+os.chmod(path, 0o600)
+\"" 2>/dev/null
+info "Gateway auth token set"
+
+# Restore device pairing — server-side (gateway) + client-side (CLI identity)
+PAIRED_FILE="$REPO_DIR/persist/gateway/paired.json"
+IDENTITY_DIR="$REPO_DIR/persist/gateway/identity"
+if [ -f "$PAIRED_FILE" ]; then
+  ssh_cmd 'mkdir -p /sandbox/.openclaw/devices'
+  base64 "$PAIRED_FILE" | ssh_cmd 'base64 -d > /sandbox/.openclaw/devices/paired.json && chmod 600 /sandbox/.openclaw/devices/paired.json'
+  info "Device pairing restored (server-side)"
+fi
+if [ -d "$IDENTITY_DIR" ]; then
+  ssh_cmd 'mkdir -p /sandbox/.openclaw/identity'
+  for f in "$IDENTITY_DIR"/*.json; do
+    [ -f "$f" ] && base64 "$f" | ssh_cmd "base64 -d > /sandbox/.openclaw/identity/$(basename "$f") && chmod 600 /sandbox/.openclaw/identity/$(basename "$f")"
+  done
+  info "Device identity restored (client-side)"
+fi
+
+# Kill any existing gateway, then start fresh
+ssh_cmd 'export HOME=/sandbox; node -e "
+const fs = require(\"fs\");
+const dirs = fs.readdirSync(\"/proc\").filter(d => /^\\d+\$/.test(d));
+for (const pid of dirs) {
+  try {
+    const cmd = fs.readFileSync(\"/proc/\" + pid + \"/cmdline\", \"utf8\");
+    if (cmd.includes(\"gateway\") && cmd.includes(\"openclaw\")) {
+      process.kill(Number(pid), 9);
+    }
+  } catch(e) {}
+}
+"' 2>/dev/null || true
+sleep 2
+# Gateway runs as root and creates root-owned files in /sandbox/.openclaw/.
+# Repair ownership on the entire tree so the sandbox user can write.
+ssh_cmd 'chown -R sandbox:sandbox /sandbox/.openclaw 2>/dev/null; chmod -R u+w /sandbox/.openclaw 2>/dev/null' 2>/dev/null || true
+# Start gateway in a separate SSH session that stays alive
+# Use nohup + disown so the SSH session survives parent shell exit (e.g. cron)
+nohup ssh -F "$SSH_CONF" -o StrictHostKeyChecking=no -o ConnectTimeout=5 "openshell-${SANDBOX}" \
+  'export HOME=/sandbox; openclaw gateway run >> /tmp/gateway.log 2>&1' </dev/null >/dev/null 2>&1 &
+disown
+
+GATEWAY_HEALTHY=false
+for i in $(seq 1 10); do
+  if ssh_cmd 'export HOME=/sandbox; openclaw gateway call health > /dev/null 2>&1' 2>/dev/null; then
+    GATEWAY_HEALTHY=true
+    break
+  fi
+  sleep 2
+done
+
+if [ "$GATEWAY_HEALTHY" != "true" ]; then
+  fail "Gateway failed health check after restart for sandbox '$SANDBOX'"
+fi
+info "Gateway started and healthy"
+
+# ── Step 6: Restore workspace personality files ──────────────────
+# Try per-user workspace first, then fall back to default
+PERSIST_DIR=""
+if [ -n "$CRED_DIR" ]; then
+  # Derive workspace dir from cred dir (sibling directory)
+  if [[ "$CRED_DIR" == /* ]]; then
+    PERSIST_DIR="$(dirname "$CRED_DIR")/workspace"
+  else
+    PERSIST_DIR="$REPO_DIR/$(dirname "$CRED_DIR")/workspace"
+  fi
+fi
+if [ -z "$PERSIST_DIR" ] || [ ! -d "$PERSIST_DIR" ]; then
+  PERSIST_DIR="$REPO_DIR/persist/workspace"
+fi
+
+if [ -d "$PERSIST_DIR" ] && [ -f "$PERSIST_DIR/SOUL.md" ]; then
+  cd "$PERSIST_DIR" && tar czf - . | ssh_cmd 'tar xzf - -C /sandbox/.openclaw/workspace/'
+  cd "$REPO_DIR"
+  info "Workspace personality files restored from $PERSIST_DIR"
+else
+  warn "No workspace backup at $PERSIST_DIR"
+fi
+
+# ── Step 6b: Upgrade Claude Code to latest ─────────────────────
+# Install to /sandbox/.local so it takes priority over the system version
+# (/sandbox/.local/bin is first on PATH via .bashrc).
+CURRENT_CC="$(ssh_cmd 'export PATH="/sandbox/.local/bin:$PATH" && claude --version 2>/dev/null' 2>/dev/null | grep -oP '[\d.]+' | head -1 || true)"
+LATEST_CC="$(npm view @anthropic-ai/claude-code version 2>/dev/null || true)"
+if [ -n "$LATEST_CC" ] && [ "$CURRENT_CC" != "$LATEST_CC" ]; then
+  ssh_cmd "npm install -g --prefix /sandbox/.local @anthropic-ai/claude-code@${LATEST_CC}" 2>&1 | tail -2
+  info "Claude Code upgraded: ${CURRENT_CC:-unknown} → ${LATEST_CC}"
+else
+  info "Claude Code already at latest (${CURRENT_CC:-unknown})"
+fi
+
+# ── Step 6c: Install freshrelease-mcp from bundled wheels ─────
+WHEELS_TAR="$REPO_DIR/persist/packages/freshrelease-mcp-wheels.tar.gz"
+if [ -f "$WHEELS_TAR" ]; then
+  CURRENT_FR="$(ssh_cmd 'freshrelease-mcp --version 2>/dev/null || true' 2>/dev/null)"
+  if [ -z "$CURRENT_FR" ]; then
+    cat "$WHEELS_TAR" | ssh_cmd 'cat > /tmp/wheels.tar.gz && mkdir -p /tmp/wheels && tar xzf /tmp/wheels.tar.gz -C /tmp/wheels && pip3 install --break-system-packages --no-deps --no-index --find-links /tmp/wheels freshrelease-mcp 2>&1 | tail -1 && rm -rf /tmp/wheels /tmp/wheels.tar.gz'
+    info "freshrelease-mcp installed from bundled wheels"
+  else
+    info "freshrelease-mcp already installed ($CURRENT_FR)"
+  fi
+fi
+
+# ── Step 7: Restore cron jobs ──────────────────────────────────
+"$SCRIPT_DIR/setup-cron.sh" 2>&1 | grep '\[cron\]' || true
+info "Cron jobs restored"
+
+# ── Step 8: Start Slack bridge ───────────────────────────────────
+"$SCRIPT_DIR/start-services.sh" --sandbox "$SANDBOX" 2>&1 | grep -E '\[services\]|┌|│|└'
+info "Services started"
+
+# ── Step 9: Ensure heartbeat cron job exists ─────────────────────
+HEARTBEAT_FLAGS=""
+[ -n "$SLACK_USER_ID" ] && HEARTBEAT_FLAGS="--slack-user-id $SLACK_USER_ID"
+SSH_CONF="$SSH_CONF" "$SCRIPT_DIR/setup-heartbeat-cron.sh" "$SANDBOX" $HEARTBEAT_FLAGS 2>&1 | grep '\[heartbeat-cron\]' || true
+info "Heartbeat cron job checked"
+
+echo ""
+info "NemoClaw fully operational — sandbox: $SANDBOX"

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -116,25 +116,69 @@ verify_config_integrity() {
 }
 
 write_auth_profile() {
-  if [ -z "${NVIDIA_API_KEY:-}" ]; then
-    return
-  fi
-
   python3 - <<'PYAUTH'
 import json
 import os
-path = os.path.expanduser('~/.openclaw/agents/main/agent/auth-profiles.json')
-os.makedirs(os.path.dirname(path), exist_ok=True)
-json.dump({
-    'nvidia:manual': {
+
+profiles = {}
+
+if os.environ.get('NVIDIA_API_KEY'):
+    profiles['nvidia:manual'] = {
         'type': 'api_key',
         'provider': 'nvidia',
         'keyRef': {'source': 'env', 'id': 'NVIDIA_API_KEY'},
         'profileId': 'nvidia:manual',
     }
-}, open(path, 'w'))
-os.chmod(path, 0o600)
+
+if os.environ.get('ANTHROPIC_API_KEY'):
+    profiles['anthropic:manual'] = {
+        'type': 'api_key',
+        'provider': 'anthropic',
+        'keyRef': {'source': 'env', 'id': 'ANTHROPIC_API_KEY'},
+        'profileId': 'anthropic:manual',
+    }
+
+if profiles:
+    path = os.path.expanduser('~/.openclaw/agents/main/agent/auth-profiles.json')
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    json.dump(profiles, open(path, 'w'))
+    os.chmod(path, 0o600)
 PYAUTH
+}
+
+extract_anthropic_key() {
+  # Extract ANTHROPIC_API_KEY from Claude credentials if not already set
+  if [ "${NEMOCLAW_SKIP_CLAUDE_AUTH:-0}" = "1" ]; then
+    echo "[credentials] skipping Claude credential extraction"
+    return
+  fi
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    return
+  fi
+  if [ -f /sandbox/.env ]; then
+    ANTHROPIC_API_KEY="$(grep '^CLAUDE_CODE_OAUTH_TOKEN=' /sandbox/.env 2>/dev/null | tail -1 | cut -d= -f2- || true)"
+  fi
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    export ANTHROPIC_API_KEY
+    echo "[credentials] ANTHROPIC_API_KEY loaded from CLAUDE_CODE_OAUTH_TOKEN in /sandbox/.env"
+    return
+  fi
+  ANTHROPIC_API_KEY="$(python3 - <<'PYKEY'
+import json, os
+cred_path = os.path.expanduser('~/.claude/.credentials.json')
+try:
+    creds = json.load(open(cred_path))
+    token = creds.get('claudeAiOauth', {}).get('accessToken', '')
+    if token:
+        print(token, end='')
+except Exception:
+    pass
+PYKEY
+)"
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    export ANTHROPIC_API_KEY
+    echo "[credentials] ANTHROPIC_API_KEY extracted from Claude credentials"
+  fi
 }
 
 print_dashboard_urls() {
@@ -252,6 +296,114 @@ PYAUTOPAIR
   echo "[gateway] auto-pair watcher launched (pid $!)" >&2
 }
 
+inject_claude_credentials() {
+  # If CLAUDE_CREDENTIALS_JSON is set, write it to ~/.claude/.credentials.json
+  if [ -n "${CLAUDE_CREDENTIALS_JSON:-}" ]; then
+    mkdir -p /sandbox/.claude
+    echo "$CLAUDE_CREDENTIALS_JSON" > /sandbox/.claude/.credentials.json
+    chmod 600 /sandbox/.claude/.credentials.json
+    echo "[credentials] Claude credentials injected from env"
+  fi
+}
+
+inject_github_token() {
+  # If GH_TOKEN is set, write gh CLI hosts config
+  if [ -n "${GH_TOKEN:-}" ]; then
+    mkdir -p /sandbox/.config/gh
+    cat > /sandbox/.config/gh/hosts.yml <<GHEOF
+github.com:
+  oauth_token: ${GH_TOKEN}
+  user: ${GH_USER:-lakamsani}
+  git_protocol: https
+GHEOF
+    chmod 600 /sandbox/.config/gh/hosts.yml
+    echo "[credentials] GitHub token injected from env"
+  fi
+}
+
+inject_google_credentials() {
+  # If GOOGLE_APPLICATION_CREDENTIALS points to a file inside the sandbox, nothing to do.
+  # If GOOGLE_SA_JSON is set (base64-encoded service account JSON), decode and write it.
+  if [ -n "${GOOGLE_SA_JSON:-}" ]; then
+    mkdir -p /sandbox/.config/gcloud
+    echo "$GOOGLE_SA_JSON" | base64 -d > /sandbox/.config/gcloud/service-account.json
+    chmod 600 /sandbox/.config/gcloud/service-account.json
+    export GOOGLE_APPLICATION_CREDENTIALS=/sandbox/.config/gcloud/service-account.json
+    echo "[credentials] Google service account injected from env"
+  fi
+}
+
+inject_gog_credentials() {
+  # If GOG_CONFIG_JSON is set (base64-encoded gogcli directory), decode and write it
+  if [ -n "${GOG_CONFIG_JSON:-}" ]; then
+    mkdir -p /sandbox/.config/gogcli/keyring /sandbox/.config/gogcli/tokens
+    echo "$GOG_CONFIG_JSON" | base64 -d | tar xz -C /sandbox/.config/gogcli/
+    chmod -R 700 /sandbox/.config/gogcli
+    echo "[credentials] gog OAuth credentials injected from env"
+  fi
+}
+
+update_anthropic_apikey_in_config() {
+  # Patch the runtime openclaw.json with the actual ANTHROPIC_API_KEY
+  if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    return
+  fi
+  python3 - <<'PYPATCH'
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+try:
+    cfg = json.load(open(path))
+except Exception:
+    cfg = {}
+providers = cfg.setdefault('models', {}).setdefault('providers', {})
+if 'anthropic' in providers:
+    providers['anthropic']['apiKey'] = os.environ['ANTHROPIC_API_KEY']
+cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = 'anthropic/claude-sonnet-4-6'
+json.dump(cfg, open(path, 'w'), indent=2)
+os.chmod(path, 0o600)
+PYPATCH
+  echo "[config] openclaw.json updated with Anthropic API key and default model"
+}
+
+inject_slack_webhook() {
+  # Persist SLACK_WEBHOOK_URL to /sandbox/.env for heartbeat notifications
+  if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+    if grep -q SLACK_WEBHOOK_URL /sandbox/.env 2>/dev/null; then
+      sed -i "s|^SLACK_WEBHOOK_URL=.*|SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}|" /sandbox/.env
+    else
+      echo "SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}" >> /sandbox/.env
+    fi
+    chmod 600 /sandbox/.env
+    echo "[credentials] Slack webhook URL injected"
+  fi
+}
+
+inject_gog_keyring_password() {
+  # Persist GOG_KEYRING_PASSWORD to /sandbox/.env for headless gog auth (heartbeat)
+  local pw="${GOG_KEYRING_PASSWORD:-nemoclaw}"
+  if grep -q GOG_KEYRING_PASSWORD /sandbox/.env 2>/dev/null; then
+    sed -i "s|^GOG_KEYRING_PASSWORD=.*|GOG_KEYRING_PASSWORD=${pw}|" /sandbox/.env
+  else
+    echo "GOG_KEYRING_PASSWORD=${pw}" >> /sandbox/.env
+  fi
+  chmod 600 /sandbox/.env
+  echo "[credentials] GOG_KEYRING_PASSWORD injected"
+}
+
+echo 'Setting up NemoClaw...'
+openclaw doctor --fix > /dev/null 2>&1 || true
+inject_claude_credentials
+extract_anthropic_key
+inject_github_token
+inject_google_credentials
+inject_gog_credentials
+inject_slack_webhook
+inject_gog_keyring_password
+write_auth_profile
+export CHAT_UI_URL PUBLIC_PORT
+update_anthropic_apikey_in_config
+openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
+
 # ── Proxy environment ────────────────────────────────────────────
 # OpenShell injects HTTP_PROXY/HTTPS_PROXY/NO_PROXY into the sandbox, but its
 # NO_PROXY is limited to 127.0.0.1,localhost,::1 — missing the gateway IP.
@@ -332,6 +484,16 @@ fi
 
 echo 'Setting up NemoClaw...' >&2
 [ -f .env ] && chmod 600 .env
+
+# ── Multi-user credential injection ─────────────────────────────
+inject_claude_credentials
+extract_anthropic_key
+inject_github_token
+inject_google_credentials
+inject_gog_credentials
+inject_slack_webhook
+inject_gog_keyring_password
+update_anthropic_apikey_in_config
 
 # ── Non-root fallback ──────────────────────────────────────────
 # OpenShell runs containers with --security-opt=no-new-privileges, which

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Send a notification to a user via Slack DM AND WhatsApp.
+#
+# Usage: notify.sh <slack-user-id> <message>
+# Env: SLACK_BOT_TOKEN (from .env), REPO_DIR or auto-detected
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+SLACK_USER_ID="${1:-}"
+MESSAGE="${2:-}"
+
+if [ -z "$SLACK_USER_ID" ] || [ -z "$MESSAGE" ]; then
+  echo "Usage: notify.sh <slack-user-id> <message>" >&2
+  exit 1
+fi
+
+# Source .env for tokens
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$REPO_DIR/.env"
+  set +a
+fi
+
+# ── Slack DM ──────────────────────────────────────────────────────
+if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+  DM_CHANNEL=$(/usr/bin/curl -s -X POST \
+    -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"users\":\"$SLACK_USER_ID\"}" \
+    "https://slack.com/api/conversations.open" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('channel',{}).get('id',''))" 2>/dev/null)
+
+  if [ -n "$DM_CHANNEL" ]; then
+    ESCAPED_MSG=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read().strip()))" <<< "$MESSAGE")
+    /usr/bin/curl -s -X POST \
+      -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "{\"channel\":\"$DM_CHANNEL\",\"text\":$ESCAPED_MSG}" \
+      "https://slack.com/api/chat.postMessage" >/dev/null 2>&1
+  fi
+fi
+
+# ── WhatsApp ──────────────────────────────────────────────────────
+# Look up user's WhatsApp number from persist config
+WA_CONFIG="$REPO_DIR/persist/users/$SLACK_USER_ID/credentials/whatsapp-number.txt"
+if [ -f "$WA_CONFIG" ]; then
+  WA_NUMBER=$(cat "$WA_CONFIG" | tr -d '[:space:]')
+  if [ -n "$WA_NUMBER" ]; then
+    # Strip markdown bold for WhatsApp (plain text)
+    WA_MESSAGE=$(echo "$MESSAGE" | sed 's/\*//g')
+    SLACK_USER_ID="$SLACK_USER_ID" timeout 30 node "$SCRIPT_DIR/whatsapp-bridge.js" send "$WA_NUMBER" "$WA_MESSAGE" >/dev/null 2>&1 || true
+  fi
+fi

--- a/scripts/ollama-https-proxy.js
+++ b/scripts/ollama-https-proxy.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// HTTPS reverse proxy for Ollama — allows sandbox pods to reach
+// Ollama (plain HTTP on :11434) through the OpenShell HTTPS-only proxy.
+//
+// Listens on HTTPS :11435 with a self-signed cert, forwards to http://localhost:11434.
+// Add ollama-proxy.local:11435 to the sandbox network policy.
+
+const https = require("https");
+const http = require("http");
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const LISTEN_PORT = 11435;
+const OLLAMA_HOST = "127.0.0.1";
+const OLLAMA_PORT = 11434;
+const CERT_DIR = "/tmp/ollama-proxy-certs";
+
+// Generate self-signed cert if needed
+function ensureCerts() {
+  const keyPath = path.join(CERT_DIR, "key.pem");
+  const certPath = path.join(CERT_DIR, "cert.pem");
+  if (fs.existsSync(keyPath) && fs.existsSync(certPath)) return { keyPath, certPath };
+
+  fs.mkdirSync(CERT_DIR, { recursive: true });
+  execSync(`openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} -days 365 -nodes -subj "/CN=ollama-proxy" 2>/dev/null`);
+  return { keyPath, certPath };
+}
+
+const { keyPath, certPath } = ensureCerts();
+
+const server = https.createServer(
+  {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath),
+  },
+  (clientReq, clientRes) => {
+    const proxyReq = http.request(
+      {
+        hostname: OLLAMA_HOST,
+        port: OLLAMA_PORT,
+        path: clientReq.url,
+        method: clientReq.method,
+        headers: { ...clientReq.headers, host: `${OLLAMA_HOST}:${OLLAMA_PORT}` },
+      },
+      (proxyRes) => {
+        clientRes.writeHead(proxyRes.statusCode, proxyRes.headers);
+        proxyRes.pipe(clientRes);
+      }
+    );
+
+    proxyReq.on("error", (err) => {
+      console.error(`[ollama-proxy] ${err.message}`);
+      clientRes.writeHead(502);
+      clientRes.end("Bad Gateway: Ollama unreachable");
+    });
+
+    clientReq.pipe(proxyReq);
+  }
+);
+
+server.listen(LISTEN_PORT, "0.0.0.0", () => {
+  console.log(`[ollama-proxy] HTTPS reverse proxy listening on :${LISTEN_PORT} → http://${OLLAMA_HOST}:${OLLAMA_PORT}`);
+});

--- a/scripts/refresh-all-credentials.sh
+++ b/scripts/refresh-all-credentials.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Refresh credentials for all registered users.
+# Falls back to single-sandbox refresh if no users.json exists.
+#
+# Usage: ./scripts/refresh-all-credentials.sh
+
+set -uo pipefail
+# Note: -e intentionally omitted — one sandbox failure must not abort the loop.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a; . "$REPO_DIR/.env"; set +a
+fi
+
+USERS_FILE="$HOME/.nemoclaw/users.json"
+
+if [ -f "$USERS_FILE" ] && python3 -c "import json; d=json.load(open('$USERS_FILE')); exit(0 if len(d.get('users',{})) > 0 else 1)" 2>/dev/null; then
+  # Multi-user mode: iterate over all enabled users
+  USER_IDS=$(python3 -c "import json; d=json.load(open('$USERS_FILE')); [print(uid) for uid, u in d.get('users',{}).items() if u.get('enabled', True)]")
+
+  for uid in $USER_IDS; do
+    SANDBOX=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid']['sandboxName'])")
+    CRED_DIR=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid'].get('credentialsDir',''))")
+    NAME=$(python3 -c "import json; print(json.load(open('$USERS_FILE'))['users']['$uid'].get('slackDisplayName','$uid'))")
+
+    echo "[refresh-all] Refreshing credentials for $NAME → $SANDBOX ($(date))"
+    CRED_FLAG=""
+    [ -n "$CRED_DIR" ] && CRED_FLAG="--cred-dir $CRED_DIR"
+    "$SCRIPT_DIR/refresh-credentials.sh" "$SANDBOX" $CRED_FLAG || {
+      echo "[refresh-all] FAILED for $NAME ($SANDBOX) — continuing..."
+    }
+  done
+else
+  # Legacy single-user mode
+  "$SCRIPT_DIR/refresh-credentials.sh"
+fi

--- a/scripts/refresh-credentials.sh
+++ b/scripts/refresh-credentials.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Lightweight credential refresh for per-user auth state.
+# Re-injects per-user Claude OAuth or per-user Anthropic API keys into the
+# sandbox and keeps runtime config aligned.
+# Run on a cron every 30 minutes.
+#
+# Usage: ./scripts/refresh-credentials.sh [sandbox-name]
+
+set -uo pipefail
+# Note: -e intentionally omitted — individual SSH commands may fail transiently
+# (e.g. during gateway restart) and we want to continue refreshing remaining steps.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a; . "$REPO_DIR/.env"; set +a
+fi
+
+# Parse arguments
+SANDBOX=""
+CRED_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cred-dir) CRED_DIR="${2:?--cred-dir requires a path}"; shift 2 ;;
+    -*) shift ;;
+    *)
+      # First positional arg is sandbox name
+      if [ -z "$SANDBOX" ]; then
+        SANDBOX="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+SANDBOX="${SANDBOX:-${NEMOCLAW_SANDBOX:-veyonce-claw}}"
+SSH_CONF="/tmp/ssh-config-${SANDBOX}"
+
+# Resolve relative cred dir to absolute
+if [ -n "$CRED_DIR" ] && [[ "$CRED_DIR" != /* ]]; then
+  CRED_DIR="$REPO_DIR/$CRED_DIR"
+fi
+
+USER_ENV_FILE=""
+if [ -n "$CRED_DIR" ]; then
+  USER_ENV_FILE="$(dirname "$CRED_DIR")/.env"
+fi
+
+# Refresh SSH config
+openshell sandbox ssh-config "$SANDBOX" > "$SSH_CONF" 2>/dev/null || exit 0
+
+ssh_cmd() {
+  ssh -F "$SSH_CONF" -o StrictHostKeyChecking=no -o ConnectTimeout=5 "openshell-${SANDBOX}" "$@"
+}
+
+restart_gateway() {
+  # Restart gateway so it picks up new config when required.
+  ssh_cmd 'export HOME=/sandbox; node -e "
+const fs = require(\"fs\");
+const dirs = fs.readdirSync(\"/proc\").filter(d => /^\\d+\$/.test(d));
+for (const pid of dirs) {
+  try {
+    const cmd = fs.readFileSync(\"/proc/\" + pid + \"/cmdline\", \"utf8\");
+    if (cmd.includes(\"gateway\") && cmd.includes(\"openclaw\")) {
+      process.kill(Number(pid), 9);
+    }
+  } catch(e) {}
+}
+"' 2>/dev/null || true
+  sleep 2
+  # Gateway runs as root — fix ownership so sandbox user can write.
+  ssh_cmd 'chown -R sandbox:sandbox /sandbox/.openclaw 2>/dev/null; chmod -R u+w /sandbox/.openclaw 2>/dev/null' 2>/dev/null || true
+  nohup ssh -F "$SSH_CONF" -o StrictHostKeyChecking=no -o ConnectTimeout=5 "openshell-${SANDBOX}" \
+    'export HOME=/sandbox; openclaw gateway run >> /tmp/gateway.log 2>&1' </dev/null >/dev/null 2>&1 &
+  disown
+  GATEWAY_HEALTHY=false
+  for _ in $(seq 1 10); do
+    if ssh_cmd 'export HOME=/sandbox; openclaw gateway call health > /dev/null 2>&1' 2>/dev/null; then
+      GATEWAY_HEALTHY=true
+      break
+    fi
+    sleep 2
+  done
+  [ "$GATEWAY_HEALTHY" = "true" ]
+}
+
+# Check sandbox is reachable
+ssh_cmd 'true' 2>/dev/null || exit 0
+
+# Re-inject per-user Claude credentials
+CLAUDE_CREDS=""
+CLAUDE_OAUTH_TOKEN_FILE=""
+DESIRED_ANTHROPIC_KEY="${ANTHROPIC_API_KEY:-}"
+DESIRED_CLAUDE_CODE_TOKEN=""
+if [ -n "$CRED_DIR" ] && [ -f "$CRED_DIR/claude-oauth-token.txt" ]; then
+  CLAUDE_OAUTH_TOKEN_FILE="$CRED_DIR/claude-oauth-token.txt"
+  DESIRED_CLAUDE_CODE_TOKEN="$(cat "$CLAUDE_OAUTH_TOKEN_FILE")"
+  DESIRED_ANTHROPIC_KEY="$DESIRED_CLAUDE_CODE_TOKEN"
+fi
+if [ -n "$CRED_DIR" ] && [ -f "$CRED_DIR/claude-credentials.json" ]; then
+  CLAUDE_CREDS="$CRED_DIR/claude-credentials.json"
+fi
+
+if [ -n "$CLAUDE_CREDS" ] && [ -z "$DESIRED_CLAUDE_CODE_TOKEN" ]; then
+  base64 "$CLAUDE_CREDS" | ssh_cmd 'base64 -d > /sandbox/.claude/.credentials.json && chmod 600 /sandbox/.claude/.credentials.json'
+  DESIRED_ANTHROPIC_KEY="$(python3 -c "import json; d=json.load(open('$CLAUDE_CREDS')); print(d.get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null || true)"
+fi
+
+# Write .credentials.json from the long-lived token (claude --print reads this, not .env)
+if [ -n "$DESIRED_CLAUDE_CODE_TOKEN" ]; then
+  ssh_cmd "python3 -c \"
+import json, os
+creds = {
+    'claudeAiOauth': {
+        'accessToken': '${DESIRED_CLAUDE_CODE_TOKEN}',
+        'refreshToken': '',
+        'expiresAt': 9999999999999,
+        'scopes': ['user:inference', 'user:mcp_servers', 'user:profile', 'user:sessions:claude_code'],
+        'subscriptionType': 'team',
+        'rateLimitTier': 'default_claude_max_5x'
+    }
+}
+os.makedirs('/sandbox/.claude', exist_ok=True)
+json.dump(creds, open('/sandbox/.claude/.credentials.json', 'w'), indent=2)
+os.chmod('/sandbox/.claude/.credentials.json', 0o600)
+\"" 2>/dev/null
+fi
+
+# Re-inject Anthropic API key if stored separately (per-user)
+# If present, this overrides OAuth-derived keys.
+ANTHROPIC_KEY_FILE=""
+if [ -n "$CRED_DIR" ] && [ -f "$CRED_DIR/anthropic-key.txt" ]; then
+  ANTHROPIC_KEY_FILE="$CRED_DIR/anthropic-key.txt"
+  DESIRED_ANTHROPIC_KEY="$(cat "$ANTHROPIC_KEY_FILE")"
+fi
+
+GATEWAY_TOKEN="${GATEWAY_AUTH_TOKEN:?GATEWAY_AUTH_TOKEN must be set}"
+CURRENT_ANTHROPIC_KEY="$(ssh_cmd "grep '^ANTHROPIC_API_KEY=' /sandbox/.env 2>/dev/null | tail -1 | cut -d= -f2-" 2>/dev/null || true)"
+CURRENT_CLAUDE_CODE_TOKEN="$(ssh_cmd "grep '^CLAUDE_CODE_OAUTH_TOKEN=' /sandbox/.env 2>/dev/null | tail -1 | cut -d= -f2-" 2>/dev/null || true)"
+CURRENT_GATEWAY_TOKEN="$(ssh_cmd "python3 -c \"
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+try:
+    cfg = json.load(open(path))
+    print(cfg.get('gateway', {}).get('auth', {}).get('token', ''))
+except Exception:
+    print('')
+\"" 2>/dev/null || true)"
+GATEWAY_RESTART_NEEDED=false
+
+if [ -n "$DESIRED_ANTHROPIC_KEY" ] && [ "$CURRENT_ANTHROPIC_KEY" != "$DESIRED_ANTHROPIC_KEY" ]; then
+  ssh_cmd "python3 -c \"
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(path))
+p = cfg.get('models',{}).get('providers',{}).get('anthropic',{})
+if p:
+    p['apiKey'] = '${DESIRED_ANTHROPIC_KEY}'
+cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = 'anthropic/claude-sonnet-4-6'
+json.dump(cfg, open(path, 'w'), indent=2)
+os.chmod(path, 0o600)
+\"" 2>/dev/null
+
+  # OpenClaw reads env vars with higher priority than models.json, so keep both in sync.
+  ssh_cmd "grep -q ANTHROPIC_API_KEY /sandbox/.env 2>/dev/null && sed -i 's|^ANTHROPIC_API_KEY=.*|ANTHROPIC_API_KEY=${DESIRED_ANTHROPIC_KEY}|' /sandbox/.env || echo 'ANTHROPIC_API_KEY=${DESIRED_ANTHROPIC_KEY}' >> /sandbox/.env; chmod 600 /sandbox/.env" 2>/dev/null
+  GATEWAY_RESTART_NEEDED=true
+fi
+
+CURRENT_PRIMARY_MODEL="$(ssh_cmd "python3 -c \"
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+try:
+    cfg = json.load(open(path))
+    print(((cfg.get('agents') or {}).get('defaults') or {}).get('model', {}).get('primary', ''))
+except Exception:
+    print('')
+\"" 2>/dev/null || true)"
+if [ -n "$DESIRED_ANTHROPIC_KEY" ] && [ "$CURRENT_PRIMARY_MODEL" != "anthropic/claude-sonnet-4-6" ]; then
+  ssh_cmd "python3 -c \"
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(path))
+cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = 'anthropic/claude-sonnet-4-6'
+json.dump(cfg, open(path, 'w'), indent=2)
+os.chmod(path, 0o600)
+\"" 2>/dev/null
+  GATEWAY_RESTART_NEEDED=true
+fi
+
+if [ -n "$DESIRED_CLAUDE_CODE_TOKEN" ] && [ "$CURRENT_CLAUDE_CODE_TOKEN" != "$DESIRED_CLAUDE_CODE_TOKEN" ]; then
+  ssh_cmd "grep -q CLAUDE_CODE_OAUTH_TOKEN /sandbox/.env 2>/dev/null && sed -i 's|^CLAUDE_CODE_OAUTH_TOKEN=.*|CLAUDE_CODE_OAUTH_TOKEN=${DESIRED_CLAUDE_CODE_TOKEN}|' /sandbox/.env || echo 'CLAUDE_CODE_OAUTH_TOKEN=${DESIRED_CLAUDE_CODE_TOKEN}' >> /sandbox/.env; chmod 600 /sandbox/.env" 2>/dev/null
+fi
+
+if [ "$CURRENT_GATEWAY_TOKEN" != "$GATEWAY_TOKEN" ]; then
+  ssh_cmd "python3 -c \"
+import json, os
+path = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(path))
+gw = cfg.setdefault('gateway', {})
+gw['auth'] = {'mode': 'token', 'token': '${GATEWAY_TOKEN}'}
+gw['controlUi'] = {'allowInsecureAuth': True, 'dangerouslyDisableDeviceAuth': True, 'allowedOrigins': ['http://127.0.0.1:18789', 'http://localhost:18789']}
+json.dump(cfg, open(path, 'w'), indent=2)
+os.chmod(path, 0o600)
+\"" 2>/dev/null
+  GATEWAY_RESTART_NEEDED=true
+fi
+
+# Restore device pairing — server-side (gateway) + client-side (CLI identity)
+PAIRED_FILE="$REPO_DIR/persist/gateway/paired.json"
+IDENTITY_DIR="$REPO_DIR/persist/gateway/identity"
+if [ -f "$PAIRED_FILE" ]; then
+  ssh_cmd 'mkdir -p /sandbox/.openclaw/devices'
+  base64 "$PAIRED_FILE" | ssh_cmd 'base64 -d > /sandbox/.openclaw/devices/paired.json && chmod 600 /sandbox/.openclaw/devices/paired.json'
+fi
+if [ -d "$IDENTITY_DIR" ]; then
+  ssh_cmd 'mkdir -p /sandbox/.openclaw/identity'
+  for f in "$IDENTITY_DIR"/*.json; do
+    [ -f "$f" ] && base64 "$f" | ssh_cmd "base64 -d > /sandbox/.openclaw/identity/$(basename "$f") && chmod 600 /sandbox/.openclaw/identity/$(basename "$f")"
+  done
+fi
+
+if ! ssh_cmd 'export HOME=/sandbox; openclaw gateway call health > /dev/null 2>&1' 2>/dev/null; then
+  GATEWAY_RESTART_NEEDED=true
+fi
+
+if [ "$GATEWAY_RESTART_NEEDED" = "true" ]; then
+  if restart_gateway; then
+    echo "[refresh] Gateway restarted for $SANDBOX ($(date))"
+  else
+    echo "[refresh] WARNING: Gateway restart failed for $SANDBOX ($(date))"
+  fi
+else
+  echo "[refresh] Gateway restart skipped for $SANDBOX — no relevant config change ($(date))"
+fi
+
+if [ -n "$CLAUDE_CREDS" ]; then
+  echo "[refresh] Claude credentials synced for $SANDBOX from $CLAUDE_CREDS ($(date))"
+fi
+if [ -n "$CLAUDE_OAUTH_TOKEN_FILE" ]; then
+  echo "[refresh] Claude long-lived token enforced from per-user credentials for $SANDBOX ($(date))"
+fi
+
+# Re-inject GOG_KEYRING_PASSWORD (strictly per-user)
+GOG_KEYRING_PW=""
+if [ -n "$USER_ENV_FILE" ] && [ -f "$USER_ENV_FILE" ]; then
+  GOG_KEYRING_PW="$(bash -lc 'set -a; . "$1"; set +a; printf "%s" "${GOG_KEYRING_PASSWORD:-}"' _ "$USER_ENV_FILE" 2>/dev/null || true)"
+fi
+if [ -n "$GOG_KEYRING_PW" ]; then
+  ssh_cmd "grep -q GOG_KEYRING_PASSWORD /sandbox/.env 2>/dev/null && sed -i 's|^GOG_KEYRING_PASSWORD=.*|GOG_KEYRING_PASSWORD=${GOG_KEYRING_PW}|' /sandbox/.env || echo 'GOG_KEYRING_PASSWORD=${GOG_KEYRING_PW}' >> /sandbox/.env; chmod 600 /sandbox/.env" 2>/dev/null
+fi
+
+# ── Proactive Google OAuth token refresh ─────────────────────────────
+# Exercise the GOG refresh token by making a lightweight Gmail labels call.
+# This keeps the refresh token alive (Google revokes unused tokens after
+# 6 months, or 7 days if the OAuth app is in "Testing" mode).
+# If the token has already been revoked (invalid_grant), log a warning.
+if [ -n "$GOG_KEYRING_PW" ] && ssh_cmd 'test -d /sandbox/.config/gogcli' 2>/dev/null; then
+  GOG_REFRESH_RESULT=$(ssh_cmd 'export HOME=/sandbox; export PATH=/sandbox/.local/bin:$PATH; export GOG_KEYRING_PASSWORD='"${GOG_KEYRING_PW}"'; gog gmail labels list -a "$(gog auth list -p 2>/dev/null | head -1)" --json 2>&1 | head -5' 2>/dev/null || true)
+  if echo "$GOG_REFRESH_RESULT" | grep -q "invalid_grant"; then
+    echo "[refresh] WARNING: Google OAuth token revoked (invalid_grant) for $SANDBOX — manual re-auth needed ($(date))"
+  elif echo "$GOG_REFRESH_RESULT" | grep -q "labels"; then
+    echo "[refresh] Google OAuth token exercised successfully for $SANDBOX ($(date))"
+  fi
+fi
+
+# Re-inject Slack bot token (for heartbeat DMs)
+if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+  ssh_cmd "grep -q SLACK_BOT_TOKEN /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_BOT_TOKEN=.*|SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}|' /sandbox/.env || echo 'SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}' >> /sandbox/.env; chmod 600 /sandbox/.env" 2>/dev/null
+fi
+
+# Re-inject Slack webhook URL (strictly per-user)
+if [ -n "$CRED_DIR" ] && [ -f "$CRED_DIR/slack-webhook-url.txt" ]; then
+  USER_SLACK_WEBHOOK="$(cat "$CRED_DIR/slack-webhook-url.txt")"
+  ssh_cmd "grep -q SLACK_WEBHOOK_URL /sandbox/.env 2>/dev/null && sed -i 's|^SLACK_WEBHOOK_URL=.*|SLACK_WEBHOOK_URL=${USER_SLACK_WEBHOOK}|' /sandbox/.env || echo 'SLACK_WEBHOOK_URL=${USER_SLACK_WEBHOOK}' >> /sandbox/.env; chmod 600 /sandbox/.env" 2>/dev/null
+fi
+
+# Re-inject per-user MCP auth cache
+MCP_CACHE=""
+if [ -n "$CRED_DIR" ] && [ -f "$CRED_DIR/mcp-needs-auth-cache.json" ]; then
+  MCP_CACHE="$CRED_DIR/mcp-needs-auth-cache.json"
+fi
+if [ -n "$MCP_CACHE" ]; then
+  base64 "$MCP_CACHE" | ssh_cmd 'base64 -d > /sandbox/.claude/mcp-needs-auth-cache.json && chmod 600 /sandbox/.claude/mcp-needs-auth-cache.json'
+fi

--- a/scripts/setup-cron.sh
+++ b/scripts/setup-cron.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Idempotent cron setup for NemoClaw. Safe to run multiple times.
+# Restores credential refresh and workspace backup cron jobs.
+# Multi-user aware: uses refresh-all/backup-all scripts when users.json exists.
+#
+# Usage: ./scripts/setup-cron.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+CRON_ENTRIES=(
+  "# NemoClaw credential refresh — all users (every 15 minutes)"
+  "*/15 * * * * $SCRIPT_DIR/refresh-all-credentials.sh >> /tmp/nemoclaw-cred-refresh.log 2>&1"
+  "# NemoClaw workspace backup — all users (every 2 hours)"
+  "0 */2 * * * $SCRIPT_DIR/backup-all-workspaces.sh >> /tmp/nemoclaw-workspace-backup.log 2>&1"
+)
+
+# Get existing crontab (without NemoClaw entries or stale env var lines)
+# Note: ANTHROPIC_API_KEY was previously hardcoded in crontab — it should come
+# from .env instead, so the refresh script can manage token lifecycle properly.
+EXISTING=$(crontab -l 2>/dev/null | grep -v 'NemoClaw\|nemoclaw-cred-refresh\|nemoclaw-workspace-backup\|refresh-credentials\|nemoclaw-backup\|refresh-all\|backup-all\|^ANTHROPIC_API_KEY=' || true)
+
+# Build new crontab
+{
+  [ -n "$EXISTING" ] && echo "$EXISTING"
+  for entry in "${CRON_ENTRIES[@]}"; do
+    echo "$entry"
+  done
+} | crontab -
+
+echo "[cron] NemoClaw cron jobs installed:"
+crontab -l | grep -A1 NemoClaw

--- a/scripts/setup-heartbeat-cron.sh
+++ b/scripts/setup-heartbeat-cron.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Create the OpenClaw heartbeat cron job inside a sandbox.
+# Idempotent — skips if heartbeat job already exists.
+# Reads heartbeat prompt from per-user HEARTBEAT.md; skips if empty/comments-only.
+#
+# Usage:
+#   ./scripts/setup-heartbeat-cron.sh [sandbox-name]
+#   SSH_CONF=/tmp/ssh-config-foo ./scripts/setup-heartbeat-cron.sh foo
+#   ./scripts/setup-heartbeat-cron.sh foo --slack-user-id U09R681EPQ9
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a; . "$REPO_DIR/.env"; set +a
+fi
+
+SANDBOX=""
+SLACK_USER_ID=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --slack-user-id) SLACK_USER_ID="${2:?--slack-user-id requires a value}"; shift 2 ;;
+    -*) shift ;;
+    *)
+      if [ -z "$SANDBOX" ]; then
+        SANDBOX="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+SANDBOX="${SANDBOX:-${NEMOCLAW_SANDBOX:-veyonce-claw}}"
+SSH_CONF="${SSH_CONF:-/tmp/ssh-config-${SANDBOX}}"
+
+# Generate SSH config if not present
+if [ ! -f "$SSH_CONF" ]; then
+  openshell sandbox ssh-config "$SANDBOX" > "$SSH_CONF" 2>/dev/null
+fi
+
+ssh_cmd() {
+  ssh -F "$SSH_CONF" -o StrictHostKeyChecking=no -o ConnectTimeout=5 "openshell-${SANDBOX}" "$@"
+}
+
+# ── Resolve heartbeat prompt from per-user HEARTBEAT.md ──────────
+HEARTBEAT_MSG=""
+
+# Try per-user file first (requires SLACK_USER_ID)
+if [ -n "$SLACK_USER_ID" ]; then
+  HB_FILE="$REPO_DIR/persist/users/$SLACK_USER_ID/workspace/HEARTBEAT.md"
+  if [ -f "$HB_FILE" ]; then
+    # Strip comment lines and blank lines, check if anything remains
+    CONTENT="$(grep -v '^\s*#' "$HB_FILE" | grep -v '^\s*$' || true)"
+    if [ -n "$CONTENT" ]; then
+      HEARTBEAT_MSG="$CONTENT"
+    fi
+  fi
+fi
+
+# Fallback: try sandbox-level default (legacy)
+if [ -z "$HEARTBEAT_MSG" ] && [ -z "$SLACK_USER_ID" ]; then
+  HB_FILE="$REPO_DIR/persist/workspace/HEARTBEAT.md"
+  if [ -f "$HB_FILE" ]; then
+    CONTENT="$(grep -v '^\s*#' "$HB_FILE" | grep -v '^\s*$' || true)"
+    if [ -n "$CONTENT" ]; then
+      HEARTBEAT_MSG="$CONTENT"
+    fi
+  fi
+fi
+
+if [ -z "$HEARTBEAT_MSG" ]; then
+  echo "[heartbeat-cron] No heartbeat prompt found for $SANDBOX (HEARTBEAT.md empty or missing), skipping"
+  exit 0
+fi
+
+# Check if heartbeat cron already exists
+if ssh_cmd 'export HOME=/sandbox; openclaw cron list 2>/dev/null | grep -q heartbeat'; then
+  echo "[heartbeat-cron] Already exists, skipping"
+  exit 0
+fi
+
+# Wait for gateway
+echo "[heartbeat-cron] Waiting for gateway..."
+for i in $(seq 1 15); do
+  if ssh_cmd 'export HOME=/sandbox; openclaw cron list >/dev/null 2>&1'; then
+    break
+  fi
+  if [ "$i" -eq 15 ]; then
+    echo "[heartbeat-cron] Gateway not ready after 30s, aborting"
+    exit 1
+  fi
+  sleep 2
+done
+
+# Write message to temp file, copy to sandbox, create cron from there
+TMPFILE="$(mktemp)"
+echo "$HEARTBEAT_MSG" > "$TMPFILE"
+cat "$TMPFILE" | ssh_cmd 'cat > /tmp/heartbeat-msg.txt'
+rm -f "$TMPFILE"
+
+ssh_cmd 'export HOME=/sandbox; openclaw cron add \
+  --name heartbeat \
+  --every 1h \
+  --agent main \
+  --session isolated \
+  --message "$(cat /tmp/heartbeat-msg.txt)" \
+  --timeout-seconds 180 \
+  --no-deliver \
+  2>&1 && rm -f /tmp/heartbeat-msg.txt'
+
+echo "[heartbeat-cron] Heartbeat cron job created (every 1h) for $SANDBOX"

--- a/scripts/setup-spark.sh
+++ b/scripts/setup-spark.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# NemoClaw setup for DGX Spark devices.
+#
+# Ensures the current user is in the docker group so NemoClaw can
+# manage containers without sudo.
+#
+# Usage:
+#   sudo bash scripts/setup-spark.sh
+#   # or via curl:
+#   curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/main/scripts/setup-spark.sh | sudo bash
+#
+# What it does:
+#   1. Adds current user to docker group (avoids sudo for everything else)
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}>>>${NC} $1"; }
+warn() { echo -e "${YELLOW}>>>${NC} $1"; }
+fail() {
+  echo -e "${RED}>>>${NC} $1"
+  exit 1
+}
+
+# ── Pre-flight checks ─────────────────────────────────────────────
+
+if [ "$(uname -s)" != "Linux" ]; then
+  fail "This script is for DGX Spark (Linux). Use 'nemoclaw setup' for macOS."
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+  fail "Must run as root: sudo nemoclaw setup-spark"
+fi
+
+# Detect the real user (not root) for docker group add
+REAL_USER="${SUDO_USER:-$(logname 2>/dev/null || echo "")}"
+if [ -z "$REAL_USER" ]; then
+  warn "Could not detect non-root user. Docker group will not be configured."
+fi
+
+command -v docker >/dev/null || fail "Docker not found. DGX Spark should have Docker pre-installed."
+
+# ── 1. Docker group ───────────────────────────────────────────────
+
+if [ -n "$REAL_USER" ]; then
+  if id -nG "$REAL_USER" | grep -qw docker; then
+    info "User '$REAL_USER' already in docker group"
+  else
+    info "Adding '$REAL_USER' to docker group..."
+    usermod -aG docker "$REAL_USER"
+    DOCKER_GROUP_ADDED=true
+  fi
+fi
+
+# ── 2. Next steps ─────────────────────────────────────────────────
+
+echo ""
+if [ "${DOCKER_GROUP_ADDED:-}" = true ]; then
+  warn "Docker group was just added. You must open a new terminal (or run 'newgrp docker') before continuing."
+else
+  info "DGX Spark Docker configuration complete."
+fi

--- a/scripts/slack-bridge-multi.js
+++ b/scripts/slack-bridge-multi.js
@@ -1,0 +1,2269 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Multi-user Slack -> NemoClaw bridge.
+ *
+ * Routes messages to different sandboxes based on Slack user ID,
+ * using the user registry (~/.nemoclaw/users.json) for lookup.
+ *
+ * Uses Socket Mode (no public URL required).
+ *
+ * Env:
+ *   SLACK_BOT_TOKEN   — Bot User OAuth Token (xoxb-...)
+ *   SLACK_APP_TOKEN   — App-Level Token with connections:write (xapp-...)
+ *   NVIDIA_API_KEY    — for inference
+ *   ALLOWED_CHANNELS  — comma-separated Slack channel IDs to accept (optional, accepts all if unset)
+ *   SLACK_ADMIN_USERS — comma-separated Slack user IDs treated as admins on DGX
+ */
+
+const { execFileSync, execSync, spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
+const userRegistry = require("../bin/lib/user-registry");
+const sandboxRegistry = require("../bin/lib/registry");
+const { isSetupCommand, handleSetup, setupHelp, normalizeText } = require("../bin/lib/credential-setup");
+const { getProviderSelectionConfig } = require("../bin/lib/inference-config");
+
+const OPENSHELL = resolveOpenshell();
+
+const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
+const SLACK_APP_TOKEN = process.env.SLACK_APP_TOKEN;
+const API_KEY = process.env.NVIDIA_API_KEY;
+const ALLOWED_CHANNELS = process.env.ALLOWED_CHANNELS
+  ? process.env.ALLOWED_CHANNELS.split(",").map((s) => s.trim())
+  : null;
+const ADMIN_USERS = new Set(
+  (process.env.SLACK_ADMIN_USERS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+);
+
+// ── Credential refresh on auth failure ────────────────────────────
+
+const REPO_DIR = require("path").resolve(__dirname, "..");
+const AUTH_ERROR_RE = /authentication_error|invalid_grant|Invalid authentication|401.*auth|expired.*token|OAuth token has expired/i;
+const RATE_LIMIT_RE = /rate.limit|429|too many requests|overloaded|capacity/i;
+const ADMIN_AUDIT_LOG = `${REPO_DIR}/persist/audit/admin-actions.log`;
+const pendingDeleteRequests = new Map();
+
+// ── Global rate limit throttle ───────────────────────────────────
+// When a rate limit is detected, pause all new agent launches for a cooldown.
+let rateLimitCooldownUntil = 0;
+const RATE_LIMIT_COOLDOWN_MS = 60000; // 1 minute cooldown after rate limit
+
+function isRateLimited() {
+  return Date.now() < rateLimitCooldownUntil;
+}
+
+function triggerRateLimitCooldown() {
+  rateLimitCooldownUntil = Date.now() + RATE_LIMIT_COOLDOWN_MS;
+  console.log(`[rate-limit] Cooldown active for ${RATE_LIMIT_COOLDOWN_MS / 1000}s (until ${new Date(rateLimitCooldownUntil).toISOString()})`);
+}
+
+async function waitForRateLimitCooldown() {
+  if (!isRateLimited()) return;
+  const waitMs = rateLimitCooldownUntil - Date.now();
+  console.log(`[rate-limit] Waiting ${Math.round(waitMs / 1000)}s for cooldown...`);
+  await new Promise((r) => setTimeout(r, waitMs));
+}
+
+// ── Per-user message queue (serializes agent runs per sandbox) ────
+// OpenClaw's lane-level session lock only allows one concurrent agent run.
+// Without queuing, a second message while the first is still running hits
+// "session file locked" and the agent exits with code 1.
+const userQueues = new Map(); // sandboxName → Promise chain
+
+function enqueueForUser(sandboxName, fn) {
+  const prev = userQueues.get(sandboxName) || Promise.resolve();
+  const next = prev.then(fn, fn); // run fn after prev settles (success or fail)
+  userQueues.set(sandboxName, next);
+  return next;
+}
+
+function sh(value) {
+  return String(value).replace(/'/g, "'\\''");
+}
+const DELETE_CONFIRM_TTL_MS = 5 * 60 * 1000;
+const MAX_DISPLAY_NAME_LENGTH = 80;
+const MAX_GITHUB_HANDLE_LENGTH = 39;
+
+function withAdminState(user) {
+  if (!user) return null;
+  const roles = new Set(user.roles || ["user"]);
+  roles.add("user");
+  if (ADMIN_USERS.has(user.slackUserId)) roles.add("admin");
+  return { ...user, roles: [...roles] };
+}
+
+function getUser(slackUserId) {
+  const user = withAdminState(userRegistry.getUser(slackUserId));
+  return user && user.enabled ? user : null;
+}
+
+function isAdminUser(user) {
+  return !!(user && Array.isArray(user.roles) && user.roles.includes("admin"));
+}
+
+function canonicalizeAdminCommand(text) {
+  return normalizeText(text)
+    .replace(/^!show\s+claws\b/i, "!show-claws")
+    .replace(/^!list\s+claws\b/i, "!list-claws")
+    .replace(/^!show\s+user\b/i, "!show-user")
+    .replace(/^!admin\s+audit\b/i, "!admin-audit")
+    .replace(/^!admin\s+help\b/i, "!admin-help")
+    .replace(/^!help\s+admin\b/i, "!help-admin")
+    .replace(/^!add\s+claw\b/i, "!add-claw")
+    .replace(/^!delete\s+claw\b/i, "!delete-claw")
+    .replace(/^!confirm(?:-|\s+)delete(?:-|\s+)claw\b/i, "!confirm-delete-claw");
+}
+
+function looksLikeAdminCommand(text) {
+  return /^!(show|list|admin|help|add|delete|confirm)\b/i.test(canonicalizeAdminCommand(text).trim());
+}
+
+function isListAdminsCommand(text) {
+  const normalized = canonicalizeAdminCommand(text).toLowerCase();
+  return normalized === "!admins" || normalized === "!admins list" || normalized === "!admin-users";
+}
+
+function isAdminAuditCommand(text) {
+  const normalized = canonicalizeAdminCommand(text).toLowerCase();
+  return normalized === "!admin-audit" || normalized === "!admin-audit 10" || normalized === "!admin-log";
+}
+
+function isShowClawsCommand(text) {
+  const normalized = canonicalizeAdminCommand(text).toLowerCase();
+  return normalized.startsWith("!show-claws") || normalized === "!claws" || normalized.startsWith("!list-claws");
+}
+
+function isShowUserCommand(text) {
+  const normalized = canonicalizeAdminCommand(text).toLowerCase();
+  return normalized.startsWith("!show-user");
+}
+
+function isAdminHelpCommand(text) {
+  const normalized = canonicalizeAdminCommand(text).toLowerCase();
+  return normalized === "!admin-help" || normalized === "!help-admin";
+}
+
+function parseCommandArgs(text) {
+  const args = [];
+  const pattern = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let match;
+  while ((match = pattern.exec(text)) !== null) {
+    args.push(match[1] ?? match[2] ?? match[3]);
+  }
+  return args;
+}
+
+function auditAdminAction(actor, action, details = {}, outcome = "started", error = "") {
+  fs.mkdirSync(`${REPO_DIR}/persist/audit`, { recursive: true });
+  const record = {
+    ts: new Date().toISOString(),
+    actorSlackUserId: actor?.slackUserId || "",
+    actorDisplayName: actor?.slackDisplayName || "",
+    action,
+    outcome,
+    details,
+    error,
+  };
+  fs.appendFileSync(ADMIN_AUDIT_LOG, `${JSON.stringify(record)}\n`, "utf-8");
+}
+
+function runAdminCommand(file, args = [], timeout = 300000) {
+  return execFileSync(file, args, {
+    cwd: REPO_DIR,
+    encoding: "utf-8",
+    timeout,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function getProvisioningSummary(slackId, clawName) {
+  try {
+    const statusOutput = runAdminCommand(process.execPath, [
+      "bin/nemoclaw.js",
+      "user-status",
+      slackId,
+    ], 120000).trim();
+    return statusOutput.slice(-2500) || "(no status output)";
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`.trim() || err.message;
+    return `Status verification failed for ${clawName}:\n${output.slice(-2500)}`;
+  }
+}
+
+function isAddClawCommand(text) {
+  return canonicalizeAdminCommand(text).toLowerCase().startsWith("!add-claw");
+}
+
+function isDeleteClawCommand(text) {
+  return canonicalizeAdminCommand(text).toLowerCase().startsWith("!delete-claw");
+}
+
+function isConfirmDeleteClawCommand(text) {
+  return canonicalizeAdminCommand(text).toLowerCase().startsWith("!confirm-delete-claw");
+}
+
+function listAdminUsers() {
+  return buildAdminUserList(userRegistry.listUsers().users, ADMIN_USERS);
+}
+
+function buildAdminUserList(users, adminUserIds = ADMIN_USERS) {
+  const admins = new Map();
+
+  for (const entry of users) {
+    const user = withAdminState({
+      ...entry,
+      roles: Array.isArray(entry.roles) ? entry.roles : ["user"],
+    });
+    if (user && user.roles.includes("admin")) {
+      admins.set(user.slackUserId, user);
+    }
+  }
+
+  for (const slackUserId of adminUserIds) {
+    if (!admins.has(slackUserId)) {
+      admins.set(slackUserId, {
+        slackUserId,
+        slackDisplayName: slackUserId,
+        sandboxName: "",
+        roles: ["user", "admin"],
+        enabled: false,
+      });
+    }
+  }
+
+  return [...admins.values()].sort((a, b) =>
+    (a.slackDisplayName || a.slackUserId).localeCompare(b.slackDisplayName || b.slackUserId)
+  );
+}
+
+function formatAdminUsers() {
+  return formatAdminUsersFromList(listAdminUsers());
+}
+
+function formatAdminUsersFromList(admins) {
+  if (admins.length === 0) {
+    return "No admin users are configured.";
+  }
+
+  const lines = ["*Admin Users*"];
+  for (const admin of admins) {
+    const label = admin.slackDisplayName || admin.slackUserId;
+    const sandbox = admin.sandboxName ? ` — sandbox: \`${admin.sandboxName}\`` : "";
+    const status = admin.enabled ? "" : " _(allowlist only or disabled)_";
+    lines.push(`• ${label} (\`${admin.slackUserId}\`)${sandbox}${status}`);
+  }
+  return lines.join("\n");
+}
+
+function readRecentAdminAudit(limit = 10) {
+  if (!fs.existsSync(ADMIN_AUDIT_LOG)) return [];
+  const lines = fs.readFileSync(ADMIN_AUDIT_LOG, "utf-8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .slice(-limit);
+  return lines.map((line) => {
+    try {
+      return JSON.parse(line);
+    } catch {
+      return null;
+    }
+  }).filter(Boolean);
+}
+
+function formatRecentAdminAudit(limit = 10) {
+  const records = readRecentAdminAudit(limit);
+  if (records.length === 0) return "No admin audit records found.";
+  const lines = [`*Recent Admin Actions* (last ${records.length})`];
+  for (const record of records.reverse()) {
+    const actor = record.actorDisplayName || record.actorSlackUserId || "unknown";
+    const target = record.details?.clawName || record.details?.slackId || "";
+    const suffix = target ? ` — ${target}` : "";
+    lines.push(`• ${record.ts} — ${actor} — ${record.action} — ${record.outcome}${suffix}`);
+  }
+  return lines.join("\n");
+}
+
+function formatAdminHelp() {
+  return [
+    "*Admin Commands*",
+    "`!admin-help`",
+    "`!admins`",
+    "`!admin-audit`",
+    "`!show-claws [ready|not-ready|registered|unregistered|admins|non-admins|gpu] [sort=name|user|status|uptime] [match=...] [policy=...] [cred=...]`",
+    "`!show-user <slack-id|claw-name|name-fragment>`",
+    "`!add-claw <slack_id> <display_name> <claw_name> <github_handle>`",
+    "`!delete-claw <claw_name>`",
+    "`!confirm-delete-claw <claw_name>`",
+    "",
+    `Delete confirmations expire after ${Math.floor(DELETE_CONFIRM_TTL_MS / 60000)} minutes and are lost if the bridge restarts.`,
+  ].join("\n");
+}
+
+function parseSandboxList(raw) {
+  const sandboxes = new Map();
+  for (const line of String(raw || "").split("\n")) {
+    const trimmed = line.replace(/\x1b\[[0-9;]*m/g, "").trim();
+    if (!trimmed || trimmed.startsWith("NAME ")) continue;
+    const match = trimmed.match(/^(\S+)\s+(\S+)\s+(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\s+(\S+)$/);
+    if (!match) continue;
+    const [, name, namespace, createdAt, phase] = match;
+    sandboxes.set(name, {
+      name,
+      namespace,
+      createdAt,
+      phase,
+    });
+  }
+  return sandboxes;
+}
+
+function loadLiveSandboxMap() {
+  try {
+    const output = execSync(`"${OPENSHELL}" sandbox list`, {
+      cwd: REPO_DIR,
+      encoding: "utf-8",
+      timeout: 30000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return parseSandboxList(output);
+  } catch {
+    return new Map();
+  }
+}
+
+function formatDurationFrom(dateLike) {
+  if (!dateLike) return "unknown";
+  const started = new Date(String(dateLike).replace(" ", "T") + (String(dateLike).includes("T") ? "" : "Z"));
+  if (Number.isNaN(started.getTime())) return "unknown";
+  let seconds = Math.max(0, Math.floor((Date.now() - started.getTime()) / 1000));
+  const days = Math.floor(seconds / 86400);
+  seconds -= days * 86400;
+  const hours = Math.floor(seconds / 3600);
+  seconds -= hours * 3600;
+  const minutes = Math.floor(seconds / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+function getInventoryStatus(item) {
+  return item.liveSandbox?.phase || (item.registrySandbox ? "Registry only" : "Unknown");
+}
+
+function getClaudeCredentialSource(user) {
+  if (!user?.credentialsDir) return { mode: "missing", path: "" };
+  const credDir = path.isAbsolute(user.credentialsDir)
+    ? user.credentialsDir
+    : path.join(REPO_DIR, user.credentialsDir);
+  const tokenPath = path.join(credDir, "claude-oauth-token.txt");
+  if (fs.existsSync(tokenPath)) {
+    return { mode: "long-lived-token", path: tokenPath };
+  }
+  const perUserPath = path.join(credDir, "claude-credentials.json");
+  if (fs.existsSync(perUserPath)) {
+    return { mode: "per-user", path: perUserPath };
+  }
+  return { mode: "missing", path: "" };
+}
+
+function describeClaudeCredentialSource(user) {
+  const source = getClaudeCredentialSource(user);
+  if (source.mode === "long-lived-token") return "per-user long-lived token";
+  if (source.mode === "per-user") return "per-user";
+  return "not configured";
+}
+
+function buildAuthRecoveryMessage(user) {
+  const source = getClaudeCredentialSource(user);
+  if (source.mode === "per-user") {
+    return [
+      "Anthropic authentication is still failing after retry.",
+      "Your sandbox is using per-user Claude OAuth credentials, and those tokens are not auto-refreshed by the bridge.",
+      "Run `claude` on your machine to refresh the login, then `!setup claude <fresh ~/.claude/.credentials.json>`. Or switch to `!setup claude-token` for a more durable auth method.",
+    ].join("\n");
+  }
+  if (source.mode === "long-lived-token") {
+    return [
+      "Anthropic authentication is still failing after retry.",
+      "Your sandbox is using a per-user Claude long-lived token from `claude setup-token`.",
+      "Re-run `claude setup-token` on your machine and DM the new token with `!setup claude-token <token>`.",
+    ].join("\n");
+  }
+  return [
+    "Anthropic authentication is not configured for this sandbox.",
+    "Run `!setup claude-token <token>` from `claude setup-token`, or `!setup claude <fresh ~/.claude/.credentials.json>`.",
+  ].join("\n");
+}
+
+function requestLikelyNeedsMcp(text) {
+  return /\bfreshrelease\b|\bmcp\b|\bepic\b|\bissue\b|\bstory\b|\bticket\b|\btask\b|\bsprint\b|\bbacklog\b|\bboard\b|\bassigned\b|\bcalendar\b|\bevent\b|\bmeeting\b|\bgmail\b|\bemail\b|\binbox\b|\bgoogle\b|\bdocs\b|\bdrive\b/i.test(String(text || ""));
+}
+
+function listConfiguredCredentials(user) {
+  if (!user?.credentialsDir) return [];
+  const credDir = path.isAbsolute(user.credentialsDir)
+    ? user.credentialsDir
+    : path.join(REPO_DIR, user.credentialsDir);
+  const configured = [];
+  const checks = [
+    ["Claude Teams token", path.join(credDir, "claude-oauth-token.txt")],
+    ["Claude OAuth", path.join(credDir, "claude-credentials.json")],
+    ["GitHub", path.join(credDir, "gh-hosts.yml")],
+    ["Google (gogcli)", path.join(credDir, "gogcli", "config.json")],
+    ["Freshrelease", path.join(credDir, "freshrelease-api-key.txt")],
+    ["Slack webhook", path.join(credDir, "slack-webhook-url.txt")],
+  ];
+
+  for (const [label, file] of checks) {
+    if (fs.existsSync(file)) configured.push(label);
+  }
+  return configured;
+}
+
+function buildClawInventory() {
+  const { users } = userRegistry.listUsers();
+  const userBySandbox = new Map(users.map((user) => [user.sandboxName, withAdminState(user)]));
+  const registrySandboxes = sandboxRegistry.listSandboxes().sandboxes;
+  const registryByName = new Map(registrySandboxes.map((sandbox) => [sandbox.name, sandbox]));
+  const liveByName = loadLiveSandboxMap();
+  const names = new Set([
+    ...userBySandbox.keys(),
+    ...registryByName.keys(),
+    ...liveByName.keys(),
+  ]);
+
+  return [...names]
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => {
+      const user = userBySandbox.get(name) || null;
+      const registrySandbox = registryByName.get(name) || null;
+      const liveSandbox = liveByName.get(name) || null;
+      const policies = Array.isArray(registrySandbox?.policies) ? registrySandbox.policies : [];
+      const credentials = listConfiguredCredentials(user);
+      return {
+        name,
+        user,
+        registrySandbox,
+        liveSandbox,
+        policies,
+        credentials,
+      };
+    });
+}
+
+function parseShowClawsOptions(text) {
+  const args = parseCommandArgs(canonicalizeAdminCommand(text)).slice(1);
+  const options = {
+    filters: [],
+    sort: "name",
+    match: "",
+    policy: "",
+    credential: "",
+  };
+
+  for (const arg of args) {
+    const lower = String(arg).toLowerCase();
+    if (lower.startsWith("sort=")) {
+      options.sort = lower.slice(5) || "name";
+      continue;
+    }
+    if (lower.startsWith("match=") || lower.startsWith("user=") || lower.startsWith("claw=")) {
+      options.match = arg.slice(arg.indexOf("=") + 1).trim();
+      continue;
+    }
+    if (lower.startsWith("policy=")) {
+      options.policy = arg.slice(arg.indexOf("=") + 1).trim().toLowerCase();
+      continue;
+    }
+    if (lower.startsWith("cred=") || lower.startsWith("credential=")) {
+      options.credential = arg.slice(arg.indexOf("=") + 1).trim().toLowerCase();
+      continue;
+    }
+    if (lower) options.filters.push(lower);
+  }
+
+  return options;
+}
+
+function filterAndSortClawInventory(inventory, options = {}) {
+  let result = [...inventory];
+  const filters = new Set(options.filters || []);
+  const match = (options.match || "").toLowerCase();
+  const policy = (options.policy || "").toLowerCase();
+  const credential = (options.credential || "").toLowerCase();
+
+  if (filters.has("ready")) {
+    result = result.filter((item) => getInventoryStatus(item).toLowerCase() === "ready");
+  }
+  if (filters.has("not-ready")) {
+    result = result.filter((item) => getInventoryStatus(item).toLowerCase() !== "ready");
+  }
+  if (filters.has("registry-only")) {
+    result = result.filter((item) => getInventoryStatus(item).toLowerCase() === "registry only");
+  }
+  if (filters.has("registered")) {
+    result = result.filter((item) => !!item.user);
+  }
+  if (filters.has("unregistered")) {
+    result = result.filter((item) => !item.user);
+  }
+  if (filters.has("admins")) {
+    result = result.filter((item) => isAdminUser(item.user));
+  }
+  if (filters.has("non-admins")) {
+    result = result.filter((item) => item.user && !isAdminUser(item.user));
+  }
+  if (filters.has("gpu")) {
+    result = result.filter((item) => !!item.registrySandbox?.gpuEnabled);
+  }
+
+  if (match) {
+    result = result.filter((item) => {
+      const haystack = [
+        item.name,
+        item.user?.slackUserId,
+        item.user?.slackDisplayName,
+        item.user?.githubUser,
+      ].filter(Boolean).join(" ").toLowerCase();
+      return haystack.includes(match);
+    });
+  }
+
+  if (policy) {
+    result = result.filter((item) => item.policies.some((entry) => entry.toLowerCase().includes(policy)));
+  }
+
+  if (credential) {
+    result = result.filter((item) => item.credentials.some((entry) => entry.toLowerCase().includes(credential)));
+  }
+
+  const sort = (options.sort || "name").toLowerCase();
+  result.sort((a, b) => {
+    if (sort === "user") {
+      return (a.user?.slackDisplayName || a.user?.slackUserId || "").localeCompare(b.user?.slackDisplayName || b.user?.slackUserId || "");
+    }
+    if (sort === "status") {
+      return getInventoryStatus(a).localeCompare(getInventoryStatus(b));
+    }
+    if (sort === "uptime" || sort === "created") {
+      const aTime = new Date((a.liveSandbox?.createdAt || a.registrySandbox?.createdAt || a.user?.createdAt || "").replace(" ", "T") + "Z").getTime() || 0;
+      const bTime = new Date((b.liveSandbox?.createdAt || b.registrySandbox?.createdAt || b.user?.createdAt || "").replace(" ", "T") + "Z").getTime() || 0;
+      return aTime - bTime;
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  return result;
+}
+
+function formatClawInventory(inventory) {
+  if (inventory.length === 0) {
+    return "No claws found in the user or sandbox registries.";
+  }
+
+  const lines = ["*Claw Inventory*"];
+  for (const item of inventory) {
+    const userLabel = item.user
+      ? `${item.user.slackDisplayName || item.user.slackUserId} (\`${item.user.slackUserId}\`)`
+      : "_unregistered_";
+    const github = item.user?.githubUser ? `\`${item.user.githubUser}\`` : "_none_";
+    const livePhase = getInventoryStatus(item);
+    const uptimeSource = item.liveSandbox?.createdAt || item.registrySandbox?.createdAt || item.user?.createdAt || null;
+    const uptime = formatDurationFrom(uptimeSource);
+    const credentials = item.credentials.length > 0 ? item.credentials.join(", ") : "none";
+    const policies = item.policies.length > 0 ? item.policies.join(", ") : "none";
+    const provider = item.registrySandbox?.provider ? `, provider=${item.registrySandbox.provider}` : "";
+    const gpu = item.registrySandbox?.gpuEnabled ? ", gpu=true" : "";
+    lines.push(`• \`${item.name}\` — ${livePhase}, up ${uptime}`);
+    lines.push(`  user: ${userLabel}`);
+    lines.push(`  github: ${github}`);
+    lines.push(`  credentials: ${credentials}`);
+    lines.push(`  policies: ${policies}${provider}${gpu}`);
+  }
+  return lines.join("\n");
+}
+
+function formatShowClaws() {
+  return formatClawInventory(buildClawInventory());
+}
+
+function truncateCell(value, max = 120) {
+  const text = String(value ?? "");
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}
+
+function buildShowClawsTablePayloadFromInventory(inventory, fallbackText = formatClawInventory(inventory)) {
+  if (inventory.length === 0) {
+    return { text: fallbackText };
+  }
+
+  const rows = [
+    [
+      { type: "raw_text", text: "Claw" },
+      { type: "raw_text", text: "User" },
+      { type: "raw_text", text: "Status" },
+      { type: "raw_text", text: "GitHub" },
+      { type: "raw_text", text: "Credentials" },
+      { type: "raw_text", text: "Policies" },
+    ],
+    ...inventory.map((item) => {
+      const userLabel = item.user
+        ? `${item.user.slackDisplayName || item.user.slackUserId} (${item.user.slackUserId})`
+        : "unregistered";
+      const status = `${getInventoryStatus(item)} • ${formatDurationFrom(item.liveSandbox?.createdAt || item.registrySandbox?.createdAt || item.user?.createdAt || null)}`;
+      const github = item.user?.githubUser || "none";
+      const credentials = item.credentials.length > 0 ? item.credentials.join(", ") : "none";
+      const policies = [
+        ...(item.policies.length > 0 ? item.policies : ["none"]),
+        item.registrySandbox?.provider ? `provider=${item.registrySandbox.provider}` : null,
+        item.registrySandbox?.gpuEnabled ? "gpu=true" : null,
+      ].filter(Boolean).join(", ");
+
+      return [
+        { type: "raw_text", text: truncateCell(item.name, 40) },
+        { type: "raw_text", text: truncateCell(userLabel, 60) },
+        { type: "raw_text", text: truncateCell(status, 40) },
+        { type: "raw_text", text: truncateCell(github, 30) },
+        { type: "raw_text", text: truncateCell(credentials, 120) },
+        { type: "raw_text", text: truncateCell(policies, 120) },
+      ];
+    }),
+  ];
+
+  return {
+    text: `Claw inventory (${inventory.length})`,
+    attachments: [
+      {
+        blocks: [
+          {
+            type: "table",
+            column_settings: [
+              { is_wrapped: true },
+              { is_wrapped: true },
+              { is_wrapped: true },
+              { is_wrapped: true },
+              { is_wrapped: true },
+              { is_wrapped: true },
+            ],
+            rows,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function buildShowClawsTablePayload() {
+  return buildShowClawsTablePayloadFromInventory(buildClawInventory());
+}
+
+function buildShowClawsPayload(text) {
+  const options = parseShowClawsOptions(text);
+  const inventory = filterAndSortClawInventory(buildClawInventory(), options);
+
+  if (inventory.length === 0) {
+    return { text: "No claws matched the requested filters." };
+  }
+
+  const payload = buildShowClawsTablePayloadFromInventory(inventory);
+  const summary = [
+    options.filters.length ? `filters=${options.filters.join(",")}` : "",
+    options.match ? `match=${options.match}` : "",
+    options.policy ? `policy=${options.policy}` : "",
+    options.credential ? `cred=${options.credential}` : "",
+    options.sort !== "name" ? `sort=${options.sort}` : "",
+  ].filter(Boolean).join(" | ");
+
+  if (summary) {
+    payload.text = `Claw inventory (${inventory.length}) — ${summary}`;
+  }
+
+  return payload;
+}
+
+function resolveUserLookup(token) {
+  const query = String(token || "").trim();
+  if (!query) return null;
+  const lower = query.toLowerCase();
+  if (/^U[A-Z0-9]+$/.test(query)) return withAdminState(userRegistry.getUser(query));
+  const bySandbox = userRegistry.getUserBySandbox(query);
+  if (bySandbox) return withAdminState(bySandbox);
+  const { users } = userRegistry.listUsers();
+  return withAdminState(users.find((entry) =>
+    entry.slackDisplayName?.toLowerCase().includes(lower) ||
+    entry.githubUser?.toLowerCase().includes(lower) ||
+    entry.sandboxName?.toLowerCase().includes(lower)
+  )) || null;
+}
+
+function buildShowUserText(user) {
+  if (!user) {
+    return "User not found. Usage: `!show-user <slack-id|claw-name|name-fragment>`";
+  }
+
+  const registrySandbox = sandboxRegistry.getSandbox(user.sandboxName);
+  const liveSandbox = loadLiveSandboxMap().get(user.sandboxName);
+  const credentials = listConfiguredCredentials(user);
+  const policies = Array.isArray(registrySandbox?.policies) ? registrySandbox.policies : [];
+  return [
+    "*User Detail*",
+    `User: ${user.slackDisplayName || user.slackUserId} (\`${user.slackUserId}\`)`,
+    `Claw: \`${user.sandboxName}\``,
+    `Enabled: ${user.enabled ? "yes" : "no"}`,
+    `Roles: ${(user.roles || ["user"]).join(", ")}`,
+    `Timezone: \`${user.timezone || "UTC"}\``,
+    `GitHub: ${user.githubUser ? `\`${user.githubUser}\`` : "_none_"}`,
+    `Status: ${liveSandbox?.phase || "Not Found"}`,
+    `Up For: ${formatDurationFrom(liveSandbox?.createdAt || registrySandbox?.createdAt || user.createdAt)}`,
+    `Claude Auth: ${describeClaudeCredentialSource(user)}`,
+    `Credentials: ${credentials.length ? credentials.join(", ") : "none"}`,
+    `Policies: ${policies.length ? policies.join(", ") : "none"}`,
+  ].join("\n");
+}
+
+function buildShowUserPayload(text) {
+  const args = parseCommandArgs(canonicalizeAdminCommand(text)).slice(1);
+  return { text: buildShowUserText(resolveUserLookup(args.join(" "))) };
+}
+
+function formatAddClawUsage() {
+  return "Usage: `!add-claw <slack_id> <display_name> <claw_name> <github_handle>`\nExample: `!add-claw U12345ABC \"Jane Doe\" jane-claw janedoe`";
+}
+
+function buildAddClawSuccessMessage({ slackId, displayName, clawName, githubHandle, userAddOutput = "", resilienceOutput = "", statusSummary = "", warningOutput = "" }) {
+  const sections = [
+    `Created claw \`${clawName}\` for ${displayName} (\`${slackId}\`).`,
+    `GitHub: \`${githubHandle}\``,
+  ];
+  if (userAddOutput.trim()) {
+    sections.push("", "*user-add output*", "```", userAddOutput.trim().slice(-2500), "```");
+  }
+  if (resilienceOutput.trim()) {
+    sections.push("", "*resilience output*", "```", resilienceOutput.trim().slice(-2500), "```");
+  }
+  if (statusSummary.trim()) {
+    sections.push("", "*verification*", "```", statusSummary, "```");
+  }
+  if (warningOutput.trim()) {
+    sections.push("", "*warning*", "```", warningOutput.trim().slice(-2500), "```");
+  }
+  sections.push("", `Claude auth source: ${describeClaudeCredentialSource(userRegistry.getUser(slackId) || { credentialsDir: `persist/users/${slackId}/credentials` })}`);
+  return sections.join("\n");
+}
+
+async function handleAddClaw(user, text) {
+  const args = parseCommandArgs(canonicalizeAdminCommand(text)).slice(1);
+  if (args.length < 4) {
+    return { ok: false, message: formatAddClawUsage() };
+  }
+
+  const [slackId, displayName, clawName, githubHandle] = args;
+  if (!/^U[A-Z0-9]+$/.test(slackId)) {
+    return { ok: false, message: `Invalid Slack user ID: \`${slackId}\`.\n${formatAddClawUsage()}` };
+  }
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(clawName)) {
+    return { ok: false, message: `Invalid claw name: \`${clawName}\`.` };
+  }
+  if (!displayName.trim() || !githubHandle.trim()) {
+    return { ok: false, message: formatAddClawUsage() };
+  }
+  if (displayName.trim().length > MAX_DISPLAY_NAME_LENGTH) {
+    return { ok: false, message: `Display name is too long. Limit is ${MAX_DISPLAY_NAME_LENGTH} characters.` };
+  }
+  if (!/^[A-Za-z0-9-]+$/.test(githubHandle) || githubHandle.length > MAX_GITHUB_HANDLE_LENGTH) {
+    return {
+      ok: false,
+      message: `Invalid GitHub handle: \`${githubHandle}\`. Use letters, numbers, hyphens, and at most ${MAX_GITHUB_HANDLE_LENGTH} characters.`,
+    };
+  }
+
+  auditAdminAction(user, "add-claw", { slackId, displayName, clawName, githubHandle }, "started");
+
+  try {
+    const userAddOutput = runAdminCommand(process.execPath, [
+      "bin/nemoclaw.js",
+      "user-add",
+      "--non-interactive",
+      "--slack-id",
+      slackId,
+      "--display-name",
+      displayName,
+      "--claw-name",
+      clawName,
+      "--github-user",
+      githubHandle,
+    ]);
+    const resilienceOutput = runAdminCommand("bash", [
+      "scripts/nemoclaw-resilience.sh",
+      "--sandbox",
+      clawName,
+      "--cred-dir",
+      `persist/users/${slackId}/credentials`,
+      "--github-user",
+      githubHandle,
+      "--slack-user-id",
+      slackId,
+    ], 600000);
+    const statusSummary = getProvisioningSummary(slackId, clawName);
+    auditAdminAction(user, "add-claw", { slackId, displayName, clawName, githubHandle }, "succeeded");
+    return {
+      ok: true,
+      message: buildAddClawSuccessMessage({ slackId, displayName, clawName, githubHandle, userAddOutput, resilienceOutput, statusSummary }),
+    };
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`.trim() || err.message;
+    const createdUser = userRegistry.getUser(slackId);
+    const liveSandbox = loadLiveSandboxMap().get(clawName);
+    const sandboxReady = liveSandbox?.phase === "Ready";
+    if (createdUser?.sandboxName === clawName && sandboxReady) {
+      const statusSummary = getProvisioningSummary(slackId, clawName);
+      auditAdminAction(user, "add-claw", { slackId, displayName, clawName, githubHandle }, "succeeded-with-warning", output.slice(0, 1000));
+      return {
+        ok: true,
+        message: buildAddClawSuccessMessage({
+          slackId,
+          displayName,
+          clawName,
+          githubHandle,
+          statusSummary,
+          warningOutput: `Provisioning completed, but an intermediate step returned a noisy error.\n${output}`,
+        }),
+      };
+    }
+    auditAdminAction(user, "add-claw", { slackId, displayName, clawName, githubHandle }, "failed", output.slice(0, 1000));
+    return {
+      ok: false,
+      message: `Failed to create claw \`${clawName}\`.\n\`\`\`\n${output.slice(-3500)}\n\`\`\``,
+    };
+  }
+}
+
+async function handleDeleteClaw(user, text) {
+  const args = parseCommandArgs(canonicalizeAdminCommand(text)).slice(1);
+  if (args.length !== 1) {
+    return {
+      ok: false,
+      message: "Usage: `!delete-claw <claw_name>`\nExample: `!delete-claw alice-claw`",
+    };
+  }
+
+  const clawName = args[0];
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(clawName)) {
+    return { ok: false, message: `Invalid claw name: \`${clawName}\`.` };
+  }
+
+  const targetUser = userRegistry.getUserBySandbox(clawName);
+  if (!targetUser) {
+    return { ok: false, message: `No registered claw found for \`${clawName}\`.` };
+  }
+
+  pendingDeleteRequests.set(user.slackUserId, {
+    clawName,
+    requestedAt: Date.now(),
+  });
+  auditAdminAction(user, "delete-claw-requested", { clawName, targetSlackUserId: targetUser.slackUserId }, "started");
+  return {
+    ok: true,
+    message: [
+      `Delete request staged for \`${clawName}\` owned by ${targetUser.slackDisplayName || targetUser.slackUserId} (\`${targetUser.slackUserId}\`).`,
+      "This will destroy the sandbox, remove the user registry entry, and delete all persist data.",
+      `Confirmation expires in ${Math.floor(DELETE_CONFIRM_TTL_MS / 60000)} minutes.`,
+      "If the bridge restarts before you confirm, the staged delete is discarded and you must run `!delete-claw` again.",
+      `If you want to continue, reply with: \`!confirm-delete-claw ${clawName}\``,
+    ].join("\n"),
+  };
+}
+
+async function handleConfirmDeleteClaw(user, text) {
+  const args = parseCommandArgs(canonicalizeAdminCommand(text)).slice(1);
+  if (args.length !== 1) {
+    return {
+      ok: false,
+      message: "Usage: `!confirm-delete-claw <claw_name>`",
+    };
+  }
+
+  const clawName = args[0];
+  const pending = pendingDeleteRequests.get(user.slackUserId);
+  if (pending && Date.now() - pending.requestedAt > DELETE_CONFIRM_TTL_MS) {
+    pendingDeleteRequests.delete(user.slackUserId);
+  }
+  const activePending = pendingDeleteRequests.get(user.slackUserId);
+  if (!activePending || activePending.clawName !== clawName) {
+    return {
+      ok: false,
+      message: `No active pending delete request found for \`${clawName}\`. It may have expired or been lost during a bridge restart. Start again with \`!delete-claw ${clawName}\`.`,
+    };
+  }
+
+  pendingDeleteRequests.delete(user.slackUserId);
+  auditAdminAction(user, "delete-claw-confirmed", { clawName }, "started");
+
+  try {
+    const purgeOutput = runAdminCommand(process.execPath, [
+      "bin/nemoclaw.js",
+      "user-purge",
+      "--sandbox",
+      clawName,
+    ], 600000);
+    auditAdminAction(user, "delete-claw-confirmed", { clawName }, "succeeded");
+    return {
+      ok: true,
+      message: [
+        `Deleted claw \`${clawName}\`.`,
+        "",
+        "```",
+        purgeOutput.trim().slice(-3000) || "(no output)",
+        "```",
+      ].join("\n"),
+    };
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`.trim() || err.message;
+    auditAdminAction(user, "delete-claw-confirmed", { clawName }, "failed", output.slice(0, 1000));
+    return {
+      ok: false,
+      message: `Failed to delete claw \`${clawName}\`.\n\`\`\`\n${output.slice(-3500)}\n\`\`\``,
+    };
+  }
+}
+
+function refreshCredentials(sandboxName, credDir = "") {
+  console.log(`[refresh] Triggering credential refresh for ${sandboxName}...`);
+  try {
+    const args = [path.join(REPO_DIR, "scripts", "refresh-credentials.sh"), sandboxName];
+    if (credDir) {
+      args.push("--cred-dir", credDir);
+    }
+    execFileSync(args[0], args.slice(1), {
+      timeout: 120000,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+    console.log(`[refresh] Credentials refreshed for ${sandboxName}`);
+    return true;
+  } catch (err) {
+    console.error(`[refresh] Failed to refresh credentials for ${sandboxName}:`, err.message);
+    return false;
+  }
+}
+
+function getRuntimeFallbackModels(sandboxName) {
+  const script = Buffer.from(
+    `import json, os\n` +
+    `path=os.path.expanduser('~/.openclaw/openclaw.json')\n` +
+    `try:\n    cfg=json.load(open(path))\nexcept Exception:\n    print('{}')\n    raise SystemExit(0)\n` +
+    `providers=((cfg.get('models') or {}).get('providers') or {})\n` +
+    `out={}\n` +
+    `for name in ('nvidia','ollama','inference'):\n` +
+    `    val=providers.get(name)\n` +
+    `    if isinstance(val, dict):\n` +
+    `        models=val.get('models') or []\n` +
+    `        mids=[m.get('id') for m in models if isinstance(m, dict) and m.get('id')]\n` +
+    `        if mids:\n            out[name]=mids\n` +
+    `print(json.dumps(out))\n`
+  ).toString("base64");
+
+  try {
+    const sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${sandboxName}"`, { encoding: "utf-8" });
+    const confPath = `/tmp/nemoclaw-fallback-${sandboxName}.conf`;
+    fs.writeFileSync(confPath, sshConfig);
+    try {
+      const raw = execFileSync("ssh", [
+        "-T", "-F", confPath, `openshell-${sandboxName}`,
+        `echo '${script}' | base64 -d | python3`,
+      ], {
+        encoding: "utf-8",
+        timeout: 30000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const parsed = JSON.parse(raw.trim() || "{}");
+      return {
+        nvidia: parsed.nvidia?.[0] || null,
+        ollama: parsed.ollama?.[0] || null,
+      };
+    } finally {
+      try { fs.unlinkSync(confPath); } catch {}
+    }
+  } catch {
+    return { nvidia: null, ollama: null };
+  }
+}
+
+function buildAgentCommand(message, sessionId, user, options = {}) {
+  const escaped = message.replace(/'/g, "'\\''");
+  const setupLines = [
+    `export NVIDIA_API_KEY='${sh(API_KEY)}'`,
+    `export OPENAI_API_KEY='${sh(API_KEY)}'`,
+    "export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache",
+    "export OPENCLAW_NO_RESPAWN=1",
+    `export NEMOCLAW_SLACK_USER_ID='${sh(user.slackUserId)}'`,
+    `export NEMOCLAW_SLACK_DISPLAY_NAME='${sh(user.slackDisplayName || user.slackUserId)}'`,
+    `export NEMOCLAW_USER_ROLES='${sh((user.roles || ["user"]).join(","))}'`,
+    `export NEMOCLAW_IS_ADMIN='${(user.roles || []).includes("admin") ? "1" : "0"}'`,
+    "source /sandbox/.bashrc 2>/dev/null",
+  ];
+  if (options.skipClaudeAuth) {
+    setupLines.push("unset ANTHROPIC_API_KEY");
+    setupLines.push("export NEMOCLAW_SKIP_CLAUDE_AUTH=1");
+  }
+  const scriptLines = [...setupLines];
+  // Clean stale session locks before running (zombie openclaw-agent processes leave orphan locks)
+  scriptLines.push(`find /sandbox/.openclaw/agents -name '*.lock' -mmin +2 -delete 2>/dev/null || true`);
+  scriptLines.push(`nemoclaw-start openclaw agent --agent main --local -m '${escaped}' --session-id 'slack-${sessionId}'`);
+  return scriptLines.join("\n");
+}
+
+function syncSandboxSelectionConfig(user, provider, model) {
+  const selectionConfig = getProviderSelectionConfig(provider, model);
+  if (!selectionConfig) return;
+  const sandboxName = user.sandboxName;
+  const cfgPayload = Buffer.from(JSON.stringify({ ...selectionConfig, onboardedAt: new Date().toISOString() })).toString("base64");
+  const script = Buffer.from(
+    `import json, os\n` +
+    `import base64\n` +
+    `path = os.path.expanduser('~/.nemoclaw/config.json')\n` +
+    `os.makedirs(os.path.dirname(path), exist_ok=True)\n` +
+    `cfg = json.loads(base64.b64decode(${JSON.stringify(cfgPayload)}).decode())\n` +
+    `json.dump(cfg, open(path, 'w'), indent=2)\n`
+  ).toString("base64");
+
+  let sshConfig;
+  try {
+    sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${sandboxName}"`, { encoding: "utf-8" });
+  } catch {
+    return;
+  }
+  const confPath = `/tmp/nemoclaw-sync-${sandboxName}-${process.pid}-${Date.now()}.conf`;
+  fs.writeFileSync(confPath, sshConfig);
+  try {
+    execFileSync("ssh", ["-T", "-F", confPath, `openshell-${sandboxName}`, `echo '${script}' | base64 -d | python3`], {
+      encoding: "utf-8",
+      timeout: 30000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } finally {
+    try { fs.unlinkSync(confPath); } catch {}
+  }
+}
+
+const _primaryModelCache = new Map();
+
+function getSandboxPrimaryModel(sandboxName) {
+  const script = Buffer.from(
+    `import json, os\n` +
+    `path = os.path.expanduser('~/.openclaw/openclaw.json')\n` +
+    `try:\n    cfg = json.load(open(path))\nexcept: exit(0)\n` +
+    `print(cfg.get('agents',{}).get('defaults',{}).get('model',{}).get('primary',''))\n`
+  ).toString("base64");
+
+  let sshConfig;
+  try {
+    sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${sandboxName}"`, { encoding: "utf-8" });
+  } catch { return null; }
+  const confPath = `/tmp/nemoclaw-getmodel-${sandboxName}-${process.pid}.conf`;
+  fs.writeFileSync(confPath, sshConfig);
+  try {
+    const result = execFileSync("ssh", ["-T", "-F", confPath, `openshell-${sandboxName}`, `echo '${script}' | base64 -d | python3`], {
+      encoding: "utf-8", timeout: 10000, stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    return result || null;
+  } catch { return null; }
+  finally { try { fs.unlinkSync(confPath); } catch {} }
+}
+
+function setSandboxPrimaryModel(user, primaryModelRef) {
+  const sandboxName = user.sandboxName;
+  if (_primaryModelCache.get(sandboxName) === primaryModelRef) return;
+
+  const script = Buffer.from(
+    `import json, os, sys\n` +
+    `path = os.path.expanduser('~/.openclaw/openclaw.json')\n` +
+    `if not os.access(path, os.W_OK):\n` +
+    `    print('skip: not writable', file=sys.stderr)\n` +
+    `    sys.exit(0)\n` +
+    `cfg = json.load(open(path))\n` +
+    `cfg.setdefault('agents', {}).setdefault('defaults', {}).setdefault('model', {})['primary'] = ${JSON.stringify(primaryModelRef)}\n` +
+    `json.dump(cfg, open(path, 'w'), indent=2)\n` +
+    `os.chmod(path, 0o600)\n`
+  ).toString("base64");
+
+  let sshConfig;
+  try {
+    sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${sandboxName}"`, { encoding: "utf-8" });
+  } catch {
+    return;
+  }
+  const confPath = `/tmp/nemoclaw-primary-${sandboxName}-${process.pid}-${Date.now()}.conf`;
+  fs.writeFileSync(confPath, sshConfig);
+  try {
+    execFileSync("ssh", ["-T", "-F", confPath, `openshell-${sandboxName}`, `echo '${script}' | base64 -d | python3`], {
+      encoding: "utf-8",
+      timeout: 30000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    _primaryModelCache.set(sandboxName, primaryModelRef);
+  } finally {
+    try { fs.unlinkSync(confPath); } catch {}
+  }
+}
+
+function selectInferenceRoute(user, provider, model) {
+  execFileSync(OPENSHELL, ["gateway", "select", "nemoclaw"], {
+    encoding: "utf-8",
+    timeout: 30000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const env = { ...process.env };
+  if (provider === "nvidia-nim") {
+    env.OPENAI_API_KEY = API_KEY;
+  } else if (provider === "ollama-local") {
+    env.OPENAI_API_KEY = "ollama";
+  }
+  execFileSync(OPENSHELL, ["inference", "set", "--no-verify", "--provider", provider, "--model", model], {
+    encoding: "utf-8",
+    timeout: 30000,
+    stdio: ["ignore", "pipe", "pipe"],
+    env,
+  });
+  syncSandboxSelectionConfig(user, provider, model);
+  if (provider === "nvidia-nim") {
+    setSandboxPrimaryModel(user, `nvidia/${model}`);
+  } else if (provider === "ollama-local") {
+    setSandboxPrimaryModel(user, `ollama/${model}`);
+  } else if (provider === "anthropic-prod") {
+    setSandboxPrimaryModel(user, `anthropic/${model}`);
+  }
+}
+
+// ── Fallback routing on auth failure or rate limit ────────────────
+
+// Fallback chain: NVIDIA Nemotron → Ollama (deepseek-r1 → qwen3-coder → gpt-oss)
+const OLLAMA_FALLBACK_MODELS = ["deepseek-r1:70b", "qwen3-coder:30b", "gpt-oss:latest"];
+
+async function attemptFallbackRouting(user, text, baseSessionId, channel, displayName) {
+  const fallbackModels = getRuntimeFallbackModels(user.sandboxName);
+  console.log(`[${channel}] fallback models for ${user.sandboxName}:`, fallbackModels);
+
+  const isUsable = (resp) => resp && !AUTH_ERROR_RE.test(resp) && !RATE_LIMIT_RE.test(resp) && !/Unknown model:/i.test(resp) && !/no response/i.test(resp);
+
+  try {
+    // 1. Try NVIDIA Nemotron
+    if (fallbackModels.nvidia) {
+      console.log(`[${channel}] trying NVIDIA fallback: ${fallbackModels.nvidia}`);
+      selectInferenceRoute(user, "nvidia-nim", fallbackModels.nvidia);
+      const nvidiaResponse = await runAgentInSandbox(text, `${baseSessionId}-nvidia`, user, { skipClaudeAuth: true });
+      console.log(`[${channel}] ${user.sandboxName} → ${displayName} (nvidia): ${nvidiaResponse.slice(0, 100)}...`);
+      if (isUsable(nvidiaResponse)) {
+        return `[fallback: NVIDIA Nemotron]\n${nvidiaResponse}`;
+      }
+    }
+
+    // 2. Try Ollama models in preference order: kimi-k2 → deepseek-r1 → gpt-oss
+    if (fallbackModels.ollama) {
+      for (const model of OLLAMA_FALLBACK_MODELS) {
+        console.log(`[${channel}] trying Ollama fallback: ${model}`);
+        selectInferenceRoute(user, "ollama-local", model);
+        const ollamaResponse = await runAgentInSandbox(text, `${baseSessionId}-ollama-${model.replace(/[^a-z0-9]/g, "")}`, user, { skipClaudeAuth: true });
+        console.log(`[${channel}] ${user.sandboxName} → ${displayName} (ollama/${model}): ${ollamaResponse.slice(0, 100)}...`);
+        if (isUsable(ollamaResponse)) {
+          return `[fallback: Ollama ${model}]\n${ollamaResponse}`;
+        }
+      }
+    }
+
+    return "All inference providers are unavailable (Anthropic rate-limited, NVIDIA and Ollama fallbacks failed). Please try again in a few minutes.";
+  } catch (fallbackErr) {
+    return `Fallback routing failed: ${fallbackErr.message}`;
+  } finally {
+    // Restore the sandbox's configured primary model (may be Ollama or Anthropic)
+    try {
+      const sandboxPrimary = getSandboxPrimaryModel(user.sandboxName);
+      if (sandboxPrimary) {
+        setSandboxPrimaryModel(user, sandboxPrimary);
+      }
+    } catch (restoreErr) {
+      console.error(`[${channel}] failed to restore primary model for ${user.sandboxName}: ${restoreErr.message}`);
+    }
+  }
+}
+
+// ── WhatsApp forwarding for notifications ────────────────────────
+// Forwards notification-like messages (heartbeat alerts, reminders) to WhatsApp.
+// Only triggers for messages with notification markers (emoji prefixes).
+
+const WA_NOTIFICATION_RE = /^[📧📅⏰🔔⚠️❗🚨📌📋✅🆘]/u;
+
+function maybeForwardToWhatsApp(user, message) {
+  if (!message || !WA_NOTIFICATION_RE.test(message.trim())) return;
+  const waNumberFile = `${REPO_DIR}/persist/users/${user.slackUserId}/credentials/whatsapp-number.txt`;
+  if (!fs.existsSync(waNumberFile)) return;
+  const waNumber = fs.readFileSync(waNumberFile, "utf-8").trim();
+  if (!waNumber) return;
+  // Strip markdown for WhatsApp
+  const plainMsg = message.replace(/\*([^*]+)\*/g, "$1").replace(/<([^|>]+)\|([^>]+)>/g, "$2").trim();
+  try {
+    execFileSync("node", [`${REPO_DIR}/scripts/whatsapp-bridge.js`, "send", waNumber, plainMsg], {
+      encoding: "utf-8",
+      timeout: 30000,
+      env: { ...process.env, SLACK_USER_ID: user.slackUserId },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    console.log(`[wa] Forwarded notification to ${waNumber} for ${user.slackDisplayName}`);
+  } catch (err) {
+    console.error(`[wa] Forward failed for ${user.slackDisplayName}: ${(err.message || "").slice(0, 100)}`);
+  }
+}
+
+// ── Response → Slack table blocks ────────────────────────────────
+// Detects markdown tables OR structured numbered/bullet lists in
+// agent responses and converts them to Slack native table blocks.
+
+const MD_TABLE_RE = /(?:^|\n)((?:\|[^\n]+\|\s*\n)*\|[^\n]+\|[^\n]*)/g;
+const MD_SEPARATOR_RE = /^\|[\s:|-]+\|$/;
+
+function parseMarkdownTable(tableText) {
+  const lines = tableText.trim().split("\n").map((l) => l.trim()).filter(Boolean);
+  if (lines.length < 2) return null;
+
+  const parseRow = (line) =>
+    line.replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => c.trim());
+
+  const header = parseRow(lines[0]);
+  const dataStart = MD_SEPARATOR_RE.test(lines[1]) ? 2 : 1;
+  const rows = lines.slice(dataStart).filter((l) => !MD_SEPARATOR_RE.test(l)).map(parseRow);
+
+  if (header.length === 0 || rows.length === 0) return null;
+  return { header, rows };
+}
+
+// Parse structured numbered lists like:
+//   1. **KEY** — Title · Status · Assignee
+//   2. **KEY** — Title · Status · Assignee
+// Also handles: - **KEY** — ... and bullet variants
+function parseStructuredList(response) {
+  const lines = response.split("\n").map((l) => l.trim()).filter(Boolean);
+
+  // Find consecutive numbered/bulleted lines with a consistent separator pattern
+  // Match: "1. **SOMETHING** — rest" or "- **SOMETHING** — rest"
+  const ITEM_RE = /^(?:\d+\.\s+|\*\s+|-\s+)\*{0,2}([A-Z][\w-]*(?:-\d+)?)\*{0,2}\s*[—–-]\s*(.+)$/;
+  const items = [];
+  let listStart = -1;
+  let listEnd = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(ITEM_RE);
+    if (m) {
+      if (listStart === -1) listStart = i;
+      listEnd = i;
+      items.push({ key: m[1], rest: m[2] });
+    } else if (items.length > 0) {
+      break; // list ended
+    }
+  }
+
+  if (items.length < 2) return null;
+
+  // Split the "rest" by · (middle dot), • (bullet), or | (pipe)
+  const splitRest = (rest) => rest.split(/\s*[·•|]\s*/).map((s) => s.replace(/\*{1,2}/g, "").trim()).filter(Boolean);
+
+  const parsed = items.map((item) => [item.key, ...splitRest(item.rest)]);
+  const maxCols = Math.max(...parsed.map((r) => r.length));
+  if (maxCols < 2) return null;
+
+  // Infer column headers from content patterns
+  const headers = ["Key"];
+  // First non-key column is usually title/name
+  if (maxCols >= 2) headers.push("Title");
+  if (maxCols >= 3) headers.push("Status");
+  if (maxCols >= 4) headers.push("Assignee");
+  for (let i = headers.length; i < maxCols; i++) headers.push(`Col ${i + 1}`);
+
+  // Pad rows
+  const rows = parsed.map((r) => {
+    while (r.length < maxCols) r.push("");
+    return r.slice(0, maxCols);
+  });
+
+  // Reconstruct which part of the response is the list
+  const beforeLines = lines.slice(0, listStart);
+  const afterLines = lines.slice(listEnd + 1);
+
+  return { header: headers, rows, before: beforeLines.join("\n").trim(), after: afterLines.join("\n").trim() };
+}
+
+// Convert markdown links [text](url) to Slack mrkdwn <url|text>
+function mdLinksToSlack(text) {
+  return String(text).replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>");
+}
+
+function cellHasLinks(text) {
+  return /\[([^\]]+)\]\(([^)]+)\)/.test(String(text));
+}
+
+function tableHasLinks(header, rows) {
+  return [...header, ...rows.flat()].some((c) => cellHasLinks(c));
+}
+
+// Convert a cell value to a rich_text element array.
+// Handles markdown links [text](url) → link elements, plain text otherwise.
+function cellToRichTextElements(cell) {
+  const text = String(cell);
+  const elements = [];
+  const linkRe = /\[([^\]]+)\]\(([^)]+)\)/g;
+  let lastIndex = 0;
+  let m;
+  while ((m = linkRe.exec(text)) !== null) {
+    if (m.index > lastIndex) {
+      elements.push({ type: "text", text: text.slice(lastIndex, m.index) });
+    }
+    elements.push({ type: "link", url: m[2], text: m[1] });
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < text.length) {
+    elements.push({ type: "text", text: text.slice(lastIndex) });
+  }
+  return elements.length > 0 ? elements : [{ type: "text", text: text || " " }];
+}
+
+// Strip markdown links to plain text for table cells: [text](url) → text
+function stripMdLinks(text) {
+  return String(text).replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1");
+}
+
+// Extract all markdown links from text as Slack mrkdwn links
+function extractLinks(rows) {
+  const links = [];
+  const seen = new Set();
+  for (const row of rows) {
+    for (const cell of row) {
+      const re = /\[([^\]]+)\]\(([^)]+)\)/g;
+      let m;
+      while ((m = re.exec(String(cell))) !== null) {
+        if (!seen.has(m[2])) {
+          seen.add(m[2]);
+          links.push(`<${m[2]}|${m[1]}>`);
+        }
+      }
+    }
+  }
+  return links;
+}
+
+function buildSlackTableBlock(header, rows) {
+  const colCount = header.length;
+  const hasLinks = tableHasLinks(header, rows);
+
+  // Always use native table block — strip links from cells to plain text
+  const slackRows = [
+    header.map((h) => ({ type: "raw_text", text: stripMdLinks(h).slice(0, 120) })),
+    ...rows.map((row) => {
+      const cells = row.map((cell) => ({ type: "raw_text", text: stripMdLinks(cell).slice(0, 120) }));
+      while (cells.length < colCount) cells.push({ type: "raw_text", text: "" });
+      return cells.slice(0, colCount);
+    }),
+  ];
+
+  const tableBlock = {
+    type: "table",
+    column_settings: header.map(() => ({ is_wrapped: true })),
+    rows: slackRows,
+  };
+
+  // If links were present, return table + links section
+  if (hasLinks) {
+    const links = extractLinks(rows);
+    if (links.length > 0) {
+      return [
+        tableBlock,
+        { type: "context", elements: [{ type: "mrkdwn", text: links.join("  ·  ") }] },
+      ];
+    }
+  }
+
+  return [tableBlock];
+}
+
+// Convert markdown formatting to Slack mrkdwn
+function mdToSlack(text) {
+  return text
+    // ## Heading → *Heading* (bold)
+    .replace(/^#{1,3}\s+(.+)$/gm, "*$1*")
+    // --- horizontal rule → newline
+    .replace(/^---$/gm, "")
+    // **bold** → *bold* (Slack uses single asterisk)
+    // But skip if the content is a URL (don't wrap links in bold asterisks)
+    .replace(/\*\*([^*]+)\*\*/g, (match, content) => {
+      if (/^https?:\/\//.test(content.trim())) return content.trim();
+      return `*${content}*`;
+    });
+}
+
+function buildSlackTablePayload(response) {
+  // Strategy 1: Look for markdown tables (| col | col |)
+  const tables = [];
+  let match;
+  MD_TABLE_RE.lastIndex = 0;
+  while ((match = MD_TABLE_RE.exec(response)) !== null) {
+    const parsed = parseMarkdownTable(match[1]);
+    if (parsed && parsed.header.length >= 2 && parsed.rows.length >= 1) {
+      tables.push({ raw: match[1], start: match.index, ...parsed });
+    }
+  }
+
+  if (tables.length > 0) {
+    const blocks = [];
+    let cursor = 0;
+    for (const table of tables) {
+      const before = response.slice(cursor, table.start).trim();
+      if (before) blocks.push({ type: "section", text: { type: "mrkdwn", text: mdToSlack(mdLinksToSlack(before)).slice(0, 3000) } });
+      blocks.push(...buildSlackTableBlock(table.header, table.rows));
+      cursor = table.start + table.raw.length;
+    }
+    const after = response.slice(cursor).trim();
+    if (after) blocks.push({ type: "section", text: { type: "mrkdwn", text: mdToSlack(mdLinksToSlack(after)).slice(0, 3000) } });
+
+    const tableBlocks = blocks.filter((b) => b.type === "table");
+    const nonTableBlocks = blocks.filter((b) => b.type !== "table");
+    const payload = { text: response.slice(0, 200) };
+    if (tableBlocks.length > 0) {
+      // Native table blocks go in attachments, everything else in main blocks
+      if (nonTableBlocks.length > 0) payload.blocks = nonTableBlocks.slice(0, 20);
+      payload.attachments = [{ blocks: tableBlocks.slice(0, 5) }];
+    } else {
+      // All blocks are sections/rich_text (no native tables)
+      payload.blocks = blocks.slice(0, 20);
+    }
+    return payload;
+  }
+
+  // Strategy 2: Look for structured numbered/bullet lists
+  const listData = parseStructuredList(response);
+  if (listData) {
+    const blocks = [];
+    if (listData.before) blocks.push({ type: "section", text: { type: "mrkdwn", text: mdToSlack(mdLinksToSlack(listData.before)).slice(0, 3000) } });
+    const tableBlocks = buildSlackTableBlock(listData.header, listData.rows);
+    if (listData.after) blocks.push({ type: "section", text: { type: "mrkdwn", text: mdToSlack(mdLinksToSlack(listData.after)).slice(0, 3000) } });
+
+    const nativeTableBlocks = tableBlocks.filter((b) => b.type === "table");
+    const otherBlocks = [...blocks, ...tableBlocks.filter((b) => b.type !== "table")];
+    const payload = { text: response.slice(0, 200) };
+    if (otherBlocks.length > 0) payload.blocks = otherBlocks.slice(0, 20);
+    if (nativeTableBlocks.length > 0) payload.attachments = [{ blocks: nativeTableBlocks.slice(0, 5) }];
+    return payload;
+  }
+
+  return null;
+}
+
+// ── Pending runs tracker (survives bridge restarts) ──────────────
+// Persists in-flight agent runs to disk so a restarted bridge can
+// deliver completed results that were orphaned by the restart.
+
+const PENDING_RUNS_FILE = path.join(REPO_DIR, "persist", "pending-slack-runs.json");
+
+function loadPendingRuns() {
+  try { return JSON.parse(fs.readFileSync(PENDING_RUNS_FILE, "utf-8")); } catch { return {}; }
+}
+
+function savePendingRuns(runs) {
+  try { fs.writeFileSync(PENDING_RUNS_FILE, JSON.stringify(runs, null, 2)); } catch {}
+}
+
+function addPendingRun(sessionId, info) {
+  const runs = loadPendingRuns();
+  runs[sessionId] = { ...info, startedAt: Date.now() };
+  savePendingRuns(runs);
+}
+
+function removePendingRun(sessionId) {
+  const runs = loadPendingRuns();
+  delete runs[sessionId];
+  savePendingRuns(runs);
+}
+
+// On bridge startup: recover orphaned completed runs
+async function recoverOrphanedRuns(slackClient) {
+  const runs = loadPendingRuns();
+  const now = Date.now();
+  let recovered = 0;
+
+  for (const [sessionId, info] of Object.entries(runs)) {
+    // Skip runs older than 1 hour (stale)
+    if (now - info.startedAt > 3600000) {
+      delete runs[sessionId];
+      continue;
+    }
+
+    const tag = `slack-${sessionId}`.replace(/[^a-zA-Z0-9_-]/g, "_");
+    const rcFile = `/tmp/nemoclaw-agent-${tag}.rc`;
+    const outFile = `/tmp/nemoclaw-agent-${tag}.out`;
+
+    let sshConfig;
+    try {
+      sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${info.sandboxName}"`, { encoding: "utf-8" });
+    } catch { continue; }
+
+    const confPath = `/tmp/nemoclaw-recover-${sessionId}.conf`;
+    fs.writeFileSync(confPath, sshConfig);
+
+    try {
+      const rc = sshExec(confPath, info.sandboxName, `cat ${rcFile} 2>/dev/null || echo __pending__`, 10000);
+      if (rc === "__pending__") {
+        // Still running — leave it, a new poll will pick it up if user resends
+        continue;
+      }
+
+      // Completed! Read and deliver
+      const raw = sshExec(confPath, info.sandboxName, `cat ${outFile} 2>/dev/null`, 15000);
+      sshExec(confPath, info.sandboxName, `rm -f ${outFile} ${rcFile} 2>/dev/null`, 5000);
+
+      const response = filterAgentOutput(raw);
+      if (response && info.channel && info.thinkingTs) {
+        const tablePayload = buildSlackTablePayload(response);
+        if (tablePayload) {
+          await slackClient.chat.update({ token: SLACK_BOT_TOKEN, channel: info.channel, ts: info.thinkingTs, ...tablePayload });
+        } else {
+          await slackClient.chat.update({ token: SLACK_BOT_TOKEN, channel: info.channel, ts: info.thinkingTs, text: response });
+        }
+        console.log(`[recovery] Delivered orphaned result for ${info.displayName}: ${response.slice(0, 80)}...`);
+        recovered++;
+      }
+    } catch (err) {
+      console.error(`[recovery] Failed for ${sessionId}: ${err.message}`);
+    } finally {
+      try { fs.unlinkSync(confPath); } catch {}
+    }
+
+    delete runs[sessionId];
+  }
+
+  savePendingRuns(runs);
+  if (recovered > 0) console.log(`[recovery] Delivered ${recovered} orphaned result(s)`);
+}
+
+// ── Run agent inside sandbox (fire-and-poll) ─────────────────────
+// Launches the agent in the background inside the sandbox and polls
+// for the result via short SSH calls.  This avoids the OpenShell SSH
+// proxy killing long-running connections (exit 255).
+
+function filterAgentOutput(raw) {
+  // First pass: strip known multi-line noise blocks
+  let cleaned = raw
+    // Strip [agent] run ... ended with stopReason lines and everything before the first real content
+    .replace(/\[agent\] run [^\n]+\n/g, "")
+    // Strip "Failing gates:" blocks (multi-line)
+    .replace(/Failing gates:[\s\S]*?(?=\n[A-Z]|\n\n)/g, "")
+    // Strip "Fix-it keys:" blocks
+    .replace(/Fix-it keys:[\s\S]*?(?=\n[A-Z]|\n\n)/g, "")
+    // Strip "Context: session=" lines
+    .replace(/Context: session=[^\n]+\n/g, "")
+    // Strip "Command not found" lines
+    .replace(/^Command not found$/gm, "")
+    // Strip trailing pipes on heading lines (agent mixes ## headings with table syntax)
+    .replace(/^(#{1,3} .+?)\s*\|\s*$/gm, "$1")
+    // Strip "On it — delegating to Claude Code" preamble noise
+    .replace(/^On it —[^\n]*delegating[^\n]*\n/gm, "")
+    // Strip standalone --- horizontal rules
+    .replace(/^---\s*$/gm, "");
+
+  // Second pass: line-by-line filter
+  return cleaned.split("\n").filter(
+    (l) =>
+      !l.startsWith("Setting up NemoClaw") &&
+      !l.startsWith("[plugins]") &&
+      !l.startsWith("[credentials]") &&
+      !l.startsWith("[config]") &&
+      !l.startsWith("[inject]") &&
+      !l.startsWith("[gateway]") &&
+      !l.startsWith("[auto-pair]") &&
+      !l.startsWith("[diagnostic]") &&
+      !l.startsWith("[SECURITY]") &&
+      !l.startsWith("[tools]") &&
+      !l.startsWith("[agent/") &&
+      !l.startsWith("[agent]") &&
+      !l.startsWith("[memory]") &&
+      !l.startsWith("[SECURITY WARNING]") &&
+      !l.startsWith("(node:") &&
+      !l.startsWith("(Use node") &&
+      !l.startsWith("(Use `node") &&
+      !/^\[UNDICI-/.test(l) &&
+      !/^Warning:.*EnvHttpProxyAgent/.test(l) &&
+      !/^Traceback \(most recent/.test(l) &&
+      !/^PermissionError:/.test(l) &&
+      !/^Error:.*ENOENT/.test(l) &&
+      !/^- tools\.elevated/.test(l) &&
+      !/^- agents\.list/.test(l) &&
+      !l.includes("NemoClaw ready") &&
+      !l.includes("NemoClaw registered") &&
+      !l.includes("openclaw agent") &&
+      !l.includes("--trace-warnings") &&
+      !l.includes("CAP_SETPCAP") &&
+      !l.includes("Config integrity check failed") &&
+      !l.includes("elevated is not available") &&
+      !l.includes("getaddrinfo EAI_AGAIN") &&
+      !l.includes("\u250C\u2500") &&
+      !l.includes("\u2502 ") &&
+      !l.includes("\u2514\u2500") &&
+      l.trim() !== "",
+  ).join("\n").trim();
+}
+
+function sshExec(confPath, sandboxName, cmd, timeoutMs = 30000) {
+  try {
+    return execFileSync("ssh", ["-T", "-o", "ConnectTimeout=10", "-F", confPath, `openshell-${sandboxName}`, cmd], {
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    if (err.stdout) return err.stdout.toString().trim();
+    throw err;
+  }
+}
+
+async function runAgentInSandbox(message, sessionId, user, options = {}) {
+  const sandboxName = user.sandboxName;
+  const dbg = (msg) => console.log(`[debug:${sessionId.slice(-12)}] ${msg}`);
+  dbg(`START sandbox=${sandboxName} msg="${message.slice(0, 60)}..."`);
+
+  let sshConfig;
+  try {
+    sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${sandboxName}"`, { encoding: "utf-8" });
+  } catch (err) {
+    dbg(`FAIL ssh-config: ${err.message}`);
+    return `Error: Cannot reach sandbox '${sandboxName}'. Is it running?`;
+  }
+
+  const confPath = `/tmp/nemoclaw-slack-ssh-${sessionId}.conf`;
+  fs.writeFileSync(confPath, sshConfig);
+
+  // Unique output/status files inside the sandbox
+  const tag = `slack-${sessionId}`.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const outFile = `/tmp/nemoclaw-agent-${tag}.out`;
+  const rcFile = `/tmp/nemoclaw-agent-${tag}.rc`;
+
+  const agentCmd = buildAgentCommand(message, sessionId, user, options);
+
+  // Fire: launch agent in background, redirect output to file, write exit code when done
+  const launchCmd = `( ${agentCmd} ) > ${outFile} 2>&1; echo $? > ${rcFile}`;
+  try {
+    sshExec(confPath, sandboxName, `nohup sh -c '${launchCmd.replace(/'/g, "'\\''")}' </dev/null >/dev/null 2>&1 &`, 15000);
+    dbg("LAUNCHED agent in sandbox");
+  } catch (err) {
+    dbg(`FAIL launch: ${err.message}`);
+    try { fs.unlinkSync(confPath); } catch {}
+    return `Error launching agent: ${err.message}`;
+  }
+
+  // Poll: wait for rcFile to appear (agent finished)
+  const maxWaitMs = 1800000; // 30 minutes
+  const pollIntervalMs = 3000;
+  const startTime = Date.now();
+  let consecutiveFailures = 0;
+  let pollCount = 0;
+
+  while (Date.now() - startTime < maxWaitMs) {
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+    pollCount++;
+    try {
+      const rc = sshExec(confPath, sandboxName, `cat ${rcFile} 2>/dev/null || echo __pending__`, 10000);
+      consecutiveFailures = 0;
+      if (rc === "__pending__") {
+        if (pollCount % 20 === 0) dbg(`POLLING #${pollCount} (${Math.round((Date.now() - startTime) / 1000)}s elapsed)`);
+        continue;
+      }
+
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      dbg(`DONE rc=${rc} polls=${pollCount} elapsed=${elapsed}s`);
+
+      // Agent finished — read output
+      const raw = sshExec(confPath, sandboxName, `cat ${outFile} 2>/dev/null`, 15000);
+      dbg(`RAW output: ${raw.length} bytes`);
+      // Cleanup
+      sshExec(confPath, sandboxName, `rm -f ${outFile} ${rcFile} 2>/dev/null`, 5000);
+      try { fs.unlinkSync(confPath); } catch {}
+
+      const response = filterAgentOutput(raw);
+      dbg(`FILTERED response: ${response.length} bytes, first 80: "${response.slice(0, 80)}"`);
+      if (response) return response;
+      if (rc !== "0") return `Agent exited with code ${rc}. ${raw.slice(0, 500)}`;
+      return "(no response)";
+    } catch (err) {
+      // Track consecutive SSH failures — bail early if sandbox is permanently unreachable
+      consecutiveFailures++;
+      if (consecutiveFailures >= 5) {
+        dbg(`BAIL ssh failed ${consecutiveFailures}x: ${err.message}`);
+        try { fs.unlinkSync(confPath); } catch {}
+        return `Error: sandbox '${sandboxName}' unreachable after ${consecutiveFailures} attempts: ${err.message}`;
+      }
+      continue;
+    }
+  }
+
+  dbg(`TIMEOUT after ${Math.round((Date.now() - startTime) / 1000)}s, polls=${pollCount}`);
+
+  // Timeout — try to read whatever output exists
+  try {
+    const raw = sshExec(confPath, sandboxName, `cat ${outFile} 2>/dev/null`, 10000);
+    sshExec(confPath, sandboxName, `rm -f ${outFile} ${rcFile} 2>/dev/null`, 5000);
+    try { fs.unlinkSync(confPath); } catch {}
+    const partial = filterAgentOutput(raw);
+    dbg(`TIMEOUT partial: ${partial.length} bytes`);
+    if (partial) return partial + "\n\n_(timed out after 30 minutes)_";
+  } catch {}
+  try { fs.unlinkSync(confPath); } catch {}
+  return "Agent timed out after 30 minutes.";
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+
+async function main() {
+  if (!OPENSHELL) {
+    console.error("openshell not found on PATH or in common locations");
+    process.exit(1);
+  }
+  if (!SLACK_BOT_TOKEN) { console.error("SLACK_BOT_TOKEN required"); process.exit(1); }
+  if (!SLACK_APP_TOKEN) { console.error("SLACK_APP_TOKEN required"); process.exit(1); }
+  if (!API_KEY) { console.error("NVIDIA_API_KEY required"); process.exit(1); }
+
+  let App;
+  try {
+    ({ App } = require("@slack/bolt"));
+  } catch {
+    console.error("@slack/bolt not installed. Run: npm install @slack/bolt");
+    process.exit(1);
+  }
+
+  const app = new App({
+    token: SLACK_BOT_TOKEN,
+    appToken: SLACK_APP_TOKEN,
+    socketMode: true,
+    convoStore: false,   // disable built-in conversation store — avoids conversations.info calls
+  });
+
+  let botUserId = null;
+  try {
+    const authResult = await app.client.auth.test({ token: SLACK_BOT_TOKEN });
+    botUserId = authResult.user_id;
+  } catch {}
+
+  // Load user registry and display registered users
+  const { users } = userRegistry.listUsers();
+  const userMap = {};
+  for (const u of users) {
+    const hydrated = withAdminState(u);
+    if (hydrated && hydrated.enabled) {
+      userMap[u.slackUserId] = hydrated;
+    }
+  }
+
+  // Handle @mentions in channels — only allowed channels, ignore bots
+  app.event("app_mention", async ({ event, say }) => {
+    if (event.subtype) return;
+    if (event.bot_id) return;
+    if (event.user === botUserId) return;
+    await handleMessage(event, say);
+  });
+
+  // Handle direct messages — only 1:1 DMs, ignore group DMs (mpim)
+  app.event("message", async ({ event, say }) => {
+    if (event.channel_type !== "im") return;
+    if (event.subtype) return;
+    if (event.bot_id) return;
+    if (event.user === botUserId) return;
+    await handleMessage(event, say);
+  });
+
+  async function handleMessage(event, say) {
+    let channel = event.channel;
+    const isDM = event.channel_type === "im";
+    const threadTs = isDM ? event.thread_ts : (event.thread_ts || event.ts);
+
+    // Ensure DM channel is open (fixes channel_not_found for new users)
+    if (isDM) {
+      try {
+        const dm = await app.client.conversations.open({
+          token: SLACK_BOT_TOKEN,
+          users: event.user,
+        });
+        if (dm.channel && dm.channel.id) {
+          channel = dm.channel.id;
+        }
+      } catch (e) {
+        console.log(`[warn] conversations.open failed for ${event.user}: ${e.message}`);
+      }
+    }
+
+    // Helper: send message to the resolved channel (avoids channel_not_found)
+    async function reply(message) {
+      const payload = typeof message === "string" ? { text: message } : message;
+      await app.client.chat.postMessage({
+        token: SLACK_BOT_TOKEN,
+        channel,
+        thread_ts: threadTs,
+        ...payload,
+      });
+    }
+
+    // Channel access control
+    if (ALLOWED_CHANNELS && !ALLOWED_CHANNELS.includes(channel)) {
+      console.log(`[ignored] channel ${channel} not in allowed list`);
+      return;
+    }
+
+    // Strip bot mention from message text
+    let text = event.text || "";
+    if (botUserId) {
+      text = text.replace(new RegExp(`<@${botUserId}>\\s*`, "g"), "").trim();
+    }
+
+    if (!text) return;
+    text = canonicalizeAdminCommand(text);
+
+    // User registry lookup replaces ALLOWED_USERS
+    const user = getUser(event.user);
+
+    if (isListAdminsCommand(text)) {
+      if (!user) {
+        await reply("You're not registered with NemoClaw. Ask an admin to run: `nemoclaw user-add`\nYour Slack ID: `" + event.user + "`");
+        return;
+      }
+      await reply(formatAdminUsers());
+      return;
+    }
+
+    if (isAdminAuditCommand(text)) {
+      if (!user) {
+        await reply("You're not registered with NemoClaw. Ask an admin to run: `nemoclaw user-add`\nYour Slack ID: `" + event.user + "`");
+        return;
+      }
+      if (!isAdminUser(user)) {
+        await reply("You are registered, but you are not an admin user.");
+        return;
+      }
+      await reply(formatRecentAdminAudit());
+      return;
+    }
+
+    if (isAdminHelpCommand(text)) {
+      if (!user) {
+        await reply("You're not registered with NemoClaw. Ask an admin to run: `nemoclaw user-add`\nYour Slack ID: `" + event.user + "`");
+        return;
+      }
+      if (!isAdminUser(user)) {
+        await reply("You are registered, but you are not an admin user.");
+        return;
+      }
+      await reply(formatAdminHelp());
+      return;
+    }
+
+    if (isShowClawsCommand(text)) {
+      if (!user) {
+        await reply("You're not registered with NemoClaw. Ask an admin to run: `nemoclaw user-add`\nYour Slack ID: `" + event.user + "`");
+        return;
+      }
+      if (!isAdminUser(user)) {
+        await reply("You are registered, but you are not an admin user.");
+        return;
+      }
+      await reply(buildShowClawsPayload(text));
+      return;
+    }
+
+    if (isShowUserCommand(text)) {
+      if (!user) {
+        await reply("You're not registered with NemoClaw. Ask an admin to run: `nemoclaw user-add`\nYour Slack ID: `" + event.user + "`");
+        return;
+      }
+      if (!isAdminUser(user)) {
+        await reply("You are registered, but you are not an admin user.");
+        return;
+      }
+      await reply(buildShowUserPayload(text));
+      return;
+    }
+
+    if (isAddClawCommand(text) || isDeleteClawCommand(text) || isConfirmDeleteClawCommand(text)) {
+      if (!isDM) {
+        await reply("Admin claw management commands must be sent as a direct message.");
+        return;
+      }
+      if (!user) {
+        await reply("You're not registered with NemoClaw. Ask an admin to run: `nemoclaw user-add`\nYour Slack ID: `" + event.user + "`");
+        return;
+      }
+      if (!isAdminUser(user)) {
+        await reply("You are registered, but you are not an admin user.");
+        return;
+      }
+
+      const thinkingMsg = await app.client.chat.postMessage({
+        token: SLACK_BOT_TOKEN,
+        channel,
+        thread_ts: threadTs,
+        text: "Running admin command...",
+      });
+
+      const result = isAddClawCommand(text)
+        ? await handleAddClaw(user, text)
+        : isDeleteClawCommand(text)
+          ? await handleDeleteClaw(user, text)
+          : await handleConfirmDeleteClaw(user, text);
+
+      await app.client.chat.update({
+        token: SLACK_BOT_TOKEN,
+        channel,
+        ts: thinkingMsg.ts,
+        text: result.message,
+      });
+      return;
+    }
+
+    if (isDM && user && isAdminUser(user) && looksLikeAdminCommand(text)) {
+      await reply("Unknown admin command. Use `!admin-help`. Admin commands are handled directly and are not sent to the sandbox agent.");
+      return;
+    }
+
+    // ── !setup commands (self-service onboarding) ──────────────
+    if (isSetupCommand(text)) {
+      // !setup help is available to everyone (normalize for mobile keyboard artifacts)
+      const normalized = normalizeText(text).toLowerCase();
+      if (normalized === "!setup help" || normalized === "!setup") {
+        await reply(setupHelp());
+        return;
+      }
+
+      // All other !setup commands require DM and registration
+      if (!isDM) {
+        await reply("For security, `!setup` commands with credentials must be sent as a *direct message* to me, not in a channel.");
+        return;
+      }
+
+      if (!user) {
+        await reply("You're not registered yet. Ask an admin to run `nemoclaw user-add` with your Slack user ID first.\nYour Slack ID: `" + event.user + "`");
+        return;
+      }
+
+      const setupText = normalizeText(text).slice("!setup ".length);
+      const displayName = user.slackDisplayName || event.user;
+      console.log(`[setup] ${displayName}: !setup ${setupText.slice(0, 30)}...`);
+
+      const { response, deleteMessage } = handleSetup(user, setupText);
+
+      // Delete the user's message containing credentials
+      if (deleteMessage) {
+        try {
+          await app.client.chat.delete({
+            token: SLACK_BOT_TOKEN,
+            channel,
+            ts: event.ts,
+          });
+          console.log(`[setup] Deleted credential message from ${displayName}`);
+        } catch (delErr) {
+          // Bot may not have permission to delete user messages in DMs
+          // That's OK — we still process the command
+          console.log(`[setup] Could not delete message (${delErr.message}) — proceeding`);
+        }
+      }
+
+      await reply(response);
+      return;
+    }
+
+    // ── !whatsapp commands (run on host — WS can't go through sandbox proxy) ──
+    if (/^!whatsapp\b|^!wa\b/i.test(normalizeText(text))) {
+      if (!user) {
+        await reply("You're not registered. Ask an admin to run `nemoclaw user-add`.");
+        return;
+      }
+      const waCmd = normalizeText(text).replace(/^!(whatsapp|wa)\s*/i, "").trim();
+      if (!waCmd || waCmd === "help") {
+        await reply("WhatsApp commands:\n`!wa send <phone> <message>` — Send a message\n`!wa contacts [--query <name>]` — List/search contacts\n`!wa inbox` — List recent conversations\n`!wa read <phone> [--count N]` — Read messages");
+        return;
+      }
+      try {
+        const result = execFileSync("node", [`${REPO_DIR}/scripts/whatsapp-bridge.js`, ...waCmd.split(/\s+/)], {
+          encoding: "utf-8",
+          timeout: 45000,
+          env: { ...process.env, SLACK_USER_ID: user.slackUserId },
+        }).trim();
+        await reply(result || "(no output)");
+      } catch (err) {
+        const stderr = err.stderr ? err.stderr.toString().slice(0, 300) : "";
+        const stdout = err.stdout ? err.stdout.toString().slice(0, 300) : "";
+        await reply(`WhatsApp error: ${stdout || stderr || err.message}`.slice(0, 500));
+      }
+      return;
+    }
+
+    // ── !yahoo commands (run on host, not sandbox — IMAP needs direct TCP) ──
+    if (/^!yahoo\b/i.test(normalizeText(text))) {
+      if (!user) {
+        await reply("You're not registered. Ask an admin to run `nemoclaw user-add`.");
+        return;
+      }
+      // Load per-user Yahoo credentials from persist dir
+      const yahooCredsPath = `${REPO_DIR}/persist/users/${user.slackUserId}/credentials/yahoo-creds.env`;
+      if (!fs.existsSync(yahooCredsPath)) {
+        await reply("No Yahoo credentials configured. Ask an admin to set up `persist/users/<id>/credentials/yahoo-creds.env` with YAHOO_EMAIL and YAHOO_APP_PWD.");
+        return;
+      }
+      const yahooCreds = {};
+      fs.readFileSync(yahooCredsPath, "utf-8").split("\n").forEach((line) => {
+        const [k, ...v] = line.split("=");
+        if (k && v.length) yahooCreds[k.trim()] = v.join("=").trim();
+      });
+      const yahooCmd = normalizeText(text).slice("!yahoo ".length).trim();
+      // Map !yahoo subcommands to script args
+      let scriptArgs;
+      if (/^inbox\b/i.test(yahooCmd)) {
+        const countMatch = yahooCmd.match(/--count\s+(\d+)/);
+        const count = countMatch ? countMatch[1] : "10";
+        const unread = /--unread/i.test(yahooCmd) ? "--unread" : "";
+        scriptArgs = `inbox --count ${count} ${unread}`;
+      } else if (/^read\s+(\d+)/i.test(yahooCmd)) {
+        scriptArgs = `read ${yahooCmd.match(/^read\s+(\d+)/i)[1]}`;
+      } else if (/^send\b/i.test(yahooCmd)) {
+        const toMatch = yahooCmd.match(/--to\s+(\S+)/);
+        const subjMatch = yahooCmd.match(/--subject\s+"([^"]+)"|--subject\s+(\S+)/);
+        const bodyMatch = yahooCmd.match(/--body\s+"([^"]+)"|--body\s+(\S+)/);
+        const ccMatch = yahooCmd.match(/--cc\s+(\S+)/);
+        if (!toMatch || !subjMatch || !bodyMatch) {
+          await reply("Usage: `!yahoo send --to addr@example.com --subject \"Subject\" --body \"Body text\"` [--cc addr]");
+          return;
+        }
+        const to = toMatch[1];
+        const subj = (subjMatch[1] || subjMatch[2]).replace(/'/g, "'\\''");
+        const body = (bodyMatch[1] || bodyMatch[2]).replace(/'/g, "'\\''");
+        scriptArgs = `send --to '${to}' --subject '${subj}' --body '${body}'`;
+        if (ccMatch) scriptArgs += ` --cc '${ccMatch[1]}'`;
+      } else if (/^search\b/i.test(yahooCmd)) {
+        const query = yahooCmd.replace(/^search\s+/i, "").replace(/'/g, "'\\''");
+        scriptArgs = `search '${query}'`;
+      } else {
+        await reply("Yahoo Mail commands:\n`!yahoo inbox [--count N] [--unread]`\n`!yahoo read <message-id>`\n`!yahoo send --to <addr> --subject \"...\" --body \"...\"`\n`!yahoo search <query>`");
+        return;
+      }
+      try {
+        const result = execFileSync("python3", [`${REPO_DIR}/scripts/yahoo-mail.py`, ...scriptArgs.split(/\s+/)], {
+          encoding: "utf-8",
+          timeout: 30000,
+          env: { ...process.env, ...yahooCreds },
+        }).trim();
+        await reply(result || "(no output)");
+      } catch (err) {
+        await reply(`Yahoo mail error: ${(err.stderr || err.message || "").slice(0, 500)}`);
+      }
+      return;
+    }
+
+    // ── Normal message routing ─────────────────────────────────
+    // Only respond to 1:1 DMs — never respond to @mentions in channels or group chats
+    if (!isDM) {
+      console.log(`[ignored] non-DM message from ${event.user} in channel ${channel} — bot only responds in 1:1 DMs`);
+      return;
+    }
+
+    if (!user) {
+      // User directly DMed the bot — tell them how to register
+      console.log(`[unregistered] user ${event.user} DMed bot`);
+      await reply("You're not registered with NemoClaw. Ask an admin to run: `nemoclaw user-add`\nYour Slack ID: `" + event.user + "`\n\nOnce registered, DM me `!setup help` to configure your credentials.");
+      return;
+    }
+
+    const displayName = user.slackDisplayName || event.user;
+    console.log(`[${channel}] ${displayName} → ${user.sandboxName}: ${text}`);
+
+    try {
+      const thinkingMsg = await app.client.chat.postMessage({
+        token: SLACK_BOT_TOKEN,
+        channel,
+        thread_ts: threadTs,
+        text: "Working on it...",
+      });
+
+      // Serialize agent runs per sandbox to avoid OpenClaw lane lock conflicts.
+      // Messages queue up and run one at a time per sandbox.
+      const agentSessionId = `${event.user}-${channel}-${Date.now()}`;
+
+      // Track pending run on disk so a restarted bridge can deliver the result
+      addPendingRun(agentSessionId, {
+        sandboxName: user.sandboxName,
+        channel,
+        thinkingTs: thinkingMsg.ts,
+        displayName,
+        slackUserId: event.user,
+      });
+
+      let response = await enqueueForUser(user.sandboxName, async () => {
+        // Wait for rate limit cooldown before launching
+        if (isRateLimited()) {
+          await app.client.chat.update({
+            token: SLACK_BOT_TOKEN,
+            channel,
+            ts: thinkingMsg.ts,
+            text: "Rate limited — waiting for cooldown, then switching to NVIDIA Nemotron...",
+          });
+          await waitForRateLimitCooldown();
+        }
+
+        // Don't override the sandbox's configured primary model — it may be Ollama, not Anthropic
+
+        let result = await runAgentInSandbox(text, agentSessionId, user);
+        console.log(`[${channel}] ${user.sandboxName} → ${displayName}: ${result.slice(0, 100)}...`);
+
+        // On rate limit: trigger cooldown, attempt NVIDIA fallback immediately
+        if (RATE_LIMIT_RE.test(result)) {
+          console.log(`[${channel}] Rate limit detected for ${user.sandboxName}, switching to NVIDIA Nemotron...`);
+          triggerRateLimitCooldown();
+          await app.client.chat.update({
+            token: SLACK_BOT_TOKEN,
+            channel,
+            ts: thinkingMsg.ts,
+            text: "Anthropic rate limited — trying NVIDIA Nemotron...",
+          });
+          result = await attemptFallbackRouting(user, text, `${event.user}-${channel}-${Date.now()}`, channel, displayName);
+        }
+
+        // On auth error: refresh credentials and retry once before giving up
+        if (AUTH_ERROR_RE.test(result)) {
+          console.log(`[${channel}] Auth error detected for ${user.sandboxName}, refreshing credentials and retrying...`);
+          await app.client.chat.update({
+            token: SLACK_BOT_TOKEN,
+            channel,
+            ts: thinkingMsg.ts,
+            text: "Refreshing credentials, one moment...",
+          });
+          if (refreshCredentials(user.sandboxName, user.credentialsDir || "")) {
+            result = await runAgentInSandbox(text, `${event.user}-${channel}-${Date.now()}-retry`, user);
+            console.log(`[${channel}] ${user.sandboxName} → ${displayName} (retry): ${result.slice(0, 100)}...`);
+          }
+          if (AUTH_ERROR_RE.test(result)) {
+            result = await attemptFallbackRouting(user, text, `${event.user}-${channel}-${Date.now()}`, channel, displayName);
+          }
+        }
+        return result;
+      });
+
+      // Redact credential/auth errors in public channels — only show details in DMs
+      const isAuthError = AUTH_ERROR_RE.test(response);
+      if (isAuthError && !isDM) {
+        console.error(`[${channel}] suppressing auth error in public channel for ${displayName}`);
+        response = "I'm having a temporary issue — please try again in a few minutes or DM me directly.";
+      }
+
+      // Convert markdown to Slack format, then build table blocks
+      response = mdToSlack(mdLinksToSlack(response));
+      const tablePayload = buildSlackTablePayload(response);
+      if (tablePayload) {
+        await app.client.chat.update({
+          token: SLACK_BOT_TOKEN,
+          channel,
+          ts: thinkingMsg.ts,
+          ...tablePayload,
+        });
+      } else {
+        await app.client.chat.update({
+          token: SLACK_BOT_TOKEN,
+          channel,
+          ts: thinkingMsg.ts,
+          text: mdToSlack(mdLinksToSlack(response)),
+        });
+      }
+
+      // Forward notification-like responses to WhatsApp
+      if (isDM) maybeForwardToWhatsApp(user, response);
+
+      // Remove from pending runs — delivery succeeded
+      removePendingRun(agentSessionId);
+    } catch (err) {
+      console.error(`[${channel}] error for ${displayName}:`, err.message);
+      // Redact auth errors in public channels
+      const errMsg = err.message || "";
+      const isAuthErr = /authentication_error|invalid_grant|Invalid authentication|401.*auth/i.test(errMsg);
+      const safeMsg = (!isDM && isAuthErr)
+        ? "I'm having a temporary issue — please try again in a few minutes or DM me directly."
+        : `Error: ${errMsg}`;
+      await say({ text: safeMsg, thread_ts: threadTs });
+    }
+  }
+
+  await app.start();
+
+  // Recover orphaned results from previous bridge instance
+  await recoverOrphanedRuns(app.client).catch((err) => {
+    console.error(`[recovery] Error: ${err.message}`);
+  });
+
+  const userCount = Object.keys(userMap).length;
+  const sandboxList = Object.values(userMap).map((u) => `${u.slackDisplayName} → ${u.sandboxName}`);
+
+  console.log("");
+  console.log("  ┌─────────────────────────────────────────────────────┐");
+  console.log("  │  NemoClaw Multi-User Slack Bridge                   │");
+  console.log("  │                                                     │");
+  console.log("  │  Users: " + (String(userCount) + " registered                            ").slice(0, 43) + "│");
+  for (const line of sandboxList) {
+    console.log("  │    " + (line + "                                              ").slice(0, 49) + "│");
+  }
+  console.log("  │                                                     │");
+  console.log("  │  Messages are routed by Slack user ID to the        │");
+  console.log("  │  correct sandbox. Run 'openshell term' to monitor.  │");
+  console.log("  └─────────────────────────────────────────────────────┘");
+  console.log("");
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  parseCommandArgs,
+  isAdminUser,
+  isListAdminsCommand,
+  isAdminAuditCommand,
+  isShowClawsCommand,
+  isShowUserCommand,
+  isAdminHelpCommand,
+  canonicalizeAdminCommand,
+  looksLikeAdminCommand,
+  isAddClawCommand,
+  isDeleteClawCommand,
+  isConfirmDeleteClawCommand,
+  parseSandboxList,
+  formatDurationFrom,
+  getInventoryStatus,
+  listConfiguredCredentials,
+  buildClawInventory,
+  parseShowClawsOptions,
+  filterAndSortClawInventory,
+  formatClawInventory,
+  buildShowClawsPayload,
+  buildShowClawsTablePayload,
+  buildShowClawsTablePayloadFromInventory,
+  resolveUserLookup,
+  buildShowUserText,
+  buildShowUserPayload,
+  buildAdminUserList,
+  formatAdminUsersFromList,
+  formatRecentAdminAudit,
+  readRecentAdminAudit,
+  withAdminState,
+  formatAdminHelp,
+  getClaudeCredentialSource,
+  describeClaudeCredentialSource,
+  buildAuthRecoveryMessage,
+  buildAgentCommand,
+  getRuntimeFallbackModels,
+};

--- a/scripts/slack-bridge.js
+++ b/scripts/slack-bridge.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Slack -> NemoClaw bridge.
+ *
+ * Messages from Slack are forwarded to the OpenClaw agent running
+ * inside the sandbox. When the agent needs external access, the
+ * OpenShell TUI lights up for approval. Responses go back to Slack.
+ *
+ * Uses Socket Mode (no public URL required).
+ *
+ * Env:
+ *   SLACK_BOT_TOKEN   — Bot User OAuth Token (xoxb-...)
+ *   SLACK_APP_TOKEN   — App-Level Token with connections:write (xapp-...)
+ *   NVIDIA_API_KEY    — for inference
+ *   SANDBOX_NAME      — sandbox name (default: nemoclaw)
+ *   ALLOWED_CHANNELS  — comma-separated Slack channel IDs to accept (optional, accepts all if unset)
+ *   ALLOWED_USERS     — comma-separated Slack user IDs to accept (optional, accepts all if unset)
+ */
+
+const { execSync, spawn } = require("child_process");
+const { resolveOpenshell } = require("../bin/lib/resolve-openshell");
+
+const OPENSHELL = resolveOpenshell();
+if (!OPENSHELL) {
+  console.error("openshell not found on PATH or in common locations");
+  process.exit(1);
+}
+
+const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
+const SLACK_APP_TOKEN = process.env.SLACK_APP_TOKEN;
+const API_KEY = process.env.NVIDIA_API_KEY;
+const SANDBOX = process.env.SANDBOX_NAME || "nemoclaw";
+const ALLOWED_CHANNELS = process.env.ALLOWED_CHANNELS
+  ? process.env.ALLOWED_CHANNELS.split(",").map((s) => s.trim())
+  : null;
+const ALLOWED_USERS = process.env.ALLOWED_USERS
+  ? process.env.ALLOWED_USERS.split(",").map((s) => s.trim())
+  : null;
+
+if (!SLACK_BOT_TOKEN) { console.error("SLACK_BOT_TOKEN required"); process.exit(1); }
+if (!SLACK_APP_TOKEN) { console.error("SLACK_APP_TOKEN required"); process.exit(1); }
+if (!API_KEY) { console.error("NVIDIA_API_KEY required"); process.exit(1); }
+
+// ── Run agent inside sandbox ──────────────────────────────────────
+
+function runAgentInSandbox(message, sessionId) {
+  return new Promise((resolve) => {
+    const sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${SANDBOX}"`, { encoding: "utf-8" });
+
+    const confPath = `/tmp/nemoclaw-slack-ssh-${sessionId}.conf`;
+    require("fs").writeFileSync(confPath, sshConfig);
+
+    const escaped = message.replace(/'/g, "'\\''");
+    const cmd = `export NVIDIA_API_KEY='${API_KEY}' && export GOG_KEYRING_PASSWORD='${process.env.GOG_KEYRING_PASSWORD || "nemoclaw"}' && export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache && export OPENCLAW_NO_RESPAWN=1 && export ANTHROPIC_API_KEY='${process.env.ANTHROPIC_API_KEY || ""}' && source /sandbox/.bashrc 2>/dev/null; nemoclaw-start openclaw agent --agent main --local -m '${escaped}' --session-id 'slack-${sessionId}'`;
+
+    const proc = spawn("ssh", ["-T", "-F", confPath, `openshell-${SANDBOX}`, cmd], {
+      timeout: 600000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (d) => (stdout += d.toString()));
+    proc.stderr.on("data", (d) => (stderr += d.toString()));
+
+    proc.on("close", (code) => {
+      try { require("fs").unlinkSync(confPath); } catch {}
+
+      // Extract the actual agent response — skip setup lines
+      const lines = stdout.split("\n");
+      const responseLines = lines.filter(
+        (l) =>
+          !l.startsWith("Setting up NemoClaw") &&
+          !l.startsWith("[plugins]") &&
+          !l.startsWith("(node:") &&
+          !l.includes("NemoClaw ready") &&
+          !l.includes("NemoClaw registered") &&
+          !l.includes("openclaw agent") &&
+          !l.includes("\u250C\u2500") &&
+          !l.includes("\u2502 ") &&
+          !l.includes("\u2514\u2500") &&
+          l.trim() !== "",
+      );
+
+      const response = responseLines.join("\n").trim();
+
+      if (response) {
+        resolve(response);
+      } else if (code !== 0) {
+        resolve(`Agent exited with code ${code}. ${stderr.trim().slice(0, 500)}`);
+      } else {
+        resolve("(no response)");
+      }
+    });
+
+    proc.on("error", (err) => {
+      resolve(`Error: ${err.message}`);
+    });
+  });
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+
+async function main() {
+  // Lazy-require @slack/bolt so the error is clear if not installed
+  let App;
+  try {
+    ({ App } = require("@slack/bolt"));
+  } catch {
+    console.error("@slack/bolt not installed. Run: npm install @slack/bolt");
+    process.exit(1);
+  }
+
+  const app = new App({
+    token: SLACK_BOT_TOKEN,
+    appToken: SLACK_APP_TOKEN,
+    socketMode: true,
+  });
+
+  // Store bot user ID so we can strip self-mentions from messages
+  let botUserId = null;
+  try {
+    const authResult = await app.client.auth.test({ token: SLACK_BOT_TOKEN });
+    botUserId = authResult.user_id;
+  } catch {}
+
+  // Handle @mentions in channels
+  app.event("app_mention", async ({ event, say }) => {
+    await handleMessage(event, say);
+  });
+
+  // Handle direct messages
+  app.event("message", async ({ event, say }) => {
+    // Only handle DMs (im), skip channel messages (handled by app_mention)
+    if (event.channel_type !== "im") return;
+    // Skip bot messages and message edits
+    if (event.subtype) return;
+    await handleMessage(event, say);
+  });
+
+  async function handleMessage(event, say) {
+    const channel = event.channel;
+    const threadTs = event.thread_ts || event.ts;
+
+    // Access control
+    if (ALLOWED_CHANNELS && !ALLOWED_CHANNELS.includes(channel)) {
+      console.log(`[ignored] channel ${channel} not in allowed list`);
+      return;
+    }
+    if (ALLOWED_USERS && !ALLOWED_USERS.includes(event.user)) {
+      console.log(`[ignored] user ${event.user} not in allowed list`);
+      return;
+    }
+
+    // Strip bot mention from message text
+    let text = event.text || "";
+    if (botUserId) {
+      text = text.replace(new RegExp(`<@${botUserId}>\\s*`, "g"), "").trim();
+    }
+
+    if (!text) return;
+
+    const userName = event.user || "someone";
+    console.log(`[${channel}] ${userName}: ${text}`);
+
+    try {
+      // Send a "thinking" message
+      const thinkingMsg = await app.client.chat.postMessage({
+        token: SLACK_BOT_TOKEN,
+        channel,
+        thread_ts: threadTs,
+        text: "Working on it...",
+      });
+
+      const response = await runAgentInSandbox(text, `${channel}-${Date.now()}`);
+      console.log(`[${channel}] agent: ${response.slice(0, 100)}...`);
+
+      // Update the thinking message with the actual response
+      await app.client.chat.update({
+        token: SLACK_BOT_TOKEN,
+        channel,
+        ts: thinkingMsg.ts,
+        text: response,
+      });
+    } catch (err) {
+      console.error(`[${channel}] error:`, err.message);
+      await say({ text: `Error: ${err.message}`, thread_ts: threadTs });
+    }
+  }
+
+  await app.start();
+
+  console.log("");
+  console.log("  \u250C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510");
+  console.log("  \u2502  NemoClaw Slack Bridge                             \u2502");
+  console.log("  \u2502                                                     \u2502");
+  console.log("  \u2502  Sandbox:  " + (SANDBOX + "                              ").slice(0, 40) + "\u2502");
+  console.log("  \u2502  Model:    anthropic/claude-sonnet-4-6             \u2502");
+  console.log("  \u2502                                                     \u2502");
+  console.log("  \u2502  Messages are forwarded to the OpenClaw agent      \u2502");
+  console.log("  \u2502  inside the sandbox. Run 'openshell term' in       \u2502");
+  console.log("  \u2502  another terminal to monitor + approve egress.     \u2502");
+  console.log("  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518");
+  console.log("");
+}
+
+main();

--- a/scripts/slack-notify.sh
+++ b/scripts/slack-notify.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Send a Slack notification from inside a sandbox.
+#
+# Default: Posts a DM to the user via the bot token (SLACK_BOT_TOKEN + SLACK_USER_ID).
+# Fallback: Posts via incoming webhook (SLACK_WEBHOOK_URL) if set and bot token is missing.
+#
+# Usage:
+#   slack-notify "Your message here"
+#   echo "Your message" | slack-notify
+#
+# Env (sourced from /sandbox/.env):
+#   SLACK_BOT_TOKEN  — Bot User OAuth Token (preferred)
+#   SLACK_USER_ID    — Slack user ID to DM (used with bot token)
+#   SLACK_WEBHOOK_URL — Incoming webhook URL (fallback)
+
+set -euo pipefail
+
+# Read message from argument or stdin
+if [ $# -gt 0 ]; then
+  MESSAGE="$*"
+else
+  MESSAGE="$(cat)"
+fi
+
+if [ -z "$MESSAGE" ]; then
+  exit 0
+fi
+
+# Escape message for JSON
+JSON_MESSAGE=$(printf '%s' "$MESSAGE" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '"%s"' "$MESSAGE")
+
+# Method 1: Bot token + user ID → DM the user directly
+if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_USER_ID:-}" ]; then
+  # Open a DM channel with the user
+  DM_RESPONSE=$(curl -s -X POST "https://slack.com/api/conversations.open" \
+    -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"users\":\"${SLACK_USER_ID}\"}" 2>/dev/null)
+
+  DM_CHANNEL=$(echo "$DM_RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('channel',{}).get('id',''))" 2>/dev/null || true)
+
+  if [ -n "$DM_CHANNEL" ]; then
+    curl -s -X POST "https://slack.com/api/chat.postMessage" \
+      -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "{\"channel\":\"${DM_CHANNEL}\",\"text\":${JSON_MESSAGE}}" > /dev/null 2>&1
+    exit 0
+  fi
+fi
+
+# Method 2: Webhook fallback
+if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+  echo "{\"text\":${JSON_MESSAGE}}" | curl -s -X POST -H 'Content-Type: application/json' -d @- "$SLACK_WEBHOOK_URL" > /dev/null 2>&1
+  exit 0
+fi
+
+echo "[slack-notify] No SLACK_BOT_TOKEN+SLACK_USER_ID or SLACK_WEBHOOK_URL set — message not sent" >&2
+exit 1

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -2,21 +2,31 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Start NemoClaw auxiliary services: Telegram bridge
-# and cloudflared tunnel for public access.
+# Start NemoClaw auxiliary services: Slack bridge.
 #
 # Usage:
-#   TELEGRAM_BOT_TOKEN=... ./scripts/start-services.sh         # start all
-#   ./scripts/start-services.sh --status                       # check status
-#   ./scripts/start-services.sh --stop                         # stop all
-#   ./scripts/start-services.sh --sandbox mybox                # start for specific sandbox
-#   ./scripts/start-services.sh --sandbox mybox --stop         # stop for specific sandbox
+#   SLACK_BOT_TOKEN=... SLACK_APP_TOKEN=... ./scripts/start-services.sh
+#   ./scripts/start-services.sh --status
+#   ./scripts/start-services.sh --stop
+#   ./scripts/start-services.sh --sandbox mybox
+#   ./scripts/start-services.sh --sandbox mybox --stop
+#
+# Optional env:
+#   ALLOWED_USERS     — comma-separated Slack user IDs to accept (default: all)
+#   ALLOWED_CHANNELS  — comma-separated Slack channel IDs to accept (default: all)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-DASHBOARD_PORT="${DASHBOARD_PORT:-18789}"
+
+# Source .env if present (tokens, access control, sandbox name)
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$REPO_DIR/.env"
+  set +a
+fi
 
 # ── Parse flags ──────────────────────────────────────────────────
 SANDBOX_NAME="${NEMOCLAW_SANDBOX:-${SANDBOX_NAME:-default}}"
@@ -56,32 +66,79 @@ fail() {
   exit 1
 }
 
-is_running() {
+service_match_pattern() {
+  case "$1" in
+    slack-bridge) echo "node .*scripts/slack-bridge(-multi)?\\.js" ;;
+    whatsapp-bridge) echo "node .*scripts/whatsapp-bridge-multi\\.js" ;;
+    telegram-bridge) echo "node .*scripts/telegram-bridge\\.js" ;;
+    cloudflared)
+      if [ -n "${DASHBOARD_PORT:-}" ]; then
+        echo "cloudflared tunnel --url http://localhost:${DASHBOARD_PORT}"
+      else
+        echo "cloudflared tunnel --url http://localhost:"
+      fi
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+resolve_running_pid() {
   local pidfile="$PIDDIR/$1.pid"
   if [ -f "$pidfile" ] && kill -0 "$(cat "$pidfile")" 2>/dev/null; then
+    cat "$pidfile"
     return 0
   fi
+  rm -f "$pidfile"
+  if command -v pgrep >/dev/null 2>&1; then
+    local pattern
+    pattern="$(service_match_pattern "$1" || true)"
+    if [ -n "$pattern" ]; then
+      local pid
+      pid="$(pgrep -fo "$pattern" || true)"
+      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        echo "$pid" >"$pidfile"
+        echo "$pid"
+        return 0
+      fi
+    fi
+  fi
   return 1
+}
+
+is_running() {
+  resolve_running_pid "$1" >/dev/null
 }
 
 start_service() {
   local name="$1"
   shift
-  if is_running "$name"; then
-    info "$name already running (PID $(cat "$PIDDIR/$name.pid"))"
+  local existing_pid
+  if existing_pid="$(resolve_running_pid "$name")"; then
+    info "$name already running (PID $existing_pid)"
     return 0
   fi
-  nohup "$@" >"$PIDDIR/$name.log" 2>&1 &
-  echo $! >"$PIDDIR/$name.pid"
-  info "$name started (PID $!)"
+  if command -v setsid >/dev/null 2>&1; then
+    setsid -f "$@" </dev/null >"$PIDDIR/$name.log" 2>&1
+  else
+    nohup "$@" </dev/null >"$PIDDIR/$name.log" 2>&1 &
+  fi
+  sleep 1
+  local pid
+  if ! pid="$(resolve_running_pid "$name")"; then
+    warn "$name failed to stay up; check $PIDDIR/$name.log"
+    tail -20 "$PIDDIR/$name.log" 2>/dev/null || true
+    rm -f "$PIDDIR/$name.pid"
+    return 1
+  fi
+  echo "$pid" >"$PIDDIR/$name.pid"
+  info "$name started (PID $pid)"
 }
 
 stop_service() {
   local name="$1"
   local pidfile="$PIDDIR/$name.pid"
-  if [ -f "$pidfile" ]; then
-    local pid
-    pid="$(cat "$pidfile")"
+  local pid
+  if pid="$(resolve_running_pid "$name")"; then
     if kill -0 "$pid" 2>/dev/null; then
       kill "$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
       info "$name stopped (PID $pid)"
@@ -97,32 +154,32 @@ stop_service() {
 show_status() {
   mkdir -p "$PIDDIR"
   echo ""
-  for svc in telegram-bridge cloudflared; do
-    if is_running "$svc"; then
-      echo -e "  ${GREEN}●${NC} $svc  (PID $(cat "$PIDDIR/$svc.pid"))"
+  for svc in slack-bridge whatsapp-bridge telegram-bridge cloudflared; do
+    local pid
+    if pid="$(resolve_running_pid "$svc")"; then
+      echo -e "  ${GREEN}●${NC} $svc  (PID $pid)"
     else
       echo -e "  ${RED}●${NC} $svc  (stopped)"
     fi
   done
   echo ""
-
-  if [ -f "$PIDDIR/cloudflared.log" ]; then
-    local url
-    url="$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$PIDDIR/cloudflared.log" 2>/dev/null | head -1 || true)"
-    if [ -n "$url" ]; then
-      info "Public URL: $url"
-    fi
-  fi
 }
 
 do_stop() {
   mkdir -p "$PIDDIR"
-  stop_service cloudflared
+  stop_service slack-bridge
+  stop_service whatsapp-bridge
   stop_service telegram-bridge
+  stop_service cloudflared
   info "All services stopped."
 }
 
 do_start() {
+  if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${SLACK_APP_TOKEN:-}" ]; then
+    warn "SLACK_BOT_TOKEN / SLACK_APP_TOKEN not set — Slack bridge will not start."
+    warn "Create a Slack app at https://api.slack.com/apps with Socket Mode enabled."
+  fi
+
   if [ -z "${TELEGRAM_BOT_TOKEN:-}" ]; then
     warn "TELEGRAM_BOT_TOKEN not set — Telegram bridge will not start."
     warn "Create a bot via @BotFather on Telegram and set the token."
@@ -145,11 +202,24 @@ do_start() {
   # Verify sandbox is running
   if command -v openshell >/dev/null 2>&1; then
     if ! openshell sandbox list 2>&1 | grep -q "Ready"; then
-      warn "No sandbox in Ready state. Telegram bridge may not work until sandbox is running."
+      warn "No sandbox in Ready state. Slack bridge may not work until sandbox is running."
     fi
   fi
 
   mkdir -p "$PIDDIR"
+
+  # Slack bridge (only if both tokens provided)
+  if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_APP_TOKEN:-}" ]; then
+    # Use multi-user bridge if users.json exists with registered users
+    USERS_FILE="$HOME/.nemoclaw/users.json"
+    if [ -f "$USERS_FILE" ] && python3 -c "import json; d=json.load(open('$USERS_FILE')); exit(0 if len(d.get('users',{})) > 0 else 1)" 2>/dev/null; then
+      start_service slack-bridge \
+        node "$REPO_DIR/scripts/slack-bridge-multi.js"
+    else
+      SANDBOX_NAME="$SANDBOX_NAME" ALLOWED_USERS="${ALLOWED_USERS:-}" start_service slack-bridge \
+        node "$REPO_DIR/scripts/slack-bridge.js"
+    fi
+  fi
 
   # Telegram bridge (only if token provided)
   if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${NVIDIA_API_KEY:-}" ]; then
@@ -157,12 +227,22 @@ do_start() {
       node "$REPO_DIR/scripts/telegram-bridge.js"
   fi
 
-  # 3. cloudflared tunnel
+  # WhatsApp bridge (runs on host — WS can't go through sandbox proxy)
+  WA_AUTH_DIR="$REPO_DIR/persist/gateway/whatsapp-auth"
+  WA_FALLBACK="/tmp/wa-login/auth"
+  if [ -f "$WA_AUTH_DIR/creds.json" ] || [ -f "$WA_FALLBACK/creds.json" ]; then
+    start_service whatsapp-bridge \
+      node "$REPO_DIR/scripts/whatsapp-bridge-multi.js"
+  else
+    warn "WhatsApp not linked — bridge will not start. Run: cd /tmp/wa-login && node login.js"
+  fi
+
+  # cloudflared tunnel
   if command -v cloudflared >/dev/null 2>&1; then
     start_service cloudflared \
       cloudflared tunnel --url "http://localhost:$DASHBOARD_PORT"
   else
-    warn "cloudflared not found — no public URL. Install it separately if you need a public tunnel."
+    warn "cloudflared not found — no public URL. Install: brev-setup.sh or manually."
   fi
 
   # Wait for cloudflared to publish URL
@@ -184,19 +264,10 @@ do_start() {
   echo "  │  NemoClaw Services                                  │"
   echo "  │                                                     │"
 
-  local tunnel_url=""
-  if [ -f "$PIDDIR/cloudflared.log" ]; then
-    tunnel_url="$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$PIDDIR/cloudflared.log" 2>/dev/null | head -1 || true)"
-  fi
-
-  if [ -n "$tunnel_url" ]; then
-    printf "  │  Public URL:  %-40s│\n" "$tunnel_url"
-  fi
-
-  if is_running telegram-bridge; then
-    echo "  │  Telegram:    bridge running                        │"
+  if is_running slack-bridge; then
+    echo "  │  Slack:       bridge running                        │"
   else
-    echo "  │  Telegram:    not started (no token)                │"
+    echo "  │  Slack:       not started (no token)                │"
   fi
 
   echo "  │                                                     │"

--- a/scripts/watchdog-bridge.sh
+++ b/scripts/watchdog-bridge.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Watchdog: restart Slack bridge if it's not running.
+# Designed to run from cron every 2 minutes.
+#
+# Usage:
+#   */2 * * * * /path/to/watchdog-bridge.sh >> /tmp/nemoclaw-watchdog.log 2>&1
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SANDBOX_NAME="${NEMOCLAW_SANDBOX:-veyonce-claw}"
+PIDDIR="/tmp/nemoclaw-services-${SANDBOX_NAME}"
+PIDFILE="$PIDDIR/slack-bridge.pid"
+LOGFILE="$PIDDIR/slack-bridge.log"
+
+ts() { date "+%Y-%m-%d %H:%M:%S"; }
+
+# Source .env for tokens
+if [ -f "$REPO_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$REPO_DIR/.env"
+  set +a
+fi
+
+# Check if bridge is running
+bridge_alive() {
+  if [ -f "$PIDFILE" ]; then
+    local pid
+    pid="$(cat "$PIDFILE")"
+    if kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+  fi
+  # Fallback: look for the process by pattern
+  if pgrep -f "node.*slack-bridge(-multi)?\\.js" >/dev/null 2>&1; then
+    # Update PID file with actual PID
+    local pid
+    pid="$(pgrep -fo "node.*slack-bridge(-multi)\\.js" 2>/dev/null || true)"
+    if [ -n "$pid" ]; then
+      mkdir -p "$PIDDIR"
+      echo "$pid" > "$PIDFILE"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+if bridge_alive; then
+  exit 0
+fi
+
+# Bridge is down — restart
+echo "$(ts) [watchdog] Bridge not running, restarting..."
+
+# Verify tokens are available
+if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${SLACK_APP_TOKEN:-}" ]; then
+  echo "$(ts) [watchdog] ERROR: SLACK_BOT_TOKEN or SLACK_APP_TOKEN missing from .env"
+  exit 1
+fi
+
+mkdir -p "$PIDDIR"
+
+# Determine which bridge script to use
+USERS_FILE="$HOME/.nemoclaw/users.json"
+if [ -f "$USERS_FILE" ] && python3 -c "import json; d=json.load(open('$USERS_FILE')); exit(0 if len(d.get('users',{})) > 0 else 1)" 2>/dev/null; then
+  BRIDGE_SCRIPT="$REPO_DIR/scripts/slack-bridge-multi.js"
+else
+  BRIDGE_SCRIPT="$REPO_DIR/scripts/slack-bridge.js"
+fi
+
+# Fix root-owned files and clean stale locks in all sandboxes
+if [ -f "$USERS_FILE" ]; then
+  for sandbox in $(python3 -c "
+import json
+d = json.load(open('$USERS_FILE'))
+for u in d.get('users', {}).values():
+  if u.get('enabled', True):
+    print(u.get('sandboxName', ''))
+" 2>/dev/null); do
+    if [ -n "$sandbox" ]; then
+      # Fix root-owned files via kubectl (runs as root inside the pod)
+      docker exec openshell-cluster-nemoclaw kubectl exec -n openshell "$sandbox" -- \
+        sh -c 'chown -R sandbox:sandbox /sandbox/.openclaw 2>/dev/null; chmod -R u+w /sandbox/.openclaw 2>/dev/null' \
+        2>/dev/null || true
+      # Clean stale session locks via SSH
+      openshell sandbox ssh-config "$sandbox" > "/tmp/watchdog-ssh-$sandbox" 2>/dev/null || continue
+      ssh -F "/tmp/watchdog-ssh-$sandbox" "openshell-$sandbox" \
+        'find /sandbox/.openclaw/agents -name "*.lock" -mmin +2 -delete 2>/dev/null' \
+        2>/dev/null || true
+      rm -f "/tmp/watchdog-ssh-$sandbox"
+    fi
+  done
+  echo "$(ts) [watchdog] Fixed ownership and cleaned stale locks"
+fi
+
+# Kill any zombie bridge processes
+pkill -f "node.*slack-bridge(-multi)?\\.js" 2>/dev/null || true
+sleep 1
+
+# Start bridge
+nohup node "$BRIDGE_SCRIPT" >> "$LOGFILE" 2>&1 &
+BRIDGE_PID=$!
+echo "$BRIDGE_PID" > "$PIDFILE"
+
+sleep 3
+
+if kill -0 "$BRIDGE_PID" 2>/dev/null; then
+  echo "$(ts) [watchdog] Bridge restarted (PID $BRIDGE_PID)"
+else
+  echo "$(ts) [watchdog] ERROR: Bridge failed to start. Check $LOGFILE"
+fi
+
+# ── WhatsApp bridge watchdog ──────────────────────────────────────
+WA_PIDFILE="$PIDDIR/whatsapp-bridge.pid"
+WA_LOGFILE="$PIDDIR/whatsapp-bridge.log"
+WA_AUTH="$REPO_DIR/persist/gateway/whatsapp-auth/creds.json"
+WA_FALLBACK="/tmp/wa-login/auth/creds.json"
+
+wa_alive() {
+  if [ -f "$WA_PIDFILE" ]; then
+    local pid
+    pid="$(cat "$WA_PIDFILE")"
+    kill -0 "$pid" 2>/dev/null && return 0
+  fi
+  if pgrep -f "node.*whatsapp-bridge-multi\\.js" >/dev/null 2>&1; then
+    pgrep -fo "node.*whatsapp-bridge-multi\\.js" > "$WA_PIDFILE" 2>/dev/null
+    return 0
+  fi
+  return 1
+}
+
+if [ -f "$WA_AUTH" ] || [ -f "$WA_FALLBACK" ]; then
+  if ! wa_alive; then
+    echo "$(ts) [watchdog] WhatsApp bridge not running, restarting..."
+    pkill -f "node.*whatsapp-bridge-multi\\.js" 2>/dev/null || true
+    sleep 1
+    nohup node "$REPO_DIR/scripts/whatsapp-bridge-multi.js" >> "$WA_LOGFILE" 2>&1 &
+    WA_PID=$!
+    echo "$WA_PID" > "$WA_PIDFILE"
+    sleep 3
+    if kill -0 "$WA_PID" 2>/dev/null; then
+      echo "$(ts) [watchdog] WhatsApp bridge restarted (PID $WA_PID)"
+    else
+      echo "$(ts) [watchdog] ERROR: WhatsApp bridge failed to start. Check $WA_LOGFILE"
+    fi
+  fi
+fi

--- a/scripts/whatsapp-bridge-multi.js
+++ b/scripts/whatsapp-bridge-multi.js
@@ -1,0 +1,596 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Multi-user WhatsApp bridge — listens for incoming WhatsApp messages,
+// routes them to the correct sandbox via the user registry, and sends
+// responses back. Runs on the HOST (not sandbox) because WhatsApp Web
+// requires a direct WebSocket that the sandbox proxy blocks.
+//
+// Setup:
+//   1. Link WhatsApp: cd /tmp/wa-login && node login.js (scan QR)
+//   2. Register users: add whatsapp-number.txt to persist/users/<id>/credentials/
+//   3. Start: node scripts/whatsapp-bridge-multi.js
+//
+// Users register their WhatsApp via Slack: !setup whatsapp +1XXXXXXXXXX
+
+"use strict";
+
+const { makeWASocket, fetchLatestBaileysVersion, useMultiFileAuthState, makeCacheableSignalKeyStore, DisconnectReason } = require("/tmp/wa-login/node_modules/@whiskeysockets/baileys");
+const pino = require("/tmp/wa-login/node_modules/pino");
+const path = require("path");
+const fs = require("fs");
+const { execSync, execFileSync, spawn } = require("child_process");
+
+const REPO_DIR = path.resolve(__dirname, "..");
+const AUTH_DIR = path.join(REPO_DIR, "persist", "gateway", "whatsapp-auth");
+const FALLBACK_AUTH_DIR = "/tmp/wa-login/auth";
+
+// Load .env
+if (fs.existsSync(path.join(REPO_DIR, ".env"))) {
+  for (const line of fs.readFileSync(path.join(REPO_DIR, ".env"), "utf-8").split("\n")) {
+    const [k, ...v] = line.split("=");
+    if (k && v.length && !k.startsWith("#")) process.env[k.trim()] = v.join("=").trim();
+  }
+}
+
+// ── User registry ────────────────────────────────────────────────
+
+const userRegistryPath = path.join(process.env.HOME || "/root", ".nemoclaw", "users.json");
+
+function loadUserRegistry() {
+  if (!fs.existsSync(userRegistryPath)) return {};
+  const data = JSON.parse(fs.readFileSync(userRegistryPath, "utf-8"));
+  return data.users || {};
+}
+
+// Map WhatsApp JID → user
+// WhatsApp uses two JID formats:
+//   - Standard: 15551234567@s.whatsapp.net
+//   - Linked ID: 39239039361092@lid (newer linked device format)
+// We store both the number-based JID and resolve LID→number at runtime.
+function buildWhatsAppUserMap() {
+  const users = loadUserRegistry();
+  const waMap = {};
+  const numberToUser = {};
+  for (const [slackId, user] of Object.entries(users)) {
+    if (!user.enabled) continue;
+    const waFile = path.join(REPO_DIR, "persist", "users", slackId, "credentials", "whatsapp-number.txt");
+    if (fs.existsSync(waFile)) {
+      const number = fs.readFileSync(waFile, "utf-8").trim().replace(/[^0-9]/g, "");
+      if (number) {
+        const userData = { ...user, slackUserId: slackId, waNumber: number };
+        waMap[`${number}@s.whatsapp.net`] = userData;
+        numberToUser[number] = userData;
+      }
+    }
+  }
+  return { waMap, numberToUser };
+}
+
+// Cache LID → phone number mappings discovered at runtime
+const lidToNumber = new Map();
+
+let { waMap: waUserMap, numberToUser } = buildWhatsAppUserMap();
+
+// Refresh user map periodically
+setInterval(() => {
+  const result = buildWhatsAppUserMap();
+  waUserMap = result.waMap;
+  numberToUser = result.numberToUser;
+}, 60000);
+
+// Resolve a JID to a registered user, handling both @s.whatsapp.net and @lid formats
+function resolveUser(jid) {
+  // Direct match (standard JID)
+  if (waUserMap[jid]) return waUserMap[jid];
+
+  // Check LID cache
+  if (jid.endsWith("@lid")) {
+    const cached = lidToNumber.get(jid);
+    if (cached && waUserMap[`${cached}@s.whatsapp.net`]) {
+      return waUserMap[`${cached}@s.whatsapp.net`];
+    }
+  }
+
+  return null;
+}
+
+// ── OpenShell / sandbox helpers ──────────────────────────────────
+
+function findOpenshell() {
+  for (const p of ["/usr/local/bin/openshell", `${process.env.HOME}/.local/bin/openshell`]) {
+    if (fs.existsSync(p)) return p;
+  }
+  try { return execSync("which openshell", { encoding: "utf-8" }).trim(); } catch {}
+  return null;
+}
+
+const OPENSHELL = findOpenshell();
+
+// ── Agent execution (fire-and-poll, same as Slack bridge) ────────
+
+function sshExec(confPath, sandboxName, cmd, timeoutMs = 30000) {
+  try {
+    return execFileSync("ssh", ["-T", "-o", "ConnectTimeout=10", "-F", confPath, `openshell-${sandboxName}`, cmd], {
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    if (err.stdout) return err.stdout.toString().trim();
+    throw err;
+  }
+}
+
+function filterAgentOutput(raw) {
+  let cleaned = raw
+    .replace(/\[agent\] run [^\n]+\n/g, "")
+    .replace(/Failing gates:[\s\S]*?(?=\n[A-Z]|\n\n)/g, "")
+    .replace(/Fix-it keys:[\s\S]*?(?=\n[A-Z]|\n\n)/g, "")
+    .replace(/Context: session=[^\n]+\n/g, "")
+    .replace(/^Command not found$/gm, "");
+
+  return cleaned.split("\n").filter(
+    (l) =>
+      !l.startsWith("Setting up NemoClaw") &&
+      !l.startsWith("[plugins]") &&
+      !l.startsWith("[credentials]") &&
+      !l.startsWith("[config]") &&
+      !l.startsWith("[inject]") &&
+      !l.startsWith("[gateway]") &&
+      !l.startsWith("[auto-pair]") &&
+      !l.startsWith("[diagnostic]") &&
+      !l.startsWith("[SECURITY]") &&
+      !l.startsWith("[tools]") &&
+      !l.startsWith("[agent/") &&
+      !l.startsWith("[agent]") &&
+      !l.startsWith("[memory]") &&
+      !l.startsWith("[SECURITY WARNING]") &&
+      !l.startsWith("(node:") &&
+      !l.startsWith("(Use node") &&
+      !l.startsWith("(Use `node") &&
+      !/^\[UNDICI-/.test(l) &&
+      !/^Warning:.*EnvHttpProxyAgent/.test(l) &&
+      !/^Traceback \(most recent/.test(l) &&
+      !/^PermissionError:/.test(l) &&
+      !/^Error:.*ENOENT/.test(l) &&
+      !/^- tools\.elevated/.test(l) &&
+      !/^- agents\.list/.test(l) &&
+      !l.includes("NemoClaw ready") &&
+      !l.includes("NemoClaw registered") &&
+      !l.includes("openclaw agent") &&
+      !l.includes("--trace-warnings") &&
+      !l.includes("Config integrity check failed") &&
+      !l.includes("elevated is not available") &&
+      !l.includes("getaddrinfo EAI_AGAIN") &&
+      !l.includes("CAP_SETPCAP") &&
+      !l.includes("\u250C\u2500") &&
+      !l.includes("\u2502 ") &&
+      !l.includes("\u2514\u2500") &&
+      l.trim() !== "",
+  ).join("\n").trim();
+}
+
+function sh(value) {
+  return String(value).replace(/'/g, "'\\''");
+}
+
+// Per-user message queue (serialize per sandbox)
+const userQueues = new Map();
+function enqueueForUser(sandboxName, fn) {
+  const prev = userQueues.get(sandboxName) || Promise.resolve();
+  const next = prev.then(fn, fn);
+  userQueues.set(sandboxName, next);
+  return next;
+}
+
+async function runAgentInSandbox(message, sessionId, user) {
+  const sandboxName = user.sandboxName;
+  if (!OPENSHELL) return "Error: openshell not found.";
+
+  let sshConfig;
+  try {
+    sshConfig = execSync(`"${OPENSHELL}" sandbox ssh-config "${sandboxName}"`, { encoding: "utf-8" });
+  } catch {
+    return `Error: Cannot reach sandbox '${sandboxName}'.`;
+  }
+
+  const confPath = `/tmp/nemoclaw-wa-ssh-${sessionId}.conf`;
+  fs.writeFileSync(confPath, sshConfig);
+
+  const escaped = message.replace(/'/g, "'\\''");
+  const tag = `wa-${sessionId}`.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const outFile = `/tmp/nemoclaw-agent-${tag}.out`;
+  const rcFile = `/tmp/nemoclaw-agent-${tag}.rc`;
+
+  const agentCmd = [
+    `export NVIDIA_API_KEY='${sh(process.env.NVIDIA_API_KEY || "")}'`,
+    `export HOME=/sandbox`,
+    `find /sandbox/.openclaw/agents -name '*.lock' -mmin +2 -delete 2>/dev/null || true`,
+    `nemoclaw-start openclaw agent --agent main --local -m '${escaped}' --session-id 'wa-${sessionId}'`,
+  ].join("\n");
+
+  const launchCmd = `( ${agentCmd} ) > ${outFile} 2>&1; echo $? > ${rcFile}`;
+
+  try {
+    sshExec(confPath, sandboxName, `nohup sh -c '${launchCmd.replace(/'/g, "'\\''")}' </dev/null >/dev/null 2>&1 &`, 15000);
+  } catch {
+    try { fs.unlinkSync(confPath); } catch {}
+    return "Error launching agent.";
+  }
+
+  const maxWaitMs = 1800000; // 30 minutes
+  const pollIntervalMs = 3000;
+  const startTime = Date.now();
+  let consecutiveFailures = 0;
+
+  while (Date.now() - startTime < maxWaitMs) {
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+    try {
+      const rc = sshExec(confPath, sandboxName, `cat ${rcFile} 2>/dev/null || echo __pending__`, 10000);
+      consecutiveFailures = 0;
+      if (rc === "__pending__") continue;
+
+      const raw = sshExec(confPath, sandboxName, `cat ${outFile} 2>/dev/null`, 15000);
+      sshExec(confPath, sandboxName, `rm -f ${outFile} ${rcFile} 2>/dev/null`, 5000);
+      try { fs.unlinkSync(confPath); } catch {}
+
+      const response = filterAgentOutput(raw);
+      if (response) return response;
+      if (rc !== "0") return `Agent error (code ${rc}).`;
+      return "(no response)";
+    } catch {
+      consecutiveFailures++;
+      if (consecutiveFailures >= 5) {
+        try { fs.unlinkSync(confPath); } catch {}
+        return "Error: sandbox unreachable.";
+      }
+    }
+  }
+
+  try {
+    const raw = sshExec(confPath, sandboxName, `cat ${outFile} 2>/dev/null`, 10000);
+    sshExec(confPath, sandboxName, `rm -f ${outFile} ${rcFile} 2>/dev/null`, 5000);
+    try { fs.unlinkSync(confPath); } catch {}
+    const partial = filterAgentOutput(raw);
+    if (partial) return partial + "\n\n(timed out after 30 minutes)";
+  } catch {}
+  try { fs.unlinkSync(confPath); } catch {}
+  return "Agent timed out.";
+}
+
+// ── Strip markdown for WhatsApp ──────────────────────────────────
+
+function toWhatsAppText(text) {
+  // Convert markdown bold **text** to WhatsApp bold *text*
+  return text
+    .replace(/\*\*([^*]+)\*\*/g, "*$1*")
+    // Convert markdown links [text](url) to text (url)
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)")
+    // Strip table pipes
+    .replace(/^\|.*\|$/gm, (line) => {
+      if (/^[\s|:-]+$/.test(line)) return "";
+      return line.replace(/^\|/, "").replace(/\|$/, "").split("|").map(c => c.trim()).join("  ·  ");
+    })
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// ── Main ─────────────────────────────────────────────────────────
+
+async function main() {
+  // Find auth dir
+  const authDir = fs.existsSync(path.join(AUTH_DIR, "creds.json")) ? AUTH_DIR :
+    fs.existsSync(path.join(FALLBACK_AUTH_DIR, "creds.json")) ? FALLBACK_AUTH_DIR : null;
+
+  if (!authDir) {
+    console.error("No WhatsApp auth found. Run: cd /tmp/wa-login && node login.js");
+    process.exit(1);
+  }
+
+  const { version } = await fetchLatestBaileysVersion();
+  const { state, saveCreds } = await useMultiFileAuthState(authDir);
+  const logger = pino({ level: "silent" });
+
+  const sock = makeWASocket({
+    auth: {
+      creds: state.creds,
+      keys: makeCacheableSignalKeyStore(state.keys, logger),
+    },
+    version,
+    logger,
+    printQRInTerminal: false,
+    browser: ["openclaw", "cli", "1.0.0"],
+    syncFullHistory: false,
+    markOnlineOnConnect: true,
+  });
+
+  sock.ev.on("creds.update", saveCreds);
+
+  // Handle connection
+  sock.ev.on("connection.update", (update) => {
+    const { connection, lastDisconnect, qr } = update;
+    if (qr) {
+      console.error("QR code displayed — session not linked. Run login.js first.");
+    }
+    if (connection === "open") {
+      console.log("[wa-bridge] WhatsApp Web connected.");
+    }
+    if (connection === "close") {
+      const code = lastDisconnect?.error?.output?.statusCode;
+      if (code === DisconnectReason.loggedOut) {
+        console.error("[wa-bridge] Logged out. Re-run login.js to re-link.");
+        process.exit(1);
+      }
+      if (code === 515) {
+        console.log("[wa-bridge] Restart requested (515). Reconnecting in 3s...");
+        setTimeout(() => main(), 3000);
+        return;
+      }
+      console.error(`[wa-bridge] Connection closed (code ${code}). Reconnecting in 5s...`);
+      setTimeout(() => main(), 5000);
+    }
+  });
+
+  // Handle incoming messages
+  sock.ev.on("messages.upsert", async ({ messages, type }) => {
+    if (type !== "notify") return;
+
+    for (const msg of messages) {
+      // Skip own messages, status broadcasts, and non-text
+      if (msg.key.fromMe) continue;
+      if (msg.key.remoteJid === "status@broadcast") continue;
+
+      const text = msg.message?.conversation ||
+        msg.message?.extendedTextMessage?.text ||
+        msg.message?.imageMessage?.caption ||
+        null;
+
+      if (!text) continue;
+
+      const jid = msg.key.remoteJid;
+      const pushName = msg.pushName || jid.split("@")[0];
+
+      // Learn LID → number mapping from message participant info
+      if (jid.endsWith("@lid") && msg.key.participant) {
+        const participantNum = msg.key.participant.split("@")[0];
+        if (/^\d+$/.test(participantNum)) {
+          lidToNumber.set(jid, participantNum);
+          console.log(`[wa-bridge] Learned LID mapping: ${jid} → ${participantNum}`);
+        }
+      }
+
+      // Look up user (handles both @s.whatsapp.net and @lid)
+      let user = resolveUser(jid);
+
+      // For LID JIDs, also try to resolve via the sender's phone in pushName or participant
+      if (!user && jid.endsWith("@lid")) {
+        // Try all registered numbers against LID mapping files
+        const lidNum = jid.split("@")[0];
+        const lidMappingFiles = [
+          `lid-mapping-${lidNum}.json`,
+          `lid-mapping-${lidNum}_reverse.json`,
+        ];
+        // Check auth dir for LID mapping hints
+        const authDir = fs.existsSync(path.join(AUTH_DIR, "creds.json")) ? AUTH_DIR : FALLBACK_AUTH_DIR;
+        for (const [num, userData] of Object.entries(numberToUser)) {
+          const mappingFile = path.join(authDir, `lid-mapping-${num}.json`);
+          if (fs.existsSync(mappingFile)) {
+            try {
+              const mapping = JSON.parse(fs.readFileSync(mappingFile, "utf-8"));
+              const lid = Object.keys(mapping)[0] || Object.values(mapping)[0];
+              if (lid && jid.includes(lid.split("@")[0])) {
+                lidToNumber.set(jid, num);
+                user = userData;
+                console.log(`[wa-bridge] Resolved LID via mapping file: ${jid} → ${num}`);
+                break;
+              }
+            } catch {}
+          }
+          // Also check reverse mapping
+          const revFile = path.join(authDir, `lid-mapping-${num}_reverse.json`);
+          if (fs.existsSync(revFile)) {
+            try {
+              const mapping = JSON.parse(fs.readFileSync(revFile, "utf-8"));
+              if (JSON.stringify(mapping).includes(jid.split("@")[0])) {
+                lidToNumber.set(jid, num);
+                user = userData;
+                console.log(`[wa-bridge] Resolved LID via reverse mapping: ${jid} → ${num}`);
+                break;
+              }
+            } catch {}
+          }
+        }
+      }
+
+      if (!user) {
+        console.log(`[wa-bridge] Unknown sender: ${pushName} (${jid}) — ignoring`);
+        await sock.sendMessage(jid, {
+          text: "You're not registered with NemoClaw. Ask an admin to add your WhatsApp number, or use Slack: !setup whatsapp +<your-number>"
+        }).catch(() => {});
+        continue;
+      }
+
+      console.log(`[wa-bridge] ${pushName} → ${user.sandboxName}: ${text.slice(0, 80)}`);
+
+      // Send typing indicator
+      await sock.sendPresenceUpdate("composing", jid).catch(() => {});
+
+      // ── Bridge commands (same as Slack bridge) ───────────
+      const normalizedText = text.trim();
+      let cmdResponse = null;
+
+      // !setup commands
+      if (/^!setup\b/i.test(normalizedText)) {
+        try {
+          const { handleSetup, setupHelp } = require("../bin/lib/credential-setup");
+          const setupText = normalizedText.slice("!setup ".length).trim();
+          if (!setupText || setupText === "help") {
+            cmdResponse = setupHelp();
+          } else {
+            const { response: r } = handleSetup(user, setupText);
+            cmdResponse = r;
+          }
+        } catch (err) {
+          cmdResponse = `Setup error: ${err.message}`;
+        }
+      }
+
+      // !yahoo commands
+      if (!cmdResponse && /^!yahoo\b/i.test(normalizedText)) {
+        const yahooCredsPath = `${REPO_DIR}/persist/users/${user.slackUserId}/credentials/yahoo-creds.env`;
+        if (!fs.existsSync(yahooCredsPath)) {
+          cmdResponse = "No Yahoo credentials configured. Use: !setup help";
+        } else {
+          const yahooCreds = {};
+          fs.readFileSync(yahooCredsPath, "utf-8").split("\n").forEach((line) => {
+            const [k, ...v] = line.split("=");
+            if (k && v.length) yahooCreds[k.trim()] = v.join("=").trim();
+          });
+          const yahooCmd = normalizedText.slice("!yahoo ".length).trim();
+          if (!yahooCmd || yahooCmd === "help") {
+            cmdResponse = "Yahoo commands:\n!yahoo inbox [--count N] [--unread]\n!yahoo read <id>\n!yahoo send --to <addr> --subject \"...\" --body \"...\"\n!yahoo search <query>";
+          } else {
+            try {
+              cmdResponse = execFileSync("python3", [`${REPO_DIR}/scripts/yahoo-mail.py`, ...yahooCmd.split(/\s+/)], {
+                encoding: "utf-8",
+                timeout: 30000,
+                env: { ...process.env, ...yahooCreds },
+              }).trim();
+            } catch (err) {
+              cmdResponse = `Yahoo error: ${(err.stderr || err.message || "").slice(0, 300)}`;
+            }
+          }
+        }
+      }
+
+      // !wa / !whatsapp commands (from WhatsApp itself)
+      if (!cmdResponse && /^!(wa|whatsapp)\b/i.test(normalizedText)) {
+        const waCmd = normalizedText.replace(/^!(whatsapp|wa)\s*/i, "").trim();
+        if (!waCmd || waCmd === "help") {
+          cmdResponse = "WhatsApp commands:\n!wa send <phone> <message>\n!wa contacts [--query <name>]\n!wa inbox\n!wa read <phone>";
+        } else if (/^send\b/i.test(waCmd)) {
+          const parts = waCmd.replace(/^send\s+/i, "").match(/^(\+?\d+)\s+(.+)$/s);
+          if (parts) {
+            try {
+              const targetJid = parts[1].replace(/[^0-9]/g, "") + "@s.whatsapp.net";
+              await sock.sendMessage(targetJid, { text: parts[2] });
+              cmdResponse = `Sent to ${parts[1]}`;
+            } catch (err) {
+              cmdResponse = `Send failed: ${err.message}`;
+            }
+          } else {
+            cmdResponse = "Usage: !wa send <phone> <message>";
+          }
+        } else {
+          try {
+            cmdResponse = execFileSync("node", [`${REPO_DIR}/scripts/whatsapp-bridge.js`, ...waCmd.split(/\s+/)], {
+              encoding: "utf-8",
+              timeout: 45000,
+              env: { ...process.env, SLACK_USER_ID: user.slackUserId },
+            }).trim();
+          } catch (err) {
+            cmdResponse = `WhatsApp error: ${(err.stderr || err.stdout || err.message || "").slice(0, 300)}`;
+          }
+        }
+      }
+
+      // !admin commands (admins only)
+      if (!cmdResponse && /^!(admin|show-claws|show-user|admins)\b/i.test(normalizedText)) {
+        const roles = user.roles || ["user"];
+        if (roles.includes("admin")) {
+          if (/^!admins$/i.test(normalizedText)) {
+            const users = loadUserRegistry();
+            const admins = Object.values(users).filter(u => (u.roles || []).includes("admin"));
+            cmdResponse = "Admins:\n" + admins.map(a => `• ${a.slackDisplayName} (${a.sandboxName})`).join("\n");
+          } else if (/^!show-claws$/i.test(normalizedText)) {
+            cmdResponse = "Use Slack for !show-claws (table formatting required).";
+          } else {
+            cmdResponse = "Admin commands with table output are best used via Slack.";
+          }
+        } else {
+          cmdResponse = "Admin commands require admin role.";
+        }
+      }
+
+      // !help
+      if (!cmdResponse && /^!help$/i.test(normalizedText)) {
+        cmdResponse = "Available commands:\n\n" +
+          "!setup help — Configure credentials\n" +
+          "!yahoo help — Yahoo mail commands\n" +
+          "!wa help — WhatsApp commands\n" +
+          "!admins — List admins\n" +
+          "!help — This message\n\n" +
+          "Or just type anything to chat with your claw.";
+      }
+
+      // If a command was handled, send response and skip agent
+      if (cmdResponse) {
+        const waResponse = toWhatsAppText(cmdResponse);
+        await sock.sendMessage(jid, { text: waResponse }).catch((err) => {
+          console.error(`[wa-bridge] Send failed: ${err.message}`);
+        });
+        await sock.sendPresenceUpdate("paused", jid).catch(() => {});
+        console.log(`[wa-bridge] cmd response → ${pushName}: ${waResponse.slice(0, 80)}...`);
+        continue;
+      }
+
+      // ── Route to sandbox agent ─────────────────────────
+      const sessionId = `${jid.split("@")[0]}-${Date.now()}`;
+      const response = await enqueueForUser(user.sandboxName, () =>
+        runAgentInSandbox(text, sessionId, user)
+      );
+
+      // Send response back via WhatsApp
+      const waResponse = toWhatsAppText(response);
+
+      // WhatsApp has a ~65K char limit but split at 4000 for readability
+      const chunks = [];
+      let remaining = waResponse;
+      while (remaining.length > 0) {
+        if (remaining.length <= 4000) {
+          chunks.push(remaining);
+          break;
+        }
+        // Split at last newline before 4000
+        const splitAt = remaining.lastIndexOf("\n", 4000);
+        const idx = splitAt > 2000 ? splitAt : 4000;
+        chunks.push(remaining.slice(0, idx));
+        remaining = remaining.slice(idx).trim();
+      }
+
+      for (const chunk of chunks) {
+        await sock.sendMessage(jid, { text: chunk }).catch((err) => {
+          console.error(`[wa-bridge] Send failed to ${jid}: ${err.message}`);
+        });
+      }
+
+      await sock.sendPresenceUpdate("paused", jid).catch(() => {});
+      console.log(`[wa-bridge] ${user.sandboxName} → ${pushName}: ${response.slice(0, 80)}...`);
+    }
+  });
+
+  // Print banner
+  const userCount = Object.keys(waUserMap).length;
+  const userList = Object.entries(waUserMap).map(([jid, u]) => `${u.slackDisplayName || u.slackUserId} → ${u.sandboxName} (${u.waNumber || jid.split("@")[0]})`);
+
+  console.log("");
+  console.log("  ┌─────────────────────────────────────────────────────┐");
+  console.log("  │  NemoClaw Multi-User WhatsApp Bridge                │");
+  console.log("  │                                                     │");
+  console.log("  │  Users: " + (String(userCount) + " registered                            ").slice(0, 43) + "│");
+  for (const line of userList) {
+    console.log("  │    " + (line + "                                               ").slice(0, 47) + "│");
+  }
+  console.log("  │                                                     │");
+  console.log("  │  Messages are routed by WhatsApp number to the      │");
+  console.log("  │  correct sandbox. DM the bot to chat with your claw.│");
+  console.log("  └─────────────────────────────────────────────────────┘");
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error("[wa-bridge] Fatal:", err.message);
+  process.exit(1);
+});

--- a/scripts/whatsapp-bridge.js
+++ b/scripts/whatsapp-bridge.js
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// WhatsApp CLI — read and send messages via Baileys (runs on host, not sandbox).
+//
+// Usage:
+//   whatsapp-bridge.js inbox [--count N]
+//   whatsapp-bridge.js read <jid> [--count N]
+//   whatsapp-bridge.js send <phone-or-jid> <message>
+//   whatsapp-bridge.js contacts [--query <name>]
+//
+// Auth dir: /tmp/wa-login/auth (created by login.js)
+
+const { makeWASocket, fetchLatestBaileysVersion, useMultiFileAuthState, makeCacheableSignalKeyStore, DisconnectReason } = require("@whiskeysockets/baileys");
+const pino = require("pino");
+const path = require("path");
+
+// Suppress Baileys session debug noise
+const origWarn = console.warn;
+const origLog = console.log;
+
+const AUTH_DIR = path.join(__dirname, "..", "..", "persist", "users", process.env.SLACK_USER_ID || "default", "credentials", "whatsapp-auth");
+const FALLBACK_AUTH_DIR = "/tmp/wa-login/auth";
+const fs = require("fs");
+
+function getAuthDir() {
+  if (fs.existsSync(path.join(AUTH_DIR, "creds.json"))) return AUTH_DIR;
+  if (fs.existsSync(path.join(FALLBACK_AUTH_DIR, "creds.json"))) return FALLBACK_AUTH_DIR;
+  console.error("No WhatsApp auth found. Run: cd /tmp/wa-login && node login.js");
+  process.exit(1);
+}
+
+function normalizeJid(input) {
+  if (input.includes("@")) return input;
+  // Strip +, spaces, dashes
+  const num = input.replace(/[^0-9]/g, "");
+  return `${num}@s.whatsapp.net`;
+}
+
+async function withSocket(fn) {
+  const authDir = getAuthDir();
+  const { version } = await fetchLatestBaileysVersion();
+  const { state, saveCreds } = await useMultiFileAuthState(authDir);
+  const logger = pino({ level: "silent" });
+
+  const sock = makeWASocket({
+    auth: {
+      creds: state.creds,
+      keys: makeCacheableSignalKeyStore(state.keys, logger),
+    },
+    version,
+    logger,
+    printQRInTerminal: false,
+    browser: ["openclaw", "cli", "1.0.0"],
+    syncFullHistory: false,
+    markOnlineOnConnect: false,
+  });
+
+  sock.ev.on("creds.update", saveCreds);
+
+  // Wait for connection
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Connection timeout (30s)")), 30000);
+    sock.ev.on("connection.update", (update) => {
+      if (update.connection === "open") { clearTimeout(timeout); resolve(); }
+      if (update.connection === "close") {
+        clearTimeout(timeout);
+        const code = update.lastDisconnect?.error?.output?.statusCode;
+        if (code === 515) {
+          // Restart requested — resolve and let caller retry
+          resolve();
+        } else {
+          reject(new Error(`Connection closed (code ${code})`));
+        }
+      }
+    });
+  });
+
+  try {
+    await fn(sock);
+  } finally {
+    // Suppress Baileys session closing noise
+    console.log = () => {};
+    console.warn = () => {};
+    setTimeout(() => { try { sock.ws?.close(); } catch {} process.exit(0); }, 1000);
+  }
+}
+
+async function cmdInbox(count) {
+  await withSocket(async (sock) => {
+    // Fetch recent chats
+    const chats = await sock.groupFetchAllParticipating().catch(() => ({}));
+    // Get recent messages from store (Baileys doesn't have a direct "inbox" — use chat list)
+    const store = sock.store;
+
+    // List recent contacts who messaged us
+    console.log("Recent WhatsApp conversations (use 'read <jid>' to view messages):\n");
+    console.log(`${"JID".padEnd(35)} Name`);
+    console.log("-".repeat(70));
+
+    // Get contacts
+    const contacts = {};
+    sock.ev.on("contacts.set", ({ contacts: c }) => {
+      for (const contact of c) contacts[contact.id] = contact;
+    });
+
+    // Wait briefly for contacts to load
+    await new Promise(r => setTimeout(r, 3000));
+
+    // Use the contacts from creds
+    const contactList = Object.entries(contacts).slice(0, count);
+    if (contactList.length === 0) {
+      console.log("(No cached contacts. Send/receive a message first to populate.)");
+    }
+    for (const [jid, contact] of contactList) {
+      const name = contact.name || contact.notify || jid;
+      console.log(`${jid.padEnd(35)} ${name}`);
+    }
+  });
+}
+
+async function cmdRead(jid, count) {
+  const normalizedJid = normalizeJid(jid);
+  await withSocket(async (sock) => {
+    console.log(`Recent messages with ${normalizedJid}:\n`);
+    // Baileys doesn't store history by default — fetch from WhatsApp
+    const messages = await sock.fetchMessagesFromWA(normalizedJid, count).catch(() => null);
+    if (!messages || messages.length === 0) {
+      console.log("(No messages found or history not available.)");
+      return;
+    }
+    for (const msg of messages) {
+      const from = msg.key.fromMe ? "You" : (msg.pushName || normalizedJid);
+      const text = msg.message?.conversation || msg.message?.extendedTextMessage?.text || "(media/other)";
+      const ts = new Date((msg.messageTimestamp || 0) * 1000).toLocaleString();
+      console.log(`[${ts}] ${from}: ${text}`);
+    }
+  });
+}
+
+async function cmdSend(jid, message) {
+  const normalizedJid = normalizeJid(jid);
+  await withSocket(async (sock) => {
+    await sock.sendMessage(normalizedJid, { text: message });
+    console.log(`✅ Sent to ${normalizedJid}`);
+  });
+}
+
+async function cmdContacts(query) {
+  await withSocket(async (sock) => {
+    const contacts = {};
+    sock.ev.on("contacts.set", ({ contacts: c }) => {
+      for (const contact of c) contacts[contact.id] = contact;
+    });
+    await new Promise(r => setTimeout(r, 3000));
+
+    console.log(`${"JID".padEnd(35)} ${"Name".padEnd(25)} Phone`);
+    console.log("-".repeat(80));
+
+    for (const [jid, contact] of Object.entries(contacts)) {
+      const name = contact.name || contact.notify || "";
+      if (query && !name.toLowerCase().includes(query.toLowerCase()) && !jid.includes(query)) continue;
+      const phone = jid.split("@")[0];
+      console.log(`${jid.padEnd(35)} ${name.padEnd(25)} ${phone}`);
+    }
+  });
+}
+
+// Parse args
+const args = process.argv.slice(2);
+const cmd = args[0];
+
+if (!cmd || cmd === "help") {
+  console.log(`WhatsApp CLI (host-side bridge)
+
+Commands:
+  inbox [--count N]              List recent conversations
+  read <phone-or-jid> [--count N] Read messages from a contact
+  send <phone-or-jid> <message>  Send a message
+  contacts [--query <name>]      List/search contacts
+
+Examples:
+  whatsapp-bridge.js send +15551234567 "Hello!"
+  whatsapp-bridge.js contacts --query "Mom"
+  whatsapp-bridge.js read 15551234567`);
+  process.exit(0);
+}
+
+const countIdx = args.indexOf("--count");
+const count = countIdx >= 0 ? parseInt(args[countIdx + 1]) || 20 : 20;
+const queryIdx = args.indexOf("--query");
+const query = queryIdx >= 0 ? args[queryIdx + 1] : null;
+
+switch (cmd) {
+  case "inbox":
+    cmdInbox(count).catch(e => { console.error("Error:", e.message); process.exit(1); });
+    break;
+  case "read":
+    cmdRead(args[1], count).catch(e => { console.error("Error:", e.message); process.exit(1); });
+    break;
+  case "send":
+    if (!args[1] || !args[2]) { console.error("Usage: send <phone-or-jid> <message>"); process.exit(1); }
+    cmdSend(args[1], args.slice(2).join(" ")).catch(e => { console.error("Error:", e.message); process.exit(1); });
+    break;
+  case "contacts":
+    cmdContacts(query).catch(e => { console.error("Error:", e.message); process.exit(1); });
+    break;
+  default:
+    console.error(`Unknown command: ${cmd}. Run with 'help' for usage.`);
+    process.exit(1);
+}

--- a/scripts/yahoo-mail.py
+++ b/scripts/yahoo-mail.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Yahoo Mail CLI — read and send email via IMAP/SMTP.
+# Supports HTTP CONNECT proxy tunneling for sandboxed environments.
+#
+# Usage:
+#   yahoo-mail inbox [--count N] [--unread]
+#   yahoo-mail read <message-id>
+#   yahoo-mail send --to <addr> --subject <subj> --body <body> [--cc <addr>]
+#   yahoo-mail search <query> [--count N]
+#
+# Env vars:
+#   YAHOO_EMAIL    — Yahoo email address
+#   YAHOO_APP_PWD  — Yahoo app password
+#   https_proxy    — HTTP proxy (auto-detected, used for CONNECT tunneling)
+
+import argparse
+import email
+import email.utils
+import imaplib
+import os
+import smtplib
+import socket
+import ssl
+import sys
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email.header import decode_header
+from urllib.parse import urlparse
+
+IMAP_HOST = "imap.mail.yahoo.com"
+IMAP_PORT = 993
+SMTP_HOST = "smtp.mail.yahoo.com"
+SMTP_PORT = 465
+
+
+def _proxy_tunnel(host, port):
+    """Create an SSL socket through the HTTP CONNECT proxy."""
+    proxy_url = os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
+    if not proxy_url:
+        sock = socket.create_connection((host, port), timeout=30)
+        return ssl.create_default_context().wrap_socket(sock, server_hostname=host)
+
+    parsed = urlparse(proxy_url)
+    proxy_host = parsed.hostname
+    proxy_port = parsed.port or 3128
+
+    sock = socket.create_connection((proxy_host, proxy_port), timeout=30)
+    sock.sendall(f"CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n".encode())
+
+    response = b""
+    while b"\r\n\r\n" not in response:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise ConnectionError(f"Proxy closed connection during CONNECT to {host}:{port}")
+        response += chunk
+
+    status_line = response.split(b"\r\n")[0].decode()
+    if "200" not in status_line:
+        raise ConnectionError(f"Proxy CONNECT failed: {status_line}")
+
+    return ssl.create_default_context().wrap_socket(sock, server_hostname=host)
+
+
+def open_imap():
+    """Connect to Yahoo IMAP. Uses proxy tunnel if https_proxy is set, else direct."""
+    proxy_url = os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
+    if not proxy_url:
+        return imaplib.IMAP4_SSL(IMAP_HOST, IMAP_PORT)
+    # Proxy path: tunnel through HTTP CONNECT
+    ssl_sock = _proxy_tunnel(IMAP_HOST, IMAP_PORT)
+    imap = imaplib.IMAP4(IMAP_HOST)
+    imap.sock = ssl_sock
+    imap.file = ssl_sock.makefile("rb")
+    imap.file.readline()  # consume greeting
+    return imap
+
+
+def open_smtp():
+    """Connect to Yahoo SMTP. Uses proxy tunnel if https_proxy is set, else direct."""
+    proxy_url = os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
+    if not proxy_url:
+        return smtplib.SMTP_SSL(SMTP_HOST, SMTP_PORT)
+    # Proxy path: tunnel through HTTP CONNECT
+    ssl_sock = _proxy_tunnel(SMTP_HOST, SMTP_PORT)
+    smtp = smtplib.SMTP()
+    smtp.sock = ssl_sock
+    smtp.file = ssl_sock.makefile("rb")
+    code, msg = smtp.getreply()
+    if code != 220:
+        raise smtplib.SMTPConnectError(code, msg)
+    smtp.ehlo()
+    return smtp
+
+
+def get_creds():
+    addr = os.environ.get("YAHOO_EMAIL")
+    pwd = os.environ.get("YAHOO_APP_PWD")
+    if not addr or not pwd:
+        print("Error: YAHOO_EMAIL and YAHOO_APP_PWD must be set", file=sys.stderr)
+        sys.exit(1)
+    return addr, pwd
+
+
+def decode_hdr(value):
+    if value is None:
+        return ""
+    parts = decode_header(value)
+    result = []
+    for data, charset in parts:
+        if isinstance(data, bytes):
+            result.append(data.decode(charset or "utf-8", errors="replace"))
+        else:
+            result.append(data)
+    return "".join(result)
+
+
+def get_body(msg):
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                payload = part.get_payload(decode=True)
+                if payload:
+                    return payload.decode(part.get_content_charset() or "utf-8", errors="replace")
+        for part in msg.walk():
+            if part.get_content_type() == "text/html":
+                payload = part.get_payload(decode=True)
+                if payload:
+                    return "[HTML] " + payload.decode(part.get_content_charset() or "utf-8", errors="replace")[:2000]
+    else:
+        payload = msg.get_payload(decode=True)
+        if payload:
+            return payload.decode(msg.get_content_charset() or "utf-8", errors="replace")
+    return "(no body)"
+
+
+def cmd_inbox(args):
+    addr, pwd = get_creds()
+    imap = open_imap()
+    try:
+        imap.login(addr, pwd)
+        imap.select("INBOX", readonly=True)
+        _, data = imap.search(None, "UNSEEN" if args.unread else "ALL")
+        ids = data[0].split()
+        if not ids:
+            print("No messages found.")
+            return
+        latest = ids[-(args.count):]
+        latest.reverse()
+        print(f"{'ID':>6}  {'Date':20}  {'From':30}  Subject")
+        print("-" * 100)
+        for mid in latest:
+            _, msg_data = imap.fetch(mid, "(BODY.PEEK[HEADER.FIELDS (FROM SUBJECT DATE)])")
+            raw = msg_data[0][1]
+            msg = email.message_from_bytes(raw)
+            frm = decode_hdr(msg.get("From", ""))[:30]
+            subj = decode_hdr(msg.get("Subject", ""))[:60]
+            date = decode_hdr(msg.get("Date", ""))[:20]
+            print(f"{mid.decode():>6}  {date:20}  {frm:30}  {subj}")
+    finally:
+        try:
+            imap.logout()
+        except Exception:
+            pass
+
+
+def cmd_read(args):
+    addr, pwd = get_creds()
+    imap = open_imap()
+    try:
+        imap.login(addr, pwd)
+        imap.select("INBOX", readonly=True)
+        _, msg_data = imap.fetch(args.message_id.encode(), "(RFC822)")
+        if not msg_data or not msg_data[0]:
+            print(f"Message {args.message_id} not found.")
+            return
+        raw = msg_data[0][1]
+        msg = email.message_from_bytes(raw)
+        print(f"From:    {decode_hdr(msg.get('From', ''))}")
+        print(f"To:      {decode_hdr(msg.get('To', ''))}")
+        print(f"Date:    {decode_hdr(msg.get('Date', ''))}")
+        print(f"Subject: {decode_hdr(msg.get('Subject', ''))}")
+        print(f"\n{get_body(msg)}")
+    finally:
+        try:
+            imap.logout()
+        except Exception:
+            pass
+
+
+def cmd_send(args):
+    addr, pwd = get_creds()
+    msg = MIMEMultipart()
+    msg["From"] = addr
+    msg["To"] = args.to
+    msg["Subject"] = args.subject
+    if args.cc:
+        msg["Cc"] = args.cc
+    msg.attach(MIMEText(args.body, "plain"))
+    smtp = open_smtp()
+    try:
+        smtp.login(addr, pwd)
+        recipients = [args.to]
+        if args.cc:
+            recipients.extend([a.strip() for a in args.cc.split(",")])
+        smtp.sendmail(addr, recipients, msg.as_string())
+        print(f"Sent to {args.to}" + (f" (cc: {args.cc})" if args.cc else ""))
+    finally:
+        try:
+            smtp.quit()
+        except Exception:
+            pass
+
+
+def cmd_search(args):
+    addr, pwd = get_creds()
+    query = " ".join(args.query)
+    imap = open_imap()
+    try:
+        imap.login(addr, pwd)
+        imap.select("INBOX", readonly=True)
+        _, data = imap.search(None, f'(OR (SUBJECT "{query}") (FROM "{query}"))')
+        ids = data[0].split()
+        if not ids:
+            print(f"No messages matching '{query}'.")
+            return
+        latest = ids[-(args.count):]
+        latest.reverse()
+        print(f"{'ID':>6}  {'Date':20}  {'From':30}  Subject")
+        print("-" * 100)
+        for mid in latest:
+            _, msg_data = imap.fetch(mid, "(BODY.PEEK[HEADER.FIELDS (FROM SUBJECT DATE)])")
+            raw = msg_data[0][1]
+            msg = email.message_from_bytes(raw)
+            frm = decode_hdr(msg.get("From", ""))[:30]
+            subj = decode_hdr(msg.get("Subject", ""))[:60]
+            date = decode_hdr(msg.get("Date", ""))[:20]
+            print(f"{mid.decode():>6}  {date:20}  {frm:30}  {subj}")
+    finally:
+        try:
+            imap.logout()
+        except Exception:
+            pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Yahoo Mail CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    p_inbox = sub.add_parser("inbox", help="List inbox messages")
+    p_inbox.add_argument("--count", type=int, default=10)
+    p_inbox.add_argument("--unread", action="store_true")
+
+    p_read = sub.add_parser("read", help="Read a message")
+    p_read.add_argument("message_id")
+
+    p_send = sub.add_parser("send", help="Send an email")
+    p_send.add_argument("--to", required=True)
+    p_send.add_argument("--subject", required=True)
+    p_send.add_argument("--body", required=True)
+    p_send.add_argument("--cc")
+
+    p_search = sub.add_parser("search", help="Search messages")
+    p_search.add_argument("query", nargs="+")
+    p_search.add_argument("--count", type=int, default=10)
+
+    args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    {"inbox": cmd_inbox, "read": cmd_read, "send": cmd_send, "search": cmd_search}[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/slack-bridge-multi.test.js
+++ b/test/slack-bridge-multi.test.js
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const bridge = await import("../scripts/slack-bridge-multi.js");
+
+describe("slack-bridge-multi helpers", () => {
+  it("parses quoted command arguments", () => {
+    expect(bridge.parseCommandArgs('!add-claw U123ABC "Jane Doe" jane-claw janedoe')).toEqual([
+      "!add-claw",
+      "U123ABC",
+      "Jane Doe",
+      "jane-claw",
+      "janedoe",
+    ]);
+  });
+
+  it("recognizes admin commands", () => {
+    expect(bridge.isListAdminsCommand("!admins")).toBe(true);
+    expect(bridge.isAdminAuditCommand("!admin-audit")).toBe(true);
+    expect(bridge.isAdminAuditCommand("!admin audit")).toBe(true);
+    expect(bridge.isAdminHelpCommand("!admin-help")).toBe(true);
+    expect(bridge.isAdminHelpCommand("!admin help")).toBe(true);
+    expect(bridge.isShowClawsCommand("!show-claws")).toBe(true);
+    expect(bridge.isShowClawsCommand("!show claws")).toBe(true);
+    expect(bridge.isShowUserCommand("!show-user U123ABC")).toBe(true);
+    expect(bridge.isShowUserCommand("!show user U123ABC")).toBe(true);
+    expect(bridge.isAddClawCommand("!add-claw U123ABC Jane jane-claw janedoe")).toBe(true);
+    expect(bridge.isAddClawCommand("!add claw U123ABC Jane jane-claw janedoe")).toBe(true);
+    expect(bridge.isDeleteClawCommand("!delete-claw jane-claw")).toBe(true);
+    expect(bridge.isDeleteClawCommand("!delete claw jane-claw")).toBe(true);
+    expect(bridge.isConfirmDeleteClawCommand("!confirm-delete-claw jane-claw")).toBe(true);
+    expect(bridge.isConfirmDeleteClawCommand("!confirm delete claw jane-claw")).toBe(true);
+  });
+
+  it("canonicalizes spaced admin commands and detects admin-like typos", () => {
+    expect(bridge.canonicalizeAdminCommand("!show claws ready")).toBe("!show-claws ready");
+    expect(bridge.canonicalizeAdminCommand("!confirm delete claw alice-claw")).toBe("!confirm-delete-claw alice-claw");
+    expect(bridge.looksLikeAdminCommand("!show clawz")).toBe(true);
+    expect(bridge.looksLikeAdminCommand("hello")).toBe(false);
+  });
+
+  it("builds actionable auth recovery guidance for per-user Claude OAuth", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auth-"));
+    const credentialsDir = path.join(tempRoot, "credentials");
+    fs.mkdirSync(credentialsDir, { recursive: true });
+    fs.writeFileSync(path.join(credentialsDir, "claude-credentials.json"), JSON.stringify({
+      claudeAiOauth: { accessToken: "sk-ant-oat01-test" },
+    }));
+
+    const text = bridge.buildAuthRecoveryMessage({ credentialsDir });
+    expect(text).toContain("per-user Claude OAuth credentials");
+    expect(text).toContain("!setup claude <fresh ~/.claude/.credentials.json>");
+  });
+
+  it("prefers a long-lived Claude token as the auth source", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
+    const credentialsDir = path.join(tempRoot, "credentials");
+    fs.mkdirSync(credentialsDir, { recursive: true });
+    fs.writeFileSync(path.join(credentialsDir, "claude-oauth-token.txt"), "sk-ant-oat01-token");
+
+    expect(bridge.describeClaudeCredentialSource({ credentialsDir })).toBe("per-user long-lived token");
+    expect(bridge.buildAuthRecoveryMessage({ credentialsDir })).toContain("!setup claude-token <token>");
+  });
+
+  it("reports Claude auth as not configured when no per-user credentials exist", () => {
+    expect(bridge.describeClaudeCredentialSource({
+      credentialsDir: path.join(os.tmpdir(), "missing-per-user-claude-creds"),
+    })).toBe("not configured");
+  });
+
+  it("builds a fallback agent command that skips Claude auth and exposes OpenAI routing env", () => {
+    const cmd = bridge.buildAgentCommand("hello", "abc", {
+      slackUserId: "U1",
+      slackDisplayName: "Alice",
+      roles: ["user"],
+    }, {
+      skipClaudeAuth: true,
+    });
+    expect(cmd).toContain("unset ANTHROPIC_API_KEY");
+    expect(cmd).toContain("NEMOCLAW_SKIP_CLAUDE_AUTH=1");
+    expect(cmd).toContain("export OPENAI_API_KEY=");
+    expect(cmd).not.toContain("PYMODEL");
+  });
+
+  it("builds admin users from roles and allowlist-only entries", () => {
+    const admins = bridge.buildAdminUserList(
+      [
+        { slackUserId: "U1", slackDisplayName: "Alice", sandboxName: "alice-claw", roles: ["user", "admin"], enabled: true },
+        { slackUserId: "U2", slackDisplayName: "Bob", sandboxName: "bob-claw", roles: ["user"], enabled: true },
+      ],
+      new Set(["U3"])
+    );
+
+    expect(admins.map((entry) => entry.slackUserId)).toEqual(["U1", "U3"]);
+    expect(admins[1].enabled).toBe(false);
+  });
+
+  it("formats admin user lists", () => {
+    const text = bridge.formatAdminUsersFromList([
+      { slackUserId: "U1", slackDisplayName: "Alice", sandboxName: "alice-claw", enabled: true },
+      { slackUserId: "U3", slackDisplayName: "U3", sandboxName: "", enabled: false },
+    ]);
+
+    expect(text).toContain("*Admin Users*");
+    expect(text).toContain("Alice (`U1`) — sandbox: `alice-claw`");
+    expect(text).toContain("U3 (`U3`)");
+  });
+
+  it("detects admin role membership", () => {
+    expect(bridge.isAdminUser({ roles: ["user", "admin"] })).toBe(true);
+    expect(bridge.isAdminUser({ roles: ["user"] })).toBe(false);
+  });
+
+  it("parses live sandbox list output", () => {
+    const sandboxes = bridge.parseSandboxList(`
+NAME          NAMESPACE  CREATED              PHASE
+alice-claw    openshell  2026-03-28 10:00:00  Ready
+bob-claw      openshell  2026-03-28 10:05:00  Pending
+`);
+
+    expect([...sandboxes.keys()]).toEqual(["alice-claw", "bob-claw"]);
+    expect(sandboxes.get("alice-claw")).toEqual({
+      name: "alice-claw",
+      namespace: "openshell",
+      createdAt: "2026-03-28 10:00:00",
+      phase: "Ready",
+    });
+  });
+
+  it("formats uptime durations", () => {
+    expect(bridge.formatDurationFrom("2999-01-01 00:00:00")).toBe("0m");
+    expect(bridge.formatDurationFrom("invalid")).toBe("unknown");
+  });
+
+  it("detects configured per-user credentials", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
+    const credentialsDir = path.join(tempRoot, "credentials");
+    fs.mkdirSync(path.join(credentialsDir, "gogcli"), { recursive: true });
+    fs.writeFileSync(path.join(credentialsDir, "gh-hosts.yml"), "github.com:\n");
+    fs.writeFileSync(path.join(credentialsDir, "freshrelease-api-key.txt"), "x");
+    fs.writeFileSync(path.join(credentialsDir, "gogcli", "config.json"), "{}");
+
+    const configured = bridge.listConfiguredCredentials({ credentialsDir });
+
+    expect(configured).toEqual(["GitHub", "Google (gogcli)", "Freshrelease"]);
+  });
+
+  it("formats claw inventory details", () => {
+    const text = bridge.formatClawInventory([
+      {
+        name: "alice-claw",
+        user: {
+          slackUserId: "U1",
+          slackDisplayName: "Alice",
+          githubUser: "alicehub",
+        },
+        registrySandbox: {
+          provider: "openshell",
+          gpuEnabled: true,
+        },
+        liveSandbox: {
+          phase: "Ready",
+          createdAt: "2999-01-01 00:00:00",
+        },
+        policies: ["npm", "pypi"],
+        credentials: ["GitHub", "Google (gogcli)"],
+      },
+    ]);
+
+    expect(text).toContain("*Claw Inventory*");
+    expect(text).toContain("`alice-claw`");
+    expect(text).toContain("Alice (`U1`)");
+    expect(text).toContain("github: `alicehub`");
+    expect(text).toContain("credentials: GitHub, Google (gogcli)");
+    expect(text).toContain("policies: npm, pypi, provider=openshell, gpu=true");
+  });
+
+  it("parses show-claws filter options", () => {
+    expect(bridge.parseShowClawsOptions('!show-claws ready admins sort=user policy=slack cred=github match=alice')).toEqual({
+      filters: ["ready", "admins"],
+      sort: "user",
+      match: "alice",
+      policy: "slack",
+      credential: "github",
+    });
+  });
+
+  it("filters and sorts claw inventory", () => {
+    const filtered = bridge.filterAndSortClawInventory([
+      {
+        name: "zeta-claw",
+        user: { slackUserId: "U2", slackDisplayName: "Zeta", roles: ["user"] },
+        liveSandbox: { phase: "Ready", createdAt: "2026-03-28 10:00:00" },
+        registrySandbox: { gpuEnabled: false },
+        policies: ["slack"],
+        credentials: ["GitHub"],
+      },
+      {
+        name: "alpha-claw",
+        user: { slackUserId: "U1", slackDisplayName: "Alpha", roles: ["user", "admin"] },
+        liveSandbox: { phase: "Ready", createdAt: "2026-03-28 09:00:00" },
+        registrySandbox: { gpuEnabled: true },
+        policies: ["slack", "npm"],
+        credentials: ["GitHub", "Google (gogcli)"],
+      },
+    ], {
+      filters: ["ready", "admins", "gpu"],
+      sort: "user",
+      match: "",
+      policy: "slack",
+      credential: "github",
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].name).toBe("alpha-claw");
+  });
+
+  it("resolves user lookup by sandbox and formats user detail", () => {
+    const user = bridge.resolveUserLookup("veyonce-claw");
+    expect(user?.sandboxName).toBe("veyonce-claw");
+
+    const text = bridge.buildShowUserText({
+      slackUserId: "U1",
+      slackDisplayName: "Alice",
+      sandboxName: "alice-claw",
+      enabled: true,
+      roles: ["user", "admin"],
+      timezone: "UTC",
+      githubUser: "alicehub",
+      createdAt: "2026-03-28T10:00:00.000Z",
+      credentialsDir: path.join(os.tmpdir(), "missing-creds"),
+    });
+
+    expect(text).toContain("*User Detail*");
+    expect(text).toContain("Alice (`U1`)");
+    expect(text).toContain("Claw: `alice-claw`");
+    expect(text).toContain("Roles: user, admin");
+    expect(text).toContain("Claude Auth:");
+  });
+
+  it("formats admin help text with delete restart guidance", () => {
+    const text = bridge.formatAdminHelp();
+    expect(text).toContain("*Admin Commands*");
+    expect(text).toContain("`!admin-help`");
+    expect(text).toContain("Delete confirmations expire after 5 minutes");
+    expect(text).toContain("lost if the bridge restarts");
+  });
+
+  it("builds a Slack table payload for claw inventory", () => {
+    const payload = bridge.buildShowClawsTablePayload();
+    expect(payload).toHaveProperty("text");
+    if (payload.attachments) {
+      expect(payload.attachments[0].blocks[0].type).toBe("table");
+      expect(payload.attachments[0].blocks[0].rows[0][0].text).toBe("Claw");
+    }
+  });
+
+  it("builds filtered show-claws payload", () => {
+    const payload = bridge.buildShowClawsPayload("!show-claws ready sort=status");
+    expect(payload).toHaveProperty("text");
+  });
+});


### PR DESCRIPTION
## Summary

Multi-user deployment of NemoClaw on DGX Spark with 8 sandboxes, per-user credential isolation, and messaging bridges for Slack and WhatsApp.

### Key additions

- **Multi-user Slack bridge** — Socket Mode, RBAC admin commands, self-service `!setup`, native table formatting, per-user message queue
- **Multi-user WhatsApp bridge** — Baileys (WhatsApp Web), two-way messaging, LID resolution, `!` commands
- **Yahoo Mail integration** — host-side IMAP/SMTP, cron unread checks with Slack + WhatsApp notifications
- **Freshrelease direct REST** — replaces expensive Claude Code MCP delegation (0 API calls vs 2 per query)
- **Fire-and-poll SSH execution** — survives OpenShell proxy connection drops (exit 255)
- **Orphaned result recovery** — pending runs persisted to disk, delivered on bridge restart
- **Rate limit detection** — auto-detect + 60s cooldown + NVIDIA Nemotron/Ollama fallback chain
- **Agent output filtering** — strips `[tools]`, `[agent/]`, `PermissionError`, `Traceback` from user responses
- **Security hardening** — removed anthropic preset, REST protocol inspection on Google/npm/pypi, narrowed Jira wildcard
- **JDK 17 + Gradle 8.13** — baked into Dockerfile and resilience script
- **Network policy presets** — google, freshworks, yahoo, whatsapp, ollama, xcurl
- **Architecture SVG diagram** — inline in multi-user-nemoclaw.md

### New files (37)

Scripts: slack-bridge-multi.js, whatsapp-bridge-multi.js, yahoo-mail.py, inject-user-credentials.sh, refresh-credentials.sh, nemoclaw-resilience.sh, watchdog-bridge.sh, and more.

Modules: user-registry.js, credential-setup.js

Docs: multi-user-nemoclaw.md, multi-user-architecture.svg

Policy presets: freshworks, google, yahoo, whatsapp, ollama, xcurl

### Modified files (9)

bin/nemoclaw.js (user lifecycle commands), Dockerfile (JDK+Gradle), package.json (@slack/bolt), start-services.sh (WhatsApp bridge), policy presets (security hardening)

## Test plan

- [ ] Run `npm test` for existing tests
- [ ] Deploy on DGX Spark with `nemoclaw user-add`
- [ ] Test Slack bridge: DM the bot, admin commands, table formatting
- [ ] Test WhatsApp bridge: two-way messaging
- [ ] Test Freshrelease REST: `!setup freshrelease`, query epics
- [ ] Test rate limit fallback: trigger rate limit, verify NVIDIA fallback
- [ ] Test credential refresh: verify `.credentials.json` survives 15-min cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-user support: Manage multiple NemoClaw users with separate sandboxes and credential isolation.
  * Slack and WhatsApp bridges: Route messages from Slack/WhatsApp to user-specific sandbox agents.
  * Credential management: Self-service credential setup and refresh via Slack DM.
  * New policy presets for Google Workspace, Yahoo Mail, Ollama, npm, PyPI, Freshworks, X/Twitter, WhatsApp.
  * Anthropic Claude model support with API key configuration.

* **Documentation**
  * Added inference profiles reference guide.
  * Added multi-user NemoClaw architecture documentation.
  * Added skill definitions for user onboarding and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->