### PR TITLE
feat(inference): validate streaming events for /v1/responses and add NEMOCLAW_PREFERRED_API override

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -128,6 +128,21 @@ $ openshell inference set --provider compatible-anthropic-endpoint --model <mode
 
 If the provider itself needs to change, rerun `nemoclaw onboard`.
 
+#### Switching from Responses API to Chat Completions
+
+If onboarding selected `/v1/responses` but the agent fails at runtime (for
+example, because the backend does not emit the streaming events OpenClaw
+requires), you can switch to `/v1/chat/completions` without a full re-onboard:
+
+```console
+$ export NEMOCLAW_INFERENCE_API_OVERRIDE=openai-completions
+$ nemoclaw onboard --resume --recreate-sandbox
+```
+
+The entrypoint patches `openclaw.json` at container startup.
+No image rebuild is needed.
+Remove the env var and recreate the sandbox to revert to the original API path.
+
 ## Step 2: Cross-Provider Switching
 
 Switching to a different provider family (for example, from NVIDIA Endpoints to Anthropic) requires updating both the gateway route and the sandbox config.
@@ -280,6 +295,33 @@ $ NEMOCLAW_PROVIDER=custom \
 | `NEMOCLAW_ENDPOINT_URL` | Base URL of the local server. |
 | `NEMOCLAW_MODEL` | Model ID as reported by the server. |
 | `COMPATIBLE_API_KEY` | API key for the endpoint. Use any non-empty value if authentication is not required. |
+
+### Forcing Chat Completions API
+
+Some OpenAI-compatible servers (such as SGLang) expose `/v1/responses` but do
+not emit the granular streaming events that OpenClaw requires.
+NemoClaw tests streaming events during onboarding and falls back to
+`/v1/chat/completions` automatically when it detects incomplete streaming.
+
+If you need to bypass the `/v1/responses` probe entirely, set
+`NEMOCLAW_PREFERRED_API` before running onboard:
+
+```console
+$ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
+```
+
+This variable tells the wizard to skip the `/v1/responses` probe and use
+`/v1/chat/completions` directly.
+It works in both interactive and non-interactive mode.
+
+| Variable | Values | Default |
+|---|---|---|
+| `NEMOCLAW_PREFERRED_API` | `openai-completions`, `chat-completions` | unset (auto-detect) |
+
+If you already onboarded and the sandbox is failing at runtime, you can switch
+the API path without re-running the full onboard wizard.
+Refer to Switch Inference Models (see the `nemoclaw-user-configure-inference` skill) for the
+`NEMOCLAW_INFERENCE_API_OVERRIDE` approach.
 
 ## Step 7: Anthropic-Compatible Server
 

--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -176,7 +176,7 @@ $ nemoclaw onboard --resume --recreate-sandbox
 ```
 
 The entrypoint patches `openclaw.json` at container startup with the override values.
-No image rebuild is needed.
+You do not need to rebuild the image.
 Remove the env vars and recreate the sandbox to revert to the original model.
 
 `NEMOCLAW_INFERENCE_API_OVERRIDE` accepts `openai-completions` (for NVIDIA, OpenAI, Gemini, compatible endpoints) or `anthropic-messages` (for Anthropic and Anthropic-compatible endpoints).
@@ -324,9 +324,9 @@ If you need to bypass the `/v1/responses` probe entirely, set
 $ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
 ```
 
-This variable tells the wizard to skip the `/v1/responses` probe and use
+Set this variable to make the wizard skip the `/v1/responses` probe and use
 `/v1/chat/completions` directly.
-It works in both interactive and non-interactive mode.
+You can use it in both interactive and non-interactive mode.
 
 | Variable | Values | Default |
 |---|---|---|

--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -132,16 +132,30 @@ If the provider itself needs to change, rerun `nemoclaw onboard`.
 
 If onboarding selected `/v1/responses` but the agent fails at runtime (for
 example, because the backend does not emit the streaming events OpenClaw
-requires), you can switch to `/v1/chat/completions` without a full re-onboard:
+requires), re-run onboarding so the wizard re-probes the endpoint and bakes
+the correct API path into the image:
 
 ```console
-$ export NEMOCLAW_INFERENCE_API_OVERRIDE=openai-completions
-$ nemoclaw onboard --resume --recreate-sandbox
+$ nemoclaw onboard
 ```
 
