### PR TITLE
fix(scripts): apply prettier --write to benchmark-sandbox-image-build.js

### DIFF
--- a/scripts/benchmark-sandbox-image-build.js
+++ b/scripts/benchmark-sandbox-image-build.js
@@ -72,7 +72,9 @@ function dockerBuild(repoRoot, stageFn, label, noCache) {
   try {
     run("docker", args);
     const elapsedSeconds = Number(process.hrtime.bigint() - startedAt) / 1e9;
-    const imageBytes = Number(run("docker", ["image", "inspect", imageTag, "--format", "{{.Size}}"]));
+    const imageBytes = Number(
+      run("docker", ["image", "inspect", imageTag, "--format", "{{.Size}}"]),
+    );
     return {
       label,
       buildCtx,
@@ -122,16 +124,34 @@ function printSummary(results) {
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const currentRepo = path.resolve(args.currentRepo);
-  const currentHead = execFileSync("git", ["rev-parse", "--short", "HEAD"], { cwd: currentRepo, encoding: "utf8" }).trim();
-  const currentDirty = execFileSync("git", ["status", "--short"], { cwd: currentRepo, encoding: "utf8" }).trim().length > 0;
+  const currentHead = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+    cwd: currentRepo,
+    encoding: "utf8",
+  }).trim();
+  const currentDirty =
+    execFileSync("git", ["status", "--short"], { cwd: currentRepo, encoding: "utf8" }).trim()
+      .length > 0;
   const currentLabel = currentDirty ? `${currentHead} + dirty` : currentHead;
   const mainWorktree = makeTempWorktree(args.mainRef, currentRepo);
 
   try {
-    const mainLabel = execFileSync("git", ["rev-parse", "--short", "HEAD"], { cwd: mainWorktree, encoding: "utf8" }).trim();
+    const mainLabel = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: mainWorktree,
+      encoding: "utf8",
+    }).trim();
     const results = [
-      dockerBuild(mainWorktree, stageLegacySandboxBuildContext, `main (${mainLabel})`, args.noCache),
-      dockerBuild(currentRepo, stageOptimizedSandboxBuildContext, `candidate (${currentLabel})`, args.noCache),
+      dockerBuild(
+        mainWorktree,
+        stageLegacySandboxBuildContext,
+        `main (${mainLabel})`,
+        args.noCache,
+      ),
+      dockerBuild(
+        currentRepo,
+        stageOptimizedSandboxBuildContext,
+        `candidate (${currentLabel})`,
+        args.noCache,
+      ),
     ];
     printSummary(results);
   } finally {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Residual fix for #1636 after #1634 cleaned up the ESLint and prettier drift in `bin/lib/onboard.js` and `test/onboard.test.js`. The benchmark script wasn't covered by that sweep, so it's the last file failing `prettier --check` on stock `main`.

## Related Issue

Refs #1636 (#1634 already handled the other two findings — this closes out the residual).

## Changes

- `scripts/benchmark-sandbox-image-build.js`: handful of `execFileSync(...)` and `run(...)` argument wraps. No semantic change — same calls, same args, same control flow, just line-broken to comply with the configured prettier max width.

Diff: +26 / −6 in 1 file.

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [x] `npx prettier --check scripts/benchmark-sandbox-image-build.js` clean
- [x] `npx prettier --check bin/lib/onboard.js test/onboard.test.js scripts/benchmark-sandbox-image-build.js` — all 3 files now clean (the first two were fixed by #1634)
- [x] `node --check scripts/benchmark-sandbox-image-build.js` clean
- [x] Re-running the prek pre-push gate with `prettier-js,shfmt` no longer surfaces any auto-fix in this file (verified by amending an unrelated branch and re-pushing on a fresh clone)
- [ ] Upstream CI (will run on PR open)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes — N/A)

### Code Changes

- [x] Formatters applied — this PR *is* the formatter output.
- [x] Tests added or updated for new or changed behavior — N/A, formatting-only.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes — N/A, no behavior change.

### Doc Changes

- N/A (no doc changes)

---
Signed-off-by: T Savo <evilgenius@nefariousplan.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal script formatting improvements with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->