### PR TITLE
fix(inference): increase timeout for local providers to 180s

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -18,6 +18,9 @@ function envInt(name, fallback) {
   const n = Number(raw);
   return Number.isFinite(n) ? Math.max(0, Math.round(n)) : fallback;
 }
+
+/** Inference timeout (seconds) for local providers (Ollama, vLLM, NIM). */
+const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 180);
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("./runner");
 const { stageOptimizedSandboxBuildContext } = require("./sandbox-build-context");
 const {
@@ -3116,7 +3119,17 @@ async function setupInference(
       console.error(`  ${providerResult.message}`);
       process.exit(providerResult.status || 1);
     }
-    runOpenshell(["inference", "set", "--no-verify", "--provider", "vllm-local", "--model", model]);
+    runOpenshell([
+      "inference",
+      "set",
+      "--no-verify",
+      "--provider",
+      "vllm-local",
+      "--model",
+      model,
+      "--timeout",
+      String(LOCAL_INFERENCE_TIMEOUT_SECS),
+    ]);
   } else if (provider === "ollama-local") {
     const validation = validateLocalProvider(provider, runCapture);
     if (!validation.ok) {
@@ -3140,6 +3153,8 @@ async function setupInference(
       "ollama-local",
       "--model",
       model,
+      "--timeout",
+      String(LOCAL_INFERENCE_TIMEOUT_SECS),
     ]);
     console.log(`  Priming Ollama model: ${model}`);
     run(getOllamaWarmupCommand(model), { ignoreError: true });

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -45,6 +45,7 @@ components:
         endpoint: "http://nim-service.local:8000/v1"
         model: "nvidia/nemotron-3-super-120b-a12b"
         credential_env: "NIM_API_KEY"
+        timeout_secs: 180
 
       vllm:
         provider_type: "openai"
@@ -53,6 +54,7 @@ components:
         model: "nvidia/nemotron-3-nano-30b-a3b"
         credential_env: "OPENAI_API_KEY"
         credential_default: "dummy"
+        timeout_secs: 180
 
   policy:
     base: "sandboxes/openclaw/policy.yaml"

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -460,6 +460,50 @@ describe("runner", () => {
       });
       expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://override.example.com/v1");
     });
+
+    it("passes --timeout when timeout_secs is set in profile", async () => {
+      const bp = {
+        components: {
+          inference: {
+            profiles: {
+              local: {
+                provider_type: "openai",
+                provider_name: "ollama-local",
+                endpoint: "http://localhost:11434/v1",
+                model: "nemotron-3-super:120b",
+                credential_env: "OPENAI_API_KEY",
+                credential_default: "ollama",
+                timeout_secs: 180,
+              },
+            },
+          },
+          sandbox: { name: "sb" },
+        },
+      };
+      process.env.OPENAI_API_KEY = "ollama";
+      try {
+        await actionApply("local", bp);
+      } finally {
+        delete process.env.OPENAI_API_KEY;
+      }
+
+      const inferenceCall = mockExeca.mock.calls.find(
+        (c) => Array.isArray(c[1]) && c[1].includes("inference") && c[1].includes("set"),
+      );
+      if (!inferenceCall) throw new Error("inference set call not found");
+      expect(inferenceCall[1]).toContain("--timeout");
+      expect(inferenceCall[1]).toContain("180");
+    });
+
+    it("omits --timeout when timeout_secs is not set in profile", async () => {
+      await actionApply("default", minimalBlueprint());
+
+      const inferenceCall = mockExeca.mock.calls.find(
+        (c) => Array.isArray(c[1]) && c[1].includes("inference") && c[1].includes("set"),
+      );
+      if (!inferenceCall) throw new Error("inference set call not found");
+      expect(inferenceCall[1]).not.toContain("--timeout");
+    });
   });
 
   describe("actionStatus", () => {

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -68,6 +68,7 @@ interface InferenceProfile {
   model?: string;
   credential_env?: string;
   credential_default?: string;
+  timeout_secs?: number;
 }
 
 interface SandboxConfig {
@@ -296,9 +297,19 @@ export async function actionApply(
   });
 
   progress(70, "Setting inference route");
-  await runCmd(["openshell", "inference", "set", "--provider", providerName, "--model", model], {
-    reject: false,
-  });
+  const inferenceArgs = [
+    "openshell",
+    "inference",
+    "set",
+    "--provider",
+    providerName,
+    "--model",
+    model,
+  ];
+  if (inferenceCfg.timeout_secs !== undefined) {
+    inferenceArgs.push("--timeout", String(inferenceCfg.timeout_secs));
+  }
+  await runCmd(inferenceArgs, { reject: false });
 
   progress(85, "Saving run state");
   const stateDir = join(homedir(), ".nemoclaw", "state", "runs", rid);


### PR DESCRIPTION
Local models on DGX Spark can exceed the default 60s inference timeout, especially with large prompts (~90k tokens of system context). Pass --timeout 180 to openshell inference set for ollama-local and vllm-local providers. The timeout is configurable via NEMOCLAW_LOCAL_INFERENCE_TIMEOUT env var. Also add timeout_secs to blueprint InferenceProfile for the nim-local and vllm profiles.

Closes #1588

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Your Name <your-email@example.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable inference timeouts for local providers with a default of 180 seconds; timeouts are applied to local inference requests so long-running operations can be controlled.
* **Tests**
  * Added tests to validate timeout behavior is applied when configured and omitted when not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->