### PR TITLE
fix(ci): remove --depth=1 from legacy guard base fetch

### DIFF
--- a/.github/workflows/legacy-path-guard.yaml
+++ b/.github/workflows/legacy-path-guard.yaml
@@ -29,7 +29,7 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Fetch base branch
-        run: git fetch origin "${{ github.base_ref }}" --depth=1
+        run: git fetch origin "${{ github.base_ref }}"
 
       - name: Guard migrated legacy paths
         run: npm run ts-migration:guard -- --base "origin/${{ github.base_ref }}" --head HEAD


### PR DESCRIPTION
## Summary

The `legacy-path-guard` CI job fails on every PR with `fatal: origin/main...HEAD: no merge base`.

**Root cause:** The checkout uses `fetch-depth: 0` (full PR history), but then `git fetch origin main --depth=1` creates a shallow reference for `origin/main` with only 1 commit. Git can't find a merge base between the shallow main ref and HEAD.

**Fix:** Remove `--depth=1` from the base branch fetch so origin/main has enough history for the three-dot diff.

## Related

Introduced in #1683 

## Test plan

- [ ] This PR's own `legacy-path-guard` job passes (self-validating)

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to improve git history fetching for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->