### PR TITLE
fix(ci): support fork PRs in e2e-brev workflow

### DIFF
--- a/.github/workflows/e2e-brev.yaml
+++ b/.github/workflows/e2e-brev.yaml
@@ -115,11 +115,13 @@ jobs:
           BRANCH=$(gh pr view ${{ inputs.pr_number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)
           echo "Resolved PR #${{ inputs.pr_number }} → branch: $BRANCH"
           echo "RESOLVED_BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          # Use the PR head ref for checkout — works for both fork and non-fork PRs.
+          echo "PR_REF=refs/pull/${{ inputs.pr_number }}/head" >> "$GITHUB_ENV"
 
       - name: Checkout target branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ env.RESOLVED_BRANCH || inputs.branch || 'main' }}
+          ref: ${{ env.PR_REF || inputs.branch || 'main' }}
 
       - name: Create check run (pending)
         if: inputs.pr_number != ''


### PR DESCRIPTION
## Summary
- Use `refs/pull/<N>/head` instead of resolving the branch name for checkout when `pr_number` is provided
- Fork branches don't exist in the base repo, so the previous approach failed with `git fetch exit code 1`
- `refs/pull/<N>/head` is created by GitHub for all open PRs regardless of origin

## Test plan
- [ ] Trigger `e2e-brev` workflow with a fork PR number (e.g. PR #892) and confirm checkout succeeds
- [ ] Trigger `e2e-brev` workflow with a non-fork PR number and confirm it still works
- [ ] Trigger `e2e-brev` workflow with `branch` input (no `pr_number`) and confirm fallback works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved branch handling in pull request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->