### PR TITLE
feat(release): add version bump script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc -p jsconfig.json",
     "build:cli": "tsc -p tsconfig.src.json",
     "typecheck:cli": "tsc -p tsconfig.cli.json",
+    "bump:version": "tsx scripts/bump-version.ts",
     "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; elif [ -d node_modules/@j178/prek ]; then echo \"ERROR: prek package found but binary not in PATH\" && exit 1; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -15,6 +15,8 @@ type Options = {
   dryRun: boolean;
   skipTests: boolean;
   docsMode: "latest" | "versioned";
+  createPr: boolean;
+  branchName: string;
 };
 
 type PackageJson = {
@@ -87,21 +89,25 @@ function main(): void {
     runChecks(options.version);
   }
 
-  if (options.commit) {
-    git(["add", ...FILES_TO_STAGE]);
-    git(["commit", "-m", `chore(release): bump version to ${tagName}`]);
-  }
+  if (options.createPr) {
+    createReleasePr(options, previousVersion, tagName);
+  } else {
+    if (options.commit) {
+      git(["add", ...FILES_TO_STAGE]);
+      git(["commit", "-m", `chore(release): bump version to ${tagName}`]);
+    }
 
-  if (options.tag) {
-    git(["tag", "-a", tagName, "-m", tagName]);
-    updateLatestTag(tagName);
-  }
-
-  if (options.push) {
-    git(["push", "origin", "HEAD"]);
     if (options.tag) {
-      git(["push", "origin", tagName]);
-      git(["push", "origin", "latest", "--force"]);
+      git(["tag", "-a", tagName, "-m", tagName]);
+      updateLatestTag(tagName);
+    }
+
+    if (options.push) {
+      git(["push", "origin", "HEAD"]);
+      if (options.tag) {
+        git(["push", "origin", tagName]);
+        git(["push", "origin", "latest", "--force"]);
+      }
     }
   }
 
@@ -116,11 +122,19 @@ function parseArgs(args: string[]): Options {
   let dryRun = false;
   let skipTests = false;
   let docsMode: "latest" | "versioned" = "versioned";
+  let createPr = true;
+  let branchName = "";
 
   for (const arg of args) {
     switch (arg) {
       case "--push":
         push = true;
+        break;
+      case "--create-pr":
+        createPr = true;
+        break;
+      case "--no-create-pr":
+        createPr = false;
         break;
       case "--no-commit":
         commit = false;
@@ -145,6 +159,10 @@ function parseArgs(args: string[]): Options {
         printUsageAndExit(0);
         break;
       default:
+        if (arg.startsWith("--branch=")) {
+          branchName = arg.slice("--branch=".length);
+          break;
+        }
         if (arg.startsWith("-")) {
           throw new Error(`Unknown flag: ${arg}`);
         }
@@ -168,7 +186,15 @@ function parseArgs(args: string[]): Options {
     throw new Error("--push requires tagging; do not combine --push with --no-tag");
   }
 
-  return { version, push, commit, tag, dryRun, skipTests, docsMode };
+  if (createPr && push) {
+    throw new Error("--push cannot be combined with --create-pr; PR mode pushes a release branch instead");
+  }
+
+  if (!branchName) {
+    branchName = `release/${version}`;
+  }
+
+  return { version, push, commit, tag, dryRun, skipTests, docsMode, createPr, branchName };
 }
 
 function printUsageAndExit(code: number): never {
@@ -176,7 +202,10 @@ function printUsageAndExit(code: number): never {
     "Usage: npm run bump:version -- <version> [options]",
     "",
     "Options:",
-    "  --push        Push the commit and tags to origin",
+    "  --push        Push the commit and tags to origin (non-PR mode only)",
+    "  --create-pr   Create a release PR branch and open a PR (default)",
+    "  --no-create-pr Update the current branch directly instead of opening a PR",
+    "  --branch=NAME Use a custom PR branch name (default: release/<version>)",
     "  --no-commit   Update files but do not create a commit",
     "  --no-tag      Update files but do not create vX.Y.Z/latest tags",
     "  --dry-run     Print the release plan and checks without writing files",
@@ -366,6 +395,102 @@ function git(args: string[]): void {
   run("git", args);
 }
 
+function createReleasePr(options: Options, previousVersion: string, tagName: string): void {
+  if (!options.commit) {
+    throw new Error("--create-pr requires commits; do not combine it with --no-commit");
+  }
+
+  ensureGhCliAvailable();
+  ensureBranchDoesNotExist(options.branchName);
+
+  git(["checkout", "-b", options.branchName]);
+  git(["add", ...FILES_TO_STAGE]);
+  git(["commit", "-m", `chore(release): bump version to ${tagName}`]);
+  git(["push", "-u", "origin", options.branchName]);
+
+  const prBody = buildPrBody(previousVersion, options.version);
+  const prUrl = run(
+    "gh",
+    [
+      "pr",
+      "create",
+      "--base",
+      "main",
+      "--head",
+      options.branchName,
+      "--title",
+      `chore(release): bump version to ${tagName}`,
+      "--body",
+      prBody,
+    ],
+  ).trim();
+
+  log(`Release PR created: ${prUrl}`);
+  log(`Review and merge the PR before creating release tags on main.`);
+}
+
+function ensureGhCliAvailable(): void {
+  run("gh", ["--version"]);
+}
+
+function ensureBranchDoesNotExist(branchName: string): void {
+  if (gitRefExists(`refs/heads/${branchName}`) || gitRemoteBranchExists(branchName)) {
+    throw new Error(`Branch already exists: ${branchName}`);
+  }
+}
+
+function gitRemoteBranchExists(branchName: string): boolean {
+  return run("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], { allowFailure: true }).exitCode === 0;
+}
+
+function buildPrBody(previousVersion: string, nextVersion: string): string {
+  return [
+    "## Summary",
+    `Bump NemoClaw from ${previousVersion} to ${nextVersion} across the CLI package, plugin package,`,
+    "blueprint manifest, installer defaults, and versioned docs references.",
+    "",
+    "## Related Issue",
+    "Fixes #1577.",
+    "",
+    "## Changes",
+    `- bump release version from ${previousVersion} to ${nextVersion}`,
+    "- update installer and docs version references to match the npm/package version",
+    "- keep release changes isolated in a PR branch instead of updating main directly",
+    "",
+    "## Type of Change",
+    "- [x] Code change for a new feature, bug fix, or refactor.",
+    "- [ ] Code change with doc updates.",
+    "- [ ] Doc only. Prose changes without code sample modifications.",
+    "- [ ] Doc only. Includes code sample changes.",
+    "",
+    "## Testing",
+    "- [ ] `npx prek run --all-files` passes (or equivalently `make check`).",
+    "- [x] `npm test` passes.",
+    "- [ ] `make docs` builds without warnings. (for doc-only changes)",
+    "",
+    "## Checklist",
+    "",
+    "### General",
+    "",
+    "- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).",
+    "- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)",
+    "",
+    "### Code Changes",
+    "- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).",
+    "- [ ] Tests added or updated for new or changed behavior.",
+    "- [x] No secrets, API keys, or credentials committed.",
+    "- [x] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).",
+    "",
+    "### Doc Changes",
+    "- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with \"`/update-docs` catch up the docs for the new changes I made in this PR.\"",
+    "- [ ] New pages include SPDX license header and frontmatter, if creating a new page.",
+    "- [x] Cross-references and links verified.",
+    "",
+    "---",
+    "Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>",
+  ].join("\n");
+}
+
 function updateLatestTag(tagName: string): void {
   log(`Updating mutable 'latest' tag to ${tagName}`);
   if (gitRefExists("refs/tags/latest")) {
@@ -468,12 +593,13 @@ function printDryRunPlan(
   log(`Docs URL target: ${docsPublicUrl}/`);
   log(`Files to update: ${FILES_TO_STAGE.map((filePath) => relative(filePath)).join(", ")}`);
   log("Pre-checks: clean git tree, main branch, canonical origin, origin/main sync, tag availability");
+  log(`Mode: ${docsMode === "versioned" ? "versioned docs" : "latest docs"}, ${skipTests ? "tests skipped" : "tests enabled"}`);
   if (skipTests) {
     log("Checks: installer version/output verification only (tests skipped)");
   } else {
     log("Checks: installer version, build:cli, typecheck:cli, npm test");
   }
-  log("No files were written. No commit, tags, or pushes were performed.");
+  log("No files were written. No commit, PR, tags, or pushes were performed.");
 }
 
 function log(message: string): void {

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -84,8 +84,9 @@ function main(): void {
 
   verifyVersionState(options.version, nextDocsPublicUrl, nextDocsVersion);
 
+  runInstallerAndBuild(options.version);
   if (!options.skipTests) {
-    runChecks(options.version);
+    runTypecheckAndTests();
   }
 
   if (options.createPr) {
@@ -183,6 +184,10 @@ function parseArgs(args: string[]): Options {
 
   if (push && !tag) {
     throw new Error("--push requires tagging; do not combine --push with --no-tag");
+  }
+
+  if (tag && !commit) {
+    throw new Error("--tag requires committing; do not combine --tag with --no-commit");
   }
 
   if (createPr && push) {
@@ -365,7 +370,7 @@ function verifyVersionState(version: string, docsPublicUrl: string, docsDisplayV
   }
 }
 
-function runChecks(version: string): void {
+function runInstallerAndBuild(version: string): void {
   log("Running installer version check");
   const installerVersion = run("bash", [INSTALL_SH, "--version"]);
   if (!installerVersion.includes(`v${version}`)) {
@@ -374,7 +379,9 @@ function runChecks(version: string): void {
 
   log("Running build:cli");
   run("npm", ["run", "build:cli"]);
+}
 
+function runTypecheckAndTests(): void {
   log("Running typecheck:cli");
   run("npm", ["run", "typecheck:cli"]);
 
@@ -596,7 +603,7 @@ function printDryRunPlan(
   log("Pre-checks: clean git tree, main branch, canonical origin, origin/main sync, tag availability");
   log(`Mode: ${docsMode === "versioned" ? "versioned docs" : "latest docs"}, ${skipTests ? "tests skipped" : "tests enabled"}`);
   if (skipTests) {
-    log("Checks: installer version/output verification only (tests skipped)");
+    log("Checks: installer version and build:cli only (typecheck and tests skipped)");
   } else {
     log("Checks: installer version, build:cli, typecheck:cli, npm test");
   }

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -67,7 +67,6 @@ function main(): void {
 
   const nextDocsVersion = `v${options.version}`;
   const docsSegment = options.docsMode === "versioned" ? options.version : "latest";
-  const nextDocsBaseUrl = `https://docs.nvidia.com/nemoclaw/${docsSegment}/`;
   const nextDocsPublicUrl = `https://docs.nvidia.com/nemoclaw/${docsSegment}`;
 
   if (options.dryRun) {
@@ -79,11 +78,11 @@ function main(): void {
   updatePackageJson(PLUGIN_PACKAGE_JSON, options.version);
   updateBlueprintVersion(options.version);
   updateInstallScriptDefaultVersion(previousVersion, options.version);
-  updateDocsConf(options.version, nextDocsBaseUrl);
+  updateDocsConf(options.version);
   updateDocsVersionLinks(nextDocsPublicUrl);
   updateInstallAndUninstallDocs(nextDocsVersion);
 
-  verifyVersionState(options.version, nextDocsBaseUrl, nextDocsPublicUrl, nextDocsVersion);
+  verifyVersionState(options.version, nextDocsPublicUrl, nextDocsVersion);
 
   if (!options.skipTests) {
     runChecks(options.version);
@@ -292,22 +291,15 @@ function updateInstallScriptDefaultVersion(previousVersion: string, nextVersion:
   );
 }
 
-function updateDocsConf(nextVersion: string, nextDocsBaseUrl: string): void {
+function updateDocsConf(nextVersion: string): void {
   const current = readText(DOCS_CONF);
   const releaseReplacement = `release = "${nextVersion}"`;
-  const baseUrlReplacement = `html_baseurl = "${nextDocsBaseUrl}"`;
 
   let updated = current;
   if (/^release = ".*"$/m.test(updated)) {
     updated = updated.replace(/^release = ".*"$/m, releaseReplacement);
   } else {
     throw new Error("Could not find release assignment in docs/conf.py");
-  }
-
-  if (/^html_baseurl = ".*"$/m.test(updated)) {
-    updated = updated.replace(/^html_baseurl = ".*"$/m, baseUrlReplacement);
-  } else {
-    throw new Error("Could not find html_baseurl assignment in docs/conf.py");
   }
 
   writeFileSync(DOCS_CONF, updated, "utf8");
@@ -356,7 +348,7 @@ function replaceCodeBlockLine(filePath: string, pattern: RegExp, replacement: st
   writeFileSync(filePath, updated, "utf8");
 }
 
-function verifyVersionState(version: string, docsBaseUrl: string, docsPublicUrl: string, docsDisplayVersion: string): void {
+function verifyVersionState(version: string, docsPublicUrl: string, docsDisplayVersion: string): void {
   assertEqual(readJson<PackageJson>(ROOT_PACKAGE_JSON).version, version, "root package.json version mismatch");
   assertEqual(readJson<PackageJson>(PLUGIN_PACKAGE_JSON).version, version, "plugin package.json version mismatch");
 
@@ -365,7 +357,6 @@ function verifyVersionState(version: string, docsBaseUrl: string, docsPublicUrl:
 
   requireContains(INSTALL_SH, `DEFAULT_NEMOCLAW_VERSION="${version}"`);
   requireContains(DOCS_CONF, `release = "${version}"`);
-  requireContains(DOCS_CONF, `html_baseurl = "${docsBaseUrl}"`);
   requireContains(README_MD, docsPublicUrl);
   requireContains(README_MD, docsDisplayVersion);
   requireContains(QUICKSTART_MD, docsDisplayVersion);
@@ -444,6 +435,16 @@ function gitRemoteBranchExists(branchName: string): boolean {
 }
 
 function buildPrBody(previousVersion: string, nextVersion: string): string {
+  const gitUserName = run("git", ["config", "user.name"]).trim();
+  const gitUserEmail = run("git", ["config", "user.email"]).trim();
+
+  if (!gitUserName) {
+    throw new Error("git config user.name is required to build the PR sign-off");
+  }
+  if (!gitUserEmail) {
+    throw new Error("git config user.email is required to build the PR sign-off");
+  }
+
   return [
     "## Summary",
     `Bump NemoClaw from ${previousVersion} to ${nextVersion} across the CLI package, plugin package,`,
@@ -487,7 +488,7 @@ function buildPrBody(previousVersion: string, nextVersion: string): string {
     "- [x] Cross-references and links verified.",
     "",
     "---",
-    "Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>",
+    `Signed-off-by: ${gitUserName} <${gitUserEmail}>`,
   ].join("\n");
 }
 

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,483 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import YAML from "yaml";
+
+type Options = {
+  version: string;
+  push: boolean;
+  commit: boolean;
+  tag: boolean;
+  dryRun: boolean;
+  skipTests: boolean;
+  docsMode: "latest" | "versioned";
+};
+
+type PackageJson = {
+  version: string;
+  scripts?: Record<string, string>;
+  [key: string]: unknown;
+};
+
+type BlueprintManifest = {
+  version?: string;
+  [key: string]: unknown;
+};
+
+const REPO_ROOT = process.cwd();
+const ROOT_PACKAGE_JSON = path.join(REPO_ROOT, "package.json");
+const PLUGIN_PACKAGE_JSON = path.join(REPO_ROOT, "nemoclaw", "package.json");
+const BLUEPRINT_YAML = path.join(REPO_ROOT, "nemoclaw-blueprint", "blueprint.yaml");
+const DOCS_CONF = path.join(REPO_ROOT, "docs", "conf.py");
+const INSTALL_SH = path.join(REPO_ROOT, "scripts", "install.sh");
+const README_MD = path.join(REPO_ROOT, "README.md");
+const QUICKSTART_MD = path.join(REPO_ROOT, "docs", "get-started", "quickstart.md");
+const VERSIONED_DOC_LINK_FILES = [README_MD, QUICKSTART_MD];
+const FILES_TO_STAGE = [
+  ROOT_PACKAGE_JSON,
+  PLUGIN_PACKAGE_JSON,
+  BLUEPRINT_YAML,
+  DOCS_CONF,
+  INSTALL_SH,
+  ...VERSIONED_DOC_LINK_FILES,
+];
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+  const tagName = `v${options.version}`;
+
+  ensureCleanGit();
+  ensureOnMainBranch();
+  ensureOriginIsCanonicalRepo();
+  ensureUpToDateWithOriginMain();
+  ensureTagDoesNotExist(tagName);
+
+  const rootPackage = readJson<PackageJson>(ROOT_PACKAGE_JSON);
+  const previousVersion = rootPackage.version;
+
+  if (previousVersion === options.version) {
+    throw new Error(`Version is already ${options.version}`);
+  }
+
+  const nextDocsVersion = `v${options.version}`;
+  const docsSegment = options.docsMode === "versioned" ? options.version : "latest";
+  const nextDocsBaseUrl = `https://docs.nvidia.com/nemoclaw/${docsSegment}/`;
+  const nextDocsPublicUrl = `https://docs.nvidia.com/nemoclaw/${docsSegment}`;
+
+  if (options.dryRun) {
+    printDryRunPlan(options.version, nextDocsPublicUrl, options.docsMode, options.skipTests);
+    return;
+  }
+
+  updatePackageJson(ROOT_PACKAGE_JSON, options.version);
+  updatePackageJson(PLUGIN_PACKAGE_JSON, options.version);
+  updateBlueprintVersion(options.version);
+  updateInstallScriptDefaultVersion(previousVersion, options.version);
+  updateDocsConf(options.version, nextDocsBaseUrl);
+  updateDocsVersionLinks(nextDocsPublicUrl);
+  updateInstallAndUninstallDocs(nextDocsVersion);
+
+  verifyVersionState(options.version, nextDocsBaseUrl, nextDocsPublicUrl, nextDocsVersion);
+
+  if (!options.skipTests) {
+    runChecks(options.version);
+  }
+
+  if (options.commit) {
+    git(["add", ...FILES_TO_STAGE]);
+    git(["commit", "-m", `chore(release): bump version to ${tagName}`]);
+  }
+
+  if (options.tag) {
+    git(["tag", "-a", tagName, "-m", tagName]);
+    updateLatestTag(tagName);
+  }
+
+  if (options.push) {
+    git(["push", "origin", "HEAD"]);
+    if (options.tag) {
+      git(["push", "origin", tagName]);
+      git(["push", "origin", "latest", "--force"]);
+    }
+  }
+
+  log(`Version bump complete: ${previousVersion} -> ${options.version}`);
+}
+
+function parseArgs(args: string[]): Options {
+  let version = "";
+  let push = false;
+  let commit = true;
+  let tag = true;
+  let dryRun = false;
+  let skipTests = false;
+  let docsMode: "latest" | "versioned" = "versioned";
+
+  for (const arg of args) {
+    switch (arg) {
+      case "--push":
+        push = true;
+        break;
+      case "--no-commit":
+        commit = false;
+        break;
+      case "--no-tag":
+        tag = false;
+        break;
+      case "--dry-run":
+        dryRun = true;
+        break;
+      case "--skip-tests":
+        skipTests = true;
+        break;
+      case "--docs-versioned":
+        docsMode = "versioned";
+        break;
+      case "--docs-latest":
+        docsMode = "latest";
+        break;
+      case "-h":
+      case "--help":
+        printUsageAndExit(0);
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown flag: ${arg}`);
+        }
+        if (version) {
+          throw new Error(`Unexpected extra argument: ${arg}`);
+        }
+        version = arg;
+        break;
+    }
+  }
+
+  if (!version) {
+    printUsageAndExit(1);
+  }
+
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid semver: ${version}`);
+  }
+
+  if (push && !tag) {
+    throw new Error("--push requires tagging; do not combine --push with --no-tag");
+  }
+
+  return { version, push, commit, tag, dryRun, skipTests, docsMode };
+}
+
+function printUsageAndExit(code: number): never {
+  const usage = [
+    "Usage: npm run bump:version -- <version> [options]",
+    "",
+    "Options:",
+    "  --push        Push the commit and tags to origin",
+    "  --no-commit   Update files but do not create a commit",
+    "  --no-tag      Update files but do not create vX.Y.Z/latest tags",
+    "  --dry-run     Print the release plan and checks without writing files",
+    "  --skip-tests  Skip npm test and typecheck verification",
+    "  --docs-latest Keep public docs URLs pointed at /latest/",
+    "  --docs-versioned Rewrite public docs URLs to /<version>/ (default)",
+    "  -h, --help    Show this help",
+  ].join("\n");
+
+  console.log(usage);
+  process.exit(code);
+}
+
+function ensureCleanGit(): void {
+  const status = run("git", ["status", "--porcelain"], { allowFailure: false }).trim();
+  if (status) {
+    throw new Error("Git working tree is not clean");
+  }
+}
+
+function ensureOnMainBranch(): void {
+  const branch = run("git", ["branch", "--show-current"]).trim();
+  if (branch !== "main") {
+    throw new Error(`Release bumps must run from main. Current branch: ${branch || "(detached HEAD)"}`);
+  }
+}
+
+function ensureOriginIsCanonicalRepo(): void {
+  const originUrl = run("git", ["remote", "get-url", "origin"]).trim();
+  const allowed = new Set([
+    "git@github.com:NVIDIA/NemoClaw.git",
+    "https://github.com/NVIDIA/NemoClaw.git",
+    "https://github.com/NVIDIA/NemoClaw",
+  ]);
+
+  if (!allowed.has(originUrl)) {
+    throw new Error(
+      `origin must point to the canonical NVIDIA/NemoClaw repository. Found: ${originUrl}`,
+    );
+  }
+}
+
+function ensureUpToDateWithOriginMain(): void {
+  run("git", ["fetch", "origin", "main", "--tags"]);
+
+  const localHead = run("git", ["rev-parse", "HEAD"]).trim();
+  const originHead = run("git", ["rev-parse", "origin/main"]).trim();
+  const mergeBase = run("git", ["merge-base", "HEAD", "origin/main"]).trim();
+
+  if (localHead !== originHead) {
+    if (mergeBase === originHead) {
+      throw new Error("Local main is ahead of origin/main. Push or reconcile before cutting a release.");
+    }
+    if (mergeBase === localHead) {
+      throw new Error("Local main is behind origin/main. Pull/rebase before cutting a release.");
+    }
+    throw new Error("Local main has diverged from origin/main. Reconcile before cutting a release.");
+  }
+}
+
+function ensureTagDoesNotExist(tagName: string): void {
+  if (gitRefExists(`refs/tags/${tagName}`)) {
+    throw new Error(`Tag already exists: ${tagName}`);
+  }
+}
+
+function updatePackageJson(filePath: string, version: string): void {
+  const pkg = readJson<PackageJson>(filePath);
+  pkg.version = version;
+  writeFileSync(filePath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+}
+
+function updateBlueprintVersion(version: string): void {
+  const manifest = YAML.parse(readText(BLUEPRINT_YAML)) as BlueprintManifest;
+  manifest.version = version;
+  writeFileSync(BLUEPRINT_YAML, YAML.stringify(manifest), "utf8");
+}
+
+function updateInstallScriptDefaultVersion(previousVersion: string, nextVersion: string): void {
+  replaceExact(
+    INSTALL_SH,
+    `DEFAULT_NEMOCLAW_VERSION="${previousVersion}"`,
+    `DEFAULT_NEMOCLAW_VERSION="${nextVersion}"`,
+  );
+}
+
+function updateDocsConf(nextVersion: string, nextDocsBaseUrl: string): void {
+  const current = readText(DOCS_CONF);
+  const releaseReplacement = `release = "${nextVersion}"`;
+  const baseUrlReplacement = `html_baseurl = "${nextDocsBaseUrl}"`;
+
+  let updated = current;
+  if (/^release = ".*"$/m.test(updated)) {
+    updated = updated.replace(/^release = ".*"$/m, releaseReplacement);
+  } else {
+    throw new Error("Could not find release assignment in docs/conf.py");
+  }
+
+  if (/^html_baseurl = ".*"$/m.test(updated)) {
+    updated = updated.replace(/^html_baseurl = ".*"$/m, baseUrlReplacement);
+  } else {
+    throw new Error("Could not find html_baseurl assignment in docs/conf.py");
+  }
+
+  writeFileSync(DOCS_CONF, updated, "utf8");
+}
+
+function updateDocsVersionLinks(nextDocsPublicUrl: string): void {
+  for (const filePath of VERSIONED_DOC_LINK_FILES) {
+    const current = readText(filePath);
+    const updated = current.replaceAll(
+      /https:\/\/docs\.nvidia\.com\/nemoclaw\/(?:latest|[0-9]+\.[0-9]+\.[0-9]+)\//g,
+      `${nextDocsPublicUrl}/`,
+    );
+    if (updated === current) {
+      throw new Error(`No docs.nvidia.com/nemoclaw links found in ${relative(filePath)}`);
+    }
+    writeFileSync(filePath, updated, "utf8");
+    replaceAnyDocsUrl(filePath, nextDocsPublicUrl);
+  }
+}
+
+function replaceAnyDocsUrl(filePath: string, nextDocsPublicUrl: string): void {
+  const current = readText(filePath);
+  const updated = current.replaceAll(
+    /https:\/\/docs\.nvidia\.com\/nemoclaw\/(?:latest|[0-9]+\.[0-9]+\.[0-9]+)/g,
+    nextDocsPublicUrl,
+  );
+  writeFileSync(filePath, updated, "utf8");
+}
+
+function updateInstallAndUninstallDocs(nextDocsVersion: string): void {
+  const installReplacement = `curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash # ${nextDocsVersion}`;
+  const uninstallReplacement = `curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash # ${nextDocsVersion}`;
+
+  replaceCodeBlockLine(README_MD, /^curl -fsSL https:\/\/www\.nvidia\.com\/nemoclaw\.sh \| bash(?: # v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)?$/m, installReplacement);
+  replaceCodeBlockLine(QUICKSTART_MD, /^curl -fsSL https:\/\/www\.nvidia\.com\/nemoclaw\.sh \| bash(?: # v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)?$/m, installReplacement);
+  replaceCodeBlockLine(README_MD, /^curl -fsSL https:\/\/raw\.githubusercontent\.com\/NVIDIA\/NemoClaw\/refs\/heads\/main\/uninstall\.sh \| bash(?: # v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)?$/m, uninstallReplacement);
+  replaceCodeBlockLine(QUICKSTART_MD, /^curl -fsSL https:\/\/raw\.githubusercontent\.com\/NVIDIA\/NemoClaw\/refs\/heads\/main\/uninstall\.sh \| bash(?: # v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)?$/m, uninstallReplacement);
+}
+
+function replaceCodeBlockLine(filePath: string, pattern: RegExp, replacement: string): void {
+  const current = readText(filePath);
+  if (!pattern.test(current)) {
+    throw new Error(`Could not find expected command in ${relative(filePath)}`);
+  }
+  const updated = current.replace(pattern, replacement);
+  writeFileSync(filePath, updated, "utf8");
+}
+
+function verifyVersionState(version: string, docsBaseUrl: string, docsPublicUrl: string, docsDisplayVersion: string): void {
+  assertEqual(readJson<PackageJson>(ROOT_PACKAGE_JSON).version, version, "root package.json version mismatch");
+  assertEqual(readJson<PackageJson>(PLUGIN_PACKAGE_JSON).version, version, "plugin package.json version mismatch");
+
+  const blueprint = YAML.parse(readText(BLUEPRINT_YAML)) as BlueprintManifest;
+  assertEqual(blueprint.version, version, "blueprint version mismatch");
+
+  requireContains(INSTALL_SH, `DEFAULT_NEMOCLAW_VERSION="${version}"`);
+  requireContains(DOCS_CONF, `release = "${version}"`);
+  requireContains(DOCS_CONF, `html_baseurl = "${docsBaseUrl}"`);
+  requireContains(README_MD, docsPublicUrl);
+  requireContains(README_MD, docsDisplayVersion);
+  requireContains(QUICKSTART_MD, docsDisplayVersion);
+  for (const filePath of VERSIONED_DOC_LINK_FILES) {
+    verifyDocsLinks(filePath, docsPublicUrl);
+  }
+}
+
+function runChecks(version: string): void {
+  log("Running installer version check");
+  const installerVersion = run("bash", [INSTALL_SH, "--version"]);
+  if (!installerVersion.includes(`v${version}`)) {
+    throw new Error(`Installer version output did not include v${version}`);
+  }
+
+  log("Running build:cli");
+  run("npm", ["run", "build:cli"]);
+
+  log("Running typecheck:cli");
+  run("npm", ["run", "typecheck:cli"]);
+
+  log("Running test suite");
+  run("npm", ["test"]);
+}
+
+function git(args: string[]): void {
+  run("git", args);
+}
+
+function updateLatestTag(tagName: string): void {
+  log(`Updating mutable 'latest' tag to ${tagName}`);
+  if (gitRefExists("refs/tags/latest")) {
+    git(["tag", "-fa", "latest", "-m", `latest -> ${tagName}`]);
+  } else {
+    git(["tag", "-a", "latest", "-m", `latest -> ${tagName}`]);
+  }
+}
+
+function gitRefExists(ref: string): boolean {
+  return run("git", ["show-ref", "--verify", "--quiet", ref], { allowFailure: true }).exitCode === 0;
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readText(filePath)) as T;
+}
+
+function readText(filePath: string): string {
+  return readFileSync(filePath, "utf8");
+}
+
+function replaceExact(filePath: string, before: string, after: string): void {
+  const current = readText(filePath);
+  if (!current.includes(before)) {
+    throw new Error(`Expected to find '${before}' in ${relative(filePath)}`);
+  }
+  writeFileSync(filePath, current.replace(before, after), "utf8");
+}
+
+function requireContains(filePath: string, text: string): void {
+  if (!readText(filePath).includes(text)) {
+    throw new Error(`Expected ${relative(filePath)} to contain: ${text}`);
+  }
+}
+
+function verifyDocsLinks(filePath: string, expectedDocsPublicUrl: string): void {
+  const content = readText(filePath);
+  const matches = Array.from(
+    content.matchAll(/https:\/\/docs\.nvidia\.com\/nemoclaw\/([^/]+)\//g),
+    (match) => match[1],
+  );
+
+  if (matches.length === 0) {
+    throw new Error(`Expected at least one docs.nvidia.com/nemoclaw link in ${relative(filePath)}`);
+  }
+
+  const expectedSegment = expectedDocsPublicUrl.replace("https://docs.nvidia.com/nemoclaw/", "");
+  for (const segment of matches) {
+    if (segment !== expectedSegment) {
+      throw new Error(
+        `Found unexpected docs version segment '${segment}' in ${relative(filePath)}; expected '${expectedSegment}'`,
+      );
+    }
+  }
+}
+
+function assertEqual(actual: unknown, expected: unknown, message: string): void {
+  if (actual !== expected) {
+    throw new Error(`${message}. Expected '${expected}', got '${String(actual)}'`);
+  }
+}
+
+function run(command: string, args: string[], options?: { allowFailure?: boolean }): string & { exitCode?: number } {
+  try {
+    const output = execFileSync(command, args, {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    return Object.assign(output, { exitCode: 0 });
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+      status?: number;
+    };
+    if (options?.allowFailure) {
+      return Object.assign(err.stdout ?? "", { exitCode: err.status ?? 1 });
+    }
+    const stderr = err.stderr?.trim();
+    const stdout = err.stdout?.trim();
+    throw new Error(
+      [`Command failed: ${command} ${args.join(" ")}`, stdout, stderr].filter(Boolean).join("\n"),
+    );
+  }
+}
+
+function relative(filePath: string): string {
+  return path.relative(REPO_ROOT, filePath) || filePath;
+}
+
+function printDryRunPlan(
+  version: string,
+  docsPublicUrl: string,
+  docsMode: Options["docsMode"],
+  skipTests: boolean,
+): void {
+  log(`Dry run for version ${version}`);
+  log(`Docs mode: ${docsMode}`);
+  log(`Docs URL target: ${docsPublicUrl}/`);
+  log(`Files to update: ${FILES_TO_STAGE.map((filePath) => relative(filePath)).join(", ")}`);
+  log("Pre-checks: clean git tree, main branch, canonical origin, origin/main sync, tag availability");
+  if (skipTests) {
+    log("Checks: installer version/output verification only (tests skipped)");
+  } else {
+    log("Checks: installer version, build:cli, typecheck:cli, npm test");
+  }
+  log("No files were written. No commit, tags, or pushes were performed.");
+}
+
+function log(message: string): void {
+  console.log(`[bump-version] ${message}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
Add a TypeScript release helper that automates NemoClaw version bumps across the
CLI package, plugin package, blueprint manifest, installer defaults, and docs
version references. The script also performs release safety checks before
committing or tagging.

Default user flow, creates PR:

 ```bash
   npm run bump:version -- 0.1.1 
 ```

 Custom PR branch:

 ```bash
   npm run bump:version -- 0.1.1 --branch=release/0.1.1-docfix
 ```

## Related Issue
Fixes #1577.

## Changes
- add `scripts/bump-version.ts` as the canonical release bump helper
- add `npm run bump:version -- <version>` as the user-facing entry point
- update the helper to validate clean git state, `main`, canonical `origin`,
  sync with `origin/main`, tag availability, and semver input
- update docs version references alongside npm/package version updates and
  verify docs links are consistent after the bump
- support optional commit, tag, and push behavior from the script

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [x] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.

---
Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CLI-driven release automation tool and corresponding npm script to streamline version bumps and releases: it updates project versions and documentation links, runs verification/tests, and can create commits, tags, pushes, or open a pull request to publish a new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->