-The entrypoint patches `openclaw.json` at container startup.
-No image rebuild is needed.
-Remove the env var and recreate the sandbox to revert to the original API path.
+Select the same provider and endpoint again.
+The updated streaming probe will detect incomplete `/v1/responses` support
+and select `/v1/chat/completions` automatically.
+
+To force `/v1/chat/completions` without re-probing, set `NEMOCLAW_PREFERRED_API`
+before onboarding:
+
+```console
+$ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
+```
+
+> **Note:** `NEMOCLAW_INFERENCE_API_OVERRIDE` patches the config at container startup but
+> does not update the Dockerfile ARG baked into the image.
+> If you recreate the sandbox without the override env var, the image reverts to
+> the original API path.
+> A fresh `nemoclaw onboard` is the reliable fix because it updates both the
+> session and the baked image.
 
 ## Step 2: Cross-Provider Switching
 
@@ -318,10 +332,10 @@ It works in both interactive and non-interactive mode.
 |---|---|---|
 | `NEMOCLAW_PREFERRED_API` | `openai-completions`, `chat-completions` | unset (auto-detect) |
 
-If you already onboarded and the sandbox is failing at runtime, you can switch
-the API path without re-running the full onboard wizard.
-Refer to Switch Inference Models (see the `nemoclaw-user-configure-inference` skill) for the
-`NEMOCLAW_INFERENCE_API_OVERRIDE` approach.
+If you already onboarded and the sandbox is failing at runtime, re-run
+`nemoclaw onboard` to re-probe the endpoint and bake the correct API path
+into the image.
+Refer to Switch Inference Models (see the `nemoclaw-user-configure-inference` skill) for details.
 
 ## Step 7: Anthropic-Compatible Server
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -256,6 +256,29 @@ $ export NEMOCLAW_LOCAL_INFERENCE_TIMEOUT=300
 $ nemoclaw onboard
 ```
 
+### Agent fails at runtime after onboarding succeeds with a compatible endpoint
+
+Some OpenAI-compatible servers (such as SGLang) expose `/v1/responses` and pass
+the onboarding validation probe, but their streaming mode is incomplete.
+OpenClaw requires granular streaming events like `response.output_text.delta`
+that these backends do not emit.
+
+NemoClaw now tests streaming events during the `/v1/responses` probe and falls
+back to `/v1/chat/completions` automatically.
+If you onboarded before this check was added, switch the API path on an existing
+sandbox:
+
+```console
+$ export NEMOCLAW_INFERENCE_API_OVERRIDE=openai-completions
+$ nemoclaw onboard --resume --recreate-sandbox
+```
+
+To force `/v1/chat/completions` during a fresh onboard, set `NEMOCLAW_PREFERRED_API`:
+
+```console
+$ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
+```
+
 ### `NEMOCLAW_DISABLE_DEVICE_AUTH=1` does not change an existing sandbox
 
 This is expected behavior.

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -265,19 +265,23 @@ that these backends do not emit.
 
 NemoClaw now tests streaming events during the `/v1/responses` probe and falls
 back to `/v1/chat/completions` automatically.
-If you onboarded before this check was added, switch the API path on an existing
-sandbox:
+If you onboarded before this check was added, re-run onboarding so the wizard
+re-probes the endpoint and bakes the correct API path into the image:
 
 ```console
-$ export NEMOCLAW_INFERENCE_API_OVERRIDE=openai-completions
-$ nemoclaw onboard --resume --recreate-sandbox
+$ nemoclaw onboard
 ```
 
-To force `/v1/chat/completions` during a fresh onboard, set `NEMOCLAW_PREFERRED_API`:
+To force `/v1/chat/completions` without re-probing, set `NEMOCLAW_PREFERRED_API`:
 
 ```console
 $ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
 ```
+
+Do not rely on `NEMOCLAW_INFERENCE_API_OVERRIDE` alone — it patches the config
+at container startup but does not update the Dockerfile ARG baked into the
+image.
+A fresh `nemoclaw onboard` is the reliable fix.
 
 ### `NEMOCLAW_DISABLE_DEVICE_AUTH=1` does not change an existing sandbox
 

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -73,6 +73,21 @@ $ openshell inference set --provider compatible-anthropic-endpoint --model <mode
 
 If the provider itself needs to change, rerun `nemoclaw onboard`.
 
+#### Switching from Responses API to Chat Completions
+
+If onboarding selected `/v1/responses` but the agent fails at runtime (for
+example, because the backend does not emit the streaming events OpenClaw
+requires), you can switch to `/v1/chat/completions` without a full re-onboard:
+
+```console
+$ export NEMOCLAW_INFERENCE_API_OVERRIDE=openai-completions
+$ nemoclaw onboard --resume --recreate-sandbox
+```
+
+The entrypoint patches `openclaw.json` at container startup.
+No image rebuild is needed.
+Remove the env var and recreate the sandbox to revert to the original API path.
+
 ## Cross-Provider Switching
 
 Switching to a different provider family (for example, from NVIDIA Endpoints to Anthropic) requires updating both the gateway route and the sandbox config.

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -123,7 +123,7 @@ $ nemoclaw onboard --resume --recreate-sandbox
 ```
 
 The entrypoint patches `openclaw.json` at container startup with the override values.
