### PR TITLE
fix(blueprint): chown copied files to sandbox user after restore (#1229)

### DIFF
--- a/nemoclaw/src/blueprint/snapshot.ts
+++ b/nemoclaw/src/blueprint/snapshot.ts
@@ -92,7 +92,36 @@ export async function restoreIntoSandbox(
     ["sandbox", "cp", source, `${sandboxName}:/sandbox/.openclaw`],
     { reject: false },
   );
-  return result.exitCode === 0;
+  if (result.exitCode !== 0) {
+    return false;
+  }
+
+  // Files copied via `openshell sandbox cp` land as root:root because
+  // the helper runs as root inside the pod. /sandbox/.openclaw is the
+  // immutable gateway-config layer, but the symlinks under it point at
+  // /sandbox/.openclaw-data (the writable side), so the copied agent
+  // workspace and per-agent runtime dirs end up unwritable by the
+  // sandbox user. That broke writes to models.json, agent state, and
+  // workspace markdown files. Fix it with a best-effort recursive
+  // chown after the cp succeeds. We deliberately keep this best-effort
+  // (don't fail the restore if the chown fails) so a future runtime
+  // that already gets ownership right doesn't trip on a missing
+  // chown binary or a tightened exec policy. See #1229.
+  await execa(
+    "openshell",
+    [
+      "sandbox",
+      "exec",
+      sandboxName,
+      "--",
+      "chown",
+      "-R",
+      "sandbox:sandbox",
+      "/sandbox/.openclaw-data",
+    ],
+    { reject: false },
+  );
+  return true;
 }
 
 export function cutoverHost(): boolean {


### PR DESCRIPTION
## Summary
- After `restoreIntoSandbox()` calls `openshell sandbox cp`, run a best-effort `chown -R sandbox:sandbox /sandbox/.openclaw-data` so the writable side of the symlink tree is owned by the sandbox user.
- Failure of the chown does **not** fail the restore (best-effort hardening).

Fixes #1229.

## Why
`openshell sandbox cp` runs as root inside the pod, so files copied into `/sandbox/.openclaw` via `restoreIntoSandbox` land as `root:root`. The symlinks under `/sandbox/.openclaw` point at the writable `/sandbox/.openclaw-data` tree, so without an explicit chown the agent workspace and per-agent runtime dirs end up unwritable by the sandbox user. The reporter saw:

```
EACCES: permission denied, open ".../agents/maggie_agent/agent/models.json"
Write: to ~/.openclaw-data/workspace-maggie_agent/MEETINGS.md failed
```

## Test plan
- [x] Manual review of the changed call site to confirm the cp success path is preserved exactly and that chown failure cannot flip the result.
- [ ] **Note on automated tests:** `nemoclaw/src/blueprint/snapshot.test.ts` has pre-existing vitest 4.x mocking breakage on `main` — 8 of its 16 tests fail before this change because the `vi.mock("node:fs", ...)` harness doesn't return what the production code expects under vitest 4.x. The failure surfaces as `expected null not to be null` from `createSnapshot()` and identical patterns in `restoreIntoSandbox`. This change adds zero new failures (8/16 fail before, still 8/16 fail after — same tests). I held back regression tests for the chown call shape because they would have hit the same mock-fs issue. Happy to add them in a follow-up PR once the snapshot test harness is repaired (which is itself worth tracking as a separate issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore now fails immediately if the initial sandbox copy encounters an error, preventing partial restores.
  * After a successful copy, sandbox data ownership is corrected in a best-effort step; ownership-fix failures no longer block the restore.
  * Improved reliability of sandbox file handling and post-restore permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: ColinM-sys <cmcdonough@50words.com>