### PR TITLE
refactor(cli): extract debug command handler

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -40,6 +40,7 @@ const { getVersion } = require("./lib/version");
 const onboardSession = require("./lib/onboard-session");
 const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
 const { NOTICE_ACCEPT_ENV, NOTICE_ACCEPT_FLAG } = require("./lib/usage-notice");
+const { runDebugCommand } = require("../dist/lib/debug-command");
 const { executeDeploy } = require("../dist/lib/deploy");
 
 // ── Global commands ──────────────────────────────────────────────
@@ -849,47 +850,13 @@ function stop() {
 
 function debug(args) {
   const { runDebug } = require("./lib/debug");
-  const opts = {};
-  for (let i = 0; i < args.length; i++) {
-    switch (args[i]) {
-      case "--help":
-      case "-h":
-        console.log("Collect NemoClaw diagnostic information\n");
-        console.log("Usage: nemoclaw debug [--quick] [--output FILE] [--sandbox NAME]\n");
-        console.log("Options:");
-        console.log("  --quick, -q        Only collect minimal diagnostics");
-        console.log("  --output, -o FILE  Write a tarball to FILE");
-        console.log("  --sandbox NAME     Target sandbox name");
-        process.exit(0);
-        break;
-      case "--quick":
-      case "-q":
-        opts.quick = true;
-        break;
-      case "--output":
-      case "-o":
-        if (!args[i + 1] || args[i + 1].startsWith("-")) {
-          console.error("Error: --output requires a file path argument");
-          process.exit(1);
-        }
-        opts.output = args[++i];
-        break;
-      case "--sandbox":
-        if (!args[i + 1] || args[i + 1].startsWith("-")) {
-          console.error("Error: --sandbox requires a name argument");
-          process.exit(1);
-        }
-        opts.sandboxName = args[++i];
-        break;
-      default:
-        console.error(`Unknown option: ${args[i]}`);
-        process.exit(1);
-    }
-  }
-  if (!opts.sandboxName) {
-    opts.sandboxName = registry.listSandboxes().defaultSandbox || undefined;
-  }
-  runDebug(opts);
+  runDebugCommand(args, {
+    getDefaultSandbox: () => registry.listSandboxes().defaultSandbox || undefined,
+    runDebug,
+    log: console.log,
+    error: console.error,
+    exit: (code) => process.exit(code),
+  });
 }
 
 function uninstall(args) {

--- a/src/lib/debug-command.test.ts
+++ b/src/lib/debug-command.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  parseDebugArgs,
+  printDebugHelp,
+  runDebugCommand,
+} from "../../dist/lib/debug-command";
+
+describe("debug command", () => {
+  it("prints help text", () => {
+    const lines: string[] = [];
+    printDebugHelp((message = "") => lines.push(message));
+    expect(lines.join("\n")).toContain("Collect NemoClaw diagnostic information");
+    expect(lines.join("\n")).toContain("--quick");
+    expect(lines.join("\n")).toContain("--sandbox");
+  });
+
+  it("parses debug options and falls back to the default sandbox", () => {
+    const opts = parseDebugArgs(["--quick", "--output", "/tmp/out.tgz"], {
+      getDefaultSandbox: () => "alpha",
+      log: () => {},
+      error: () => {},
+      exit: ((code: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never,
+    });
+    expect(opts).toEqual({ quick: true, output: "/tmp/out.tgz", sandboxName: "alpha" });
+  });
+
+  it("runs the debug command with parsed options", () => {
+    const runDebug = vi.fn();
+    runDebugCommand(["--sandbox", "beta"], {
+      getDefaultSandbox: () => "alpha",
+      runDebug,
+      log: () => {},
+      error: () => {},
+      exit: ((code: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never,
+    });
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "beta" });
+  });
+
+  it("exits on invalid arguments", () => {
+    expect(() =>
+      parseDebugArgs(["--output"], {
+        getDefaultSandbox: () => undefined,
+        log: () => {},
+        error: () => {},
+        exit: ((code: number) => {
+          throw new Error(`exit:${code}`);
+        }) as never,
+      }),
+    ).toThrow("exit:1");
+  });
+});

--- a/src/lib/debug-command.ts
+++ b/src/lib/debug-command.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { DebugOptions } from "./debug";
+
+export interface RunDebugCommandDeps {
+  getDefaultSandbox: () => string | undefined;
+  runDebug: (options: DebugOptions) => void;
+  log?: (message?: string) => void;
+  error?: (message?: string) => void;
+  exit?: (code: number) => never;
+}
+
+export function printDebugHelp(log: (message?: string) => void = console.log): void {
+  log("Collect NemoClaw diagnostic information\n");
+  log("Usage: nemoclaw debug [--quick] [--output FILE] [--sandbox NAME]\n");
+  log("Options:");
+  log("  --quick, -q        Only collect minimal diagnostics");
+  log("  --output, -o FILE  Write a tarball to FILE");
+  log("  --sandbox NAME     Target sandbox name");
+}
+
+export function parseDebugArgs(
+  args: string[],
+  deps: Pick<RunDebugCommandDeps, "getDefaultSandbox" | "log" | "error" | "exit">,
+): DebugOptions {
+  const log = deps.log ?? console.log;
+  const error = deps.error ?? console.error;
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
+  const opts: DebugOptions = {};
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--help":
+      case "-h":
+        printDebugHelp(log);
+        exit(0);
+      case "--quick":
+      case "-q":
+        opts.quick = true;
+        break;
+      case "--output":
+      case "-o":
+        if (!args[i + 1] || args[i + 1].startsWith("-")) {
+          error("Error: --output requires a file path argument");
+          exit(1);
+        }
+        opts.output = args[++i];
+        break;
+      case "--sandbox":
+        if (!args[i + 1] || args[i + 1].startsWith("-")) {
+          error("Error: --sandbox requires a name argument");
+          exit(1);
+        }
+        opts.sandboxName = args[++i];
+        break;
+      default:
+        error(`Unknown option: ${args[i]}`);
+        exit(1);
+    }
+  }
+
+  if (!opts.sandboxName) {
+    opts.sandboxName = deps.getDefaultSandbox();
+  }
+
+  return opts;
+}
+
+export function runDebugCommand(args: string[], deps: RunDebugCommandDeps): void {
+  const opts = parseDebugArgs(args, deps);
+  deps.runDebug(opts);
+}


### PR DESCRIPTION
## Summary

Extract the top-level `nemoclaw debug` argument parsing and help handling from `bin/nemoclaw.js` into a typed module under `src/lib/debug-command.ts`.

## Why

This continues the #924 follow-through by shrinking the monolithic dispatcher and moving command logic into reusable typed modules before the eventual CLI framework migration.

## Changes

- add `src/lib/debug-command.ts` with:
  - `printDebugHelp()`
  - `parseDebugArgs()`
  - `runDebugCommand()`
- add focused tests in `src/lib/debug-command.test.ts`
- reduce `bin/nemoclaw.js` to a thin wrapper that injects legacy dependencies

## Testing

- `npm run build:cli`
- `npx vitest run src/lib/debug-command.test.ts test/cli.test.js`

Relates to #924.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized debug command implementation into a dedicated module for improved separation of concerns.

* **Tests**
  * Added comprehensive test suite for debug command functionality covering flag parsing and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->