### PR TITLE
fix(scripts): warn when active sandbox sessions exist during install

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -72,6 +72,13 @@ For NemoClaw-managed environments, use `nemoclaw onboard` when you need to creat
 Avoid `openshell self-update`, `npm update -g openshell`, `openshell gateway start --recreate`, or `openshell sandbox create` directly unless you intend to manage OpenShell separately and then rerun `nemoclaw onboard`.
 :::
 
+The installer detects existing sandbox sessions before onboarding and prints a warning if any are found.
+To make the installer abort instead of continuing, set `NEMOCLAW_PROTECT_SESSIONS=1`:
+
+```console
+$ NEMOCLAW_PROTECT_SESSIONS=1 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
 The wizard prompts for a provider first, then collects the provider credential if needed.
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.
 Credentials are stored in `~/.nemoclaw/credentials.json`. For file permissions, plaintext storage behavior, and hardening guidance, see [Credential Storage](../security/credential-storage.md).

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -73,10 +73,10 @@ Avoid `openshell self-update`, `npm update -g openshell`, `openshell gateway sta
 :::
 
 The installer detects existing sandbox sessions before onboarding and prints a warning if any are found.
-To make the installer abort instead of continuing, set `NEMOCLAW_PROTECT_SESSIONS=1`:
+To make the installer abort instead of continuing, set `NEMOCLAW_SINGLE_SESSION=1`:
 
 ```console
-$ NEMOCLAW_PROTECT_SESSIONS=1 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+$ NEMOCLAW_SINGLE_SESSION=1 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
 The wizard prompts for a provider first, then collects the provider credential if needed.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -292,6 +292,7 @@ usage() {
   printf "    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
   printf "    NEMOCLAW_NON_INTERACTIVE=1    Same as --non-interactive\n"
   printf "    NEMOCLAW_SANDBOX_NAME         Sandbox name to create/use\n"
+  printf "    NEMOCLAW_PROTECT_SESSIONS=1   Abort if active sandbox sessions exist\n"
   printf "    NEMOCLAW_RECREATE_SANDBOX=1   Recreate an existing sandbox\n"
   printf "    NEMOCLAW_INSTALL_TAG         Git ref to install (default: latest release)\n"
   printf "    NEMOCLAW_PROVIDER             cloud | ollama | nim | vllm\n"
@@ -1203,6 +1204,15 @@ main() {
 
   step 3 "Onboarding"
   if command_exists nemoclaw; then
+    if ! nemoclaw list 2>&1 | grep -q "No sandboxes registered"; then
+      warn "Active sandbox sessions detected. Onboarding may disrupt running agents."
+      if [[ "${NEMOCLAW_PROTECT_SESSIONS:-}" == "1" ]]; then
+        error "Aborting — NEMOCLAW_PROTECT_SESSIONS is set. Destroy existing sessions with 'nemoclaw <name> destroy' before reinstalling."
+        exit 1
+      fi
+      warn "Consider destroying existing sessions with 'nemoclaw <name> destroy' first."
+      warn "Set NEMOCLAW_PROTECT_SESSIONS=1 to abort the installer when sessions are active."
+    fi
     if run_installer_host_preflight; then
       run_onboard
       ONBOARD_RAN=true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -292,7 +292,7 @@ usage() {
   printf "    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
   printf "    NEMOCLAW_NON_INTERACTIVE=1    Same as --non-interactive\n"
   printf "    NEMOCLAW_SANDBOX_NAME         Sandbox name to create/use\n"
-  printf "    NEMOCLAW_PROTECT_SESSIONS=1   Abort if active sandbox sessions exist\n"
+  printf "    NEMOCLAW_SINGLE_SESSION=1     Abort if active sandbox sessions exist\n"
   printf "    NEMOCLAW_RECREATE_SANDBOX=1   Recreate an existing sandbox\n"
   printf "    NEMOCLAW_INSTALL_TAG         Git ref to install (default: latest release)\n"
   printf "    NEMOCLAW_PROVIDER             cloud | ollama | nim | vllm\n"
@@ -1204,14 +1204,22 @@ main() {
 
   step 3 "Onboarding"
   if command_exists nemoclaw; then
-    if ! nemoclaw list 2>&1 | grep -q "No sandboxes registered"; then
-      warn "Active sandbox sessions detected. Onboarding may disrupt running agents."
-      if [[ "${NEMOCLAW_PROTECT_SESSIONS:-}" == "1" ]]; then
-        error "Aborting — NEMOCLAW_PROTECT_SESSIONS is set. Destroy existing sessions with 'nemoclaw <name> destroy' before reinstalling."
-        exit 1
+    if [[ -f "${HOME}/.nemoclaw/sandboxes.json" ]] && node -e '
+      const fs = require("fs");
+      try {
+        const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        const count = Object.keys(data.sandboxes || {}).length;
+        process.exit(count > 0 ? 0 : 1);
+      } catch {
+        process.exit(1);
+      }
+    ' "${HOME}/.nemoclaw/sandboxes.json"; then
+      warn "Existing sandbox sessions detected. Onboarding may disrupt running agents."
+      if [[ "${NEMOCLAW_SINGLE_SESSION:-}" == "1" ]]; then
+        error "Aborting — NEMOCLAW_SINGLE_SESSION is set. Destroy existing sessions with 'nemoclaw <name> destroy' before reinstalling."
       fi
       warn "Consider destroying existing sessions with 'nemoclaw <name> destroy' first."
-      warn "Set NEMOCLAW_PROTECT_SESSIONS=1 to abort the installer when sessions are active."
+      warn "Set NEMOCLAW_SINGLE_SESSION=1 to abort the installer when sessions are active."
     fi
     if run_installer_host_preflight; then
       run_onboard


### PR DESCRIPTION
The installer now detects registered sandboxes before onboarding and warns that proceeding may disrupt running agents. Set NEMOCLAW_PROTECT_SESSIONS=1 to make the installer abort instead.

Closes #1826

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [x] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [x] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [x] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now detects existing sandbox sessions during onboarding and warns if active sessions are present; set NEMOCLAW_SINGLE_SESSION=1 to abort installation instead of continuing.

* **Documentation**
  * Added docs describing sandbox-session protection, the NEMOCLAW_SINGLE_SESSION usage, and an example invocation (curl ... | bash).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->