### PR TITLE
refactor(cli): extract HTTP probe helpers from onboard.js

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -63,6 +63,7 @@ const validation = require("../../dist/lib/validation");
 const urlUtils = require("../../dist/lib/url-utils");
 const buildContext = require("../../dist/lib/build-context");
 const dashboard = require("../../dist/lib/dashboard");
+const httpProbe = require("../../dist/lib/http-probe");
 const webSearch = require("../../dist/lib/web-search");
 
 /**
@@ -625,23 +626,7 @@ function hydrateCredentialEnv(envName) {
   return value || null;
 }
 
-function getCurlTimingArgs() {
-  return ["--connect-timeout", "10", "--max-time", "60"];
-}
-
-function summarizeCurlFailure(curlStatus = 0, stderr = "", body = "") {
-  const detail = compactText(stderr || body);
-  return detail
-    ? `curl failed (exit ${curlStatus}): ${detail.slice(0, 200)}`
-    : `curl failed (exit ${curlStatus})`;
-}
-
-function summarizeProbeFailure(body = "", status = 0, curlStatus = 0, stderr = "") {
-  if (curlStatus) {
-    return summarizeCurlFailure(curlStatus, stderr, body);
-  }
-  return summarizeProbeError(body, status);
-}
+const { getCurlTimingArgs, summarizeCurlFailure, summarizeProbeFailure, runCurlProbe } = httpProbe;
 
 function getNavigationChoice(value = "") {
   const normalized = String(value || "")
@@ -724,65 +709,6 @@ function getProbeRecovery(probe, options = {}) {
     return { kind: "unknown", retry: "selection" };
   }
   return fallback;
-}
-
-// eslint-disable-next-line complexity
-function runCurlProbe(argv) {
-  const bodyFile = secureTempFile("nemoclaw-curl-probe", ".json");
-  try {
-    const args = [...argv];
-    const url = args.pop();
-    const result = spawnSync("curl", [...args, "-o", bodyFile, "-w", "%{http_code}", url], {
-      cwd: ROOT,
-      encoding: "utf8",
-      timeout: 30_000,
-      env: {
-        ...process.env,
-      },
-    });
-    const body = fs.existsSync(bodyFile) ? fs.readFileSync(bodyFile, "utf8") : "";
-    if (result.error) {
-      const spawnError = /** @type {NodeJS.ErrnoException} */ (result.error);
-      const rawErrorCode = spawnError.errno ?? spawnError.code;
-      const errorCode = typeof rawErrorCode === "number" ? rawErrorCode : 1;
-      const errorMessage = compactText(
-        `${spawnError.message || String(spawnError)} ${String(result.stderr || "")}`,
-      );
-      return {
-        ok: false,
-        httpStatus: 0,
-        curlStatus: errorCode,
-        body,
-        stderr: errorMessage,
-        message: summarizeProbeFailure(body, 0, errorCode, errorMessage),
-      };
-    }
-    const status = Number(String(result.stdout || "").trim());
-    return {
-      ok: result.status === 0 && status >= 200 && status < 300,
-      httpStatus: Number.isFinite(status) ? status : 0,
-      curlStatus: result.status || 0,
-      body,
-      stderr: String(result.stderr || ""),
-      message: summarizeProbeFailure(
-        body,
-        status || 0,
-        result.status || 0,
-        String(result.stderr || ""),
-      ),
-    };
-  } catch (error) {
-    return {
-      ok: false,
-      httpStatus: 0,
-      curlStatus: error?.status || 1,
-      body: "",
-      stderr: error?.message || String(error),
-      message: summarizeCurlFailure(error?.status || 1, error?.message || String(error)),
-    };
-  } finally {
-    cleanupTempDir(bodyFile, "nemoclaw-curl-probe");
-  }
 }
 
 // validateNvidiaApiKeyValue — see validation import above
