### PR TITLE
feat(install): add Jetson platform setup via scripts/setup-jetson.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -693,7 +693,6 @@ run_platform_setup_step() {
   fi
   [[ -n "$family" ]] || return 0
 
-  step 0 "Platform-specific Setup"
   bash "$setup_script" "$family"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -683,6 +683,20 @@ detect_gpu() {
   return 1
 }
 
+run_platform_setup_step() {
+  local setup_script="${SCRIPT_DIR}/setup-jetson.sh"
+  [[ -f "$setup_script" ]] || return 0
+
+  local family=""
+  if detect_gpu; then
+    family="$(bash "$setup_script" --detect)"
+  fi
+  [[ -n "$family" ]] || return 0
+
+  step 0 "Platform-specific Setup"
+  bash "$setup_script" "$family"
+}
+
 get_vram_mb() {
   # Returns total VRAM in MiB (NVIDIA only). Falls back to 0.
   if command_exists nvidia-smi; then
@@ -1189,6 +1203,7 @@ main() {
 
   _INSTALL_START=$SECONDS
   print_banner
+  run_platform_setup_step
 
   step 1 "Node.js"
   install_nodejs

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Jetson host setup for NemoClaw.
+#
+# Usage:
+#   bash scripts/setup-jetson.sh              # detect family and configure
+#   bash scripts/setup-jetson.sh --detect     # print detected family (thor|orin) and exit
+#   bash scripts/setup-jetson.sh orin         # configure for a specific family
+#
+# Root operations are performed with inline sudo — the invoking user will be
+# prompted for their password if needed. Do NOT run this script with sudo.
+
+set -euo pipefail
+
+C_GREEN='\033[0;32m'
+C_YELLOW='\033[1;33m'
+C_RED='\033[0;31m'
+C_RESET='\033[0m'
+
+info() { printf "${C_GREEN}[INFO]${C_RESET}  %s\n" "$*"; }
+warn() { printf "${C_YELLOW}[WARN]${C_RESET}  %s\n" "$*"; }
+ok() { printf "  ${C_GREEN}✓${C_RESET}  %s\n" "$*"; }
+error() {
+  printf "${C_RED}[ERROR]${C_RESET} %s\n" "$*" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+detect_jetson() {
+  local gpu_name
+  gpu_name="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)"
+  local normalized="${gpu_name,,}"
+
+  if [[ "$normalized" == *thor* ]]; then
+    printf "%s" "thor"
+  elif [[ "$normalized" == *orin* ]]; then
+    printf "%s" "orin"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+configure_jetson_host() {
+  local family="$1"
+
+  info "Jetson ${family} detected — applying required host configuration"
+  info "Sudo is required for kernel and Docker configuration — you may be prompted for your password."
+
+  case "$family" in
+    orin)
+      sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+
+      if [[ -f /etc/docker/daemon.json ]]; then
+        sudo cp /etc/docker/daemon.json /etc/docker/daemon.json.bak
+        sudo python3 -c "
+import json, os, tempfile
+path = '/etc/docker/daemon.json'
+with open(path) as f:
+    cfg = json.load(f)
+cfg.pop('iptables', None)
+cfg.pop('bridge', None)
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path))
+with os.fdopen(fd, 'w') as f:
+    json.dump(cfg, f, indent=2)
+os.replace(tmp, path)
+"
+      else
+        warn "/etc/docker/daemon.json not found — skipping Docker daemon patch"
+      fi
+      ;;
+    thor) ;; # No daemon.json or iptables changes needed on Thor
+    *)
+      error "Unsupported Jetson family: $family"
+      ;;
+  esac
+
+  # Load br_netfilter now and persist it across reboots.
+  sudo modprobe br_netfilter
+  echo "br_netfilter" | sudo tee /etc/modules-load.d/nemoclaw.conf >/dev/null
+
+  # Enable iptables processing for bridged traffic (required by k3s).
+  # Persist via sysctl.d so the setting survives reboots.
+  sudo sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
+  sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=1 >/dev/null
+  printf 'net.bridge.bridge-nf-call-iptables=1\nnet.bridge.bridge-nf-call-ip6tables=1\n' \
+    | sudo tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+
+  if [[ "$family" == "orin" ]]; then
+    if sudo systemctl list-unit-files docker.service >/dev/null 2>&1; then
+      sudo systemctl restart docker
+    else
+      warn "Docker service not found — skipping restart"
+    fi
+  fi
+
+  ok "Jetson ${family} host configuration applied"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  if [[ "${1:-}" == "--detect" ]]; then
+    detect_jetson
+    exit 0
+  fi
+
+  local family="${1:-$(detect_jetson)}"
+  if [[ -z "$family" ]]; then
+    exit 0
+  fi
+
+  configure_jetson_host "$family"
+}
+
+main "$@"

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -33,7 +33,7 @@ error() {
 
 detect_jetson() {
   local gpu_name
-  gpu_name="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)"
+  gpu_name="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 || true)"
   local normalized="${gpu_name,,}"
 
   if [[ "$normalized" == *thor* ]]; then
@@ -50,8 +50,12 @@ detect_jetson() {
 configure_jetson_host() {
   local family="$1"
 
+  if [[ "${NEMOCLAW_NON_INTERACTIVE:-}" == "1" ]] && ! sudo -n true 2>/dev/null; then
+    error "Jetson host setup requires sudo but no password-less sudo is available in non-interactive mode."
+  fi
+
   info "Jetson ${family} detected — applying required host configuration"
-  info "Sudo is required for kernel and Docker configuration — you may be prompted for your password."
+  info "Sudo is required for kernel configuration — you may be prompted for your password."
 
   # Load br_netfilter now and persist it across reboots.
   sudo modprobe br_netfilter

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -53,34 +53,6 @@ configure_jetson_host() {
   info "Jetson ${family} detected — applying required host configuration"
   info "Sudo is required for kernel and Docker configuration — you may be prompted for your password."
 
-  case "$family" in
-    orin)
-      sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
-
-      if [[ -f /etc/docker/daemon.json ]]; then
-        sudo cp /etc/docker/daemon.json /etc/docker/daemon.json.bak
-        sudo python3 -c "
-import json, os, tempfile
-path = '/etc/docker/daemon.json'
-with open(path) as f:
-    cfg = json.load(f)
-cfg.pop('iptables', None)
-cfg.pop('bridge', None)
-fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path))
-with os.fdopen(fd, 'w') as f:
-    json.dump(cfg, f, indent=2)
-os.replace(tmp, path)
-"
-      else
-        warn "/etc/docker/daemon.json not found — skipping Docker daemon patch"
-      fi
-      ;;
-    thor) ;; # No daemon.json or iptables changes needed on Thor
-    *)
-      error "Unsupported Jetson family: $family"
-      ;;
-  esac
-
   # Load br_netfilter now and persist it across reboots.
   sudo modprobe br_netfilter
   echo "br_netfilter" | sudo tee /etc/modules-load.d/nemoclaw.conf >/dev/null
