### PR TITLE
ci: skip dco-check for Dependabot PRs (fixes #1698)

### DIFF
--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   dco-check:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Problem

Dependabot PRs fail the `dco-check` workflow because Dependabot cannot add `Signed-off-by:` lines to PR descriptions.

## Fix

Add a job-level `if` condition to skip the entire `dco-check` job when `github.event.pull_request.user.login == 'dependabot[bot]'`.

This is simpler and more maintainable than adding `dependabot[bot]` to `dco-bypass.txt`, since the bypass file requires exact username matching and Dependabot's `[bot]` suffix could cause edge cases with grep.

Closes #1698

Signed-off-by: kagura-agent <kagura-agent@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to skip validation checks for automated pull requests, preventing those entire job runs (including sign-off and bypass checks) from executing for bot-authored changes. This reduces noise and avoids applying manual contributor validations to automated updates while preserving checks for human-authored pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->