@@ -1292,24 +1218,6 @@ function patchStagedDockerfile(
     );
   }
   fs.writeFileSync(dockerfilePath, dockerfile);
-}
-
-function summarizeProbeError(body, status) {
-  if (!body) return `HTTP ${status} with no response body`;
-  try {
-    const parsed = JSON.parse(body);
-    const message =
-      parsed?.error?.message ||
-      parsed?.error?.details ||
-      parsed?.message ||
-      parsed?.detail ||
-      parsed?.details;
-    if (message) return `HTTP ${status}: ${String(message)}`;
-  } catch {
-    /* non-JSON body — fall through to raw text */
-  }
-  const compact = String(body).replace(/\s+/g, " ").trim();
-  return `HTTP ${status}: ${compact.slice(0, 200)}`;
 }
 
 function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey) {

--- a/src/lib/http-probe.test.ts
+++ b/src/lib/http-probe.test.ts
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import { describe, expect, it } from "vitest";
+
+import {
+  getCurlTimingArgs,
+  runCurlProbe,
+  summarizeCurlFailure,
+  summarizeProbeError,
+  summarizeProbeFailure,
+} from "./http-probe";
+
+describe("http-probe helpers", () => {
+  it("returns explicit curl timeouts", () => {
+    expect(getCurlTimingArgs()).toEqual(["--connect-timeout", "10", "--max-time", "60"]);
+  });
+
+  it("summarizes curl failures from stderr or body", () => {
+    expect(summarizeCurlFailure(28, "  timed out   while connecting  ")).toBe(
+      "curl failed (exit 28): timed out while connecting",
+    );
+    expect(summarizeCurlFailure(7, "", " connection refused ")).toBe(
+      "curl failed (exit 7): connection refused",
+    );
+  });
+
+  it("summarizes JSON and text HTTP probe failures", () => {
+    expect(summarizeProbeError('{"error":{"message":"bad key"}}', 401)).toBe(
+      "HTTP 401: bad key",
+    );
+    expect(summarizeProbeError(" plain  text   body ", 500)).toBe("HTTP 500: plain text body");
+    expect(summarizeProbeFailure("", 0, 28, "timeout")).toBe("curl failed (exit 28): timeout");
+  });
+
+  it("captures successful curl output and cleans up the temp file", () => {
+    const countProbeDirs = () =>
+      fs
+        .readdirSync(os.tmpdir())
+        .filter((entry) => entry.startsWith("nemoclaw-curl-probe-"))
+        .sort();
+
+    const before = countProbeDirs();
+    const result = runCurlProbe(["-sS", "https://example.test/models"], {
+      spawnSyncImpl: (_command, args) => {
+        const outputPath = args[args.indexOf("-o") + 1];
+        fs.writeFileSync(outputPath, JSON.stringify({ data: [{ id: "foo" }] }));
+        return {
+          pid: 1,
+          output: [],
+          stdout: "200",
+          stderr: "",
+          status: 0,
+          signal: null,
+        };
+      },
+    });
+    const after = countProbeDirs();
+
+    expect(result).toMatchObject({
+      ok: true,
+      httpStatus: 200,
+      curlStatus: 0,
+      body: '{"data":[{"id":"foo"}]}',
+    });
+    expect(after).toEqual(before);
+  });
+
+  it("reports spawn errors as curl failures", () => {
+    const result = runCurlProbe(["-sS", "https://example.test/models"], {
+      spawnSyncImpl: () => {
+        const error = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
+        return {
+          pid: 1,
+          output: [],
+          stdout: "",
+          stderr: "curl missing",
+          status: null,
+          signal: null,
+          error,
+        };
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.curlStatus).toBe(1);
+    expect(result.message).toContain("curl failed");
+    expect(result.stderr).toContain("spawn ENOENT");
+  });
+});

--- a/src/lib/http-probe.ts
+++ b/src/lib/http-probe.ts
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  spawnSync,
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+} from "node:child_process";
+
+import { compactText } from "./url-utils";
+
+// runner.js is CJS — use require so we don't pull it into the TS build.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { ROOT } = require("../../bin/lib/runner");
+
+export interface CurlProbeResult {
+  ok: boolean;
+  httpStatus: number;
+  curlStatus: number;
+  body: string;
+  stderr: string;
+  message: string;
+}
+
+export interface CurlProbeOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  spawnSyncImpl?: (
+    command: string,
+    args: readonly string[],
+    options: SpawnSyncOptionsWithStringEncoding,
+  ) => SpawnSyncReturns<string>;
+}
+
+function secureTempFile(prefix: string, ext = ""): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+  return path.join(dir, `${prefix}${ext}`);
+}
+
+function cleanupTempDir(filePath: string, expectedPrefix: string): void {
+  const parentDir = path.dirname(filePath);
+  if (parentDir !== os.tmpdir() && path.basename(parentDir).startsWith(`${expectedPrefix}-`)) {
+    fs.rmSync(parentDir, { recursive: true, force: true });
+  }
+}
+
+export function getCurlTimingArgs(): string[] {
+  return ["--connect-timeout", "10", "--max-time", "60"];
+}
+
+export function summarizeCurlFailure(curlStatus = 0, stderr = "", body = ""): string {
+  const detail = compactText(stderr || body);
+  return detail
+    ? `curl failed (exit ${curlStatus}): ${detail.slice(0, 200)}`
+    : `curl failed (exit ${curlStatus})`;
+}
+
+export function summarizeProbeError(body = "", status = 0): string {
+  if (!body) return `HTTP ${status} with no response body`;
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: { message?: unknown; details?: unknown };
+      message?: unknown;
+      detail?: unknown;
+      details?: unknown;
+    };
+    const message =
+      parsed?.error?.message ||
+      parsed?.error?.details ||
+      parsed?.message ||
+      parsed?.detail ||
+      parsed?.details;
+    if (message) return `HTTP ${status}: ${String(message)}`;
+  } catch {
+    /* non-JSON body — fall through to raw text */
+  }
+  const compact = String(body).replace(/\s+/g, " ").trim();
+  return `HTTP ${status}: ${compact.slice(0, 200)}`;
+}
+
+export function summarizeProbeFailure(
+  body = "",
+  status = 0,
+  curlStatus = 0,
+  stderr = "",
+): string {
+  if (curlStatus) {
+    return summarizeCurlFailure(curlStatus, stderr, body);
+  }
+  return summarizeProbeError(body, status);
+}
+
+// eslint-disable-next-line complexity
+export function runCurlProbe(argv: string[], opts: CurlProbeOptions = {}): CurlProbeResult {
+  const bodyFile = secureTempFile("nemoclaw-curl-probe", ".json");
+  try {
+    const args = [...argv];
+    const url = args.pop();
+    const spawnSyncImpl = opts.spawnSyncImpl ?? spawnSync;
+    const result = spawnSyncImpl(
+      "curl",
+      [...args, "-o", bodyFile, "-w", "%{http_code}", String(url || "")],
+      {
+        cwd: opts.cwd ?? ROOT,
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          ...opts.env,
+        },
+      },
+    );
+    const body = fs.existsSync(bodyFile) ? fs.readFileSync(bodyFile, "utf8") : "";
+    if (result.error) {
+      const spawnError = result.error as NodeJS.ErrnoException;
+      const rawErrorCode = spawnError.errno ?? spawnError.code;
+      const errorCode = typeof rawErrorCode === "number" ? rawErrorCode : 1;
+      const errorMessage = compactText(
+        `${spawnError.message || String(spawnError)} ${String(result.stderr || "")}`,
+      );
+      return {
+        ok: false,
+        httpStatus: 0,
+        curlStatus: errorCode,
+        body,
+        stderr: errorMessage,
+        message: summarizeProbeFailure(body, 0, errorCode, errorMessage),
+      };
+    }
+    const status = Number(String(result.stdout || "").trim());
+    return {
+      ok: result.status === 0 && status >= 200 && status < 300,
+      httpStatus: Number.isFinite(status) ? status : 0,
+      curlStatus: result.status || 0,
+      body,
+      stderr: String(result.stderr || ""),
+      message: summarizeProbeFailure(body, status || 0, result.status || 0, String(result.stderr || "")),
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      httpStatus: 0,
+      curlStatus: typeof error === "object" && error && "status" in error ? Number(error.status) || 1 : 1,
+      body: "",
+      stderr: detail,
+      message: summarizeCurlFailure(
+        typeof error === "object" && error && "status" in error ? Number(error.status) || 1 : 1,
+        detail,
+      ),
+    };
+  } finally {
+    cleanupTempDir(bodyFile, "nemoclaw-curl-probe");
+  }
+}