-No image rebuild is needed.
+You do not need to rebuild the image.
 Remove the env vars and recreate the sandbox to revert to the original model.
 
 `NEMOCLAW_INFERENCE_API_OVERRIDE` accepts `openai-completions` (for NVIDIA, OpenAI, Gemini, compatible endpoints) or `anthropic-messages` (for Anthropic and Anthropic-compatible endpoints).

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -77,16 +77,32 @@ If the provider itself needs to change, rerun `nemoclaw onboard`.
 
 If onboarding selected `/v1/responses` but the agent fails at runtime (for
 example, because the backend does not emit the streaming events OpenClaw
-requires), you can switch to `/v1/chat/completions` without a full re-onboard:
+requires), re-run onboarding so the wizard re-probes the endpoint and bakes
+the correct API path into the image:
 
 ```console
-$ export NEMOCLAW_INFERENCE_API_OVERRIDE=openai-completions
-$ nemoclaw onboard --resume --recreate-sandbox
+$ nemoclaw onboard
 ```
 
-The entrypoint patches `openclaw.json` at container startup.
-No image rebuild is needed.
-Remove the env var and recreate the sandbox to revert to the original API path.
+Select the same provider and endpoint again.
+The updated streaming probe will detect incomplete `/v1/responses` support
+and select `/v1/chat/completions` automatically.
+
+To force `/v1/chat/completions` without re-probing, set `NEMOCLAW_PREFERRED_API`
+before onboarding:
+
+```console
+$ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
+```
+
+:::{note}
+`NEMOCLAW_INFERENCE_API_OVERRIDE` patches the config at container startup but
+does not update the Dockerfile ARG baked into the image.
+If you recreate the sandbox without the override env var, the image reverts to
+the original API path.
+A fresh `nemoclaw onboard` is the reliable fix because it updates both the
+session and the baked image.
+:::
 
 ## Cross-Provider Switching
 

--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -152,10 +152,10 @@ It works in both interactive and non-interactive mode.
 |---|---|---|
 | `NEMOCLAW_PREFERRED_API` | `openai-completions`, `chat-completions` | unset (auto-detect) |
 
-If you already onboarded and the sandbox is failing at runtime, you can switch
-the API path without re-running the full onboard wizard.
-Refer to [Switch Inference Models](switch-inference-providers.md) for the
-`NEMOCLAW_INFERENCE_API_OVERRIDE` approach.
+If you already onboarded and the sandbox is failing at runtime, re-run
+`nemoclaw onboard` to re-probe the endpoint and bake the correct API path
+into the image.
+Refer to [Switch Inference Models](switch-inference-providers.md) for details.
 
 ## Anthropic-Compatible Server
 

--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -130,6 +130,33 @@ $ NEMOCLAW_PROVIDER=custom \
 | `NEMOCLAW_MODEL` | Model ID as reported by the server. |
 | `COMPATIBLE_API_KEY` | API key for the endpoint. Use any non-empty value if authentication is not required. |
 
+### Forcing Chat Completions API
+
+Some OpenAI-compatible servers (such as SGLang) expose `/v1/responses` but do
+not emit the granular streaming events that OpenClaw requires.
+NemoClaw tests streaming events during onboarding and falls back to
+`/v1/chat/completions` automatically when it detects incomplete streaming.
+
+If you need to bypass the `/v1/responses` probe entirely, set
+`NEMOCLAW_PREFERRED_API` before running onboard:
+
+```console
+$ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
+```
+
+This variable tells the wizard to skip the `/v1/responses` probe and use
+`/v1/chat/completions` directly.
+It works in both interactive and non-interactive mode.
+
+| Variable | Values | Default |
+|---|---|---|
+| `NEMOCLAW_PREFERRED_API` | `openai-completions`, `chat-completions` | unset (auto-detect) |
+
+If you already onboarded and the sandbox is failing at runtime, you can switch
+the API path without re-running the full onboard wizard.
+Refer to [Switch Inference Models](switch-inference-providers.md) for the
+`NEMOCLAW_INFERENCE_API_OVERRIDE` approach.
+
 ## Anthropic-Compatible Server
 
 If your local server implements the Anthropic Messages API (`/v1/messages`), choose **Other Anthropic-compatible endpoint** during onboarding instead.

