### PR TITLE
fix(cli): add reconfiguration guidance to help and post-onboard output

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5944,6 +5944,7 @@ function getDashboardGuidanceLines(dashboardAccess = [], options = {}) {
   return guidance;
 }
 
+/** Print the post-onboard dashboard with sandbox status and reconfiguration hints. */
 function printDashboard(sandboxName, model, provider, nimContainer = null, agent = null) {
   const nimStat = nimContainer ? nim.nimStatusByName(nimContainer) : nim.nimStatus(sandboxName);
   const nimLabel = nimStat.running ? "running" : "not running";
@@ -6017,6 +6018,11 @@ function printDashboard(sandboxName, model, provider, nimContainer = null, agent
     );
   }
   console.log(`  ${"─".repeat(50)}`);
+  console.log("");
+  console.log("  To change settings later:");
+  console.log(`    Model:       openshell inference set -g nemoclaw -m <model> -p <provider>`);
+  console.log(`    Policies:    nemoclaw ${sandboxName} policy-add`);
+  console.log("    Credentials: nemoclaw credentials reset <KEY>  then  nemoclaw onboard");
   console.log("");
 }
 

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2620,6 +2620,7 @@ function backupAll() {
 
 // ── Help ─────────────────────────────────────────────────────────
 
+/** Print CLI usage with all commands, flags, and reconfiguration guidance. */
 function help() {
   console.log(`
   ${B}${G}NemoClaw${R}  ${D}v${getVersion()}${R}
@@ -2686,6 +2687,19 @@ function help() {
     --yes                            Skip the confirmation prompt
     --keep-openshell                 Leave the openshell binary installed
     --delete-models                  Remove NemoClaw-pulled Ollama models
+
+  ${G}Reconfiguration (after onboard):${R}
+    ${D}Change inference model at runtime (no re-onboard needed):${R}
+      openshell inference set -g nemoclaw -m <model> -p <provider>
+
+    ${D}Add network presets (e.g. Telegram, GitHub) to a running sandbox:${R}
+      nemoclaw <name> policy-add
+
+    ${D}Change credentials, messaging channels, or sandbox image settings:${R}
+      nemoclaw credentials reset <KEY>   ${D}then${R}   nemoclaw onboard
+
+    ${D}openclaw.json is read-only inside the sandbox (Landlock enforced).${R}
+    ${D}To change OpenClaw settings, re-run nemoclaw onboard to rebuild the sandbox.${R}
 
   ${D}Powered by NVIDIA OpenShell · Nemotron · Agent Toolkit
   Credentials saved in ~/.nemoclaw/credentials.json (mode 600)${R}


### PR DESCRIPTION
## Summary

New users hit `openclaw configure` inside the sandbox and get a read-only error with no guidance on what to do instead. This adds clear reconfiguration instructions in two places.

## Problem

`openclaw.json` is read-only inside the sandbox (Landlock enforced) by design. When users try `openclaw configure`, they see:

```
Error: 'openclaw configure' cannot modify config inside the sandbox.
The sandbox config is read-only (Landlock enforced) for security.
```

No NemoClaw documentation or CLI output explains the three available reconfiguration paths. Users are left guessing.

## Changes

1. **`nemoclaw --help`**: Added a "Reconfiguration (after onboard)" section listing the three paths:
   - Runtime model switch: `openshell inference set`
   - Policy presets: `nemoclaw <name> policy-add`
   - Credential/image changes: `nemoclaw credentials reset <KEY>` then `nemoclaw onboard`

2. **Post-onboard dashboard**: Added a "To change settings later" block at the end of the completion output so users see the reconfiguration paths immediately after their first onboard.

## Test plan

- [x] `npm run build:cli` passes
- [x] `npm run typecheck:cli` passes
- [x] `npm run lint` passes
- [x] All 6 messaging onboard tests pass
- [x] All 44 CLI tests pass

Closes #1699

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "To change settings later" section to onboarding output with copy‑paste reconfiguration commands for model routing, sandbox policies, and credential reset.
  * Extended CLI help with a "Reconfiguration (after onboard)" section describing how to change inference models/providers, apply network/policy updates to running sandboxes, and when re‑onboarding is needed.
  * Confirmed runtime behavior and public APIs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->