### PR TITLE
docs: refresh docs for post-0.0.11 changes

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-security/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "nemoclaw-user-configure-security"
-description: "Presents a risk framework for every configurable security control in NemoClaw. Use when evaluating security posture, reviewing sandbox security defaults, or assessing control trade-offs. Explains where NemoClaw stores provider credentials, the file permissions it applies, and the operational security trade-offs of plaintext local storage. Use when reviewing credential handling or advising users how to secure stored API keys."
+description: "Presents a risk framework for every configurable security control in NemoClaw. Use when evaluating security posture, reviewing sandbox security defaults, or assessing control trade-offs. Explains where NemoClaw stores provider credentials, the file permissions it applies, and the operational security trade-offs of plaintext local storage. Use when reviewing credential handling or advising users how to secure stored API keys. Lists OpenClaw security controls that operate independently of NemoClaw, including prompt injection detection, tool access control, rate limiting, environment variable policy, audit framework, supply chain scanning, messaging access policy, context visibility, and safe regex. Use when reviewing the security boundary between NemoClaw and OpenClaw or assessing what NemoClaw does not cover."
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -82,6 +82,69 @@ flowchart TB
     style GW fill:#2a2a2a,stroke:#76b900,stroke-width:2px,color:#fff
 
 *Full details in `references/best-practices.md`.*
