### PR TITLE
fix(onboard): respect messaging channel toggle in sandbox creation

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -2656,8 +2656,9 @@ async function createSandbox(
   // Each channel with a userIdEnvKey in MESSAGING_CHANNELS may have a
   // comma-separated list of IDs (e.g. TELEGRAM_ALLOWED_IDS="123,456").
   const messagingAllowedIds = {};
+  const enabledTokenEnvKeys = new Set(messagingTokenDefs.map(({ envKey }) => envKey));
   for (const ch of MESSAGING_CHANNELS) {
-    if (ch.userIdEnvKey && process.env[ch.userIdEnvKey]) {
+    if (enabledTokenEnvKeys.has(ch.envKey) && ch.userIdEnvKey && process.env[ch.userIdEnvKey]) {
       const ids = process.env[ch.userIdEnvKey]
         .split(",")
         .map((s) => s.trim())

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -2515,6 +2515,7 @@ async function createSandbox(
   preferredInferenceApi = null,
   sandboxNameOverride = null,
   webSearchConfig = null,
+  enabledChannels = null,
 ) {
   step(6, 8, "Creating sandbox");
 
@@ -2526,6 +2527,15 @@ async function createSandbox(
   // without provider attachments (security: prevents legacy raw-env-var leaks).
   const getMessagingToken = (envKey) =>
     getCredential(envKey) || normalizeCredentialValue(process.env[envKey]) || null;
+
+  // When enabledChannels is provided (from the toggle picker), only include
+  // channels the user selected. When null (backward compat), include all.
+  const enabledEnvKeys =
+    enabledChannels != null
+      ? new Set(
+          MESSAGING_CHANNELS.filter((c) => enabledChannels.includes(c.name)).map((c) => c.envKey),
+        )
+      : null;
 
   const messagingTokenDefs = [
     {
@@ -2543,7 +2553,7 @@ async function createSandbox(
       envKey: "TELEGRAM_BOT_TOKEN",
       token: getMessagingToken("TELEGRAM_BOT_TOKEN"),
     },
-  ];
+  ].filter(({ envKey }) => !enabledEnvKeys || enabledEnvKeys.has(envKey));
   const hasMessagingTokens = messagingTokenDefs.some(({ token }) => !!token);
 
   // Reconcile local registry state with the live OpenShell gateway state.
@@ -3570,7 +3580,7 @@ async function setupMessagingChannels() {
     } else {
       note("  [non-interactive] No messaging tokens configured. Skipping.");
     }
-    return;
+    return found;
   }
 
   // Single-keypress toggle selector — pre-select channels that already have tokens.
@@ -3663,7 +3673,7 @@ async function setupMessagingChannels() {
   const selected = Array.from(enabled);
   if (selected.length === 0) {
     console.log("  Skipping messaging channels.");
-    return;
+    return [];
   }
 
   // For each selected channel, prompt for token if not already set
@@ -3706,6 +3716,7 @@ async function setupMessagingChannels() {
     }
   }
   console.log("");
+  return selected;
 }
 
 // ── Step 7: OpenClaw ─────────────────────────────────────────────
@@ -4448,7 +4459,7 @@ async function onboard(opts = {}) {
           }
         }
       }
-      await setupMessagingChannels();
+      const enabledChannels = await setupMessagingChannels();
 
       startRecordedStep("sandbox", { sandboxName, provider, model });
       sandboxName = await createSandbox(
@@ -4458,6 +4469,7 @@ async function onboard(opts = {}) {
         preferredInferenceApi,
         sandboxName,
         webSearchConfig,
+        enabledChannels,
       );
       onboardSession.markStepComplete("sandbox", { sandboxName, provider, model, nimContainer });
     }

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -4577,6 +4577,7 @@ module.exports = {
   startGatewayForRecovery,
   runCaptureOpenshell,
   setupInference,
+  setupMessagingChannels,
   setupNim,
   isInferenceRouteReady,
   isOpenclawReady,

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -1269,7 +1269,7 @@ const { setupInference } = require(${onboardPath});
 
     assert.match(
       source,
-      /startRecordedStep\("sandbox", \{ sandboxName, provider, model \}\);\s*sandboxName = await createSandbox\(\s*gpu,\s*model,\s*provider,\s*preferredInferenceApi,\s*sandboxName,\s*webSearchConfig,\s*\);/,
+      /startRecordedStep\("sandbox", \{ sandboxName, provider, model \}\);\s*sandboxName = await createSandbox\(\s*gpu,\s*model,\s*provider,\s*preferredInferenceApi,\s*sandboxName,\s*webSearchConfig,\s*enabledChannels,\s*\);/,
     );
   });
 

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -2600,6 +2600,373 @@ const { setupInference } = require(${onboardPath});
     assert.equal(commands.length, 3);
   });
 
