### PR TITLE
fix(policy): block POST to sentry.io to prevent multi-tenant data exfiltration (#1437)

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -63,6 +63,20 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
+      # sentry.io is a multi-tenant SaaS — any authenticated client can POST
+      # to ANY Sentry project, not just NemoClaw's. Allowing POST /** turned
+      # the host into a generic exfiltration channel: a compromised agent
+      # could ship stack traces, env vars, file contents, etc. to a Sentry
+      # project controlled by an attacker via the public envelope endpoint
+      # (https://sentry.io/api/<any-project>/envelope/). Path-pattern
+      # restrictions cannot fix this because the project ID is part of the
+      # URL and there is no server-side allowlist of legitimate projects.
+      #
+      # Block POST entirely. GET stays allowed because it has no request
+      # body and is harmless for exfil. Side effect: Claude Code's crash
+      # telemetry to Sentry is silently dropped — that is the right
+      # tradeoff for a sandbox whose stated goal is preventing data egress.
+      # See #1437.
       - host: sentry.io
         port: 443
         protocol: rest
@@ -70,7 +84,6 @@ network_policies:
         tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/claude }
 

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -83,4 +83,50 @@ describe("base sandbox policy", () => {
   it("has 'network_policies'", () => {
     expect("network_policies" in policy).toBe(true);
   });
+
+  // Walk every endpoint in every network_policies entry and return the
+  // entries whose host matches `hostMatcher`. Used by the regressions below.
+  type Rule = { allow?: { method?: string; path?: string } };
+  type Endpoint = { host?: string; rules?: Rule[] };
+  function findEndpoints(hostMatcher: (h: string) => boolean): Endpoint[] {
+    const out: Endpoint[] = [];
+    const np = (policy as Record<string, unknown>).network_policies;
+    if (!np || typeof np !== "object") return out;
+    for (const value of Object.values(np as Record<string, unknown>)) {
+      if (!value || typeof value !== "object") continue;
+      const endpoints = (value as { endpoints?: unknown }).endpoints;
+      if (!Array.isArray(endpoints)) continue;
+      for (const ep of endpoints) {
+        if (ep && typeof ep === "object" && typeof (ep as Endpoint).host === "string") {
+          if (hostMatcher((ep as Endpoint).host as string)) {
+            out.push(ep as Endpoint);
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  it("regression #1437: sentry.io has no POST allow rule (multi-tenant exfiltration vector)", () => {
+    const sentryEndpoints = findEndpoints((h) => h === "sentry.io");
+    expect(sentryEndpoints.length).toBeGreaterThan(0); // should still appear
+    for (const ep of sentryEndpoints) {
+      const rules = Array.isArray(ep.rules) ? ep.rules : [];
+      const hasPost = rules.some(
+        (r) => r && r.allow && typeof r.allow.method === "string" && r.allow.method.toUpperCase() === "POST",
+      );
+      expect(hasPost).toBe(false);
+    }
+  });
+
+  it("regression #1437: sentry.io retains GET (harmless, no body for exfil)", () => {
+    const sentryEndpoints = findEndpoints((h) => h === "sentry.io");
+    for (const ep of sentryEndpoints) {
+      const rules = Array.isArray(ep.rules) ? ep.rules : [];
+      const hasGet = rules.some(
+        (r) => r && r.allow && typeof r.allow.method === "string" && r.allow.method.toUpperCase() === "GET",
+      );
+      expect(hasGet).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes #1437.

The baseline sandbox network policy allowed `POST` to `sentry.io` with `path: "/**"`. Because sentry.io is a multi-tenant SaaS — any client with a project ID can post to any Sentry project — this turned the host into a generic exfiltration channel: a compromised agent inside the sandbox could ship stack traces, environment variables, file contents, etc. to a Sentry project controlled by an attacker via the public envelope endpoint:

```
POST https://sentry.io/api/<any-project-id>/envelope/
```

Path-pattern restrictions cannot fix this on their own — the project ID is part of the URL and there is no server-side allowlist of legitimate projects from the policy engine's perspective.

This is a follow-up to #1214, which added `protocol: rest` to the sentry.io entry. That PR closed the wire-protocol gap; this PR closes the remaining HTTP-method-level gap.

## Fix

Drop the `method: POST, path: "/**"` allow rule from the sentry.io endpoint in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`. `GET` stays allowed because `GET` has no request body and is harmless for exfiltration.

Side effect: Claude Code's crash telemetry to Sentry is silently dropped from inside the sandbox. That is the right tradeoff for a sandbox whose stated goal is preventing data egress, and the sandbox already blocks many similar telemetry channels by default.

A long inline comment in the YAML documents the rationale so a future contributor doesn't re-add the rule "to fix Sentry telemetry" without understanding why it was removed.

## Test plan

- [x] **New regression tests** in `test/validate-blueprint.test.ts` walk every endpoint in every entry under `network_policies` and assert:
  1. At least one `sentry.io` endpoint still exists (so a future edit that *removes* the host entirely also gets noticed)
  2. No `sentry.io` endpoint has any `POST` allow rule
  3. `sentry.io` retains its `GET` allow rule
- [x] **Negative case verified**: stashed the YAML fix, re-ran the test against an unfixed `main`. The `no POST allow rule` assertion correctly **fails**, proving the test catches the bug.
- [x] **Positive case verified**: re-applied the YAML fix, re-ran the test. All 24 `validate-blueprint` tests pass, including the 2 new regressions.
- [x] No other test in the repo references `sentry.io` (`grep -rn sentry test/ nemoclaw-blueprint/`), so there is no risk of breaking unrelated coverage.

## Why GET stays

`GET` requests cannot carry a request body. Exfiltration via `GET` is bounded by the URL length limit and stripped of any meaningful data structure. The realistic exfil channels (envelope, store, security report endpoints) all use `POST`. Keeping `GET` lets any read-only Sentry SDK code paths (e.g. fetching public DSN config) continue to work without re-introducing the exfiltration vector.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened network access policies by restricting HTTP methods for external service communications, removing unnecessary request capabilities while maintaining essential monitoring operations

* **Tests**
  * Added regression tests to validate that network policy restrictions are properly enforced across all configured endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->