### PR TITLE
refactor(cli): introduce shared onboarding result types

### DIFF
--- a/src/lib/http-probe.ts
+++ b/src/lib/http-probe.ts
@@ -10,20 +10,14 @@ import {
   type SpawnSyncReturns,
 } from "node:child_process";
 
+import type { ProbeResult } from "./onboard-types";
 import { compactText } from "./url-utils";
 
 // runner.js is CJS — use require so we don't pull it into the TS build.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { ROOT } = require("../../bin/lib/runner");
 
-export interface CurlProbeResult {
-  ok: boolean;
-  httpStatus: number;
-  curlStatus: number;
-  body: string;
-  stderr: string;
-  message: string;
-}
+export type CurlProbeResult = ProbeResult;
 
 export interface CurlProbeOptions {
   cwd?: string;

--- a/src/lib/onboard-types.ts
+++ b/src/lib/onboard-types.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared result and failure contracts used by the extracted onboarding helper modules.
+ *
+ * Keeping these shapes in one place avoids subtle field drift across http probing,
+ * provider-model validation, and recovery classification.
+ */
+
+export interface ValidationFailureLike {
+  httpStatus?: number;
+  curlStatus?: number;
+  message?: string;
+  stderr?: string;
+}
+
+export interface ProbeResultBase {
+  httpStatus: number;
+  curlStatus: number;
+  body: string;
+  stderr: string;
+  message: string;
+}
+
+export type ProbeResult =
+  | ({ ok: true } & ProbeResultBase)
+  | ({ ok: false } & ProbeResultBase);
+
+export interface ModelCatalogFetchSuccess {
+  ok: true;
+  ids: string[];
+}
+
+export interface ModelCatalogFetchFailure extends ValidationFailureLike {
+  ok: false;
+  httpStatus: number;
+  curlStatus: number;
+  message: string;
+}
+
+export type ModelCatalogFetchResult = ModelCatalogFetchSuccess | ModelCatalogFetchFailure;
+
+export interface ModelValidationSuccess {
+  ok: true;
+  validated?: boolean;
+}
+
+export interface ModelValidationFailure extends ValidationFailureLike {
+  ok: false;
+  httpStatus: number;
+  curlStatus: number;
+  message: string;
+}
+
+export type ModelValidationResult = ModelValidationSuccess | ModelValidationFailure;

--- a/src/lib/provider-models.test.ts
+++ b/src/lib/provider-models.test.ts
@@ -33,6 +33,21 @@ describe("provider model helpers", () => {
     expect(result).toEqual({ ok: true, ids: ["nemotron", "llama"] });
   });
 
+  it("returns explicit validated=true for NVIDIA model matches", () => {
+    const result = validateNvidiaEndpointModel("nemotron", "nvapi-x", {
+      runCurlProbeImpl: () => ({
+        ok: true,
+        httpStatus: 200,
+        curlStatus: 0,
+        body: JSON.stringify({ data: [{ id: "nemotron" }] }),
+        stderr: "",
+        message: "",
+      }),
+    });
+
+    expect(result).toEqual({ ok: true, validated: true });
+  });
+
   it("reports NVIDIA validation failures with the checked endpoint", () => {
     const result = validateNvidiaEndpointModel("missing", "nvapi-x", {
       runCurlProbeImpl: () => ({

--- a/src/lib/provider-models.test.ts
+++ b/src/lib/provider-models.test.ts
@@ -47,6 +47,8 @@ describe("provider model helpers", () => {
 
     expect(result).toEqual({
       ok: false,
+      httpStatus: 200,
+      curlStatus: 0,
       message: `Model 'missing' is not available from NVIDIA Endpoints. Checked ${BUILD_ENDPOINT_URL}/models.`,
     });
   });
@@ -96,6 +98,26 @@ describe("provider model helpers", () => {
         }),
       }),
     ).toEqual({ ok: true, validated: false });
+  });
+
+  it("preserves structured status fields through validation failures", () => {
+    const result = validateOpenAiLikeModel("Example", "https://example.test/v1", "gpt-4.1", "sk-x", {
+      runCurlProbeImpl: () => ({
+        ok: false,
+        httpStatus: 429,
+        curlStatus: 0,
+        body: "",
+        stderr: "",
+        message: "rate limited",
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      httpStatus: 429,
+      curlStatus: 0,
+      message: "Could not validate model against https://example.test/v1/models: rate limited",
+    });
   });
 
   it("accepts Anthropic model ids from either id or name fields", () => {

--- a/src/lib/provider-models.test.ts
+++ b/src/lib/provider-models.test.ts
@@ -169,4 +169,24 @@ describe("provider model helpers", () => {
       message: expect.stringMatching(/JSON|Unexpected token|not-json/i),
     });
   });
+
+  it("fails fast when the model catalog payload omits the top-level data array", () => {
+    const result = fetchOpenAiLikeModels("https://example.test/v1", "sk-x", {
+      runCurlProbeImpl: () => ({
+        ok: true,
+        httpStatus: 200,
+        curlStatus: 0,
+        body: JSON.stringify({ error: { message: "bad payload" } }),
+        stderr: "",
+        message: "",
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      httpStatus: 200,
+      curlStatus: 0,
+      message: "Unexpected model catalog response: expected a top-level data array",
+    });
+  });
 });

--- a/src/lib/provider-models.test.ts
+++ b/src/lib/provider-models.test.ts
@@ -134,4 +134,24 @@ describe("provider model helpers", () => {
 
     expect(result).toEqual({ ok: true, ids: ["claude-sonnet-4-6", "claude-haiku-4-5"] });
   });
+
+  it("preserves probe status when model catalog JSON parsing fails", () => {
+    const result = fetchOpenAiLikeModels("https://example.test/v1", "sk-x", {
+      runCurlProbeImpl: () => ({
+        ok: true,
+        httpStatus: 502,
+        curlStatus: 7,
+        body: "not-json",
+        stderr: "",
+        message: "",
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      httpStatus: 502,
+      curlStatus: 7,
+      message: expect.stringMatching(/JSON|Unexpected token|not-json/i),
+    });
+  });
 });

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -33,6 +33,31 @@ function parseModelIds(body: string, itemKeys: string[] = ["id"]): string[] {
     .filter((value): value is string => Boolean(value));
 }
 
+function toModelCatalogFetchResult(
+  result: CurlProbeResult,
+  itemKeys: string[] = ["id"],
+): ModelCatalogFetchResult {
+  if (!result.ok) {
+    return {
+      ok: false,
+      message: result.message,
+      httpStatus: result.httpStatus,
+      curlStatus: result.curlStatus,
+    };
+  }
+
+  try {
+    return { ok: true, ids: parseModelIds(result.body, itemKeys) };
+  } catch (error) {
+    return {
+      ok: false,
+      httpStatus: result.httpStatus,
+      curlStatus: result.curlStatus,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export function fetchNvidiaEndpointModels(
   apiKey: string,
   options: ProviderModelOptions = {},
@@ -49,24 +74,7 @@ export function fetchNvidiaEndpointModels(
       `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`,
       `${buildEndpointUrl}/models`,
     ]);
-    if (!result.ok) {
-      return {
-        ok: false,
-        message: result.message,
-        httpStatus: result.httpStatus,
-        curlStatus: result.curlStatus,
-      };
-    }
-    try {
-      return { ok: true, ids: parseModelIds(result.body) };
-    } catch (error) {
-      return {
-        ok: false,
-        httpStatus: result.httpStatus,
-        curlStatus: result.curlStatus,
-        message: error instanceof Error ? error.message : String(error),
-      };
-    }
+    return toModelCatalogFetchResult(result);
   } catch (error) {
     return {
       ok: false,
@@ -93,7 +101,7 @@ export function validateNvidiaEndpointModel(
     };
   }
   if (available.ids.includes(model)) {
-    return { ok: true };
+    return { ok: true, validated: true };
   }
   return {
     ok: false,
@@ -116,24 +124,7 @@ export function fetchOpenAiLikeModels(
       ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
       `${String(endpointUrl).replace(/\/+$/, "")}/models`,
     ]);
-    if (!result.ok) {
-      return {
-        ok: false,
-        httpStatus: result.httpStatus,
-        curlStatus: result.curlStatus,
-        message: result.message,
-      };
-    }
-    try {
-      return { ok: true, ids: parseModelIds(result.body) };
-    } catch (error) {
-      return {
-        ok: false,
-        httpStatus: result.httpStatus,
-        curlStatus: result.curlStatus,
-        message: error instanceof Error ? error.message : String(error),
-      };
-    }
+    return toModelCatalogFetchResult(result);
   } catch (error) {
     return {
       ok: false,
@@ -160,24 +151,7 @@ export function fetchAnthropicModels(
       "anthropic-version: 2023-06-01",
       `${String(endpointUrl).replace(/\/+$/, "")}/v1/models`,
     ]);
-    if (!result.ok) {
-      return {
-        ok: false,
-        httpStatus: result.httpStatus,
-        curlStatus: result.curlStatus,
-        message: result.message,
-      };
-    }
-    try {
-      return { ok: true, ids: parseModelIds(result.body, ["id", "name"]) };
-    } catch (error) {
-      return {
-        ok: false,
-        httpStatus: result.httpStatus,
-        curlStatus: result.curlStatus,
-        message: error instanceof Error ? error.message : String(error),
-      };
-    }
+    return toModelCatalogFetchResult(result, ["id", "name"]);
   } catch (error) {
     return {
       ok: false,

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -1,33 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getCurlTimingArgs, runCurlProbe, type CurlProbeResult } from "./http-probe";
+import type { CurlProbeResult } from "./http-probe";
+import { getCurlTimingArgs, runCurlProbe } from "./http-probe";
+import type { ModelCatalogFetchResult, ModelValidationResult } from "./onboard-types";
 
 // credentials.js is CJS.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { normalizeCredentialValue } = require("../../bin/lib/credentials");
 
 export const BUILD_ENDPOINT_URL = "https://integrate.api.nvidia.com/v1";
-
-export interface FetchModelsSuccess {
-  ok: true;
-  ids: string[];
-}
-
-export interface FetchModelsFailure {
-  ok: false;
-  message: string;
-  status?: number;
-  curlStatus?: number;
-}
-
-export type FetchModelsResult = FetchModelsSuccess | FetchModelsFailure;
-
-export interface ValidateModelResult {
-  ok: boolean;
-  message?: string;
-  validated?: boolean;
-}
 
 export interface ProviderModelOptions {
   runCurlProbeImpl?: (argv: string[]) => CurlProbeResult;
@@ -54,7 +36,7 @@ function parseModelIds(body: string, itemKeys: string[] = ["id"]): string[] {
 export function fetchNvidiaEndpointModels(
   apiKey: string,
   options: ProviderModelOptions = {},
-): FetchModelsResult {
+): ModelCatalogFetchResult {
   const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
   const buildEndpointUrl = options.buildEndpointUrl ?? BUILD_ENDPOINT_URL;
   try {
@@ -71,7 +53,7 @@ export function fetchNvidiaEndpointModels(
       return {
         ok: false,
         message: result.message,
-        status: result.httpStatus,
+        httpStatus: result.httpStatus,
         curlStatus: result.curlStatus,
       };
     }
@@ -79,7 +61,7 @@ export function fetchNvidiaEndpointModels(
   } catch (error) {
     return {
       ok: false,
-      status: 0,
+      httpStatus: 0,
       curlStatus: 0,
       message: error instanceof Error ? error.message : String(error),
     };
@@ -90,12 +72,14 @@ export function validateNvidiaEndpointModel(
   model: string,
   apiKey: string,
   options: ProviderModelOptions = {},
-): ValidateModelResult {
+): ModelValidationResult {
   const buildEndpointUrl = options.buildEndpointUrl ?? BUILD_ENDPOINT_URL;
   const available = fetchNvidiaEndpointModels(apiKey, options);
   if (!available.ok) {
     return {
       ok: false,
+      httpStatus: available.httpStatus,
+      curlStatus: available.curlStatus,
       message: `Could not validate model against ${buildEndpointUrl}/models: ${available.message}`,
     };
   }
@@ -104,6 +88,8 @@ export function validateNvidiaEndpointModel(
   }
   return {
     ok: false,
+    httpStatus: 200,
+    curlStatus: 0,
     message: `Model '${model}' is not available from NVIDIA Endpoints. Checked ${buildEndpointUrl}/models.`,
   };
 }
@@ -112,7 +98,7 @@ export function fetchOpenAiLikeModels(
   endpointUrl: string,
   apiKey: string,
   options: ProviderModelOptions = {},
-): FetchModelsResult {
+): ModelCatalogFetchResult {
   const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
   try {
     const result = runCurlProbeImpl([
@@ -124,7 +110,7 @@ export function fetchOpenAiLikeModels(
     if (!result.ok) {
       return {
         ok: false,
-        status: result.httpStatus,
+        httpStatus: result.httpStatus,
         curlStatus: result.curlStatus,
         message: result.message,
       };
@@ -133,7 +119,8 @@ export function fetchOpenAiLikeModels(
   } catch (error) {
     return {
       ok: false,
-      status: 0,
+      httpStatus: 0,
+      curlStatus: 0,
       message: error instanceof Error ? error.message : String(error),
     };
   }
@@ -143,7 +130,7 @@ export function fetchAnthropicModels(
   endpointUrl: string,
   apiKey: string,
   options: ProviderModelOptions = {},
-): FetchModelsResult {
+): ModelCatalogFetchResult {
   const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
   try {
     const result = runCurlProbeImpl([
@@ -158,7 +145,7 @@ export function fetchAnthropicModels(
     if (!result.ok) {
       return {
         ok: false,
-        status: result.httpStatus,
+        httpStatus: result.httpStatus,
         curlStatus: result.curlStatus,
         message: result.message,
       };
@@ -167,7 +154,8 @@ export function fetchAnthropicModels(
   } catch (error) {
     return {
       ok: false,
-      status: 0,
+      httpStatus: 0,
+      curlStatus: 0,
       message: error instanceof Error ? error.message : String(error),
     };
   }
@@ -178,15 +166,17 @@ export function validateAnthropicModel(
   model: string,
   apiKey: string,
   options: ProviderModelOptions = {},
-): ValidateModelResult {
+): ModelValidationResult {
   const normalizedEndpointUrl = String(endpointUrl).replace(/\/+$/, "");
   const available = fetchAnthropicModels(endpointUrl, apiKey, options);
   if (!available.ok) {
-    if (available.status === 404 || available.status === 405) {
+    if (available.httpStatus === 404 || available.httpStatus === 405) {
       return { ok: true, validated: false };
     }
     return {
       ok: false,
+      httpStatus: available.httpStatus,
+      curlStatus: available.curlStatus,
       message: `Could not validate model against ${normalizedEndpointUrl}/v1/models: ${available.message}`,
     };
   }
@@ -195,6 +185,8 @@ export function validateAnthropicModel(
   }
   return {
     ok: false,
+    httpStatus: 200,
+    curlStatus: 0,
     message: `Model '${model}' is not available from Anthropic. Checked ${normalizedEndpointUrl}/v1/models.`,
   };
 }
@@ -205,15 +197,17 @@ export function validateOpenAiLikeModel(
   model: string,
   apiKey: string,
   options: ProviderModelOptions = {},
-): ValidateModelResult {
+): ModelValidationResult {
   const normalizedEndpointUrl = String(endpointUrl).replace(/\/+$/, "");
   const available = fetchOpenAiLikeModels(endpointUrl, apiKey, options);
   if (!available.ok) {
-    if (available.status === 404 || available.status === 405) {
+    if (available.httpStatus === 404 || available.httpStatus === 405) {
       return { ok: true, validated: false };
     }
     return {
       ok: false,
+      httpStatus: available.httpStatus,
+      curlStatus: available.curlStatus,
       message: `Could not validate model against ${normalizedEndpointUrl}/models: ${available.message}`,
     };
   }
@@ -222,6 +216,8 @@ export function validateOpenAiLikeModel(
   }
   return {
     ok: false,
+    httpStatus: 200,
+    curlStatus: 0,
     message: `Model '${model}' is not available from ${label}. Checked ${normalizedEndpointUrl}/models.`,
   };
 }

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -18,7 +18,9 @@ export interface ProviderModelOptions {
 
 function parseModelIds(body: string, itemKeys: string[] = ["id"]): string[] {
   const parsed = JSON.parse(body) as { data?: Array<Record<string, unknown> | null> };
-  if (!Array.isArray(parsed?.data)) return [];
+  if (!Array.isArray(parsed?.data)) {
+    throw new Error("Unexpected model catalog response: expected a top-level data array");
+  }
   return parsed.data
     .map((item) => {
       if (!item) return null;

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -57,7 +57,16 @@ export function fetchNvidiaEndpointModels(
         curlStatus: result.curlStatus,
       };
     }
-    return { ok: true, ids: parseModelIds(result.body) };
+    try {
+      return { ok: true, ids: parseModelIds(result.body) };
+    } catch (error) {
+      return {
+        ok: false,
+        httpStatus: result.httpStatus,
+        curlStatus: result.curlStatus,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
   } catch (error) {
     return {
       ok: false,
@@ -115,7 +124,16 @@ export function fetchOpenAiLikeModels(
         message: result.message,
       };
     }
-    return { ok: true, ids: parseModelIds(result.body) };
+    try {
+      return { ok: true, ids: parseModelIds(result.body) };
+    } catch (error) {
+      return {
+        ok: false,
+        httpStatus: result.httpStatus,
+        curlStatus: result.curlStatus,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
   } catch (error) {
     return {
       ok: false,
@@ -150,7 +168,16 @@ export function fetchAnthropicModels(
         message: result.message,
       };
     }
-    return { ok: true, ids: parseModelIds(result.body, ["id", "name"]) };
+    try {
+      return { ok: true, ids: parseModelIds(result.body, ["id", "name"]) };
+    } catch (error) {
+      return {
+        ok: false,
+        httpStatus: result.httpStatus,
+        curlStatus: result.curlStatus,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
   } catch (error) {
     return {
       ok: false,

--- a/src/lib/validation-recovery.ts
+++ b/src/lib/validation-recovery.ts
@@ -1,15 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ValidationFailureLike } from "./onboard-types";
 import { compactText } from "./url-utils";
 import { classifyValidationFailure, type ValidationClassification } from "./validation";
-
-export interface ValidationFailureLike {
-  httpStatus?: number;
-  curlStatus?: number;
-  message?: string;
-  stderr?: string;
-}
 
 export interface ProbeRecoveryOptions {
   allowModelRetry?: boolean;


### PR DESCRIPTION
## Summary
- add a shared `src/lib/onboard-types.ts` module for probe, model-catalog, and model-validation result contracts
- migrate `http-probe`, `provider-models`, and `validation-recovery` to reuse those shared types instead of redefining overlapping shapes
- normalize provider-model failure fields to use `httpStatus` / `curlStatus` consistently and preserve them through validation failures

## Testing
- `npm run build:cli`
- `npx vitest run --project cli src/lib/http-probe.test.ts src/lib/provider-models.test.ts src/lib/validation-recovery.test.ts`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized shared result/validation types so probe, fetch, and validation responses are consistent.

* **Bug Fixes**
  * Preserve and propagate HTTP and transport status details on probe/fetch/validation failures.
  * Treat malformed model catalogs as explicit failures with clear parse error messages.

* **Tests**
  * Added tests for probe failures, status propagation, and model-catalog parse/structure errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->