### PR TITLE
ci: add nightly e2e for v0.0.7.2 hotfix tag

### DIFF
--- a/.github/workflows/nightly-e2e-v0.0.7.yaml
+++ b/.github/workflows/nightly-e2e-v0.0.7.yaml
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Nightly E2E for the v0.0.7.2 hotfix tag.
+#
+# Runs the same jobs that existed at v0.0.7 against the patched tag so QA
+# has continuous validation of the OpenShell 0.0.25 pin while VDR4 Mac
+# testing is in progress. Remove this workflow once v0.0.8+ ships and QA
+# moves off the v0.0.7 line.
+#
+# Jobs: cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e,
+#       sandbox-survival-e2e, gpu-e2e (if enabled), notify-on-failure.
+# NOT included: hermes-e2e, skip-permissions-e2e (added after v0.0.7).
+
+name: nightly-e2e-v0.0.7
+
+on:
+  schedule:
+    - cron: "30 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-v007
+  cancel-in-progress: true
+
+jobs:
+  cloud-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout v0.0.7.1
+        uses: actions/checkout@v6
+        with:
+          ref: v0.0.7.2
+
+      - name: Run cloud E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-nightly-v007"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-full-e2e.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-log-v007
+          path: /tmp/nemoclaw-e2e-install.log
+          if-no-files-found: ignore
+
+  cloud-experimental-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout v0.0.7.1
+        uses: actions/checkout@v6
+        with:
+          ref: v0.0.7.2
+
+      - name: Run cloud-experimental E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_E2E_CLOUD_EXPERIMENTAL_INTERACTIVE_INSTALL: "0"
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          NEMOCLAW_POLICY_MODE: "custom"
+          NEMOCLAW_POLICY_PRESETS: "npm,pypi"
+          RUN_E2E_CLOUD_EXPERIMENTAL_SKIP_FINAL_CLEANUP: "1"
+          RUN_E2E_CLOUD_EXPERIMENTAL_SKIP_CHECK_DOCS: "1"
+        run: bash test/e2e/test-e2e-cloud-experimental.sh
+
+      - name: Documentation checks (check-docs.sh)
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -f "$HOME/.bashrc" ]; then source "$HOME/.bashrc" 2>/dev/null || true; fi
+          export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+          if [ -s "$NVM_DIR/nvm.sh" ]; then . "$NVM_DIR/nvm.sh"; fi
+          if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          bash test/e2e/e2e-cloud-experimental/check-docs.sh
+
+      - name: Network policy checks (skip/05-network-policy.sh)
+        if: always()
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SANDBOX_NAME: e2e-cloud-experimental
+          NEMOCLAW_SANDBOX_NAME: e2e-cloud-experimental
+        run: |
+          set -euo pipefail
+          if [ -f "$HOME/.bashrc" ]; then source "$HOME/.bashrc" 2>/dev/null || true; fi
+          export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+          if [ -s "$NVM_DIR/nvm.sh" ]; then . "$NVM_DIR/nvm.sh"; fi
+          if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          bash test/e2e/e2e-cloud-experimental/skip/05-network-policy.sh
+
+      - name: Tear down cloud-experimental sandbox (always)
+        if: always()
+        env:
+          SANDBOX_NAME: e2e-cloud-experimental
+          NEMOCLAW_SANDBOX_NAME: e2e-cloud-experimental
+        run: |
+          set -euo pipefail
+          if [ -f "$HOME/.bashrc" ]; then source "$HOME/.bashrc" 2>/dev/null || true; fi
+          export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+          if [ -s "$NVM_DIR/nvm.sh" ]; then . "$NVM_DIR/nvm.sh"; fi
+          if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          bash test/e2e/e2e-cloud-experimental/cleanup.sh --verify
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-log-cloud-experimental-v007
+          path: /tmp/nemoclaw-e2e-cloud-experimental-install.log
+          if-no-files-found: ignore
+
+  messaging-providers-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout v0.0.7.1
+        uses: actions/checkout@v6
+        with:
+          ref: v0.0.7.2
+
+      - name: Run messaging providers E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-msg-provider-v007"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+          TELEGRAM_BOT_TOKEN: "test-fake-telegram-token-e2e"
+          DISCORD_BOT_TOKEN: "test-fake-discord-token-e2e"
+        run: bash test/e2e/test-messaging-providers.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-log-messaging-providers-v007
+          path: /tmp/nemoclaw-e2e-install.log
+          if-no-files-found: ignore
+
+  sandbox-survival-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout v0.0.7.1
+        uses: actions/checkout@v6
+        with:
+          ref: v0.0.7.2
+
+      - name: Run sandbox survival E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-survival-v007"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-sandbox-survival.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandbox-survival-install-log-v007
+          path: /tmp/nemoclaw-e2e-install.log
+          if-no-files-found: ignore
+
+  gpu-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw' && vars.GPU_E2E_ENABLED == 'true'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    env:
+      NEMOCLAW_NON_INTERACTIVE: "1"
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+      NEMOCLAW_SANDBOX_NAME: "e2e-gpu-ollama-v007"
+      NEMOCLAW_RECREATE_SANDBOX: "1"
+      NEMOCLAW_PROVIDER: "ollama"
+    steps:
+      - name: Checkout v0.0.7.1
+        uses: actions/checkout@v6
+        with:
+          ref: v0.0.7.2
+
+      - name: Verify GPU availability
+        run: |
+          echo "=== GPU Info ==="
+          nvidia-smi
+          echo ""
+          echo "=== VRAM ==="
+          nvidia-smi --query-gpu=name,memory.total --format=csv,noheader
+          echo ""
+          echo "=== Docker ==="
+          docker info --format '{{.ServerVersion}}'
+
+      - name: Run GPU E2E test (Ollama local inference)
+        run: bash test/e2e/test-gpu-e2e.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-e2e-install-log-v007
+          path: /tmp/nemoclaw-gpu-e2e-install.log
+          if-no-files-found: ignore
+
+      - name: Upload test log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-e2e-test-log-v007
+          path: /tmp/nemoclaw-gpu-e2e-test.log
+          if-no-files-found: ignore
+
+  notify-on-failure:
+    runs-on: ubuntu-latest
+    needs: [cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e, sandbox-survival-e2e, gpu-e2e]
+    if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.messaging-providers-e2e.result == 'failure' || needs.sandbox-survival-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
+    permissions:
+      issues: write
+    steps:
+      - name: Create or update failure issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = 'Nightly E2E (v0.0.7) failed';
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'CI/CD',
+              per_page: 100,
+            });
+            const match = existing.find(i => !i.pull_request && i.title.startsWith(title));
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Failed again on ${new Date().toISOString().split('T')[0]}.\n\n**Run:** ${runUrl}\n**Artifacts:** Check the run artifacts for install/test logs.`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `${title} — ${new Date().toISOString().split('T')[0]}`,
+                body: `The v0.0.7 nightly E2E pipeline failed.\n\n**Run:** ${runUrl}\n**Branch:** release/v0.0.7.1\n**Artifacts:** Check the run artifacts for install/test logs.`,
+                labels: ['bug', 'CI/CD'],
+              });
+            }


### PR DESCRIPTION
## Summary
- Adds a nightly e2e workflow that checks out `v0.0.7.2` and runs the test suite that existed at v0.0.7
- Runs at 00:30 UTC (30 min after the main nightly), separate concurrency group
- Includes: cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e, sandbox-survival-e2e, gpu-e2e
- Does NOT include hermes-e2e or skip-permissions-e2e (added after v0.0.7)
- Remove this workflow once v0.0.8+ ships and QA moves off the v0.0.7 line

## Context
QA is validating VDR4 on Mac against `v0.0.7.2` (OpenShell pinned to 0.0.23-0.0.25). This workflow gives continuous e2e coverage of that tag until the next release supersedes it.

## Test plan
- [ ] Merge and trigger manually to verify the workflow runs against v0.0.7.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration with automated nightly end-to-end testing pipeline across multiple test suites with failure notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->