### PR TITLE
fix(test): bump cli.test.ts runWithEnv default timeout from 10s to 30s

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -14,7 +14,7 @@ function run(args) {
   return runWithEnv(args);
 }
 
-function runWithEnv(args, env = {}, timeout = 10000) {
+function runWithEnv(args, env = {}, timeout = 30000) {
   try {
     const out = execSync(`node "${CLI}" ${args}`, {
       encoding: "utf-8",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,12 @@ export default defineConfig({
           name: "cli",
           include: ["test/**/*.test.{js,ts}", "src/**/*.test.ts"],
           exclude: ["**/node_modules/**", "**/.claude/**", "test/e2e/**"],
+          // Match the bumped `runWithEnv` execSync timeout in test/cli.test.ts.
+          // Vitest's default `testTimeout` is 5000ms, which would abort tests
+          // long before the 30s execSync ceiling — making the bumped child
+          // timeout useless on slow CI hosts.
+          testTimeout: 30_000,
+          hookTimeout: 30_000,
         },
       },
       {


### PR DESCRIPTION
## Summary

Salvaged from https://github.com/NVIDIA/NemoClaw/pull/1627 by @TSavo (fork returned 503, could not push there).

- `test/cli.test.ts`: bump `runWithEnv` default `timeout` from 10s to 30s
- `vitest.config.ts`: add `testTimeout: 30_000` and `hookTimeout: 30_000` to the `cli` project so Vitest's per-test ceiling matches the `execSync` timeout

The TS migration renamed `test/cli.test.js` to `test/cli.test.ts`; the timeout change was applied to the new filename. The vitest.config.ts comment was also updated to reference `.ts`.

Closes #1621 (sub-item 1 of three).

## Test plan

- [x] `vitest run test/cli.test.ts` -- 44/44 tests pass
- [ ] Full CI passes

Co-authored-by: @TSavo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased test and hook execution timeouts to 30 seconds across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->