### PR TITLE
feat(policy): add --dangerously-skip-permissions flag

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Permissive policy for development/testing — used by --dangerously-skip-permissions.
+# All known endpoints are opened with access: full (CONNECT tunnel, no L7 filtering).
+# Filesystem: include_workdir: true makes the sandbox home directory writable.
+#
+# WARNING: This policy disables most sandbox security restrictions.
+# Do not use in production.
+
+version: 1
+
+filesystem_policy:
+  # PERMISSIVE: true grants read-write to the container WORKDIR (/sandbox).
+  # The default policy sets this to false for security (see openclaw-sandbox.yaml).
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /proc
+    - /dev/urandom
+    - /app
+    - /etc
+    - /var/log
+  read_write:
+    - /tmp
+    - /dev/null
+    - /sandbox/.openclaw-data
+    - /sandbox/.nemoclaw
+
+landlock:
+  compatibility: best_effort
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  # ── Base policy endpoints (access: full, no method/path restrictions) ──
+
+  claude_code:
+    name: claude_code
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+        access: full
+      - host: statsig.anthropic.com
+        port: 443
+        access: full
+      - host: sentry.io
+        port: 443
+        access: full
+
+  nvidia:
+    name: nvidia
+    endpoints:
+      - host: integrate.api.nvidia.com
+        port: 443
+        access: full
+      - host: inference-api.nvidia.com
+        port: 443
+        access: full
+
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+        access: full
+      - host: api.github.com
+        port: 443
+        access: full
+
+  clawhub:
+    name: clawhub
+    endpoints:
+      - host: clawhub.ai
+        port: 443
+        access: full
+
+  openclaw_api:
+    name: openclaw_api
+    endpoints:
+      - host: openclaw.ai
+        port: 443
+        access: full
+
+  openclaw_docs:
+    name: openclaw_docs
+    endpoints:
+      - host: docs.openclaw.ai
+        port: 443
+        access: full
+
+  npm_registry:
+    name: npm_registry
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+        access: full
+      - host: registry.yarnpkg.com
+        port: 443
+        access: full
+
+  # ── Messaging endpoints ──
+
+  telegram:
+    name: telegram
+    endpoints:
+      - host: api.telegram.org
+        port: 443
+        access: full
+
+  discord:
+    name: discord
+    endpoints:
+      - host: discord.com
+        port: 443
+        access: full
+      - host: gateway.discord.gg
+        port: 443
+        access: full
+      - host: cdn.discordapp.com
+        port: 443
+        access: full
+      - host: media.discordapp.net
+        port: 443
+        access: full
+
+  slack:
+    name: slack
+    endpoints:
+      - host: slack.com
+        port: 443
+        access: full
+      - host: api.slack.com
+        port: 443
+        access: full
+      - host: hooks.slack.com
+        port: 443
+        access: full
+      - host: wss-primary.slack.com
+        port: 443
+        access: full
+      - host: wss-backup.slack.com
+        port: 443
+        access: full
+
+  # ── Package registries ──
+
+  pypi:
+    name: pypi
+    endpoints:
+      - host: pypi.org
+        port: 443
+        access: full
+      - host: files.pythonhosted.org
+        port: 443
+        access: full
+
+  brew:
+    name: brew
+    endpoints:
+      - host: formulae.brew.sh
+        port: 443
+        access: full
+      - host: ghcr.io
+        port: 443
+        access: full
+      - host: raw.githubusercontent.com
+        port: 443
+        access: full
+
+  # ── Third-party services ──
+
+  jira:
+    name: jira
+    endpoints:
+      - host: jira.atlassian.net
+        port: 443
+        access: full
+
+  outlook:
+    name: outlook
+    endpoints:
+      - host: outlook.office365.com
+        port: 443
+        access: full
+      - host: outlook.office.com
+        port: 443
+        access: full
+
+  huggingface:
+    name: huggingface
+    endpoints:
+      - host: huggingface.co
+        port: 443
+        access: full
+      - host: cdn-lfs.huggingface.co
+        port: 443
+        access: full
+
+  brave:
+    name: brave
+    endpoints:
+      - host: api.search.brave.com
+        port: 443
+        access: full

