### PR TITLE
ci(pr): skip e2e tests for docs-only changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect which files changed so we can skip expensive jobs for docs-only PRs.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+
   checks:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -26,7 +45,8 @@ jobs:
         uses: ./.github/actions/basic-checks
 
   sandbox-images-and-e2e:
-    needs: checks
+    needs: [checks, changes]
+    if: needs.changes.outputs.code == 'true'
     uses: ./.github/workflows/sandbox-images-and-e2e.yaml
     with:
       run_arm64: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,6 +19,8 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
@@ -29,8 +31,10 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          predicate-quantifier: every
           filters: |
             code:
+              - '**'
               - '!**/*.md'
               - '!docs/**'
 


### PR DESCRIPTION
## Summary

- Adds a `changes` job using `dorny/paths-filter@v3` to detect whether any non-markdown, non-docs files changed
- Skips the `sandbox-images-and-e2e` pipeline (~10 min) when a PR only touches `*.md` files or the `docs/` directory
- `checks` job (linting, commitlint) still runs on every PR

## Test plan

- [ ] Open a docs-only PR and verify `sandbox-images-and-e2e` is skipped
- [ ] Open a code PR and verify `sandbox-images-and-e2e` still runs

Signed-off-by: Prekshi Vyas <prekshivyas@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI optimized to detect whether a PR includes non-documentation changes and run sandbox and end-to-end checks only when code changes are present, reducing unnecessary runs and speeding feedback for documentation-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->