### PR TITLE
fix(policy): restrict npm and PyPI presets to GET-only REST rules

### DIFF
--- a/nemoclaw-blueprint/policies/presets/npm.yaml
+++ b/nemoclaw-blueprint/policies/presets/npm.yaml
@@ -11,10 +11,18 @@ network_policies:
     endpoints:
       - host: registry.npmjs.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
       - host: registry.yarnpkg.com
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
     binaries:
       - { path: /usr/local/bin/npm* }
       - { path: /usr/local/bin/npx* }

--- a/nemoclaw-blueprint/policies/presets/pypi.yaml
+++ b/nemoclaw-blueprint/policies/presets/pypi.yaml
@@ -11,10 +11,20 @@ network_policies:
     endpoints:
       - host: pypi.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: HEAD, path: "/**" }
       - host: files.pythonhosted.org
         port: 443
-        access: full
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: HEAD, path: "/**" }
     binaries:
       - { path: /usr/bin/python3* }
       - { path: /usr/bin/pip* }

--- a/test/policies.test.js
+++ b/test/policies.test.js
@@ -563,17 +563,29 @@ describe("policies", () => {
       }
     });
 
-    it("package-manager presets use access: full (not tls: terminate)", () => {
-      // Package managers (pip, npm, yarn) use CONNECT tunneling which breaks
-      // under tls: terminate. Ensure these presets use access: full like the
-      // github policy in openclaw-sandbox.yaml.
+    it("package-manager presets use protocol: rest with read-only rules", () => {
+      // Package managers only need read access to install packages.
+      // Using access: full opens a raw CONNECT tunnel that allows
+      // PUT/POST (publish, exfiltrate). Restrict via rest rules.
       const packagePresets = ["pypi", "npm"];
       for (const name of packagePresets) {
         const content = policies.loadPreset(name);
         expect(content).toBeTruthy();
-        expect(content.includes("tls: terminate")).toBe(false);
-        expect(content.includes("access: full")).toBe(true);
+        expect(content.includes("access: full")).toBe(false);
+        expect(content.includes("protocol: rest")).toBe(true);
+        expect(content.includes("method: GET")).toBe(true);
+        // No write methods allowed
+        expect(content.includes("method: PUT")).toBe(false);
+        expect(content.includes("method: POST")).toBe(false);
+        expect(content.includes("method: DELETE")).toBe(false);
       }
+    });
+
+    it("pypi preset allows HEAD for pip lazy-wheel metadata checks", () => {
+      // pip and uv use HEAD requests for lazy wheel downloads and
+      // range-request support. GET-only would break pip install.
+      const content = policies.loadPreset("pypi");
+      expect(content.includes("method: HEAD")).toBe(true);
     });
 
     it("package-manager presets include binaries section", () => {


### PR DESCRIPTION
## Summary
- Replace `access: full` (raw CONNECT tunnel) with `protocol: rest` + read-only rules in `presets/npm.yaml` and `presets/pypi.yaml`
- Prevents package publishing (`npm publish`, `pip upload`) and data exfiltration through registry endpoints
- npm: GET-only (sufficient for `npm install`)
- PyPI: GET + HEAD (`pip`/`uv` use HEAD for lazy-wheel metadata checks)
- Updates test assertions to match new expected policy shape

Closes #1439

## Affected files
- `nemoclaw-blueprint/policies/presets/npm.yaml` — `registry.npmjs.org`, `registry.yarnpkg.com`
- `nemoclaw-blueprint/policies/presets/pypi.yaml` — `pypi.org`, `files.pythonhosted.org`
- `test/policies.test.js` — updated assertions + new test for pypi HEAD

## Issue checklist

| Issue item | Status | Notes |
|---|---|---|
| `presets/npm.yaml` uses `access: full` | Fixed | Replaced with `protocol: rest` + GET-only |
| `presets/pypi.yaml` uses `access: full` | Fixed | Replaced with `protocol: rest` + GET + HEAD |
| `openclaw-sandbox.yaml` lines 131-137 | N/A | GitHub policies — `access: full` is intentional for git push/clone |
| `openclaw-sandbox.yaml` lines 163-166 | N/A | `binaries:` entries for clawhub — not related to npm/pypi |
| `openclaw-sandbox.yaml` npm entry (lines 194-209) | Already fixed | Uses `protocol: rest` + GET-only in main |
| Explicit `deny` rules (recommended fix) | Not needed | With `protocol: rest` + allow-list, everything not allowed is implicitly denied — matches `huggingface.yaml` pattern |

## Why PyPI needs HEAD

`pip install` and `uv pip install` use HEAD requests for lazy-wheel downloads and range-request support (checking `Accept-Ranges: bytes` before partial downloads). GET-only would degrade pip to full-file downloads. HEAD is read-only and poses no security risk.

## Reproduction verification

```
# access: full is gone from both presets
$ grep 'access: full' presets/npm.yaml presets/pypi.yaml
(no matches)

# protocol: rest present on all 4 endpoints
$ grep -c 'protocol: rest' presets/npm.yaml → 2
$ grep -c 'protocol: rest' presets/pypi.yaml → 2

# Only safe read methods allowed
$ grep -cE 'method: (PUT|POST|DELETE)' presets/npm.yaml → 0
$ grep -cE 'method: (PUT|POST|DELETE)' presets/pypi.yaml → 0
```

## Test plan
- [x] `npx vitest run test/policies.test.js` — all 60 tests pass
- [ ] Verify `npm install` works inside sandbox with updated npm preset
- [ ] Verify `pip install` works inside sandbox with updated pypi preset
- [ ] Verify `npm publish` / `pip upload` is blocked inside sandbox

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)