### PR TITLE
fix(security): harden auto-pair with one-shot exit and shorter timeout

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -341,20 +341,23 @@ import subprocess
 import time
 
 OPENCLAW = os.environ.get('OPENCLAW_BIN', 'openclaw')
-DEADLINE = time.time() + 600
+DEADLINE = time.time() + 180
 QUIET_POLLS = 0
 APPROVED = 0
 HANDLED = set()  # Track rejected/approved requestIds to avoid reprocessing
 # SECURITY NOTE: clientId/clientMode are client-supplied and spoofable
 # (the gateway stores connectParams.client.id verbatim). This allowlist
-# is defense-in-depth, not a trust boundary. PR #690 adds one-shot exit,
-# timeout reduction, and token cleanup for a more comprehensive fix.
+# is defense-in-depth, not a trust boundary — real identity validation
+# would need to happen in the gateway itself.
 ALLOWED_CLIENTS = {'openclaw-control-ui'}
 ALLOWED_MODES = {'webchat', 'cli'}
 
 def run(*args):
     proc = subprocess.run(args, capture_output=True, text=True)
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+# Clear stale device tokens from previous sessions
+run(OPENCLAW, 'devices', 'clear', '--yes')
 
 while time.time() < DEADLINE:
     rc, out, err = run(OPENCLAW, 'devices', 'list', '--json')
@@ -384,12 +387,18 @@ while time.time() < DEADLINE:
             if client_id not in ALLOWED_CLIENTS and client_mode not in ALLOWED_MODES:
                 HANDLED.add(request_id)
                 print(f'[auto-pair] rejected unknown client={client_id} mode={client_mode}')
+                run(OPENCLAW, 'devices', 'reject', request_id, '--json')
                 continue
             arc, aout, aerr = run(OPENCLAW, 'devices', 'approve', request_id, '--json')
             HANDLED.add(request_id)
             if arc == 0:
                 APPROVED += 1
                 print(f'[auto-pair] approved request={request_id} client={client_id}')
+                # One-shot: after first approval, shrink deadline and stop
+                # processing further pending requests in this poll
+                if APPROVED == 1:
+                    DEADLINE = time.time() + 5
+                break
             elif aout or aerr:
                 print(f'[auto-pair] approve failed request={request_id}: {(aerr or aout)[:400]}')
         time.sleep(1)
@@ -408,6 +417,8 @@ while time.time() < DEADLINE:
     time.sleep(1)
 else:
     print(f'[auto-pair] watcher timed out approvals={APPROVED}')
+    # Clear any remaining pending requests on timeout
+    run(OPENCLAW, 'devices', 'clear', '--pending', '--yes')
 PYAUTOPAIR
   AUTO_PAIR_PID=$!
   echo "[gateway] auto-pair watcher launched (pid $AUTO_PAIR_PID)" >&2


### PR DESCRIPTION
## Summary

Fixes #1310 — after a fresh `nemoclaw onboard`, `openclaw tui` fails with "Pairing required" because the auto-pair watcher either doesn't approve in time or leaves stale tokens from previous sessions.

Supersedes #690 (closed), incorporating cv's review feedback.

**Changes to `start_auto_pair()` in `scripts/nemoclaw-start.sh`:**

- **Timeout 600s → 180s** — shrinks the open approval window
- **Clear stale tokens on start** — `openclaw devices clear --yes` before polling, preventing "Token Mismatch" errors from previous sessions (reported by rp-tn in #1310)
- **One-shot exit** — after the first successful approval, set deadline to now+5s and `break` out of the inner loop. The `APPROVED == 1` guard ensures the deadline is only set once (addresses cv's review on #690)
- **Explicitly reject non-allowlisted clients** — `openclaw devices reject` instead of silently skipping
- **Clear pending on timeout** — `openclaw devices clear --pending --yes` in the `else` clause

**Not changed:** The `clientId` allowlist comment was updated to correctly frame it as defense-in-depth, not a security boundary (per cv's review). Real identity validation would need gateway-side changes.

## Test plan

- [x] `nemoclaw-start.test.js` — 31/31 pass
- [x] shellcheck passes
- [ ] Manual: `nemoclaw onboard` with defaults → `nemoclaw <sandbox> connect` → `openclaw tui` → verify chat works without manual device approval
- [ ] Manual: verify second device request after first approval is NOT auto-approved
- [ ] Manual: verify stale tokens from previous session don't cause "Token Mismatch" errors on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved device auto-pairing workflow with faster processing and enhanced cleanup procedures.
  * Strengthened request validation by explicitly rejecting non-conforming device requests.
  * Optimized timeout handling to prevent unnecessary pending requests from accumulating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->