### PR TITLE
fix: harden test-inference scripts with error handling and cleanup

### DIFF
--- a/scripts/test-inference-local.sh
+++ b/scripts/test-inference-local.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Test inference.local routing through OpenShell provider (local vLLM).
 
-# Test inference.local routing through OpenShell provider (local vLLM)
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-echo '{"model":"nvidia/nemotron-3-nano-30b-a3b","messages":[{"role":"user","content":"say hello"}]}' >"$TMPFILE"
-curl -s https://inference.local/v1/chat/completions -H "Content-Type: application/json" -d @"$TMPFILE"
+set -euo pipefail
+
+REQ_FILE="$(mktemp /tmp/nemoclaw-test-req-XXXXXX.json)"
+trap 'rm -f "$REQ_FILE"' EXIT
+
+cat > "$REQ_FILE" <<'JSON'
+{"model":"nvidia/nemotron-3-nano-30b-a3b","messages":[{"role":"user","content":"say hello"}]}
+JSON
+
+curl -sf --max-time 30 https://inference.local/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d @"$REQ_FILE"
+echo ""

--- a/scripts/test-inference.sh
+++ b/scripts/test-inference.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Test inference.local routing through OpenShell provider (NVIDIA cloud).
 
-# Test inference.local routing through OpenShell provider
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-echo '{"model":"nvidia/nemotron-3-super-120b-a12b","messages":[{"role":"user","content":"say hello"}]}' >"$TMPFILE"
-curl -s https://inference.local/v1/chat/completions -H "Content-Type: application/json" -d @"$TMPFILE"
+set -euo pipefail
+
+REQ_FILE="$(mktemp /tmp/nemoclaw-test-req-XXXXXX.json)"
+trap 'rm -f "$REQ_FILE"' EXIT
+
+cat > "$REQ_FILE" <<'JSON'
+{"model":"nvidia/nemotron-3-super-120b-a12b","messages":[{"role":"user","content":"say hello"}]}
+JSON
+
+curl -sf --max-time 30 https://inference.local/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d @"$REQ_FILE"
+echo ""


### PR DESCRIPTION
## Summary
- Adds `set -euo pipefail` to both test-inference scripts for fail-fast behavior
- Uses predictable temp file names (`/tmp/nemoclaw-test-req-XXXXXX.json`) with proper cleanup trap
- Adds `--max-time 30` and `-sf` flags to curl for bounded, silent-on-success requests
- Uses heredoc for JSON payload instead of inline echo

## Test plan
- [x] Both scripts pass ShellCheck
- [x] Scripts tested against local sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Intern Dev <dev@wukongai.io>