### PR TITLE
fix(cli): preserve shared host services when destroying non-default sandboxes (#1690)

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1220,13 +1220,8 @@ function sandboxPolicyList(sandboxName) {
   console.log("");
 }
 
-function cleanupSandboxServices(sandboxName) {
-  const { defaultSandbox } = registry.listSandboxes();
-  const shouldStopHostServices = !defaultSandbox || defaultSandbox === sandboxName;
-
-  // Host-side services/forwards are effectively singleton state. Only stop
-  // them when destroying the default sandbox (or when no default remains).
-  if (shouldStopHostServices) {
+function cleanupSandboxServices(sandboxName, { stopHostServices = false } = {}) {
+  if (stopHostServices) {
     const { stopAll } = require("./lib/services");
     stopAll({ sandboxName });
   }
@@ -1259,8 +1254,6 @@ async function sandboxDestroy(sandboxName, args = []) {
   if (sb && sb.nimContainer) nim.stopNimContainerByName(sb.nimContainer);
   else nim.stopNimContainer(sandboxName);
 
-  cleanupSandboxServices(sandboxName);
-
   console.log(`  Deleting sandbox '${sandboxName}'...`);
   const deleteResult = runOpenshell(["sandbox", "delete", sandboxName], {
     ignoreError: true,
@@ -1275,6 +1268,13 @@ async function sandboxDestroy(sandboxName, args = []) {
     console.error(`  Failed to destroy sandbox '${sandboxName}'.`);
     process.exit(deleteResult.status || 1);
   }
+
+  const shouldStopHostServices =
+    (deleteResult.status === 0 || alreadyGone) &&
+    registry.listSandboxes().sandboxes.length === 1 &&
+    !!registry.getSandbox(sandboxName);
+
+  cleanupSandboxServices(sandboxName, { stopHostServices: shouldStopHostServices });
 
   const removed = registry.removeSandbox(sandboxName);
   const session = onboardSession.loadSession();

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1221,9 +1221,15 @@ function sandboxPolicyList(sandboxName) {
 }
 
 function cleanupSandboxServices(sandboxName) {
-  // Stop host services (cloudflared) and clean up PID directory.
-  const { stopAll } = require("./lib/services");
-  stopAll({ sandboxName });
+  const { defaultSandbox } = registry.listSandboxes();
+  const shouldStopHostServices = !defaultSandbox || defaultSandbox === sandboxName;
+
+  // Host-side services/forwards are effectively singleton state. Only stop
+  // them when destroying the default sandbox (or when no default remains).
+  if (shouldStopHostServices) {
+    const { stopAll } = require("./lib/services");
+    stopAll({ sandboxName });
+  }
   try {
     fs.rmSync(`/tmp/nemoclaw-services-${sandboxName}`, { recursive: true, force: true });
   } catch {


### PR DESCRIPTION
## Summary
This fixes sandbox destroy cleanup so shared host-side services are only torn down when the final sandbox is removed. The regression came from calling `stopAll({ sandboxName })` for every destroy, even though the dashboard forward and related host-side service state are effectively shared process state rather than per-sandbox state.

## Related Issue
Fixes #1690

## Changes
- defer host-side service teardown until sandbox deletion succeeds and the destroyed sandbox was the last registered sandbox
- keep per-sandbox cleanup unchanged by still removing the sandbox PID directory and deleting per-sandbox messaging providers on every destroy
- preserve existing last-sandbox gateway cleanup behavior elsewhere in the destroy flow

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
Signed-off-by: sh4 <sh4@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sandbox deletion and cleanup with optimized host service shutdown timing to prevent premature or unnecessary service termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->