### PR TITLE
feat: argumentizing OpenClaw version

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -19,6 +19,11 @@ on:
     paths:
       - "Dockerfile.base"
   workflow_dispatch:
+    inputs:
+      openclaw_version:
+        description: "OpenClaw version to install (leave blank for default 2026.3.11)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -74,3 +79,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            OPENCLAW_VERSION=${{ inputs.openclaw_version || '2026.3.11' }}

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       openclaw_version:
-        description: "OpenClaw version to install (leave blank for default 2026.3.11)"
+        description: "OpenClaw version to install (leave blank to use the default in Dockerfile.base)"
         required: false
         default: ""
 

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -70,6 +70,10 @@ jobs:
             type=raw,value=latest
             type=sha,prefix=,format=short
 
+      - name: Validate OpenClaw version input
+        if: inputs.openclaw_version != ''
+        run: echo "${{ inputs.openclaw_version }}" | grep -qxE '[0-9]+(\.[0-9]+)*'
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -80,4 +80,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            OPENCLAW_VERSION=${{ inputs.openclaw_version || '' }}
+            ${{ inputs.openclaw_version && format('OPENCLAW_VERSION={0}', inputs.openclaw_version) || '' }}

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -80,4 +80,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            OPENCLAW_VERSION=${{ inputs.openclaw_version || '2026.3.11' }}
+            OPENCLAW_VERSION=${{ inputs.openclaw_version || '' }}

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -4,7 +4,7 @@
 # Build and push the sandbox base image to GHCR.
 #
 # Triggers:
-#   - Push to main when Dockerfile.base changes (new apt pkgs, openclaw bump, etc.)
+#   - Push to main when Dockerfile.base or the blueprint minimum version changes
 #   - Manual dispatch for ad-hoc rebuilds
 #
 # The base image contains the expensive, rarely-changing layers (apt, gosu,
@@ -18,6 +18,8 @@ on:
     branches: [main]
     paths:
       - "Dockerfile.base"
+      # Dockerfile.base validates min_openclaw_version from this file at build time.
+      - "nemoclaw-blueprint/blueprint.yaml"
   workflow_dispatch:
     inputs:
       openclaw_version:

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -163,5 +163,5 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
         echo "Error: OpenClaw version ${OPENCLAW_VERSION} not found on npm registry"; \
         echo "Hint: Check available versions with: npm view openclaw versions"; exit 1; \
     fi; \
-    npm install -g openclaw@${OPENCLAW_VERSION} \
+    npm install -g "openclaw@${OPENCLAW_VERSION}" \
     && pip3 install --no-cache-dir --break-system-packages "pyyaml==6.0.3"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -145,5 +145,16 @@ RUN printf '%s\n' \
 
 # Install OpenClaw CLI + PyYAML for inline Python scripts in e2e tests.
 # When bumping the openclaw version, rebuild this base image.
-RUN npm install -g openclaw@2026.3.11 \
+ARG OPENCLAW_VERSION=2026.3.11
+RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
+    OPENCLAW_MIN_VERSION=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"') \
+    && if [ "$(printf '%s\n%s' "$OPENCLAW_MIN_VERSION" "$OPENCLAW_VERSION" | sort -V | head -n1)" != "$OPENCLAW_MIN_VERSION" ]; then \
+        echo "Error: OpenClaw version ${OPENCLAW_VERSION} is below the minimum required version ${OPENCLAW_MIN_VERSION}"; \
+        echo "Hint: Update min_openclaw_version in nemoclaw-blueprint/blueprint.yaml or use a newer version."; exit 1; \
+    fi \
+    && if ! npm view openclaw@${OPENCLAW_VERSION} version > /dev/null 2>&1; then \
+        echo "Error: OpenClaw version ${OPENCLAW_VERSION} not found on npm registry"; \
+        echo "Hint: Check available versions with: npm view openclaw versions"; exit 1; \
+    fi \
+    && npm install -g openclaw@${OPENCLAW_VERSION} \
     && pip3 install --no-cache-dir --break-system-packages "pyyaml==6.0.3"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -21,7 +21,7 @@
 #   .openclaw dirs      — directory structure + symlinks are dictated by
 #     + symlinks          the OpenClaw CLI layout; new dirs are additive
 #                          (add them here and rebuild)
-#   openclaw CLI        — pinned to exact npm version (e.g., 2026.3.11)
+#   openclaw CLI        — version set by ARG OPENCLAW_VERSION (default below); override with --build-arg
 #   pyyaml              — pinned to exact pip version (6.0.3)
 #
 # Nothing here references NemoClaw plugin source, blueprint files,
@@ -33,7 +33,7 @@
 # The base-image.yaml workflow rebuilds automatically on main merges that
 # touch this file. You need to edit this file (triggering a rebuild) when:
 #
