### PR TITLE
fix(runner): surface OpenShell origin in CLI error messages

### DIFF
--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -31,6 +31,10 @@ function run(cmd, opts = {}) {
   }
   if (result.status !== 0 && !opts.ignoreError) {
     console.error(`  Command failed (exit ${result.status}): ${redact(cmd).slice(0, 80)}`);
+    if (/^\s*openshell\s/.test(cmd)) {
+      console.error("  This error originated from the OpenShell runtime layer.");
+      console.error("  Docs: https://github.com/NVIDIA/OpenShell");
+    }
     process.exit(result.status || 1);
   }
   return result;
@@ -53,6 +57,10 @@ function runInteractive(cmd, opts = {}) {
   }
   if (result.status !== 0 && !opts.ignoreError) {
     console.error(`  Command failed (exit ${result.status}): ${redact(cmd).slice(0, 80)}`);
+    if (/^\s*openshell\s/.test(cmd)) {
+      console.error("  This error originated from the OpenShell runtime layer.");
+      console.error("  Docs: https://github.com/NVIDIA/OpenShell");
+    }
     process.exit(result.status || 1);
   }
   return result;


### PR DESCRIPTION
## Summary
When a NemoClaw CLI command fails because the underlying \`openshell\` call errored, the user only sees a generic "Command failed (exit N): openshell ..." message. They don't know the failure came from the OpenShell runtime layer, not NemoClaw itself, which sends them debugging in the wrong place.

This PR makes both \`run()\` and \`runInteractive()\` in \`src/lib/runner.ts\` detect when the failing command starts with \`openshell\` and append a one-line note pointing to the OpenShell runtime and its docs, so users can quickly find the right layer to troubleshoot.

Fixes #60 (partial — this covers the core runner path; additional per-command hints may follow).

## Changes
- \`src/lib/runner.ts\` — add \`/^\\s*openshell\\s/\` check in the failure branches of \`run()\` and \`runInteractive()\`; when matched, print:
  - \`This error originated from the OpenShell runtime layer.\`
  - \`Docs: https://github.com/NVIDIA/OpenShell\`

## Test plan
- [x] Minimal 8-line diff, no behavior change for non-openshell commands
- [x] Exit code preserved unchanged
- [x] Regex matches \`openshell foo\`, tolerates leading whitespace, does not match substrings like \`my-openshell\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for OpenShell command failures with enhanced error context messages and convenient documentation links to help users troubleshoot issues more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->