### PR TITLE
supports jira credentials

### DIFF
--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -320,3 +320,60 @@ export async function ensureGithubToken(): Promise<void> {
   console.log("  Token saved to ~/.nemoclaw/credentials.json (mode 600)");
   console.log("");
 }
+
+export async function ensureJiraCredentials(): Promise<void> {
+  let url = getCredential("JIRA_BASE_URL");
+  let email = getCredential("JIRA_USER_EMAIL");
+  let token = getCredential("JIRA_API_TOKEN");
+
+  if (url && email && token) {
+    process.env.JIRA_BASE_URL = url;
+    process.env.JIRA_USER_EMAIL = email;
+    process.env.JIRA_API_TOKEN = token;
+    return;
+  }
+
+  console.log("");
+  console.log("  ┌─────────────────────────────────────────────────────────────────┐");
+  console.log("  │  Jira credentials required                                      │");
+  console.log("  │                                                                 │");
+  console.log("  │  1. Your Jira base URL (e.g. https://mycompany.atlassian.net)   │");
+  console.log("  │  2. Your Atlassian account email                                │");
+  console.log("  │  3. An Atlassian API token (account settings → security)        │");
+  console.log("  └─────────────────────────────────────────────────────────────────┘");
+  console.log("");
+
+  if (!url) {
+    url = normalizeCredentialValue(await prompt("  Jira Base URL: "));
+    if (!url) {
+      console.error("  Jira base URL is required.");
+      process.exit(1);
+    }
+    saveCredential("JIRA_BASE_URL", url);
+    process.env.JIRA_BASE_URL = url;
+  }
+
+  if (!email) {
+    email = normalizeCredentialValue(await prompt("  Atlassian account email: "));
+    if (!email) {
+      console.error("  Atlassian account email is required.");
+      process.exit(1);
+    }
+    saveCredential("JIRA_USER_EMAIL", email);
+    process.env.JIRA_USER_EMAIL = email;
+  }
+
+  if (!token) {
+    token = normalizeCredentialValue(await prompt("  Jira API Token: ", { secret: true }));
+    if (!token) {
+      console.error("  Jira API token is required.");
+      process.exit(1);
+    }
+    saveCredential("JIRA_API_TOKEN", token);
+    process.env.JIRA_API_TOKEN = token;
+  }
+
+  console.log("");
+  console.log("  Credentials saved to ~/.nemoclaw/credentials.json (mode 600)");
+  console.log("");
+}

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -350,7 +350,6 @@ export async function ensureJiraCredentials(): Promise<void> {
       process.exit(1);
     }
     saveCredential("JIRA_BASE_URL", url);
-    process.env.JIRA_BASE_URL = url;
   }
 
   if (!email) {
@@ -360,7 +359,6 @@ export async function ensureJiraCredentials(): Promise<void> {
       process.exit(1);
     }
     saveCredential("JIRA_USER_EMAIL", email);
-    process.env.JIRA_USER_EMAIL = email;
   }
 
   if (!token) {
@@ -370,8 +368,11 @@ export async function ensureJiraCredentials(): Promise<void> {
       process.exit(1);
     }
     saveCredential("JIRA_API_TOKEN", token);
-    process.env.JIRA_API_TOKEN = token;
   }
