### PR TITLE
fix(cli): warn on stale default sandbox in nemoclaw debug

### DIFF
--- a/src/lib/debug-command.test.ts
+++ b/src/lib/debug-command.test.ts
@@ -44,6 +44,34 @@ describe("debug command", () => {
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "beta" });
   });
 
+  it("--sandbox overrides the default sandbox", () => {
+    const runDebug = vi.fn();
+    runDebugCommand(["--sandbox", "mybox"], {
+      getDefaultSandbox: () => "stale-default",
+      runDebug,
+      log: () => {},
+      error: () => {},
+      exit: ((code: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never,
+    });
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "mybox" });
+  });
+
+  it("falls back to undefined when getDefaultSandbox returns undefined", () => {
+    const runDebug = vi.fn();
+    runDebugCommand(["--quick"], {
+      getDefaultSandbox: () => undefined,
+      runDebug,
+      log: () => {},
+      error: () => {},
+      exit: ((code: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never,
+    });
+    expect(runDebug).toHaveBeenCalledWith({ quick: true, sandboxName: undefined });
+  });
+
   it("exits on invalid arguments", () => {
     expect(() =>
       parseDebugArgs(["--output"], {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -859,8 +859,24 @@ function stop() {
 
 function debug(args) {
   const { runDebug } = require("./lib/debug");
+  const getDefaultSandbox = (): string | undefined => {
+    const { defaultSandbox, sandboxes } = registry.listSandboxes();
+    if (!defaultSandbox) return undefined;
+    if (!sandboxes.find((s) => s.name === defaultSandbox)) {
+      console.error(`${_RD}Warning:${R} default sandbox '${defaultSandbox}' is no longer in the registry.`);
+      console.error(`  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}nemoclaw onboard${R} again.\n`);
+      return undefined;
+    }
+    const liveList = captureOpenshell(["sandbox", "list"], { ignoreError: true });
+    if (liveList.status === 0 && !parseLiveSandboxNames(liveList.output).has(defaultSandbox)) {
+      console.error(`${_RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`);
+      console.error(`  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}nemoclaw onboard${R} again.\n`);
+      return undefined;
+    }
+    return defaultSandbox;
+  };
   runDebugCommand(args, {
-    getDefaultSandbox: () => registry.listSandboxes().defaultSandbox || undefined,
+    getDefaultSandbox,
     runDebug,
     log: console.log,
     error: console.error,
@@ -1490,7 +1506,8 @@ function help() {
     nemoclaw status                  Show sandbox list and service status
 
   Troubleshooting:
-    nemoclaw debug [--quick]         Collect diagnostics for bug reports
+    nemoclaw debug [--quick] [--sandbox NAME]
+                                     Collect diagnostics for bug reports
     nemoclaw debug --output FILE     Save diagnostics tarball for GitHub issues
 
   ${G}Credentials:${R}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -211,6 +211,46 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("nemoclaw debug")).toBeTruthy();
   });
 
+  it("debug --sandbox NAME targets the specified sandbox", { timeout: 15000 }, () => {
+    const r = run("debug --quick --sandbox mybox");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("Collecting diagnostics for sandbox 'mybox'");
+  });
+
+  it("debug --sandbox without a name exits 1", () => {
+    const r = run("debug --sandbox");
+    expect(r.code).not.toBe(0);
+  });
+
+  it("debug warns when default sandbox is stale", { timeout: 15000 }, () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-stale-"));
+    fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, ".nemoclaw", "sandboxes.json"),
+      JSON.stringify({ sandboxes: {}, defaultSandbox: "ghost" }),
+      { mode: 0o600 },
+    );
+    const r = runWithEnv("debug --quick 2>&1", { HOME: home });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("Warning");
+    expect(r.out).toContain("ghost");
+    expect(r.out).toContain("--sandbox NAME");
+  });
+
+  it("debug --sandbox skips stale default warning", { timeout: 15000 }, () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-stale-"));
+    fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, ".nemoclaw", "sandboxes.json"),
+      JSON.stringify({ sandboxes: {}, defaultSandbox: "ghost" }),
+      { mode: 0o600 },
+    );
+    const r = runWithEnv("debug --quick --sandbox mybox 2>&1", { HOME: home });
+    expect(r.code).toBe(0);
+    expect(r.out).not.toContain("Warning");
+    expect(r.out).toContain("Collecting diagnostics for sandbox 'mybox'");
+  });
+
   it("maps --follow to openshell --tail", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-"));
     const localBin = path.join(home, "bin");

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -97,6 +97,20 @@ describe("registry", () => {
     expect(registry.getDefault()).toBe("y");
   });
 
+  it("getDefault falls back when defaultSandbox points to a stale name", () => {
+    registry.registerSandbox({ name: "alive" });
+    const data = registry.load();
+    data.defaultSandbox = "deleted-sandbox";
+    registry.save(data);
+    expect(registry.getDefault()).toBe("alive");
+  });
+
+  it("getDefault returns null when registry is empty with stale pointer", () => {
+    const data = { sandboxes: {}, defaultSandbox: "ghost" };
+    registry.save(data);
+    expect(registry.getDefault()).toBe(null);
+  });
+
   it("removeSandbox last sandbox sets default to null", () => {
     registry.registerSandbox({ name: "only" });
     registry.removeSandbox("only");


### PR DESCRIPTION
## Summary

- When `defaultSandbox` in `sandboxes.json` points to a sandbox no longer in the local registry or absent from the live OpenShell runtime, `nemoclaw debug` now warns the user and falls back to auto-detection instead of silently targeting a ghost sandbox
- When `--sandbox` is explicitly provided, `parseDebugArgs` handles it directly — `getDefaultSandbox()` is never called
- Surfaces `--sandbox NAME` in `nemoclaw help` so users know the override flag exists
- If OpenShell is unreachable (no gateway), the live check is skipped gracefully

Closes #1837

## Changes

- `src/nemoclaw.ts`: `getDefaultSandbox()` validates the stored default against both the local sandbox list and the live OpenShell runtime, warns if stale
- `src/nemoclaw.ts`: Updated help text to show `--sandbox NAME`
- `src/lib/debug-command.test.ts`: Tests for `--sandbox` override and undefined default fallback
- `test/cli.test.ts`: Integration tests for stale warning, `--sandbox` override, and missing name
- `test/registry.test.ts`: Tests for `getDefault()` fallback with stale pointer

## Test plan

- [x] `nemoclaw debug --quick` with valid default sandbox works unchanged
- [x] `nemoclaw debug --quick` with stale registry pointer prints warning, falls back to auto-detection
- [x] `nemoclaw debug --quick` with sandbox in registry but absent from OpenShell prints warning, falls back
- [x] `nemoclaw debug --quick --sandbox mybox` targets mybox, no warning
- [x] `nemoclaw debug --sandbox` (no name) exits non-zero
- [x] OpenShell unreachable — live check skipped gracefully, no crash
- [x] All registry, debug-command, and CLI integration tests pass

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `--sandbox NAME` parameter to the debug command for explicit sandbox selection.
  * Added validation and warning messages for stale default sandbox references with corrective guidance.

* **Tests**
  * Added comprehensive test coverage for debug command sandbox handling and default sandbox validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->