-#   1. OpenClaw CLI version bump    — change the openclaw@version below
+#   1. OpenClaw CLI version bump    — update OPENCLAW_VERSION default below, or override via --build-arg / workflow_dispatch
 #   2. New apt package needed       — add it to the apt-get install list
 #   3. gosu upgrade                 — update URL, checksum, and version
 #   4. node:22-slim digest rotated  — update-docker-pin.sh updates both
@@ -144,9 +144,15 @@ RUN printf '%s\n' \
     && chown sandbox:sandbox /sandbox/.bashrc /sandbox/.profile
 
 # Install OpenClaw CLI + PyYAML for inline Python scripts in e2e tests.
-# When bumping the openclaw version, rebuild this base image.
+# OpenClaw version: change the OPENCLAW_VERSION ARG default so CI rebuilds
+# the base image on push to main, or use workflow_dispatch on base-image.yaml
+# with the openclaw_version input for a one-off build without editing this file.
 ARG OPENCLAW_VERSION=2026.3.11
+
 RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
+    v="$OPENCLAW_VERSION"; \
+    echo "$v" | grep -qxE '[0-9]+(\.[0-9]+)*' \
+    || { echo "Error: OPENCLAW_VERSION='$v' is invalid (expected e.g. 2026.3.11)."; exit 1; }; \
     OPENCLAW_MIN_VERSION=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"') \
     && if [ "$(printf '%s\n%s' "$OPENCLAW_MIN_VERSION" "$OPENCLAW_VERSION" | sort -V | head -n1)" != "$OPENCLAW_MIN_VERSION" ]; then \
         echo "Error: OpenClaw version ${OPENCLAW_VERSION} is below the minimum required version ${OPENCLAW_MIN_VERSION}"; \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -152,14 +152,16 @@ ARG OPENCLAW_VERSION=2026.3.11
 RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
     echo "$OPENCLAW_VERSION" | grep -qxE '[0-9]+(\.[0-9]+)*' \
     || { echo "Error: OPENCLAW_VERSION='$OPENCLAW_VERSION' is invalid (expected e.g. 2026.3.11)."; exit 1; }; \
-    OPENCLAW_MIN_VERSION=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"') \
-    && if [ "$(printf '%s\n%s' "$OPENCLAW_MIN_VERSION" "$OPENCLAW_VERSION" | sort -V | head -n1)" != "$OPENCLAW_MIN_VERSION" ]; then \
+    OPENCLAW_MIN_VERSION=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
+    [ -n "$OPENCLAW_MIN_VERSION" ] \
+    || { echo "Error: Could not parse min_openclaw_version from nemoclaw-blueprint/blueprint.yaml"; exit 1; }; \
+    if [ "$(printf '%s\n%s' "$OPENCLAW_MIN_VERSION" "$OPENCLAW_VERSION" | sort -V | head -n1)" != "$OPENCLAW_MIN_VERSION" ]; then \
         echo "Error: OpenClaw version ${OPENCLAW_VERSION} is below the minimum required version ${OPENCLAW_MIN_VERSION}"; \
         echo "Hint: Update min_openclaw_version in nemoclaw-blueprint/blueprint.yaml or use a newer version."; exit 1; \
-    fi \
-    && if ! npm view openclaw@${OPENCLAW_VERSION} version > /dev/null 2>&1; then \
+    fi; \
+    if ! npm view openclaw@${OPENCLAW_VERSION} version > /dev/null 2>&1; then \
         echo "Error: OpenClaw version ${OPENCLAW_VERSION} not found on npm registry"; \
         echo "Hint: Check available versions with: npm view openclaw versions"; exit 1; \
-    fi \
-    && npm install -g openclaw@${OPENCLAW_VERSION} \
+    fi; \
+    npm install -g openclaw@${OPENCLAW_VERSION} \
     && pip3 install --no-cache-dir --break-system-packages "pyyaml==6.0.3"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -150,9 +150,8 @@ RUN printf '%s\n' \
 ARG OPENCLAW_VERSION=2026.3.11
 
 RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
-    v="$OPENCLAW_VERSION"; \
-    echo "$v" | grep -qxE '[0-9]+(\.[0-9]+)*' \
-    || { echo "Error: OPENCLAW_VERSION='$v' is invalid (expected e.g. 2026.3.11)."; exit 1; }; \
+    echo "$OPENCLAW_VERSION" | grep -qxE '[0-9]+(\.[0-9]+)*' \
+    || { echo "Error: OPENCLAW_VERSION='$OPENCLAW_VERSION' is invalid (expected e.g. 2026.3.11)."; exit 1; }; \
     OPENCLAW_MIN_VERSION=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"') \
     && if [ "$(printf '%s\n%s' "$OPENCLAW_MIN_VERSION" "$OPENCLAW_VERSION" | sort -V | head -n1)" != "$OPENCLAW_MIN_VERSION" ]; then \
         echo "Error: OpenClaw version ${OPENCLAW_VERSION} is below the minimum required version ${OPENCLAW_MIN_VERSION}"; \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -149,6 +149,8 @@ RUN printf '%s\n' \
 # with the openclaw_version input for a one-off build without editing this file.
 ARG OPENCLAW_VERSION=2026.3.11
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
     echo "$OPENCLAW_VERSION" | grep -qxE '[0-9]+(\.[0-9]+)*' \
     || { echo "Error: OPENCLAW_VERSION='$OPENCLAW_VERSION' is invalid (expected e.g. 2026.3.11)."; exit 1; }; \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -822,6 +822,12 @@ resolve_openclaw_version() {
         print substr($0, RSTART + 9, RLENGTH - 9)
         exit
       }
