### PR TITLE
docs(network-policy): clarify host-side policy editing

### DIFF
--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -32,6 +32,11 @@ NemoClaw supports both static policy changes that persist across restarts and dy
 - A running NemoClaw sandbox for dynamic changes, or the NemoClaw source repository for static changes.
 - The OpenShell CLI on your `PATH`.
 
+> [!IMPORTANT]
+> Make static policy edits on the host, not inside the sandbox.
+> The sandbox image is intentionally minimal and may not include editors or package-management tools.
+> Changes made only inside the sandbox are also ephemeral and are lost when the sandbox is recreated.
+
 ## Static Changes
 
 Static changes modify the baseline policy file and take effect after the next sandbox creation.
@@ -39,6 +44,14 @@ Static changes modify the baseline policy file and take effect after the next sa
 ### Edit the Policy File
 
 Open `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` and add or modify endpoint entries.
+
+If you only need one of the built-in presets, use `nemoclaw <name> policy-add` instead of editing YAML by hand:
+
+```console
+$ nemoclaw my-assistant policy-add
+```
+
+Use a manual YAML edit when you need to allow custom hosts that are not covered by a preset, such as an internal API or a weather service.
 
 Each entry in the `network` section defines an endpoint group with the following fields:
 
@@ -93,6 +106,16 @@ The change takes effect immediately.
 Dynamic changes apply only to the current session.
 When the sandbox stops, the running policy resets to the baseline defined in the policy file.
 To make changes permanent, update the static policy file and re-run setup.
+
+### Approve Requests Interactively
+
+For one-off access, you can approve blocked requests in the OpenShell TUI instead of editing the baseline policy:
+
+```console
+$ openshell term
+```
+
+This is useful when you want to test a destination before deciding whether it belongs in a permanent preset or custom policy file.
 
 ## Policy Presets
 


### PR DESCRIPTION
## Summary
- Adds an "Approve Requests Interactively" subsection explaining how to use the OpenShell TUI for one-off access approval
- Helps users understand the workflow of testing destinations before committing them to permanent policy files

## Test plan
- [x] Docs render correctly in Sphinx/MyST preview
- [x] Links to related topics verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: peteryuqin <peter.yuqin@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that static policy edits must be performed on the host, not within the sandbox, as in-sandbox changes are ephemeral and lost upon recreation
  * Added alternative preset-based workflow option for adding policies alongside manual YAML edits
  * Enhanced dynamic policy changes with interactive workflow to approve blocked requests for one-off access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->