### PR TITLE
fix(onboard): improve gateway startup diagnostics (#1605)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2088,9 +2088,13 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
           },
         );
         if (startResult.status !== 0) {
-          const output = compactText(String(startResult.output || ""));
-          if (output) {
-            console.log(`  Gateway start returned before healthy: ${output.slice(0, 240)}`);
+          const lines = String(startResult.output || "")
+            .split("\n")
+            .map((l) => compactText(l))
+            .filter(Boolean)
+            .map((l) => `    ${l}`);
+          if (lines.length > 0) {
+            console.log(`  Gateway start returned before healthy:\n${lines.join("\n")}`);
           }
         }
         console.log("  Waiting for gateway health...");
@@ -2130,6 +2134,20 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
       console.error(`  Gateway failed to start after ${retries + 1} attempts.`);
       console.error("  Gateway state preserved for diagnostics.");
       console.error("");
+      try {
+        const logs = runCaptureOpenshell(["doctor", "logs", "--name", GATEWAY_NAME], {
+          ignoreError: true,
+        });
+        if (logs) {
+          console.error("  Gateway logs:");
+          for (const line of String(logs).split("\n").filter(Boolean)) {
+            console.error(`    ${line}`);
+          }
+          console.error("");
+        }
+      } catch {
+        // doctor logs unavailable — fall through to manual instructions
+      }
       console.error("  Troubleshooting:");
       console.error("    openshell doctor logs --name nemoclaw");
       console.error("    openshell doctor check");
@@ -4794,6 +4812,7 @@ module.exports = {
   repairRecordedSandbox,
   recoverGatewayRuntime,
   resolveDashboardForwardTarget,
+  startGateway,
   startGatewayForRecovery,
   runCaptureOpenshell,
   setupInference,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -23,8 +23,9 @@ function envInt(name, fallback) {
 /** Inference timeout (seconds) for local providers (Ollama, vLLM, NIM). */
 const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 180);
 
-/** Strip ANSI escape sequences before printing process output to the terminal. */
-const ANSI_RE = /\x1b\[[0-9;]*m/g;
+/** Strip ANSI escape sequences before printing process output to the terminal.
+ *  Covers CSI (color, erase, cursor), OSC, and C1 two-byte escapes per ECMA-48. */
+const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/g;
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("./runner");
 const { stageOptimizedSandboxBuildContext } = require("./sandbox-build-context");
 const {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -22,6 +22,9 @@ function envInt(name, fallback) {
 
 /** Inference timeout (seconds) for local providers (Ollama, vLLM, NIM). */
 const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 180);
+
+/** Strip ANSI escape sequences before printing process output to the terminal. */
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("./runner");
 const { stageOptimizedSandboxBuildContext } = require("./sandbox-build-context");
 const {
@@ -2090,7 +2093,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
         if (startResult.status !== 0) {
           const lines = String(redact(startResult.output || ""))
             .split("\n")
-            .map((l) => compactText(l))
+            .map((l) => compactText(l.replace(ANSI_RE, "")))
             .filter(Boolean)
             .map((l) => `    ${l}`);
           if (lines.length > 0) {
@@ -2144,7 +2147,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
           console.error("  Gateway logs:");
           for (const line of String(logs)
             .split("\n")
-            .map((l) => l.replace(/\r/g, ""))
+            .map((l) => l.replace(/\r/g, "").replace(ANSI_RE, ""))
             .filter(Boolean)) {
             console.error(`    ${line}`);
           }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2088,7 +2088,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
           },
         );
         if (startResult.status !== 0) {
-          const lines = String(startResult.output || "")
+          const lines = String(redact(startResult.output || ""))
             .split("\n")
             .map((l) => compactText(l))
             .filter(Boolean)
@@ -2135,12 +2135,17 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
       console.error("  Gateway state preserved for diagnostics.");
       console.error("");
       try {
-        const logs = runCaptureOpenshell(["doctor", "logs", "--name", GATEWAY_NAME], {
-          ignoreError: true,
-        });
+        const logs = redact(
+          runCaptureOpenshell(["doctor", "logs", "--name", GATEWAY_NAME], {
+            ignoreError: true,
+          }),
+        );
         if (logs) {
           console.error("  Gateway logs:");
-          for (const line of String(logs).split("\n").filter(Boolean)) {
+          for (const line of String(logs)
+            .split("\n")
+            .map((l) => l.replace(/\r/g, ""))
+            .filter(Boolean)) {
             console.error(`    ${line}`);
           }
           console.error("");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -658,8 +658,8 @@ function upsertProvider(name, type, credentialEnv, baseUrl, env = {}) {
   const updateResult = runOpenshell(updateArgs, runOpts);
   if (updateResult.status !== 0) {
     const output =
-      compactText(`${createResult.stderr || ""} ${updateResult.stderr || ""}`) ||
-      compactText(`${createResult.stdout || ""} ${updateResult.stdout || ""}`) ||
+      compactText(redact(`${createResult.stderr || ""} ${updateResult.stderr || ""}`)) ||
+      compactText(redact(`${createResult.stdout || ""} ${updateResult.stdout || ""}`)) ||
       `Failed to create or update provider '${name}'.`;
     return {
       ok: false,
@@ -3428,7 +3428,7 @@ async function setupInference(
         break;
       }
       const message =
-        compactText(`${applyResult.stderr || ""} ${applyResult.stdout || ""}`) ||
+        compactText(redact(`${applyResult.stderr || ""} ${applyResult.stdout || ""}`)) ||
         `Failed to configure inference provider '${provider}'.`;
       console.error(`  ${message}`);
       if (isNonInteractive()) {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -830,6 +830,80 @@ describe("onboard helpers", () => {
     expect(getGatewayReuseState("", "")).toBe("missing");
   });
 
+  it("prints doctor logs automatically when gateway fails to start (#1605)", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-diag-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "gateway-diag.cjs");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    // Fake openshell: returns diagnostic log output for `doctor logs`, fails otherwise.
+    fs.writeFileSync(
+      path.join(fakeBin, "openshell"),
+      `#!/usr/bin/env bash
+if [[ "$*" == *"doctor"*"logs"* ]]; then
+  printf "k3s cluster crashed: OOMKilled\\n  Container nemoclaw_k3s ran out of memory\\n"
+  exit 0
+fi
+exit 1
+`,
+      { mode: 0o755 },
+    );
+
+    // Script runs in a child process: patching p-retry to be immediate avoids the
+    // 10 s + 30 s minTimeout delays, and NEMOCLAW_HEALTH_POLL_COUNT=0 skips the
+    // health-poll loop so the function throws "Gateway failed to start" on the
+    // first attempt. With exitOnFailure:true the catch block should auto-print
+    // doctor logs to stderr and then call process.exit(1).
+    const script = `
+const mod = require("module");
+const origLoad = mod._load;
+mod._load = function(req, parent, isMain) {
+  if (req === "p-retry") {
+    return async (fn, opts) => {
+      try {
+        return await fn({ attemptNumber: 1, retriesLeft: 0 });
+      } catch (e) {
+        if (opts && opts.onFailedAttempt) {
+          opts.onFailedAttempt(Object.assign(e, { attemptNumber: 1, retriesLeft: 0 }));
+        }
+        throw e;
+      }
+    };
+  }
+  return origLoad.call(this, req, parent, isMain);
+};
+const { startGateway } = require(${onboardPath});
+startGateway(null).catch(() => {});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const nodeExec = process.execPath;
+    const result = spawnSync(nodeExec, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_HEALTH_POLL_COUNT: "0",
+        NEMOCLAW_NON_INTERACTIVE: "1",
+      },
+    });
+
+    // The process exits 1 because startGateway calls process.exit(1) on failure.
+    assert.equal(result.status, 1, `unexpected exit code; stderr:\n${result.stderr}`);
+    assert.ok(
+      result.stderr.includes("Gateway logs:"),
+      `expected "Gateway logs:" header in stderr:\n${result.stderr}`,
+    );
+    assert.ok(
+      result.stderr.includes("OOMKilled"),
+      `expected doctor log output in stderr:\n${result.stderr}`,
+    );
+  });
+
   it("classifies sandbox reuse states from openshell outputs", () => {
     expect(
       getSandboxStateFromOutputs(

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -838,13 +838,23 @@ describe("onboard helpers", () => {
     const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
 
     fs.mkdirSync(fakeBin, { recursive: true });
-    // Fake openshell: returns diagnostic log output for `doctor logs`, fails otherwise.
+    // Fake openshell:
+    //   gateway start  — emits ANSI color codes + \r\n (mirrors real gateway output), exits 1
+    //   doctor logs    — emits ANSI sequences, an OOMKilled message, and a fake nvapi- credential
+    //                    to exercise ANSI stripping and redaction in the doctor-log path
     fs.writeFileSync(
       path.join(fakeBin, "openshell"),
       `#!/usr/bin/env bash
 if [[ "$*" == *"doctor"*"logs"* ]]; then
-  printf "k3s cluster crashed: OOMKilled\\n  Container nemoclaw_k3s ran out of memory\\n"
+  printf "\\033[31mERROR\\033[0m k3s cluster crashed: OOMKilled\\r\\n"
+  printf "  Container nemoclaw_k3s ran out of memory\\r\\n"
+  printf "  Gateway auth token: nvapi-fakecredential-9999\\r\\n"
   exit 0
+fi
+if [[ "$*" == *"gateway"*"start"* ]]; then
+  printf "\\033[33mDeploying\\033[0m gateway nemoclaw...\\r\\n"
+  printf "\\r\\nWaiting for gateway health...\\r\\n"
+  exit 1
 fi
 exit 1
 `,
@@ -894,6 +904,8 @@ startGateway(null).catch(() => {});
 
     // The process exits 1 because startGateway calls process.exit(1) on failure.
     assert.equal(result.status, 1, `unexpected exit code; stderr:\n${result.stderr}`);
+
+    // Fix 3: doctor logs are auto-printed to stderr.
     assert.ok(
       result.stderr.includes("Gateway logs:"),
       `expected "Gateway logs:" header in stderr:\n${result.stderr}`,
@@ -901,6 +913,39 @@ startGateway(null).catch(() => {});
     assert.ok(
       result.stderr.includes("OOMKilled"),
       `expected doctor log output in stderr:\n${result.stderr}`,
+    );
+
+    // ANSI sequences must be stripped from both stdout (gateway start output) and
+    // stderr (doctor logs). A raw \x1b in the output means the regex failed.
+    assert.ok(
+      !result.stdout.includes("\x1b"),
+      `unexpected ANSI escape in stdout:\n${result.stdout}`,
+    );
+    assert.ok(
+      !result.stderr.includes("\x1b"),
+      `unexpected ANSI escape in stderr:\n${result.stderr}`,
+    );
+
+    // Credentials in doctor logs must be redacted, never printed verbatim.
+    assert.ok(
+      !result.stderr.includes("nvapi-fakecredential-9999"),
+      `credential leaked verbatim in stderr:\n${result.stderr}`,
+    );
+
+    // Fix 2: the \r\n -> \naiting rendering artifact must not appear.
+    assert.ok(
+      !result.stdout.includes("\naiting"),
+      `\\naiting artifact present in stdout:\n${result.stdout}`,
+    );
+
+    // Fix 1: gateway start output is printed per-line under the header, not as
+    // one collapsed blob. "Deploying" and "Waiting" must appear on separate lines.
+    const gatewayLines = result.stdout
+      .split("\n")
+      .filter((l) => l.includes("Deploying") || l.includes("Waiting"));
+    assert.ok(
+      gatewayLines.length >= 2,
+      `expected "Deploying" and "Waiting" on separate lines in stdout:\n${result.stdout}`,
     );
   });
 


### PR DESCRIPTION
## Summary

- **Remove 240-char truncation** on gateway start output; split on newlines first, apply \`compactText\` per-line, and print each line indented under a header — fixes the \`\naiting\` rendering artifact caused by embedded \`\r\` overwriting the terminal cursor
- **Auto-capture \`openshell doctor logs\`** in the final-failure catch block so users see the actual k3s/flannel/AppArmor errors without having to run a separate command manually
- **Export \`startGateway\`** and add a test that verifies doctor log output appears in stderr when the gateway fails
- **Redact all new output paths** with \`redact()\` + ANSI stripping before printing (addresses CodeRabbit security review)
- **Redact \`upsertProvider\` and \`setupInference\` stderr** — \`openshell provider create/update\` and \`openshell inference set\` run with credential env in scope; their stderr was passed through \`compactText()\` without \`redact()\`, same class of bug as #1423

**Note:** The underlying gateway startup failure on Ubuntu 24.04 (overlayfs/AppArmor/flannel incompatibility reported in #1605) is an OpenShell upstream issue. This PR improves diagnostics so users and maintainers can see the actual error — it does not fix the root cause. Issue #1605 should remain open until an upstream fix or workaround lands.

Improves diagnostics for #1605

## Test plan

- [ ] \`npm test\` passes (only pre-existing \`runtime-shell.test.ts\` failures)
- [ ] New test \`prints doctor logs automatically when gateway fails to start (#1605)\` passes
- [ ] Manual: \`nemoclaw onboard\` on a system where the gateway fails now shows \`Gateway logs:\` section with k3s output before the troubleshooting hints

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)