--- a/test/credential-exposure.test.js
+++ b/test/credential-exposure.test.js
@@ -82,11 +82,15 @@ describe("credential exposure in process arguments", () => {
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_BOT_TOKEN"/);
   });
 
-  it("onboard.js curl probes use explicit timeouts", () => {
-    const src = fs.readFileSync(ONBOARD_JS, "utf-8");
+  it("onboard curl probes use explicit timeouts", () => {
+    const onboardSrc = fs.readFileSync(ONBOARD_JS, "utf-8");
+    const probeSrc = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "http-probe.ts"),
+      "utf-8",
+    );
 
-    expect(src).toMatch(/function getCurlTimingArgs\(\)/);
-    expect(src).toMatch(/"--connect-timeout", "10"/);
-    expect(src).toMatch(/"--max-time", "60"/);
+    expect(onboardSrc).toMatch(/http-probe/);
+    expect(probeSrc).toMatch(/"--connect-timeout", "10"/);
+    expect(probeSrc).toMatch(/"--max-time", "60"/);
   });
 });

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -1240,14 +1240,23 @@ const { setupInference } = require(${onboardPath});
   });
 
   it("uses split curl timeout args and does not mislabel curl usage errors as timeouts", () => {
-    const source = fs.readFileSync(
+    const onboardSource = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "bin", "lib", "onboard.js"),
+      "utf-8",
+    );
+    const probeSource = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "http-probe.ts"),
+      "utf-8",
+    );
+    const recoverySource = fs.readFileSync(
       path.join(import.meta.dirname, "..", "bin", "lib", "onboard.js"),
       "utf-8",
     );
 
