### PR TITLE
fix(onboard): forward SLACK_APP_TOKEN to sandbox for Socket Mode

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2477,6 +2477,7 @@ async function createSandbox(
     );
     process.exit(1);
   }
+  const tokensByEnvKey = Object.fromEntries(messagingTokenDefs.map(({ envKey, token }) => [envKey, token]));
   const activeMessagingChannels = [
     ...new Set(
       messagingTokenDefs
@@ -2484,7 +2485,8 @@ async function createSandbox(
         .map(({ envKey }) => {
           if (envKey === "DISCORD_BOT_TOKEN") return "discord";
           if (envKey === "SLACK_BOT_TOKEN") return "slack";
-          if (envKey === "SLACK_APP_TOKEN") return "slack";
+          // SLACK_APP_TOKEN alone does not enable slack; bot token is required.
+          if (envKey === "SLACK_APP_TOKEN") return tokensByEnvKey["SLACK_BOT_TOKEN"] ? "slack" : null;
           if (envKey === "TELEGRAM_BOT_TOKEN") return "telegram";
           return null;
         })

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2303,7 +2303,9 @@ async function createSandbox(
   const enabledEnvKeys =
     enabledChannels != null
       ? new Set(
-          MESSAGING_CHANNELS.filter((c) => enabledChannels.includes(c.name)).map((c) => c.envKey),
+          MESSAGING_CHANNELS.filter((c) => enabledChannels.includes(c.name)).flatMap((c) =>
+            c.appTokenEnvKey ? [c.envKey, c.appTokenEnvKey] : [c.envKey],
+          ),
         )
       : null;
 
@@ -2317,6 +2319,11 @@ async function createSandbox(
       name: `${sandboxName}-slack-bridge`,
       envKey: "SLACK_BOT_TOKEN",
       token: getMessagingToken("SLACK_BOT_TOKEN"),
+    },
+    {
+      name: `${sandboxName}-slack-app`,
+      envKey: "SLACK_APP_TOKEN",
+      token: getMessagingToken("SLACK_APP_TOKEN"),
     },
     {
       name: `${sandboxName}-telegram-bridge`,
@@ -2470,15 +2477,20 @@ async function createSandbox(
     );
     process.exit(1);
   }
-  const activeMessagingChannels = messagingTokenDefs
-    .filter(({ token }) => !!token)
-    .map(({ envKey }) => {
-      if (envKey === "DISCORD_BOT_TOKEN") return "discord";
-      if (envKey === "SLACK_BOT_TOKEN") return "slack";
-      if (envKey === "TELEGRAM_BOT_TOKEN") return "telegram";
-      return null;
-    })
-    .filter(Boolean);
+  const activeMessagingChannels = [
+    ...new Set(
+      messagingTokenDefs
+        .filter(({ token }) => !!token)
+        .map(({ envKey }) => {
+          if (envKey === "DISCORD_BOT_TOKEN") return "discord";
+          if (envKey === "SLACK_BOT_TOKEN") return "slack";
+          if (envKey === "SLACK_APP_TOKEN") return "slack";
+          if (envKey === "TELEGRAM_BOT_TOKEN") return "telegram";
+          return null;
+        })
+        .filter(Boolean),
+    ),
+  ];
   // Build allowed sender IDs map from env vars set during the messaging prompt.
   // Each channel with a userIdEnvKey in MESSAGING_CHANNELS may have a
   // comma-separated list of IDs (e.g. TELEGRAM_ALLOWED_IDS="123,456").
@@ -2553,6 +2565,7 @@ async function createSandbox(
     "BEDROCK_API_KEY",
     "DISCORD_BOT_TOKEN",
     "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
     "TELEGRAM_BOT_TOKEN",
   ]);
   const sandboxEnv = Object.fromEntries(
@@ -3488,6 +3501,10 @@ const MESSAGING_CHANNELS = [
     description: "Slack bot messaging",
     help: "Slack API → Your Apps → OAuth & Permissions → Bot User OAuth Token (xoxb-...).",
     label: "Slack Bot Token",
+    appTokenEnvKey: "SLACK_APP_TOKEN",
+    appTokenHelp:
+      "Slack API → Your Apps → Basic Information → App-Level Tokens (xapp-...).",
+    appTokenLabel: "Slack App Token (Socket Mode)",
   },
 ];
 

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -76,11 +76,13 @@ describe("credential exposure in process arguments", () => {
     expect(blocklist).toContain('"BEDROCK_API_KEY"');
     expect(blocklist).toContain('"DISCORD_BOT_TOKEN"');
     expect(blocklist).toContain('"SLACK_BOT_TOKEN"');
+    expect(blocklist).toContain('"SLACK_APP_TOKEN"');
     expect(blocklist).toContain('"TELEGRAM_BOT_TOKEN"');
     expect(src).toMatch(/streamSandboxCreate\(createCommand, sandboxEnv(?:, \{)?/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("NVIDIA_API_KEY"/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("DISCORD_BOT_TOKEN"/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_BOT_TOKEN"/);
+    expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_APP_TOKEN"/);
   });
 
   it("onboard curl probes use explicit timeouts", () => {


### PR DESCRIPTION
## Summary

Slack Socket Mode requires both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`, but only the bot token was collected and forwarded during onboarding. Without the app-level token, OpenClaw cannot start Socket Mode and Slack shows as "enabled, not configured, stopped".

## Problem

`SLACK_APP_TOKEN` appears nowhere in the NemoClaw source. The onboard flow creates an OpenShell provider for `SLACK_BOT_TOKEN` and attaches it to the sandbox, but the `SLACK_APP_TOKEN` credential is never prompted for, stored, or passed through. OpenShell strips non-OPENSHELL env vars from the sandbox entrypoint, so even if the token is set in the host environment it never reaches the sandbox.

## Changes

- Add `SLACK_APP_TOKEN` entry to `messagingTokenDefs` (creates a dedicated `slack-app` OpenShell provider)
- Include `appTokenEnvKey` in `enabledEnvKeys` filter so the app token is forwarded when the user selects the slack channel
- Deduplicate `activeMessagingChannels` since both tokens map to `"slack"`
- Block `SLACK_APP_TOKEN` from raw sandbox env passthrough (credentials flow through providers)
- Add `appTokenEnvKey`/help/label metadata to `MESSAGING_CHANNELS`

## Test plan

- [x] `npm run build:cli` passes
- [x] `npm run typecheck:cli` passes
- [x] `npm run lint` passes
- [x] All 6 messaging-related onboard tests pass
- [x] All 95 onboard tests pass (1 pre-existing timeout unrelated to this change)
- [x] All 105 onboard-selection + presets-checkbox + policies tests pass

Closes #1688

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Slack integration: added support for app-level tokens as an authentication option.

* **Behavior / Security**
  * Sandbox environment handling updated to block app-level Slack tokens from being injected and to require the bot token for enabling Slack channels.

* **Tests**
  * Added test coverage to assert app-level Slack tokens are excluded from sandbox runtime arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->