### PR TITLE
fix(cli): suppress redundant --output suggestion when already using --output

### DIFF
--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -485,8 +485,12 @@ export function runDebug(opts: DebugOptions = {}): void {
     }
 
     console.log("");
-    info("Done. If filing a bug, run with --output and attach the tarball to your issue:");
-    info("  nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz");
+    if (output) {
+      info("Done. Tarball written. Attach it to your bug report.");
+    } else {
+      info("Done. If filing a bug, run with --output and attach the tarball to your issue:");
+      info("  nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz");
+    }
   } finally {
     rmSync(collectDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

`nemoclaw debug --output` no longer shows a redundant "run with --output" suggestion after already writing the tarball.

## Problem

Running `nemoclaw debug --output /tmp/debug.tar.gz` writes the tarball successfully, then prints:

```
Done. If filing a bug, run with --output and attach the tarball to your issue:
  nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz
```

The user already used `--output` -- the suggestion is redundant and confusing.

## Fix

Condition the completion message on whether `output` was provided. When `--output` was used, show "Tarball written. Attach it to your bug report." When not, show the existing suggestion.

## Test plan

- [x] `npm run build:cli` passes
- [x] `npm run typecheck:cli` passes

Closes #1732

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Debug output messages now correctly adapt based on whether an output file is specified. When output is provided, confirmation of the tarball write is displayed. When omitted, usage guidance with the default output path is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->