--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -144,9 +144,9 @@ If you need to bypass the `/v1/responses` probe entirely, set
 $ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
 ```
 
-This variable tells the wizard to skip the `/v1/responses` probe and use
+Set this variable to make the wizard skip the `/v1/responses` probe and use
 `/v1/chat/completions` directly.
-It works in both interactive and non-interactive mode.
+You can use it in both interactive and non-interactive mode.
 
 | Variable | Values | Default |
 |---|---|---|

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -295,19 +295,23 @@ that these backends do not emit.
 
 NemoClaw now tests streaming events during the `/v1/responses` probe and falls
 back to `/v1/chat/completions` automatically.
-If you onboarded before this check was added, switch the API path on an existing
-sandbox:
+If you onboarded before this check was added, re-run onboarding so the wizard
+re-probes the endpoint and bakes the correct API path into the image:
 
 ```console
-$ export NEMOCLAW_INFERENCE_API_OVERRIDE=openai-completions
-$ nemoclaw onboard --resume --recreate-sandbox
+$ nemoclaw onboard
 ```
 
-To force `/v1/chat/completions` during a fresh onboard, set `NEMOCLAW_PREFERRED_API`:
+To force `/v1/chat/completions` without re-probing, set `NEMOCLAW_PREFERRED_API`:
 
 ```console
 $ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
 ```
+
+Do not rely on `NEMOCLAW_INFERENCE_API_OVERRIDE` alone — it patches the config
+at container startup but does not update the Dockerfile ARG baked into the
+image.
+A fresh `nemoclaw onboard` is the reliable fix.
 
 ### `NEMOCLAW_DISABLE_DEVICE_AUTH=1` does not change an existing sandbox
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -286,6 +286,29 @@ $ export NEMOCLAW_LOCAL_INFERENCE_TIMEOUT=300
 $ nemoclaw onboard
 ```
 
+### Agent fails at runtime after onboarding succeeds with a compatible endpoint
+
+Some OpenAI-compatible servers (such as SGLang) expose `/v1/responses` and pass
+the onboarding validation probe, but their streaming mode is incomplete.
+OpenClaw requires granular streaming events like `response.output_text.delta`
+that these backends do not emit.
+
+NemoClaw now tests streaming events during the `/v1/responses` probe and falls
+back to `/v1/chat/completions` automatically.
+If you onboarded before this check was added, switch the API path on an existing
+sandbox:
+
+```console
+$ export NEMOCLAW_INFERENCE_API_OVERRIDE=openai-completions
+$ nemoclaw onboard --resume --recreate-sandbox
+```
+
+To force `/v1/chat/completions` during a fresh onboard, set `NEMOCLAW_PREFERRED_API`:
+
+```console
+$ NEMOCLAW_PREFERRED_API=openai-completions nemoclaw onboard
+```
+
 ### `NEMOCLAW_DISABLE_DEVICE_AUTH=1` does not change an existing sandbox
 
 This is expected behavior.

--- a/src/lib/http-probe.test.ts
+++ b/src/lib/http-probe.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   getCurlTimingArgs,
   runCurlProbe,
+  runStreamingEventProbe,
   summarizeCurlFailure,
   summarizeProbeError,
   summarizeProbeFailure,
