### PR TITLE
feat(onboard): support Telegram mention-only mode (fixes #1737)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,11 @@ ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=
 # (e.g. {"1234567890":{"requireMention":true,"users":["555"]}}).
 # Used to enable guild-channel responses for native Discord. Default: empty map.
 ARG NEMOCLAW_DISCORD_GUILDS_B64=e30=
+# Base64-encoded JSON config for Telegram group behavior
+# (e.g. {"requireMention":true}). When requireMention is true the bot only
+# replies to messages that @mention it in group chats. Default: empty map
+# (groupPolicy stays "open").
+ARG NEMOCLAW_TELEGRAM_CONFIG_B64=e30=
 # Set to "1" to disable device-pairing auth (development/headless only).
 # Default: "0" (device auth enabled — secure by default).
 ARG NEMOCLAW_DISABLE_DEVICE_AUTH=0
@@ -100,6 +105,7 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
     NEMOCLAW_MESSAGING_CHANNELS_B64=${NEMOCLAW_MESSAGING_CHANNELS_B64} \
     NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=${NEMOCLAW_MESSAGING_ALLOWED_IDS_B64} \
     NEMOCLAW_DISCORD_GUILDS_B64=${NEMOCLAW_DISCORD_GUILDS_B64} \
+    NEMOCLAW_TELEGRAM_CONFIG_B64=${NEMOCLAW_TELEGRAM_CONFIG_B64} \
     NEMOCLAW_DISABLE_DEVICE_AUTH=${NEMOCLAW_DISABLE_DEVICE_AUTH} \
     NEMOCLAW_PROXY_HOST=${NEMOCLAW_PROXY_HOST} \
     NEMOCLAW_PROXY_PORT=${NEMOCLAW_PROXY_PORT}
@@ -126,9 +132,10 @@ web_config = json.loads(base64.b64decode(os.environ.get('NEMOCLAW_WEB_CONFIG_B64
 msg_channels = json.loads(base64.b64decode(os.environ.get('NEMOCLAW_MESSAGING_CHANNELS_B64', 'W10=') or 'W10=').decode('utf-8')); \
 _allowed_ids = json.loads(base64.b64decode(os.environ.get('NEMOCLAW_MESSAGING_ALLOWED_IDS_B64', 'e30=') or 'e30=').decode('utf-8')); \
 _discord_guilds = json.loads(base64.b64decode(os.environ.get('NEMOCLAW_DISCORD_GUILDS_B64', 'e30=') or 'e30=').decode('utf-8')); \
+_telegram_config = json.loads(base64.b64decode(os.environ.get('NEMOCLAW_TELEGRAM_CONFIG_B64', 'e30=') or 'e30=').decode('utf-8')); \
 _token_keys = {'discord': 'token', 'telegram': 'botToken', 'slack': 'botToken'}; \
 _env_keys = {'discord': 'DISCORD_BOT_TOKEN', 'telegram': 'TELEGRAM_BOT_TOKEN', 'slack': 'SLACK_BOT_TOKEN'}; \
-_ch_cfg = {ch: {'accounts': {'default': {_token_keys[ch]: f'openshell:resolve:env:{_env_keys[ch]}', 'enabled': True, **({'groupPolicy': 'open'} if ch == 'telegram' else {}), **({'dmPolicy': 'allowlist', 'allowFrom': _allowed_ids[ch]} if ch in _allowed_ids and _allowed_ids[ch] else {})}}} for ch in msg_channels if ch in _token_keys}; \
+_ch_cfg = {ch: {'accounts': {'default': {_token_keys[ch]: f'openshell:resolve:env:{_env_keys[ch]}', 'enabled': True, **({'groupPolicy': 'mentions' if _telegram_config.get('requireMention') else 'open'} if ch == 'telegram' else {}), **({'dmPolicy': 'allowlist', 'allowFrom': _allowed_ids[ch]} if ch in _allowed_ids and _allowed_ids[ch] else {})}}} for ch in msg_channels if ch in _token_keys}; \
 _ch_cfg['discord'].update({'groupPolicy': 'allowlist', 'guilds': _discord_guilds}) if 'discord' in _ch_cfg and _discord_guilds else None; \
 parsed = urlparse(chat_ui_url); \
 chat_origin = f'{parsed.scheme}://{parsed.netloc}' if parsed.scheme and parsed.netloc else 'http://127.0.0.1:18789'; \

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -958,6 +958,7 @@ function patchStagedDockerfile(
   messagingChannels = [],
   messagingAllowedIds = {},
   discordGuilds = {},
+  telegramConfig = {},
 ) {
   const { providerKey, primaryModelRef, inferenceBaseUrl, inferenceApi, inferenceCompat } =
     getSandboxInferenceConfig(model, provider, preferredInferenceApi);
@@ -1034,6 +1035,12 @@ function patchStagedDockerfile(
     dockerfile = dockerfile.replace(
       /^ARG NEMOCLAW_DISCORD_GUILDS_B64=.*$/m,
       `ARG NEMOCLAW_DISCORD_GUILDS_B64=${encodeDockerJsonArg(discordGuilds)}`,
+    );
+  }
+  if (Object.keys(telegramConfig).length > 0) {
+    dockerfile = dockerfile.replace(
+      /^ARG NEMOCLAW_TELEGRAM_CONFIG_B64=.*$/m,
+      `ARG NEMOCLAW_TELEGRAM_CONFIG_B64=${encodeDockerJsonArg(telegramConfig)}`,
     );
   }
   fs.writeFileSync(dockerfilePath, dockerfile);
@@ -2536,6 +2543,11 @@ async function createSandbox(
       };
     }
   }
+  const telegramConfig = {};
+  if (enabledTokenEnvKeys.has("TELEGRAM_BOT_TOKEN")) {
+    const requireMention = process.env.TELEGRAM_REQUIRE_MENTION === "1";
+    telegramConfig.requireMention = requireMention;
+  }
   patchStagedDockerfile(
     stagedDockerfile,
     model,
@@ -2547,6 +2559,7 @@ async function createSandbox(
     activeMessagingChannels,
     messagingAllowedIds,
     discordGuilds,
+    telegramConfig,
   );
   // Only pass non-sensitive env vars to the sandbox. Credentials flow through
   // OpenShell providers — the gateway injects them as placeholders and the L7
@@ -3497,6 +3510,9 @@ const MESSAGING_CHANNELS = [
     description: "Telegram bot messaging",
     help: "Create a bot via @BotFather on Telegram, then copy the token.",
     label: "Telegram Bot Token",
+    requireMentionEnvKey: "TELEGRAM_REQUIRE_MENTION",
+    requireMentionHelp:
+      "Choose whether the bot should reply only when @mentioned or to all messages in Telegram groups.",
     userIdEnvKey: "TELEGRAM_ALLOWED_IDS",
     userIdHelp: "Send /start to @userinfobot on Telegram to get your numeric user ID.",
     userIdLabel: "Telegram User ID (for DM access)",
@@ -3681,7 +3697,7 @@ async function setupMessagingChannels() {
         }
       }
     }
-    if (ch.requireMentionEnvKey && ch.serverIdEnvKey && process.env[ch.serverIdEnvKey]) {
+    if (ch.requireMentionEnvKey && (!ch.serverIdEnvKey || process.env[ch.serverIdEnvKey])) {
       const existingRequireMention = process.env[ch.requireMentionEnvKey];
       if (existingRequireMention === "0" || existingRequireMention === "1") {
         const mode = existingRequireMention === "0" ? "all messages" : "@mentions only";

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2545,7 +2545,14 @@ async function createSandbox(
   }
   const telegramConfig = {};
   if (enabledTokenEnvKeys.has("TELEGRAM_BOT_TOKEN")) {
-    const requireMention = process.env.TELEGRAM_REQUIRE_MENTION === "1";
+    const rawTelegramRequireMention = process.env.TELEGRAM_REQUIRE_MENTION;
+    if (rawTelegramRequireMention != null && rawTelegramRequireMention !== "0" && rawTelegramRequireMention !== "1") {
+      console.error(
+        `  Error: TELEGRAM_REQUIRE_MENTION must be '0', '1', or unset, got '${rawTelegramRequireMention}'.`,
+      );
+      process.exit(1);
+    }
+    const requireMention = rawTelegramRequireMention === "1";
     telegramConfig.requireMention = requireMention;
   }
   patchStagedDockerfile(

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -283,6 +283,146 @@ describe("onboard helpers", () => {
     }
   });
 
+  it("patches the staged Dockerfile with Telegram mention-only config", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-dockerfile-telegram-mention-"),
+    );
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_CONFIG_B64=e30=",
+        "ARG NEMOCLAW_MESSAGING_CHANNELS_B64=W10=",
+        "ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=",
+        "ARG NEMOCLAW_DISCORD_GUILDS_B64=e30=",
+        "ARG NEMOCLAW_TELEGRAM_CONFIG_B64=e30=",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-telegram-mention",
+        "openai-api",
+        null,
+        null,
+        ["telegram"],
+        {},
+        {},
+        { requireMention: true },
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      assert.match(patched, /^ARG NEMOCLAW_MESSAGING_CHANNELS_B64=/m);
+      const telegramLine = patched
+        .split("\n")
+        .find((line) => line.startsWith("ARG NEMOCLAW_TELEGRAM_CONFIG_B64="));
+      assert.ok(telegramLine, "expected telegram config build arg");
+      const encoded = telegramLine.split("=")[1];
+      const decoded = JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+      assert.deepEqual(decoded, { requireMention: true });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patches the staged Dockerfile with Telegram open group config", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-dockerfile-telegram-open-"),
+    );
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_CONFIG_B64=e30=",
+        "ARG NEMOCLAW_MESSAGING_CHANNELS_B64=W10=",
+        "ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=",
+        "ARG NEMOCLAW_DISCORD_GUILDS_B64=e30=",
+        "ARG NEMOCLAW_TELEGRAM_CONFIG_B64=e30=",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-telegram-open",
+        "openai-api",
+        null,
+        null,
+        ["telegram"],
+        {},
+        {},
+        { requireMention: false },
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      const telegramLine = patched
+        .split("\n")
+        .find((line) => line.startsWith("ARG NEMOCLAW_TELEGRAM_CONFIG_B64="));
+      assert.ok(telegramLine, "expected telegram config build arg");
+      const encoded = telegramLine.split("=")[1];
+      const decoded = JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+      assert.deepEqual(decoded, { requireMention: false });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not patch Telegram config when telegramConfig is empty", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-dockerfile-telegram-empty-"),
+    );
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_CONFIG_B64=e30=",
+        "ARG NEMOCLAW_MESSAGING_CHANNELS_B64=W10=",
+        "ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=",
+        "ARG NEMOCLAW_DISCORD_GUILDS_B64=e30=",
+        "ARG NEMOCLAW_TELEGRAM_CONFIG_B64=e30=",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-telegram-empty",
+        "openai-api",
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      const telegramLine = patched
+        .split("\n")
+        .find((line) => line.startsWith("ARG NEMOCLAW_TELEGRAM_CONFIG_B64="));
+      assert.ok(telegramLine, "expected telegram config build arg to remain");
+      assert.equal(telegramLine, "ARG NEMOCLAW_TELEGRAM_CONFIG_B64=e30=");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("maps NVIDIA Endpoints to the routed inference provider", () => {
     assert.deepEqual(
       getSandboxInferenceConfig("qwen/qwen3.5-397b-a17b", "nvidia-prod", "openai-completions"),

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -423,6 +423,94 @@ describe("onboard helpers", () => {
     }
   });
 
+  it(
+    "rejects invalid TELEGRAM_REQUIRE_MENTION values",
+    { timeout: 60_000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-telegram-require-mention-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "telegram-require-mention-check.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+      const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+      const preflightPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "preflight.js"));
+      const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+
+      try {
+        for (const badValue of ["true", "yes", "2", "on"]) {
+          const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const preflight = require(${preflightPath});
+const credentials = require(${credentialsPath});
+const childProcess = require("node:child_process");
+const { EventEmitter } = require("node:events");
+
+runner.run = (command, opts = {}) => ({ status: 0 });
+runner.runCapture = (command) => {
+  if (command.includes("'sandbox' 'get'")) return "";
+  if (command.includes("'sandbox' 'list'")) return "";
+  return "";
+};
+registry.registerSandbox = () => true;
+registry.removeSandbox = () => true;
+preflight.checkPortAvailable = async () => ({ ok: true });
+credentials.prompt = async () => "";
+
+const { createSandbox } = require(${onboardPath});
+
+(async () => {
+  process.env.OPENSHELL_GATEWAY = "nemoclaw";
+  process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-test-telegram-token";
+  process.env.TELEGRAM_REQUIRE_MENTION = "${badValue}";
+  await createSandbox(null, "gpt-5.4");
+  console.log("ERROR_DID_NOT_EXIT");
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+          fs.writeFileSync(scriptPath, script);
+
+          const result = spawnSync(process.execPath, [scriptPath], {
+            cwd: repoRoot,
+            encoding: "utf-8",
+            env: {
+              ...process.env,
+              HOME: tmpDir,
+              PATH: `${fakeBin}:${process.env.PATH || ""}`,
+              NEMOCLAW_NON_INTERACTIVE: "1",
+            },
+          });
+
+          assert.notEqual(
+            result.status,
+            0,
+            `expected non-zero exit for TELEGRAM_REQUIRE_MENTION='${badValue}'`,
+          );
+          assert.ok(
+            !result.stdout.includes("ERROR_DID_NOT_EXIT"),
+            `onboard should have exited before sandbox create for value '${badValue}'`,
+          );
+          assert.ok(
+            result.stderr.includes("TELEGRAM_REQUIRE_MENTION must be"),
+            `expected validation error in stderr for value '${badValue}', got: ${result.stderr}`,
+          );
+        }
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("maps NVIDIA Endpoints to the routed inference provider", () => {
     assert.deepEqual(
       getSandboxInferenceConfig("qwen/qwen3.5-397b-a17b", "nvidia-prod", "openai-completions"),


### PR DESCRIPTION
## Summary

Add Telegram mention-only mode parity with Discord's existing `requireMention` support.

Fixes #1737

## Changes

### `src/lib/onboard.ts`
- Add `requireMentionEnvKey` and `requireMentionHelp` to the Telegram `MESSAGING_CHANNELS` entry
- Fix the interactive prompt condition: was gated on `serverIdEnvKey` (which Telegram doesn't have), now fires for any channel with `requireMentionEnvKey`
- Build `telegramConfig` from `TELEGRAM_REQUIRE_MENTION` env var and pass to `patchStagedDockerfile`
- Add `telegramConfig` parameter to `patchStagedDockerfile()` → writes `NEMOCLAW_TELEGRAM_CONFIG_B64` ARG

### `Dockerfile`
- Add `ARG NEMOCLAW_TELEGRAM_CONFIG_B64=e30=` and promote to ENV
- Read config in Python openclaw.json generator: set `groupPolicy: 'mentions'` when `requireMention` is true, else `'open'` (preserving default behavior)

## Usage

**Interactive onboarding:**
```
nemoclaw my-assistant onboard
# → When Telegram is enabled, prompts: "Reply only when @mentioned? [Y/n]"
```

**Non-interactive:**
```bash
TELEGRAM_REQUIRE_MENTION=1 nemoclaw my-assistant onboard --non-interactive
```

## Testing
- 3 new vitest tests: mention-only config, open config, empty config (default behavior)
- All 99 onboard tests pass (1 pre-existing failure unrelated)
- `tsc --noEmit` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Telegram setting to require mentions for reply-only behavior.
  * Onboarding now prompts for and validates the Telegram mention setting; group policy is assigned dynamically based on that choice.

* **Tests**
  * Added end-to-end and unit tests covering Telegram mention behavior and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->