### PR TITLE
fix(cli): report skipped hidden directories during skill install

### DIFF
--- a/src/lib/skill-install.test.ts
+++ b/src/lib/skill-install.test.ts
@@ -158,6 +158,22 @@ describe("collectFiles", () => {
     }
   });
 
+  it("reports hidden directories in skippedDotfiles", () => {
+    setup({
+      "SKILL.md": "---\nname: safe\n---\n",
+      ".secret/token.txt": "secret-value",
+      "scripts/visible.sh": "#!/bin/sh",
+      "scripts/.hidden.sh": "#!/bin/sh",
+    });
+    try {
+      const { files, skippedDotfiles } = collectFiles(tmpDir);
+      expect(files.sort()).toEqual(["SKILL.md", "scripts/visible.sh"]);
+      expect(skippedDotfiles.sort()).toEqual([".secret/", "scripts/.hidden.sh"]);
+    } finally {
+      cleanup();
+    }
+  });
+
   it("flags files with unsafe characters", () => {
     setup({
       "SKILL.md": "---\nname: bad\n---\n",

--- a/src/lib/skill-install.ts
+++ b/src/lib/skill-install.ts
@@ -220,7 +220,7 @@ export function collectFiles(dir: string): CollectedFiles {
     for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
       const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
       if (entry.name.startsWith(".")) {
-        if (entry.isFile()) skippedDotfiles.push(rel);
+        skippedDotfiles.push(entry.isDirectory() ? `${rel}/` : rel);
         continue;
       }
       if (entry.isDirectory()) {
@@ -293,8 +293,8 @@ export function postInstall(
           : paths.mirrorDir;
         const mirrorFile = `${paths.mirrorDir}/${rel}`;
         // mirrorDir contains $HOME which must expand, so we use double
-        // quotes for the mkdir target but shellQuote the relative part
-        // to prevent injection from file names.
+        // quotes (not shellQuote). Safe because validateRelativePath
+        // restricts filenames to [A-Za-z0-9._-/] before we reach here.
         const result = sshExec(
           ctx,
           `mkdir -p "${mirrorSubdir}" && cat > "${mirrorFile}"`,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1306,7 +1306,7 @@ async function sandboxSkillInstall(sandboxName, args = []) {
     process.exit(1);
   }
   if (collected.skippedDotfiles.length > 0) {
-    console.log(`  ${D}Skipping ${collected.skippedDotfiles.length} dotfile(s): ${collected.skippedDotfiles.join(", ")}${R}`);
+    console.log(`  ${D}Skipping ${collected.skippedDotfiles.length} hidden path(s): ${collected.skippedDotfiles.join(", ")}${R}`);
   }
   const fileLabel = collected.files.length === 1 ? "1 file" : `${collected.files.length} files`;
   console.log(`  ${G}✓${R} Validated SKILL.md (name: ${frontmatter.name}, ${fileLabel})`);


### PR DESCRIPTION
## Summary

- `collectFiles()` silently dropped dot-directories (e.g. `.secret/`) without reporting them in `skippedDotfiles`. Users were warned about skipped dot-files but not about entire hidden directory trees being omitted.
- Now both dot-files and dot-directories are reported, with a trailing `/` to distinguish directories in the CLI output (e.g. `Skipping 2 hidden path(s): .env, .secret/`).
- Fixed misleading comment in `postInstall()` that said "shellQuote the relative part" when the code actually uses double-quoted interpolation (safe due to `validateRelativePath` charset restriction).

Reported by @brandonpelfrey.

## Test plan

- [x] Added regression test: hidden directory with nested files (`.secret/token.txt`) is now reported as `.secret/` in `skippedDotfiles`
- [x] All 25 unit tests pass (`npx vitest run src/lib/skill-install.test.ts`)
- [x] Pre-commit hooks pass (lint, commitlint, gitleaks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden directories and dot-prefixed files inside folders are now properly recorded and reported when skipped during skill installation.
  * Status messaging updated to display "hidden path(s)" instead of "dotfile(s)" for clearer upload feedback.

* **Tests**
  * Added test coverage validating collection and reporting of non-hidden files and skipped hidden paths (directories and dot-prefixed files).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->