### PR TITLE
docs: add Windows prerequisites page and WSL troubleshooting

### DIFF
--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "nemoclaw-user-get-started"
-description: "Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when onboarding, installing, or launching a NemoClaw sandbox for the first time. Windows-only prerequisites before the Quickstart. Enables WSL 2, installs Ubuntu, and configures Docker Desktop with the WSL 2 backend. Use when installing NemoClaw on Windows, setting up WSL, or troubleshooting Windows-specific prerequisites."
+description: "Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when onboarding, installing, or launching a NemoClaw sandbox for the first time. There are additional Windows-only prerequisites before the Quickstart to install NemoClaw on Windows."
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -13,9 +13,6 @@ Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when
 ## Prerequisites
 
 Before getting started, check the prerequisites to ensure you have the necessary software and hardware to run NemoClaw.
-
-- Windows 10 (build 19041 or later) or Windows 11.
-- Hardware requirements are the same as the Quickstart (see the `nemoclaw-user-get-started` skill).
 
 > **Alpha software:** NemoClaw is in alpha, available as an early preview since March 16, 2026.
 > APIs, configuration schemas, and runtime behavior are subject to breaking changes between releases.
@@ -93,89 +90,9 @@ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uni
 
 For troubleshooting installation or onboarding issues, see the Troubleshooting guide (see the `nemoclaw-user-reference` skill).
 
----
+## Reference
 
-NemoClaw runs inside Windows Subsystem for Linux (WSL 2) on Windows.
-Complete these steps before following the Quickstart (see the `nemoclaw-user-get-started` skill).
-Linux and macOS users do not need this page and can go directly to the Quickstart.
-
-> **Note:** This guide has been tested on x86-64.
-
-## Step 4: Enable WSL 2
-
-Open an elevated PowerShell (Run as Administrator):
-
-```console
-$ wsl --install --no-distribution
-```
-
-This enables both the Windows Subsystem for Linux and Virtual Machine Platform features.
-
-Reboot if prompted.
-
-## Step 5: Install and Register Ubuntu
-
-After reboot, open an elevated PowerShell again:
-
-```console
-$ wsl --install -d Ubuntu
-```
-
-Let the distribution launch and complete first-run setup (pick a Unix username and password), then type `exit` to return to PowerShell.
-
-> **Warning:** Do not use the `--no-launch` flag.
-> The `--no-launch` flag downloads the package but does not register the distribution with WSL.
-> Commands like `wsl -d Ubuntu` fail with "There is no distribution with the supplied name" until the distribution has been launched at least once.
-
-Verify the distribution is registered and running WSL 2:
-
-```console
-$ wsl -l -v
-```
-
-Expected output:
-
-```text
-  NAME      STATE           VERSION
-* Ubuntu    Running         2
-```
-
-## Step 6: Install Docker Desktop
-
-Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) with the WSL 2 backend (the default on Windows 11).
-
-After installation, open Docker Desktop Settings and confirm that WSL integration is enabled for your Ubuntu distribution (Settings > Resources > WSL integration).
-
-Verify from inside WSL:
-
-```console
-$ wsl
-$ docker info
-```
-
-`docker info` prints server information.
-If you see "Cannot connect to the Docker daemon", confirm that Docker Desktop is running and that WSL integration is enabled.
-
-## Step 7: Set Up Local Inference with Ollama (Optional)
-
-If you plan to select Ollama as your inference provider during onboarding, install it inside WSL before running the NemoClaw installer:
-
-```console
-$ curl -fsSL https://ollama.com/install.sh | sh
-```
-
-If Ollama is also running on the Windows side, quit it before running `nemoclaw onboard` (system tray > right-click > Quit).
-The Windows and WSL instances bind to the same port and conflict.
-
-The onboarding process starts Ollama in WSL if it is not already running.
-You can also start it yourself beforehand with `ollama serve`.
-
-## Step 8: Next Step
-
-Your Windows environment is ready.
-Open a WSL terminal (type `wsl` in PowerShell, or open Ubuntu from Windows Terminal) and continue with the Quickstart (see the `nemoclaw-user-get-started` skill) to install NemoClaw and launch your first sandbox.
-
-All NemoClaw commands run inside WSL, not in PowerShell.
+- [Windows Prerequisites for NemoClaw](references/windows-setup.md)
 
 ## Related Skills
 

