### PR TITLE
fix(ci): add pipefail and integrity check to docker save pipeline

### DIFF
--- a/.github/workflows/sandbox-images-and-e2e.yaml
+++ b/.github/workflows/sandbox-images-and-e2e.yaml
@@ -34,8 +34,14 @@ jobs:
 
       - name: Save images to tarballs
         run: |
+          set -euo pipefail
           docker save nemoclaw-sandbox-test | gzip > /tmp/sandbox-test-image.tar.gz
           docker save nemoclaw-production | gzip > /tmp/isolation-image.tar.gz
+
+      - name: Verify tarballs
+        run: |
+          gzip -t /tmp/sandbox-test-image.tar.gz
+          gzip -t /tmp/isolation-image.tar.gz
 
       - name: Upload sandbox test image
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Add `set -euo pipefail` to the "Save images to tarballs" step so a `docker save` failure aborts the pipeline instead of silently writing a truncated gzip file
- Add a `gzip -t` integrity check step before uploading artifacts to catch corruption early

## Problem

`docker save nemoclaw-sandbox-test | gzip > /tmp/sandbox-test-image.tar.gz` uses a bare pipeline. Bash only checks the exit code of the last command (`gzip`), not `docker save`. If `docker save` is killed or fails mid-stream (OOM, timeout, I/O error), `gzip` writes a truncated but valid-looking file and the step exits 0. The corrupt artifact gets uploaded successfully, and the downstream `test-e2e-sandbox` job fails with:

```
gzip: /tmp/sandbox-test-image.tar.gz: unexpected end of file
unexpected EOF
```

This is intermittent and difficult to diagnose because the build job appears green.

## Test plan

- [ ] CI passes on this PR (checks + E2E jobs)
- [ ] Verify the new "Verify tarballs" step appears in the build-sandbox-images job log
- [ ] If `docker save` were to fail, the step would now exit non-zero before upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

No user-visible changes in this release. This update includes internal infrastructure improvements to enhance build validation and reliability.

* **Chores**
  * Strengthened CI shell safety to fail fast on command errors, unset variables, or pipeline failures.
  * Added verification of generated archive artifacts prior to upload to ensure integrity and prevent corrupted uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->