### PR TITLE
fix: verify local inference route during onboarding

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -22,6 +22,12 @@ function envInt(name, fallback) {
 
 /** Inference timeout (seconds) for local providers (Ollama, vLLM, NIM). */
 const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 180);
+/** Retry budget for sandbox-local inference.local verification. */
+const LOCAL_SANDBOX_PROBE_ATTEMPTS = envInt("NEMOCLAW_LOCAL_SANDBOX_PROBE_ATTEMPTS", 3);
+/** Delay between retryable sandbox-local inference.local probes. */
+const LOCAL_SANDBOX_PROBE_DELAY_SECS = envInt("NEMOCLAW_LOCAL_SANDBOX_PROBE_DELAY", 2);
+/** curl --max-time bound (seconds) for sandbox-local inference.local probes. */
+const LOCAL_SANDBOX_PROBE_MAX_TIME_SECS = envInt("NEMOCLAW_LOCAL_SANDBOX_PROBE_MAX_TIME", 20);
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("./runner");
 const { stageOptimizedSandboxBuildContext } = require("./sandbox-build-context");
 const {
@@ -731,6 +737,21 @@ function isInferenceRouteReady(provider, model) {
   return Boolean(live && live.provider === provider && live.model === model);
 }
 
+/**
+ * @typedef {Object} SandboxInferenceProbeResult
+ * @property {boolean} ok
+ * @property {boolean} [retryable]
+ * @property {string} [message]
+ */
+
+/** @typedef {typeof runCaptureOpenshell} SandboxProbeRunner */
+
+/**
+ * Parse the response from a sandbox-local `inference.local` probe.
+ *
+ * @param {string | undefined} output
+ * @returns {SandboxInferenceProbeResult}
+ */
 function parseSandboxInferenceProbe(output) {
   if (!output) {
     return {
@@ -787,6 +808,15 @@ function parseSandboxInferenceProbe(output) {
   };
 }
 
+/**
+ * Confirm that sandbox-local `inference.local` can serve the selected local model.
+ *
+ * @param {string | undefined} sandboxName
+ * @param {string} model
+ * @param {string} provider
+ * @param {SandboxProbeRunner} [runCaptureOpenshellImpl]
+ * @returns {SandboxInferenceProbeResult}
+ */
 function verifyLocalSandboxInference(
   sandboxName,
   model,
@@ -809,7 +839,7 @@ function verifyLocalSandboxInference(
     message: "inference.local did not return a response.",
   };
 
-  for (let attempt = 1; attempt <= 3; attempt += 1) {
+  for (let attempt = 1; attempt <= LOCAL_SANDBOX_PROBE_ATTEMPTS; attempt += 1) {
     const output = runCaptureOpenshellImpl(
       [
         "sandbox",
@@ -818,7 +848,7 @@ function verifyLocalSandboxInference(
         "curl",
         "-sS",
         "--max-time",
-        "20",
+        String(LOCAL_SANDBOX_PROBE_MAX_TIME_SECS),
         "https://inference.local/v1/chat/completions",
         "-H",
         "Content-Type: application/json",
@@ -836,10 +866,10 @@ function verifyLocalSandboxInference(
       return { ok: true };
     }
     lastResult = result;
-    if (!result.retryable || attempt === 3) {
+    if (!result.retryable || attempt === LOCAL_SANDBOX_PROBE_ATTEMPTS) {
       break;
     }
-    sleep(2);
+    sleep(LOCAL_SANDBOX_PROBE_DELAY_SECS);
   }
 
   return {
@@ -850,6 +880,14 @@ function verifyLocalSandboxInference(
   };
 }
 
+/**
+ * Persist local-provider sandbox metadata only after the in-sandbox probe succeeds.
+ *
+ * @param {string} sandboxName
+ * @param {string} model
+ * @param {string} provider
+ * @param {string | null} [nimContainer]
+ */
 function finalizeSandboxInferenceSetup(sandboxName, model, provider, nimContainer = null) {
   const sandboxProbe = verifyLocalSandboxInference(sandboxName, model, provider);
   if (!sandboxProbe.ok) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -711,6 +711,15 @@ function verifyInferenceRoute(_provider, _model) {
     console.error("  OpenShell inference route was not configured.");
     process.exit(1);
   }
+  if (_provider && _model && !isInferenceRouteReady(_provider, _model)) {
+    const live = parseGatewayInference(output);
+    const liveProvider = live?.provider || "unknown";
+    const liveModel = live?.model || "unknown";
+    console.error(
+      `  OpenShell inference route mismatch. Expected ${_provider} / ${_model}, got ${liveProvider} / ${liveModel}.`,
+    );
+    process.exit(1);
+  }
 }
 
 function isInferenceRouteReady(provider, model) {
@@ -718,6 +727,125 @@ function isInferenceRouteReady(provider, model) {
     runCaptureOpenshell(["inference", "get"], { ignoreError: true }),
   );
   return Boolean(live && live.provider === provider && live.model === model);
+}
+
+function parseSandboxInferenceProbe(output) {
+  if (!output) {
+    return {
+      ok: false,
+      retryable: true,
+      message: "inference.local did not return a response.",
+    };
+  }
+
+  const statusMarker = "__NEMOCLAW_HTTP_STATUS__:";
+  const markerIndex = output.lastIndexOf(statusMarker);
+  const body = markerIndex === -1 ? output.trim() : output.slice(0, markerIndex).trim();
+  const statusText =
+    markerIndex === -1 ? "" : output.slice(markerIndex + statusMarker.length).trim();
+  const status = Number.parseInt(statusText, 10);
+
+  if (!Number.isFinite(status)) {
+    return {
+      ok: false,
+      retryable: true,
+      message: "inference.local did not report an HTTP status.",
+    };
+  }
+
+  if (status !== 200) {
+    const detail = compactText(body) || `HTTP ${status}`;
+    return {
+      ok: false,
+      retryable: [408, 425, 429, 500, 502, 503, 504].includes(status),
+      message: `HTTP ${status}: ${detail}`,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(body || "{}");
+    if (parsed?.error) {
+      return {
+        ok: false,
+        retryable: false,
+        message: compactText(JSON.stringify(parsed.error)) || "inference.local returned an error.",
+      };
+    }
+    if (Array.isArray(parsed?.choices) || Array.isArray(parsed?.output) || typeof parsed?.id === "string") {
+      return { ok: true };
+    }
+  } catch {
+    // handled below
+  }
+
+  return {
+    ok: false,
+    retryable: false,
+    message: `Unexpected inference.local response: ${compactText(body) || "empty body"}`,
+  };
+}
+
+function verifyLocalSandboxInference(
+  sandboxName,
+  model,
+  provider,
+  runCaptureOpenshellImpl = runCaptureOpenshell,
+) {
+  if (!sandboxName || (provider !== "ollama-local" && provider !== "vllm-local")) {
+    return { ok: true };
+  }
+
+  const providerLabel = provider === "ollama-local" ? "Local Ollama" : "Local vLLM";
+  const payload = JSON.stringify({
+    model,
+    messages: [{ role: "user", content: "Reply with exactly one word: PONG" }],
+    max_tokens: 8,
+  });
+  let lastResult = {
+    ok: false,
+    retryable: false,
+    message: "inference.local did not return a response.",
+  };
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const output = runCaptureOpenshellImpl(
+      [
+        "sandbox",
+        "exec",
+        sandboxName,
+        "curl",
+        "-sS",
+        "--max-time",
+        "20",
+        "https://inference.local/v1/chat/completions",
+        "-H",
+        "Content-Type: application/json",
+        "-d",
+        payload,
+        "-o",
+        "-",
+        "-w",
+        "\\n__NEMOCLAW_HTTP_STATUS__:%{http_code}",
+      ],
+      { ignoreError: true },
+    );
+    const result = parseSandboxInferenceProbe(output);
+    if (result.ok) {
+      return { ok: true };
+    }
+    lastResult = result;
+    if (!result.retryable || attempt === 3) {
+      break;
+    }
+    sleep(2);
+  }
+
+  return {
+    ok: false,
+    message:
+      `${providerLabel} was configured, but inference.local inside sandbox '${sandboxName}' ` +
+      `could not serve model '${model}'. ${lastResult.message}`,
+  };
 }
 
 function sandboxExistsInGateway(sandboxName) {
@@ -3444,6 +3572,11 @@ async function setupInference(
   }
 
   verifyInferenceRoute(provider, model);
+  const sandboxProbe = verifyLocalSandboxInference(sandboxName, model, provider);
+  if (!sandboxProbe.ok) {
+    console.error(`  ${sandboxProbe.message}`);
+    process.exit(1);
+  }
   registry.updateSandbox(sandboxName, { model, provider });
   console.log(`  ✓ Inference route set: ${provider} / ${model}`);
   return { ok: true };
@@ -4748,6 +4881,7 @@ module.exports = {
   setupMessagingChannels,
   setupNim,
   isInferenceRouteReady,
+  verifyLocalSandboxInference,
   isOpenclawReady,
   arePolicyPresetsApplied,
   getSuggestedPolicyPresets,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -780,7 +780,8 @@ function parseSandboxInferenceProbe(output) {
     const detail = compactText(body) || `HTTP ${status}`;
     return {
       ok: false,
-      retryable: [408, 425, 429, 500, 502, 503, 504].includes(status),
+      // curl can report `000` (parsed as 0) for transient connection/proxy failures.
+      retryable: [0, 408, 425, 429, 500, 502, 503, 504].includes(status),
       message: `HTTP ${status}: ${detail}`,
     };
   }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -794,7 +794,7 @@ function parseSandboxInferenceProbe(output) {
         message: compactText(JSON.stringify(parsed.error)) || "inference.local returned an error.",
       };
     }
-    if (Array.isArray(parsed?.choices) || Array.isArray(parsed?.output) || typeof parsed?.id === "string") {
+    if (Array.isArray(parsed?.choices) && parsed.choices.length > 0) {
       return { ok: true };
     }
   } catch {
@@ -899,7 +899,15 @@ function finalizeSandboxInferenceSetup(sandboxName, model, provider, nimContaine
   if (nimContainer) {
     sandboxUpdate.nimContainer = nimContainer;
   }
-  registry.updateSandbox(sandboxName, sandboxUpdate);
+  const updated = registry.updateSandbox(sandboxName, sandboxUpdate);
+  if (!updated) {
+    registry.registerSandbox({
+      name: sandboxName,
+      model,
+      provider,
+      ...(nimContainer ? { nimContainer } : {}),
+    });
+  }
 }
 
 function sandboxExistsInGateway(sandboxName) {
@@ -4925,6 +4933,7 @@ module.exports = {
   setupMessagingChannels,
   setupNim,
   isInferenceRouteReady,
+  finalizeSandboxInferenceSetup,
   verifyLocalSandboxInference,
   isOpenclawReady,
   arePolicyPresetsApplied,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -711,14 +711,16 @@ function verifyInferenceRoute(_provider, _model) {
     console.error("  OpenShell inference route was not configured.");
     process.exit(1);
   }
-  if (_provider && _model && !isInferenceRouteReady(_provider, _model)) {
+  if (_provider && _model) {
     const live = parseGatewayInference(output);
     const liveProvider = live?.provider || "unknown";
     const liveModel = live?.model || "unknown";
-    console.error(
-      `  OpenShell inference route mismatch. Expected ${_provider} / ${_model}, got ${liveProvider} / ${liveModel}.`,
-    );
-    process.exit(1);
+    if (liveProvider !== _provider || liveModel !== _model) {
+      console.error(
+        `  OpenShell inference route mismatch. Expected ${_provider} / ${_model}, got ${liveProvider} / ${liveModel}.`,
+      );
+      process.exit(1);
+    }
   }
 }
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -911,6 +911,65 @@ function finalizeSandboxInferenceSetup(sandboxName, model, provider, nimContaine
   }
 }
 
+/**
+ * Create the sandbox, mark the sandbox step complete, then finalize
+ * sandbox-local inference metadata in that order.
+ *
+ * @param {object} options
+ * @param {any} options.gpu
+ * @param {string} options.model
+ * @param {string} options.provider
+ * @param {string | null} options.preferredInferenceApi
+ * @param {string} options.sandboxName
+ * @param {object | null} options.webSearchConfig
+ * @param {string[]} options.selectedMessagingChannels
+ * @param {string | null} options.fromDockerfile
+ * @param {object | null} options.agent
+ * @param {boolean} options.dangerouslySkipPermissions
+ * @param {string | null} [options.nimContainer]
+ * @param {typeof createSandbox} [options.createSandboxImpl]
+ * @param {{ markStepComplete: Function }} [options.onboardSessionImpl]
+ * @param {typeof finalizeSandboxInferenceSetup} [options.finalizeSandboxInferenceSetupImpl]
+ * @returns {Promise<string>}
+ */
+async function createReadySandbox({
+  gpu,
+  model,
+  provider,
+  preferredInferenceApi,
+  sandboxName,
+  webSearchConfig,
+  selectedMessagingChannels,
+  fromDockerfile,
+  agent,
+  dangerouslySkipPermissions,
+  nimContainer = null,
+  createSandboxImpl = createSandbox,
+  onboardSessionImpl = onboardSession,
+  finalizeSandboxInferenceSetupImpl = finalizeSandboxInferenceSetup,
+}) {
+  const createdSandboxName = await createSandboxImpl(
+    gpu,
+    model,
+    provider,
+    preferredInferenceApi,
+    sandboxName,
+    webSearchConfig,
+    selectedMessagingChannels,
+    fromDockerfile,
+    agent,
+    dangerouslySkipPermissions,
+  );
+  onboardSessionImpl.markStepComplete("sandbox", {
+    sandboxName: createdSandboxName,
+    provider,
+    model,
+    nimContainer,
+  });
+  finalizeSandboxInferenceSetupImpl(createdSandboxName, model, provider, nimContainer);
+  return createdSandboxName;
+}
+
 function sandboxExistsInGateway(sandboxName) {
   const output = runCaptureOpenshell(["sandbox", "get", sandboxName], { ignoreError: true });
   return Boolean(output);
@@ -4836,7 +4895,7 @@ async function onboard(opts = {}) {
         current.messagingChannels = selectedMessagingChannels;
         return current;
       });
-      sandboxName = await createSandbox(
+      sandboxName = await createReadySandbox({
         gpu,
         model,
         provider,
@@ -4847,11 +4906,9 @@ async function onboard(opts = {}) {
         fromDockerfile,
         agent,
         dangerouslySkipPermissions,
-      );
-      onboardSession.markStepComplete("sandbox", { sandboxName, provider, model, nimContainer });
+        nimContainer,
+      });
     }
-
-    finalizeSandboxInferenceSetup(sandboxName, model, provider, nimContainer);
 
     if (agent) {
       await agentOnboard.handleAgentSetup(sandboxName, model, provider, agent, resume, session, {
@@ -4947,6 +5004,7 @@ module.exports = {
   copyBuildContextDir,
   classifySandboxCreateFailure,
   createSandbox,
+  createReadySandbox,
   formatEnvAssignment,
   getFutureShellPathHint,
   getGatewayStartEnv,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -23,7 +23,10 @@ function envInt(name, fallback) {
 /** Inference timeout (seconds) for local providers (Ollama, vLLM, NIM). */
 const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 180);
 /** Retry budget for sandbox-local inference.local verification. */
-const LOCAL_SANDBOX_PROBE_ATTEMPTS = envInt("NEMOCLAW_LOCAL_SANDBOX_PROBE_ATTEMPTS", 3);
+const LOCAL_SANDBOX_PROBE_ATTEMPTS = Math.max(
+  1,
+  envInt("NEMOCLAW_LOCAL_SANDBOX_PROBE_ATTEMPTS", 3),
+);
 /** Delay between retryable sandbox-local inference.local probes. */
 const LOCAL_SANDBOX_PROBE_DELAY_SECS = envInt("NEMOCLAW_LOCAL_SANDBOX_PROBE_DELAY", 2);
 /** curl --max-time bound (seconds) for sandbox-local inference.local probes. */
@@ -912,8 +915,8 @@ function finalizeSandboxInferenceSetup(sandboxName, model, provider, nimContaine
 }
 
 /**
- * Create the sandbox, mark the sandbox step complete, then finalize
- * sandbox-local inference metadata in that order.
+ * Create the sandbox, finalize sandbox-local inference metadata, then mark the
+ * sandbox step complete once the guard has passed.
  *
  * @param {object} options
  * @param {any} options.gpu
@@ -960,13 +963,13 @@ async function createReadySandbox({
     agent,
     dangerouslySkipPermissions,
   );
+  finalizeSandboxInferenceSetupImpl(createdSandboxName, model, provider, nimContainer);
   onboardSessionImpl.markStepComplete("sandbox", {
     sandboxName: createdSandboxName,
     provider,
     model,
     nimContainer,
   });
-  finalizeSandboxInferenceSetupImpl(createdSandboxName, model, provider, nimContainer);
   return createdSandboxName;
 }
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -848,6 +848,20 @@ function verifyLocalSandboxInference(
   };
 }
 
+function finalizeSandboxInferenceSetup(sandboxName, model, provider, nimContainer = null) {
+  const sandboxProbe = verifyLocalSandboxInference(sandboxName, model, provider);
+  if (!sandboxProbe.ok) {
+    console.error(`  ${sandboxProbe.message}`);
+    process.exit(1);
+  }
+
+  const sandboxUpdate = { model, provider };
+  if (nimContainer) {
+    sandboxUpdate.nimContainer = nimContainer;
+  }
+  registry.updateSandbox(sandboxName, sandboxUpdate);
+}
+
 function sandboxExistsInGateway(sandboxName) {
   const output = runCaptureOpenshell(["sandbox", "get", sandboxName], { ignoreError: true });
   return Boolean(output);
@@ -3425,7 +3439,7 @@ async function setupNim(gpu) {
 
 // eslint-disable-next-line complexity
 async function setupInference(
-  sandboxName,
+  _sandboxName,
   model,
   provider,
   endpointUrl = null,
@@ -3572,12 +3586,6 @@ async function setupInference(
   }
 
   verifyInferenceRoute(provider, model);
-  const sandboxProbe = verifyLocalSandboxInference(sandboxName, model, provider);
-  if (!sandboxProbe.ok) {
-    console.error(`  ${sandboxProbe.message}`);
-    process.exit(1);
-  }
-  registry.updateSandbox(sandboxName, { model, provider });
   console.log(`  ✓ Inference route set: ${provider} / ${model}`);
   return { ok: true };
 }
@@ -4651,9 +4659,6 @@ async function onboard(opts = {}) {
         isInferenceRouteReady(provider, model);
       if (resumeInference) {
         skippedStepMessage("inference", `${provider} / ${model}`);
-        if (nimContainer) {
-          registry.updateSandbox(sandboxName, { nimContainer });
-        }
         onboardSession.markStepComplete("inference", {
           sandboxName,
           provider,
@@ -4675,9 +4680,6 @@ async function onboard(opts = {}) {
       if (inferenceResult?.retry === "selection") {
         forceProviderSelection = true;
         continue;
-      }
-      if (nimContainer) {
-        registry.updateSandbox(sandboxName, { nimContainer });
       }
       onboardSession.markStepComplete("inference", { sandboxName, provider, model, nimContainer });
       break;
@@ -4747,6 +4749,8 @@ async function onboard(opts = {}) {
       );
       onboardSession.markStepComplete("sandbox", { sandboxName, provider, model, nimContainer });
     }
+
+    finalizeSandboxInferenceSetup(sandboxName, model, provider, nimContainer);
 
     if (agent) {
       await agentOnboard.handleAgentSetup(sandboxName, model, provider, agent, resume, session, {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -43,6 +43,7 @@ import {
   summarizeCurlFailure,
   summarizeProbeFailure,
   shouldIncludeBuildContextPath,
+  finalizeSandboxInferenceSetup,
   verifyLocalSandboxInference,
   writeSandboxConfigSyncFile,
 } from "../dist/lib/onboard";
@@ -51,6 +52,7 @@ import { buildWebSearchDockerConfig } from "../dist/lib/web-search";
 
 const require = createRequire(import.meta.url);
 const { getSuggestedPolicyPresets } = require("../dist/lib/onboard.js");
+const registry = require("../dist/lib/registry.js");
 
 describe("onboard helpers", () => {
   it("classifies sandbox create timeout failures and tracks upload progress", () => {
@@ -1437,6 +1439,46 @@ const { setupInference } = require(${onboardPath});
     expect(result.message).toContain("model 'smollm2:135m'");
     expect(result.message).toContain("HTTP 404");
     expect(result.message).toContain("could not serve");
+  });
+
+  it("rejects sandbox probe payloads that are not chat completions responses", () => {
+    const result = verifyLocalSandboxInference("sandbox-box", "smollm2:135m", "ollama-local", () =>
+      ['{"id":"resp-test","output":[{"content":[{"type":"output_text","text":"PONG"}]}]}', "__NEMOCLAW_HTTP_STATUS__:200"].join(
+        "\n",
+      ),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("Unexpected inference.local response");
+  });
+
+  it("registers sandbox metadata when updateSandbox cannot find the sandbox entry", () => {
+    const originalUpdateSandbox = registry.updateSandbox;
+    const originalRegisterSandbox = registry.registerSandbox;
+    const registrations = [];
+    registry.updateSandbox = () => false;
+    registry.registerSandbox = (entry) => {
+      registrations.push(entry);
+    };
+
+    try {
+      finalizeSandboxInferenceSetup(
+        "sandbox-box",
+        "nvidia/nemotron-3-super-120b-a12b",
+        "nvidia-nim",
+        "nvcr.io/test/container:latest",
+      );
+      expect(registrations).toEqual([
+        {
+          name: "sandbox-box",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          provider: "nvidia-nim",
+          nimContainer: "nvcr.io/test/container:latest",
+        },
+      ]);
+    } finally {
+      registry.updateSandbox = originalUpdateSandbox;
+      registry.registerSandbox = originalRegisterSandbox;
+    }
   });
 
   it("detects when OpenClaw is already configured inside the sandbox", () => {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1481,7 +1481,7 @@ const { setupInference } = require(${onboardPath});
     expect(result.message).toContain("Unexpected inference.local response");
   });
 
-  it("registers sandbox metadata when updateSandbox cannot find the sandbox entry", () => {
+  it("registers sandbox metadata when updateSandbox cannot find the local vLLM sandbox entry", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-finalize-register-"));
     const fakeBin = path.join(tmpDir, "bin");
@@ -1514,7 +1514,7 @@ registry.registerSandbox = (entry) => {
 resolveOpenshellModule.resolveOpenshell = () => ${fakeOpenshellPath};
 
 const { finalizeSandboxInferenceSetup } = require(${onboardPath});
-finalizeSandboxInferenceSetup("sandbox-box", "smollm2:135m", "ollama-local");
+finalizeSandboxInferenceSetup("sandbox-box", "nim/meta-llama-3.1-8b-instruct", "vllm-local");
 console.log(JSON.stringify({ probeCalls, registrations }));
 `;
     fs.writeFileSync(scriptPath, script);
@@ -1537,7 +1537,7 @@ console.log(JSON.stringify({ probeCalls, registrations }));
       expect(payload.probeCalls[0]).toContain("https://inference.local/v1/chat/completions");
       expect(payload.probeCalls[0]).toContain(
         JSON.stringify({
-          model: "smollm2:135m",
+          model: "nim/meta-llama-3.1-8b-instruct",
           messages: [{ role: "user", content: "Reply with exactly one word: PONG" }],
           max_tokens: 8,
         }),
@@ -1546,10 +1546,81 @@ console.log(JSON.stringify({ probeCalls, registrations }));
       expect(payload.registrations).toEqual([
         {
           name: "sandbox-box",
-          model: "smollm2:135m",
-          provider: "ollama-local",
+          model: "nim/meta-llama-3.1-8b-instruct",
+          provider: "vllm-local",
         },
       ]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces local vLLM sandbox probe failures before persisting sandbox metadata", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-finalize-vllm-fail-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "finalize-vllm-fail-check.js");
+    const markerPath = path.join(tmpDir, "finalize-vllm-fail-marker.json");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+    const resolveOpenshellPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "resolve-openshell.js"));
+    const fakeOpenshellPath = JSON.stringify(path.join(fakeBin, "openshell"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const resolveOpenshellModule = require(${resolveOpenshellPath});
+const fs = require("node:fs");
+const markerPath = ${JSON.stringify(markerPath)};
+const markers = { updateCalls: 0, registrations: [] };
+const writeMarkers = () => {
+  fs.writeFileSync(markerPath, JSON.stringify(markers));
+};
+runner.runCapture = () => [
+  "{\"error\":{\"message\":\"model 'nim/meta-llama-3.1-8b-instruct' not found\"}}",
+  "__NEMOCLAW_HTTP_STATUS__:404",
+].join("\n");
+registry.updateSandbox = (...args) => {
+  markers.updateCalls += 1;
+  writeMarkers();
+  return true;
+};
+registry.registerSandbox = (entry) => {
+  markers.registrations.push(entry);
+  writeMarkers();
+};
+resolveOpenshellModule.resolveOpenshell = () => ${fakeOpenshellPath};
+
+const { finalizeSandboxInferenceSetup } = require(${onboardPath});
+finalizeSandboxInferenceSetup("sandbox-box", "nim/meta-llama-3.1-8b-instruct", "vllm-local");
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    });
+
+    try {
+      expect(result.status).toBe(1);
+      const markers = fs.existsSync(markerPath)
+        ? JSON.parse(fs.readFileSync(markerPath, "utf-8"))
+        : { updateCalls: 0, registrations: [] };
+      expect(markers.updateCalls).toBe(0);
+      expect(markers.registrations).toEqual([]);
+      expect(result.stderr).toContain("Local vLLM was configured");
+      expect(result.stderr).toContain("nim/meta-llama-3.1-8b-instruct");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1329,6 +1329,90 @@ console.log(JSON.stringify({
     }
   });
 
+  it("reuses the first captured inference route when verifying setup success", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-inference-verify-once-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "setup-inference-verify-once-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+    const resolveOpenshellPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "resolve-openshell.js"));
+    const fakeOpenshellPath = JSON.stringify(path.join(tmpDir, "openshell"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const resolveOpenshellModule = require(${resolveOpenshellPath});
+
+let inferenceGetCalls = 0;
+runner.run = () => ({ status: 0, stdout: "", stderr: "" });
+runner.runCapture = (command) => {
+  if (command.includes("inference") && command.includes("get")) {
+    inferenceGetCalls += 1;
+    if (inferenceGetCalls === 1) {
+      return [
+        "Gateway inference:",
+        "",
+        "  Route: inference.local",
+        "  Provider: openai-api",
+        "  Model: gpt-5.4",
+        "  Version: 1",
+      ].join("\n");
+    }
+    return "";
+  }
+  return "";
+};
+registry.updateSandbox = () => true;
+resolveOpenshellModule.resolveOpenshell = () => ${fakeOpenshellPath};
+
+process.env.OPENAI_API_KEY = "sk-secret-value";
+
+const { setupInference } = require(${onboardPath});
+
+(async () => {
+  const result = await setupInference(
+    "test-box",
+    "gpt-5.4",
+    "openai-api",
+    "https://api.openai.com/v1",
+    "OPENAI_API_KEY",
+  );
+  console.log(JSON.stringify({ result, inferenceGetCalls }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    });
+
+    try {
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout.trim().split("\n").pop())).toEqual({
+        result: { ok: true },
+        inferenceGetCalls: 1,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("verifies local Ollama inference.local chat routing from inside the sandbox", () => {
     expect(
       verifyLocalSandboxInference("sandbox-box", "smollm2:135m", "ollama-local", () =>

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1482,32 +1482,146 @@ const { setupInference } = require(${onboardPath});
   });
 
   it("registers sandbox metadata when updateSandbox cannot find the sandbox entry", () => {
-    const originalUpdateSandbox = registry.updateSandbox;
-    const originalRegisterSandbox = registry.registerSandbox;
-    const registrations = [];
-    registry.updateSandbox = () => false;
-    registry.registerSandbox = (entry) => {
-      registrations.push(entry);
-    };
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-finalize-register-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "finalize-register-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+    const resolveOpenshellPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "resolve-openshell.js"));
+    const fakeOpenshellPath = JSON.stringify(path.join(fakeBin, "openshell"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const resolveOpenshellModule = require(${resolveOpenshellPath});
+const probeCalls = [];
+const registrations = [];
+runner.runCapture = (command) => {
+  probeCalls.push(command);
+  return ['{"choices":[{"message":{"role":"assistant","content":"PONG"}}]}', "__NEMOCLAW_HTTP_STATUS__:200"].join("\n");
+};
+registry.updateSandbox = () => false;
+registry.registerSandbox = (entry) => {
+  registrations.push(entry);
+};
+resolveOpenshellModule.resolveOpenshell = () => ${fakeOpenshellPath};
+
+const { finalizeSandboxInferenceSetup } = require(${onboardPath});
+finalizeSandboxInferenceSetup("sandbox-box", "smollm2:135m", "ollama-local");
+console.log(JSON.stringify({ probeCalls, registrations }));
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    });
 
     try {
-      finalizeSandboxInferenceSetup(
-        "sandbox-box",
-        "nvidia/nemotron-3-super-120b-a12b",
-        "nvidia-nim",
-        "nvcr.io/test/container:latest",
+      expect(result.status).toBe(0);
+      const payload = JSON.parse(result.stdout.trim());
+      expect(payload.probeCalls).toHaveLength(1);
+      expect(payload.probeCalls[0]).toContain("sandbox-box");
+      expect(payload.probeCalls[0]).toContain("https://inference.local/v1/chat/completions");
+      expect(payload.probeCalls[0]).toContain(
+        JSON.stringify({
+          model: "smollm2:135m",
+          messages: [{ role: "user", content: "Reply with exactly one word: PONG" }],
+          max_tokens: 8,
+        }),
       );
-      expect(registrations).toEqual([
+      expect(payload.probeCalls[0]).toContain("\\n__NEMOCLAW_HTTP_STATUS__:%{http_code}");
+      expect(payload.registrations).toEqual([
         {
           name: "sandbox-box",
-          model: "nvidia/nemotron-3-super-120b-a12b",
-          provider: "nvidia-nim",
-          nimContainer: "nvcr.io/test/container:latest",
+          model: "smollm2:135m",
+          provider: "ollama-local",
         },
       ]);
     } finally {
-      registry.updateSandbox = originalUpdateSandbox;
-      registry.registerSandbox = originalRegisterSandbox;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces local sandbox probe failures before persisting sandbox metadata", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-finalize-fail-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "finalize-fail-check.js");
+    const markerPath = path.join(tmpDir, "finalize-fail-marker.json");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+    const resolveOpenshellPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "resolve-openshell.js"));
+    const fakeOpenshellPath = JSON.stringify(path.join(fakeBin, "openshell"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const resolveOpenshellModule = require(${resolveOpenshellPath});
+const fs = require("node:fs");
+const markerPath = ${JSON.stringify(markerPath)};
+const markers = { updateCalls: 0, registrations: [] };
+const writeMarkers = () => {
+  fs.writeFileSync(markerPath, JSON.stringify(markers));
+};
+runner.runCapture = () => [
+  "{\"error\":{\"message\":\"model 'smollm2:135m' not found\"}}",
+  "__NEMOCLAW_HTTP_STATUS__:404",
+].join("\n");
+registry.updateSandbox = (...args) => {
+  markers.updateCalls += 1;
+  writeMarkers();
+  return true;
+};
+registry.registerSandbox = (entry) => {
+  markers.registrations.push(entry);
+  writeMarkers();
+};
+resolveOpenshellModule.resolveOpenshell = () => ${fakeOpenshellPath};
+
+const { finalizeSandboxInferenceSetup } = require(${onboardPath});
+finalizeSandboxInferenceSetup("sandbox-box", "smollm2:135m", "ollama-local");
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    });
+
+    try {
+      expect(result.status).toBe(1);
+      const markers = fs.existsSync(markerPath)
+        ? JSON.parse(fs.readFileSync(markerPath, "utf-8"))
+        : { updateCalls: 0, registrations: [] };
+      expect(markers.updateCalls).toBe(0);
+      expect(markers.registrations).toEqual([]);
+      expect(result.stderr).toContain("Local Ollama was configured");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -52,7 +52,37 @@ import { buildWebSearchDockerConfig } from "../dist/lib/web-search";
 
 const require = createRequire(import.meta.url);
 const { getSuggestedPolicyPresets } = require("../dist/lib/onboard.js");
+// Keep the CJS export object here so onboard helper monkey-patches affect the same module instance.
 const registry = require("../dist/lib/registry.js");
+
+function extractFunctionBody(source, signature) {
+  const signatureIndex = source.indexOf(signature);
+  assert.notEqual(signatureIndex, -1, `Missing function signature: ${signature}`);
+
+  const signatureClose = source.indexOf(")", signatureIndex + signature.length);
+  assert.notEqual(signatureClose, -1, `Missing function signature close for: ${signature}`);
+
+  const bodyStart = source.indexOf("{", signatureClose);
+  assert.notEqual(bodyStart, -1, `Missing function body start for: ${signature}`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char !== "}") {
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0) {
+      return source.slice(bodyStart + 1, index);
+    }
+  }
+
+  throw new Error(`Missing closing brace for function: ${signature}`);
+}
 
 describe("onboard helpers", () => {
   it("classifies sandbox create timeout failures and tracks upload progress", () => {
@@ -1340,7 +1370,7 @@ console.log(JSON.stringify({
     const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
     const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
     const resolveOpenshellPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "resolve-openshell.js"));
-    const fakeOpenshellPath = JSON.stringify(path.join(tmpDir, "openshell"));
+    const fakeOpenshellPath = JSON.stringify(path.join(fakeBin, "openshell"));
 
     fs.mkdirSync(fakeBin, { recursive: true });
     fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
@@ -1937,14 +1967,15 @@ const { setupInference } = require(${onboardPath});
       path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
       "utf-8",
     );
+    const onboardBody = extractFunctionBody(source, "async function onboard(");
 
     assert.match(source, /function finalizeSandboxInferenceSetup\(sandboxName, model, provider, nimContainer = null\)/);
     assert.doesNotMatch(
-      source,
-      /async function setupInference\([\s\S]*?verifyLocalSandboxInference\(/,
+      onboardBody,
+      /verifyLocalSandboxInference\(/,
     );
     assert.match(
-      source,
+      onboardBody,
       /sandboxName = await createSandbox\([\s\S]*?\);\s*onboardSession\.markStepComplete\("sandbox", \{ sandboxName, provider, model, nimContainer \}\);\s*\}\s*finalizeSandboxInferenceSetup\(sandboxName, model, provider, nimContainer\);/,
     );
   });

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -43,6 +43,7 @@ import {
   summarizeCurlFailure,
   summarizeProbeFailure,
   shouldIncludeBuildContextPath,
+  verifyLocalSandboxInference,
   writeSandboxConfigSyncFile,
 } from "../dist/lib/onboard";
 import { stageOptimizedSandboxBuildContext } from "../dist/lib/sandbox-build-context";
@@ -1326,6 +1327,32 @@ console.log(JSON.stringify({
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it("verifies local Ollama inference.local chat routing from inside the sandbox", () => {
+    expect(
+      verifyLocalSandboxInference("sandbox-box", "smollm2:135m", "ollama-local", () =>
+        [
+          '{"id":"chatcmpl-test","choices":[{"index":0,"message":{"role":"assistant","content":"PONG"}}]}',
+          "__NEMOCLAW_HTTP_STATUS__:200",
+        ].join("\n"),
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("reports a local Ollama model mismatch when inference.local returns 404 in the sandbox", () => {
+    expect(
+      verifyLocalSandboxInference("sandbox-box", "smollm2:135m", "ollama-local", () =>
+        [
+          '{"error":{"message":"model \'smollm2:135m\' not found"}}',
+          "__NEMOCLAW_HTTP_STATUS__:404",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      ok: false,
+      message:
+        "Local Ollama was configured, but inference.local inside sandbox 'sandbox-box' could not serve model 'smollm2:135m'. HTTP 404: {\"error\":{\"message\":\"model 'smollm2:135m' not found\"}}",
+    });
   });
 
   it("detects when OpenClaw is already configured inside the sandbox", () => {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1456,6 +1456,26 @@ const { setupInference } = require(${onboardPath});
     ).toEqual({ ok: true });
   });
 
+  it("treats sandbox-local inference probe status 0 as retryable", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const onboardSource = fs.readFileSync(path.join(repoRoot, "src", "lib", "onboard.ts"), "utf8");
+    const parseSandboxInferenceProbeBody = extractFunctionBody(
+      onboardSource,
+      "function parseSandboxInferenceProbe(",
+    );
+    const parseSandboxInferenceProbe = new Function(
+      "compactText",
+      `return function parseSandboxInferenceProbe(output) {${parseSandboxInferenceProbeBody}}`,
+    )(compactText);
+
+    const result = parseSandboxInferenceProbe(
+      ["curl: (7) Failed to connect", "__NEMOCLAW_HTTP_STATUS__:0"].join("\n"),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.retryable).toBe(true);
+    expect(result.message).toContain("HTTP 0");
+  });
+
   it("reports a local Ollama model mismatch when inference.local returns 404 in the sandbox", () => {
     const result =
       verifyLocalSandboxInference("sandbox-box", "smollm2:135m", "ollama-local", () =>

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -55,33 +56,53 @@ const { getSuggestedPolicyPresets } = require("../dist/lib/onboard.js");
 // Keep the CJS export object here so onboard helper monkey-patches affect the same module instance.
 const registry = require("../dist/lib/registry.js");
 
-function extractFunctionBody(source, signature) {
-  const signatureIndex = source.indexOf(signature);
-  assert.notEqual(signatureIndex, -1, `Missing function signature: ${signature}`);
+function createSourceFile(source) {
+  return ts.createSourceFile("onboard.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
 
-  const signatureClose = source.indexOf(")", signatureIndex + signature.length);
-  assert.notEqual(signatureClose, -1, `Missing function signature close for: ${signature}`);
+function findFunctionNode(sourceFile, functionName) {
+  let found = null;
+  function visit(node) {
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isMethodDeclaration(node)) &&
+      node.name?.getText(sourceFile) === functionName
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  assert.ok(found, `Missing function: ${functionName}`);
+  assert.ok(found.body, `Missing function body for: ${functionName}`);
+  return found;
+}
 
-  const bodyStart = source.indexOf("{", signatureClose);
-  assert.notEqual(bodyStart, -1, `Missing function body start for: ${signature}`);
+function getFunctionBody(source, functionName) {
+  const sourceFile = createSourceFile(source);
+  return findFunctionNode(sourceFile, functionName).body.getText(sourceFile);
+}
 
-  let depth = 0;
-  for (let index = bodyStart; index < source.length; index += 1) {
-    const char = source[index];
-    if (char === "{") {
-      depth += 1;
-      continue;
+function getFunctionCallSequence(source, functionName) {
+  const sourceFile = createSourceFile(source);
+  const functionNode = findFunctionNode(sourceFile, functionName);
+  const calls = [];
+
+  function visit(node) {
+    if (ts.isCallExpression(node)) {
+      calls.push({
+        callee: node.expression.getText(sourceFile),
+        args: node.arguments.map((arg) => arg.getText(sourceFile)),
+        start: node.getStart(sourceFile),
+      });
     }
-    if (char !== "}") {
-      continue;
-    }
-    depth -= 1;
-    if (depth === 0) {
-      return source.slice(bodyStart + 1, index);
-    }
+    ts.forEachChild(node, visit);
   }
 
-  throw new Error(`Missing closing brace for function: ${signature}`);
+  visit(functionNode.body);
+  return calls;
 }
 
 describe("onboard helpers", () => {
@@ -1459,13 +1480,9 @@ const { setupInference } = require(${onboardPath});
   it("treats sandbox-local inference probe status 0 as retryable", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const onboardSource = fs.readFileSync(path.join(repoRoot, "src", "lib", "onboard.ts"), "utf8");
-    const parseSandboxInferenceProbeBody = extractFunctionBody(
-      onboardSource,
-      "function parseSandboxInferenceProbe(",
-    );
     const parseSandboxInferenceProbe = new Function(
       "compactText",
-      `return function parseSandboxInferenceProbe(output) {${parseSandboxInferenceProbeBody}}`,
+      `return function parseSandboxInferenceProbe(output) ${getFunctionBody(onboardSource, "parseSandboxInferenceProbe")}`,
     )(compactText);
 
     const result = parseSandboxInferenceProbe(
@@ -2172,16 +2189,36 @@ const { setupInference } = require(${onboardPath});
       path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
       "utf-8",
     );
-    const onboardBody = extractFunctionBody(source, "async function onboard(");
-
-    assert.match(source, /function finalizeSandboxInferenceSetup\(sandboxName, model, provider, nimContainer = null\)/);
-    assert.doesNotMatch(
-      onboardBody,
-      /verifyLocalSandboxInference\(/,
-    );
     assert.match(
-      onboardBody,
-      /sandboxName = await createSandbox\([\s\S]*?\);\s*onboardSession\.markStepComplete\("sandbox", \{ sandboxName, provider, model, nimContainer \}\);\s*\}\s*finalizeSandboxInferenceSetup\(sandboxName, model, provider, nimContainer\);/,
+      source,
+      /function finalizeSandboxInferenceSetup\(sandboxName, model, provider, nimContainer = null\)/,
+    );
+
+    const callSequence = getFunctionCallSequence(source, "onboard");
+    const createSandboxCall = callSequence.find(({ callee }) => callee === "createSandbox");
+    const finalizeCall = callSequence.find(
+      ({ callee }) => callee === "finalizeSandboxInferenceSetup",
+    );
+    const markSandboxStepCall = callSequence.find(
+      ({ callee, args }) =>
+        callee === "onboardSession.markStepComplete" && args[0] === '"sandbox"',
+    );
+
+    assert.ok(createSandboxCall, "Expected onboard to create the sandbox");
+    assert.ok(finalizeCall, "Expected onboard to finalize sandbox inference setup");
+    assert.ok(markSandboxStepCall, "Expected onboard to mark the sandbox step complete");
+    assert.equal(
+      callSequence.some(({ callee }) => callee === "verifyLocalSandboxInference"),
+      false,
+      "onboard should not call verifyLocalSandboxInference before the sandbox exists",
+    );
+    assert.ok(
+      createSandboxCall.start < markSandboxStepCall.start,
+      "createSandbox should happen before marking the sandbox step complete",
+    );
+    assert.ok(
+      markSandboxStepCall.start < finalizeCall.start,
+      "finalizeSandboxInferenceSetup should run after the sandbox step is complete",
     );
   });
 
@@ -4634,19 +4671,9 @@ const { createSandbox } = require(${onboardPath});
       path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
       "utf-8",
     );
-    // Extract the promptValidatedSandboxName function body
-    const fnMatch = source.match(
-      /async function promptValidatedSandboxName\(\)\s*\{([\s\S]*?)\n\}/,
-    );
-    assert.ok(fnMatch, "promptValidatedSandboxName function not found");
-    const fnBody = fnMatch[1];
-    // Verify the bounded retry loop exists within this function
-    assert.match(fnBody, /MAX_ATTEMPTS/);
-    assert.match(fnBody, /for\s*\(let attempt/);
+    const fnBody = getFunctionBody(source, "promptValidatedSandboxName");
     assert.match(fnBody, /Please try again/);
-    // Exits after too many invalid attempts
     assert.match(fnBody, /Too many invalid attempts/);
-    // Non-interactive still exits within this function
     assert.match(fnBody, /isNonInteractive\(\)/);
     assert.match(fnBody, /process\.exit\(1\)/);
   });

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1341,18 +1341,18 @@ console.log(JSON.stringify({
   });
 
   it("reports a local Ollama model mismatch when inference.local returns 404 in the sandbox", () => {
-    expect(
+    const result =
       verifyLocalSandboxInference("sandbox-box", "smollm2:135m", "ollama-local", () =>
         [
           '{"error":{"message":"model \'smollm2:135m\' not found"}}',
           "__NEMOCLAW_HTTP_STATUS__:404",
         ].join("\n"),
-      ),
-    ).toEqual({
-      ok: false,
-      message:
-        "Local Ollama was configured, but inference.local inside sandbox 'sandbox-box' could not serve model 'smollm2:135m'. HTTP 404: {\"error\":{\"message\":\"model 'smollm2:135m' not found\"}}",
-    });
+      );
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("sandbox 'sandbox-box'");
+    expect(result.message).toContain("model 'smollm2:135m'");
+    expect(result.message).toContain("HTTP 404");
+    expect(result.message).toContain("could not serve");
   });
 
   it("detects when OpenClaw is already configured inside the sandbox", () => {
@@ -1803,6 +1803,23 @@ const { setupInference } = require(${onboardPath});
     assert.match(
       source,
       /startRecordedStep\("sandbox", \{ sandboxName, provider, model \}\);\s*selectedMessagingChannels = await setupMessagingChannels\(\);\s*onboardSession\.updateSession\(\(current\) => \{\s*current\.messagingChannels = selectedMessagingChannels;\s*return current;\s*\}\);\s*sandboxName = await createSandbox\(\s*gpu,\s*model,\s*provider,\s*preferredInferenceApi,\s*sandboxName,\s*webSearchConfig,\s*selectedMessagingChannels,\s*fromDockerfile,\s*agent,\s*dangerouslySkipPermissions,\s*\);/,
+    );
+  });
+
+  it("verifies local sandbox inference only after the sandbox exists", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+
+    assert.match(source, /function finalizeSandboxInferenceSetup\(sandboxName, model, provider, nimContainer = null\)/);
+    assert.doesNotMatch(
+      source,
+      /async function setupInference\([\s\S]*?verifyLocalSandboxInference\(/,
+    );
+    assert.match(
+      source,
+      /sandboxName = await createSandbox\([\s\S]*?\);\s*onboardSession\.markStepComplete\("sandbox", \{ sandboxName, provider, model, nimContainer \}\);\s*\}\s*finalizeSandboxInferenceSetup\(sandboxName, model, provider, nimContainer\);/,
     );
   });
 

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -16,6 +16,7 @@ import {
   buildSandboxConfigSyncScript,
   classifySandboxCreateFailure,
   compactText,
+  createReadySandbox,
   formatEnvAssignment,
   getNavigationChoice,
   getGatewayReuseState,
@@ -83,26 +84,6 @@ function findFunctionNode(sourceFile, functionName) {
 function getFunctionBody(source, functionName) {
   const sourceFile = createSourceFile(source);
   return findFunctionNode(sourceFile, functionName).body.getText(sourceFile);
-}
-
-function getFunctionCallSequence(source, functionName) {
-  const sourceFile = createSourceFile(source);
-  const functionNode = findFunctionNode(sourceFile, functionName);
-  const calls = [];
-
-  function visit(node) {
-    if (ts.isCallExpression(node)) {
-      calls.push({
-        callee: node.expression.getText(sourceFile),
-        args: node.arguments.map((arg) => arg.getText(sourceFile)),
-        start: node.getStart(sourceFile),
-      });
-    }
-    ts.forEachChild(node, visit);
-  }
-
-  visit(functionNode.body);
-  return calls;
 }
 
 describe("onboard helpers", () => {
@@ -2184,42 +2165,57 @@ const { setupInference } = require(${onboardPath});
     );
   });
 
-  it("verifies local sandbox inference only after the sandbox exists", () => {
-    const source = fs.readFileSync(
-      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
-      "utf-8",
-    );
-    assert.match(
-      source,
-      /function finalizeSandboxInferenceSetup\(sandboxName, model, provider, nimContainer = null\)/,
-    );
+  it("creates the sandbox before completing the step and finalizing inference setup", async () => {
+    const calls = [];
+    const onboardSessionImpl = {
+      markStepComplete: (...args) => {
+        calls.push({ name: "markStepComplete", args });
+      },
+    };
 
-    const callSequence = getFunctionCallSequence(source, "onboard");
-    const createSandboxCall = callSequence.find(({ callee }) => callee === "createSandbox");
-    const finalizeCall = callSequence.find(
-      ({ callee }) => callee === "finalizeSandboxInferenceSetup",
-    );
-    const markSandboxStepCall = callSequence.find(
-      ({ callee, args }) =>
-        callee === "onboardSession.markStepComplete" && args[0] === '"sandbox"',
-    );
+    const sandboxName = await createReadySandbox({
+      gpu: { vendor: "nvidia" },
+      model: "smollm2:135m",
+      provider: "ollama-local",
+      preferredInferenceApi: null,
+      sandboxName: "sandbox-requested",
+      webSearchConfig: null,
+      selectedMessagingChannels: ["discord"],
+      fromDockerfile: null,
+      agent: null,
+      dangerouslySkipPermissions: false,
+      createSandboxImpl: async (...args) => {
+        calls.push({ name: "createSandbox", args });
+        return "sandbox-created";
+      },
+      onboardSessionImpl,
+      finalizeSandboxInferenceSetupImpl: (...args) => {
+        calls.push({ name: "finalizeSandboxInferenceSetup", args });
+      },
+    });
 
-    assert.ok(createSandboxCall, "Expected onboard to create the sandbox");
-    assert.ok(finalizeCall, "Expected onboard to finalize sandbox inference setup");
-    assert.ok(markSandboxStepCall, "Expected onboard to mark the sandbox step complete");
-    assert.equal(
-      callSequence.some(({ callee }) => callee === "verifyLocalSandboxInference"),
-      false,
-      "onboard should not call verifyLocalSandboxInference before the sandbox exists",
-    );
-    assert.ok(
-      createSandboxCall.start < markSandboxStepCall.start,
-      "createSandbox should happen before marking the sandbox step complete",
-    );
-    assert.ok(
-      markSandboxStepCall.start < finalizeCall.start,
-      "finalizeSandboxInferenceSetup should run after the sandbox step is complete",
-    );
+    expect(sandboxName).toBe("sandbox-created");
+    expect(calls.map(({ name }) => name)).toEqual([
+      "createSandbox",
+      "markStepComplete",
+      "finalizeSandboxInferenceSetup",
+    ]);
+    expect(calls[0].args[4]).toBe("sandbox-requested");
+    expect(calls[1].args).toEqual([
+      "sandbox",
+      {
+        sandboxName: "sandbox-created",
+        provider: "ollama-local",
+        model: "smollm2:135m",
+        nimContainer: null,
+      },
+    ]);
+    expect(calls[2].args).toEqual([
+      "sandbox-created",
+      "smollm2:135m",
+      "ollama-local",
+      null,
+    ]);
   });
 
   it("prints numbered step headers even when onboarding skips resumed steps", () => {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1459,19 +1459,23 @@ const { setupInference } = require(${onboardPath});
   });
 
   it("treats sandbox-local inference probe status 0 as retryable", () => {
-    const repoRoot = path.join(import.meta.dirname, "..");
-    const onboardSource = fs.readFileSync(path.join(repoRoot, "src", "lib", "onboard.ts"), "utf8");
-    const parseSandboxInferenceProbe = new Function(
-      "compactText",
-      `return function parseSandboxInferenceProbe(output) ${getFunctionBody(onboardSource, "parseSandboxInferenceProbe")}`,
-    )(compactText);
-
-    const result = parseSandboxInferenceProbe(
+    const outputs = [
       ["curl: (7) Failed to connect", "__NEMOCLAW_HTTP_STATUS__:0"].join("\n"),
-    );
-    expect(result.ok).toBe(false);
-    expect(result.retryable).toBe(true);
-    expect(result.message).toContain("HTTP 0");
+      [
+        '{"id":"chatcmpl-test","choices":[{"index":0,"message":{"role":"assistant","content":"PONG"}}]}',
+        "__NEMOCLAW_HTTP_STATUS__:200",
+      ].join("\n"),
+    ];
+    let calls = 0;
+
+    const result = verifyLocalSandboxInference("sandbox-box", "smollm2:135m", "ollama-local", () => {
+      const output = outputs[calls];
+      calls += 1;
+      return output;
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toBe(2);
   });
 
   it("reports a local Ollama model mismatch when inference.local returns 404 in the sandbox", () => {
@@ -1497,6 +1501,48 @@ const { setupInference } = require(${onboardPath});
     );
     expect(result.ok).toBe(false);
     expect(result.message).toContain("Unexpected inference.local response");
+  });
+
+  it("clamps sandbox probe attempts so a zero env setting still performs one check", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-probe-attempt-floor-"));
+    const scriptPath = path.join(tmpDir, "probe-attempt-floor-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+
+    const script = String.raw`
+const { verifyLocalSandboxInference } = require(${onboardPath});
+
+let calls = 0;
+const result = verifyLocalSandboxInference("sandbox-box", "smollm2:135m", "ollama-local", () => {
+  calls += 1;
+  return [
+    '{"error":{"message":"model not found"}}',
+    "__NEMOCLAW_HTTP_STATUS__:404",
+  ].join("\\n");
+});
+
+console.log(JSON.stringify({ calls, result }));
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NEMOCLAW_LOCAL_SANDBOX_PROBE_ATTEMPTS: "0",
+      },
+    });
+
+    try {
+      expect(result.status).toBe(0);
+      const payload = JSON.parse(result.stdout.trim());
+      expect(payload.calls).toBe(1);
+      expect(payload.result.ok).toBe(false);
+      expect(payload.result.message).toContain("could not serve");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("registers sandbox metadata when updateSandbox cannot find the local vLLM sandbox entry", () => {
@@ -2197,11 +2243,17 @@ const { setupInference } = require(${onboardPath});
     expect(sandboxName).toBe("sandbox-created");
     expect(calls.map(({ name }) => name)).toEqual([
       "createSandbox",
-      "markStepComplete",
       "finalizeSandboxInferenceSetup",
+      "markStepComplete",
     ]);
     expect(calls[0].args[4]).toBe("sandbox-requested");
     expect(calls[1].args).toEqual([
+      "sandbox-created",
+      "smollm2:135m",
+      "ollama-local",
+      null,
+    ]);
+    expect(calls[2].args).toEqual([
       "sandbox",
       {
         sandboxName: "sandbox-created",
@@ -2209,12 +2261,6 @@ const { setupInference } = require(${onboardPath});
         model: "smollm2:135m",
         nimContainer: null,
       },
-    ]);
-    expect(calls[2].args).toEqual([
-      "sandbox-created",
-      "smollm2:135m",
-      "ollama-local",
-      null,
     ]);
   });
 


### PR DESCRIPTION
## What

- tighten `verifyInferenceRoute()` so onboarding fails if the live OpenShell route does not match the selected provider/model
- add a local-provider onboarding guard that sends a tiny `https://inference.local/v1/chat/completions` request from inside the sandbox before reporting success
- add focused tests for the local Ollama success and model-404 paths

## Why

Issue #1750 shows a Windows + WSL2 false-success lane: onboarding can finish and the model can be discovered, but live requests through `inference.local` still fail at runtime. This change keeps NemoClaw from declaring success when the sandbox cannot actually serve the selected local model.

## Validation

- `npm run build:cli -- --pretty false`
- `npx vitest run test/onboard.test.ts -t "local Ollama inference.local chat routing|local Ollama model mismatch"`

## Notes

- this is intentionally scoped to local providers (`ollama-local`, `vllm-local`)
- it is a maintainer-friendly guard against the false-positive onboarding path reported in #1750, not a broad inference pipeline rewrite
- refs #1750


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now performs controlled, retryable probes of local sandbox inference endpoints and only marks sandboxes ready and saves metadata after successful local verification.

* **Bug Fixes**
  * Stronger validation and clearer abort messages when live or local inference responses don’t match the selected provider/model or expected response format; probes respect configured attempt/delay limits.

* **Tests**
  * Expanded tests covering probe success, retryable failures, mismatches, malformed responses, persistence gating, and sandbox readiness ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->