@@ -83,5 +84,156 @@ describe("http-probe helpers", () => {
     expect(result.curlStatus).toBe(1);
     expect(result.message).toContain("curl failed");
     expect(result.stderr).toContain("spawn ENOENT");
+  });
+});
+
+describe("runStreamingEventProbe", () => {
+  /** Helper to build a spawnSyncImpl that writes SSE content to the -o file. */
+  function mockStreaming(sseBody: string, exitCode = 0) {
+    return (_command: string, args: readonly string[]) => {
+      const oIdx = args.indexOf("-o");
+      if (oIdx !== -1) {
+        const outputPath = args[oIdx + 1] as string;
+        fs.writeFileSync(outputPath, sseBody);
+      }
+      return {
+        pid: 1,
+        output: [],
+        stdout: "",
+        stderr: "",
+        status: exitCode,
+        signal: null,
+      };
+    };
+  }
+
+  it("passes when all required streaming events are present", () => {
+    const sseBody = [
+      "event: response.created",
+      'data: {"id":"resp_1"}',
+      "",
+      "event: response.in_progress",
+      'data: {"id":"resp_1"}',
+      "",
+      "event: response.output_item.added",
+      'data: {"id":"resp_1"}',
+      "",
+      "event: response.content_part.added",
+      'data: {"id":"resp_1"}',
+      "",
+      "event: response.output_text.delta",
+      'data: {"delta":"OK"}',
+      "",
+      "event: response.output_text.done",
+      'data: {"text":"OK"}',
+      "",
+      "event: response.content_part.done",
+      'data: {"id":"resp_1"}',
+      "",
+      "event: response.completed",
+      'data: {"id":"resp_1"}',
+      "",
+    ].join("\n");
+
+    const result = runStreamingEventProbe(
+      ["-sS", "--max-time", "15", "https://example.test/v1/responses"],
+      { spawnSyncImpl: mockStreaming(sseBody) },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.missingEvents).toEqual([]);
+  });
+
+  it("fails when only basic lifecycle events are present (SGLang-like)", () => {
+    const sseBody = [
+      "event: response.created",
+      'data: {"id":"resp_1"}',
+      "",
+      "event: response.in_progress",
+      'data: {"id":"resp_1"}',
+      "",
+      "event: response.completed",
+      'data: {"id":"resp_1","text":"OK"}',
+      "",
+    ].join("\n");
+
+    const result = runStreamingEventProbe(
+      ["-sS", "--max-time", "15", "https://example.test/v1/responses"],
+      { spawnSyncImpl: mockStreaming(sseBody) },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.missingEvents).toContain("response.output_text.delta");
+    expect(result.message).toContain("response.output_text.delta");
+  });
+
+  it("still passes if curl exits with 28 (timeout) but events were captured", () => {
+    const sseBody = [
+      "event: response.created",
+      'data: {"id":"resp_1"}',
+      "",
+      "event: response.output_text.delta",
+      'data: {"delta":"O"}',
+      "",
+    ].join("\n");
+
+    const result = runStreamingEventProbe(
+      ["-sS", "--max-time", "15", "https://example.test/v1/responses"],
+      { spawnSyncImpl: mockStreaming(sseBody, 28) },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.missingEvents).toEqual([]);
+  });
+
+  it("fails on spawn error", () => {
+    const result = runStreamingEventProbe(
+      ["-sS", "https://example.test/v1/responses"],
+      {
+        spawnSyncImpl: () => {
+          const error = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
+          return {
+            pid: 1,
+            output: [],
+            stdout: "",
+            stderr: "",
+            status: null,
+            signal: null,
+            error,
+          };
+        },
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("Streaming probe failed");
+  });
+
+  it("cleans up temp files after probe", () => {
+    let outputPath = "";
+    runStreamingEventProbe(
+      ["-sS", "--max-time", "15", "https://example.test/v1/responses"],
+      {
+        spawnSyncImpl: (_command, args) => {
+          const oIdx = args.indexOf("-o");
+          if (oIdx !== -1) {
+            outputPath = args[oIdx + 1] as string;
+            fs.writeFileSync(outputPath, "event: response.output_text.delta\ndata: {}\n");
+          }
+          return {
+            pid: 1,
+            output: [],
+            stdout: "",
+            stderr: "",
+            status: 0,
+            signal: null,
+          };
+        },
+      },
+    );
+
+    expect(outputPath).not.toBe("");
+    expect(fs.existsSync(outputPath)).toBe(false);
+    expect(fs.existsSync(path.dirname(outputPath))).toBe(false);
   });
 });

--- a/src/lib/http-probe.ts
+++ b/src/lib/http-probe.ts
@@ -26,6 +26,12 @@ export interface CurlProbeOptions {
   ) => SpawnSyncReturns<string>;
 }
 
+export interface StreamingProbeResult {
+  ok: boolean;
+  missingEvents: string[];
+  message: string;
+}
+
 function secureTempFile(prefix: string, ext = ""): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
   return path.join(dir, `${prefix}${ext}`);
@@ -145,5 +151,94 @@ export function runCurlProbe(argv: string[], opts: CurlProbeOptions = {}): CurlP
     };
   } finally {
     cleanupTempDir(bodyFile, "nemoclaw-curl-probe");
+  }
+}
+
+/**
+ * The minimum set of streaming events that OpenClaw requires from a
+ * `/v1/responses` endpoint. Backends that only emit the top-level lifecycle
+ * events (created / in_progress / completed) will cause runtime failures
+ * because OpenClaw never receives the incremental content deltas.
+ */
+const REQUIRED_STREAMING_EVENTS = ["response.output_text.delta"];
+
+/**
+ * Send a streaming request to a `/v1/responses`-style endpoint and verify
+ * that the SSE event stream includes the granular events OpenClaw needs.
+ *
+ * This catches backends like SGLang that return valid non-streaming
+ * responses but emit only `response.created`, `response.in_progress`, and
+ * `response.completed` in streaming mode — missing the content deltas that
+ * OpenClaw relies on.
+ */
+export function runStreamingEventProbe(
+  argv: string[],
+  opts: CurlProbeOptions = {},
+): StreamingProbeResult {
+  const bodyFile = secureTempFile("nemoclaw-streaming-probe", ".sse");
+  try {
+    const args = [...argv];
+    const url = args.pop();
+    const spawnSyncImpl = opts.spawnSyncImpl ?? spawnSync;
+    const result = spawnSyncImpl(
+      "curl",
+      [...args, "-N", "-o", bodyFile, String(url || "")],
+      {
+        cwd: opts.cwd ?? ROOT,
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          ...opts.env,
+        },
+      },
+    );
+
+    const body = fs.existsSync(bodyFile) ? fs.readFileSync(bodyFile, "utf8") : "";
+
+    if (result.error || (result.status !== null && result.status !== 0 && result.status !== 28)) {
+      // curl exit 28 = timeout, which is expected — we cap with --max-time
+      // and may still have collected enough events before the timeout.
+      const detail = result.error
+        ? String((result.error as Error).message || result.error)
+        : String(result.stderr || "");
+      return {
+        ok: false,
+        missingEvents: REQUIRED_STREAMING_EVENTS,
+        message: `Streaming probe failed: ${compactText(detail).slice(0, 200)}`,
+      };
+    }
+
+    // Parse SSE event types from the raw output.
+    // Each event line looks like: "event: response.output_text.delta"
+    const eventTypes = new Set<string>();
+    for (const line of body.split("\n")) {
+      const match = /^event:\s*(.+)$/i.exec(line.trim());
+      if (match) {
+        eventTypes.add(match[1].trim());
+      }
+    }
+
+    const missing = REQUIRED_STREAMING_EVENTS.filter((e) => !eventTypes.has(e));
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        missingEvents: missing,
+        message:
+          `Responses API streaming is missing required events: ${missing.join(", ")}. ` +
+          "Falling back to chat completions API.",
+      };
+    }
+
+    return { ok: true, missingEvents: [], message: "" };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      missingEvents: REQUIRED_STREAMING_EVENTS,
+      message: `Streaming probe error: ${detail}`,
+    };
+  } finally {
+    cleanupTempDir(bodyFile, "nemoclaw-streaming-probe");
   }
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1216,7 +1216,9 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
           }),
           `${String(endpointUrl).replace(/\/+$/, "")}/responses`,
         ]);
