### PR TITLE
fix(onboard): forward SLACK_APP_TOKEN to sandbox for Socket Mode

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2473,6 +2473,7 @@ async function createSandbox(
     );
     process.exit(1);
   }
+  const tokensByEnvKey = Object.fromEntries(messagingTokenDefs.map(({ envKey, token }) => [envKey, token]));
   const activeMessagingChannels = [
     ...new Set(
       messagingTokenDefs
@@ -2480,7 +2481,8 @@ async function createSandbox(
         .map(({ envKey }) => {
           if (envKey === "DISCORD_BOT_TOKEN") return "discord";
           if (envKey === "SLACK_BOT_TOKEN") return "slack";
-          if (envKey === "SLACK_APP_TOKEN") return "slack";
+          // SLACK_APP_TOKEN alone does not enable slack; bot token is required.
+          if (envKey === "SLACK_APP_TOKEN") return tokensByEnvKey["SLACK_BOT_TOKEN"] ? "slack" : null;
           if (envKey === "TELEGRAM_BOT_TOKEN") return "telegram";
           return null;
         })

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2291,7 +2291,9 @@ async function createSandbox(
   const enabledEnvKeys =
     enabledChannels != null
       ? new Set(
-          MESSAGING_CHANNELS.filter((c) => enabledChannels.includes(c.name)).map((c) => c.envKey),
+          MESSAGING_CHANNELS.filter((c) => enabledChannels.includes(c.name)).flatMap((c) =>
+            c.appTokenEnvKey ? [c.envKey, c.appTokenEnvKey] : [c.envKey],
+          ),
         )
       : null;
 
@@ -2305,6 +2307,11 @@ async function createSandbox(
       name: `${sandboxName}-slack-bridge`,
       envKey: "SLACK_BOT_TOKEN",
       token: getMessagingToken("SLACK_BOT_TOKEN"),
+    },
+    {
+      name: `${sandboxName}-slack-app`,
+      envKey: "SLACK_APP_TOKEN",
+      token: getMessagingToken("SLACK_APP_TOKEN"),
     },
     {
       name: `${sandboxName}-telegram-bridge`,
@@ -2466,15 +2473,20 @@ async function createSandbox(
     );
     process.exit(1);
   }
-  const activeMessagingChannels = messagingTokenDefs
-    .filter(({ token }) => !!token)
-    .map(({ envKey }) => {
-      if (envKey === "DISCORD_BOT_TOKEN") return "discord";
-      if (envKey === "SLACK_BOT_TOKEN") return "slack";
-      if (envKey === "TELEGRAM_BOT_TOKEN") return "telegram";
-      return null;
-    })
-    .filter(Boolean);
+  const activeMessagingChannels = [
+    ...new Set(
+      messagingTokenDefs
+        .filter(({ token }) => !!token)
+        .map(({ envKey }) => {
+          if (envKey === "DISCORD_BOT_TOKEN") return "discord";
+          if (envKey === "SLACK_BOT_TOKEN") return "slack";
+          if (envKey === "SLACK_APP_TOKEN") return "slack";
+          if (envKey === "TELEGRAM_BOT_TOKEN") return "telegram";
+          return null;
+        })
+        .filter(Boolean),
+    ),
+  ];
   // Build allowed sender IDs map from env vars set during the messaging prompt.
   // Each channel with a userIdEnvKey in MESSAGING_CHANNELS may have a
   // comma-separated list of IDs (e.g. TELEGRAM_ALLOWED_IDS="123,456").
@@ -2549,6 +2561,7 @@ async function createSandbox(
     "BEDROCK_API_KEY",
     "DISCORD_BOT_TOKEN",
     "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
     "TELEGRAM_BOT_TOKEN",
     webSearch.BRAVE_API_KEY_ENV,
   ]);
@@ -3512,6 +3525,10 @@ const MESSAGING_CHANNELS = [
     description: "Slack bot messaging",
     help: "Slack API → Your Apps → OAuth & Permissions → Bot User OAuth Token (xoxb-...).",
     label: "Slack Bot Token",
+    appTokenEnvKey: "SLACK_APP_TOKEN",
+    appTokenHelp:
+      "Slack API → Your Apps → Basic Information → App-Level Tokens (xapp-...).",
+    appTokenLabel: "Slack App Token (Socket Mode)",
   },
 ];
 

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -76,11 +76,13 @@ describe("credential exposure in process arguments", () => {
     expect(blocklist).toContain('"BEDROCK_API_KEY"');
     expect(blocklist).toContain('"DISCORD_BOT_TOKEN"');
     expect(blocklist).toContain('"SLACK_BOT_TOKEN"');
+    expect(blocklist).toContain('"SLACK_APP_TOKEN"');
     expect(blocklist).toContain('"TELEGRAM_BOT_TOKEN"');
     expect(src).toMatch(/streamSandboxCreate\(createCommand, sandboxEnv(?:, \{)?/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("NVIDIA_API_KEY"/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("DISCORD_BOT_TOKEN"/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_BOT_TOKEN"/);
+    expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_APP_TOKEN"/);
   });
 
   it("onboard curl probes use explicit timeouts", () => {


### PR DESCRIPTION
## Summary

Cherry-pick of #1724 by @latenighthackathon.

Slack Socket Mode requires both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`, but only the bot token was collected and forwarded during onboarding. Without the app-level token, OpenClaw cannot start Socket Mode.

- Add `SLACK_APP_TOKEN` entry to `messagingTokenDefs` (dedicated `slack-app` OpenShell provider)
- Include `appTokenEnvKey` in `enabledEnvKeys` filter so the app token is forwarded when the user selects the slack channel
- Deduplicate `activeMessagingChannels` since both tokens map to `"slack"`
- Block `SLACK_APP_TOKEN` from raw sandbox env passthrough (credentials flow through providers)
- Require `SLACK_BOT_TOKEN` for slack channel activation; add credential-exposure regression test

## Test plan

- [x] `npm run build:cli` passes
- [x] `npm run typecheck:cli` passes
- [x] `npm run lint` passes
- [x] Full test suite: 72 files passed, 1350 tests passed, 0 failures

Closes #1688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Slack app-level token configuration alongside bot tokens for Socket Mode integration.

* **Security**
  * Updated credential blocklist to prevent Slack app tokens from being passed to sandbox environments.

* **Improvements**
  * Enhanced Slack channel activation logic requiring bot token presence for channel enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->