### PR TITLE
fix(ci): write onboarding_step.json to skip Brev first-run wizard

### DIFF
--- a/.github/workflows/e2e-brev.yaml
+++ b/.github/workflows/e2e-brev.yaml
@@ -164,6 +164,8 @@ jobs:
           umask 077
           printf '{"refresh_token":"%s"}' "$BREV_API_TOKEN" > ~/.brev/credentials.json
           chmod 600 ~/.brev/credentials.json
+          # Skip the first-run onboarding wizard that blocks on stdin (also removed in #1470)
+          printf '{"step":1,"hasRunBrevShell":true,"hasRunBrevOpen":true}' > ~/.brev/onboarding_step.json
           brev ls >/dev/null
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Add `onboarding_step.json` to the Brev CLI setup in the E2E workflow
- Without it, `brev ls` triggers an interactive onboarding tutorial that hangs on the CI runner waiting for stdin

## Root Cause
Follow-up to #1639. The credentials file fix restored auth, but `brev ls` still hangs because the Brev CLI's first-run onboarding wizard blocks on stdin. This file was also removed in 374a847d (#1470).

## Evidence
- Stuck run: [24213469934](https://github.com/NVIDIA/NemoClaw/actions/runs/24213469934/job/70688110743) — "Install Brev CLI" step hangs indefinitely
- Local test with clean HOME + both files: `brev ls` returns immediately

## Test plan
- [ ] Merge to main, trigger `e2e-brev` with `TEST_SUITE=full` — confirm `brev ls` passes and tests actually run

Fixes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/workflow configuration to prevent onboarding prompts from interfering with automated authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->