+      match($0, /ARG[[:space:]]+OPENCLAW_VERSION[[:space:]]*=[[:space:]]*[0-9][0-9.]+/) {
+        line = substr($0, RSTART, RLENGTH)
+        sub(/^[^=]+=[[:space:]]*/, "", line)
+        print line
+        exit
+      }
     ' "$dockerfile_base"
   fi
 }

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -1550,7 +1550,10 @@ describe("installer pure helpers", () => {
   });
 
   it("resolve_openclaw_version: falls back to Dockerfile.base when package.json omits it", () => {
-    const dockerfileContent = fs.readFileSync(path.join(import.meta.dirname, "..", "Dockerfile.base"), "utf-8");
+    const dockerfileContent = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "Dockerfile.base"),
+      "utf-8",
+    );
     const expected = dockerfileContent.match(/ARG\s+OPENCLAW_VERSION\s*=\s*(\S+)/)?.[1];
     expect(expected).toBeDefined();
     const r = callInstallerFn('resolve_openclaw_version "$PWD"');

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -1550,8 +1550,9 @@ describe("installer pure helpers", () => {
   });
 
   it("resolve_openclaw_version: falls back to Dockerfile.base when package.json omits it", () => {
-    const expected = fs.readFileSync(path.join(import.meta.dirname, "..", "Dockerfile.base"), "utf-8")
-      .match(/ARG OPENCLAW_VERSION=(\S+)/)?.[1];
+    const dockerfileContent = fs.readFileSync(path.join(import.meta.dirname, "..", "Dockerfile.base"), "utf-8");
+    const expected = dockerfileContent.match(/ARG\s+OPENCLAW_VERSION\s*=\s*(\S+)/)?.[1];
+    expect(expected).toBeDefined();
     const r = callInstallerFn('resolve_openclaw_version "$PWD"');
     expect(r.stdout.trim()).toBe(expected);
   });

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -1550,8 +1550,10 @@ describe("installer pure helpers", () => {
   });
 
   it("resolve_openclaw_version: falls back to Dockerfile.base when package.json omits it", () => {
+    const expected = fs.readFileSync(path.join(import.meta.dirname, "..", "Dockerfile.base"), "utf-8")
+      .match(/ARG OPENCLAW_VERSION=(\S+)/)?.[1];
     const r = callInstallerFn('resolve_openclaw_version "$PWD"');
-    expect(r.stdout.trim()).toBe("2026.3.11");
+    expect(r.stdout.trim()).toBe(expected);
   });
 
   it("is_source_checkout: rejects a payload-like checkout without git metadata", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
Argumentizing the OpenClaw version in the base image build so it can be overridden at build time via `--build-arg` or workflow dispatch, while keeping the default version. This is the first step toward an OpenClaw version integration pipeline that validates how different OpenClaw releases adapt to NemoClaw.

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->
Closes #1525

## Changes
<!-- Bullet list of key changes. -->
- **`Dockerfile.base`**: Replace the hardcoded `openclaw@2026.3.11` install with an `ARG OPENCLAW_VERSION` (default `2026.3.11`). At build time, the provided version is validated against:
  1. The `min_openclaw_version` declared in `nemoclaw-blueprint/blueprint.yaml`.
  2. The npm registry, to confirm the version actually exists before attempting install.
- **`.github/workflows/base-image.yaml`**: Add an `openclaw_version` input to `workflow_dispatch` and forward it as a `build-args` entry to the Docker build step, falling back to `2026.3.11` when left blank.

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [x] `make check` passes.

## Checklist

### General

- [ ] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual workflow now accepts an optional OpenClaw version and base-image builds also trigger when blueprint changes.
  * Base image build accepts a configurable OpenClaw version instead of a fixed release.

* **Improvements**
  * Build now validates requested OpenClaw versions for format, minimum compatibility with the blueprint, and registry availability before installing.
  * Version-detection logic improved to consider build-time declarations as a fallback.

* **Tests**
  * Tests updated to derive the expected OpenClaw version from configuration rather than using a hard-coded value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Hung Le <hple@nvidia.com>