### PR TITLE
fix(onboard): correct Brave Search API key URL

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -105,7 +105,7 @@ const BUILD_ENDPOINT_URL = "https://integrate.api.nvidia.com/v1";
 const OPENAI_ENDPOINT_URL = "https://api.openai.com/v1";
 const ANTHROPIC_ENDPOINT_URL = "https://api.anthropic.com";
 const GEMINI_ENDPOINT_URL = "https://generativelanguage.googleapis.com/v1beta/openai/";
-const BRAVE_SEARCH_HELP_URL = "https://api.search.brave.com/app/keys";
+const BRAVE_SEARCH_HELP_URL = "https://api-dashboard.search.brave.com/app/keys";
 
 const REMOTE_PROVIDER_CONFIG = {
   build: {


### PR DESCRIPTION
## What

The Brave Search API key help URL shown during onboarding points to `https://api.search.brave.com/app/keys`, which returns a **403 Forbidden** error.

## Fix

Updated the URL to `https://api-dashboard.search.brave.com/app/keys`, which is the correct dashboard URL (redirects to login page as expected).

## Verification

```bash
# Old URL → 403
curl -sI 'https://api.search.brave.com/app/keys' | head -3
# HTTP/2 403

# New URL → 303 redirect to login
curl -sI 'https://api-dashboard.search.brave.com/app/keys' | head -3
# HTTP/2 303 → /login?redirect=%2Fapp%2Fkeys
```

Closes #1573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Brave Search API key retrieval URL in the onboarding process to direct users to the correct location for obtaining their API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->