### PR TITLE
fix(test): isolate sysbin in install-preflight tests to prevent host PATH leakage

### DIFF
--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -11,7 +11,53 @@ const INSTALLER = path.join(import.meta.dirname, "..", "install.sh");
 const CURL_PIPE_INSTALLER = path.join(import.meta.dirname, "..", "install.sh");
 const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
 const GITHUB_INSTALL_URL = "git+https://github.com/NVIDIA/NemoClaw.git";
-const TEST_SYSTEM_PATH = "/usr/bin:/bin";
+
+/**
+ * Build an isolated "system bin" directory used by every test in this file
+ * via TEST_SYSTEM_PATH. The directory mirrors /usr/bin and /bin via symlinks
+ * — EXCEPT for `node`, `npm`, and `npx`, which are deliberately excluded.
+ *
+ * Why: the runtime preflight tests need a PATH where the host's real `node`
+ * and `npm` are NOT visible, so the "node missing" / "npm missing" error
+ * branches are actually exercised. The previous `"/usr/bin:/bin"` literal
+ * leaks /usr/bin/node on any Linux distribution that installs Node via
+ * `apt install nodejs` (i.e. most of them), causing those tests to assert
+ * the wrong code path on developer machines while passing on the upstream
+ * CI runners (where Node is installed under /opt/hostedtoolcache/, not
+ * /usr/bin/).
+ *
+ * Tests that need a fake `node` or `npm` continue to write a stub into
+ * `fakeBin` and prepend it to PATH (`${fakeBin}:${TEST_SYSTEM_PATH}`); the
+ * fake still wins because it comes first.
+ *
+ * The directory lives under `os.tmpdir()` and is intentionally not cleaned
+ * up — it's tiny (a few hundred symlinks), the OS reaps it on reboot, and
+ * cleanup would require an `afterAll` hook in every describe block.
+ */
+function buildIsolatedSystemPath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-preflight-sysbin-"));
+  const EXCLUDE = new Set(["node", "npm", "npx"]);
+  for (const sysDir of ["/usr/bin", "/bin"]) {
+    if (!fs.existsSync(sysDir)) continue;
+    for (const name of fs.readdirSync(sysDir)) {
+      if (EXCLUDE.has(name)) continue;
+      try {
+        fs.symlinkSync(path.join(sysDir, name), path.join(dir, name));
+      } catch (err) {
+        // Only swallow EEXIST — the expected case is when /bin is a symlink
+        // to /usr/bin (modern Linux) and we already linked the same name on
+        // the first pass. Any other error (EPERM, EACCES, EINVAL, ENOENT…)
+        // would leave TEST_SYSTEM_PATH partially populated and turn into a
+        // confusing downstream test failure, so re-throw it.
+        if (err && err.code === "EEXIST") continue;
+        throw err;
+      }
+    }
+  }
+  return dir;
+}
+
+const TEST_SYSTEM_PATH = buildIsolatedSystemPath();
 
 function writeExecutable(target, contents) {
   fs.writeFileSync(target, contents, { mode: 0o755 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Replaces the `TEST_SYSTEM_PATH = "/usr/bin:/bin"` literal in `test/install-preflight.test.js` with `buildIsolatedSystemPath()`, a small helper that creates a tmpdir at module load and symlinks every entry from `/usr/bin` and `/bin` into it — **except `node`, `npm`, and `npx`**, which are deliberately excluded so the runtime preflight's "node missing" / "npm missing" branches are actually exercised.

## Related Issue

Closes #1621 (sub-item 2 of three: install-preflight tests leak host `/usr/bin/node` through `TEST_SYSTEM_PATH`).

## Changes

- `test/install-preflight.test.js`:
  - Adds `buildIsolatedSystemPath()` helper at module top.
  - Changes `const TEST_SYSTEM_PATH = "/usr/bin:/bin";` to `const TEST_SYSTEM_PATH = buildIsolatedSystemPath();`.
  - All ~19 existing call sites that use `${fakeBin}:${TEST_SYSTEM_PATH}` continue to work unchanged because the fake bin still wins (it comes first in the PATH).
  - The 3 sites that use `PATH: TEST_SYSTEM_PATH` directly (the "node missing" / "npm missing" cases) now correctly see neither node nor npm.

Diff: +42 / −1 in 1 file.

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx vitest run --project cli test/install-preflight.test.js` — all 56 tests pass locally on a Linux host with `/usr/bin/node` present (the previously-failing "node missing" / "npm missing" cases now correctly report missing)
- [x] `npx prettier --check test/install-preflight.test.js` clean
- [x] `node --check test/install-preflight.test.js` clean
- [ ] `npx prek run --all-files` / `npm test` — *not run on the local machine because the full CLI test suite hits a separate baseline failure on a WSL2 host: the `shouldPatchCoredns` issue covered by #1626. Upstream CI runs on Linux runners so it'll exercise the full suite normally.*
- [ ] `make docs` builds without warnings. (for doc-only changes — N/A)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes — N/A)

### Code Changes

- [x] Formatters applied — `npx prettier --check` clean.
- [x] Tests added or updated for new or changed behavior — the 3 previously-broken "missing binary" test cases now correctly assert the missing branch.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes — N/A, test infrastructure only.

### Doc Changes

- N/A (no doc changes)

---
Signed-off-by: T Savo <evilgenius@nefariousplan.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment isolation to prevent unintended system dependencies during testing, ensuring more reliable and predictable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->