### PR TITLE
fix(security): remove npm registry from base sandbox policy (#1458)

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -191,22 +191,15 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/openclaw }
 
-  # npm registry — needed for `openclaw plugins install` and `npm install`.
-  # Read-only: agents only fetch packages, never publish.
-  npm_registry:
-    name: npm_registry
-    endpoints:
-      - host: registry.npmjs.org
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-    binaries:
-      - { path: /usr/local/bin/openclaw }
-      - { path: /usr/local/bin/npm }
-      - { path: /usr/local/bin/node }
+  # NOTE: registry.npmjs.org and the npm/node binaries used to live
+  # here as `npm_registry` and were therefore granted to every sandbox
+  # regardless of whether the user picked the `npm` preset during
+  # onboard. That created the regression in #1458 where a sandbox
+  # onboarded with NO policies could still run `npm install` (while
+  # `pip install` was correctly rejected). The entry has been removed
+  # from the base policy; users who need npm should select the `npm`
+  # preset (`presets/npm.yaml`) during onboard or apply it later via
+  # `openshell policy set`. See #1458.
 
   # ── Messaging — pre-allowed for OpenClaw agent notifications ────
   # Restricted to node processes to prevent arbitrary data exfiltration

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -188,4 +188,21 @@ describe("base sandbox policy", () => {
       expect(hasGet).toBe(true);
     }
   });
+
+  it("regression #1458: base policy does not silently grant npm registry access", () => {
+    // Until #1458, registry.npmjs.org and the npm/node binaries lived
+    // in network_policies.npm_registry, so a sandbox onboarded with
+    // ZERO policy presets could still run `npm install` (while
+    // `pip install` was correctly rejected because PyPI was only in
+    // the pypi preset). Removing the entry restores parity: neither
+    // npm nor pypi are reachable until the user opts into the
+    // matching preset. This assertion blocks a re-add by name AND a
+    // smuggle-in via a renamed key that still references the npm
+    // registry host.
+    const np = policy.network_policies as Record<string, unknown> | undefined;
+    expect(np && typeof np === "object" && "npm_registry" in np).toBe(false);
+
+    const npmHosts = findEndpoints((h) => h === "registry.npmjs.org");
+    expect(npmHosts).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- Remove the hardcoded `npm_registry` entry from the base sandbox policy. npm registry access was being granted to every sandbox regardless of opt-in.
- Add a regression test asserting the base policy never re-declares `npm_registry` or references `registry.npmjs.org`.

Fixes #1458.

## Why
The reporter onboarded a sandbox with **zero** policy presets and observed that `npm install` still succeeded inside the sandbox, while `pip install` was correctly rejected. The root cause: `network_policies.npm_registry` was hardcoded into the base policy with `GET /**` on `registry.npmjs.org` plus the npm/node binaries, while PyPI was only declared in `presets/pypi.yaml`. Two equivalent package-manager paths, one silently allowed and one correctly gated — exactly the same shape as the GitHub leak fixed in #1583/#1660.

## What changed
- `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` — remove the `npm_registry` block, leave a comment pointing at the existing `presets/npm.yaml` and #1458.
- `test/validate-blueprint.test.ts` — new regression test under `#1458` asserting the base policy declares no `npm_registry` entry and references no `registry.npmjs.org` host.

## Test plan
- [x] `npx vitest run test/validate-blueprint.test.ts` → 28/28 passing.
- [x] Negative-case verification: stash the YAML edit and re-run — the new regression test fails as expected, then passes again after pop.
- [ ] Maintainer should sanity-check that no runtime-time `openclaw plugins install` flow depends on npm reachability from inside the sandbox. The build-time `openclaw plugins install /opt/nemoclaw` step in the Dockerfile is a local-path install, not an npm fetch, so it is unaffected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed npm registry access from the base sandbox policy to prevent unintended npm installs in sandboxes that haven't explicitly selected the npm preset. npm functionality must now be enabled through the dedicated npm preset.

* **Tests**
  * Added regression test to ensure npm registry access is not present in base sandbox policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->