### PR TITLE
feat: verify if tokens exposed in sandbox

### DIFF
--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -14,7 +14,8 @@
 #
 #   1. Provider creation — openshell stores the real token
 #   2. Sandbox attachment — --provider flags wire providers to the sandbox
-#   3. Credential isolation — real tokens never appear in sandbox env
+#   3. Credential isolation — real tokens never appear in sandbox env,
+#      process list, or filesystem
 #   4. Config patching — openclaw.json channels use placeholder values
 #   5. Network reachability — Node.js can reach messaging APIs through proxy
 #   6. Native Discord gateway path — WebSocket path is probed separately from REST
@@ -275,6 +276,81 @@ if [ -n "$TELEGRAM_PLACEHOLDER" ] || [ -n "$DISCORD_PLACEHOLDER" ]; then
 else
   skip "M5: No messaging placeholders found — OpenShell may not inject them as env vars"
   info "Subsequent phases that depend on placeholders will adapt"
+fi
+
+# M3/M4 verify the specific TELEGRAM_BOT_TOKEN / DISCORD_BOT_TOKEN
+# env vars hold placeholders. The checks below verify the real
+# host-side tokens do not appear on ANY observable surface inside
+# the sandbox: full environment, process list, or filesystem.
+
+sandbox_env_all=$(sandbox_exec "env 2>/dev/null" 2>/dev/null || true)
+sandbox_ps=$(sandbox_exec "ps aux 2>/dev/null || ps -ef 2>/dev/null" 2>/dev/null || true)
+
+# M5a: Full environment dump must not contain the real Telegram token
+if [ -n "$sandbox_env_all" ] && echo "$sandbox_env_all" | grep -qF "$TELEGRAM_TOKEN"; then
+  fail "M5a: Real Telegram token found in full sandbox environment dump"
+else
+  pass "M5a: Real Telegram token absent from full sandbox environment"
+fi
+
+# M5b: Process list must not contain the real Telegram token
+if [ -n "$sandbox_ps" ] && echo "$sandbox_ps" | grep -qF "$TELEGRAM_TOKEN"; then
+  fail "M5b: Real Telegram token found in sandbox process list"
+else
+  pass "M5b: Real Telegram token absent from sandbox process list"
+fi
+
+# M5c: Recursive filesystem search for the real Telegram token.
+# Covers /sandbox (workspace), /home, /etc, /tmp, /var.
+sandbox_fs_tg=$(sandbox_exec "grep -rFl '$TELEGRAM_TOKEN' /sandbox /home /etc /tmp /var 2>/dev/null || true" 2>/dev/null || true)
+if [ -n "$sandbox_fs_tg" ]; then
+  fail "M5c: Real Telegram token found on sandbox filesystem: ${sandbox_fs_tg}"
+else
+  pass "M5c: Real Telegram token absent from sandbox filesystem"
+fi
+
+# M5d: Placeholder string must be present in the sandbox environment
+if [ -n "$TELEGRAM_PLACEHOLDER" ]; then
+  if echo "$sandbox_env_all" | grep -qF "$TELEGRAM_PLACEHOLDER"; then
+    pass "M5d: Telegram placeholder confirmed present in sandbox environment"
+  else
+    fail "M5d: Telegram placeholder not found in sandbox environment"
+  fi
+else
+  skip "M5d: No Telegram placeholder to verify (provider-only mode)"
+fi
+
+# M5e: Full environment dump must not contain the real Discord token
+if [ -n "$sandbox_env_all" ] && echo "$sandbox_env_all" | grep -qF "$DISCORD_TOKEN"; then
+  fail "M5e: Real Discord token found in full sandbox environment dump"
+else
+  pass "M5e: Real Discord token absent from full sandbox environment"
+fi
+
+# M5f: Process list must not contain the real Discord token
+if [ -n "$sandbox_ps" ] && echo "$sandbox_ps" | grep -qF "$DISCORD_TOKEN"; then
+  fail "M5f: Real Discord token found in sandbox process list"
+else
+  pass "M5f: Real Discord token absent from sandbox process list"
+fi
+
+# M5g: Recursive filesystem search for the real Discord token
+sandbox_fs_dc=$(sandbox_exec "grep -rFl '$DISCORD_TOKEN' /sandbox /home /etc /tmp /var 2>/dev/null || true" 2>/dev/null || true)
+if [ -n "$sandbox_fs_dc" ]; then
+  fail "M5g: Real Discord token found on sandbox filesystem: ${sandbox_fs_dc}"
+else
+  pass "M5g: Real Discord token absent from sandbox filesystem"
+fi
+
+# M5h: Discord placeholder must be present in the sandbox environment
+if [ -n "$DISCORD_PLACEHOLDER" ]; then
+  if echo "$sandbox_env_all" | grep -qF "$DISCORD_PLACEHOLDER"; then
+    pass "M5h: Discord placeholder confirmed present in sandbox environment"
+  else
+    fail "M5h: Discord placeholder not found in sandbox environment"
+  fi
+else
+  skip "M5h: No Discord placeholder to verify (provider-only mode)"
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -334,7 +334,7 @@ fi
 
 # M5c: Recursive filesystem search for the real Telegram token.
 # Covers /sandbox (workspace), /home, /etc, /tmp, /var.
