### PR TITLE
fix(install): cap OpenShell at 0.0.25 to prevent Mac onboard hang

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -374,6 +374,49 @@ function step(n, total, msg) {
   console.log(`  ${"─".repeat(50)}`);
 }
 
+/**
+ * Returns true if left >= right (semver comparison).
+ */
+function versionGte(left, right) {
+  const lhs = String(left || "0.0.0")
+    .split(".")
+    .map((p) => parseInt(p, 10) || 0);
+  const rhs = String(right || "0.0.0")
+    .split(".")
+    .map((p) => parseInt(p, 10) || 0);
+  const length = Math.max(lhs.length, rhs.length);
+  for (let i = 0; i < length; i++) {
+    const a = lhs[i] || 0;
+    const b = rhs[i] || 0;
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+  return true;
+}
+
+/**
+ * Read max_openshell_version from nemoclaw-blueprint/blueprint.yaml.
+ * Returns null if missing or unparseable — callers must treat null as
+ * "no constraint configured" to avoid blocking onboard on malformed installs.
+ */
+function getBlueprintMaxOpenshellVersion(rootDir) {
+  rootDir = rootDir || ROOT;
+  try {
+    const YAML = require("yaml");
+    const blueprintPath = path.join(rootDir, "nemoclaw-blueprint", "blueprint.yaml");
+    if (!fs.existsSync(blueprintPath)) return null;
+    const raw = fs.readFileSync(blueprintPath, "utf8");
+    const parsed = YAML.parse(raw);
+    const value = parsed && parsed.max_openshell_version;
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!/^[0-9]+\.[0-9]+\.[0-9]+/.test(trimmed)) return null;
+    return trimmed;
+  } catch (_e) {
+    return null;
+  }
+}
+
 function getInstalledOpenshellVersion(versionOutput = null) {
   const output = String(versionOutput ?? runCapture("openshell -V", { ignoreError: true })).trim();
   const match = output.match(/openshell\s+([0-9]+\.[0-9]+\.[0-9]+)/i);
@@ -1559,9 +1602,30 @@ async function preflight() {
       process.exit(1);
     }
   }
