### PR TITLE
fix(test): isolate sysbin in install-preflight tests to prevent host $PATH leakage

### DIFF
--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -12,7 +12,52 @@ const INSTALLER = path.join(import.meta.dirname, "..", "install.sh");
 const CURL_PIPE_INSTALLER = path.join(import.meta.dirname, "..", "install.sh");
 const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
 const GITHUB_INSTALL_URL = "git+https://github.com/NVIDIA/NemoClaw.git";
-const TEST_SYSTEM_PATH = "/usr/bin:/bin";
+/**
+ * Build an isolated "system bin" directory used by every test in this file
+ * via TEST_SYSTEM_PATH. The directory mirrors /usr/bin and /bin via symlinks
+ * — EXCEPT for `node`, `npm`, and `npx`, which are deliberately excluded.
+ *
+ * Why: the runtime preflight tests need a PATH where the host's real `node`
+ * and `npm` are NOT visible, so the "node missing" / "npm missing" error
+ * branches are actually exercised. The previous `"/usr/bin:/bin"` literal
+ * leaks /usr/bin/node on any Linux distribution that installs Node via
+ * `apt install nodejs` (i.e. most of them), causing those tests to assert
+ * the wrong code path on developer machines while passing on the upstream
+ * CI runners (where Node is installed under /opt/hostedtoolcache/, not
+ * /usr/bin/).
+ *
+ * Tests that need a fake `node` or `npm` continue to write a stub into
+ * `fakeBin` and prepend it to PATH (`${fakeBin}:${TEST_SYSTEM_PATH}`); the
+ * fake still wins because it comes first.
+ *
+ * The directory lives under `os.tmpdir()` and is intentionally not cleaned
+ * up — it's tiny (a few hundred symlinks), the OS reaps it on reboot, and
+ * cleanup would require an `afterAll` hook in every describe block.
+ */
+function buildIsolatedSystemPath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-preflight-sysbin-"));
+  const EXCLUDE = new Set(["node", "npm", "npx"]);
+  for (const sysDir of ["/usr/bin", "/bin"]) {
+    if (!fs.existsSync(sysDir)) continue;
+    for (const name of fs.readdirSync(sysDir)) {
+      if (EXCLUDE.has(name)) continue;
+      try {
+        fs.symlinkSync(path.join(sysDir, name), path.join(dir, name));
+      } catch (err) {
+        // Only swallow EEXIST — the expected case is when /bin is a symlink
+        // to /usr/bin (modern Linux) and we already linked the same name on
+        // the first pass. Any other error (EPERM, EACCES, EINVAL, ENOENT…)
+        // would leave TEST_SYSTEM_PATH partially populated and turn into a
+        // confusing downstream test failure, so re-throw it.
+        if (err && err.code === "EEXIST") continue;
+        throw err;
+      }
+    }
+  }
+  return dir;
+}
+
+const TEST_SYSTEM_PATH = buildIsolatedSystemPath();
 
 function writeExecutable(target, contents) {
   fs.writeFileSync(target, contents, { mode: 0o755 });


### PR DESCRIPTION
The "node missing" / "npm missing" runtime preflight tests need a PATH where the host's real `node` and `npm` are NOT visible, so the error branches are actually exercised. The previous `TEST_SYSTEM_PATH = "/usr/bin:/bin"` literal leaks `/usr/bin/node` on any Linux distribution that installs Node via `apt install nodejs` (i.e. most of them). On those hosts the affected tests assert the wrong code path — they expect "node missing" but the preflight finds the system `/usr/bin/node` and reports a version mismatch instead.

This replaces the literal with `buildIsolatedSystemPath()`, a small helper that creates a tmpdir under `os.tmpdir()` at module load and symlinks every entry from `/usr/bin` and `/bin` into it — except `node`, `npm`, and `npx`, which are deliberately excluded.

Rebased onto the renamed .ts file from the TS migration stack.

Closes #1621 (sub-item 2 of three).

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [ ] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for preflight/runtime checks by using an isolated system PATH to avoid interference from host-provided tools.
  * Made test setup more robust when preparing the isolated PATH by handling filesystem errors during population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->