-sandbox_fs_tg=$(printf '%s' "$TELEGRAM_TOKEN" | sandbox_exec_stdin "grep -rFl -f /dev/stdin /sandbox /home /etc /tmp /var 2>/dev/null || true")
+sandbox_fs_tg=$(printf '%s' "$TELEGRAM_TOKEN" | sandbox_exec_stdin "grep -rFlm1 -f - /sandbox /home /etc /tmp /var 2>/dev/null || true")
 if [ -n "$sandbox_fs_tg" ]; then
   fail "M5c: Real Telegram token found on sandbox filesystem: ${sandbox_fs_tg}"
 else
@@ -371,7 +371,7 @@ else
 fi
 
 # M5g: Recursive filesystem search for the real Discord token
-sandbox_fs_dc=$(printf '%s' "$DISCORD_TOKEN" | sandbox_exec_stdin "grep -rFl -f /dev/stdin /sandbox /home /etc /tmp /var 2>/dev/null || true")
+sandbox_fs_dc=$(printf '%s' "$DISCORD_TOKEN" | sandbox_exec_stdin "grep -rFlm1 -f - /sandbox /home /etc /tmp /var 2>/dev/null || true")
 if [ -n "$sandbox_fs_dc" ]; then
   fail "M5g: Real Discord token found on sandbox filesystem: ${sandbox_fs_dc}"
 else

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -99,6 +99,27 @@ export TELEGRAM_BOT_TOKEN="$TELEGRAM_TOKEN"
 export DISCORD_BOT_TOKEN="$DISCORD_TOKEN"
 export TELEGRAM_ALLOWED_IDS="$TELEGRAM_IDS"
 
