### PR TITLE
fix(platform): allow shouldPatchCoredns isWsl override for deterministic WSL2 tests

### DIFF
--- a/bin/lib/platform.js
+++ b/bin/lib/platform.js
@@ -5,6 +5,13 @@ const os = require("os");
 const path = require("path");
 
 function isWsl(opts = {}) {
+  // Explicit override — lets tests pin behavior regardless of the host kernel.
+  // Useful because the WSL detection below consults `os.release()`, which
+  // returns a "microsoft"-tagged string on WSL2 hosts even when env vars are
+  // unset. Without this override, any test calling functions that consult
+  // `isWsl()` becomes non-deterministic on WSL2 dev machines.
+  if (typeof opts.isWsl === "boolean") return opts.isWsl;
+
   const platform = opts.platform ?? process.platform;
   if (platform !== "linux") return false;
 

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -159,11 +159,22 @@ describe("platform helpers", () => {
   });
 
   describe("shouldPatchCoredns", () => {
-    it("patches CoreDNS for Colima and Podman", () => {
-      expect(shouldPatchCoredns("colima")).toBe(true);
-      expect(shouldPatchCoredns("podman")).toBe(true);
-      expect(shouldPatchCoredns("docker-desktop")).toBe(false);
-      expect(shouldPatchCoredns("docker")).toBe(false);
+    // Pass explicit `isWsl: false` so this test pins the function's runtime
+    // matching logic on every host. Without the override, `shouldPatchCoredns`
+    // consults `isWsl()`, which returns true on WSL2 dev machines (via
+    // `os.release()`), and the assertions flip below.
+    it("patches CoreDNS for Colima and Podman (non-WSL host)", () => {
+      expect(shouldPatchCoredns("colima", { isWsl: false })).toBe(true);
+      expect(shouldPatchCoredns("podman", { isWsl: false })).toBe(true);
+      expect(shouldPatchCoredns("docker-desktop", { isWsl: false })).toBe(false);
+      expect(shouldPatchCoredns("docker", { isWsl: false })).toBe(false);
+    });
+
+    it("never patches CoreDNS on WSL2 (host DNS unreachable from k3s pods)", () => {
+      expect(shouldPatchCoredns("colima", { isWsl: true })).toBe(false);
+      expect(shouldPatchCoredns("podman", { isWsl: true })).toBe(false);
+      expect(shouldPatchCoredns("docker-desktop", { isWsl: true })).toBe(false);
+      expect(shouldPatchCoredns("docker", { isWsl: true })).toBe(false);
     });
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds an `opts.isWsl` short-circuit to `isWsl()` in `bin/lib/platform.js` so the `shouldPatchCoredns` test can pin its assertions on every host. Without the override the existing test fails on WSL2 dev machines because `os.release()` always reports a "microsoft"-tagged kernel string there.

## Related Issue

Closes #1621 (sub-item 3 of three: `shouldPatchCoredns` non-deterministic on WSL2 hosts).

## Changes

- `bin/lib/platform.js`: `isWsl()` now returns `opts.isWsl` directly when it's a boolean, before falling through to the existing detection logic. Production callers (which don't pass `opts.isWsl`) keep the existing behavior unchanged.
- `test/platform.test.js`: existing `shouldPatchCoredns` test now passes `{ isWsl: false }` so the runtime-matching assertions exercise the *function* rather than the *kernel*. A second test case is added with `{ isWsl: true }` to lock the "skip CoreDNS patching on WSL2" branch so a future change to that branch is caught.

Diff: +23 / −5 across 2 files.

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx vitest run --project cli test/platform.test.js -t shouldPatchCoredns` — both new test cases pass on a WSL2 Ubuntu host (the existing test was the failure that prompted this PR)
- [x] `npx prettier --check bin/lib/platform.js test/platform.test.js` clean
- [x] `npx tsc --noEmit -p tsconfig.cli.json` clean
- [ ] `npx prek run --all-files` / `npm test` — *not run on the local machine because the full CLI test suite hits two separate baseline failures on a WSL2 host: this very `shouldPatchCoredns` issue (which this PR fixes) and the `install-preflight` sysbin leakage covered by #1628. Upstream CI runs on Linux runners so it'll exercise the full suite normally.*
- [ ] `make docs` builds without warnings. (for doc-only changes — N/A)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes — N/A)

### Code Changes

- [x] Formatters applied — `npx prettier --check` clean for both touched files.
- [x] Tests added or updated for new or changed behavior — the existing `shouldPatchCoredns` test now uses the `opts.isWsl` override; a new test case pins the WSL2 branch.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes — N/A, the new opts argument is test-only API surface; production callers don't pass it.

### Doc Changes

- N/A (no doc changes)

---
Signed-off-by: T Savo <evilgenius@nefariousplan.com>