--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -100,7 +100,6 @@ Complete these steps before following the Quickstart (see the `nemoclaw-user-get
 Linux and macOS users do not need this page and can go directly to the Quickstart.
 
 > **Note:** This guide has been tested on x86-64.
-> The installation process may differ on Windows on Arm (WoA).
 
 ## Step 4: Enable WSL 2
 

--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "nemoclaw-user-get-started"
-description: "Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when onboarding, installing, or launching a NemoClaw sandbox for the first time."
+description: "Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when onboarding, installing, or launching a NemoClaw sandbox for the first time. Windows-only prerequisites before the Quickstart. Enables WSL 2, installs Ubuntu, and configures Docker Desktop with the WSL 2 backend. Use when installing NemoClaw on Windows, setting up WSL, or troubleshooting Windows-specific prerequisites."
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -13,6 +13,9 @@ Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when
 ## Prerequisites
 
 Before getting started, check the prerequisites to ensure you have the necessary software and hardware to run NemoClaw.
+
+- Windows 10 (build 19041 or later) or Windows 11.
+- Hardware requirements are the same as the Quickstart (see the `nemoclaw-user-get-started` skill).
 
 > **Alpha software:** NemoClaw is in alpha, available as an early preview since March 16, 2026.
 > APIs, configuration schemas, and runtime behavior are subject to breaking changes between releases.
@@ -89,6 +92,91 @@ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uni
 | `--delete-models`  | Also remove NemoClaw-pulled Ollama models.           |
 
 For troubleshooting installation or onboarding issues, see the Troubleshooting guide (see the `nemoclaw-user-reference` skill).
+
+---
+
+NemoClaw runs inside Windows Subsystem for Linux (WSL 2) on Windows.
+Complete these steps before following the Quickstart (see the `nemoclaw-user-get-started` skill).
+Linux and macOS users do not need this page and can go directly to the Quickstart.
+
+> **Note:** This guide has been tested on x86-64.
+> The installation process may differ on Windows on Arm (WoA).
+
+## Step 4: Enable WSL 2
+
+Open an elevated PowerShell (Run as Administrator):
+
+```console
+$ wsl --install --no-distribution
+```
+
+This enables both the Windows Subsystem for Linux and Virtual Machine Platform features.
+
+Reboot if prompted.
+
+## Step 5: Install and Register Ubuntu
+
+After reboot, open an elevated PowerShell again:
+
+```console
+$ wsl --install -d Ubuntu
+```
+
+Let the distribution launch and complete first-run setup (pick a Unix username and password), then type `exit` to return to PowerShell.
+
+> **Warning:** Do not use the `--no-launch` flag.
+> The `--no-launch` flag downloads the package but does not register the distribution with WSL.
+> Commands like `wsl -d Ubuntu` fail with "There is no distribution with the supplied name" until the distribution has been launched at least once.
+
+Verify the distribution is registered and running WSL 2:
+
+```console
+$ wsl -l -v
+```
+
+Expected output:
+
+```text
+  NAME      STATE           VERSION
+* Ubuntu    Running         2
+```
+
+## Step 6: Install Docker Desktop
+
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) with the WSL 2 backend (the default on Windows 11).
+
+After installation, open Docker Desktop Settings and confirm that WSL integration is enabled for your Ubuntu distribution (Settings > Resources > WSL integration).
+
+Verify from inside WSL:
+
+```console
+$ wsl
+$ docker info
+```
+
+`docker info` prints server information.
+If you see "Cannot connect to the Docker daemon", confirm that Docker Desktop is running and that WSL integration is enabled.
+
+## Step 7: Set Up Local Inference with Ollama (Optional)
+
+If you plan to select Ollama as your inference provider during onboarding, install it inside WSL before running the NemoClaw installer:
+
+```console
+$ curl -fsSL https://ollama.com/install.sh | sh
+```
+
+If Ollama is also running on the Windows side, quit it before running `nemoclaw onboard` (system tray > right-click > Quit).
+The Windows and WSL instances bind to the same port and conflict.
+
+The onboarding process starts Ollama in WSL if it is not already running.
+You can also start it yourself beforehand with `ollama serve`.
+
+## Step 8: Next Step
+
+Your Windows environment is ready.
+Open a WSL terminal (type `wsl` in PowerShell, or open Ubuntu from Windows Terminal) and continue with the Quickstart (see the `nemoclaw-user-get-started` skill) to install NemoClaw and launch your first sandbox.
+
+All NemoClaw commands run inside WSL, not in PowerShell.
 
 ## Related Skills
 

--- a/.agents/skills/nemoclaw-user-get-started/references/windows-setup.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/windows-setup.md
@@ -1,41 +1,19 @@
----
-title:
-  page: "Windows Prerequisites for NemoClaw"
-  nav: "Windows Prerequisites"
-description:
-  main: "Complete these steps on Windows before running the NemoClaw Quickstart: enable WSL 2, install Ubuntu, and configure Docker Desktop."
-  agent: "There are additional Windows-only prerequisites before the Quickstart to install NemoClaw on Windows."
-keywords: ["nemoclaw windows wsl2 setup", "nemoclaw install windows docker desktop"]
-topics: ["generative_ai", "ai_agents"]
-tags: ["openclaw", "openshell", "sandboxing", "nemoclaw", "windows", "wsl"]
-content:
-  type: reference
-  difficulty: technical_beginner
-  audience: ["developer", "engineer"]
-status: published
----
-
-<!--
-  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-  SPDX-License-Identifier: Apache-2.0
--->
-
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 # Windows Prerequisites
 
 NemoClaw runs inside Windows Subsystem for Linux (WSL 2) on Windows.
-Complete these steps before following the [Quickstart](quickstart.md).
+Complete these steps before following the Quickstart (see the `nemoclaw-user-get-started` skill).
 Linux and macOS users do not need this page and can go directly to the Quickstart.
 
-:::{note}
-This guide has been tested on x86-64.
-:::
+> **Note:** This guide has been tested on x86-64.
 
 ## Prerequisites
 
 Verify the following before you begin:
 
 - Windows 10 (build 19041 or later) or Windows 11.
-- Hardware requirements are the same as the [Quickstart](quickstart.md).
+- Hardware requirements are the same as the Quickstart (see the `nemoclaw-user-get-started` skill).
 
 ## Enable WSL 2
 
@@ -59,11 +37,9 @@ $ wsl --install -d Ubuntu
 
 Let the distribution launch and complete first-run setup (pick a Unix username and password), then type `exit` to return to PowerShell.
 
-:::{warning}
-Do not use the `--no-launch` flag.
-The `--no-launch` flag downloads the package but does not register the distribution with WSL.
-Commands like `wsl -d Ubuntu` fail with "There is no distribution with the supplied name" until the distribution has been launched at least once.
-:::
+> **Warning:** Do not use the `--no-launch` flag.
+> The `--no-launch` flag downloads the package but does not register the distribution with WSL.
+> Commands like `wsl -d Ubuntu` fail with "There is no distribution with the supplied name" until the distribution has been launched at least once.
 
 Verify the distribution is registered and running WSL 2:
 
@@ -111,7 +87,7 @@ You can also start it yourself beforehand with `ollama serve`.
 ## Next Step
 
 Your Windows environment is ready.
-Open a WSL terminal (type `wsl` in PowerShell, or open Ubuntu from Windows Terminal) and continue with the [Quickstart](quickstart.md) to install NemoClaw and launch your first sandbox.
+Open a WSL terminal (type `wsl` in PowerShell, or open Ubuntu from Windows Terminal) and continue with the Quickstart (see the `nemoclaw-user-get-started` skill) to install NemoClaw and launch your first sandbox.
 
 All NemoClaw commands run inside WSL, not in PowerShell.
 

--- a/.agents/skills/nemoclaw-user-get-started/references/windows-setup.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/windows-setup.md
@@ -93,4 +93,4 @@ All NemoClaw commands run inside WSL, not in PowerShell.
 
 ## Troubleshooting
 
-For Windows-specific troubleshooting, see the [Windows Subsystem for Linux section](../reference/troubleshooting.md#windows-subsystem-for-linux) in the Troubleshooting guide.
+For Windows-specific troubleshooting, see the Windows Subsystem for Linux section (see the `nemoclaw-user-reference` skill) in the Troubleshooting guide.

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -349,6 +349,72 @@ $ nemoclaw <name> logs
 
 Use `--follow` to stream logs in real time while debugging.
 
+(windows-wsl-2)=
+
+## Windows Subsystem for Linux
+
+For environment setup steps, see Windows Prerequisites (see the `nemoclaw-user-get-started` skill).
+
+### `wsl --install --no-distribution` returns Forbidden (403)
+
+Check your network connectivity.
+If you are behind a VPN, try reconnecting or switching to a different network.
+
+### `wsl -d Ubuntu` says "There is no distribution with the supplied name"
+
+The Ubuntu package was installed with `--no-launch` but never registered.
+Run `ubuntu.exe install --root` from PowerShell to register it, or reinstall without `--no-launch`:
+
+```console
+$ wsl --unregister Ubuntu
+$ wsl --install -d Ubuntu
+```
+
+### `docker info` fails inside WSL
+
+Confirm that Docker Desktop is running and that WSL integration is enabled for Ubuntu (Settings > Resources > WSL integration).
+Then restart WSL:
+
+```console
+$ wsl --shutdown
+$ wsl -d Ubuntu
+$ docker info
+```
+
+### Ollama inference fails or hangs in WSL
+
+Ollama configures context length based on your hardware.
+On some GPUs (for example RTX 3500), the default context length is not sufficient for OpenClaw.
+Force a larger context length:
+
+```console
+$ pkill -f 'ollama serve'
+$ OLLAMA_CONTEXT_LENGTH=16384 ollama serve
+```
+
+Verify that Ollama inference works:
+
+```console
+$ echo "Hello" | ollama run <model-id>
+```
+
+Replace `<model-id>` with the model you selected during onboarding (for example `qwen3.5:4b`).
+
+If `ollama serve` fails with `Error: listen tcp 127.0.0.1:11434: bind: address already in use`, check whether Ollama is configured for automatic startup:
+
+```console
+$ sudo systemctl status ollama
+```
+
+If it is active, stop it first, then start with the custom context length:
+
+```console
+$ sudo systemctl stop ollama
+$ OLLAMA_CONTEXT_LENGTH=16384 ollama serve
+```
+
+For additional troubleshooting, see the Quickstart (see the `nemoclaw-user-get-started` skill) and Windows Setup (see the `nemoclaw-user-get-started` skill) pages.
+
 ## Podman
 
 Podman is not a tested runtime.

--- a/docs/get-started/windows-setup.md
+++ b/docs/get-started/windows-setup.md
@@ -1,0 +1,121 @@
+---
+title:
+  page: "Windows Prerequisites for NemoClaw"
+  nav: "Windows Prerequisites"
+description:
+  main: "Complete these steps on Windows before running the NemoClaw Quickstart: enable WSL 2, install Ubuntu, and configure Docker Desktop."
+  agent: "Windows-only prerequisites before the Quickstart. Enables WSL 2, installs Ubuntu, and configures Docker Desktop with the WSL 2 backend. Use when installing NemoClaw on Windows, setting up WSL, or troubleshooting Windows-specific prerequisites."
+keywords: ["nemoclaw windows wsl2 setup", "nemoclaw install windows docker desktop"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["openclaw", "openshell", "sandboxing", "nemoclaw", "windows", "wsl"]
+content:
+  type: how_to
+  difficulty: technical_beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Windows Prerequisites
+
+NemoClaw runs inside Windows Subsystem for Linux (WSL 2) on Windows.
+Complete these steps before following the [Quickstart](quickstart.md).
+Linux and macOS users do not need this page and can go directly to the Quickstart.
+
+:::{note}
+This guide has been tested on x86-64.
+The installation process may differ on Windows on Arm (WoA).
+:::
+
+## Prerequisites
+
+Verify the following before you begin:
+
+- Windows 10 (build 19041 or later) or Windows 11.
+- Hardware requirements are the same as the [Quickstart](quickstart.md).
+
+## Enable WSL 2
+
+Open an elevated PowerShell (Run as Administrator):
+
+```console
+$ wsl --install --no-distribution
+```
+
+This enables both the Windows Subsystem for Linux and Virtual Machine Platform features.
+
+Reboot if prompted.
+
+## Install and Register Ubuntu
+
+After reboot, open an elevated PowerShell again:
+
+```console
+$ wsl --install -d Ubuntu
+```
+
+Let the distribution launch and complete first-run setup (pick a Unix username and password), then type `exit` to return to PowerShell.
+
+:::{warning}
+Do not use the `--no-launch` flag.
+The `--no-launch` flag downloads the package but does not register the distribution with WSL.
+Commands like `wsl -d Ubuntu` fail with "There is no distribution with the supplied name" until the distribution has been launched at least once.
+:::
+
+Verify the distribution is registered and running WSL 2:
+
+```console
+$ wsl -l -v
+```
+
+Expected output:
+
+```text
+  NAME      STATE           VERSION
+* Ubuntu    Running         2
+```
+
+## Install Docker Desktop
+
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) with the WSL 2 backend (the default on Windows 11).
+
+After installation, open Docker Desktop Settings and confirm that WSL integration is enabled for your Ubuntu distribution (Settings > Resources > WSL integration).
+
+Verify from inside WSL:
+
+```console
+$ wsl
+$ docker info
+```
+
+`docker info` prints server information.
+If you see "Cannot connect to the Docker daemon", confirm that Docker Desktop is running and that WSL integration is enabled.
+
+## Set Up Local Inference with Ollama (Optional)
+
+If you plan to select Ollama as your inference provider during onboarding, install it inside WSL before running the NemoClaw installer:
+
+```console
+$ curl -fsSL https://ollama.com/install.sh | sh
+```
+
+If Ollama is also running on the Windows side, quit it before running `nemoclaw onboard` (system tray > right-click > Quit).
+The Windows and WSL instances bind to the same port and conflict.
+
+The onboarding process starts Ollama in WSL if it is not already running.
+You can also start it yourself beforehand with `ollama serve`.
+
+## Next Step
+
+Your Windows environment is ready.
+Open a WSL terminal (type `wsl` in PowerShell, or open Ubuntu from Windows Terminal) and continue with the [Quickstart](quickstart.md) to install NemoClaw and launch your first sandbox.
+
+All NemoClaw commands run inside WSL, not in PowerShell.
+
+## Troubleshooting
+
+For Windows-specific troubleshooting, see the [Windows Subsystem for Linux section](windows-wsl-2) in the Troubleshooting guide.

--- a/docs/get-started/windows-setup.md
+++ b/docs/get-started/windows-setup.md
@@ -28,7 +28,6 @@ Linux and macOS users do not need this page and can go directly to the Quickstar
 
 :::{note}
 This guide has been tested on x86-64.
-The installation process may differ on Windows on Arm (WoA).
 :::
 
 ## Prerequisites

--- a/docs/get-started/windows-setup.md
+++ b/docs/get-started/windows-setup.md
@@ -118,4 +118,4 @@ All NemoClaw commands run inside WSL, not in PowerShell.
 
 ## Troubleshooting
 
-For Windows-specific troubleshooting, see the [Windows Subsystem for Linux section](windows-wsl-2) in the Troubleshooting guide.
+For Windows-specific troubleshooting, see the [Windows Subsystem for Linux section](../reference/troubleshooting.md#windows-subsystem-for-linux) in the Troubleshooting guide.

--- a/docs/index.md
+++ b/docs/index.md
@@ -241,6 +241,7 @@ Release Notes <about/release-notes>
 :hidden:
 
 Quickstart <get-started/quickstart>
+Windows Prerequisites <get-started/windows-setup>
 ```
 
 ```{toctree}

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -379,6 +379,72 @@ $ nemoclaw <name> logs
 
 Use `--follow` to stream logs in real time while debugging.
 
+(windows-wsl-2)=
+
+## Windows Subsystem for Linux
+
+For environment setup steps, see [Windows Prerequisites](../get-started/windows-setup.md).
+
+### `wsl --install --no-distribution` returns Forbidden (403)
+
+Check your network connectivity.
+If you are behind a VPN, try reconnecting or switching to a different network.
+
+### `wsl -d Ubuntu` says "There is no distribution with the supplied name"
+
+The Ubuntu package was installed with `--no-launch` but never registered.
+Run `ubuntu.exe install --root` from PowerShell to register it, or reinstall without `--no-launch`:
+
+```console
+$ wsl --unregister Ubuntu
+$ wsl --install -d Ubuntu
+```
+
+### `docker info` fails inside WSL
+
+Confirm that Docker Desktop is running and that WSL integration is enabled for Ubuntu (Settings > Resources > WSL integration).
+Then restart WSL:
+
+```console
+$ wsl --shutdown
+$ wsl -d Ubuntu
+$ docker info
+```
+
+### Ollama inference fails or hangs in WSL
+
+Ollama configures context length based on your hardware.
+On some GPUs (for example RTX 3500), the default context length is not sufficient for OpenClaw.
+Force a larger context length:
+
+```console
+$ pkill -f 'ollama serve'
+$ OLLAMA_CONTEXT_LENGTH=16384 ollama serve
+```
+
+Verify that Ollama inference works:
+
+```console
+$ echo "Hello" | ollama run <model-id>
+```
+
+Replace `<model-id>` with the model you selected during onboarding (for example `qwen3.5:4b`).
+
+If `ollama serve` fails with `Error: listen tcp 127.0.0.1:11434: bind: address already in use`, check whether Ollama is configured for automatic startup:
+
+```console
+$ sudo systemctl status ollama
+```
+
+If it is active, stop it first, then start with the custom context length:
+
+```console
+$ sudo systemctl stop ollama
+$ OLLAMA_CONTEXT_LENGTH=16384 ollama serve
+```
+
+For additional troubleshooting, see the [Quickstart](../get-started/quickstart.md) and [Windows Setup](../get-started/windows-setup.md) pages.
+
 ## Podman
 
 Podman is not a tested runtime.

--- a/scripts/docs-to-skills.py
+++ b/scripts/docs-to-skills.py
@@ -447,12 +447,15 @@ def rewrite_doc_paths(
         if raw_path.startswith(("http://", "https://", "#", "mailto:")):
             return match.group(0)
 
+        # Strip fragment anchors before checking extension
+        path_no_frag = raw_path.split("#")[0]
+
         # Skip non-doc files
-        if not raw_path.endswith(".md") and not raw_path.endswith(".html"):
+        if not path_no_frag.endswith(".md") and not path_no_frag.endswith(".html"):
             return match.group(0)
 
         # Resolve relative path against the source doc's directory
-        resolved = (source_dir / raw_path).resolve()
+        resolved = (source_dir / path_no_frag).resolve()
         try:
             rel_to_repo = resolved.relative_to(repo_root)
         except ValueError:

--- a/scripts/docs-to-skills.py
+++ b/scripts/docs-to-skills.py
@@ -978,6 +978,8 @@ def generate_skill(
                 for item_line in cleaned.split("\n"):
                     stripped = item_line.strip()
                     if stripped.startswith("- "):
+                        if prereq_items and not prereq_items[-1].startswith("- "):
+                            prereq_items.append("")
                         norm = stripped.lower().strip("- .")
                         if norm not in seen_prereqs:
                             seen_prereqs.add(norm)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preview: https://nvidia.github.io/NemoClaw/pr-preview/pr-1850/get-started/windows-setup.html

Windows users need WSL 2, Ubuntu, and Docker Desktop configured before the Quickstart installer can run. This PR adds a Windows Prerequisites page under Get Started and merges Windows-specific troubleshooting entries into the existing Troubleshooting reference.

## Changes

- Add `docs/get-started/windows-setup.md` covering WSL 2 enablement, Ubuntu registration, Docker Desktop with WSL 2 backend, and optional Ollama setup in WSL.
- Add a "Windows Subsystem for Linux" troubleshooting section to `docs/reference/troubleshooting.md` with entries for WSL install failures, Docker in WSL, and Ollama context length issues.
- Add toctree entry in `docs/index.md` under Get Started.
- Add link from the quickstart platform matrix to the new Windows Prerequisites page.

## Type of Change

- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Doc Changes

- [x] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [x] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published a Windows-only setup guide covering WSL 2, Ubuntu registration, Docker Desktop (WSL backend), and optional Ollama in WSL; includes next-step guidance to continue the Quickstart and a new WSL troubleshooting section.
  * Expanded troubleshooting with fixes for WSL install errors, distribution registration, Docker connectivity, and Ollama inference/port issues.
  * Updated skill guidance to reference the Windows prerequisites.
* **Chores**
  * Improved prerequisite formatting in generated docs for clearer visual separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->