### PR TITLE
fix(security): drop POST allow rule from huggingface preset (#1432)

### DIFF
--- a/nemoclaw-blueprint/policies/presets/huggingface.yaml
+++ b/nemoclaw-blueprint/policies/presets/huggingface.yaml
@@ -15,8 +15,15 @@ network_policies:
         enforcement: enforce
         tls: terminate
         rules:
+          # Download-only. POST /** used to be allowed here, which let
+          # any sandboxed agent that happened to find an HF token in
+          # the environment publish models, datasets, and create
+          # repositories on the Hub via /api/repos/create and friends.
+          # Inference traffic flows through router.huggingface.co
+          # (declared below), not huggingface.co, so the POST rule
+          # was never required for read-only `from_pretrained` use.
+          # See #1432.
           - allow: { method: GET, path: "/**" }
-          - allow: { method: POST, path: "/**" }
       - host: cdn-lfs.huggingface.co
         port: 443
         protocol: rest

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -189,3 +189,57 @@ describe("base sandbox policy", () => {
     }
   });
 });
+
+describe("huggingface preset", () => {
+  // The huggingface preset used to allow POST /** on huggingface.co,
+  // which let an agent that found an HF token in the environment
+  // publish models, datasets, and create repositories via
+  // /api/repos/create and friends. Inference Provider traffic flows
+  // through router.huggingface.co, not huggingface.co, so the POST
+  // rule was never required for read-only `from_pretrained` flows.
+  // The fix removes the POST rule from huggingface.co (download-only).
+  // These tests block a regression where someone re-adds it.
+  // See #1432.
+  const HUGGINGFACE_PRESET_PATH = new URL(
+    "../nemoclaw-blueprint/policies/presets/huggingface.yaml",
+    import.meta.url,
+  );
+  const huggingfacePreset = YAML.parse(
+    readFileSync(HUGGINGFACE_PRESET_PATH, "utf-8"),
+  ) as Record<string, unknown>;
+
+  type Rule = { allow?: { method?: string; path?: string } };
+  type Endpoint = { host?: string; rules?: Rule[] };
+
+  function presetEndpoints(): Endpoint[] {
+    const np = huggingfacePreset.network_policies as Record<string, unknown> | undefined;
+    if (!np) return [];
+    const hf = np.huggingface as { endpoints?: unknown } | undefined;
+    return Array.isArray(hf?.endpoints) ? (hf!.endpoints as Endpoint[]) : [];
+  }
+
+  it("regression #1432: huggingface.co has no POST allow rule", () => {
+    const endpoints = presetEndpoints().filter((ep) => ep.host === "huggingface.co");
+    expect(endpoints.length).toBeGreaterThan(0);
+    for (const ep of endpoints) {
+      const rules = Array.isArray(ep.rules) ? ep.rules : [];
+      const hasPost = rules.some(
+        (r) =>
+          r && r.allow && typeof r.allow.method === "string" && r.allow.method.toUpperCase() === "POST",
+      );
+      expect(hasPost).toBe(false);
+    }
+  });
+
+  it("regression #1432: huggingface.co retains GET so downloads still work", () => {
+    const endpoints = presetEndpoints().filter((ep) => ep.host === "huggingface.co");
+    for (const ep of endpoints) {
+      const rules = Array.isArray(ep.rules) ? ep.rules : [];
+      const hasGet = rules.some(
+        (r) =>
+          r && r.allow && typeof r.allow.method === "string" && r.allow.method.toUpperCase() === "GET",
+      );
+      expect(hasGet).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the `POST /**` rule from `huggingface.co` in the huggingface preset, leaving the host download-only.
- Add regression tests asserting `huggingface.co` has no POST allow rule and still retains the GET rule.

Fixes #1432.

## Why
The huggingface preset allowed both GET and POST on `huggingface.co/**`. The POST rule let any sandboxed agent that found an HF token in the environment publish models, datasets, and create repositories on the Hub via `/api/repos/create` and friends — far beyond what a download-only `from_pretrained` workflow needs. Same shape as #1437 (sentry POST) and matches the principle of least privilege the preset system is built around.

Inference traffic flows through `router.huggingface.co` (declared separately in the same preset), not `huggingface.co`, so removing the POST rule from `huggingface.co` does not break the inference path. `cdn-lfs.huggingface.co` stays GET-only as before.

## Test plan
- [x] `npx vitest run test/validate-blueprint.test.ts` → 29/29 passing.
- [x] Negative-case verification: stash the preset edit, re-run — the new regression test fails as expected, then passes again after pop.
- [ ] Maintainer should sanity-check that no internal NemoClaw flow `POST`s to `huggingface.co` (grep currently shows the only reference is the preset file itself).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated huggingface.co endpoint access control to restrict to read-only operations; POST method access has been removed while GET access remains available and functional
  * Added regression tests to validate that access control rules are properly enforced for huggingface.co endpoints and prevent unauthorized write operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->