### PR TITLE
fix(onboard): activate permissive policy and fix access: full endpoints

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -13,6 +13,8 @@
 #                            gateway stop/start, verify sandbox + workspace + inference).
 #   hermes-e2e               Hermes Agent E2E — install → onboard --agent hermes → health
 #                            probe → live inference. Validates the multi-agent architecture.
+#   skip-permissions-e2e     Validates --dangerously-skip-permissions activates the permissive
+#                            policy (not stuck in Pending) and sandbox egress works (not 403).
 #   gpu-e2e                  Local Ollama inference on a GPU self-hosted runner.
 #                            Controlled by the GPU_E2E_ENABLED repository variable.
 #                            Set vars.GPU_E2E_ENABLED to "true" in repo settings to enable.
@@ -258,6 +260,38 @@ jobs:
           path: /tmp/nemoclaw-e2e-hermes-install.log
           if-no-files-found: ignore
 
+  # ── Skip-permissions policy activation ────────────────────────
+  # Validates the --dangerously-skip-permissions onboard flag correctly
+  # activates the permissive network policy (not stuck in Pending).
+  # Reproduces the exact scenario from the bug report: onboard, verify
+  # policy is Active, curl from inside sandbox must not return 403.
+  skip-permissions-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run skip-permissions policy E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-skip-perms"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-skip-permissions-policy.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skip-permissions-install-log
+          path: /tmp/nemoclaw-e2e-install.log
+          if-no-files-found: ignore
+
   # ── GPU E2E (Ollama local inference) ──────────────────────────
   # Enable by setting repository variable GPU_E2E_ENABLED=true
   # (Settings → Secrets and variables → Actions → Variables)
@@ -310,8 +344,8 @@ jobs:
 
   notify-on-failure:
     runs-on: ubuntu-latest
-    needs: [cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e, sandbox-survival-e2e, hermes-e2e, gpu-e2e]
-    if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.messaging-providers-e2e.result == 'failure' || needs.sandbox-survival-e2e.result == 'failure' || needs.hermes-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
+    needs: [cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e, sandbox-survival-e2e, hermes-e2e, skip-permissions-e2e, gpu-e2e]
+    if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.messaging-providers-e2e.result == 'failure' || needs.sandbox-survival-e2e.result == 'failure' || needs.hermes-e2e.result == 'failure' || needs.skip-permissions-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
     permissions:
       issues: write
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ desktop.ini
 Thumbs.db
 
 # Project-specific
+.nemoclaw-maintainer/
 draft_newsletter_*
 research/
 specs/

--- a/agents/hermes/policy-permissive.yaml
+++ b/agents/hermes/policy-permissive.yaml
@@ -41,56 +41,90 @@ network_policies:
     endpoints:
       - host: api.anthropic.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: statsig.anthropic.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: sentry.io
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   nvidia:
     name: nvidia
     endpoints:
       - host: integrate.api.nvidia.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: inference-api.nvidia.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   github:
     name: github
     endpoints:
       - host: github.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.github.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   nous_research:
     name: nous_research
     endpoints:
       - host: nousresearch.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: hermes-agent.nousresearch.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.nousresearch.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   pypi:
     name: pypi
     endpoints:
       - host: pypi.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: files.pythonhosted.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   # ── Messaging endpoints ──
 
@@ -99,42 +133,68 @@ network_policies:
     endpoints:
       - host: api.telegram.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   discord:
     name: discord
     endpoints:
       - host: discord.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: gateway.discord.gg
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: cdn.discordapp.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: media.discordapp.net
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   slack:
     name: slack
     endpoints:
       - host: slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: hooks.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: wss-primary.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: wss-backup.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   # ── Third-party services ──
 
@@ -143,65 +203,107 @@ network_policies:
     endpoints:
       - host: formulae.brew.sh
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: ghcr.io
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: raw.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: objects.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: pkg-containers.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   jira:
     name: jira
     endpoints:
       - host: "*.atlassian.net"
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.atlassian.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: auth.atlassian.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   outlook:
     name: outlook
     endpoints:
       - host: outlook.office365.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: outlook.office.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: graph.microsoft.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: login.microsoftonline.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   huggingface:
     name: huggingface
     endpoints:
       - host: huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: cdn-lfs.huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: router.huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   brave:
     name: brave
     endpoints:
       - host: api.search.brave.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }

