### PR TITLE
fix: harden responses API probing and fallback selection

### DIFF
--- a/.agents/skills/nemoclaw-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-configure-inference/SKILL.md
@@ -32,10 +32,10 @@ Ollama appears when it is installed or running on the host.
 |--------|-------------|----------------|
 | NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, Kimi K2.5, GLM-5, MiniMax M2.5, GPT-OSS 120B |
 | OpenAI | Routes to the OpenAI API. Set `OPENAI_API_KEY`. | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro-2026-03-05` |
-| Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
+| Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. If the endpoint also supports `/responses` with OpenClaw-style tool calling, NemoClaw can use that path; otherwise it falls back to `/chat/completions`. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
 | Anthropic | Routes to the Anthropic Messages API. Set `ANTHROPIC_API_KEY`. | `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-6` |
 | Other Anthropic-compatible endpoint | Routes to any server that implements the Anthropic Messages API (`/v1/messages`). The wizard prompts for a base URL and model name. Set `COMPATIBLE_ANTHROPIC_API_KEY`. | You provide the model name. |
-| Google Gemini | Routes to Google's OpenAI-compatible endpoint. Set `GEMINI_API_KEY`. | `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
+| Google Gemini | Routes to Google's OpenAI-compatible endpoint. NemoClaw prefers `/responses` only when the endpoint proves it can handle tool calling in a way OpenClaw uses; otherwise it falls back to `/chat/completions`. Set `GEMINI_API_KEY`. | `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
 | Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to Use a Local Inference Server (see the `nemoclaw-configure-inference` skill). |
 
 ## Experimental Options
@@ -56,10 +56,13 @@ If validation fails, the wizard returns to provider selection.
 
 | Provider type | Validation method |
 |---|---|
-| OpenAI-compatible | Tries `/responses` first, then `/chat/completions`. |
+| OpenAI | Tries `/responses` first, then `/chat/completions`. |
+| NVIDIA Endpoints | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
+| Google Gemini | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
+| Other OpenAI-compatible endpoint | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
 | Anthropic-compatible | Tries `/v1/messages`. |
 | NVIDIA Endpoints (manual model entry) | Validates the model name against the catalog API. |
-| Compatible endpoints | Sends a real inference request because many proxies do not expose a `/models` endpoint. |
+| Compatible endpoints | Sends a real inference request because many proxies do not expose a `/models` endpoint. For OpenAI-compatible endpoints, the probe includes tool calling before NemoClaw favors `/responses`. |
 
 ## Prerequisites
 
@@ -195,6 +198,8 @@ If `NEMOCLAW_MODEL` is not set, NemoClaw selects a default model based on availa
 ## Step 5: OpenAI-Compatible Server
 
 This option works with any server that implements `/v1/chat/completions`, including vLLM, TensorRT-LLM, llama.cpp, LocalAI, and others.
+If the server also supports `/v1/responses`, NemoClaw only favors that path when onboarding can verify tool-calling behavior that matches what OpenClaw actually sends.
+Otherwise NemoClaw falls back to `/v1/chat/completions`.
 
 Start your model server.
 The examples below use vLLM, but any OpenAI-compatible server works.
@@ -216,6 +221,8 @@ The wizard prompts for an API key.
 If your server does not require authentication, enter any non-empty string (for example, `dummy`).
 
 NemoClaw validates the endpoint by sending a test inference request before continuing.
+For OpenAI-compatible endpoints, the validation prefers `/responses` only when the probe produces a compatible function or tool call.
+Endpoints that return `200 OK` on `/responses` but do not format tool calls the way OpenClaw expects are configured to use `/chat/completions` instead.
 
 ### Non-Interactive Setup
 

--- a/.agents/skills/nemoclaw-configure-inference/references/inference-options.md
+++ b/.agents/skills/nemoclaw-configure-inference/references/inference-options.md
@@ -23,10 +23,10 @@ Ollama appears when it is installed or running on the host.
 |--------|-------------|----------------|
 | NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, Kimi K2.5, GLM-5, MiniMax M2.5, GPT-OSS 120B |
 | OpenAI | Routes to the OpenAI API. Set `OPENAI_API_KEY`. | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro-2026-03-05` |
-| Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
+| Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. If the endpoint also supports `/responses` with OpenClaw-style tool calling, NemoClaw can use that path; otherwise it falls back to `/chat/completions`. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
 | Anthropic | Routes to the Anthropic Messages API. Set `ANTHROPIC_API_KEY`. | `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-6` |
 | Other Anthropic-compatible endpoint | Routes to any server that implements the Anthropic Messages API (`/v1/messages`). The wizard prompts for a base URL and model name. Set `COMPATIBLE_ANTHROPIC_API_KEY`. | You provide the model name. |
-| Google Gemini | Routes to Google's OpenAI-compatible endpoint. Set `GEMINI_API_KEY`. | `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
+| Google Gemini | Routes to Google's OpenAI-compatible endpoint. NemoClaw prefers `/responses` only when the endpoint proves it can handle tool calling in a way OpenClaw uses; otherwise it falls back to `/chat/completions`. Set `GEMINI_API_KEY`. | `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
 | Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to Use a Local Inference Server (see the `nemoclaw-configure-inference` skill). |
 
 ## Experimental Options
@@ -47,10 +47,13 @@ If validation fails, the wizard returns to provider selection.
 
 | Provider type | Validation method |
 |---|---|
-| OpenAI-compatible | Tries `/responses` first, then `/chat/completions`. |
+| OpenAI | Tries `/responses` first, then `/chat/completions`. |
+| NVIDIA Endpoints | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
+| Google Gemini | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
+| Other OpenAI-compatible endpoint | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
 | Anthropic-compatible | Tries `/v1/messages`. |
 | NVIDIA Endpoints (manual model entry) | Validates the model name against the catalog API. |
-| Compatible endpoints | Sends a real inference request because many proxies do not expose a `/models` endpoint. |
+| Compatible endpoints | Sends a real inference request because many proxies do not expose a `/models` endpoint. For OpenAI-compatible endpoints, the probe includes tool calling before NemoClaw favors `/responses`. |
 
 ## Next Steps
 

