### PR TITLE
fix(nim): bound curl health probes with --max-time

### DIFF
--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -209,9 +209,10 @@ export function waitForNimHealth(port = 8000, timeout = 300): boolean {
 
   while ((Date.now() - start) / 1000 < timeout) {
     try {
-      const result = runCapture(`curl -sf http://localhost:${hostPort}/v1/models`, {
-        ignoreError: true,
-      });
+      const result = runCapture(
+        `curl -sf --max-time 5 http://localhost:${hostPort}/v1/models`,
+        { ignoreError: true },
+      );
       if (result) {
         console.log("  NIM is healthy.");
         return true;
@@ -263,7 +264,7 @@ export function nimStatusByName(name: string, port?: number): NimStatus {
         resolvedHostPort = m ? Number(m[1]) : 8000;
       }
       const health = runCapture(
-        `curl -sf http://localhost:${resolvedHostPort}/v1/models 2>/dev/null`,
+        `curl -sf --max-time 5 http://localhost:${resolvedHostPort}/v1/models 2>/dev/null`,
         { ignoreError: true },
       );
       healthy = !!health;


### PR DESCRIPTION
## Summary
The NIM health probe loop and `nimStatusByName()` use `curl -sf` without a timeout in `src/lib/nim.ts`. On a hung or silently-dropping NIM endpoint, the curl call can block indefinitely, stalling `onboard`/`waitForNimHealth` and CLI `status`.

Add `--max-time 5` to both probe calls so each attempt times out cleanly and the outer retry loop can make progress.

## Changes
- `src/lib/nim.ts:212` — `waitForNimHealth` loop probe now `curl -sf --max-time 5 ...`
- `src/lib/nim.ts:265` — `nimStatusByName` health probe now `curl -sf --max-time 5 ...`

## Test plan
- [x] Code review — minimal diff, existing retry/interval behavior preserved
- [x] 5s timeout chosen to fit under the 5s inter-retry `sleep` interval in `waitForNimHealth`
- [x] No new dependencies, no test changes required (probes are shelled out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health check responsiveness by adding a timeout mechanism to ensure faster detection and recovery from unresponsive health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->