### PR TITLE
docs: catch up documentation for v0.0.13 changes

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -85,6 +85,10 @@ The wizard prompts for a sandbox name.
 Names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.
 Uppercase letters are automatically lowercased.
 
+If you enable Slack during onboarding, the wizard collects both the Bot Token (`SLACK_BOT_TOKEN`) and the App-Level Token (`SLACK_APP_TOKEN`).
+Socket Mode requires both tokens.
+The app-level token is stored in a dedicated `slack-app` OpenShell provider and forwarded to the sandbox alongside the bot token.
+
 If you enable Discord during onboarding, the wizard can also prompt for a Discord Server ID, whether the bot should reply only to `@mentions` or to all messages in that server, and an optional Discord User ID.
 NemoClaw bakes those values into the sandbox image as Discord guild workspace config so the bot can respond in the selected server, not just in DMs.
 If you leave the Discord User ID blank, the guild config omits the user allowlist and any member of the configured server can message the bot.
@@ -136,6 +140,8 @@ $ nemoclaw deploy <instance-name>
 ### `nemoclaw <name> connect`
 
 Connect to a sandbox by name.
+On a TTY, a one-shot hint prints before dropping into the sandbox shell, reminding you to run `openclaw tui` inside.
+Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 
 ```console
 $ nemoclaw my-assistant connect

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -99,6 +99,16 @@ $ export PATH=~/.npm-global/bin:$PATH
 
 Add the `export` line to your `~/.bashrc` or `~/.zshrc` to make it permanent, then re-run the installer.
 
+### Installer fails on NVIDIA Jetson
+
+The installer auto-detects NVIDIA Jetson devices (Orin and Thor) and applies required host configuration before the normal install flow.
+If the Jetson setup step fails, verify that you have `sudo` access and that Docker is installed and running.
+
+For JetPack 6 (L4T 36.x), the setup switches iptables to legacy mode and adjusts the Docker daemon configuration.
+For JetPack 7 (L4T 38.x / Thor), only bridge netfilter and sysctl settings are applied.
+
+If the L4T version is not recognized, the setup step is skipped and the installer continues normally.
+
 ### Port already in use
 
 The NemoClaw gateway uses port `18789` by default.
@@ -333,6 +343,20 @@ In that case:
 - verify the sandbox was created with the Discord provider attached
 - inspect gateway logs and blocked requests with `openshell term`
 - treat the failure as a native Discord gateway problem, not as a bridge startup problem
+
+### Landlock filesystem restrictions silently degraded
+
+After sandbox creation, NemoClaw checks whether the host kernel supports Landlock (Linux 5.13+).
+If the kernel is too old or you are running on macOS (where the Docker VM kernel may lack Landlock), a warning prints:
+
+```text
+⚠ Landlock: Docker VM kernel <version> does not support Landlock (requires ≥5.13).
+  Sandbox filesystem restrictions will silently degrade (best_effort mode).
+```
+
+This warning is informational and does not block sandbox creation.
+The sandbox runs without kernel-level filesystem restrictions, relying on container mount configuration instead.
+For full filesystem enforcement, run on a Linux kernel 5.13 or later (Ubuntu 22.04 LTS and later include Landlock support).
 
 ### Sandbox lost after gateway restart
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -107,6 +107,10 @@ The wizard prompts for a sandbox name.
 Names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.
 Uppercase letters are automatically lowercased.
 
+If you enable Slack during onboarding, the wizard collects both the Bot Token (`SLACK_BOT_TOKEN`) and the App-Level Token (`SLACK_APP_TOKEN`).
+Socket Mode requires both tokens.
+The app-level token is stored in a dedicated `slack-app` OpenShell provider and forwarded to the sandbox alongside the bot token.
+
 If you enable Discord during onboarding, the wizard can also prompt for a Discord Server ID, whether the bot should reply only to `@mentions` or to all messages in that server, and an optional Discord User ID.
 NemoClaw bakes those values into the sandbox image as Discord guild workspace config so the bot can respond in the selected server, not just in DMs.
 If you leave the Discord User ID blank, the guild config omits the user allowlist and any member of the configured server can message the bot.
@@ -160,6 +164,8 @@ $ nemoclaw deploy <instance-name>
 ### `nemoclaw <name> connect`
 
 Connect to a sandbox by name.
+On a TTY, a one-shot hint prints before dropping into the sandbox shell, reminding you to run `openclaw tui` inside.
+Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 
 ```console
 $ nemoclaw my-assistant connect

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -125,6 +125,16 @@ $ export PATH=~/.npm-global/bin:$PATH
 
 Add the `export` line to your `~/.bashrc` or `~/.zshrc` to make it permanent, then re-run the installer.
 