--- a/.agents/skills/nemoclaw-configure-security/SKILL.md
+++ b/.agents/skills/nemoclaw-configure-security/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: "nemoclaw-configure-security"
+description: "Presents a risk framework for every configurable security control in NemoClaw. Use when evaluating security posture, reviewing sandbox security defaults, or assessing control trade-offs. Explains where NemoClaw stores provider credentials, the file permissions it applies, and the operational security trade-offs of plaintext local storage. Use when reviewing credential handling or advising users how to secure stored API keys."
+---
+
+# NemoClaw Configure Security
+
+Presents a risk framework for every configurable security control in NemoClaw. Use when evaluating security posture, reviewing sandbox security defaults, or assessing control trade-offs.
+
+## Context
+
+NemoClaw ships with deny-by-default security controls across four layers: network, filesystem, process, and inference.
+You can tune every control, but each change shifts the risk profile.
+This page documents every configurable knob, its default, what it protects, the concrete risk of relaxing it, and a recommendation for common use cases.
+
+For background on how the layers fit together, refer to How It Works (see the `nemoclaw-overview` skill).
+
+<!-- TODO: uncomment after the OpenShell docs are published
+:::{seealso}
+OpenShell enforces the platform-level mechanisms that NemoClaw configures, including network namespace isolation, seccomp filters, SSRF protection, TLS termination, and gateway authentication.
+For the full platform-level controls reference, see [OpenShell Security Best Practices](https://docs.nvidia.com/openshell/latest/security/best-practices.html).
+:::
+-->
+
+## Protection Layers at a Glance
+
+NemoClaw enforces security at four layers.
+NemoClaw locks some when it creates the sandbox and requires a restart to change them.
+You can hot-reload others while the sandbox runs.
+
+The following diagram shows the default posture immediately after `nemoclaw onboard`, before you approve any endpoints or apply any presets.
+
+```mermaid
+flowchart TB
+    subgraph HOST["Your Machine: default posture after nemoclaw onboard"]
+        direction TB
+
+        YOU["👤 Operator"]
+
+        subgraph NC["NemoClaw + OpenShell"]
+            direction TB
+
+            subgraph SB["Sandbox: the agent's isolated world"]
+                direction LR
+                PROC["⚙️ Process Layer<br/>Controls what the agent can execute"]
+                FS["📁 Filesystem Layer<br/>Controls what the agent can read and write"]
+                AGENT["🤖 Agent"]
+            end
+
+            subgraph GW["Gateway: the gatekeeper"]
+                direction LR
+                NET["🌐 Network Layer<br/>Controls where the agent can connect"]
+                INF["🧠 Inference Layer<br/>Controls which AI models the agent can use"]
+            end
+        end
+    end
+
+    OUTSIDE["🌍 Outside World<br/>Internet · AI Providers · APIs"]
+
+    AGENT -- "all requests" --> GW
+    GW -- "approved only" --> OUTSIDE
+    YOU -. "approve / deny" .-> GW
+
+    classDef agent fill:#76b900,stroke:#5a8f00,color:#fff,stroke-width:2px,font-weight:bold
+    classDef locked fill:#1a1a1a,stroke:#76b900,color:#fff,stroke-width:2px
+    classDef hot fill:#333,stroke:#76b900,color:#e6f2cc,stroke-width:2px
+    classDef external fill:#f5f5f5,stroke:#ccc,color:#1a1a1a,stroke-width:1px
+    classDef operator fill:#fff,stroke:#76b900,color:#1a1a1a,stroke-width:2px,font-weight:bold
+
+    class AGENT agent
+    class PROC,FS locked
+    class NET,INF hot
+    class OUTSIDE external
+    class YOU operator
+
+    style HOST fill:none,stroke:#76b900,stroke-width:2px,color:#1a1a1a
+    style NC fill:none,stroke:#76b900,stroke-width:1px,stroke-dasharray:5 5,color:#1a1a1a
+    style SB fill:#f5faed,stroke:#76b900,stroke-width:2px,color:#1a1a1a
+    style GW fill:#2a2a2a,stroke:#76b900,stroke-width:2px,color:#fff
+
+*Full details in `references/best-practices.md`.*
+
+## Reference
+
+- [NemoClaw Credential Storage](references/credential-storage.md)

--- a/.agents/skills/nemoclaw-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-configure-security/references/best-practices.md
@@ -1,0 +1,487 @@
+# Security Best Practices
+
+NemoClaw ships with deny-by-default security controls across four layers: network, filesystem, process, and inference.
+You can tune every control, but each change shifts the risk profile.
+This page documents every configurable knob, its default, what it protects, the concrete risk of relaxing it, and a recommendation for common use cases.
+
+For background on how the layers fit together, refer to How It Works (see the `nemoclaw-overview` skill).
+
+<!-- TODO: uncomment after the OpenShell docs are published
+:::{seealso}
+OpenShell enforces the platform-level mechanisms that NemoClaw configures, including network namespace isolation, seccomp filters, SSRF protection, TLS termination, and gateway authentication.
+For the full platform-level controls reference, see [OpenShell Security Best Practices](https://docs.nvidia.com/openshell/latest/security/best-practices.html).
+:::
+-->
+
+## Protection Layers at a Glance
+
+NemoClaw enforces security at four layers.
+NemoClaw locks some when it creates the sandbox and requires a restart to change them.
+You can hot-reload others while the sandbox runs.
+
+The following diagram shows the default posture immediately after `nemoclaw onboard`, before you approve any endpoints or apply any presets.
+
+```mermaid
+flowchart TB
+    subgraph HOST["Your Machine: default posture after nemoclaw onboard"]
+        direction TB
+
+        YOU["👤 Operator"]
+
+        subgraph NC["NemoClaw + OpenShell"]
+            direction TB
+
+            subgraph SB["Sandbox: the agent's isolated world"]
+                direction LR
+                PROC["⚙️ Process Layer<br/>Controls what the agent can execute"]
+                FS["📁 Filesystem Layer<br/>Controls what the agent can read and write"]
+                AGENT["🤖 Agent"]
+            end
+
+            subgraph GW["Gateway: the gatekeeper"]
+                direction LR
+                NET["🌐 Network Layer<br/>Controls where the agent can connect"]
+                INF["🧠 Inference Layer<br/>Controls which AI models the agent can use"]
+            end
+        end
+    end
+
+    OUTSIDE["🌍 Outside World<br/>Internet · AI Providers · APIs"]
+
+    AGENT -- "all requests" --> GW
+    GW -- "approved only" --> OUTSIDE
+    YOU -. "approve / deny" .-> GW
+
+    classDef agent fill:#76b900,stroke:#5a8f00,color:#fff,stroke-width:2px,font-weight:bold
+    classDef locked fill:#1a1a1a,stroke:#76b900,color:#fff,stroke-width:2px
+    classDef hot fill:#333,stroke:#76b900,color:#e6f2cc,stroke-width:2px
+    classDef external fill:#f5f5f5,stroke:#ccc,color:#1a1a1a,stroke-width:1px
+    classDef operator fill:#fff,stroke:#76b900,color:#1a1a1a,stroke-width:2px,font-weight:bold
+
+    class AGENT agent
+    class PROC,FS locked
+    class NET,INF hot
+    class OUTSIDE external
+    class YOU operator
+
+    style HOST fill:none,stroke:#76b900,stroke-width:2px,color:#1a1a1a
+    style NC fill:none,stroke:#76b900,stroke-width:1px,stroke-dasharray:5 5,color:#1a1a1a
+    style SB fill:#f5faed,stroke:#76b900,stroke-width:2px,color:#1a1a1a
+    style GW fill:#2a2a2a,stroke:#76b900,stroke-width:2px,color:#fff
+```
+
+:::{list-table}
+:header-rows: 1
+:widths: 20 30 20 30
+
+* - Layer
+  - What it protects
+  - Enforcement point
+  - Changeable at runtime
+
+* - Network
+  - Unauthorized outbound connections and data exfiltration.
+  - OpenShell gateway
+  - Yes. Use `openshell policy set` or operator approval.
+
+* - Filesystem
+  - System binary tampering, credential theft, config manipulation.
+  - Landlock LSM + container mounts
+  - No. Requires sandbox re-creation.
+
+* - Process
+  - Privilege escalation, fork bombs, syscall abuse.
+  - Container runtime (Docker/K8s `securityContext`)
+  - No. Requires sandbox re-creation.
+
+* - Inference
+  - Credential exposure, unauthorized model access, cost overruns.
+  - OpenShell gateway
+  - Yes. Use `openshell inference set`.
+
+:::
+
+## Network Controls
+
+NemoClaw controls which hosts, ports, and HTTP methods the sandbox can reach, and lets operators approve or deny requests in real time.
+
+<!-- OpenShell provides additional network enforcement mechanisms not covered here, including network namespace isolation, SSRF protection, TLS auto-detection and termination, and audit-vs-enforce modes.
+See the [Network Controls](https://docs.nvidia.com/openshell/latest/security/best-practices.html#network-controls) section of the OpenShell Security Best Practices. -->
+
+### Deny-by-Default Egress
+
+The sandbox blocks all outbound connections unless you explicitly list the endpoint in the policy file `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`.
+
+| Aspect | Detail |
+|---|---|
+| Default | All egress denied. Only endpoints in the baseline policy can receive traffic. |
+| What you can change | Add endpoints to the policy file (static) or with `openshell policy set` (dynamic). |
+| Risk if relaxed | Each allowed endpoint is a potential data exfiltration path. The agent can send workspace content, credentials, or conversation history to any reachable host. |
+| Recommendation | Add only endpoints the agent needs for its task. Prefer operator approval for one-off requests over permanently widening the baseline. |
+
+### Binary-Scoped Endpoint Rules
+
+Each network policy entry restricts which executables can reach the endpoint using the `binaries` field.
+
+OpenShell identifies the calling binary by reading `/proc/<pid>/exe` (the kernel-trusted executable path, not `argv[0]`), walking the process tree for ancestor binaries, and computing a SHA256 hash of each binary on first use.
+If someone replaces a binary while the sandbox runs, the hash mismatch triggers an immediate deny.
+
+| Aspect | Detail |
+|---|---|
+| Default | Each endpoint restricts access to specific binaries. For example, only `/usr/bin/gh` and `/usr/bin/git` can reach `github.com`. Binary paths support glob patterns (`*` matches one path component, `**` matches recursively). |
+| What you can change | Add binaries to an endpoint entry, or omit the `binaries` field to allow any executable. |
+| Risk if relaxed | Removing binary restrictions lets any process in the sandbox reach the endpoint. An agent could use `curl`, `wget`, or a Python script to exfiltrate data to an allowed host, bypassing the intended usage pattern. |
+| Recommendation | Always scope endpoints to the binaries that need them. If the agent needs a host from a new binary, add that binary explicitly rather than removing the restriction. |
+
+### Path-Scoped HTTP Rules
+
+Endpoint rules restrict allowed HTTP methods and URL paths.
+
+| Aspect | Detail |
+|---|---|
+| Default | Most endpoints allow GET and POST on `/**`. Some allow GET only (read-only), such as `docs.openclaw.ai`. |
+| What you can change | Add methods (PUT, DELETE, PATCH) or restrict paths to specific prefixes. |
+| Risk if relaxed | Allowing all methods on an API endpoint gives the agent write and delete access. For example, allowing DELETE on `api.github.com` lets the agent delete repositories. |
+| Recommendation | Use GET-only rules for endpoints that the agent only reads. Add write methods only for endpoints where the agent must create or modify resources. Restrict paths to specific API routes when possible. |
+
+### L4-Only vs L7 Inspection (`protocol` Field)
+
+All sandbox egress goes through OpenShell's CONNECT proxy.
+The `protocol` field on an endpoint controls whether the proxy also inspects individual HTTP requests inside the tunnel.
+
+| Aspect | Detail |
+|---|---|
+| Default | Endpoints without a `protocol` field use L4-only enforcement: the proxy checks host, port, and binary identity, then relays the TCP stream without inspecting payloads. Setting `protocol: rest` enables L7 inspection: the proxy auto-detects and terminates TLS, then evaluates each HTTP request's method and path against the endpoint's `rules` or `access` preset. |
+| What you can change | Add `protocol: rest` to an endpoint to enable per-request HTTP inspection. Use the `access` preset (`full`, `read-only`, `read-write`) or explicit `rules` to control allowed methods and paths. |
+| Risk if relaxed | L4-only endpoints (no `protocol` field) allow the agent to send any data through the tunnel after the initial connection is permitted. The proxy cannot see or filter the HTTP method, path, or body. The `access: full` preset with `protocol: rest` enables inspection but allows all methods and paths, so it does not restrict what the agent can do at the HTTP level. |
+| Recommendation | Use `protocol: rest` with specific `rules` for REST APIs where you want method and path control. Use `protocol: rest` with `access: read-only` for read-only endpoints. Omit `protocol` only for non-HTTP protocols (WebSocket, gRPC streaming) or endpoints that do not need HTTP inspection. |
+
+### Operator Approval Flow
+
+When the agent reaches an unlisted endpoint, OpenShell blocks the request and prompts the operator in the TUI.
+
+| Aspect | Detail |
+|---|---|
+| Default | Enabled. The gateway blocks all unlisted endpoints and requires approval. |
+| What you can change | The system merges approved endpoints into the sandbox's policy as a new durable revision. They persist across sandbox restarts within the same sandbox instance. However, when you destroy and recreate the sandbox (for example, by running `nemoclaw onboard`), the policy resets to the baseline defined in the blueprint. |
+| Risk if relaxed | Approving an endpoint permanently widens the running sandbox's policy. If you approve a broad domain (such as a CDN that hosts arbitrary content), the agent can fetch anything from that domain until you destroy and recreate the sandbox. |
+| Recommendation | Review each blocked request before approving. If you find yourself approving the same endpoint repeatedly, add it to the baseline policy with appropriate binary and path restrictions. To reset approved endpoints, destroy and recreate the sandbox. |
+
+### Policy Presets
+
+NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for common integrations.
+
+| Preset | What it enables | Key risk |
+|---|---|---|
+| `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
+| `docker` | Docker Hub, NVIDIA container registry. | Allows pulling arbitrary container images into the sandbox. |
+| `huggingface` | Hugging Face model registry. | Allows downloading arbitrary models and datasets. |
+| `jira` | Atlassian Jira API. | Gives agent read/write access to project issues and comments. |
+| `npm` | npm and Yarn registries. | Allows installing arbitrary npm packages, which may contain malicious code. |
+| `outlook` | Microsoft 365, Outlook. | Gives agent access to email. |
+| `pypi` | Python Package Index. | Allows installing arbitrary Python packages, which may contain malicious code. |
+| `slack` | Slack API, Socket Mode, webhooks. | WebSocket uses `access: full`. Agent can post to any channel the bot token has access to. |
+| `telegram` | Telegram Bot API. | Agent can send messages to any chat the bot token has access to. |
+
+**Recommendation:** Apply presets only when the agent's task requires the integration. Review the preset's YAML file before applying to understand the endpoints, methods, and binary restrictions it adds.
+
+## Filesystem Controls
+
+NemoClaw restricts which paths the agent can read and write, protecting system binaries, configuration files, and gateway credentials.
+
+<!-- OpenShell covers additional filesystem enforcement details, including `hard_requirement` compatibility mode for Landlock and policy path validation rules.
+See the [Filesystem Controls](https://docs.nvidia.com/openshell/latest/security/best-practices.html#filesystem-controls) section of the OpenShell Security Best Practices. -->
+
+### Read-Only System Paths
+
+The container mounts system directories read-only to prevent the agent from modifying binaries, libraries, or configuration files.
+
+| Aspect | Detail |
+|---|---|
+| Default | `/usr`, `/lib`, `/proc`, `/dev/urandom`, `/app`, `/etc`, `/var/log` are read-only. |
+| What you can change | Add or remove paths in the `filesystem_policy.read_only` section of the policy file. |
+| Risk if relaxed | Making `/usr` or `/lib` writable lets the agent replace system binaries (such as `curl` or `node`) with trojanized versions. Making `/etc` writable lets the agent modify DNS resolution, TLS trust stores, or user accounts. |
+| Recommendation | Never make system paths writable. If the agent needs a writable location for generated files, use a subdirectory of `/sandbox`. |
+
+### Read-Only `.openclaw` Config
+
+The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration, including auth tokens and CORS settings.
+The container mounts it read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
+
+Multiple defense layers protect this directory:
+
+- **DAC permissions.** Root owns the directory and `openclaw.json` with `chmod 444`, so the sandbox user cannot write to them.
+- **Immutable flag.** The entrypoint applies `chattr +i` to the directory and all symlinks, preventing modification even if other controls fail.
+- **Symlink validation.** At startup, the entrypoint verifies every symlink in `.openclaw` points to the expected `.openclaw-data` target. If any symlink points elsewhere, the container refuses to start.
+- **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match.
+
+| Aspect | Detail |
+|---|---|
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. |
+| What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
+| Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS, changing auth tokens, or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
+| Recommendation | Never make `/sandbox/.openclaw` writable. |
+
+### Writable Paths
+
+The agent has read-write access to `/sandbox`, `/tmp`, and `/dev/null`.
+
+| Aspect | Detail |
+|---|---|
+| Default | `/sandbox` (agent workspace), `/tmp` (temporary files), `/dev/null`. |
+| What you can change | Add additional writable paths in `filesystem_policy.read_write`. |
+| Risk if relaxed | Each additional writable path expands the agent's ability to persist data and potentially modify system behavior. Adding `/var` lets the agent write to log directories. Adding `/home` gives access to other user directories. |
+| Recommendation | Keep writable paths to `/sandbox` and `/tmp`. If the agent needs a persistent working directory, create a subdirectory under `/sandbox`. |
+
+### Landlock LSM Enforcement
+
+Landlock is a Linux Security Module that enforces filesystem access rules at the kernel level.
+
+| Aspect | Detail |
+|---|---|
+| Default | `compatibility: best_effort`. The entrypoint applies Landlock rules when the kernel supports them and silently skips them on older kernels. |
+| What you can change | This is a NemoClaw default, not a user-facing knob. |
+| Risk if relaxed | On kernels without Landlock support (pre-5.13), filesystem restrictions rely solely on container mount configuration, which is less granular. |
+| Recommendation | Run on a kernel that supports Landlock (5.13+). Ubuntu 22.04 LTS and later include Landlock support. |
+
+## Process Controls
+
+NemoClaw limits the capabilities, user privileges, and resource quotas available to processes inside the sandbox.
+
+<!-- OpenShell enforces additional process-level controls not covered here, including seccomp BPF socket domain filters and a specific enforcement application order (namespace entry, privilege drop, Landlock, seccomp).
+See the [Process Controls](https://docs.nvidia.com/openshell/latest/security/best-practices.html#process-controls) section of the OpenShell Security Best Practices. -->
+
+### Capability Drops
+
+The entrypoint drops dangerous Linux capabilities from the bounding set at startup using `capsh`.
+This limits what capabilities any child process (gateway, sandbox, agent) can ever acquire.
+
+The entrypoint drops these capabilities: `cap_net_raw`, `cap_dac_override`, `cap_sys_chroot`, `cap_fsetid`, `cap_setfcap`, `cap_mknod`, `cap_audit_write`, `cap_net_bind_service`.
+The entrypoint keeps these because it needs them for privilege separation using gosu: `cap_chown`, `cap_setuid`, `cap_setgid`, `cap_fowner`, `cap_kill`.
+
+This is best-effort: if `capsh` is not available or `CAP_SETPCAP` is not in the bounding set, the entrypoint logs a warning and continues with the default capability set.
+For additional protection, pass `--cap-drop=ALL` with `docker run` or Compose (see Sandbox Hardening (see the `nemoclaw-deploy-remote` skill)).
+
+| Aspect | Detail |
+|---|---|
+| Default | The entrypoint drops dangerous capabilities at startup using `capsh`. Best-effort. |
+| What you can change | When launching with `docker run` directly, pass `--cap-drop=ALL --cap-add=NET_BIND_SERVICE` for stricter enforcement. In the standard NemoClaw flow (with `nemoclaw onboard`), the entrypoint handles capability dropping automatically. |
+| Risk if relaxed | `CAP_NET_RAW` allows raw socket access for network sniffing. `CAP_DAC_OVERRIDE` bypasses filesystem permission checks. Attackers can use `CAP_SYS_CHROOT` in container escape chains. If `capsh` is unavailable, the container runs with the default Docker capability set. |
+| Recommendation | Run on an image that includes `capsh` (the NemoClaw image includes it through `libcap2-bin`). For defense-in-depth, also pass `--cap-drop=ALL` at the container runtime level. |
+
+### Gateway Process Isolation
+
+The OpenClaw gateway runs as a separate `gateway` user, not as the `sandbox` user that runs the agent.
+
+| Aspect | Detail |
+|---|---|
+| Default | The entrypoint starts the gateway process using `gosu gateway`, isolating it from the agent's `sandbox` user. |
+| What you can change | This is not a user-facing knob. The entrypoint enforces it when running as root. In non-root mode (when OpenShell sets `no-new-privileges`), gateway process isolation does not work because `gosu` cannot change users. |
+| Risk if relaxed | If the gateway and agent run as the same user, the agent can kill the gateway process and restart it with a tampered configuration (the "fake-HOME" attack). |
+| Recommendation | No action needed. The entrypoint handles this automatically. Be aware that non-root mode disables this isolation. |
+
+### No New Privileges
+
+The `no-new-privileges` flag prevents processes from gaining additional privileges through setuid binaries or capability inheritance.
+
+| Aspect | Detail |
+|---|---|
+| Default | OpenShell sets `PR_SET_NO_NEW_PRIVS` using `prctl()` inside the sandbox process as part of the seccomp filter setup. The NemoClaw Compose example also shows the equivalent `security_opt: no-new-privileges:true` setting. |
+| What you can change | OpenShell's seccomp path enforces this inside the sandbox. It is not a user-facing knob. |
+| Risk if relaxed | Without this flag, a compromised process could execute a setuid binary to escalate to root inside the container, then attempt container escape techniques. |
+| Recommendation | No action needed. OpenShell enforces this automatically when the sandbox network policy is active. This flag prevents `gosu` from switching users, so non-root mode disables gateway process isolation in the NemoClaw entrypoint. |
+
+### Process Limit
+
+A process limit caps the number of processes the sandbox user can spawn.
+The entrypoint sets both soft and hard limits using `ulimit -u 512`.
+This is best-effort: if the container runtime restricts `ulimit` modification, the entrypoint logs a security warning and continues without the limit.
+
+| Aspect | Detail |
+|---|---|
+| Default | 512 processes (`ulimit -u 512`), best-effort. |
+| What you can change | Increase or decrease the limit with `--ulimit nproc=N:N` in `docker run` or the `ulimits` section in Compose. The runtime-level ulimit takes precedence over the entrypoint's setting. |
+| Risk if relaxed | Removing or raising the limit makes the sandbox vulnerable to fork-bomb attacks, where a runaway process spawns children until the host runs out of resources. If the entrypoint cannot set the limit (logs `[SECURITY] Could not set soft/hard nproc limit`), the container runs without process limits. |
+| Recommendation | Keep the default at 512. If the agent runs workloads that spawn many child processes (such as parallel test runners), increase to 1024 and monitor host resource usage. If the entrypoint logs a warning about ulimit restrictions, set the limit through the container runtime instead. |
+
+### Non-Root User
+
+The sandbox runs agent processes as a dedicated `sandbox` user and group.
+The entrypoint starts as root for privilege separation, then drops to the `sandbox` user for all agent commands.
+
+| Aspect | Detail |
+|---|---|
+| Default | `run_as_user: sandbox`, `run_as_group: sandbox`. A separate `gateway` user runs the gateway process. |
+| What you can change | Change the `process` section in the policy file to run as a different user. |
+| Risk if relaxed | Running as `root` inside the container gives the agent access to modify any file in the container filesystem and increases the impact of container escape vulnerabilities. |
+| Recommendation | Never run as root. Keep the `sandbox` user. |
+
+### PATH Hardening
+
+The entrypoint locks the `PATH` environment variable to system directories, preventing the agent from injecting malicious binaries into command resolution.
+
+| Aspect | Detail |
+|---|---|
+| Default | The entrypoint sets `PATH` to `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` at startup. |
+| What you can change | This is not a user-facing knob. The entrypoint enforces it. |
+| Risk if relaxed | Without PATH hardening, the agent could create an executable named `curl` or `git` in a writable directory earlier in the PATH, intercepting commands run by the entrypoint or other processes. |
+| Recommendation | No action needed. The entrypoint handles this automatically. |
+
+### Build Toolchain Removal
+
+The Dockerfile removes compilers and network probes from the runtime image.
+
+| Aspect | Detail |
+|---|---|
+| Default | The Dockerfile purges `gcc`, `gcc-12`, `g++`, `g++-12`, `cpp`, `cpp-12`, `make`, `netcat-openbsd`, `netcat-traditional`, and `ncat` from the sandbox image. |
+| What you can change | Modify the Dockerfile to keep these tools, or install them at runtime if package manager access is allowed. |
+| Risk if relaxed | A compiler lets the agent build arbitrary native code, including kernel exploits or custom network tools. `netcat` enables arbitrary TCP connections that bypass HTTP-level policy enforcement. |
+| Recommendation | Keep build tools removed. If the agent needs to compile code, run the build in a separate, purpose-built container and copy artifacts into the sandbox. |
+
+## Gateway Authentication Controls
+
+The OpenClaw gateway authenticates devices that connect to the Control UI dashboard.
+NemoClaw hardens these defaults at image build time.
+
+### Device Authentication
+
+Device authentication requires each connecting device to go through a pairing flow before it can interact with the gateway.
+
+| Aspect | Detail |
+|---|---|
+| Default | Enabled. The gateway requires device pairing for all connections. |
+| What you can change | Set `NEMOCLAW_DISABLE_DEVICE_AUTH=1` as a Docker build argument to disable device authentication. This is a build-time setting baked into `openclaw.json` and verified by hash at startup. |
+| Risk if relaxed | Disabling device auth allows any device on the network to connect to the gateway without proving identity. This is dangerous when combined with LAN-bind changes or cloudflared tunnels in remote deployments, resulting in an unauthenticated, publicly reachable dashboard. |
+| Recommendation | Keep device auth enabled (the default). Only disable it for headless or development environments where no untrusted devices can reach the gateway. |
+
+### Insecure Auth Derivation
+
+The `allowInsecureAuth` setting controls whether the gateway permits non-HTTPS authentication.
+
+| Aspect | Detail |
+|---|---|
+| Default | Derived from the `CHAT_UI_URL` scheme at build time. When the URL uses `http://` (local development), insecure auth is allowed. When it uses `https://` (remote or production), insecure auth is blocked. |
+| What you can change | This is derived automatically from `CHAT_UI_URL`. Set `CHAT_UI_URL` to an `https://` URL to enforce secure auth. |
+| Risk if relaxed | Allowing insecure auth over HTTPS defeats the purpose of TLS, because authentication tokens transit in cleartext. |
+| Recommendation | Use `https://` for any deployment accessible beyond `localhost`. The default local URL (`http://127.0.0.1:18789`) correctly allows insecure auth for local development. |
+
+### Auto-Pair Client Allowlist
+
+The auto-pair watcher automatically approves device pairing requests from recognized clients, so you do not need to manually approve the Control UI.
+
+| Aspect | Detail |
+|---|---|
+| Default | The watcher approves devices with `clientId` set to `openclaw-control-ui` or `clientMode` set to `webchat`. All other clients are rejected and logged. |
+| What you can change | This is not a user-facing knob. The allowlist is defined in the entrypoint script. |
+| Risk if relaxed | Approving all device types without validation lets rogue or unexpected clients pair with the gateway unchallenged. |
+| Recommendation | No action needed. The entrypoint handles this automatically. If you see `[auto-pair] rejected unknown client=...` in the logs, investigate the source of the unexpected connection. |
+
+### CLI Secret Redaction
+
+The CLI automatically redacts secret patterns (API keys, bearer tokens, provider credentials) from command output and error messages before logging them.
+
+| Aspect | Detail |
+|---|---|
+| Default | Enabled. The runner redacts secrets from stdout, stderr, and thrown error messages. |
+| What you can change | This is not a user-facing knob. The CLI enforces it on all command output paths. |
+| Risk if relaxed | Without redaction, secrets could appear in terminal scrollback, log files, or debug output shared in bug reports. |
+| Recommendation | No action needed. If you share `nemoclaw debug` output, verify that no secrets appear in the collected diagnostics. |
+
+## Inference Controls
+
+OpenShell routes all inference traffic through the gateway to isolate provider credentials from the sandbox.
+
+### Routed Inference through `inference.local`
+
+The OpenShell gateway intercepts all inference requests from the agent and routes them to the configured provider.
+The agent never receives the provider API key.
+
+| Aspect | Detail |
+|---|---|
+| Default | The agent talks to `inference.local`. The host owns the credential and upstream endpoint. |
+| What you can change | You cannot configure this architecture. The system always enforces it. |
+| Risk if bypassed | If the agent could reach an inference endpoint directly (by adding it to the network policy), it would need an API key. Since the sandbox does not contain credentials, this acts as defense-in-depth. However, adding an inference provider's host to the network policy without going through OpenShell routing could let the agent use a stolen or hardcoded key. |
+| Recommendation | Do not add inference provider hosts (such as `api.openai.com` or `api.anthropic.com`) to the network policy. Use OpenShell inference routing instead. |
+
+### Provider Trust Tiers
+
+Different inference providers have different trust and cost profiles.
+
+| Provider | Trust level | Cost risk | Data handling |
+|---|---|---|---|
+| NVIDIA Endpoints | High. Hosted on `build.nvidia.com`. | Pay-per-token with an API key. Unattended agents can accumulate cost. | NVIDIA infrastructure processes requests. |
+| OpenAI | High. Commercial API. | Pay-per-token. Same cost risk as NVIDIA Endpoints. | Subject to OpenAI data policies. |
+| Anthropic | High. Commercial API. | Pay-per-token. Same cost risk as NVIDIA Endpoints. | Subject to Anthropic data policies. |
+| Google Gemini | High. Commercial API. | Pay-per-token. Same cost risk as NVIDIA Endpoints. | Subject to Google data policies. |
+| Local Ollama | Self-hosted. No data leaves the machine. | No per-token cost. GPU/CPU resource cost. | Data stays local. |
+| Custom compatible endpoint | Varies. Depends on the proxy or gateway. | Varies. | Depends on the endpoint operator. |
+
+**Recommendation:** For sensitive workloads, use local Ollama to keep data on-premise. For general use, NVIDIA Endpoints provide a good balance of capability and trust. Review the data policies of any cloud provider you use.
+
+### Experimental Providers
+
+The `NEMOCLAW_EXPERIMENTAL=1` environment variable gates local NVIDIA NIM and local vLLM.
+
+| Aspect | Detail |
+|---|---|
+| Default | Disabled. The onboarding wizard does not show these providers. |
+| What you can change | Set `NEMOCLAW_EXPERIMENTAL=1` before running `nemoclaw onboard`. |
+| Risk if relaxed | NemoClaw has not fully validated these providers. NIM requires a NIM-capable GPU. vLLM must already be running on `localhost:8000`. Misconfiguration can cause failed inference or unexpected behavior. |
+| Recommendation | Use experimental providers only for evaluation. Do not rely on them for always-on assistants. |
+
+## Posture Profiles
+
+The following profiles describe how to configure NemoClaw for different use cases.
+These are not separate policy files.
+They provide guidance on which controls to keep tight or relax.
+
+### Locked-Down (Default)
+
+Use for always-on assistants with minimal external access.
+
+- Keep all defaults. Do not add presets.
+- Use operator approval for any endpoint the agent requests.
+- Use NVIDIA Endpoints or local Ollama for inference.
+- Monitor the TUI for unexpected network requests.
+
+### Development
+
+Use when the agent needs package registries, Docker Hub, or broader GitHub access during development tasks.
+
+- Apply the `pypi` and `npm` presets for package installation.
+- Apply the `docker` preset if the agent builds or pulls container images.
+- Keep binary restrictions on all presets.
+- Review the agent's network activity periodically with `openshell term`.
+- Use operator approval for any endpoint not covered by a preset.
+
+### Integration Testing
+
+Use when the agent talks to internal APIs or third-party services during testing.
+
+- Add custom endpoint entries with tight path and method restrictions.
+- Use `protocol: rest` for all HTTP APIs to maintain inspection.
+- Use operator approval for unknown endpoints during test runs.
+- Review and clean up the baseline policy after testing. Remove endpoints that are no longer needed.
+
+## Common Mistakes
+
+The following patterns weaken security without providing meaningful benefit.
+
+| Mistake | Why it matters | What to do instead |
+|---------|---------------|-------------------|
+| Omitting `protocol: rest` on REST API endpoints | Endpoints without a `protocol` field use L4-only enforcement. The proxy allows the TCP stream through after checking host, port, and binary, but cannot see or filter individual HTTP requests. | Add `protocol: rest` with explicit `rules` to enable per-request method and path control on REST APIs. |
+| Adding endpoints to the baseline policy for one-off requests | Adding an endpoint to the baseline policy makes it permanently reachable across all sandbox instances. | Use operator approval. Approved endpoints persist within the sandbox instance but reset when you destroy and recreate the sandbox. |
+| Relying solely on the entrypoint for capability drops | The entrypoint drops dangerous capabilities using `capsh`, but this is best-effort. If `capsh` is unavailable or `CAP_SETPCAP` is not in the bounding set, the container runs with the default capability set. | Pass `--cap-drop=ALL` at the container runtime level as defense-in-depth. |
+| Granting write access to `/sandbox/.openclaw` | This directory contains the OpenClaw gateway configuration. A writable `.openclaw` lets the agent modify auth tokens, disable CORS, or redirect inference routing. | Store agent-writable state in `/sandbox/.openclaw-data`. |
+| Adding inference provider hosts to the network policy | Direct network access to an inference host bypasses credential isolation and usage tracking. | Use OpenShell inference routing instead of adding hosts like `api.openai.com` or `api.anthropic.com` to the network policy. |
+| Disabling device auth for remote deployments | Without device auth, any device on the network can connect to the gateway without pairing. Combined with a cloudflared tunnel, this makes the dashboard publicly accessible and unauthenticated. | Keep `NEMOCLAW_DISABLE_DEVICE_AUTH` at its default (`0`). Only set it to `1` for local headless or development environments. |
+
+## Related Topics
+
+- Network Policies (see the `nemoclaw-reference` skill) for the full baseline policy reference.
+- Customize the Network Policy (see the `nemoclaw-manage-policy` skill) for static and dynamic policy changes.
+- Approve or Deny Network Requests (see the `nemoclaw-manage-policy` skill) for the operator approval flow.
+- Sandbox Hardening (see the `nemoclaw-deploy-remote` skill) for container-level security measures.
+- Inference Options (see the `nemoclaw-configure-inference` skill) for provider configuration details.
+- How It Works (see the `nemoclaw-overview` skill) for the protection layer architecture.
+<!-- - OpenShell [Security Best Practices](https://docs.nvidia.com/openshell/latest/security/best-practices.html) for the platform-level controls reference, including network namespace isolation, seccomp filters, SSRF protection, TLS termination, and gateway authentication. -->

--- a/.agents/skills/nemoclaw-configure-security/references/credential-storage.md
+++ b/.agents/skills/nemoclaw-configure-security/references/credential-storage.md
@@ -1,0 +1,111 @@
+# Credential Storage
+
+NemoClaw stores operator-provided host-side credentials under `~/.nemoclaw/`.
+These credentials are used during onboarding and host-side lifecycle operations.
+They are not encrypted at rest by NemoClaw.
+Instead, NemoClaw relies on local filesystem ownership and Unix permissions to limit access.
+
+## Location and Permissions
+
+By default, NemoClaw stores credentials in:
+
+```text
+~/.nemoclaw/credentials.json
+```
+
+When NemoClaw creates this state directory, it uses owner-only permissions:
+
+- `~/.nemoclaw/` is created with mode `0700`
+- `~/.nemoclaw/credentials.json` is written with mode `0600`
+
+That means only the local account that owns the files should be able to read or modify them.
+
+NemoClaw also refuses to use obviously unsafe `HOME` paths such as `/tmp`, `/var/tmp`, `/dev/shm`, or `/` for credential storage.
+If `HOME` points to one of those locations, onboarding exits with an error instead of writing secrets there.
+
+## Plaintext Storage Warning
+
+The credential file is plaintext JSON.
+NemoClaw does **not** currently encrypt the file or integrate with the host operating system keychain.
+
+A typical file looks like this:
+
+```json
+{
+  "NVIDIA_API_KEY": "nvapi-...",
+  "GITHUB_TOKEN": "ghp_...",
+  "OPENAI_API_KEY": "sk-..."
+}
+```
+
+Treat this file like any other local secret material.
+Anyone who can read it can reuse those credentials with the upstream provider.
+
+## Precedence and Scope
+
+When NemoClaw looks up a credential, it checks environment variables first.
+If the corresponding environment variable is set, NemoClaw uses that value instead of the stored file.
+
+This behavior is useful for:
+
+- CI or automation where you do not want to persist secrets to disk
+- temporary overrides during testing
+- short-lived or rotated credentials
+
+For interactive local use, `nemoclaw onboard` can save credentials into `~/.nemoclaw/credentials.json` so future runs do not prompt again.
+
+## Security Recommendations
+
+Use the following practices to reduce the risk of credential exposure.
+
+1. Keep your home directory private and owned by your user account.
+2. Exclude `~/.nemoclaw/` from cloud-sync folders, shared folders, and broad backup exports unless those systems are already approved for secret storage.
+3. Prefer short-lived or low-scope provider credentials where the upstream service supports them.
+4. Rotate keys after suspected exposure, machine transfer, or account changes.
+5. Prefer environment variables for ephemeral automation instead of persisting long-lived secrets locally.
+6. Do not copy `credentials.json` into container images, Git repositories, bug reports, or support bundles.
+
+## Inspect and Repair Permissions
+
+To inspect the current permissions:
+
+```console
+$ ls -ld ~/.nemoclaw ~/.nemoclaw/credentials.json
+```
+
+Expected output should show a private directory and file, for example:
+
+```text
+drwx------  ... ~/.nemoclaw
+-rw-------  ... ~/.nemoclaw/credentials.json
+```
+
+If the permissions are broader than expected, tighten them:
+
+```console
+$ chmod 700 ~/.nemoclaw
+$ chmod 600 ~/.nemoclaw/credentials.json
+```
+
+## Rotate or Remove Stored Credentials
+
+The simplest way to replace a stored provider key is to rerun onboarding and provide the new value when prompted:
+
+```console
+$ nemoclaw onboard
+```
+
+To remove the stored file entirely:
+
+```console
+$ rm -f ~/.nemoclaw/credentials.json
+```
+
+On the next run, NemoClaw prompts again unless the credential is supplied through the environment.
+
+## Related Files
+
+Other NemoClaw host-side state also lives under `~/.nemoclaw/`, such as sandbox registry metadata.
+These files are operational state, not provider secrets, but they should still remain in a user-owned home directory.
+
+For the broader sandbox security model and operational trade-offs, see Security Best Practices (see the `nemoclaw-configure-security` skill) and Architecture (see the `nemoclaw-reference` skill).

--- a/.agents/skills/nemoclaw-reference/references/architecture.md
+++ b/.agents/skills/nemoclaw-reference/references/architecture.md
@@ -156,7 +156,7 @@ NemoClaw keeps its operator-facing state on the host rather than inside the sand
 
 | Path | Purpose |
 |---|---|
-| `~/.nemoclaw/credentials.json` | Provider credentials saved during onboarding. |
+| `~/.nemoclaw/credentials.json` | Provider credentials saved during onboarding. Stored as plaintext JSON protected by local filesystem permissions; see Credential Storage (see the `nemoclaw-configure-security` skill). |
 | `~/.nemoclaw/sandboxes.json` | Registered sandbox metadata, including the default sandbox selection. |
 | `~/.openclaw/openclaw.json` | Host OpenClaw configuration that NemoClaw snapshots or restores during migration flows. |
 

--- a/.agents/skills/nemoclaw-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-reference/references/commands.md
@@ -49,7 +49,7 @@ $ nemoclaw onboard [--non-interactive] [--resume] [--from <Dockerfile>]
 
 The wizard prompts for a provider first, then collects the provider credential if needed.
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.
-Credentials are stored in `~/.nemoclaw/credentials.json`.
+Credentials are stored in `~/.nemoclaw/credentials.json`. For file permissions, plaintext storage behavior, and hardening guidance, see Credential Storage (see the `nemoclaw-configure-security` skill).
 The legacy `nemoclaw setup` command is deprecated; use `nemoclaw onboard` instead.
 
 If you enable Brave Search during onboarding, NemoClaw currently stores the Brave API key in the sandbox's OpenClaw configuration.

--- a/.agents/skills/nemoclaw-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-reference/references/troubleshooting.md
@@ -230,7 +230,7 @@ This is expected behavior.
 Changing or exporting it later does not rewrite the baked `openclaw.json` inside an existing sandbox.
 
 If you need a different device-auth setting, rerun onboarding so NemoClaw rebuilds the sandbox image with the desired configuration.
-For the security trade-offs, refer to Security Best Practices (see the `nemoclaw-security-best` skill).
+For the security trade-offs, refer to Security Best Practices (see the `nemoclaw-configure-security` skill).
 
 ### Agent cannot reach an external host
 
@@ -253,3 +253,56 @@ $ nemoclaw <name> logs
 ```
 
 Use `--follow` to stream logs in real time while debugging.
+
+## Podman
+
+### `open /dev/kmsg: operation not permitted`
+
+This error appears when the Podman machine is running in rootless mode.
+K3s kubelet requires `/dev/kmsg` access for its OOM watcher, which is not available in rootless containers.
+
+Switch the Podman machine to rootful mode and restart:
+
+```console
+$ podman machine stop
+$ podman machine set --rootful
+$ podman machine start
+```
+
+Then destroy and recreate the gateway:
+
+```console
+$ openshell gateway destroy --name nemoclaw
+$ nemoclaw onboard
+```
+
+### Image push timeout with Podman
+
+When creating a sandbox, the 1.5 GB sandbox image push into K3s may time out through Podman's API socket.
+This is a known limitation of the bollard Docker client's default timeout.
+
+Manually push the image using the Docker CLI, which has no such timeout:
+
+```console
+$ docker images --format '{{.Repository}}:{{.Tag}}' | grep sandbox-from
+$ docker save <IMAGE_NAME:TAG> | \
+    docker exec -i openshell-cluster-nemoclaw \
+    ctr -a /run/k3s/containerd/containerd.sock -n k8s.io images import -
+```
+
+After the import completes, create the sandbox manually:
+
+```console
+$ openshell sandbox create --name my-assistant --from <IMAGE_NAME:TAG>
+```
+
+### Podman machine resources
+
+The default Podman machine has 2 GB RAM, which is insufficient for the sandbox image push and K3s cluster overhead.
+Allocate at least 8 GB RAM and 4 CPUs:
+
+```console
+$ podman machine stop
+$ podman machine set --cpus 6 --memory 8192
+$ podman machine start
+```

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -968,40 +968,139 @@ function patchStagedDockerfile(
   fs.writeFileSync(dockerfilePath, dockerfile);
 }
 
-function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey) {
+function parseJsonObject(body) {
+  if (!body) return null;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return null;
+  }
+}
+
+function hasResponsesToolCall(body) {
+  const parsed = parseJsonObject(body);
+  if (!parsed || !Array.isArray(parsed.output)) return false;
+
+  const stack = [...parsed.output];
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item || typeof item !== "object") continue;
+    if (item.type === "function_call" || item.type === "tool_call") return true;
+    if (Array.isArray(item.content)) {
+      stack.push(...item.content);
+    }
+  }
+
+  return false;
+}
+
+function shouldRequireResponsesToolCalling(provider) {
+  return (
+    provider === "nvidia-prod" || provider === "gemini-api" || provider === "compatible-endpoint"
+  );
+}
+
+function probeResponsesToolCalling(endpointUrl, model, apiKey) {
+  const result = runCurlProbe([
+    "-sS",
+    ...getCurlTimingArgs(),
+    "-H",
+    "Content-Type: application/json",
+    ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
+    "-d",
+    JSON.stringify({
+      model,
+      input: "Call the emit_ok function with value OK. Do not answer with plain text.",
+      tool_choice: "required",
+      tools: [
+        {
+          type: "function",
+          name: "emit_ok",
+          description: "Returns the probe value for validation.",
+          parameters: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            required: ["value"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    }),
+    `${String(endpointUrl).replace(/\/+$/, "")}/responses`,
+  ]);
+
+  if (!result.ok) {
+    return result;
+  }
+  if (hasResponsesToolCall(result.body)) {
+    return result;
+  }
+  return {
+    ok: false,
+    httpStatus: result.httpStatus,
+    curlStatus: result.curlStatus,
+    body: result.body,
+    stderr: result.stderr,
+    message: `HTTP ${result.httpStatus}: Responses API did not return a tool call`,
+  };
+}
+
+function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
+  const responsesProbe =
+    options.requireResponsesToolCalling === true
+      ? {
+          name: "Responses API with tool calling",
+          api: "openai-responses",
+          execute: () => probeResponsesToolCalling(endpointUrl, model, apiKey),
+        }
+      : {
+          name: "Responses API",
+          api: "openai-responses",
+          execute: () =>
+            runCurlProbe([
+              "-sS",
+              ...getCurlTimingArgs(),
+              "-H",
+              "Content-Type: application/json",
+              ...(apiKey
+                ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`]
+                : []),
+              "-d",
+              JSON.stringify({
+                model,
+                input: "Reply with exactly: OK",
+              }),
+              `${String(endpointUrl).replace(/\/+$/, "")}/responses`,
+            ]),
+        };
+
   const probes = [
-    {
-      name: "Responses API",
-      api: "openai-responses",
-      url: `${String(endpointUrl).replace(/\/+$/, "")}/responses`,
-      body: JSON.stringify({
-        model,
-        input: "Reply with exactly: OK",
-      }),
-    },
+    responsesProbe,
     {
       name: "Chat Completions API",
       api: "openai-completions",
-      url: `${String(endpointUrl).replace(/\/+$/, "")}/chat/completions`,
-      body: JSON.stringify({
-        model,
-        messages: [{ role: "user", content: "Reply with exactly: OK" }],
-      }),
+      execute: () =>
+        runCurlProbe([
+          "-sS",
+          ...getCurlTimingArgs(),
+          "-H",
+          "Content-Type: application/json",
+          ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
+          "-d",
+          JSON.stringify({
+            model,
+            messages: [{ role: "user", content: "Reply with exactly: OK" }],
+          }),
+          `${String(endpointUrl).replace(/\/+$/, "")}/chat/completions`,
+        ]),
     },
   ];
 
   const failures = [];
   for (const probe of probes) {
-    const result = runCurlProbe([
-      "-sS",
-      ...getCurlTimingArgs(),
-      "-H",
-      "Content-Type: application/json",
-      ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
-      "-d",
-      probe.body,
-      probe.url,
-    ]);
+    const result = probe.execute();
     if (result.ok) {
       return { ok: true, api: probe.api, label: probe.name };
     }
@@ -1062,9 +1161,10 @@ async function validateOpenAiLikeSelection(
   credentialEnv = null,
   retryMessage = "Please choose a provider/model again.",
   helpUrl = null,
+  options = {},
 ) {
   const apiKey = credentialEnv ? getCredential(credentialEnv) : "";
-  const probe = probeOpenAiLikeEndpoint(endpointUrl, model, apiKey);
+  const probe = probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options);
   if (!probe.ok) {
     console.error(`  ${label} endpoint validation failed.`);
     console.error(`  ${probe.message}`);
@@ -1127,7 +1227,9 @@ async function validateCustomOpenAiLikeSelection(
   helpUrl = null,
 ) {
   const apiKey = getCredential(credentialEnv);
-  const probe = probeOpenAiLikeEndpoint(endpointUrl, model, apiKey);
+  const probe = probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, {
+    requireResponsesToolCalling: true,
+  });
   if (probe.ok) {
     console.log(`  ${probe.label} available — OpenClaw will use ${probe.api}.`);
     return { ok: true, api: probe.api };
@@ -2597,6 +2699,9 @@ async function setupNim(gpu) {
                   credentialEnv,
                   retryMessage,
                   remoteConfig.helpUrl,
+                  {
+                    requireResponsesToolCalling: shouldRequireResponsesToolCalling(provider),
+                  },
                 );
                 if (validation.ok) {
                   preferredInferenceApi = validation.api;
@@ -2624,6 +2729,9 @@ async function setupNim(gpu) {
               credentialEnv,
               "Please choose a provider/model again.",
               remoteConfig.helpUrl,
+              {
+                requireResponsesToolCalling: shouldRequireResponsesToolCalling(provider),
+              },
             );
             if (validation.ok) {
               preferredInferenceApi = validation.api;
@@ -4227,6 +4335,7 @@ module.exports = {
   setupPoliciesWithSelection,
   summarizeCurlFailure,
   summarizeProbeFailure,
+  hasResponsesToolCall,
   upsertProvider,
   hydrateCredentialEnv,
   pruneKnownHostsEntries,

--- a/docs/inference/inference-options.md
+++ b/docs/inference/inference-options.md
@@ -45,10 +45,10 @@ Ollama appears when it is installed or running on the host.
 |--------|-------------|----------------|
 | NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, Kimi K2.5, GLM-5, MiniMax M2.5, GPT-OSS 120B |
 | OpenAI | Routes to the OpenAI API. Set `OPENAI_API_KEY`. | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro-2026-03-05` |
-| Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
+| Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. If the endpoint also supports `/responses` with OpenClaw-style tool calling, NemoClaw can use that path; otherwise it falls back to `/chat/completions`. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
 | Anthropic | Routes to the Anthropic Messages API. Set `ANTHROPIC_API_KEY`. | `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-6` |
 | Other Anthropic-compatible endpoint | Routes to any server that implements the Anthropic Messages API (`/v1/messages`). The wizard prompts for a base URL and model name. Set `COMPATIBLE_ANTHROPIC_API_KEY`. | You provide the model name. |
-| Google Gemini | Routes to Google's OpenAI-compatible endpoint. Set `GEMINI_API_KEY`. | `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
+| Google Gemini | Routes to Google's OpenAI-compatible endpoint. NemoClaw prefers `/responses` only when the endpoint proves it can handle tool calling in a way OpenClaw uses; otherwise it falls back to `/chat/completions`. Set `GEMINI_API_KEY`. | `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
 | Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to [Use a Local Inference Server](use-local-inference.md). |
 
 ## Experimental Options
@@ -69,10 +69,13 @@ If validation fails, the wizard returns to provider selection.
 
 | Provider type | Validation method |
 |---|---|
-| OpenAI-compatible | Tries `/responses` first, then `/chat/completions`. |
+| OpenAI | Tries `/responses` first, then `/chat/completions`. |
+| NVIDIA Endpoints | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
+| Google Gemini | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
+| Other OpenAI-compatible endpoint | Tries `/responses` first with a tool-calling probe that matches OpenClaw behavior. Falls back to `/chat/completions` if the endpoint does not return a compatible tool call. |
 | Anthropic-compatible | Tries `/v1/messages`. |
 | NVIDIA Endpoints (manual model entry) | Validates the model name against the catalog API. |
-| Compatible endpoints | Sends a real inference request because many proxies do not expose a `/models` endpoint. |
+| Compatible endpoints | Sends a real inference request because many proxies do not expose a `/models` endpoint. For OpenAI-compatible endpoints, the probe includes tool calling before NemoClaw favors `/responses`. |
 
 ## Next Steps
 

--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -85,6 +85,8 @@ If `NEMOCLAW_MODEL` is not set, NemoClaw selects a default model based on availa
 ## OpenAI-Compatible Server
 
 This option works with any server that implements `/v1/chat/completions`, including vLLM, TensorRT-LLM, llama.cpp, LocalAI, and others.
+If the server also supports `/v1/responses`, NemoClaw only favors that path when onboarding can verify tool-calling behavior that matches what OpenClaw actually sends.
+Otherwise NemoClaw falls back to `/v1/chat/completions`.
 
 Start your model server.
 The examples below use vLLM, but any OpenAI-compatible server works.
@@ -106,6 +108,8 @@ The wizard prompts for an API key.
 If your server does not require authentication, enter any non-empty string (for example, `dummy`).
 
 NemoClaw validates the endpoint by sending a test inference request before continuing.
+For OpenAI-compatible endpoints, the validation prefers `/responses` only when the probe produces a compatible function or tool call.
+Endpoints that return `200 OK` on `/responses` but do not format tool calls the way OpenClaw expects are configured to use `/chat/completions` instead.
 
 ### Non-Interactive Setup
 

--- a/src/lib/http-probe.test.ts
+++ b/src/lib/http-probe.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
-import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -36,16 +36,10 @@ describe("http-probe helpers", () => {
   });
 
   it("captures successful curl output and cleans up the temp file", () => {
-    const countProbeDirs = () =>
-      fs
-        .readdirSync(os.tmpdir())
-        .filter((entry) => entry.startsWith("nemoclaw-curl-probe-"))
-        .sort();
-
-    const before = countProbeDirs();
+    let outputPath = "";
     const result = runCurlProbe(["-sS", "https://example.test/models"], {
       spawnSyncImpl: (_command, args) => {
-        const outputPath = args[args.indexOf("-o") + 1];
+        outputPath = args[args.indexOf("-o") + 1];
         fs.writeFileSync(outputPath, JSON.stringify({ data: [{ id: "foo" }] }));
         return {
           pid: 1,
@@ -57,7 +51,6 @@ describe("http-probe helpers", () => {
         };
       },
     });
-    const after = countProbeDirs();
 
     expect(result).toMatchObject({
       ok: true,
@@ -65,8 +58,9 @@ describe("http-probe helpers", () => {
       curlStatus: 0,
       body: '{"data":[{"id":"foo"}]}',
     });
-    const leaked = after.filter((d) => !before.includes(d));
-    expect(leaked).toEqual([]);
+    expect(outputPath).not.toBe("");
+    expect(fs.existsSync(outputPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(outputPath))).toBe(false);
   });
 
   it("reports spawn errors as curl failures", () => {

--- a/test/onboard-selection.test.js
+++ b/test/onboard-selection.test.js
@@ -168,13 +168,13 @@ const { setupNim } = require(${onboardPath});
     const payload = JSON.parse(result.stdout.trim());
     assert.equal(payload.result.provider, "nvidia-prod");
     assert.equal(payload.result.model, "nvidia/nemotron-3-super-120b-a12b");
-    assert.equal(payload.result.preferredInferenceApi, "openai-responses");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
     assert.equal(payload.promptCalls, 2);
     assert.match(payload.messages[0], /Choose \[/);
     assert.match(payload.messages[1], /Choose model \[1\]/);
     assert.ok(payload.lines.some((line) => line.includes("Detected local inference option")));
     assert.ok(payload.lines.some((line) => line.includes("Cloud models:")));
-    assert.ok(payload.lines.some((line) => line.includes("Responses API available")));
+    assert.ok(payload.lines.some((line) => line.includes("Chat Completions API available")));
   });
 
   it("does not label NVIDIA Endpoints as recommended in the provider list", () => {
@@ -341,7 +341,7 @@ const { setupNim } = require(${onboardPath});
     const payload = JSON.parse(result.stdout.trim());
     assert.equal(payload.result.provider, "nvidia-prod");
     assert.equal(payload.result.model, "custom/provider-model");
-    assert.equal(payload.result.preferredInferenceApi, "openai-responses");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
     assert.match(payload.messages[1], /Choose model \[1\]/);
     assert.match(payload.messages[2], /NVIDIA Endpoints model id:/);
     assert.ok(payload.lines.some((line) => line.includes("Other...")));
@@ -1316,7 +1316,10 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 if echo "$url" | grep -q '/responses$' && echo "$body_arg" | grep -q 'good-model'; then
-  body='{"id":"resp_123"}'
+  body='{"id":"resp_123","output":[{"type":"message","content":[{"type":"output_text","text":"OK"}]}]}'
+  status="200"
+elif echo "$url" | grep -q '/chat/completions$' && echo "$body_arg" | grep -q 'good-model'; then
+  body='{"id":"chatcmpl-123","choices":[{"message":{"content":"OK"}}]}'
   status="200"
 fi
 printf '%s' "$body" > "$outfile"
@@ -1375,7 +1378,7 @@ const { setupNim } = require(${onboardPath});
     const payload = JSON.parse(result.stdout.trim());
     assert.equal(payload.result.provider, "compatible-endpoint");
     assert.equal(payload.result.model, "good-model");
-    assert.equal(payload.result.preferredInferenceApi, "openai-responses");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
     assert.ok(
       payload.lines.some((line) =>
         line.includes("Other OpenAI-compatible endpoint endpoint validation failed"),
@@ -1396,6 +1399,100 @@ const { setupNim } = require(${onboardPath});
       2,
     );
     assert.equal(payload.messages.filter((message) => /Choose \[/.test(message)).length, 1);
+  });
+
+  it("falls back to chat completions for custom OpenAI-compatible endpoints when /responses lacks tool calls", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-custom-openai-responses-fallback-"),
+    );
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "custom-openai-responses-fallback-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "credentials.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+body='{"error":{"message":"bad request"}}'
+status="400"
+outfile=""
+body_arg=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) outfile="$2"; shift 2 ;;
+    -d) body_arg="$2"; shift 2 ;;
+    *) url="$1"; shift ;;
+  esac
+done
+if echo "$url" | grep -q '/responses$'; then
+  body='{"id":"resp_123","output":[{"type":"message","content":[{"type":"output_text","text":"OK"}]}]}'
+  status="200"
+elif echo "$url" | grep -q '/chat/completions$'; then
+  body='{"id":"chatcmpl-123","choices":[{"message":{"content":"OK"}}]}'
+  status="200"
+fi
+printf '%s' "$body" > "$outfile"
+printf '%s' "$status"
+`,
+      { mode: 0o755 },
+    );
+
+    const script = String.raw`
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+
+const answers = ["3", "https://proxy.example.com/v1", "custom-model"];
+const messages = [];
+
+credentials.prompt = async (message) => {
+  messages.push(message);
+  return answers.shift() || "";
+};
+runner.runCapture = () => "";
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  process.env.COMPATIBLE_API_KEY = "proxy-key";
+  const originalLog = console.log;
+  const originalError = console.error;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  console.error = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim(null);
+    originalLog(JSON.stringify({ result, messages, lines }));
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.equal(payload.result.provider, "compatible-endpoint");
+    assert.equal(payload.result.model, "custom-model");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
+    assert.ok(payload.lines.some((line) => line.includes("Chat Completions API available")));
   });
 
   it("returns to provider selection instead of exiting on blank custom endpoint input", () => {
@@ -1807,6 +1904,15 @@ done
 if echo "$url" | grep -q 'generativelanguage.googleapis.com' && echo "$url" | grep -q '/responses$'; then
   body='{"id":"ok"}'
   status="200"
+elif echo "$url" | grep -q 'generativelanguage.googleapis.com' && echo "$url" | grep -q '/chat/completions$'; then
+  body='{"id":"chatcmpl-123","choices":[{"message":{"content":"OK"}}]}'
+  status="200"
+elif echo "$url" | grep -q 'integrate.api.nvidia.com' && echo "$url" | grep -q '/responses$'; then
+  body='{"id":"resp_123"}'
+  status="200"
+elif echo "$url" | grep -q 'integrate.api.nvidia.com' && echo "$url" | grep -q '/chat/completions$'; then
+  body='{"id":"chatcmpl-123","choices":[{"message":{"content":"OK"}}]}'
+  status="200"
 fi
 printf '%s' "$body" > "$outfile"
 printf '%s' "$status"
@@ -1818,13 +1924,14 @@ printf '%s' "$status"
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
-const answers = ["2", "", "6", ""];
+const answers = ["2", "", "back", "1", ""];
 const messages = [];
 
 credentials.prompt = async (message) => {
   messages.push(message);
   return answers.shift() || "";
 };
+credentials.ensureApiKey = async () => { process.env.NVIDIA_API_KEY = "nvapi-good"; };
 runner.runCapture = () => "";
 
 const { setupNim } = require(${onboardPath});
@@ -1863,8 +1970,8 @@ const { setupNim } = require(${onboardPath});
 
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.result.provider, "gemini-api");
-    assert.equal(payload.result.preferredInferenceApi, "openai-responses");
+    assert.equal(payload.result.provider, "nvidia-prod");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
     assert.ok(payload.lines.some((line) => line.includes("OpenAI endpoint validation failed")));
     assert.ok(payload.lines.some((line) => line.includes("Please choose a provider/model again")));
     assert.equal(payload.messages.filter((message) => /Choose \[/.test(message)).length, 2);
@@ -2064,7 +2171,7 @@ const { setupNim } = require(${onboardPath});
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim());
     assert.equal(payload.result.provider, "nvidia-prod");
-    assert.equal(payload.result.preferredInferenceApi, "openai-responses");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
     assert.equal(payload.key, "nvapi-good");
     assert.ok(payload.lines.some((line) => line.includes("NVIDIA Endpoints authorization failed")));
     assert.equal(payload.messages.filter((message) => /Choose \[/.test(message)).length, 1);
@@ -2305,7 +2412,7 @@ const { setupNim } = require(${onboardPath});
     const payload = JSON.parse(result.stdout.trim());
     assert.equal(payload.result.provider, "gemini-api");
     assert.equal(payload.result.model, "gemini-2.5-flash");
-    assert.equal(payload.result.preferredInferenceApi, "openai-responses");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
     assert.equal(payload.key, "gemini-good");
     assert.ok(payload.lines.some((line) => line.includes("Google Gemini authorization failed")));
     assert.ok(
@@ -2386,7 +2493,7 @@ const { setupNim } = require(${onboardPath});
     assert.equal(payload.result.provider, "compatible-endpoint");
     assert.equal(payload.result.model, "custom-model");
     assert.equal(payload.result.endpointUrl, "https://proxy.example.com/v1");
-    assert.equal(payload.result.preferredInferenceApi, "openai-responses");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
     assert.equal(payload.key, "proxy-good");
     assert.ok(
       payload.lines.some((line) =>

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -29,6 +29,7 @@ import {
   getStableGatewayImageRef,
   isGatewayHealthy,
   classifyValidationFailure,
+  hasResponsesToolCall,
   isLoopbackHostname,
   normalizeProviderBaseUrl,
   parsePolicyPresetEnv,
@@ -160,6 +161,53 @@ describe("onboard helpers", () => {
         message: "HTTP 405: unsupported model",
       }),
     ).toEqual({ kind: "model", retry: "model" });
+  });
+
+  it("detects tool-calling responses payloads conservatively", () => {
+    expect(
+      hasResponsesToolCall(
+        JSON.stringify({
+          output: [
+            {
+              type: "function_call",
+              name: "emit_ok",
+              arguments: '{"value":"OK"}',
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      hasResponsesToolCall(
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              content: [
+                {
+                  type: "function_call",
+                  name: "emit_ok",
+                  arguments: '{"value":"OK"}',
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      hasResponsesToolCall(
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "OK" }],
+            },
+          ],
+        }),
+      ),
+    ).toBe(false);
+    expect(hasResponsesToolCall("{")).toBe(false);
   });
 
   it("normalizes anthropic-compatible base URLs with a trailing /v1", () => {


### PR DESCRIPTION
## Summary
- harden onboarding so NVIDIA Endpoints, Gemini, and other OpenAI-compatible endpoints only favor /responses when a tool-calling probe matches OpenClaw behavior
- fall back to /chat/completions when /responses returns 200 but does not produce compatible tool-call output
- document the updated selection policy and add regression coverage for the fallback paths

## Testing
- npx vitest run src/lib/http-probe.test.ts test/onboard.test.js test/onboard-selection.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security configuration guide covering network, filesystem, process, and inference controls with Locked-Down and Development posture profiles
  * New credential storage documentation detailing plaintext JSON format and best practices
  * Enhanced inference endpoint selection guidance with tool-calling validation and fallback behavior
  * Expanded Podman troubleshooting with rootless mode resolution and resource tuning guidance

* **Bug Fixes**
  * Improved OpenAI-compatible endpoint validation with enhanced tool-calling detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->