### PR TITLE
fix(cli): surface local inference health in status

### DIFF
--- a/.agents/skills/nemoclaw-user-monitor-sandbox/SKILL.md
+++ b/.agents/skills/nemoclaw-user-monitor-sandbox/SKILL.md
@@ -19,17 +19,21 @@ Use the NemoClaw status, logs, and TUI tools together to inspect sandbox health,
 
 ## Step 1: Check Sandbox Health
 
-Run the status command to view the sandbox state, blueprint run information, and active inference configuration:
+Run the status command to view the sandbox state, gateway health, and active inference configuration:
 
 ```console
 $ nemoclaw <name> status
 ```
 
+For local Ollama and local vLLM routes, `nemoclaw <name> status` also probes the host-side health endpoint directly.
+This catches a stopped local backend before you retry `inference.local` from inside the sandbox.
+
 Key fields in the output include the following:
 
-- Sandbox state, which indicates whether the sandbox is running, stopped, or in an error state.
-- Blueprint run ID, which is the identifier for the most recent blueprint execution.
-- Inference provider, which shows the active provider, model, and endpoint.
+- Sandbox details, which show the configured model, provider, GPU mode, and applied policy presets.
+- Gateway and process health, which show whether NemoClaw can still reach the OpenShell gateway and whether the in-sandbox agent process is running.
+- Inference health for local Ollama and local vLLM, which shows `healthy` or `unreachable` together with the probed local URL.
+- NIM status, which shows whether a NIM container is running and healthy when that path is in use.
 
 Run `nemoclaw <name> status` on the host to check sandbox state.
 Use `openshell sandbox list` for the underlying sandbox details.
@@ -78,6 +82,8 @@ $ openclaw agent --agent main --local -m "Test inference" --session-id debug
 If the request fails, check the following:
 
 1. Run `nemoclaw <name> status` to confirm the active provider and endpoint.
+   For local Ollama and local vLLM, check the `Inference` line first.
+   If it shows `unreachable`, restart the local backend before retrying from inside the sandbox.
 2. Run `nemoclaw <name> logs --follow` to view error messages from the blueprint runner.
 3. Verify that the inference endpoint is reachable from the host.
 

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -144,6 +144,8 @@ $ nemoclaw my-assistant connect
 ### `nemoclaw <name> status`
 
 Show sandbox status, health, and inference configuration.
+For local Ollama and local vLLM routes, the command also probes the host-side health endpoint and reports whether the backend is reachable.
+If the backend is down, the output includes an `Inference: unreachable` line with the local URL and a remediation hint.
 
 ```console
 $ nemoclaw my-assistant status

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -242,6 +242,9 @@ Check the active provider and endpoint:
 $ nemoclaw <name> status
 ```
 
+For local Ollama and local vLLM, `nemoclaw <name> status` also prints an `Inference` line that probes the host-side health endpoint directly.
+If that line shows `unreachable`, start the local backend first and then retry the request.
+
 If the endpoint is correct but requests still fail, check for network policy rules that may block the connection.
 Then verify the credential and base URL for the provider you selected during onboarding.
 

--- a/docs/monitoring/monitor-sandbox-activity.md
+++ b/docs/monitoring/monitor-sandbox-activity.md
@@ -31,17 +31,21 @@ Use the NemoClaw status, logs, and TUI tools together to inspect sandbox health,
 
 ## Check Sandbox Health
 
-Run the status command to view the sandbox state, blueprint run information, and active inference configuration:
+Run the status command to view the sandbox state, gateway health, and active inference configuration:
 
 ```console
 $ nemoclaw <name> status
 ```
 
+For local Ollama and local vLLM routes, `nemoclaw <name> status` also probes the host-side health endpoint directly.
+This catches a stopped local backend before you retry `inference.local` from inside the sandbox.
+
 Key fields in the output include the following:
 
-- Sandbox state, which indicates whether the sandbox is running, stopped, or in an error state.
-- Blueprint run ID, which is the identifier for the most recent blueprint execution.
-- Inference provider, which shows the active provider, model, and endpoint.
+- Sandbox details, which show the configured model, provider, GPU mode, and applied policy presets.
+- Gateway and process health, which show whether NemoClaw can still reach the OpenShell gateway and whether the in-sandbox agent process is running.
+- Inference health for local Ollama and local vLLM, which shows `healthy` or `unreachable` together with the probed local URL.
+- NIM status, which shows whether a NIM container is running and healthy when that path is in use.
 
 Run `nemoclaw <name> status` on the host to check sandbox state.
 Use `openshell sandbox list` for the underlying sandbox details.
@@ -90,6 +94,8 @@ $ openclaw agent --agent main --local -m "Test inference" --session-id debug
 If the request fails, check the following:
 
 1. Run `nemoclaw <name> status` to confirm the active provider and endpoint.
