### PR TITLE
fix(k8s): add third-party software acceptance for non-interactive install

### DIFF
--- a/k8s/nemoclaw-k8s.yaml
+++ b/k8s/nemoclaw-k8s.yaml
@@ -73,7 +73,7 @@ spec:
           value: unix:///var/run/docker.sock
         # Dynamo endpoint (raw host:port for socat) - UPDATE THIS FOR YOUR CLUSTER
         - name: DYNAMO_HOST
-          value: "vllm-agg-frontend.dynamo.svc.cluster.local:8000"
+          value: "vllm-disagg-frontend.dynamo.svc.cluster.local:8000"
         # NemoClaw config (uses host.openshell.internal via socat)
         - name: NEMOCLAW_NON_INTERACTIVE
           value: "1"
@@ -89,6 +89,8 @@ spec:
           value: "my-assistant"
         - name: NEMOCLAW_POLICY_MODE
           value: "skip"
+        - name: NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE
+          value: "1"
       volumeMounts:
         - name: docker-socket
           mountPath: /var/run


### PR DESCRIPTION
## Summary

- Add `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` env var for unattended K8s onboarding
- Update `DYNAMO_HOST` to `vllm-disagg-frontend` for disaggregated Dynamo serving

## Problem

The K8s deployment fails during non-interactive onboarding because the installer requires explicit acceptance of third-party software terms.

## Solution

Add the `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` environment variable to the pod spec to enable fully unattended installation.

## Test plan

- [x] Deployed on EKS cluster with Dynamo disagg backend
- [x] Verified onboard completes successfully
- [x] Verified inference works from sandbox via `https://inference.local`
- [x] Verified OpenClaw agent works with Dynamo

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled acceptance of third-party software during installer and configuration workflows

* **Chores**
  * Updated backend service connectivity configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->