### PR TITLE
docs: update contributing guide about docs-to-skills pre-commit hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ All git hooks are managed by [prek](https://prek.j178.dev/), a fast, single-bina
 
 | Hook | What runs |
 |------|-----------|
-| **pre-commit** | File fixers, formatters, linters, Vitest (plugin) |
+| **pre-commit** | File fixers, formatters, linters, doc-to-skills regeneration, Vitest (plugin) |
 | **commit-msg** | commitlint (Conventional Commits) |
 | **pre-push** | TypeScript type check (`tsc --noEmit` for plugin, JS, and CLI) |
 
@@ -128,7 +128,9 @@ These generated skills let AI agents answer user questions and walk through proc
 Always edit pages in `docs/`.
 Never edit generated skill files under `.agents/skills/nemoclaw-*/` — your changes will be overwritten on the next run.
 
-After changing any page in `docs/`, regenerate the skills from the repo root:
+A pre-commit hook regenerates skills automatically whenever you commit changes to `docs/**/*.md` files. The hook runs `scripts/docs-to-skills.py` and stages the updated skills so they are included in the same commit. No manual step is needed for normal workflows.
+
+To regenerate skills manually (for example, after rebasing or outside of a commit), run from the repo root:
 
 ```bash
 python scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -48,7 +48,11 @@ The current generated skills and their source pages are:
 
 ### Regenerating skills after doc changes
 
-After changing any page in `docs/`, regenerate the skills from the repo root:
+A pre-commit hook regenerates skills automatically whenever you commit changes to `docs/**/*.md` files.
+The hook runs `scripts/docs-to-skills.py` and stages the updated skills so they are included in the same commit.
+No manual step is needed for normal workflows.
+
+To regenerate skills manually (for example, after rebasing or outside of a commit), run from the repo root:
 
 ```bash
 python scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw


### PR DESCRIPTION
## Summary

Document the new `docs-to-skills` pre-commit hook added in #1538. The hook automatically regenerates agent skills from docs whenever `docs/**/*.md` files are committed, so contributors no longer need to remember to run the script manually.

## Related Issue

Follow-up to #1538 (the hook implementation).

## Changes

- **`CONTRIBUTING.md`**: Updated the prek hooks table to mention doc-to-skills regeneration. Revised the "Doc-to-Skills Pipeline" section to lead with the automated hook behavior, keeping the manual command for edge cases.
- **`docs/CONTRIBUTING.md`**: Updated the "Regenerating skills after doc changes" subsection with the same automation-first framing.

## Type of Change

- [x] Doc only. Prose changes without code sample modifications.

## Testing

- [x] `make docs` builds without warnings.

## Checklist

### General

- [x] I have read and followed the contributing guide.
- [x] I have read and followed the style guide.

### Doc Changes

- [x] Follows the style guide.
- [x] Cross-references and links verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated contribution guidelines to clarify that skill regeneration now occurs automatically when documentation changes are committed.
  * Added guidance for manual skill regeneration in special scenarios such as rebasing or working outside of standard commit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->