+### Installer fails on NVIDIA Jetson
+
+The installer auto-detects NVIDIA Jetson devices (Orin and Thor) and applies required host configuration before the normal install flow.
+If the Jetson setup step fails, verify that you have `sudo` access and that Docker is installed and running.
+
+For JetPack 6 (L4T 36.x), the setup switches iptables to legacy mode and adjusts the Docker daemon configuration.
+For JetPack 7 (L4T 38.x / Thor), only bridge netfilter and sysctl settings are applied.
+
+If the L4T version is not recognized, the setup step is skipped and the installer continues normally.
+
 ### Port already in use
 
 The NemoClaw gateway uses port `18789` by default.
@@ -363,6 +373,20 @@ In that case:
 - verify the sandbox was created with the Discord provider attached
 - inspect gateway logs and blocked requests with `openshell term`
 - treat the failure as a native Discord gateway problem, not as a bridge startup problem
+
+### Landlock filesystem restrictions silently degraded
+
+After sandbox creation, NemoClaw checks whether the host kernel supports Landlock (Linux 5.13+).
+If the kernel is too old or you are running on macOS (where the Docker VM kernel may lack Landlock), a warning prints:
+
+```text
+⚠ Landlock: Docker VM kernel <version> does not support Landlock (requires ≥5.13).
+  Sandbox filesystem restrictions will silently degrade (best_effort mode).
+```
+
+This warning is informational and does not block sandbox creation.
+The sandbox runs without kernel-level filesystem restrictions, relying on container mount configuration instead.
+For full filesystem enforcement, run on a Linux kernel 5.13 or later (Ubuntu 22.04 LTS and later include Landlock support).
 
 ### Sandbox lost after gateway restart
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/node": "^25.5.2",
         "@typescript-eslint/parser": "^8.58.1",
         "@vitest/coverage-v8": "^4.1.0",
+        "ajv": "^8.17.0",
         "eslint": "^10.1.0",
         "execa": "^9.6.1",
         "prettier": "^3.8.1",


### PR DESCRIPTION
## Summary

Catches up documentation for user-facing changes merged between v0.0.12 and v0.0.13 that shipped without doc updates.

- **Quickstart**: Add NVIDIA Jetson (Orin, Thor) to the platform compatibility matrix
- **Commands**: Document Slack Socket Mode support (`SLACK_APP_TOKEN`) during onboarding, and the TTY connect hint (`NEMOCLAW_NO_CONNECT_HINT`)
- **Troubleshooting**: Add entries for Jetson installer failures and Landlock filesystem degradation warnings

### Commits covered

| Commit | Change |
|--------|--------|
| `a7d8812e` | `fix(install): add Jetson host setup to installer` |
| `f16ceedf` | `fix(onboard): forward SLACK_APP_TOKEN to sandbox for Socket Mode` |
| `43d323f4` | `fix(cli): print TTY hint after sandbox connect` |
| `035144e5` | `fix(security): warn when Landlock may silently degrade` |

### Commits with no doc impact (v0.0.13)

- `e02150b8` — destroy warning text changed (already covered by existing commands.md admonition)
- `942a1200` — preserve shared host services (internal behavior fix)
- `99bd0629` — complete SSRF blocklist (security internals)
- `222aafcf` — mitigate Brave API key exposure (build-arg fix)
- `b4098219` — unify secret redaction patterns (internal)
- `9c51f305` — version stamp fix (bug fix, no behavior doc change)
- `ee5fce20`, `bfff9a3b` — CI-only
- `aa52ed85` — internal refactor

## Test plan

- [x] `make docs` builds without warnings
- [x] Pre-commit hooks pass
- [ ] Review rendered pages for accuracy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Slack setup documentation to clarify dual token collection and Socket Mode requirements
  * Added TTY-only hint to `nemoclaw <name> connect` with `NEMOCLAW_NO_CONNECT_HINT=1` suppression option
  * Added NVIDIA Jetson troubleshooting guidance with auto-detection and JetPack/L4T configuration support
  * Added Landlock filesystem restriction degradation warnings and best-effort mode fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->