### PR TITLE
fix(blueprint): restore min_openshell_version to 0.0.24

### DIFF
--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version: "0.1.0"
-min_openshell_version: "0.1.0"
+min_openshell_version: "0.0.24"
 min_openclaw_version: "2026.3.0"
 digest: ""  # Computed at release time
 


### PR DESCRIPTION
## Summary
- Restores `min_openshell_version` in `nemoclaw-blueprint/blueprint.yaml` from `0.1.0` back to `0.0.24`
- OpenShell 0.1.0 does not exist yet, so this was blocking onboarding for anyone running OpenShell 0.0.25 or earlier

## Test plan
- [ ] Run `nemoclaw onboard` with OpenShell 0.0.25 installed and verify preflight passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum version requirement to enable compatibility with earlier platform releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->