### PR TITLE
fix(onboard): persist enabledChannels across resume path

### DIFF
--- a/src/lib/onboard-session.test.ts
+++ b/src/lib/onboard-session.test.ts
@@ -338,6 +338,40 @@ describe("onboard session", () => {
     expect(loaded.failure.message).toBe(loaded.steps.inference.error);
   });
 
+  it("round-trips null messagingChannels through normalizeSession", () => {
+    const created = session.createSession();
+    expect(created.messagingChannels).toBeNull();
+    const saved = session.saveSession(created);
+    const loaded = session.loadSession();
+    expect(saved.messagingChannels).toBeNull();
+    expect(loaded.messagingChannels).toBeNull();
+  });
+
+  it("round-trips messagingChannels=['telegram'] through normalizeSession", () => {
+    const created = session.createSession({ messagingChannels: ["telegram"] });
+    expect(created.messagingChannels).toEqual(["telegram"]);
+    const saved = session.saveSession(created);
+    const loaded = session.loadSession();
+    expect(saved.messagingChannels).toEqual(["telegram"]);
+    expect(loaded.messagingChannels).toEqual(["telegram"]);
+  });
+
+  it("filterSafeUpdates preserves messagingChannels field", () => {
+    session.saveSession(session.createSession());
+    session.markStepComplete("provider_selection", {
+      messagingChannels: ["slack", "discord"],
+    });
+
+    const loaded = session.loadSession();
+    expect(loaded.messagingChannels).toEqual(["slack", "discord"]);
+  });
+
+  it("createSession with messagingChannels override", () => {
+    const created = session.createSession({ messagingChannels: ["telegram", "slack"] });
+    expect(created.messagingChannels).toEqual(["telegram", "slack"]);
+    expect(created.provider).toBeNull();
+  });
+
   it("summarizes the session for debug output", () => {
     session.saveSession(session.createSession({ sandboxName: "my-assistant" }));
     session.markStepStarted("preflight");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6190,6 +6190,7 @@ async function onboard(opts = {}) {
       if (webSearchConfig) {
         note("  [resume] Reusing Brave Search configuration already baked into the sandbox.");
       }
+      selectedMessagingChannels = session?.messagingChannels ?? [];
       skippedStepMessage("sandbox", sandboxName);
     } else {
       if (resume && session?.steps?.sandbox?.status === "complete") {


### PR DESCRIPTION
## Problem

When resuming an onboard session, `enabledChannels` was lost because it was declared as `const` inside the `else` (non-resume) block of the sandbox setup step. Resumed sessions had no channel selection, causing `setupPoliciesWithSelection` to fall back to credential-only checks — users who selected messaging channels (Telegram/Slack/Discord) would not see the corresponding policy presets suggested after resume.

## Root Cause

In `src/lib/onboard.ts`, line ~4443:
```ts
const enabledChannels = await setupMessagingChannels();
```
This was scoped inside the else block. The resume path (`if (resumeSandbox)`) never set `enabledChannels`, and it was never persisted to session state.

## Fix

1. **Hoist** `enabledChannels` to function scope (`let enabledChannels: string[] | null = null`)
2. **Resume path**: restore from `session.enabledChannels`
3. **Non-resume path**: persist to session via `onboardSession.updateSession()`
4. **Session layer** (`onboard-session.ts`): add `enabledChannels` to Session/SessionUpdates interfaces, createSession, normalizeSession, filterSafeUpdates, and summarizeForDebug
5. **Policy suggestions**: pass `enabledChannels` to `setupPoliciesWithSelection` — when provided, use the channel list instead of credential checks (with credential fallback for backward compat)

## Testing

- `npm run check` (lint + format + tsc): ✅ all pass

Fixes #1610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now captures and persists selected messaging channels and uses them to seed policy suggestions; debug output includes the persisted channel selection.

* **Bug Fixes / Improvements**
  * Channel selection is consistently preserved across session creation, normalization, updates, and resume flows.

* **Tests**
  * Added tests verifying channel persistence, safe-update handling, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: kagura-agent <kagura.chen28@gmail.com>
