### PR TITLE
fix(onboard): validate NEMOCLAW_PROVIDER before preflight checks

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4327,6 +4327,13 @@ async function onboard(opts = {}) {
   if (!noticeAccepted) {
     process.exit(1);
   }
+  // Validate NEMOCLAW_PROVIDER early so invalid values fail before
+  // preflight (Docker/OpenShell checks). Without this, users see a
+  // misleading 'Docker is not reachable' error instead of the real
+  // problem: an unsupported provider value.
+  if (isNonInteractive()) {
+    getRequestedProviderHint(true);
+  }
   const lockResult = onboardSession.acquireOnboardLock(
     `nemoclaw onboard${resume ? " --resume" : ""}${isNonInteractive() ? " --non-interactive" : ""}${requestedFromDockerfile ? ` --from ${requestedFromDockerfile}` : ""}`,
   );

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4331,9 +4331,7 @@ async function onboard(opts = {}) {
   // preflight (Docker/OpenShell checks). Without this, users see a
   // misleading 'Docker is not reachable' error instead of the real
   // problem: an unsupported provider value.
-  if (isNonInteractive()) {
-    getRequestedProviderHint(true);
-  }
+  getRequestedProviderHint();
   const lockResult = onboardSession.acquireOnboardLock(
     `nemoclaw onboard${resume ? " --resume" : ""}${isNonInteractive() ? " --non-interactive" : ""}${requestedFromDockerfile ? ` --from ${requestedFromDockerfile}` : ""}`,
   );


### PR DESCRIPTION
## Summary

Invalid `NEMOCLAW_PROVIDER` values in non-interactive mode now fail immediately with a clear error instead of falling through to misleading preflight failures.

## Problem

`NEMOCLAW_PROVIDER=invalid nemoclaw onboard --non-interactive` reaches preflight (Docker/OpenShell checks) before provider validation. If Docker isn't installed, the user sees "Docker is not reachable" and installs Docker -- only to discover on the next run that the real issue was an invalid provider value.

## Fix

Call `getRequestedProviderHint()` immediately after the third-party notice consent, before preflight and lock acquisition. The existing `getNonInteractiveProvider()` validation already has the right error message and `process.exit(1)` -- it just needed to run earlier.

## Test plan

- [x] `npm run build:cli` passes
- [x] `npm run typecheck:cli` passes
- [x] `npm run lint` passes
- [x] All 22 provider-related onboard tests pass
- [x] All 35 onboard-selection tests pass

Closes #1729

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-interactive runs now validate the configured provider earlier and fail fast for unsupported values, preventing the onboarding flow from proceeding into later preflight steps with invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->