### PR TITLE
fix(docs): add 0.0.10 as preferred recent docs version

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
   {
     "preferred": true,
+    "version": "0.0.10",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.10/"
+  },
+  {
     "version": "0.0.9",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.9/"
   }


### PR DESCRIPTION
## Summary

Add version 0.0.10 as the preferred entry in `docs/versions1.json` so the docs version switcher defaults to the latest release.

## Related Issue

None.

## Changes

- Added a new entry for `0.0.10` with `"preferred": true` to `docs/versions1.json`.
- Moved the `"preferred"` flag from the `0.0.9` entry to the new `0.0.10` entry.

## Type of Change

- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Doc Changes

- [x] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md).
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.

---
Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation for version 0.0.10 is now available and marked as the preferred version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->