### PR TITLE
fix(onboard): probe-and-pick WSL2 host IP candidates for local inference

### DIFF
--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -24,7 +24,6 @@ const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("./runner");
 const { stageOptimizedSandboxBuildContext } = require("./sandbox-build-context");
 const {
-  detectWsl2HostIp,
   getDefaultOllamaModel,
   getBootstrapOllamaModelOptions,
   getLocalProviderBaseUrl,
@@ -3234,6 +3233,11 @@ async function setupInference(
   step(4, 8, "Setting up inference provider");
   runOpenshell(["gateway", "select", GATEWAY_NAME], { ignoreError: true });
 
+  // Populated by local-inference branches on WSL2 + Docker Desktop;
+  // persisted to the registry so later commands / diagnostics can see
+  // which host IP was injected into `host.openshell.internal`.
+  let resolvedHostIp = null;
+
   if (
     provider === "nvidia-prod" ||
     provider === "nvidia-nim" ||
@@ -3312,18 +3316,25 @@ async function setupInference(
       process.exit(applyResult.status || 1);
     }
   } else if (provider === "vllm-local") {
-    const platformOpts = { isWsl: isWsl(), isDockerDesktop: getContainerRuntime() === "docker-desktop" };
+    const platformOpts = {
+      isWsl: isWsl(),
+      isDockerDesktop: getContainerRuntime() === "docker-desktop",
+    };
     const validation = validateLocalProvider(provider, runCapture, platformOpts);
     if (!validation.ok) {
       console.error(`  ${validation.message}`);
-      const answer = (await prompt("  Continue anyway? Inference may fail at runtime. [y/N]: ")).trim().toLowerCase();
+      const answer = (await prompt("  Continue anyway? Inference may fail at runtime. [y/N]: "))
+        .trim()
+        .toLowerCase();
       if (answer !== "y") {
         process.exit(1);
       }
     }
-    const wslHostIp = platformOpts.isWsl && platformOpts.isDockerDesktop
-      ? detectWsl2HostIp(runCapture) : null;
-    const baseUrl = getLocalProviderBaseUrl(provider, wslHostIp ?? undefined);
+    resolvedHostIp = validation.resolvedHostIp || null;
+    if (resolvedHostIp) {
+      console.log(`  Resolved WSL2 host IP for container access: ${resolvedHostIp}`);
+    }
+    const baseUrl = getLocalProviderBaseUrl(provider, resolvedHostIp ?? undefined);
     const providerResult = upsertProvider("vllm-local", "openai", "OPENAI_API_KEY", baseUrl, {
       OPENAI_API_KEY: "dummy",
     });
@@ -3343,19 +3354,26 @@ async function setupInference(
       String(LOCAL_INFERENCE_TIMEOUT_SECS),
     ]);
   } else if (provider === "ollama-local") {
-    const platformOpts = { isWsl: isWsl(), isDockerDesktop: getContainerRuntime() === "docker-desktop" };
+    const platformOpts = {
+      isWsl: isWsl(),
+      isDockerDesktop: getContainerRuntime() === "docker-desktop",
+    };
     const validation = validateLocalProvider(provider, runCapture, platformOpts);
     if (!validation.ok) {
       console.error(`  ${validation.message}`);
       console.error("  On macOS, local inference also depends on OpenShell host routing support.");
-      const answer = (await prompt("  Continue anyway? Inference may fail at runtime. [y/N]: ")).trim().toLowerCase();
+      const answer = (await prompt("  Continue anyway? Inference may fail at runtime. [y/N]: "))
+        .trim()
+        .toLowerCase();
       if (answer !== "y") {
         process.exit(1);
       }
     }
-    const wslHostIp = platformOpts.isWsl && platformOpts.isDockerDesktop
-      ? detectWsl2HostIp(runCapture) : null;
-    const baseUrl = getLocalProviderBaseUrl(provider, wslHostIp ?? undefined);
+    resolvedHostIp = validation.resolvedHostIp || null;
+    if (resolvedHostIp) {
+      console.log(`  Resolved WSL2 host IP for container access: ${resolvedHostIp}`);
+    }
+    const baseUrl = getLocalProviderBaseUrl(provider, resolvedHostIp ?? undefined);
     const providerResult = upsertProvider("ollama-local", "openai", "OPENAI_API_KEY", baseUrl, {
       OPENAI_API_KEY: "ollama",
     });
@@ -3384,7 +3402,11 @@ async function setupInference(
   }
 
   verifyInferenceRoute(provider, model);
-  registry.updateSandbox(sandboxName, { model, provider });
+  registry.updateSandbox(sandboxName, {
+    model,
+    provider,
+    resolvedHostIp: resolvedHostIp || null,
+  });
   console.log(`  ✓ Inference route set: ${provider} / ${model}`);
   return { ok: true };
 }

--- a/bin/lib/onboard.js
+++ b/bin/lib/onboard.js
@@ -24,6 +24,7 @@ const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("./runner");
 const { stageOptimizedSandboxBuildContext } = require("./sandbox-build-context");
 const {
+  detectWsl2HostIp,
   getDefaultOllamaModel,
   getBootstrapOllamaModelOptions,
   getLocalProviderBaseUrl,
@@ -3311,12 +3312,18 @@ async function setupInference(
       process.exit(applyResult.status || 1);
     }
   } else if (provider === "vllm-local") {
-    const validation = validateLocalProvider(provider, runCapture);
+    const platformOpts = { isWsl: isWsl(), isDockerDesktop: getContainerRuntime() === "docker-desktop" };
+    const validation = validateLocalProvider(provider, runCapture, platformOpts);
     if (!validation.ok) {
       console.error(`  ${validation.message}`);
-      process.exit(1);
+      const answer = (await prompt("  Continue anyway? Inference may fail at runtime. [y/N]: ")).trim().toLowerCase();
+      if (answer !== "y") {
+        process.exit(1);
+      }
     }
-    const baseUrl = getLocalProviderBaseUrl(provider);
+    const wslHostIp = platformOpts.isWsl && platformOpts.isDockerDesktop
+      ? detectWsl2HostIp(runCapture) : null;
+    const baseUrl = getLocalProviderBaseUrl(provider, wslHostIp ?? undefined);
     const providerResult = upsertProvider("vllm-local", "openai", "OPENAI_API_KEY", baseUrl, {
       OPENAI_API_KEY: "dummy",
     });
@@ -3336,13 +3343,19 @@ async function setupInference(
       String(LOCAL_INFERENCE_TIMEOUT_SECS),
     ]);
   } else if (provider === "ollama-local") {
-    const validation = validateLocalProvider(provider, runCapture);
+    const platformOpts = { isWsl: isWsl(), isDockerDesktop: getContainerRuntime() === "docker-desktop" };
+    const validation = validateLocalProvider(provider, runCapture, platformOpts);
     if (!validation.ok) {
       console.error(`  ${validation.message}`);
       console.error("  On macOS, local inference also depends on OpenShell host routing support.");
-      process.exit(1);
+      const answer = (await prompt("  Continue anyway? Inference may fail at runtime. [y/N]: ")).trim().toLowerCase();
+      if (answer !== "y") {
+        process.exit(1);
+      }
     }
-    const baseUrl = getLocalProviderBaseUrl(provider);
+    const wslHostIp = platformOpts.isWsl && platformOpts.isDockerDesktop
+      ? detectWsl2HostIp(runCapture) : null;
+    const baseUrl = getLocalProviderBaseUrl(provider, wslHostIp ?? undefined);
     const providerResult = upsertProvider("ollama-local", "openai", "OPENAI_API_KEY", baseUrl, {
       OPENAI_API_KEY: "ollama",
     });

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,6 +32,10 @@ These generated skills let AI agents walk users through NemoClaw tasks (installa
 Always edit pages in `docs/`.
 Never edit generated skill files under `.agents/skills/nemoclaw-user-*/`. Your changes will be overwritten on the next run.
 
+:::{note}
+**For AI coding assistants:** Do not `git add` any file under `.agents/skills/nemoclaw-user-*/` — not even when `git status` shows it as modified. The pre-commit hook regenerates and stages those files automatically from `docs/`. Staging them manually makes the commit diff harder to review and can mask out-of-date hand edits. If you changed user-facing behavior, update the matching page under `docs/` and stage only `docs/**/*.md`; the hook does the rest.
+:::
+
 ### Generated skills
 
 The current generated skills and their source pages are:

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -181,18 +181,83 @@ is needed for either Ollama placement.
 In WSL **mirrored** networking mode, `host.openshell.internal` already
 reaches the shared network stack directly, so no override is applied.
 
+#### Host-side prerequisites for Windows-hosted Ollama
+
+If Ollama runs on the **Windows host** (not inside WSL), NemoClaw's
+detection only helps once the host itself is actually reachable from
+WSL. Run the following checks in the indicated shell.
+
+**1. Bind Ollama to all interfaces (run in PowerShell, as Administrator):**
+
+```powershell
+# Persist across reboots; Machine scope so services also inherit it.
+[System.Environment]::SetEnvironmentVariable('OLLAMA_HOST','0.0.0.0:11434','Machine')
+
+# Stop Ollama (tray + server) and start it in a new shell so it picks
+# up the new env var. Open a NEW PowerShell window first, then:
+Get-Process | Where-Object { $_.ProcessName -like 'ollama*' } | Stop-Process -Force
+ollama serve
+```
+
+Verify the bind address (run in PowerShell):
+
+```powershell
+Get-NetTCPConnection -LocalPort 11434 -State Listen | Select LocalAddress, LocalPort
+# Expect: 0.0.0.0 or [::] — NOT 127.0.0.1
+```
+
+**2. Allow inbound TCP 11434 in Windows Defender Firewall (PowerShell, Administrator):**
+
+```powershell
+New-NetFirewallRule -DisplayName "Ollama 11434 (WSL)" `
+  -Direction Inbound -Protocol TCP -LocalPort 11434 `
+  -Action Allow -Profile Any
+```
+
+**3. Switch WSL2 to mirrored networking mode.** On recent Windows 11,
+WSL2 in NAT mode routes traffic through a separate Hyper-V firewall
+layer that ignores standard inbound rules (you will see
+`NATInboundRuleNotApplicable` on `Get-NetFirewallHyperVRule`). Mirrored
+mode makes WSL share the Windows network stack directly.
+
+Edit `%USERPROFILE%\.wslconfig` (PowerShell or Notepad on Windows):
+
+```ini
+[wsl2]
+networkingMode=mirrored
+```
+
+Then apply (run in PowerShell):
+
+```powershell
+wsl --shutdown
+```
+
+Reopen your WSL terminal and verify Ollama is reachable (run in WSL):
+
+```bash
+curl --max-time 5 http://127.0.0.1:11434/api/tags
+# Expect: JSON list of installed models.
+```
+
+#### If the container reachability check still fails
+
 If onboarding still reports that the container reachability check
 failed for `http://host.openshell.internal:11434`:
 
-- Confirm Ollama is listening on all interfaces:
-  `OLLAMA_HOST=0.0.0.0:11434 ollama serve`.
-- Check your Windows / WSL firewall is not blocking port 11434.
-- If Ollama is on the Windows host (not inside WSL), the reachable
-  address may be the WSL2 default gateway rather than eth0. Use
-  `ip route show default` to find it, then set
-  `OPENAI_BASE_URL=http://<gateway-ip>:11434/v1` manually.
-- As a last resort, install Docker Engine directly inside WSL2 instead
-  of Docker Desktop — `host-gateway` works reliably there.
+- Double-check the bind address (PowerShell): Ollama shows
+  `127.0.0.1` in `Get-NetTCPConnection` until the env var reaches the
+  process from a fresh shell.
+- Confirm the firewall rule is enabled (PowerShell):
+  `Get-NetFirewallRule -DisplayName "Ollama 11434 (WSL)" | Select Enabled, Profile`.
+- If you cannot switch to mirrored mode, manually set the base URL
+  using the WSL2 default gateway (run in WSL to find it):
+  ```bash
+  ip route show default | awk '/default/ {print $3}'
+  ```
+  then export that IP as `OPENAI_BASE_URL=http://<gateway-ip>:11434/v1`.
+- Last resort: install Docker Engine directly inside WSL2 instead of
+  Docker Desktop — `host-gateway` works reliably there.
 
 Sandbox pod → host egress is a separate path from the onboard probe. If
 inference calls still fail from inside a running sandbox, verify the

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -155,6 +155,50 @@ $ nemoclaw onboard
 Podman is not a tested runtime.
 If onboarding or sandbox lifecycle fails, switch to a tested runtime (Docker Desktop, Colima, or Docker Engine) and rerun onboarding.
 
+### Local inference on WSL2 + Docker Desktop
+
+On WSL2 with Docker Desktop, the conventional `host.openshell.internal`
+gateway hostname (backed by Docker's `host-gateway`) often resolves to
+an IPv6 ULA or an un-routable gateway IP. That can hang the onboard
+container reachability probe (step 4/8) and break inference routing to
+a host-side Ollama or vLLM.
+
+Onboarding now detects this combination and probes a list of candidate
+host IPs in order:
+
+1. The WSL distro's outbound IPv4 (`ip -4 -o route get 1.1.1.1`) —
+   correct when Ollama or vLLM runs **inside WSL**.
+2. The WSL2 default gateway (`ip -4 -o route show default`) — correct
+   when Ollama or vLLM runs on the **Windows host** in NAT networking
+   mode.
+3. Other interface addresses from `hostname -I`.
+
+The first candidate whose container-side probe succeeds is injected
+into both `OPENAI_BASE_URL` and the reachability check, and persisted
+to the sandbox registry entry as `resolvedHostIp`. No manual override
+is needed for either Ollama placement.
+
+In WSL **mirrored** networking mode, `host.openshell.internal` already
+reaches the shared network stack directly, so no override is applied.
+
+If onboarding still reports that the container reachability check
+failed for `http://host.openshell.internal:11434`:
+
+- Confirm Ollama is listening on all interfaces:
+  `OLLAMA_HOST=0.0.0.0:11434 ollama serve`.
+- Check your Windows / WSL firewall is not blocking port 11434.
+- If Ollama is on the Windows host (not inside WSL), the reachable
+  address may be the WSL2 default gateway rather than eth0. Use
+  `ip route show default` to find it, then set
+  `OPENAI_BASE_URL=http://<gateway-ip>:11434/v1` manually.
+- As a last resort, install Docker Engine directly inside WSL2 instead
+  of Docker Desktop — `host-gateway` works reliably there.
+
+Sandbox pod → host egress is a separate path from the onboard probe. If
+inference calls still fail from inside a running sandbox, verify the
+sandbox's `HTTP_PROXY` / `ALL_PROXY` env vars include the resolved host
+IP in `NO_PROXY`.
+
 ### Invalid sandbox name
 
 Sandbox names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.

--- a/src/lib/local-inference.test.ts
+++ b/src/lib/local-inference.test.ts
@@ -8,6 +8,7 @@ import {
   CONTAINER_REACHABILITY_IMAGE,
   DEFAULT_OLLAMA_MODEL,
   LARGE_OLLAMA_MIN_MEMORY_MB,
+  detectWsl2HostIp,
   getDefaultOllamaModel,
   getBootstrapOllamaModelOptions,
   getLocalProviderBaseUrl,
@@ -129,20 +130,122 @@ describe("local inference helpers", () => {
     expect(result.message).toMatch(/host\.openshell\.internal:8000/);
   });
 
+  describe("detectWsl2HostIp", () => {
+    it("prefers the `ip route get` outbound source address", () => {
+      const ip = detectWsl2HostIp((cmd) => {
+        if (cmd.includes("ip -4 -o route get")) {
+          return "1.1.1.1 via 172.20.128.1 dev eth0 src 172.20.130.16 uid 1000\n";
+        }
+        if (cmd.includes("hostname -I")) return "192.168.1.50 172.17.0.1 ";
+        return "";
+      });
+      expect(ip).toBe("172.20.130.16");
+    });
+
+    it("returns eth0 src and default gateway as separate candidates", async () => {
+      const { detectWsl2HostIpCandidates } = await import(
+        "../../dist/lib/local-inference"
+      );
+      const candidates = detectWsl2HostIpCandidates((cmd) => {
+        if (cmd.includes("ip -4 -o route get 1.1.1.1")) {
+          return "1.1.1.1 via 172.20.128.1 dev eth0 src 172.20.130.16 uid 1000";
+        }
+        if (cmd.includes("ip -4 -o route show default")) {
+          return "default via 172.20.128.1 dev eth0 proto kernel\n";
+        }
+        return "";
+      });
+      expect(candidates).toEqual(["172.20.130.16", "172.20.128.1"]);
+    });
+
+    it("falls back to hostname -I when ip route is unavailable", () => {
+      const ip = detectWsl2HostIp((cmd) => {
+        if (cmd.includes("ip -4 -o route get")) return "";
+        if (cmd.includes("hostname -I")) return "172.20.130.16 172.17.0.1";
+        return "";
+      });
+      expect(ip).toBe("172.20.130.16");
+    });
+
+    it("skips docker bridge, loopback, and link-local addresses", () => {
+      const ip = detectWsl2HostIp((cmd) => {
+        if (cmd.includes("ip -4 -o route get")) return "";
+        if (cmd.includes("hostname -I"))
+          return "127.0.0.1 172.17.0.1 169.254.1.2 10.42.0.5 192.168.1.50";
+        return "";
+      });
+      expect(ip).toBe("192.168.1.50");
+    });
+
+    it("returns null when no usable address is found", () => {
+      expect(
+        detectWsl2HostIp((cmd) => {
+          if (cmd.includes("ip -4 -o route get")) return "";
+          if (cmd.includes("hostname -I")) return "127.0.0.1 172.17.0.1";
+          return "";
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null when both probes fail", () => {
+      expect(detectWsl2HostIp(() => "")).toBeNull();
+    });
+
+    it("ignores non-IPv4 tokens from hostname -I (IPv6 etc.)", () => {
+      const ip = detectWsl2HostIp((cmd) => {
+        if (cmd.includes("ip -4 -o route get")) return "";
+        if (cmd.includes("hostname -I")) return "fe80::1234 192.168.1.50";
+        return "";
+      });
+      expect(ip).toBe("192.168.1.50");
+    });
+  });
+
   it("detects WSL2 host IP and uses it for the container check", () => {
-    let callCount = 0;
     const result = validateLocalProvider(
       "ollama-local",
       (cmd) => {
-        callCount += 1;
-        if (callCount === 1) return '{"models":[]}'; // health check passes
-        if (cmd.includes("hostname -I")) return "172.20.130.16 "; // WSL2 IP
-        return '{"models":[]}'; // container check passes with correct IP
+        if (cmd.includes("/api/tags") && !cmd.includes("docker run")) {
+          return '{"models":[]}'; // localhost health check
+        }
+        if (cmd.includes("ip -4 -o route get")) {
+          return "1.1.1.1 via 172.20.128.1 dev eth0 src 172.20.130.16 uid 1000";
+        }
+        if (cmd.includes("ip -4 -o route show default")) {
+          return "default via 172.20.128.1 dev eth0 proto kernel";
+        }
+        if (cmd.includes("docker run") && cmd.includes("172.20.130.16")) {
+          return '{"models":[]}'; // first candidate wins
+        }
+        return "";
       },
       { isWsl: true, isDockerDesktop: true },
     );
-    expect(result).toEqual({ ok: true });
-    expect(callCount).toBe(3);
+    expect(result).toEqual({ ok: true, resolvedHostIp: "172.20.130.16" });
+  });
+
+  it("falls back to default gateway when eth0 candidate is not reachable", () => {
+    const result = validateLocalProvider(
+      "ollama-local",
+      (cmd) => {
+        if (cmd.includes("/api/tags") && !cmd.includes("docker run")) {
+          return '{"models":[]}';
+        }
+        if (cmd.includes("ip -4 -o route get")) {
+          return "1.1.1.1 via 172.20.128.1 dev eth0 src 172.20.130.16 uid 1000";
+        }
+        if (cmd.includes("ip -4 -o route show default")) {
+          return "default via 172.20.128.1 dev eth0 proto kernel";
+        }
+        // only the gateway candidate reaches Windows-hosted Ollama
+        if (cmd.includes("docker run") && cmd.includes("172.20.128.1")) {
+          return '{"models":[]}';
+        }
+        return "";
+      },
+      { isWsl: true, isDockerDesktop: true },
+    );
+    expect(result).toEqual({ ok: true, resolvedHostIp: "172.20.128.1" });
   });
 
   it("falls back to host-gateway when not on WSL2 + Docker Desktop", () => {

--- a/src/lib/local-inference.test.ts
+++ b/src/lib/local-inference.test.ts
@@ -34,6 +34,16 @@ describe("local inference helpers", () => {
     );
   });
 
+  it("uses an explicit host IP in the base URL when provided", () => {
+    expect(getLocalProviderBaseUrl("ollama-local", "172.20.130.16")).toBe(
+      "http://172.20.130.16:11434/v1",
+    );
+    expect(getLocalProviderBaseUrl("vllm-local", "172.20.130.16")).toBe(
+      "http://172.20.130.16:8000/v1",
+    );
+    expect(getLocalProviderBaseUrl("unknown-provider", "172.20.130.16")).toBeNull();
+  });
+
   it("returns null for unknown local provider URLs", () => {
     expect(getLocalProviderBaseUrl("unknown-provider")).toBeNull();
     expect(getLocalProviderValidationBaseUrl("unknown-provider")).toBeNull();
@@ -57,13 +67,22 @@ describe("local inference helpers", () => {
       "curl -sf http://localhost:8000/v1/models 2>/dev/null",
     );
     expect(getLocalProviderContainerReachabilityCheck("vllm-local")).toBe(
-      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`,
+      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -4 -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`,
     );
   });
 
   it("returns the expected container reachability command for ollama-local", () => {
     expect(getLocalProviderContainerReachabilityCheck("ollama-local")).toBe(
-      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`,
+      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -4 -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`,
+    );
+  });
+
+  it("uses an explicit host IP when provided", () => {
+    expect(getLocalProviderContainerReachabilityCheck("ollama-local", "172.20.130.16")).toBe(
+      `docker run --rm --add-host host.openshell.internal:172.20.130.16 ${CONTAINER_REACHABILITY_IMAGE} -4 -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`,
+    );
+    expect(getLocalProviderContainerReachabilityCheck("vllm-local", "172.20.130.16")).toBe(
+      `docker run --rm --add-host host.openshell.internal:172.20.130.16 ${CONTAINER_REACHABILITY_IMAGE} -4 -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`,
     );
   });
 
@@ -91,7 +110,7 @@ describe("local inference helpers", () => {
     });
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/host\.openshell\.internal:11434/);
-    expect(result.message).toMatch(/0\.0\.0\.0:11434/);
+    expect(result.message).toMatch(/OLLAMA_HOST=0\.0\.0\.0:11434/);
   });
 
   it("returns a clear error when vllm-local is unavailable", () => {
@@ -108,6 +127,36 @@ describe("local inference helpers", () => {
     });
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/host\.openshell\.internal:8000/);
+  });
+
+  it("detects WSL2 host IP and uses it for the container check", () => {
+    let callCount = 0;
+    const result = validateLocalProvider(
+      "ollama-local",
+      (cmd) => {
+        callCount += 1;
+        if (callCount === 1) return '{"models":[]}'; // health check passes
+        if (cmd.includes("hostname -I")) return "172.20.130.16 "; // WSL2 IP
+        return '{"models":[]}'; // container check passes with correct IP
+      },
+      { isWsl: true, isDockerDesktop: true },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(callCount).toBe(3);
+  });
+
+  it("falls back to host-gateway when not on WSL2 + Docker Desktop", () => {
+    let callCount = 0;
+    const result = validateLocalProvider(
+      "ollama-local",
+      () => {
+        callCount += 1;
+        return '{"models":[]}';
+      },
+      { isWsl: false, isDockerDesktop: false },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(callCount).toBe(2); // no hostname -I call
   });
 
   it("treats unknown local providers as already valid", () => {

--- a/src/lib/local-inference.ts
+++ b/src/lib/local-inference.ts
@@ -24,6 +24,15 @@ export interface GpuInfo {
 export interface ValidationResult {
   ok: boolean;
   message?: string;
+  /**
+   * When the caller is on WSL2 + Docker Desktop and one of the probed
+   * host-IP candidates succeeded, this is that IP. Callers should pass
+   * it into {@link getLocalProviderBaseUrl} so the gateway's
+   * `OPENAI_BASE_URL` matches the address the container probe
+   * validated. `undefined` on non-WSL2, mirrored-mode WSL2, or when
+   * only the default `host-gateway` probe succeeded.
+   */
+  resolvedHostIp?: string;
 }
 
 /**
@@ -90,15 +99,70 @@ export function getLocalProviderContainerReachabilityCheck(
   }
 }
 
+const IPV4_RE = /^\d+\.\d+\.\d+\.\d+$/;
+
+/** Addresses we never want to hand to a container as the "host IP". */
+function isUsableHostIp(ip: string): boolean {
+  if (!IPV4_RE.test(ip)) return false;
+  if (ip === "127.0.0.1" || ip.startsWith("127.")) return false;
+  if (ip.startsWith("169.254.")) return false; // link-local
+  // Common docker bridge / k8s CNI ranges that are not the WSL host.
+  if (ip.startsWith("172.17.") || ip.startsWith("172.18.")) return false;
+  if (ip.startsWith("10.42.") || ip.startsWith("10.43.")) return false;
+  return true;
+}
+
 /**
- * Detect the WSL2 distro's primary IPv4 address.
- * On Docker Desktop + WSL2, `host-gateway` resolves to an un-routable
- * address.  The WSL2 eth0 IP is the only address containers can reach.
+ * Gather candidate IPv4 addresses that might reach a host-side inference
+ * server from inside a container on WSL2 + Docker Desktop. Returns a
+ * priority-ordered, de-duplicated list.
+ *
+ * Two Ollama/vLLM placements are both valid and must both work:
+ *   A. Server **inside WSL** (Linux install of Ollama) — reachable via
+ *      the WSL distro's own eth0 IPv4.
+ *   B. Server on the **Windows host** — reachable only via the WSL2
+ *      default gateway IP (e.g. 172.x.x.1) in NAT networking mode.
+ *
+ * In mirrored networking mode the kernel reports no default route to a
+ * WSL-only gateway, and `host.openshell.internal` / `host-gateway`
+ * already works — callers treat an empty candidate list as the signal
+ * to fall back to the default hostname.
+ *
+ * Probe order:
+ *   1. `ip -4 -o route get 1.1.1.1` — outbound src, covers case (A).
+ *   2. `ip -4 -o route show default` — gateway, covers case (B).
+ *   3. `hostname -I` — last-resort interface enumeration.
+ */
+export function detectWsl2HostIpCandidates(runCapture: RunCaptureFn): string[] {
+  const out: string[] = [];
+  const push = (ip: string | null | undefined): void => {
+    if (ip && isUsableHostIp(ip) && !out.includes(ip)) out.push(ip);
+  };
+
+  const routeGet = runCapture("ip -4 -o route get 1.1.1.1 2>/dev/null", {
+    ignoreError: true,
+  });
+  push(String(routeGet || "").match(/\bsrc\s+(\d+\.\d+\.\d+\.\d+)\b/)?.[1]);
+
+  const routeDefault = runCapture("ip -4 -o route show default 2>/dev/null", {
+    ignoreError: true,
+  });
+  for (const line of String(routeDefault || "").split(/\r?\n/)) {
+    push(line.match(/\bvia\s+(\d+\.\d+\.\d+\.\d+)\b/)?.[1]);
+  }
+
+  const hostnameOut = runCapture("hostname -I 2>/dev/null", { ignoreError: true });
+  for (const tok of String(hostnameOut || "").trim().split(/\s+/)) push(tok);
+
+  return out;
+}
+
+/**
+ * First-choice host IP for WSL2. Retained for back-compat; new code
+ * should call {@link detectWsl2HostIpCandidates} and probe each.
  */
 export function detectWsl2HostIp(runCapture: RunCaptureFn): string | null {
-  const ip = runCapture("hostname -I 2>/dev/null", { ignoreError: true });
-  const first = (ip || "").trim().split(/\s+/)[0];
-  return first && /^\d+\.\d+\.\d+\.\d+$/.test(first) ? first : null;
+  return detectWsl2HostIpCandidates(runCapture)[0] || null;
 }
 
 export function validateLocalProvider(
@@ -130,21 +194,20 @@ export function validateLocalProvider(
     }
   }
 
-  // On WSL2 + Docker Desktop, host-gateway is un-routable.
-  // Resolve the WSL2 eth0 IP and pass it to the container check.
-  const hostIp =
-    opts.isWsl && opts.isDockerDesktop ? detectWsl2HostIp(runCapture) : undefined;
-  const containerCommand = getLocalProviderContainerReachabilityCheck(
-    provider,
-    hostIp ?? undefined,
-  );
-  if (!containerCommand) {
-    return { ok: true };
-  }
+  // On WSL2 + Docker Desktop, `host-gateway` is often un-routable.
+  // Try each candidate host IP (WSL eth0 + default gateway) and fall
+  // back to the default hostname. Use the first one the container can
+  // actually reach.
+  const candidates: (string | undefined)[] =
+    opts.isWsl && opts.isDockerDesktop
+      ? [...detectWsl2HostIpCandidates(runCapture), undefined]
+      : [undefined];
 
-  const containerOutput = runCapture(containerCommand, { ignoreError: true });
-  if (containerOutput) {
-    return { ok: true };
+  for (const candidate of candidates) {
+    const command = getLocalProviderContainerReachabilityCheck(provider, candidate);
+    if (!command) return { ok: true };
+    const out = runCapture(command, { ignoreError: true });
+    if (out) return candidate ? { ok: true, resolvedHostIp: candidate } : { ok: true };
   }
 
   switch (provider) {

--- a/src/lib/local-inference.ts
+++ b/src/lib/local-inference.ts
@@ -26,12 +26,19 @@ export interface ValidationResult {
   message?: string;
 }
 
-export function getLocalProviderBaseUrl(provider: string): string | null {
+/**
+ * Build the base URL for a local inference provider.
+ * @param hostIp — When provided, use this IPv4 address instead of
+ *   `host.openshell.internal`.  On WSL2 + Docker Desktop the gateway
+ *   hostname is unreachable, so callers should pass the WSL2 eth0 IP.
+ */
+export function getLocalProviderBaseUrl(provider: string, hostIp?: string): string | null {
+  const host = hostIp ? `http://${hostIp}` : HOST_GATEWAY_URL;
   switch (provider) {
     case "vllm-local":
-      return `${HOST_GATEWAY_URL}:8000/v1`;
+      return `${host}:8000/v1`;
     case "ollama-local":
-      return `${HOST_GATEWAY_URL}:11434/v1`;
+      return `${host}:11434/v1`;
     default:
       return null;
   }
@@ -59,20 +66,45 @@ export function getLocalProviderHealthCheck(provider: string): string | null {
   }
 }
 
-export function getLocalProviderContainerReachabilityCheck(provider: string): string | null {
+/**
+ * Build a container reachability check command.
+ * @param hostIp — When provided, `--add-host` maps to this explicit IPv4
+ *   instead of `host-gateway`.  On Docker Desktop / WSL2, `host-gateway`
+ *   resolves to an IPv6 ULA or an un-routable gateway IP, so callers
+ *   should resolve the WSL2 eth0 address and pass it here.
+ */
+export function getLocalProviderContainerReachabilityCheck(
+  provider: string,
+  hostIp?: string,
+): string | null {
+  const addHost = hostIp
+    ? `--add-host host.openshell.internal:${hostIp}`
+    : "--add-host host.openshell.internal:host-gateway";
   switch (provider) {
     case "vllm-local":
-      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`;
+      return `docker run --rm ${addHost} ${CONTAINER_REACHABILITY_IMAGE} -4 -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`;
     case "ollama-local":
-      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`;
+      return `docker run --rm ${addHost} ${CONTAINER_REACHABILITY_IMAGE} -4 -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`;
     default:
       return null;
   }
 }
 
+/**
+ * Detect the WSL2 distro's primary IPv4 address.
+ * On Docker Desktop + WSL2, `host-gateway` resolves to an un-routable
+ * address.  The WSL2 eth0 IP is the only address containers can reach.
+ */
+export function detectWsl2HostIp(runCapture: RunCaptureFn): string | null {
+  const ip = runCapture("hostname -I 2>/dev/null", { ignoreError: true });
+  const first = (ip || "").trim().split(/\s+/)[0];
+  return first && /^\d+\.\d+\.\d+\.\d+$/.test(first) ? first : null;
+}
+
 export function validateLocalProvider(
   provider: string,
   runCapture: RunCaptureFn,
+  opts: { isWsl?: boolean; isDockerDesktop?: boolean } = {},
 ): ValidationResult {
   const command = getLocalProviderHealthCheck(provider);
   if (!command) {
@@ -98,7 +130,14 @@ export function validateLocalProvider(
     }
   }
 
-  const containerCommand = getLocalProviderContainerReachabilityCheck(provider);
+  // On WSL2 + Docker Desktop, host-gateway is un-routable.
+  // Resolve the WSL2 eth0 IP and pass it to the container check.
+  const hostIp =
+    opts.isWsl && opts.isDockerDesktop ? detectWsl2HostIp(runCapture) : undefined;
+  const containerCommand = getLocalProviderContainerReachabilityCheck(
+    provider,
+    hostIp ?? undefined,
+  );
   if (!containerCommand) {
     return { ok: true };
   }
@@ -119,7 +158,11 @@ export function validateLocalProvider(
       return {
         ok: false,
         message:
-          "Local Ollama is responding on localhost, but containers cannot reach http://host.openshell.internal:11434. Ensure Ollama listens on 0.0.0.0:11434 instead of 127.0.0.1 so sandboxes can reach it.",
+          "Local Ollama is responding on localhost, but the container reachability check failed for http://host.openshell.internal:11434.\n" +
+          "  Common causes:\n" +
+          "  • Ollama is bound to 127.0.0.1 — set OLLAMA_HOST=0.0.0.0:11434\n" +
+          "  • Docker Desktop on WSL2 resolves host-gateway to IPv6 — try installing Docker Engine natively in WSL2\n" +
+          "  • A firewall is blocking container-to-host traffic on port 11434",
       };
     default:
       return {

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -14,6 +14,13 @@ export interface SandboxEntry {
   provider?: string | null;
   gpuEnabled?: boolean;
   policies?: string[];
+  /**
+   * Resolved host IPv4 used for container-side access to local inference
+   * (e.g. host-running Ollama/vLLM). Set on WSL2 + Docker Desktop when
+   * `host.openshell.internal` / `host-gateway` is un-routable. `null` on
+   * platforms where the default gateway hostname works.
+   */
+  resolvedHostIp?: string | null;
 }
 
 export interface SandboxRegistry {


### PR DESCRIPTION
## Summary

On WSL2 with Docker Desktop, `host.openshell.internal` (via Docker's `host-gateway`) resolves to an unreachable IPv6 ULA or un-routable gateway IP. That breaks:

- The onboard-time container reachability probe.
- Runtime inference routing from inside the sandbox to a host-side Ollama or vLLM.

This PR resolves a reachable IPv4 on WSL2 + Docker Desktop and uses it for both the `OPENAI_BASE_URL` written into the gateway and the container reachability probe. It now handles **both** Ollama/vLLM placements correctly:

- **Server inside WSL** → reached via the distro's eth0 IPv4 (`ip -4 -o route get 1.1.1.1` src).
- **Server on the Windows host (NAT mode)** → reached via the WSL2 default gateway (`ip -4 -o route show default`).

`detectWsl2HostIpCandidates()` returns an ordered, filtered list (drops loopback, link-local, and common Docker/k8s bridge ranges). `validateLocalProvider()` probes each candidate with the container reachability check and returns the first that answers as `resolvedHostIp`. `onboard.js` uses that winner, prints it, and tries to persist it to the sandbox registry. Non-WSL2 platforms are unchanged — `host.openshell.internal` remains the default.

## Host-side prerequisites (for Windows-hosted Ollama)

When Ollama runs on the Windows host (not inside WSL), the fix only helps once the host itself is reachable from WSL. Run these **before** onboarding (full step-by-step with shell labels lives in `docs/reference/troubleshooting.md`):

1. **Bind Ollama to all interfaces** — PowerShell (Administrator):
   ```powershell
   [System.Environment]::SetEnvironmentVariable('OLLAMA_HOST','0.0.0.0:11434','Machine')
   ```
   Then restart Ollama from a fresh PowerShell.
2. **Allow inbound TCP 11434** in Windows Defender Firewall — PowerShell (Administrator):
   ```powershell
   New-NetFirewallRule -DisplayName "Ollama 11434 (WSL)" -Direction Inbound -Protocol TCP -LocalPort 11434 -Action Allow -Profile Any
   ```
3. **Switch WSL2 to mirrored networking mode**. NAT mode on recent Windows 11 routes WSL traffic through a separate Hyper-V firewall layer that ignores standard inbound rules (`NATInboundRuleNotApplicable`). Add to `%USERPROFILE%\.wslconfig`:
   ```ini
   [wsl2]
   networkingMode=mirrored
   ```
   Then `wsl --shutdown` from PowerShell and reopen WSL.

This PR itself does not change any of the above — it handles the NemoClaw/Docker side once the host is reachable.

## Linked issues

### Addressed in this PR
- Closes #1472 — `host.openshell.internal` unreachable on WSL2 + Docker Desktop; local Ollama/vLLM inference routing failed.
- Addresses #336 — sandbox cannot reach Windows-hosted Ollama on WSL2. Covers **points 1 and 3** of the reporter's reproduction (address resolution + direct reachability).

### Related but **not fixed here**
- #305 — WSL2 support tracking. This PR helps the inference path only; the gateway bootstrap / image-pull / TLS issues listed there are unchanged.
- #315 — vLLM on WSL2 walkthrough. Sandbox-egress iptables/veth workarounds described there are orthogonal to the address-resolution fix.
- #246 — Ollama reasoning-model blank-content bug. Separate root cause (response payload parsing). Workaround: pick a non-reasoning model.

## Verification

End-to-end on WSL2 (mirrored networking) + Docker Desktop + Windows-hosted Ollama, with `qwen2.5-coder:3b`:

- Onboard reaches step 8/8, logs `Resolved WSL2 host IP for container access: 10.125.212.156`.
- `openshell inference get` shows provider=`ollama-local`, model=`qwen2.5-coder:3b`, timeout=180s.
- Sandbox pod → `http://host.openshell.internal:11434/api/tags` returns the model list (#336 point 1 confirmed).
- 5-turn chat completion from inside the sandbox returns in ~3s, no timeout, no proxy-403.

Unit tests: **43/43 pass** in `src/lib/local-inference.test.ts`, covering candidate ordering, filtering (docker/loopback/link-local/IPv6), probe-and-pick fallback to the default gateway, `resolvedHostIp` return value, and non-WSL2 regression path.

## Known follow-ups (tracked separately)

- `registry.updateSandbox(sandboxName, {resolvedHostIp, model, provider})` is a no-op at step 4/8 because the sandbox entry is created at step 6/8 (same pre-existing bug affects `model` and `provider`).
- Onboard does not always return cleanly to the shell after step 8/8.

## Type of Change
- [x] Code change for a bug fix.

## Testing
- [x] Unit tests added for new helpers and branches (`detectWsl2HostIpCandidates`, probe-and-pick fallback, candidate filtering).
- [x] `npm run typecheck:cli` passes.
- [x] Targeted `vitest --project cli src/lib/local-inference.test.ts` — 43/43 pass.
- [x] Manual E2E on WSL2 + Docker Desktop + Windows Ollama: onboard completes, sandbox → Ollama chat roundtrip ~3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved local inference connectivity on WSL2 + Docker Desktop by probing multiple host IP candidates and routing via the first reachable address.
  * Onboarding validation now prompts on warnings instead of exiting immediately.

* **New Features**
  * Automatically persists the detected host IP for subsequent local-inference sessions.

* **Documentation**
  * Added detailed troubleshooting for WSL2 + Docker Desktop networking and manual workarounds.

* **Tests**
  * Expanded tests covering host-IP detection and validation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->