### PR TITLE
fix(security): verify checksum before executing NodeSource installer as root (#576)

### DIFF
--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -96,8 +96,8 @@ retry() {
 # Brev VMs sometimes have unattended-upgrades running at boot.
 wait_for_apt_lock() {
   local max_wait=120 elapsed=0
-  while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 \
-    || fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
+  while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 ||
+    fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
     if ((elapsed >= max_wait)); then
       warn "apt lock not released after ${max_wait}s — proceeding anyway"
       return 0
@@ -155,8 +155,11 @@ else
   NODESOURCE_URL="https://deb.nodesource.com/setup_22.x"
   NODESOURCE_SHA256="575583bbac2fccc0b5edd0dbc03e222d9f9dc8d724da996d22754d6411104fd1"
   ns_tmp="$(mktemp)"
-  curl -fsSL "$NODESOURCE_URL" -o "$ns_tmp" \
-    || { rm -f "$ns_tmp"; fail "Failed to download NodeSource installer"; }
+  curl -fsSL "$NODESOURCE_URL" -o "$ns_tmp" ||
+    {
+      rm -f "$ns_tmp"
+      fail "Failed to download NodeSource installer"
+    }
   if command -v sha256sum >/dev/null 2>&1; then
     actual_hash="$(sha256sum "$ns_tmp" | awk '{print $1}')"
   elif command -v shasum >/dev/null 2>&1; then
@@ -189,9 +192,9 @@ if command -v openshell >/dev/null 2>&1; then
     info "OpenShell CLI $_installed_ver does not match pinned ${_pinned_ver} — reinstalling..."
     ARCH="$(uname -m)"
     case "$ARCH" in
-      x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
-      aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
-      *) fail "Unsupported architecture: $ARCH" ;;
+    x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
+    aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
+    *) fail "Unsupported architecture: $ARCH" ;;
     esac
     tmpdir="$(mktemp -d)"
     retry 3 10 "download openshell" \
@@ -206,9 +209,9 @@ else
   info "Installing OpenShell CLI ${OPENSHELL_VERSION}..."
   ARCH="$(uname -m)"
   case "$ARCH" in
-    x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
-    aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
-    *) fail "Unsupported architecture: $ARCH" ;;
+  x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
+  aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
+  *) fail "Unsupported architecture: $ARCH" ;;
   esac
   tmpdir="$(mktemp -d)"
   retry 3 10 "download openshell" \
@@ -257,8 +260,8 @@ else
   # Use sg docker to ensure docker group is active without re-login
   for image in "${DOCKER_IMAGES[@]}"; do
     info "  Pulling $image..."
-    sg docker -c "docker pull $image" 2>&1 | tail -1 \
-      || warn "  Failed to pull $image (will be pulled at test time)"
+    sg docker -c "docker pull $image" 2>&1 | tail -1 ||
+      warn "  Failed to pull $image (will be pulled at test time)"
   done
 
   # The openshell/cluster image tag should match the CLI version.
@@ -268,8 +271,8 @@ else
   info "  Pulling $CLUSTER_IMAGE..."
   if ! sg docker -c "docker pull $CLUSTER_IMAGE" 2>&1 | tail -1; then
     warn "  Could not pull $CLUSTER_IMAGE — trying :latest"
-    sg docker -c "docker pull ghcr.io/nvidia/openshell/cluster:latest" 2>&1 | tail -1 \
-      || warn "  Failed to pull openshell/cluster (will be pulled at test time)"
+    sg docker -c "docker pull ghcr.io/nvidia/openshell/cluster:latest" 2>&1 | tail -1 ||
+      warn "  Failed to pull openshell/cluster (will be pulled at test time)"
   fi
 
   info "Docker images pre-pulled"

--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -151,7 +151,27 @@ if command -v npm >/dev/null 2>&1 && [[ -n "$node_major" ]] && ((node_major >= 2
   info "Node.js already installed: $(node --version)"
 else
   info "Installing Node.js 22..."
-  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - >/dev/null 2>&1
+  # IMPORTANT: update NODESOURCE_SHA256 when changing setup_22.x URL
+  NODESOURCE_URL="https://deb.nodesource.com/setup_22.x"
+  NODESOURCE_SHA256="575583bbac2fccc0b5edd0dbc03e222d9f9dc8d724da996d22754d6411104fd1"
+  ns_tmp="$(mktemp)"
+  curl -fsSL "$NODESOURCE_URL" -o "$ns_tmp" \
+    || { rm -f "$ns_tmp"; fail "Failed to download NodeSource installer"; }
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_hash="$(sha256sum "$ns_tmp" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual_hash="$(shasum -a 256 "$ns_tmp" | awk '{print $1}')"
+  else
+    warn "No SHA-256 tool found — skipping NodeSource integrity check"
+    actual_hash="$NODESOURCE_SHA256"
+  fi
+  if [[ "$actual_hash" != "$NODESOURCE_SHA256" ]]; then
+    rm -f "$ns_tmp"
+    fail "NodeSource installer integrity check failed\n  Expected: $NODESOURCE_SHA256\n  Actual:   $actual_hash"
+  fi
+  info "NodeSource installer integrity verified"
+  sudo -E bash "$ns_tmp" >/dev/null 2>&1
+  rm -f "$ns_tmp"
   wait_for_apt_lock
   retry 3 10 "install nodejs" sudo apt-get install -y -qq nodejs >/dev/null 2>&1
   info "Node.js $(node --version) installed"


### PR DESCRIPTION
## Summary

Closes #576.

The NodeSource installer in `scripts/brev-launchable-ci-cpu.sh` is downloaded via `curl | sudo bash` with no integrity verification (CWE-494). This executes arbitrary remote code as **root**.

**Fix:** follows the exact SHA-256 verification pattern already used for nvm in `scripts/install.sh:634-657`:
- Download NodeSource script to temp file instead of piping to bash
- Compute SHA-256 and verify against pinned hash
- Only execute with `sudo -E bash` if hash matches
- Refuse to execute and exit non-zero on mismatch, printing expected vs actual hash
- Clean up temp file in all code paths

**Note:** The issue references `scripts/brev-setup.sh` and `scripts/install.sh`, but in the current codebase the only vulnerable occurrence is in `scripts/brev-launchable-ci-cpu.sh:154`. `scripts/install.sh` uses nvm (not NodeSource) and already has integrity verification.

## Test plan

- [x] Verified pinned SHA-256 matches current NodeSource setup_22.x script
- [x] Verified hash mismatch path prints both hashes and exits non-zero
- [x] Verified temp file cleanup in both success and failure paths
- [x] Pattern matches existing nvm verification in `scripts/install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Node.js 22 installation security by downloading the installer, verifying its SHA-256 integrity before execution, and aborting on mismatch.
* **Style**
  * Minor script formatting and control-flow whitespace adjustments to improve readability without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: ColinM-sys <cmcdonough@50words.com>