+
+  process.env.JIRA_BASE_URL = url;
+  process.env.JIRA_USER_EMAIL = email;
+  process.env.JIRA_API_TOKEN = token;
 
   console.log("");
   console.log("  Credentials saved to ~/.nemoclaw/credentials.json (mode 600)");

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -17,6 +17,9 @@ export interface DeployCredentials {
   ALLOWED_CHAT_IDS?: string | null;
   DISCORD_BOT_TOKEN?: string | null;
   SLACK_BOT_TOKEN?: string | null;
+  JIRA_BASE_URL?: string | null;
+  JIRA_USER_EMAIL?: string | null;
+  JIRA_API_TOKEN?: string | null;
 }
 
 export interface BrevInstanceStatus {
@@ -261,6 +264,9 @@ export async function executeDeploy(opts: DeployExecutionOptions): Promise<void>
     ALLOWED_CHAT_IDS: getCredential("ALLOWED_CHAT_IDS"),
     DISCORD_BOT_TOKEN: getCredential("DISCORD_BOT_TOKEN"),
     SLACK_BOT_TOKEN: getCredential("SLACK_BOT_TOKEN"),
+    JIRA_BASE_URL: getCredential("JIRA_BASE_URL"),
+    JIRA_USER_EMAIL: getCredential("JIRA_USER_EMAIL"),
+    JIRA_API_TOKEN: getCredential("JIRA_API_TOKEN"),
   };
   const provider = inferDeployProvider(env.NEMOCLAW_PROVIDER, credentials);
   if (!provider) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -45,6 +45,7 @@ const { resolveOpenshell } = require("./resolve-openshell");
 const {
   prompt,
   ensureApiKey,
+  ensureJiraCredentials,
   getCredential,
   normalizeCredentialValue,
   saveCredential,
@@ -2671,9 +2672,12 @@ async function createSandbox(
   const jiraUrl = getCredential("JIRA_BASE_URL") || process.env.JIRA_BASE_URL;
   const jiraEmail = getCredential("JIRA_USER_EMAIL") || process.env.JIRA_USER_EMAIL;
   const jiraToken = getCredential("JIRA_API_TOKEN") || process.env.JIRA_API_TOKEN;
-  if (jiraUrl) sandboxEnv.JIRA_BASE_URL = jiraUrl;
-  if (jiraEmail) sandboxEnv.JIRA_USER_EMAIL = jiraEmail;
-  if (jiraToken) sandboxEnv.JIRA_API_TOKEN = jiraToken;
+  if (jiraUrl || jiraEmail || jiraToken) {
+    await ensureJiraCredentials();
+  }
+  if (process.env.JIRA_BASE_URL) sandboxEnv.JIRA_BASE_URL = process.env.JIRA_BASE_URL;
+  if (process.env.JIRA_USER_EMAIL) sandboxEnv.JIRA_USER_EMAIL = process.env.JIRA_USER_EMAIL;
+  if (process.env.JIRA_API_TOKEN) sandboxEnv.JIRA_API_TOKEN = process.env.JIRA_API_TOKEN;
   // Run without piping through awk — the pipe masked non-zero exit codes
   // from openshell because bash returns the status of the last pipeline
   // command (awk, always 0) unless pipefail is set. Removing the pipe

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2668,6 +2668,12 @@ async function createSandbox(
   const sandboxEnv = Object.fromEntries(
     Object.entries(process.env).filter(([name]) => !blockedSandboxEnvNames.has(name)),
   );
+  const jiraUrl = getCredential("JIRA_BASE_URL") || process.env.JIRA_BASE_URL;
+  const jiraEmail = getCredential("JIRA_USER_EMAIL") || process.env.JIRA_USER_EMAIL;
+  const jiraToken = getCredential("JIRA_API_TOKEN") || process.env.JIRA_API_TOKEN;
+  if (jiraUrl) sandboxEnv.JIRA_BASE_URL = jiraUrl;
+  if (jiraEmail) sandboxEnv.JIRA_USER_EMAIL = jiraEmail;
+  if (jiraToken) sandboxEnv.JIRA_API_TOKEN = jiraToken;
   // Run without piping through awk — the pipe masked non-zero exit codes
   // from openshell because bash returns the status of the last pipeline
   // command (awk, always 0) unless pipefail is set. Removing the pipe
@@ -3842,6 +3848,13 @@ function getSuggestedPolicyPresets({ enabledChannels = null, webSearchConfig = n
   maybeSuggestMessagingPreset("discord", "DISCORD_BOT_TOKEN");
 
   if (webSearchConfig) suggestions.push("brave");
+
+  if (getCredential("JIRA_API_TOKEN") || process.env.JIRA_API_TOKEN) {
+    suggestions.push("jira");
+    if (process.stdout.isTTY && !isNonInteractive() && process.env.CI !== "true") {
+      console.log("  Auto-detected: JIRA_API_TOKEN -> suggesting jira preset");
+    }
+  }
 
   return suggestions;
 }

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -214,6 +214,26 @@ describe("credential prompts", () => {
     expect(process.env.JIRA_API_TOKEN).toBe("atl-env-token-xyz");
   });
 
+  it("ensureJiraCredentials sets process.env from mixed on-disk and env-var sources", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-jira-mixed-"));
+    const credentials = await importCredentialsModule(home);
+
+    credentials.saveCredential("JIRA_BASE_URL", "https://disk.atlassian.net");
+    credentials.saveCredential("JIRA_API_TOKEN", "atl-disk-token-xyz");
+    vi.stubEnv("JIRA_USER_EMAIL", "env-user@example.com");
+
+    await credentials.ensureJiraCredentials();
+
+    try {
+      expect(process.env.JIRA_BASE_URL).toBe("https://disk.atlassian.net");
+      expect(process.env.JIRA_USER_EMAIL).toBe("env-user@example.com");
+      expect(process.env.JIRA_API_TOKEN).toBe("atl-disk-token-xyz");
+    } finally {
+      delete process.env.JIRA_BASE_URL;
+      delete process.env.JIRA_API_TOKEN;
+    }
+  });
+
   it("ensureJiraCredentials prompts for and saves each missing Jira credential", () => {
     const source = fs.readFileSync(
       path.join(import.meta.dirname, "..", "src", "lib", "credentials.ts"),

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -216,7 +216,7 @@ describe("credential prompts", () => {
 
   it("ensureJiraCredentials prompts for and saves each missing Jira credential", () => {
     const source = fs.readFileSync(
-      path.join(import.meta.dirname, "..", "bin", "lib", "credentials.js"),
+      path.join(import.meta.dirname, "..", "src", "lib", "credentials.ts"),
       "utf-8",
     );
 

--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -178,4 +178,56 @@ describe("credential prompts", () => {
     expect(source).toContain('output.write("*")');
     expect(source).toContain('output.write("\\b \\b")');
   });
+
+  it("ensureJiraCredentials loads saved credentials from disk and sets env vars", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-jira-creds-"));
+    const credentials = await importCredentialsModule(home);
+
+    credentials.saveCredential("JIRA_BASE_URL", "https://mycompany.atlassian.net");
+    credentials.saveCredential("JIRA_USER_EMAIL", "user@example.com");
+    credentials.saveCredential("JIRA_API_TOKEN", "atl-token-abc123");
+
+    await credentials.ensureJiraCredentials();
+
+    try {
+      expect(process.env.JIRA_BASE_URL).toBe("https://mycompany.atlassian.net");
+      expect(process.env.JIRA_USER_EMAIL).toBe("user@example.com");
+      expect(process.env.JIRA_API_TOKEN).toBe("atl-token-abc123");
+    } finally {
+      delete process.env.JIRA_BASE_URL;
+      delete process.env.JIRA_USER_EMAIL;
+      delete process.env.JIRA_API_TOKEN;
+    }
+  });
+
+  it("ensureJiraCredentials prefers environment variables over saved credentials", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-jira-env-"));
+    vi.stubEnv("JIRA_BASE_URL", "https://env.atlassian.net");
+    vi.stubEnv("JIRA_USER_EMAIL", "env-user@example.com");
+    vi.stubEnv("JIRA_API_TOKEN", "atl-env-token-xyz");
+
+    const credentials = await importCredentialsModule(home);
+    await credentials.ensureJiraCredentials();
+
+    expect(process.env.JIRA_BASE_URL).toBe("https://env.atlassian.net");
+    expect(process.env.JIRA_USER_EMAIL).toBe("env-user@example.com");
+    expect(process.env.JIRA_API_TOKEN).toBe("atl-env-token-xyz");
+  });
+
+  it("ensureJiraCredentials prompts for and saves each missing Jira credential", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "bin", "lib", "credentials.js"),
+      "utf-8",
+    );
+
+    expect(source).toMatch(/Jira Base URL/);
+    expect(source).toMatch(/Atlassian account email/);
+    expect(source).toMatch(/Jira API Token/);
+
+    expect(source).toMatch(/saveCredential\("JIRA_BASE_URL"/);
+    expect(source).toMatch(/saveCredential\("JIRA_USER_EMAIL"/);
+    expect(source).toMatch(/saveCredential\("JIRA_API_TOKEN"/);
+
+    expect(source).toMatch(/prompt\(.*Jira API Token.*\{.*secret.*true/s);
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds Jira credential support to the NemoClaw CLI. Users are now prompted to enter their Jira base URL, Atlassian account email, and API token during onboarding; credentials are  persisted to ~/.nemoclaw/credentials.json and forwarded into the sandbox environment and remote deployments.

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
- Added ensureJiraCredentials() in bin/lib/credentials.js — interactive prompt for JIRA_BASE_URL, JIRA_USER_EMAIL, and JIRA_API_TOKEN with secure input for the token; saves each to the credentials store.
- Forwarded Jira credentials into the sandbox environment in bin/lib/onboard.js (createSandbox), consistent with how Slack and Discord tokens are handled.
- Auto-detects JIRA_API_TOKEN in _setupPolicies and setupPoliciesWithSelection to suggest the jira network policy preset.
- Forwarded Jira credentials into remote deploy env file in bin/nemoclaw.js (deploy).

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [ ] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Karim Mourra <karim@jwx.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Jira credential management with interactive setup, persistence, and automatic injection into deploy and sandbox environments
  * Onboarding now auto-detects Jira configuration and suggests a "jira" policy preset, with an informational message in interactive runs

* **Tests**
  * Added tests covering Jira credential initialization, environment population, mixed precedence with env vars, and secret-mode token prompting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->