### PR TITLE
fix: revert unauthorized CLAUDE.md change from #1081

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,3 @@ All hooks managed by [prek](https://prek.j178.dev/) (installed via `npm install`
 - Update docs for any user-facing behavior changes
 - No secrets, API keys, or credentials committed
 - Limit open PRs to fewer than 10
-
-## Claude Behavior Rules
-
-- **"cloude2e" = trigger `nightly-e2e.yaml` on the current branch.** No exploring workflows, no asking which one. One command: `gh api repos/NVIDIA/NemoClaw/actions/workflows/nightly-e2e.yaml/dispatches -f ref=<branch>`, then give the run link.


### PR DESCRIPTION
## Summary

- Reverts the unrelated `CLAUDE.md` modification that was inadvertently included in the security credential injection PR (#1081)
- The added "Claude Behavior Rules" section was never reviewed as part of that security change and was not requested

## Test plan

- [x] Verify `CLAUDE.md` matches its pre-#1081 state
- [x] No other files affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete internal documentation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->