### PR TITLE
fix(image): add missing openclaw-data symlinks for runtime-writable paths

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -102,6 +102,8 @@ RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
         /sandbox/.openclaw-data/canvas \
         /sandbox/.openclaw-data/cron \
         /sandbox/.openclaw-data/memory \
+        /sandbox/.openclaw-data/telegram \
+        /sandbox/.openclaw-data/credentials \
     && mkdir -p /sandbox/.openclaw \
     && ln -s /sandbox/.openclaw-data/agents /sandbox/.openclaw/agents \
     && ln -s /sandbox/.openclaw-data/extensions /sandbox/.openclaw/extensions \
@@ -115,6 +117,10 @@ RUN mkdir -p /sandbox/.openclaw-data/agents/main/agent \
     && ln -s /sandbox/.openclaw-data/memory /sandbox/.openclaw/memory \
     && touch /sandbox/.openclaw-data/update-check.json \
     && ln -s /sandbox/.openclaw-data/update-check.json /sandbox/.openclaw/update-check.json \
+    && touch /sandbox/.openclaw-data/exec-approvals.json \
+    && ln -s /sandbox/.openclaw-data/exec-approvals.json /sandbox/.openclaw/exec-approvals.json \
+    && ln -s /sandbox/.openclaw-data/telegram /sandbox/.openclaw/telegram \
+    && ln -s /sandbox/.openclaw-data/credentials /sandbox/.openclaw/credentials \
     && chown -R sandbox:sandbox /sandbox/.openclaw /sandbox/.openclaw-data
 
 # Install OpenClaw CLI + PyYAML for inline Python scripts in e2e tests.


### PR DESCRIPTION
## Summary

- Add symlinks for `exec-approvals.json`, `telegram/`, and `credentials/` from `.openclaw/` to `.openclaw-data/`
- These paths are written by OpenClaw at runtime but had no writable target, causing EACCES errors
- Follows the exact same pattern as the 11 existing symlinks in `Dockerfile.base`

## Security posture

Unchanged. The `.openclaw/` directory remains root-owned (755), all symlinks are root-owned and `chattr +i` locked at runtime by `nemoclaw-start.sh`. The agent can only write file contents through the symlinks to sandbox-owned `.openclaw-data/`.

## Fixes

- Fixes #1027 — `exec-approvals.json` EACCES
- Refs #975 — Telegram offset persistence EACCES
- Refs #1114 — WhatsApp credentials EACCES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Docker image filesystem with new data storage directories for telegram and credentials management.
  * Added approvals configuration file to the Docker environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->