### PR TITLE
fix(onboard): reject sandbox names that collide with global CLI commands

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2233,7 +2233,20 @@ async function promptValidatedSandboxName() {
     // Validate: RFC 1123 subdomain — lowercase alphanumeric and hyphens,
     // must start with a letter (not a digit) to satisfy Kubernetes naming.
     if (/^[a-z]([a-z0-9-]*[a-z0-9])?$/.test(sandboxName)) {
-      return sandboxName;
+      // Reject names that collide with global CLI commands.
+      // A sandbox named 'status' makes 'nemoclaw status connect' route to
+      // the global status command instead of the sandbox.
+      const RESERVED_NAMES = new Set([
+        "onboard", "list", "deploy", "setup", "setup-spark",
+        "start", "stop", "status", "debug", "uninstall",
+        "credentials", "help",
+      ]);
+      if (RESERVED_NAMES.has(sandboxName)) {
+        console.error(`  Reserved name: '${sandboxName}' is a NemoClaw CLI command.`);
+        console.error("  Choose a different name to avoid routing conflicts.");
+      } else {
+        return sandboxName;
+      }
     }
 
     console.error(`  Invalid sandbox name: '${sandboxName}'`);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2244,9 +2244,15 @@ async function promptValidatedSandboxName() {
       if (RESERVED_NAMES.has(sandboxName)) {
         console.error(`  Reserved name: '${sandboxName}' is a NemoClaw CLI command.`);
         console.error("  Choose a different name to avoid routing conflicts.");
-      } else {
-        return sandboxName;
+        if (isNonInteractive()) {
+          process.exit(1);
+        }
+        if (attempt < MAX_ATTEMPTS - 1) {
+          console.error("  Please try again.\n");
+        }
+        continue;
       }
+      return sandboxName;
     }
 
     console.error(`  Invalid sandbox name: '${sandboxName}'`);


### PR DESCRIPTION
## Summary

Sandbox names that match global CLI commands (e.g. 'status', 'list', 'debug') are now rejected during onboarding with a clear error message.

## Problem

If a user names their sandbox 'status', running `nemoclaw status connect` routes to the global `status` command instead of the sandbox. The sandbox becomes inaccessible via normal CLI workflows since the global command always takes routing priority.

## Fix

Add a reserved-name check in `promptValidatedSandboxName()` after RFC 1123 validation passes. Names matching any entry in the global commands set (onboard, list, deploy, setup, start, stop, status, debug, uninstall, credentials, help) are rejected with a prompt to choose a different name. In non-interactive mode, this exits with code 1 (existing behavior for invalid names).

## Test plan

- [x] `npm run build:cli` passes
- [x] `npm run typecheck:cli` passes
- [x] `npm run lint` passes
- [x] Existing digit-rejection test still passes
- [x] All onboard tests pass (1 pre-existing timeout)

Closes #1731

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox name validation now rejects names that match reserved CLI commands (e.g., status, list, deploy, help) and displays a clear error.
  * Non-interactive sandbox creation now terminates immediately on reserved-name errors; interactive flows show the error and allow retrying until attempts are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->