-        if (!streamResult.ok) {
+        if (!streamResult.ok && streamResult.missingEvents.length > 0) {
+          // Backend responds but lacks required streaming events — fall back
+          // to /chat/completions silently.
           console.log(`  ℹ ${streamResult.message}`);
           failures.push({
             name: probe.name + " (streaming)",
@@ -1226,6 +1228,23 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
             body: "",
           });
           continue;
+        }
+        if (!streamResult.ok) {
+          // Transport or execution failure — surface as a hard error instead
+          // of silently switching APIs.
+          return {
+            ok: false,
+            message: `${probe.name} (streaming): ${streamResult.message}`,
+            failures: [
+              {
+                name: probe.name + " (streaming)",
+                httpStatus: 0,
+                curlStatus: 0,
+                message: streamResult.message,
+                body: "",
+              },
+            ],
+          };
         }
       }
       return { ok: true, api: probe.api, label: probe.name };
@@ -1376,7 +1395,7 @@ async function validateCustomOpenAiLikeSelection(
   const apiKey = getCredential(credentialEnv);
   const probe = probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, {
     requireResponsesToolCalling: true,
-    skipResponsesProbe: shouldForceCompletionsApi(),
+    skipResponsesProbe: shouldForceCompletionsApi(process.env.NEMOCLAW_PREFERRED_API),
     probeStreaming: true,
   });
   if (probe.ok) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -495,7 +495,7 @@ function hydrateCredentialEnv(envName) {
   return value || null;
 }
 
