### PR TITLE
[codex] fix(policy): remove deprecated tls termination directives

### DIFF
--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -44,7 +44,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/v1/messages" }
           - allow: { method: POST, path: "/v1/messages/batches" }
@@ -54,14 +53,12 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/**" }
       - host: sentry.io
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/api/*/envelope/**" }
           - allow: { method: POST, path: "/api/*/store/**" }
@@ -75,7 +72,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/v1/chat/completions" }
           - allow: { method: POST, path: "/v1/completions" }
@@ -86,7 +82,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/v1/chat/completions" }
           - allow: { method: POST, path: "/v1/completions" }
@@ -119,7 +114,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -127,7 +121,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -135,7 +128,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -151,14 +143,12 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
       - host: files.pythonhosted.org
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
     binaries:
@@ -173,7 +163,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/bot*/**" }
           - allow: { method: POST, path: "/bot*/**" }
@@ -189,7 +178,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -200,7 +188,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
     binaries:

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -63,7 +63,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/v1/messages" }
           - allow: { method: POST, path: "/v1/messages/batches" }
@@ -73,7 +72,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/**" }
       # sentry.io is a multi-tenant SaaS — any authenticated client can POST
@@ -94,7 +92,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
     binaries:
@@ -107,7 +104,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/v1/chat/completions" }
           - allow: { method: POST, path: "/v1/completions" }
@@ -118,7 +114,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: POST, path: "/v1/chat/completions" }
           - allow: { method: POST, path: "/v1/completions" }
@@ -149,7 +144,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -164,7 +158,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -179,7 +172,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
     binaries:
@@ -194,7 +186,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
     binaries:

--- a/nemoclaw-blueprint/policies/presets/brave.yaml
+++ b/nemoclaw-blueprint/policies/presets/brave.yaml
@@ -13,7 +13,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/huggingface.yaml
+++ b/nemoclaw-blueprint/policies/presets/huggingface.yaml
@@ -13,7 +13,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           # Download-only. POST /** used to be allowed here, which let
           # any sandboxed agent that happened to find an HF token in
@@ -28,14 +27,12 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
       - host: router.huggingface.co
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/jira.yaml
+++ b/nemoclaw-blueprint/policies/presets/jira.yaml
@@ -13,7 +13,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -21,7 +20,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -29,7 +27,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/npm.yaml
+++ b/nemoclaw-blueprint/policies/presets/npm.yaml
@@ -13,14 +13,12 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
       - host: registry.yarnpkg.com
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
     binaries:

--- a/nemoclaw-blueprint/policies/presets/outlook.yaml
+++ b/nemoclaw-blueprint/policies/presets/outlook.yaml
@@ -13,7 +13,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -21,7 +20,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -29,7 +27,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -37,7 +34,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }

--- a/nemoclaw-blueprint/policies/presets/pypi.yaml
+++ b/nemoclaw-blueprint/policies/presets/pypi.yaml
@@ -13,7 +13,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: HEAD, path: "/**" }
@@ -21,7 +20,6 @@ network_policies:
         port: 443
         protocol: rest
         enforcement: enforce
-        tls: terminate
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: HEAD, path: "/**" }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -621,10 +621,12 @@ describe("policies", () => {
         }
       }
 
+      const deprecatedTlsPattern = /^\s*tls\s*:\s*["']?terminate["']?(?:\s+#.*)?\s*$/m;
+
       for (const file of yamlFiles) {
         const content = fs.readFileSync(file, "utf-8");
         assert.equal(
-          content.includes("tls: terminate"),
+          deprecatedTlsPattern.test(content),
           false,
           `${path.relative(REPO_ROOT, file)} still contains tls: terminate`,
         );

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -599,6 +599,38 @@ describe("policies", () => {
       }
     });
 
+    it("policy YAML files do not use deprecated tls termination", () => {
+      const roots = [
+        path.join(REPO_ROOT, "nemoclaw-blueprint", "policies"),
+        path.join(REPO_ROOT, "agents"),
+      ];
+      const stack = [...roots];
+      const yamlFiles = [];
+
+      while (stack.length > 0) {
+        const current = stack.pop();
+        for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+          const fullPath = path.join(current, entry.name);
+          if (entry.isDirectory()) {
+            stack.push(fullPath);
+            continue;
+          }
+          if (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml")) {
+            yamlFiles.push(fullPath);
+          }
+        }
+      }
+
+      for (const file of yamlFiles) {
+        const content = fs.readFileSync(file, "utf-8");
+        assert.equal(
+          content.includes("tls: terminate"),
+          false,
+          `${path.relative(REPO_ROOT, file)} still contains tls: terminate`,
+        );
+      }
+    });
+
     it("pypi preset allows HEAD for pip lazy-wheel metadata checks", () => {
       // pip and uv use HEAD requests for lazy wheel downloads and
       // range-request support. GET-only would break pip install.


### PR DESCRIPTION
Fixes #1686.

## What changed

- removed the remaining deprecated `tls: terminate` directives from shipped policy YAML
- updated both the main blueprint policies and the Hermes agent policy additions
- added a regression test that scans policy YAML under `nemoclaw-blueprint/policies` and `agents` to keep the deprecated directive from returning

## Why

`tls: terminate` is deprecated, and the repository still had several remaining occurrences outside the earlier messaging-preset cleanup. This finishes the cleanup so the shipped policy blueprints no longer pin the deprecated setting.

## Validation

- `npm run validate:configs`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:cli`
- `npx vitest run test/policies.test.ts test/validate-blueprint.test.ts test/onboard.test.ts`
- `npm run build:cli`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed deprecated TLS termination configuration from network policies across multiple services, including AI APIs, package registries, and messaging platforms.

* **Tests**
  * Added a validation test that scans policy files and fails if the deprecated TLS termination setting is present to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->