+   For local Ollama and local vLLM, check the `Inference` line first.
+   If it shows `unreachable`, restart the local backend before retrying from inside the sandbox.
 2. Run `nemoclaw <name> logs --follow` to view error messages from the blueprint runner.
 3. Verify that the inference endpoint is reachable from the host.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -168,6 +168,8 @@ $ nemoclaw my-assistant connect
 ### `nemoclaw <name> status`
 
 Show sandbox status, health, and inference configuration.
+For local Ollama and local vLLM routes, the command also probes the host-side health endpoint and reports whether the backend is reachable.
+If the backend is down, the output includes an `Inference: unreachable` line with the local URL and a remediation hint.
 
 ```console
 $ nemoclaw my-assistant status

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -272,6 +272,9 @@ Check the active provider and endpoint:
 $ nemoclaw <name> status
 ```
 
+For local Ollama and local vLLM, `nemoclaw <name> status` also prints an `Inference` line that probes the host-side health endpoint directly.
+If that line shows `unreachable`, start the local backend first and then retry the request.
+
 If the endpoint is correct but requests still fail, check for network policy rules that may block the connection.
 Then verify the credential and base URL for the provider you selected during onboarding.
 

--- a/src/lib/local-inference.test.ts
+++ b/src/lib/local-inference.test.ts
@@ -13,12 +13,15 @@ import {
   getLocalProviderBaseUrl,
   getLocalProviderContainerReachabilityCheck,
   getLocalProviderHealthCheck,
+  getLocalProviderHealthEndpoint,
+  getLocalProviderLabel,
   getLocalProviderValidationBaseUrl,
   getOllamaModelOptions,
   getOllamaProbeCommand,
   getOllamaWarmupCommand,
   parseOllamaList,
   parseOllamaTags,
+  probeLocalProviderHealth,
   validateOllamaModel,
   validateLocalProvider,
 } from "../../dist/lib/local-inference";