@@ -91,14 +63,6 @@ os.replace(tmp, path)
   sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=1 >/dev/null
   printf 'net.bridge.bridge-nf-call-iptables=1\nnet.bridge.bridge-nf-call-ip6tables=1\n' \
     | sudo tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
-
-  if [[ "$family" == "orin" ]]; then
-    if sudo systemctl list-unit-files docker.service >/dev/null 2>&1; then
-      sudo systemctl restart docker
-    else
-      warn "Docker service not found — skipping restart"
-    fi
-  fi
 
   ok "Jetson ${family} host configuration applied"
 }


### PR DESCRIPTION
  Introduce scripts/setup-jetson.sh to handle all Jetson-specific host
  configuration. The script is self-contained and uses inline sudo so the
  main installer runs as the invoking user without a re-exec dance.

  - Detects Thor/Orin via nvidia-smi (--detect mode for caller gating)
  - Orin: switches to legacy iptables, patches daemon.json atomically via Python (with .bak before write), restarts Docker
  - Both: loads br_netfilter and persists it via modules-load.d; sets net.bridge.bridge-nf-call-iptables/ip6tables and persists via sysctl.d

  install.sh gains run_platform_setup_step which delegates to the script
  when a Jetson GPU is detected; no Jetson logic lives in install.sh.

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Your Name <your-email@example.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now detects Jetson GPUs (Orin/Thor families) and runs a platform-specific setup step early in installation.
  * The Jetson setup step is optional and is skipped silently when no compatible platform is found.
  * Host configuration enables and persists required kernel and bridged-iptables/sysctl network settings for Jetson systems and reports completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->