-  console.log(
-    `  ✓ openshell CLI: ${runCaptureOpenshell(["--version"], { ignoreError: true }) || "unknown"}`,
-  );
+  const openshellVersionOutput = runCaptureOpenshell(["--version"], { ignoreError: true });
+  console.log(`  ✓ openshell CLI: ${openshellVersionOutput || "unknown"}`);
+  // Enforce max OpenShell version from blueprint.yaml.
+  // OpenShell 0.0.26 hangs during onboard on macOS. Block early with
+  // actionable guidance rather than letting the user hit a silent hang.
+  const installedOpenshellVersion = getInstalledOpenshellVersion(openshellVersionOutput);
+  const maxOpenshellVersion = getBlueprintMaxOpenshellVersion();
+  if (
+    installedOpenshellVersion &&
+    maxOpenshellVersion &&
+    !versionGte(maxOpenshellVersion, installedOpenshellVersion)
+  ) {
+    console.error("");
+    console.error(
+      `  ✗ openshell ${installedOpenshellVersion} exceeds the maximum (${maxOpenshellVersion}) supported by this NemoClaw release.`,
+    );
+    console.error("");
+    console.error("    Downgrade OpenShell to a supported version:");
+    console.error(`      https://github.com/NVIDIA/OpenShell/releases/tag/v${maxOpenshellVersion}`);
+    console.error("");
+    console.error("    Or upgrade NemoClaw to a version that supports your OpenShell release.");
+    console.error("");
+    process.exit(1);
+  }
   if (openshellInstall.futureShellPathHint) {
     console.log(
       `  Note: openshell was installed to ${openshellInstall.localBin} for this onboarding run.`,
@@ -4159,6 +4223,8 @@ module.exports = {
   getNavigationChoice,
   getSandboxInferenceConfig,
   getInstalledOpenshellVersion,
+  getBlueprintMaxOpenshellVersion,
+  versionGte,
   getRequestedModelHint,
   getRequestedProviderHint,
   getStableGatewayImageRef,

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version: "0.1.0"
-min_openshell_version: "0.0.22"
+min_openshell_version: "0.0.23"
 max_openshell_version: "0.0.25"
 min_openclaw_version: "2026.3.0"
 digest: ""  # Computed at release time

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version: "0.1.0"
-min_openshell_version: "0.1.0"
+min_openshell_version: "0.0.22"
+max_openshell_version: "0.0.25"
 min_openclaw_version: "2026.3.0"
 digest: ""  # Computed at release time
 

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -36,6 +36,11 @@ info "Detected $OS_LABEL ($ARCH_LABEL)"
 # Minimum version required for sandbox persistence across gateway restarts
 # (deterministic k3s node name + workspace PVC: NVIDIA/OpenShell#739, #488)
 MIN_VERSION="0.0.22"
+# Maximum version validated for this NemoClaw release (v0.0.7.1).
+# OpenShell 0.0.26 hangs during onboard preflight on macOS.
+MAX_VERSION="0.0.25"
+# Pin fresh installs to this exact version instead of pulling "latest".
+PIN_VERSION="0.0.25"
 
 version_gte() {
   # Returns 0 (true) if $1 >= $2 — portable, no sort -V (BSD compat)
@@ -54,7 +59,10 @@ version_gte() {
 if command -v openshell >/dev/null 2>&1; then
   INSTALLED_VERSION="$(openshell --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo '0.0.0')"
   if version_gte "$INSTALLED_VERSION" "$MIN_VERSION"; then
-    info "openshell already installed: $INSTALLED_VERSION (>= $MIN_VERSION)"
+    if ! version_gte "$MAX_VERSION" "$INSTALLED_VERSION"; then
+      fail "openshell $INSTALLED_VERSION exceeds the maximum ($MAX_VERSION) validated for this NemoClaw release.\n  Downgrade: https://github.com/NVIDIA/OpenShell/releases/tag/v${PIN_VERSION}"
+    fi
+    info "openshell already installed: $INSTALLED_VERSION (>= $MIN_VERSION, <= $MAX_VERSION)"
     exit 0
   fi
   warn "openshell $INSTALLED_VERSION is below minimum $MIN_VERSION — upgrading..."
@@ -82,16 +90,16 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 CHECKSUM_FILE="openshell-checksums-sha256.txt"
 download_with_curl() {
-  curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/latest/download/$ASSET" \
+  curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/download/v${PIN_VERSION}/$ASSET" \
     -o "$tmpdir/$ASSET"
-  curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/latest/download/$CHECKSUM_FILE" \
+  curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/download/v${PIN_VERSION}/$CHECKSUM_FILE" \
     -o "$tmpdir/$CHECKSUM_FILE"
 }
 
 if command -v gh >/dev/null 2>&1; then
-  if GH_PROMPT_DISABLED=1 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh release download --repo NVIDIA/OpenShell \
+  if GH_PROMPT_DISABLED=1 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh release download "v${PIN_VERSION}" --repo NVIDIA/OpenShell \
     --pattern "$ASSET" --dir "$tmpdir" 2>/dev/null \
-    && GH_PROMPT_DISABLED=1 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh release download --repo NVIDIA/OpenShell \
+    && GH_PROMPT_DISABLED=1 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh release download "v${PIN_VERSION}" --repo NVIDIA/OpenShell \
       --pattern "$CHECKSUM_FILE" --dir "$tmpdir" 2>/dev/null; then
     : # gh succeeded
   else

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -35,7 +35,7 @@ info "Detected $OS_LABEL ($ARCH_LABEL)"
 
 # Minimum version required for sandbox persistence across gateway restarts
 # (deterministic k3s node name + workspace PVC: NVIDIA/OpenShell#739, #488)
-MIN_VERSION="0.0.22"
+MIN_VERSION="0.0.23"
 # Maximum version validated for this NemoClaw release (v0.0.7.1).
 # OpenShell 0.0.26 hangs during onboard preflight on macOS.
 MAX_VERSION="0.0.25"

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -361,7 +361,7 @@ exit 98
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
-    expect(output.trim()).toMatch(/^nemoclaw-installer(?: v\d+\.\d+\.\d+(?:-.+)?)?$/);
+    expect(output.trim()).toMatch(/^nemoclaw-installer(?: v\d+\.\d+\.\d+(?:\.\d+)?(?:-.+)?)?$/);
     expect(output).not.toMatch(/0\.1\.0/);
   });
 
@@ -373,7 +373,7 @@ exit 98
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}${result.stderr}`;
-    expect(output.trim()).toMatch(/^nemoclaw-installer(?: v\d+\.\d+\.\d+(?:-.+)?)?$/);
+    expect(output.trim()).toMatch(/^nemoclaw-installer(?: v\d+\.\d+\.\d+(?:\.\d+)?(?:-.+)?)?$/);
     expect(output).not.toMatch(/0\.1\.0/);
   });
 
@@ -1512,8 +1512,8 @@ describe("installer pure helpers", () => {
 
   it("resolve_installer_version: reads version from git or package.json", () => {
     const r = callInstallerFn("resolve_installer_version");
-    // May return clean semver ("0.0.2") or git describe format ("0.0.2-3-gabcdef1")
-    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+(-.+)?$/);
+    // May return clean semver ("0.0.2"), git describe ("0.0.2-3-gabcdef1"), or 4-part ("0.0.7.1")
+    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+(?:\.\d+)?(?:-.+)?$/);
   });
 
   it("resolve_openclaw_version: falls back to Dockerfile.base when package.json omits it", () => {

--- a/test/onboard.test.js
+++ b/test/onboard.test.js
@@ -20,6 +20,8 @@ import {
   getFutureShellPathHint,
   getSandboxInferenceConfig,
   getInstalledOpenshellVersion,
+  getBlueprintMaxOpenshellVersion,
+  versionGte,
   getRequestedModelHint,
   getRequestedProviderHint,
   getRequestedSandboxNameHint,
@@ -299,6 +301,38 @@ describe("onboard helpers", () => {
       inferenceApi: "openai-responses",
       inferenceCompat: null,
     });
+  });
+
+  it("compares semantic versions with versionGte", () => {
+    expect(versionGte("0.0.25", "0.0.25")).toBe(true);
+    expect(versionGte("0.0.26", "0.0.25")).toBe(true);
+    expect(versionGte("0.1.0", "0.0.99")).toBe(true);
+    expect(versionGte("1.0.0", "0.99.99")).toBe(true);
+    expect(versionGte("0.0.24", "0.0.25")).toBe(false);
+    expect(versionGte(null, "0.0.1")).toBe(false);
+    expect(versionGte("0.0.1", null)).toBe(true);
+  });
+
+  it("reads max_openshell_version from shipped blueprint.yaml", () => {
+    const repoRoot = path.resolve(import.meta.dirname, "..");
+    const v = getBlueprintMaxOpenshellVersion(repoRoot);
+    expect(v).toBe("0.0.25");
+  });
+
+  it("returns null for max_openshell_version when blueprint dir is missing", () => {
+    expect(getBlueprintMaxOpenshellVersion("/nonexistent/path")).toBe(null);
+  });
+
+  it("returns null for max_openshell_version when field is absent", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-blueprint-no-max-"));
+    const blueprintDir = path.join(tmpDir, "nemoclaw-blueprint");
+    fs.mkdirSync(blueprintDir, { recursive: true });
+    fs.writeFileSync(path.join(blueprintDir, "blueprint.yaml"), 'version: "0.1.0"\n');
+    try {
+      expect(getBlueprintMaxOpenshellVersion(tmpDir)).toBe(null);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("pins the gateway image to the installed OpenShell release version", () => {


### PR DESCRIPTION
## Summary
- Backport of max OpenShell version enforcement onto v0.0.7 to unblock QA on Mac
- OpenShell 0.0.26 causes `nemoclaw onboard` to hang during preflight on macOS when paired with NemoClaw v0.0.7
- Caps at 0.0.25 (one below the known-broken version), pins fresh installs to v0.0.25 instead of pulling `latest`
- Enforcement at two layers: `bin/lib/onboard.js` preflight exits with actionable error + downgrade link, `scripts/install-openshell.sh` fails fast if installed version exceeds the cap
- Also fixes incorrect `min_openshell_version` in blueprint.yaml from `"0.1.0"` to `"0.0.22"` (was never enforced, now matches the install script)

## Context
QA (Sayali) reported Mac onboard hang with OpenShell 0.0.26. Lynn diagnosed that VDR4 was validated with OpenShell 0.0.23 and the issue is NemoClaw always pulling latest. This is the immediate fix on the v0.0.7 JavaScript codebase; PR #1809 adds the same enforcement pattern to main's TypeScript codebase.

Tagged as `v0.0.7.1`. Nightly e2e triggered on this branch.

## Test plan
- [x] Unit tests: `versionGte`, `getBlueprintMaxOpenshellVersion` parsing, null on missing data, shipped blueprint sanity
- [x] Nightly e2e triggered on this branch (run 24323103344)
- [ ] QA: Mac onboard with OpenShell 0.0.26 installed — should get clear error with downgrade link instead of hang
- [ ] QA: Fresh Mac install — should download OpenShell 0.0.25, complete onboard normally