### PR TITLE
test(cli): lock in #1555 destroy-side session clear so list cannot resurrect destroyed sandboxes (#1641)

### DIFF
--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -20,6 +20,43 @@ describe("inventory commands", () => {
     );
   });
 
+  it("regression #1641: after destroy clears the session, list shows the onboard hint instead of resurrecting the sandbox", async () => {
+    // Reproduces the loop the reporter described in #1641: a sandbox
+    // is destroyed, registry is empty, the destroy code clears
+    // session.sandboxName to null (added in #1555), and the next
+    // `nemoclaw list` MUST NOT recover the destroyed sandbox from
+    // the session. Without the destroy-side clear, list would print
+    // "Recovered sandbox inventory from the last onboard session"
+    // and the user would loop between `list` (showing the sandbox)
+    // and `connect` (removing it as stale).
+    const lines: string[] = [];
+    await listSandboxesCommand({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [],
+        defaultSandbox: null,
+        recoveredFromSession: false,
+        recoveredFromGateway: 0,
+      }),
+      getLiveInference: () => null,
+      // Post-destroy session: sandboxName has been cleared. The
+      // session object itself still exists (other fields populated)
+      // but loadLastSession returning a session with sandboxName=null
+      // must NOT trip the "last onboarded sandbox was 'X'" hint.
+      loadLastSession: () => ({ sandboxName: null }),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain(
+      "  No sandboxes registered. Run `nemoclaw onboard` to get started.",
+    );
+    expect(
+      lines.some((line) =>
+        line.includes("Recovered sandbox inventory from the last onboard session"),
+      ),
+    ).toBe(false);
+    expect(lines.some((line) => line.includes("last onboarded sandbox was"))).toBe(false);
+  });
+
   it("prints recovered sandbox inventory details", async () => {
     const lines: string[] = [];
     await listSandboxesCommand({


### PR DESCRIPTION
## Summary
- Add a regression test in \`src/lib/inventory-commands.test.ts\` that locks in the \`#1555\` destroy-side session clear: after destroy, \`list\` MUST print the onboard hint and MUST NOT print "Recovered sandbox inventory from the last onboard session" or "last onboarded sandbox was 'X'".

Refs #1641, #1555.

## Why
#1641 reported that after \`nemoclaw <name> destroy\`, \`nemoclaw list\` re-recovered the destroyed sandbox from the onboard session, and \`nemoclaw <name> connect\` then marked it stale and removed it — looping forever between the two commands. The reporter ran on \`v0.0.6-19-gea9a6f2\`, which is 13 commits **behind** \`ecc1277d\` (PR #1555). #1555 added the destroy-side \`session.sandboxName = null\` clear that breaks the loop. So **the bug is already fixed on \`main\`**, but there is no regression test pinning the behavior, which means a future refactor of either the destroy path or the list/recovery path could silently re-introduce it.

## What changed
- **\`src/lib/inventory-commands.test.ts\`** — new test under "regression #1641" that exercises the post-destroy state: empty registry, session present with \`sandboxName: null\`. Asserts the empty-state hint is printed and neither of the two recovery messages appears.

## Test plan
- [x] \`npx vitest run src/lib/inventory-commands.test.ts\` → 5/5 passing.
- [x] Test catches the regression by code inspection: the existing "empty-state onboarding hint" test (line 9-21) shows that swapping \`sandboxName: null\` for \`sandboxName: "alpha"\` routes to the other branch which prints \`"...the last onboarded sandbox was 'alpha'"\`, which my new test explicitly asserts does not appear.

## Reporter follow-up
Suggesting on the issue that the reporter retest on current \`main\` (post-#1555). If the loop still reproduces on a current build, that's a separate bug and I'll re-investigate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test ensuring that when no sandboxes remain and session recovery yields nothing, the CLI displays the generic onboarding empty-state message ("No sandboxes registered. Run nemoclaw onboard to get started.") and omits any session-recovery or "last onboarded sandbox" hints, improving clarity during onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: ColinM-sys <cmcdonough@50words.com>