### PR TITLE
fix(preflight): distinguish docker socket permission from daemon-down

### DIFF
--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -375,6 +375,37 @@ describe("planHostRemediation", () => {
     expect(actions[0].commands).toContain("sudo systemctl start docker");
   });
 
+  it("flags socket permission instead of 'start docker' when daemon is active but unreachable (#1574)", () => {
+    const actions = planHostRemediation({
+      platform: "linux",
+      isWsl: false,
+      runtime: "unknown",
+      packageManager: "apt",
+      systemctlAvailable: true,
+      dockerServiceActive: true,
+      dockerServiceEnabled: true,
+      dockerInstalled: true,
+      dockerRunning: false,
+      dockerReachable: false,
+      nodeInstalled: true,
+      openshellInstalled: true,
+      dockerCgroupVersion: "unknown",
+      dockerDefaultCgroupnsMode: "unknown",
+      requiresHostCgroupnsFix: false,
+      isUnsupportedRuntime: false,
+      isHeadlessLikely: false,
+      hasNvidiaGpu: false,
+      notes: [],
+    });
+
+    expect(actions[0].id).toBe("fix_docker_socket_permission");
+    expect(actions[0].blocking).toBe(true);
+    expect(actions[0].commands).toContain("sudo usermod -aG docker $USER");
+    // Must NOT suggest starting docker — that's the misleading message #1574 calls out.
+    expect(actions[0].commands).not.toContain("sudo systemctl start docker");
+    expect(actions[0].reason).toMatch(/socket/i);
+  });
+
   it("warns that podman is unsupported on macOS without blocking onboarding", () => {
     const actions = planHostRemediation({
       platform: "darwin",

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -352,19 +352,42 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
       blocking: true,
     });
   } else if (!assessment.dockerReachable) {
-    actions.push({
-      id: "start_docker",
-      title: "Start Docker",
-      kind: "manual",
-      reason: "Docker is installed but NemoClaw could not talk to the Docker daemon.",
-      commands:
-        assessment.platform === "darwin"
-          ? ["Start Docker Desktop or Colima, then rerun `nemoclaw onboard`."]
-          : assessment.systemctlAvailable
-            ? ["sudo systemctl start docker", "nemoclaw onboard"]
-            : ["Start the Docker daemon, then rerun `nemoclaw onboard`."],
-      blocking: true,
-    });
+    // Distinguish "daemon not running" from "daemon running but the current
+    // user can't reach the socket". When systemd reports docker.service is
+    // active but `docker info` still fails, asking the user to start docker
+    // is misleading — the real fix is to grant socket access (typically by
+    // adding the user to the docker group). See issue #1574.
+    if (assessment.platform === "linux" && assessment.dockerServiceActive === true) {
+      actions.push({
+        id: "fix_docker_socket_permission",
+        title: "Grant Docker socket access",
+        kind: "manual",
+        reason:
+          "Docker daemon is running but NemoClaw could not talk to the Docker socket. " +
+          "This usually means your user does not have permission to access /var/run/docker.sock.",
+        commands: [
+          "sudo usermod -aG docker $USER",
+          "newgrp docker  # or log out and back in",
+          "docker info  # confirm the socket is reachable",
+          "nemoclaw onboard",
+        ],
+        blocking: true,
+      });
+    } else {
+      actions.push({
+        id: "start_docker",
+        title: "Start Docker",
+        kind: "manual",
+        reason: "Docker is installed but NemoClaw could not talk to the Docker daemon.",
+        commands:
+          assessment.platform === "darwin"
+            ? ["Start Docker Desktop or Colima, then rerun `nemoclaw onboard`."]
+            : assessment.systemctlAvailable
+              ? ["sudo systemctl start docker", "nemoclaw onboard"]
+              : ["Start the Docker daemon, then rerun `nemoclaw onboard`."],
+        blocking: true,
+      });
+    }
   }
 
   if (assessment.isUnsupportedRuntime) {


### PR DESCRIPTION
## Summary

- Detect the case where Docker daemon is running but the user can't reach the socket, and emit a dedicated `fix_docker_socket_permission` remediation
- Keep the existing `start_docker` remediation for the case where the daemon is actually down
- Add a regression test for the new branch
- Closes #1574

## Problem

On DGX Spark (and any Linux host where the user isn't in the `docker` group), `nemoclaw onboard` reports that Docker is not reachable and suggests `sudo systemctl start docker`, even when `docker.service` is already active and running. The current preflight already collects `dockerServiceActive` via `systemctl is-active docker` but never uses it in the remediation logic — so a socket permission error and a daemon-down error get the same misleading message.

The reporter verified that `systemctl status docker` returned `active (running)` and was still told to start docker. This sends users down a dead end because re-running `systemctl start docker` does nothing when it's already up.

## Fix

In `planHostRemediation`, when `dockerInstalled && !dockerReachable && dockerServiceActive === true && platform === "linux"`, emit a new remediation:

- **id:** `fix_docker_socket_permission`
- **reason:** "Docker daemon is running but NemoClaw could not talk to the Docker socket. This usually means your user does not have permission to access /var/run/docker.sock."
- **commands:** `sudo usermod -aG docker $USER` → `newgrp docker` (or relogin) → `docker info` → `nemoclaw onboard`

The original `start_docker` remediation is preserved for the daemon-actually-down case.

## Test plan

- [x] New regression test asserts:
  - The new action id is returned for the active-but-unreachable case
  - `sudo usermod -aG docker $USER` is in the commands
  - The misleading `sudo systemctl start docker` command is NOT present
  - The reason text mentions the socket so users understand the root cause
- [x] All 36 preflight tests pass (`npx vitest run src/lib/preflight.test.ts`)
- [x] Existing `start_docker` test still passes — the daemon-down branch is unchanged
- [x] Prettier clean, ESLint clean
- [x] Signed commit + DCO sign-off

Closes #1574

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker troubleshooting: when the daemon is already running but inaccessible on Linux, the system now correctly guides users to grant socket permissions instead of attempting to restart Docker.

* **Tests**
  * Added test coverage for Docker socket permission remediation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->