+# Run a command inside the sandbox via stdin (avoids exposing sensitive args in process list)
+sandbox_exec_stdin() {
+  local cmd="$1"
+  local ssh_config
+  ssh_config="$(mktemp)"
+  openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_config" 2>/dev/null
+
+  local result
+  result=$(timeout 60 ssh -F "$ssh_config" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o ConnectTimeout=10 \
+    -o LogLevel=ERROR \
+    "openshell-${SANDBOX_NAME}" \
+    "$cmd" \
+    2>/dev/null) || true
+
+  rm -f "$ssh_config"
+  echo "$result"
+}
+
 # Run a command inside the sandbox and capture output
 sandbox_exec() {
   local cmd="$1"
@@ -302,7 +323,7 @@ fi
 
 # M5c: Recursive filesystem search for the real Telegram token.
 # Covers /sandbox (workspace), /home, /etc, /tmp, /var.
-sandbox_fs_tg=$(sandbox_exec "grep -rFl '$TELEGRAM_TOKEN' /sandbox /home /etc /tmp /var 2>/dev/null || true" 2>/dev/null || true)
+sandbox_fs_tg=$(printf '%s' "$TELEGRAM_TOKEN" | sandbox_exec_stdin "grep -rFl -f /dev/stdin /sandbox /home /etc /tmp /var 2>/dev/null || true")
 if [ -n "$sandbox_fs_tg" ]; then
   fail "M5c: Real Telegram token found on sandbox filesystem: ${sandbox_fs_tg}"
 else
@@ -335,7 +356,7 @@ else
 fi
 
 # M5g: Recursive filesystem search for the real Discord token
-sandbox_fs_dc=$(sandbox_exec "grep -rFl '$DISCORD_TOKEN' /sandbox /home /etc /tmp /var 2>/dev/null || true" 2>/dev/null || true)
+sandbox_fs_dc=$(printf '%s' "$DISCORD_TOKEN" | sandbox_exec_stdin "grep -rFl -f /dev/stdin /sandbox /home /etc /tmp /var 2>/dev/null || true")
 if [ -n "$sandbox_fs_dc" ]; then
   fail "M5g: Real Discord token found on sandbox filesystem: ${sandbox_fs_dc}"
 else

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -305,17 +305,28 @@ fi
 # the sandbox: full environment, process list, or filesystem.
 
 sandbox_env_all=$(sandbox_exec "env 2>/dev/null" 2>/dev/null || true)
-sandbox_ps=$(sandbox_exec "ps aux 2>/dev/null || ps -ef 2>/dev/null" 2>/dev/null || true)
+sandbox_ps=$(openshell sandbox exec -n "$SANDBOX_NAME" -- \
+  sh -c 'cat /proc/[0-9]*/cmdline 2>/dev/null | tr "\0" "\n"' 2>/dev/null || true)
+
+if [ -n "$sandbox_ps" ]; then
+  info "Process cmdlines captured ($(echo "$sandbox_ps" | wc -l | tr -d ' ') lines)"
+else
+  info "Process cmdline capture returned empty — M5b/M5f will skip"
+fi
 
 # M5a: Full environment dump must not contain the real Telegram token
-if [ -n "$sandbox_env_all" ] && echo "$sandbox_env_all" | grep -qF "$TELEGRAM_TOKEN"; then
+if [ -z "$sandbox_env_all" ]; then
+  skip "M5a: Environment variable list is empty"
+elif echo "$sandbox_env_all" | grep -qF "$TELEGRAM_TOKEN"; then
   fail "M5a: Real Telegram token found in full sandbox environment dump"
 else
   pass "M5a: Real Telegram token absent from full sandbox environment"
 fi
 
 # M5b: Process list must not contain the real Telegram token
-if [ -n "$sandbox_ps" ] && echo "$sandbox_ps" | grep -qF "$TELEGRAM_TOKEN"; then
+if [ -z "$sandbox_ps" ]; then
+  skip "M5b: Process list is empty"
+elif echo "$sandbox_ps" | grep -qF "$TELEGRAM_TOKEN"; then
   fail "M5b: Real Telegram token found in sandbox process list"
 else
   pass "M5b: Real Telegram token absent from sandbox process list"
@@ -342,14 +353,18 @@ else
 fi
 
 # M5e: Full environment dump must not contain the real Discord token
-if [ -n "$sandbox_env_all" ] && echo "$sandbox_env_all" | grep -qF "$DISCORD_TOKEN"; then
+if [ -z "$sandbox_env_all" ]; then
+  skip "M5e: Environment variable list is empty"
+elif echo "$sandbox_env_all" | grep -qF "$DISCORD_TOKEN"; then
   fail "M5e: Real Discord token found in full sandbox environment dump"
 else
   pass "M5e: Real Discord token absent from full sandbox environment"
 fi
 
 # M5f: Process list must not contain the real Discord token
-if [ -n "$sandbox_ps" ] && echo "$sandbox_ps" | grep -qF "$DISCORD_TOKEN"; then
+if [ -z "$sandbox_ps" ]; then
+  skip "M5f: Process list is empty"
+elif echo "$sandbox_ps" | grep -qF "$DISCORD_TOKEN"; then
   fail "M5f: Real Discord token found in sandbox process list"
 else
   pass "M5f: Real Discord token absent from sandbox process list"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Add deep credential exposure checks (M5a–M5h) to the messaging provider E2E test.
These verify that real bot tokens never appear on any observable surface inside the
sandbox — full environment dump, process cmdlines, and filesystem — beyond the existing
single-env-var check (M3/M4).

## Related Issue
Closes #1852

## Changes
- Extend Phase 2 (Credential Isolation) of `test/e2e/test-messaging-providers.sh` with 8 new assertions (M5a–M5h):
  - M5a/M5e: full `env` dump must not contain the real Telegram/Discord token.
  - M5b/M5f: `process cmdlines` must not contain the real Telegram/Discord token.
  - M5c/M5g: recursive filesystem grep (`/sandbox`, `/home`, `/etc`, `/tmp`, `/var`) must not find the real token.
  - M5d/M5h: placeholder string must be present in the sandbox environment (positive check).
- Capture `env` and `process cmdlines` once via SSH and reuse across all checks to avoid redundant round-trips.
- Update header comment to reflect the broader credential isolation scope.

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.

## Testing
<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [ ] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).


---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Hung Le <hple@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended credential-isolation checks for Telegram and Discord: verify real tokens are absent from sandbox environment variables, process listings, and filesystem scans.
  * Added safe remote execution mode that pipes sensitive input via stdin to avoid exposing tokens in command lines.
  * Added provider placeholder presence checks and new capture-and-evaluate points with pass/fail/skip outcomes for improved observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->