### PR TITLE
refactor(cli): remove TS backedges for shared paths

### DIFF
--- a/src/lib/http-probe.ts
+++ b/src/lib/http-probe.ts
@@ -11,11 +11,8 @@ import {
 } from "node:child_process";
 
 import type { ProbeResult } from "./onboard-types";
+import { ROOT } from "./paths";
 import { compactText } from "./url-utils";
-
-// runner.js is CJS — use require so we don't pull it into the TS build.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { ROOT } = require("../../bin/lib/runner");
 
 export type CurlProbeResult = ProbeResult;
 

--- a/src/lib/inference-config.ts
+++ b/src/lib/inference-config.ts
@@ -6,8 +6,7 @@
  * inference output parsing. All functions are pure.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { DEFAULT_OLLAMA_MODEL } = require("../../bin/lib/local-inference");
+import { DEFAULT_OLLAMA_MODEL } from "./local-inference";
 
 export const INFERENCE_ROUTE_URL = "https://inference.local/v1";
 export const DEFAULT_CLOUD_MODEL = "nvidia/nemotron-3-super-120b-a12b";

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { ROOT, SCRIPTS } from "../../dist/lib/paths";
+
+describe("paths", () => {
+  it("resolves the repo root", () => {
+    expect(existsSync(join(ROOT, "package.json"))).toBe(true);
+    expect(existsSync(join(ROOT, "bin", "nemoclaw.js"))).toBe(true);
+  });
+
+  it("resolves the scripts directory from the repo root", () => {
+    expect(SCRIPTS).toBe(join(ROOT, "scripts"));
+    expect(existsSync(join(SCRIPTS, "debug.sh"))).toBe(true);
+  });
+});

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+export const ROOT = path.resolve(__dirname, "..", "..");
+export const SCRIPTS = path.join(ROOT, "scripts");

--- a/src/lib/sandbox-create-stream.ts
+++ b/src/lib/sandbox-create-stream.ts
@@ -3,9 +3,7 @@
 
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 
-// runner.js is CJS.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { ROOT } = require("../../bin/lib/runner");
+import { ROOT } from "./paths";
 
 export interface StreamSandboxCreateResult {
   status: number;


### PR DESCRIPTION
## Summary

Remove a few easy TypeScript -> legacy JS backedges by extracting shared path constants into `src/lib/paths.ts` and importing `DEFAULT_OLLAMA_MODEL` from the TypeScript local-inference module directly.

## Why

This continues the #924 follow-through by tightening the TS dependency graph before the remaining runner/credentials migrations land.

## Changes

- add `src/lib/paths.ts` with `ROOT` and `SCRIPTS`
- add focused tests in `src/lib/paths.test.ts`
- switch `src/lib/http-probe.ts` and `src/lib/sandbox-create-stream.ts` off `bin/lib/runner` for path resolution
- switch `src/lib/inference-config.ts` off `bin/lib/local-inference` for `DEFAULT_OLLAMA_MODEL`

## Testing

- `npm run build:cli`
- `npx vitest run src/lib/paths.test.ts src/lib/http-probe.test.ts src/lib/sandbox-create-stream.test.ts src/lib/inference-config.test.ts`
- `npx vitest run --project cli`

Relates to #924.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module dependencies to improve code organization and consistency across the codebase
  * Centralized path management configuration to reduce code duplication and enhance maintainability

* **Tests**
  * Added comprehensive test coverage for path resolution functionality to validate file system operations and ensure proper directory structure handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->