### PR TITLE
docs: clarify NEMOCLAW_DISABLE_DEVICE_AUTH behavior

### DIFF
--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -116,6 +116,12 @@ available when the installer builds the sandbox image. If `CHAT_UI_URL` is not
 set on a headless host, the compatibility wrapper prints a warning.
 :::
 
+:::{warning}
+`NEMOCLAW_DISABLE_DEVICE_AUTH` is also evaluated at image build time.
+If you disable device auth for a remote deployment, any device that can reach the dashboard origin can connect without pairing.
+Avoid this on internet-reachable or shared-network deployments.
+:::
+
 ## GPU Configuration
 
 The deploy script uses the `NEMOCLAW_GPU` environment variable to select the GPU type.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -81,6 +81,12 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 If you use nvm or fnm to manage Node.js, the installer may not update your current shell's PATH.
 If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
 
+:::{note}
+The onboard flow builds the sandbox image with `NEMOCLAW_DISABLE_DEVICE_AUTH=1` so the dashboard is immediately usable during setup.
+This is a build-time setting baked into the sandbox image, not a runtime knob.
+If you export `NEMOCLAW_DISABLE_DEVICE_AUTH` after onboarding finishes, it has no effect on an existing sandbox.
+:::
+
 When the install completes, a summary confirms the running environment:
 
 ```text

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -189,5 +189,7 @@ The following environment variables configure optional services and local access
 | `TELEGRAM_BOT_TOKEN` | Bot token for the Telegram bridge. |
 | `ALLOWED_CHAT_IDS` | Comma-separated list of Telegram chat IDs allowed to message the agent. |
 | `CHAT_UI_URL` | URL for the optional chat UI endpoint. |
+| `NEMOCLAW_DISABLE_DEVICE_AUTH` | Build-time-only toggle that disables gateway device pairing when set to `1` before the sandbox image is created. |
 
 For normal setup and reconfiguration, prefer `nemoclaw onboard` over editing these files by hand.
+Do not treat `NEMOCLAW_DISABLE_DEVICE_AUTH` as a runtime setting for an already-created sandbox.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -253,6 +253,15 @@ $ nemoclaw <name> status
 If the endpoint is correct but requests still fail, check for network policy rules that may block the connection.
 Then verify the credential and base URL for the provider you selected during onboarding.
 
+### `NEMOCLAW_DISABLE_DEVICE_AUTH=1` does not change an existing sandbox
+
+This is expected behavior.
+`NEMOCLAW_DISABLE_DEVICE_AUTH` is a build-time setting used when NemoClaw creates the sandbox image.
+Changing or exporting it later does not rewrite the baked `openclaw.json` inside an existing sandbox.
+
+If you need a different device-auth setting, rerun onboarding so NemoClaw rebuilds the sandbox image with the desired configuration.
+For the security trade-offs, refer to [Security Best Practices](../security/best-practices.md).
+
 ### Agent cannot reach an external host
 
 OpenShell blocks outbound connections to hosts not listed in the network policy.


### PR DESCRIPTION
## Summary
Document `NEMOCLAW_DISABLE_DEVICE_AUTH` more clearly across the user docs so operators understand that it is a build-time-only setting and why changing it after onboarding does not affect an existing sandbox.
This closes the documentation gap called out in issue #1443.

## Related Issue
Fixes #1443

## Changes
- add a Quickstart note that onboarding bakes `NEMOCLAW_DISABLE_DEVICE_AUTH=1` into the sandbox image for immediate dashboard access
- document in the architecture reference that `NEMOCLAW_DISABLE_DEVICE_AUTH` is build-time only
- add troubleshooting guidance explaining why exporting the variable later does not change an existing sandbox
- add a remote deployment warning about the security implications of disabling device auth on internet-reachable or shared-network hosts

## Type of Change
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
- [x] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [x] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.

---
Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that configuration settings are applied at sandbox image build time and cannot be modified for existing sandboxes
  * Added security warnings for remote and shared-network deployments
  * Enhanced troubleshooting and quickstart guides with rebuild instructions and configuration timing details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->