### PR TITLE
fix(hermes): restore stripped features and fix interactive chat

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -88,12 +88,16 @@ RUN node --experimental-strip-types /opt/nemoclaw-generate-config.ts
 RUN mkdir -p /sandbox/.hermes-data/plugins/nemoclaw \
     && cp -r /opt/nemoclaw-hermes-plugin/* /sandbox/.hermes-data/plugins/nemoclaw/
 
-# Write a default SOUL.md for the sandboxed agent
+# Write a default SOUL.md for the sandboxed agent.
+# Hermes's ensure_hermes_home() expects SOUL.md in the home directory
+# (/sandbox/.hermes/), which is immutable. Write the content to the
+# writable data dir and symlink from the immutable dir.
 RUN printf '%s\n' \
     'You are a helpful AI assistant running inside an NVIDIA OpenShell sandbox.' \
     'Your inference is routed through NemoClaw. You have access to terminal,' \
     'file, and web tools. Be concise and helpful.' \
-    > /sandbox/.hermes-data/memories/SOUL.md
+    > /sandbox/.hermes-data/memories/SOUL.md \
+    && ln -s /sandbox/.hermes-data/memories/SOUL.md /sandbox/.hermes/SOUL.md
 
 # Lock .hermes via DAC: chown to root so sandbox user cannot modify config.
 # Same pattern as OpenClaw — Landlock provides defense-in-depth.

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -88,6 +88,13 @@ RUN node --experimental-strip-types /opt/nemoclaw-generate-config.ts
 RUN mkdir -p /sandbox/.hermes-data/plugins/nemoclaw \
     && cp -r /opt/nemoclaw-hermes-plugin/* /sandbox/.hermes-data/plugins/nemoclaw/
 
+# Write a default SOUL.md for the sandboxed agent
+RUN printf '%s\n' \
+    'You are a helpful AI assistant running inside an NVIDIA OpenShell sandbox.' \
+    'Your inference is routed through NemoClaw. You have access to terminal,' \
+    'file, and web tools. Be concise and helpful.' \
+    > /sandbox/.hermes-data/memories/SOUL.md
+
 # Lock .hermes via DAC: chown to root so sandbox user cannot modify config.
 # Same pattern as OpenClaw — Landlock provides defense-in-depth.
 # hadolint ignore=DL3002

--- a/agents/hermes/generate-config.ts
+++ b/agents/hermes/generate-config.ts
@@ -7,11 +7,11 @@
 //   ~/.hermes/config.yaml  — Hermes configuration (immutable at runtime)
 //   ~/.hermes/.env         — Messaging token placeholders (immutable at runtime)
 //
-// Only sets what's required for Hermes to run inside OpenShell:
+// Sets what's required for Hermes to run inside OpenShell:
 //   - Model and inference endpoint (custom provider pointing at inference.local)
 //   - API server on internal port (socat forwards to public port)
 //   - Messaging platform tokens (if configured during onboard)
-// Everything else uses Hermes defaults.
+//   - Agent defaults (terminal, memory, skills, display)
 
 import { writeFileSync, chmodSync } from "node:fs";
 import { join } from "node:path";
@@ -43,6 +43,25 @@ function main(): void {
       default: model,
       provider: "custom",
       base_url: baseUrl,
+    },
+    terminal: {
+      backend: "local",
+      timeout: 180,
+    },
+    agent: {
+      max_turns: 60,
+      reasoning_effort: "medium",
+    },
+    memory: {
+      memory_enabled: true,
+      user_profile_enabled: true,
+    },
+    skills: {
+      creation_nudge_interval: 15,
+    },
+    display: {
+      compact: false,
+      tool_progress: "all",
     },
   };
 
@@ -83,8 +102,11 @@ function main(): void {
   writeFileSync(configPath, toYaml(config));
   chmodSync(configPath, 0o600);
 
-  // Write .env — only messaging token placeholders
-  const envLines: string[] = [];
+  // Write .env — API server config and messaging token placeholders
+  const envLines: string[] = [
+    "API_SERVER_PORT=18642",
+    "API_SERVER_HOST=127.0.0.1",
+  ];
   for (const ch of msgChannels) {
     if (ch in TOKEN_ENV) {
       envLines.push(`${TOKEN_ENV[ch]}=openshell:resolve:env:${TOKEN_ENV[ch]}`);

--- a/agents/hermes/plugin/__init__.py
+++ b/agents/hermes/plugin/__init__.py
@@ -3,11 +3,162 @@
 """
 NemoClaw plugin for Hermes Agent.
 
-Placeholder — registers with Hermes so NemoClaw can be discovered
-as an installed plugin. No tools or hooks are added.
+Provides sandbox status tools and a startup banner when Hermes runs inside
+an OpenShell sandbox managed by NemoClaw.
 """
+
+import json
+import os
+import subprocess
+import yaml
+
+
+def _load_nemoclaw_config():
+    """Load NemoClaw onboard config from ~/.nemoclaw/config.json."""
+    config_path = os.path.expanduser("~/.nemoclaw/config.json")
+    if not os.path.exists(config_path):
+        return None
+    try:
+        with open(config_path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def _load_hermes_config():
+    """Load Hermes config.yaml from the sandbox."""
+    for path in [
+        os.path.expanduser("~/.hermes/config.yaml"),
+        "/sandbox/.hermes/config.yaml",
+    ]:
+        if os.path.exists(path):
+            try:
+                with open(path) as f:
+                    return yaml.safe_load(f)
+            except Exception:
+                continue
+    return None
+
+
+def _get_sandbox_info():
+    """Gather sandbox status information."""
+    hermes_cfg = _load_hermes_config()
+    nemoclaw_cfg = _load_nemoclaw_config()
+
+    model = "unknown"
+    provider = "custom"
+    base_url = "unknown"
+
+    if hermes_cfg:
+        model_cfg = hermes_cfg.get("model", {})
+        model = model_cfg.get("default", "unknown")
+        provider = model_cfg.get("provider", "custom")
+        base_url = model_cfg.get("base_url", "unknown")
+
+    if nemoclaw_cfg:
+        model = nemoclaw_cfg.get("model", model)
+        provider = nemoclaw_cfg.get("provider", provider)
+
+    # Check gateway health
+    gateway_ok = False
+    try:
+        result = subprocess.run(
+            ["curl", "-sf", "http://localhost:8642/health"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            gateway_ok = True
+    except Exception:
+        pass
+
+    return {
+        "agent": "hermes",
+        "model": model,
+        "provider": provider,
+        "base_url": base_url,
+        "gateway": "running" if gateway_ok else "stopped",
+        "port": 8642,
+    }
+
+
+def _handle_status(tool_input, context):
+    """Handle the nemoclaw_status tool call."""
+    info = _get_sandbox_info()
+    lines = [
+        "NemoClaw Sandbox Status (Hermes)",
+        "\u2500" * 40,
+        f"  Agent:    Hermes Agent",
+        f"  Gateway:  {info['gateway']}",
+        f"  Model:    {info['model']}",
+        f"  Provider: {info['provider']}",
+        f"  Endpoint: {info['base_url']}",
+        f"  API:      http://localhost:{info['port']}/v1",
+    ]
+    return "\n".join(lines)
+
+
+def _handle_info(tool_input, context):
+    """Handle the nemoclaw_info tool call \u2014 returns structured JSON."""
+    return json.dumps(_get_sandbox_info(), indent=2)
 
 
 def register(ctx):
-    """No-op registration. Hermes requires this function to exist."""
-    pass
+    """Register NemoClaw tools and hooks with Hermes."""
+
+    # Register status tool
+    ctx.register_tool(
+        name="nemoclaw_status",
+        toolset="nemoclaw",
+        schema={
+            "type": "function",
+            "function": {
+                "name": "nemoclaw_status",
+                "description": (
+                    "Show NemoClaw sandbox status: agent type, gateway health, "
+                    "model, provider, and inference endpoint."
+                ),
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        handler=_handle_status,
+        description="NemoClaw sandbox status",
+    )
+
+    # Register info tool (structured JSON output)
+    ctx.register_tool(
+        name="nemoclaw_info",
+        toolset="nemoclaw",
+        schema={
+            "type": "function",
+            "function": {
+                "name": "nemoclaw_info",
+                "description": "Get NemoClaw sandbox info as structured JSON.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        handler=_handle_info,
+        description="NemoClaw sandbox info (JSON)",
+    )
+
+    # Startup banner on session start
+    def _on_session_start(**kwargs):
+        info = _get_sandbox_info()
+        banner = (
+            "\n"
+            "  \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n"
+            "  \u2502  NemoClaw registered (Hermes)                       \u2502\n"
+            "  \u2502                                                     \u2502\n"
+            f"  \u2502  Model:     {info['model']:<40}\u2502\n"
+            f"  \u2502  Provider:  {info['provider']:<40}\u2502\n"
+            f"  \u2502  Gateway:   {info['gateway']:<40}\u2502\n"
+            "  \u2502  Tools:     nemoclaw_status, nemoclaw_info          \u2502\n"
+            "  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n"
+        )
+        try:
+            ctx.inject_message(banner, role="system")
+        except Exception:
+            print(banner)
+
+    ctx.register_hook("on_session_start", _on_session_start)

--- a/agents/hermes/plugin/plugin.yaml
+++ b/agents/hermes/plugin/plugin.yaml
@@ -3,6 +3,13 @@
 
 name: nemoclaw
 version: "0.0.11"
-description: "NemoClaw sandbox integration for Hermes running inside OpenShell"
+description: "NemoClaw sandbox management for Hermes running inside OpenShell"
 author: "NVIDIA Corporation"
 manifest_version: 1
+
+provides_tools:
+  - nemoclaw_status
+  - nemoclaw_info
+
+provides_hooks:
+  - on_session_start

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -294,6 +294,7 @@ export NO_PROXY=\"$_NO_PROXY_VAL\"
 export http_proxy=\"$_PROXY_URL\"
 export https_proxy=\"$_PROXY_URL\"
 export no_proxy=\"$_NO_PROXY_VAL\"
+export HERMES_HOME=\"${HERMES_WRITABLE}\"
 ${_PROXY_MARKER_END}"
 
 if [ "$(id -u)" -eq 0 ]; then

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -212,6 +212,7 @@ print_dashboard_urls() {
   local_url="http://127.0.0.1:${PUBLIC_PORT}/v1"
   echo "[gateway] Hermes API: ${local_url}" >&2
   echo "[gateway] Health:     ${local_url%/v1}/health" >&2
+  echo "[gateway] Connect any OpenAI-compatible frontend to this endpoint." >&2
 }
 
 # ── socat forwarder ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Restore config overrides, SOUL.md, NemoClaw plugin, and dashboard message that were incorrectly removed in 53a440bf ("strip invented features")
- Symlink SOUL.md from immutable .hermes/ dir to writable .hermes-data/memories/ so Hermes's ensure_hermes_home() doesn't crash on PermissionError
- Export HERMES_HOME to .bashrc/.profile via the proxy snippet so `hermes chat` uses the writable data directory

## Test plan
- [x] `hermes chat` works interactively inside the sandbox
- [x] NemoClaw plugin banner shows on session start
- [x] `nemoclaw_status` tool available in chat
- [x] Config includes terminal, agent, memory, skills, display sections
- [ ] Nightly E2E hermes-e2e job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sandbox management tools for querying system status and configuration information.
  * Integrated startup banner with system metadata injection during session initialization.

* **Improvements**
  * Enhanced gateway messaging with connection instructions for compatible clients.
  * Applied explicit default configuration values for core services (terminal, agent, memory, skills, display).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->