--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -170,13 +170,25 @@ network_policies:
       - host: raw.githubusercontent.com
         port: 443
         access: full
+      - host: objects.githubusercontent.com
+        port: 443
+        access: full
+      - host: pkg-containers.githubusercontent.com
+        port: 443
+        access: full
 
   # ── Third-party services ──
 
   jira:
     name: jira
     endpoints:
-      - host: jira.atlassian.net
+      - host: "*.atlassian.net"
+        port: 443
+        access: full
+      - host: api.atlassian.com
+        port: 443
+        access: full
+      - host: auth.atlassian.com
         port: 443
         access: full
 
@@ -189,6 +201,12 @@ network_policies:
       - host: outlook.office.com
         port: 443
         access: full
+      - host: graph.microsoft.com
+        port: 443
+        access: full
+      - host: login.microsoftonline.com
+        port: 443
+        access: full
 
   huggingface:
     name: huggingface
@@ -197,6 +215,9 @@ network_policies:
         port: 443
         access: full
       - host: cdn-lfs.huggingface.co
+        port: 443
+        access: full
+      - host: router.huggingface.co
         port: 443
         access: full
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2264,6 +2264,7 @@ async function createSandbox(
   webSearchConfig = null,
   enabledChannels = null,
   fromDockerfile = null,
+  dangerouslySkipPermissions = false,
 ) {
   step(6, 8, "Creating sandbox");
 
@@ -2406,7 +2407,9 @@ async function createSandbox(
 
   // Create sandbox (use -- echo to avoid dropping into interactive shell)
   // Pass the base policy so sandbox starts in proxy mode (required for policy updates later)
-  const basePolicyPath = path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
+  const basePolicyPath = dangerouslySkipPermissions
+    ? path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml")
+    : path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
   const createArgs = [
     "--from",
     `${buildCtx}/Dockerfile`,
@@ -2595,6 +2598,7 @@ async function createSandbox(
   registry.registerSandbox({
     name: sandboxName,
     gpuEnabled: !!gpu,
+    dangerouslySkipPermissions: dangerouslySkipPermissions || undefined,
   });
 
   // DNS proxy — run a forwarder in the sandbox pod so the isolated
@@ -4147,6 +4151,16 @@ function skippedStepMessage(stepName, detail, reason = "resume") {
 async function onboard(opts = {}) {
   NON_INTERACTIVE = opts.nonInteractive || process.env.NEMOCLAW_NON_INTERACTIVE === "1";
   RECREATE_SANDBOX = opts.recreateSandbox || process.env.NEMOCLAW_RECREATE_SANDBOX === "1";
+  const dangerouslySkipPermissions =
+    opts.dangerouslySkipPermissions || process.env.NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS === "1";
+  if (dangerouslySkipPermissions) {
+    console.error("");
+    console.error("  \u26a0  --dangerously-skip-permissions: sandbox security restrictions disabled.");
+    console.error("     Network:    all known endpoints open (no method/path filtering)");
+    console.error("     Filesystem: sandbox home directory is writable");
+    console.error("     Use for development/testing only.");
+    console.error("");
+  }
   delete process.env.OPENSHELL_GATEWAY;
   const resume = opts.resume === true;
   // In non-interactive mode also accept the env var so CI pipelines can set it.
@@ -4452,6 +4466,7 @@ async function onboard(opts = {}) {
         webSearchConfig,
         enabledChannels,
         fromDockerfile,
+        dangerouslySkipPermissions,
       );
       onboardSession.markStepComplete("sandbox", { sandboxName, provider, model, nimContainer });
     }
@@ -4469,45 +4484,56 @@ async function onboard(opts = {}) {
     const recordedPolicyPresets = Array.isArray(session?.policyPresets)
       ? session.policyPresets
       : null;
-    const resumePolicies =
-      resume && sandboxName && arePolicyPresetsApplied(sandboxName, recordedPolicyPresets || []);
-    if (resumePolicies) {
-      skippedStepMessage("policies", (recordedPolicyPresets || []).join(", "));
+    if (dangerouslySkipPermissions) {
+      step(8, 8, "Policy presets");
+      console.log("  Skipped — --dangerously-skip-permissions applies permissive base policy.");
       onboardSession.markStepComplete("policies", {
         sandboxName,
         provider,
         model,
-        policyPresets: recordedPolicyPresets || [],
+        policyPresets: [],
       });
     } else {
-      startRecordedStep("policies", {
-        sandboxName,
-        provider,
-        model,
-        policyPresets: recordedPolicyPresets || [],
-      });
-      const appliedPolicyPresets = await setupPoliciesWithSelection(sandboxName, {
-        selectedPresets:
-          resume &&
-          session?.steps?.policies?.status !== "complete" &&
-          Array.isArray(recordedPolicyPresets) &&
-          recordedPolicyPresets.length > 0
-            ? recordedPolicyPresets
-            : null,
-        webSearchConfig,
-        onSelection: (policyPresets) => {
-          onboardSession.updateSession((current) => {
-            current.policyPresets = policyPresets;
-            return current;
-          });
-        },
-      });
-      onboardSession.markStepComplete("policies", {
-        sandboxName,
-        provider,
-        model,
-        policyPresets: appliedPolicyPresets,
-      });
+      const resumePolicies =
+        resume && sandboxName && arePolicyPresetsApplied(sandboxName, recordedPolicyPresets || []);
+      if (resumePolicies) {
+        skippedStepMessage("policies", (recordedPolicyPresets || []).join(", "));
+        onboardSession.markStepComplete("policies", {
+          sandboxName,
+          provider,
+          model,
+          policyPresets: recordedPolicyPresets || [],
+        });
+      } else {
+        startRecordedStep("policies", {
+          sandboxName,
+          provider,
+          model,
+          policyPresets: recordedPolicyPresets || [],
+        });
+        const appliedPolicyPresets = await setupPoliciesWithSelection(sandboxName, {
+          selectedPresets:
+            resume &&
+            session?.steps?.policies?.status !== "complete" &&
+            Array.isArray(recordedPolicyPresets) &&
+            recordedPolicyPresets.length > 0
+              ? recordedPolicyPresets
+              : null,
+          webSearchConfig,
+          onSelection: (policyPresets) => {
+            onboardSession.updateSession((current) => {
+              current.policyPresets = policyPresets;
+              return current;
+            });
+          },
+        });
+        onboardSession.markStepComplete("policies", {
+          sandboxName,
+          provider,
+          model,
+          policyPresets: appliedPolicyPresets,
+        });
+      }
     }
 
     onboardSession.completeSession({ sandboxName, provider, model });

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -342,8 +342,39 @@ function selectFromList(items, { applied = [] } = {}) {
   });
 }
 
+const PERMISSIVE_POLICY_PATH = path.join(
+  ROOT,
+  "nemoclaw-blueprint",
+  "policies",
+  "openclaw-sandbox-permissive.yaml",
+);
+
+function applyPermissivePolicy(sandboxName) {
+  const isRfc1123Label = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(sandboxName);
+  if (!sandboxName || sandboxName.length > 63 || !isRfc1123Label) {
+    throw new Error(
+      `Invalid or truncated sandbox name: '${sandboxName}'. ` +
+        `Names must be 1-63 chars, lowercase alphanumeric, with optional internal hyphens.`,
+    );
+  }
+
+  if (!fs.existsSync(PERMISSIVE_POLICY_PATH)) {
+    throw new Error(`Permissive policy not found: ${PERMISSIVE_POLICY_PATH}`);
+  }
+
+  console.log("  Applying permissive policy (--dangerously-skip-permissions)...");
+  run(buildPolicySetCommand(PERMISSIVE_POLICY_PATH, sandboxName));
+  console.log("  Applied permissive policy.");
+
+  const sandbox = registry.getSandbox(sandboxName);
+  if (sandbox) {
+    registry.updateSandbox(sandboxName, { dangerouslySkipPermissions: true });
+  }
+}
+
 export {
   PRESETS_DIR,
+  PERMISSIVE_POLICY_PATH,
   listPresets,
   loadPreset,
   getPresetEndpoints,
@@ -353,6 +384,7 @@ export {
   buildPolicyGetCommand,
   mergePresetIntoPolicy,
   applyPreset,
+  applyPermissivePolicy,
   getAppliedPresets,
   selectFromList,
 };

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -14,6 +14,7 @@ export interface SandboxEntry {
   provider?: string | null;
   gpuEnabled?: boolean;
   policies?: string[];
+  dangerouslySkipPermissions?: boolean;
 }
 
 export interface SandboxRegistry {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -157,6 +157,8 @@ export function registerSandbox(entry: SandboxEntry): void {
       provider: entry.provider || null,
       gpuEnabled: entry.gpuEnabled || false,
       policies: entry.policies || [],
+      dangerouslySkipPermissions:
+        entry.dangerouslySkipPermissions === true ? true : undefined,
     };
     if (!data.defaultSandbox) {
       data.defaultSandbox = entry.name;

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -757,6 +757,15 @@ function exitWithSpawnResult(result) {
   process.exit(1);
 }
 
+function printDangerouslySkipPermissionsWarning() {
+  console.error("");
+  console.error("  \u26a0  --dangerously-skip-permissions: sandbox security restrictions disabled.");
+  console.error("     Network:    all known endpoints open (no method/path filtering)");
+  console.error("     Filesystem: sandbox home directory is writable");
+  console.error("     Use for development/testing only.");
+  console.error("");
+}
+
 // ── Commands ─────────────────────────────────────────────────────
 
 async function onboard(args) {
@@ -771,7 +780,7 @@ async function onboard(args) {
     if (!fromDockerfile || fromDockerfile.startsWith("--")) {
       console.error("  --from requires a path to a Dockerfile");
       console.error(
-        `  Usage: nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [${NOTICE_ACCEPT_FLAG}]`,
+        `  Usage: nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--dangerously-skip-permissions] [${NOTICE_ACCEPT_FLAG}]`,
       );
       process.exit(1);
     }
@@ -782,19 +791,21 @@ async function onboard(args) {
     "--non-interactive",
     "--resume",
     "--recreate-sandbox",
+    "--dangerously-skip-permissions",
     NOTICE_ACCEPT_FLAG,
   ]);
   const unknownArgs = args.filter((arg) => !allowedArgs.has(arg));
   if (unknownArgs.length > 0) {
     console.error(`  Unknown onboard option(s): ${unknownArgs.join(", ")}`);
     console.error(
-      `  Usage: nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [${NOTICE_ACCEPT_FLAG}]`,
+      `  Usage: nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--dangerously-skip-permissions] [${NOTICE_ACCEPT_FLAG}]`,
     );
     process.exit(1);
   }
   const nonInteractive = args.includes("--non-interactive");
   const resume = args.includes("--resume");
   const recreateSandbox = args.includes("--recreate-sandbox");
+  const dangerouslySkipPermissions = args.includes("--dangerously-skip-permissions");
   const acceptThirdPartySoftware =
     args.includes(NOTICE_ACCEPT_FLAG) || String(process.env[NOTICE_ACCEPT_ENV] || "") === "1";
   await runOnboard({
@@ -803,6 +814,7 @@ async function onboard(args) {
     recreateSandbox,
     fromDockerfile,
     acceptThirdPartySoftware,
+    dangerouslySkipPermissions,
   });
 }
 
@@ -985,8 +997,13 @@ async function listSandboxes() {
 
 // ── Sandbox-scoped actions ───────────────────────────────────────
 
-async function sandboxConnect(sandboxName) {
+async function sandboxConnect(sandboxName, { dangerouslySkipPermissions = false } = {}) {
   await ensureLiveSandboxOrExit(sandboxName);
+  if (dangerouslySkipPermissions) {
+    printDangerouslySkipPermissionsWarning();
+    const policies = require("../bin/lib/policies");
+    policies.applyPermissivePolicy(sandboxName);
+  }
   checkAndRecoverSandboxProcesses(sandboxName);
   const result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {
     stdio: "inherit",
@@ -1009,6 +1026,9 @@ async function sandboxStatus(sandboxName) {
     console.log(`    Provider: ${(live && live.provider) || sb.provider || "unknown"}`);
     console.log(`    GPU:      ${sb.gpuEnabled ? "yes" : "no"}`);
     console.log(`    Policies: ${(sb.policies || []).join(", ") || "none"}`);
+    if (sb.dangerouslySkipPermissions) {
+      console.log(`    Permissions: dangerously-skip-permissions (open)`);
+    }
   }
 
   const lookup = await getReconciledSandboxGatewayState(sandboxName);
@@ -1283,6 +1303,7 @@ function help() {
   ${G}Getting Started:${R}
     ${B}nemoclaw onboard${R}                 Configure inference endpoint and credentials
     nemoclaw onboard ${D}--from <Dockerfile>${R}  Use a custom Dockerfile for the sandbox image
+    nemoclaw onboard ${D}--dangerously-skip-permissions${R}  Apply maximally permissive sandbox policy
                                     ${D}(non-interactive: ${NOTICE_ACCEPT_FLAG} or ${NOTICE_ACCEPT_ENV}=1)${R}
 
   ${G}Sandbox Management:${R}
@@ -1397,7 +1418,9 @@ const [cmd, ...args] = process.argv.slice(2);
 
     switch (action) {
       case "connect":
-        await sandboxConnect(cmd);
+        await sandboxConnect(cmd, {
+          dangerouslySkipPermissions: actionArgs.includes("--dangerously-skip-permissions"),
+        });
         break;
       case "status":
         await sandboxStatus(cmd);

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1600,7 +1600,7 @@ const { setupInference } = require(${onboardPath});
 
     assert.match(
       source,
-      /startRecordedStep\("sandbox", \{ sandboxName, provider, model \}\);\s*sandboxName = await createSandbox\(\s*gpu,\s*model,\s*provider,\s*preferredInferenceApi,\s*sandboxName,\s*webSearchConfig,\s*enabledChannels,\s*fromDockerfile,\s*\);/,
+      /startRecordedStep\("sandbox", \{ sandboxName, provider, model \}\);\s*sandboxName = await createSandbox\(\s*gpu,\s*model,\s*provider,\s*preferredInferenceApi,\s*sandboxName,\s*webSearchConfig,\s*enabledChannels,\s*fromDockerfile,\s*dangerouslySkipPermissions,\s*\);/,
     );
   });
 


### PR DESCRIPTION
## Summary

- Adds `--dangerously-skip-permissions` flag to `nemoclaw onboard` and `nemoclaw <name> connect` that applies a maximally permissive sandbox policy
- Creates `openclaw-sandbox-permissive.yaml` with `include_workdir: true` and all known endpoints using `access: full` (CONNECT tunnel, no L7 filtering)
- When used on onboard: uses the permissive base policy and skips preset selection entirely
- When used on connect: applies the permissive policy to a running sandbox on the fly
- Also accepts `NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1` env var for CI/CD

## Test plan

- [ ] `nemoclaw onboard --dangerously-skip-permissions --non-interactive` — verify warning printed, permissive policy applied, presets skipped
- [ ] `openshell policy get --full <sandbox>` — confirm permissive YAML active
- [ ] `nemoclaw <sandbox> connect --dangerously-skip-permissions` — verify policy updated on running sandbox
- [ ] `nemoclaw <sandbox> status` — verify "dangerously-skip-permissions (open)" shown
- [ ] `make check` and `npm test` pass (no new failures beyond pre-existing main issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a permissive sandbox mode and a new sandbox policy file enabling broader filesystem and network access.
  * Added a CLI flag to enable the permissive mode for onboarding and connecting; prints a prominent security warning when used.
  * Registry now records when a sandbox runs in permissive mode so status output reflects this.

* **Tests**
  * Updated onboarding tests to account for the permissive-mode option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->