-    assert.match(source, /return \["--connect-timeout", "10", "--max-time", "60"\];/);
-    assert.match(source, /failure\.curlStatus === 2/);
-    assert.match(source, /local curl invocation error/);
+    assert.match(onboardSource, /http-probe/);
+    assert.match(probeSource, /return \["--connect-timeout", "10", "--max-time", "60"\];/);
+    assert.match(recoverySource, /failure\.curlStatus === 2/);
+    assert.match(recoverySource, /local curl invocation error/);
   });
 
   it("suppresses expected provider-create AlreadyExists noise when update succeeds", () => {


### PR DESCRIPTION
## Summary
- move curl probe helpers out of `bin/lib/onboard.js` into `src/lib/http-probe.ts`
- keep `onboard.js` as a thin caller of the compiled TypeScript module
- add focused tests for curl probe parsing, failure summaries, and temp-file cleanup

## Testing
- npm run build:cli
- npx vitest run --project cli src/lib/http-probe.test.ts test/onboard.test.js test/credential-exposure.test.js
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved HTTP probing logic into a dedicated module and updated onboarding to use it, improving organization.

* **Behavior**
  * Improved HTTP probe handling and clearer, more consistent failure/time‑out messages.

* **Tests**
  * Added comprehensive tests for the probe utilities and updated existing tests to reflect the reorganization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->