### PR TITLE
docs: clarify that the installer does not require root or sudo (#406)

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -64,6 +64,15 @@ To avoid these issues, install the prerequisites in the following order before r
 1. Install Xcode Command Line Tools (`xcode-select --install`). These are needed by the installer and Node.js toolchain.
 2. Install and start a supported container runtime (Docker Desktop or Colima). Without a running runtime, the installer cannot connect to Docker.
 
+### Permission errors during installation
+
+The NemoClaw installer does not require `sudo` or root.
+It installs Node.js via nvm and NemoClaw via npm, both into user-local directories.
+The installer also handles OpenShell installation automatically using a pinned release.
+
+If you see permission errors during installation, they typically come from Docker, not the NemoClaw installer itself.
+Docker must be installed and running before you run the installer, and installing Docker may require elevated privileges on Linux.
+
 ### npm install fails with permission errors
 
 If `npm install` fails with an `EACCES` permission error, do not run npm with `sudo`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # 🦞 NVIDIA NemoClaw: Reference Stack for Running OpenClaw in OpenShell
 
 <!-- start-badges -->
@@ -75,6 +80,10 @@ The script installs Node.js if it is not already present, then runs the guided o
 > **ℹ️ Note**
 >
 > NemoClaw creates a fresh OpenClaw instance inside the sandbox during the onboarding process.
+>
+> The installer runs as your normal user and does not require `sudo` or root.
+> It installs Node.js via nvm and NemoClaw via npm, both into user-local directories.
+> Docker must be installed and running before you run the installer. Installing Docker may require elevated privileges on Linux.
 
 ```bash
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -92,6 +92,15 @@ To avoid these issues, install the prerequisites in the following order before r
 1. Install Xcode Command Line Tools (`xcode-select --install`). These are needed by the installer and Node.js toolchain.
 2. Install and start a supported container runtime (Docker Desktop or Colima). Without a running runtime, the installer cannot connect to Docker.
 
+### Permission errors during installation
+
+The NemoClaw installer does not require `sudo` or root.
+It installs Node.js via nvm and NemoClaw via npm, both into user-local directories.
+The installer also handles OpenShell installation automatically using a pinned release.
+
+If you see permission errors during installation, they typically come from Docker, not the NemoClaw installer itself.
+Docker must be installed and running before you run the installer, and installing Docker may require elevated privileges on Linux.
+
 ### npm install fails with permission errors
 
 If `npm install` fails with an `EACCES` permission error, do not run npm with `sudo`.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Clarify privilege requirements for the NemoClaw installer.
The install one-liner gave no indication of whether root was needed, causing confusion when users
hit permission errors from prerequisite tools (Docker, OpenShell) and assumed the installer itself
required elevated privileges.

This is a scoped-down refresh of #760, incorporating maintainer feedback.

## Related Issue

Closes #406

## Changes

- Add a privileges note to the README quickstart callout explaining that the installer runs as a
  normal user and does not need `sudo` or root.
- Add a new "Permission errors during installation" entry to the troubleshooting page
  (`docs/reference/troubleshooting.md`) explaining that permission errors typically come from
  prerequisites, not the NemoClaw installer.
- Include auto-regenerated agent skill files from the `docs-to-skills` pipeline.

## Type of Change

- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

All pre-commit hooks passed: trailing-whitespace, end-of-file-fixer, markdownlint-cli2,
gitleaks, commitlint, skills YAML, and the `Regenerate agent skills from docs` hook.

## Checklist

### General

- [x] I have read and followed the [contributing guide](CONTRIBUTING.md).
- [x] I have read and followed the [style guide](docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

_N/A — doc-only PR._

### Doc Changes

- [x] Follows the [style guide](docs/CONTRIBUTING.md).
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with clarified installation prerequisites and requirements
  * Added troubleshooting section for permission errors during installation
  * Documented that the installer runs as a normal user without elevated privileges, installs Node.js and packages to user-local directories via standard package managers, and requires Docker to be pre-installed and running on the system
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: SudheerDev-AIML <gsk.aiml@gmail.com>