### PR TITLE
fix(blueprint): correct min_openshell_version to match supported floor (#1612)

### DIFF
--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -2,7 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version: "0.1.0"
-min_openshell_version: "0.1.0"
+# OpenShell 0.0.24 is the lowest version NV QA validates against
+# (see #1607, #1609, #1612 — all reproduced on 0.0.24). The previous
+# floor of 0.1.0 had been hardcoded since the initial blueprint
+# scaffold and did not match any released or supported version, so
+# the preflight gate added in #1317 was rejecting environments QA
+# had explicitly signed off on. Bump the floor in lockstep with the
+# next OpenShell release if a feature in the blueprint actually
+# requires a newer minimum.
+min_openshell_version: "0.0.24"
 min_openclaw_version: "2026.3.0"
 digest: ""  # Computed at release time
 


### PR DESCRIPTION
## Summary
- Lower `min_openshell_version` in `nemoclaw-blueprint/blueprint.yaml` from `0.1.0` to `0.0.24` to match the version NV QA actually validates against.

Fixes #1612.

## Why
The blueprint has hardcoded `min_openshell_version: "0.1.0"` since the initial scaffold (commit `bd2bf9b9`, March 14). 0.1.0 is not a version any current NV QA environment actually runs — the QA reports in #1607, #1609, and #1612 all reproduce on **OpenShell 0.0.24**. After #1317 wired the blueprint floor into preflight as a hard gate, the wrong floor started rejecting environments QA had explicitly signed off on.

This change just brings the floor in line with reality. If a future blueprint feature actually requires a newer OpenShell, the floor should be bumped in lockstep with that release — not preemptively to a version that doesn't exist.

## Test plan
- [x] `npx vitest run test/onboard.test.js` — same 33/91 pre-existing test failures on `main` and on this branch (zero new failures from this change). The pre-existing failures are unrelated to the version field and are tracked separately.
- [ ] No new regression test added: the existing `regression #1317: getBlueprintMinOpenshellVersion reads min_openshell_version from blueprint.yaml` test in `test/onboard.test.js` already covers the read path; this PR is a value change, not a behavior change. A test asserting "the value is exactly 0.0.24" would have to be updated every time the floor moves, which is exactly what blueprint.yaml itself already records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required OpenShell version for the blueprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->