### PR TITLE
fix(onboard): make installer and session agent-aware

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -210,7 +210,11 @@ print_banner() {
   printf "  ${C_GREEN}${C_BOLD} ██║ ╚████║███████╗██║ ╚═╝ ██║╚██████╔╝╚██████╗███████╗██║  ██║╚███╔███╔╝${C_RESET}\n"
   printf "  ${C_GREEN}${C_BOLD} ╚═╝  ╚═══╝╚══════╝╚═╝     ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝${C_RESET}\n"
   printf "\n"
-  printf "  ${C_DIM}Launch OpenClaw in an OpenShell sandbox.%s${C_RESET}\n" "$version_suffix"
+  if [[ -n "${NEMOCLAW_AGENT:-}" && "${NEMOCLAW_AGENT}" != "openclaw" ]]; then
+    printf "  ${C_DIM}Launch %s in an OpenShell sandbox.%s${C_RESET}\n" "${NEMOCLAW_AGENT^}" "$version_suffix"
+  else
+    printf "  ${C_DIM}Launch OpenClaw in an OpenShell sandbox.%s${C_RESET}\n" "$version_suffix"
+  fi
   printf "\n"
 }
 
@@ -880,7 +884,7 @@ install_nemoclaw() {
   if is_source_checkout "$repo_root"; then
     info "NemoClaw package.json found in the selected source checkout — installing from source…"
     NEMOCLAW_SOURCE_ROOT="$repo_root"
-    spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$NEMOCLAW_SOURCE_ROOT" \
+    spin "Preparing agent dependencies" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$NEMOCLAW_SOURCE_ROOT" \
       || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
     spin "Installing NemoClaw dependencies" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm install --ignore-scripts"
     spin "Building NemoClaw CLI modules" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm run --if-present build:cli"
@@ -911,7 +915,7 @@ install_nemoclaw() {
     # unavailable or tags are pruned later.
     git -C "$nemoclaw_src" describe --tags --match 'v*' 2>/dev/null \
       | sed 's/^v//' >"$nemoclaw_src/.version" || true
-    spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$nemoclaw_src" \
+    spin "Preparing agent dependencies" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$nemoclaw_src" \
       || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
     spin "Installing NemoClaw dependencies" bash -c "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
     spin "Building NemoClaw CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -175,6 +175,21 @@ resolve_default_sandbox_name() {
   printf "%s" "${sandbox_name:-my-assistant}"
 }
 
+resolve_onboarded_agent() {
+  local session_file="${HOME}/.nemoclaw/onboard-session.json"
+  if [[ -f "$session_file" ]] && command_exists node; then
+    node -e '
+      const fs = require("fs");
+      try {
+        const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        process.stdout.write(data.agent || "openclaw");
+      } catch { process.stdout.write("openclaw"); }
+    ' "$session_file" 2>/dev/null || printf "openclaw"
+  else
+    printf "openclaw"
+  fi
+}
+
 # step N "Description" — numbered section header
 step() {
   local n=$1 msg=$2
@@ -209,9 +224,14 @@ print_done() {
   printf "  ${C_GREEN}${C_BOLD}NemoClaw${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$elapsed"
   printf "\n"
   if [[ "$ONBOARD_RAN" == true ]]; then
-    local sandbox_name
+    local sandbox_name agent_name
     sandbox_name="$(resolve_default_sandbox_name)"
-    printf "  ${C_GREEN}Your OpenClaw Sandbox is live.${C_RESET}\n"
+    agent_name="$(resolve_onboarded_agent)"
+    if [[ "$agent_name" == "openclaw" || -z "$agent_name" ]]; then
+      printf "  ${C_GREEN}Your OpenClaw Sandbox is live.${C_RESET}\n"
+    else
+      printf "  ${C_GREEN}Your %s Sandbox is live.${C_RESET}\n" "${agent_name^}"
+    fi
     printf "  ${C_DIM}Sandbox in, break things, and tell us what you find.${C_RESET}\n"
     printf "\n"
     printf "  ${C_GREEN}Next:${C_RESET}\n"
@@ -219,7 +239,9 @@ print_done() {
       printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$(detect_shell_profile)"
     fi
     printf "  %s$%s nemoclaw %s connect\n" "$C_GREEN" "$C_RESET" "$sandbox_name"
-    printf "  %ssandbox@%s$%s openclaw tui\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
+    if [[ "$agent_name" == "openclaw" || -z "$agent_name" ]]; then
+      printf "  %ssandbox@%s$%s openclaw tui\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
+    fi
   elif [[ "$NEMOCLAW_READY_NOW" == true ]]; then
     printf "  ${C_GREEN}NemoClaw CLI is installed.${C_RESET}\n"
     printf "  ${C_DIM}Onboarding has not run yet.${C_RESET}\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -884,8 +884,10 @@ install_nemoclaw() {
   if is_source_checkout "$repo_root"; then
     info "NemoClaw package.json found in the selected source checkout — installing from source…"
     NEMOCLAW_SOURCE_ROOT="$repo_root"
-    spin "Preparing agent dependencies" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$NEMOCLAW_SOURCE_ROOT" \
-      || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+    if [[ -z "${NEMOCLAW_AGENT:-}" || "${NEMOCLAW_AGENT}" == "openclaw" ]]; then
+      spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$NEMOCLAW_SOURCE_ROOT" \
+        || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+    fi
     spin "Installing NemoClaw dependencies" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm install --ignore-scripts"
     spin "Building NemoClaw CLI modules" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm run --if-present build:cli"
     spin "Building NemoClaw plugin" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\"/nemoclaw && npm install --ignore-scripts && npm run build"
@@ -915,8 +917,10 @@ install_nemoclaw() {
     # unavailable or tags are pruned later.
     git -C "$nemoclaw_src" describe --tags --match 'v*' 2>/dev/null \
       | sed 's/^v//' >"$nemoclaw_src/.version" || true
-    spin "Preparing agent dependencies" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$nemoclaw_src" \
-      || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+    if [[ -z "${NEMOCLAW_AGENT:-}" || "${NEMOCLAW_AGENT}" == "openclaw" ]]; then
+      spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$nemoclaw_src" \
+        || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
+    fi
     spin "Installing NemoClaw dependencies" bash -c "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
     spin "Building NemoClaw CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"
     spin "Building NemoClaw plugin" bash -c "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -113,6 +113,7 @@ function defaultSteps(): Record<string, StepState> {
     provider_selection: { status: "pending", startedAt: null, completedAt: null, error: null },
     inference: { status: "pending", startedAt: null, completedAt: null, error: null },
     openclaw: { status: "pending", startedAt: null, completedAt: null, error: null },
+    agent_setup: { status: "pending", startedAt: null, completedAt: null, error: null },
     policies: { status: "pending", startedAt: null, completedAt: null, error: null },
   };
 }


### PR DESCRIPTION
## Summary
- Installer `print_done()` hardcoded "Your OpenClaw Sandbox is live" and `openclaw tui` regardless of which agent was onboarded. Now reads the agent from the onboard session and adjusts the completion message accordingly — non-OpenClaw agents get their own name and no `openclaw tui` hint.
- Adds missing `agent_setup` step to `defaultSteps()` in `onboard-session.ts`. Without it, `markStepStarted("agent_setup")` silently no-ops because the step key doesn't exist in the session, making the Hermes setup step invisible to resume logic and session tracking.

## Test plan
- [ ] `NEMOCLAW_INSTALL_REF=main NEMOCLAW_AGENT=hermes curl -fsSL .../install.sh | bash` — verify completion message says "Your Hermes Sandbox is live" and does not show `openclaw tui`
- [ ] Same flow with default OpenClaw agent — verify message still says "Your OpenClaw Sandbox is live" with `openclaw tui`
- [ ] `npm test` passes (1277 tests, 0 failures)

Closes #1618 (partial — installer integration for multi-agent onboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding completion messages now show the configured agent name (defaults to OpenClaw).
  * Onboarding session now tracks an "agent setup" step.
  * Next-step instructions are tailored per agent and omitted when not applicable.

* **Bug Fixes / Improvements**
  * Installer skips pre-extraction for non-OpenClaw agents and updates progress text to reflect preparing agent dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->