### PR TITLE
fix(preflight): detect docker group permission issue and suggest usermod

### DIFF
--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -401,7 +401,9 @@ describe("planHostRemediation", () => {
     expect(actions[0].id).toBe("docker_group_permission");
     expect(actions[0].kind).toBe("sudo");
     expect(actions[0].blocking).toBe(true);
-    expect(actions[0].commands[0]).toContain("sudo usermod -aG docker $USER");
+    expect(actions[0].commands[0]).toBe("sudo usermod -aG docker $USER");
+    expect(actions[0].commands[1]).toContain("newgrp docker");
+    expect(actions[0].commands[2]).toBe("nemoclaw onboard");
     expect(actions[0].reason).toContain("docker group");
   });
 

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -347,7 +347,7 @@ describe("assessHost", () => {
 });
 
 describe("planHostRemediation", () => {
-  it("recommends starting docker when installed but unreachable", () => {
+  it("recommends starting docker when installed but unreachable and service inactive", () => {
     const actions = planHostRemediation({
       platform: "linux",
       isWsl: false,
@@ -373,6 +373,36 @@ describe("planHostRemediation", () => {
     expect(actions[0].id).toBe("start_docker");
     expect(actions[0].blocking).toBe(true);
     expect(actions[0].commands).toContain("sudo systemctl start docker");
+  });
+
+  it("suggests usermod when docker service is active but daemon is unreachable", () => {
+    const actions = planHostRemediation({
+      platform: "linux",
+      isWsl: false,
+      runtime: "unknown",
+      packageManager: "apt",
+      systemctlAvailable: true,
+      dockerServiceActive: true,
+      dockerServiceEnabled: true,
+      dockerInstalled: true,
+      dockerRunning: false,
+      dockerReachable: false,
+      nodeInstalled: true,
+      openshellInstalled: true,
+      dockerCgroupVersion: "unknown",
+      dockerDefaultCgroupnsMode: "unknown",
+      requiresHostCgroupnsFix: false,
+      isUnsupportedRuntime: false,
+      isHeadlessLikely: false,
+      hasNvidiaGpu: false,
+      notes: [],
+    });
+
+    expect(actions[0].id).toBe("docker_group_permission");
+    expect(actions[0].kind).toBe("sudo");
+    expect(actions[0].blocking).toBe(true);
+    expect(actions[0].commands[0]).toContain("sudo usermod -aG docker $USER");
+    expect(actions[0].reason).toContain("docker group");
   });
 
   it("warns that podman is unsupported on macOS without blocking onboarding", () => {

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -352,19 +352,41 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
       blocking: true,
     });
   } else if (!assessment.dockerReachable) {
-    actions.push({
-      id: "start_docker",
-      title: "Start Docker",
-      kind: "manual",
-      reason: "Docker is installed but NemoClaw could not talk to the Docker daemon.",
-      commands:
-        assessment.platform === "darwin"
-          ? ["Start Docker Desktop or Colima, then rerun `nemoclaw onboard`."]
-          : assessment.systemctlAvailable
-            ? ["sudo systemctl start docker", "nemoclaw onboard"]
-            : ["Start the Docker daemon, then rerun `nemoclaw onboard`."],
-      blocking: true,
-    });
+    // On Linux, if the systemd service is already active but the daemon is
+    // unreachable, the most likely cause is a permissions / docker-group issue
+    // rather than a stopped service.
+    const likelyGroupIssue =
+      assessment.platform === "linux" && assessment.dockerServiceActive === true;
+
+    if (likelyGroupIssue) {
+      actions.push({
+        id: "docker_group_permission",
+        title: "Add user to docker group",
+        kind: "sudo",
+        reason:
+          "Docker is installed and the service is running, but the current user cannot reach the daemon. " +
+          "This usually means your user is not in the docker group.",
+        commands: [
+          "sudo usermod -aG docker $USER && newgrp docker",
+          "nemoclaw onboard",
+        ],
+        blocking: true,
+      });
+    } else {
+      actions.push({
+        id: "start_docker",
+        title: "Start Docker",
+        kind: "manual",
+        reason: "Docker is installed but NemoClaw could not talk to the Docker daemon.",
+        commands:
+          assessment.platform === "darwin"
+            ? ["Start Docker Desktop or Colima, then rerun `nemoclaw onboard`."]
+            : assessment.systemctlAvailable
+              ? ["sudo systemctl start docker", "nemoclaw onboard"]
+              : ["Start the Docker daemon, then rerun `nemoclaw onboard`."],
+        blocking: true,
+      });
+    }
   }
 
   if (assessment.isUnsupportedRuntime) {

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -367,7 +367,8 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
           "Docker is installed and the service is running, but the current user cannot reach the daemon. " +
           "This usually means your user is not in the docker group.",
         commands: [
-          "sudo usermod -aG docker $USER && newgrp docker",
+          "sudo usermod -aG docker $USER",
+          "newgrp docker   # or log out and back in",
           "nemoclaw onboard",
         ],
         blocking: true,

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -587,6 +587,18 @@ fi
 exit 0
 `,
     );
+    // Stub systemctl so preflight sees docker service as inactive (not a
+    // group/permission issue).  Without this, a CI host whose real systemctl
+    // reports docker as active would trigger the docker-group remediation
+    // instead of the "Start Docker" path this test expects.
+    writeExecutable(
+      path.join(fakeBin, "systemctl"),
+      `#!/usr/bin/env bash
+if [ "$1" = "is-active" ] && [ "$2" = "docker" ]; then echo "inactive"; exit 3; fi
+if [ "$1" = "is-enabled" ] && [ "$2" = "docker" ]; then echo "disabled"; exit 1; fi
+exit 0
+`,
+    );
     writeNpmStub(
       fakeBin,
       `if [ "$1" = "pack" ]; then


### PR DESCRIPTION
## Summary
- When Docker is installed and the systemd service is active but the daemon is unreachable, suggest `sudo usermod -aG docker $USER && newgrp docker` instead of the generic "Start Docker" remediation
- Adds a new `docker_group_permission` remediation action (kind: `sudo`, blocking) for this case
- Existing `start_docker` path remains for when the service is inactive

## Test plan
- [x] New test: `suggests usermod when docker service is active but daemon is unreachable`
- [x] Existing test renamed and still passes: `recommends starting docker when installed but unreachable and service inactive`
- [x] `make check` passes (all linters + tests)
- [x] Full `vitest run` passes (1178 tests, 0 failures)

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and refined tests to cover Docker unreachable scenarios (service inactive vs. active-but-unreachable) and added a test stub to enforce expected remediation paths.

* **Bug Fixes**
  * Remediation updated: when Docker is installed and the service is active but the daemon is unreachable on Linux, recommend adjusting Docker group permissions (with re-login) instead of always proposing to start the service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->