### PR TITLE
fix(security): bundle Telegram allowlist and update hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ config = { \
     'agents': {'defaults': {'model': {'primary': primary_model_ref}}}, \
     'models': {'mode': 'merge', 'providers': providers}, \
     'channels': {'defaults': {'configWrites': False}}, \
+    'update': {'checkOnStart': False}, \
     'gateway': { \
         'mode': 'local', \
         'controlUi': { \

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -56,6 +56,7 @@ const {
   getMemoryInfo,
   planHostRemediation,
 } = require("./preflight");
+const { validateSandboxName } = require("./sandbox-names");
 
 // Typed modules (compiled from src/lib/*.ts → dist/lib/*.js)
 const gatewayState = require("../../dist/lib/gateway-state");
@@ -2403,20 +2404,19 @@ async function promptValidatedSandboxName() {
     );
     const sandboxName = (nameAnswer || "my-assistant").trim().toLowerCase();
 
-    // Validate: RFC 1123 subdomain — lowercase alphanumeric and hyphens,
-    // must start with a letter (not a digit) to satisfy Kubernetes naming.
-    if (/^[a-z]([a-z0-9-]*[a-z0-9])?$/.test(sandboxName)) {
-      return sandboxName;
+    try {
+      return validateSandboxName(sandboxName);
+    } catch (err) {
+      console.error(`  ${err.message}`);
+      if (/reserved by the CLI/.test(err.message)) {
+        console.error("  Choose a different name to avoid colliding with top-level commands.");
+      } else if (/^[0-9]/.test(sandboxName)) {
+        console.error("  Names must start with a letter, not a digit.");
+      } else {
+        console.error("  Names must be lowercase, contain only letters, numbers, and hyphens,");
+        console.error("  must start with a letter, and end with a letter or number.");
+      }
     }
-
-    console.error(`  Invalid sandbox name: '${sandboxName}'`);
-    if (/^[0-9]/.test(sandboxName)) {
-      console.error("  Names must start with a letter, not a digit.");
-    } else {
-      console.error("  Names must be lowercase, contain only letters, numbers, and hyphens,");
-      console.error("  must start with a letter, and end with a letter or number.");
-    }
-
     // Non-interactive runs cannot re-prompt — abort so the caller can fix the
     // NEMOCLAW_SANDBOX_NAME env var and retry.
     if (isNonInteractive()) {
@@ -2445,7 +2445,9 @@ async function createSandbox(
 ) {
   step(5, 7, "Creating sandbox");
 
-  const sandboxName = sandboxNameOverride || (await promptValidatedSandboxName());
+  const sandboxName = sandboxNameOverride
+    ? validateSandboxName(String(sandboxNameOverride).trim().toLowerCase())
+    : await promptValidatedSandboxName();
   const chatUiUrl = process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`;
 
   // Reconcile local registry state with the live OpenShell gateway state.

--- a/bin/lib/sandbox-names.js
+++ b/bin/lib/sandbox-names.js
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const { validateName } = require("./runner");
+
+const RESERVED_SANDBOX_NAMES = new Set([
+  "onboard",
+  "list",
+  "deploy",
+  "setup",
+  "setup-spark",
+  "start",
+  "telegram",
+  "stop",
+  "status",
+  "debug",
+  "uninstall",
+  "help",
+]);
+
+const SANDBOX_ACTIONS = new Set([
+  "connect",
+  "status",
+  "logs",
+  "policy-add",
+  "policy-list",
+  "destroy",
+]);
+
+function validateSandboxName(name, label = "sandbox name") {
+  const validName = validateName(name, label);
+  if (!/^[a-z](?:[a-z0-9-]*[a-z0-9])?$/.test(validName)) {
+    throw new Error(
+      `Invalid ${label}: '${validName}'. Must start with a letter and use lowercase letters, numbers, and internal hyphens only.`,
+    );
+  }
+  if (RESERVED_SANDBOX_NAMES.has(validName)) {
+    throw new Error(
+      `Invalid ${label}: '${validName}'. This name is reserved by the CLI. Use a different name, or target an existing sandbox with 'nemoclaw -- ${validName} <action>'.`,
+    );
+  }
+  return validName;
+}
+
+module.exports = { RESERVED_SANDBOX_NAMES, SANDBOX_ACTIONS, validateSandboxName };

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -31,7 +31,7 @@ const {
 } = require("./lib/runner");
 const { resolveOpenshell } = require("./lib/resolve-openshell");
 const { startGatewayForRecovery } = require("./lib/onboard");
-const { getCredential } = require("./lib/credentials");
+const { getCredential, saveCredential } = require("./lib/credentials");
 const registry = require("./lib/registry");
 const nim = require("./lib/nim");
 const policies = require("./lib/policies");
@@ -51,6 +51,7 @@ const GLOBAL_COMMANDS = new Set([
   "setup",
   "setup-spark",
   "start",
+  "telegram",
   "stop",
   "status",
   "debug",
@@ -831,12 +832,44 @@ async function deploy(instanceName) {
   });
 }
 
-async function start() {
+async function start(args = []) {
+  const supportedFlags = new Set(["--discover-chat-id"]);
+  const unknown = args.filter((arg) => !supportedFlags.has(arg));
+  if (unknown.length > 0) {
+    console.error(`  Unknown start option(s): ${unknown.join(", ")}`);
+    process.exit(1);
+  }
+
+  const discoveryMode = args.includes("--discover-chat-id");
   const { startAll } = require("./lib/services");
   const { defaultSandbox } = registry.listSandboxes();
   const safeName =
     defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
+  const allowedChatIds = getCredential("ALLOWED_CHAT_IDS");
+  if (allowedChatIds) {
+    process.env.ALLOWED_CHAT_IDS = allowedChatIds;
+  } else {
+    delete process.env.ALLOWED_CHAT_IDS;
+  }
+  process.env.NEMOCLAW_TELEGRAM_DISCOVERY = discoveryMode ? "1" : "0";
   await startAll({ sandboxName: safeName || undefined });
+}
+
+function normalizeTelegramChatIds(rawValue) {
+  const chatIds = String(rawValue || "")
+    .split(/[,\s]+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (chatIds.length === 0) {
+    throw new Error("At least one Telegram chat ID is required.");
+  }
+  for (const chatId of chatIds) {
+    if (!/^-?\d+$/.test(chatId)) {
+      throw new Error(`Invalid Telegram chat ID: ${chatId}`);
+    }
+  }
+  return [...new Set(chatIds)].join(",");
+}
 }
 
 function stop() {
@@ -845,6 +878,64 @@ function stop() {
   const safeName =
     defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
   stopAll({ sandboxName: safeName || undefined });
+}
+
+function telegramHelp() {
+  console.log(`
+  ${G}Telegram:${R}
+    nemoclaw telegram allow <chat-id[,chat-id...]>   Save allowed Telegram chat IDs
+    nemoclaw telegram show                           Show saved Telegram chat IDs
+    nemoclaw telegram clear                          Remove the saved Telegram allowlist
+    nemoclaw telegram discover                       Start services in discovery-only mode
+
+  ${D}Tip:${R} use ${B}nemoclaw start --discover-chat-id${R}${D} to reply with your chat ID
+  without forwarding messages to the agent.${R}
+`);
+}
+
+async function telegramCommand(args = []) {
+  const [action, ...rest] = args;
+  switch (action) {
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      telegramHelp();
+      return;
+    case "allow": {
+      let allowlist;
+      try {
+        allowlist = normalizeTelegramChatIds(rest.join(","));
+      } catch (err) {
+        console.error(`  ${err.message}`);
+        process.exit(1);
+      }
+      saveCredential("ALLOWED_CHAT_IDS", allowlist);
+      console.log(`  Saved Telegram allowlist: ${allowlist}`);
+      console.log("  Stored in ~/.nemoclaw/credentials.json (mode 600)");
+      return;
+    }
+    case "show": {
+      const allowlist = getCredential("ALLOWED_CHAT_IDS");
+      if (!allowlist) {
+        console.log("  No Telegram allowlist configured.");
+        return;
+      }
+      console.log(`  Telegram allowlist: ${allowlist}`);
+      return;
+    }
+    case "clear":
+      saveCredential("ALLOWED_CHAT_IDS", "");
+      console.log("  Cleared Telegram allowlist.");
+      return;
+    case "discover":
+      await start(["--discover-chat-id"]);
+      return;
+    default:
+      console.error(`  Unknown telegram action: ${action}`);
+      console.error("  Valid actions: allow, show, clear, discover");
+      process.exit(1);
+  }
 }
 
 function debug(args) {
@@ -1281,9 +1372,10 @@ function help() {
     nemoclaw deploy <instance>       Deprecated Brev-specific bootstrap path
 
   ${G}Services:${R}
-    nemoclaw start                   Start auxiliary services ${D}(Telegram, tunnel)${R}
+    nemoclaw start ${D}[--discover-chat-id]${R} Start auxiliary services ${D}(Telegram, tunnel)${R}
     nemoclaw stop                    Stop all services
     nemoclaw status                  Show sandbox list and service status
+    nemoclaw telegram allow <id>     Save allowed Telegram chat IDs
 
   Troubleshooting:
     nemoclaw debug [--quick]         Collect diagnostics for bug reports
@@ -1331,7 +1423,10 @@ const [cmd, ...args] = process.argv.slice(2);
         await deploy(args[0]);
         break;
       case "start":
-        await start();
+        await start(args);
+        break;
+      case "telegram":
+        await telegramCommand(args);
         break;
       case "stop":
         stop();

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -40,28 +40,12 @@ const { getVersion } = require("./lib/version");
 const onboardSession = require("./lib/onboard-session");
 const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
 const { NOTICE_ACCEPT_ENV, NOTICE_ACCEPT_FLAG } = require("./lib/usage-notice");
+const { RESERVED_SANDBOX_NAMES, SANDBOX_ACTIONS } = require("./lib/sandbox-names");
 const { executeDeploy } = require("../dist/lib/deploy");
 
 // ── Global commands ──────────────────────────────────────────────
 
-const GLOBAL_COMMANDS = new Set([
-  "onboard",
-  "list",
-  "deploy",
-  "setup",
-  "setup-spark",
-  "start",
-  "telegram",
-  "stop",
-  "status",
-  "debug",
-  "uninstall",
-  "help",
-  "--help",
-  "-h",
-  "--version",
-  "-v",
-]);
+const GLOBAL_COMMANDS = new Set([...RESERVED_SANDBOX_NAMES, "--help", "-h", "--version", "-v"]);
 
 const REMOTE_UNINSTALL_URL =
   "https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh";
@@ -845,13 +829,13 @@ async function start(args = []) {
   const { defaultSandbox } = registry.listSandboxes();
   const safeName =
     defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  const allowedChatIds = getCredential("ALLOWED_CHAT_IDS");
+  const { allowedChatIds, discoveryFlag } = getTelegramServiceEnv(discoveryMode);
   if (allowedChatIds) {
     process.env.ALLOWED_CHAT_IDS = allowedChatIds;
   } else {
     delete process.env.ALLOWED_CHAT_IDS;
   }
-  process.env.NEMOCLAW_TELEGRAM_DISCOVERY = discoveryMode ? "1" : "0";
+  process.env.NEMOCLAW_TELEGRAM_DISCOVERY = discoveryFlag;
   await startAll({ sandboxName: safeName || undefined });
 }
 
@@ -869,6 +853,25 @@ function normalizeTelegramChatIds(rawValue) {
     }
   }
   return [...new Set(chatIds)].join(",");
+}
+
+function getTelegramServiceEnv(discoveryMode = false) {
+  return {
+    allowedChatIds: getCredential("ALLOWED_CHAT_IDS") || "",
+    discoveryFlag: discoveryMode ? "1" : "0",
+  };
+}
+
+function rejectUnexpectedTelegramOperands(action, rest = []) {
+  if (rest.length === 0) return;
+  console.error(`  Unknown telegram ${action} option(s): ${rest.join(", ")}`);
+  process.exit(1);
+}
+
+function printReservedSandboxHint(name, args = []) {
+  const suffix = args.length > 0 ? ` ${args.join(" ")}` : "";
+  console.error(`  Sandbox '${name}' conflicts with a global command.`);
+  console.error(`  Use 'nemoclaw -- ${name}${suffix}' to target the sandbox explicitly.`);
 }
 }
 
@@ -916,6 +919,7 @@ async function telegramCommand(args = []) {
       return;
     }
     case "show": {
+      rejectUnexpectedTelegramOperands("show", rest);
       const allowlist = getCredential("ALLOWED_CHAT_IDS");
       if (!allowlist) {
         console.log("  No Telegram allowlist configured.");
@@ -925,10 +929,12 @@ async function telegramCommand(args = []) {
       return;
     }
     case "clear":
+      rejectUnexpectedTelegramOperands("clear", rest);
       saveCredential("ALLOWED_CHAT_IDS", "");
       console.log("  Cleared Telegram allowlist.");
       return;
     case "discover":
+      rejectUnexpectedTelegramOperands("discover", rest);
       await start(["--discover-chat-id"]);
       return;
     default:
@@ -1361,6 +1367,7 @@ function help() {
     nemoclaw <name> status           Sandbox health + NIM status
     nemoclaw <name> logs ${D}[--follow]${R}  Stream sandbox logs
     nemoclaw <name> destroy          Stop NIM + delete sandbox ${D}(--yes to skip prompt)${R}
+    nemoclaw -- <name> <action>      Target a sandbox whose name matches a global command
 
   ${G}Policy Presets:${R}
     nemoclaw <name> policy-add       Add a network or filesystem policy preset
@@ -1375,7 +1382,7 @@ function help() {
     nemoclaw start ${D}[--discover-chat-id]${R} Start auxiliary services ${D}(Telegram, tunnel)${R}
     nemoclaw stop                    Stop all services
     nemoclaw status                  Show sandbox list and service status
-    nemoclaw telegram allow <id>     Save allowed Telegram chat IDs
+    nemoclaw telegram [help]         Manage Telegram allowlist + discovery mode
 
   Troubleshooting:
     nemoclaw debug [--quick]         Collect diagnostics for bug reports
@@ -1397,7 +1404,9 @@ function help() {
 
 // ── Dispatch ─────────────────────────────────────────────────────
 
-const [cmd, ...args] = process.argv.slice(2);
+const rawArgs = process.argv.slice(2);
+const forceSandboxDispatch = rawArgs[0] === "--";
+const [cmd, ...args] = forceSandboxDispatch ? rawArgs.slice(1) : rawArgs;
 
 // eslint-disable-next-line complexity
 (async () => {
@@ -1408,7 +1417,18 @@ const [cmd, ...args] = process.argv.slice(2);
   }
 
   // Global commands
-  if (GLOBAL_COMMANDS.has(cmd)) {
+  if (
+    !forceSandboxDispatch &&
+    GLOBAL_COMMANDS.has(cmd) &&
+    registry.getSandbox(cmd) &&
+    args[0] &&
+    SANDBOX_ACTIONS.has(args[0])
+  ) {
+    printReservedSandboxHint(cmd, args);
+    process.exit(1);
+  }
+
+  if (!forceSandboxDispatch && GLOBAL_COMMANDS.has(cmd)) {
     switch (cmd) {
       case "onboard":
         await onboard(args);

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -873,7 +873,6 @@ function printReservedSandboxHint(name, args = []) {
   console.error(`  Sandbox '${name}' conflicts with a global command.`);
   console.error(`  Use 'nemoclaw -- ${name}${suffix}' to target the sandbox explicitly.`);
 }
-}
 
 function stop() {
   const { stopAll } = require("./lib/services");

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -69,7 +69,8 @@ The legacy compatibility flow performs the following steps on the VM:
 
 By default, the compatibility wrapper asks Brev to provision on `gcp`. Override this with `NEMOCLAW_BREV_PROVIDER` if you need a different Brev cloud provider.
 
-If you configured a Telegram bot token but not an allowlist yet, the bridge stays disabled until you either save `ALLOWED_CHAT_IDS` with `nemoclaw telegram allow <chat-id>` or run discovery mode with `nemoclaw start --discover-chat-id`.
+If you configured a Telegram bot token but not an allowlist yet, the bridge stays disabled.
+Save `ALLOWED_CHAT_IDS` with `nemoclaw telegram allow <chat-id>` or run discovery mode with `nemoclaw start --discover-chat-id` to enable it.
 
 ## Connect to the Remote Sandbox
 

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -69,6 +69,8 @@ The legacy compatibility flow performs the following steps on the VM:
 
 By default, the compatibility wrapper asks Brev to provision on `gcp`. Override this with `NEMOCLAW_BREV_PROVIDER` if you need a different Brev cloud provider.
 
+If you configured a Telegram bot token but not an allowlist yet, the bridge stays disabled until you either save `ALLOWED_CHAT_IDS` with `nemoclaw telegram allow <chat-id>` or run discovery mode with `nemoclaw start --discover-chat-id`.
+
 ## Connect to the Remote Sandbox
 
 After deployment finishes, the deploy command opens an interactive shell inside the remote sandbox.

--- a/docs/deployment/set-up-telegram-bridge.md
+++ b/docs/deployment/set-up-telegram-bridge.md
@@ -56,7 +56,19 @@ The `start` command launches the following services:
 - The Telegram bridge forwards messages between Telegram and the agent.
 - The cloudflared tunnel provides external access to the sandbox.
 
-The Telegram bridge starts only when the `TELEGRAM_BOT_TOKEN` environment variable is set.
+The Telegram bridge starts only when the following are configured:
+
+- `TELEGRAM_BOT_TOKEN`
+- `NVIDIA_API_KEY`
+- `ALLOWED_CHAT_IDS`
+
+If you do not know your Telegram chat ID yet, start the bridge in discovery-only mode:
+
+```console
+$ nemoclaw start --discover-chat-id
+```
+
+Then send any message to the bot. The bridge replies with your chat ID and does not forward the message to the agent.
 
 ## Verify the Services
 
@@ -73,13 +85,20 @@ The output shows the status of all auxiliary services.
 Open Telegram, find your bot, and send a message.
 The bridge forwards the message to the OpenClaw agent inside the sandbox and returns the agent response.
 
-## Restrict Access by Chat ID
+## Allow Telegram Chats by Chat ID
 
-To restrict which Telegram chats can interact with the agent, set the `ALLOWED_CHAT_IDS` environment variable to a comma-separated list of Telegram chat IDs:
+Save the Telegram chat IDs allowed to interact with the agent:
 
 ```console
-$ export ALLOWED_CHAT_IDS="123456789,987654321"
+$ nemoclaw telegram allow 123456789,987654321
 $ nemoclaw start
+```
+
+To inspect or clear the saved allowlist:
+
+```console
+$ nemoclaw telegram show
+$ nemoclaw telegram clear
 ```
 
 ## Stop the Services

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -187,7 +187,7 @@ The following environment variables configure optional services and local access
 | Variable | Purpose |
 |---|---|
 | `TELEGRAM_BOT_TOKEN` | Bot token for the Telegram bridge. |
-| `ALLOWED_CHAT_IDS` | Comma-separated list of Telegram chat IDs allowed to message the agent. |
+| `ALLOWED_CHAT_IDS` | Comma-separated list of Telegram chat IDs allowed to message the agent. Required for normal Telegram bridge forwarding. |
 | `CHAT_UI_URL` | URL for the optional chat UI endpoint. |
 
 For normal setup and reconfiguration, prefer `nemoclaw onboard` over editing these files by hand.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -202,7 +202,24 @@ Start auxiliary services, such as the Telegram bridge and cloudflared tunnel.
 $ nemoclaw start
 ```
 
-Requires `TELEGRAM_BOT_TOKEN` for the Telegram bridge.
+Use discovery-only mode to have the bot reply with your Telegram chat ID without forwarding messages to the agent:
+
+```console
+$ nemoclaw start --discover-chat-id
+```
+
+The Telegram bridge requires `TELEGRAM_BOT_TOKEN`, `NVIDIA_API_KEY`, and an `ALLOWED_CHAT_IDS` allowlist for normal operation.
+
+### `nemoclaw telegram`
+
+Manage the Telegram bridge allowlist.
+
+```console
+$ nemoclaw telegram allow 123456789
+$ nemoclaw telegram show
+$ nemoclaw telegram clear
+$ nemoclaw telegram discover
+```
 
 ### `nemoclaw stop`
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -214,6 +214,13 @@ The Telegram bridge requires `TELEGRAM_BOT_TOKEN`, `NVIDIA_API_KEY`, and an `ALL
 
 Manage the Telegram bridge allowlist.
 
+| Subcommand | Description |
+|------------|-------------|
+| `allow <id>` | Save one or more Telegram chat IDs in the allowlist |
+| `show` | Display the current Telegram allowlist |
+| `clear` | Remove all saved Telegram chat IDs |
+| `discover` | Start the bridge in discovery-only mode to reveal your chat ID |
+
 ```console
 $ nemoclaw telegram allow 123456789
 $ nemoclaw telegram show

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -241,6 +241,18 @@ The status command detects the sandbox context and reports "active (inside sandb
 
 Run `openshell sandbox list` on the host to check the underlying sandbox state.
 
+### `openclaw update` hangs or times out inside the sandbox
+
+This is expected for the current NemoClaw deployment model.
+NemoClaw installs `openclaw` into the sandbox image at build time, so the CLI is image-pinned rather than updated in place inside a running sandbox.
+
+Do not run `openclaw update` inside the sandbox.
+Instead:
+
+1. Upgrade to a NemoClaw release that includes the newer `openclaw` version.
+2. If you build NemoClaw from source, bump the pinned `openclaw` version in `Dockerfile.base` and rebuild the sandbox base image.
+3. Back up any workspace files you need, then recreate the sandbox so it uses the rebuilt image.
+
 ### Inference requests time out
 
 Verify that the inference provider endpoint is reachable from the host.

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -123,12 +123,24 @@ do_stop() {
 }
 
 do_start() {
+  local telegram_status="not started (no token)"
+
   if [ -z "${TELEGRAM_BOT_TOKEN:-}" ]; then
     warn "TELEGRAM_BOT_TOKEN not set — Telegram bridge will not start."
     warn "Create a bot via @BotFather on Telegram and set the token."
+    telegram_status="not started (no token)"
   elif [ -z "${NVIDIA_API_KEY:-}" ]; then
     warn "NVIDIA_API_KEY not set — Telegram bridge will not start."
     warn "Set NVIDIA_API_KEY if you want Telegram requests to reach inference."
+    telegram_status="not started (missing NVIDIA_API_KEY)"
+  elif [ -z "${ALLOWED_CHAT_IDS:-}" ] && [ "${NEMOCLAW_TELEGRAM_DISCOVERY:-0}" != "1" ]; then
+    warn "ALLOWED_CHAT_IDS not set — Telegram bridge will not start."
+    warn "Run 'nemoclaw start --discover-chat-id' to return your Telegram chat ID safely."
+    warn "Then run 'nemoclaw telegram allow <chat-id>' and start services again."
+    telegram_status="not started (allowlist required)"
+  elif [ "${NEMOCLAW_TELEGRAM_DISCOVERY:-0}" = "1" ] && [ -z "${ALLOWED_CHAT_IDS:-}" ]; then
+    info "Telegram discovery mode enabled — messages will return their chat ID only."
+    telegram_status="discovery only"
   fi
 
   command -v node >/dev/null || fail "node not found. Install Node.js first."
@@ -152,9 +164,14 @@ do_start() {
   mkdir -p "$PIDDIR"
 
   # Telegram bridge (only if token provided)
-  if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${NVIDIA_API_KEY:-}" ]; then
+  if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${NVIDIA_API_KEY:-}" ] && { [ -n "${ALLOWED_CHAT_IDS:-}" ] || [ "${NEMOCLAW_TELEGRAM_DISCOVERY:-0}" = "1" ]; }; then
     SANDBOX_NAME="$SANDBOX_NAME" start_service telegram-bridge \
       node "$REPO_DIR/scripts/telegram-bridge.js"
+    if [ "${NEMOCLAW_TELEGRAM_DISCOVERY:-0}" = "1" ] && [ -z "${ALLOWED_CHAT_IDS:-}" ]; then
+      telegram_status="discovery only"
+    else
+      telegram_status="bridge running"
+    fi
   fi
 
   # 3. cloudflared tunnel
@@ -194,9 +211,23 @@ do_start() {
   fi
 
   if is_running telegram-bridge; then
-    echo "  │  Telegram:    bridge running                        │"
+    if [ "${NEMOCLAW_TELEGRAM_DISCOVERY:-0}" = "1" ] && [ -z "${ALLOWED_CHAT_IDS:-}" ]; then
+      echo "  │  Telegram:    discovery only                       │"
+    else
+      echo "  │  Telegram:    bridge running                        │"
+    fi
   else
-    echo "  │  Telegram:    not started (no token)                │"
+    case "$telegram_status" in
+      "not started (missing NVIDIA_API_KEY)")
+        echo "  │  Telegram:    not started (missing API key)         │"
+        ;;
+      "not started (allowlist required)")
+        echo "  │  Telegram:    not started (allowlist required)      │"
+        ;;
+      *)
+        echo "  │  Telegram:    not started (no token)                │"
+        ;;
+    esac
   fi
 
   echo "  │                                                     │"

--- a/scripts/telegram-bridge.js
+++ b/scripts/telegram-bridge.js
@@ -13,7 +13,8 @@
  *   TELEGRAM_BOT_TOKEN  — from @BotFather
  *   NVIDIA_API_KEY      — for inference
  *   SANDBOX_NAME        — sandbox name (default: nemoclaw)
- *   ALLOWED_CHAT_IDS    — comma-separated Telegram chat IDs to accept (optional, accepts all if unset)
+ *   ALLOWED_CHAT_IDS    — comma-separated Telegram chat IDs to accept
+ *   NEMOCLAW_TELEGRAM_DISCOVERY=1 — reply with the sender chat ID instead of forwarding
  */
 
 const https = require("https");
@@ -31,11 +32,28 @@ if (!OPENSHELL) {
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const API_KEY = process.env.NVIDIA_API_KEY;
 const SANDBOX = process.env.SANDBOX_NAME || "nemoclaw";
-try { validateName(SANDBOX, "SANDBOX_NAME"); } catch (e) { console.error(e.message); process.exit(1); }
+try {
+  validateName(SANDBOX, "SANDBOX_NAME");
+} catch (e) {
+  console.error(e.message);
+  process.exit(1);
+}
+const DISCOVERY_MODE = process.env.NEMOCLAW_TELEGRAM_DISCOVERY === "1";
 const ALLOWED_CHATS = parseAllowedChatIds(process.env.ALLOWED_CHAT_IDS);
+const DISCOVERY_ONLY = DISCOVERY_MODE && ALLOWED_CHATS.length === 0;
 
-if (!TOKEN) { console.error("TELEGRAM_BOT_TOKEN required"); process.exit(1); }
-if (!API_KEY) { console.error("NVIDIA_API_KEY required"); process.exit(1); }
+if (!TOKEN) {
+  console.error("TELEGRAM_BOT_TOKEN required");
+  process.exit(1);
+}
+if (!API_KEY) {
+  console.error("NVIDIA_API_KEY required");
+  process.exit(1);
+}
+if (!DISCOVERY_ONLY && ALLOWED_CHATS.length === 0) {
+  console.error("ALLOWED_CHAT_IDS required unless NEMOCLAW_TELEGRAM_DISCOVERY=1");
+  process.exit(1);
+}
 
 let offset = 0;
 const activeSessions = new Map(); // chatId → message history
@@ -60,7 +78,11 @@ function tgApi(method, body) {
         let buf = "";
         res.on("data", (c) => (buf += c));
         res.on("end", () => {
-          try { resolve(JSON.parse(buf)); } catch { resolve({ ok: false, error: buf }); }
+          try {
+            resolve(JSON.parse(buf));
+          } catch {
+            resolve({ ok: false, error: buf });
+          }
         });
       },
     );
@@ -97,7 +119,9 @@ async function sendTyping(chatId) {
 
 function runAgentInSandbox(message, sessionId) {
   return new Promise((resolve) => {
-    const sshConfig = execFileSync(OPENSHELL, ["sandbox", "ssh-config", SANDBOX], { encoding: "utf-8" });
+    const sshConfig = execFileSync(OPENSHELL, ["sandbox", "ssh-config", SANDBOX], {
+      encoding: "utf-8",
+    });
 
     // Write temp ssh config with unpredictable name
     const confDir = require("fs").mkdtempSync("/tmp/nemoclaw-tg-ssh-");
@@ -122,7 +146,12 @@ function runAgentInSandbox(message, sessionId) {
     proc.stderr.on("data", (d) => (stderr += d.toString()));
 
     proc.on("close", (code) => {
-      try { require("fs").unlinkSync(confPath); require("fs").rmdirSync(confDir); } catch { /* ignored */ }
+      try {
+        require("fs").unlinkSync(confPath);
+        require("fs").rmdirSync(confDir);
+      } catch {
+        /* ignored */
+      }
 
       // Extract the actual agent response — skip setup lines
       const lines = stdout.split("\n");
@@ -173,13 +202,27 @@ async function poll() {
         const chatId = String(msg.chat.id);
 
         // Access control
-        if (!isChatAllowed(ALLOWED_CHATS, chatId)) {
+        if (!DISCOVERY_ONLY && !isChatAllowed(ALLOWED_CHATS, chatId)) {
           console.log(`[ignored] chat ${chatId} not in allowed list`);
+          await sendMessage(
+            chatId,
+            `This chat is not authorized.\n\nYour Telegram chat ID is \`${chatId}\`.\nAsk the operator to run \`nemoclaw telegram allow ${chatId}\`.`,
+            msg.message_id,
+          );
           continue;
         }
 
         const userName = msg.from?.first_name || "someone";
         console.log(`[${chatId}] ${userName}: ${msg.text}`);
+
+        if (DISCOVERY_ONLY) {
+          await sendMessage(
+            chatId,
+            `Discovery mode is enabled.\n\nYour Telegram chat ID is \`${chatId}\`.\nRun \`nemoclaw telegram allow ${chatId}\`, then restart the bridge with \`nemoclaw start\`.`,
+            msg.message_id,
+          );
+          continue;
+        }
 
         // Handle /start
         if (msg.text === "/start") {
@@ -206,7 +249,11 @@ async function poll() {
         const lastTime = lastMessageTime.get(chatId) || 0;
         if (now - lastTime < COOLDOWN_MS) {
           const wait = Math.ceil((COOLDOWN_MS - (now - lastTime)) / 1000);
-          await sendMessage(chatId, `Please wait ${wait}s before sending another message.`, msg.message_id);
+          await sendMessage(
+            chatId,
+            `Please wait ${wait}s before sending another message.`,
+            msg.message_id,
+          );
           continue;
         }
 
@@ -263,9 +310,15 @@ async function main() {
   console.log("  │  Sandbox:  " + (SANDBOX + "                              ").slice(0, 40) + "│");
   console.log("  │  Model:    nvidia/nemotron-3-super-120b-a12b       │");
   console.log("  │                                                     │");
-  console.log("  │  Messages are forwarded to the OpenClaw agent      │");
-  console.log("  │  inside the sandbox. Run 'openshell term' in       │");
-  console.log("  │  another terminal to monitor + approve egress.     │");
+  if (DISCOVERY_ONLY) {
+    console.log("  │  Discovery mode: incoming messages return chat ID  │");
+    console.log("  │  only. Agent forwarding stays disabled until       │");
+    console.log("  │  ALLOWED_CHAT_IDS is configured.                   │");
+  } else {
+    console.log("  │  Messages are forwarded to the OpenClaw agent      │");
+    console.log("  │  inside the sandbox. Run 'openshell term' in       │");
+    console.log("  │  another terminal to monitor + approve egress.     │");
+  }
   console.log("  └─────────────────────────────────────────────────────┘");
   console.log("");
 

--- a/src/lib/deploy.test.ts
+++ b/src/lib/deploy.test.ts
@@ -60,6 +60,26 @@ describe("buildDeployEnvLines", () => {
     expect(envLines).toContain("NEMOCLAW_POLICY_MODE='suggested'");
     expect(envLines).toContain("NVIDIA_API_KEY='nvapi-test'");
   });
+
+  it("propagates Telegram allowlist settings to remote deploy env", () => {
+    const envLines = buildDeployEnvLines({
+      env: {
+        NEMOCLAW_TELEGRAM_DISCOVERY: "1",
+      },
+      sandboxName: "my-assistant",
+      provider: "build",
+      credentials: {
+        NVIDIA_API_KEY: "nvapi-test",
+        ALLOWED_CHAT_IDS: "111,222",
+        TELEGRAM_BOT_TOKEN: "123456:abc",
+      },
+      shellQuote: (value: string) => `'${value}'`,
+    });
+
+    expect(envLines).toContain("ALLOWED_CHAT_IDS='111,222'");
+    expect(envLines).toContain("NEMOCLAW_TELEGRAM_DISCOVERY='1'");
+    expect(envLines).toContain("TELEGRAM_BOT_TOKEN='123456:abc'");
+  });
 });
 
 describe("Brev status helpers", () => {

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -13,6 +13,7 @@ export interface DeployCredentials {
   COMPATIBLE_API_KEY?: string | null;
   COMPATIBLE_ANTHROPIC_API_KEY?: string | null;
   GITHUB_TOKEN?: string | null;
+  ALLOWED_CHAT_IDS?: string | null;
   TELEGRAM_BOT_TOKEN?: string | null;
   DISCORD_BOT_TOKEN?: string | null;
   SLACK_BOT_TOKEN?: string | null;
@@ -91,6 +92,7 @@ export function buildDeployEnvLines(opts: {
     "NEMOCLAW_ENDPOINT_URL",
     "NEMOCLAW_POLICY_MODE",
     "NEMOCLAW_POLICY_PRESETS",
+    "NEMOCLAW_TELEGRAM_DISCOVERY",
     "CHAT_UI_URL",
   ] as const;
   for (const key of passthroughVars) {
@@ -218,6 +220,7 @@ export async function executeDeploy(opts: DeployExecutionOptions): Promise<void>
     COMPATIBLE_API_KEY: getCredential("COMPATIBLE_API_KEY"),
     COMPATIBLE_ANTHROPIC_API_KEY: getCredential("COMPATIBLE_ANTHROPIC_API_KEY"),
     GITHUB_TOKEN: getCredential("GITHUB_TOKEN"),
+    ALLOWED_CHAT_IDS: getCredential("ALLOWED_CHAT_IDS"),
     TELEGRAM_BOT_TOKEN: getCredential("TELEGRAM_BOT_TOKEN"),
     DISCORD_BOT_TOKEN: getCredential("DISCORD_BOT_TOKEN"),
     SLACK_BOT_TOKEN: getCredential("SLACK_BOT_TOKEN"),

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -15,7 +15,7 @@ function run(args) {
 
 function runWithEnv(args, env = {}, timeout = 10000) {
   try {
-    const out = execSync(`node "${CLI}" ${args}`, {
+    const out = execSync(`${JSON.stringify(process.execPath)} "${CLI}" ${args}`, {
       encoding: "utf-8",
       timeout,
       env: {
@@ -50,6 +50,32 @@ function writeBashCaptureStub(localBin, markerFile) {
     ].join("\n"),
     { mode: 0o755 },
   );
+}
+
+function writeNodeCaptureStub(localBin, markerFile) {
+  fs.writeFileSync(
+    path.join(localBin, "node"),
+    [
+      "#!/bin/sh",
+      `marker_file=${JSON.stringify(markerFile)}`,
+      'printf \'SANDBOX_NAME=%s\\nALLOWED_CHAT_IDS=%s\\nNEMOCLAW_TELEGRAM_DISCOVERY=%s\\nARGS=%s\\n\' "$SANDBOX_NAME" "$ALLOWED_CHAT_IDS" "$NEMOCLAW_TELEGRAM_DISCOVERY" "$*" > "$marker_file"',
+      "exit 0",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+}
+
+function readFileEventually(filePath, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) {
+      const content = fs.readFileSync(filePath, "utf8");
+      if (content.includes("ARGS=")) {
+        return content;
+      }
+    }
+  }
+  return fs.readFileSync(filePath, "utf8");
 }
 
 describe("CLI dispatch", () => {
@@ -153,24 +179,23 @@ describe("CLI dispatch", () => {
       }),
       { mode: 0o600 },
     );
-    writeBashCaptureStub(localBin, markerFile);
+    writeNodeCaptureStub(localBin, markerFile);
 
     expect(runWithEnv("telegram allow 12345,67890", { HOME: home }).code).toBe(0);
 
     const r = runWithEnv("start", {
       HOME: home,
       PATH: `${localBin}:${process.env.PATH || ""}`,
-      TELEGRAM_BOT_TOKEN: "",
-      ALLOWED_CHAT_IDS: "",
+      NVIDIA_API_KEY: "nvapi-test",
+      TELEGRAM_BOT_TOKEN: "telegram-token",
     });
 
     expect(r.code).toBe(0);
-    const marker = fs.readFileSync(markerFile, "utf8");
+    const marker = readFileEventually(markerFile);
     expect(marker).toContain("SANDBOX_NAME=alpha");
     expect(marker).toContain("ALLOWED_CHAT_IDS=12345,67890");
     expect(marker).toContain("NEMOCLAW_TELEGRAM_DISCOVERY=0");
-    expect(marker).toContain("ARGS=");
-    expect(marker).toContain("start-services.sh");
+    expect(marker).toContain("scripts/telegram-bridge.js");
   });
 
   it("start clears Telegram allowlist and discovery mode when unset", () => {
@@ -196,20 +221,20 @@ describe("CLI dispatch", () => {
       }),
       { mode: 0o600 },
     );
-    writeBashCaptureStub(localBin, markerFile);
+    writeNodeCaptureStub(localBin, markerFile);
 
     const r = runWithEnv("start", {
       HOME: home,
       PATH: `${localBin}:${process.env.PATH || ""}`,
-      TELEGRAM_BOT_TOKEN: "",
-      ALLOWED_CHAT_IDS: "",
+      NVIDIA_API_KEY: "nvapi-test",
+      TELEGRAM_BOT_TOKEN: "telegram-token",
     });
 
     expect(r.code).toBe(0);
-    const marker = fs.readFileSync(markerFile, "utf8");
+    const marker = readFileEventually(markerFile);
     expect(marker).toContain("ALLOWED_CHAT_IDS=");
     expect(marker).toContain("NEMOCLAW_TELEGRAM_DISCOVERY=0");
-    expect(marker).toContain("start-services.sh");
+    expect(marker).toContain("scripts/telegram-bridge.js");
   });
 
   it("start --discover-chat-id enables discovery mode", () => {
@@ -217,19 +242,19 @@ describe("CLI dispatch", () => {
     const localBin = path.join(home, "bin");
     const markerFile = path.join(home, "start-env");
     fs.mkdirSync(localBin, { recursive: true });
-    writeBashCaptureStub(localBin, markerFile);
+    writeNodeCaptureStub(localBin, markerFile);
 
     const r = runWithEnv("start --discover-chat-id", {
       HOME: home,
       PATH: `${localBin}:${process.env.PATH || ""}`,
-      TELEGRAM_BOT_TOKEN: "",
-      ALLOWED_CHAT_IDS: "",
+      NVIDIA_API_KEY: "nvapi-test",
+      TELEGRAM_BOT_TOKEN: "telegram-token",
     });
 
     expect(r.code).toBe(0);
-    const marker = fs.readFileSync(markerFile, "utf8");
+    const marker = readFileEventually(markerFile);
     expect(marker).toContain("NEMOCLAW_TELEGRAM_DISCOVERY=1");
-    expect(marker).toContain("start-services.sh");
+    expect(marker).toContain("scripts/telegram-bridge.js");
   });
 
   it("telegram allow rejects invalid chat ids", () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -121,6 +121,7 @@ describe("CLI dispatch", () => {
       PATH: `${localBin}:${process.env.PATH || ""}`,
       NVIDIA_API_KEY: "",
       TELEGRAM_BOT_TOKEN: "",
+      ALLOWED_CHAT_IDS: "",
     });
 
     expect(r.code).toBe(0);
@@ -159,6 +160,8 @@ describe("CLI dispatch", () => {
     const r = runWithEnv("start", {
       HOME: home,
       PATH: `${localBin}:${process.env.PATH || ""}`,
+      TELEGRAM_BOT_TOKEN: "",
+      ALLOWED_CHAT_IDS: "",
     });
 
     expect(r.code).toBe(0);
@@ -198,6 +201,8 @@ describe("CLI dispatch", () => {
     const r = runWithEnv("start", {
       HOME: home,
       PATH: `${localBin}:${process.env.PATH || ""}`,
+      TELEGRAM_BOT_TOKEN: "",
+      ALLOWED_CHAT_IDS: "",
     });
 
     expect(r.code).toBe(0);
@@ -217,6 +222,8 @@ describe("CLI dispatch", () => {
     const r = runWithEnv("start --discover-chat-id", {
       HOME: home,
       PATH: `${localBin}:${process.env.PATH || ""}`,
+      TELEGRAM_BOT_TOKEN: "",
+      ALLOWED_CHAT_IDS: "",
     });
 
     expect(r.code).toBe(0);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -32,6 +32,26 @@ function runWithEnv(args, env = {}, timeout = 10000) {
   }
 }
 
+function writeBashCaptureStub(localBin, markerFile) {
+  fs.writeFileSync(
+    path.join(localBin, "bash"),
+    [
+      "#!/bin/sh",
+      `marker_file=${JSON.stringify(markerFile)}`,
+      'if [ "${NEMOCLAW_BASH_STUB_CHILD:-}" = "1" ]; then',
+      '  printf \'SANDBOX_NAME=%s\\nALLOWED_CHAT_IDS=%s\\nNEMOCLAW_TELEGRAM_DISCOVERY=%s\\nARGS=%s\\n\' "$SANDBOX_NAME" "$ALLOWED_CHAT_IDS" "$NEMOCLAW_TELEGRAM_DISCOVERY" "$*" > "$marker_file"',
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "-c" ]; then',
+      '  NEMOCLAW_BASH_STUB_CHILD=1 eval "$2"',
+      "  exit $?",
+      "fi",
+      "exit 0",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+}
+
 describe("CLI dispatch", () => {
   it("help exits 0 and shows sections", () => {
     const r = run("help");
@@ -40,6 +60,8 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("Sandbox Management")).toBeTruthy();
     expect(r.out.includes("Policy Presets")).toBeTruthy();
     expect(r.out.includes("Compatibility Commands")).toBeTruthy();
+    expect(r.out.includes("nemoclaw telegram [help]")).toBeTruthy();
+    expect(r.out.includes("nemoclaw -- <name> <action>")).toBeTruthy();
   });
 
   it("--help exits 0", () => {
@@ -92,16 +114,7 @@ describe("CLI dispatch", () => {
       }),
       { mode: 0o600 },
     );
-    fs.writeFileSync(
-      path.join(localBin, "bash"),
-      [
-        "#!/bin/sh",
-        `marker_file=${JSON.stringify(markerFile)}`,
-        'printf \'%s\\n\' "$@" > "$marker_file"',
-        "exit 0",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
+    writeBashCaptureStub(localBin, markerFile);
 
     const r = runWithEnv("start", {
       HOME: home,
@@ -139,16 +152,7 @@ describe("CLI dispatch", () => {
       }),
       { mode: 0o600 },
     );
-    fs.writeFileSync(
-      path.join(localBin, "bash"),
-      [
-        "#!/bin/sh",
-        `marker_file=${JSON.stringify(markerFile)}`,
-        'printf \'SANDBOX_NAME=%s\\nALLOWED_CHAT_IDS=%s\\nNEMOCLAW_TELEGRAM_DISCOVERY=%s\\nARGS=%s\\n\' "$SANDBOX_NAME" "$ALLOWED_CHAT_IDS" "$NEMOCLAW_TELEGRAM_DISCOVERY" "$*" > "$marker_file"',
-        "exit 0",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
+    writeBashCaptureStub(localBin, markerFile);
 
     expect(runWithEnv("telegram allow 12345,67890", { HOME: home }).code).toBe(0);
 
@@ -159,9 +163,47 @@ describe("CLI dispatch", () => {
 
     expect(r.code).toBe(0);
     const marker = fs.readFileSync(markerFile, "utf8");
-    expect(marker).toContain("SANDBOX_NAME='alpha'");
-    expect(marker).toContain("ALLOWED_CHAT_IDS='12345,67890'");
+    expect(marker).toContain("SANDBOX_NAME=alpha");
+    expect(marker).toContain("ALLOWED_CHAT_IDS=12345,67890");
+    expect(marker).toContain("NEMOCLAW_TELEGRAM_DISCOVERY=0");
     expect(marker).toContain("ARGS=");
+    expect(marker).toContain("start-services.sh");
+  });
+
+  it("start clears Telegram allowlist and discovery mode when unset", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-start-default-env-"));
+    const localBin = path.join(home, "bin");
+    const registryDir = path.join(home, ".nemoclaw");
+    const markerFile = path.join(home, "start-env");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify({
+        sandboxes: {
+          alpha: {
+            name: "alpha",
+            model: "test-model",
+            provider: "nvidia-prod",
+            gpuEnabled: false,
+            policies: [],
+          },
+        },
+        defaultSandbox: "alpha",
+      }),
+      { mode: 0o600 },
+    );
+    writeBashCaptureStub(localBin, markerFile);
+
+    const r = runWithEnv("start", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(0);
+    const marker = fs.readFileSync(markerFile, "utf8");
+    expect(marker).toContain("ALLOWED_CHAT_IDS=");
+    expect(marker).toContain("NEMOCLAW_TELEGRAM_DISCOVERY=0");
     expect(marker).toContain("start-services.sh");
   });
 
@@ -170,16 +212,7 @@ describe("CLI dispatch", () => {
     const localBin = path.join(home, "bin");
     const markerFile = path.join(home, "start-env");
     fs.mkdirSync(localBin, { recursive: true });
-    fs.writeFileSync(
-      path.join(localBin, "bash"),
-      [
-        "#!/bin/sh",
-        `marker_file=${JSON.stringify(markerFile)}`,
-        'printf \'NEMOCLAW_TELEGRAM_DISCOVERY=%s\\nARGS=%s\\n\' "$NEMOCLAW_TELEGRAM_DISCOVERY" "$*" > "$marker_file"',
-        "exit 0",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
+    writeBashCaptureStub(localBin, markerFile);
 
     const r = runWithEnv("start --discover-chat-id", {
       HOME: home,
@@ -196,6 +229,60 @@ describe("CLI dispatch", () => {
     const r = run("telegram allow not-a-chat-id");
     expect(r.code).toBe(1);
     expect(r.out).toContain("Invalid Telegram chat ID");
+  });
+
+  for (const action of ["show", "clear", "discover"]) {
+    it(`telegram ${action} rejects extra operands`, () => {
+      const r = run(`telegram ${action} unexpected`);
+      expect(r.code).toBe(1);
+      expect(r.out).toContain(`Unknown telegram ${action} option(s): unexpected`);
+    });
+  }
+
+  it("supports sandbox escape hatch for names that collide with global commands", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-reserved-sandbox-"));
+    const localBin = path.join(home, "bin");
+    const registryDir = path.join(home, ".nemoclaw");
+    const markerFile = path.join(home, "openshell-args");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify({
+        sandboxes: {
+          telegram: {
+            name: "telegram",
+            model: "test-model",
+            provider: "nvidia-prod",
+            gpuEnabled: false,
+            policies: [],
+          },
+        },
+        defaultSandbox: "telegram",
+      }),
+      { mode: 0o600 },
+    );
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/bin/sh",
+        `marker_file=${JSON.stringify(markerFile)}`,
+        'printf \'%s\\n\' "$@" > "$marker_file"',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("-- telegram connect", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(0);
+    const marker = fs.readFileSync(markerFile, "utf8");
+    expect(marker).toContain("sandbox");
+    expect(marker).toContain("connect");
+    expect(marker).toContain("telegram");
   });
 
   it("unknown onboard option exits 1", () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -116,6 +116,88 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("NemoClaw Services");
   });
 
+  it("start forwards stored Telegram allowlist to start-services", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-start-allowlist-"));
+    const localBin = path.join(home, "bin");
+    const registryDir = path.join(home, ".nemoclaw");
+    const markerFile = path.join(home, "start-env");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify({
+        sandboxes: {
+          alpha: {
+            name: "alpha",
+            model: "test-model",
+            provider: "nvidia-prod",
+            gpuEnabled: false,
+            policies: [],
+          },
+        },
+        defaultSandbox: "alpha",
+      }),
+      { mode: 0o600 },
+    );
+    fs.writeFileSync(
+      path.join(localBin, "bash"),
+      [
+        "#!/bin/sh",
+        `marker_file=${JSON.stringify(markerFile)}`,
+        'printf \'SANDBOX_NAME=%s\\nALLOWED_CHAT_IDS=%s\\nNEMOCLAW_TELEGRAM_DISCOVERY=%s\\nARGS=%s\\n\' "$SANDBOX_NAME" "$ALLOWED_CHAT_IDS" "$NEMOCLAW_TELEGRAM_DISCOVERY" "$*" > "$marker_file"',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    expect(runWithEnv("telegram allow 12345,67890", { HOME: home }).code).toBe(0);
+
+    const r = runWithEnv("start", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(0);
+    const marker = fs.readFileSync(markerFile, "utf8");
+    expect(marker).toContain("SANDBOX_NAME='alpha'");
+    expect(marker).toContain("ALLOWED_CHAT_IDS='12345,67890'");
+    expect(marker).toContain("ARGS=");
+    expect(marker).toContain("start-services.sh");
+  });
+
+  it("start --discover-chat-id enables discovery mode", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-start-discovery-"));
+    const localBin = path.join(home, "bin");
+    const markerFile = path.join(home, "start-env");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(localBin, "bash"),
+      [
+        "#!/bin/sh",
+        `marker_file=${JSON.stringify(markerFile)}`,
+        'printf \'NEMOCLAW_TELEGRAM_DISCOVERY=%s\\nARGS=%s\\n\' "$NEMOCLAW_TELEGRAM_DISCOVERY" "$*" > "$marker_file"',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("start --discover-chat-id", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(0);
+    const marker = fs.readFileSync(markerFile, "utf8");
+    expect(marker).toContain("NEMOCLAW_TELEGRAM_DISCOVERY=1");
+    expect(marker).toContain("start-services.sh");
+  });
+
+  it("telegram allow rejects invalid chat ids", () => {
+    const r = run("telegram allow not-a-chat-id");
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("Invalid Telegram chat ID");
+  });
+
   it("unknown onboard option exits 1", () => {
     const r = run("onboard --non-interactiv");
     expect(r.code).toBe(1);

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -102,9 +102,19 @@ else
   fail "config hash mismatch: $OUT"
 fi
 
-# ── Test 5: Config hash is not writable by sandbox ───────────────
+# ── Test 5: Update hints are disabled in sandbox config ──────────
 
-info "5. Config hash not writable by sandbox user"
+info "5. Sandbox config disables startup update hints"
+OUT=$(run_as_root "python3 -c 'import json; cfg=json.load(open(\"/sandbox/.openclaw/openclaw.json\")); print(\"OK\" if cfg.get(\"update\", {}).get(\"checkOnStart\") is False else \"BAD\")'")
+if echo "$OUT" | grep -q "OK"; then
+  pass "startup update hints disabled"
+else
+  fail "startup update hints not disabled: $OUT"
+fi
+
+# ── Test 6: Config hash is not writable by sandbox ───────────────
+
+info "6. Config hash not writable by sandbox user"
 OUT=$(run_as_sandbox "echo fake > /sandbox/.openclaw/.config-hash 2>&1 || echo BLOCKED")
 if echo "$OUT" | grep -q "BLOCKED\|Permission denied"; then
   pass "sandbox cannot tamper with config hash"
@@ -112,9 +122,9 @@ else
   fail "sandbox CAN write to config hash: $OUT"
 fi
 
-# ── Test 6: gosu is installed ────────────────────────────────────
+# ── Test 7: gosu is installed ────────────────────────────────────
 
-info "6. gosu binary is available"
+info "7. gosu binary is available"
 OUT=$(run_as_root "command -v gosu && gosu --version")
 if echo "$OUT" | grep -q "gosu"; then
   pass "gosu installed"
@@ -122,9 +132,9 @@ else
   fail "gosu not found: $OUT"
 fi
 
-# ── Test 7: Entrypoint PATH is locked to system dirs ─────────────
+# ── Test 8: Entrypoint PATH is locked to system dirs ─────────────
 
-info "7. Entrypoint locks PATH to system directories"
+info "8. Entrypoint locks PATH to system directories"
 # Walk the entrypoint line-by-line, eval only export lines, stop after PATH.
 OUT=$(run_as_root "bash -c 'while IFS= read -r line; do case \"\$line\" in export\\ *) eval \"\$line\" 2>/dev/null;; esac; case \"\$line\" in \"export PATH=\"*) break;; esac; done < /usr/local/bin/nemoclaw-start; echo \$PATH'")
 if echo "$OUT" | grep -q "^/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin$"; then
@@ -133,9 +143,9 @@ else
   fail "PATH not locked as expected: $OUT"
 fi
 
-# ── Test 8: openclaw resolves to expected absolute path ──────────
+# ── Test 9: openclaw resolves to expected absolute path ──────────
 
-info "8. Gateway runs the expected openclaw binary"
+info "9. Gateway runs the expected openclaw binary"
 OUT=$(run_as_root "gosu gateway which openclaw")
 if [ "$OUT" = "/usr/local/bin/openclaw" ]; then
   pass "openclaw resolves to /usr/local/bin/openclaw"
@@ -143,9 +153,9 @@ else
   fail "openclaw resolves to unexpected path: $OUT"
 fi
 
-# ── Test 9: Symlinks point to expected targets ───────────────────
+# ── Test 10: Symlinks point to expected targets ──────────────────
 
-info "9. All .openclaw symlinks point to .openclaw-data"
+info "10. All .openclaw symlinks point to .openclaw-data"
 FAILED_LINKS=""
 for link in agents extensions workspace skills hooks identity devices canvas cron; do
   OUT=$(run_as_root "readlink -f /sandbox/.openclaw/$link")
@@ -159,9 +169,9 @@ else
   fail "symlink targets wrong:$FAILED_LINKS"
 fi
 
-# ── Test 10: iptables is installed (required for network policy enforcement) ──
+# ── Test 11: iptables is installed (required for network policy enforcement) ──
 
-info "10. iptables is installed"
+info "11. iptables is installed"
 OUT=$(run_as_root "iptables --version 2>&1")
 if echo "$OUT" | grep -q "iptables v"; then
   pass "iptables installed: $OUT"
@@ -169,9 +179,9 @@ else
   fail "iptables not found — sandbox network policies will not be enforced: $OUT"
 fi
 
-# ── Test 11: Sandbox user cannot kill gateway-user processes ─────
+# ── Test 12: Sandbox user cannot kill gateway-user processes ─────
 
-info "11. Sandbox user cannot kill gateway-user processes"
+info "12. Sandbox user cannot kill gateway-user processes"
 # Start a dummy process as gateway, try to kill it as sandbox
 OUT=$(docker run --rm --entrypoint "" "$IMAGE" bash -c '
   gosu gateway sleep 60 &
@@ -187,9 +197,9 @@ else
   fail "sandbox CAN kill gateway processes: $OUT"
 fi
 
-# ── Test 12: Dangerous capabilities are dropped by entrypoint ────
+# ── Test 13: Dangerous capabilities are dropped by entrypoint ────
 
-info "12. Entrypoint drops dangerous capabilities from bounding set"
+info "13. Entrypoint drops dangerous capabilities from bounding set"
 # Run capsh directly with the same --drop flags as the entrypoint, then
 # check CapBnd. This avoids running the full entrypoint which starts
 # gateway services that fail in CI without a running OpenShell environment.

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -11,6 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 import { runCapture } from "../bin/lib/runner";
 
 const runnerPath = path.join(import.meta.dirname, "..", "bin", "lib", "runner");
+const sandboxNamesPath = path.join(import.meta.dirname, "..", "bin", "lib", "sandbox-names");
 
 describe("runner helpers", () => {
   it("does not let child commands consume installer stdin", () => {
@@ -264,6 +265,23 @@ describe("redact", () => {
     expect(redact(null)).toBe(null);
     expect(redact(undefined)).toBe(undefined);
     expect(redact(42)).toBe(42);
+  });
+});
+
+describe("validateSandboxName", () => {
+  it("rejects names reserved by the CLI", () => {
+    const { validateSandboxName } = require(sandboxNamesPath);
+    expect(() => validateSandboxName("telegram")).toThrow(/reserved by the CLI/);
+  });
+
+  it("accepts sandbox names that do not collide with commands", () => {
+    const { validateSandboxName } = require(sandboxNamesPath);
+    expect(validateSandboxName("my-sandbox")).toBe("my-sandbox");
+  });
+
+  it("rejects names that do not start with a letter", () => {
+    const { validateSandboxName } = require(sandboxNamesPath);
+    expect(() => validateSandboxName("1sandbox")).toThrow(/Must start with a letter/);
   });
 });
 

--- a/test/service-env.test.js
+++ b/test/service-env.test.js
@@ -46,7 +46,26 @@ describe("service environment", () => {
 
       expect(result).not.toContain("NVIDIA_API_KEY required");
       expect(result).toContain("NVIDIA_API_KEY not set");
-      expect(result).toContain("Telegram:    not started (no token)");
+      expect(result).toContain("Telegram:    not started (missing API key)");
+    });
+
+    it("warns and skips Telegram bridge when allowlist is missing", () => {
+      const workspace = mkdtempSync(join(tmpdir(), "nemoclaw-services-missing-allowlist-"));
+      const result = execFileSync("bash", [scriptPath], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          NVIDIA_API_KEY: "nvapi-test",
+          TELEGRAM_BOT_TOKEN: "test-token",
+          ALLOWED_CHAT_IDS: "",
+          SANDBOX_NAME: "test-box",
+          TMPDIR: workspace,
+        },
+      });
+
+      expect(result).toContain("ALLOWED_CHAT_IDS not set");
+      expect(result).toContain("discover-chat-id");
+      expect(result).toContain("Telegram:    not started (allowlist required)");
     });
   });
 


### PR DESCRIPTION
## Summary
- group the Telegram allowlist hardening from `#1218` with the sandbox self-update-hint fix from `#1215`
- keep `#1416` and `#1499` separate on purpose
- carry the smaller integration follow-up needed to make the grouped branch fit current `main`

## Related PRs / Issues
- bundles `#1218`
- bundles `#1215`
- keeps `#1416` separate
- keeps `#1499` separate
- addresses `#896`
- addresses `#1029`

## Why
These two changes both tighten the default runtime posture for operator-managed deployments:
- `#1218` makes Telegram bridge access fail closed unless a chat allowlist is configured, with a safe discovery mode for retrieving chat IDs
- `#1215` removes misleading in-sandbox self-update hints so the supported upgrade path stays image-based instead of mutable in-container updates

Grouping them into one cleanup PR reduces review fragmentation for the remaining security work without collapsing unrelated security follow-ups like `#1416` or `#1499`.

## Changes
- require an explicit Telegram allowlist before the bridge forwards prompts
- add `nemoclaw telegram` subcommands and `nemoclaw start --discover-chat-id`
- preserve the reserved-sandbox-name guard added during the Telegram review follow-up
- disable unsupported OpenClaw self-update hints in the generated sandbox config
- propagate saved Telegram allowlists into the remote deploy env so deployed bridges stay fail-closed too
- update focused CLI/deploy tests to match the current services-based startup path on `main`

## Follow-up Improvement
- carry the Telegram allowlist into `src/lib/deploy.ts` so a locally saved allowlist is not lost when operators use the remote `deploy` flow

## Validation
- `npm run build:cli`
- `npx vitest run src/lib/deploy.test.ts test/onboard.test.js test/cli.test.js test/runner.test.js test/service-env.test.js`

## Risks / Notes
- `npm run typecheck:cli` still hits the repo’s existing `src/lib/*.test.ts -> ../../dist/lib/*` type-resolution issue in this environment, so validation here relies on the targeted build plus Vitest coverage above
- `#1416` and `#1499` are intentionally left out of this bundle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram discovery mode via `nemoclaw start --discover-chat-id` to retrieve chat IDs without forwarding messages to the agent.
  * Introduced `nemoclaw telegram` management commands (`allow`, `show`, `clear`, `discover`) for Telegram allowlist configuration.
  * Added CLI escape mechanism `nemoclaw -- <name> <action>` to invoke sandboxes with names matching global commands.
  * Disabled automatic update checking on application startup.

* **Improvements**
  * Enhanced Telegram bridge status reporting with specific failure reasons.
  * Improved sandbox name validation with clearer error messages.

* **Documentation**
  * Updated Telegram bridge setup guides with discovery workflow and allowlist management instructions.
  * Added troubleshooting guidance for update command behavior in sandboxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->