### PR TITLE
fix(security): mitigate Brave API key exposure in Docker build args

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -771,13 +771,7 @@ function isAffirmativeAnswer(value) {
   );
 }
 
-function printBraveExposureWarning() {
-  console.log("");
-  for (const line of webSearch.getBraveExposureWarningLines()) {
-    console.log(`  ${line}`);
-  }
-  console.log("");
-}
+
 
 function validateBraveSearchApiKey(apiKey) {
   return runCurlProbe([
@@ -882,7 +876,6 @@ async function configureWebSearch(existingConfig = null) {
       return null;
     }
     note("  [non-interactive] Brave Web Search requested.");
-    printBraveExposureWarning();
     const validation = validateBraveSearchApiKey(braveApiKey);
     if (!validation.ok) {
       console.error("  Brave Search API key validation failed.");
@@ -895,8 +888,6 @@ async function configureWebSearch(existingConfig = null) {
     process.env[webSearch.BRAVE_API_KEY_ENV] = braveApiKey;
     return { fetchEnabled: true };
   }
-
-  printBraveExposureWarning();
   const enableAnswer = await prompt("  Enable Brave Web Search? [y/N]: ");
   if (!isAffirmativeAnswer(enableAnswer)) {
     return null;
@@ -1019,10 +1010,7 @@ function patchStagedDockerfile(
   }
   dockerfile = dockerfile.replace(
     /^ARG NEMOCLAW_WEB_CONFIG_B64=.*$/m,
-    `ARG NEMOCLAW_WEB_CONFIG_B64=${webSearch.buildWebSearchDockerConfig(
-      webSearchConfig,
-      webSearchConfig ? getCredential(webSearch.BRAVE_API_KEY_ENV) : null,
-    )}`,
+    `ARG NEMOCLAW_WEB_CONFIG_B64=${webSearch.buildWebSearchDockerConfig(webSearchConfig)}`,
   );
   // Onboard flow expects immediate dashboard access without device pairing,
   // so disable device auth for images built during onboard (see #1217).
@@ -2324,6 +2312,14 @@ async function createSandbox(
       token: getMessagingToken("TELEGRAM_BOT_TOKEN"),
     },
   ].filter(({ envKey }) => !enabledEnvKeys || enabledEnvKeys.has(envKey));
+
+  if (webSearchConfig) {
+    messagingTokenDefs.push({
+      name: `${sandboxName}-brave-search`,
+      envKey: webSearch.BRAVE_API_KEY_ENV,
+      token: getCredential(webSearch.BRAVE_API_KEY_ENV),
+    });
+  }
   const hasMessagingTokens = messagingTokenDefs.some(({ token }) => !!token);
 
   // Reconcile local registry state with the live OpenShell gateway state.

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4573,13 +4573,22 @@ async function onboard(opts = {}) {
     }
 
     const sandboxReuseState = getSandboxReuseState(sandboxName);
+    const webSearchConfigChanged = Boolean(session?.webSearchConfig) !== Boolean(webSearchConfig);
     const resumeSandbox =
-      resume && session?.steps?.sandbox?.status === "complete" && sandboxReuseState === "ready";
+      resume && 
+      !webSearchConfigChanged && 
+      session?.steps?.sandbox?.status === "complete" && 
+      sandboxReuseState === "ready";
     if (resumeSandbox) {
       skippedStepMessage("sandbox", sandboxName);
     } else {
       if (resume && session?.steps?.sandbox?.status === "complete") {
-        if (sandboxReuseState === "not_ready") {
+        if (webSearchConfigChanged) {
+          note("  [resume] Web Search configuration changed; recreating sandbox.");
+          if (sandboxName) {
+            registry.removeSandbox(sandboxName);
+          }
+        } else if (sandboxReuseState === "not_ready") {
           note(
             `  [resume] Recorded sandbox '${sandboxName}' exists but is not ready; recreating it.`,
           );

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2550,6 +2550,7 @@ async function createSandbox(
     "DISCORD_BOT_TOKEN",
     "SLACK_BOT_TOKEN",
     "TELEGRAM_BOT_TOKEN",
+    webSearch.BRAVE_API_KEY_ENV,
   ]);
   const sandboxEnv = Object.fromEntries(
     Object.entries(process.env).filter(([name]) => !blockedSandboxEnvNames.has(name)),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4575,9 +4575,9 @@ async function onboard(opts = {}) {
     const sandboxReuseState = getSandboxReuseState(sandboxName);
     const webSearchConfigChanged = Boolean(session?.webSearchConfig) !== Boolean(webSearchConfig);
     const resumeSandbox =
-      resume && 
-      !webSearchConfigChanged && 
-      session?.steps?.sandbox?.status === "complete" && 
+      resume &&
+      !webSearchConfigChanged &&
+      session?.steps?.sandbox?.status === "complete" &&
       sandboxReuseState === "ready";
     if (resumeSandbox) {
       skippedStepMessage("sandbox", sandboxName);

--- a/src/lib/web-search.test.ts
+++ b/src/lib/web-search.test.ts
@@ -5,12 +5,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildWebSearchDockerConfig,
-  getBraveExposureWarningLines,
 } from "./web-search";
 
 describe("web-search helpers", () => {
   it("emits empty docker config when web search is disabled", () => {
-    expect(Buffer.from(buildWebSearchDockerConfig(null, null), "base64").toString("utf8")).toBe(
+    expect(Buffer.from(buildWebSearchDockerConfig(null), "base64").toString("utf8")).toBe(
       "{}",
     );
   });
@@ -18,24 +17,18 @@ describe("web-search helpers", () => {
   it("emits empty docker config when fetchEnabled is false", () => {
     expect(
       Buffer.from(
-        buildWebSearchDockerConfig({ fetchEnabled: false }, null),
+        buildWebSearchDockerConfig({ fetchEnabled: false }),
         "base64",
       ).toString("utf8"),
     ).toBe("{}");
   });
 
-  it("encodes Brave Search docker config including the api key", () => {
-    const encoded = buildWebSearchDockerConfig({ fetchEnabled: true }, "brv-x");
+  it("encodes Brave Search docker config using proxy placeholder for api key", () => {
+    const encoded = buildWebSearchDockerConfig({ fetchEnabled: true });
     expect(JSON.parse(Buffer.from(encoded, "base64").toString("utf8"))).toEqual({
       provider: "brave",
       fetchEnabled: true,
-      apiKey: "brv-x",
+      apiKey: "openshell:resolve:env:BRAVE_API_KEY",
     });
-  });
-
-  it("includes the explicit exposure caveat in the warning text", () => {
-    const warning = getBraveExposureWarningLines().join(" ");
-    expect(warning).toContain("sandbox agent config");
-    expect(warning).toContain("sandboxed agent will be able to read");
   });
 });

--- a/src/lib/web-search.ts
+++ b/src/lib/web-search.ts
@@ -11,23 +11,17 @@ export function encodeDockerJsonArg(value: unknown): string {
   return Buffer.from(JSON.stringify(value ?? {}), "utf8").toString("base64");
 }
 
-export function getBraveExposureWarningLines(): string[] {
-  return [
-    "NemoClaw will store the Brave API key in the sandbox agent config.",
-    "The sandboxed agent will be able to read that key.",
-  ];
-}
-
 export function buildWebSearchDockerConfig(
   config: WebSearchConfig | null,
-  braveApiKey: string | null,
 ): string {
   if (!config || config.fetchEnabled !== true) return encodeDockerJsonArg({});
 
   const payload = {
     provider: "brave",
     fetchEnabled: Boolean(config.fetchEnabled),
-    apiKey: braveApiKey || "",
+    // Use the OpenShell proxy placeholder instead of the raw API key to ensure
+    // credentials are never baked into Docker images or raw sandbox configuration.
+    apiKey: `openshell:resolve:env:${BRAVE_API_KEY_ENV}`,
   };
   return encodeDockerJsonArg(payload);
 }

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -604,7 +604,7 @@ describe("onboard helpers", () => {
         { fetchEnabled: true },
       );
       const patched = fs.readFileSync(dockerfilePath, "utf8");
-      const expected = buildWebSearchDockerConfig({ fetchEnabled: true }, "brv-test-key");
+      const expected = buildWebSearchDockerConfig({ fetchEnabled: true });
       assert.match(
         patched,
         new RegExp(


### PR DESCRIPTION
Migrate Brave API key to OpenShell generic provider system to inject tokens at proxy egress, eliminating plaintext credential leaks in build logs and 'openclaw.json' baked configurations.

## Summary
This PR remediates a critical security vulnerability where the Brave Search API key was passed as a Docker ARG (`NEMOCLAW_WEB_CONFIG_B64`), exposing it to Docker build logs and writing it permanently into `openclaw.json`. The implementation now creates a generic OpenShell provider during `nemoclaw onboard` so that credentials stay within the OpenShell secret manager and are only injected via proxy placeholder replacement at egress.

## Related Issue
Fixes [[NVB# 6066540]](https://github.com/NVIDIA/NemoClaw/issues/1741)

## Changes
- Replaced the plaintext API key in `buildWebSearchDockerConfig()` with the `openshell:resolve:env:BRAVE_API_KEY` placeholder.
- Attached `BRAVE_API_KEY` via `upsertMessagingProviders()` during `openshell sandbox create` rather than Docker build arguments.
- Removed `getBraveExposureWarningLines()` and the `printBraveExposureWarning()` function since the exposure risk is eliminated.
- Updated `web-search.test.ts` to assert the updated configuration behavior.

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes. *(Note: Unrelated timeouts due to recent `main` JS to TS migrations are known, but `src/lib/web-search.test.ts` passes)*
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
Signed-off-by: Krish Sapru <ksapru@bu.edu>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified web search configuration and Docker build flow.
  * Brave Search credentials now referenced via environment variables instead of embedding keys.
  * Removed console warning messages from the Brave Search setup flow.

* **Behavior**
  * Sandbox resume now detects Brave Web Search config changes and recreates the sandbox when needed.
  * Sandbox no longer forwards the Brave API key into the sandbox environment.

* **Tests**
  * Updated web search tests to match the new credential handling and Docker config format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->