### PR TITLE
fix(onboard): filter policy presets by enabled channels, not stored credentials

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -4388,6 +4388,7 @@ async function onboard(opts = {}) {
       });
     }
 
+    let enabledChannels = null;
     const sandboxReuseState = getSandboxReuseState(sandboxName);
     const resumeSandbox =
       resume && session?.steps?.sandbox?.status === "complete" && sandboxReuseState === "ready";
@@ -4407,7 +4408,7 @@ async function onboard(opts = {}) {
           }
         }
       }
-      const enabledChannels = await setupMessagingChannels();
+      enabledChannels = await setupMessagingChannels();
 
       startRecordedStep("sandbox", { sandboxName, provider, model });
       sandboxName = await createSandbox(

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -3829,7 +3829,7 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
   step(8, 8, "Policy presets");
 
   const suggestions = ["pypi", "npm"];
-  if (getCredential("TELEGRAM_BOT_TOKEN") && (!enabledChannels || enabledChannels.includes("telegram")))
+  if ((getCredential("TELEGRAM_BOT_TOKEN") || process.env.TELEGRAM_BOT_TOKEN) && (!enabledChannels || enabledChannels.includes("telegram")))
     suggestions.push("telegram");
   if (
     (getCredential("SLACK_BOT_TOKEN") || process.env.SLACK_BOT_TOKEN) &&
@@ -4394,6 +4394,9 @@ async function onboard(opts = {}) {
       resume && session?.steps?.sandbox?.status === "complete" && sandboxReuseState === "ready";
     if (resumeSandbox) {
       skippedStepMessage("sandbox", sandboxName);
+      enabledChannels = Array.isArray(session?.steps?.sandbox?.enabledChannels)
+        ? session.steps.sandbox.enabledChannels
+        : null;
     } else {
       if (resume && session?.steps?.sandbox?.status === "complete") {
         if (sandboxReuseState === "not_ready") {
@@ -4409,6 +4412,12 @@ async function onboard(opts = {}) {
         }
       }
       enabledChannels = await setupMessagingChannels();
+      onboardSession.updateSession((current) => {
+        if (!current.steps) current.steps = {};
+        if (!current.steps.sandbox) current.steps.sandbox = {};
+        current.steps.sandbox.enabledChannels = enabledChannels;
+        return current;
+      });
 
       startRecordedStep("sandbox", { sandboxName, provider, model });
       sandboxName = await createSandbox(
@@ -4421,7 +4430,7 @@ async function onboard(opts = {}) {
         enabledChannels,
         fromDockerfile,
       );
-      onboardSession.markStepComplete("sandbox", { sandboxName, provider, model, nimContainer });
+      onboardSession.markStepComplete("sandbox", { sandboxName, provider, model, nimContainer, enabledChannels });
     }
 
     const resumeOpenclaw = resume && sandboxName && isOpenclawReady(sandboxName);

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -3824,13 +3824,22 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
   const selectedPresets = Array.isArray(options.selectedPresets) ? options.selectedPresets : null;
   const onSelection = typeof options.onSelection === "function" ? options.onSelection : null;
   const webSearchConfig = options.webSearchConfig || null;
+  const enabledChannels = Array.isArray(options.enabledChannels) ? options.enabledChannels : null;
 
   step(8, 8, "Policy presets");
 
   const suggestions = ["pypi", "npm"];
-  if (getCredential("TELEGRAM_BOT_TOKEN")) suggestions.push("telegram");
-  if (getCredential("SLACK_BOT_TOKEN") || process.env.SLACK_BOT_TOKEN) suggestions.push("slack");
-  if (getCredential("DISCORD_BOT_TOKEN") || process.env.DISCORD_BOT_TOKEN)
+  if (getCredential("TELEGRAM_BOT_TOKEN") && (!enabledChannels || enabledChannels.includes("telegram")))
+    suggestions.push("telegram");
+  if (
+    (getCredential("SLACK_BOT_TOKEN") || process.env.SLACK_BOT_TOKEN) &&
+    (!enabledChannels || enabledChannels.includes("slack"))
+  )
+    suggestions.push("slack");
+  if (
+    (getCredential("DISCORD_BOT_TOKEN") || process.env.DISCORD_BOT_TOKEN) &&
+    (!enabledChannels || enabledChannels.includes("discord"))
+  )
     suggestions.push("discord");
   if (webSearchConfig) suggestions.push("brave");
 
@@ -4453,6 +4462,7 @@ async function onboard(opts = {}) {
             ? recordedPolicyPresets
             : null,
         webSearchConfig,
+        enabledChannels,
         onSelection: (policyPresets) => {
           onboardSession.updateSession((current) => {
             current.policyPresets = policyPresets;


### PR DESCRIPTION
## Summary

Fixes #1610 — onboard policy preset step was suggesting messaging presets based on stored credentials instead of the channels selected during the current onboard session.

## Root Cause

`setupPoliciesWithSelection()` checked `getCredential('TELEGRAM_BOT_TOKEN')` etc. to build suggestions, but the user may have skipped messaging channel selection entirely. The `enabledChannels` array from `setupMessagingChannels()` was never passed to the preset step.

## Fix

- Add `enabledChannels` option to `setupPoliciesWithSelection()`
- Only suggest messaging presets (telegram/discord/slack) when the corresponding channel is in `enabledChannels`
- When `enabledChannels` is not provided (backward compat), falls back to credential-only check
- Pass `enabledChannels` from `createSandbox` flow to the policy selection call

## Changes

- `bin/lib/onboard.js`: 13 insertions, 3 deletions — minimal, surgical fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Messaging channel policy suggestions during onboarding now respect the channels users enable and only suggest presets for configured, enabled channels.
  * Onboarding now remembers and persists the selected messaging channels so recommendations remain consistent when resuming or reusing a sandbox.
  * Sandbox completion now records enabled channels so non-interactive and resumed flows reflect user choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->