--- a/agents/openclaw/policy-permissive.yaml
+++ b/agents/openclaw/policy-permissive.yaml
@@ -40,64 +40,102 @@ network_policies:
     endpoints:
       - host: api.anthropic.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: statsig.anthropic.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: sentry.io
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   nvidia:
     name: nvidia
     endpoints:
       - host: integrate.api.nvidia.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: inference-api.nvidia.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   github:
     name: github
     endpoints:
       - host: github.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.github.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   clawhub:
     name: clawhub
     endpoints:
       - host: clawhub.ai
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   openclaw_api:
     name: openclaw_api
     endpoints:
       - host: openclaw.ai
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   openclaw_docs:
     name: openclaw_docs
     endpoints:
       - host: docs.openclaw.ai
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   npm_registry:
     name: npm_registry
     endpoints:
       - host: registry.npmjs.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: registry.yarnpkg.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   # ── Messaging endpoints ──
 
@@ -106,42 +144,68 @@ network_policies:
     endpoints:
       - host: api.telegram.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   discord:
     name: discord
     endpoints:
       - host: discord.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: gateway.discord.gg
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: cdn.discordapp.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: media.discordapp.net
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   slack:
     name: slack
     endpoints:
       - host: slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: hooks.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: wss-primary.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: wss-backup.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   # ── Third-party services ──
 
@@ -150,65 +214,107 @@ network_policies:
     endpoints:
       - host: formulae.brew.sh
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: ghcr.io
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: raw.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: objects.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: pkg-containers.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   jira:
     name: jira
     endpoints:
       - host: "*.atlassian.net"
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.atlassian.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: auth.atlassian.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   outlook:
     name: outlook
     endpoints:
       - host: outlook.office365.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: outlook.office.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: graph.microsoft.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: login.microsoftonline.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   huggingface:
     name: huggingface
     endpoints:
       - host: huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: cdn-lfs.huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: router.huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   brave:
     name: brave
     endpoints:
       - host: api.search.brave.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }

--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Permissive policy for development/testing — used by --dangerously-skip-permissions.
-# All known endpoints are opened with access: full (CONNECT tunnel, no L7 filtering).
+# All known endpoints use protocol: rest + access: full (allow any HTTP method on
+# any path). This routes traffic through the L7 proxy's normal TLS-termination
+# path so it works transparently from any execution context (sandbox exec, SSH,
+# interactive shell) without requiring proxy environment setup.
 # Filesystem: include_workdir: true makes the sandbox home directory writable.
 #
 # WARNING: This policy disables most sandbox security restrictions.
@@ -36,71 +39,109 @@ process:
   run_as_group: sandbox
 
 network_policies:
-  # ── Base policy endpoints (access: full, no method/path restrictions) ──
+  # ── Base policy endpoints (all methods, all paths) ──
 
   claude_code:
     name: claude_code
     endpoints:
       - host: api.anthropic.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: statsig.anthropic.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: sentry.io
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   nvidia:
     name: nvidia
     endpoints:
       - host: integrate.api.nvidia.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: inference-api.nvidia.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   github:
     name: github
     endpoints:
       - host: github.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.github.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   clawhub:
     name: clawhub
     endpoints:
       - host: clawhub.ai
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   openclaw_api:
     name: openclaw_api
     endpoints:
       - host: openclaw.ai
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   openclaw_docs:
     name: openclaw_docs
     endpoints:
       - host: docs.openclaw.ai
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   npm_registry:
     name: npm_registry
     endpoints:
       - host: registry.npmjs.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: registry.yarnpkg.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   # ── Messaging endpoints ──
 
@@ -109,42 +150,68 @@ network_policies:
     endpoints:
       - host: api.telegram.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   discord:
     name: discord
     endpoints:
       - host: discord.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: gateway.discord.gg
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: cdn.discordapp.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: media.discordapp.net
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   slack:
     name: slack
     endpoints:
       - host: slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: hooks.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: wss-primary.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: wss-backup.slack.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   # ── Package registries ──
 
@@ -153,29 +220,47 @@ network_policies:
     endpoints:
       - host: pypi.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: files.pythonhosted.org
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   brew:
     name: brew
     endpoints:
       - host: formulae.brew.sh
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: ghcr.io
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: raw.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: objects.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: pkg-containers.githubusercontent.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   # ── Third-party services ──
 
