### PR TITLE
fix(e2e): fix messaging-providers and sandbox-survival nightly E2E regressions

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -187,6 +187,7 @@ jobs:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           NEMOCLAW_NON_INTERACTIVE: "1"
           NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_POLICY_TIER: "open"
           NEMOCLAW_SANDBOX_NAME: "e2e-msg-provider"
           NEMOCLAW_RECREATE_SANDBOX: "1"
           GITHUB_TOKEN: ${{ github.token }}

--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -552,13 +552,25 @@ fi
 pass "SSH config available after restart"
 
 # 8a: Raw SSH connectivity — the #888/#1086 handshake test
-if ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "echo alive" >/dev/null 2>&1; then
-  pass "SSH into sandbox works after restart (no handshake failure — #888/#1086)"
+# The sandbox SSH agent may take a few seconds to become reachable after
+# the gateway reports healthy (especially with newer OpenClaw versions that
+# do more startup work). Retry up to 30 seconds before declaring failure.
+SSH_OK=0
+for ssh_attempt in $(seq 1 6); do
+  if ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "echo alive" >/dev/null 2>&1; then
+    SSH_OK=1
+    break
+  fi
+  [ "$ssh_attempt" -lt 6 ] && sleep 5
+done
+
+if [ "$SSH_OK" -eq 1 ]; then
+  pass "SSH into sandbox works after restart (attempt $ssh_attempt, no handshake failure — #888/#1086)"
 else
   fail "SSH into sandbox FAILED after restart — handshake verification likely failed (#888/#1086)"
   info "This is the core bug: gateway regenerated secrets, sandbox has stale ones"
-  cleanup_ssh
-  # Still try to get logs for diagnosis
+  # Do NOT call cleanup_ssh here — subsequent phases need the config file
+  # to attempt marker reads and produce meaningful diagnostics.
   nemoclaw "$SANDBOX_NAME" logs 2>&1 | grep -i "handshake" | head -5 || true
 fi
 


### PR DESCRIPTION
## Summary
- **messaging-providers-e2e**: The tier-based policy selector (#1753) defaults non-interactive onboard to `balanced`, which excludes messaging presets. Adds `NEMOCLAW_POLICY_TIER: "open"` to the workflow env.
- **sandbox-survival-e2e**: SSH after gateway restart can fail because the sandbox SSH agent isn't immediately reachable when the gateway reports healthy (more noticeable with OpenClaw 2026.4.2). Adds a 30s retry loop for SSH connectivity. Also removes `cleanup_ssh()` from the failure path — deleting the SSH config was causing all subsequent phases to fail with "Can't open user config file", masking whether data actually persisted.

## Test plan
- [ ] Nightly E2E messaging-providers job passes
- [ ] Nightly E2E sandbox-survival job passes (or produces real diagnostics if data is actually lost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Nightly end-to-end test environment configuration updated to set the test policy tier.

* **Tests**
  * End-to-end test flow now retries SSH connectivity multiple times and preserves connection data on failure, improving test stability and enabling richer diagnostic logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->