+
+NemoClaw provides infrastructure-layer security through sandbox isolation, network policy, filesystem restrictions, SSRF validation, and credential handling.
+It delegates all application-layer security to OpenClaw.
+This page documents areas where NemoClaw adds no independent protection beyond what OpenClaw already provides.
+
+The details below reflect the OpenClaw documentation at the time of writing.
+Consult the [OpenClaw Security docs](https://docs.openclaw.ai/gateway/security/index) for the current state.
+
+## Prompt Injection Detection and Prevention
+
+OpenClaw detects and neutralizes prompt injection attempts before they reach the agent.
+
+| Control | Detail |
+|---|---|
+| Regex detection | Pattern matching detects common injection vectors such as "ignore all previous instructions" and `<system>` tag spoofing |
+| Boundary wrapping | Untrusted input is wrapped in randomized XML boundary markers |
+| Unicode folding | Homoglyph folding normalizes bracket variants to prevent visual spoofing |
+| Invisible character stripping | Zero-width invisible characters are removed from input |
+| Boundary sanitization | Fake boundary markers are sanitized to prevent marker injection |
+| Auto-wrapping | Web fetch and search results are automatically wrapped as untrusted external content |
+
+## Tool Access Control and Policy Pipeline
+
+OpenClaw enforces a multi-layer tool policy pipeline that gates every tool call.
+
+| Control | Detail |
+|---|---|
+| Deny list | High-risk tools (`exec`, `spawn`, `shell`, `fs_write`, `fs_delete`, and others) are blocked from Gateway HTTP by default |
+| Policy pipeline | Multi-layer pipeline evaluates tool calls through profile, provider, agent, sandbox, and per-provider policies |
+| Fail-closed semantics | Tool call hooks block execution on any error |
+| Loop detection | Optional guard detects and blocks repeated identical tool call patterns (disabled by default, opt-in via `tools.loopDetection.enabled`) |
+| Plugin approval | Approval workflow defaults to deny on timeout |
+
+## Authentication Rate Limiting and Flood Protection
+
+OpenClaw rate-limits authentication attempts and guards against connection floods.
+
+| Control | Detail |
+|---|---|
+| Auth rate limiter | Sliding-window rate limiter tracks failed authentication attempts per IP and per scope |
+| Control plane limiter | Per-device write rate limiting for control plane operations |
+| WebSocket flood guard | Closes connections after repeated unauthorized attempts |
+| Pre-auth budget | Limits connections before authentication completes |
+
+## Environment Variable Security Policy
+
+OpenClaw blocks environment variables that could enable code injection, privilege escalation, or credential theft.
+
+| Category | Detail |
+|---|---|
+| Always-blocked keys | Keys such as `NODE_OPTIONS`, `LD_PRELOAD`, shell injection vectors, crypto mining variables, and `GIT_*` hijacking paths |
+| Override-blocked keys | Additional keys blocked unless explicitly overridden |
+| Blocked prefixes | Prefixes such as `GIT_CONFIG_`, `NPM_CONFIG_`, `CARGO_REGISTRIES_`, `TF_VAR_` |
+| Universal blocked prefixes | `DYLD_`, `LD_`, `BASH_FUNC_` |
+
+## Security Audit Framework
+
+OpenClaw runs automated security checks (50+ distinct check types) that cover configuration, credential handling, and sandbox posture.
+Run `openclaw security audit` to see all findings for your deployment.
+
+These checks include:
+
+*Full details in `references/openclaw-controls.md`.*
 
 ## Reference
 

--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -141,7 +141,7 @@ Endpoint rules restrict allowed HTTP methods and URL paths.
 
 | Aspect | Detail |
 |---|---|
-| Default | Most endpoints allow GET and POST on `/**`. Some allow GET only (read-only), such as `docs.openclaw.ai`. |
+| Default | Some endpoints allow GET and POST on `/**` (for example, `clawhub.ai`). Others restrict methods and paths to specific API routes (for example, `api.anthropic.com` allows POST only to inference paths). Read-only endpoints such as `docs.openclaw.ai` and `sentry.io` allow GET only. The `npm_registry` baseline entry and the `npm`/`pypi` presets are GET-only (plus HEAD for PyPI). |
 | What you can change | Add methods (PUT, DELETE, PATCH) or restrict paths to specific prefixes. |
 | Risk if relaxed | Allowing all methods on an API endpoint gives the agent write and delete access. For example, allowing DELETE on `api.github.com` lets the agent delete repositories. |
 | Recommendation | Use GET-only rules for endpoints that the agent only reads. Add write methods only for endpoints where the agent must create or modify resources. Restrict paths to specific API routes when possible. |
@@ -341,6 +341,30 @@ The Dockerfile removes compilers and network probes from the runtime image.
 | What you can change | Modify the Dockerfile to keep these tools, or install them at runtime if package manager access is allowed. |
 | Risk if relaxed | A compiler lets the agent build arbitrary native code, including kernel exploits or custom network tools. `netcat` enables arbitrary TCP connections that bypass HTTP-level policy enforcement. |
 | Recommendation | Keep build tools removed. If the agent needs to compile code, run the build in a separate, purpose-built container and copy artifacts into the sandbox. |
+
+### Image Digest Pinning
+
+The blueprint references the sandbox image by an immutable `@sha256:` digest instead of a mutable tag such as `:latest`.
+A registry compromise or accidental force-push cannot silently swap the sandbox image.
+
+| Aspect | Detail |
+|---|---|
+| Default | `nemoclaw-blueprint/blueprint.yaml` pins the sandbox image by digest. A CI regression test blocks any mutable-tag reference from merging. |
+| What you can change | Contributors bumping the sandbox image must update the digest in `blueprint.yaml`. Release tooling should rewrite the digest automatically. |
+| Risk if relaxed | Reverting to a mutable tag (`:latest`) allows a registry-side change to replace the sandbox image without any blueprint update, which is a supply-chain risk. |
+| Recommendation | Always reference the sandbox image by digest. If you build a custom image with `nemoclaw onboard --from`, the digest constraint does not apply to your local build. |
+
+### Auth Profile Permissions
+
+The entrypoint and migration flows enforce `chmod 600` on all `auth-profiles.json` files under `~/.openclaw`.
+This prevents other users on the host from reading stored credentials.
+
+| Aspect | Detail |
+|---|---|
+| Default | `600` permissions applied recursively at startup and after migration restores. |
+| What you can change | This is not a user-facing knob. The entrypoint enforces it. |
+| Risk if relaxed | Looser permissions let other users or processes on the host read provider API keys and tokens stored in auth profiles. |
+| Recommendation | No action needed. If you see a `permission denied` error when reading auth profiles, verify that you are running as the same user who created them. |
 
 ## Gateway Authentication Controls
 

--- a/.agents/skills/nemoclaw-user-configure-security/references/openclaw-controls.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/openclaw-controls.md
@@ -117,5 +117,5 @@ The implementation detects unsafe nested quantifiers, bounds input length, and c
 
 ## Next Steps
 
-- See {doc}`/security/best-practices` for NemoClaw's own security controls and risk framework.
-- See {doc}`/security/credential-storage` for how NemoClaw stores and protects provider credentials.
+- Security Best Practices (see the `nemoclaw-user-configure-security` skill) for NemoClaw's own security controls and risk framework.
+- Credential Storage (see the `nemoclaw-user-configure-security` skill) for how NemoClaw stores and protects provider credentials.

--- a/.agents/skills/nemoclaw-user-configure-security/references/openclaw-controls.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/openclaw-controls.md
@@ -1,0 +1,121 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# OpenClaw Security Controls Beyond NemoClaw's Scope
+
+NemoClaw provides infrastructure-layer security through sandbox isolation, network policy, filesystem restrictions, SSRF validation, and credential handling.
+It delegates all application-layer security to OpenClaw.
+This page documents areas where NemoClaw adds no independent protection beyond what OpenClaw already provides.
+
+The details below reflect the OpenClaw documentation at the time of writing.
+Consult the [OpenClaw Security docs](https://docs.openclaw.ai/gateway/security/index) for the current state.
+
+## Prompt Injection Detection and Prevention
+
+OpenClaw detects and neutralizes prompt injection attempts before they reach the agent.
+
+| Control | Detail |
+|---|---|
+| Regex detection | Pattern matching detects common injection vectors such as "ignore all previous instructions" and `<system>` tag spoofing |
+| Boundary wrapping | Untrusted input is wrapped in randomized XML boundary markers |
+| Unicode folding | Homoglyph folding normalizes bracket variants to prevent visual spoofing |
+| Invisible character stripping | Zero-width invisible characters are removed from input |
+| Boundary sanitization | Fake boundary markers are sanitized to prevent marker injection |
+| Auto-wrapping | Web fetch and search results are automatically wrapped as untrusted external content |
+
+## Tool Access Control and Policy Pipeline
+
+OpenClaw enforces a multi-layer tool policy pipeline that gates every tool call.
+
+| Control | Detail |
+|---|---|
+| Deny list | High-risk tools (`exec`, `spawn`, `shell`, `fs_write`, `fs_delete`, and others) are blocked from Gateway HTTP by default |
+| Policy pipeline | Multi-layer pipeline evaluates tool calls through profile, provider, agent, sandbox, and per-provider policies |
+| Fail-closed semantics | Tool call hooks block execution on any error |
+| Loop detection | Optional guard detects and blocks repeated identical tool call patterns (disabled by default, opt-in via `tools.loopDetection.enabled`) |
+| Plugin approval | Approval workflow defaults to deny on timeout |
+
+## Authentication Rate Limiting and Flood Protection
+
+OpenClaw rate-limits authentication attempts and guards against connection floods.
+
+| Control | Detail |
+|---|---|
+| Auth rate limiter | Sliding-window rate limiter tracks failed authentication attempts per IP and per scope |
+| Control plane limiter | Per-device write rate limiting for control plane operations |
+| WebSocket flood guard | Closes connections after repeated unauthorized attempts |
+| Pre-auth budget | Limits connections before authentication completes |
+
+## Environment Variable Security Policy
+
+OpenClaw blocks environment variables that could enable code injection, privilege escalation, or credential theft.
+
+| Category | Detail |
+|---|---|
+| Always-blocked keys | Keys such as `NODE_OPTIONS`, `LD_PRELOAD`, shell injection vectors, crypto mining variables, and `GIT_*` hijacking paths |
+| Override-blocked keys | Additional keys blocked unless explicitly overridden |
+| Blocked prefixes | Prefixes such as `GIT_CONFIG_`, `NPM_CONFIG_`, `CARGO_REGISTRIES_`, `TF_VAR_` |
+| Universal blocked prefixes | `DYLD_`, `LD_`, `BASH_FUNC_` |
+
+## Security Audit Framework
+
+OpenClaw runs automated security checks (50+ distinct check types) that cover configuration, credential handling, and sandbox posture.
+Run `openclaw security audit` to see all findings for your deployment.
+
+These checks include:
+
+- Synced-folder leak detection.
+- Plaintext secrets in configuration files.
+- Hooks hardening verification.
+- Gateway no-auth detection.
+- Sandbox misconfiguration scanning.
+- Weak-model susceptibility assessment.
+- Multi-user exposure matrix.
+- Node command policy validation.
+- Dangerous config flag scanning (`allowInsecureAuth`, `dangerouslyDisableDeviceAuth`, and similar flags).
+
+## Skill and Extension Supply Chain Scanning
+
+OpenClaw scans skills and extensions with a built-in static analysis scanner before installation.
+Critical findings block installation by default.
+
+The scanner checks for patterns including:
+
+- Direct process execution calls.
+- Dynamic code execution (`eval`, `new Function`, and similar constructs).
+- Cryptocurrency mining patterns.
+- Unexpected network activity.
+- Potential data exfiltration (file read combined with network calls).
+- Obfuscated code.
+- Environment variable harvesting combined with network calls.
+
+## DM and Group Messaging Access Policy
+
+OpenClaw controls who can interact with the agent through direct messages and group channels.
+
+| Control | Detail |
+|---|---|
+| DM policy modes | 4 modes: open, disabled, pairing, allowlist |
+| Group policies | Per-group access rules |
+| Per-sender authorization | Individual sender gating |
+| Command authorization | Command-level access control |
+| Multi-user detection | Heuristic that detects multi-user scenarios |
+
+## Context Visibility and Output Controls
+
+OpenClaw restricts what supplemental context the agent can see and how it can modify outputs.
+
+| Control | Detail |
+|---|---|
+| Mode-based restrictions | Limits visibility of history, threads, quotes, and forwarded messages based on the active mode |
+| Sender-based restrictions | Limits visibility based on who sent the message |
+| Plugin output hooks | Plugin hooks intercept and modify tool results before they reach the user |
+
+## Safe Regex (ReDoS Prevention)
+
+OpenClaw includes safe regex compilation to prevent Regular Expression Denial of Service (ReDoS) attacks.
+The implementation detects unsafe nested quantifiers, bounds input length, and caches results.
+
+## Next Steps
+
+- See {doc}`/security/best-practices` for NemoClaw's own security controls and risk framework.
+- See {doc}`/security/credential-storage` for how NemoClaw stores and protects provider credentials.

--- a/.agents/skills/nemoclaw-user-reference/references/network-policies.md
+++ b/.agents/skills/nemoclaw-user-reference/references/network-policies.md
@@ -36,12 +36,12 @@ The following endpoint groups are allowed by default:
 * - `claude_code`
   - `api.anthropic.com:443`, `statsig.anthropic.com:443`, `sentry.io:443`
   - `/usr/local/bin/claude`
-  - All methods
+  - POST to inference paths on `api.anthropic.com`, POST on `statsig.anthropic.com`, GET only on `sentry.io`
 
 * - `nvidia`
   - `integrate.api.nvidia.com:443`, `inference-api.nvidia.com:443`
   - `/usr/local/bin/claude`, `/usr/local/bin/openclaw`
-  - All methods
+  - POST to inference and embedding paths, GET to model listings
 
 * - `clawhub`
   - `clawhub.ai:443`
@@ -61,7 +61,7 @@ The following endpoint groups are allowed by default:
 * - `npm_registry`
   - `registry.npmjs.org:443`
   - `/usr/local/bin/openclaw`, `/usr/local/bin/npm`, `/usr/local/bin/node`
-  - All methods, all paths
+  - GET only
 
 :::
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -227,12 +227,6 @@ This software automatically retrieves, accesses or interacts with external mater
 ```
 
 ```{toctree}
-:hidden:
-
-Home <self>
-```
-
-```{toctree}
 :caption: About NemoClaw
 :hidden:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -266,6 +266,7 @@ Customize the Network Policy <network-policy/customize-network-policy>
 
 Security Best Practices <security/best-practices>
 Credential Storage <security/credential-storage>
+OpenClaw Controls <security/openclaw-controls>
 ```
 
 ```{toctree}

--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -56,12 +56,12 @@ The following endpoint groups are allowed by default:
 * - `claude_code`
   - `api.anthropic.com:443`, `statsig.anthropic.com:443`, `sentry.io:443`
   - `/usr/local/bin/claude`
-  - All methods
+  - POST to inference paths on `api.anthropic.com`, POST on `statsig.anthropic.com`, GET only on `sentry.io`
 
 * - `nvidia`
   - `integrate.api.nvidia.com:443`, `inference-api.nvidia.com:443`
   - `/usr/local/bin/claude`, `/usr/local/bin/openclaw`
-  - All methods
+  - POST to inference and embedding paths, GET to model listings
 
 * - `clawhub`
   - `clawhub.ai:443`
@@ -81,7 +81,7 @@ The following endpoint groups are allowed by default:
 * - `npm_registry`
   - `registry.npmjs.org:443`
   - `/usr/local/bin/openclaw`, `/usr/local/bin/npm`, `/usr/local/bin/node`
-  - All methods, all paths
+  - GET only
 
 :::
 

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -161,7 +161,7 @@ Endpoint rules restrict allowed HTTP methods and URL paths.
 
 | Aspect | Detail |
 |---|---|
-| Default | Most endpoints allow GET and POST on `/**`. Some allow GET only (read-only), such as `docs.openclaw.ai`. |
+| Default | Some endpoints allow GET and POST on `/**` (for example, `clawhub.ai`). Others restrict methods and paths to specific API routes (for example, `api.anthropic.com` allows POST only to inference paths). Read-only endpoints such as `docs.openclaw.ai` and `sentry.io` allow GET only. The `npm_registry` baseline entry and the `npm`/`pypi` presets are GET-only (plus HEAD for PyPI). |
 | What you can change | Add methods (PUT, DELETE, PATCH) or restrict paths to specific prefixes. |
 | Risk if relaxed | Allowing all methods on an API endpoint gives the agent write and delete access. For example, allowing DELETE on `api.github.com` lets the agent delete repositories. |
 | Recommendation | Use GET-only rules for endpoints that the agent only reads. Add write methods only for endpoints where the agent must create or modify resources. Restrict paths to specific API routes when possible. |
@@ -361,6 +361,30 @@ The Dockerfile removes compilers and network probes from the runtime image.
 | What you can change | Modify the Dockerfile to keep these tools, or install them at runtime if package manager access is allowed. |
 | Risk if relaxed | A compiler lets the agent build arbitrary native code, including kernel exploits or custom network tools. `netcat` enables arbitrary TCP connections that bypass HTTP-level policy enforcement. |
 | Recommendation | Keep build tools removed. If the agent needs to compile code, run the build in a separate, purpose-built container and copy artifacts into the sandbox. |
+
+### Image Digest Pinning
+
+The blueprint references the sandbox image by an immutable `@sha256:` digest instead of a mutable tag such as `:latest`.
+A registry compromise or accidental force-push cannot silently swap the sandbox image.
+
+| Aspect | Detail |
+|---|---|
+| Default | `nemoclaw-blueprint/blueprint.yaml` pins the sandbox image by digest. A CI regression test blocks any mutable-tag reference from merging. |
+| What you can change | Contributors bumping the sandbox image must update the digest in `blueprint.yaml`. Release tooling should rewrite the digest automatically. |
+| Risk if relaxed | Reverting to a mutable tag (`:latest`) allows a registry-side change to replace the sandbox image without any blueprint update, which is a supply-chain risk. |
+| Recommendation | Always reference the sandbox image by digest. If you build a custom image with `nemoclaw onboard --from`, the digest constraint does not apply to your local build. |
+
+### Auth Profile Permissions
+
+The entrypoint and migration flows enforce `chmod 600` on all `auth-profiles.json` files under `~/.openclaw`.
+This prevents other users on the host from reading stored credentials.
+
+| Aspect | Detail |
+|---|---|
+| Default | `600` permissions applied recursively at startup and after migration restores. |
+| What you can change | This is not a user-facing knob. The entrypoint enforces it. |
+| Risk if relaxed | Looser permissions let other users or processes on the host read provider API keys and tokens stored in auth profiles. |
+| Recommendation | No action needed. If you see a `permission denied` error when reading auth profiles, verify that you are running as the same user who created them. |
 
 ## Gateway Authentication Controls
 

--- a/docs/security/openclaw-controls.md
+++ b/docs/security/openclaw-controls.md
@@ -137,5 +137,5 @@ The implementation detects unsafe nested quantifiers, bounds input length, and c
 
 ## Next Steps
 
-- See {doc}`/security/best-practices` for NemoClaw's own security controls and risk framework.
-- See {doc}`/security/credential-storage` for how NemoClaw stores and protects provider credentials.
+- [Security Best Practices](best-practices.md) for NemoClaw's own security controls and risk framework.
+- [Credential Storage](credential-storage.md) for how NemoClaw stores and protects provider credentials.

--- a/docs/security/openclaw-controls.md
+++ b/docs/security/openclaw-controls.md
@@ -1,0 +1,141 @@
+---
+title:
+  page: "OpenClaw Security Controls Beyond NemoClaw's Scope"
+  nav: "OpenClaw Controls"
+description:
+  main: "Documents application-layer security controls that OpenClaw provides independently, where NemoClaw adds no additional protection."
+  agent: "Lists OpenClaw security controls that operate independently of NemoClaw, including prompt injection detection, tool access control, rate limiting, environment variable policy, audit framework, supply chain scanning, messaging access policy, context visibility, and safe regex. Use when reviewing the security boundary between NemoClaw and OpenClaw or assessing what NemoClaw does not cover."
+keywords: ["openclaw security controls", "nemoclaw security boundary", "prompt injection", "tool access control"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "security", "prompt_injection", "tool_policy"]
+content:
+  type: concept
+  difficulty: intermediate
+  audience: ["developer", "engineer", "security_engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# OpenClaw Security Controls Beyond NemoClaw's Scope
+
+NemoClaw provides infrastructure-layer security through sandbox isolation, network policy, filesystem restrictions, SSRF validation, and credential handling.
+It delegates all application-layer security to OpenClaw.
+This page documents areas where NemoClaw adds no independent protection beyond what OpenClaw already provides.
+
+The details below reflect the OpenClaw documentation at the time of writing.
+Consult the [OpenClaw Security docs](https://docs.openclaw.ai/gateway/security/index) for the current state.
+
+## Prompt Injection Detection and Prevention
+
+OpenClaw detects and neutralizes prompt injection attempts before they reach the agent.
+
+| Control | Detail |
+|---|---|
+| Regex detection | Pattern matching detects common injection vectors such as "ignore all previous instructions" and `<system>` tag spoofing |
+| Boundary wrapping | Untrusted input is wrapped in randomized XML boundary markers |
+| Unicode folding | Homoglyph folding normalizes bracket variants to prevent visual spoofing |
+| Invisible character stripping | Zero-width invisible characters are removed from input |
+| Boundary sanitization | Fake boundary markers are sanitized to prevent marker injection |
+| Auto-wrapping | Web fetch and search results are automatically wrapped as untrusted external content |
+
+## Tool Access Control and Policy Pipeline
+
+OpenClaw enforces a multi-layer tool policy pipeline that gates every tool call.
+
+| Control | Detail |
+|---|---|
+| Deny list | High-risk tools (`exec`, `spawn`, `shell`, `fs_write`, `fs_delete`, and others) are blocked from Gateway HTTP by default |
+| Policy pipeline | Multi-layer pipeline evaluates tool calls through profile, provider, agent, sandbox, and per-provider policies |
+| Fail-closed semantics | Tool call hooks block execution on any error |
+| Loop detection | Optional guard detects and blocks repeated identical tool call patterns (disabled by default, opt-in via `tools.loopDetection.enabled`) |
+| Plugin approval | Approval workflow defaults to deny on timeout |
+
+## Authentication Rate Limiting and Flood Protection
+
+OpenClaw rate-limits authentication attempts and guards against connection floods.
+
+| Control | Detail |
+|---|---|
+| Auth rate limiter | Sliding-window rate limiter tracks failed authentication attempts per IP and per scope |
+| Control plane limiter | Per-device write rate limiting for control plane operations |
+| WebSocket flood guard | Closes connections after repeated unauthorized attempts |
+| Pre-auth budget | Limits connections before authentication completes |
+
+## Environment Variable Security Policy
+
+OpenClaw blocks environment variables that could enable code injection, privilege escalation, or credential theft.
+
+| Category | Detail |
+|---|---|
+| Always-blocked keys | Keys such as `NODE_OPTIONS`, `LD_PRELOAD`, shell injection vectors, crypto mining variables, and `GIT_*` hijacking paths |
+| Override-blocked keys | Additional keys blocked unless explicitly overridden |
+| Blocked prefixes | Prefixes such as `GIT_CONFIG_`, `NPM_CONFIG_`, `CARGO_REGISTRIES_`, `TF_VAR_` |
+| Universal blocked prefixes | `DYLD_`, `LD_`, `BASH_FUNC_` |
+
+## Security Audit Framework
+
+OpenClaw runs automated security checks (50+ distinct check types) that cover configuration, credential handling, and sandbox posture.
+Run `openclaw security audit` to see all findings for your deployment.
+
+These checks include:
+
+- Synced-folder leak detection.
+- Plaintext secrets in configuration files.
+- Hooks hardening verification.
+- Gateway no-auth detection.
+- Sandbox misconfiguration scanning.
+- Weak-model susceptibility assessment.
+- Multi-user exposure matrix.
+- Node command policy validation.
+- Dangerous config flag scanning (`allowInsecureAuth`, `dangerouslyDisableDeviceAuth`, and similar flags).
+
+## Skill and Extension Supply Chain Scanning
+
+OpenClaw scans skills and extensions with a built-in static analysis scanner before installation.
+Critical findings block installation by default.
+
+The scanner checks for patterns including:
+
+- Direct process execution calls.
+- Dynamic code execution (`eval`, `new Function`, and similar constructs).
+- Cryptocurrency mining patterns.
+- Unexpected network activity.
+- Potential data exfiltration (file read combined with network calls).
+- Obfuscated code.
+- Environment variable harvesting combined with network calls.
+
+## DM and Group Messaging Access Policy
+
+OpenClaw controls who can interact with the agent through direct messages and group channels.
+
+| Control | Detail |
+|---|---|
+| DM policy modes | 4 modes: open, disabled, pairing, allowlist |
+| Group policies | Per-group access rules |
+| Per-sender authorization | Individual sender gating |
+| Command authorization | Command-level access control |
+| Multi-user detection | Heuristic that detects multi-user scenarios |
+
+## Context Visibility and Output Controls
+
+OpenClaw restricts what supplemental context the agent can see and how it can modify outputs.
+
+| Control | Detail |
+|---|---|
+| Mode-based restrictions | Limits visibility of history, threads, quotes, and forwarded messages based on the active mode |
+| Sender-based restrictions | Limits visibility based on who sent the message |
+| Plugin output hooks | Plugin hooks intercept and modify tool results before they reach the user |
+
+## Safe Regex (ReDoS Prevention)
+
+OpenClaw includes safe regex compilation to prevent Regular Expression Denial of Service (ReDoS) attacks.
+The implementation detects unsafe nested quantifiers, bounds input length, and caches results.
+
+## Next Steps
+
+- See {doc}`/security/best-practices` for NemoClaw's own security controls and risk framework.
+- See {doc}`/security/credential-storage` for how NemoClaw stores and protects provider credentials.


### PR DESCRIPTION
## Summary

Catches up documentation for all commits since the v0.0.11 docs refresh (`9075e68e`). Scanned ~50 recent commits using the `nemoclaw-contributor-update-docs` skill, filtering by the `docs/.docs-skip` list and agent support matrix.

### Changes

**`docs/reference/network-policies.md`** — Fix stale baseline policy table
- `claude_code` rules: "All methods" → "POST to inference paths on `api.anthropic.com`, POST on `statsig.anthropic.com`, GET only on `sentry.io`"
- `nvidia` rules: "All methods" → "POST to inference and embedding paths, GET to model listings"
- `npm_registry` rules: "All methods, all paths" → "GET only"

**`docs/security/best-practices.md`** — Three updates
- **Path-Scoped HTTP Rules default**: Rewrote from "Most endpoints allow GET and POST" to accurately describe the current mix of path-scoped, method-restricted, and read-only rules across baseline entries and presets.
- **New section: Image Digest Pinning**: Documents that `blueprint.yaml` pins the sandbox image by `@sha256:` digest instead of `:latest`, with CI regression test enforcement (from `e140f0a6`, #1438).
- **New section: Auth Profile Permissions**: Documents recursive `chmod 600` enforcement on all `auth-profiles.json` files at startup and after migration restores (from `b39bf9fa`, #188).

**`docs/security/openclaw-controls.md`** — New page
- Documents application-layer security controls that OpenClaw provides independently of NemoClaw: prompt injection detection, tool access control, rate limiting, environment variable policy, audit framework, supply chain scanning, messaging access policy, context visibility, and safe regex.

**`docs/index.md`** — Toctree updates
- Removed duplicate `Home <self>` toctree entry.
- Added `OpenClaw Controls` to the security section toctree.

**Autogenerated skill references** — Regenerated via `docs-to-skills.py`
- `.agents/skills/nemoclaw-user-reference/references/network-policies.md`
- `.agents/skills/nemoclaw-user-configure-security/references/best-practices.md`
- `.agents/skills/nemoclaw-user-configure-security/references/openclaw-controls.md`
- `.agents/skills/nemoclaw-user-configure-security/SKILL.md`

## Test plan
- [x] `make docs` builds with no errors or warnings
- [x] All pre-commit and pre-push hooks pass
- [x] No skip-terms (`dangerously-skip-permissions`, `permissive mode`, `Hermes`) appear in any drafted content
- [x] Skills regenerated via `docs-to-skills.py`
- [ ] Visual review of rendered pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OpenClaw controls documentation covering prompt-injection defenses, tool access policies, auth rate-limiting and flood protection, environment-variable safeguards, a 50+ check security audit framework, safe-regex guidance, messaging/access controls, and supply-chain scanning.
  * Updated security best practices with image-digest pinning and auth-profile permission guidance.
  * Refined network policy docs to stricter, method/path-specific access rules.
  * Clarified infrastructure vs. application security boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->