### PR TITLE
feat(security-m9): add staged dangerous-command policy and warn mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
-# 🦞 NVIDIA NemoClaw: Reference Stack for Running OpenClaw in OpenShell
+# 🦞 ClawKeeper: Reference Stack for Running OpenClaw in OpenShell
 
 <!-- start-badges -->
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue)](https://github.com/NVIDIA/NemoClaw/blob/main/LICENSE)
-[![Security Policy](https://img.shields.io/badge/Security-Report%20a%20Vulnerability-red)](https://github.com/NVIDIA/NemoClaw/blob/main/SECURITY.md)
-[![Project Status](https://img.shields.io/badge/status-alpha-orange)](https://github.com/NVIDIA/NemoClaw/blob/main/docs/about/release-notes.md)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue)](https://github.com/hollyhongever/ClawKeeper/blob/main/LICENSE)
+[![Security Policy](https://img.shields.io/badge/Security-Report%20a%20Vulnerability-red)](https://github.com/hollyhongever/ClawKeeper/blob/main/SECURITY.md)
+[![Project Status](https://img.shields.io/badge/status-alpha-orange)](https://github.com/hollyhongever/ClawKeeper/blob/main/docs/about/release-notes.md)
 [![Discord](https://img.shields.io/badge/Discord-Join-7289da)](https://discord.gg/XFpfPv9Uvx)
 <!-- end-badges -->
 
 <!-- start-intro -->
-NVIDIA NemoClaw is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants more safely.
+ClawKeeper is an open source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants more safely.
 It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of NVIDIA Agent Toolkit, which provides additional security for running autonomous agents.
 <!-- end-intro -->
 
 > **Alpha software**
 >
-> NemoClaw is available in early preview starting March 16, 2026.
+> ClawKeeper is available in early preview starting March 16, 2026.
 > This software is not production-ready.
 > Interfaces, APIs, and behavior may change without notice as we iterate on the design.
 > The project is shared to gather feedback and enable early experimentation.
 > We welcome issues and discussion from the community while the project evolves.
 
-NemoClaw adds guided onboarding, a hardened blueprint, state management, messaging bridges, routed inference, and layered protection on top of the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime. For the full feature list, refer to [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html). For the system diagram, component model, and blueprint lifecycle, refer to [How It Works](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html) and [Architecture](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html).
+ClawKeeper adds guided onboarding, a hardened blueprint, state management, messaging bridges, routed inference, and layered protection on top of the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime. For the full feature list, refer to [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html). For the system diagram, component model, and blueprint lifecycle, refer to [How It Works](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html) and [Architecture](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html).
 
 ## Getting Started
 
-Follow these steps to install NemoClaw and run your first sandboxed OpenClaw agent.
+Follow these steps to install ClawKeeper and run your first sandboxed OpenClaw agent.
 
 <!-- start-quickstart-guide -->
 
 ### Prerequisites
 
-Before getting started, check the prerequisites to ensure you have the necessary software and hardware to run NemoClaw.
+Before getting started, check the prerequisites to ensure you have the necessary software and hardware to run ClawKeeper.
 
 #### Hardware
 
@@ -60,23 +60,24 @@ The sandbox image is approximately 2.4 GB compressed. During image push, the Doc
 | macOS (Apple Silicon) | Colima, Docker Desktop | Install Xcode Command Line Tools (`xcode-select --install`) and start the runtime before running the installer. |
 | macOS (Intel) | Podman | Not supported yet. Depends on OpenShell support for Podman on macOS. |
 | Windows WSL | Docker Desktop (WSL backend) | Supported target path. |
-| DGX Spark | Docker | Refer to the [DGX Spark setup guide](https://github.com/NVIDIA/NemoClaw/blob/main/spark-install.md) for cgroup v2 and Docker configuration. |
+| DGX Spark | Docker | Refer to the [DGX Spark setup guide](https://github.com/hollyhongever/ClawKeeper/blob/main/spark-install.md) for cgroup v2 and Docker configuration. |
 
-### Install NemoClaw and Onboard OpenClaw Agent
+### Install ClawKeeper and Onboard OpenClaw Agent
 
 Download and run the installer script.
 The script installs Node.js if it is not already present, then runs the guided onboard wizard to create a sandbox, configure inference, and apply security policies.
 
 > **ℹ️ Note**
 >
-> NemoClaw creates a fresh OpenClaw instance inside the sandbox during the onboarding process.
+> ClawKeeper creates a fresh OpenClaw instance inside the sandbox during the onboarding process.
 
 ```bash
-curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+curl -fsSL https://raw.githubusercontent.com/hollyhongever/ClawKeeper/main/install.sh | bash
 ```
 
 If you use nvm or fnm to manage Node.js, the installer may not update your current shell's PATH.
-If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
+If `clawkeeper` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
+Legacy command `nemoclaw` remains available as a compatibility alias.
 
 When the install completes, a summary confirms the running environment:
 
@@ -85,9 +86,9 @@ When the install completes, a summary confirms the running environment:
 Sandbox      my-assistant (Landlock + seccomp + netns)
 Model        nvidia/nemotron-3-super-120b-a12b (NVIDIA Endpoints)
 ──────────────────────────────────────────────────
-Run:         nemoclaw my-assistant connect
-Status:      nemoclaw my-assistant status
-Logs:        nemoclaw my-assistant logs --follow
+Run:         clawkeeper my-assistant connect
+Status:      clawkeeper my-assistant status
+Logs:        clawkeeper my-assistant logs --follow
 ──────────────────────────────────────────────────
 
 [INFO]  === Installation complete ===
@@ -98,7 +99,7 @@ Logs:        nemoclaw my-assistant logs --follow
 Connect to the sandbox, then chat with the agent through the TUI or the CLI.
 
 ```bash
-nemoclaw my-assistant connect
+clawkeeper my-assistant connect
 ```
 
 In the sandbox shell, open the OpenClaw terminal UI and start a chat:
@@ -115,17 +116,17 @@ openclaw agent --agent main --local -m "hello" --session-id test
 
 ### Uninstall
 
-To remove NemoClaw and all resources created during setup, run the uninstall script:
+To remove ClawKeeper and all resources created during setup, run the uninstall script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/hollyhongever/ClawKeeper/main/uninstall.sh | bash
 ```
 
 | Flag               | Effect                                              |
 |--------------------|-----------------------------------------------------|
 | `--yes`            | Skip the confirmation prompt.                       |
 | `--keep-openshell` | Leave the `openshell` binary installed.              |
-| `--delete-models`  | Also remove NemoClaw-pulled Ollama models.           |
+| `--delete-models`  | Also remove ClawKeeper-pulled Ollama models.         |
 
 For troubleshooting installation or onboarding issues, see the [Troubleshooting guide](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html).
 
@@ -133,11 +134,11 @@ For troubleshooting installation or onboarding issues, see the [Troubleshooting 
 
 ## Documentation
 
-Refer to the following pages on the official documentation website for more information on NemoClaw.
+Refer to the following pages on the official documentation website for more information on ClawKeeper.
 
 | Page | Description |
 |------|-------------|
-| [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html) | What NemoClaw does and how it fits together. |
+| [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html) | What ClawKeeper does and how it fits together. |
 | [How It Works](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html) | Plugin, blueprint, sandbox lifecycle, and protection layers. |
 | [Architecture](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html) | Plugin structure, blueprint lifecycle, sandbox environment, and host-side state. |
 | [Inference Options](https://docs.nvidia.com/nemoclaw/latest/inference/inference-options.html) | Supported providers, validation, and routed inference configuration. |
@@ -145,15 +146,15 @@ Refer to the following pages on the official documentation website for more info
 | [Customize Network Policy](https://docs.nvidia.com/nemoclaw/latest/network-policy/customize-network-policy.html) | Static and dynamic policy changes, presets. |
 | [Security Best Practices](https://docs.nvidia.com/nemoclaw/latest/security/best-practices.html) | Controls reference, risk framework, and posture profiles for sandbox security. |
 | [Sandbox Hardening](https://docs.nvidia.com/nemoclaw/latest/deployment/sandbox-hardening.html) | Container security measures, capability drops, process limits. |
-| [CLI Commands](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html) | Full NemoClaw CLI command reference. |
+| [CLI Commands](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html) | Full ClawKeeper CLI command reference. |
 | [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html) | Common issues and resolution steps. |
 
 ## Project Structure
 
-The following directories make up the NemoClaw repository.
+The following directories make up the ClawKeeper repository.
 
 ```text
-NemoClaw/
+ClawKeeper/
 ├── bin/              # CLI entry point and library modules (CJS)
 ├── nemoclaw/         # TypeScript plugin (Commander CLI extension)
 │   └── src/
@@ -168,11 +169,11 @@ NemoClaw/
 
 ## Community
 
-Join the NemoClaw community to ask questions, share feedback, and report issues.
+Join the ClawKeeper community to ask questions, share feedback, and report issues.
 
 - [Discord](https://discord.gg/XFpfPv9Uvx)
-- [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions)
-- [GitHub Issues](https://github.com/NVIDIA/NemoClaw/issues)
+- [GitHub Discussions](https://github.com/hollyhongever/ClawKeeper/discussions)
+- [GitHub Issues](https://github.com/hollyhongever/ClawKeeper/issues)
 
 ## Contributing
 
@@ -181,7 +182,7 @@ We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for development
 ## Security
 
 NVIDIA takes security seriously.
-If you discover a vulnerability in NemoClaw, **DO NOT open a public issue.**
+If you discover a vulnerability in ClawKeeper, **DO NOT open a public issue.**
 Use one of the private reporting channels described in [SECURITY.md](SECURITY.md):
 
 - Submit a report through the [NVIDIA Vulnerability Disclosure Program](https://www.nvidia.com/en-us/security/report-vulnerability/).

--- a/bin/lib/credentials.js
+++ b/bin/lib/credentials.js
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -8,6 +9,38 @@ const readline = require("readline");
 const { execFileSync } = require("child_process");
 
 const UNSAFE_HOME_PATHS = new Set(["/tmp", "/var/tmp", "/dev/shm", "/"]);
+const CRED_STORE_KEY_ENV = "NEMOCLAW_CRED_STORE_KEY";
+
+const CRED_ENVELOPE_FORMAT = "nemoclaw.credentials.v1";
+const CRED_ENVELOPE_VERSION = 1;
+const CRED_ENCRYPTION = "aes-256-gcm";
+const CRED_KDF_NAME = "scrypt";
+const CRED_SCRYPT_N = 16384;
+const CRED_SCRYPT_R = 8;
+const CRED_SCRYPT_P = 1;
+const CRED_SCRYPT_KEYLEN = 32;
+const CRED_SCRYPT_MAXMEM = 128 * 1024 * 1024;
+const CRED_SALT_BYTES = 16;
+const CRED_IV_BYTES = 12;
+
+let _credsDir = null;
+let _credsFile = null;
+let _warnedMissingStoreKey = false;
+
+function credentialStoreError(message, code) {
+  const err = new Error(message);
+  err.code = code;
+  return err;
+}
+
+function normalizeCredentialStoreKey(value) {
+  if (typeof value !== "string") return "";
+  return value.replace(/\r/g, "").replace(/\n/g, "");
+}
+
+function getCredentialStoreKeyFromEnv() {
+  return normalizeCredentialStoreKey(process.env[CRED_STORE_KEY_ENV] || "");
+}
 
 function resolveHomeDir() {
   const raw = process.env.HOME || os.homedir();
@@ -42,9 +75,6 @@ function resolveHomeDir() {
   return home;
 }
 
-let _credsDir = null;
-let _credsFile = null;
-
 function getCredsDir() {
   if (!_credsDir) _credsDir = path.join(resolveHomeDir(), ".nemoclaw");
   return _credsDir;
@@ -55,16 +85,18 @@ function getCredsFile() {
   return _credsFile;
 }
 
-function loadCredentials() {
-  try {
-    const file = getCredsFile();
-    if (fs.existsSync(file)) {
-      return JSON.parse(fs.readFileSync(file, "utf-8"));
-    }
-  } catch {
-    /* ignored */
-  }
-  return {};
+function isPlainObject(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isEncryptedEnvelope(payload) {
+  if (!isPlainObject(payload)) return false;
+  if (payload.format !== CRED_ENVELOPE_FORMAT) return false;
+  if (payload.encryption !== CRED_ENCRYPTION) return false;
+  if (!isPlainObject(payload.kdf)) return false;
+  if (payload.kdf.name !== CRED_KDF_NAME) return false;
+  if (!isPlainObject(payload.cipher)) return false;
+  return typeof payload.ciphertext === "string";
 }
 
 function normalizeCredentialValue(value) {
@@ -72,22 +104,308 @@ function normalizeCredentialValue(value) {
   return value.replace(/\r/g, "").trim();
 }
 
-function saveCredential(key, value) {
+function normalizeCredentialMap(raw) {
+  if (!isPlainObject(raw)) return {};
+  const normalized = {};
+  for (const [key, value] of Object.entries(raw)) {
+    normalized[String(key)] = normalizeCredentialValue(value);
+  }
+  return normalized;
+}
+
+function deriveStoreKey(password, saltB64, kdf = {}) {
+  const salt = Buffer.from(String(saltB64 || ""), "base64");
+  if (salt.length === 0) {
+    throw credentialStoreError("Credential store metadata is invalid (missing salt).", "CREDENTIAL_STORE_INVALID");
+  }
+  const N = Number.parseInt(kdf.N, 10) || CRED_SCRYPT_N;
+  const r = Number.parseInt(kdf.r, 10) || CRED_SCRYPT_R;
+  const p = Number.parseInt(kdf.p, 10) || CRED_SCRYPT_P;
+  return crypto.scryptSync(password, salt, CRED_SCRYPT_KEYLEN, {
+    N,
+    r,
+    p,
+    maxmem: CRED_SCRYPT_MAXMEM,
+  });
+}
+
+function encryptCredentialMap(credentials, password) {
+  const normalized = normalizeCredentialMap(credentials);
+  const salt = crypto.randomBytes(CRED_SALT_BYTES);
+  const iv = crypto.randomBytes(CRED_IV_BYTES);
+  const key = crypto.scryptSync(password, salt, CRED_SCRYPT_KEYLEN, {
+    N: CRED_SCRYPT_N,
+    r: CRED_SCRYPT_R,
+    p: CRED_SCRYPT_P,
+    maxmem: CRED_SCRYPT_MAXMEM,
+  });
+
+  const cipher = crypto.createCipheriv(CRED_ENCRYPTION, key, iv);
+  const plaintext = Buffer.from(JSON.stringify(normalized), "utf8");
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return {
+    format: CRED_ENVELOPE_FORMAT,
+    version: CRED_ENVELOPE_VERSION,
+    encryption: CRED_ENCRYPTION,
+    credentialCount: Object.keys(normalized).length,
+    kdf: {
+      name: CRED_KDF_NAME,
+      N: CRED_SCRYPT_N,
+      r: CRED_SCRYPT_R,
+      p: CRED_SCRYPT_P,
+      salt: salt.toString("base64"),
+    },
+    cipher: {
+      iv: iv.toString("base64"),
+      tag: tag.toString("base64"),
+    },
+    ciphertext: ciphertext.toString("base64"),
+  };
+}
+
+function decryptCredentialEnvelope(payload, password) {
+  if (!password) {
+    throw credentialStoreError(
+      `Credential store is encrypted. Set ${CRED_STORE_KEY_ENV} or run 'clawkeeper security set-password'.`,
+      "CREDENTIAL_STORE_KEY_REQUIRED",
+    );
+  }
+  try {
+    const key = deriveStoreKey(password, payload.kdf?.salt, payload.kdf);
+    const iv = Buffer.from(String(payload.cipher?.iv || ""), "base64");
+    const tag = Buffer.from(String(payload.cipher?.tag || ""), "base64");
+    const ciphertext = Buffer.from(String(payload.ciphertext || ""), "base64");
+    if (iv.length === 0 || tag.length === 0 || ciphertext.length === 0) {
+      throw credentialStoreError(
+        "Credential store metadata is invalid (cipher payload missing).",
+        "CREDENTIAL_STORE_INVALID",
+      );
+    }
+    const decipher = crypto.createDecipheriv(CRED_ENCRYPTION, key, iv);
+    decipher.setAuthTag(tag);
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    const parsed = JSON.parse(decrypted.toString("utf8"));
+    return normalizeCredentialMap(parsed);
+  } catch (error) {
+    if (error && error.code === "CREDENTIAL_STORE_INVALID") {
+      throw error;
+    }
+    throw credentialStoreError(
+      `Credential store decryption failed. Check ${CRED_STORE_KEY_ENV} or rotate with 'clawkeeper security set-password'.`,
+      "CREDENTIAL_STORE_DECRYPT_FAILED",
+    );
+  }
+}
+
+function parseCredentialStoreFile() {
+  const file = getCredsFile();
+  if (!fs.existsSync(file)) {
+    return {
+      exists: false,
+      mode: "plaintext",
+      credentials: {},
+      payload: null,
+      malformed: false,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+    if (isEncryptedEnvelope(parsed)) {
+      return {
+        exists: true,
+        mode: "encrypted",
+        credentials: null,
+        payload: parsed,
+        malformed: false,
+      };
+    }
+    if (isPlainObject(parsed)) {
+      return {
+        exists: true,
+        mode: "plaintext",
+        credentials: normalizeCredentialMap(parsed),
+        payload: parsed,
+        malformed: false,
+      };
+    }
+  } catch {
+    // Keep backwards-compatible behavior for malformed files: treat as empty.
+  }
+
+  return {
+    exists: true,
+    mode: "plaintext",
+    credentials: {},
+    payload: null,
+    malformed: true,
+  };
+}
+
+function writeCredentialStorePayload(payload) {
   const dir = getCredsDir();
   const file = getCredsFile();
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   fs.chmodSync(dir, 0o700);
-  const creds = loadCredentials();
-  creds[key] = normalizeCredentialValue(value);
-  fs.writeFileSync(file, JSON.stringify(creds, null, 2), { mode: 0o600 });
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2), { mode: 0o600 });
   fs.chmodSync(file, 0o600);
+}
+
+function loadCredentialStore(opts = {}) {
+  const { password = "", migratePlaintext = true } = opts;
+  const parsed = parseCredentialStoreFile();
+  const envPassword = getCredentialStoreKeyFromEnv();
+
+  if (parsed.mode === "encrypted") {
+    const secret = normalizeCredentialStoreKey(password) || envPassword;
+    const credentials = decryptCredentialEnvelope(parsed.payload, secret);
+    return { mode: "encrypted", credentials, migrated: false, encryptedPayload: parsed.payload };
+  }
+
+  const credentials = parsed.credentials || {};
+  if (!migratePlaintext) {
+    return { mode: "plaintext", credentials, migrated: false, encryptedPayload: null };
+  }
+
+  if (envPassword) {
+    const envelope = encryptCredentialMap(credentials, envPassword);
+    writeCredentialStorePayload(envelope);
+    return { mode: "encrypted", credentials, migrated: true, encryptedPayload: envelope };
+  }
+
+  return { mode: "plaintext", credentials, migrated: false, encryptedPayload: null };
+}
+
+function writeCredentialMap(credentials, opts = {}) {
+  const forceEncrypted = opts.forceEncrypted === true;
+  const password = normalizeCredentialStoreKey(opts.password || "") || getCredentialStoreKeyFromEnv();
+  const payload = normalizeCredentialMap(credentials);
+  if (forceEncrypted || password) {
+    if (!password) {
+      throw credentialStoreError(
+        `Credential store is encrypted. Set ${CRED_STORE_KEY_ENV} or run 'clawkeeper security set-password'.`,
+        "CREDENTIAL_STORE_KEY_REQUIRED",
+      );
+    }
+    writeCredentialStorePayload(encryptCredentialMap(payload, password));
+    return "encrypted";
+  }
+  writeCredentialStorePayload(payload);
+  return "plaintext";
+}
+
+function reportCredentialStoreAccessWarning(error) {
+  if (!error || _warnedMissingStoreKey) return;
+  if (
+    error.code === "CREDENTIAL_STORE_KEY_REQUIRED" ||
+    error.code === "CREDENTIAL_STORE_DECRYPT_FAILED" ||
+    error.code === "CREDENTIAL_STORE_INVALID"
+  ) {
+    _warnedMissingStoreKey = true;
+    console.error(`  ${error.message}`);
+  }
+}
+
+function loadCredentials() {
+  try {
+    return loadCredentialStore({ migratePlaintext: true }).credentials;
+  } catch (error) {
+    if (
+      error &&
+      (error.code === "CREDENTIAL_STORE_KEY_REQUIRED" ||
+        error.code === "CREDENTIAL_STORE_DECRYPT_FAILED" ||
+        error.code === "CREDENTIAL_STORE_INVALID")
+    ) {
+      throw error;
+    }
+    return {};
+  }
+}
+
+function saveCredential(key, value) {
+  const parsed = parseCredentialStoreFile();
+  const store = loadCredentialStore({ migratePlaintext: true });
+  const creds = { ...store.credentials };
+  creds[key] = normalizeCredentialValue(value);
+
+  const shouldEncrypt = parsed.mode === "encrypted" || store.mode === "encrypted";
+  writeCredentialMap(creds, { forceEncrypted: shouldEncrypt });
 }
 
 function getCredential(key) {
   if (process.env[key]) return normalizeCredentialValue(process.env[key]);
-  const creds = loadCredentials();
-  const value = normalizeCredentialValue(creds[key]);
-  return value || null;
+
+  try {
+    const creds = loadCredentials();
+    const value = normalizeCredentialValue(creds[key]);
+    return value || null;
+  } catch (error) {
+    reportCredentialStoreAccessWarning(error);
+    return null;
+  }
+}
+
+function getCredentialStoreStatus() {
+  const parsed = parseCredentialStoreFile();
+  const envPassword = getCredentialStoreKeyFromEnv();
+
+  if (parsed.mode === "encrypted") {
+    let credentialCount = Number.parseInt(parsed.payload?.credentialCount, 10);
+    if (!Number.isFinite(credentialCount) || credentialCount < 0) credentialCount = 0;
+
+    if (envPassword) {
+      try {
+        credentialCount = Object.keys(decryptCredentialEnvelope(parsed.payload, envPassword)).length;
+      } catch {
+        // Keep envelope metadata count when decryption fails.
+      }
+    }
+
+    return {
+      mode: "encrypted",
+      credentialCount,
+      passwordEnvDetected: Boolean(envPassword),
+      path: getCredsFile(),
+    };
+  }
+
+  return {
+    mode: "plaintext",
+    credentialCount: Object.keys(parsed.credentials || {}).length,
+    passwordEnvDetected: Boolean(envPassword),
+    path: getCredsFile(),
+  };
+}
+
+function setCredentialStorePassword(nextPassword, opts = {}) {
+  const newPassword = normalizeCredentialStoreKey(nextPassword || "");
+  if (!newPassword) {
+    throw credentialStoreError("Credential-store password cannot be empty.", "CREDENTIAL_STORE_PASSWORD_REQUIRED");
+  }
+
+  const parsed = parseCredentialStoreFile();
+  let credentials = {};
+  let previousMode = "plaintext";
+
+  if (parsed.mode === "encrypted") {
+    previousMode = "encrypted";
+    const currentPassword =
+      normalizeCredentialStoreKey(opts.currentPassword || "") || getCredentialStoreKeyFromEnv();
+    credentials = decryptCredentialEnvelope(parsed.payload, currentPassword);
+  } else {
+    credentials = normalizeCredentialMap(parsed.credentials || {});
+  }
+
+  writeCredentialMap(credentials, { forceEncrypted: true, password: newPassword });
+
+  return {
+    previousMode,
+    mode: "encrypted",
+    credentialCount: Object.keys(credentials).length,
+    path: getCredsFile(),
+  };
 }
 
 function promptSecret(question) {
@@ -251,7 +569,7 @@ async function ensureApiKey() {
   saveCredential("NVIDIA_API_KEY", key);
   process.env.NVIDIA_API_KEY = key;
   console.log("");
-  console.log("  Key saved to ~/.nemoclaw/credentials.json (mode 600)");
+  console.log("  Credential saved to ~/.nemoclaw/credentials.json");
   console.log("");
 }
 
@@ -306,7 +624,7 @@ async function ensureGithubToken() {
   saveCredential("GITHUB_TOKEN", token);
   process.env.GITHUB_TOKEN = token;
   console.log("");
-  console.log("  Token saved to ~/.nemoclaw/credentials.json (mode 600)");
+  console.log("  Credential saved to ~/.nemoclaw/credentials.json");
   console.log("");
 }
 
@@ -315,10 +633,14 @@ const exports_ = {
   normalizeCredentialValue,
   saveCredential,
   getCredential,
+  getCredentialStoreStatus,
+  setCredentialStorePassword,
+  getCredentialStoreKeyFromEnv,
   prompt,
   ensureApiKey,
   ensureGithubToken,
   isRepoPrivate,
+  CRED_STORE_KEY_ENV,
 };
 
 Object.defineProperty(exports_, "CREDS_DIR", { get: getCredsDir, enumerable: true });

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -834,7 +834,10 @@ async function replaceNamedCredential(envName, label, helpUrl = null, validator 
     saveCredential(envName, key);
     process.env[envName] = key;
     console.log("");
-    console.log(`  Key saved to ~/.nemoclaw/credentials.json (mode 600)`);
+    console.log(`  Credential saved to ~/.nemoclaw/credentials.json`);
+    if (!process.env.NEMOCLAW_CRED_STORE_KEY) {
+      console.log("  Security tip: set NEMOCLAW_CRED_STORE_KEY and run `clawkeeper security set-password`.");
+    }
     console.log("");
     return key;
   }
@@ -3728,8 +3731,8 @@ function findOpenclawJsonPath(dir) {
 }
 
 /**
- * Pull gateway.auth.token from the sandbox image via openshell sandbox download
- * so onboard can print copy-paste Control UI URLs with #token= (same idea as nemoclaw-start.sh).
+ * Pull gateway.auth.token from the sandbox image via openshell sandbox download.
+ * This is used as a readiness signal for OpenClaw startup checks.
  */
 function fetchGatewayAuthTokenFromSandbox(sandboxName) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
@@ -3773,8 +3776,6 @@ function printDashboard(sandboxName, model, provider, nimContainer = null) {
   else if (provider === "vllm-local") providerLabel = "Local vLLM";
   else if (provider === "ollama-local") providerLabel = "Local Ollama";
 
-  const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
-
   console.log("");
   console.log(`  ${"─".repeat(50)}`);
   // console.log(`  Dashboard    http://localhost:18789/`);
@@ -3786,26 +3787,14 @@ function printDashboard(sandboxName, model, provider, nimContainer = null) {
   console.log(`  Status:      nemoclaw ${sandboxName} status`);
   console.log(`  Logs:        nemoclaw ${sandboxName} logs --follow`);
   console.log("");
-  if (token) {
-    console.log("  OpenClaw UI (tokenized URL; treat it like a password)");
-    console.log(`  Port ${CONTROL_UI_PORT} must be forwarded before opening this URL.`);
-    for (const url of buildControlUiUrls(token)) {
-      console.log(`  ${url}`);
-    }
-  } else {
-    note("  Could not read gateway token from the sandbox (download failed).");
-    console.log("  OpenClaw UI");
-    console.log(`  Port ${CONTROL_UI_PORT} must be forwarded before opening this URL.`);
-    for (const url of buildControlUiUrls()) {
-      console.log(`  ${url}`);
-    }
-    console.log(
-      `  Token:       nemoclaw ${sandboxName} connect  →  jq -r '.gateway.auth.token' /sandbox/.openclaw/openclaw.json`,
-    );
-    console.log(
-      `               append  #token=<token>  to the URL, or see /tmp/gateway.log inside the sandbox.`,
-    );
+  console.log("  OpenClaw UI");
+  console.log(`  Port ${CONTROL_UI_PORT} must be forwarded before opening this URL.`);
+  for (const url of buildControlUiUrls()) {
+    console.log(`  ${url}`);
   }
+  console.log(`  Security:    set ${"NEMOCLAW_CRED_STORE_KEY"} before storing credentials`);
+  console.log("               then run: clawkeeper security set-password");
+  console.log("               verify with: clawkeeper security status");
   console.log(`  ${"─".repeat(50)}`);
   console.log("");
 }

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -3,7 +3,8 @@
 //
 // Interactive onboarding wizard — 7 steps from zero to running sandbox.
 // Supports non-interactive mode via --non-interactive flag or
-// NEMOCLAW_NON_INTERACTIVE=1 env var for CI/CD pipelines.
+// NEMOCLAW_NON_INTERACTIVE=1 / CLAWKEEPER_NON_INTERACTIVE=1 env vars
+// for CI/CD pipelines.
 
 const fs = require("fs");
 const os = require("os");
@@ -85,6 +86,32 @@ function cleanupTempDir(filePath, expectedPrefix) {
     fs.rmSync(parentDir, { recursive: true, force: true });
   }
 }
+
+// Compatibility bridge for the first ClawKeeper branding phase.
+// Legacy NEMOCLAW_* still wins when both are set.
+const CLAWKEEPER_COMPAT_ENV_SUFFIXES = [
+  "NON_INTERACTIVE",
+  "ACCEPT_THIRD_PARTY_SOFTWARE",
+  "SANDBOX_NAME",
+  "PROVIDER",
+  "MODEL",
+  "POLICY_MODE",
+  "POLICY_PRESETS",
+  "RECREATE_SANDBOX",
+  "ENDPOINT_URL",
+];
+
+function applyClawkeeperCompatEnv() {
+  for (const suffix of CLAWKEEPER_COMPAT_ENV_SUFFIXES) {
+    const legacy = `NEMOCLAW_${suffix}`;
+    const branded = `CLAWKEEPER_${suffix}`;
+    if (process.env[legacy] === undefined && process.env[branded] !== undefined) {
+      process.env[legacy] = process.env[branded];
+    }
+  }
+}
+
+applyClawkeeperCompatEnv();
 
 const EXPERIMENTAL = process.env.NEMOCLAW_EXPERIMENTAL === "1";
 const USE_COLOR = !process.env.NO_COLOR && !!process.stdout.isTTY;

--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -78,24 +78,22 @@ function runCapture(cmd, opts = {}) {
 
 /**
  * Redact known secret patterns from a string to prevent accidental leaks
- * in CLI log and error output. Covers NVIDIA API keys, bearer tokens,
- * generic API key assignments, and base64-style long tokens.
+ * in CLI log and error output.
  */
+const REDACTION_TOKEN = "<REDACTED>";
+const URL_PATTERN = /https?:\/\/[^\s'"`]+/g;
+const URL_TOKEN_PARAM_RE = /(^|[-_])(?:signature|sig|token|auth|access_token)$/i;
 const SECRET_PATTERNS = [
-  /nvapi-[A-Za-z0-9_-]{10,}/g,
-  /nvcf-[A-Za-z0-9_-]{10,}/g,
-  /ghp_[A-Za-z0-9_-]{10,}/g,
-  /(?<=Bearer\s+)[A-Za-z0-9_.+/=-]{10,}/gi,
-  /(?<=(?:_KEY|API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[=: ]['"]?)[A-Za-z0-9_.+/=-]{10,}/gi,
+  [
+    /((?:["'])?(?:[A-Za-z0-9_.-]*?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|credential|private[_-]?key|client[_-]?secret)|[A-Za-z0-9_.-]+_key)(?:["'])?\s*[:=]\s*)(?:"[^"\n]*"|'[^'\n]*'|[^\s,&}"'\]]+)/gi,
+    `$1${REDACTION_TOKEN}`,
+  ],
+  [/\bnvapi-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/\bnvcf-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/\b(?:ghp_|github_pat_)[A-Za-z0-9_]{20,}\b/g, REDACTION_TOKEN],
+  [/\bsk-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/(Bearer\s+)\S+/gi, `$1${REDACTION_TOKEN}`],
 ];
-
-/**
- * Partially redact a matched secret string: keep the first 4 chars and replace
- * the rest with asterisks (capped at 20 asterisks).
- */
-function redactMatch(match) {
-  return match.slice(0, 4) + "*".repeat(Math.min(match.length - 4, 20));
-}
 
 /**
  * Redact credentials from a URL string: clears url.password and blanks
@@ -106,14 +104,16 @@ function redactUrl(value) {
   if (typeof value !== "string" || value.length === 0) return value;
   try {
     const url = new URL(value);
-    if (url.password) {
-      url.password = "****";
+    if (url.username || url.password) {
+      url.username = "";
+      url.password = "";
     }
     for (const key of [...url.searchParams.keys()]) {
-      if (/(^|[-_])(?:signature|sig|token|auth|access_token)$/i.test(key)) {
-        url.searchParams.set(key, "****");
+      if (URL_TOKEN_PARAM_RE.test(key)) {
+        url.searchParams.set(key, REDACTION_TOKEN);
       }
     }
+    url.hash = "";
     return url.toString();
   } catch {
     return value;
@@ -126,10 +126,11 @@ function redactUrl(value) {
  */
 function redact(str) {
   if (typeof str !== "string") return str;
-  let out = str.replace(/https?:\/\/[^\s'"]+/g, redactUrl);
-  for (const pat of SECRET_PATTERNS) {
-    out = out.replace(pat, redactMatch);
+  let out = str;
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    out = out.replace(pattern, replacement);
   }
+  out = out.replace(URL_PATTERN, redactUrl);
   return out;
 }
 

--- a/bin/lib/security.js
+++ b/bin/lib/security.js
@@ -76,39 +76,137 @@ function camelCase(value) {
   return String(value).replace(/_([a-z])/g, (_, ch) => ch.toUpperCase());
 }
 
-function readEvents(filePath = defaultEventsPath(), limit = 50) {
+function normalizeEvent(rawEvent, lineNo) {
+  if (!rawEvent || typeof rawEvent !== "object" || Array.isArray(rawEvent)) return null;
+  const event = { ...rawEvent };
+  event._line = lineNo;
+  event.id = typeof event.id === "string" ? event.id : `line-${lineNo}`;
+  event.hook = typeof event.hook === "string" ? event.hook : "unknown-hook";
+  event.action =
+    typeof event.effectiveAction === "string"
+      ? event.effectiveAction
+      : typeof event.action === "string"
+        ? event.action
+        : "allow";
+  event.riskLevel = typeof event.riskLevel === "string" ? event.riskLevel : "low";
+  event.target = typeof event.target === "string" ? event.target : "unknown";
+  event.timestamp = typeof event.timestamp === "string" ? event.timestamp : "";
+  return event;
+}
+
+function readEvents(filePath = defaultEventsPath(), options = {}) {
   const resolved = path.resolve(filePath);
   if (!fs.existsSync(resolved)) {
-    return { path: resolved, events: [] };
+    return {
+      path: resolved,
+      events: [],
+      totalEvents: 0,
+      returnedEvents: 0,
+      malformedLines: 0,
+      filters: {},
+    };
   }
+
+  const normalizedOptions =
+    typeof options === "number"
+      ? { limit: options }
+      : options && typeof options === "object"
+        ? options
+        : {};
+  const limit = Math.max(1, Number.parseInt(String(normalizedOptions.limit ?? 50), 10) || 50);
+  const actionFilter =
+    typeof normalizedOptions.action === "string" ? normalizedOptions.action.trim() : "";
+  const hookFilter = typeof normalizedOptions.hook === "string" ? normalizedOptions.hook.trim() : "";
+  const riskFilter = typeof normalizedOptions.risk === "string" ? normalizedOptions.risk.trim() : "";
+  const idFilter = typeof normalizedOptions.id === "string" ? normalizedOptions.id.trim() : "";
 
   const lines = fs
     .readFileSync(resolved, "utf-8")
     .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
+    .map((line, index) => ({ line: line.trim(), lineNo: index + 1 }))
+    .filter((entry) => entry.line.length > 0);
 
-  const events = [];
-  for (const line of lines) {
+  let malformedLines = 0;
+  const allEvents = [];
+  for (const { line, lineNo } of lines) {
     try {
-      const event = JSON.parse(line);
-      if (event && typeof event === "object" && !Array.isArray(event)) {
-        events.push(event);
+      const parsed = JSON.parse(line);
+      const event = normalizeEvent(parsed, lineNo);
+      if (event) {
+        allEvents.push(event);
+      } else {
+        malformedLines += 1;
       }
     } catch {
       // Ignore malformed lines to keep event browsing resilient.
+      malformedLines += 1;
     }
   }
 
-  const bounded = Math.max(1, Number.parseInt(String(limit), 10) || 50);
-  return { path: resolved, events: events.slice(-bounded).reverse() };
+  allEvents.sort((a, b) => {
+    const at = a.timestamp || "";
+    const bt = b.timestamp || "";
+    if (at === bt) return b._line - a._line;
+    return bt.localeCompare(at);
+  });
+
+  let filtered = allEvents;
+  if (actionFilter) filtered = filtered.filter((event) => event.action === actionFilter);
+  if (hookFilter) filtered = filtered.filter((event) => event.hook === hookFilter);
+  if (riskFilter) filtered = filtered.filter((event) => event.riskLevel === riskFilter);
+  if (idFilter) filtered = filtered.filter((event) => String(event.id).includes(idFilter));
+
+  const events = filtered.slice(0, limit);
+  return {
+    path: resolved,
+    events,
+    totalEvents: allEvents.length,
+    returnedEvents: events.length,
+    malformedLines,
+    filters: {
+      action: actionFilter || null,
+      hook: hookFilter || null,
+      risk: riskFilter || null,
+      id: idFilter || null,
+      limit,
+    },
+  };
 }
 
 function replayEvent(eventId, filePath = defaultEventsPath()) {
   const resolved = path.resolve(filePath);
-  const { events } = readEvents(resolved, Number.MAX_SAFE_INTEGER);
-  const event = events.find((entry) => entry.id === eventId) || null;
-  return { path: resolved, event };
+  const { events, totalEvents, malformedLines } = readEvents(resolved, {
+    limit: Number.MAX_SAFE_INTEGER,
+  });
+  const exact = events.filter((entry) => entry.id === eventId);
+  if (exact.length > 0) {
+    return {
+      path: resolved,
+      event: exact[0],
+      matches: exact.length,
+      totalEvents,
+      malformedLines,
+    };
+  }
+
+  const prefix = events.filter((entry) => String(entry.id).startsWith(eventId));
+  if (prefix.length === 1) {
+    return {
+      path: resolved,
+      event: prefix[0],
+      matches: 1,
+      totalEvents,
+      malformedLines,
+    };
+  }
+
+  return {
+    path: resolved,
+    event: null,
+    matches: prefix.length,
+    totalEvents,
+    malformedLines,
+  };
 }
 
 module.exports = {

--- a/bin/lib/security.js
+++ b/bin/lib/security.js
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const YAML = require("yaml");
+
+const { ROOT } = require("./runner");
+
+function defaultPolicyPath() {
+  return path.join(ROOT, "nemoclaw", "security-policy.yaml");
+}
+
+function defaultEventsPath() {
+  return (
+    process.env.CLAWKEEPER_SECURITY_EVENTS_PATH ||
+    path.join(os.homedir(), ".nemoclaw", "security", "events.jsonl")
+  );
+}
+
+function readPolicy(policyPath = defaultPolicyPath()) {
+  const resolved = path.resolve(policyPath);
+  if (!fs.existsSync(resolved)) {
+    return { resolved, parsed: null, errors: ["Policy file not found"] };
+  }
+
+  try {
+    const content = fs.readFileSync(resolved, "utf-8");
+    const parsed = YAML.parse(content);
+    return { resolved, parsed, errors: [] };
+  } catch (error) {
+    return {
+      resolved,
+      parsed: null,
+      errors: [`Failed to parse YAML: ${String(error)}`],
+    };
+  }
+}
+
+function validatePolicy(policyPath = defaultPolicyPath()) {
+  const { resolved, parsed, errors } = readPolicy(policyPath);
+  const warnings = [];
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    if (errors.length === 0) errors.push("Policy root must be a YAML object");
+    return { ok: false, path: resolved, errors, warnings, policy: null };
+  }
+
+  const decisionMatrix = parsed.decision_matrix || parsed.decisionMatrix;
+  const validActions = new Set(["allow", "block", "require_approval"]);
+  const requiredRiskLevels = ["low", "medium", "high", "critical"];
+
+  if (!decisionMatrix || typeof decisionMatrix !== "object" || Array.isArray(decisionMatrix)) {
+    errors.push("Missing decision_matrix object");
+  } else {
+    for (const risk of requiredRiskLevels) {
+      const action = decisionMatrix[risk];
+      if (!validActions.has(action)) {
+        errors.push(`decision_matrix.${risk} must be one of allow|block|require_approval`);
+      }
+    }
+  }
+
+  const requiredSections = ["command_rules", "path_rules", "network_rules", "install_rules", "audit"];
+  for (const section of requiredSections) {
+    if (!(section in parsed) && !(camelCase(section) in parsed)) {
+      warnings.push(`Missing section: ${section}`);
+    }
+  }
+
+  return { ok: errors.length === 0, path: resolved, errors, warnings, policy: parsed };
+}
+
+function camelCase(value) {
+  return String(value).replace(/_([a-z])/g, (_, ch) => ch.toUpperCase());
+}
+
+function readEvents(filePath = defaultEventsPath(), limit = 50) {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    return { path: resolved, events: [] };
+  }
+
+  const lines = fs
+    .readFileSync(resolved, "utf-8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const events = [];
+  for (const line of lines) {
+    try {
+      const event = JSON.parse(line);
+      if (event && typeof event === "object" && !Array.isArray(event)) {
+        events.push(event);
+      }
+    } catch {
+      // Ignore malformed lines to keep event browsing resilient.
+    }
+  }
+
+  const bounded = Math.max(1, Number.parseInt(String(limit), 10) || 50);
+  return { path: resolved, events: events.slice(-bounded).reverse() };
+}
+
+function replayEvent(eventId, filePath = defaultEventsPath()) {
+  const resolved = path.resolve(filePath);
+  const { events } = readEvents(resolved, Number.MAX_SAFE_INTEGER);
+  const event = events.find((entry) => entry.id === eventId) || null;
+  return { path: resolved, event };
+}
+
+module.exports = {
+  defaultPolicyPath,
+  defaultEventsPath,
+  validatePolicy,
+  readEvents,
+  replayEvent,
+};

--- a/bin/lib/usage-notice.json
+++ b/bin/lib/usage-notice.json
@@ -1,9 +1,9 @@
 {
   "version": "2026-04-01b",
-  "title": "Third-Party Software Notice - NemoClaw Installer",
+  "title": "Third-Party Software Notice - ClawKeeper Installer",
   "referenceUrl": "https://docs.openclaw.ai/gateway/security",
   "body": [
-    "NemoClaw is licensed under Apache 2.0 and automatically",
+    "ClawKeeper is licensed under Apache 2.0 and automatically",
     "retrieves, accesses or interacts with third-party software",
     "and materials, including by deploying OpenClaw in an",
     "OpenShell sandbox. Those retrieved materials are not",
@@ -28,5 +28,5 @@
     "https://docs.openclaw.ai/gateway/security"
   ],
   "links": [],
-  "interactivePrompt": "Type 'yes' to accept the NemoClaw license and and third-party software notice and continue [no]: "
+  "interactivePrompt": "Type 'yes' to accept the ClawKeeper license and third-party software notice and continue [no]: "
 }

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -36,6 +36,11 @@ const {
   ensureApiKey,
   ensureGithubToken,
   getCredential,
+  getCredentialStoreStatus,
+  setCredentialStorePassword,
+  getCredentialStoreKeyFromEnv,
+  CRED_STORE_KEY_ENV,
+  prompt: credentialPrompt,
   isRepoPrivate,
 } = require("./lib/credentials");
 const registry = require("./lib/registry");
@@ -1399,12 +1404,82 @@ function optionValue(args, flag, fallback = "") {
 function securityHelp() {
   console.log("");
   console.log("  Security commands:");
+  console.log(`    ${preferredCmd("security status")}`);
+  console.log(`    ${preferredCmd("security set-password")}`);
   console.log(`    ${preferredCmd("security policy validate [--file PATH]")}`);
   console.log(
     `    ${preferredCmd("security events [--limit N] [--action A] [--hook H] [--risk R] [--id PATTERN] [--json] [--file PATH]")}`,
   );
   console.log(`    ${preferredCmd("security replay <event-id> [--json] [--file PATH]")}`);
   console.log("");
+}
+
+function handleSecurityStatus() {
+  const status = getCredentialStoreStatus();
+  console.log("  Credential store status:");
+  console.log(`  Mode: ${status.mode}`);
+  console.log(`  Credential keys: ${status.credentialCount}`);
+  console.log(
+    `  ${CRED_STORE_KEY_ENV}: ${status.passwordEnvDetected ? "detected" : "not detected"}`,
+  );
+}
+
+async function handleSecuritySetPassword() {
+  const status = getCredentialStoreStatus();
+  const envPassword = getCredentialStoreKeyFromEnv();
+  const interactive = process.stdin.isTTY && process.stderr.isTTY;
+  let currentPassword = envPassword;
+  let nextPassword = "";
+
+  if (interactive) {
+    if (status.mode === "encrypted" && !currentPassword) {
+      currentPassword = await credentialPrompt("  Current credential-store password: ", {
+        secret: true,
+      });
+    }
+    if (envPassword) {
+      const typed = await credentialPrompt(
+        `  New credential-store password (leave blank to reuse ${CRED_STORE_KEY_ENV}): `,
+        { secret: true },
+      );
+      nextPassword = typed || envPassword;
+    } else {
+      const first = await credentialPrompt("  New credential-store password: ", { secret: true });
+      const second = await credentialPrompt("  Confirm credential-store password: ", {
+        secret: true,
+      });
+      if (first !== second) {
+        console.error("  Password confirmation did not match.");
+        process.exit(1);
+      }
+      nextPassword = first;
+    }
+  } else {
+    nextPassword = envPassword;
+  }
+
+  if (!nextPassword) {
+    console.error(
+      `  Missing password. Set ${CRED_STORE_KEY_ENV} or run this command in an interactive terminal.`,
+    );
+    process.exit(1);
+  }
+
+  try {
+    const result = setCredentialStorePassword(nextPassword, {
+      currentPassword,
+    });
+    process.env[CRED_STORE_KEY_ENV] = nextPassword;
+    console.log(
+      `  ${G}✓${R} Credential store encrypted (${result.credentialCount} key${
+        result.credentialCount === 1 ? "" : "s"
+      }).`,
+    );
+    console.log(`  ${CRED_STORE_KEY_ENV} is required to unlock stored credentials.`);
+  } catch (error) {
+    console.error(`  ${error?.message || String(error)}`);
+    process.exit(1);
+  }
 }
 
 function handleSecurityPolicyValidate(args) {
@@ -1509,10 +1584,18 @@ function handleSecurityReplay(args) {
   }
 }
 
-function securityCommand(args) {
+async function securityCommand(args) {
   const [sub, ...rest] = args;
   if (!sub || sub === "help" || sub === "--help" || sub === "-h") {
     securityHelp();
+    return;
+  }
+  if (sub === "status") {
+    handleSecurityStatus(rest);
+    return;
+  }
+  if (sub === "set-password") {
+    await handleSecuritySetPassword(rest);
     return;
   }
   if (sub === "policy" && rest[0] === "validate") {
@@ -1565,6 +1648,8 @@ function help() {
     ${preferredCmd("status")}                  Show sandbox list and service status
 
   ${G}Security:${R}
+    ${preferredCmd("security status")}
+    ${preferredCmd("security set-password")}
     ${preferredCmd("security policy validate [--file PATH]")}
     ${preferredCmd("security events [--limit N] [--action A] [--hook H] [--risk R] [--id PATTERN] [--json] [--file PATH]")}
     ${preferredCmd("security replay <event-id> [--json] [--file PATH]")}
@@ -1582,7 +1667,7 @@ function help() {
     --delete-models                  Remove ClawKeeper-pulled Ollama models
 
   ${D}Powered by NVIDIA OpenShell · Nemotron · Agent Toolkit
-  Credentials saved in ~/.nemoclaw/credentials.json (mode 600)${R}
+  Credentials stored in ~/.nemoclaw/credentials.json (${preferredCmd("security set-password")} to encrypt)${R}
   ${D}https://github.com/hollyhongever/ClawKeeper${R}
 `);
 }
@@ -1627,7 +1712,7 @@ const [cmd, ...args] = process.argv.slice(2);
         debug(args);
         break;
       case "security":
-        securityCommand(args);
+        await securityCommand(args);
         break;
       case "uninstall":
         uninstall(args);

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -47,6 +47,26 @@ const onboardSession = require("./lib/onboard-session");
 const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
 const { NOTICE_ACCEPT_ENV, NOTICE_ACCEPT_FLAG } = require("./lib/usage-notice");
 
+const PRIMARY_CLI_NAME = "clawkeeper";
+const LEGACY_CLI_NAME = "nemoclaw";
+
+function detectInvokedCliName() {
+  const invoked = path.basename(process.argv[1] || "");
+  if (invoked === LEGACY_CLI_NAME || invoked === `${LEGACY_CLI_NAME}.js`) return LEGACY_CLI_NAME;
+  if (invoked === PRIMARY_CLI_NAME || invoked === `${PRIMARY_CLI_NAME}.js`) return PRIMARY_CLI_NAME;
+  return PRIMARY_CLI_NAME;
+}
+
+const INVOKED_CLI_NAME = detectInvokedCliName();
+
+function preferredCmd(args = "") {
+  return args ? `${PRIMARY_CLI_NAME} ${args}` : PRIMARY_CLI_NAME;
+}
+
+function invokedCmd(args = "") {
+  return args ? `${INVOKED_CLI_NAME} ${args}` : INVOKED_CLI_NAME;
+}
+
 // ── Global commands ──────────────────────────────────────────────
 
 const GLOBAL_COMMANDS = new Set([
@@ -68,7 +88,7 @@ const GLOBAL_COMMANDS = new Set([
 ]);
 
 const REMOTE_UNINSTALL_URL =
-  "https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh";
+  "https://raw.githubusercontent.com/hollyhongever/ClawKeeper/refs/heads/main/uninstall.sh";
 let OPENSHELL_BIN = null;
 const MIN_LOGS_OPENSHELL_VERSION = "0.0.7";
 const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
@@ -569,7 +589,7 @@ function printGatewayLifecycleHint(output = "", sandboxName = "", writer = conso
   const cleanOutput = stripAnsi(output);
   if (/No gateway configured/i.test(cleanOutput)) {
     writer(
-      "  The selected NemoClaw gateway is no longer configured or its metadata/runtime has been lost.",
+      "  The selected ClawKeeper gateway is no longer configured or its metadata/runtime has been lost.",
     );
     writer(
       "  Start the gateway again with `openshell gateway start --name nemoclaw` before expecting existing sandboxes to reconnect.",
@@ -584,7 +604,7 @@ function printGatewayLifecycleHint(output = "", sandboxName = "", writer = conso
     /Gateway:\s+nemoclaw/i.test(cleanOutput)
   ) {
     writer(
-      "  The selected NemoClaw gateway exists in metadata, but its API is refusing connections after restart.",
+      "  The selected ClawKeeper gateway exists in metadata, but its API is refusing connections after restart.",
     );
     writer("  This usually means the gateway runtime did not come back cleanly after the restart.");
     writer(
@@ -598,7 +618,7 @@ function printGatewayLifecycleHint(output = "", sandboxName = "", writer = conso
       "  Existing sandboxes may still be recorded locally, but the current gateway no longer trusts their prior connection state.",
     );
     writer(
-      "  Try re-establishing the NemoClaw gateway/runtime first. If the sandbox is still unreachable, recreate just that sandbox with `nemoclaw onboard`.",
+      `  Try re-establishing the ClawKeeper gateway/runtime first. If the sandbox is still unreachable, recreate just that sandbox with \`${preferredCmd("onboard")}\`.`,
     );
     return;
   }
@@ -686,7 +706,7 @@ async function ensureLiveSandboxOrExit(sandboxName) {
     console.error(`  Sandbox '${sandboxName}' is not present in the live OpenShell gateway.`);
     console.error("  Removed stale local registry entry.");
     console.error(
-      "  Run `nemoclaw list` to confirm the remaining sandboxes, or `nemoclaw onboard` to create a new one.",
+      `  Run \`${preferredCmd("list")}\` to confirm the remaining sandboxes, or \`${preferredCmd("onboard")}\` to create a new one.`,
     );
     process.exit(1);
   }
@@ -701,13 +721,13 @@ async function ensureLiveSandboxOrExit(sandboxName) {
       "  Existing sandbox connections cannot be reattached safely after this gateway identity change.",
     );
     console.error(
-      "  Recreate this sandbox with `nemoclaw onboard` once the gateway runtime is stable.",
+      `  Recreate this sandbox with \`${preferredCmd("onboard")}\` once the gateway runtime is stable.`,
     );
     process.exit(1);
   }
   if (lookup.state === "gateway_unreachable_after_restart") {
     console.error(
-      `  Sandbox '${sandboxName}' may still exist, but the selected NemoClaw gateway is still refusing connections after restart.`,
+      `  Sandbox '${sandboxName}' may still exist, but the selected ClawKeeper gateway is still refusing connections after restart.`,
     );
     if (lookup.output) {
       console.error(lookup.output);
@@ -722,7 +742,7 @@ async function ensureLiveSandboxOrExit(sandboxName) {
   }
   if (lookup.state === "gateway_missing_after_restart") {
     console.error(
-      `  Sandbox '${sandboxName}' may still exist locally, but the NemoClaw gateway is no longer configured after restart/rebuild.`,
+      `  Sandbox '${sandboxName}' may still exist locally, but the ClawKeeper gateway is no longer configured after restart/rebuild.`,
     );
     if (lookup.output) {
       console.error(lookup.output);
@@ -747,11 +767,11 @@ async function ensureLiveSandboxOrExit(sandboxName) {
 function printOldLogsCompatibilityGuidance(installedVersion = null) {
   const versionText = installedVersion ? ` (${installedVersion})` : "";
   console.error(
-    `  Installed OpenShell${versionText} is too old or incompatible with \`nemoclaw logs\`.`,
+    `  Installed OpenShell${versionText} is too old or incompatible with \`${preferredCmd("logs")}\`.`,
   );
-  console.error(`  NemoClaw expects \`openshell logs <name>\` and live streaming via \`--tail\`.`);
+  console.error(`  ClawKeeper expects \`openshell logs <name>\` and live streaming via \`--tail\`.`);
   console.error(
-    "  Upgrade OpenShell by rerunning `nemoclaw onboard`, or reinstall the OpenShell CLI and try again.",
+    `  Upgrade OpenShell by rerunning \`${preferredCmd("onboard")}\`, or reinstall the OpenShell CLI and try again.`,
   );
 }
 
@@ -789,7 +809,7 @@ async function onboard(args) {
   if (unknownArgs.length > 0) {
     console.error(`  Unknown onboard option(s): ${unknownArgs.join(", ")}`);
     console.error(
-      `  Usage: nemoclaw onboard [--non-interactive] [--resume] [${NOTICE_ACCEPT_FLAG}]`,
+      `  Usage: ${invokedCmd(`onboard [--non-interactive] [--resume] [${NOTICE_ACCEPT_FLAG}]`)}`,
     );
     process.exit(1);
   }
@@ -802,7 +822,9 @@ async function onboard(args) {
 
 async function setup(args = []) {
   console.log("");
-  console.log("  ⚠  `nemoclaw setup` is deprecated. Use `nemoclaw onboard` instead.");
+  console.log(
+    `  ⚠  \`${invokedCmd("setup")}\` is deprecated. Use \`${preferredCmd("onboard")}\` instead.`,
+  );
   console.log("");
   await onboard(args);
 }
@@ -815,12 +837,12 @@ async function setupSpark() {
 // eslint-disable-next-line complexity
 async function deploy(instanceName) {
   if (!instanceName) {
-    console.error("  Usage: nemoclaw deploy <instance-name>");
+    console.error(`  Usage: ${invokedCmd("deploy <instance-name>")}`);
     console.error("");
     console.error("  Examples:");
-    console.error("    nemoclaw deploy my-gpu-box");
-    console.error("    nemoclaw deploy nemoclaw-prod");
-    console.error("    nemoclaw deploy nemoclaw-test");
+    console.error(`    ${preferredCmd("deploy my-gpu-box")}`);
+    console.error(`    ${preferredCmd("deploy clawkeeper-prod")}`);
+    console.error(`    ${preferredCmd("deploy clawkeeper-test")}`);
     process.exit(1);
   }
   await ensureApiKey();
@@ -833,7 +855,7 @@ async function deploy(instanceName) {
   const gpu = process.env.NEMOCLAW_GPU || "a2-highgpu-1g:nvidia-tesla-a100:1";
 
   console.log("");
-  console.log(`  Deploying NemoClaw to Brev instance: ${name}`);
+  console.log(`  Deploying ClawKeeper to Brev instance: ${name}`);
   console.log("");
 
   try {
@@ -882,7 +904,7 @@ async function deploy(instanceName) {
     }
   }
 
-  console.log("  Syncing NemoClaw to VM...");
+  console.log("  Syncing ClawKeeper to VM...");
   run(
     `ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR ${qname} 'mkdir -p /home/ubuntu/nemoclaw'`,
   );
@@ -965,8 +987,8 @@ function debug(args) {
     switch (args[i]) {
       case "--help":
       case "-h":
-        console.log("Collect NemoClaw diagnostic information\n");
-        console.log("Usage: nemoclaw debug [--quick] [--output FILE] [--sandbox NAME]\n");
+        console.log("Collect ClawKeeper diagnostic information\n");
+        console.log(`Usage: ${preferredCmd("debug [--quick] [--output FILE] [--sandbox NAME]")}\n`);
         console.log("Options:");
         console.log("  --quick, -q        Only collect minimal diagnostics");
         console.log("  --output, -o FILE  Write a tarball to FILE");
@@ -1078,10 +1100,10 @@ async function listSandboxes() {
         `  No sandboxes registered locally, but the last onboarded sandbox was '${session.sandboxName}'.`,
       );
       console.log(
-        "  Retry `nemoclaw <name> connect` or `nemoclaw <name> status` once the gateway/runtime is healthy.",
+        `  Retry \`${preferredCmd("<name> connect")}\` or \`${preferredCmd("<name> status")}\` once the gateway/runtime is healthy.`,
       );
     } else {
-      console.log("  No sandboxes registered. Run `nemoclaw onboard` to get started.");
+      console.log(`  No sandboxes registered. Run \`${preferredCmd("onboard")}\` to get started.`);
     }
     console.log("");
     return;
@@ -1151,7 +1173,7 @@ async function sandboxStatus(sandboxName) {
     console.log("");
     if (lookup.recoveredGateway) {
       console.log(
-        `  Recovered NemoClaw gateway runtime via ${lookup.recoveryVia || "gateway reattach"}.`,
+        `  Recovered ClawKeeper gateway runtime via ${lookup.recoveryVia || "gateway reattach"}.`,
       );
       console.log("");
     }
@@ -1173,12 +1195,12 @@ async function sandboxStatus(sandboxName) {
       "  Existing sandbox connections cannot be reattached safely after this gateway identity change.",
     );
     console.log(
-      "  Recreate this sandbox with `nemoclaw onboard` once the gateway runtime is stable.",
+      `  Recreate this sandbox with \`${preferredCmd("onboard")}\` once the gateway runtime is stable.`,
     );
   } else if (lookup.state === "gateway_unreachable_after_restart") {
     console.log("");
     console.log(
-      `  Sandbox '${sandboxName}' may still exist, but the selected NemoClaw gateway is still refusing connections after restart.`,
+      `  Sandbox '${sandboxName}' may still exist, but the selected ClawKeeper gateway is still refusing connections after restart.`,
     );
     if (lookup.output) {
       console.log(lookup.output);
@@ -1192,7 +1214,7 @@ async function sandboxStatus(sandboxName) {
   } else if (lookup.state === "gateway_missing_after_restart") {
     console.log("");
     console.log(
-      `  Sandbox '${sandboxName}' may still exist locally, but the NemoClaw gateway is no longer configured after restart/rebuild.`,
+      `  Sandbox '${sandboxName}' may still exist locally, but the ClawKeeper gateway is no longer configured after restart/rebuild.`,
     );
     if (lookup.output) {
       console.log(lookup.output);
@@ -1227,7 +1249,7 @@ async function sandboxStatus(sandboxName) {
         console.log("  This typically happens after a gateway restart (e.g., laptop close/open).");
         console.log("");
         console.log("  To recover, run:");
-        console.log(`    ${D}nemoclaw ${sandboxName} connect${R}  (auto-recovers on connect)`);
+        console.log(`    ${D}${preferredCmd(`${sandboxName} connect`)}${R}  (auto-recovers on connect)`);
         console.log("  Or manually inside the sandbox:");
         console.log(`    ${D}nohup openclaw gateway run > /tmp/gateway.log 2>&1 &${R}`);
       }
@@ -1368,48 +1390,49 @@ async function sandboxDestroy(sandboxName, args = []) {
 
 function help() {
   console.log(`
-  ${B}${G}NemoClaw${R}  ${D}v${getVersion()}${R}
+  ${B}${G}ClawKeeper${R}  ${D}v${getVersion()}${R}
   ${D}Deploy more secure, always-on AI assistants with a single command.${R}
+  ${D}Primary command: ${PRIMARY_CLI_NAME} · Legacy alias: ${LEGACY_CLI_NAME}${R}
 
   ${G}Getting Started:${R}
-    ${B}nemoclaw onboard${R}                 Configure inference endpoint and credentials
-                                    ${D}(non-interactive: ${NOTICE_ACCEPT_FLAG} or ${NOTICE_ACCEPT_ENV}=1)${R}
-    nemoclaw setup-spark             Set up on DGX Spark ${D}(fixes cgroup v2 + Docker)${R}
+    ${B}${preferredCmd("onboard")}${R}                 Configure inference endpoint and credentials
+                                    ${D}(non-interactive: ${NOTICE_ACCEPT_FLAG}, CLAWKEEPER_ACCEPT_THIRD_PARTY_SOFTWARE=1, or ${NOTICE_ACCEPT_ENV}=1)${R}
+    ${preferredCmd("setup-spark")}             Set up on DGX Spark ${D}(fixes cgroup v2 + Docker)${R}
 
   ${G}Sandbox Management:${R}
-    ${B}nemoclaw list${R}                    List all sandboxes
-    nemoclaw <name> connect          Shell into a running sandbox
-    nemoclaw <name> status           Sandbox health + NIM status
-    nemoclaw <name> logs ${D}[--follow]${R}  Stream sandbox logs
-    nemoclaw <name> destroy          Stop NIM + delete sandbox ${D}(--yes to skip prompt)${R}
+    ${B}${preferredCmd("list")}${R}                    List all sandboxes
+    ${preferredCmd("<name> connect")}          Shell into a running sandbox
+    ${preferredCmd("<name> status")}           Sandbox health + NIM status
+    ${preferredCmd("<name> logs")} ${D}[--follow]${R}  Stream sandbox logs
+    ${preferredCmd("<name> destroy")}          Stop NIM + delete sandbox ${D}(--yes to skip prompt)${R}
 
   ${G}Policy Presets:${R}
-    nemoclaw <name> policy-add       Add a network or filesystem policy preset
-    nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
+    ${preferredCmd("<name> policy-add")}       Add a network or filesystem policy preset
+    ${preferredCmd("<name> policy-list")}      List presets ${D}(● = applied)${R}
 
   ${G}Deploy:${R}
-    nemoclaw deploy <instance>       Deploy to a Brev VM and start services
+    ${preferredCmd("deploy <instance>")}       Deploy to a Brev VM and start services
 
   ${G}Services:${R}
-    nemoclaw start                   Start auxiliary services ${D}(Telegram, tunnel)${R}
-    nemoclaw stop                    Stop all services
-    nemoclaw status                  Show sandbox list and service status
+    ${preferredCmd("start")}                   Start auxiliary services ${D}(Telegram, tunnel)${R}
+    ${preferredCmd("stop")}                    Stop all services
+    ${preferredCmd("status")}                  Show sandbox list and service status
 
   Troubleshooting:
-    nemoclaw debug [--quick]         Collect diagnostics for bug reports
-    nemoclaw debug --output FILE     Save diagnostics tarball for GitHub issues
+    ${preferredCmd("debug [--quick]")}         Collect diagnostics for bug reports
+    ${preferredCmd("debug --output FILE")}     Save diagnostics tarball for GitHub issues
 
   Cleanup:
-    nemoclaw uninstall [flags]       Run uninstall.sh (local first, curl fallback)
+    ${preferredCmd("uninstall [flags]")}       Run uninstall.sh (local first, curl fallback)
 
   ${G}Uninstall flags:${R}
     --yes                            Skip the confirmation prompt
     --keep-openshell                 Leave the openshell binary installed
-    --delete-models                  Remove NemoClaw-pulled Ollama models
+    --delete-models                  Remove ClawKeeper-pulled Ollama models
 
   ${D}Powered by NVIDIA OpenShell · Nemotron · Agent Toolkit
   Credentials saved in ~/.nemoclaw/credentials.json (mode 600)${R}
-  ${D}https://www.nvidia.com/nemoclaw${R}
+  ${D}https://github.com/hollyhongever/ClawKeeper${R}
 `);
 }
 
@@ -1460,7 +1483,7 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       case "--version":
       case "-v": {
-        console.log(`nemoclaw v${getVersion()}`);
+        console.log(`${INVOKED_CLI_NAME} v${getVersion()}`);
         break;
       }
       default:
@@ -1470,7 +1493,7 @@ const [cmd, ...args] = process.argv.slice(2);
     return;
   }
 
-  // Sandbox-scoped commands: nemoclaw <name> <action>
+  // Sandbox-scoped commands: <cli> <name> <action>
   const sandbox = registry.getSandbox(cmd);
   if (sandbox) {
     validateName(cmd, "sandbox name");
@@ -1521,10 +1544,10 @@ const [cmd, ...args] = process.argv.slice(2);
   const allNames = registry.listSandboxes().sandboxes.map((s) => s.name);
   if (allNames.length > 0) {
     console.error(`  Registered sandboxes: ${allNames.join(", ")}`);
-    console.error(`  Try: nemoclaw <sandbox-name> connect`);
+    console.error(`  Try: ${preferredCmd("<sandbox-name> connect")}`);
     console.error("");
   }
 
-  console.error(`  Run 'nemoclaw help' for usage.`);
+  console.error(`  Run '${preferredCmd("help")}' for usage.`);
   process.exit(1);
 })();

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -1400,8 +1400,10 @@ function securityHelp() {
   console.log("");
   console.log("  Security commands:");
   console.log(`    ${preferredCmd("security policy validate [--file PATH]")}`);
-  console.log(`    ${preferredCmd("security events [--limit N] [--json] [--file PATH]")}`);
-  console.log(`    ${preferredCmd("security replay <event-id> [--file PATH]")}`);
+  console.log(
+    `    ${preferredCmd("security events [--limit N] [--action A] [--hook H] [--risk R] [--id PATTERN] [--json] [--file PATH]")}`,
+  );
+  console.log(`    ${preferredCmd("security replay <event-id> [--json] [--file PATH]")}`);
   console.log("");
 }
 
@@ -1424,25 +1426,41 @@ function handleSecurityPolicyValidate(args) {
 
 function handleSecurityEvents(args) {
   const limit = Number.parseInt(optionValue(args, "--limit", "50"), 10) || 50;
+  const action = optionValue(args, "--action", "");
+  const hook = optionValue(args, "--hook", "");
+  const risk = optionValue(args, "--risk", "");
+  const id = optionValue(args, "--id", "");
   const eventsPath = optionValue(args, "--file", security.defaultEventsPath());
   const asJson = args.includes("--json");
-  const { path: resolvedPath, events } = security.readEvents(eventsPath, limit);
+  const result = security.readEvents(eventsPath, { limit, action, hook, risk, id });
 
   if (asJson) {
-    console.log(JSON.stringify({ path: resolvedPath, events }, null, 2));
+    console.log(JSON.stringify(result, null, 2));
     return;
   }
 
-  console.log(`  Security events (${events.length}) from ${resolvedPath}`);
-  if (events.length === 0) {
+  console.log(`  Security events (${result.returnedEvents}/${result.totalEvents}) from ${result.path}`);
+  if (result.malformedLines > 0) {
+    console.log(`  Note: skipped ${result.malformedLines} malformed event line(s).`);
+  }
+  if (result.filters.action || result.filters.hook || result.filters.risk || result.filters.id) {
+    const filters = [];
+    if (result.filters.action) filters.push(`action=${result.filters.action}`);
+    if (result.filters.hook) filters.push(`hook=${result.filters.hook}`);
+    if (result.filters.risk) filters.push(`risk=${result.filters.risk}`);
+    if (result.filters.id) filters.push(`id~=${result.filters.id}`);
+    console.log(`  Filters: ${filters.join(", ")}`);
+  }
+
+  if (result.events.length === 0) {
     console.log("  No events recorded yet.");
     return;
   }
-  for (const event of events) {
+  for (const event of result.events) {
     const ts = event.timestamp || "unknown-time";
     const hook = event.hook || "unknown-hook";
     const id = event.id || "unknown-id";
-    const action = event.effectiveAction || event.action || "allow";
+    const action = event.action || "allow";
     const risk = event.riskLevel || "low";
     const target = event.target || "unknown";
     console.log(`  - ${ts}  ${hook}  ${action}  ${risk}  ${target}  (${id})`);
@@ -1455,9 +1473,23 @@ function handleSecurityReplay(args) {
     console.error("  Missing event ID. Usage: clawkeeper security replay <event-id> [--file PATH]");
     process.exit(1);
   }
+  const asJson = args.includes("--json");
   const eventsPath = optionValue(args, "--file", security.defaultEventsPath());
-  const { path: resolvedPath, event } = security.replayEvent(eventId, eventsPath);
+  const replay = security.replayEvent(eventId, eventsPath);
+  const { path: resolvedPath, event, matches, totalEvents, malformedLines } = replay;
+  if (asJson) {
+    console.log(JSON.stringify(replay, null, 2));
+    if (!event) {
+      process.exit(1);
+    }
+    return;
+  }
   if (!event) {
+    if (matches > 1) {
+      console.error(
+        `  Event ID prefix is ambiguous in ${resolvedPath}: ${eventId} (matches=${matches}).`,
+      );
+    }
     console.error(`  Event not found in ${resolvedPath}: ${eventId}`);
     process.exit(1);
   }
@@ -1468,6 +1500,7 @@ function handleSecurityReplay(args) {
   console.log(`  Risk: ${event.riskLevel} (${event.riskScore})`);
   console.log(`  Target: ${event.target}`);
   console.log(`  Reason: ${event.reason}`);
+  console.log(`  Dataset: total=${totalEvents}, malformed=${malformedLines}, matches=${matches}`);
   if (Array.isArray(event.evidence) && event.evidence.length > 0) {
     console.log("  Evidence:");
     for (const item of event.evidence) {
@@ -1533,8 +1566,8 @@ function help() {
 
   ${G}Security:${R}
     ${preferredCmd("security policy validate [--file PATH]")}
-    ${preferredCmd("security events [--limit N] [--json] [--file PATH]")}
-    ${preferredCmd("security replay <event-id> [--file PATH]")}
+    ${preferredCmd("security events [--limit N] [--action A] [--hook H] [--risk R] [--id PATTERN] [--json] [--file PATH]")}
+    ${preferredCmd("security replay <event-id> [--json] [--file PATH]")}
 
   Troubleshooting:
     ${preferredCmd("debug [--quick]")}         Collect diagnostics for bug reports

--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -41,6 +41,7 @@ const {
 const registry = require("./lib/registry");
 const nim = require("./lib/nim");
 const policies = require("./lib/policies");
+const security = require("./lib/security");
 const { parseGatewayInference } = require("./lib/inference-config");
 const { getVersion } = require("./lib/version");
 const onboardSession = require("./lib/onboard-session");
@@ -79,6 +80,7 @@ const GLOBAL_COMMANDS = new Set([
   "stop",
   "status",
   "debug",
+  "security",
   "uninstall",
   "help",
   "--help",
@@ -1386,6 +1388,117 @@ async function sandboxDestroy(sandboxName, args = []) {
   console.log(`  ${G}✓${R} Sandbox '${sandboxName}' destroyed`);
 }
 
+function optionValue(args, flag, fallback = "") {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return fallback;
+  const value = args[idx + 1];
+  if (!value || value.startsWith("--")) return fallback;
+  return value;
+}
+
+function securityHelp() {
+  console.log("");
+  console.log("  Security commands:");
+  console.log(`    ${preferredCmd("security policy validate [--file PATH]")}`);
+  console.log(`    ${preferredCmd("security events [--limit N] [--json] [--file PATH]")}`);
+  console.log(`    ${preferredCmd("security replay <event-id> [--file PATH]")}`);
+  console.log("");
+}
+
+function handleSecurityPolicyValidate(args) {
+  const policyPath = optionValue(args, "--file", security.defaultPolicyPath());
+  const result = security.validatePolicy(policyPath);
+  if (result.ok) {
+    console.log(`  ${G}✓${R} Security policy is valid: ${result.path}`);
+    for (const warning of result.warnings) {
+      console.log(`  ${YW}!${R} ${warning}`);
+    }
+    return;
+  }
+  console.error(`  Security policy validation failed: ${result.path}`);
+  for (const error of result.errors) {
+    console.error(`   - ${error}`);
+  }
+  process.exit(1);
+}
+
+function handleSecurityEvents(args) {
+  const limit = Number.parseInt(optionValue(args, "--limit", "50"), 10) || 50;
+  const eventsPath = optionValue(args, "--file", security.defaultEventsPath());
+  const asJson = args.includes("--json");
+  const { path: resolvedPath, events } = security.readEvents(eventsPath, limit);
+
+  if (asJson) {
+    console.log(JSON.stringify({ path: resolvedPath, events }, null, 2));
+    return;
+  }
+
+  console.log(`  Security events (${events.length}) from ${resolvedPath}`);
+  if (events.length === 0) {
+    console.log("  No events recorded yet.");
+    return;
+  }
+  for (const event of events) {
+    const ts = event.timestamp || "unknown-time";
+    const hook = event.hook || "unknown-hook";
+    const id = event.id || "unknown-id";
+    const action = event.effectiveAction || event.action || "allow";
+    const risk = event.riskLevel || "low";
+    const target = event.target || "unknown";
+    console.log(`  - ${ts}  ${hook}  ${action}  ${risk}  ${target}  (${id})`);
+  }
+}
+
+function handleSecurityReplay(args) {
+  const eventId = args[0];
+  if (!eventId || eventId.startsWith("--")) {
+    console.error("  Missing event ID. Usage: clawkeeper security replay <event-id> [--file PATH]");
+    process.exit(1);
+  }
+  const eventsPath = optionValue(args, "--file", security.defaultEventsPath());
+  const { path: resolvedPath, event } = security.replayEvent(eventId, eventsPath);
+  if (!event) {
+    console.error(`  Event not found in ${resolvedPath}: ${eventId}`);
+    process.exit(1);
+  }
+  console.log(`  Event: ${event.id}`);
+  console.log(`  Time: ${event.timestamp}`);
+  console.log(`  Hook: ${event.hook}`);
+  console.log(`  Action: ${event.effectiveAction || event.action}`);
+  console.log(`  Risk: ${event.riskLevel} (${event.riskScore})`);
+  console.log(`  Target: ${event.target}`);
+  console.log(`  Reason: ${event.reason}`);
+  if (Array.isArray(event.evidence) && event.evidence.length > 0) {
+    console.log("  Evidence:");
+    for (const item of event.evidence) {
+      console.log(`   - ${item.code}: ${item.message}`);
+    }
+  }
+}
+
+function securityCommand(args) {
+  const [sub, ...rest] = args;
+  if (!sub || sub === "help" || sub === "--help" || sub === "-h") {
+    securityHelp();
+    return;
+  }
+  if (sub === "policy" && rest[0] === "validate") {
+    handleSecurityPolicyValidate(rest);
+    return;
+  }
+  if (sub === "events") {
+    handleSecurityEvents(rest);
+    return;
+  }
+  if (sub === "replay") {
+    handleSecurityReplay(rest);
+    return;
+  }
+  console.error(`  Unknown security command: ${[sub, ...rest].join(" ")}`);
+  securityHelp();
+  process.exit(1);
+}
+
 // ── Help ─────────────────────────────────────────────────────────
 
 function help() {
@@ -1417,6 +1530,11 @@ function help() {
     ${preferredCmd("start")}                   Start auxiliary services ${D}(Telegram, tunnel)${R}
     ${preferredCmd("stop")}                    Stop all services
     ${preferredCmd("status")}                  Show sandbox list and service status
+
+  ${G}Security:${R}
+    ${preferredCmd("security policy validate [--file PATH]")}
+    ${preferredCmd("security events [--limit N] [--json] [--file PATH]")}
+    ${preferredCmd("security replay <event-id> [--file PATH]")}
 
   Troubleshooting:
     ${preferredCmd("debug [--quick]")}         Collect diagnostics for bug reports
@@ -1474,6 +1592,9 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       case "debug":
         debug(args);
+        break;
+      case "security":
+        securityCommand(args);
         break;
       case "uninstall":
         uninstall(args);

--- a/docs/index.md
+++ b/docs/index.md
@@ -249,6 +249,8 @@ Customize the Network Policy <network-policy/customize-network-policy>
 :hidden:
 
 Security Best Practices <security/best-practices>
+ClawKeeper Security Enhancement Plan <security/clawkeeper-security-enhancement-plan>
+Security Module Updates <security/security-module-updates>
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -242,6 +242,7 @@ Switch Inference Providers <inference/switch-inference-providers>
 
 Approve or Deny Network Requests <network-policy/approve-network-requests>
 Customize the Network Policy <network-policy/customize-network-policy>
+Use Security Policy Templates <network-policy/security-policy-templates>
 ```
 
 ```{toctree}

--- a/docs/network-policy/security-policy-templates.md
+++ b/docs/network-policy/security-policy-templates.md
@@ -1,0 +1,95 @@
+---
+title:
+  page: "Use ClawKeeper Security Policy Templates"
+  nav: "Security Policy Templates"
+description:
+  main: "Apply curated security policy templates for strict, balanced, and CI-focused sandbox postures."
+  agent: "Explains ClawKeeper security policy templates and how to apply them safely. Use when selecting strict, balanced, or CI-oriented policy baselines."
+keywords: ["clawkeeper security policy templates", "nemoclaw policy templates", "sandbox posture templates"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "network_policy", "security", "nemoclaw"]
+content:
+  type: how_to
+  difficulty: intermediate
+  audience: ["developer", "engineer", "security_engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Use ClawKeeper Security Policy Templates
+
+ClawKeeper ships policy templates to help you apply common security postures quickly.
+Templates are additive policy files that you can review and apply to running sandboxes.
+
+## Template Catalog
+
+The templates live in `nemoclaw-blueprint/policies/templates/`.
+
+| Template | Focus | When to use |
+|---|---|---|
+| `security-strict-egress.yaml` | Tight outbound allowlist for core inference and OpenClaw API flows. | Production assistants with minimum required egress. |
+| `security-sensitive-readonly.yaml` | Read-only protection for sensitive runtime paths and credentials directories. | Any deployment where config and credential tamper resistance is required. |
+| `security-dev-balanced.yaml` | Balanced developer posture for source access plus package registries with binary scoping. | Daily development tasks that require GitHub and package installs. |
+| `security-ci-minimal.yaml` | Minimal CI-friendly egress for source retrieval and package dependency resolution. | Build and verification pipelines with strict external access requirements. |
+
+## Prerequisites
+
+- A running NemoClaw sandbox.
+- The OpenShell CLI on your `PATH`.
+- The repository root as your working directory.
+
+## Apply a Template to a Running Sandbox
+
+Apply one template at a time and validate behavior before switching to another template.
+
+### Balanced Development Template
+
+```console
+$ openshell policy set nemoclaw-blueprint/policies/templates/security-dev-balanced.yaml
+```
+
+Use this when your workflow needs source access (`git`, `gh`) and package install traffic (`pip`, `npm`, `node`).
+
+### Minimal CI Template
+
+```console
+$ openshell policy set nemoclaw-blueprint/policies/templates/security-ci-minimal.yaml
+```
+
+Use this in build/test pipelines that only need source and dependency retrieval.
+
+### Switch Back to Baseline Policy
+
+```console
+$ openshell policy set nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+```
+
+Use this to restore the baseline policy after a template trial.
+
+## Validate Before Applying
+
+Before rollout, review each template file and confirm scope:
+
+- Endpoints are limited to required hosts and ports.
+- `binaries` are explicitly scoped.
+- REST endpoints use method and path rules where possible.
+
+After applying, run representative workflow commands and confirm they behave as expected.
+If a required destination is blocked, inspect in `openshell term` and refine policy scope instead of broadening to wildcard hosts.
+
+## Recommended Rollout Pattern
+
+1. Start in a non-production sandbox and apply one template.
+2. Run expected agent workflows and watch for blocked requests.
+3. Refine policy scope before production rollout.
+4. Record approved template combinations in your operational runbook.
+
+## Related Topics
+
+- [Customize the Network Policy](customize-network-policy.md) for baseline and dynamic policy updates.
+- [Approve or Deny Agent Network Requests](approve-network-requests.md) for runtime approval handling.
+- [Security Best Practices](../security/best-practices.md) for risk trade-offs across security controls.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -221,6 +221,32 @@ Show the sandbox list and the status of auxiliary services.
 $ clawkeeper status
 ```
 
+### `clawkeeper security policy validate`
+
+Validate a ClawKeeper security policy file before enforcing semantic security hooks.
+By default this validates `nemoclaw/security-policy.yaml`.
+
+```console
+$ clawkeeper security policy validate [--file <path>]
+```
+
+### `clawkeeper security events`
+
+Print recent structured security events from the JSONL audit log.
+By default this reads `~/.nemoclaw/security/events.jsonl`.
+
+```console
+$ clawkeeper security events [--limit <n>] [--json] [--file <path>]
+```
+
+### `clawkeeper security replay`
+
+Show full details for a single security event by ID.
+
+```console
+$ clawkeeper security replay <event-id> [--file <path>]
+```
+
 ### `clawkeeper setup-spark`
 
 Set up ClawKeeper on DGX Spark.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,13 +1,13 @@
 ---
 title:
-  page: "NemoClaw CLI Commands Reference"
+  page: "ClawKeeper CLI Commands Reference"
   nav: "Commands"
 description:
-  main: "Full CLI reference for slash commands and standalone NemoClaw commands."
-  agent: "Lists all slash commands and standalone NemoClaw CLI commands. Use when looking up a command, checking command syntax, or browsing the CLI reference."
-keywords: ["nemoclaw cli commands", "nemoclaw command reference"]
+  main: "Full CLI reference for slash commands and standalone ClawKeeper commands."
+  agent: "Lists all slash commands and standalone ClawKeeper CLI commands. Use when looking up a command, checking command syntax, or browsing the CLI reference."
+keywords: ["clawkeeper cli commands", "clawkeeper command reference", "nemoclaw compatibility alias"]
 topics: ["generative_ai", "ai_agents"]
-tags: ["openclaw", "openshell", "nemoclaw", "cli"]
+tags: ["openclaw", "openshell", "clawkeeper", "cli", "nemoclaw"]
 content:
   type: reference
   difficulty: technical_beginner
@@ -22,77 +22,79 @@ status: published
 
 # Commands
 
-The `nemoclaw` CLI is the primary interface for managing NemoClaw sandboxes. It is installed when you run `npm install -g nemoclaw`.
+The `clawkeeper` CLI is the primary interface for managing ClawKeeper sandboxes.
+Legacy alias: `nemoclaw` is still supported for compatibility.
 
-## `/nemoclaw` Slash Command
+## `/clawkeeper` Slash Command
 
-The `/nemoclaw` slash command is available inside the OpenClaw chat interface for quick actions:
+The `/clawkeeper` slash command is available inside the OpenClaw chat interface for quick actions.
+Legacy alias: `/nemoclaw`.
 
 | Subcommand | Description |
 |---|---|
-| `/nemoclaw` | Show slash-command help and host CLI pointers |
-| `/nemoclaw status` | Show sandbox and inference state |
-| `/nemoclaw onboard` | Show onboarding status and reconfiguration guidance |
-| `/nemoclaw eject` | Show rollback instructions for returning to the host installation |
+| `/clawkeeper` | Show slash-command help and host CLI pointers |
+| `/clawkeeper status` | Show sandbox and inference state |
+| `/clawkeeper onboard` | Show onboarding status and reconfiguration guidance |
+| `/clawkeeper eject` | Show rollback instructions for returning to the host installation |
 
 ## Standalone Host Commands
 
-The `nemoclaw` binary handles host-side operations that run outside the OpenClaw plugin context.
+The `clawkeeper` binary handles host-side operations that run outside the OpenClaw plugin context.
 
-### `nemoclaw help`, `nemoclaw --help`, `nemoclaw -h`
+### `clawkeeper help`, `clawkeeper --help`, `clawkeeper -h`
 
 Show the top-level usage summary and command groups.
-Running `nemoclaw` with no arguments shows the same help output.
+Running `clawkeeper` with no arguments shows the same help output.
 
 ```console
-$ nemoclaw help
+$ clawkeeper help
 ```
 
-### `nemoclaw --version`, `nemoclaw -v`
+### `clawkeeper --version`, `clawkeeper -v`
 
-Print the installed NemoClaw CLI version.
+Print the installed ClawKeeper CLI version.
 
 ```console
-$ nemoclaw --version
+$ clawkeeper --version
 ```
 
-### `nemoclaw onboard`
+### `clawkeeper onboard`
 
 Run the interactive setup wizard (recommended for new installs).
 The wizard creates an OpenShell gateway, registers inference providers, builds the sandbox image, and creates the sandbox.
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard
+$ clawkeeper onboard
 ```
 
 The wizard prompts for a provider first, then collects the provider credential if needed.
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.
 Credentials are stored in `~/.nemoclaw/credentials.json`.
-The legacy `nemoclaw setup` command is deprecated; use `nemoclaw onboard` instead.
+The legacy `nemoclaw setup` command is deprecated; use `clawkeeper onboard` instead.
 
-If you enable Brave Search during onboarding, NemoClaw currently stores the Brave API key in the sandbox's OpenClaw configuration.
+If you enable Brave Search during onboarding, ClawKeeper currently stores the Brave API key in the sandbox's OpenClaw configuration.
 That means the OpenClaw agent can read the key.
-NemoClaw explores an OpenShell-hosted credential path first, but the current OpenClaw Brave runtime does not consume that path end to end yet.
+ClawKeeper explores an OpenShell-hosted credential path first, but the current OpenClaw Brave runtime does not consume that path end to end yet.
 Treat Brave Search as an explicit opt-in and use a dedicated low-privilege Brave key.
 
 For non-interactive onboarding, you must explicitly accept the third-party software notice:
 
 ```console
-$ nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
+$ clawkeeper onboard --non-interactive --yes-i-accept-third-party-software
 ```
 
 or:
 
 ```console
-$ NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 nemoclaw onboard --non-interactive
+$ CLAWKEEPER_ACCEPT_THIRD_PARTY_SOFTWARE=1 clawkeeper onboard --non-interactive
 ```
 
 To enable Brave Search in non-interactive mode, set:
 
 ```console
 $ BRAVE_API_KEY=... \
-  nemoclaw onboard --non-interactive
+  clawkeeper onboard --non-interactive
 ```
 
 `BRAVE_API_KEY` enables Brave Search in non-interactive mode and also enables `web_fetch`.
@@ -104,53 +106,53 @@ Uppercase letters are automatically lowercased.
 Before creating the gateway, the wizard runs preflight checks.
 On systems with cgroup v2 (Ubuntu 24.04, DGX Spark, WSL2), it verifies that Docker is configured with `"default-cgroupns-mode": "host"` and provides fix instructions if the setting is missing.
 
-### `nemoclaw list`
+### `clawkeeper list`
 
 List all registered sandboxes with their model, provider, and policy presets.
 
 ```console
-$ nemoclaw list
+$ clawkeeper list
 ```
 
-### `nemoclaw deploy`
+### `clawkeeper deploy`
 
 :::{warning}
-The `nemoclaw deploy` command is experimental and may not work as expected.
+The `clawkeeper deploy` command is experimental and may not work as expected.
 :::
 
-Deploy NemoClaw to a remote GPU instance through [Brev](https://brev.nvidia.com).
-The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present, and OpenShell on the VM, then runs `nemoclaw onboard` and connects to the sandbox.
+Deploy ClawKeeper to a remote GPU instance through [Brev](https://brev.nvidia.com).
+The deploy script installs Docker, NVIDIA Container Toolkit if a GPU is present, and OpenShell on the VM, then runs `clawkeeper onboard` and connects to the sandbox.
 
 ```console
-$ nemoclaw deploy <instance-name>
+$ clawkeeper deploy <instance-name>
 ```
 
-### `nemoclaw <name> connect`
+### `clawkeeper <name> connect`
 
 Connect to a sandbox by name.
 
 ```console
-$ nemoclaw my-assistant connect
+$ clawkeeper my-assistant connect
 ```
 
-### `nemoclaw <name> status`
+### `clawkeeper <name> status`
 
 Show sandbox status, health, and inference configuration.
 
 ```console
-$ nemoclaw my-assistant status
+$ clawkeeper my-assistant status
 ```
 
-### `nemoclaw <name> logs`
+### `clawkeeper <name> logs`
 
 View sandbox logs.
 Use `--follow` to stream output in real time.
 
 ```console
-$ nemoclaw my-assistant logs [--follow]
+$ clawkeeper my-assistant logs [--follow]
 ```
 
-### `nemoclaw <name> destroy`
+### `clawkeeper <name> destroy`
 
 Stop the NIM container and delete the sandbox.
 This removes the sandbox from the registry.
@@ -162,24 +164,24 @@ Back up your workspace first by following the instructions at [Back Up and Resto
 :::
 
 ```console
-$ nemoclaw my-assistant destroy
+$ clawkeeper my-assistant destroy
 ```
 
-### `nemoclaw <name> policy-add`
+### `clawkeeper <name> policy-add`
 
 Add a policy preset to a sandbox.
 Presets extend the baseline network policy with additional endpoints.
 
 ```console
-$ nemoclaw my-assistant policy-add
+$ clawkeeper my-assistant policy-add
 ```
 
-### `nemoclaw <name> policy-list`
+### `clawkeeper <name> policy-list`
 
 List available policy presets and show which ones are applied to the sandbox.
 
 ```console
-$ nemoclaw my-assistant policy-list
+$ clawkeeper my-assistant policy-list
 ```
 
 ### `openshell term`
@@ -193,51 +195,51 @@ $ openshell term
 
 For a remote Brev instance, SSH to the instance and run `openshell term` there, or use a port-forward to the gateway.
 
-### `nemoclaw start`
+### `clawkeeper start`
 
 Start auxiliary services, such as the Telegram bridge and cloudflared tunnel.
 
 ```console
-$ nemoclaw start
+$ clawkeeper start
 ```
 
 Requires `TELEGRAM_BOT_TOKEN` for the Telegram bridge.
 
-### `nemoclaw stop`
+### `clawkeeper stop`
 
 Stop all auxiliary services.
 
 ```console
-$ nemoclaw stop
+$ clawkeeper stop
 ```
 
-### `nemoclaw status`
+### `clawkeeper status`
 
 Show the sandbox list and the status of auxiliary services.
 
 ```console
-$ nemoclaw status
+$ clawkeeper status
 ```
 
-### `nemoclaw setup-spark`
+### `clawkeeper setup-spark`
 
-Set up NemoClaw on DGX Spark.
+Set up ClawKeeper on DGX Spark.
 This command applies cgroup v2 and Docker fixes required for Ubuntu 24.04.
 Run with `sudo` on the Spark host.
-After the fixes complete, the script prompts you to run `nemoclaw onboard` to continue setup.
+After the fixes complete, the script prompts you to run `clawkeeper onboard` to continue setup.
 
 ```console
-$ sudo nemoclaw setup-spark
+$ sudo clawkeeper setup-spark
 ```
 
-### `nemoclaw debug`
+### `clawkeeper debug`
 
 Collect diagnostics for bug reports.
 Gathers system info, Docker state, gateway logs, and sandbox status into a summary or tarball.
 Use `--sandbox <name>` to target a specific sandbox, `--quick` for a smaller snapshot, or `--output <path>` to save a tarball that you can attach to an issue.
 
 ```console
-$ nemoclaw debug [--quick] [--sandbox NAME] [--output PATH]
+$ clawkeeper debug [--quick] [--sandbox NAME] [--output PATH]
 ```
 
 | Flag | Description |
@@ -246,25 +248,25 @@ $ nemoclaw debug [--quick] [--sandbox NAME] [--output PATH]
 | `--sandbox NAME` | Target a specific sandbox (default: auto-detect) |
 | `--output PATH` | Write diagnostics tarball to the given path |
 
-### `nemoclaw uninstall`
+### `clawkeeper uninstall`
 
-Run `uninstall.sh` to remove NemoClaw sandboxes, gateway resources, related images and containers, and local state.
+Run `uninstall.sh` to remove ClawKeeper sandboxes, gateway resources, related images and containers, and local state.
 The CLI uses the local `uninstall.sh` first and falls back to the hosted script if the local file is unavailable.
 
 | Flag | Effect |
 |---|---|
 | `--yes` | Skip the confirmation prompt |
 | `--keep-openshell` | Leave the `openshell` binary installed |
-| `--delete-models` | Also remove NemoClaw-pulled Ollama models |
+| `--delete-models` | Also remove ClawKeeper-pulled Ollama models |
 
 ```console
-$ nemoclaw uninstall [--yes] [--keep-openshell] [--delete-models]
+$ clawkeeper uninstall [--yes] [--keep-openshell] [--delete-models]
 ```
 
-### Legacy `nemoclaw setup`
+### Legacy `nemoclaw` Compatibility
 
-Deprecated. Use `nemoclaw onboard` instead.
-Running `nemoclaw setup` now delegates directly to `nemoclaw onboard`.
+`nemoclaw` remains available as a compatibility alias for `clawkeeper`.
+Deprecated `nemoclaw setup` delegates directly to `clawkeeper onboard`.
 
 ```console
 $ nemoclaw setup

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -236,16 +236,36 @@ Print recent structured security events from the JSONL audit log.
 By default this reads `~/.nemoclaw/security/events.jsonl`.
 
 ```console
-$ clawkeeper security events [--limit <n>] [--json] [--file <path>]
+$ clawkeeper security events [--limit <n>] [--action <name>] [--hook <name>] [--risk <level>] [--id <pattern>] [--json] [--file <path>]
 ```
+
+Use filters to narrow event lists for demos and incident triage.
+Malformed JSONL records are skipped so listing remains resilient, and the CLI reports how many malformed lines were ignored.
+
+| Flag | Description |
+|------|-------------|
+| `--limit <n>` | Maximum number of matching events to print (default: `50`) |
+| `--action <name>` | Filter by effective action (`allow`, `block`, `require_approval`) |
+| `--hook <name>` | Filter by hook name (for example `before_tool_call`) |
+| `--risk <level>` | Filter by risk level (`low`, `medium`, `high`, `critical`) |
+| `--id <pattern>` | Filter by event ID substring match |
+| `--json` | Print structured JSON output including filters and malformed-line count |
+| `--file <path>` | Read from an alternate JSONL audit log file |
 
 ### `clawkeeper security replay`
 
 Show full details for a single security event by ID.
+Replay first checks exact IDs, then falls back to ID prefix matching.
+If the provided prefix is ambiguous (matches multiple events), the command exits non-zero.
 
 ```console
-$ clawkeeper security replay <event-id> [--file <path>]
+$ clawkeeper security replay <event-id> [--json] [--file <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Print replay result as JSON (includes dataset totals and match count) |
+| `--file <path>` | Read from an alternate JSONL audit log file |
 
 ### `clawkeeper setup-spark`
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -71,6 +71,8 @@ $ clawkeeper onboard
 The wizard prompts for a provider first, then collects the provider credential if needed.
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.
 Credentials are stored in `~/.nemoclaw/credentials.json`.
+Set `NEMOCLAW_CRED_STORE_KEY` and run `clawkeeper security set-password` to migrate plaintext credentials into an encrypted AES-256-GCM envelope (scrypt KDF).
+Use `clawkeeper security status` to confirm the active storage mode and key count.
 The legacy `nemoclaw setup` command is deprecated; use `clawkeeper onboard` instead.
 
 If you enable Brave Search during onboarding, ClawKeeper currently stores the Brave API key in the sandbox's OpenClaw configuration.
@@ -228,6 +230,25 @@ By default this validates `nemoclaw/security-policy.yaml`.
 
 ```console
 $ clawkeeper security policy validate [--file <path>]
+```
+
+### `clawkeeper security status`
+
+Show credential-store mode (`plaintext` or `encrypted`), stored credential key count, and whether `NEMOCLAW_CRED_STORE_KEY` is detected in the current environment.
+
+```console
+$ clawkeeper security status
+```
+
+### `clawkeeper security set-password`
+
+Set or rotate the credential-store password and re-encrypt `~/.nemoclaw/credentials.json`.
+In non-interactive contexts this command uses `NEMOCLAW_CRED_STORE_KEY`.
+In interactive terminals, you can enter and confirm a password if the environment variable is not set.
+
+```console
+$ export NEMOCLAW_CRED_STORE_KEY='my-credential-store-password'
+$ clawkeeper security set-password
 ```
 
 ### `clawkeeper security events`

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -28,6 +28,24 @@ This page documents every configurable knob, its default, what it protects, the 
 
 For background on how the layers fit together, refer to [How It Works](../about/how-it-works.md).
 
+## Deterministic Secret Redaction
+
+NemoClaw applies the same high-confidence redaction rules across all runtime surfaces:
+
+- CLI runtime output (command output and error surfaces)
+- `nemoclaw debug` collection artifacts
+- onboard session persistence (`~/.nemoclaw/onboard-session.json`)
+
+The redactor deterministically replaces sensitive values with `<REDACTED>` for:
+
+- API keys and common key formats (for example `nvapi-`, `nvcf-`, `ghp_`, `github_pat_`, `sk-`)
+- Bearer tokens (`Authorization: Bearer ...`)
+- Common secret assignment patterns (`..._KEY=...`, `...TOKEN: ...`, `...SECRET=...`)
+- Credential-bearing URLs and token-like query parameters (`token`, `auth`, `sig`, `signature`, `access_token`)
+
+For incident replay and postmortem workflows, identical input always produces identical redacted output.
+This makes debug bundles, logs, and onboard session traces consistent and safe to correlate.
+
 <!-- TODO: uncomment after the OpenShell docs are published
 :::{seealso}
 OpenShell enforces the platform-level mechanisms that NemoClaw configures, including network namespace isolation, seccomp filters, SSRF protection, TLS termination, and gateway authentication.

--- a/docs/security/clawkeeper-security-enhancement-plan.md
+++ b/docs/security/clawkeeper-security-enhancement-plan.md
@@ -128,6 +128,25 @@ If a release introduces unacceptable regressions, use phased rollback.
 Use this plan as the source of truth for implementation order.
 Each milestone should land in an independent PR to keep review scope and rollback boundaries clear.
 
+## Execution Status Snapshot
+
+This section tracks implementation status for milestone execution and parallel coordination.
+
+| Milestone | Status | Notes |
+|---|---|---|
+| M1 Security Core Skeleton | Completed | `security` config namespace, policy loader, shared decision types are implemented. |
+| M2 High-Risk Operation Interception | Completed (v1) | `before_tool_call` and `after_tool_call` hooks with command, path, network, prompt, and quota signals are active. |
+| M3 Malicious Skill Admission Control | Completed (v1) | `before_install` admission path with offline-first pattern scanning and optional external scanner command is active. |
+| M4 Audit and Alert Closure | Completed (v1) | `security-event.v1` JSONL logging, webhook alert path, and security CLI commands are implemented. |
+| M5 Sandbox Policy Complements | Completed (v1) | strict egress and sensitive read-only policy templates are present under blueprint templates. |
+| M6-M10 Public Exposure Addendum | Planned | Password-first, encrypted credential store, unified redaction, staged dangerous-command policy, and rollout playbooks remain queued. |
+
+Current implementation branch baseline for parallel streams:
+
+- Base branch: `feature/security`
+- Parallel branches: `feature/security-main`, `feature/security-m2-hooks`, `feature/security-m3-install-gate`, `feature/security-m4-audit-cli`, `feature/security-m5-policy`, `feature/security-m6m8-exposure`, `feature/security-m9m10-rollout`
+- Worktrees are provisioned for each branch to avoid cross-stream file contention.
+
 ## Parallel Workstream Strategy
 
 This section defines how to execute milestone work in parallel without creating merge instability.
@@ -192,6 +211,46 @@ Recommended model:
    Merge contract baseline first, then M2-M5 branches, then M6-M10 branches.
 5. Final integration pass.
    Run full regression after all branches are rebased onto the latest integration branch.
+
+## Demo Runbook
+
+Use this runbook for a concise technical demo of the current security module baseline.
+
+### Demo Goals
+
+Show that policy validation, event browsing, and event replay are operational.
+Show that semantic security hooks and policy contracts are wired without breaking existing CLI flows.
+
+### Demo Script
+
+1. Validate security policy.
+
+```console
+$ clawkeeper security policy validate --file nemoclaw/security-policy.yaml
+```
+
+Expected outcome: validation succeeds and reports the resolved policy path.
+
+2. Show latest security events.
+
+```console
+$ clawkeeper security events --limit 5
+```
+
+Expected outcome: event summary list appears, or an explicit "No events recorded yet" message.
+
+3. Replay one event by ID.
+
+```console
+$ clawkeeper security replay <event-id>
+```
+
+Expected outcome: event detail includes hook, action, risk, reason, and evidence.
+
+### Demo Notes
+
+- If no events exist yet, generate one in a test environment before live demo.
+- Keep demo runs in `audit` mode when demonstrating behavior to stakeholders without operational interruption.
 
 ## Safe-OpenClaw Integration Addendum (Public Exposure)
 

--- a/docs/security/clawkeeper-security-enhancement-plan.md
+++ b/docs/security/clawkeeper-security-enhancement-plan.md
@@ -127,3 +127,154 @@ If a release introduces unacceptable regressions, use phased rollback.
 
 Use this plan as the source of truth for implementation order.
 Each milestone should land in an independent PR to keep review scope and rollback boundaries clear.
+
+## Parallel Workstream Strategy
+
+This section defines how to execute milestone work in parallel without creating merge instability.
+
+### Interface Freeze Before Parallel Build
+
+`Interface freeze` means locking shared contracts before parallel coding starts.
+Do not start concurrent implementation until all teams agree on these contracts.
+
+Freeze scope for this plan:
+
+1. Plugin config contract.
+   The `security` schema keys and default semantics in `openclaw.plugin.json` and parser logic.
+2. Decision contract.
+   `SecurityDecision` fields, allowed action values, and risk-level definitions.
+3. Event contract.
+   `security-event.v1` required fields and field meanings.
+4. Policy contract.
+   `security-policy.yaml` top-level sections and core key names.
+5. CLI contract.
+   Command names and required argument shapes for `security policy validate`, `security events`, and `security replay`.
+
+If any frozen contract must change, open one small contract PR first, merge it, and then rebase all active parallel branches.
+
+### Recommended Parallel Branch Mapping
+
+Use one branch per workstream with explicit ownership.
+
+| Workstream | Recommended branch | Primary owner |
+|---|---|---|
+| M2 hook interception | `feature/security-m2-hooks` | Runtime and plugin owner |
+| M3 install admission | `feature/security-m3-install-gate` | Supply-chain controls owner |
+| M4 audit and CLI | `feature/security-m4-audit-cli` | Platform tooling owner |
+| M5 policy templates | `feature/security-m5-policy` | Policy and docs owner |
+| M6-M8 public-exposure hardening | `feature/security-m6m8-exposure` | Gateway and credentials owner |
+| M9-M10 rollout and playbooks | `feature/security-m9m10-rollout` | Ops and release owner |
+
+### Synchronization Cadence
+
+Use fixed sync points to prevent drift.
+
+1. Contract sync.
+   Confirm no contract deltas before opening new parallel branches.
+2. Midpoint integration sync.
+   Merge test fixtures, shared helpers, and schema updates.
+3. Pre-merge gate sync.
+   Require green checks for `nemoclaw/npm run check`, targeted `vitest`, and doc references.
+
+### Codex Threading Guidance
+
+You can run parallel execution in Codex with either multiple chats or delegated sub-agents.
+
+Recommended model:
+
+1. Main agent.
+   Keep one main agent as coordinator for contract ownership, review, and merge order.
+2. Sub-agents or separate threads.
+   Assign each workstream to one sub-agent or one dedicated chat thread with a single branch owner.
+3. Non-overlapping write scope.
+   Avoid assigning the same file to multiple workers in the same phase unless explicitly planned.
+4. Merge sequence.
+   Merge contract baseline first, then M2-M5 branches, then M6-M10 branches.
+5. Final integration pass.
+   Run full regression after all branches are rebased onto the latest integration branch.
+
+## Safe-OpenClaw Integration Addendum (Public Exposure)
+
+This addendum extends the core ClawKeeper security blueprint for public gateway exposure scenarios.
+It defines how to selectively integrate safe-openclaw concepts without replacing the existing NemoClaw and OpenShell security foundation.
+
+### Decision Summary
+
+- Integration strategy is selective module adoption, not full fork replacement.
+- The deployment context is public gateway exposure, where authentication and operator-safe defaults are mandatory.
+- OpenShell sandbox and policy enforcement remain the primary boundary, while this addendum introduces semantic and credential-focused defense-in-depth controls.
+
+### Adopt / Adapt / Reject Matrix
+
+| Category | Decision | Scope |
+|---|---|---|
+| Adopt | Password-first gateway onboarding | Require password bootstrap flow for exposed gateways and avoid token-first onboarding guidance. |
+| Adopt | Localhost-only sensitive setup and reset endpoints | Restrict password setup and reset interfaces to local direct access. |
+| Adopt | Outbound secret redaction pipeline | Redact API key and token patterns in outbound, diagnostic, and operator-facing outputs. |
+| Adapt | Credential-at-rest encryption for `~/.nemoclaw/credentials.json` | Use modern KDF plus AES-256-GCM envelope encryption with migration support from plaintext entries. |
+| Reject | Unsalted SHA-256 password storage | Do not use unsalted password hashes as a durable credential primitive. |
+| Reject | Linux `unshare` and `mount` command wrapping as primary isolation | Keep OpenShell policy and sandbox boundary as primary isolation controls. |
+
+### Delivery Milestones (M6-M10)
+
+#### M6 Password-First Gateway Bootstrap
+
+- Introduce password-first bootstrap for publicly exposed gateway workflows.
+- Remove onboarding guidance that promotes `#token` control UI URLs.
+- Ensure pre-setup remote access is denied while local setup path remains available.
+
+#### M7 Encrypted Credential Store Migration
+
+- Add encrypted storage format for `~/.nemoclaw/credentials.json`.
+- Use modern KDF-derived keys and AES-256-GCM for value encryption.
+- Support automatic migration from existing plaintext credential records.
+
+#### M8 Unified Redaction Across Runtime Surfaces
+
+- Apply a shared redaction policy to CLI output, onboarding session records, and debug reports.
+- Cover high-confidence API key, bearer token, and credential assignment patterns.
+- Keep redaction behavior deterministic for incident review and reproducibility.
+
+#### M9 Semantic Dangerous-Command Policy
+
+- Introduce semantic dangerous-command policy with staged behavior: `warn` first, then `block`.
+- Align policy outcomes with OpenShell network and filesystem policy posture.
+- Emit auditable decision metadata for allow, warn, and block outcomes.
+
+#### M10 Rollout Controls and Operator Playbooks
+
+- Define staged rollout toggles for `audit`, `warn`, and `enforce` modes.
+- Update operator docs and troubleshooting playbooks for public exposure scenarios.
+- Add release gating checkpoints for docs parity and backward compatibility.
+
+### Public Interfaces and Contracts
+
+- Planned CLI contracts:
+  - `nemoclaw security set-password`
+  - `nemoclaw security status`
+- Planned environment contract:
+  - `NEMOCLAW_CRED_STORE_KEY`
+- Updated behavior contract:
+  - Onboarding output no longer promotes tokenized control UI URL guidance.
+
+### Acceptance Criteria for Addendum
+
+- Remote pre-setup access is blocked and localhost setup remains available.
+- Credential store migration leaves no plaintext provider keys in `~/.nemoclaw/credentials.json`.
+- Redaction consistently covers API key and token patterns across diagnostic and operator-visible outputs.
+- Existing `onboard`, `connect`, `status`, and `logs` flows remain backward compatible.
+
+### Test Plan
+
+1. Run markdown quality checks for this document and ensure no structural issues are introduced.
+2. Validate section discoverability and heading hierarchy for the appended addendum.
+3. Verify cross-document consistency against:
+   - `docs/security/best-practices.md`
+   - `docs/reference/commands.md`
+4. Confirm no conflicting security guidance remains for tokenized dashboard URL promotion in security-facing docs.
+
+### Assumptions
+
+- The existing security blueprint remains authoritative; this addendum is implementation-focused.
+- OpenShell policy and sandbox isolation remain the primary boundary; all additions are defense-in-depth.
+- Planned interface names are accepted as v1 contracts and may be refined in implementation PRs.

--- a/docs/security/clawkeeper-security-enhancement-plan.md
+++ b/docs/security/clawkeeper-security-enhancement-plan.md
@@ -135,10 +135,10 @@ This section tracks implementation status for milestone execution and parallel c
 | Milestone | Status | Notes |
 |---|---|---|
 | M1 Security Core Skeleton | Completed | `security` config namespace, policy loader, shared decision types are implemented. |
-| M2 High-Risk Operation Interception | Completed (v1) | `before_tool_call` and `after_tool_call` hooks with command, path, network, prompt, and quota signals are active. |
-| M3 Malicious Skill Admission Control | Completed (v1) | `before_install` admission path with offline-first pattern scanning and optional external scanner command is active. |
-| M4 Audit and Alert Closure | Completed (v1) | `security-event.v1` JSONL logging, webhook alert path, and security CLI commands are implemented. |
-| M5 Sandbox Policy Complements | Completed (v1) | strict egress and sensitive read-only policy templates are present under blueprint templates. |
+| M2 High-Risk Operation Interception | Completed (v2 hardening) | Adds semantic command signals for privilege escalation, dynamic substitution, decoded payload execution, command chaining, and sensitive-path redirection detection. |
+| M3 Malicious Skill Admission Control | Completed (v2 hardening) | Adds install target hardening for symlink escape detection, lifecycle-script detection, remote/insecure source handling, and structured scanner severity parsing with explicit fallback evidence. |
+| M4 Audit and Alert Closure | Completed (v2 hardening) | Adds filtered event browsing (`--action`, `--hook`, `--risk`, `--id`), malformed-line accounting, replay JSON mode, and prefix disambiguation with non-zero exit on ambiguity. |
+| M5 Sandbox Policy Complements | Completed (v2 hardening) | Adds `security-dev-balanced.yaml` and `security-ci-minimal.yaml` templates with docs and validation coverage for template parse/shape checks. |
 | M6-M10 Public Exposure Addendum | Planned | Password-first, encrypted credential store, unified redaction, staged dangerous-command policy, and rollout playbooks remain queued. |
 
 Current implementation branch baseline for parallel streams:
@@ -146,6 +146,7 @@ Current implementation branch baseline for parallel streams:
 - Base branch: `feature/security`
 - Parallel branches: `feature/security-main`, `feature/security-m2-hooks`, `feature/security-m3-install-gate`, `feature/security-m4-audit-cli`, `feature/security-m5-policy`, `feature/security-m6m8-exposure`, `feature/security-m9m10-rollout`
 - Worktrees are provisioned for each branch to avoid cross-stream file contention.
+- Integration status (2026-04-04): `feature/security-main` has integrated M2-M5 stream outputs and is the current baseline for M6-M10 development.
 
 ## Parallel Workstream Strategy
 
@@ -234,18 +235,18 @@ Expected outcome: validation succeeds and reports the resolved policy path.
 2. Show latest security events.
 
 ```console
-$ clawkeeper security events --limit 5
+$ clawkeeper security events --limit 5 --hook before_tool_call --risk high
 ```
 
-Expected outcome: event summary list appears, or an explicit "No events recorded yet" message.
+Expected outcome: filtered event summary appears, including malformed-line notice when present.
 
 3. Replay one event by ID.
 
 ```console
-$ clawkeeper security replay <event-id>
+$ clawkeeper security replay <event-id> --json
 ```
 
-Expected outcome: event detail includes hook, action, risk, reason, and evidence.
+Expected outcome: replay JSON includes event details plus dataset metadata (`matches`, `totalEvents`, `malformedLines`).
 
 ### Demo Notes
 

--- a/docs/security/clawkeeper-security-enhancement-plan.md
+++ b/docs/security/clawkeeper-security-enhancement-plan.md
@@ -1,0 +1,129 @@
+---
+title:
+  page: "ClawKeeper Security Enhancement Plan"
+  nav: "Security Enhancement Plan"
+description:
+  main: "Implementation blueprint for ClawKeeper security hardening across runtime interception, supply-chain admission, and audit pipelines."
+  agent: "Defines the ClawKeeper security implementation blueprint. Use when implementing security hooks, policy decisions, audit events, and rollout milestones."
+keywords: ["clawkeeper security enhancement plan", "before_tool_call", "before_install", "security policy"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "security", "policy", "supply_chain"]
+content:
+  type: reference
+  difficulty: intermediate
+  audience: ["developer", "engineer", "security_engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# ClawKeeper Security Enhancement Plan
+
+This page is the implementation blueprint for ClawKeeper security hardening.
+All security implementation work follows this document in sequence.
+
+## Threat Model
+
+ClawKeeper extends NemoClaw, so it inherits runtime isolation but still faces semantic execution risks.
+The security model treats the following as primary threats.
+
+| Threat | Description | Primary control |
+|---|---|---|
+| Dangerous tool execution | Agent requests high-impact shell or filesystem operations. | `before_tool_call` risk grading and enforcement. |
+| Data exfiltration | Agent attempts to send sensitive data to external destinations. | Network risk grading plus policy-scoped endpoint controls. |
+| Malicious or unsafe skill installation | Third-party skills contain prompt injection, exfiltration paths, or malicious code. | `before_install` admission scanning and approval gates. |
+| Prompt injection and jailbreak influence | Untrusted inputs attempt to alter tool behavior or safety constraints. | Prompt signal detection as auxiliary risk input. |
+| Silent security drift | Risky actions happen without operator visibility. | Structured audit events and alert delivery. |
+
+## Target Architecture
+
+ClawKeeper security is implemented as a layered control plane on top of OpenClaw plugin hooks.
+The architecture keeps OpenShell boundary isolation as a foundational layer and adds semantic action arbitration.
+
+1. Hook layer.
+   `before_tool_call`, `after_tool_call`, and `before_install` are registered in the ClawKeeper plugin.
+2. Decision layer.
+   A unified risk engine computes `SecurityDecision` with `allow`, `block`, or `require_approval`.
+3. Policy layer.
+   `security-policy.yaml` defines rule inputs and decision matrix behavior.
+4. Audit and alert layer.
+   Every decision emits `security-event.v1` records to JSONL and optional webhook sinks.
+
+## Policy Matrix
+
+ClawKeeper v1 runs in offline-first mode.
+Rules, static signatures, and local scanning run first.
+Optional remote adjudication can be added later.
+
+| Risk level | Default action | Rationale |
+|---|---|---|
+| Critical | Block | Immediate prevention for destructive or exfiltration-prone actions. |
+| High | Require approval | Human-in-the-loop for potentially legitimate but risky operations. |
+| Medium | Allow + audit | Preserve workflow while maintaining traceability. |
+| Low | Allow + audit | Minimize friction and keep observability. |
+
+The decision matrix is enforced only when mode is `enforce`.
+When mode is `audit`, all actions continue but security events still record recommended actions.
+When mode is `off`, the hook layer returns allow and logs minimal telemetry.
+
+## Implementation Milestones
+
+### M1 Security Core Skeleton
+
+- Add plugin `security` configuration namespace.
+- Introduce shared security types and policy loader.
+- Implement unified decision interface for tool and install flows.
+
+### M2 High-Risk Operation Interception
+
+- Register `before_tool_call` and `after_tool_call` hooks.
+- Grade command, path, and network risk.
+- Enforce `allow`, `block`, and `require_approval` based on decision matrix.
+
+### M3 Malicious Skill Admission Control
+
+- Register `before_install` hook.
+- Run offline-first skill scanning with pattern and static checks.
+- Block or require approval based on install risk level.
+
+### M4 Audit and Alert Closure
+
+- Emit `security-event.v1` JSONL events for all hook decisions.
+- Add webhook alert path for block and approval outcomes.
+- Add CLI commands for policy validation, event listing, and event replay.
+
+### M5 Sandbox Policy Complements
+
+- Add hardened policy templates for stricter egress posture.
+- Keep sensitive runtime directories read-only by default.
+- Ensure policy templates align with semantic arbitration, not replace it.
+
+## Acceptance Criteria
+
+A milestone is accepted only when all related tests pass and behavior is reproducible.
+
+| Area | Acceptance criteria |
+|---|---|
+| Hook enforcement | Critical tool requests are blocked, high-risk requests require approval, medium and low requests are allowed with audit events. |
+| Skill admission | Known malicious skill fixtures are blocked and medium-risk fixtures trigger approval paths. |
+| Audit integrity | Every hook decision emits a valid `security-event.v1` line with event ID, decision, risk level, and evidence. |
+| CLI operations | `security policy validate`, `security events`, and `security replay` return stable results and non-zero exits on invalid input. |
+| Regression safety | Existing onboard, policy, status, and logs flows remain functional. |
+
+## Rollback Plan
+
+If a release introduces unacceptable regressions, use phased rollback.
+
+1. Switch plugin security mode from `enforce` to `audit`.
+2. Keep event logging enabled for diagnosis.
+3. Disable webhook alerts if they introduce operational noise.
+4. Revert the affected milestone changeset while retaining prior stable milestones.
+5. Re-run regression and security fixture tests before re-enabling `enforce`.
+
+## Next Steps
+
+Use this plan as the source of truth for implementation order.
+Each milestone should land in an independent PR to keep review scope and rollback boundaries clear.

--- a/docs/security/security-module-updates.md
+++ b/docs/security/security-module-updates.md
@@ -84,6 +84,44 @@ Use it as the release log for security milestones after the baseline plan is app
 - Security events command handles empty event logs with explicit user-facing output.
 - Branch and worktree topology for parallel execution has been created and verified.
 
+## 2026-04-04 (M2-M5 Parallel Hardening Pass)
+
+### Added
+
+- Added semantic high-risk command signals in tool-call interception:
+  - privilege escalation (`sudo`, `su`)
+  - dynamic shell substitution (backticks, `$()`)
+  - decoded payload execution pipelines
+  - sensitive system-path redirection detection
+- Added install-admission hardening for local and remote targets:
+  - symlink escape detection
+  - install lifecycle-script detection (`preinstall`, `install`, `postinstall`)
+  - insecure `http://` source escalation
+  - structured scanner severity parsing and explicit scanner fallback evidence
+- Added event browsing filters to `clawkeeper security events`:
+  - `--action`
+  - `--hook`
+  - `--risk`
+  - `--id`
+- Added replay JSON mode and ambiguity handling to `clawkeeper security replay`, including non-zero exit on ambiguous ID prefixes.
+- Added new M5 policy templates:
+  - `nemoclaw-blueprint/policies/templates/security-dev-balanced.yaml`
+  - `nemoclaw-blueprint/policies/templates/security-ci-minimal.yaml`
+- Added new docs page for template operations: `docs/network-policy/security-policy-templates.md`.
+- Added template-shape validation coverage in `test/validate-blueprint.test.ts` for security template files.
+
+### Changed
+
+- Updated `docs/reference/commands.md` with new `security events` filter flags and `security replay --json` behavior.
+- Updated `docs/index.md` Network Policy toctree to include the security policy templates guide.
+- Updated `docs/security/clawkeeper-security-enhancement-plan.md` execution snapshot to reflect M2-M5 v2 hardening and demo command updates.
+
+### Validation Snapshot
+
+- `npm test -- test/security-engine.test.js` passes on the integration baseline.
+- `npm test -- test/security-cli.test.js` passes with new filter/replay behaviors.
+- `npm test -- test/validate-blueprint.test.ts` passes with template parse/shape assertions.
+
 ## Next Steps
 
 - Continue appending future security changes here with exact dates and concise impact notes.

--- a/docs/security/security-module-updates.md
+++ b/docs/security/security-module-updates.md
@@ -1,0 +1,62 @@
+---
+title:
+  page: "ClawKeeper Security Module Updates"
+  nav: "Security Module Updates"
+description:
+  main: "Changelog for ClawKeeper security module implementation milestones and behavior changes."
+  agent: "Tracks ClawKeeper security module updates over time. Use when auditing what changed in hooks, policy, CLI security commands, and test coverage."
+keywords: ["clawkeeper security changelog", "security module updates", "before_tool_call updates"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "security", "changelog"]
+content:
+  type: reference
+  difficulty: intermediate
+  audience: ["developer", "engineer", "security_engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# ClawKeeper Security Module Updates
+
+This page records implementation updates for the ClawKeeper security module.
+Use it as the release log for security milestones after the baseline plan is approved.
+
+## 2026-04-04
+
+### Added
+
+- Added the security enhancement implementation blueprint page and connected it to the Security docs navigation.
+- Added plugin security config namespace in `openclaw.plugin.json` and runtime parsing in plugin registration.
+- Added security policy file support (`security-policy.yaml`) with defaults and fallback behavior.
+- Added hook-based semantic controls for `before_tool_call`, `after_tool_call`, and `before_install`.
+- Added rule-based risk evaluation across command, path, network, prompt-signal, and quota dimensions.
+- Added install-time admission evaluation with offline-first scanning patterns and optional external scanner command support.
+- Added structured audit event output (`security-event.v1`) to JSONL and optional webhook alert delivery.
+- Added CLI security commands:
+  - `clawkeeper security policy validate`
+  - `clawkeeper security events`
+  - `clawkeeper security replay`
+- Added hardened policy template files for strict egress and sensitive path read-only posture.
+- Added tests for security engine behavior, security CLI workflows, plugin hook registration, and config parsing.
+
+### Changed
+
+- Updated help output to include security command group and usage examples.
+- Updated command reference docs with new security command documentation.
+- Updated Security toctree with the plan page and this update log page.
+
+### Validation Snapshot
+
+- Plugin package checks pass (`npm run check` under `nemoclaw/`).
+- Plugin project test suite passes.
+- Security-focused CLI and engine tests pass.
+- Core CLI regression tests still pass for existing flows.
+
+## Next Steps
+
+- Continue appending future security changes here with exact dates and concise impact notes.
+- Keep each entry grouped into `Added`, `Changed`, and `Validation Snapshot` for consistent release review.

--- a/docs/security/security-module-updates.md
+++ b/docs/security/security-module-updates.md
@@ -56,6 +56,34 @@ Use it as the release log for security milestones after the baseline plan is app
 - Security-focused CLI and engine tests pass.
 - Core CLI regression tests still pass for existing flows.
 
+## 2026-04-04 (Parallel Execution and Demo Readiness)
+
+### Added
+
+- Added parallel execution strategy to the security enhancement plan, including interface-freeze scope and branch ownership model.
+- Added explicit Codex coordination guidance for main-agent ownership and non-overlapping write scopes.
+- Added execution status snapshot to the plan, including milestone completion state and active parallel branch baseline.
+- Added demo runbook to the plan for policy validation, event listing, and event replay walkthroughs.
+- Provisioned dedicated parallel branches and worktrees for M2-M10 streams:
+  - `feature/security-main`
+  - `feature/security-m2-hooks`
+  - `feature/security-m3-install-gate`
+  - `feature/security-m4-audit-cli`
+  - `feature/security-m5-policy`
+  - `feature/security-m6m8-exposure`
+  - `feature/security-m9m10-rollout`
+
+### Changed
+
+- Updated planning docs to support technical write-up and stakeholder demo preparation.
+- Clarified that contract changes must land as isolated interface PRs before stream-level implementation rebases.
+
+### Validation Snapshot
+
+- Security policy validation command remains operational against `nemoclaw/security-policy.yaml`.
+- Security events command handles empty event logs with explicit user-facing output.
+- Branch and worktree topology for parallel execution has been created and verified.
+
 ## Next Steps
 
 - Continue appending future security changes here with exact dates and concise impact notes.

--- a/install.sh
+++ b/install.sh
@@ -2,12 +2,32 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Thin bootstrap for the NemoClaw installer.
+# Thin bootstrap for the ClawKeeper installer.
 # Public curl|bash installs should select a ref once, clone that ref, then
 # execute installer logic from that same clone. Historical tags that predate
 # the extracted payload fall back to their own root install.sh.
 
 set -euo pipefail
+
+apply_brand_compat_env() {
+  local legacy="$1" branded="$2"
+  if [[ -z "${!legacy+x}" && -n "${!branded+x}" ]]; then
+    export "$legacy=${!branded}"
+  fi
+}
+
+apply_brand_compat_env "NEMOCLAW_INSTALL_TAG" "CLAWKEEPER_INSTALL_TAG"
+apply_brand_compat_env "NEMOCLAW_INSTALL_REF" "CLAWKEEPER_INSTALL_REF"
+apply_brand_compat_env "NEMOCLAW_NON_INTERACTIVE" "CLAWKEEPER_NON_INTERACTIVE"
+apply_brand_compat_env \
+  "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE" \
+  "CLAWKEEPER_ACCEPT_THIRD_PARTY_SOFTWARE"
+apply_brand_compat_env "NEMOCLAW_SANDBOX_NAME" "CLAWKEEPER_SANDBOX_NAME"
+apply_brand_compat_env "NEMOCLAW_PROVIDER" "CLAWKEEPER_PROVIDER"
+apply_brand_compat_env "NEMOCLAW_MODEL" "CLAWKEEPER_MODEL"
+apply_brand_compat_env "NEMOCLAW_RECREATE_SANDBOX" "CLAWKEEPER_RECREATE_SANDBOX"
+apply_brand_compat_env "NEMOCLAW_POLICY_MODE" "CLAWKEEPER_POLICY_MODE"
+apply_brand_compat_env "NEMOCLAW_POLICY_PRESETS" "CLAWKEEPER_POLICY_PRESETS"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 LOCAL_PAYLOAD="${SCRIPT_DIR}/scripts/install.sh"
@@ -46,7 +66,7 @@ exec_installer_from_ref() {
   source_root="${tmpdir}/source"
 
   git -c advice.detachedHead=false clone --quiet --depth 1 --branch "$ref" \
-    https://github.com/NVIDIA/NemoClaw.git "$source_root"
+    https://github.com/hollyhongever/ClawKeeper.git "$source_root"
 
   payload_script="${source_root}/scripts/install.sh"
   legacy_script="${source_root}/install.sh"
@@ -63,27 +83,31 @@ exec_installer_from_ref() {
 }
 
 bootstrap_version() {
-  printf "nemoclaw-installer\n"
+  printf "clawkeeper-installer\n"
 }
 
 bootstrap_usage() {
   printf "\n"
-  printf "  NemoClaw Installer\n\n"
+  printf "  ClawKeeper Installer\n\n"
   printf "  Usage:\n"
-  printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash\n"
-  printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
+  printf "    curl -fsSL https://raw.githubusercontent.com/hollyhongever/ClawKeeper/main/install.sh | bash\n"
+  printf "    curl -fsSL https://raw.githubusercontent.com/hollyhongever/ClawKeeper/main/install.sh | bash -s -- [options]\n\n"
   printf "  Options:\n"
   printf "    --non-interactive    Skip prompts (uses env vars / defaults)\n"
   printf "    --yes-i-accept-third-party-software Accept the third-party software notice in non-interactive mode\n"
   printf "    --version, -v        Print installer version and exit\n"
   printf "    --help, -h           Show this help message and exit\n\n"
   printf "  Environment:\n"
-  printf "    NEMOCLAW_INSTALL_TAG         Git ref to install (default: latest release)\n"
-  printf "    NEMOCLAW_NON_INTERACTIVE=1   Same as --non-interactive\n"
-  printf "    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
-  printf "    NEMOCLAW_SANDBOX_NAME        Sandbox name to create/use\n"
-  printf "    NEMOCLAW_PROVIDER            cloud | ollama | nim | vllm\n"
-  printf "    NEMOCLAW_POLICY_MODE         suggested | custom | skip\n"
+  printf "    CLAWKEEPER_INSTALL_TAG       Git ref to install (fallback: NEMOCLAW_INSTALL_TAG)\n"
+  printf "    CLAWKEEPER_NON_INTERACTIVE=1 Same as --non-interactive\n"
+  printf "    CLAWKEEPER_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
+  printf "    CLAWKEEPER_SANDBOX_NAME      Sandbox name to create/use\n"
+  printf "    CLAWKEEPER_PROVIDER          cloud | ollama | nim | vllm\n"
+  printf "    CLAWKEEPER_MODEL             Inference model to configure\n"
+  printf "    CLAWKEEPER_RECREATE_SANDBOX=1 Recreate an existing sandbox\n"
+  printf "    CLAWKEEPER_POLICY_MODE       suggested | custom | skip\n"
+  printf "    CLAWKEEPER_POLICY_PRESETS    Comma-separated policy presets\n"
+  printf "    (legacy NEMOCLAW_* variables are still supported)\n"
   printf "\n"
 }
 

--- a/nemoclaw-blueprint/policies/templates/security-ci-minimal.yaml
+++ b/nemoclaw-blueprint/policies/templates/security-ci-minimal.yaml
@@ -1,0 +1,40 @@
+version: 1
+
+network_policies:
+  source_and_artifacts:
+    name: source_and_artifacts
+    endpoints:
+      - host: github.com
+        port: 443
+        access: full
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: '/**' }
+      - host: pypi.org
+        port: 443
+        access: full
+      - host: files.pythonhosted.org
+        port: 443
+        access: full
+      - host: registry.npmjs.org
+        port: 443
+        access: full
+    binaries:
+      - { path: /usr/bin/git }
+      - { path: /usr/local/bin/git }
+      - { path: /usr/bin/python3* }
+      - { path: /usr/bin/pip* }
+      - { path: /usr/local/bin/python3* }
+      - { path: /usr/local/bin/pip* }
+      - { path: /sandbox/.venv/bin/python* }
+      - { path: /sandbox/.venv/bin/pip* }
+      - { path: /sandbox/.uv/python/**/python* }
+      - { path: /sandbox/.local/bin/pip* }
+      - { path: /usr/bin/npm* }
+      - { path: /usr/bin/node* }
+      - { path: /usr/local/bin/npm* }
+      - { path: /usr/local/bin/node* }

--- a/nemoclaw-blueprint/policies/templates/security-dev-balanced.yaml
+++ b/nemoclaw-blueprint/policies/templates/security-dev-balanced.yaml
@@ -1,0 +1,48 @@
+version: 1
+
+network_policies:
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+        access: full
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: '/**' }
+          - allow: { method: POST, path: '/**' }
+    binaries:
+      - { path: /usr/bin/git }
+      - { path: /usr/bin/gh }
+      - { path: /usr/local/bin/git }
+      - { path: /usr/local/bin/gh }
+
+  package_registries:
+    name: package_registries
+    endpoints:
+      - host: pypi.org
+        port: 443
+        access: full
+      - host: files.pythonhosted.org
+        port: 443
+        access: full
+      - host: registry.npmjs.org
+        port: 443
+        access: full
+    binaries:
+      - { path: /usr/bin/python3* }
+      - { path: /usr/bin/pip* }
+      - { path: /usr/local/bin/python3* }
+      - { path: /usr/local/bin/pip* }
+      - { path: /sandbox/.venv/bin/python* }
+      - { path: /sandbox/.venv/bin/pip* }
+      - { path: /sandbox/.uv/python/**/python* }
+      - { path: /sandbox/.local/bin/pip* }
+      - { path: /usr/bin/npm* }
+      - { path: /usr/bin/node* }
+      - { path: /usr/local/bin/npm* }
+      - { path: /usr/local/bin/node* }

--- a/nemoclaw-blueprint/policies/templates/security-sensitive-readonly.yaml
+++ b/nemoclaw-blueprint/policies/templates/security-sensitive-readonly.yaml
@@ -1,0 +1,17 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /etc
+    - /var/log
+    - /sandbox/.openclaw
+    - /sandbox/.openclaw-data/credentials
+    - /sandbox/.openclaw-data/tokens
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null

--- a/nemoclaw-blueprint/policies/templates/security-strict-egress.yaml
+++ b/nemoclaw-blueprint/policies/templates/security-strict-egress.yaml
@@ -1,0 +1,40 @@
+version: 1
+
+network_policies:
+  nvidia:
+    name: nvidia
+    endpoints:
+      - host: integrate.api.nvidia.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: '/**' }
+          - allow: { method: POST, path: '/**' }
+      - host: inference-api.nvidia.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: '/**' }
+          - allow: { method: POST, path: '/**' }
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/claude }
+
+  openclaw_api:
+    name: openclaw_api
+    endpoints:
+      - host: openclaw.ai
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: '/**' }
+          - allow: { method: POST, path: '/**' }
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }

--- a/nemoclaw/openclaw.plugin.json
+++ b/nemoclaw/openclaw.plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "nemoclaw",
-  "name": "NemoClaw",
+  "name": "ClawKeeper",
   "version": "0.1.0",
-  "description": "Migrate and run OpenClaw inside OpenShell with optional NIM-backed inference",
+  "description": "ClawKeeper: run OpenClaw inside OpenShell with optional NIM-backed inference",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/nemoclaw/openclaw.plugin.json
+++ b/nemoclaw/openclaw.plugin.json
@@ -33,7 +33,7 @@
           "mode": {
             "type": "string",
             "description": "Security enforcement mode",
-            "enum": ["off", "audit", "enforce"],
+            "enum": ["off", "audit", "warn", "enforce"],
             "default": "enforce"
           },
           "policyPath": {

--- a/nemoclaw/openclaw.plugin.json
+++ b/nemoclaw/openclaw.plugin.json
@@ -25,6 +25,58 @@
         "type": "string",
         "description": "Default inference provider type (nvidia, vllm, openai-compatible)",
         "default": "nvidia"
+      },
+      "security": {
+        "type": "object",
+        "description": "Semantic security controls for hook-based action arbitration",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "description": "Security enforcement mode",
+            "enum": ["off", "audit", "enforce"],
+            "default": "enforce"
+          },
+          "policyPath": {
+            "type": "string",
+            "description": "Path to security-policy.yaml (relative to plugin root or absolute path)",
+            "default": "security-policy.yaml"
+          },
+          "approvalTimeoutMs": {
+            "type": "number",
+            "description": "Maximum wait for approval-mediated decisions in milliseconds",
+            "default": 120000
+          },
+          "scanTimeoutMs": {
+            "type": "number",
+            "description": "Timeout in milliseconds for install-time external scanner calls",
+            "default": 30000
+          },
+          "alertWebhook": {
+            "type": "string",
+            "description": "Optional webhook endpoint for security alert delivery",
+            "default": ""
+          },
+          "quota": {
+            "type": "object",
+            "description": "Runtime quota guardrails used by the security engine",
+            "properties": {
+              "maxToolCallsPerMinute": {
+                "type": "number",
+                "default": 120
+              },
+              "maxInstallsPerHour": {
+                "type": "number",
+                "default": 20
+              },
+              "maxEstimatedTokensPerHour": {
+                "type": "number",
+                "default": 200000
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     },
     "additionalProperties": false

--- a/nemoclaw/package.json
+++ b/nemoclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nemoclaw",
   "version": "0.1.0",
-  "description": "Migrate and run OpenClaw inside OpenShell with optional NIM-backed inference",
+  "description": "ClawKeeper plugin for running OpenClaw inside OpenShell with optional NIM-backed inference",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/nemoclaw/package.json
+++ b/nemoclaw/package.json
@@ -43,6 +43,7 @@
   },
   "files": [
     "dist/",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "security-policy.yaml"
   ]
 }

--- a/nemoclaw/security-policy.yaml
+++ b/nemoclaw/security-policy.yaml
@@ -1,0 +1,83 @@
+version: 1
+
+decision_matrix:
+  critical: block
+  high: require_approval
+  medium: allow
+  low: allow
+
+command_rules:
+  critical_patterns:
+    - '(^|\s)rm\s+-rf\s+/(\s|$)'
+    - '(^|\s)mkfs(\.|\s)'
+    - '(^|\s)dd\s+if='
+    - '(^|\s)(shutdown|reboot|poweroff)(\s|$)'
+    - '(:\(\)\s*\{\s*:\|:\s*&\s*\};:)'
+  high_patterns:
+    - 'https?://[^\s]+\s*\|\s*(bash|sh)'
+    - '(^|\s)(chmod\s+777|chown\s+-R\s+root)(\s|$)'
+    - '(^|\s)(iptables|ufw|firewall-cmd)(\s|$)'
+  medium_patterns:
+    - '(^|\s)curl(\s|$)'
+    - '(^|\s)wget(\s|$)'
+    - '(^|\s)scp(\s|$)'
+
+path_rules:
+  critical_prefixes:
+    - /etc
+    - /root
+    - /var/lib/docker
+    - /sandbox/.openclaw
+  high_prefixes:
+    - /home
+    - /var/log
+    - /proc
+    - /dev
+  allow_prefixes:
+    - /sandbox
+    - /tmp
+
+network_rules:
+  critical_hosts:
+    - 169.254.169.254
+    - metadata.google.internal
+    - localhost
+    - 127.0.0.1
+  high_hosts:
+    - ngrok.io
+    - trycloudflare.com
+    - transfer.sh
+  allow_hosts:
+    - integrate.api.nvidia.com
+    - inference-api.nvidia.com
+
+install_rules:
+  critical_patterns:
+    - 'ignore\s+all\s+previous\s+instructions'
+    - 'process\.env\.[A-Z0-9_]{3,}'
+    - child_process
+    - 'https?://[^\s]+\s*\|\s*(bash|sh)'
+  high_patterns:
+    - 'prompt\s*injection'
+    - 'data\s*exfil'
+    - 'base64\s+-d'
+  medium_patterns:
+    - 'eval\('
+    - 'Function\('
+    - 'new\s+WebSocket\('
+  scanner_command: ""
+  scanner_args: []
+
+prompt_rules:
+  injection_patterns:
+    - 'ignore\s+system\s+instructions'
+    - 'disable\s+guardrails'
+    - 'developer\s+mode'
+    - jailbreak
+
+audit:
+  event_log_path: ~/.nemoclaw/security/events.jsonl
+  include_allow_events: false
+  webhook_on:
+    - block
+    - require_approval

--- a/nemoclaw/src/commands/slash.test.ts
+++ b/nemoclaw/src/commands/slash.test.ts
@@ -29,12 +29,12 @@ const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
 const mockedDescribeOnboardEndpoint = vi.mocked(describeOnboardEndpoint);
 const mockedDescribeOnboardProvider = vi.mocked(describeOnboardProvider);
 
-function makeCtx(args?: string): PluginCommandContext {
+function makeCtx(args?: string, slashCommand = "clawkeeper"): PluginCommandContext {
   return {
     channel: "test-channel",
     isAuthorizedSender: true,
     args,
-    commandBody: `/nemoclaw${args ? ` ${args}` : ""}`,
+    commandBody: `/${slashCommand}${args ? ` ${args}` : ""}`,
     config: {},
   };
 }
@@ -42,7 +42,7 @@ function makeCtx(args?: string): PluginCommandContext {
 function makeApi(): OpenClawPluginApi {
   return {
     id: "nemoclaw",
-    name: "NemoClaw",
+    name: "ClawKeeper",
     config: {},
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     registerCommand: vi.fn(),
@@ -80,7 +80,8 @@ describe("commands/slash", () => {
   describe("help", () => {
     it("returns help text for empty args", () => {
       const result = handleSlashCommand(makeCtx(), makeApi());
-      expect(result.text).toContain("NemoClaw");
+      expect(result.text).toContain("ClawKeeper");
+      expect(result.text).toContain("Legacy alias: `/nemoclaw");
       expect(result.text).toContain("Subcommands:");
       expect(result.text).toContain("status");
       expect(result.text).toContain("eject");
@@ -144,7 +145,7 @@ describe("commands/slash", () => {
   describe("eject", () => {
     it("reports nothing to eject when state is blank", () => {
       const result = handleSlashCommand(makeCtx("eject"), makeApi());
-      expect(result.text).toContain("No NemoClaw deployment found");
+      expect(result.text).toContain("No ClawKeeper deployment found");
     });
 
     it("reports manual rollback required when no snapshot exists", () => {
@@ -174,8 +175,8 @@ describe("commands/slash", () => {
         updatedAt: "2026-03-01T00:00:00.000Z",
       });
       const result = handleSlashCommand(makeCtx("eject"), makeApi());
-      expect(result.text).toContain("Eject from NemoClaw");
-      expect(result.text).toContain("nemoclaw <name> destroy");
+      expect(result.text).toContain("Eject from ClawKeeper");
+      expect(result.text).toContain("clawkeeper <name> destroy");
       expect(result.text).toContain("Snapshot: /snapshots/snap-001");
     });
 
@@ -203,7 +204,7 @@ describe("commands/slash", () => {
     it("shows setup instructions when no config exists", () => {
       const result = handleSlashCommand(makeCtx("onboard"), makeApi());
       expect(result.text).toContain("No configuration found");
-      expect(result.text).toContain("nemoclaw onboard");
+      expect(result.text).toContain("clawkeeper onboard");
     });
 
     it("shows onboard status when config exists", () => {
@@ -220,7 +221,7 @@ describe("commands/slash", () => {
       mockedDescribeOnboardEndpoint.mockReturnValue("build (https://api.build.nvidia.com/v1)");
       mockedDescribeOnboardProvider.mockReturnValue("NVIDIA Endpoint API");
       const result = handleSlashCommand(makeCtx("onboard"), makeApi());
-      expect(result.text).toContain("NemoClaw Onboard Status");
+      expect(result.text).toContain("ClawKeeper Onboard Status");
       expect(result.text).toContain("NVIDIA Endpoint API");
       expect(result.text).toContain("nvidia/nemotron-3-super-120b-a12b");
       expect(result.text).toContain("NVIDIA_API_KEY");
@@ -241,6 +242,14 @@ describe("commands/slash", () => {
       mockedDescribeOnboardProvider.mockReturnValue("NVIDIA Cloud Partner");
       const result = handleSlashCommand(makeCtx("onboard"), makeApi());
       expect(result.text).toContain("NCP Partner: PartnerCo");
+    });
+  });
+
+  describe("legacy slash alias", () => {
+    it("returns the same help body for /nemoclaw and /clawkeeper", () => {
+      const legacy = handleSlashCommand(makeCtx(undefined, "nemoclaw"), makeApi());
+      const primary = handleSlashCommand(makeCtx(undefined, "clawkeeper"), makeApi());
+      expect(legacy.text).toBe(primary.text);
     });
   });
 });

--- a/nemoclaw/src/commands/slash.ts
+++ b/nemoclaw/src/commands/slash.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Handler for the /nemoclaw slash command (chat interface).
+ * Handler for the /clawkeeper slash command (chat interface).
  *
  * Supports subcommands:
- *   /nemoclaw status   - show sandbox/blueprint/inference state
- *   /nemoclaw eject    - rollback to host installation
- *   /nemoclaw          - show help
+ *   /clawkeeper status   - show sandbox/blueprint/inference state
+ *   /clawkeeper eject    - rollback to host installation
+ *   /clawkeeper          - show help
  */
 
 import type { PluginCommandContext, PluginCommandResult, OpenClawPluginApi } from "../index.js";
@@ -39,20 +39,22 @@ export function handleSlashCommand(
 function slashHelp(): PluginCommandResult {
   return {
     text: [
-      "**NemoClaw**",
+      "**ClawKeeper**",
       "",
-      "Usage: `/nemoclaw <subcommand>`",
+      "Usage: `/clawkeeper <subcommand>`",
+      "Legacy alias: `/nemoclaw <subcommand>`",
       "",
       "Subcommands:",
       "  `status`  - Show sandbox, blueprint, and inference state",
       "  `eject`   - Show rollback instructions",
       "  `onboard` - Show onboarding status and instructions",
       "",
-      "For full management use the NemoClaw CLI:",
-      "  `nemoclaw <name> status`",
-      "  `nemoclaw <name> connect`",
-      "  `nemoclaw <name> logs`",
-      "  `nemoclaw <name> destroy`",
+      "For full management use the ClawKeeper CLI:",
+      "  `clawkeeper <name> status`",
+      "  `clawkeeper <name> connect`",
+      "  `clawkeeper <name> logs`",
+      "  `clawkeeper <name> destroy`",
+      "Legacy CLI alias remains available: `nemoclaw`",
     ].join("\n"),
   };
 }
@@ -62,12 +64,12 @@ function slashStatus(): PluginCommandResult {
 
   if (!state.lastAction) {
     return {
-      text: "**NemoClaw**: No operations performed yet. Run `nemoclaw onboard` to get started.",
+      text: "**ClawKeeper**: No operations performed yet. Run `clawkeeper onboard` to get started.",
     };
   }
 
   const lines = [
-    "**NemoClaw Status**",
+    "**ClawKeeper Status**",
     "",
     `Last action: ${state.lastAction}`,
     `Blueprint: ${state.blueprintVersion ?? "unknown"}`,
@@ -88,7 +90,7 @@ function slashOnboard(): PluginCommandResult {
   if (config) {
     return {
       text: [
-        "**NemoClaw Onboard Status**",
+        "**ClawKeeper Onboard Status**",
         "",
         `Endpoint: ${describeOnboardEndpoint(config)}`,
         `Provider: ${describeOnboardProvider(config)}`,
@@ -98,7 +100,7 @@ function slashOnboard(): PluginCommandResult {
         `Profile: ${config.profile}`,
         `Onboarded: ${config.onboardedAt}`,
         "",
-        "To reconfigure, run: `nemoclaw onboard`",
+        "To reconfigure, run: `clawkeeper onboard`",
       ]
         .filter(Boolean)
         .join("\n"),
@@ -106,12 +108,12 @@ function slashOnboard(): PluginCommandResult {
   }
   return {
     text: [
-      "**NemoClaw Onboarding**",
+      "**ClawKeeper Onboarding**",
       "",
       "No configuration found. Run the onboard command to set up inference:",
       "",
       "```",
-      "nemoclaw onboard",
+      "clawkeeper onboard",
       "```",
     ].join("\n"),
   };
@@ -121,7 +123,7 @@ function slashEject(): PluginCommandResult {
   const state = loadState();
 
   if (!state.lastAction) {
-    return { text: "No NemoClaw deployment found. Nothing to eject from." };
+    return { text: "No ClawKeeper deployment found. Nothing to eject from." };
   }
 
   if (!state.migrationSnapshot && !state.hostBackupPath) {
@@ -132,12 +134,12 @@ function slashEject(): PluginCommandResult {
 
   return {
     text: [
-      "**Eject from NemoClaw**",
+      "**Eject from ClawKeeper**",
       "",
       "To rollback to your host OpenClaw installation, run:",
       "",
       "```",
-      "nemoclaw <name> destroy",
+      "clawkeeper <name> destroy",
       "```",
       "",
       `Snapshot: ${state.migrationSnapshot ?? state.hostBackupPath ?? "none"}`,

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -143,7 +143,14 @@ function asRecord(value: unknown): Record<string, unknown> {
 }
 
 function pickMode(value: unknown, fallback: SecurityMode): SecurityMode {
-  if (value === "off" || value === "audit" || value === "enforce") return value;
+  if (
+    value === "off" ||
+    value === "audit" ||
+    value === "warn" ||
+    value === "enforce"
+  ) {
+    return value;
+  }
   return fallback;
 }
 

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * NemoClaw — OpenClaw Plugin for OpenShell
+ * ClawKeeper — OpenClaw Plugin for OpenShell
  *
  * Uses the real OpenClaw plugin API. Types defined locally are minimal stubs
  * that match the OpenClaw SDK interfaces available at runtime via
@@ -235,10 +235,16 @@ export function getPluginConfig(api: OpenClawPluginApi): NemoClawConfig {
 // ---------------------------------------------------------------------------
 
 export default function register(api: OpenClawPluginApi): void {
-  // 1. Register /nemoclaw slash command (chat interface)
+  // 1. Register slash commands (chat interface)
+  api.registerCommand({
+    name: "clawkeeper",
+    description: "ClawKeeper sandbox management (status, eject).",
+    acceptsArgs: true,
+    handler: (ctx) => handleSlashCommand(ctx, api),
+  });
   api.registerCommand({
     name: "nemoclaw",
-    description: "NemoClaw sandbox management (status, eject).",
+    description: "Legacy alias for ClawKeeper sandbox management (status, eject).",
     acceptsArgs: true,
     handler: (ctx) => handleSlashCommand(ctx, api),
   });
@@ -254,12 +260,12 @@ export default function register(api: OpenClawPluginApi): void {
 
   api.logger.info("");
   api.logger.info("  ┌─────────────────────────────────────────────────────┐");
-  api.logger.info("  │  NemoClaw registered                                │");
+  api.logger.info("  │  ClawKeeper registered                              │");
   api.logger.info("  │                                                     │");
   api.logger.info(`  │  Endpoint:  ${bannerEndpoint.padEnd(40)}│`);
   api.logger.info(`  │  Provider:  ${bannerProvider.padEnd(40)}│`);
   api.logger.info(`  │  Model:     ${bannerModel.padEnd(40)}│`);
-  api.logger.info("  │  Slash:     /nemoclaw                               │");
+  api.logger.info("  │  Slash:     /clawkeeper (alias: /nemoclaw)          │");
   api.logger.info("  └─────────────────────────────────────────────────────┘");
   api.logger.info("");
 }

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -17,6 +17,8 @@ import {
   describeOnboardProvider,
   loadOnboardConfig,
 } from "./onboard/config.js";
+import { registerSecurityHooks } from "./security/hooks.js";
+import type { PluginSecurityConfig, SecurityMode } from "./security/types.js";
 
 // ---------------------------------------------------------------------------
 // OpenClaw Plugin SDK compatible types (mirrors openclaw/plugin-sdk)
@@ -119,7 +121,7 @@ export interface OpenClawPluginApi {
   registerProvider: (provider: ProviderPlugin) => void;
   registerService: (service: PluginService) => void;
   resolvePath: (input: string) => string;
-  on: (hookName: string, handler: (...args: unknown[]) => void) => void;
+  on: (hookName: string, handler: (...args: unknown[]) => unknown) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +133,22 @@ export interface NemoClawConfig {
   blueprintRegistry: string;
   sandboxName: string;
   inferenceProvider: string;
+  security: PluginSecurityConfig;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function pickMode(value: unknown, fallback: SecurityMode): SecurityMode {
+  if (value === "off" || value === "audit" || value === "enforce") return value;
+  return fallback;
+}
+
+function pickNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
 function activeModelEntries(
@@ -206,10 +224,24 @@ const DEFAULT_PLUGIN_CONFIG: NemoClawConfig = {
   blueprintRegistry: "ghcr.io/nvidia/nemoclaw-blueprint",
   sandboxName: "openclaw",
   inferenceProvider: "nvidia",
+  security: {
+    mode: "enforce",
+    policyPath: "security-policy.yaml",
+    approvalTimeoutMs: 120000,
+    scanTimeoutMs: 30000,
+    alertWebhook: "",
+    quota: {
+      maxToolCallsPerMinute: 120,
+      maxInstallsPerHour: 20,
+      maxEstimatedTokensPerHour: 200000,
+    },
+  },
 };
 
 export function getPluginConfig(api: OpenClawPluginApi): NemoClawConfig {
   const raw = api.pluginConfig ?? {};
+  const securityRaw = asRecord(raw["security"]);
+  const quotaRaw = asRecord(securityRaw["quota"]);
   return {
     blueprintVersion:
       typeof raw["blueprintVersion"] === "string"
@@ -227,6 +259,39 @@ export function getPluginConfig(api: OpenClawPluginApi): NemoClawConfig {
       typeof raw["inferenceProvider"] === "string"
         ? raw["inferenceProvider"]
         : DEFAULT_PLUGIN_CONFIG.inferenceProvider,
+    security: {
+      mode: pickMode(securityRaw["mode"], DEFAULT_PLUGIN_CONFIG.security.mode),
+      policyPath:
+        typeof securityRaw["policyPath"] === "string"
+          ? securityRaw["policyPath"]
+          : DEFAULT_PLUGIN_CONFIG.security.policyPath,
+      approvalTimeoutMs: pickNumber(
+        securityRaw["approvalTimeoutMs"],
+        DEFAULT_PLUGIN_CONFIG.security.approvalTimeoutMs,
+      ),
+      scanTimeoutMs: pickNumber(
+        securityRaw["scanTimeoutMs"],
+        DEFAULT_PLUGIN_CONFIG.security.scanTimeoutMs,
+      ),
+      alertWebhook:
+        typeof securityRaw["alertWebhook"] === "string"
+          ? securityRaw["alertWebhook"]
+          : DEFAULT_PLUGIN_CONFIG.security.alertWebhook,
+      quota: {
+        maxToolCallsPerMinute: pickNumber(
+          quotaRaw["maxToolCallsPerMinute"],
+          DEFAULT_PLUGIN_CONFIG.security.quota.maxToolCallsPerMinute,
+        ),
+        maxInstallsPerHour: pickNumber(
+          quotaRaw["maxInstallsPerHour"],
+          DEFAULT_PLUGIN_CONFIG.security.quota.maxInstallsPerHour,
+        ),
+        maxEstimatedTokensPerHour: pickNumber(
+          quotaRaw["maxEstimatedTokensPerHour"],
+          DEFAULT_PLUGIN_CONFIG.security.quota.maxEstimatedTokensPerHour,
+        ),
+      },
+    },
   };
 }
 
@@ -235,6 +300,8 @@ export function getPluginConfig(api: OpenClawPluginApi): NemoClawConfig {
 // ---------------------------------------------------------------------------
 
 export default function register(api: OpenClawPluginApi): void {
+  const pluginCfg = getPluginConfig(api);
+
   // 1. Register slash commands (chat interface)
   api.registerCommand({
     name: "clawkeeper",
@@ -254,6 +321,9 @@ export default function register(api: OpenClawPluginApi): void {
   const providerCredentialEnv = onboardCfg?.credentialEnv ?? "NVIDIA_API_KEY";
   api.registerProvider(registeredProviderForConfig(onboardCfg, providerCredentialEnv));
 
+  // 3. Register semantic security hooks
+  registerSecurityHooks(api, pluginCfg);
+
   const bannerEndpoint = onboardCfg ? describeOnboardEndpoint(onboardCfg) : "build.nvidia.com";
   const bannerProvider = onboardCfg ? describeOnboardProvider(onboardCfg) : "NVIDIA Endpoints";
   const bannerModel = onboardCfg?.model ?? "nvidia/nemotron-3-super-120b-a12b";
@@ -265,6 +335,7 @@ export default function register(api: OpenClawPluginApi): void {
   api.logger.info(`  │  Endpoint:  ${bannerEndpoint.padEnd(40)}│`);
   api.logger.info(`  │  Provider:  ${bannerProvider.padEnd(40)}│`);
   api.logger.info(`  │  Model:     ${bannerModel.padEnd(40)}│`);
+  api.logger.info(`  │  Security:  ${pluginCfg.security.mode.padEnd(40)}│`);
   api.logger.info("  │  Slash:     /clawkeeper (alias: /nemoclaw)          │");
   api.logger.info("  └─────────────────────────────────────────────────────┘");
   api.logger.info("");

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -116,6 +116,17 @@ describe("getPluginConfig", () => {
     expect(config.security.mode).toBe("enforce");
   });
 
+  it("accepts warn security mode from pluginConfig", () => {
+    const api = createMockApi();
+    api.pluginConfig = {
+      security: {
+        mode: "warn",
+      },
+    };
+    const config = getPluginConfig(api);
+    expect(config.security.mode).toBe("warn");
+  });
+
   it("uses string values from pluginConfig", () => {
     const api = createMockApi();
     api.pluginConfig = {

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -45,7 +45,7 @@ describe("plugin registration", () => {
   it("registers slash commands with a legacy alias", () => {
     const api = createMockApi();
     register(api);
-    const registered = vi.mocked(api.registerCommand).mock.calls.map((call) => call[0]?.name);
+    const registered = vi.mocked(api.registerCommand).mock.calls.map((call) => call[0].name);
     expect(registered).toContain("clawkeeper");
     expect(registered).toContain("nemoclaw");
   });
@@ -54,6 +54,15 @@ describe("plugin registration", () => {
     const api = createMockApi();
     register(api);
     expect(api.registerProvider).toHaveBeenCalledWith(expect.objectContaining({ id: "inference" }));
+  });
+
+  it("registers security hooks", () => {
+    const api = createMockApi();
+    register(api);
+    const hookNames = vi.mocked(api.on).mock.calls.map((call) => call[0]);
+    expect(hookNames).toContain("before_tool_call");
+    expect(hookNames).toContain("after_tool_call");
+    expect(hookNames).toContain("before_install");
   });
 
   it("does NOT register CLI commands", () => {
@@ -90,6 +99,12 @@ describe("getPluginConfig", () => {
     expect(config.blueprintRegistry).toBe("ghcr.io/nvidia/nemoclaw-blueprint");
     expect(config.sandboxName).toBe("openclaw");
     expect(config.inferenceProvider).toBe("nvidia");
+    expect(config.security.mode).toBe("enforce");
+    expect(config.security.policyPath).toBe("security-policy.yaml");
+    expect(config.security.approvalTimeoutMs).toBe(120000);
+    expect(config.security.scanTimeoutMs).toBe(30000);
+    expect(config.security.alertWebhook).toBe("");
+    expect(config.security.quota.maxToolCallsPerMinute).toBe(120);
   });
 
   it("returns defaults when pluginConfig has non-string values", () => {
@@ -98,6 +113,7 @@ describe("getPluginConfig", () => {
     const config = getPluginConfig(api);
     expect(config.blueprintVersion).toBe("latest");
     expect(config.sandboxName).toBe("openclaw");
+    expect(config.security.mode).toBe("enforce");
   });
 
   it("uses string values from pluginConfig", () => {
@@ -107,11 +123,31 @@ describe("getPluginConfig", () => {
       blueprintRegistry: "ghcr.io/custom/registry",
       sandboxName: "custom-sandbox",
       inferenceProvider: "openai",
+      security: {
+        mode: "audit",
+        policyPath: "/tmp/security-policy.yaml",
+        approvalTimeoutMs: 90000,
+        scanTimeoutMs: 10000,
+        alertWebhook: "https://alerts.example.com/hook",
+        quota: {
+          maxToolCallsPerMinute: 10,
+          maxInstallsPerHour: 2,
+          maxEstimatedTokensPerHour: 5000,
+        },
+      },
     };
     const config = getPluginConfig(api);
     expect(config.blueprintVersion).toBe("2.0.0");
     expect(config.blueprintRegistry).toBe("ghcr.io/custom/registry");
     expect(config.sandboxName).toBe("custom-sandbox");
     expect(config.inferenceProvider).toBe("openai");
+    expect(config.security.mode).toBe("audit");
+    expect(config.security.policyPath).toBe("/tmp/security-policy.yaml");
+    expect(config.security.approvalTimeoutMs).toBe(90000);
+    expect(config.security.scanTimeoutMs).toBe(10000);
+    expect(config.security.alertWebhook).toBe("https://alerts.example.com/hook");
+    expect(config.security.quota.maxToolCallsPerMinute).toBe(10);
+    expect(config.security.quota.maxInstallsPerHour).toBe(2);
+    expect(config.security.quota.maxEstimatedTokensPerHour).toBe(5000);
   });
 });

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -18,7 +18,7 @@ const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
 function createMockApi(): OpenClawPluginApi {
   return {
     id: "nemoclaw",
-    name: "NemoClaw",
+    name: "ClawKeeper",
     version: "0.1.0",
     config: {},
     pluginConfig: {},
@@ -42,10 +42,12 @@ describe("plugin registration", () => {
     mockedLoadOnboardConfig.mockReturnValue(null);
   });
 
-  it("registers a slash command", () => {
+  it("registers slash commands with a legacy alias", () => {
     const api = createMockApi();
     register(api);
-    expect(api.registerCommand).toHaveBeenCalledWith(expect.objectContaining({ name: "nemoclaw" }));
+    const registered = vi.mocked(api.registerCommand).mock.calls.map((call) => call[0]?.name);
+    expect(registered).toContain("clawkeeper");
+    expect(registered).toContain("nemoclaw");
   });
 
   it("registers an inference provider", () => {

--- a/nemoclaw/src/security/engine.ts
+++ b/nemoclaw/src/security/engine.ts
@@ -1,0 +1,521 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { execa } from "execa";
+
+import type {
+  PluginSecurityConfig,
+  SecurityDecision,
+  SecurityEvidence,
+  SecurityPolicy,
+  SecurityRiskLevel,
+} from "./types.js";
+
+const RISK_ORDER: SecurityRiskLevel[] = ["low", "medium", "high", "critical"];
+
+interface ExtractedContext {
+  toolName: string;
+  command: string;
+  target: string;
+  text: string;
+  paths: string[];
+  hosts: string[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function collectStrings(value: unknown, depth = 0): string[] {
+  if (depth > 4 || value === null || value === undefined) return [];
+  if (typeof value === "string") return [value];
+  if (typeof value === "number" || typeof value === "boolean") return [String(value)];
+  if (Array.isArray(value)) return value.flatMap((entry) => collectStrings(entry, depth + 1));
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap((entry) =>
+      collectStrings(entry, depth + 1),
+    );
+  }
+  return [];
+}
+
+function extractPaths(text: string): string[] {
+  const matches = text.match(/(?:^|\s)(\/[A-Za-z0-9._\/-]{2,})/g) ?? [];
+  return [...new Set(matches.map((entry) => entry.trim()))];
+}
+
+function extractHosts(text: string): string[] {
+  const out = new Set<string>();
+  const urls = text.match(/https?:\/\/[^\s"'`]+/gi) ?? [];
+  for (const url of urls) {
+    try {
+      out.add(new URL(url).hostname.toLowerCase());
+    } catch {
+      // ignored
+    }
+  }
+
+  const hostHints = text.match(/\bhost(?:name)?\s*[:=]\s*([a-z0-9.-]+\.[a-z]{2,})/gi) ?? [];
+  for (const hint of hostHints) {
+    const match = /([a-z0-9.-]+\.[a-z]{2,})/i.exec(hint);
+    if (match) out.add(match[1].toLowerCase());
+  }
+  return [...out];
+}
+
+function compilePattern(pattern: string): RegExp {
+  try {
+    return new RegExp(pattern, "i");
+  } catch {
+    return new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+  }
+}
+
+function matchesAnyPattern(text: string, patterns: string[]): string[] {
+  const matched: string[] = [];
+  for (const pattern of patterns) {
+    const regex = compilePattern(pattern);
+    if (regex.test(text)) matched.push(pattern);
+  }
+  return matched;
+}
+
+function higherRisk(a: SecurityRiskLevel, b: SecurityRiskLevel): SecurityRiskLevel {
+  return RISK_ORDER.indexOf(a) >= RISK_ORDER.indexOf(b) ? a : b;
+}
+
+function riskScore(level: SecurityRiskLevel, evidenceCount: number): number {
+  const base = {
+    low: 20,
+    medium: 50,
+    high: 75,
+    critical: 95,
+  } satisfies Record<SecurityRiskLevel, number>;
+  return Math.min(100, base[level] + Math.min(4, evidenceCount) * 2);
+}
+
+function buildDecision(
+  level: SecurityRiskLevel,
+  action: SecurityDecision["action"],
+  evidence: SecurityEvidence[],
+): SecurityDecision {
+  return {
+    action,
+    riskLevel: level,
+    riskScore: riskScore(level, evidence.length),
+    reason: evidence[0]?.message ?? `Risk level ${level}`,
+    evidence,
+  };
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function normalizePath(p: string): string {
+  return p.replace(/\\+/g, "/").trim();
+}
+
+function extractContext(payload: unknown): ExtractedContext {
+  const raw = asRecord(payload);
+  const toolName =
+    typeof raw["toolName"] === "string"
+      ? raw["toolName"]
+      : typeof raw["name"] === "string"
+        ? raw["name"]
+        : "unknown-tool";
+  const command =
+    typeof raw["command"] === "string"
+      ? raw["command"]
+      : typeof raw["cmd"] === "string"
+        ? raw["cmd"]
+        : "";
+  const target =
+    typeof raw["target"] === "string"
+      ? raw["target"]
+      : typeof raw["source"] === "string"
+        ? raw["source"]
+        : typeof raw["path"] === "string"
+          ? raw["path"]
+          : "";
+
+  const text = [command, target, ...collectStrings(payload)]
+    .filter(Boolean)
+    .join("\n")
+    .slice(0, 200_000);
+  return {
+    toolName,
+    command,
+    target,
+    text,
+    paths: extractPaths(text).map(normalizePath),
+    hosts: extractHosts(text),
+  };
+}
+
+function findRiskByPath(
+  paths: string[],
+  policy: SecurityPolicy,
+  evidence: SecurityEvidence[],
+): SecurityRiskLevel {
+  let level: SecurityRiskLevel = "low";
+  for (const path of paths) {
+    if (policy.pathRules.criticalPrefixes.some((prefix) => path.startsWith(prefix))) {
+      level = higherRisk(level, "critical");
+      evidence.push({ code: "path_critical", message: `Sensitive path targeted: ${path}` });
+      continue;
+    }
+    if (policy.pathRules.highPrefixes.some((prefix) => path.startsWith(prefix))) {
+      level = higherRisk(level, "high");
+      evidence.push({ code: "path_high", message: `High-risk path targeted: ${path}` });
+      continue;
+    }
+    if (
+      path.startsWith("/") &&
+      !policy.pathRules.allowPrefixes.some((prefix) => path.startsWith(prefix))
+    ) {
+      level = higherRisk(level, "medium");
+      evidence.push({ code: "path_unknown", message: `Path outside allowlist: ${path}` });
+    }
+  }
+  return level;
+}
+
+function findRiskByHosts(
+  hosts: string[],
+  policy: SecurityPolicy,
+  evidence: SecurityEvidence[],
+): SecurityRiskLevel {
+  let level: SecurityRiskLevel = "low";
+  for (const host of hosts) {
+    if (policy.networkRules.criticalHosts.includes(host)) {
+      level = higherRisk(level, "critical");
+      evidence.push({ code: "network_critical", message: `Critical host targeted: ${host}` });
+      continue;
+    }
+    if (policy.networkRules.highHosts.some((entry) => host.includes(entry))) {
+      level = higherRisk(level, "high");
+      evidence.push({ code: "network_high", message: `High-risk host targeted: ${host}` });
+      continue;
+    }
+    if (!policy.networkRules.allowHosts.some((entry) => host.includes(entry))) {
+      level = higherRisk(level, "medium");
+      evidence.push({ code: "network_unknown", message: `Host not in allowlist: ${host}` });
+    }
+  }
+  return level;
+}
+
+function scanPatterns(
+  text: string,
+  patterns: { critical: string[]; high: string[]; medium: string[] },
+  evidencePrefix: string,
+  evidence: SecurityEvidence[],
+): SecurityRiskLevel {
+  let level: SecurityRiskLevel = "low";
+
+  const criticalMatches = matchesAnyPattern(text, patterns.critical);
+  if (criticalMatches.length > 0) {
+    level = "critical";
+    evidence.push({
+      code: `${evidencePrefix}_critical`,
+      message: `Matched critical ${evidencePrefix.replace(/_/g, " ")} pattern`,
+      metadata: { patterns: criticalMatches.slice(0, 5) },
+    });
+  }
+
+  const highMatches = matchesAnyPattern(text, patterns.high);
+  if (highMatches.length > 0) {
+    level = higherRisk(level, "high");
+    evidence.push({
+      code: `${evidencePrefix}_high`,
+      message: `Matched high ${evidencePrefix.replace(/_/g, " ")} pattern`,
+      metadata: { patterns: highMatches.slice(0, 5) },
+    });
+  }
+
+  const mediumMatches = matchesAnyPattern(text, patterns.medium);
+  if (mediumMatches.length > 0) {
+    level = higherRisk(level, "medium");
+    evidence.push({
+      code: `${evidencePrefix}_medium`,
+      message: `Matched medium ${evidencePrefix.replace(/_/g, " ")} pattern`,
+      metadata: { patterns: mediumMatches.slice(0, 5) },
+    });
+  }
+
+  return level;
+}
+
+function walkFiles(basePath: string, maxFiles: number): string[] {
+  const queue: string[] = [basePath];
+  const files: string[] = [];
+
+  while (queue.length > 0 && files.length < maxFiles) {
+    const current = queue.shift();
+    if (!current) break;
+
+    try {
+      const st = statSync(current);
+      if (st.isDirectory()) {
+        const entries = readdirSync(current).slice(0, maxFiles);
+        for (const entry of entries) {
+          queue.push(join(current, entry));
+        }
+      } else if (st.isFile()) {
+        files.push(current);
+      }
+    } catch {
+      // ignored
+    }
+  }
+
+  return files;
+}
+
+function readScanTextFromTarget(target: string): string {
+  if (!target || !existsSync(target)) return "";
+  const files = walkFiles(target, 30);
+  if (files.length === 0) return "";
+
+  const textParts: string[] = [];
+  for (const file of files) {
+    const lower = file.toLowerCase();
+    if (!/(\.md|\.txt|\.json|\.ya?ml|\.js|\.ts|\.py|\.sh)$/i.test(lower)) continue;
+    try {
+      textParts.push(readFileSync(file, "utf-8").slice(0, 10_000));
+    } catch {
+      // ignored
+    }
+    if (textParts.join("\n").length > 180_000) break;
+  }
+  return textParts.join("\n");
+}
+
+export class SecurityEngine {
+  private readonly toolCallTimes: number[] = [];
+
+  private readonly installTimes: number[] = [];
+
+  private estimatedTokenUsage: Array<{ ts: number; tokens: number }> = [];
+
+  constructor(
+    private readonly policy: SecurityPolicy,
+    private readonly config: PluginSecurityConfig,
+  ) {}
+
+  private pruneCounters(now: number): void {
+    while (this.toolCallTimes.length > 0 && now - this.toolCallTimes[0] > 60_000) {
+      this.toolCallTimes.shift();
+    }
+    while (this.installTimes.length > 0 && now - this.installTimes[0] > 3_600_000) {
+      this.installTimes.shift();
+    }
+    this.estimatedTokenUsage = this.estimatedTokenUsage.filter(
+      (item) => now - item.ts <= 3_600_000,
+    );
+  }
+
+  private actionForRisk(level: SecurityRiskLevel): SecurityDecision["action"] {
+    return this.policy.decisionMatrix[level];
+  }
+
+  evaluateBeforeToolCall(payload: unknown): SecurityDecision {
+    const now = Date.now();
+    this.pruneCounters(now);
+    this.toolCallTimes.push(now);
+
+    const context = extractContext(payload);
+    const evidence: SecurityEvidence[] = [];
+    let risk: SecurityRiskLevel = "low";
+
+    risk = higherRisk(
+      risk,
+      scanPatterns(
+        context.text,
+        {
+          critical: this.policy.commandRules.criticalPatterns,
+          high: this.policy.commandRules.highPatterns,
+          medium: this.policy.commandRules.mediumPatterns,
+        },
+        "command",
+        evidence,
+      ),
+    );
+
+    risk = higherRisk(risk, findRiskByPath(context.paths, this.policy, evidence));
+    risk = higherRisk(risk, findRiskByHosts(context.hosts, this.policy, evidence));
+
+    const promptMatches = matchesAnyPattern(
+      context.text,
+      this.policy.promptRules.injectionPatterns,
+    );
+    if (promptMatches.length > 0) {
+      risk = higherRisk(risk, "high");
+      evidence.push({
+        code: "prompt_injection_signal",
+        message: "Prompt injection signal detected in tool payload",
+        metadata: { patterns: promptMatches.slice(0, 5) },
+      });
+    }
+
+    const estimatedTokens = estimateTokensFromText(context.text);
+    this.estimatedTokenUsage.push({ ts: now, tokens: estimatedTokens });
+
+    if (this.toolCallTimes.length > this.config.quota.maxToolCallsPerMinute) {
+      risk = higherRisk(risk, "high");
+      evidence.push({
+        code: "quota_tool_calls",
+        message: `Tool call quota exceeded (${String(this.toolCallTimes.length)}/${String(this.config.quota.maxToolCallsPerMinute)} per minute)`,
+      });
+    }
+
+    const totalTokens = this.estimatedTokenUsage.reduce((acc, item) => acc + item.tokens, 0);
+    if (totalTokens > this.config.quota.maxEstimatedTokensPerHour) {
+      risk = higherRisk(risk, "high");
+      evidence.push({
+        code: "quota_estimated_tokens",
+        message: `Estimated token quota exceeded (${String(totalTokens)}/${String(this.config.quota.maxEstimatedTokensPerHour)} per hour)`,
+      });
+    }
+
+    if (evidence.length === 0) {
+      evidence.push({
+        code: "baseline_allow",
+        message: `No high-risk signals for tool ${context.toolName}`,
+      });
+    }
+
+    return buildDecision(risk, this.actionForRisk(risk), evidence);
+  }
+
+  evaluateAfterToolCall(payload: unknown): SecurityDecision {
+    const context = extractContext(payload);
+    const evidence: SecurityEvidence[] = [];
+    let risk: SecurityRiskLevel = "low";
+
+    const secretLeakMatches = matchesAnyPattern(context.text, [
+      "(nvapi-|nvcf-|ghp_)[A-Za-z0-9_-]{10,}",
+      "Bearer\\s+[A-Za-z0-9_.+/=-]{10,}",
+      "(API_KEY|TOKEN|SECRET|PASSWORD)\\s*[:=]\\s*['\"]?[A-Za-z0-9_.+/=-]{8,}",
+    ]);
+    if (secretLeakMatches.length > 0) {
+      risk = "high";
+      evidence.push({
+        code: "post_tool_secret_leak",
+        message: "Potential secret leakage detected in tool result",
+        metadata: { patterns: secretLeakMatches.slice(0, 5) },
+      });
+    } else {
+      evidence.push({
+        code: "post_tool_observed",
+        message: "Tool call completed without high-risk output signals",
+      });
+    }
+
+    return buildDecision(risk, this.actionForRisk(risk), evidence);
+  }
+
+  async evaluateBeforeInstall(payload: unknown): Promise<SecurityDecision> {
+    const now = Date.now();
+    this.pruneCounters(now);
+    this.installTimes.push(now);
+
+    const context = extractContext(payload);
+    const evidence: SecurityEvidence[] = [];
+    let risk: SecurityRiskLevel = "low";
+
+    if (context.target.includes("..")) {
+      risk = "critical";
+      evidence.push({
+        code: "install_path_traversal",
+        message: `Path traversal-like install target: ${context.target}`,
+      });
+    }
+
+    const localScanText = context.target ? readScanTextFromTarget(context.target) : "";
+    const scanText = `${context.text}\n${localScanText}`;
+
+    risk = higherRisk(
+      risk,
+      scanPatterns(
+        scanText,
+        {
+          critical: this.policy.installRules.criticalPatterns,
+          high: this.policy.installRules.highPatterns,
+          medium: this.policy.installRules.mediumPatterns,
+        },
+        "install",
+        evidence,
+      ),
+    );
+
+    if (this.installTimes.length > this.config.quota.maxInstallsPerHour) {
+      risk = higherRisk(risk, "high");
+      evidence.push({
+        code: "quota_installs",
+        message: `Install quota exceeded (${String(this.installTimes.length)}/${String(this.config.quota.maxInstallsPerHour)} per hour)`,
+      });
+    }
+
+    if (this.policy.installRules.scannerCommand.trim()) {
+      try {
+        const args = [...this.policy.installRules.scannerArgs];
+        if (context.target) args.push(context.target);
+        const result = await execa(this.policy.installRules.scannerCommand, args, {
+          reject: false,
+          timeout: this.config.scanTimeoutMs,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+
+        if (output.includes("critical")) {
+          risk = higherRisk(risk, "critical");
+          evidence.push({
+            code: "scanner_critical",
+            message: "External scanner reported critical risk",
+          });
+        } else if (output.includes("high") || result.exitCode !== 0) {
+          risk = higherRisk(risk, "high");
+          evidence.push({
+            code: "scanner_high",
+            message: "External scanner reported high risk or non-zero exit",
+            metadata: { exitCode: result.exitCode },
+          });
+        } else if (output.includes("medium")) {
+          risk = higherRisk(risk, "medium");
+          evidence.push({
+            code: "scanner_medium",
+            message: "External scanner reported medium risk",
+          });
+        } else {
+          evidence.push({
+            code: "scanner_clean",
+            message: "External scanner did not report elevated risk",
+          });
+        }
+      } catch {
+        risk = higherRisk(risk, "high");
+        evidence.push({
+          code: "scanner_timeout",
+          message: `External scanner failed or timed out (> ${String(this.config.scanTimeoutMs)} ms)`,
+        });
+      }
+    }
+
+    if (evidence.length === 0) {
+      evidence.push({
+        code: "install_baseline_allow",
+        message: "Install request did not trigger risk patterns",
+      });
+    }
+
+    return buildDecision(risk, this.actionForRisk(risk), evidence);
+  }
+}

--- a/nemoclaw/src/security/engine.ts
+++ b/nemoclaw/src/security/engine.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { execa } from "execa";
@@ -278,6 +278,120 @@ function walkFiles(basePath: string, maxFiles: number): string[] {
   return files;
 }
 
+function safeRealPath(target: string): string {
+  try {
+    return realpathSync(target);
+  } catch {
+    return target;
+  }
+}
+
+function inspectLocalInstallTarget(
+  target: string,
+  evidence: SecurityEvidence[],
+): SecurityRiskLevel {
+  if (!target || !existsSync(target)) return "low";
+
+  const rootRealPath = safeRealPath(target);
+  const queue: string[] = [target];
+  let level: SecurityRiskLevel = "low";
+  let inspectedEntries = 0;
+
+  while (queue.length > 0 && inspectedEntries < 200) {
+    const current = queue.shift();
+    if (!current) break;
+
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch {
+      continue;
+    }
+    inspectedEntries += 1;
+
+    if (stat.isSymbolicLink()) {
+      const currentRealPath = safeRealPath(current);
+      if (!currentRealPath.startsWith(rootRealPath)) {
+        level = higherRisk(level, "critical");
+        evidence.push({
+          code: "install_symlink_escape",
+          message: `Install target contains symlink escaping root: ${current}`,
+          metadata: { resolvedPath: currentRealPath },
+        });
+      } else {
+        level = higherRisk(level, "medium");
+        evidence.push({
+          code: "install_symlink_present",
+          message: `Install target contains symlink: ${current}`,
+        });
+      }
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      try {
+        const entries = readdirSync(current).slice(0, 200);
+        for (const entry of entries) {
+          queue.push(join(current, entry));
+        }
+      } catch {
+        // ignored
+      }
+      continue;
+    }
+
+    if (!stat.isFile()) continue;
+
+    if (current.toLowerCase().endsWith("package.json")) {
+      try {
+        const parsed = JSON.parse(readFileSync(current, "utf-8")) as Record<string, unknown>;
+        const scripts =
+          parsed["scripts"] &&
+          typeof parsed["scripts"] === "object" &&
+          !Array.isArray(parsed["scripts"])
+            ? (parsed["scripts"] as Record<string, unknown>)
+            : {};
+        const lifecycleHooks = ["preinstall", "install", "postinstall"];
+        const presentHooks = lifecycleHooks.filter((hook) => {
+          const scriptValue = scripts[hook];
+          return typeof scriptValue === "string" && scriptValue.trim().length > 0;
+        });
+        if (presentHooks.length > 0) {
+          level = higherRisk(level, "high");
+          evidence.push({
+            code: "install_lifecycle_scripts",
+            message: `Lifecycle install scripts detected in ${current}`,
+            metadata: { hooks: presentHooks },
+          });
+        }
+      } catch {
+        // ignored
+      }
+    }
+  }
+
+  return level;
+}
+
+function parseScannerSeverity(output: string): SecurityRiskLevel | null {
+  const normalized = output.toLowerCase();
+  if (/\bcritical\b/.test(normalized)) return "critical";
+  if (/\bhigh\b/.test(normalized)) return "high";
+  if (/\bmedium\b/.test(normalized)) return "medium";
+  if (/\blow\b/.test(normalized)) return "low";
+
+  // Structured output support, e.g. {"severity":"high"} or "severity=critical".
+  const jsonLike = /"severity"\s*:\s*"(critical|high|medium|low)"/.exec(normalized);
+  if (jsonLike) return jsonLike[1] as SecurityRiskLevel;
+  const kvLike = /\bseverity\s*=\s*(critical|high|medium|low)\b/.exec(normalized);
+  if (kvLike) return kvLike[1] as SecurityRiskLevel;
+  return null;
+}
+
+function targetLooksLikeUrl(target: string): boolean {
+  return /^https?:\/\//i.test(target.trim());
+}
+
 function readScanTextFromTarget(target: string): string {
   if (!target || !existsSync(target)) return "";
   const files = walkFiles(target, 30);
@@ -430,6 +544,14 @@ export class SecurityEngine {
     const evidence: SecurityEvidence[] = [];
     let risk: SecurityRiskLevel = "low";
 
+    if (!context.target.trim()) {
+      risk = higherRisk(risk, "high");
+      evidence.push({
+        code: "install_target_missing",
+        message: "Install request has no explicit target path or source",
+      });
+    }
+
     if (context.target.includes("..")) {
       risk = "critical";
       evidence.push({
@@ -437,6 +559,27 @@ export class SecurityEngine {
         message: `Path traversal-like install target: ${context.target}`,
       });
     }
+
+    if (targetLooksLikeUrl(context.target)) {
+      const urlScheme = context.target.slice(0, context.target.indexOf("://"));
+      if (urlScheme.toLowerCase() === "http") {
+        risk = higherRisk(risk, "high");
+        evidence.push({
+          code: "install_insecure_transport",
+          message: `Install target uses insecure transport: ${context.target}`,
+        });
+      } else {
+        risk = higherRisk(risk, "medium");
+        evidence.push({
+          code: "install_remote_source",
+          message: `Install target uses remote source: ${context.target}`,
+        });
+      }
+    }
+
+    risk = higherRisk(risk, findRiskByPath(context.paths, this.policy, evidence));
+    risk = higherRisk(risk, findRiskByHosts(context.hosts, this.policy, evidence));
+    risk = higherRisk(risk, inspectLocalInstallTarget(context.target, evidence));
 
     const localScanText = context.target ? readScanTextFromTarget(context.target) : "";
     const scanText = `${context.text}\n${localScanText}`;
@@ -473,40 +616,57 @@ export class SecurityEngine {
           stdout: "pipe",
           stderr: "pipe",
         });
-        const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+        const output = `${result.stdout}\n${result.stderr}`.slice(0, 20000);
+        const severity = parseScannerSeverity(output);
 
-        if (output.includes("critical")) {
+        if (severity === "critical") {
           risk = higherRisk(risk, "critical");
           evidence.push({
             code: "scanner_critical",
             message: "External scanner reported critical risk",
+            metadata: { exitCode: result.exitCode },
           });
-        } else if (output.includes("high") || result.exitCode !== 0) {
+        } else if (severity === "high") {
           risk = higherRisk(risk, "high");
           evidence.push({
             code: "scanner_high",
-            message: "External scanner reported high risk or non-zero exit",
+            message: "External scanner reported high risk",
             metadata: { exitCode: result.exitCode },
           });
-        } else if (output.includes("medium")) {
+        } else if (severity === "medium") {
           risk = higherRisk(risk, "medium");
           evidence.push({
             code: "scanner_medium",
             message: "External scanner reported medium risk",
+            metadata: { exitCode: result.exitCode },
+          });
+        } else if (result.exitCode !== 0) {
+          risk = higherRisk(risk, "high");
+          evidence.push({
+            code: "scanner_nonzero_exit",
+            message: "External scanner returned non-zero exit without structured severity",
+            metadata: { exitCode: result.exitCode },
           });
         } else {
           evidence.push({
             code: "scanner_clean",
             message: "External scanner did not report elevated risk",
+            metadata: { exitCode: result.exitCode },
           });
         }
-      } catch {
+      } catch (error) {
         risk = higherRisk(risk, "high");
         evidence.push({
-          code: "scanner_timeout",
+          code: "scanner_unavailable",
           message: `External scanner failed or timed out (> ${String(this.config.scanTimeoutMs)} ms)`,
+          metadata: { error: String(error) },
         });
       }
+    } else {
+      evidence.push({
+        code: "scanner_not_configured",
+        message: "External scanner command is not configured; relying on local pattern analysis",
+      });
     }
 
     if (evidence.length === 0) {

--- a/nemoclaw/src/security/engine.ts
+++ b/nemoclaw/src/security/engine.ts
@@ -298,6 +298,17 @@ function analyzeCommandSemantics(command: string, evidence: SecurityEvidence[]):
     });
   }
 
+  const criticalRedirects =
+    cmd.match(/(?:>|>>)\s*(\/(?:etc|root|proc|dev|sys)\/[^\s;|&]*)/gi) ?? [];
+  if (criticalRedirects.length > 0) {
+    level = higherRisk(level, "critical");
+    evidence.push({
+      code: "command_sensitive_redirection",
+      message: "Command redirects output into sensitive system paths",
+      metadata: { targets: criticalRedirects.slice(0, 5) },
+    });
+  }
+
   return level;
 }
 

--- a/nemoclaw/src/security/engine.ts
+++ b/nemoclaw/src/security/engine.ts
@@ -252,6 +252,55 @@ function scanPatterns(
   return level;
 }
 
+function countCommandVerbs(command: string): number {
+  const matches =
+    command.match(
+      /\b(rm|mv|cp|cat|echo|curl|wget|bash|sh|python|node|npm|git|docker|kubectl|chmod|chown|tar|zip|unzip)\b/gi,
+    ) ?? [];
+  return new Set(matches.map((entry) => entry.toLowerCase())).size;
+}
+
+function analyzeCommandSemantics(command: string, evidence: SecurityEvidence[]): SecurityRiskLevel {
+  const cmd = command.trim();
+  if (!cmd) return "low";
+
+  let level: SecurityRiskLevel = "low";
+
+  if (/(^|\s)(sudo|su)\s+/i.test(cmd)) {
+    level = higherRisk(level, "high");
+    evidence.push({
+      code: "command_privilege_escalation",
+      message: "Command requests privilege escalation",
+    });
+  }
+
+  if (/`[^`]+`|\$\([^)]*\)/.test(cmd)) {
+    level = higherRisk(level, "high");
+    evidence.push({
+      code: "command_dynamic_substitution",
+      message: "Command uses dynamic shell substitution",
+    });
+  }
+
+  if (/(;|&&|\|\|)/.test(cmd) && countCommandVerbs(cmd) >= 2) {
+    level = higherRisk(level, "medium");
+    evidence.push({
+      code: "command_chaining",
+      message: "Command contains chained operations",
+    });
+  }
+
+  if (/\b(base64|openssl)\b[\s\S]{0,80}\b(-d|decode)\b[\s\S]{0,80}\|\s*(bash|sh)\b/i.test(cmd)) {
+    level = higherRisk(level, "high");
+    evidence.push({
+      code: "command_decoded_payload_execution",
+      message: "Command decodes and executes payload in shell",
+    });
+  }
+
+  return level;
+}
+
 function walkFiles(basePath: string, maxFiles: number): string[] {
   const queue: string[] = [basePath];
   const files: string[] = [];
@@ -462,6 +511,7 @@ export class SecurityEngine {
       ),
     );
 
+    risk = higherRisk(risk, analyzeCommandSemantics(context.command || context.text, evidence));
     risk = higherRisk(risk, findRiskByPath(context.paths, this.policy, evidence));
     risk = higherRisk(risk, findRiskByHosts(context.hosts, this.policy, evidence));
 

--- a/nemoclaw/src/security/hooks.ts
+++ b/nemoclaw/src/security/hooks.ts
@@ -89,10 +89,12 @@ function postJson(urlValue: string, payload: unknown, timeoutMs: number): Promis
 
 function normalizeDecisionByMode(decision: SecurityDecision, mode: SecurityMode): SecurityDecision {
   if (mode === "off") {
+    const recommendedAction = decision.action === "allow" ? undefined : decision.action;
     return {
       ...decision,
       action: "allow",
-      recommendedAction: decision.action,
+      recommendedAction,
+      rolloutStage: "off",
       riskLevel: "low",
       riskScore: 0,
       reason: "Security mode is off",
@@ -104,33 +106,55 @@ function normalizeDecisionByMode(decision: SecurityDecision, mode: SecurityMode)
       ...decision,
       action: "allow",
       recommendedAction: decision.action,
+      rolloutStage: "audit",
     };
   }
 
-  return decision;
+  if (mode === "warn" && decision.action !== "allow") {
+    return {
+      ...decision,
+      action: "allow",
+      recommendedAction: decision.action,
+      rolloutStage: "warn",
+    };
+  }
+
+  return {
+    ...decision,
+    rolloutStage: mode,
+  };
 }
 
 function ensureEventPath(pathValue: string): void {
   mkdirSync(dirname(pathValue), { recursive: true });
 }
 
-function shouldWriteEvent(action: SecurityAction, includeAllowEvents: boolean): boolean {
-  return includeAllowEvents || action !== "allow";
+function shouldWriteEvent(
+  decision: SecurityDecision,
+  mode: SecurityMode,
+  includeAllowEvents: boolean,
+): boolean {
+  if (includeAllowEvents) return true;
+  if (decision.action !== "allow") return true;
+  return mode === "warn" && decision.recommendedAction !== undefined;
 }
 
 function toHookResponse(
   decision: SecurityDecision,
+  mode: SecurityMode,
   approvalTimeoutMs: number,
 ): Record<string, unknown> {
+  const security = {
+    riskLevel: decision.riskLevel,
+    riskScore: decision.riskScore,
+    evidence: decision.evidence,
+  };
+
   if (decision.action === "block") {
     return {
       block: true,
       reason: decision.reason,
-      security: {
-        riskLevel: decision.riskLevel,
-        riskScore: decision.riskScore,
-        evidence: decision.evidence,
-      },
+      security,
     };
   }
 
@@ -139,22 +163,37 @@ function toHookResponse(
       requireApproval: true,
       timeoutMs: approvalTimeoutMs,
       reason: decision.reason,
-      security: {
-        riskLevel: decision.riskLevel,
-        riskScore: decision.riskScore,
-        evidence: decision.evidence,
-      },
+      security,
     };
   }
 
-  return {
+  const response: Record<string, unknown> = {
     allow: true,
-    security: {
-      riskLevel: decision.riskLevel,
-      riskScore: decision.riskScore,
-      evidence: decision.evidence,
-    },
+    security,
   };
+
+  if (
+    mode === "warn" &&
+    decision.recommendedAction !== undefined &&
+    decision.recommendedAction !== "allow"
+  ) {
+    response["warning"] = {
+      message: `Allowed by warn mode; recommended action is ${decision.recommendedAction}`,
+      recommendedAction: decision.recommendedAction,
+      rolloutStage: "warn",
+      reason: decision.reason,
+      security,
+    };
+  }
+
+  return response;
+}
+
+function deriveEventRolloutStage(decision: SecurityDecision, mode: SecurityMode): SecurityMode {
+  if (decision.rolloutStage !== undefined) {
+    return decision.rolloutStage;
+  }
+  return mode;
 }
 
 function createEvent(
@@ -165,6 +204,10 @@ function createEvent(
   target: string,
   details: Record<string, unknown>,
 ): SecurityEventV1 {
+  const recommendedAction = decision.recommendedAction;
+  const action = recommendedAction ?? decision.action;
+  const rolloutStage = deriveEventRolloutStage(decision, mode);
+
   return {
     eventVersion: "security-event.v1",
     id: randomUUID(),
@@ -172,14 +215,23 @@ function createEvent(
     hook,
     mode,
     sandboxName,
-    action: decision.recommendedAction ?? decision.action,
+    action,
     effectiveAction: decision.action,
+    recommendedAction,
+    rolloutStage,
     riskLevel: decision.riskLevel,
     riskScore: decision.riskScore,
     reason: decision.reason,
     evidence: decision.evidence,
     target,
-    details,
+    details: {
+      ...details,
+      stagedDecision: {
+        recommendedAction: action,
+        effectiveAction: decision.action,
+        rolloutStage,
+      },
+    },
   };
 }
 
@@ -230,13 +282,13 @@ export function registerSecurityHooks(api: OpenClawPluginApi, config: NemoClawCo
       },
     );
 
-    if (shouldWriteEvent(effectiveDecision.action, policy.audit.includeAllowEvents)) {
+    if (shouldWriteEvent(effectiveDecision, mode, policy.audit.includeAllowEvents)) {
       appendFileSync(eventsPath, `${JSON.stringify(event)}\n`, { encoding: "utf-8" });
     }
 
     await maybeSendAlert(api, config.security.alertWebhook, policy.audit.webhookOn, event);
 
-    return toHookResponse(effectiveDecision, config.security.approvalTimeoutMs);
+    return toHookResponse(effectiveDecision, mode, config.security.approvalTimeoutMs);
   };
 
   api.on("before_tool_call", async (...args: unknown[]) =>

--- a/nemoclaw/src/security/hooks.ts
+++ b/nemoclaw/src/security/hooks.ts
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomUUID } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import http from "node:http";
+import https from "node:https";
+
+import type { NemoClawConfig, OpenClawPluginApi } from "../index.js";
+
+import { SecurityEngine } from "./engine.js";
+import { loadSecurityPolicy } from "./policy.js";
+import type {
+  SecurityAction,
+  SecurityDecision,
+  SecurityEventV1,
+  SecurityMode,
+  SecurityRiskLevel,
+} from "./types.js";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function extractTarget(payload: unknown): string {
+  const raw = asRecord(payload);
+  const targetCandidates = [
+    raw["toolName"],
+    raw["name"],
+    raw["target"],
+    raw["source"],
+    raw["path"],
+    raw["command"],
+    raw["cmd"],
+  ];
+  for (const candidate of targetCandidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim().slice(0, 500);
+    }
+  }
+  return "unknown";
+}
+
+function postJson(urlValue: string, payload: unknown, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let target: URL;
+    try {
+      target = new URL(urlValue);
+    } catch {
+      reject(new Error("Invalid webhook URL"));
+      return;
+    }
+
+    const body = Buffer.from(JSON.stringify(payload));
+    const module = target.protocol === "https:" ? https : http;
+    const req = module.request(
+      {
+        hostname: target.hostname,
+        port: target.port || (target.protocol === "https:" ? 443 : 80),
+        path: `${target.pathname}${target.search}`,
+        method: "POST",
+        timeout: timeoutMs,
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(body.length),
+        },
+      },
+      (res) => {
+        res.resume();
+        if ((res.statusCode ?? 500) >= 200 && (res.statusCode ?? 500) < 300) {
+          resolve();
+          return;
+        }
+        reject(new Error(`Webhook HTTP ${String(res.statusCode ?? 500)}`));
+      },
+    );
+
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy(new Error("Webhook timeout"));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+function normalizeDecisionByMode(decision: SecurityDecision, mode: SecurityMode): SecurityDecision {
+  if (mode === "off") {
+    return {
+      ...decision,
+      action: "allow",
+      recommendedAction: decision.action,
+      riskLevel: "low",
+      riskScore: 0,
+      reason: "Security mode is off",
+    };
+  }
+
+  if (mode === "audit" && decision.action !== "allow") {
+    return {
+      ...decision,
+      action: "allow",
+      recommendedAction: decision.action,
+    };
+  }
+
+  return decision;
+}
+
+function ensureEventPath(pathValue: string): void {
+  mkdirSync(dirname(pathValue), { recursive: true });
+}
+
+function shouldWriteEvent(action: SecurityAction, includeAllowEvents: boolean): boolean {
+  return includeAllowEvents || action !== "allow";
+}
+
+function toHookResponse(
+  decision: SecurityDecision,
+  approvalTimeoutMs: number,
+): Record<string, unknown> {
+  if (decision.action === "block") {
+    return {
+      block: true,
+      reason: decision.reason,
+      security: {
+        riskLevel: decision.riskLevel,
+        riskScore: decision.riskScore,
+        evidence: decision.evidence,
+      },
+    };
+  }
+
+  if (decision.action === "require_approval") {
+    return {
+      requireApproval: true,
+      timeoutMs: approvalTimeoutMs,
+      reason: decision.reason,
+      security: {
+        riskLevel: decision.riskLevel,
+        riskScore: decision.riskScore,
+        evidence: decision.evidence,
+      },
+    };
+  }
+
+  return {
+    allow: true,
+    security: {
+      riskLevel: decision.riskLevel,
+      riskScore: decision.riskScore,
+      evidence: decision.evidence,
+    },
+  };
+}
+
+function createEvent(
+  hook: SecurityEventV1["hook"],
+  mode: SecurityMode,
+  sandboxName: string,
+  decision: SecurityDecision,
+  target: string,
+  details: Record<string, unknown>,
+): SecurityEventV1 {
+  return {
+    eventVersion: "security-event.v1",
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    hook,
+    mode,
+    sandboxName,
+    action: decision.recommendedAction ?? decision.action,
+    effectiveAction: decision.action,
+    riskLevel: decision.riskLevel,
+    riskScore: decision.riskScore,
+    reason: decision.reason,
+    evidence: decision.evidence,
+    target,
+    details,
+  };
+}
+
+async function maybeSendAlert(
+  api: OpenClawPluginApi,
+  webhook: string,
+  actions: SecurityAction[],
+  event: SecurityEventV1,
+): Promise<void> {
+  if (!webhook.trim()) return;
+  if (!actions.includes(event.action) && !actions.includes(event.effectiveAction)) return;
+  try {
+    await postJson(webhook, event, 5000);
+  } catch (error) {
+    api.logger.warn(`[security] alert delivery failed: ${String(error)}`);
+  }
+}
+
+export function registerSecurityHooks(api: OpenClawPluginApi, config: NemoClawConfig): void {
+  const loaded = loadSecurityPolicy(config.security.policyPath, api.resolvePath);
+  const policy = loaded.policy;
+  const engine = new SecurityEngine(policy, config.security);
+  const mode = config.security.mode;
+  const eventsPath = process.env.CLAWKEEPER_SECURITY_EVENTS_PATH || policy.audit.eventLogPath;
+
+  ensureEventPath(eventsPath);
+
+  api.logger.info(
+    `[security] mode=${mode} policy=${loaded.resolvedPath} source=${loaded.source} events=${eventsPath}`,
+  );
+
+  const runHook = async (
+    hook: SecurityEventV1["hook"],
+    payload: unknown,
+    evaluate: (input: unknown) => SecurityDecision | Promise<SecurityDecision>,
+  ): Promise<Record<string, unknown>> => {
+    const rawDecision = await evaluate(payload);
+    const effectiveDecision = normalizeDecisionByMode(rawDecision, mode);
+
+    const event = createEvent(
+      hook,
+      mode,
+      config.sandboxName,
+      effectiveDecision,
+      extractTarget(payload),
+      {
+        pluginId: api.id,
+      },
+    );
+
+    if (shouldWriteEvent(effectiveDecision.action, policy.audit.includeAllowEvents)) {
+      appendFileSync(eventsPath, `${JSON.stringify(event)}\n`, { encoding: "utf-8" });
+    }
+
+    await maybeSendAlert(api, config.security.alertWebhook, policy.audit.webhookOn, event);
+
+    return toHookResponse(effectiveDecision, config.security.approvalTimeoutMs);
+  };
+
+  api.on("before_tool_call", async (...args: unknown[]) =>
+    runHook("before_tool_call", args[0], (input) => engine.evaluateBeforeToolCall(input)),
+  );
+
+  api.on("after_tool_call", async (...args: unknown[]) =>
+    runHook("after_tool_call", args[0], (input) => engine.evaluateAfterToolCall(input)),
+  );
+
+  api.on("before_install", async (...args: unknown[]) =>
+    runHook("before_install", args[0], (input) => engine.evaluateBeforeInstall(input)),
+  );
+}
+
+export function worstRiskLevel(lhs: SecurityRiskLevel, rhs: SecurityRiskLevel): SecurityRiskLevel {
+  const order: SecurityRiskLevel[] = ["low", "medium", "high", "critical"];
+  return order.indexOf(lhs) >= order.indexOf(rhs) ? lhs : rhs;
+}

--- a/nemoclaw/src/security/policy.ts
+++ b/nemoclaw/src/security/policy.ts
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import YAML from "yaml";
+
+import type {
+  SecurityAction,
+  SecurityAuditRules,
+  SecurityInstallRules,
+  SecurityNetworkRules,
+  SecurityPathRules,
+  SecurityPatternRules,
+  SecurityPolicy,
+  SecurityPromptRules,
+  SecurityRiskLevel,
+} from "./types.js";
+
+const ALLOWED_ACTIONS: SecurityAction[] = ["allow", "block", "require_approval"];
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function readStringArray(value: unknown, fallback: string[] = []): string[] {
+  if (!Array.isArray(value)) return [...fallback];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function expandHomePath(value: string): string {
+  if (value === "~") return homedir();
+  if (value.startsWith("~/")) return join(homedir(), value.slice(2));
+  return value;
+}
+
+function readPatternRules(value: unknown, fallback: SecurityPatternRules): SecurityPatternRules {
+  const raw = asRecord(value);
+  return {
+    criticalPatterns: readStringArray(
+      raw["criticalPatterns"] ?? raw["critical_patterns"],
+      fallback.criticalPatterns,
+    ),
+    highPatterns: readStringArray(
+      raw["highPatterns"] ?? raw["high_patterns"],
+      fallback.highPatterns,
+    ),
+    mediumPatterns: readStringArray(
+      raw["mediumPatterns"] ?? raw["medium_patterns"],
+      fallback.mediumPatterns,
+    ),
+  };
+}
+
+function readPathRules(value: unknown, fallback: SecurityPathRules): SecurityPathRules {
+  const raw = asRecord(value);
+  return {
+    criticalPrefixes: readStringArray(
+      raw["criticalPrefixes"] ?? raw["critical_prefixes"],
+      fallback.criticalPrefixes,
+    ),
+    highPrefixes: readStringArray(
+      raw["highPrefixes"] ?? raw["high_prefixes"],
+      fallback.highPrefixes,
+    ),
+    allowPrefixes: readStringArray(
+      raw["allowPrefixes"] ?? raw["allow_prefixes"],
+      fallback.allowPrefixes,
+    ),
+  };
+}
+
+function readNetworkRules(value: unknown, fallback: SecurityNetworkRules): SecurityNetworkRules {
+  const raw = asRecord(value);
+  return {
+    criticalHosts: readStringArray(
+      raw["criticalHosts"] ?? raw["critical_hosts"],
+      fallback.criticalHosts,
+    ),
+    highHosts: readStringArray(raw["highHosts"] ?? raw["high_hosts"], fallback.highHosts),
+    allowHosts: readStringArray(raw["allowHosts"] ?? raw["allow_hosts"], fallback.allowHosts),
+  };
+}
+
+function readInstallRules(value: unknown, fallback: SecurityInstallRules): SecurityInstallRules {
+  const base = readPatternRules(value, fallback);
+  const raw = asRecord(value);
+  return {
+    ...base,
+    scannerCommand: readString(
+      raw["scannerCommand"] ?? raw["scanner_command"],
+      fallback.scannerCommand,
+    ),
+    scannerArgs: readStringArray(raw["scannerArgs"] ?? raw["scanner_args"], fallback.scannerArgs),
+  };
+}
+
+function readPromptRules(value: unknown, fallback: SecurityPromptRules): SecurityPromptRules {
+  const raw = asRecord(value);
+  return {
+    injectionPatterns: readStringArray(
+      raw["injectionPatterns"] ?? raw["injection_patterns"],
+      fallback.injectionPatterns,
+    ),
+  };
+}
+
+function readAuditRules(value: unknown, fallback: SecurityAuditRules): SecurityAuditRules {
+  const raw = asRecord(value);
+  return {
+    eventLogPath: expandHomePath(
+      readString(raw["eventLogPath"] ?? raw["event_log_path"], fallback.eventLogPath),
+    ),
+    includeAllowEvents: readBoolean(
+      raw["includeAllowEvents"] ?? raw["include_allow_events"],
+      fallback.includeAllowEvents,
+    ),
+    webhookOn: readStringArray(raw["webhookOn"] ?? raw["webhook_on"], fallback.webhookOn).filter(
+      (item): item is SecurityAction => ALLOWED_ACTIONS.includes(item as SecurityAction),
+    ),
+  };
+}
+
+function readDecisionMatrix(
+  value: unknown,
+  fallback: Record<SecurityRiskLevel, SecurityAction>,
+): Record<SecurityRiskLevel, SecurityAction> {
+  const raw = asRecord(value);
+  const pick = (level: SecurityRiskLevel): SecurityAction => {
+    const candidate = raw[level];
+    if (typeof candidate === "string" && ALLOWED_ACTIONS.includes(candidate as SecurityAction)) {
+      return candidate as SecurityAction;
+    }
+    return fallback[level];
+  };
+  return {
+    critical: pick("critical"),
+    high: pick("high"),
+    medium: pick("medium"),
+    low: pick("low"),
+  };
+}
+
+export const DEFAULT_SECURITY_POLICY: SecurityPolicy = {
+  version: 1,
+  decisionMatrix: {
+    critical: "block",
+    high: "require_approval",
+    medium: "allow",
+    low: "allow",
+  },
+  commandRules: {
+    criticalPatterns: [
+      "(^|\\s)rm\\s+-rf\\s+/(\\s|$)",
+      "(^|\\s)mkfs(\\.|\\s)",
+      "(^|\\s)dd\\s+if=",
+      "(^|\\s)(shutdown|reboot|poweroff)(\\s|$)",
+      "(:\\(\\)\\s*\\{\\s*:\\|:\\s*&\\s*\\};:)",
+    ],
+    highPatterns: [
+      "https?://[^\\s]+\\s*\\|\\s*(bash|sh)",
+      "(^|\\s)(chmod\\s+777|chown\\s+-R\\s+root)(\\s|$)",
+      "(^|\\s)(iptables|ufw|firewall-cmd)(\\s|$)",
+    ],
+    mediumPatterns: ["(^|\\s)curl(\\s|$)", "(^|\\s)wget(\\s|$)", "(^|\\s)scp(\\s|$)"],
+  },
+  pathRules: {
+    criticalPrefixes: ["/etc", "/root", "/var/lib/docker", "/sandbox/.openclaw"],
+    highPrefixes: ["/home", "/var/log", "/proc", "/dev"],
+    allowPrefixes: ["/sandbox", "/tmp"],
+  },
+  networkRules: {
+    criticalHosts: ["169.254.169.254", "metadata.google.internal", "localhost", "127.0.0.1"],
+    highHosts: ["ngrok.io", "trycloudflare.com", "transfer.sh"],
+    allowHosts: ["integrate.api.nvidia.com", "inference-api.nvidia.com"],
+  },
+  installRules: {
+    criticalPatterns: [
+      "ignore\\s+all\\s+previous\\s+instructions",
+      "process\\.env\\.[A-Z0-9_]{3,}",
+      "child_process",
+      "https?://[^\\s]+\\s*\\|\\s*(bash|sh)",
+    ],
+    highPatterns: ["prompt\\s*injection", "data\\s*exfil", "base64\\s+-d"],
+    mediumPatterns: ["eval\\(", "Function\\(", "new\\s+WebSocket\\("],
+    scannerCommand: "",
+    scannerArgs: [],
+  },
+  promptRules: {
+    injectionPatterns: [
+      "ignore\\s+system\\s+instructions",
+      "disable\\s+guardrails",
+      "developer\\s+mode",
+      "jailbreak",
+    ],
+  },
+  audit: {
+    eventLogPath: join(homedir(), ".nemoclaw", "security", "events.jsonl"),
+    includeAllowEvents: false,
+    webhookOn: ["block", "require_approval"],
+  },
+};
+
+export function normalizeSecurityPolicy(rawPolicy: unknown): SecurityPolicy {
+  const raw = asRecord(rawPolicy);
+  return {
+    version: readNumber(raw["version"], DEFAULT_SECURITY_POLICY.version),
+    decisionMatrix: readDecisionMatrix(
+      raw["decisionMatrix"] ?? raw["decision_matrix"],
+      DEFAULT_SECURITY_POLICY.decisionMatrix,
+    ),
+    commandRules: readPatternRules(
+      raw["commandRules"] ?? raw["command_rules"],
+      DEFAULT_SECURITY_POLICY.commandRules,
+    ),
+    pathRules: readPathRules(
+      raw["pathRules"] ?? raw["path_rules"],
+      DEFAULT_SECURITY_POLICY.pathRules,
+    ),
+    networkRules: readNetworkRules(
+      raw["networkRules"] ?? raw["network_rules"],
+      DEFAULT_SECURITY_POLICY.networkRules,
+    ),
+    installRules: readInstallRules(
+      raw["installRules"] ?? raw["install_rules"],
+      DEFAULT_SECURITY_POLICY.installRules,
+    ),
+    promptRules: readPromptRules(
+      raw["promptRules"] ?? raw["prompt_rules"],
+      DEFAULT_SECURITY_POLICY.promptRules,
+    ),
+    audit: readAuditRules(raw["audit"], DEFAULT_SECURITY_POLICY.audit),
+  };
+}
+
+export function loadSecurityPolicy(
+  policyPath: string,
+  resolvePath: (input: string) => string,
+): { policy: SecurityPolicy; resolvedPath: string; source: "default" | "file" } {
+  const requested = policyPath.trim().length > 0 ? policyPath : "security-policy.yaml";
+  const resolvedPath = resolvePath(requested);
+
+  if (!existsSync(resolvedPath)) {
+    return { policy: DEFAULT_SECURITY_POLICY, resolvedPath, source: "default" };
+  }
+
+  try {
+    const content = readFileSync(resolvedPath, "utf-8");
+    const parsed: unknown = YAML.parse(content);
+    return {
+      policy: normalizeSecurityPolicy(parsed),
+      resolvedPath,
+      source: "file",
+    };
+  } catch {
+    return {
+      policy: DEFAULT_SECURITY_POLICY,
+      resolvedPath,
+      source: "default",
+    };
+  }
+}

--- a/nemoclaw/src/security/types.ts
+++ b/nemoclaw/src/security/types.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type SecurityMode = "off" | "audit" | "enforce";
+export type SecurityMode = "off" | "audit" | "warn" | "enforce";
 
 export type SecurityAction = "allow" | "block" | "require_approval";
 
@@ -79,6 +79,7 @@ export interface SecurityDecision {
   reason: string;
   evidence: SecurityEvidence[];
   recommendedAction?: SecurityAction;
+  rolloutStage?: SecurityMode;
 }
 
 export interface SecurityEventV1 {
@@ -90,6 +91,8 @@ export interface SecurityEventV1 {
   sandboxName: string;
   action: SecurityAction;
   effectiveAction: SecurityAction;
+  recommendedAction?: SecurityAction;
+  rolloutStage?: SecurityMode;
   riskLevel: SecurityRiskLevel;
   riskScore: number;
   reason: string;

--- a/nemoclaw/src/security/types.ts
+++ b/nemoclaw/src/security/types.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type SecurityMode = "off" | "audit" | "enforce";
+
+export type SecurityAction = "allow" | "block" | "require_approval";
+
+export type SecurityRiskLevel = "low" | "medium" | "high" | "critical";
+
+export interface SecurityQuotaConfig {
+  maxToolCallsPerMinute: number;
+  maxInstallsPerHour: number;
+  maxEstimatedTokensPerHour: number;
+}
+
+export interface PluginSecurityConfig {
+  mode: SecurityMode;
+  policyPath: string;
+  approvalTimeoutMs: number;
+  scanTimeoutMs: number;
+  alertWebhook: string;
+  quota: SecurityQuotaConfig;
+}
+
+export interface SecurityPatternRules {
+  criticalPatterns: string[];
+  highPatterns: string[];
+  mediumPatterns: string[];
+}
+
+export interface SecurityPathRules {
+  criticalPrefixes: string[];
+  highPrefixes: string[];
+  allowPrefixes: string[];
+}
+
+export interface SecurityNetworkRules {
+  criticalHosts: string[];
+  highHosts: string[];
+  allowHosts: string[];
+}
+
+export interface SecurityInstallRules extends SecurityPatternRules {
+  scannerCommand: string;
+  scannerArgs: string[];
+}
+
+export interface SecurityPromptRules {
+  injectionPatterns: string[];
+}
+
+export interface SecurityAuditRules {
+  eventLogPath: string;
+  includeAllowEvents: boolean;
+  webhookOn: SecurityAction[];
+}
+
+export interface SecurityPolicy {
+  version: number;
+  decisionMatrix: Record<SecurityRiskLevel, SecurityAction>;
+  commandRules: SecurityPatternRules;
+  pathRules: SecurityPathRules;
+  networkRules: SecurityNetworkRules;
+  installRules: SecurityInstallRules;
+  promptRules: SecurityPromptRules;
+  audit: SecurityAuditRules;
+}
+
+export interface SecurityEvidence {
+  code: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SecurityDecision {
+  action: SecurityAction;
+  riskLevel: SecurityRiskLevel;
+  riskScore: number;
+  reason: string;
+  evidence: SecurityEvidence[];
+  recommendedAction?: SecurityAction;
+}
+
+export interface SecurityEventV1 {
+  eventVersion: "security-event.v1";
+  id: string;
+  timestamp: string;
+  hook: "before_tool_call" | "after_tool_call" | "before_install";
+  mode: SecurityMode;
+  sandboxName: string;
+  action: SecurityAction;
+  effectiveAction: SecurityAction;
+  riskLevel: SecurityRiskLevel;
+  riskScore: number;
+  reason: string;
+  evidence: SecurityEvidence[];
+  target: string;
+  details: Record<string, unknown>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "yaml": "^2.8.3"
       },
       "bin": {
+        "clawkeeper": "bin/nemoclaw.js",
         "nemoclaw": "bin/nemoclaw.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "nemoclaw",
   "version": "0.1.0",
-  "description": "NemoClaw — run OpenClaw inside OpenShell with NVIDIA inference",
+  "description": "ClawKeeper — run OpenClaw inside OpenShell with NVIDIA inference",
   "license": "Apache-2.0",
   "bin": {
+    "clawkeeper": "./bin/nemoclaw.js",
     "nemoclaw": "./bin/nemoclaw.js"
   },
   "scripts": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,9 +4,47 @@
 #
 # NEMOCLAW_VERSIONED_INSTALLER_PAYLOAD=1
 #
-# NemoClaw installer — installs Node.js, Ollama (if GPU present), and NemoClaw.
+# ClawKeeper installer — installs Node.js, Ollama (if GPU present), and ClawKeeper.
 
 set -euo pipefail
+
+PREFERRED_CLI_CMD="clawkeeper"
+LEGACY_CLI_CMD="nemoclaw"
+
+compat_env_export() {
+  local legacy="$1" branded="$2"
+  if [[ -z "${!legacy+x}" && -n "${!branded+x}" ]]; then
+    export "$legacy=${!branded}"
+  fi
+}
+
+# Brand-compat environment bridge: legacy NEMOCLAW_* keeps precedence.
+compat_env_export "NEMOCLAW_INSTALL_TAG" "CLAWKEEPER_INSTALL_TAG"
+compat_env_export "NEMOCLAW_INSTALL_REF" "CLAWKEEPER_INSTALL_REF"
+compat_env_export "NEMOCLAW_NON_INTERACTIVE" "CLAWKEEPER_NON_INTERACTIVE"
+compat_env_export \
+  "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE" \
+  "CLAWKEEPER_ACCEPT_THIRD_PARTY_SOFTWARE"
+compat_env_export "NEMOCLAW_SANDBOX_NAME" "CLAWKEEPER_SANDBOX_NAME"
+compat_env_export "NEMOCLAW_RECREATE_SANDBOX" "CLAWKEEPER_RECREATE_SANDBOX"
+compat_env_export "NEMOCLAW_PROVIDER" "CLAWKEEPER_PROVIDER"
+compat_env_export "NEMOCLAW_MODEL" "CLAWKEEPER_MODEL"
+compat_env_export "NEMOCLAW_POLICY_MODE" "CLAWKEEPER_POLICY_MODE"
+compat_env_export "NEMOCLAW_POLICY_PRESETS" "CLAWKEEPER_POLICY_PRESETS"
+compat_env_export "NEMOCLAW_EXPERIMENTAL" "CLAWKEEPER_EXPERIMENTAL"
+compat_env_export "NEMOCLAW_REPO_ROOT" "CLAWKEEPER_REPO_ROOT"
+
+choose_cli_command() {
+  if command -v "$PREFERRED_CLI_CMD" >/dev/null 2>&1; then
+    printf "%s" "$PREFERRED_CLI_CMD"
+    return
+  fi
+  if command -v "$LEGACY_CLI_CMD" >/dev/null 2>&1; then
+    printf "%s" "$LEGACY_CLI_CMD"
+    return
+  fi
+  printf "%s" "$PREFERRED_CLI_CMD"
+}
 
 # Global cleanup state — ensures background processes are killed and temp files
 # are removed on any exit path (set -e, unhandled signal, unexpected error).
@@ -206,7 +244,7 @@ print_done() {
 
   info "=== Installation complete ==="
   printf "\n"
-  printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$elapsed"
+  printf "  ${C_GREEN}${C_BOLD}ClawKeeper${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$elapsed"
   printf "\n"
   if [[ "$ONBOARD_RAN" == true ]]; then
     local sandbox_name
@@ -218,20 +256,20 @@ print_done() {
     if [[ "$_needs_reload" == true ]]; then
       printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$(detect_shell_profile)"
     fi
-    printf "  %s$%s nemoclaw %s connect\n" "$C_GREEN" "$C_RESET" "$sandbox_name"
+    printf "  %s$%s %s %s connect\n" "$C_GREEN" "$C_RESET" "$PREFERRED_CLI_CMD" "$sandbox_name"
     printf "  %ssandbox@%s$%s openclaw tui\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
   elif [[ "$NEMOCLAW_READY_NOW" == true ]]; then
-    printf "  ${C_GREEN}NemoClaw CLI is installed.${C_RESET}\n"
+    printf "  ${C_GREEN}ClawKeeper CLI is installed.${C_RESET}\n"
     printf "  ${C_DIM}Onboarding has not run yet.${C_RESET}\n"
     printf "\n"
     printf "  ${C_GREEN}Next:${C_RESET}\n"
     if [[ "$_needs_reload" == true ]]; then
       printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$(detect_shell_profile)"
     fi
-    printf "  %s$%s nemoclaw onboard\n" "$C_GREEN" "$C_RESET"
+    printf "  %s$%s %s onboard\n" "$C_GREEN" "$C_RESET" "$PREFERRED_CLI_CMD"
   else
-    printf "  ${C_GREEN}NemoClaw CLI is installed.${C_RESET}\n"
-    printf "  ${C_DIM}Onboarding did not run because this shell cannot resolve 'nemoclaw' yet.${C_RESET}\n"
+    printf "  ${C_GREEN}ClawKeeper CLI is installed.${C_RESET}\n"
+    printf "  ${C_DIM}Onboarding did not run because this shell cannot resolve '%s' yet.${C_RESET}\n" "$PREFERRED_CLI_CMD"
     printf "\n"
     printf "  ${C_GREEN}Next:${C_RESET}\n"
     if [[ -n "$NEMOCLAW_RECOVERY_EXPORT_DIR" ]]; then
@@ -240,11 +278,11 @@ print_done() {
     if [[ -n "$NEMOCLAW_RECOVERY_PROFILE" ]]; then
       printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$NEMOCLAW_RECOVERY_PROFILE"
     fi
-    printf "  %s$%s nemoclaw onboard\n" "$C_GREEN" "$C_RESET"
+    printf "  %s$%s %s onboard\n" "$C_GREEN" "$C_RESET" "$PREFERRED_CLI_CMD"
   fi
   printf "\n"
-  printf "  ${C_BOLD}GitHub${C_RESET}  ${C_DIM}https://github.com/nvidia/nemoclaw${C_RESET}\n"
-  printf "  ${C_BOLD}Docs${C_RESET}    ${C_DIM}https://docs.nvidia.com/nemoclaw/latest/${C_RESET}\n"
+  printf "  ${C_BOLD}GitHub${C_RESET}  ${C_DIM}https://github.com/hollyhongever/ClawKeeper${C_RESET}\n"
+  printf "  ${C_BOLD}Docs${C_RESET}    ${C_DIM}https://docs.openclaw.ai/gateway/sandboxing${C_RESET}\n"
   printf "\n"
 }
 
@@ -252,10 +290,10 @@ usage() {
   local version_suffix
   version_suffix="$(installer_version_for_display)"
   printf "\n"
-  printf "  ${C_BOLD}NemoClaw Installer${C_RESET}${C_DIM}%s${C_RESET}\n\n" "$version_suffix"
+  printf "  ${C_BOLD}ClawKeeper Installer${C_RESET}${C_DIM}%s${C_RESET}\n\n" "$version_suffix"
   printf "  ${C_DIM}Usage:${C_RESET}\n"
-  printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash\n"
-  printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
+  printf "    curl -fsSL https://raw.githubusercontent.com/hollyhongever/ClawKeeper/main/install.sh | bash\n"
+  printf "    curl -fsSL https://raw.githubusercontent.com/hollyhongever/ClawKeeper/main/install.sh | bash -s -- [options]\n\n"
   printf "  ${C_DIM}Options:${C_RESET}\n"
   printf "    --non-interactive    Skip prompts (uses env vars / defaults)\n"
   printf "    --yes-i-accept-third-party-software Accept the third-party software notice in non-interactive mode\n"
@@ -263,17 +301,18 @@ usage() {
   printf "    --help, -h           Show this help message and exit\n\n"
   printf "  ${C_DIM}Environment:${C_RESET}\n"
   printf "    NVIDIA_API_KEY                API key (skips credential prompt)\n"
-  printf "    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
-  printf "    NEMOCLAW_NON_INTERACTIVE=1    Same as --non-interactive\n"
-  printf "    NEMOCLAW_SANDBOX_NAME         Sandbox name to create/use\n"
-  printf "    NEMOCLAW_RECREATE_SANDBOX=1   Recreate an existing sandbox\n"
-  printf "    NEMOCLAW_INSTALL_TAG         Git ref to install (default: latest release)\n"
-  printf "    NEMOCLAW_PROVIDER             cloud | ollama | nim | vllm\n"
-  printf "    NEMOCLAW_MODEL                Inference model to configure\n"
-  printf "    NEMOCLAW_POLICY_MODE          suggested | custom | skip\n"
-  printf "    NEMOCLAW_POLICY_PRESETS       Comma-separated policy presets\n"
+  printf "    CLAWKEEPER_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
+  printf "    CLAWKEEPER_NON_INTERACTIVE=1  Same as --non-interactive\n"
+  printf "    CLAWKEEPER_SANDBOX_NAME       Sandbox name to create/use\n"
+  printf "    CLAWKEEPER_RECREATE_SANDBOX=1 Recreate an existing sandbox\n"
+  printf "    CLAWKEEPER_INSTALL_TAG        Git ref to install (default: latest release)\n"
+  printf "    CLAWKEEPER_PROVIDER           cloud | ollama | nim | vllm\n"
+  printf "    CLAWKEEPER_MODEL              Inference model to configure\n"
+  printf "    CLAWKEEPER_POLICY_MODE        suggested | custom | skip\n"
+  printf "    CLAWKEEPER_POLICY_PRESETS     Comma-separated policy presets\n"
   printf "    BRAVE_API_KEY                 Enable Brave Search with this API key (stored in sandbox OpenClaw config)\n"
-  printf "    NEMOCLAW_EXPERIMENTAL=1       Show experimental/local options\n"
+  printf "    CLAWKEEPER_EXPERIMENTAL=1     Show experimental/local options\n"
+  printf "    (legacy NEMOCLAW_* variables are still supported)\n"
   printf "    CHAT_UI_URL                   Chat UI URL to open after setup\n"
   printf "    DISCORD_BOT_TOKEN             Auto-enable Discord policy support\n"
   printf "    SLACK_BOT_TOKEN               Auto-enable Slack policy support\n"
@@ -305,7 +344,7 @@ show_usage_notice() {
     exec 3<&-
     return "$status"
   else
-    error "Interactive third-party software acceptance requires a TTY. Re-run in a terminal or set NEMOCLAW_NON_INTERACTIVE=1 with --yes-i-accept-third-party-software."
+    error "Interactive third-party software acceptance requires a TTY. Re-run in a terminal or set CLAWKEEPER_NON_INTERACTIVE=1 (or NEMOCLAW_NON_INTERACTIVE=1) with --yes-i-accept-third-party-software."
   fi
 }
 
@@ -371,7 +410,7 @@ command_exists() { command -v "$1" &>/dev/null; }
 
 MIN_NODE_VERSION="22.16.0"
 MIN_NPM_MAJOR=10
-RUNTIME_REQUIREMENT_MSG="NemoClaw requires Node.js >=${MIN_NODE_VERSION} and npm >=${MIN_NPM_MAJOR}."
+RUNTIME_REQUIREMENT_MSG="ClawKeeper requires Node.js >=${MIN_NODE_VERSION} and npm >=${MIN_NPM_MAJOR}."
 NEMOCLAW_SHIM_DIR="${HOME}/.local/bin"
 NEMOCLAW_READY_NOW=false
 NEMOCLAW_RECOVERY_PROFILE=""
@@ -591,7 +630,7 @@ install_nodejs() {
       info "Node.js found: ${current_version}"
       return
     fi
-    warn "Node.js ${current_version}, npm major ${current_npm_major:-unknown} found but NemoClaw requires Node.js >=${MIN_NODE_VERSION} and npm >=${MIN_NPM_MAJOR} — upgrading via nvm…"
+    warn "Node.js ${current_version}, npm major ${current_npm_major:-unknown} found but ClawKeeper requires Node.js >=${MIN_NODE_VERSION} and npm >=${MIN_NPM_MAJOR} — upgrading via nvm…"
   else
     info "Node.js not found — installing via nvm…"
   fi
@@ -850,19 +889,19 @@ install_nemoclaw() {
   repo_root="$(resolve_repo_root)"
   package_json="${repo_root}/package.json"
   if is_source_checkout "$repo_root"; then
-    info "NemoClaw package.json found in the selected source checkout — installing from source…"
+    info "ClawKeeper package.json found in the selected source checkout — installing from source…"
     NEMOCLAW_SOURCE_ROOT="$repo_root"
     spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$NEMOCLAW_SOURCE_ROOT" \
       || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
-    spin "Installing NemoClaw dependencies" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm install --ignore-scripts"
-    spin "Building NemoClaw CLI modules" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm run --if-present build:cli"
-    spin "Building NemoClaw plugin" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\"/nemoclaw && npm install --ignore-scripts && npm run build"
-    spin "Linking NemoClaw CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link"
+    spin "Installing ClawKeeper dependencies" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm install --ignore-scripts"
+    spin "Building ClawKeeper CLI modules" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm run --if-present build:cli"
+    spin "Building ClawKeeper plugin" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\"/nemoclaw && npm install --ignore-scripts && npm run build"
+    spin "Linking ClawKeeper CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link"
   else
     if [[ -f "$package_json" ]]; then
       info "Installer payload is not a persistent source checkout — installing from GitHub…"
     fi
-    info "Installing NemoClaw from GitHub…"
+    info "Installing ClawKeeper from GitHub…"
     # Resolve the latest release tag so we never install raw main.
     local release_ref
     release_ref="$(resolve_release_tag)"
@@ -874,7 +913,7 @@ install_nemoclaw() {
     rm -rf "$nemoclaw_src"
     mkdir -p "$(dirname "$nemoclaw_src")"
     NEMOCLAW_SOURCE_ROOT="$nemoclaw_src"
-    spin "Cloning NemoClaw source" git clone --depth 1 --branch "$release_ref" https://github.com/NVIDIA/NemoClaw.git "$nemoclaw_src"
+    spin "Cloning ClawKeeper source" git clone --depth 1 --branch "$release_ref" https://github.com/hollyhongever/ClawKeeper.git "$nemoclaw_src"
     # Fetch version tags into the shallow clone so `git describe --tags
     # --match "v*"` works at runtime (the shallow clone only has the
     # single ref we asked for).
@@ -885,10 +924,10 @@ install_nemoclaw() {
       | sed 's/^v//' >"$nemoclaw_src/.version" || true
     spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$nemoclaw_src" \
       || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
-    spin "Installing NemoClaw dependencies" bash -c "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
-    spin "Building NemoClaw CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"
-    spin "Building NemoClaw plugin" bash -c "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
-    spin "Linking NemoClaw CLI" bash -c "cd \"$nemoclaw_src\" && npm link"
+    spin "Installing ClawKeeper dependencies" bash -c "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
+    spin "Building ClawKeeper CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"
+    spin "Building ClawKeeper plugin" bash -c "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
+    spin "Linking ClawKeeper CLI" bash -c "cd \"$nemoclaw_src\" && npm link"
   fi
 
   refresh_path
@@ -899,10 +938,13 @@ install_nemoclaw() {
 # 4. Verify
 # ---------------------------------------------------------------------------
 verify_nemoclaw() {
-  if command_exists nemoclaw; then
+  local cli_cmd
+  cli_cmd="$(choose_cli_command)"
+
+  if command_exists "$cli_cmd"; then
     NEMOCLAW_READY_NOW=true
     ensure_nemoclaw_shim || true
-    info "Verified: nemoclaw is available at $(command -v nemoclaw)"
+    info "Verified: ${cli_cmd} is available at $(command -v "$cli_cmd")"
     return 0
   fi
 
@@ -911,9 +953,10 @@ verify_nemoclaw() {
 
   if [[ -n "$npm_bin" && -x "$npm_bin/nemoclaw" ]]; then
     ensure_nemoclaw_shim || true
-    if command_exists nemoclaw; then
+    cli_cmd="$(choose_cli_command)"
+    if command_exists "$cli_cmd"; then
       NEMOCLAW_READY_NOW=true
-      info "Verified: nemoclaw is available at $(command -v nemoclaw)"
+      info "Verified: ${cli_cmd} is available at $(command -v "$cli_cmd")"
       return 0
     fi
 
@@ -923,15 +966,15 @@ verify_nemoclaw() {
     else
       NEMOCLAW_RECOVERY_EXPORT_DIR="$npm_bin"
     fi
-    warn "Found nemoclaw at $npm_bin/nemoclaw but this shell still cannot resolve it."
+    warn "Found the CLI at $npm_bin/nemoclaw but this shell still cannot resolve '$PREFERRED_CLI_CMD' yet."
     warn "Onboarding will be skipped until PATH is updated."
     return 0
   else
-    warn "Could not locate the nemoclaw executable."
-    warn "Try running:  npm install -g git+https://github.com/NVIDIA/NemoClaw.git"
+    warn "Could not locate the ClawKeeper executable."
+    warn "Try running:  npm install -g git+https://github.com/hollyhongever/ClawKeeper.git"
   fi
 
-  error "Installation failed: nemoclaw binary not found."
+  error "Installation failed: ClawKeeper binary not found."
 }
 
 # ---------------------------------------------------------------------------
@@ -939,7 +982,9 @@ verify_nemoclaw() {
 # ---------------------------------------------------------------------------
 run_onboard() {
   show_usage_notice
-  info "Running nemoclaw onboard…"
+  local cli_cmd
+  cli_cmd="$(choose_cli_command)"
+  info "Running ${cli_cmd} onboard…"
   local -a onboard_cmd=(onboard)
   if command_exists node && [[ -f "${HOME}/.nemoclaw/onboard-session.json" ]]; then
     if node -e '
@@ -963,17 +1008,17 @@ run_onboard() {
     if [ "${ACCEPT_THIRD_PARTY_SOFTWARE:-}" = "1" ]; then
       onboard_cmd+=(--yes-i-accept-third-party-software)
     fi
-    nemoclaw "${onboard_cmd[@]}"
+    "$cli_cmd" "${onboard_cmd[@]}"
   elif [ -t 0 ]; then
-    nemoclaw "${onboard_cmd[@]}"
+    "$cli_cmd" "${onboard_cmd[@]}"
   elif exec 3</dev/tty; then
     info "Installer stdin is piped; attaching onboarding to /dev/tty…"
     local status=0
-    nemoclaw "${onboard_cmd[@]}" <&3 || status=$?
+    "$cli_cmd" "${onboard_cmd[@]}" <&3 || status=$?
     exec 3<&-
     return "$status"
   else
-    error "Interactive onboarding requires a TTY. Re-run in a terminal or set NEMOCLAW_NON_INTERACTIVE=1 with --yes-i-accept-third-party-software."
+    error "Interactive onboarding requires a TTY. Re-run in a terminal or set CLAWKEEPER_NON_INTERACTIVE=1 (or NEMOCLAW_NON_INTERACTIVE=1) with --yes-i-accept-third-party-software."
   fi
 }
 
@@ -994,16 +1039,16 @@ post_install_message() {
 
   echo ""
   echo "  ──────────────────────────────────────────────────"
-  warn "Your current shell cannot resolve 'nemoclaw' yet."
+  warn "Your current shell cannot resolve '$PREFERRED_CLI_CMD' yet."
   echo ""
-  echo "  To use nemoclaw now, run:"
+  echo "  To use $PREFERRED_CLI_CMD now, run:"
   echo ""
   echo "    export PATH=\"${NEMOCLAW_RECOVERY_EXPORT_DIR}:\$PATH\""
   echo "    source ${NEMOCLAW_RECOVERY_PROFILE}"
   echo ""
   echo "  Then run:"
   echo ""
-  echo "    nemoclaw onboard"
+  echo "    $PREFERRED_CLI_CMD onboard"
   echo ""
   echo "  Or open a new terminal window after updating your shell profile."
   echo "  ──────────────────────────────────────────────────"
@@ -1024,7 +1069,7 @@ main() {
       --version | -v)
         local version_suffix
         version_suffix="$(installer_version_for_display)"
-        printf "nemoclaw-installer%s\n" "${version_suffix# }"
+        printf "clawkeeper-installer%s\n" "${version_suffix# }"
         exit 0
         ;;
       --help | -h)
@@ -1038,8 +1083,8 @@ main() {
     esac
   done
   # Also honor env var
-  NON_INTERACTIVE="${NON_INTERACTIVE:-${NEMOCLAW_NON_INTERACTIVE:-}}"
-  ACCEPT_THIRD_PARTY_SOFTWARE="${ACCEPT_THIRD_PARTY_SOFTWARE:-${NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE:-}}"
+  NON_INTERACTIVE="${NON_INTERACTIVE:-${NEMOCLAW_NON_INTERACTIVE:-${CLAWKEEPER_NON_INTERACTIVE:-}}}"
+  ACCEPT_THIRD_PARTY_SOFTWARE="${ACCEPT_THIRD_PARTY_SOFTWARE:-${NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE:-${CLAWKEEPER_ACCEPT_THIRD_PARTY_SOFTWARE:-}}}"
   export NEMOCLAW_NON_INTERACTIVE="${NON_INTERACTIVE}"
   export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE="${ACCEPT_THIRD_PARTY_SOFTWARE}"
 
@@ -1050,18 +1095,20 @@ main() {
   install_nodejs
   ensure_supported_runtime
 
-  step 2 "NemoClaw CLI"
+  step 2 "ClawKeeper CLI"
   # install_or_upgrade_ollama
   fix_npm_permissions
   install_nemoclaw
   verify_nemoclaw
 
   step 3 "Onboarding"
-  if command_exists nemoclaw; then
+  local cli_cmd
+  cli_cmd="$(choose_cli_command)"
+  if command_exists "$cli_cmd"; then
     run_onboard
     ONBOARD_RAN=true
   else
-    warn "Skipping onboarding — this shell still cannot resolve 'nemoclaw'."
+    warn "Skipping onboarding — this shell still cannot resolve '$PREFERRED_CLI_CMD'."
   fi
 
   print_done

--- a/src/lib/debug.test.ts
+++ b/src/lib/debug.test.ts
@@ -37,6 +37,16 @@ describe("redact", () => {
     );
   });
 
+  it("redacts URL credentials and token-like query parameters", () => {
+    expect(
+      redact(
+        "visit https://alice:secret@example.com/v1/models?token=abc&sig=def&keep=yes#token=frag",
+      ),
+    ).toBe(
+      "visit https://example.com/v1/models?token=%3CREDACTED%3E&sig=%3CREDACTED%3E&keep=yes",
+    );
+  });
+
   it("handles multiple patterns in one string", () => {
     const input = "API_KEY=secret nvapi-abcdefghijk Bearer tok123";
     const result = redact(input);
@@ -48,5 +58,16 @@ describe("redact", () => {
   it("leaves clean text unchanged", () => {
     const clean = "Hello world, no secrets here";
     expect(redact(clean)).toBe(clean);
+  });
+
+  it("is deterministic for repeated identical input", () => {
+    const input =
+      "Authorization: Bearer abc123def456 API_KEY=secret https://alice:secret@example.com/?token=abc123";
+    const first = redact(input);
+    const second = redact(input);
+    expect(second).toBe(first);
+    expect(first).toBe(
+      "Authorization: Bearer <REDACTED> API_KEY=<REDACTED> https://example.com/?token=%3CREDACTED%3E",
+    );
   });
 });

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -45,19 +45,46 @@ function section(title: string): void {
 // Secret redaction
 // ---------------------------------------------------------------------------
 
-const REDACT_PATTERNS: [RegExp, string][] = [
-  [/(NVIDIA_API_KEY|API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|_KEY)=\S+/gi, "$1=<REDACTED>"],
-  [/nvapi-[A-Za-z0-9_-]{10,}/g, "<REDACTED>"],
-  [/(?:ghp_|github_pat_)[A-Za-z0-9_]{30,}/g, "<REDACTED>"],
-  [/(Bearer )\S+/gi, "$1<REDACTED>"],
+const REDACTION_TOKEN = "<REDACTED>";
+const URL_PATTERN = /https?:\/\/[^\s'"`]+/g;
+const URL_TOKEN_PARAM_RE = /(^|[-_])(?:signature|sig|token|auth|access_token)$/i;
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  [
+    /((?:["'])?(?:[A-Za-z0-9_.-]*?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|credential|private[_-]?key|client[_-]?secret)|[A-Za-z0-9_.-]+_key)(?:["'])?\s*[:=]\s*)(?:"[^"\n]*"|'[^'\n]*'|[^\s,&}"'\]]+)/gi,
+    `$1${REDACTION_TOKEN}`,
+  ],
+  [/\bnvapi-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/\bnvcf-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/\b(?:ghp_|github_pat_)[A-Za-z0-9_]{20,}\b/g, REDACTION_TOKEN],
+  [/\bsk-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/(Bearer\s+)\S+/gi, `$1${REDACTION_TOKEN}`],
 ];
+
+function redactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.username || url.password) {
+      url.username = "";
+      url.password = "";
+    }
+    for (const key of [...url.searchParams.keys()]) {
+      if (URL_TOKEN_PARAM_RE.test(key)) {
+        url.searchParams.set(key, REDACTION_TOKEN);
+      }
+    }
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
 
 export function redact(text: string): string {
   let result = text;
   for (const [pattern, replacement] of REDACT_PATTERNS) {
     result = result.replace(pattern, replacement);
   }
-  return result;
+  return result.replace(URL_PATTERN, (value) => redactUrl(value));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/onboard-session.test.ts
+++ b/src/lib/onboard-session.test.ts
@@ -206,6 +206,18 @@ describe("onboard session", () => {
     expect(loaded.failure.message).toBe(loaded.steps.inference.error);
   });
 
+  it("applies deterministic redaction for mixed secret content", () => {
+    const input =
+      "Authorization: Bearer abc123def456 API_KEY=secret https://alice:secret@example.com/?token=abc123";
+    const first = session.redactSensitiveText(input);
+    const second = session.redactSensitiveText(input);
+
+    expect(second).toBe(first);
+    expect(first).toBe(
+      "Authorization: Bearer <REDACTED> API_KEY=<REDACTED> https://example.com/?token=%3CREDACTED%3E",
+    );
+  });
+
   it("summarizes the session for debug output", () => {
     session.saveSession(session.createSession({ sandboxName: "my-assistant" }));
     session.markStepStarted("preflight");

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -90,6 +90,20 @@ export interface SessionUpdates {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
+const REDACTION_TOKEN = "<REDACTED>";
+const URL_PATTERN = /https?:\/\/[^\s'"`]+/g;
+const URL_TOKEN_PARAM_RE = /(^|[-_])(?:signature|sig|token|auth|access_token)$/i;
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  [
+    /((?:["'])?(?:[A-Za-z0-9_.-]*?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|credential|private[_-]?key|client[_-]?secret)|[A-Za-z0-9_.-]+_key)(?:["'])?\s*[:=]\s*)(?:"[^"\n]*"|'[^'\n]*'|[^\s,&}"'\]]+)/gi,
+    `$1${REDACTION_TOKEN}`,
+  ],
+  [/\bnvapi-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/\bnvcf-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/\b(?:ghp_|github_pat_)[A-Za-z0-9_]{20,}\b/g, REDACTION_TOKEN],
+  [/\bsk-[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKEN],
+  [/(Bearer\s+)\S+/gi, `$1${REDACTION_TOKEN}`],
+];
 
 function ensureSessionDir(): void {
   fs.mkdirSync(SESSION_DIR, { recursive: true, mode: 0o700 });
@@ -119,17 +133,18 @@ export function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function applySecretRedaction(input: string): string {
+  let result = input;
+  for (const [pattern, replacement] of REDACT_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
 export function redactSensitiveText(value: unknown): string | null {
   if (typeof value !== "string") return null;
-  return value
-    .replace(
-      /(NVIDIA_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|COMPATIBLE_API_KEY|COMPATIBLE_ANTHROPIC_API_KEY|BRAVE_API_KEY)=\S+/gi,
-      "$1=<REDACTED>",
-    )
-    .replace(/Bearer\s+\S+/gi, "Bearer <REDACTED>")
-    .replace(/nvapi-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
-    .replace(/ghp_[A-Za-z0-9]{20,}/g, "<REDACTED>")
-    .replace(/sk-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
+  return applySecretRedaction(value)
+    .replace(URL_PATTERN, (candidate) => redactUrl(candidate) ?? candidate)
     .slice(0, 240);
 }
 
@@ -159,14 +174,14 @@ export function redactUrl(value: unknown): string | null {
       url.password = "";
     }
     for (const key of [...url.searchParams.keys()]) {
-      if (/(^|[-_])(?:signature|sig|token|auth|access_token)$/i.test(key)) {
-        url.searchParams.set(key, "<REDACTED>");
+      if (URL_TOKEN_PARAM_RE.test(key)) {
+        url.searchParams.set(key, REDACTION_TOKEN);
       }
     }
     url.hash = "";
     return url.toString();
   } catch {
-    return redactSensitiveText(value);
+    return applySecretRedaction(value);
   }
 }
 

--- a/test/cli-branding.test.js
+++ b/test/cli-branding.test.js
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, it } from "vitest";
+
+function runAs(commandName, args = []) {
+  const repoRoot = path.join(import.meta.dirname, "..");
+  const scriptPath = path.join(repoRoot, "bin", "nemoclaw.js");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-cli-test-"));
+  const aliasPath = path.join(tmpDir, commandName);
+  fs.symlinkSync(scriptPath, aliasPath);
+  try {
+    return spawnSync(process.execPath, [aliasPath, ...args], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: process.env,
+    });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe("CLI branding and compatibility aliases", () => {
+  it("prints clawkeeper version when invoked via the clawkeeper entrypoint", () => {
+    const result = runAs("clawkeeper", ["--version"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout.trim(), /^clawkeeper v\d+\.\d+\.\d+/);
+  });
+
+  it("keeps nemoclaw version output for the legacy entrypoint", () => {
+    const result = runAs("nemoclaw", ["--version"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout.trim(), /^nemoclaw v\d+\.\d+\.\d+/);
+  });
+
+  it("shows clawkeeper as the primary command in help", () => {
+    const result = runAs("clawkeeper", ["help"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Primary command:\s*clawkeeper\s*·\s*Legacy alias:\s*nemoclaw/);
+    assert.match(result.stdout, /clawkeeper onboard/);
+  });
+});
+

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -150,7 +150,7 @@ describe("CLI dispatch", () => {
   it("debug --help exits 0 and shows usage", () => {
     const r = run("debug --help");
     expect(r.code).toBe(0);
-    expect(r.out.includes("Collect NemoClaw diagnostic information")).toBeTruthy();
+    expect(r.out.includes("Collect ClawKeeper diagnostic information")).toBeTruthy();
     expect(r.out.includes("--quick")).toBeTruthy();
     expect(r.out.includes("--output")).toBeTruthy();
   });
@@ -174,7 +174,7 @@ describe("CLI dispatch", () => {
     const r = run("help");
     expect(r.code).toBe(0);
     expect(r.out.includes("Troubleshooting")).toBeTruthy();
-    expect(r.out.includes("nemoclaw debug")).toBeTruthy();
+    expect(r.out.includes("clawkeeper debug")).toBeTruthy();
   });
 
   it("maps --follow to openshell --tail", () => {
@@ -639,8 +639,8 @@ describe("CLI dispatch", () => {
     });
 
     expect(r.code).toBe(1);
-    expect(r.out.includes("too old or incompatible with `nemoclaw logs`")).toBeTruthy();
-    expect(r.out.includes("Upgrade OpenShell by rerunning `nemoclaw onboard`")).toBeTruthy();
+    expect(r.out.includes("too old or incompatible with `clawkeeper logs`")).toBeTruthy();
+    expect(r.out.includes("Upgrade OpenShell by rerunning `clawkeeper onboard`")).toBeTruthy();
   });
 
   it("connect does not pre-start a duplicate port forward", () => {
@@ -1295,7 +1295,7 @@ describe("CLI dispatch", () => {
 
     expect(r.code).toBe(1);
     expect(r.out.includes("Unknown command: beta")).toBeTruthy();
-    expect(r.out.includes("Try: nemoclaw <sandbox-name> connect")).toBeTruthy();
+    expect(r.out.includes("Try: clawkeeper <sandbox-name> connect")).toBeTruthy();
   });
 
   it("preserves SIGINT exit semantics for logs --follow", () => {
@@ -1456,7 +1456,7 @@ describe("CLI dispatch", () => {
     });
 
     expect(r.code).toBe(0);
-    expect(r.out.includes("Recovered NemoClaw gateway runtime")).toBeTruthy();
+    expect(r.out.includes("Recovered ClawKeeper gateway runtime")).toBeTruthy();
     expect(r.out.includes("Sandbox: alpha")).toBeTruthy();
   });
 

--- a/test/credentials.test.js
+++ b/test/credentials.test.js
@@ -64,6 +64,63 @@ describe("credential prompts", () => {
     expect(credentials.getCredential("EMPTY_VALUE")).toBe(null);
   });
 
+  it("auto-migrates plaintext credentials to encrypted envelope when password env is set", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
+    const credsDir = path.join(home, ".nemoclaw");
+    const credsFile = path.join(credsDir, "credentials.json");
+    fs.mkdirSync(credsDir, { recursive: true });
+    fs.writeFileSync(
+      credsFile,
+      JSON.stringify({ OPENAI_API_KEY: "sk-before-migration" }, null, 2),
+      "utf-8",
+    );
+
+    vi.stubEnv("NEMOCLAW_CRED_STORE_KEY", "migration-pass");
+    const credentials = await importCredentialsModule(home);
+
+    expect(credentials.loadCredentials()).toEqual({ OPENAI_API_KEY: "sk-before-migration" });
+    const migrated = JSON.parse(fs.readFileSync(credsFile, "utf-8"));
+    expect(migrated.format).toBe("nemoclaw.credentials.v1");
+    expect(migrated.encryption).toBe("aes-256-gcm");
+    expect(migrated.credentialCount).toBe(1);
+    expect(migrated.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  it("reports encrypted-store access clearly when password is missing", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
+    vi.stubEnv("NEMOCLAW_CRED_STORE_KEY", "encrypt-pass");
+    const withPassword = await importCredentialsModule(home);
+    withPassword.saveCredential("NVIDIA_API_KEY", "nvapi-encrypted-key");
+
+    vi.unstubAllEnvs();
+    const credentials = await importCredentialsModule(home);
+
+    expect(() => credentials.loadCredentials()).toThrow(/Credential store is encrypted/);
+    expect(credentials.getCredential("NVIDIA_API_KEY")).toBe(null);
+  });
+
+  it("sets and rotates the credential-store password while preserving stored keys", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
+    const credentials = await importCredentialsModule(home);
+    credentials.saveCredential("TEST_KEY", "value-1");
+
+    const first = credentials.setCredentialStorePassword("first-password");
+    expect(first.previousMode).toBe("plaintext");
+    expect(first.mode).toBe("encrypted");
+    expect(first.credentialCount).toBe(1);
+
+    const second = credentials.setCredentialStorePassword("second-password", {
+      currentPassword: "first-password",
+    });
+    expect(second.previousMode).toBe("encrypted");
+    expect(second.mode).toBe("encrypted");
+    expect(second.credentialCount).toBe(1);
+
+    vi.stubEnv("NEMOCLAW_CRED_STORE_KEY", "second-password");
+    const reopened = await importCredentialsModule(home);
+    expect(reopened.getCredential("TEST_KEY")).toBe("value-1");
+  });
+
   it("exits cleanly when answers are staged through a pipe", () => {
     const script = `
       set -euo pipefail

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -10,7 +10,7 @@ import { spawnSync } from "node:child_process";
 const INSTALLER = path.join(import.meta.dirname, "..", "install.sh");
 const CURL_PIPE_INSTALLER = path.join(import.meta.dirname, "..", "install.sh");
 const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
-const GITHUB_INSTALL_URL = "git+https://github.com/NVIDIA/NemoClaw.git";
+const GITHUB_INSTALL_URL = "git+https://github.com/hollyhongever/ClawKeeper.git";
 const TEST_SYSTEM_PATH = "/usr/bin:/bin";
 
 function writeExecutable(target, contents) {
@@ -107,7 +107,7 @@ exit 1
 
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status).not.toBe(0);
-    expect(output).toMatch(/v18\.19\.1.*found but NemoClaw requires/);
+    expect(output).toMatch(/v18\.19\.1.*found but ClawKeeper requires/);
     expect(output).toMatch(/upgrading via nvm/);
     expect(output).toMatch(/Failed to download nvm installer/);
   });
@@ -312,7 +312,7 @@ exit 98
 
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status).toBe(0);
-    expect(output).toMatch(/NemoClaw Installer/);
+    expect(output).toMatch(/ClawKeeper Installer/);
     expect(output).not.toMatch(/deprecated compatibility wrapper/);
   });
 
@@ -332,7 +332,7 @@ exit 98
 
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status).toBe(0);
-    expect(output).toMatch(/NemoClaw Installer/);
+    expect(output).toMatch(/ClawKeeper Installer/);
     expect(output).not.toMatch(/deprecated compatibility wrapper/);
   });
 
@@ -344,13 +344,13 @@ exit 98
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
-    expect(output).toMatch(/NemoClaw Installer/);
+    expect(output).toMatch(/ClawKeeper Installer/);
     expect(output).toMatch(/--non-interactive/);
     expect(output).toMatch(/--version/);
-    expect(output).toMatch(/NEMOCLAW_PROVIDER/);
-    expect(output).toMatch(/NEMOCLAW_POLICY_MODE/);
-    expect(output).toMatch(/NEMOCLAW_SANDBOX_NAME/);
-    expect(output).toMatch(/nvidia\.com\/nemoclaw\.sh/);
+    expect(output).toMatch(/CLAWKEEPER_PROVIDER/);
+    expect(output).toMatch(/CLAWKEEPER_POLICY_MODE/);
+    expect(output).toMatch(/CLAWKEEPER_SANDBOX_NAME/);
+    expect(output).toMatch(/raw\.githubusercontent\.com\/hollyhongever\/ClawKeeper\/main\/install\.sh/);
   });
 
   it("--version exits 0 and prints the version number", () => {
@@ -361,7 +361,7 @@ exit 98
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
-    expect(output.trim()).toMatch(/^nemoclaw-installer(?: v\d+\.\d+\.\d+(?:-.+)?)?$/);
+    expect(output.trim()).toMatch(/^clawkeeper-installer(?: v\d+\.\d+\.\d+(?:-.+)?)?$/);
     expect(output).not.toMatch(/0\.1\.0/);
   });
 
@@ -373,7 +373,7 @@ exit 98
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
-    expect(output.trim()).toMatch(/^nemoclaw-installer(?: v\d+\.\d+\.\d+(?:-.+)?)?$/);
+    expect(output.trim()).toMatch(/^clawkeeper-installer(?: v\d+\.\d+\.\d+(?:-.+)?)?$/);
     expect(output).not.toMatch(/0\.1\.0/);
   });
 
@@ -386,7 +386,7 @@ exit 98
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
-    expect(output).toMatch(/NemoClaw Installer/);
+    expect(output).toMatch(/ClawKeeper Installer/);
     expect(output).not.toMatch(/0\.1\.0/);
   });
 
@@ -399,7 +399,7 @@ exit 98
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
-    expect(output.trim()).toBe("nemoclaw-installer");
+    expect(output.trim()).toBe("clawkeeper-installer");
     expect(output).not.toMatch(/0\.1\.0/);
   });
 
@@ -997,7 +997,7 @@ fi`,
     expect(output).not.toContain(
       "Onboarding did not run because this shell cannot resolve 'nemoclaw' yet.",
     );
-    expect(output).toMatch(/\$ nemoclaw my-assistant connect/);
+    expect(output).toMatch(/\$ clawkeeper my-assistant connect/);
   });
 });
 
@@ -1463,17 +1463,17 @@ describe("installer flag parsing", () => {
     expect(result.status).not.toBe(0);
     const output = `${result.stdout}${result.stderr}`;
     expect(output).toMatch(/Unknown option: --bogus/);
-    expect(output).toMatch(/NemoClaw Installer/); // usage was printed
+    expect(output).toMatch(/ClawKeeper Installer/); // usage was printed
   });
 
-  it("--help shows NEMOCLAW_INSTALL_TAG in environment section", () => {
+  it("--help shows CLAWKEEPER_INSTALL_TAG in environment section", () => {
     const result = spawnSync("bash", [INSTALLER, "--help"], {
       cwd: path.join(import.meta.dirname, ".."),
       encoding: "utf-8",
     });
 
     expect(result.status).toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toMatch(/NEMOCLAW_INSTALL_TAG/);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/CLAWKEEPER_INSTALL_TAG/);
   });
 });
 

--- a/test/nemoclaw-cli-recovery.test.js
+++ b/test/nemoclaw-cli-recovery.test.js
@@ -103,7 +103,7 @@ process.exit(0);
     );
 
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /Recovered NemoClaw gateway runtime via (start|select)/);
+    assert.match(result.stdout, /Recovered ClawKeeper gateway runtime via (start|select)/);
     assert.match(result.stdout, /Phase: Ready/);
   });
 });

--- a/test/onboard-env-compat.test.js
+++ b/test/onboard-env-compat.test.js
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+function runProbe(env = {}) {
+  const repoRoot = path.join(import.meta.dirname, "..");
+  const script = `
+    const onboard = require("./bin/lib/onboard");
+    const payload = {
+      sandbox: onboard.getRequestedSandboxNameHint(),
+      provider: onboard.getRequestedProviderHint(true),
+      model: onboard.getRequestedModelHint(true),
+    };
+    process.stdout.write(JSON.stringify(payload));
+  `;
+  const result = spawnSync(process.execPath, ["-e", script], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+describe("onboard env compatibility bridge", () => {
+  it("uses CLAWKEEPER_* values when NEMOCLAW_* is not set", () => {
+    const payload = runProbe({
+      NEMOCLAW_SANDBOX_NAME: undefined,
+      NEMOCLAW_PROVIDER: undefined,
+      NEMOCLAW_MODEL: undefined,
+      CLAWKEEPER_SANDBOX_NAME: "Compat-Assistant",
+      CLAWKEEPER_PROVIDER: "cloud",
+      CLAWKEEPER_MODEL: "nvidia/compat-model",
+    });
+    assert.equal(payload.sandbox, "compat-assistant");
+    assert.equal(payload.provider, "build");
+    assert.equal(payload.model, "nvidia/compat-model");
+  });
+
+  it("keeps NEMOCLAW_* precedence when both prefixes are set", () => {
+    const payload = runProbe({
+      NEMOCLAW_SANDBOX_NAME: "legacy-assistant",
+      NEMOCLAW_PROVIDER: "cloud",
+      NEMOCLAW_MODEL: "nvidia/legacy-model",
+      CLAWKEEPER_SANDBOX_NAME: "new-assistant",
+      CLAWKEEPER_PROVIDER: "ollama",
+      CLAWKEEPER_MODEL: "nvidia/new-model",
+    });
+    assert.equal(payload.sandbox, "legacy-assistant");
+    assert.equal(payload.provider, "build");
+    assert.equal(payload.model, "nvidia/legacy-model");
+  });
+});
+

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -36,6 +36,18 @@ import {
 import { buildWebSearchDockerConfig } from "../dist/lib/web-search";
 
 describe("onboard helpers", () => {
+  it("uses password-first guidance and avoids tokenized Control UI URL instructions", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "bin", "lib", "onboard.js"),
+      "utf-8",
+    );
+
+    expect(source).toContain("NEMOCLAW_CRED_STORE_KEY");
+    expect(source).toContain("clawkeeper security set-password");
+    expect(source).not.toContain("tokenized URL");
+    expect(source).not.toContain("#token=<token>");
+  });
+
   it("classifies sandbox create timeout failures and tracks upload progress", () => {
     expect(
       classifySandboxCreateFailure("Error: failed to read image export stream\nTimeout error").kind,

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -173,70 +173,65 @@ describe("validateName", () => {
 describe("redact", () => {
   it("masks NVIDIA API keys", () => {
     const { redact } = require(runnerPath);
-    expect(redact("key is nvapi-abc123XYZ_def456")).toBe("key is nvap******************");
+    expect(redact("key is nvapi-abc123XYZ_def456")).toBe("key is <REDACTED>");
   });
 
   it("masks NVCF keys", () => {
     const { redact } = require(runnerPath);
-    expect(redact("nvcf-abcdef1234567890")).toBe("nvcf*****************");
+    expect(redact("nvcf-abcdef1234567890")).toBe("<REDACTED>");
   });
 
   it("masks bearer tokens", () => {
     const { redact } = require(runnerPath);
     expect(redact("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload")).toBe(
-      "Authorization: Bearer eyJh********************",
+      "Authorization: Bearer <REDACTED>",
     );
   });
 
   it("masks key assignments in commands", () => {
     const { redact } = require(runnerPath);
-    expect(redact("export NVIDIA_API_KEY=nvapi-realkey12345")).toContain("nvap");
-    expect(redact("export NVIDIA_API_KEY=nvapi-realkey12345")).not.toContain("realkey12345");
+    expect(redact("export NVIDIA_API_KEY=nvapi-realkey12345")).toBe(
+      "export NVIDIA_API_KEY=<REDACTED>",
+    );
   });
 
   it("masks variables ending in _KEY", () => {
     const { redact } = require(runnerPath);
     const output = redact('export SERVICE_KEY="supersecretvalue12345"');
-    expect(output).not.toContain("supersecretvalue12345");
-    expect(output).toContain('export SERVICE_KEY="supe');
+    expect(output).toBe("export SERVICE_KEY=<REDACTED>");
   });
 
   it("masks bare GitHub personal access tokens", () => {
     const { redact } = require(runnerPath);
     const output = redact("token ghp_abcdefghijklmnopqrstuvwxyz1234567890");
-    expect(output).toContain("ghp_");
-    expect(output).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
+    expect(output).toBe("token <REDACTED>");
   });
 
   it("masks bearer tokens case-insensitively", () => {
     const { redact } = require(runnerPath);
-    expect(redact("authorization: bearer someBearerToken")).toContain("some****");
+    expect(redact("authorization: bearer someBearerToken")).toContain("bearer <REDACTED>");
     expect(redact("authorization: bearer someBearerToken")).not.toContain("someBearerToken");
-    expect(redact("AUTHORIZATION: BEARER someBearerToken")).toContain("some****");
+    expect(redact("AUTHORIZATION: BEARER someBearerToken")).toContain("BEARER <REDACTED>");
     expect(redact("AUTHORIZATION: BEARER someBearerToken")).not.toContain("someBearerToken");
   });
 
   it("masks bearer tokens with repeated spacing", () => {
     const { redact } = require(runnerPath);
     const output = redact("Authorization: Bearer   someBearerToken");
-    expect(output).toContain("some****");
+    expect(output).toContain("Bearer   <REDACTED>");
     expect(output).not.toContain("someBearerToken");
   });
 
   it("masks quoted assignment values", () => {
     const { redact } = require(runnerPath);
     const output = redact('API_KEY="secret123abc"');
-    expect(output).not.toContain("secret123abc");
-    expect(output).toContain('API_KEY="sec');
+    expect(output).toBe("API_KEY=<REDACTED>");
   });
 
   it("masks multiple secrets in one string", () => {
     const { redact } = require(runnerPath);
     const output = redact("nvapi-firstkey12345 nvapi-secondkey67890");
-    expect(output).not.toContain("firstkey12345");
-    expect(output).not.toContain("secondkey67890");
-    expect(output).toContain("nvap");
-    expect(output).toContain(" ");
+    expect(output).toBe("<REDACTED> <REDACTED>");
   });
 
   it("masks URL credentials and auth query parameters", () => {
@@ -244,13 +239,29 @@ describe("redact", () => {
     const output = redact(
       "https://alice:secret@example.com/v1/models?auth=abc123456789&sig=def987654321&keep=yes",
     );
-    expect(output).toBe("https://alice:****@example.com/v1/models?auth=****&sig=****&keep=yes");
+    expect(output).toBe(
+      "https://example.com/v1/models?auth=%3CREDACTED%3E&sig=%3CREDACTED%3E&keep=yes",
+    );
   });
 
   it("masks auth-style query parameters case-insensitively", () => {
     const { redact } = require(runnerPath);
     const output = redact("https://example.com?Signature=secret123456&AUTH=anothersecret123");
-    expect(output).toBe("https://example.com/?Signature=****&AUTH=****");
+    expect(output).toBe(
+      "https://example.com/?Signature=%3CREDACTED%3E&AUTH=%3CREDACTED%3E",
+    );
+  });
+
+  it("is deterministic for repeated identical input", () => {
+    const { redact } = require(runnerPath);
+    const input =
+      "Authorization: Bearer abc123def456 API_KEY=secret https://alice:secret@example.com/?token=abc123";
+    const first = redact(input);
+    const second = redact(input);
+    expect(second).toBe(first);
+    expect(first).toBe(
+      "Authorization: Bearer <REDACTED> API_KEY=<REDACTED> https://example.com/?token=%3CREDACTED%3E",
+    );
   });
 
   it("leaves non-secret strings untouched", () => {
@@ -288,7 +299,7 @@ describe("regression guards", () => {
       }
 
       expect(error).toBeInstanceOf(Error);
-      expect(error.message).toContain("ghp_");
+      expect(error.message).toContain("<REDACTED>");
       expect(error.message).not.toContain("supersecretvalue12345");
       expect(error.message).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
     } finally {
@@ -324,8 +335,8 @@ describe("regression guards", () => {
       expect(Array.isArray(error.output)).toBe(true);
       expect(error.output[0]).not.toContain("nvapi-aaaabbbbcccc1111");
       expect(error.output[1]).not.toContain("secret123456");
-      expect(error.output[0]).toContain("****");
-      expect(error.output[1]).toContain("****");
+      expect(error.output[0]).toContain("<REDACTED>");
+      expect(error.output[1]).toContain("<REDACTED>");
     } finally {
       childProcess.execSync = originalExecSync;
       delete require.cache[require.resolve(runnerPath)];
@@ -353,8 +364,8 @@ describe("regression guards", () => {
       delete require.cache[require.resolve(runnerPath)];
       const { run } = require(runnerPath);
       expect(() => run("echo fail")).toThrow("exit:1");
-      expect(stdoutSpy).toHaveBeenCalledWith("token ghp_********************\n");
-      expect(stderrSpy).toHaveBeenCalledWith('export SERVICE_KEY="supe*****************"\n');
+      expect(stdoutSpy).toHaveBeenCalledWith("token <REDACTED>\n");
+      expect(stderrSpy).toHaveBeenCalledWith("export SERVICE_KEY=<REDACTED>\n");
       expect(errorSpy).toHaveBeenCalledWith("  Command failed (exit 1): echo fail");
     } finally {
       childProcess.spawnSync = originalSpawnSync;
@@ -387,7 +398,9 @@ describe("regression guards", () => {
       const { runInteractive } = require(runnerPath);
       runInteractive("echo interactive");
       expect(calls[0][2].stdio).toEqual(["inherit", "pipe", "pipe"]);
-      expect(stdoutSpy).toHaveBeenCalledWith("visit https://alice:****@example.com/?token=****\n");
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        "visit https://example.com/?token=%3CREDACTED%3E\n",
+      );
       expect(stderrSpy).not.toHaveBeenCalled();
     } finally {
       childProcess.spawnSync = originalSpawnSync;

--- a/test/security-cli.test.js
+++ b/test/security-cli.test.js
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
+
+function runWithEnv(args, env = {}) {
+  try {
+    const out = execSync(`node "${CLI}" ${args}`, {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        ...env,
+      },
+    });
+    return { code: 0, out };
+  } catch (err) {
+    return { code: err.status ?? 1, out: `${err.stdout || ""}${err.stderr || ""}` };
+  }
+}
+
+describe("security CLI commands", () => {
+  it("validates a well-formed security policy", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-policy-"));
+    const policyPath = path.join(tmp, "security-policy.yaml");
+    fs.writeFileSync(
+      policyPath,
+      [
+        "version: 1",
+        "decision_matrix:",
+        "  low: allow",
+        "  medium: allow",
+        "  high: require_approval",
+        "  critical: block",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = runWithEnv(`security policy validate --file "${policyPath}"`);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("Security policy is valid");
+  });
+
+  it("fails validation on malformed policy", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-policy-invalid-"));
+    const policyPath = path.join(tmp, "security-policy.yaml");
+    fs.writeFileSync(policyPath, "not: [valid", "utf-8");
+
+    const result = runWithEnv(`security policy validate --file "${policyPath}"`);
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("Security policy validation failed");
+  });
+
+  it("prints events and replays a specific event", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-events-"));
+    const eventsDir = path.join(home, ".nemoclaw", "security");
+    fs.mkdirSync(eventsDir, { recursive: true });
+    const eventsPath = path.join(eventsDir, "events.jsonl");
+
+    const event = {
+      eventVersion: "security-event.v1",
+      id: "evt-123",
+      timestamp: "2026-04-04T12:34:56.000Z",
+      hook: "before_tool_call",
+      action: "block",
+      effectiveAction: "block",
+      riskLevel: "critical",
+      riskScore: 99,
+      target: "rm -rf /",
+      reason: "Matched critical command pattern",
+      evidence: [{ code: "command_critical", message: "Matched critical pattern" }],
+    };
+
+    fs.writeFileSync(eventsPath, `${JSON.stringify(event)}\n`, "utf-8");
+
+    const list = runWithEnv("security events --limit 1", { HOME: home });
+    expect(list.code).toBe(0);
+    expect(list.out).toContain("evt-123");
+    expect(list.out).toContain("before_tool_call");
+
+    const replay = runWithEnv("security replay evt-123", { HOME: home });
+    expect(replay.code).toBe(0);
+    expect(replay.out).toContain("Event: evt-123");
+    expect(replay.out).toContain("Matched critical command pattern");
+  });
+});

--- a/test/security-cli.test.js
+++ b/test/security-cli.test.js
@@ -24,6 +24,15 @@ function runWithEnv(args, env = {}) {
   }
 }
 
+function setupSecurityEventsHome(lines) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-events-"));
+  const eventsDir = path.join(home, ".nemoclaw", "security");
+  fs.mkdirSync(eventsDir, { recursive: true });
+  const eventsPath = path.join(eventsDir, "events.jsonl");
+  fs.writeFileSync(eventsPath, `${lines.join("\n")}\n`, "utf-8");
+  return { home, eventsPath };
+}
+
 describe("security CLI commands", () => {
   it("validates a well-formed security policy", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-policy-"));
@@ -56,12 +65,53 @@ describe("security CLI commands", () => {
     expect(result.out).toContain("Security policy validation failed");
   });
 
-  it("prints events and replays a specific event", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-events-"));
-    const eventsDir = path.join(home, ".nemoclaw", "security");
-    fs.mkdirSync(eventsDir, { recursive: true });
-    const eventsPath = path.join(eventsDir, "events.jsonl");
+  it("supports combined filters and reports malformed JSONL lines", () => {
+    const eventLow = {
+      id: "evt-low",
+      timestamp: "2026-04-04T10:00:00.000Z",
+      hook: "before_tool_call",
+      action: "allow",
+      effectiveAction: "allow",
+      riskLevel: "low",
+      target: "ls -la",
+    };
+    const eventCriticalMatch = {
+      id: "evt-critical-match",
+      timestamp: "2026-04-04T11:00:00.000Z",
+      hook: "before_tool_call",
+      action: "block",
+      effectiveAction: "block",
+      riskLevel: "critical",
+      target: "rm -rf /",
+    };
+    const eventCriticalOtherHook = {
+      id: "evt-critical-other-hook",
+      timestamp: "2026-04-04T12:00:00.000Z",
+      hook: "after_tool_result",
+      action: "block",
+      effectiveAction: "block",
+      riskLevel: "critical",
+      target: "curl example.com",
+    };
+    const { home } = setupSecurityEventsHome([
+      JSON.stringify(eventLow),
+      "{invalid-jsonl",
+      JSON.stringify(eventCriticalMatch),
+      JSON.stringify(eventCriticalOtherHook),
+    ]);
 
+    const list = runWithEnv("security events --hook before_tool_call --risk critical --limit 10", {
+      HOME: home,
+    });
+    expect(list.code).toBe(0);
+    expect(list.out).toContain("Note: skipped 1 malformed event line(s).");
+    expect(list.out).toContain("Filters: hook=before_tool_call, risk=critical");
+    expect(list.out).toContain("evt-critical-match");
+    expect(list.out).not.toContain("evt-low");
+    expect(list.out).not.toContain("evt-critical-other-hook");
+  });
+
+  it("supports replay JSON output", () => {
     const event = {
       eventVersion: "security-event.v1",
       id: "evt-123",
@@ -75,17 +125,40 @@ describe("security CLI commands", () => {
       reason: "Matched critical command pattern",
       evidence: [{ code: "command_critical", message: "Matched critical pattern" }],
     };
+    const { home } = setupSecurityEventsHome([JSON.stringify(event)]);
 
-    fs.writeFileSync(eventsPath, `${JSON.stringify(event)}\n`, "utf-8");
-
-    const list = runWithEnv("security events --limit 1", { HOME: home });
-    expect(list.code).toBe(0);
-    expect(list.out).toContain("evt-123");
-    expect(list.out).toContain("before_tool_call");
-
-    const replay = runWithEnv("security replay evt-123", { HOME: home });
+    const replay = runWithEnv("security replay evt-123 --json", { HOME: home });
     expect(replay.code).toBe(0);
-    expect(replay.out).toContain("Event: evt-123");
-    expect(replay.out).toContain("Matched critical command pattern");
+    const payload = JSON.parse(replay.out);
+    expect(payload.event?.id).toBe("evt-123");
+    expect(payload.matches).toBe(1);
+  });
+
+  it("returns non-zero for ambiguous replay ID prefix (including JSON mode)", () => {
+    const event1 = {
+      id: "evt-prefix-a",
+      timestamp: "2026-04-04T12:00:00.000Z",
+      hook: "before_tool_call",
+      action: "block",
+      effectiveAction: "block",
+      riskLevel: "high",
+      target: "npm install foo",
+    };
+    const event2 = {
+      id: "evt-prefix-b",
+      timestamp: "2026-04-04T12:01:00.000Z",
+      hook: "before_tool_call",
+      action: "block",
+      effectiveAction: "block",
+      riskLevel: "high",
+      target: "npm install bar",
+    };
+    const { home } = setupSecurityEventsHome([JSON.stringify(event1), JSON.stringify(event2)]);
+
+    const replay = runWithEnv("security replay evt-prefix --json", { HOME: home });
+    expect(replay.code).toBe(1);
+    const payload = JSON.parse(replay.out);
+    expect(payload.event).toBeNull();
+    expect(payload.matches).toBe(2);
   });
 });

--- a/test/security-cli.test.js
+++ b/test/security-cli.test.js
@@ -9,10 +9,11 @@ import { describe, expect, it } from "vitest";
 
 const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
 
-function runWithEnv(args, env = {}) {
+function runWithEnv(args, env = {}, opts = {}) {
   try {
     const out = execSync(`node "${CLI}" ${args}`, {
       encoding: "utf-8",
+      input: opts.input,
       env: {
         ...process.env,
         ...env,
@@ -34,6 +35,53 @@ function setupSecurityEventsHome(lines) {
 }
 
 describe("security CLI commands", () => {
+  it("reports credential-store status for plaintext files", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-status-"));
+    const credsDir = path.join(home, ".nemoclaw");
+    fs.mkdirSync(credsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(credsDir, "credentials.json"),
+      JSON.stringify({ NVIDIA_API_KEY: "nvapi-1", OPENAI_API_KEY: "sk-2" }, null, 2),
+      "utf-8",
+    );
+
+    const status = runWithEnv("security status", { HOME: home });
+    expect(status.code).toBe(0);
+    expect(status.out).toContain("Mode: plaintext");
+    expect(status.out).toContain("Credential keys: 2");
+    expect(status.out).toContain("NEMOCLAW_CRED_STORE_KEY: not detected");
+  });
+
+  it("encrypts credential store with security set-password and reports encrypted mode", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-password-"));
+    const credsDir = path.join(home, ".nemoclaw");
+    fs.mkdirSync(credsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(credsDir, "credentials.json"),
+      JSON.stringify({ NVIDIA_API_KEY: "nvapi-1" }, null, 2),
+      "utf-8",
+    );
+
+    const set = runWithEnv("security set-password", {
+      HOME: home,
+      NEMOCLAW_CRED_STORE_KEY: "store-secret-1",
+    });
+    expect(set.code).toBe(0);
+    expect(set.out).toContain("Credential store encrypted (1 key)");
+
+    const encrypted = JSON.parse(
+      fs.readFileSync(path.join(credsDir, "credentials.json"), "utf-8"),
+    );
+    expect(encrypted.format).toBe("nemoclaw.credentials.v1");
+    expect(encrypted.encryption).toBe("aes-256-gcm");
+
+    const statusLocked = runWithEnv("security status", { HOME: home });
+    expect(statusLocked.code).toBe(0);
+    expect(statusLocked.out).toContain("Mode: encrypted");
+    expect(statusLocked.out).toContain("Credential keys: 1");
+    expect(statusLocked.out).toContain("NEMOCLAW_CRED_STORE_KEY: not detected");
+  });
+
   it("validates a well-formed security policy", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawkeeper-security-policy-"));
     const policyPath = path.join(tmp, "security-policy.yaml");

--- a/test/security-engine.test.js
+++ b/test/security-engine.test.js
@@ -44,6 +44,28 @@ describe("security engine", () => {
     expect(decision.action).toBe("require_approval");
   });
 
+  it("requires approval for privilege escalation commands", async () => {
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeToolCall({
+      toolName: "shell",
+      command: "sudo cat /tmp/notes.txt",
+    });
+    expect(decision.riskLevel).toBe("high");
+    expect(decision.action).toBe("require_approval");
+    expect(decision.evidence.some((item) => item.code === "command_privilege_escalation")).toBe(true);
+  });
+
+  it("requires approval for dynamic shell substitution", async () => {
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeToolCall({
+      toolName: "shell",
+      command: "echo $(cat /tmp/a.txt)",
+    });
+    expect(decision.riskLevel).toBe("high");
+    expect(decision.action).toBe("require_approval");
+    expect(decision.evidence.some((item) => item.code === "command_dynamic_substitution")).toBe(true);
+  });
+
   it("allows low-risk commands", async () => {
     const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
     const decision = await engine.evaluateBeforeToolCall({

--- a/test/security-engine.test.js
+++ b/test/security-engine.test.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -69,6 +69,76 @@ describe("security engine", () => {
     const decision = await engine.evaluateBeforeToolCall({ command: "echo four > /sandbox/d.txt" });
     expect(decision.riskLevel).toBe("high");
     expect(decision.action).toBe("require_approval");
+  });
+
+  it("flags install lifecycle scripts as high risk", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "clawkeeper-skill-lifecycle-"));
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify(
+        {
+          name: "demo-skill",
+          scripts: {
+            postinstall: "node scripts/setup.js",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeInstall({ target: dir });
+    expect(decision.riskLevel).toBe("high");
+    expect(decision.evidence.some((item) => item.code === "install_lifecycle_scripts")).toBe(true);
+  });
+
+  it("flags insecure HTTP install sources", async () => {
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeInstall({
+      target: "http://evil.example.com/skill.tgz",
+    });
+    expect(decision.riskLevel).toBe("high");
+    expect(decision.evidence.some((item) => item.code === "install_insecure_transport")).toBe(true);
+  });
+
+  it("flags scanner unavailability when scanner is configured but missing", async () => {
+    const policy = {
+      ...DEFAULT_SECURITY_POLICY,
+      installRules: {
+        ...DEFAULT_SECURITY_POLICY.installRules,
+        scannerCommand: "__definitely_missing_scanner__",
+        scannerArgs: [],
+      },
+    };
+    const engine = new SecurityEngine(policy, {
+      ...config,
+      scanTimeoutMs: 1000,
+    });
+
+    const decision = await engine.evaluateBeforeInstall({
+      target: "/sandbox/skill",
+    });
+    expect(decision.riskLevel).toBe("high");
+    expect(
+      decision.evidence.some(
+        (item) => item.code === "scanner_unavailable" || item.code === "scanner_nonzero_exit",
+      ),
+    ).toBe(true);
+  });
+
+  it("flags symlink escape in local install targets", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "clawkeeper-skill-symlink-"));
+    const safeDir = join(dir, "skill");
+    mkdirSync(safeDir, { recursive: true });
+    const outside = mkdtempSync(join(tmpdir(), "clawkeeper-outside-"));
+    symlinkSync(outside, join(safeDir, "outside-link"));
+
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeInstall({ target: safeDir });
+    expect(decision.riskLevel).toBe("critical");
+    expect(decision.evidence.some((item) => item.code === "install_symlink_escape")).toBe(true);
   });
 });
 

--- a/test/security-engine.test.js
+++ b/test/security-engine.test.js
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SecurityEngine } from "../nemoclaw/src/security/engine.ts";
+import { DEFAULT_SECURITY_POLICY, loadSecurityPolicy, normalizeSecurityPolicy } from "../nemoclaw/src/security/policy.ts";
+
+const config = {
+  mode: "enforce",
+  policyPath: "security-policy.yaml",
+  approvalTimeoutMs: 120000,
+  scanTimeoutMs: 30000,
+  alertWebhook: "",
+  quota: {
+    maxToolCallsPerMinute: 3,
+    maxInstallsPerHour: 2,
+    maxEstimatedTokensPerHour: 100000,
+  },
+};
+
+describe("security engine", () => {
+  it("blocks critical tool commands", async () => {
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeToolCall({
+      toolName: "shell",
+      command: "rm -rf /",
+    });
+    expect(decision.riskLevel).toBe("critical");
+    expect(decision.action).toBe("block");
+  });
+
+  it("requires approval for high-risk hosts", async () => {
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeToolCall({
+      toolName: "shell",
+      command: "curl https://my.trycloudflare.com/token",
+    });
+    expect(decision.riskLevel).toBe("high");
+    expect(decision.action).toBe("require_approval");
+  });
+
+  it("allows low-risk commands", async () => {
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeToolCall({
+      toolName: "shell",
+      command: "echo hello > /sandbox/notes.txt",
+    });
+    expect(decision.riskLevel).toBe("low");
+    expect(decision.action).toBe("allow");
+  });
+
+  it("blocks path traversal installs", async () => {
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    const decision = await engine.evaluateBeforeInstall({ target: "../../malicious-skill" });
+    expect(decision.riskLevel).toBe("critical");
+    expect(decision.action).toBe("block");
+  });
+
+  it("raises risk on tool-call quota exceed", async () => {
+    const engine = new SecurityEngine(DEFAULT_SECURITY_POLICY, config);
+    await engine.evaluateBeforeToolCall({ command: "echo one > /sandbox/a.txt" });
+    await engine.evaluateBeforeToolCall({ command: "echo two > /sandbox/b.txt" });
+    await engine.evaluateBeforeToolCall({ command: "echo three > /sandbox/c.txt" });
+    const decision = await engine.evaluateBeforeToolCall({ command: "echo four > /sandbox/d.txt" });
+    expect(decision.riskLevel).toBe("high");
+    expect(decision.action).toBe("require_approval");
+  });
+});
+
+describe("security policy loading", () => {
+  it("uses defaults when file is missing", () => {
+    const loaded = loadSecurityPolicy("missing.yaml", (input) => `/tmp/${input}`);
+    expect(loaded.source).toBe("default");
+    expect(loaded.policy.decisionMatrix.high).toBe("require_approval");
+  });
+
+  it("normalizes snake_case fields", () => {
+    const policy = normalizeSecurityPolicy({
+      decision_matrix: { low: "allow", medium: "allow", high: "block", critical: "block" },
+      install_rules: {
+        critical_patterns: ["evil"],
+        high_patterns: ["warn"],
+        medium_patterns: [],
+      },
+      audit: {
+        include_allow_events: true,
+      },
+    });
+    expect(policy.decisionMatrix.high).toBe("block");
+    expect(policy.installRules.criticalPatterns).toEqual(["evil"]);
+    expect(policy.audit.includeAllowEvents).toBe(true);
+  });
+
+  it("loads policy from file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "clawkeeper-policy-"));
+    const file = join(dir, "security-policy.yaml");
+    writeFileSync(
+      file,
+      [
+        "version: 1",
+        "decision_matrix:",
+        "  low: allow",
+        "  medium: allow",
+        "  high: require_approval",
+        "  critical: block",
+      ].join("\n"),
+      "utf-8",
+    );
+    const loaded = loadSecurityPolicy(file, (input) => input);
+    expect(loaded.source).toBe("file");
+    expect(loaded.policy.decisionMatrix.critical).toBe("block");
+  });
+});

--- a/test/security-engine.test.js
+++ b/test/security-engine.test.js
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import { SecurityEngine } from "../nemoclaw/src/security/engine.ts";
+import { registerSecurityHooks } from "../nemoclaw/src/security/hooks.ts";
 import { DEFAULT_SECURITY_POLICY, loadSecurityPolicy, normalizeSecurityPolicy } from "../nemoclaw/src/security/policy.ts";
 
 const config = {
@@ -22,6 +23,38 @@ const config = {
     maxEstimatedTokensPerHour: 100000,
   },
 };
+
+function createHookApiHarness() {
+  const handlers = new Map();
+  const api = {
+    id: "nemoclaw",
+    name: "ClawKeeper",
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
+    resolvePath: (input) => input,
+    on: (hookName, handler) => {
+      handlers.set(hookName, handler);
+    },
+  };
+  return { api, handlers };
+}
+
+function createPluginConfig(mode) {
+  return {
+    blueprintVersion: "latest",
+    blueprintRegistry: "ghcr.io/nvidia/nemoclaw-blueprint",
+    sandboxName: "openclaw",
+    inferenceProvider: "nvidia",
+    security: {
+      ...config,
+      mode,
+    },
+  };
+}
 
 describe("security engine", () => {
   it("blocks critical tool commands", async () => {
@@ -206,5 +239,95 @@ describe("security policy loading", () => {
     const loaded = loadSecurityPolicy(file, (input) => input);
     expect(loaded.source).toBe("file");
     expect(loaded.policy.decisionMatrix.critical).toBe("block");
+  });
+});
+
+describe("security hook mode rollout", () => {
+  it("warn mode allows high-risk commands with visible warning and audit metadata", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "clawkeeper-warn-rollout-"));
+    const eventsPath = join(dir, "events.jsonl");
+    const previousEventsPath = process.env.CLAWKEEPER_SECURITY_EVENTS_PATH;
+    process.env.CLAWKEEPER_SECURITY_EVENTS_PATH = eventsPath;
+
+    try {
+      const { api, handlers } = createHookApiHarness();
+      registerSecurityHooks(api, createPluginConfig("warn"));
+
+      const beforeToolCall = handlers.get("before_tool_call");
+      expect(typeof beforeToolCall).toBe("function");
+
+      const response = await beforeToolCall({
+        toolName: "shell",
+        command: "rm -rf /",
+      });
+      expect(response.allow).toBe(true);
+      expect(response.block).toBeUndefined();
+      expect(response.warning).toMatchObject({
+        recommendedAction: "block",
+        rolloutStage: "warn",
+      });
+
+      const lines = readFileSync(eventsPath, "utf-8")
+        .split("\n")
+        .filter((line) => line.trim().length > 0);
+      expect(lines.length).toBe(1);
+
+      const event = JSON.parse(lines[0]);
+      expect(event.eventVersion).toBe("security-event.v1");
+      expect(event.mode).toBe("warn");
+      expect(event.action).toBe("block");
+      expect(event.effectiveAction).toBe("allow");
+      expect(event.recommendedAction).toBe("block");
+      expect(event.rolloutStage).toBe("warn");
+      expect(event.details?.stagedDecision).toMatchObject({
+        recommendedAction: "block",
+        rolloutStage: "warn",
+      });
+    } finally {
+      if (previousEventsPath === undefined) {
+        delete process.env.CLAWKEEPER_SECURITY_EVENTS_PATH;
+      } else {
+        process.env.CLAWKEEPER_SECURITY_EVENTS_PATH = previousEventsPath;
+      }
+    }
+  });
+
+  it("enforce mode keeps blocking critical commands", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "clawkeeper-enforce-rollout-"));
+    const eventsPath = join(dir, "events.jsonl");
+    const previousEventsPath = process.env.CLAWKEEPER_SECURITY_EVENTS_PATH;
+    process.env.CLAWKEEPER_SECURITY_EVENTS_PATH = eventsPath;
+
+    try {
+      const { api, handlers } = createHookApiHarness();
+      registerSecurityHooks(api, createPluginConfig("enforce"));
+
+      const beforeToolCall = handlers.get("before_tool_call");
+      expect(typeof beforeToolCall).toBe("function");
+
+      const response = await beforeToolCall({
+        toolName: "shell",
+        command: "rm -rf /",
+      });
+      expect(response.block).toBe(true);
+      expect(response.allow).toBeUndefined();
+      expect(response.warning).toBeUndefined();
+
+      const lines = readFileSync(eventsPath, "utf-8")
+        .split("\n")
+        .filter((line) => line.trim().length > 0);
+      expect(lines.length).toBe(1);
+
+      const event = JSON.parse(lines[0]);
+      expect(event.mode).toBe("enforce");
+      expect(event.action).toBe("block");
+      expect(event.effectiveAction).toBe("block");
+    } finally {
+      if (previousEventsPath === undefined) {
+        delete process.env.CLAWKEEPER_SECURITY_EVENTS_PATH;
+      } else {
+        process.env.CLAWKEEPER_SECURITY_EVENTS_PATH = previousEventsPath;
+      }
+    }
   });
 });

--- a/test/uninstall.test.js
+++ b/test/uninstall.test.js
@@ -30,7 +30,7 @@ describe("uninstall CLI flags", () => {
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
-    expect(output).toMatch(/NemoClaw Uninstaller/);
+    expect(output).toMatch(/ClawKeeper Uninstaller/);
     expect(output).toMatch(/--yes/);
     expect(output).toMatch(/--keep-openshell/);
     expect(output).toMatch(/--delete-models/);
@@ -61,7 +61,7 @@ describe("uninstall CLI flags", () => {
 
       expect(result.status).toBe(0);
       const output = `${result.stdout}${result.stderr}`;
-      expect(output).toMatch(/NemoClaw/);
+      expect(output).toMatch(/ClawKeeper/);
       expect(output).toMatch(/Claws retracted/);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -17,6 +17,10 @@ const BASE_POLICY_PATH = new URL(
   "../nemoclaw-blueprint/policies/openclaw-sandbox.yaml",
   import.meta.url,
 );
+const SECURITY_TEMPLATE_PATHS = [
+  "../nemoclaw-blueprint/policies/templates/security-dev-balanced.yaml",
+  "../nemoclaw-blueprint/policies/templates/security-ci-minimal.yaml",
+] as const;
 const REQUIRED_PROFILE_FIELDS = ["provider_type", "endpoint"] as const;
 
 const bp = YAML.parse(readFileSync(BLUEPRINT_PATH, "utf-8")) as Record<string, unknown>;
@@ -83,4 +87,23 @@ describe("base sandbox policy", () => {
   it("has 'network_policies'", () => {
     expect("network_policies" in policy).toBe(true);
   });
+});
+
+describe("security policy templates", () => {
+  for (const path of SECURITY_TEMPLATE_PATHS) {
+    const templatePath = new URL(path, import.meta.url);
+    const policy = YAML.parse(readFileSync(templatePath, "utf-8")) as Record<string, unknown>;
+
+    it(`${path} parses as a YAML mapping`, () => {
+      expect(policy).toEqual(expect.objectContaining({}));
+    });
+
+    it(`${path} has 'version'`, () => {
+      expect("version" in policy).toBe(true);
+    });
+
+    it(`${path} has 'network_policies'`, () => {
+      expect("network_policies" in policy).toBe(true);
+    });
+  }
 });

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,11 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# NemoClaw uninstaller.
+# ClawKeeper uninstaller.
 # Removes the host-side resources created by the installer/setup flow:
-#   - NemoClaw helper services
-#   - All OpenShell sandboxes plus the NemoClaw gateway/providers
-#   - NemoClaw/OpenShell/OpenClaw Docker images built or pulled for the sandbox flow
+#   - ClawKeeper helper services
+#   - All OpenShell sandboxes plus the ClawKeeper gateway/providers
+#   - ClawKeeper/OpenShell/OpenClaw Docker images built or pulled for the sandbox flow
 #   - ~/.nemoclaw plus ~/.config/{openshell,nemoclaw} state, including onboard-session.json
 #   - Global nemoclaw npm install/link
 #   - OpenShell binary if it was installed to the standard installer path
@@ -96,18 +96,18 @@ print_banner() {
   printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
   printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
   printf "\n"
-  printf "  ${C_DIM}Uninstaller — This will remove all NemoClaw resources.${C_RESET}\n"
+  printf "  ${C_DIM}Uninstaller — This will remove all ClawKeeper resources.${C_RESET}\n"
   printf "  ${C_DIM}Docker, Node.js, Ollama, and npm are preserved.${C_RESET}\n"
   printf "\n"
 }
 
 print_bye() {
   printf "\n"
-  printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}\n"
+  printf "  ${C_GREEN}${C_BOLD}ClawKeeper${C_RESET}\n"
   printf "\n"
   printf "  ${C_GREEN}${C_BOLD}Claws retracted.${C_RESET}  ${C_DIM}Until next time.${C_RESET}\n"
   printf "\n"
-  printf "  ${C_DIM}https://www.nvidia.com/nemoclaw${C_RESET}\n"
+  printf "  ${C_DIM}https://github.com/hollyhongever/ClawKeeper${C_RESET}\n"
   printf "\n"
 }
 
@@ -128,13 +128,13 @@ DELETE_MODELS=false
 
 usage() {
   printf "\n"
-  printf "  ${C_BOLD}NemoClaw Uninstaller${C_RESET}\n\n"
+  printf "  ${C_BOLD}ClawKeeper Uninstaller${C_RESET}\n\n"
   printf "  ${C_DIM}Usage:${C_RESET}\n"
   printf "    ./uninstall.sh [--yes] [--keep-openshell] [--delete-models]\n\n"
   printf "  ${C_GREEN}Options:${C_RESET}\n"
   printf "    --yes             Skip the confirmation prompt\n"
   printf "    --keep-openshell  Leave the openshell binary installed\n"
-  printf "    --delete-models   Remove NemoClaw-pulled Ollama models\n"
+  printf "    --delete-models   Remove ClawKeeper-pulled Ollama models\n"
   printf "    -h, --help        Show this help\n"
   printf "\n"
 }
@@ -170,7 +170,7 @@ confirm() {
 
   printf "\n"
   printf "  ${C_YELLOW}What will be removed:${C_RESET}\n"
-  printf "  ${C_DIM}  · All OpenShell sandboxes, gateway, and NemoClaw providers${C_RESET}\n"
+  printf "  ${C_DIM}  · All OpenShell sandboxes, gateway, and ClawKeeper providers${C_RESET}\n"
   printf "  ${C_DIM}  · Related Docker containers, images, and volumes${C_RESET}\n"
   printf "  ${C_DIM}  · ~/.nemoclaw  ~/.config/openshell  ~/.config/nemoclaw${C_RESET}\n"
   printf "  ${C_DIM}  · Global nemoclaw npm package${C_RESET}\n"
@@ -245,7 +245,7 @@ remove_file_with_optional_sudo() {
 
 stop_helper_services() {
   if [ -x "$SCRIPT_DIR/scripts/start-services.sh" ]; then
-    run_optional "Stopped NemoClaw helper services" "$SCRIPT_DIR/scripts/start-services.sh" --stop
+    run_optional "Stopped ClawKeeper helper services" "$SCRIPT_DIR/scripts/start-services.sh" --stop
   fi
 
   remove_glob_paths "${TMP_ROOT}/nemoclaw-services-*"
@@ -321,7 +321,7 @@ remove_nemoclaw_alias_from_profile() {
       changed=true
     fi
     if [ "$changed" = true ]; then
-      info "Removed NemoClaw PATH entries from $p"
+      info "Removed ClawKeeper PATH entries from $p"
     fi
   done
 }
@@ -410,7 +410,7 @@ remove_related_docker_containers() {
   )
 
   if [ "${#container_ids[@]}" -eq 0 ]; then
-    info "No NemoClaw/OpenShell Docker containers found"
+    info "No ClawKeeper/OpenShell Docker containers found"
     return 0
   fi
 
@@ -461,7 +461,7 @@ remove_related_docker_images() {
   )
 
   if [ "${#image_ids[@]}" -eq 0 ]; then
-    info "No NemoClaw/OpenShell Docker images found"
+    info "No ClawKeeper/OpenShell Docker images found"
     return 0
   fi
 
@@ -506,7 +506,7 @@ remove_related_docker_volumes() {
   done < <(gateway_volume_candidates "$DEFAULT_GATEWAY")
 
   if [ "${#volume_names[@]}" -eq 0 ]; then
-    info "No NemoClaw/OpenShell Docker volumes found"
+    info "No ClawKeeper/OpenShell Docker volumes found"
     return 0
   fi
 
@@ -523,7 +523,7 @@ remove_related_docker_volumes() {
   done
 
   if [ "$removed_any" = false ]; then
-    info "No NemoClaw/OpenShell Docker volumes found"
+    info "No ClawKeeper/OpenShell Docker volumes found"
   fi
 }
 
@@ -555,7 +555,7 @@ remove_nemoclaw_swap() {
   fi
 
   if [ ! -f "$NEMOCLAW_STATE_DIR/managed_swap" ]; then
-    warn "No NemoClaw-managed swap marker found, skipping swap cleanup."
+    warn "No ClawKeeper-managed swap marker found, skipping swap cleanup."
     return 0
   fi
 
@@ -630,8 +630,8 @@ main() {
   step 2 "OpenShell resources"
   remove_openshell_resources
 
-  step 3 "NemoClaw CLI"
-  spin "Removing NemoClaw CLI..." remove_nemoclaw_cli
+  step 3 "ClawKeeper CLI"
+  spin "Removing ClawKeeper CLI..." remove_nemoclaw_cli
 
   step 4 "Docker resources"
   spin "Removing Docker resources..." remove_docker_resources
@@ -640,7 +640,7 @@ main() {
   remove_optional_ollama_models
 
   step 6 "State and binaries"
-  info "Removing NemoClaw-managed swap file..."
+  info "Removing ClawKeeper-managed swap file..."
   remove_nemoclaw_swap
 
   info "Removing runtime temp artifacts..."


### PR DESCRIPTION
## Summary

- Adds staged dangerous-command policy controls with warn-mode behavior for gradual rollout.
- Wires policy and hook updates through plugin config, security types, and runtime registration.
- Expands engine, CLI, and registration tests for staged enforcement coverage.

## Scope

- In scope: dangerous-command policy controls, warn-mode behavior, config and hook wiring, docs, and test updates.
- Out of scope: rollout playbook automation, credential store changes, and redaction behavior redesign.

## Validation

- [ ] `npm run check`
- [ ] `npm test -- test/security-engine.test.js`
- [ ] `npm test -- nemoclaw/src/register.test.ts`
- [ ] Confirm warn-mode preserves audit visibility while avoiding unintended hard blocks

## Risks

- Policy staging mistakes can either under-enforce truly dangerous commands or over-enforce legitimate operator actions.

## Rollback

- Revert this PR if warn-mode or staged enforcement produces unstable decisions, and keep operators on the prior decision matrix.

## Follow-ups

- Rebase on the latest merged baseline before opening the PR so policy and hook diffs stay reviewable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `clawkeeper security` command suite with policy validation, audit event viewing, and replay capabilities
  * Added optional AES-256-GCM encryption for credential storage with password protection
  * Rebranded CLI to ClawKeeper; `nemoclaw` remains available as a legacy alias
  * Four new security policy templates for strict egress, CI minimal, sensitive read-only, and balanced development scenarios

* **Documentation**
  * New security guides covering best practices, policy templates, and event auditing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->