-const { getCurlTimingArgs, summarizeCurlFailure, summarizeProbeFailure, runCurlProbe } = httpProbe;
+const { getCurlTimingArgs, summarizeCurlFailure, summarizeProbeFailure, runCurlProbe, runStreamingEventProbe } = httpProbe;
 
 function getNavigationChoice(value = "") {
   const normalized = String(value || "")
@@ -523,6 +523,7 @@ const {
   isNvcfFunctionNotFoundForAccount,
   nvcfFunctionNotFoundMessage,
   shouldSkipResponsesProbe,
+  shouldForceCompletionsApi,
 } = validation;
 
 // validateNvidiaApiKeyValue — see validation import above
@@ -1196,6 +1197,37 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
   for (const probe of probes) {
     const result = probe.execute();
     if (result.ok) {
+      // Streaming event validation — catch backends like SGLang that return
+      // valid non-streaming responses but emit incomplete SSE events in
+      // streaming mode. Only run for /responses probes on custom endpoints
+      // where probeStreaming was requested.
+      if (probe.api === "openai-responses" && options.probeStreaming === true) {
+        const streamResult = runStreamingEventProbe([
+          "-sS",
+          ...getValidationProbeCurlArgs(),
+          "-H",
+          "Content-Type: application/json",
+          ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
+          "-d",
+          JSON.stringify({
+            model,
+            input: "Reply with exactly: OK",
+            stream: true,
+          }),
+          `${String(endpointUrl).replace(/\/+$/, "")}/responses`,
+        ]);
+        if (!streamResult.ok) {
+          console.log(`  ℹ ${streamResult.message}`);
+          failures.push({
+            name: probe.name + " (streaming)",
+            httpStatus: 0,
+            curlStatus: 0,
+            message: streamResult.message,
+            body: "",
+          });
+          continue;
+        }
+      }
       return { ok: true, api: probe.api, label: probe.name };
     }
     // Preserve the raw response body alongside the summarized message so the
@@ -1344,6 +1376,8 @@ async function validateCustomOpenAiLikeSelection(
   const apiKey = getCredential(credentialEnv);
   const probe = probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, {
     requireResponsesToolCalling: true,
+    skipResponsesProbe: shouldForceCompletionsApi(),
+    probeStreaming: true,
   });
   if (probe.ok) {
     console.log(`  ${probe.label} available — OpenClaw will use ${probe.api}.`);

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 // Import from compiled dist/ so coverage is attributed correctly.
 import {
   classifyValidationFailure,
@@ -12,6 +12,7 @@ import {
   isNvcfFunctionNotFoundForAccount,
   nvcfFunctionNotFoundMessage,
   shouldSkipResponsesProbe,
+  shouldForceCompletionsApi,
 } from "../../dist/lib/validation";
 
 describe("classifyValidationFailure", () => {
@@ -220,5 +221,47 @@ describe("shouldSkipResponsesProbe", () => {
     expect(shouldSkipResponsesProbe("anthropic-api")).toBe(false);
     expect(shouldSkipResponsesProbe("compatible-endpoint")).toBe(false);
     expect(shouldSkipResponsesProbe("")).toBe(false);
+  });
+});
+
+describe("shouldForceCompletionsApi", () => {
+  const ORIGINAL = process.env.NEMOCLAW_PREFERRED_API;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.NEMOCLAW_PREFERRED_API;
+    } else {
+      process.env.NEMOCLAW_PREFERRED_API = ORIGINAL;
+    }
+  });
+
+  it("returns true when NEMOCLAW_PREFERRED_API is openai-completions", () => {
+    process.env.NEMOCLAW_PREFERRED_API = "openai-completions";
+    expect(shouldForceCompletionsApi()).toBe(true);
+  });
+
+  it("returns true for the chat-completions alias", () => {
+    process.env.NEMOCLAW_PREFERRED_API = "chat-completions";
+    expect(shouldForceCompletionsApi()).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    process.env.NEMOCLAW_PREFERRED_API = "OpenAI-Completions";
+    expect(shouldForceCompletionsApi()).toBe(true);
+  });
+
+  it("returns false when unset", () => {
+    delete process.env.NEMOCLAW_PREFERRED_API;
+    expect(shouldForceCompletionsApi()).toBe(false);
+  });
+
+  it("returns false for openai-responses", () => {
+    process.env.NEMOCLAW_PREFERRED_API = "openai-responses";
+    expect(shouldForceCompletionsApi()).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    process.env.NEMOCLAW_PREFERRED_API = "";
+    expect(shouldForceCompletionsApi()).toBe(false);
   });
 });

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, describe, it, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 // Import from compiled dist/ so coverage is attributed correctly.
 import {
   classifyValidationFailure,
@@ -225,43 +225,27 @@ describe("shouldSkipResponsesProbe", () => {
 });
 
 describe("shouldForceCompletionsApi", () => {
-  const ORIGINAL = process.env.NEMOCLAW_PREFERRED_API;
-
-  afterEach(() => {
-    if (ORIGINAL === undefined) {
-      delete process.env.NEMOCLAW_PREFERRED_API;
-    } else {
-      process.env.NEMOCLAW_PREFERRED_API = ORIGINAL;
-    }
-  });
-
-  it("returns true when NEMOCLAW_PREFERRED_API is openai-completions", () => {
-    process.env.NEMOCLAW_PREFERRED_API = "openai-completions";
-    expect(shouldForceCompletionsApi()).toBe(true);
+  it("returns true when passed openai-completions", () => {
+    expect(shouldForceCompletionsApi("openai-completions")).toBe(true);
   });
 
   it("returns true for the chat-completions alias", () => {
-    process.env.NEMOCLAW_PREFERRED_API = "chat-completions";
-    expect(shouldForceCompletionsApi()).toBe(true);
+    expect(shouldForceCompletionsApi("chat-completions")).toBe(true);
   });
 
   it("is case-insensitive", () => {
-    process.env.NEMOCLAW_PREFERRED_API = "OpenAI-Completions";
-    expect(shouldForceCompletionsApi()).toBe(true);
+    expect(shouldForceCompletionsApi("OpenAI-Completions")).toBe(true);
   });
 
-  it("returns false when unset", () => {
-    delete process.env.NEMOCLAW_PREFERRED_API;
-    expect(shouldForceCompletionsApi()).toBe(false);
+  it("returns false when undefined", () => {
+    expect(shouldForceCompletionsApi(undefined)).toBe(false);
   });
 
   it("returns false for openai-responses", () => {
-    process.env.NEMOCLAW_PREFERRED_API = "openai-responses";
-    expect(shouldForceCompletionsApi()).toBe(false);
+    expect(shouldForceCompletionsApi("openai-responses")).toBe(false);
   });
 
   it("returns false for empty string", () => {
-    process.env.NEMOCLAW_PREFERRED_API = "";
-    expect(shouldForceCompletionsApi()).toBe(false);
+    expect(shouldForceCompletionsApi("")).toBe(false);
   });
 });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -130,12 +130,12 @@ export function shouldSkipResponsesProbe(provider: string): boolean {
 }
 
 /**
- * Whether the user has explicitly requested the chat completions API path
- * via the `NEMOCLAW_PREFERRED_API` environment variable. This lets users
- * with backends that expose `/v1/responses` but lack full streaming-event
+ * Whether the caller has explicitly requested the chat completions API path.
+ * Pass the value of `NEMOCLAW_PREFERRED_API` (or any other source). This lets
+ * users with backends that expose `/v1/responses` but lack full streaming-event
  * support (e.g. SGLang) skip the Responses API probe during onboarding.
  */
-export function shouldForceCompletionsApi(): boolean {
-  const value = (process.env.NEMOCLAW_PREFERRED_API || "").trim().toLowerCase();
+export function shouldForceCompletionsApi(preferredApi?: string): boolean {
+  const value = (preferredApi || "").trim().toLowerCase();
   return value === "openai-completions" || value === "chat-completions";
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -128,3 +128,14 @@ export function nvcfFunctionNotFoundMessage(model: string): string {
 export function shouldSkipResponsesProbe(provider: string): boolean {
   return provider === "nvidia-prod";
 }
+
+/**
+ * Whether the user has explicitly requested the chat completions API path
+ * via the `NEMOCLAW_PREFERRED_API` environment variable. This lets users
+ * with backends that expose `/v1/responses` but lack full streaming-event
+ * support (e.g. SGLang) skip the Responses API probe during onboarding.
+ */
+export function shouldForceCompletionsApi(): boolean {
+  const value = (process.env.NEMOCLAW_PREFERRED_API || "").trim().toLowerCase();
+  return value === "openai-completions" || value === "chat-completions";
+}


### PR DESCRIPTION
## Summary

- Adds streaming SSE event validation to the `/v1/responses` probe for custom OpenAI-compatible endpoints, catching backends like SGLang that return valid non-streaming responses but emit incomplete streaming events
- Adds `NEMOCLAW_PREFERRED_API=openai-completions` env var to bypass `/v1/responses` probe entirely during onboarding
- Documents both the env var override and the existing `NEMOCLAW_INFERENCE_API_OVERRIDE` workaround for already-onboarded sandboxes

## Context

Community user reported SGLang passes onboarding validation for `/v1/responses` but fails at runtime because its streaming mode only emits 3 lifecycle events (`response.created`, `response.in_progress`, `response.completed`) — missing the granular content deltas OpenClaw requires (`response.output_text.delta`, etc.).

## Test plan

- [ ] Unit tests for `shouldForceCompletionsApi()` (6 cases) and `runStreamingEventProbe()` (5 cases) pass
- [ ] `NEMOCLAW_PREFERRED_API=openai-completions` skips `/v1/responses` probe during custom endpoint onboarding
- [ ] Streaming probe detects SGLang-like incomplete SSE events and falls back to `/chat/completions`
- [ ] Full test suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NEMOCLAW_PREFERRED_API to force Chat Completions (works interactive/non‑interactive) and optionally skip the /v1/responses probe
  * Onboarding now validates streaming events and will automatically fall back to Chat Completions if required events are missing; transport/probe failures produce a hard failure

* **Documentation**
  * New troubleshooting and recovery steps (rerun `nemoclaw onboard` to re‑probe and bake the correct API)
  * Clarified that NEMOCLAW_INFERENCE_API_OVERRIDE only patches startup config and does not update baked image ARGs
  * Minor wording tweak about image rebuilds

* **Tests**
  * Added tests covering streaming probes, cleanup, error cases, and the preference logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->