### PR TITLE
fix(testing): harden gateway bind verification

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -630,9 +630,17 @@ function getGatewayClusterContainerName(gatewayName = GATEWAY_NAME) {
   return `openshell-cluster-${gatewayName}`;
 }
 
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(value = "") {
+  return String(value).replace(ANSI_RE, "");
+}
+
 function parseGatewayEndpointHost(gatewayInfoOutput = "") {
   if (typeof gatewayInfoOutput !== "string") return null;
-  const match = gatewayInfoOutput.match(/Gateway endpoint:\s+(\S+)/i);
+  const plainOutput = stripAnsi(gatewayInfoOutput);
+  const match = plainOutput.match(/Gateway endpoint:\s+(\S+)/i);
   if (!match) return null;
   try {
     return new URL(match[1]).hostname;
@@ -661,6 +669,8 @@ function isLoopbackBindHost(hostIp = "") {
   return hostIp === "127.0.0.1" || hostIp === "::1";
 }
 
+// Serializes a container inspection into an equivalent docker run command.
+// eslint-disable-next-line complexity
 function buildGatewayDockerRunCommand(inspection, hostIp) {
   const containerName = inspection?.Name?.replace(/^\//, "") || getGatewayClusterContainerName();
   const hostConfig = inspection?.HostConfig || {};

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -624,6 +624,211 @@ function hydrateCredentialEnv(envName) {
   return value || null;
 }
 
+const GATEWAY_CLUSTER_CONTAINER_PORT = "30051/tcp";
+
+function getGatewayClusterContainerName(gatewayName = GATEWAY_NAME) {
+  return `openshell-cluster-${gatewayName}`;
+}
+
+function parseGatewayEndpointHost(gatewayInfoOutput = "") {
+  if (typeof gatewayInfoOutput !== "string") return null;
+  const match = gatewayInfoOutput.match(/Gateway endpoint:\s+(\S+)/i);
+  if (!match) return null;
+  try {
+    return new URL(match[1]).hostname;
+  } catch {
+    return null;
+  }
+}
+
+function dockerInspectContainer(containerName) {
+  const raw = runCapture(`docker inspect ${shellQuote(containerName)} --format '{{json .}}'`, {
+    ignoreError: true,
+  });
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function getGatewayLoopbackBinding(inspection) {
+  return inspection?.HostConfig?.PortBindings?.[GATEWAY_CLUSTER_CONTAINER_PORT]?.[0] || null;
+}
+
+function isLoopbackBindHost(hostIp = "") {
+  return hostIp === "127.0.0.1" || hostIp === "::1";
+}
+
+function buildGatewayDockerRunCommand(inspection, hostIp) {
+  const containerName = inspection?.Name?.replace(/^\//, "") || getGatewayClusterContainerName();
+  const hostConfig = inspection?.HostConfig || {};
+  const config = inspection?.Config || {};
+  const cmdParts = ["docker", "run", "-d", "--name", containerName];
+
+  if (config.Hostname) {
+    cmdParts.push("--hostname", config.Hostname);
+  }
+  if (hostConfig.NetworkMode) {
+    cmdParts.push("--network", hostConfig.NetworkMode);
+  }
+  if (hostConfig.RestartPolicy?.Name) {
+    cmdParts.push("--restart", hostConfig.RestartPolicy.Name);
+  }
+  if (hostConfig.Privileged) {
+    cmdParts.push("--privileged");
+  }
+  for (const securityOpt of hostConfig.SecurityOpt || []) {
+    cmdParts.push("--security-opt", securityOpt);
+  }
+  for (const extraHost of hostConfig.ExtraHosts || []) {
+    cmdParts.push("--add-host", extraHost);
+  }
+  for (const bind of hostConfig.Binds || []) {
+    cmdParts.push("-v", bind);
+  }
+  for (const envPair of config.Env || []) {
+    cmdParts.push("-e", envPair);
+  }
+  for (const cap of hostConfig.CapAdd || []) {
+    cmdParts.push("--cap-add", cap);
+  }
+  for (const cap of hostConfig.CapDrop || []) {
+    cmdParts.push("--cap-drop", cap);
+  }
+  for (const dns of hostConfig.Dns || []) {
+    cmdParts.push("--dns", dns);
+  }
+  for (const dnsOption of hostConfig.DnsOptions || []) {
+    cmdParts.push("--dns-option", dnsOption);
+  }
+  for (const dnsSearch of hostConfig.DnsSearch || []) {
+    cmdParts.push("--dns-search", dnsSearch);
+  }
+  for (const device of hostConfig.Devices || []) {
+    const permissions = device?.CgroupPermissions ? `:${device.CgroupPermissions}` : "";
+    cmdParts.push("--device", `${device.PathOnHost}:${device.PathInContainer}${permissions}`);
+  }
+  if (hostConfig.DeviceRequests?.length) {
+    const hasGpuRequest = hostConfig.DeviceRequests.some(
+      (request) =>
+        Array.isArray(request?.Capabilities) &&
+        request.Capabilities.some((group) => Array.isArray(group) && group.includes("gpu")),
+    );
+    if (hasGpuRequest) {
+      cmdParts.push("--gpus", "all");
+    }
+  }
+  if (hostConfig.ReadonlyRootfs) {
+    cmdParts.push("--read-only");
+  }
+  if (hostConfig.Init) {
+    cmdParts.push("--init");
+  }
+  if (hostConfig.IpcMode && hostConfig.IpcMode !== "private") {
+    cmdParts.push("--ipc", hostConfig.IpcMode);
+  }
+  if (hostConfig.PidMode) {
+    cmdParts.push("--pid", hostConfig.PidMode);
+  }
+  if (config.User) {
+    cmdParts.push("--user", config.User);
+  }
+  if (config.WorkingDir) {
+    cmdParts.push("--workdir", config.WorkingDir);
+  }
+  if (hostConfig.ShmSize && hostConfig.ShmSize !== 67_108_864) {
+    cmdParts.push("--shm-size", String(hostConfig.ShmSize));
+  }
+
+  const portBindings = hostConfig.PortBindings || {};
+  for (const [containerPort, bindings] of Object.entries(portBindings)) {
+    for (const binding of bindings || []) {
+      const publishHost =
+        containerPort === GATEWAY_CLUSTER_CONTAINER_PORT ? hostIp : binding.HostIp;
+      const hostPort = binding.HostPort ? `${binding.HostPort}:` : "";
+      const publishTarget =
+        publishHost && publishHost.length > 0
+          ? `${publishHost}:${hostPort}${containerPort}`
+          : `${hostPort}${containerPort}`;
+      cmdParts.push("-p", publishTarget);
+    }
+  }
+
+  if (Array.isArray(config.Entrypoint) && config.Entrypoint.length === 1) {
+    cmdParts.push("--entrypoint", config.Entrypoint[0]);
+  }
+
+  cmdParts.push(config.Image);
+  if (Array.isArray(config.Cmd) && config.Cmd.length > 0) {
+    cmdParts.push(...config.Cmd);
+  }
+
+  return cmdParts.map((part) => shellQuote(part)).join(" ");
+}
+
+function waitForGatewayContainerHealthy(containerName, attempts = 30, sleepSeconds = 2) {
+  for (let i = 0; i < attempts; i++) {
+    const state = runCapture(
+      `docker inspect ${shellQuote(containerName)} --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'`,
+      { ignoreError: true },
+    );
+    if (state === "healthy" || state === "running") {
+      return true;
+    }
+    sleep(sleepSeconds);
+  }
+  return false;
+}
+
+function enforceLoopbackGatewayBinding(gatewayName = GATEWAY_NAME, gatewayInfoOutput = null) {
+  const gatewayInfo =
+    gatewayInfoOutput ??
+    runCaptureOpenshell(["gateway", "info", "-g", gatewayName], {
+      ignoreError: true,
+    });
+  const endpointHost = parseGatewayEndpointHost(gatewayInfo);
+  if (!endpointHost || !isLoopbackHostname(endpointHost)) {
+    return false;
+  }
+
+  const containerName = getGatewayClusterContainerName(gatewayName);
+  const inspection = dockerInspectContainer(containerName);
+  if (!inspection) {
+    return false;
+  }
+  const binding = getGatewayLoopbackBinding(inspection);
+  if (!binding?.HostPort || isLoopbackBindHost(binding.HostIp)) {
+    return false;
+  }
+
+  console.log(
+    `  Securing OpenShell gateway port ${binding.HostPort} to loopback only (${binding.HostIp || "0.0.0.0"} -> 127.0.0.1)...`,
+  );
+  run(`docker stop ${shellQuote(containerName)} >/dev/null 2>&1 || true`, {
+    ignoreError: true,
+    suppressOutput: true,
+  });
+  run(`docker rm ${shellQuote(containerName)} >/dev/null 2>&1 || true`, {
+    ignoreError: true,
+    suppressOutput: true,
+  });
+  const recreateCommand = buildGatewayDockerRunCommand(inspection, "127.0.0.1");
+  const recreateResult = run(recreateCommand, {
+    ignoreError: true,
+    suppressOutput: true,
+  });
+  if (recreateResult.status !== 0) {
+    throw new Error("Could not recreate the OpenShell gateway container with a loopback-only bind");
+  }
+  if (!waitForGatewayContainerHealthy(containerName)) {
+    throw new Error("Recreated OpenShell gateway container did not become healthy");
+  }
+  console.log("  ✓ OpenShell gateway is now bound to 127.0.0.1 only");
+  return true;
+}
+
 function getCurlTimingArgs() {
   return ["--connect-timeout", "10", "--max-time", "60"];
 }
@@ -2210,6 +2415,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
   if (isGatewayHealthy(gatewayStatus, gwInfo, activeGatewayInfo)) {
     console.log("  ✓ Reusing existing gateway");
     runOpenshell(["gateway", "select", GATEWAY_NAME], { ignoreError: true });
+    enforceLoopbackGatewayBinding(GATEWAY_NAME, gwInfo || activeGatewayInfo);
     process.env.OPENSHELL_GATEWAY = GATEWAY_NAME;
     return;
   }
@@ -2301,6 +2507,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
   }
 
   console.log("  ✓ Gateway is healthy");
+  enforceLoopbackGatewayBinding(GATEWAY_NAME);
 
   // CoreDNS fix — k3s-inside-Docker has broken DNS forwarding on all platforms.
   const runtime = getContainerRuntime();
@@ -2340,6 +2547,7 @@ async function recoverGatewayRuntime() {
   runOpenshell(["gateway", "select", GATEWAY_NAME], { ignoreError: true });
   let status = runCaptureOpenshell(["status"], { ignoreError: true });
   if (status.includes("Connected") && isSelectedGateway(status)) {
+    enforceLoopbackGatewayBinding(GATEWAY_NAME);
     process.env.OPENSHELL_GATEWAY = GATEWAY_NAME;
     return true;
   }
@@ -2366,6 +2574,7 @@ async function recoverGatewayRuntime() {
     status = runCaptureOpenshell(["status"], { ignoreError: true });
     if (status.includes("Connected") && isSelectedGateway(status)) {
       process.env.OPENSHELL_GATEWAY = GATEWAY_NAME;
+      enforceLoopbackGatewayBinding(GATEWAY_NAME);
       const runtime = getContainerRuntime();
       if (shouldPatchCoredns(runtime)) {
         run(`bash "${path.join(SCRIPTS, "fix-coredns.sh")}" ${GATEWAY_NAME} 2>&1 || true`, {
@@ -4159,7 +4368,9 @@ module.exports = {
   copyBuildContextDir,
   classifySandboxCreateFailure,
   createSandbox,
+  enforceLoopbackGatewayBinding,
   getFutureShellPathHint,
+  getGatewayClusterContainerName,
   getGatewayStartEnv,
   getGatewayReuseState,
   getSandboxInferenceConfig,
@@ -4167,6 +4378,7 @@ module.exports = {
   getRequestedModelHint,
   getRequestedProviderHint,
   getStableGatewayImageRef,
+  parseGatewayEndpointHost,
   getResumeConfigConflicts,
   isGatewayHealthy,
   hasStaleGateway,

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -107,17 +107,27 @@ Add the `export` line to your `~/.bashrc` or `~/.zshrc` to make it permanent, th
 
 ### Port already in use
 
-The NemoClaw gateway uses port `18789` by default.
-If another process is already bound to this port, onboarding fails.
+The local NemoClaw/OpenShell runtime uses:
+
+- gateway: `8080` on `127.0.0.1`
+- dashboard: `18789`
+
+If another process is already bound to either port, onboarding fails.
 Identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```console
+$ sudo lsof -i :8080
 $ sudo lsof -i :18789
 $ kill <PID>
 ```
 
 If the process does not exit, use `kill -9 <PID>` to force-terminate it.
 Then retry onboarding.
+
+For local gateways, NemoClaw expects the OpenShell gateway to stay bound to
+`127.0.0.1:8080`. During gateway reuse and recovery, NemoClaw now repairs any
+accidental `0.0.0.0:8080` bind back to loopback automatically when the gateway
+metadata advertises a loopback endpoint.
 
 ## Onboarding
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ export default [
       "nemoclaw/**",
       "node_modules/**",
       "docs/_build/**",
+      "dist/**",
     ],
   },
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -837,7 +837,7 @@ is_source_checkout() {
     return 1
   fi
 
-  if [[ -n "${NEMOCLAW_REPO_ROOT:-}" || -d "${repo_root}/.git" ]]; then
+  if [[ -n "${NEMOCLAW_REPO_ROOT:-}" || -e "${repo_root}/.git" ]]; then
     return 0
   fi
 

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -285,7 +285,7 @@ else
   fail "Second onboard exited $exit2 (expected 0)"
 fi
 
-if grep -q "Reusing existing NemoClaw gateway" <<<"$output2"; then
+if grep -Eq "Reusing (existing|healthy) (NemoClaw )?gateway|\[reuse\] Skipping gateway \(running\)" <<<"$output2"; then
   pass "Healthy gateway reused on second onboard"
 else
   fail "Healthy gateway was not reused on second onboard"
@@ -325,7 +325,7 @@ else
   fail "Third onboard exited $exit3 (expected 0)"
 fi
 
-if grep -q "Reusing existing NemoClaw gateway" <<<"$output3"; then
+if grep -Eq "Reusing (existing|healthy) (NemoClaw )?gateway|\[reuse\] Skipping gateway \(running\)" <<<"$output3"; then
   pass "Healthy gateway reused on third onboard"
 else
   fail "Healthy gateway was not reused on third onboard"

--- a/test/install-preflight.test.js
+++ b/test/install-preflight.test.js
@@ -212,7 +212,7 @@ exit 98
     });
 
     expect(result.status).toBe(0);
-    const gitCalls = fs.readFileSync(gitLog, "utf-8");
+    const gitCalls = fs.existsSync(gitLog) ? fs.readFileSync(gitLog, "utf-8") : "";
     expect(gitCalls).not.toMatch(/clone/);
     expect(gitCalls).not.toMatch(/fetch/);
   }, 60_000);
@@ -1203,7 +1203,7 @@ fi`,
     });
 
     expect(result.status).toBe(0);
-    const gitCalls = fs.readFileSync(gitLog, "utf-8");
+    const gitCalls = fs.existsSync(gitLog) ? fs.readFileSync(gitLog, "utf-8") : "";
     expect(gitCalls).not.toMatch(/clone/);
     expect(gitCalls).not.toMatch(/fetch/);
   });
@@ -1316,6 +1316,29 @@ describe("installer pure helpers", () => {
   it("is_source_checkout: accepts an explicit source checkout with git metadata", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-checkout-git-"));
     fs.mkdirSync(path.join(tmp, ".git"));
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
+    );
+    const r = spawnSync(
+      "bash",
+      [
+        "-c",
+        `source "${INSTALLER}" 2>/dev/null; is_source_checkout "${tmp}" && echo yes || echo no`,
+      ],
+      {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: { HOME: tmp, PATH: TEST_SYSTEM_PATH },
+      },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("yes");
+  });
+
+  it("is_source_checkout: accepts a git worktree .git file", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-checkout-worktree-"));
+    fs.writeFileSync(path.join(tmp, ".git"), "gitdir: /tmp/nemoclaw/worktrees/example\n");
     fs.writeFileSync(
       path.join(tmp, "package.json"),
       JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
@@ -1717,7 +1740,7 @@ exit 0`,
     });
 
     expect(result.status).toBe(0);
-    const gitCalls = fs.readFileSync(gitLog, "utf-8");
+    const gitCalls = fs.existsSync(gitLog) ? fs.readFileSync(gitLog, "utf-8") : "";
     expect(gitCalls).not.toMatch(/clone/);
     expect(gitCalls).not.toMatch(/fetch/);
   });
@@ -1764,7 +1787,7 @@ exit 0`,
     });
 
     expect(result.status).toBe(0);
-    const gitCalls = fs.readFileSync(gitLog, "utf-8");
+    const gitCalls = fs.existsSync(gitLog) ? fs.readFileSync(gitLog, "utf-8") : "";
     expect(gitCalls).not.toMatch(/clone/);
     expect(gitCalls).not.toMatch(/fetch/);
     expect(`${result.stdout}${result.stderr}`).not.toMatch(/curl should not hit the releases API/);

--- a/test/onboard.gateway-bind.test.js
+++ b/test/onboard.gateway-bind.test.js
@@ -40,7 +40,7 @@ describe("gateway loopback binding hardening", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
     const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
-    const inspectPayload = JSON.stringify({
+    const inspectPayload = {
       Name: "/openshell-cluster-nemoclaw",
       Config: {
         Image: "ghcr.io/nvidia/openshell/cluster:0.0.23",
@@ -64,7 +64,7 @@ describe("gateway loopback binding hardening", () => {
         ExtraHosts: ["host.docker.internal:host-gateway"],
         Binds: ["openshell-cluster-nemoclaw:/var/lib/rancher/k3s"],
       },
-    });
+    };
 
     const script = String.raw`
 const runner = require(${runnerPath});
@@ -81,7 +81,7 @@ runner.runCapture = (command) => {
     return "Gateway Info\n\n  Gateway: nemoclaw\n  Gateway endpoint: https://127.0.0.1:8080";
   }
   if (command.includes("docker inspect") && command.includes("{{json .}}")) {
-    return ${inspectPayload};
+    return ${JSON.stringify(JSON.stringify(inspectPayload))};
   }
   if (command.includes("docker inspect") && command.includes("State.Health")) {
     return "healthy";
@@ -106,28 +106,32 @@ const { startGatewayForRecovery } = require(${onboardPath});
 
     const result = runNodeScript(script);
     expect(result.status).toBe(0);
-    const commands = JSON.parse(result.stdout.trim().split("\n").pop());
-    expect(
-      commands.some((entry) => entry.includes("'docker' 'stop' 'openshell-cluster-nemoclaw'")),
-    ).toBe(true);
-    expect(
-      commands.some((entry) => entry.includes("'docker' 'rm' 'openshell-cluster-nemoclaw'")),
-    ).toBe(true);
-    expect(
-      commands.some(
-        (entry) =>
-          entry.includes("'docker' 'run'") &&
-          entry.includes("'-p' '127.0.0.1:8080:30051/tcp'") &&
-          entry.includes("'ghcr.io/nvidia/openshell/cluster:0.0.23'"),
-      ),
-    ).toBe(true);
+    expect(result.stdout).toContain("docker stop 'openshell-cluster-nemoclaw'");
+    expect(result.stdout).toContain("docker rm 'openshell-cluster-nemoclaw'");
+    expect(result.stdout).toContain("'-p' '127.0.0.1:8080:30051/tcp'");
+    expect(result.stdout).toContain("'ghcr.io/nvidia/openshell/cluster:0.0.23'");
+  });
+
+  it("parses colored gateway info output before enforcing loopback binding", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+
+    const script = String.raw`
+const { parseGatewayEndpointHost } = require(${onboardPath});
+const sample = "\u001b[1m\u001b[36mGateway Info\u001b[39m\u001b[0m\n\n  \u001b[2mGateway:\u001b[0m nemoclaw\n  \u001b[2mGateway endpoint:\u001b[0m https://127.0.0.1:8080\n";
+console.log(parseGatewayEndpointHost(sample) || "null");
+`;
+
+    const result = runNodeScript(script);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("127.0.0.1");
   });
 
   it("skips the rebind when the gateway endpoint is not loopback", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
     const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
-    const inspectPayload = JSON.stringify({
+    const inspectPayload = {
       Name: "/openshell-cluster-nemoclaw",
       Config: {
         Image: "ghcr.io/nvidia/openshell/cluster:0.0.23",
@@ -137,7 +141,7 @@ const { startGatewayForRecovery } = require(${onboardPath});
           "30051/tcp": [{ HostIp: "0.0.0.0", HostPort: "8080" }],
         },
       },
-    });
+    };
 
     const script = String.raw`
 const runner = require(${runnerPath});
@@ -145,7 +149,7 @@ const commands = [];
 
 runner.runCapture = (command) => {
   if (command.includes("docker inspect") && command.includes("{{json .}}")) {
-    return ${inspectPayload};
+    return ${JSON.stringify(JSON.stringify(inspectPayload))};
   }
   return "";
 };

--- a/test/onboard.gateway-bind.test.js
+++ b/test/onboard.gateway-bind.test.js
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function writeFakeOpenshell(binDir) {
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+    mode: 0o755,
+  });
+}
+
+function runNodeScript(script, extraEnv = {}) {
+  const repoRoot = path.join(import.meta.dirname, "..");
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-bind-"));
+  const fakeBin = path.join(tmpDir, "bin");
+  const scriptPath = path.join(tmpDir, "script.js");
+  writeFakeOpenshell(fakeBin);
+  fs.writeFileSync(scriptPath, script);
+  const result = spawnSync(process.execPath, [scriptPath], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      HOME: tmpDir,
+      PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      ...extraEnv,
+    },
+  });
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  return result;
+}
+
+describe("gateway loopback binding hardening", () => {
+  it("rebinds a localhost gateway container to 127.0.0.1 during recovery", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
+    const inspectPayload = JSON.stringify({
+      Name: "/openshell-cluster-nemoclaw",
+      Config: {
+        Image: "ghcr.io/nvidia/openshell/cluster:0.0.23",
+        Hostname: "openshell-nemoclaw",
+        Env: [
+          "OPENSHELL_NODE_NAME=openshell-nemoclaw",
+          "IMAGE_TAG=0.0.23",
+          "REGISTRY_MODE=external",
+        ],
+        Cmd: ["server", "--disable=traefik", "--tls-san=127.0.0.1"],
+        Entrypoint: ["/usr/local/bin/cluster-entrypoint.sh"],
+      },
+      HostConfig: {
+        NetworkMode: "openshell-cluster-nemoclaw",
+        PortBindings: {
+          "30051/tcp": [{ HostIp: "0.0.0.0", HostPort: "8080" }],
+        },
+        RestartPolicy: { Name: "unless-stopped" },
+        Privileged: true,
+        SecurityOpt: ["label=disable"],
+        ExtraHosts: ["host.docker.internal:host-gateway"],
+        Binds: ["openshell-cluster-nemoclaw:/var/lib/rancher/k3s"],
+      },
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const commands = [];
+
+runner.runCapture = (command) => {
+  if (command.includes("'status'")) {
+    return "Server Status\n\n  Gateway: nemoclaw\n  Server: https://127.0.0.1:8080\n  Status: Connected";
+  }
+  if (command.includes("'gateway' 'info' '-g' 'nemoclaw'")) {
+    return "Gateway Info\n\n  Gateway: nemoclaw\n  Gateway endpoint: https://127.0.0.1:8080";
+  }
+  if (command.includes("'gateway' 'info'")) {
+    return "Gateway Info\n\n  Gateway: nemoclaw\n  Gateway endpoint: https://127.0.0.1:8080";
+  }
+  if (command.includes("docker inspect") && command.includes("{{json .}}")) {
+    return ${inspectPayload};
+  }
+  if (command.includes("docker inspect") && command.includes("State.Health")) {
+    return "healthy";
+  }
+  return "";
+};
+runner.run = (command) => {
+  commands.push(command);
+  return { status: 0 };
+};
+
+const { startGatewayForRecovery } = require(${onboardPath});
+
+(async () => {
+  await startGatewayForRecovery();
+  console.log(JSON.stringify(commands));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+
+    const result = runNodeScript(script);
+    expect(result.status).toBe(0);
+    const commands = JSON.parse(result.stdout.trim().split("\n").pop());
+    expect(
+      commands.some((entry) => entry.includes("'docker' 'stop' 'openshell-cluster-nemoclaw'")),
+    ).toBe(true);
+    expect(
+      commands.some((entry) => entry.includes("'docker' 'rm' 'openshell-cluster-nemoclaw'")),
+    ).toBe(true);
+    expect(
+      commands.some(
+        (entry) =>
+          entry.includes("'docker' 'run'") &&
+          entry.includes("'-p' '127.0.0.1:8080:30051/tcp'") &&
+          entry.includes("'ghcr.io/nvidia/openshell/cluster:0.0.23'"),
+      ),
+    ).toBe(true);
+  });
+
+  it("skips the rebind when the gateway endpoint is not loopback", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "bin", "lib", "runner.js"));
+    const inspectPayload = JSON.stringify({
+      Name: "/openshell-cluster-nemoclaw",
+      Config: {
+        Image: "ghcr.io/nvidia/openshell/cluster:0.0.23",
+      },
+      HostConfig: {
+        PortBindings: {
+          "30051/tcp": [{ HostIp: "0.0.0.0", HostPort: "8080" }],
+        },
+      },
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const commands = [];
+
+runner.runCapture = (command) => {
+  if (command.includes("docker inspect") && command.includes("{{json .}}")) {
+    return ${inspectPayload};
+  }
+  return "";
+};
+runner.run = (command) => {
+  commands.push(command);
+  return { status: 0 };
+};
+
+const { enforceLoopbackGatewayBinding } = require(${onboardPath});
+const repaired = enforceLoopbackGatewayBinding(
+  "nemoclaw",
+  "Gateway Info\n\n  Gateway: nemoclaw\n  Gateway endpoint: https://host.docker.internal:8080",
+);
+
+console.log(JSON.stringify({ repaired, commands }));
+`;
+
+    const result = runNodeScript(script);
+    expect(result.status).toBe(0);
+    const payload = JSON.parse(result.stdout.trim().split("\n").pop());
+    expect(payload.repaired).toBe(false);
+    expect(payload.commands).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- harden gateway endpoint parsing so loopback enforcement works with ANSI-colored openshell output
- make source checkout detection accept git worktrees
- align the double-onboard lifecycle E2E with current gateway reuse messaging
- keep root lint clean by ignoring generated dist artifacts

## Testing
- npm run test
- npm run lint
- npm run format:check
- npm run build:cli
- npm run typecheck:cli
- npm run typecheck
- cd nemoclaw && npm run check
- cd nemoclaw && npm run build
- bash test/e2e/e2e-cloud-experimental/check-docs.sh --local-only
- NEMOCLAW_E2E_NO_TIMEOUT=1 bash test/e2e/test-double-onboard.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gateway port binding is now automatically enforced to localhost only for local deployments.

* **Bug Fixes**
  * Improved Git repository detection to support Git worktrees.

* **Documentation**
  * Updated port conflict troubleshooting guide with current port mappings and automatic repair guidance.

* **Tests**
  * Added comprehensive test coverage for gateway binding enforcement and improved existing test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->