### PR TITLE
docs(reference): align onboard usage with supported flags

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -44,7 +44,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard [--non-interactive] [--resume] [--from <Dockerfile>]
+$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--yes-i-accept-third-party-software]
 ```
 
 > **Warning:** For NemoClaw-managed environments, use `nemoclaw onboard` when you need to create or recreate the OpenShell gateway or sandbox.
@@ -70,6 +70,23 @@ or:
 
 ```console
 $ NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 nemoclaw onboard --non-interactive
+```
+
+#### `--recreate-sandbox`
+
+Delete and recreate the existing sandbox instead of reusing it.
+Use this when you need onboarding to rebuild the sandbox after configuration changes or to recover from a broken sandbox state.
+
+```console
+$ nemoclaw onboard --resume --recreate-sandbox
+```
+
+#### `--agent <name>`
+
+Select a specific packaged agent during onboarding instead of using the default agent.
+
+```console
+$ nemoclaw onboard --agent hermes
 ```
 
 To enable Brave Search in non-interactive mode, set:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -64,7 +64,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard [--non-interactive] [--resume] [--from <Dockerfile>]
+$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--yes-i-accept-third-party-software]
 ```
 
 :::{warning}
@@ -92,6 +92,23 @@ or:
 
 ```console
 $ NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 nemoclaw onboard --non-interactive
+```
+
+#### `--recreate-sandbox`
+
+Delete and recreate the existing sandbox instead of reusing it.
+Use this when you need onboarding to rebuild the sandbox after configuration changes or to recover from a broken sandbox state.
+
+```console
+$ nemoclaw onboard --resume --recreate-sandbox
+```
+
+#### `--agent <name>`
+
+Select a specific packaged agent during onboarding instead of using the default agent.
+
+```console
+$ nemoclaw onboard --agent hermes
 ```
 
 To enable Brave Search in non-interactive mode, set:


### PR DESCRIPTION
## Summary
- update the `nemoclaw onboard` synopsis to include documented supported flags
- add reference entries for `--recreate-sandbox` and `--agent <name>`
- regenerate the derived user-reference skill content from `docs/`

## Testing
- `npm test -- test/check-docs-links.test.ts`

## Related
- closes #1730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `nemoclaw onboard` command reference with new CLI flags: `--recreate-sandbox`, `--agent <name>`, and `--yes-i-accept-third-party-software`.
  * Added descriptions for `--recreate-sandbox` to delete and recreate existing sandboxes and `--agent <name>` to select specific packaged agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->