### PR TITLE
fix(test): update onboard test mocks to match shell-quoted sandboxName

### DIFF
--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -1486,7 +1486,7 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (command.includes("'sandbox' 'get' 'my-assistant'")) return "";
   if (command.includes("'sandbox' 'list'")) return "my-assistant Ready";
-  if (command.includes("sandbox exec my-assistant curl -sf http://localhost:18789/")) return "ok";
+  if (command.includes("sandbox exec 'my-assistant' curl -sf http://localhost:18789/")) return "ok";
   if (command.includes("'forward' 'list'")) return "18789 -> my-assistant:18789";
   return "";
 };
@@ -1591,7 +1591,7 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (command.includes("'sandbox' 'get' 'my-assistant'")) return "";
   if (command.includes("'sandbox' 'list'")) return "my-assistant Ready";
-  if (command.includes("sandbox exec my-assistant curl -sf http://localhost:18789/")) return "ok";
+  if (command.includes("sandbox exec 'my-assistant' curl -sf http://localhost:18789/")) return "ok";
   if (command.includes("'forward' 'list'")) return "18789 -> my-assistant:18789";
   return "";
 };
@@ -2319,7 +2319,7 @@ runner.runCapture = (command) => {
     sandboxListCalls += 1;
     return sandboxListCalls >= 2 ? "my-assistant Ready" : "my-assistant Pending";
   }
-  if (command.includes("sandbox exec my-assistant curl -sf http://localhost:18789/")) return "ok";
+  if (command.includes("sandbox exec 'my-assistant' curl -sf http://localhost:18789/")) return "ok";
   if (command.includes("'forward' 'list'")) return "18789 -> my-assistant:18789";
   return "";
 };
@@ -2700,7 +2700,7 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (command.includes("'sandbox' 'get' 'my-assistant'")) return "";
   if (command.includes("'sandbox' 'list'")) return "my-assistant Ready";
-  if (command.includes("sandbox exec my-assistant curl -sf http://localhost:18789/")) return "ok";
+  if (command.includes("sandbox exec 'my-assistant' curl -sf http://localhost:18789/")) return "ok";
   if (command.includes("'forward' 'list'")) return "18789 -> my-assistant:18789";
   return "";
 };
@@ -2827,7 +2827,7 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (command.includes("'sandbox' 'get' 'my-assistant'")) return "";
   if (command.includes("'sandbox' 'list'")) return "my-assistant Ready";
-  if (command.includes("sandbox exec my-assistant curl -sf http://localhost:18789/")) return "ok";
+  if (command.includes("sandbox exec 'my-assistant' curl -sf http://localhost:18789/")) return "ok";
   if (command.includes("'forward' 'list'")) return "18789 -> my-assistant:18789";
   return "";
 };
@@ -3085,7 +3085,7 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (command.includes("'sandbox' 'get' 'my-assistant'")) return "";
   if (command.includes("'sandbox' 'list'")) return "my-assistant Ready";
-  if (command.includes("sandbox exec my-assistant curl -sf http://localhost:18789/")) return "ok";
+  if (command.includes("sandbox exec 'my-assistant' curl -sf http://localhost:18789/")) return "ok";
   if (command.includes("'forward' 'list'")) return "18789 -> my-assistant:18789";
   return "";
 };

--- a/test/shellquote-sandbox.test.js
+++ b/test/shellquote-sandbox.test.js
@@ -30,10 +30,7 @@ describe("sandboxName shell quoting in onboard.js", () => {
     let match;
     while ((match = callPattern.exec(src)) !== null) {
       const template = match[2];
-      if (
-        template.includes("${sandboxName}") &&
-        !template.includes("shellQuote(sandboxName)")
-      ) {
+      if (template.includes("${sandboxName}") && !template.includes("shellQuote(sandboxName)")) {
         const line = src.slice(0, match.index).split("\n").length;
         violations.push(`Line ${line}: ${match[0].slice(0, 120).trim()}`);
       }


### PR DESCRIPTION
## Summary

- Update 6 `runCapture` mock matchers in `test/onboard.test.js` to match the shell-quoted sandbox name format introduced by 8f8b4e7
- The security fix wrapped `sandboxName` with `shellQuote()` in exec and DNS proxy commands, but the test mocks still matched the old unquoted format (`sandbox exec my-assistant curl` vs `sandbox exec 'my-assistant' curl`)
- This caused 4 CI failures: 3 timeouts (dashboard readiness loop never matched) and 1 assertion error (`null !== 0`)

## Test plan

- [x] `npx vitest run` — all 1126 tests pass (67 files, 0 failures)
- [x] All pre-commit and pre-push hooks pass

Fixes the CI break introduced by #1392.

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test matchers to correctly detect sandbox invocations that use a quoted sandbox name in command strings.
  * Simplified test logic for scanning run/runCapture templates into an equivalent single-line expression, preserving existing violation detection and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->