### PR TITLE
feat(blueprint): enforce maximum OpenShell version constraint

### DIFF
--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -3,6 +3,7 @@
 
 version: "0.1.0"
 min_openshell_version: "0.0.24"
+max_openshell_version: "0.0.26"
 min_openclaw_version: "2026.3.0"
 # Mirrors the components.sandbox.image manifest digest below. Lets a
 # downstream consumer (or release tooling) verify the blueprint declares

--- a/schemas/blueprint.schema.json
+++ b/schemas/blueprint.schema.json
@@ -17,6 +17,11 @@
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
       "description": "Minimum compatible OpenShell version."
     },
+    "max_openshell_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Maximum compatible OpenShell version."
+    },
     "min_openclaw_version": {
       "type": "string",
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -36,6 +36,9 @@ info "Detected $OS_LABEL ($ARCH_LABEL)"
 # Minimum version required for sandbox persistence across gateway restarts
 # (deterministic k3s node name + workspace PVC: NVIDIA/OpenShell#739, #488)
 MIN_VERSION="0.0.24"
+# Maximum version validated for this NemoClaw release. Newer OpenShell builds
+# may change sandbox semantics; upgrade NemoClaw before upgrading past this.
+MAX_VERSION="0.0.26"
 
 version_gte() {
   # Returns 0 (true) if $1 >= $2 — portable, no sort -V (BSD compat)
@@ -54,7 +57,10 @@ version_gte() {
 if command -v openshell >/dev/null 2>&1; then
   INSTALLED_VERSION="$(openshell --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo '0.0.0')"
   if version_gte "$INSTALLED_VERSION" "$MIN_VERSION"; then
-    info "openshell already installed: $INSTALLED_VERSION (>= $MIN_VERSION)"
+    if ! version_gte "$MAX_VERSION" "$INSTALLED_VERSION"; then
+      fail "openshell $INSTALLED_VERSION is above the maximum ($MAX_VERSION) supported by this NemoClaw release. Upgrade NemoClaw first."
+    fi
+    info "openshell already installed: $INSTALLED_VERSION (>= $MIN_VERSION, <= $MAX_VERSION)"
     exit 0
   fi
   warn "openshell $INSTALLED_VERSION is below minimum $MIN_VERSION — upgrading..."

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -39,6 +39,8 @@ MIN_VERSION="0.0.24"
 # Maximum version validated for this NemoClaw release. Newer OpenShell builds
 # may change sandbox semantics; upgrade NemoClaw before upgrading past this.
 MAX_VERSION="0.0.26"
+# Pin fresh installs to this version instead of pulling "latest".
+PIN_VERSION="$MAX_VERSION"
 
 version_gte() {
   # Returns 0 (true) if $1 >= $2 — portable, no sort -V (BSD compat)
@@ -88,16 +90,16 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 CHECKSUM_FILE="openshell-checksums-sha256.txt"
 download_with_curl() {
-  curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/latest/download/$ASSET" \
+  curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/download/v${PIN_VERSION}/$ASSET" \
     -o "$tmpdir/$ASSET"
-  curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/latest/download/$CHECKSUM_FILE" \
+  curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/download/v${PIN_VERSION}/$CHECKSUM_FILE" \
     -o "$tmpdir/$CHECKSUM_FILE"
 }
 
 if command -v gh >/dev/null 2>&1; then
-  if GH_PROMPT_DISABLED=1 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh release download --repo NVIDIA/OpenShell \
+  if GH_PROMPT_DISABLED=1 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh release download "v${PIN_VERSION}" --repo NVIDIA/OpenShell \
     --pattern "$ASSET" --dir "$tmpdir" 2>/dev/null \
-    && GH_PROMPT_DISABLED=1 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh release download --repo NVIDIA/OpenShell \
+    && GH_PROMPT_DISABLED=1 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh release download "v${PIN_VERSION}" --repo NVIDIA/OpenShell \
       --pattern "$CHECKSUM_FILE" --dir "$tmpdir" 2>/dev/null; then
     : # gh succeeded
   else

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -414,12 +414,12 @@ function versionGte(left = "0.0.0", right = "0.0.0") {
 }
 
 /**
- * Read `min_openshell_version` from nemoclaw-blueprint/blueprint.yaml. Returns
- * null if the blueprint or field is missing or unparseable — callers must
- * treat null as "no constraint configured" so a malformed install does not
- * become a hard onboard blocker. See #1317.
+ * Read a semver field from nemoclaw-blueprint/blueprint.yaml. Returns null if
+ * the blueprint or field is missing or unparseable — callers must treat null
+ * as "no constraint configured" so a malformed install does not become a hard
+ * onboard blocker. See #1317.
  */
-function getBlueprintMinOpenshellVersion(rootDir = ROOT) {
+function getBlueprintVersionField(field, rootDir = ROOT) {
   try {
     // Lazy require: yaml is already a dependency via the policy helpers but
     // pulling it at module load would slow down `nemoclaw --help` for users
@@ -429,7 +429,7 @@ function getBlueprintMinOpenshellVersion(rootDir = ROOT) {
     if (!fs.existsSync(blueprintPath)) return null;
     const raw = fs.readFileSync(blueprintPath, "utf8");
     const parsed = YAML.parse(raw);
-    const value = parsed && parsed.min_openshell_version;
+    const value = parsed && parsed[field];
     if (typeof value !== "string") return null;
     const trimmed = value.trim();
     if (!/^[0-9]+\.[0-9]+\.[0-9]+/.test(trimmed)) return null;
@@ -437,6 +437,14 @@ function getBlueprintMinOpenshellVersion(rootDir = ROOT) {
   } catch {
     return null;
   }
+}
+
+function getBlueprintMinOpenshellVersion(rootDir = ROOT) {
+  return getBlueprintVersionField("min_openshell_version", rootDir);
+}
+
+function getBlueprintMaxOpenshellVersion(rootDir = ROOT) {
+  return getBlueprintVersionField("max_openshell_version", rootDir);
 }
 
 function getStableGatewayImageRef(versionOutput = null) {
@@ -1836,6 +1844,29 @@ async function preflight() {
       "    Or remove the existing binary so the installer can re-fetch a current build:",
     );
     console.error('      command -v openshell && rm -f "$(command -v openshell)"');
+    console.error("");
+    process.exit(1);
+  }
+  // Enforce nemoclaw-blueprint/blueprint.yaml's max_openshell_version. Newer
+  // OpenShell releases may change sandbox semantics that this NemoClaw version
+  // has not been validated against. Blocking early avoids silent runtime
+  // breakage. Users should upgrade NemoClaw to pick up support for newer
+  // OpenShell releases.
+  const maxOpenshellVersion = getBlueprintMaxOpenshellVersion();
+  if (
+    installedOpenshellVersion &&
+    maxOpenshellVersion &&
+    !versionGte(maxOpenshellVersion, installedOpenshellVersion)
+  ) {
+    console.error("");
+    console.error(
+      `  ✗ openshell ${installedOpenshellVersion} is above the maximum supported by this NemoClaw release.`,
+    );
+    console.error(`    blueprint.yaml max_openshell_version: ${maxOpenshellVersion}`);
+    console.error("");
+    console.error("    Upgrade NemoClaw to a version that supports your OpenShell release,");
+    console.error("    or install a supported OpenShell version:");
+    console.error("      https://github.com/NVIDIA/OpenShell/releases");
     console.error("");
     process.exit(1);
   }
@@ -4769,6 +4800,7 @@ module.exports = {
   getSandboxInferenceConfig,
   getInstalledOpenshellVersion,
   getBlueprintMinOpenshellVersion,
+  getBlueprintMaxOpenshellVersion,
   versionGte,
   getRequestedModelHint,
   getRequestedProviderHint,

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -23,6 +23,7 @@ import {
   getSandboxInferenceConfig,
   getInstalledOpenshellVersion,
   getBlueprintMinOpenshellVersion,
+  getBlueprintMaxOpenshellVersion,
   versionGte,
   getRequestedModelHint,
   getRequestedProviderHint,
@@ -744,6 +745,62 @@ describe("onboard helpers", () => {
     const v = getBlueprintMinOpenshellVersion(repoRoot);
     expect(v).not.toBe(null);
     expect(/^[0-9]+\.[0-9]+\.[0-9]+/.test(v)).toBe(true);
+  });
+
+  it("getBlueprintMaxOpenshellVersion reads max_openshell_version from blueprint.yaml", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-blueprint-max-version-"));
+    const blueprintDir = path.join(tmpDir, "nemoclaw-blueprint");
+    fs.mkdirSync(blueprintDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(blueprintDir, "blueprint.yaml"),
+      [
+        'version: "0.1.0"',
+        'min_openshell_version: "0.0.24"',
+        'max_openshell_version: "0.0.26"',
+        'min_openclaw_version: "2026.3.0"',
+      ].join("\n"),
+    );
+    try {
+      expect(getBlueprintMaxOpenshellVersion(tmpDir)).toBe("0.0.26");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("getBlueprintMaxOpenshellVersion returns null on missing or unparseable blueprint", () => {
+    // Missing directory
+    const missingDir = path.join(
+      os.tmpdir(),
+      "nemoclaw-blueprint-max-missing-" + Date.now().toString(),
+    );
+    expect(getBlueprintMaxOpenshellVersion(missingDir)).toBe(null);
+
+    // Present file, missing field — must NOT block onboard
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-blueprint-no-max-field-"));
+    const blueprintDir = path.join(tmpDir, "nemoclaw-blueprint");
+    fs.mkdirSync(blueprintDir, { recursive: true });
+    fs.writeFileSync(path.join(blueprintDir, "blueprint.yaml"), 'version: "0.1.0"\n');
+    try {
+      expect(getBlueprintMaxOpenshellVersion(tmpDir)).toBe(null);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("shipped blueprint.yaml exposes a parseable max_openshell_version", () => {
+    const repoRoot = path.resolve(import.meta.dirname, "..");
+    const v = getBlueprintMaxOpenshellVersion(repoRoot);
+    expect(v).not.toBe(null);
+    expect(/^[0-9]+\.[0-9]+\.[0-9]+/.test(v)).toBe(true);
+  });
+
+  it("max_openshell_version is greater than or equal to min_openshell_version in shipped blueprint", () => {
+    const repoRoot = path.resolve(import.meta.dirname, "..");
+    const min = getBlueprintMinOpenshellVersion(repoRoot);
+    const max = getBlueprintMaxOpenshellVersion(repoRoot);
+    expect(min).not.toBe(null);
+    expect(max).not.toBe(null);
+    expect(versionGte(max, min)).toBe(true);
   });
 
   it("pins the gateway image to the installed OpenShell release version", () => {


### PR DESCRIPTION
## Summary
- Adds `max_openshell_version` enforcement to the blueprint, mirroring the existing `min_openshell_version` pattern
- OpenShell 0.0.26 causes `nemoclaw onboard` to hang on Mac when paired with NemoClaw v0.0.7 — this establishes the version ceiling mechanism on main so future releases ship with validated upper bounds
- On main, the max is set to 0.0.26 (main's TypeScript codebase works with it); the v0.0.7.1 backport tag separately caps at 0.0.25 to unblock QA
- Enforcement at two layers: `onboard.ts` preflight exits with actionable error + downgrade link, `install-openshell.sh` fails fast if installed version exceeds the cap
- Blueprint schema updated to accept the new field

## Context
QA hit a Mac onboard hang with OpenShell 0.0.26 + NemoClaw v0.0.7. Root cause is NemoClaw always pulling latest OpenShell with no upper bound. This PR adds the enforcement infrastructure on main; the immediate fix for QA is the v0.0.7.1 backport tag.

## Test plan
- [x] Unit tests: blueprint max version parsing, null on missing/bad data, shipped blueprint sanity, max >= min invariant
- [ ] Manual: verify `nemoclaw onboard` rejects an OpenShell version above the configured max
- [ ] Manual: verify `install-openshell.sh` fails fast when installed version exceeds the cap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maximum OpenShell version constraint (0.0.26) to prevent installation of incompatible newer versions.
  * Installation process now validates against both minimum (0.0.24) and maximum supported OpenShell versions, blocking upgrades beyond the supported range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->