### PR TITLE
fix(security): unify secret redaction patterns across all modules (#1736)

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -122,11 +122,15 @@ if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
 fi
 
 # Redact known sensitive patterns (API keys, tokens, passwords in env/args).
+# Keep in sync with src/lib/secret-patterns.ts — consistency test enforces this.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/1736
 redact() {
   sed -E \
     -e 's/(NVIDIA_API_KEY|API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|_KEY)=\S+/\1=<REDACTED>/gi' \
-    -e 's/(nvapi-[A-Za-z0-9_-]{10,})/<REDACTED>/g' \
-    -e 's/(ghp_[A-Za-z0-9]{30,})/<REDACTED>/g' \
+    -e 's/nvapi-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    -e 's/nvcf-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    -e 's/ghp_[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    -e 's/github_pat_[A-Za-z0-9_]{30,}/<REDACTED>/g' \
     -e 's/(Bearer )[^ ]+/\1<REDACTED>/gi'
 }
 

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -45,10 +45,16 @@ function section(title: string): void {
 // Secret redaction
 // ---------------------------------------------------------------------------
 
+// Import canonical patterns from single source of truth (secret-patterns.ts).
+// debug.ts uses [pattern, replacement] tuples for full-replacement redaction,
+// while runner.ts uses the raw patterns with partial-redaction (keep first 4 chars).
+import { TOKEN_PREFIX_PATTERNS } from "./secret-patterns";
+
 const REDACT_PATTERNS: [RegExp, string][] = [
   [/(NVIDIA_API_KEY|API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|_KEY)=\S+/gi, "$1=<REDACTED>"],
-  [/nvapi-[A-Za-z0-9_-]{10,}/g, "<REDACTED>"],
-  [/(?:ghp_|github_pat_)[A-Za-z0-9_]{30,}/g, "<REDACTED>"],
+  ...TOKEN_PREFIX_PATTERNS.map(
+    (p): [RegExp, string] => [new RegExp(p.source, p.flags), "<REDACTED>"],
+  ),
   [/(Bearer )\S+/gi, "$1<REDACTED>"],
 ];
 

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -82,13 +82,8 @@ function runCapture(cmd, opts = {}) {
  * in CLI log and error output. Covers NVIDIA API keys, bearer tokens,
  * generic API key assignments, and base64-style long tokens.
  */
-const SECRET_PATTERNS = [
-  /nvapi-[A-Za-z0-9_-]{10,}/g,
-  /nvcf-[A-Za-z0-9_-]{10,}/g,
-  /ghp_[A-Za-z0-9_-]{10,}/g,
-  /(?<=Bearer\s+)[A-Za-z0-9_.+/=-]{10,}/gi,
-  /(?<=(?:_KEY|API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[=: ]['"]?)[A-Za-z0-9_.+/=-]{10,}/gi,
-];
+// Single source of truth for secret patterns — see secret-patterns.ts
+const { SECRET_PATTERNS } = require("./secret-patterns");
 
 /**
  * Partially redact a matched secret string: keep the first 4 chars and replace

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canonical secret redaction patterns — single source of truth.
+ *
+ * Used by runner.ts (CLI output), debug.ts (diagnostic dumps), and
+ * mirrored in debug.sh (shell diagnostics). If you add a pattern here,
+ * also add it to scripts/debug.sh:redact() and update the consistency
+ * test in test/secret-redaction.test.ts.
+ *
+ * Ref: https://github.com/NVIDIA/NemoClaw/issues/1736
+ */
+
+/** Token-prefix patterns that match standalone (no context needed). */
+export const TOKEN_PREFIX_PATTERNS: RegExp[] = [
+  /nvapi-[A-Za-z0-9_-]{10,}/g,
+  /nvcf-[A-Za-z0-9_-]{10,}/g,
+  /ghp_[A-Za-z0-9_-]{10,}/g,
+  /(?:github_pat_)[A-Za-z0-9_]{30,}/g,
+];
+
+/** Context-anchored patterns (require a prefix like KEY=, Bearer, etc.). */
+export const CONTEXT_PATTERNS: RegExp[] = [
+  /(?<=Bearer\s+)[A-Za-z0-9_.+/=-]{10,}/gi,
+  /(?<=(?:_KEY|API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[=: ]['"]?)[A-Za-z0-9_.+/=-]{10,}/gi,
+];
+
+/** All secret patterns combined. */
+export const SECRET_PATTERNS: RegExp[] = [
+  ...TOKEN_PREFIX_PATTERNS,
+  ...CONTEXT_PATTERNS,
+];
+
+/**
+ * Token prefixes that debug.sh must also handle.
+ * Used by the consistency test to verify debug.sh stays in sync.
+ */
+export const EXPECTED_SHELL_PREFIXES = [
+  "nvapi-",
+  "nvcf-",
+  "ghp_",
+  "github_pat_",
+];

--- a/test/secret-redaction.test.ts
+++ b/test/secret-redaction.test.ts
@@ -8,6 +8,12 @@ import {
   SECRET_PATTERNS,
   EXPECTED_SHELL_PREFIXES,
 } from "../src/lib/secret-patterns";
+import { redact as debugRedact } from "../src/lib/debug";
+// runner.ts uses CJS exports — import via dist
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { redact: runnerRedact } = require("../dist/lib/runner");
 
 const DEBUG_SH = readFileSync(
   join(import.meta.dirname, "..", "scripts", "debug.sh"),
@@ -39,13 +45,20 @@ describe("secret redaction consistency (#1736)", () => {
   describe("runner.ts redacts all token types", () => {
     for (const { name, token } of TEST_TOKENS) {
       it(`redacts ${name}`, () => {
-        let text = `error: authentication failed with ${token}`;
-        for (const pattern of SECRET_PATTERNS) {
-          const fresh = new RegExp(pattern.source, pattern.flags);
-          text = text.replace(fresh, (m: string) =>
-            m.slice(0, 4) + "*".repeat(Math.min(m.length - 4, 20)),
-          );
-        }
+        const text = runnerRedact(
+          `error: authentication failed with ${token}`,
+        );
+        expect(text).not.toContain(token);
+      });
+    }
+  });
+
+  describe("debug.ts redacts all token types", () => {
+    for (const { name, token } of TEST_TOKENS) {
+      it(`redacts ${name}`, () => {
+        const text = debugRedact(
+          `error: authentication failed with ${token}`,
+        );
         expect(text).not.toContain(token);
       });
     }

--- a/test/secret-redaction.test.ts
+++ b/test/secret-redaction.test.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  SECRET_PATTERNS,
+  EXPECTED_SHELL_PREFIXES,
+} from "../src/lib/secret-patterns";
+
+const DEBUG_SH = readFileSync(
+  join(import.meta.dirname, "..", "scripts", "debug.sh"),
+  "utf-8",
+);
+
+const RUNNER_TS = readFileSync(
+  join(import.meta.dirname, "..", "src", "lib", "runner.ts"),
+  "utf-8",
+);
+
+const DEBUG_TS = readFileSync(
+  join(import.meta.dirname, "..", "src", "lib", "debug.ts"),
+  "utf-8",
+);
+
+describe("secret redaction consistency (#1736)", () => {
+  // Test tokens that MUST be redacted by all three modules
+  const TEST_TOKENS = [
+    { name: "NVIDIA API key", token: "nvapi-" + "a".repeat(30) },
+    { name: "NVIDIA Cloud Functions", token: "nvcf-" + "b".repeat(30) },
+    { name: "GitHub PAT (classic)", token: "ghp_" + "c".repeat(36) },
+    {
+      name: "GitHub PAT (fine-grained)",
+      token: "github_pat_" + "d".repeat(50),
+    },
+  ];
+
+  describe("runner.ts redacts all token types", () => {
+    for (const { name, token } of TEST_TOKENS) {
+      it(`redacts ${name}`, () => {
+        let text = `error: authentication failed with ${token}`;
+        for (const pattern of SECRET_PATTERNS) {
+          const fresh = new RegExp(pattern.source, pattern.flags);
+          text = text.replace(fresh, (m: string) =>
+            m.slice(0, 4) + "*".repeat(Math.min(m.length - 4, 20)),
+          );
+        }
+        expect(text).not.toContain(token);
+      });
+    }
+  });
+
+  describe("runner.ts imports from secret-patterns.ts", () => {
+    it("uses the shared module", () => {
+      expect(RUNNER_TS).toContain("secret-patterns");
+    });
+  });
+
+  describe("debug.ts imports from secret-patterns.ts", () => {
+    it("uses the shared module", () => {
+      expect(DEBUG_TS).toContain("secret-patterns");
+    });
+  });
+
+  describe("debug.sh includes all token prefixes", () => {
+    for (const prefix of EXPECTED_SHELL_PREFIXES) {
+      it(`includes ${prefix} pattern`, () => {
+        expect(DEBUG_SH).toContain(prefix);
+      });
+    }
+  });
+
+  describe("debug.sh redact() function handles all token types", () => {
+    for (const { name, token } of TEST_TOKENS) {
+      it(`redacts ${name}`, () => {
+        // Extract the redact function's sed patterns and verify they match
+        const redactFn = DEBUG_SH.match(
+          /redact\(\) \{[\s\S]*?^\}/m,
+        );
+        expect(redactFn).toBeTruthy();
+        // The token prefix should appear in a sed expression
+        const prefix = token.split(/[A-Za-z0-9]{10}/)[0];
+        expect(redactFn![0]).toContain(prefix);
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Create `src/lib/secret-patterns.ts` as single source of truth for secret redaction patterns
- `runner.ts` and `debug.ts` now import from the shared module instead of maintaining independent copies
- `debug.sh` updated with all missing patterns (`nvcf-*`, `github_pat_*`)
- 14 consistency tests ensure all three modules stay in sync

## Problem

Three modules independently maintained their own secret pattern lists, which had diverged:

| Token Pattern | runner.ts | debug.ts | debug.sh |
|---|---|---|---|
| `nvapi-*` | Redacted | Redacted | Redacted |
| `nvcf-*` | Redacted | **LEAKED** | **LEAKED** |
| `ghp_*` | Redacted | Redacted | Redacted |
| `github_pat_*` | **LEAKED** | Redacted | **LEAKED** |

## Fix

After this PR, all four token types are redacted consistently across all output paths. The consistency test reads `debug.sh` source and verifies every prefix from the shared TypeScript module appears in the shell function.

Closes #1736

## Test plan

- [x] 14 new tests in `test/secret-redaction.test.ts`
- [x] All 1098 CLI tests pass
- [x] TypeScript build clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and standardized secret redaction rules into a shared source and expanded coverage to additional token prefixes so all components redact the same token types (including shell tooling).

* **Tests**
  * Added a comprehensive test suite that verifies consistent redaction across implementations and ensures shell-side redaction supports every expected token prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->