### PR TITLE
perf(e2e): parallelize Docker pulls with npm install in launchable

### DIFF
--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -113,6 +113,12 @@ wait_for_apt_lock() {
 # ══════════════════════════════════════════════════════════════════════
 # 1. System packages
 # ══════════════════════════════════════════════════════════════════════
+# Kill unattended-upgrades immediately — it grabs the apt lock on boot
+# and can block for 60-120s. Irrelevant on an ephemeral CI VM.
+sudo systemctl stop unattended-upgrades 2>/dev/null || true
+sudo systemctl disable unattended-upgrades 2>/dev/null || true
+sudo killall -9 unattended-upgr 2>/dev/null || true
+
 info "Installing system packages..."
 wait_for_apt_lock
 retry 3 10 "apt-get update" sudo apt-get update -qq

--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -214,6 +214,32 @@ else
     "https://github.com/NVIDIA/NemoClaw.git" "$NEMOCLAW_CLONE_DIR"
 fi
 
+# ── Start Docker image pulls in the background ─────────────────────
+# Docker pulls are network-bound and independent of npm install / plugin
+# build (CPU-bound). Running them in parallel saves ~60-80s.
+DOCKER_PULL_PID=""
+if [[ "${SKIP_DOCKER_PULL:-0}" != "1" ]]; then
+  info "Pre-pulling Docker images in background..."
+  (
+    CLUSTER_TAG="${OPENSHELL_VERSION#v}" # v0.0.20 → 0.0.20
+    CLUSTER_IMAGE="ghcr.io/nvidia/openshell/cluster:${CLUSTER_TAG}"
+
+    # Pull all images in parallel
+    for image in "${DOCKER_IMAGES[@]}" "$CLUSTER_IMAGE"; do
+      sg docker -c "docker pull $image" 2>&1 | tail -1 &
+    done
+    wait
+
+    # If pinned cluster tag failed, try :latest
+    if ! sg docker -c "docker image inspect $CLUSTER_IMAGE" >/dev/null 2>&1; then
+      warn "  Could not pull $CLUSTER_IMAGE — trying :latest"
+      sg docker -c "docker pull ghcr.io/nvidia/openshell/cluster:latest" 2>&1 | tail -1 \
+        || warn "  Failed to pull openshell/cluster (will be pulled at test time)"
+    fi
+  ) &
+  DOCKER_PULL_PID=$!
+fi
+
 info "Installing npm dependencies..."
 cd "$NEMOCLAW_CLONE_DIR"
 npm install --ignore-scripts 2>&1 | tail -3
@@ -227,32 +253,14 @@ cd "$NEMOCLAW_CLONE_DIR"
 info "Plugin built"
 
 # ══════════════════════════════════════════════════════════════════════
-# 6. Pre-pull Docker images
+# 6. Wait for Docker image pulls to finish
 # ══════════════════════════════════════════════════════════════════════
-if [[ "${SKIP_DOCKER_PULL:-0}" == "1" ]]; then
-  info "Skipping Docker image pre-pulls (SKIP_DOCKER_PULL=1)"
-else
-  info "Pre-pulling Docker images (this saves 3-5 min per CI run)..."
-
-  # Use sg docker to ensure docker group is active without re-login
-  for image in "${DOCKER_IMAGES[@]}"; do
-    info "  Pulling $image..."
-    sg docker -c "docker pull $image" 2>&1 | tail -1 \
-      || warn "  Failed to pull $image (will be pulled at test time)"
-  done
-
-  # The openshell/cluster image tag should match the CLI version.
-  # Try the pinned version first, fall back to latest.
-  CLUSTER_TAG="${OPENSHELL_VERSION#v}" # v0.0.20 → 0.0.20
-  CLUSTER_IMAGE="ghcr.io/nvidia/openshell/cluster:${CLUSTER_TAG}"
-  info "  Pulling $CLUSTER_IMAGE..."
-  if ! sg docker -c "docker pull $CLUSTER_IMAGE" 2>&1 | tail -1; then
-    warn "  Could not pull $CLUSTER_IMAGE — trying :latest"
-    sg docker -c "docker pull ghcr.io/nvidia/openshell/cluster:latest" 2>&1 | tail -1 \
-      || warn "  Failed to pull openshell/cluster (will be pulled at test time)"
-  fi
-
+if [[ -n "$DOCKER_PULL_PID" ]]; then
+  info "Waiting for background Docker pulls to finish..."
+  wait "$DOCKER_PULL_PID" || warn "Some Docker pulls failed (will be pulled at test time)"
   info "Docker images pre-pulled"
+elif [[ "${SKIP_DOCKER_PULL:-0}" == "1" ]]; then
+  info "Skipping Docker image pre-pulls (SKIP_DOCKER_PULL=1)"
 fi
 
 # ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Start Docker image pulls in the background while npm install + plugin build runs in the foreground
- Pull all Docker images (sandbox-base, node:22-slim, openshell/cluster) in parallel with each other
- Docker pulls are network-bound, npm/build are CPU-bound — no contention
- Expected savings: ~60-80s from the launchable setup phase

## Test plan
- [ ] Run e2e-brev with `TEST_SUITE=full` and compare launchable setup time vs baseline (~232s → ~150s)
- [ ] Verify all Docker images are pulled (check `docker images` on the instance)
- [ ] Verify fallback to `:latest` still works if pinned cluster tag fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container images are preloaded in parallel to speed up CI pipeline startup.
  * Improved management of background image pulls with clearer wait/skip behavior and failure warnings.
  * Reduced interference from system package processes to minimize install conflicts and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->