### PR TITLE
fix(onboard): check provider existence before create to avoid Already…

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -642,8 +642,8 @@ function buildProviderArgs(action, name, type, credentialEnv, baseUrl) {
 /**
  * Create or update an OpenShell provider in the gateway.
  *
- * Attempts `openshell provider create`; if that fails (provider already exists),
- * falls back to `openshell provider update` with the same credential.
+ * Checks whether the provider already exists via `openshell provider get`;
+ * uses `create` for new providers and `update` for existing ones.
  * @param {string} name - Provider name (e.g. "discord-bridge", "inference").
  * @param {string} type - Provider type ("openai", "anthropic", "generic").
  * @param {string} credentialEnv - Environment variable name for the credential.
@@ -652,25 +652,17 @@ function buildProviderArgs(action, name, type, credentialEnv, baseUrl) {
  * @returns {{ ok: boolean, status?: number, message?: string }}
  */
 function upsertProvider(name, type, credentialEnv, baseUrl, env = {}) {
-  const createArgs = buildProviderArgs("create", name, type, credentialEnv, baseUrl);
+  const exists = providerExistsInGateway(name);
+  const action = exists ? "update" : "create";
+  const args = buildProviderArgs(action, name, type, credentialEnv, baseUrl);
   const runOpts = { ignoreError: true, env, stdio: ["ignore", "pipe", "pipe"] };
-  const createResult = runOpenshell(createArgs, runOpts);
-  if (createResult.status === 0) {
-    return { ok: true };
-  }
-
-  const updateArgs = buildProviderArgs("update", name, type, credentialEnv, baseUrl);
-  const updateResult = runOpenshell(updateArgs, runOpts);
-  if (updateResult.status !== 0) {
+  const result = runOpenshell(args, runOpts);
+  if (result.status !== 0) {
     const output =
-      compactText(`${createResult.stderr || ""} ${updateResult.stderr || ""}`) ||
-      compactText(`${createResult.stdout || ""} ${updateResult.stdout || ""}`) ||
-      `Failed to create or update provider '${name}'.`;
-    return {
-      ok: false,
-      status: updateResult.status || createResult.status || 1,
-      message: output,
-    };
+      compactText(`${result.stderr || ""}`) ||
+      compactText(`${result.stdout || ""}`) ||
+      `Failed to ${action} provider '${name}'.`;
+    return { ok: false, status: result.status || 1, message: output };
   }
   return { ok: true };
 }

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1318,12 +1318,13 @@ const { setupInference } = require(${onboardPath});
 
     expect(result.status).toBe(0);
     const commands = JSON.parse(result.stdout.trim().split("\n").pop());
-    assert.equal(commands.length, 3);
+    assert.equal(commands.length, 4);
     assert.match(commands[0].command, /gateway' 'select' 'nemoclaw'/);
-    assert.match(commands[1].command, /'--credential' 'NVIDIA_API_KEY'/);
-    assert.doesNotMatch(commands[1].command, /nvapi-secret-value/);
-    assert.match(commands[1].command, /provider' 'create'/);
-    assert.match(commands[2].command, /inference' 'set'/);
+    assert.match(commands[1].command, /'provider' 'get'/);
+    assert.match(commands[2].command, /'--credential' 'NVIDIA_API_KEY'/);
+    assert.doesNotMatch(commands[2].command, /nvapi-secret-value/);
+    assert.match(commands[2].command, /provider' 'update'/);
+    assert.match(commands[3].command, /inference' 'set'/);
   });
 
   it("detects when the live inference route already matches the requested provider and model", () => {
@@ -1516,6 +1517,8 @@ const registry = require(${registryPath});
 const commands = [];
 runner.run = (command, opts = {}) => {
   commands.push({ command, env: opts.env || null });
+  // provider-get returns not-found so we exercise the create path
+  if (command.includes("'provider' 'get'")) return { status: 1 };
   return { status: 0 };
 };
 runner.runCapture = (command) => {
@@ -1559,12 +1562,13 @@ const { setupInference } = require(${onboardPath});
 
     assert.equal(result.status, 0, result.stderr);
     const commands = JSON.parse(result.stdout.trim().split("\n").pop());
-    assert.equal(commands.length, 3);
+    assert.equal(commands.length, 4);
     assert.match(commands[0].command, /gateway' 'select' 'nemoclaw'/);
-    assert.match(commands[1].command, /'--type' 'anthropic'/);
-    assert.match(commands[1].command, /'--credential' 'ANTHROPIC_API_KEY'/);
-    assert.doesNotMatch(commands[1].command, /sk-ant-secret-value/);
-    assert.match(commands[2].command, /'--provider' 'anthropic-prod'/);
+    assert.match(commands[1].command, /'provider' 'get'/);
+    assert.match(commands[2].command, /'--type' 'anthropic'/);
+    assert.match(commands[2].command, /'--credential' 'ANTHROPIC_API_KEY'/);
+    assert.doesNotMatch(commands[2].command, /sk-ant-secret-value/);
+    assert.match(commands[3].command, /'--provider' 'anthropic-prod'/);
   });
 
   it("updates OpenAI-compatible providers without passing an unsupported --type flag", () => {
@@ -1586,11 +1590,9 @@ const runner = require(${runnerPath});
 const registry = require(${registryPath});
 
 const commands = [];
-let callIndex = 0;
 runner.run = (command, opts = {}) => {
   commands.push({ command, env: opts.env || null });
-  callIndex += 1;
-  return { status: callIndex === 2 ? 1 : 0 };
+  return { status: 0 };
 };
 runner.runCapture = (command) => {
   if (command.includes("inference") && command.includes("get")) {
@@ -1635,7 +1637,7 @@ const { setupInference } = require(${onboardPath});
     const commands = JSON.parse(result.stdout.trim().split("\n").pop());
     assert.equal(commands.length, 4);
     assert.match(commands[0].command, /gateway' 'select' 'nemoclaw'/);
-    assert.match(commands[1].command, /provider' 'create'/);
+    assert.match(commands[1].command, /'provider' 'get'/);
     assert.match(commands[2].command, /provider' 'update' 'openai-api'/);
     assert.doesNotMatch(commands[2].command, /'--type'/);
     assert.match(commands[3].command, /inference' 'set' '--no-verify'/);
@@ -1811,17 +1813,17 @@ const { setupInference } = require(${onboardPath});
     assert.match(recoverySource, /local curl invocation error/);
   });
 
-  it("suppresses expected provider-create AlreadyExists noise when update succeeds", () => {
+  it("checks provider existence before create/update to avoid AlreadyExists noise (#1155)", () => {
     const source = fs.readFileSync(
       path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
       "utf-8",
     );
 
-    assert.match(source, /stdio: \["ignore", "pipe", "pipe"\]/);
-    // upsertProvider must NOT have its own console.log for Created/Updated —
-    // runner passthrough handles output, so duplicating it causes #1506.
-    assert.doesNotMatch(source, /console\.log\(`✓ Created provider \$\{name\}`\)/);
-    assert.doesNotMatch(source, /console\.log\(`✓ Updated provider \$\{name\}`\)/);
+    // upsertProvider must check existence first so it never triggers AlreadyExists.
+    assert.match(source, /providerExistsInGateway\(name\)/);
+    assert.match(source, /exists \? "update" : "create"/);
+    // Only one openshell call should be made (no create-then-update fallback).
+    assert.match(source, /const result = runOpenshell\(args, runOpts\)/);
   });
 
   it("starts the sandbox step before prompting for the sandbox name", () => {
@@ -1951,8 +1953,9 @@ const { setupInference } = require(${onboardPath});
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim().split("\n").pop());
     assert.equal(payload.openai, "sk-stored-secret");
-    assert.equal(payload.commands[1].env.OPENAI_API_KEY, "sk-stored-secret");
-    assert.doesNotMatch(payload.commands[1].command, /sk-stored-secret/);
+    // commands[0]=gateway select, [1]=provider get, [2]=provider update
+    assert.equal(payload.commands[2].env.OPENAI_API_KEY, "sk-stored-secret");
+    assert.doesNotMatch(payload.commands[2].command, /sk-stored-secret/);
   });
 
   it("drops stale local sandbox registry entries when the live sandbox is gone", () => {
@@ -2231,6 +2234,8 @@ const { EventEmitter } = require("node:events");
 const commands = [];
 runner.run = (command, opts = {}) => {
   commands.push({ command, env: opts.env || null });
+  // provider-get returns not-found so messaging providers are created fresh
+  if (command.includes("'provider' 'get'")) return { status: 1 };
   return { status: 0 };
 };
 runner.runCapture = (command) => {
@@ -2526,9 +2531,11 @@ const { createSandbox } = require(${onboardPath});
         "should NOT delete sandbox when providers already exist in gateway",
       );
 
-      // Providers should still be upserted on reuse (credential refresh)
+      // Providers should still be upserted on reuse (credential refresh).
+      // Since the mock reports providers as existing (run returns status 0),
+      // upsertProvider issues 'update' rather than 'create'.
       const providerUpserts = payload.commands.filter((entry) =>
-        entry.command.includes("'provider' 'create'"),
+        entry.command.includes("'provider' 'update'"),
       );
       assert.ok(
         providerUpserts.some((e) => e.command.includes("my-assistant-discord-bridge")),
@@ -3071,6 +3078,8 @@ const runner = require(${runnerPath});
 const commands = [];
 runner.run = (command, opts = {}) => {
   commands.push(command);
+  // First call is provider-get (not found), second is provider-create (success)
+  if (command.includes("'provider' 'get'")) return { status: 1, stdout: "", stderr: "" };
   return { status: 0, stdout: "", stderr: "" };
 };
 const { upsertProvider } = require(${onboardPath});
@@ -3088,9 +3097,10 @@ console.log(JSON.stringify({ result, commands }));
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim().split("\n").pop());
     assert.deepEqual(payload.result, { ok: true });
-    assert.equal(payload.commands.length, 1);
-    assert.match(payload.commands[0], /'provider' 'create' '--name' 'discord-bridge'/);
-    assert.match(payload.commands[0], /'--credential' 'DISCORD_BOT_TOKEN'/);
+    assert.equal(payload.commands.length, 2);
+    assert.match(payload.commands[0], /'provider' 'get'/);
+    assert.match(payload.commands[1], /'provider' 'create' '--name' 'discord-bridge'/);
+    assert.match(payload.commands[1], /'--credential' 'DISCORD_BOT_TOKEN'/);
   });
 
   it("upsertProvider does not add its own log line on top of runner output (#1506)", () => {
@@ -3109,6 +3119,8 @@ console.log(JSON.stringify({ result, commands }));
     const script = `
 const runner = require(${runnerPath});
 runner.run = (command, opts = {}) => {
+  // First call is provider-get (not found)
+  if (command.includes("'provider' 'get'")) return { status: 1, stdout: "", stderr: "" };
   // Simulate runner passthrough: writeRedactedResult writes stdout to terminal
   process.stdout.write("✓ Created provider test-bridge\\n");
   return { status: 0, stdout: "✓ Created provider test-bridge", stderr: "" };
@@ -3131,7 +3143,7 @@ upsertProvider("test-bridge", "generic", "TEST_TOKEN", null, { TEST_TOKEN: "tok"
     assert.equal(lines.length, 1, `Expected 1 log line but got ${lines.length}: ${result.stdout}`);
   });
 
-  it("upsertProvider falls back to update when create fails", () => {
+  it("upsertProvider updates existing provider instead of creating (#1155)", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-upsert-provider-update-"));
     const fakeBin = path.join(tmpDir, "bin");
@@ -3147,14 +3159,10 @@ upsertProvider("test-bridge", "generic", "TEST_TOKEN", null, { TEST_TOKEN: "tok"
     const script = `
 const runner = require(${runnerPath});
 const commands = [];
-let callCount = 0;
 runner.run = (command, opts = {}) => {
   commands.push(command);
-  callCount++;
-  // First call (create) fails, second call (update) succeeds
-  return callCount === 1
-    ? { status: 1, stdout: "", stderr: "already exists" }
-    : { status: 0, stdout: "", stderr: "" };
+  // provider-get succeeds (provider exists), then update succeeds
+  return { status: 0, stdout: "", stderr: "" };
 };
 const { upsertProvider } = require(${onboardPath});
 const result = upsertProvider("inference", "openai", "NVIDIA_API_KEY", "https://integrate.api.nvidia.com/v1");
@@ -3172,7 +3180,7 @@ console.log(JSON.stringify({ result, commands }));
     const payload = JSON.parse(result.stdout.trim().split("\n").pop());
     assert.deepEqual(payload.result, { ok: true });
     assert.equal(payload.commands.length, 2);
-    assert.match(payload.commands[0], /'provider' 'create'/);
+    assert.match(payload.commands[0], /'provider' 'get'/);
     assert.match(payload.commands[1], /'provider' 'update'/);
     assert.match(
       payload.commands[1],
@@ -3180,7 +3188,7 @@ console.log(JSON.stringify({ result, commands }));
     );
   });
 
-  it("upsertProvider returns error details when both create and update fail", () => {
+  it("upsertProvider returns error details when create or update fails", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-upsert-provider-fail-"));
     const fakeBin = path.join(tmpDir, "bin");
@@ -3196,6 +3204,8 @@ console.log(JSON.stringify({ result, commands }));
     const script = `
 const runner = require(${runnerPath});
 runner.run = (command, opts = {}) => {
+  // provider-get says not found, then create fails
+  if (command.includes("'provider' 'get'")) return { status: 1, stdout: "", stderr: "" };
   return { status: 1, stdout: "", stderr: "gateway unreachable" };
 };
 const { upsertProvider } = require(${onboardPath});
@@ -3656,7 +3666,8 @@ const { setupInference } = require(${onboardPath});
 
     assert.equal(result.status, 0, result.stderr);
     const commands = JSON.parse(result.stdout.trim().split("\n").pop());
-    assert.equal(commands.length, 3);
+    // gateway select + provider get + provider update + inference set
+    assert.equal(commands.length, 4);
   });
 
   it("accepts gateway inference output that omits the Route line", () => {
@@ -3725,7 +3736,8 @@ const { setupInference } = require(${onboardPath});
 
     assert.equal(result.status, 0, result.stderr);
     const commands = JSON.parse(result.stdout.trim().split("\n").pop());
-    assert.equal(commands.length, 3);
+    // gateway select + provider get + provider update + inference set
+    assert.equal(commands.length, 4);
   });
 
   it(
@@ -3760,6 +3772,8 @@ const { EventEmitter } = require("node:events");
 const commands = [];
 runner.run = (command, opts = {}) => {
   commands.push({ command, env: opts.env || null });
+  // provider-get returns not-found so messaging providers are created fresh
+  if (command.includes("'provider' 'get'")) return { status: 1 };
   return { status: 0 };
 };
 runner.runCapture = (command) => {


### PR DESCRIPTION
…Exists error

Replace the create-then-update fallback in upsertProvider with a check-first approach using providerExistsInGateway. This prevents the confusing gRPC AlreadyExists error from leaking to the terminal during re-onboarding while preserving confirmation output on first-time provider creation.

Fixes #1155

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Your Name <your-email@example.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider registration now checks existence first and performs a single create-or-update action, avoiding redundant attempts and producing clearer, focused error messages on failure.

* **Tests**
  * Test suite updated to reflect the new existence-check flow and validate the single-operation upsert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->