### PR TITLE
fix(install): list all valid NEMOCLAW_PROVIDER values in help text

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,7 @@ bootstrap_usage() {
   printf "    NEMOCLAW_NON_INTERACTIVE=1   Same as --non-interactive\n"
   printf "    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
   printf "    NEMOCLAW_SANDBOX_NAME        Sandbox name to create/use\n"
-  printf "    NEMOCLAW_PROVIDER            cloud | ollama | nim | vllm\n"
+  printf "    NEMOCLAW_PROVIDER            cloud | openai | anthropic | anthropicCompatible | gemini | ollama | custom | nim | vllm\n"
   printf "    NEMOCLAW_POLICY_MODE         suggested | custom | skip\n"
   printf "\n"
 }

--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,8 @@ bootstrap_usage() {
   printf "    NEMOCLAW_NON_INTERACTIVE=1   Same as --non-interactive\n"
   printf "    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
   printf "    NEMOCLAW_SANDBOX_NAME        Sandbox name to create/use\n"
-  printf "    NEMOCLAW_PROVIDER            cloud | openai | anthropic | anthropicCompatible | gemini | ollama | custom | nim | vllm\n"
+  printf "    NEMOCLAW_PROVIDER            build | openai | anthropic | anthropicCompatible | gemini | ollama | custom | nim-local | vllm\n"
+  printf "                                  (aliases: cloud=build, nim=nim-local)\n"
   printf "    NEMOCLAW_POLICY_MODE         suggested | custom | skip\n"
   printf "\n"
 }


### PR DESCRIPTION
## Summary
`install.sh --help` only listed 4 of 9 valid `NEMOCLAW_PROVIDER` values (`cloud | ollama | nim | vllm`). This adds the 5 missing values: `openai`, `anthropic`, `anthropicCompatible`, `gemini`, and `custom`.

The updated list matches the full set accepted by `getNonInteractiveProvider()` in `src/lib/onboard.ts`.

## Changes
- **install.sh**: Updated the `NEMOCLAW_PROVIDER` line in `bootstrap_usage()` to show all 9 valid values

## Testing
- Verified the provider list matches `validProviders` set in `src/lib/onboard.ts` (line ~1720)
- `bash install.sh --help` now shows the complete list

Fixes #1766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installer help text updated: expanded list of supported provider options (build, OpenAI, Anthropic, Anthropic-compatible, Gemini, Ollama, custom, nim-local, vllm) and added convenient aliases (cloud→build, nim→nim-local) for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->