### PR TITLE
fix(lint): resolve ESLint errors introduced by #1564

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -1785,8 +1785,10 @@ async function preflight() {
     console.error("");
     console.error("    Upgrade openshell and retry:");
     console.error("      https://github.com/NVIDIA/OpenShell/releases");
-    console.error("    Or remove the existing binary so the installer can re-fetch a current build:");
-    console.error("      command -v openshell && rm -f \"$(command -v openshell)\"");
+    console.error(
+      "    Or remove the existing binary so the installer can re-fetch a current build:",
+    );
+    console.error('      command -v openshell && rm -f "$(command -v openshell)"');
     console.error("");
     process.exit(1);
   }

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -421,7 +421,6 @@ function getBlueprintMinOpenshellVersion(rootDir = ROOT) {
     // Lazy require: yaml is already a dependency via bin/lib/policies.js but
     // pulling it at module load would slow down `nemoclaw --help` for users
     // who never reach the preflight path.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const YAML = require("yaml");
     const blueprintPath = path.join(rootDir, "nemoclaw-blueprint", "blueprint.yaml");
     if (!fs.existsSync(blueprintPath)) return null;

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -331,7 +331,9 @@ describe("onboard helpers", () => {
   });
 
   it("regression #1409: leaves Dockerfile defaults when proxy env is unset", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-dockerfile-proxy-default-"));
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-dockerfile-proxy-default-"),
+    );
     const dockerfilePath = path.join(tmpDir, "Dockerfile");
     fs.writeFileSync(
       dockerfilePath,
@@ -529,17 +531,17 @@ describe("onboard helpers", () => {
 
   it("regression #1317: getBlueprintMinOpenshellVersion returns null on missing or unparseable blueprint", () => {
     // Missing directory
-    const missingDir = path.join(os.tmpdir(), "nemoclaw-blueprint-missing-" + Date.now().toString());
+    const missingDir = path.join(
+      os.tmpdir(),
+      "nemoclaw-blueprint-missing-" + Date.now().toString(),
+    );
     expect(getBlueprintMinOpenshellVersion(missingDir)).toBe(null);
 
     // Present file, missing field — must NOT block onboard
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-blueprint-no-field-"));
     const blueprintDir = path.join(tmpDir, "nemoclaw-blueprint");
     fs.mkdirSync(blueprintDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(blueprintDir, "blueprint.yaml"),
-      'version: "0.1.0"\n',
-    );
+    fs.writeFileSync(path.join(blueprintDir, "blueprint.yaml"), 'version: "0.1.0"\n');
     try {
       expect(getBlueprintMinOpenshellVersion(tmpDir)).toBe(null);
     } finally {

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -592,7 +592,7 @@ describe("onboard helpers", () => {
     // Sanity check against the real on-disk blueprint so a future edit that
     // accidentally drops or breaks the field is caught by CI rather than at
     // a user's onboard time.
-    const repoRoot = path.resolve(__dirname, "..");
+    const repoRoot = path.resolve(import.meta.dirname, "..");
     const v = getBlueprintMinOpenshellVersion(repoRoot);
     expect(v).not.toBe(null);
     expect(/^[0-9]+\.[0-9]+\.[0-9]+/.test(v)).toBe(true);


### PR DESCRIPTION
## Summary

Fixes the broken `main` build caused by two ESLint errors from #1564:

- `test/onboard.test.js:597` — `__dirname` is not defined in ESM. Replaced with `import.meta.dirname`.
- `bin/lib/onboard.js:424` — `@typescript-eslint/no-require-imports` rule doesn't exist in the CJS ESLint config. Removed the unnecessary disable comment (`require` is valid in CJS).

## Test plan

- [ ] CI `checks` job passes (ESLint CLI step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preflight error output for insufficient runtime version — clearer, multi-line removal instruction for easier copy/paste.

* **Chores**
  * Minor internal formatting and cleanup with no behavioral changes.

* **Tests**
  * Updated test harness and formatting to align with codebase style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->