### PR TITLE
fix(plugin): show actual configured model in banner (Closes #24)

### DIFF
--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -11,12 +11,37 @@
  * time.
  */
 
+import { execFileSync } from "node:child_process";
 import { handleSlashCommand } from "./commands/slash.js";
 import {
   describeOnboardEndpoint,
   describeOnboardProvider,
   loadOnboardConfig,
 } from "./onboard/config.js";
+
+// Resolve live inference config from OpenShell as a fallback when the
+// onboard config file is not available (e.g. when running inside the
+// sandbox). Returns empty strings if the probe fails.
+function probeOpenShellInference(): { endpoint: string; model: string } {
+  try {
+    const raw = execFileSync("openshell", ["inference", "get", "--json"], {
+      encoding: "utf-8",
+      timeout: 3000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const parsed = JSON.parse(raw) as {
+      provider?: string;
+      model?: string;
+      endpoint?: string;
+    };
+    return {
+      endpoint: parsed.endpoint ?? parsed.provider ?? "",
+      model: parsed.model ?? "",
+    };
+  } catch {
+    return { endpoint: "", model: "" };
+  }
+}
 
 // ---------------------------------------------------------------------------
 // OpenClaw Plugin SDK compatible types (mirrors openclaw/plugin-sdk)
@@ -248,9 +273,21 @@ export default function register(api: OpenClawPluginApi): void {
   const providerCredentialEnv = onboardCfg?.credentialEnv ?? "NVIDIA_API_KEY";
   api.registerProvider(registeredProviderForConfig(onboardCfg, providerCredentialEnv));
 
-  const bannerEndpoint = onboardCfg ? describeOnboardEndpoint(onboardCfg) : "build.nvidia.com";
+  // Prefer onboard config; fall back to live OpenShell inference state when
+  // the config file is unavailable (e.g. inside the sandbox). Only resort to
+  // hardcoded defaults if both lookups fail.
+  let bannerEndpoint = onboardCfg ? describeOnboardEndpoint(onboardCfg) : "";
   const bannerProvider = onboardCfg ? describeOnboardProvider(onboardCfg) : "NVIDIA Endpoints";
-  const bannerModel = onboardCfg?.model ?? "nvidia/nemotron-3-super-120b-a12b";
+  let bannerModel = onboardCfg?.model ?? "";
+
+  if (!bannerEndpoint || !bannerModel) {
+    const probed = probeOpenShellInference();
+    if (!bannerEndpoint) bannerEndpoint = probed.endpoint;
+    if (!bannerModel) bannerModel = probed.model;
+  }
+
+  if (!bannerEndpoint) bannerEndpoint = "build.nvidia.com";
+  if (!bannerModel) bannerModel = "nvidia/nemotron-3-super-120b-a12b";
 
   api.logger.info("");
   api.logger.info("  ┌─────────────────────────────────────────────────────┐");


### PR DESCRIPTION
## Summary
When the onboard config file is not available (e.g. when running inside the sandbox), the plugin banner in \`nemoclaw/src/index.ts\` hardcodes the model as \`nvidia/nemotron-3-super-120b-a12b\` and the endpoint as \`build.nvidia.com\` regardless of what is actually configured in OpenShell.

This PR queries the live OpenShell inference state via \`openshell inference get --json\` as a fallback before resorting to hardcoded defaults. The probe has a 3-second timeout and falls back cleanly to the existing defaults if anything goes wrong.

Closes #24.

## Changes
- \`nemoclaw/src/index.ts\` — add \`probeOpenShellInference()\` helper and wire it into banner resolution after onboard config lookup, before hardcoded defaults

## Test plan
- [x] Minimal diff, existing defaults preserved as final fallback
- [x] 3s timeout prevents banner from hanging on a slow/broken openshell binary
- [x] No new runtime dependencies (uses stdlib \`node:child_process\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of inference configuration from OpenShell. The system now prioritizes onboard configuration settings, attempts auto-detection from OpenShell, and uses default values as a final fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->