### PR TITLE
docs(skill): integrate bump-version.ts into cut-release-tag skill

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: nemoclaw-maintainer-cut-release-tag
-description: Cut a new semver release tag on main, move the `latest` tag, and push. Use when cutting a release, tagging a version, shipping a build, or preparing a deployment. Trigger keywords - cut tag, release tag, new tag, cut release, tag version, ship it.
+description: Cut a new semver release — bump all version strings via bump-version.ts, open a release PR, and after merge tag main and push. Use when cutting a release, tagging a version, shipping a build, or preparing a deployment. Trigger keywords - cut tag, release tag, new tag, cut release, tag version, ship it.
 user_invocable: true
 ---
 
 # Cut Release Tag
 
-Create an annotated semver tag on `origin/main` HEAD, move the `latest` floating tag, and push both.
+Bump all version strings, open a release PR, and after merge create annotated semver + `latest` tags on `origin/main`.
+
+This skill delegates the version-bump work to `scripts/bump-version.ts` (invoked via `npm run bump:version`). That script updates package.json (root + plugin), blueprint.yaml, installer defaults, docs config, and versioned doc links — then runs the build and tests before opening a PR.
 
 ## Prerequisites
 
@@ -54,14 +56,58 @@ git log --oneline origin/main -1
 git log --oneline <previous-tag>..origin/main
 ```
 
-Ask for confirmation: "Tag `<new-version>` at commit `<sha>`?"
+Ask for confirmation before proceeding.
 
-## Step 4: Create and Push Tags
+## Step 4: Run the Version Bump Script
 
-Create the annotated tag, move `latest`, and push:
+First, preview the plan with `--dry-run`:
 
 ```bash
-# Create annotated tag on main HEAD
+npm run bump:version -- <version-without-v-prefix> --dry-run
+```
+
+Show the dry-run output to the user. After confirmation, ask the user which mode they want:
+
+### Option A: PR mode (default, recommended)
+
+```bash
+npm run bump:version -- <version-without-v-prefix>
+```
+
+This will:
+
+1. Update all version strings across the repo
+2. Run the build and tests
+3. Create a `release/<version>` branch and open a release PR against `main`
+
+In PR mode, tagging is deferred — proceed to Step 5 after the PR merges.
+
+### Option B: Direct mode (no PR)
+
+```bash
+npm run bump:version -- <version-without-v-prefix> --no-create-pr --push
+```
+
+This will:
+
+1. Update all version strings across the repo
+2. Run the build and tests
+3. Commit directly on `main`
+4. Create annotated `v<version>` and `latest` tags
+5. Push the commit and both tags to origin
+
+In direct mode, tagging and pushing are handled by the script — skip to Step 6.
+
+If the user wants to skip tests (e.g., they already ran them), add `--skip-tests` to either mode.
+
+## Step 5: Create and Push Tags (PR mode only, after PR merge)
+
+Skip this step if you used direct mode in Step 4 — the script already tagged and pushed.
+
+Once the release PR is merged into `main`, create the annotated tag, move `latest`, and push:
+
+```bash
+git fetch origin main --tags
 git tag -a <new-version> origin/main -m "<new-version>"
 
 # Move the latest tag (delete old, create new)
@@ -73,7 +119,7 @@ git push origin <new-version>
 git push origin latest --force
 ```
 
-## Step 5: Verify
+## Step 6: Verify
 
 ```bash
 git ls-remote --tags origin | grep -E '(<new-version>|latest)'
@@ -87,4 +133,4 @@ Confirm both tags point to the same commit on the remote.
 - NEVER tag a branch other than `origin/main`.
 - Always use annotated tags (`-a`), not lightweight tags.
 - The `latest` tag is a floating tag that always points to the most recent release — it requires `--force` to push.
-- Do NOT update `package.json` version — that is handled separately.
+- The version string passed to `npm run bump:version` should NOT have a `v` prefix (e.g., `0.0.3`, not `v0.0.3`). The script adds the `v` prefix for tags internally.


### PR DESCRIPTION
## Summary

- The `cut-release-tag` skill now delegates version-bump work to `scripts/bump-version.ts` (`npm run bump:version`) instead of only handling git tags manually
- Documents both PR mode (default) and direct mode (`--no-create-pr --push`) which includes tagging
- Removes the old "Do NOT update package.json version" note since the script handles everything

## Test plan

- [ ] Invoke `/nemoclaw-maintainer-cut-release-tag` and verify the skill guides through `bump-version.ts` usage
- [ ] Confirm dry-run step is presented before real execution
- [ ] Confirm PR mode vs direct mode options are clear

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release tag creation workflow: added a dry-run preview and restructured steps for clarity.
  * Introduced two release modes: PR-based (tags created after merge) and direct commit/tag flows.
  * Clarified confirmation is now a generic proceed prompt and requires supplying the version without a leading "v" (the process adds the prefix).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->