### PR TITLE
fix(install): skip shim when npm prefix equals shim dir

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -472,6 +472,16 @@ ensure_nemoclaw_shim() {
   fi
   node_dir="$(dirname "$node_path")"
 
+  # If npm placed the binary at the same path as the shim target (e.g. when
+  # npm_config_prefix=$HOME/.local), writing a shim would overwrite the real
+  # binary with a script that exec's itself — an infinite loop.  In that case
+  # the binary is already where it needs to be; skip shim creation.
+  if [[ "$cli_path" -ef "$shim_path" ]]; then
+    refresh_path
+    ensure_local_bin_in_profile
+    return 0
+  fi
+
   mkdir -p "$NEMOCLAW_SHIM_DIR"
   cat >"$shim_path" <<EOF
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- \`ensure_nemoclaw_shim()\` creates a self-referential shell script when \`npm_config_prefix=\$HOME/.local\` (set in the brev E2E environment), because \`cli_path\` and \`shim_path\` resolve to the same file (\`\$HOME/.local/bin/nemoclaw\`)
- The shim overwrites the real npm-linked binary with a wrapper that \`exec\`s itself → infinite loop on invocation
- \`is_real_nemoclaw_cli()\` (added in #1606) correctly detected the broken binary but misidentified it as the npm placeholder package → \`npm uninstall -g nemoclaw\` → binary gone → install fails

**Fix:** Add a \`-ef\` guard before writing the shim. If \`cli_path\` and \`shim_path\` refer to the same file, the binary is already in place — return early.

**Why #1606 didn't catch this:** All local/unit tests use the default npm prefix, which differs from \`NEMOCLAW_SHIM_DIR\`. The self-reference only occurs when \`npm_config_prefix=\$HOME/.local\` is explicitly exported — exclusive to the brev E2E runner. Before #1606 the broken shim was silently accepted (no verification step existed).

Fixes regression from #1606, caught by E2E brev run [24216985741](https://github.com/NVIDIA/NemoClaw/actions/runs/24216985741/job/70699774556).

## Test plan

- [x] Local test suite passes (\`npm test\`) — 12 pre-existing failures in \`runtime-shell.test.js\` unchanged
- [ ] E2E brev CI passes Phase 2 (install.sh) on this PR

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)