### PR TITLE
fix(test): isolate deleteCredential test from host environment

### DIFF
--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -74,6 +74,8 @@ describe("credential prompts", () => {
 
   it("deleteCredential removes a stored key and leaves the file mode intact", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
+    // Isolate from real environment so getCredential only checks the file.
+    vi.stubEnv("NVIDIA_API_KEY", "");
     const credentials = await importCredentialsModule(home);
 
     credentials.saveCredential("NVIDIA_API_KEY", "nvapi-bad-key");


### PR DESCRIPTION
## Summary
- `deleteCredential` test used `NVIDIA_API_KEY` as the test key, but `getCredential()` checks `process.env` before the credentials file
- When a real `NVIDIA_API_KEY` is set in the host environment, the post-delete assertion fails because `getCredential` returns the env var instead of `null`
- Stubs the env var to empty string so the test exercises file-only credential lookup

## Test plan
- [x] `npm test` passes with `NVIDIA_API_KEY` set in environment (1243 passed, 0 failed)
- [x] `npm test` passes without `NVIDIA_API_KEY` set (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for credential handling tests by explicitly stubbing environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->