### PR TITLE
refactor(cli): extract start and stop handlers

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -41,6 +41,7 @@ const onboardSession = require("./lib/onboard-session");
 const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
 const { NOTICE_ACCEPT_ENV, NOTICE_ACCEPT_FLAG } = require("./lib/usage-notice");
 const { executeDeploy } = require("../dist/lib/deploy");
+const { runStartCommand, runStopCommand } = require("../dist/lib/services-command");
 
 // ── Global commands ──────────────────────────────────────────────
 
@@ -833,18 +834,18 @@ async function deploy(instanceName) {
 
 async function start() {
   const { startAll } = require("./lib/services");
-  const { defaultSandbox } = registry.listSandboxes();
-  const safeName =
-    defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  await startAll({ sandboxName: safeName || undefined });
+  await runStartCommand({
+    listSandboxes: () => registry.listSandboxes(),
+    startAll,
+  });
 }
 
 function stop() {
   const { stopAll } = require("./lib/services");
-  const { defaultSandbox } = registry.listSandboxes();
-  const safeName =
-    defaultSandbox && /^[a-zA-Z0-9._-]+$/.test(defaultSandbox) ? defaultSandbox : null;
-  stopAll({ sandboxName: safeName || undefined });
+  runStopCommand({
+    listSandboxes: () => registry.listSandboxes(),
+    stopAll,
+  });
 }
 
 function debug(args) {

--- a/src/lib/services-command.test.ts
+++ b/src/lib/services-command.test.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolveDefaultSandboxName,
+  runStartCommand,
+  runStopCommand,
+} from "../../dist/lib/services-command";
+
+describe("services command", () => {
+  it("returns a safe default sandbox name", () => {
+    expect(resolveDefaultSandboxName(() => ({ defaultSandbox: "alpha-1" }))).toBe("alpha-1");
+  });
+
+  it("drops an unsafe default sandbox name", () => {
+    expect(resolveDefaultSandboxName(() => ({ defaultSandbox: "bad name" }))).toBeUndefined();
+    expect(resolveDefaultSandboxName(() => ({ defaultSandbox: "../../oops" }))).toBeUndefined();
+  });
+
+  it("starts services for the default sandbox when present", async () => {
+    const startAll = vi.fn(async () => {});
+    await runStartCommand({
+      listSandboxes: () => ({ defaultSandbox: "alpha" }),
+      startAll,
+    });
+    expect(startAll).toHaveBeenCalledWith({ sandboxName: "alpha" });
+  });
+
+  it("stops services without a sandbox override when the default sandbox is unsafe", () => {
+    const stopAll = vi.fn();
+    runStopCommand({
+      listSandboxes: () => ({ defaultSandbox: "bad name" }),
+      stopAll,
+    });
+    expect(stopAll).toHaveBeenCalledWith({ sandboxName: undefined });
+  });
+});

--- a/src/lib/services-command.test.ts
+++ b/src/lib/services-command.test.ts
@@ -17,6 +17,8 @@ describe("services command", () => {
   it("drops an unsafe default sandbox name", () => {
     expect(resolveDefaultSandboxName(() => ({ defaultSandbox: "bad name" }))).toBeUndefined();
     expect(resolveDefaultSandboxName(() => ({ defaultSandbox: "../../oops" }))).toBeUndefined();
+    expect(resolveDefaultSandboxName(() => ({ defaultSandbox: ".hidden" }))).toBeUndefined();
+    expect(resolveDefaultSandboxName(() => ({ defaultSandbox: "-leading-dash" }))).toBeUndefined();
   });
 
   it("starts services for the default sandbox when present", async () => {

--- a/src/lib/services-command.ts
+++ b/src/lib/services-command.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface SandboxSummary {
+  defaultSandbox?: string | null;
+}
+
+export interface StartCommandDeps {
+  listSandboxes: () => SandboxSummary;
+  startAll: (options: { sandboxName?: string }) => Promise<void>;
+}
+
+export interface StopCommandDeps {
+  listSandboxes: () => SandboxSummary;
+  stopAll: (options: { sandboxName?: string }) => void;
+}
+
+const SAFE_SANDBOX_RE = /^[a-zA-Z0-9._-]+$/;
+
+export function resolveDefaultSandboxName(listSandboxes: () => SandboxSummary): string | undefined {
+  const { defaultSandbox } = listSandboxes();
+  return defaultSandbox && SAFE_SANDBOX_RE.test(defaultSandbox) ? defaultSandbox : undefined;
+}
+
+export async function runStartCommand(deps: StartCommandDeps): Promise<void> {
+  await deps.startAll({ sandboxName: resolveDefaultSandboxName(deps.listSandboxes) });
+}
+
+export function runStopCommand(deps: StopCommandDeps): void {
+  deps.stopAll({ sandboxName: resolveDefaultSandboxName(deps.listSandboxes) });
+}

--- a/src/lib/services-command.ts
+++ b/src/lib/services-command.ts
@@ -15,7 +15,7 @@ export interface StopCommandDeps {
   stopAll: (options: { sandboxName?: string }) => void;
 }
 
-const SAFE_SANDBOX_RE = /^[a-zA-Z0-9._-]+$/;
+const SAFE_SANDBOX_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
 
 export function resolveDefaultSandboxName(listSandboxes: () => SandboxSummary): string | undefined {
   const { defaultSandbox } = listSandboxes();


### PR DESCRIPTION
## Summary

Extract the top-level `nemoclaw start` and `nemoclaw stop` wrappers from `bin/nemoclaw.js` into a typed module under `src/lib/services-command.ts`.

## Why

This continues the #924 follow-through by shrinking the monolithic dispatcher and moving simple command logic into reusable typed modules ahead of the eventual CLI framework migration.

## Changes

- add `src/lib/services-command.ts` with:
  - `resolveDefaultSandboxName()`
  - `runStartCommand()`
  - `runStopCommand()`
- add focused tests in `src/lib/services-command.test.ts`
- reduce `bin/nemoclaw.js` to thin wrappers around the extracted handlers

## Testing

- `npm run build:cli`
- `npx vitest run src/lib/services-command.test.ts test/cli.test.js`

Relates to #924.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized start and stop command implementations to use shared command runners for improved consistency.
  * Enhanced sandbox name validation to ensure safer command execution.

* **Tests**
  * Added comprehensive test coverage for command validation and sandbox handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->