### PR TITLE
fix(onboard): three NVIDIA Endpoints model probe bugs (#1601)

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1193,19 +1193,26 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
     if (result.ok) {
       return { ok: true, api: probe.api, label: probe.name };
     }
+    // Preserve the raw response body alongside the summarized message so the
+    // NVCF "Function not found for account" detector below can fall back to
+    // the raw body if summarizeProbeError ever stops surfacing the marker
+    // through `message`.
     failures.push({
       name: probe.name,
       httpStatus: result.httpStatus,
       curlStatus: result.curlStatus,
       message: result.message,
+      body: result.body,
     });
   }
 
   // Detect the NVCF "Function not found for account" error and reframe it
   // with an actionable next step instead of dumping the raw NVCF body.
   // See issue #1601 (Bug 2).
-  const accountFailure = failures.find((failure) =>
-    isNvcfFunctionNotFoundForAccount(failure.message),
+  const accountFailure = failures.find(
+    (failure) =>
+      isNvcfFunctionNotFoundForAccount(failure.message) ||
+      isNvcfFunctionNotFoundForAccount(failure.body),
   );
   if (accountFailure) {
     return {

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -510,6 +510,9 @@ const {
   classifySandboxCreateFailure,
   validateNvidiaApiKeyValue,
   isSafeModelId,
+  isNvcfFunctionNotFoundForAccount,
+  nvcfFunctionNotFoundMessage,
+  shouldSkipResponsesProbe,
 } = validation;
 
 // validateNvidiaApiKeyValue — see validation import above
@@ -1071,10 +1074,21 @@ function shouldRequireResponsesToolCalling(provider) {
   );
 }
 
+// shouldSkipResponsesProbe and isNvcfFunctionNotFoundForAccount /
+// nvcfFunctionNotFoundMessage — see validation import above. They live in
+// src/lib/validation.ts so they can be unit-tested independently.
+
+// Per-validation-probe curl timing. Tighter than the default 60s in
+// getCurlTimingArgs() because validation must not hang the wizard for a
+// minute on a misbehaving model. See issue #1601 (Bug 3).
+function getValidationProbeCurlArgs() {
+  return ["--connect-timeout", "10", "--max-time", "15"];
+}
+
 function probeResponsesToolCalling(endpointUrl, model, apiKey) {
   const result = runCurlProbe([
     "-sS",
-    ...getCurlTimingArgs(),
+    ...getValidationProbeCurlArgs(),
     "-H",
     "Content-Type: application/json",
     ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
@@ -1132,7 +1146,7 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
           execute: () =>
             runCurlProbe([
               "-sS",
-              ...getCurlTimingArgs(),
+              ...getValidationProbeCurlArgs(),
               "-H",
               "Content-Type: application/json",
               ...(apiKey
@@ -1147,27 +1161,31 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
             ]),
         };
 
-  const probes = [
-    responsesProbe,
-    {
-      name: "Chat Completions API",
-      api: "openai-completions",
-      execute: () =>
-        runCurlProbe([
-          "-sS",
-          ...getCurlTimingArgs(),
-          "-H",
-          "Content-Type: application/json",
-          ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
-          "-d",
-          JSON.stringify({
-            model,
-            messages: [{ role: "user", content: "Reply with exactly: OK" }],
-          }),
-          `${String(endpointUrl).replace(/\/+$/, "")}/chat/completions`,
-        ]),
-    },
-  ];
+  const chatCompletionsProbe = {
+    name: "Chat Completions API",
+    api: "openai-completions",
+    execute: () =>
+      runCurlProbe([
+        "-sS",
+        ...getValidationProbeCurlArgs(),
+        "-H",
+        "Content-Type: application/json",
+        ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
+        "-d",
+        JSON.stringify({
+          model,
+          messages: [{ role: "user", content: "Reply with exactly: OK" }],
+        }),
+        `${String(endpointUrl).replace(/\/+$/, "")}/chat/completions`,
+      ]),
+  };
+
+  // NVIDIA Build does not expose /v1/responses; probing it always returns
+  // "404 page not found" and only adds noise to error messages. Skip it
+  // entirely for that provider. See issue #1601.
+  const probes = options.skipResponsesProbe
+    ? [chatCompletionsProbe]
+    : [responsesProbe, chatCompletionsProbe];
 
   const failures = [];
   for (const probe of probes) {
@@ -1181,6 +1199,20 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
       curlStatus: result.curlStatus,
       message: result.message,
     });
+  }
+
+  // Detect the NVCF "Function not found for account" error and reframe it
+  // with an actionable next step instead of dumping the raw NVCF body.
+  // See issue #1601 (Bug 2).
+  const accountFailure = failures.find((failure) =>
+    isNvcfFunctionNotFoundForAccount(failure.message),
+  );
+  if (accountFailure) {
+    return {
+      ok: false,
+      message: nvcfFunctionNotFoundMessage(model),
+      failures,
+    };
   }
 
   return {
@@ -2879,6 +2911,7 @@ async function setupNim(gpu) {
                   remoteConfig.helpUrl,
                   {
                     requireResponsesToolCalling: shouldRequireResponsesToolCalling(provider),
+                    skipResponsesProbe: shouldSkipResponsesProbe(provider),
                   },
                 );
                 if (validation.ok) {
@@ -2909,6 +2942,7 @@ async function setupNim(gpu) {
               remoteConfig.helpUrl,
               {
                 requireResponsesToolCalling: shouldRequireResponsesToolCalling(provider),
+                skipResponsesProbe: shouldSkipResponsesProbe(provider),
               },
             );
             if (validation.ok) {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -195,6 +195,19 @@ describe("nvcfFunctionNotFoundMessage", () => {
     expect(msg).toContain("not deployed for your account");
     expect(msg).toContain("https://build.nvidia.com");
   });
+
+  it("opens with 'Model <id> not found' so classifyValidationFailure routes to the model recovery path", () => {
+    // classifyValidationFailure() in this same file matches /model.+not found/i
+    // and uses that to return { kind: "model", retry: "model" }. The reframed
+    // message must hit that regex so the wizard prompts the user to pick a
+    // different model instead of falling through to the generic recovery.
+    const msg = nvcfFunctionNotFoundMessage("mistralai/mistral-large");
+    expect(msg).toMatch(/model.+not found/i);
+    expect(classifyValidationFailure({ message: msg })).toEqual({
+      kind: "model",
+      retry: "model",
+    });
+  });
 });
 
 describe("shouldSkipResponsesProbe", () => {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -9,6 +9,9 @@ import {
   classifySandboxCreateFailure,
   validateNvidiaApiKeyValue,
   isSafeModelId,
+  isNvcfFunctionNotFoundForAccount,
+  nvcfFunctionNotFoundMessage,
+  shouldSkipResponsesProbe,
 } from "../../dist/lib/validation";
 
 describe("classifyValidationFailure", () => {
@@ -151,5 +154,58 @@ describe("isSafeModelId", () => {
     expect(isSafeModelId("model name")).toBe(false);
     expect(isSafeModelId("model;rm -rf /")).toBe(false);
     expect(isSafeModelId("")).toBe(false);
+  });
+});
+
+describe("isNvcfFunctionNotFoundForAccount", () => {
+  it("matches the literal NVCF detail string from /v1/chat/completions", () => {
+    expect(
+      isNvcfFunctionNotFoundForAccount(
+        "Function '767b5b9a-3f9d-4c1d-86e8-fa861988cee7': Not found for account 'yBLCN5kgzhvIn_SHbXDVGyQ-wEuSUKmFoZaC_JpS30c'",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches when wrapped inside an HTTP error summary", () => {
+    expect(
+      isNvcfFunctionNotFoundForAccount("HTTP 404: Function 'abc123': Not found for account 'xyz'"),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive on the 'Not found for account' clause", () => {
+    expect(isNvcfFunctionNotFoundForAccount("Function 'abc': not FOUND for ACCOUNT 'xyz'")).toBe(
+      true,
+    );
+  });
+
+  it("does not match generic 404 page-not-found bodies", () => {
+    expect(isNvcfFunctionNotFoundForAccount("404 page not found")).toBe(false);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isNvcfFunctionNotFoundForAccount("Connection refused")).toBe(false);
+    expect(isNvcfFunctionNotFoundForAccount("")).toBe(false);
+  });
+});
+
+describe("nvcfFunctionNotFoundMessage", () => {
+  it("includes the model id and points the user at build.nvidia.com", () => {
+    const msg = nvcfFunctionNotFoundMessage("mistralai/mistral-large");
+    expect(msg).toContain("mistralai/mistral-large");
+    expect(msg).toContain("not deployed for your account");
+    expect(msg).toContain("https://build.nvidia.com");
+  });
+});
+
+describe("shouldSkipResponsesProbe", () => {
+  it("skips the Responses probe for nvidia-prod (Build does not expose /v1/responses)", () => {
+    expect(shouldSkipResponsesProbe("nvidia-prod")).toBe(true);
+  });
+
+  it("does not skip the Responses probe for other providers", () => {
+    expect(shouldSkipResponsesProbe("openai-api")).toBe(false);
+    expect(shouldSkipResponsesProbe("anthropic-api")).toBe(false);
+    expect(shouldSkipResponsesProbe("compatible-endpoint")).toBe(false);
+    expect(shouldSkipResponsesProbe("")).toBe(false);
   });
 });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -103,12 +103,17 @@ export function isNvcfFunctionNotFoundForAccount(message: string): boolean {
 /**
  * Build the user-facing message for an NVCF "Function not found for account"
  * failure. The model is in the catalog but cannot be invoked from this key.
+ *
+ * The wording deliberately starts with "Model '<id>' not found" so that
+ * `classifyValidationFailure()` matches its `model.+not found` regex and
+ * routes the user into the model-selection recovery path instead of
+ * collapsing to the generic `unknown`/`selection` branch.
  */
 export function nvcfFunctionNotFoundMessage(model: string): string {
   return (
-    `Model '${model}' is in the NVIDIA Build catalog but is not deployed for your account. ` +
-    "Pick a different model, or check the model card on https://build.nvidia.com to see " +
-    "if it requires org-level access."
+    `Model '${model}' not found — it is in the NVIDIA Build catalog but is not deployed ` +
+    "for your account. Pick a different model, or check the model card on " +
+    "https://build.nvidia.com to see if it requires org-level access."
   );
 }
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -82,3 +82,44 @@ export function validateNvidiaApiKeyValue(key: string): string | null {
 export function isSafeModelId(value: string): boolean {
   return /^[A-Za-z0-9._:/-]+$/.test(value);
 }
+
+/**
+ * Detect NVIDIA Cloud Functions "Function not found for account" errors.
+ *
+ * NVIDIA Build (integrate.api.nvidia.com) returns this when a model is in the
+ * public catalog but is not deployed for the caller's account/org. The raw
+ * body looks like:
+ *
+ *   {"status":404,"title":"Not Found",
+ *    "detail":"Function '<uuid>': Not found for account '<account-id>'"}
+ *
+ * Detecting this lets the wizard surface an actionable error instead of the
+ * raw NVCF body. See issue #1601.
+ */
+export function isNvcfFunctionNotFoundForAccount(message: string): boolean {
+  return /Function\s+'[^']+':\s*Not found for account/i.test(String(message || ""));
+}
+
+/**
+ * Build the user-facing message for an NVCF "Function not found for account"
+ * failure. The model is in the catalog but cannot be invoked from this key.
+ */
+export function nvcfFunctionNotFoundMessage(model: string): string {
+  return (
+    `Model '${model}' is in the NVIDIA Build catalog but is not deployed for your account. ` +
+    "Pick a different model, or check the model card on https://build.nvidia.com to see " +
+    "if it requires org-level access."
+  );
+}
+
+/**
+ * Whether the wizard should skip probing the OpenAI Responses API entirely
+ * for the given inference provider. NVIDIA Build does not expose
+ * `/v1/responses` for any model — every probe to that path returns
+ * "404 page not found". Skipping the probe removes wasted round-trips and
+ * stops the failure-message noise from leaking into chat-completions errors.
+ * See issue #1601 (Bug 1).
+ */
+export function shouldSkipResponsesProbe(provider: string): boolean {
+  return provider === "nvidia-prod";
+}


### PR DESCRIPTION
## Summary

- Skip the OpenAI Responses probe entirely for `nvidia-prod` (NVIDIA Build does not expose `/v1/responses` for any model — every probe to that path returns `404 page not found`)
- Detect the NVCF `Function '<uuid>': Not found for account '<id>'` failure and surface an actionable message that points the user at picking a different model on https://build.nvidia.com
- Tighten the per-validation-probe `--max-time` from the default 60s to 15s so a hung NVIDIA backend (confirmed live on `mistralai/mistral-medium-3-instruct`) cannot block the wizard for a full minute per failure mode
- Closes #1601

## Problem

Three quirks of NVIDIA Build (https://integrate.api.nvidia.com/v1) combine to make custom-model selection in `nemoclaw onboard` look broken even when the model would otherwise work. The default Nemotron path is unaffected because it picks models that happen to mask all three behaviors.

The reporter (**@kaviin27** in the NVIDIA Developer Discord) saw this exact failure pasted in their bug report:

> ```
> Responses API with tool calling: HTTP 404: 404 page not found
> Chat Completions API: HTTP 404: Function 'ZZZZ': Not found for account 'XXXX'
> ```

I reproduced both halves of that against a live free-tier NVIDIA Build key and traced them to three independent code paths.

### 1. Responses probe always 404s on NVIDIA Build

[`bin/lib/onboard.js:probeOpenAiLikeEndpoint()`](bin/lib/onboard.js) probes `/v1/responses` first when `requireResponsesToolCalling` is true (which is gated on `provider === 'nvidia-prod'`). NVIDIA Build does not expose `/v1/responses` for **any** model — even nemotron-49b returns `404 page not found`. The probe loop silently falls through to chat completions on success, so working models still onboard, but the noisy 404 leaks into error messages whenever chat completions also fails. That's why @kaviin27's error string had both halves.

Fix: skip the Responses probe entirely for nvidia-prod via a new `shouldSkipResponsesProbe()` helper.

### 2. NVCF `Function not found for account` is opaque to the user

Many catalog models return:
```json
{"status":404,"title":"Not Found","detail":"Function 'a1b2c3': Not found for account 'xyz'"}
```

This means the model is in the public catalog but is not deployed for the user's account/org. The current code joins all probe failures into one raw string and surfaces the NVCF body verbatim, leaving the user with no idea what to do.

Fix: detect the pattern with `isNvcfFunctionNotFoundForAccount()` and replace the message with `nvcfFunctionNotFoundMessage(model)`, which says:

> Model '<id>' is in the NVIDIA Build catalog but is not deployed for your account. Pick a different model, or check the model card on https://build.nvidia.com to see if it requires org-level access.

### 3. Validation probes inherit a 60s curl timeout

`getCurlTimingArgs()` returns `--max-time 60`. That is fine for inference calls, but a misbehaving model (confirmed: `mistralai/mistral-medium-3-instruct` hangs 30+ seconds with zero bytes returned, 3 attempts in a row) should not block the wizard for a full minute per failure mode. The user-visible result is a wizard that just sits there for ages on a model the user can't fix.

Fix: add `getValidationProbeCurlArgs()` that returns `--max-time 15` and use it in `probeOpenAiLikeEndpoint` and `probeResponsesToolCalling`.

## Test plan

- [x] **6 new unit tests** in `src/lib/validation.test.ts` covering `isNvcfFunctionNotFoundForAccount`, `nvcfFunctionNotFoundMessage`, and `shouldSkipResponsesProbe` — including the literal NVCF error string captured from a live API run
- [x] All 30 validation tests pass: `npx vitest run src/lib/validation.test.ts` → 30/30
- [x] Existing onboard test suites unaffected — verified `test/onboard-selection.test.js` and `test/onboard-readiness.test.js` pass
- [x] **Live reproduction** against `https://integrate.api.nvidia.com/v1`:
  - `nvidia/llama-3.3-nemotron-super-49b-v1` chat → 200 in 0.67s (control)
  - `mistralai/mistral-large` chat → `404 Function 'XXX': Not found for account 'YYY'` (NVCF account-not-deployed error)
  - `mistralai/mistral-medium-3-instruct` chat → 30+ second hang, no bytes
  - `/v1/responses` for any model → `404 page not found`
- [x] `npx prettier --check` clean
- [x] `npx eslint` clean
- [x] Signed commit + DCO sign-off

Closes #1601

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of NVIDIA “function not found” failures and return of a clearer, model-specific message and guidance.
  * Validation now preserves raw probe response bodies for better failure reporting.

* **Performance**
  * Tighter per-probe timeouts and optional skipping of unnecessary Responses probes for specific providers to reduce noise and speed up validation.

* **Tests**
  * Added unit tests covering the new validation helpers and probe-skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
