### PR TITLE
refactor(cli): remove TS dependency on onboard-session shim

### DIFF
--- a/src/lib/runtime-recovery.ts
+++ b/src/lib/runtime-recovery.ts
@@ -6,9 +6,7 @@
  * output and determine recovery strategy.
  */
 
-// onboard-session is CJS — keep as require
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const onboardSession = require("../../bin/lib/onboard-session");
+import { loadSession } from "./onboard-session";
 
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
@@ -82,7 +80,7 @@ export function shouldAttemptGatewayRecovery({
 }
 
 export function getRecoveryCommand(): string {
-  const session = onboardSession.loadSession();
+  const session = loadSession();
   if (session && session.resumable !== false) {
     return "nemoclaw onboard --resume";
   }


### PR DESCRIPTION
## Summary

Remove the `src/lib/runtime-recovery.ts` dependency on the legacy `bin/lib/onboard-session` shim and import the TypeScript module directly.

## Why

This is the first small cleanup PR in the #924 follow-through: reduce TS -> legacy JS backedges so the CLI TS modules form cleaner islands.

## Changes

- replace `require("../../bin/lib/onboard-session")` with a local TS import
- keep runtime behavior unchanged

## Testing

- `npm run build:cli`
- `npx vitest run src/lib/runtime-recovery.test.ts`

Relates to #924.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module loading system to improve code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->