### PR TITLE
fix: clear onboard session when stale sandbox is removed (#1316)

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -678,6 +678,13 @@ async function ensureLiveSandboxOrExit(sandboxName) {
   }
   if (lookup.state === "missing") {
     registry.removeSandbox(sandboxName);
+    const session = onboardSession.loadSession();
+    if (session && session.sandboxName === sandboxName) {
+      onboardSession.updateSession((s) => {
+        s.sandboxName = null;
+        return s;
+      });
+    }
     console.error(`  Sandbox '${sandboxName}' is not present in the live OpenShell gateway.`);
     console.error("  Removed stale local registry entry.");
     console.error(
@@ -1047,6 +1054,13 @@ async function sandboxStatus(sandboxName) {
     console.log(lookup.output);
   } else if (lookup.state === "missing") {
     registry.removeSandbox(sandboxName);
+    const session = onboardSession.loadSession();
+    if (session && session.sandboxName === sandboxName) {
+      onboardSession.updateSession((s) => {
+        s.sandboxName = null;
+        return s;
+      });
+    }
     console.log("");
     console.log(`  Sandbox '${sandboxName}' is not present in the live OpenShell gateway.`);
     console.log("  Removed stale local registry entry.");
@@ -1239,6 +1253,13 @@ async function sandboxDestroy(sandboxName, args = []) {
   }
 
   const removed = registry.removeSandbox(sandboxName);
+  const session = onboardSession.loadSession();
+  if (session && session.sandboxName === sandboxName) {
+    onboardSession.updateSession((s) => {
+      s.sandboxName = null;
+      return s;
+    });
+  }
   if (
     (deleteResult.status === 0 || alreadyGone) &&
     removed &&


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
 After a sandbox deletion , `nemoclaw list` shows ghost sandboxes recovered from `onboard-session.json`. The `status`  
  command detect the sandbox is missing and remove it from the registry, but `onboard-session.json` is never cleaned, causing `nemoclaw list` to re-add it every time.

## Related Issue
 Fixes #1316

## Changes
`bin/nemoclaw.js`: Clear `sandboxName` from `onboard-session.json` when a sandbox is removed from the registry, at all three  `registry.removeSandbox()` call sites (connect, status, destroy paths).   

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
`openshell sandbox delete` -> `nemoclaw list` (deleted sandbox still shown) -> `nemoclaw status` (removes  
  stale entry) → `nemoclaw list` (deleted sandbox reappears). After the fix, the deleted sandbox does not reappear.   

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>