@@ -37,7 +40,9 @@ describe("local inference helpers", () => {
   it("returns null for unknown local provider URLs", () => {
     expect(getLocalProviderBaseUrl("unknown-provider")).toBeNull();
     expect(getLocalProviderValidationBaseUrl("unknown-provider")).toBeNull();
+    expect(getLocalProviderHealthEndpoint("unknown-provider")).toBeNull();
     expect(getLocalProviderHealthCheck("unknown-provider")).toBeNull();
+    expect(getLocalProviderLabel("unknown-provider")).toBeNull();
     expect(getLocalProviderContainerReachabilityCheck("unknown-provider")).toBeNull();
   });
 
@@ -46,6 +51,10 @@ describe("local inference helpers", () => {
   });
 
   it("returns the expected health check command for ollama-local", () => {
+    expect(getLocalProviderHealthEndpoint("ollama-local")).toBe(
+      "http://localhost:11434/api/tags",
+    );
+    expect(getLocalProviderLabel("ollama-local")).toBe("Local Ollama");
     expect(getLocalProviderHealthCheck("ollama-local")).toBe(
       "curl -sf http://localhost:11434/api/tags 2>/dev/null",
     );
@@ -53,6 +62,8 @@ describe("local inference helpers", () => {
 
   it("returns the expected validation and health check commands for vllm-local", () => {
     expect(getLocalProviderValidationBaseUrl("ollama-local")).toBe("http://localhost:11434/v1");
+    expect(getLocalProviderHealthEndpoint("vllm-local")).toBe("http://localhost:8000/v1/models");
+    expect(getLocalProviderLabel("vllm-local")).toBe("Local vLLM");
     expect(getLocalProviderHealthCheck("vllm-local")).toBe(
       "curl -sf http://localhost:8000/v1/models 2>/dev/null",
     );
@@ -98,6 +109,48 @@ describe("local inference helpers", () => {
     const result = validateLocalProvider("vllm-local", () => "");
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/http:\/\/localhost:8000/);
+  });
+
+  it("probes local provider health successfully", () => {
+    const result = probeLocalProviderHealth("ollama-local", {
+      runCurlProbeImpl: () => ({
+        ok: true,
+        httpStatus: 200,
+        curlStatus: 0,
+        body: "{}",
+        stderr: "",
+        message: "HTTP 200",
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      providerLabel: "Local Ollama",
+      endpoint: "http://localhost:11434/api/tags",
+      detail: "Local Ollama is reachable on http://localhost:11434/api/tags.",
+    });
+  });
+
+  it("reports a clear local provider outage when the host probe cannot connect", () => {
+    const result = probeLocalProviderHealth("ollama-local", {
+      runCurlProbeImpl: () => ({
+        ok: false,
+        httpStatus: 0,
+        curlStatus: 7,
+        body: "",
+        stderr: "Failed to connect",
+        message: "curl failed (exit 7): Failed to connect",
+      }),
+    });
+
+    expect(result?.ok).toBe(false);
+    expect(result?.detail).toContain("Local Ollama is selected for inference");
+    expect(result?.detail).toContain("Start Ollama and retry");
+    expect(result?.detail).toContain("http://localhost:11434/api/tags");
+  });
+
+  it("returns null when provider health probing is not supported", () => {
+    expect(probeLocalProviderHealth("nvidia-prod")).toBeNull();
   });
 
   it("returns a clear error when vllm-local is not reachable from containers", () => {

--- a/src/lib/local-inference.ts
+++ b/src/lib/local-inference.ts
@@ -6,6 +6,9 @@
  * health checks, and command generators for vLLM and Ollama.
  */
 
+import type { CurlProbeResult } from "./http-probe";
+import { runCurlProbe } from "./http-probe";
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { shellQuote } = require("./runner");
 
@@ -24,6 +27,17 @@ export interface GpuInfo {
 export interface ValidationResult {
   ok: boolean;
   message?: string;
+}
+
+export interface LocalProviderHealthStatus {
+  ok: boolean;
+  providerLabel: string;
+  endpoint: string;
+  detail: string;
+}
+
+export interface LocalProviderHealthProbeOptions {
+  runCurlProbeImpl?: (argv: string[]) => CurlProbeResult;
 }
 
 export function getLocalProviderBaseUrl(provider: string): string | null {
@@ -48,15 +62,86 @@ export function getLocalProviderValidationBaseUrl(provider: string): string | nu
   }
 }
 
-export function getLocalProviderHealthCheck(provider: string): string | null {
+export function getLocalProviderHealthEndpoint(provider: string): string | null {
   switch (provider) {
     case "vllm-local":
-      return "curl -sf http://localhost:8000/v1/models 2>/dev/null";
+      return "http://localhost:8000/v1/models";
     case "ollama-local":
-      return "curl -sf http://localhost:11434/api/tags 2>/dev/null";
+      return "http://localhost:11434/api/tags";
     default:
       return null;
   }
+}
+
+export function getLocalProviderHealthCheck(provider: string): string | null {
+  const endpoint = getLocalProviderHealthEndpoint(provider);
+  return endpoint ? `curl -sf ${endpoint} 2>/dev/null` : null;
+}
+
+export function getLocalProviderLabel(provider: string): string | null {
+  switch (provider) {
+    case "vllm-local":
+      return "Local vLLM";
+    case "ollama-local":
+      return "Local Ollama";
+    default:
+      return null;
+  }
+}
+
+function buildLocalProviderProbeDetail(
+  provider: string,
+  endpoint: string,
+  result: CurlProbeResult,
+): string {
+  const label = getLocalProviderLabel(provider) || "Local inference provider";
+  if (result.httpStatus === 0) {
+    switch (provider) {
+      case "ollama-local":
+        return (
+          `${label} is selected for inference, but the host probe to ${endpoint} failed. ` +
+          `Start Ollama and retry. (${result.message})`
+        );
+      case "vllm-local":
+        return (
+          `${label} is selected for inference, but the host probe to ${endpoint} failed. ` +
+          `Start the local vLLM server and retry. (${result.message})`
+        );
+      default:
+        return `${label} is selected for inference, but the host probe to ${endpoint} failed. (${result.message})`;
+    }
+  }
+  return `${label} is reachable on ${endpoint}, but the health probe failed. (${result.message})`;
+}
+
+export function probeLocalProviderHealth(
+  provider: string,
+  options: LocalProviderHealthProbeOptions = {},
+): LocalProviderHealthStatus | null {
+  const endpoint = getLocalProviderHealthEndpoint(provider);
+  const providerLabel = getLocalProviderLabel(provider);
+  if (!endpoint || !providerLabel) {
+    return null;
+  }
+
+  const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
+  const result = runCurlProbeImpl(["-sS", "--connect-timeout", "3", "--max-time", "5", endpoint]);
+
+  if (result.ok) {
+    return {
+      ok: true,
+      providerLabel,
+      endpoint,
+      detail: `${providerLabel} is reachable on ${endpoint}.`,
+    };
+  }
+
+  return {
+    ok: false,
+    providerLabel,
+    endpoint,
+    detail: buildLocalProviderProbeDetail(provider, endpoint, result),
+  };
 }
 
 export function getLocalProviderContainerReachabilityCheck(provider: string): string | null {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -41,6 +41,7 @@ const registry = require("./lib/registry");
 const nim = require("./lib/nim");
 const policies = require("./lib/policies");
 const { parseGatewayInference } = require("./lib/inference-config");
+const { probeLocalProviderHealth } = require("./lib/local-inference");
 const { getVersion } = require("./lib/version");
 const onboardSession = require("./lib/onboard-session");
 const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
@@ -1003,11 +1004,23 @@ async function sandboxStatus(sandboxName) {
   const live = parseGatewayInference(
     captureOpenshell(["inference", "get"], { ignoreError: true }).output,
   );
+  const currentModel = (live && live.model) || (sb && sb.model) || "unknown";
+  const currentProvider = (live && live.provider) || (sb && sb.provider) || "unknown";
+  const localInferenceHealth =
+    typeof currentProvider === "string" ? probeLocalProviderHealth(currentProvider) : null;
   if (sb) {
     console.log("");
     console.log(`  Sandbox: ${sb.name}`);
-    console.log(`    Model:    ${(live && live.model) || sb.model || "unknown"}`);
-    console.log(`    Provider: ${(live && live.provider) || sb.provider || "unknown"}`);
+    console.log(`    Model:    ${currentModel}`);
+    console.log(`    Provider: ${currentProvider}`);
+    if (localInferenceHealth) {
+      console.log(
+        `    Inference: ${localInferenceHealth.ok ? `${G}healthy${R}` : `${_RD}unreachable${R}`} (${localInferenceHealth.endpoint})`,
+      );
+      if (!localInferenceHealth.ok) {
+        console.log(`      ${localInferenceHealth.detail}`);
+      }
+    }
     console.log(`    GPU:      ${sb.gpuEnabled ? "yes" : "no"}`);
     console.log(`    Policies: ${(sb.policies || []).join(", ") || "none"}`);
     if (sb.dangerouslySkipPermissions) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1555,6 +1555,88 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("Sandbox: alpha")).toBeTruthy();
   });
 
+  it("shows a clear local inference warning when Ollama is down", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-local-inference-down-"));
+    const localBin = path.join(home, "bin");
+    const registryDir = path.join(home, ".nemoclaw");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify({
+        sandboxes: {
+          alpha: {
+            name: "alpha",
+            model: "llama3.2:1b",
+            provider: "ollama-local",
+            gpuEnabled: false,
+            policies: [],
+          },
+        },
+        defaultSandbox: "alpha",
+      }),
+      { mode: 0o600 },
+    );
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "alpha" ]; then',
+        "  echo 'Sandbox: alpha'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "ssh-config" ] && [ "$3" = "alpha" ]; then',
+        "  exit 1",
+        "fi",
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
+        "  echo 'Gateway inference:'",
+        "  echo",
+        "  echo '  Provider: ollama-local'",
+        "  echo '  Model: llama3.2:1b'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(localBin, "curl"),
+      [
+        "#!/usr/bin/env bash",
+        'out=""',
+        'url=""',
+        'while [ "$#" -gt 0 ]; do',
+        '  case "$1" in',
+        '    -o) out="$2"; shift 2 ;;',
+        '    -w|--connect-timeout|--max-time) shift 2 ;;',
+        '    -s|-S|-sS|-f) shift ;;',
+        '    http://*|https://*) url="$1"; shift ;;',
+        '    *) shift ;;',
+        '  esac',
+        'done',
+        'if [ -n "$out" ]; then : > "$out"; fi',
+        'if echo "$url" | grep -q "11434/api/tags"; then',
+        '  printf "000"',
+        '  exit 7',
+        'fi',
+        'printf "000"',
+        'exit 7',
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("alpha status", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("Inference:");
+    expect(r.out).toContain("unreachable");
+    expect(r.out).toContain("Start Ollama and retry");
+    expect(r.out).toContain("http://localhost:11434/api/tags");
+  });
+
   it("does not treat a different connected gateway as a healthy nemoclaw gateway", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-mixed-gateway-"));
     const localBin = path.join(home, "bin");


### PR DESCRIPTION
## Summary
Add a host-side local inference health probe to `nemoclaw <name> status` so users get a clear warning when Ollama or vLLM is down instead of only discovering the failure later through a silent `inference.local` request inside the sandbox.

## Related Issue
Fixes #995.

## Changes
- add a lightweight localhost health probe helper for local inference providers
- show `Inference: healthy|unreachable` in `nemoclaw <name> status` for local providers
- print actionable Ollama/vLLM remediation text when the host-side probe fails
- add unit coverage for the new probe helper and CLI coverage for the Ollama-down status path

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status command now shows local inference health (healthy vs unreachable) for Ollama and vLLM, including probed endpoint and remediation hints.

* **Tests**
  * Added coverage for local provider health probing: successful probes, unreachable hosts with guidance, and unsupported-provider behavior.

* **Documentation**
  * Updated status, troubleshooting, monitoring, and user guidance to describe the new local inference health checks and recommended recovery steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->