### PR TITLE
chore(lint): exclude dist/ from eslint to silence post-build noise

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,15 @@ export default [
       "nemoclaw/**",
       "node_modules/**",
       "docs/_build/**",
+      // Compiled output of `npm run build:cli` (tsc → dist/). The
+      // generated files contain `// eslint-disable-next-line` comments
+      // that reference TypeScript-eslint rules which are not loaded by
+      // this config (the source-side config that owns those rules
+      // lives in the nemoclaw/ sub-project), so linting dist/ produces
+      // spurious "rule not found" errors after a local build. dist/ is
+      // also gitignored — there is no scenario in which it should be
+      // linted.
+      "dist/**",
     ],
   },
 


### PR DESCRIPTION
## Summary
- Add \`dist/**\` to the \`ignores\` list in \`eslint.config.mjs\`.

## Why
After running \`npm run build:cli\`, the generated \`dist/lib/*.js\` files contain \`// eslint-disable-next-line @typescript-eslint/no-require-imports\` comments. The root eslint config does not load \`@typescript-eslint\` (the source-side config that owns those rules lives in the \`nemoclaw/\` sub-project), so linting \`dist/\` produces 8 "rule not found" errors and 7 unused-disable warnings — pure local-build noise.

\`dist/\` is already gitignored, and CI lints on a fresh clone before any build (so \`dist/\` doesn't exist there). The footgun is purely local: a contributor who runs \`npm run build:cli && npm run lint\` to verify their change gets a wall of errors that are unrelated to anything they touched.

## Test plan
- [x] **Before:** \`npm run build:cli && npm run lint\` → \`✖ 15 problems (8 errors, 7 warnings)\`, all in \`dist/lib/*.js\`.
- [x] **After:** same command → 0 problems.
- [x] No change to any source file or runtime behavior. Pure config edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to exclude compiled build output from linting checks, reducing unnecessary lint warnings during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->