### PR TITLE
feat(policy): add policy-remove command to remove applied presets

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4593,7 +4593,9 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
   for (const name of deselected) {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
-        policies.removePreset(sandboxName, name);
+        if (!policies.removePreset(sandboxName, name)) {
+          throw new Error(`Failed to remove preset '${name}'.`);
+        }
         break;
       } catch (err) {
         const message = err && err.message ? err.message : String(err);
@@ -4608,9 +4610,15 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
   for (const name of newlySelected) {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
+<<<<<<< HEAD
         // Pass access mode so applyPreset can distinguish read vs read-write
         // when preset infrastructure supports it.
         policies.applyPreset(sandboxName, name, { access: accessByName[name] });
+=======
+        if (!policies.applyPreset(sandboxName, name)) {
+          throw new Error(`Failed to apply preset '${name}'.`);
+        }
+>>>>>>> d63c919a (fix: address suggestions)
         break;
       } catch (err) {
         const message = err && err.message ? err.message : String(err);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3986,11 +3986,6 @@ async function _setupPolicies(sandboxName, options = {}) {
           break;
         } catch (err) {
           const message = err && err.message ? err.message : String(err);
-          if (message.includes("Unimplemented")) {
-            console.error("  OpenShell policy updates are not supported by this gateway build.");
-            console.error("  This is a known issue tracked in NemoClaw #536.");
-            throw err;
-          }
           if (!message.includes("sandbox not found") || attempt === 2) {
             throw err;
           }
@@ -4030,30 +4025,12 @@ async function _setupPolicies(sandboxName, options = {}) {
         .map((s) => s.trim())
         .filter(Boolean);
       for (const name of selected) {
-        try {
-          policies.applyPreset(sandboxName, name);
-        } catch (err) {
-          const message = err && err.message ? err.message : String(err);
-          if (message.includes("Unimplemented")) {
-            console.error("  OpenShell policy updates are not supported by this gateway build.");
-            console.error("  This is a known issue tracked in NemoClaw #536.");
-          }
-          throw err;
-        }
+        policies.applyPreset(sandboxName, name);
       }
     } else {
       // Apply suggested
       for (const name of suggestions) {
-        try {
-          policies.applyPreset(sandboxName, name);
-        } catch (err) {
-          const message = err && err.message ? err.message : String(err);
-          if (message.includes("Unimplemented")) {
-            console.error("  OpenShell policy updates are not supported by this gateway build.");
-            console.error("  This is a known issue tracked in NemoClaw #536.");
-          }
-          throw err;
-        }
+        policies.applyPreset(sandboxName, name);
       }
     }
   }
@@ -4580,11 +4557,6 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
           break;
         } catch (err) {
           const message = err && err.message ? err.message : String(err);
-          if (message.includes("Unimplemented")) {
-            console.error("  OpenShell policy updates are not supported by this gateway build.");
-            console.error("  This is a known issue tracked in NemoClaw #536.");
-            throw err;
-          }
           if (!message.includes("sandbox not found") || attempt === 2) {
             throw err;
           }
@@ -4616,6 +4588,23 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
   const accessByName = {};
   for (const p of resolvedPresets) accessByName[p.name] = p.access;
   const newlySelected = interactiveChoice.filter((name) => !applied.includes(name));
+  const deselected = applied.filter((name) => !interactiveChoice.includes(name));
+
+  for (const name of deselected) {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        policies.removePreset(sandboxName, name);
+        break;
+      } catch (err) {
+        const message = err && err.message ? err.message : String(err);
+        if (!message.includes("sandbox not found") || attempt === 2) {
+          throw err;
+        }
+        sleep(2);
+      }
+    }
+  }
+
   for (const name of newlySelected) {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
@@ -4625,11 +4614,6 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
         break;
       } catch (err) {
         const message = err && err.message ? err.message : String(err);
-        if (message.includes("Unimplemented")) {
-          console.error("  OpenShell policy updates are not supported by this gateway build.");
-          console.error("  This is a known issue tracked in NemoClaw #536.");
-          throw err;
-        }
         if (!message.includes("sandbox not found") || attempt === 2) {
           throw err;
         }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4610,15 +4610,9 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
   for (const name of newlySelected) {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
-<<<<<<< HEAD
         // Pass access mode so applyPreset can distinguish read vs read-write
         // when preset infrastructure supports it.
         policies.applyPreset(sandboxName, name, { access: accessByName[name] });
-=======
-        if (!policies.applyPreset(sandboxName, name)) {
-          throw new Error(`Failed to apply preset '${name}'.`);
-        }
->>>>>>> d63c919a (fix: address suggestions)
         break;
       } catch (err) {
         const message = err && err.message ? err.message : String(err);

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -312,6 +312,11 @@ function removePreset(sandboxName, presetName) {
   const currentPolicy = parseCurrentPolicy(rawPolicy);
   const updated = removePresetFromPolicy(currentPolicy, presetEntries);
 
+  if (updated === currentPolicy) {
+    console.error(`  Preset '${presetName}' could not be removed from the current policy.`);
+    return false;
+  }
+
   const endpoints = getPresetEndpoints(presetContent);
   if (endpoints.length > 0) {
     console.log(`  Narrowing sandbox egress — removing: ${endpoints.join(", ")}`);

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -310,6 +310,11 @@ function removePreset(sandboxName, presetName) {
   }
 
   const currentPolicy = parseCurrentPolicy(rawPolicy);
+  if (!currentPolicy) {
+    console.error(`  Could not read current policy for sandbox '${sandboxName}'.`);
+    return false;
+  }
+
   const updated = removePresetFromPolicy(currentPolicy, presetEntries);
 
   if (updated === currentPolicy) {

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -219,6 +219,177 @@ function mergePresetIntoPolicy(currentPolicy, presetEntries) {
 
   return YAML.stringify(output);
 }
+
+/**
+ * Remove preset entries from existing policy YAML using structured YAML
+ * parsing. Identifies which network_policies keys belong to the preset,
+ * removes them, and returns the resulting YAML.
+ *
+ * @param {string} currentPolicy - Existing policy YAML
+ * @param {string} presetEntries - Indented network_policies entries from preset
+ * @returns {string} Policy YAML with the preset's entries removed
+ */
+function removePresetFromPolicy(currentPolicy, presetEntries) {
+  const normalizedCurrentPolicy = parseCurrentPolicy(currentPolicy);
+  if (!presetEntries) {
+    return normalizedCurrentPolicy || "version: 1\n\nnetwork_policies:\n";
+  }
+
+  if (!normalizedCurrentPolicy) return "version: 1\n\nnetwork_policies:\n";
+
+  // Parse preset entries to extract the network_policies key names.
+  // They come as indented content under network_policies:,
+  // so we wrap them to make valid YAML for parsing.
+  let presetKeys;
+  try {
+    const wrapped = "network_policies:\n" + presetEntries;
+    const parsed = YAML.parse(wrapped);
+    presetKeys = parsed?.network_policies
+      ? Object.keys(parsed.network_policies)
+      : [];
+  } catch {
+    presetKeys = [];
+  }
+
+  if (presetKeys.length === 0) return normalizedCurrentPolicy;
+
+  // Parse the current policy as structured YAML
+  let current;
+  try {
+    current = YAML.parse(normalizedCurrentPolicy);
+  } catch {
+    return normalizedCurrentPolicy;
+  }
+
+  if (!current || typeof current !== "object") return normalizedCurrentPolicy;
+
+  // Guard: network_policies may be an array in legacy policies — only
+  // delete keys when it is a plain object.
+  const existingNp = current.network_policies;
+  if (!existingNp || typeof existingNp !== "object" || Array.isArray(existingNp)) {
+    return normalizedCurrentPolicy;
+  }
+
+  for (const key of presetKeys) {
+    delete existingNp[key];
+  }
+
+  current.network_policies = existingNp;
+  return YAML.stringify(current);
+}
+
+function removePreset(sandboxName, presetName) {
+  // Guard against truncated sandbox names — WSL can truncate hyphenated
+  // names during argument parsing, e.g. "my-assistant" → "m"
+  const isRfc1123Label = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(sandboxName);
+  if (!sandboxName || sandboxName.length > 63 || !isRfc1123Label) {
+    throw new Error(
+      `Invalid or truncated sandbox name: '${sandboxName}'. ` +
+        `Names must be 1-63 chars, lowercase alphanumeric, with optional internal hyphens.`,
+    );
+  }
+
+  const presetContent = loadPreset(presetName);
+  if (!presetContent) {
+    console.error(`  Cannot load preset: ${presetName}`);
+    return false;
+  }
+
+  const presetEntries = extractPresetEntries(presetContent);
+  if (!presetEntries) {
+    console.error(`  Preset ${presetName} has no network_policies section.`);
+    return false;
+  }
+
+  // Get current policy YAML from sandbox
+  let rawPolicy = "";
+  try {
+    rawPolicy = runCapture(buildPolicyGetCommand(sandboxName), { ignoreError: true });
+  } catch {
+    /* ignored */
+  }
+
+  const currentPolicy = parseCurrentPolicy(rawPolicy);
+  const updated = removePresetFromPolicy(currentPolicy, presetEntries);
+
+  const endpoints = getPresetEndpoints(presetContent);
+  if (endpoints.length > 0) {
+    console.log(`  Narrowing sandbox egress — removing: ${endpoints.join(", ")}`);
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-policy-"));
+  const tmpFile = path.join(tmpDir, "policy.yaml");
+  fs.writeFileSync(tmpFile, updated, { encoding: "utf-8", mode: 0o600 });
+
+  try {
+    run(buildPolicySetCommand(tmpFile, sandboxName));
+    console.log(`  Removed preset: ${presetName}`);
+  } finally {
+    try {
+      fs.unlinkSync(tmpFile);
+    } catch {
+      /* ignored */
+    }
+    try {
+      fs.rmdirSync(tmpDir);
+    } catch {
+      /* ignored */
+    }
+  }
+
+  const sandbox = registry.getSandbox(sandboxName);
+  if (sandbox) {
+    const pols = (sandbox.policies || []).filter((p) => p !== presetName);
+    registry.updateSandbox(sandboxName, { policies: pols });
+  }
+
+  return true;
+}
+
+function selectForRemoval(items, { applied = [] } = {}) {
+  return new Promise((resolve) => {
+    const appliedItems = items.filter((item) => applied.includes(item.name));
+    if (appliedItems.length === 0) {
+      process.stderr.write("\n  No presets are currently applied.\n\n");
+      resolve(null);
+      return;
+    }
+    process.stderr.write("\n  Applied presets:\n");
+    appliedItems.forEach((item, i) => {
+      const description = item.description ? ` — ${item.description}` : "";
+      process.stderr.write(`    ${i + 1}) ${item.name}${description}\n`);
+    });
+    process.stderr.write("\n");
+    const question = "  Choose preset to remove: ";
+    const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+    rl.question(question, (answer) => {
+      rl.close();
+      if (!process.stdin.isTTY) {
+        if (typeof process.stdin.pause === "function") process.stdin.pause();
+        if (typeof process.stdin.unref === "function") process.stdin.unref();
+      }
+      const trimmed = answer.trim();
+      if (!trimmed) {
+        resolve(null);
+        return;
+      }
+      if (!/^\d+$/.test(trimmed)) {
+        process.stderr.write("\n  Invalid preset number.\n");
+        resolve(null);
+        return;
+      }
+      const num = Number(trimmed);
+      const item = appliedItems[num - 1];
+      if (!item) {
+        process.stderr.write("\n  Invalid preset number.\n");
+        resolve(null);
+        return;
+      }
+      resolve(item.name);
+    });
+  });
+}
+
 function applyPreset(sandboxName, presetName, _options = {}) {
   // Guard against truncated sandbox names — WSL can truncate hyphenated
   // names during argument parsing, e.g. "my-assistant" → "m"
@@ -403,8 +574,11 @@ export {
   buildPolicySetCommand,
   buildPolicyGetCommand,
   mergePresetIntoPolicy,
+  removePresetFromPolicy,
   applyPreset,
+  removePreset,
   applyPermissivePolicy,
   getAppliedPresets,
   selectFromList,
+  selectForRemoval,
 };

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1374,6 +1374,33 @@ async function sandboxSkillInstall(sandboxName, args = []) {
   }
 }
 
+async function sandboxPolicyRemove(sandboxName, args = []) {
+  const dryRun = args.includes("--dry-run");
+  const allPresets = policies.listPresets();
+  const applied = policies.getAppliedPresets(sandboxName);
+
+  const answer = await policies.selectForRemoval(allPresets, { applied });
+  if (!answer) return;
+
+  const presetContent = policies.loadPreset(answer);
+  if (!presetContent) return;
+
+  const endpoints = policies.getPresetEndpoints(presetContent);
+  if (endpoints.length > 0) {
+    console.log(`  Endpoints that would be removed: ${endpoints.join(", ")}`);
+  }
+
+  if (dryRun) {
+    console.log("  --dry-run: no changes applied.");
+    return;
+  }
+
+  const confirm = await askPrompt(`  Remove '${answer}' from sandbox '${sandboxName}'? [Y/n]: `);
+  if (confirm.toLowerCase() === "n") return;
+
+  policies.removePreset(sandboxName, answer);
+}
+
 function cleanupSandboxServices(sandboxName, { stopHostServices = false } = {}) {
   if (stopHostServices) {
     const { stopAll } = require("./lib/services");
@@ -1477,6 +1504,7 @@ function help() {
 
   ${G}Policy Presets:${R}
     nemoclaw <name> policy-add       Add a network or filesystem policy preset ${D}(--dry-run to preview)${R}
+    nemoclaw <name> policy-remove    Remove an applied policy preset ${D}(--dry-run to preview)${R}
     nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
   ${G}Compatibility Commands:${R}
@@ -1599,6 +1627,9 @@ const [cmd, ...args] = process.argv.slice(2);
       case "policy-add":
         await sandboxPolicyAdd(cmd, actionArgs);
         break;
+      case "policy-remove":
+        await sandboxPolicyRemove(cmd, actionArgs);
+        break;
       case "policy-list":
         sandboxPolicyList(cmd);
         break;
@@ -1610,7 +1641,7 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       default:
         console.error(`  Unknown action: ${action}`);
-        console.error(`  Valid actions: connect, status, logs, policy-add, policy-list, skill, destroy`);
+        console.error(`  Valid actions: connect, status, logs, policy-add, policy-remove, policy-list, skill, destroy`);
         process.exit(1);
     }
     return;

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1398,7 +1398,9 @@ async function sandboxPolicyRemove(sandboxName, args = []) {
   const confirm = await askPrompt(`  Remove '${answer}' from sandbox '${sandboxName}'? [Y/n]: `);
   if (confirm.toLowerCase() === "n") return;
 
-  policies.removePreset(sandboxName, answer);
+  if (!policies.removePreset(sandboxName, answer)) {
+    process.exit(1);
+  }
 }
 
 function cleanupSandboxServices(sandboxName, { stopHostServices = false } = {}) {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -902,6 +902,7 @@ policies.listPresets = () => [
 policies.getAppliedPresets = () => ["pypi"];
 policies.removePreset = (sandboxName, presetName) => {
   calls.push({ type: "remove", sandboxName, presetName });
+  return true;
 };
 process.argv = ["node", "nemoclaw.js", "test-sandbox", "policy-remove", ...${JSON.stringify(extraArgs)}];
 require(${CLI_PATH});

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -684,6 +684,158 @@ describe("policies", () => {
     });
   });
 
+  describe("removePresetFromPolicy", () => {
+    const pypiEntries =
+      "  pypi:\n" +
+      "    name: pypi\n" +
+      "    endpoints:\n" +
+      "      - host: pypi.org\n" +
+      "        port: 443\n";
+
+    it("removes preset keys from policy YAML", () => {
+      const current =
+        "version: 1\n\n" +
+        "network_policies:\n" +
+        "  npm_yarn:\n" +
+        "    name: npm_yarn\n" +
+        "    endpoints:\n" +
+        "      - host: registry.npmjs.org\n" +
+        "        port: 443\n" +
+        "        access: full\n" +
+        "  pypi:\n" +
+        "    name: pypi\n" +
+        "    endpoints:\n" +
+        "      - host: pypi.org\n" +
+        "        port: 443\n" +
+        "        access: full\n";
+      const result = policies.removePresetFromPolicy(current, pypiEntries);
+      expect(result).toContain("npm_yarn");
+      expect(result).toContain("registry.npmjs.org");
+      expect(result).not.toContain("pypi");
+    });
+
+    it("preserves non-network sections when removing preset", () => {
+      const current =
+        "version: 1\n\n" +
+        "filesystem_policy:\n" +
+        "  include_workdir: true\n\n" +
+        "network_policies:\n" +
+        "  pypi:\n" +
+        "    name: pypi\n" +
+        "    endpoints:\n" +
+        "      - host: pypi.org\n" +
+        "        port: 443\n";
+      const result = policies.removePresetFromPolicy(current, pypiEntries);
+      expect(result).toContain("filesystem_policy");
+      expect(result).toContain("include_workdir");
+      expect(result).not.toContain("pypi");
+    });
+
+    it("returns scaffold when current policy is empty", () => {
+      const result = policies.removePresetFromPolicy("", pypiEntries);
+      expect(result).toContain("version: 1");
+    });
+
+    it("returns current policy unchanged when presetEntries is null", () => {
+      const current = "version: 1\n\nnetwork_policies:\n  npm_yarn:\n    name: npm_yarn\n";
+      const result = policies.removePresetFromPolicy(current, null);
+      expect(result).toContain("npm_yarn");
+    });
+
+    it("handles removing all network policies", () => {
+      const current =
+        "version: 1\n\nnetwork_policies:\n  pypi:\n    name: pypi\n    endpoints:\n      - host: pypi.org\n";
+      const result = policies.removePresetFromPolicy(current, pypiEntries);
+      expect(result).toContain("version: 1");
+      expect(result).toContain("network_policies");
+      expect(result).not.toContain("pypi");
+    });
+
+    it("returns policy unchanged when network_policies is a legacy array", () => {
+      const current =
+        "version: 1\n\nnetwork_policies:\n  - host: pypi.org\n    allow: true\n";
+      const result = policies.removePresetFromPolicy(current, pypiEntries);
+      expect(result).toContain("pypi.org");
+      expect(result).toContain("allow: true");
+    });
+  });
+
+  describe("selectForRemoval", () => {
+    function runSelectForRemoval(input, { applied = [] } = {}) {
+      const script = String.raw`
+const { selectForRemoval } = require(${POLICIES_PATH});
+const items = JSON.parse(process.env.NEMOCLAW_TEST_ITEMS);
+const options = JSON.parse(process.env.NEMOCLAW_TEST_OPTIONS || "{}");
+
+selectForRemoval(items, options)
+  .then((value) => {
+    process.stdout.write(String(value) + "\n");
+  })
+  .catch((error) => {
+    const message = error && error.message ? error.message : String(error);
+    process.stderr.write(message);
+    process.exit(1);
+  });
+`;
+
+      return spawnSync(process.execPath, ["-e", script], {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+        timeout: 5000,
+        input,
+        env: {
+          ...process.env,
+          NEMOCLAW_TEST_ITEMS: JSON.stringify(SELECT_FROM_LIST_ITEMS),
+          NEMOCLAW_TEST_OPTIONS: JSON.stringify({ applied }),
+        },
+      });
+    }
+
+    it("returns null when no presets are applied", () => {
+      const result = runSelectForRemoval("1\n", { applied: [] });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("No presets are currently applied");
+      expect(result.stdout.trim()).toBe("null");
+    });
+
+    it("shows only applied presets and returns selected name", () => {
+      const result = runSelectForRemoval("1\n", { applied: ["npm"] });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("Applied presets:");
+      expect(result.stderr).toContain("1) npm");
+      expect(result.stderr).not.toContain("pypi");
+      expect(result.stdout.trim()).toBe("npm");
+    });
+
+    it("returns null for empty input", () => {
+      const result = runSelectForRemoval("\n", { applied: ["npm"] });
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe("null");
+    });
+
+    it("rejects non-numeric input", () => {
+      const result = runSelectForRemoval("npm\n", { applied: ["npm"] });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("Invalid preset number");
+      expect(result.stdout.trim()).toBe("null");
+    });
+
+    it("rejects out-of-range number", () => {
+      const result = runSelectForRemoval("99\n", { applied: ["npm"] });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("Invalid preset number");
+      expect(result.stdout.trim()).toBe("null");
+    });
+
+    it("selects second preset when both are applied", () => {
+      const result = runSelectForRemoval("2\n", { applied: ["npm", "pypi"] });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("1) npm");
+      expect(result.stderr).toContain("2) pypi");
+      expect(result.stdout.trim()).toBe("pypi");
+    });
+  });
+
   describe("policy-add confirmation", () => {
     it("prompts for confirmation before applying a preset", () => {
       const result = runPolicyAdd("y");
@@ -721,6 +873,91 @@ describe("policies", () => {
       expect(calls.some((call) => call.type === "prompt")).toBeFalsy();
       expect(calls.some((call) => call.type === "apply")).toBeFalsy();
       expect(result.stdout).toMatch(/Endpoints that would be opened: pypi\.org/);
+      expect(result.stdout).toMatch(/--dry-run: no changes applied\./);
+    });
+  });
+
+  describe("policy-remove confirmation", () => {
+    function runPolicyRemove(confirmAnswer, extraArgs = []) {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-policy-remove-"));
+      const scriptPath = path.join(tmpDir, "policy-remove-check.js");
+      const script = String.raw`
+const registry = require(${REGISTRY_PATH});
+const policies = require(${POLICIES_PATH});
+const credentials = require(${CREDENTIALS_PATH});
+const calls = [];
+policies.selectForRemoval = async () => "pypi";
+policies.loadPreset = () => "network_policies:\n  pypi:\n    host: pypi.org\n";
+policies.getPresetEndpoints = () => ["pypi.org"];
+credentials.prompt = async (message) => {
+  calls.push({ type: "prompt", message });
+  return ${JSON.stringify(confirmAnswer)};
+};
+registry.getSandbox = (name) => (name === "test-sandbox" ? { name, policies: ["pypi"] } : null);
+registry.listSandboxes = () => ({ sandboxes: [{ name: "test-sandbox" }] });
+policies.listPresets = () => [
+  { name: "npm", description: "npm and Yarn registry access" },
+  { name: "pypi", description: "Python Package Index (PyPI) access" },
+];
+policies.getAppliedPresets = () => ["pypi"];
+policies.removePreset = (sandboxName, presetName) => {
+  calls.push({ type: "remove", sandboxName, presetName });
+};
+process.argv = ["node", "nemoclaw.js", "test-sandbox", "policy-remove", ...${JSON.stringify(extraArgs)}];
+require(${CLI_PATH});
+setImmediate(() => {
+  process.stdout.write("\n__CALLS__" + JSON.stringify(calls));
+});
+`;
+
+      fs.writeFileSync(scriptPath, script);
+
+      return spawnSync(process.execPath, [scriptPath], {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+        },
+      });
+    }
+
+    it("prompts for confirmation before removing a preset", () => {
+      const result = runPolicyRemove("y");
+
+      expect(result.status).toBe(0);
+      const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim());
+      expect(calls).toContainEqual({
+        type: "prompt",
+        message: "  Remove 'pypi' from sandbox 'test-sandbox'? [Y/n]: ",
+      });
+      expect(calls).toContainEqual({
+        type: "remove",
+        sandboxName: "test-sandbox",
+        presetName: "pypi",
+      });
+    });
+
+    it("skips removing the preset when confirmation is declined", () => {
+      const result = runPolicyRemove("n");
+
+      expect(result.status).toBe(0);
+      const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim());
+      expect(calls).toContainEqual({
+        type: "prompt",
+        message: "  Remove 'pypi' from sandbox 'test-sandbox'? [Y/n]: ",
+      });
+      expect(calls.some((call) => call.type === "remove")).toBeFalsy();
+    });
+
+    it("does not prompt or remove when --dry-run is passed", () => {
+      const result = runPolicyRemove("y", ["--dry-run"]);
+
+      expect(result.status).toBe(0);
+      const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim());
+      expect(calls.some((call) => call.type === "prompt")).toBeFalsy();
+      expect(calls.some((call) => call.type === "remove")).toBeFalsy();
+      expect(result.stdout).toMatch(/Endpoints that would be removed: pypi\.org/);
       expect(result.stdout).toMatch(/--dry-run: no changes applied\./);
     });
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Add `nemoclaw <name> policy-remove` to remove previously applied network policy presets from a sandbox. 
```bash
node bin/nemoclaw.js my-assistant policy-remove

  Applied presets:
    1) npm — npm and Yarn registry access
    2) pypi — Python Package Index (PyPI) access

  Choose preset to remove: 2
  Endpoints that would be removed: pypi.org, files.pythonhosted.org
  Remove 'pypi' from sandbox 'my-assistant'? [Y/n]: 
  Narrowing sandbox egress — removing: pypi.org, files.pythonhosted.org

✓ Policy version 5 submitted (hash: 440e75a56b48)
✓ Policy version 5 loaded (active version: 5)
  Removed preset: pypi
```

Also fix onboard TUI checkbox so unchecking an applied preset actually removes it.

```bash

    [8/8] Policy presets
  ──────────────────────────────────────────────────

  Available policy presets:
     [ ] brave          — Brave Search API access
     [ ] brew           — Homebrew (Linuxbrew) package manager access
     [ ] discord        — Discord API, gateway, and CDN access
     [ ] github         — GitHub.com and GitHub API access (git, gh)
     [ ] huggingface    — Hugging Face Hub, LFS, and Inference API access
     [ ] jira           — Jira and Atlassian Cloud access
     [✓] npm            — npm and Yarn registry access
     [ ] outlook        — Microsoft Outlook and Graph API access
   > [ ] pypi           — Python Package Index (PyPI) access      <--- uncheck pypi
     [ ] slack          — Slack API, Socket Mode, and webhooks access
     [ ] telegram       — Telegram Bot API access

  ↑/↓ j/k  move    Space  toggle    a  all/none    Enter  confirm

  Narrowing sandbox egress — removing: pypi.org, files.pythonhosted.org
✓ Policy version 7 submitted (hash: 440e75a56b48)
✓ Policy version 7 loaded (active version: 7)
  Removed preset: pypi
```
## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->
Fixes #1727

## Changes
<!-- Bullet list of key changes. -->

## Changes

- added `nemoclaw <name> policy-remove` command that reads the sandbox's current policy, strips the selected preset's `network_policies` entries, and writes it back via `openshell policy set`
- added interactive picker that only lists applied presets for removal, with `--dry-run` to preview which endpoints would be narrowed
- fixed onboard TUI checkbox to actually remove presets the user unchecks — previously deselecting an applied preset was silently ignored
- removed 6 dead `Unimplemented` gRPC error handlers that became unreachable after minimum OpenShell version was raised to 0.0.24
- added 12 new tests covering YAML removal logic, interactive selection edge cases, and CLI integration for `policy-remove`

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [x] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Seven Cheng <sevenc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sandbox command to remove applied policy presets with interactive selection, confirmation prompt, and a --dry-run preview.

* **Improvements**
  * Automatic removal reconciliation of deselected presets when updating sandbox policies.
  * More consistent retry and error handling for policy apply/remove operations with clearer failure messages.

* **Tests**
  * Added comprehensive tests for preset removal logic, interactive selection behavior, dry-run previews, and confirmation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->