### PR TITLE
fix(scripts): use PYTHON_HISTORY instead of unsupported PYTHONHISTFILE

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -65,7 +65,7 @@ _TOOL_REDIRECTS=(
   'GIT_CONFIG_GLOBAL=/tmp/.gitconfig'
   'GNUPGHOME=/tmp/.gnupg'
   'PYTHONUSERBASE=/tmp/.local'
-  'PYTHONHISTFILE=/tmp/.python_history'
+  'PYTHON_HISTORY=/tmp/.python_history'
   'CLAUDE_CONFIG_DIR=/tmp/.claude'
   'npm_config_prefix=/tmp/npm-global'
 )

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -176,7 +176,7 @@ describe("service environment", () => {
       expect(src).toContain("XDG_RUNTIME_DIR=/tmp/.runtime");
       // Tool-specific redirects
       expect(src).toContain("GNUPGHOME=/tmp/.gnupg");
-      expect(src).toContain("PYTHONHISTFILE=/tmp/.python_history");
+      expect(src).toContain("PYTHON_HISTORY=/tmp/.python_history");
       expect(src).toContain("npm_config_prefix=/tmp/npm-global");
     });
 
@@ -352,7 +352,7 @@ describe("service environment", () => {
         expect(envFile).toContain("XDG_STATE_HOME=/tmp/.local/state");
         expect(envFile).toContain("XDG_RUNTIME_DIR=/tmp/.runtime");
         expect(envFile).toContain("GNUPGHOME=/tmp/.gnupg");
-        expect(envFile).toContain("PYTHONHISTFILE=/tmp/.python_history");
+        expect(envFile).toContain("PYTHON_HISTORY=/tmp/.python_history");
         expect(envFile).toContain("npm_config_prefix=/tmp/npm-global");
       } finally {
         try {


### PR DESCRIPTION
## Summary

Replace `PYTHONHISTFILE` with `PYTHON_HISTORY` in the sandbox environment variable redirects.

## Problem

`nemoclaw-start.sh` sets `PYTHONHISTFILE=/tmp/.python_history` to redirect the Python REPL history file to `/tmp/`. However, `PYTHONHISTFILE` is not a recognized CPython environment variable. Python 3.13+ uses `PYTHON_HISTORY` for this purpose, and earlier versions have no environment variable control at all. The current setting is silently ignored.

## Fix

One-line change: `PYTHONHISTFILE` to `PYTHON_HISTORY` on line 68 of `scripts/nemoclaw-start.sh`.

## Test plan

- [x] All 58 nemoclaw-start tests pass

Closes #1735

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the environment variable used to direct Python history to a temporary file in startup scripts and aligned tests to expect the new variable name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->