@@ -184,46 +269,76 @@ network_policies:
     endpoints:
       - host: "*.atlassian.net"
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: api.atlassian.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: auth.atlassian.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   outlook:
     name: outlook
     endpoints:
       - host: outlook.office365.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: outlook.office.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: graph.microsoft.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: login.microsoftonline.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   huggingface:
     name: huggingface
     endpoints:
       - host: huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: cdn-lfs.huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
       - host: router.huggingface.co
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }
 
   brave:
     name: brave
     endpoints:
       - host: api.search.brave.com
         port: 443
+        protocol: rest
+        enforcement: enforce
         access: full
+    binaries:
+      - { path: "/**" }

--- a/schemas/sandbox-policy.schema.json
+++ b/schemas/sandbox-policy.schema.json
@@ -86,7 +86,12 @@
         "properties": { "protocol": { "const": "rest" } },
         "required": ["protocol"]
       },
-      "then": { "required": ["rules"] }
+      "then": {
+        "anyOf": [
+          { "required": ["rules"] },
+          { "required": ["access"] }
+        ]
+      }
     },
     "rule": {
       "type": "object",

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4643,7 +4643,7 @@ async function onboard(opts = {}) {
       : null;
     if (dangerouslySkipPermissions) {
       step(8, 8, "Policy presets");
-      console.log("  Skipped — --dangerously-skip-permissions applies permissive base policy.");
+      policies.applyPermissivePolicy(sandboxName);
       onboardSession.markStepComplete("policies", {
         sandboxName,
         provider,

--- a/test/e2e/test-skip-permissions-policy.sh
+++ b/test/e2e/test-skip-permissions-policy.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# E2E: --dangerously-skip-permissions policy activation
+#
+# Validates the exact scenario from the bug report:
+#   1. Onboard with --dangerously-skip-permissions (via env var)
+#   2. Verify policy is Active (not stuck in Pending)
+#   3. Verify outbound HTTPS from inside the sandbox succeeds (not 403)
+#   4. Verify the permissive policy contains access: full endpoints
+#
+# Without the fix, the permissive base policy from sandbox creation stays
+# in Pending status because no `openshell policy set --wait` is called.
+# All outbound requests return 403 Forbidden.
+#
+# Prerequisites:
+#   - Docker running
+#   - NVIDIA_API_KEY set (real key, starts with nvapi-)
+#   - Network access to integrate.api.nvidia.com
+#
+# Environment variables:
+#   NEMOCLAW_NON_INTERACTIVE=1             — required
+#   NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 — required
+#   NVIDIA_API_KEY                         — required for NVIDIA Endpoints inference
+#   NEMOCLAW_SANDBOX_NAME                  — sandbox name (default: e2e-skip-perms)
+#   NEMOCLAW_E2E_TIMEOUT_SECONDS           — overall timeout (default: 900)
+#
+# Usage:
+#   NEMOCLAW_NON_INTERACTIVE=1 \
+#   NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
+#   NVIDIA_API_KEY=nvapi-... \
+#     bash test/e2e/test-skip-permissions-policy.sh
+
+set -uo pipefail
+
+if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
+  export NEMOCLAW_E2E_NO_TIMEOUT=1
+  TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
+  if command -v timeout >/dev/null 2>&1; then
+    exec timeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    exec gtimeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
+  fi
+fi
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() {
+  ((PASS++))
+  ((TOTAL++))
+  printf '\033[32m  PASS: %s\033[0m\n' "$1"
+}
+fail() {
+  ((FAIL++))
+  ((TOTAL++))
+  printf '\033[31m  FAIL: %s\033[0m\n' "$1"
+}
+section() {
+  echo ""
+  printf '\033[1;36m=== %s ===\033[0m\n' "$1"
+}
+info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
+
+SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-skip-perms}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# ══════════════════════════════════════════════════════════════════
+# Phase 0: Prerequisites
+# ══════════════════════════════════════════════════════════════════
+section "Phase 0: Prerequisites"
+
+if docker info >/dev/null 2>&1; then
+  pass "Docker is running"
+else
+  fail "Docker is not running — cannot continue"
+  exit 1
+fi
+
+if [ -n "${NVIDIA_API_KEY:-}" ] && [[ "${NVIDIA_API_KEY}" == nvapi-* ]]; then
+  pass "NVIDIA_API_KEY is set (starts with nvapi-)"
+else
+  fail "NVIDIA_API_KEY not set or invalid — required for NVIDIA Endpoints inference"
+  exit 1
+fi
+
+if [ "${NEMOCLAW_NON_INTERACTIVE:-}" != "1" ]; then
+  fail "NEMOCLAW_NON_INTERACTIVE=1 is required"
+  exit 1
+fi
+
+if [ "${NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE:-}" != "1" ]; then
+  fail "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 is required"
+  exit 1
+fi
+
+if [ ! -f "$REPO_ROOT/install.sh" ]; then
+  fail "Cannot find install.sh at $REPO_ROOT/install.sh"
+  exit 1
+fi
+pass "Repo root found: $REPO_ROOT"
+
+# ══════════════════════════════════════════════════════════════════
+# Phase 1: Pre-cleanup
+# ══════════════════════════════════════════════════════════════════
+section "Phase 1: Pre-cleanup"
+
+info "Destroying any leftover sandbox/gateway from previous runs..."
+if command -v nemoclaw >/dev/null 2>&1; then
+  nemoclaw "$SANDBOX_NAME" destroy --yes 2>/dev/null || true
+fi
+if command -v openshell >/dev/null 2>&1; then
+  openshell sandbox delete "$SANDBOX_NAME" 2>/dev/null || true
+  openshell gateway destroy -g nemoclaw 2>/dev/null || true
+fi
+rm -f "$HOME/.nemoclaw/onboard.lock" 2>/dev/null || true
+pass "Pre-cleanup complete"
+
+# ══════════════════════════════════════════════════════════════════
+# Phase 2: Install with --dangerously-skip-permissions
+# ══════════════════════════════════════════════════════════════════
+section "Phase 2: Install NemoClaw with --dangerously-skip-permissions"
+
+info "Running install.sh --non-interactive with NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1..."
+info "This is the exact flag that caused the Pending policy bug."
+
+cd "$REPO_ROOT" || {
+  fail "Could not cd to repo root: $REPO_ROOT"
+  exit 1
+}
+
+INSTALL_LOG="${NEMOCLAW_E2E_INSTALL_LOG:-/tmp/nemoclaw-e2e-install.log}"
+env \
+  NEMOCLAW_NON_INTERACTIVE=1 \
+  NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
+  NEMOCLAW_SANDBOX_NAME="$SANDBOX_NAME" \
+  NEMOCLAW_RECREATE_SANDBOX=1 \
+  NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1 \
+  bash install.sh --non-interactive >"$INSTALL_LOG" 2>&1 &
+install_pid=$!
+tail -f "$INSTALL_LOG" --pid=$install_pid 2>/dev/null &
+tail_pid=$!
+wait $install_pid
+install_exit=$?
+kill $tail_pid 2>/dev/null || true
+wait $tail_pid 2>/dev/null || true
+# Keep install log for CI artifact upload on failure
+
+# Source shell profile to pick up nvm/PATH changes from install.sh
+if [ -f "$HOME/.bashrc" ]; then
+  # shellcheck source=/dev/null
+  source "$HOME/.bashrc" 2>/dev/null || true
+fi
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+fi
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+if [ $install_exit -eq 0 ]; then
+  pass "install.sh completed (exit 0)"
+else
+  fail "install.sh failed (exit $install_exit)"
+  exit 1
+fi
+
+if command -v nemoclaw >/dev/null 2>&1; then
+  pass "nemoclaw on PATH: $(command -v nemoclaw)"
+else
+  fail "nemoclaw not found on PATH after install"
+  exit 1
+fi
+
+if command -v openshell >/dev/null 2>&1; then
+  pass "openshell on PATH"
+else
+  fail "openshell not found on PATH after install"
+  exit 1
+fi
+
+# ══════════════════════════════════════════════════════════════════
+# Phase 3: Verify policy is Active (THE bug report's core check)
+# ══════════════════════════════════════════════════════════════════
+section "Phase 3: Verify policy activation (the bug report)"
+
+# 3a: openshell policy list — must NOT show "Pending" as the latest version
+info "Checking openshell policy list..."
+policy_list=$(openshell policy list "$SANDBOX_NAME" 2>&1) || true
+info "Policy list output:"
+echo "$policy_list" | while IFS= read -r line; do info "  $line"; done
+
+# The latest policy version must not be Pending
+if echo "$policy_list" | grep -qi "Pending"; then
+  fail "Policy is stuck in Pending — the bug is NOT fixed"
+  info "This is the exact symptom from the bug report: policy never activates"
+else
+  pass "No Pending policies found"
+fi
+
+# 3b: openshell policy get --full — must contain network_policies with access: full
+info "Checking openshell policy get --full..."
+policy_full=$(openshell policy get --full "$SANDBOX_NAME" 2>&1) || true
+if echo "$policy_full" | grep -qi "network_policies"; then
+  pass "Policy contains network_policies section"
+else
+  fail "Policy missing network_policies section"
+fi
+
+if echo "$policy_full" | grep -qi "access: full"; then
+  pass "Policy contains 'access: full' endpoints (permissive mode active)"
+else
+  fail "Policy does not contain 'access: full' — permissive policy was not applied"
+fi
+
+# 3c: nemoclaw status must show dangerously-skip-permissions
+if status_output=$(nemoclaw "$SANDBOX_NAME" status 2>&1); then
+  if echo "$status_output" | grep -qi "dangerously-skip-permissions"; then
+    pass "nemoclaw status shows dangerously-skip-permissions mode"
+  else
+    fail "nemoclaw status does not indicate dangerously-skip-permissions mode"
+  fi
+else
+  fail "nemoclaw status failed: ${status_output:0:200}"
+fi
+
+# ══════════════════════════════════════════════════════════════════
+# Phase 4: Verify outbound HTTPS from inside sandbox
+# ══════════════════════════════════════════════════════════════════
+section "Phase 4: Verify sandbox egress"
+
+# All sandbox traffic routes through the OpenShell proxy (HTTPS_PROXY).
+# When the policy is Pending (the bug), the proxy rejects everything
+# with 403 Forbidden. When Active, it allows CONNECT tunnels for
+# `access: full` endpoints.
+#
+# Uses `openshell sandbox exec` — the same command the bug reporter used.
+
+# 4a: npm ping — application-level proof that egress works through the proxy
+info "[EGRESS] Testing npm ping from inside sandbox..."
+if npm_result=$(openshell sandbox exec -n "$SANDBOX_NAME" -- \
+  npm ping --silent 2>&1); then
+  pass "[EGRESS] npm ping succeeded (registry.npmjs.org reachable through proxy)"
+elif echo "$npm_result" | grep -qi "403\|BLOCKED\|ECONNREFUSED"; then
+  fail "[EGRESS] npm ping failed — proxy rejected traffic: ${npm_result:0:200}"
+else
+  info "npm ping failed: ${npm_result:0:200}"
+  fail "[EGRESS] npm ping failed"
+fi
+
+# 4b: curl api.github.com — bug reporter's exact repro command
+# api.github.com can return 403 for unauthenticated rate limiting, so
+# treat any non-000 response (including 403) as proof that egress works.
+# Code 000 means curl could not connect at all (policy/proxy blocking).
+info "[EGRESS] Testing curl https://api.github.com/ via openshell sandbox exec..."
+egress_response=$(openshell sandbox exec -n "$SANDBOX_NAME" -- \
+  curl -s --connect-timeout 15 -o /dev/null -w '%{http_code}' \
+  https://api.github.com/ 2>&1) || true
+
+egress_code=$(echo "$egress_response" | tr -d '\r' | tail -1)
+if echo "$egress_code" | grep -qE '^[2-5][0-9][0-9]$'; then
+  pass "[EGRESS] curl https://api.github.com/ returned HTTP $egress_code (egress works)"
+elif [ "$egress_code" = "000" ]; then
+  fail "[EGRESS] curl https://api.github.com/ could not connect (code 000 — policy/proxy blocked)"
+else
+  info "curl returned code '$egress_code': ${egress_response:0:500}"
+  fail "[EGRESS] curl https://api.github.com/ failed (code $egress_code)"
+fi
+
+# ══════════════════════════════════════════════════════════════════
+# Phase 5: Cleanup
+# ══════════════════════════════════════════════════════════════════
+section "Phase 5: Cleanup"
+
+nemoclaw "$SANDBOX_NAME" destroy --yes 2>&1 | tail -3 || true
+openshell gateway destroy -g nemoclaw 2>/dev/null || true
+
+registry_file="${HOME}/.nemoclaw/sandboxes.json"
+if [ -f "$registry_file" ] && grep -Fq "\"${SANDBOX_NAME}\"" "$registry_file"; then
+  fail "Sandbox ${SANDBOX_NAME} still in registry after destroy"
+else
+  pass "Sandbox ${SANDBOX_NAME} cleaned up"
+fi
+
+# ══════════════════════════════════════════════════════════════════
+# Summary
+# ══════════════════════════════════════════════════════════════════
+echo ""
+echo "========================================"
+echo "  Skip-Permissions Policy E2E Results:"
+echo "    Passed:  $PASS"
+echo "    Failed:  $FAIL"
+echo ""
+echo "    Total:   $TOTAL"
+echo "========================================"
+
+if [ "$FAIL" -eq 0 ]; then
+  printf '\n\033[1;32m  Skip-permissions policy PASSED — policy activates and sandbox egress works.\033[0m\n'
+  exit 0
+else
+  printf '\n\033[1;31m  %d test(s) failed.\033[0m\n' "$FAIL"
+  exit 1
+fi

--- a/test/e2e/test-skip-permissions-policy.sh
+++ b/test/e2e/test-skip-permissions-policy.sh
@@ -195,12 +195,16 @@ policy_list=$(openshell policy list "$SANDBOX_NAME" 2>&1) || true
 info "Policy list output:"
 echo "$policy_list" | while IFS= read -r line; do info "  $line"; done
 
-# The latest policy version must not be Pending
-if echo "$policy_list" | grep -qi "Pending"; then
-  fail "Policy is stuck in Pending — the bug is NOT fixed"
+# The latest (highest) policy version must not be Pending.
+# Policy list is sorted descending — first data row is the effective version.
+latest_status=$(echo "$policy_list" | grep -E '^\s*[0-9]' | head -1 | awk '{print $3}')
+if [ "$latest_status" = "Pending" ]; then
+  fail "Latest policy version is Pending — the bug is NOT fixed"
   info "This is the exact symptom from the bug report: policy never activates"
+elif [ "$latest_status" = "Loaded" ]; then
+  pass "Latest policy version is Loaded (active)"
 else
-  pass "No Pending policies found"
+  pass "Latest policy version status: $latest_status (not Pending)"
 fi
 
 # 3b: openshell policy get --full — must contain network_policies with access: full

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1795,6 +1795,26 @@ const { setupInference } = require(${onboardPath});
     );
   });
 
+  it("activates permissive policy via policy set when dangerouslySkipPermissions is true", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+
+    // The dangerouslySkipPermissions branch must call applyPermissivePolicy to
+    // activate the policy via `openshell policy set --wait`.  Without this,
+    // the base policy from sandbox create stays in Pending status (#897).
+    assert.match(
+      source,
+      /if \(dangerouslySkipPermissions\) \{\s*step\(8, 8, "Policy presets"\);\s*policies\.applyPermissivePolicy\(sandboxName\);/,
+    );
+    // Must NOT just print a skip message without activating the policy.
+    assert.doesNotMatch(
+      source,
+      /dangerouslySkipPermissions\)[\s\S]*?Skipped —.*permissive base policy/,
+    );
+  });
+
   it("delegates sandbox-create progress streaming to the extracted helper module", () => {
     const onboardSource = fs.readFileSync(
       path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),


### PR DESCRIPTION
## Summary

- **Policy stuck in Pending**: onboard step 8 skipped activation when `--dangerously-skip-permissions` was set. Now calls `policies.applyPermissivePolicy()` which runs `openshell policy set --wait`.
- **access: full without protocol: rest**: OpenShell's L7 proxy only expands the `access: full` shorthand when `protocol: rest` is set. Added `protocol: rest` + `enforcement: enforce` to every endpoint in all three permissive policies.
- **Missing binaries wildcard**: OpenShell's Rego engine requires binary path matches. Added `binaries: [{ path: "/**" }]` to every policy entry so any executable can use any allowed endpoint.
- **E2E test**: Nightly suite job reproducing the exact bug report scenario (onboard, verify policy Active, `openshell sandbox exec -- curl` succeeds).
- **Schema fix**: Allow `access` as an alternative to `rules` when `protocol: rest` is set, matching OpenShell's actual validation.

## Test plan

- [x] `npm test` — 1314 tests pass
- [x] All pre-commit and pre-push hooks pass (single signed commit)
- [x] E2E validated: npm ping + curl HTTP 200 from sandbox via `openshell sandbox exec`
- [x] Nightly E2E `skip-permissions-e2e` job validates full scenario on ubuntu-latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated end-to-end validation for the skip-permissions onboarding flow.

* **Policy Updates**
  * Strengthened sandbox and agent network policies with explicit REST enforcement and expanded binaries access.

* **Bug Fixes**
  * Onboarding now applies the permissive sandbox policy correctly when skip-permissions is enabled.

* **Tests**
  * Added unit and E2E tests asserting skip-permissions policy activation and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->