+  it(
+    "filters messaging providers to only enabledChannels when provided",
+    { timeout: 60_000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-enabled-channels-filter-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "enabled-channels-filter.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
+      const registryPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "registry.js"));
+      const preflightPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "preflight.js"));
+      const credentialsPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "credentials.js"));
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+
+      const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const preflight = require(${preflightPath});
+const credentials = require(${credentialsPath});
+const childProcess = require("node:child_process");
+const { EventEmitter } = require("node:events");
+
+const commands = [];
+runner.run = (command, opts = {}) => {
+  commands.push({ command, env: opts.env || null });
+  return { status: 0 };
+};
+runner.runCapture = (command) => {
+  if (command.includes("'sandbox' 'get' 'my-assistant'")) return "";
+  if (command.includes("'sandbox' 'list'")) return "my-assistant Ready";
+  if (command.includes("sandbox exec my-assistant curl -sf http://localhost:18789/")) return "ok";
+  if (command.includes("'forward' 'list'")) return "18789 -> my-assistant:18789";
+  return "";
+};
+registry.registerSandbox = () => true;
+registry.removeSandbox = () => true;
+preflight.checkPortAvailable = async () => ({ ok: true });
+credentials.prompt = async () => "";
+
+childProcess.spawn = (...args) => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  commands.push({ command: args[1][1], env: args[2]?.env || null });
+  process.nextTick(() => {
+    child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
+    child.emit("close", 0);
+  });
+  return child;
+};
+
+const { createSandbox } = require(${onboardPath});
+
+(async () => {
+  process.env.OPENSHELL_GATEWAY = "nemoclaw";
+  process.env.DISCORD_BOT_TOKEN = "test-discord-token-value";
+  process.env.SLACK_BOT_TOKEN = "xoxb-test-slack-token-value";
+  process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-test-telegram-token";
+  // Only enable telegram — discord and slack should be filtered out
+  const sandboxName = await createSandbox(
+    null, "gpt-5.4", "nvidia-prod", null, "my-assistant", null, ["telegram"],
+  );
+  console.log(JSON.stringify({ sandboxName, commands }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+      fs.writeFileSync(scriptPath, script);
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const payloadLine = result.stdout
+        .trim()
+        .split("\n")
+        .slice()
+        .reverse()
+        .find((line) => line.startsWith("{") && line.endsWith("}"));
+      assert.ok(payloadLine, `expected JSON payload in stdout:\n${result.stdout}`);
+      const payload = JSON.parse(payloadLine);
+
+      // Only telegram provider should be created
+      const providerCommands = payload.commands.filter((e) =>
+        e.command.includes("'provider' 'create'"),
+      );
+      const telegramProvider = providerCommands.find((e) =>
+        e.command.includes("my-assistant-telegram-bridge"),
+      );
+      assert.ok(telegramProvider, "expected telegram provider to be created");
+
+      // Discord and slack providers should NOT be created
+      const discordProvider = providerCommands.find((e) =>
+        e.command.includes("my-assistant-discord-bridge"),
+      );
+      assert.ok(!discordProvider, "discord provider should be filtered out");
+
+      const slackProvider = providerCommands.find((e) =>
+        e.command.includes("my-assistant-slack-bridge"),
+      );
+      assert.ok(!slackProvider, "slack provider should be filtered out");
+
+      // Sandbox create should only have the telegram --provider flag
+      const createCommand = payload.commands.find((e) => e.command.includes("'sandbox' 'create'"));
+      assert.ok(createCommand, "expected sandbox create command");
+      assert.match(createCommand.command, /'--provider' 'my-assistant-telegram-bridge'/);
+      assert.doesNotMatch(createCommand.command, /my-assistant-discord-bridge/);
+      assert.doesNotMatch(createCommand.command, /my-assistant-slack-bridge/);
+    },
+  );
+
+  it(
+    "creates no messaging providers when enabledChannels is empty",
+    { timeout: 60_000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-enabled-channels-empty-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "enabled-channels-empty.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
+      const registryPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "registry.js"));
+      const preflightPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "preflight.js"));
+      const credentialsPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "credentials.js"));
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+
+      const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const preflight = require(${preflightPath});
+const credentials = require(${credentialsPath});
+const childProcess = require("node:child_process");
+const { EventEmitter } = require("node:events");
+
+const commands = [];
+runner.run = (command, opts = {}) => {
+  commands.push({ command, env: opts.env || null });
+  return { status: 0 };
+};
+runner.runCapture = (command) => {
+  if (command.includes("'sandbox' 'get' 'my-assistant'")) return "";
+  if (command.includes("'sandbox' 'list'")) return "my-assistant Ready";
+  if (command.includes("sandbox exec my-assistant curl -sf http://localhost:18789/")) return "ok";
+  if (command.includes("'forward' 'list'")) return "18789 -> my-assistant:18789";
+  return "";
+};
+registry.registerSandbox = () => true;
+registry.removeSandbox = () => true;
+preflight.checkPortAvailable = async () => ({ ok: true });
+credentials.prompt = async () => "";
+
+childProcess.spawn = (...args) => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  commands.push({ command: args[1][1], env: args[2]?.env || null });
+  process.nextTick(() => {
+    child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
+    child.emit("close", 0);
+  });
+  return child;
+};
+
+const { createSandbox } = require(${onboardPath});
+
+(async () => {
+  process.env.OPENSHELL_GATEWAY = "nemoclaw";
+  process.env.DISCORD_BOT_TOKEN = "test-discord-token-value";
+  process.env.SLACK_BOT_TOKEN = "xoxb-test-slack-token-value";
+  process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-test-telegram-token";
+  // Empty array — user deselected all channels
+  const sandboxName = await createSandbox(
+    null, "gpt-5.4", "nvidia-prod", null, "my-assistant", null, [],
+  );
+  console.log(JSON.stringify({ sandboxName, commands }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+      fs.writeFileSync(scriptPath, script);
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const payloadLine = result.stdout
+        .trim()
+        .split("\n")
+        .slice()
+        .reverse()
+        .find((line) => line.startsWith("{") && line.endsWith("}"));
+      assert.ok(payloadLine, `expected JSON payload in stdout:\n${result.stdout}`);
+      const payload = JSON.parse(payloadLine);
+
+      // No messaging providers should be created at all
+      const providerCommands = payload.commands.filter((e) =>
+        e.command.includes("'provider' 'create'"),
+      );
+      assert.equal(
+        providerCommands.length,
+        0,
+        "no providers should be created when enabledChannels is empty",
+      );
+
+      // Sandbox create should have no --provider flags for messaging bridges
+      const createCommand = payload.commands.find((e) => e.command.includes("'sandbox' 'create'"));
+      assert.ok(createCommand, "expected sandbox create command");
+      assert.doesNotMatch(createCommand.command, /discord-bridge/);
+      assert.doesNotMatch(createCommand.command, /slack-bridge/);
+      assert.doesNotMatch(createCommand.command, /telegram-bridge/);
+    },
+  );
+
+  it(
+    "non-interactive setupMessagingChannels returns channels with tokens",
+    { timeout: 60_000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-messaging-noninteractive-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "messaging-noninteractive.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+
+      const script = String.raw`
+const runner = require(${runnerPath});
+runner.run = () => ({ status: 0 });
+runner.runCapture = () => "";
+
+const { setupMessagingChannels } = require(${onboardPath});
+
+(async () => {
+  // Only set telegram and slack tokens — discord should be absent
+  process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-test-telegram-token";
+  process.env.SLACK_BOT_TOKEN = "xoxb-test-slack-token";
+  const result = await setupMessagingChannels();
+  console.log(JSON.stringify(result));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+      fs.writeFileSync(scriptPath, script);
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const outputLine = result.stdout.trim().split("\n").pop();
+      const channels = JSON.parse(outputLine);
+
+      // Should return only the channels that have tokens set
+      assert.ok(Array.isArray(channels), "expected an array return value");
+      assert.ok(channels.includes("telegram"), "expected telegram in returned channels");
+      assert.ok(channels.includes("slack"), "expected slack in returned channels");
+      assert.ok(!channels.includes("discord"), "discord should not be in returned channels");
+    },
+  );
+
+  it(
+    "non-interactive setupMessagingChannels returns empty array when no tokens set",
+    { timeout: 60_000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-messaging-no-tokens-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "messaging-no-tokens.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+
+      const script = String.raw`
+const runner = require(${runnerPath});
+runner.run = () => ({ status: 0 });
+runner.runCapture = () => "";
+
+const { setupMessagingChannels } = require(${onboardPath});
+
+(async () => {
+  // No messaging tokens set
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.DISCORD_BOT_TOKEN;
+  delete process.env.SLACK_BOT_TOKEN;
+  const result = await setupMessagingChannels();
+  console.log(JSON.stringify(result));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+      fs.writeFileSync(scriptPath, script);
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+          TELEGRAM_BOT_TOKEN: "",
+          DISCORD_BOT_TOKEN: "",
+          SLACK_BOT_TOKEN: "",
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const outputLine = result.stdout.trim().split("\n").pop();
+      const channels = JSON.parse(outputLine);
+
+      assert.ok(Array.isArray(channels), "expected an array return value");
+      assert.equal(channels.length, 0, "expected empty array when no tokens are set");
+    },
+  );
+
   it("re-prompts on invalid sandbox names instead of exiting in interactive mode", () => {
     const source = fs.readFileSync(
       path.join(import.meta.dirname, "..", "bin", "lib", "onboard.js"),


### PR DESCRIPTION
## Summary

- `setupMessagingChannels()` now returns the selected channel names
- `createSandbox()` accepts `enabledChannels` param and filters `messagingTokenDefs` to only include user-selected channels
- When `enabledChannels` is null (backward compat / direct calls), all channels with tokens are included

Closes #1505

## Test plan

- [ ] Run onboarding with a Slack token saved from a prior session
- [ ] Deselect Slack in the toggle picker
- [ ] Verify no `slack-bridge` provider is created during sandbox setup
- [ ] Verify non-interactive mode still auto-enables all detected channels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can select specific messaging channels to enable during sandbox onboarding.

* **Improvements**
  * Sandbox setup now includes only the messaging channels selected by the user.
  * Non-interactive onboarding now reports detected configured channels (and returns an empty list when none are configured).

* **Tests**
  * Added automated tests covering channel filtering and non-interactive channel detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->