### PR TITLE
fix(install): read sandbox name from onboard session instead of stale registry

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -156,6 +156,23 @@ resolve_default_sandbox_name() {
   local registry_file="${HOME}/.nemoclaw/sandboxes.json"
   local sandbox_name="${NEMOCLAW_SANDBOX_NAME:-}"
 
+  # Prefer the sandbox name from the current onboard session — it reflects
+  # the sandbox just created, whereas sandboxes.json may hold a stale default
+  # from a previous gateway that no longer exists (#1839).
+  local session_file="${HOME}/.nemoclaw/onboard-session.json"
+  if [[ -z "$sandbox_name" && -f "$session_file" ]] && command_exists node; then
+    sandbox_name="$(
+      node -e '
+        const fs = require("fs");
+        try {
+          const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+          const name = data.sandboxName || "";
+          process.stdout.write(name);
+        } catch {}
+      ' "$session_file" 2>/dev/null || true
+    )"
+  fi
+
   if [[ -z "$sandbox_name" && -f "$registry_file" ]] && command_exists node; then
     sandbox_name="$(
       node -e '


### PR DESCRIPTION
## Summary

`resolve_default_sandbox_name()` reads from `~/.nemoclaw/sandboxes.json`,
which may hold a stale `defaultSandbox` entry from a previous gateway.
After re-onboarding (e.g. `colima delete` + reinstall), the installer
completion message shows the old sandbox name instead of the one just created.

## Problem

The "Next:" completion message after `curl|bash` install always reads the
default sandbox name from the local registry. When the gateway has been
rebuilt, the old entry becomes stale but is still referenced:

```
Next:
  $ nemoclaw old-sandbox connect     ← wrong: stale name from sandboxes.json
```

Running `nemoclaw old-sandbox connect` then fails with
"Sandbox 'old-sandbox' is not present in the live OpenShell gateway."

## Fix

Check `~/.nemoclaw/onboard-session.json` first — it always contains the
sandbox name from the current onboard run. Fall back to the registry
only when no session file exists. Priority order:

1. `NEMOCLAW_SANDBOX_NAME` env var (existing behavior, unchanged)
2. `onboard-session.json` → `sandboxName` (new: session-first)
3. `sandboxes.json` → `defaultSandbox` (existing fallback)
4. `"my-assistant"` (existing default)

## Test plan

- [x] Session has new sandbox + registry has stale → returns session name
- [x] No session file → falls back to registry name
- [x] `NEMOCLAW_SANDBOX_NAME` env var → overrides everything
- [x] Session exists but `sandboxName` is empty → falls through to registry
- [x] No session, no registry → returns `"my-assistant"` default
- [x] `npm run build:cli` clean
- [x] `npm run typecheck:cli` clean
- [x] `test/install-preflight.test.ts` — 56/56 pass

Closes #1839

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation process with enhanced sandbox configuration detection. The system now respects user preferences set via environment variables and remembers configuration from previous sessions. Fallback mechanisms have been refined to ensure reliable configuration discovery across various installation scenarios, providing users a more flexible and smoother overall setup experience with better backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->