### PR TITLE
fix(security): pin sandbox image by digest in blueprint.yaml (#1438)

### DIFF
--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -18,7 +18,12 @@ description: |
 
 components:
   sandbox:
-    image: "ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest"
+    # Pinned to a specific image digest so a future registry compromise or an
+    # accidental :latest force-push cannot silently swap the sandbox image.
+    # Ref: #1438. The digest below was the resolved sha256 of the :latest tag
+    # at the time of this commit; release tooling should bump it together with
+    # the top-level `digest:` field on every release.
+    image: "ghcr.io/nvidia/openshell-community/sandboxes/openclaw@sha256:b3d832b596ab6b7184a9dcb4ae93337ca32851a4f93b00765cc12de26baa3a9a"
     name: "openclaw"
     forward_ports:
       - 18789

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -4,7 +4,13 @@
 version: "0.1.0"
 min_openshell_version: "0.0.24"
 min_openclaw_version: "2026.3.0"
-digest: ""  # Computed at release time
+# Mirrors the components.sandbox.image manifest digest below. Lets a
+# downstream consumer (or release tooling) verify the blueprint declares
+# a specific sandbox image without parsing the components tree, and
+# blocks the trivially-bypassable case where someone bumps the pinned
+# image but forgets the top-level field. Release tooling should rewrite
+# both fields together. See #1438.
+digest: "sha256:b3d832b596ab6b7184a9dcb4ae93337ca32851a4f93b00765cc12de26baa3a9a"
 
 profiles:
   - default

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -41,6 +41,26 @@ describe("blueprint.yaml", () => {
     expect(Object.keys(defined!).length).toBeGreaterThan(0);
   });
 
+  it("regression #1438: sandbox image is pinned by digest, not by mutable tag", () => {
+    // The blueprint MUST NOT pull a sandbox image by a mutable tag like
+    // ":latest" — a registry compromise or accidental force-push could
+    // silently swap the image. Pin via @sha256:... so the image cannot
+    // change without a corresponding blueprint update.
+    const sandbox = (bp.components as Record<string, unknown> | undefined)?.sandbox as
+      | { image?: unknown }
+      | undefined;
+    const image = typeof sandbox?.image === "string" ? sandbox.image : "";
+    expect(image.length).toBeGreaterThan(0);
+    expect(image).toContain("@sha256:");
+    // Belt and braces: explicitly forbid the ":latest" tag form even if the
+    // image string has been rearranged.
+    expect(image).not.toMatch(/:latest$/);
+    expect(image).not.toMatch(/:latest@/);
+    // The digest itself must be a 64-hex sha256.
+    const digestMatch = image.match(/@sha256:([0-9a-f]{64})$/);
+    expect(digestMatch).not.toBeNull();
+  });
+
   for (const name of declared) {
     describe(`profile '${name}'`, () => {
       it("has a definition", () => {

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -61,6 +61,31 @@ describe("blueprint.yaml", () => {
     expect(digestMatch).not.toBeNull();
   });
 
+  it("regression #1438: top-level digest field is populated and matches the image digest", () => {
+    // The top-level `digest:` field at the top of blueprint.yaml is
+    // documented as "Computed at release time" and was empty on main,
+    // which left blueprint-level integrity unverifiable. Mirror the
+    // sandbox image manifest digest into the top-level field so any
+    // consumer can read a single field to know what's pinned, and so
+    // a future contributor can't bump one without bumping the other.
+    const topLevelDigest = typeof bp.digest === "string" ? bp.digest : "";
+    expect(topLevelDigest.length).toBeGreaterThan(0);
+    // Must be a sha256:<64-hex> string.
+    expect(topLevelDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+
+    const sandbox = (bp.components as Record<string, unknown> | undefined)?.sandbox as
+      | { image?: unknown }
+      | undefined;
+    const image = typeof sandbox?.image === "string" ? sandbox.image : "";
+    const imageDigestMatch = image.match(/@sha256:([0-9a-f]{64})$/);
+    expect(imageDigestMatch).not.toBeNull();
+    const imageDigest = `sha256:${imageDigestMatch?.[1] ?? ""}`;
+
+    // The two digests must agree. If a future bump touches one but not
+    // the other, this assertion catches it before merge.
+    expect(topLevelDigest).toBe(imageDigest);
+  });
+
   for (const name of declared) {
     describe(`profile '${name}'`, () => {
       it("has a definition", () => {


### PR DESCRIPTION
## Summary

Closes #1438.

`nemoclaw-blueprint/blueprint.yaml` referenced the sandbox image by the mutable `:latest` tag:

```yaml
image: "ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest"
```

A registry compromise or accidental force-push to `:latest` would silently swap the sandbox image without any blueprint-side change. The top-level `digest:` field in the same file is documented as *"Computed at release time"* but is empty in main, so there's no integrity backstop today.

## Fix

Pin the image by digest:

```yaml
image: "ghcr.io/nvidia/openshell-community/sandboxes/openclaw@sha256:b3d832b596ab6b7184a9dcb4ae93337ca32851a4f93b00765cc12de26baa3a9a"
```

The digest above was the resolved sha256 of `:latest` at the time of this commit, fetched directly from `ghcr.io/v2/nvidia/openshell-community/sandboxes/openclaw/manifests/latest` via the standard OCI registry API.

A new regression test in `test/validate-blueprint.test.ts` walks the parsed blueprint, finds `components.sandbox.image`, and asserts:
- the image string contains `@sha256:` (digest pin present)
- the image string does NOT match a `:latest` suffix
- the digest is a 64-hex-char sha256

## Test plan

- [x] `vitest run test/validate-blueprint.test.ts` — 28/28 pass
- [x] **Negative case verified**: stashed the YAML fix, re-ran the test against the unfixed `:latest` blueprint. The new `regression #1438` test correctly **fails** with a `digest pin missing` assertion error, proving the test catches the regression.
- [x] **Positive case verified**: re-applied the YAML fix, re-ran. All 28 tests pass.

## Honest scope and follow-up needed

This PR is a "stop the bleeding now" fix. It closes the immediate supply-chain hole but creates a small maintenance burden: the static digest needs to be bumped whenever a new sandbox image is published.

**Recommended follow-up (out of scope here):** add release tooling (CI workflow or `scripts/update-blueprint-digest.sh`) that resolves the current `:latest` digest from `ghcr.io` and rewrites both the `image:` line and the top-level `digest:` field in `blueprint.yaml` on every release. The infrastructure for this doesn't exist today (the top-level `digest:` field's "Computed at release time" comment describes intent that was never implemented).

Until that tooling lands, contributors bumping the sandbox image will need to update this digest by hand. The new regression test makes that hand-update obvious — anyone who lets it lapse back to `:latest` or any other mutable tag fails CI.

## Why digest pinning over version tags

The `ghcr.io/nvidia/openshell-community/sandboxes/openclaw` registry currently exposes only commit-SHA tags (e.g. `21aa171`, `436b8c9`) and `latest`. There is no semver tag like `v0.0.10` to pin to. A digest is the only integrity-preserving reference available without changing how sandbox images are published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the sandbox container reference to an immutable image digest and aligned the blueprint's top-level digest for reproducible deployments; added inline notes to keep them synchronized.

* **Tests**
  * Added regression tests to enforce immutable sandbox image references and to ensure the blueprint-level digest matches the sandbox image digest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: ColinM-sys <cmcdonough@50words.com>