### PR TITLE
docs: catch up documentation for v0.0.14 changes

### DIFF
--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -170,7 +170,7 @@ Check for:
 
 ## Step 8: Label PRs
 
-When the workflow produces a pull request, apply the `documentation` label so reviewers and CI can identify doc-only changes:
+When the workflow produces a pull request, apply the `documentation` label so reviewers can identify doc-only changes:
 
 ```bash
 gh pr edit <number> --add-label documentation

--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -168,6 +168,14 @@ Check for:
 - Broken cross-references.
 - Correct rendering of new content.
 
+## Step 8: Label PRs
+
+When the workflow produces a pull request, apply the `documentation` label so reviewers and CI can identify doc-only changes:
+
+```bash
+gh pr edit <number> --add-label documentation
+```
+
 ## Tips
 
 - When in doubt about whether a commit needs a doc update, check if the commit message references a CLI flag, config option, or user-visible behavior.

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -92,6 +92,8 @@ Guild responses remain mention-gated by default unless you opt into all-message 
 
 Before creating the gateway, the wizard runs preflight checks.
 It verifies that Docker is reachable, warns on untested runtimes such as Podman, and prints host remediation guidance when prerequisites are missing.
+The preflight also enforces the OpenShell version range declared in the blueprint (`min_openshell_version` and `max_openshell_version`).
+If the installed OpenShell version falls outside this range, onboarding exits with an actionable error and a link to compatible releases.
 
 #### `--from <Dockerfile>`
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -129,6 +129,20 @@ $ nemoclaw onboard
 Podman is not a tested runtime.
 If onboarding or sandbox lifecycle fails, switch to a tested runtime (Docker Desktop, Colima, or Docker Engine) and rerun onboarding.
 
+### OpenShell version above maximum
+
+Each NemoClaw release validates against a range of tested OpenShell versions.
+If the installed OpenShell version exceeds the configured maximum, `nemoclaw onboard` exits with an error:
+
+```text
+✗ openshell <version> is above the maximum supported by this NemoClaw release.
+  blueprint.yaml max_openshell_version: <max>
+```
+
+Upgrade NemoClaw to a version that supports your OpenShell release, or install a supported OpenShell version from the [OpenShell releases page](https://github.com/NVIDIA/OpenShell/releases).
+
+The `install-openshell.sh` script also enforces this constraint and pins fresh installs to the validated maximum version.
+
 ### Invalid sandbox name
 
 Sandbox names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -114,6 +114,8 @@ Guild responses remain mention-gated by default unless you opt into all-message 
 
 Before creating the gateway, the wizard runs preflight checks.
 It verifies that Docker is reachable, warns on untested runtimes such as Podman, and prints host remediation guidance when prerequisites are missing.
+The preflight also enforces the OpenShell version range declared in the blueprint (`min_openshell_version` and `max_openshell_version`).
+If the installed OpenShell version falls outside this range, onboarding exits with an actionable error and a link to compatible releases.
 
 #### `--from <Dockerfile>`
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -155,6 +155,20 @@ $ nemoclaw onboard
 Podman is not a tested runtime.
 If onboarding or sandbox lifecycle fails, switch to a tested runtime (Docker Desktop, Colima, or Docker Engine) and rerun onboarding.
 
+### OpenShell version above maximum
+
+Each NemoClaw release validates against a range of tested OpenShell versions.
+If the installed OpenShell version exceeds the configured maximum, `nemoclaw onboard` exits with an error:
+
+```text
+✗ openshell <version> is above the maximum supported by this NemoClaw release.
+  blueprint.yaml max_openshell_version: <max>
+```
+
+Upgrade NemoClaw to a version that supports your OpenShell release, or install a supported OpenShell version from the [OpenShell releases page](https://github.com/NVIDIA/OpenShell/releases).
+
+The `install-openshell.sh` script also enforces this constraint and pins fresh installs to the validated maximum version.
+
 ### Invalid sandbox name
 
 Sandbox names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.


### PR DESCRIPTION
## Summary

Catches up documentation for user-facing changes merged between v0.0.13 and v0.0.14 that shipped without doc updates.

- **Troubleshooting**: Add entry for "OpenShell version above maximum" error when installed OpenShell exceeds the blueprint's `max_openshell_version`
- **Commands**: Document version range enforcement (`min_openshell_version` / `max_openshell_version`) in the onboard preflight section

### Commits covered

| Commit | Change |
|--------|--------|
| `d4aac4c6` | `feat(blueprint): enforce maximum OpenShell version constraint` |

### Commits with no doc impact (v0.0.14)

- `fcb5fd66` — block secret writes into persistent workspace memory (already shipped with doc updates in the same commit)
- `1ba57abf` — CI-only (skip dco-check for Dependabot)

## Test plan

- [x] `make docs` builds without warnings
- [x] Pre-commit hooks pass
- [ ] Review rendered pages for accuracy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Onboarding docs updated to validate installed OpenShell against blueprint min/max versions and immediately surface actionable errors with links to compatible releases.
  * New troubleshooting entry for OpenShell version mismatches (above maximum) with remediation steps and note that fresh installs are pinned to the validated maximum.
  * Docs-update workflow now includes a step to label documentation-only pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->