### PR TITLE
fix(security): replace process.env spread with allowlist in blueprint runner

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -173,9 +173,9 @@ $ nemoclaw my-assistant logs [--follow]
 Stop the NIM container and delete the sandbox.
 This removes the sandbox from the registry.
 
-> **Warning:** Destroying a sandbox permanently deletes all files inside it, including
-> workspace files (see the `nemoclaw-user-workspace` skill) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes).
-> Back up your workspace first by following the instructions at Back Up and Restore (see the `nemoclaw-user-workspace` skill).
+> **Warning:** This command permanently deletes the sandbox **and its persistent volume**.
+> All workspace files (see the `nemoclaw-user-workspace` skill) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
+> Back up your workspace first — see Backup and Restore (see the `nemoclaw-user-workspace` skill).
 
 ```console
 $ nemoclaw my-assistant destroy

--- a/.agents/skills/nemoclaw-user-workspace/SKILL.md
+++ b/.agents/skills/nemoclaw-user-workspace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "nemoclaw-user-workspace"
-description: "Backs up and restores OpenClaw workspace files before destructive operations. Use when backing up a sandbox, restoring workspace state, or preparing for a destructive operation. Explains what workspace files are, where they live, and how they persist across sandbox restarts. Use when asking about soul.md, identity.md, memory.md, agents.md, or sandbox file persistence."
+description: "Hows to back up and restore OpenClaw workspace files before destructive operations. Whats workspace personality and configuration files are, where they live, and how they persist across sandbox restarts."
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -8,25 +8,23 @@ description: "Backs up and restores OpenClaw workspace files before destructive 
 
 # NemoClaw User Workspace
 
-Backs up and restores OpenClaw workspace files before destructive operations. Use when backing up a sandbox, restoring workspace state, or preparing for a destructive operation.
+How to back up and restore OpenClaw workspace files before destructive operations.
 
 ## Context
 
-OpenClaw stores agent identity, behavior, and memory in a set of Markdown files inside the sandbox.
-These files live at `/sandbox/.openclaw/workspace/` and are read by the agent at the start of every session.
+OpenClaw stores its personality, user context, and behavioral configuration in a set of Markdown files inside the sandbox.
+These files live at `/sandbox/.openclaw/workspace/` and are collectively called **workspace files**.
 
 ## File Reference
 
-Each file controls a distinct aspect of the agent's behavior and memory.
-
-| File | Purpose | Upstream Docs |
-|---|---|---|
-| `SOUL.md` | Core personality, tone, and behavioral rules. | [SOUL template](https://docs.openclaw.ai/reference/templates/SOUL) |
-| `USER.md` | Preferences, context, and facts the agent learns about you. | [USER template](https://docs.openclaw.ai/reference/templates/USER) |
-| `IDENTITY.md` | Agent name, creature type, emoji, and self-presentation. | [IDENTITY template](https://docs.openclaw.ai/reference/templates/IDENTITY) |
-| `AGENTS.md` | Multi-agent coordination, memory conventions, and safety guidelines. | [AGENTS template](https://docs.openclaw.ai/reference/templates/AGENTS) |
-| `MEMORY.md` | Curated long-term memory distilled from daily notes. | — |
-| `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. | — |
+| File | Purpose |
+|---|---|
+| `SOUL.md` | Defines the agent's persona, tone, and communication style. |
+| `USER.md` | Stores information about the human the agent assists. |
+| `IDENTITY.md` | Short identity card — name, language, emoji, creature type. |
+| `AGENTS.md` | Behavioral rules, memory conventions, safety guidelines, and session workflow. |
+| `MEMORY.md` | Curated long-term memory distilled from daily notes. |
+| `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. |
 
 ## Where They Live
 
@@ -44,34 +42,30 @@ All workspace files reside inside the sandbox filesystem:
     └── 2026-03-19.md
 ```
 
-> **Note:** The workspace directory is hidden (`.openclaw`).
-> The files are not at `/sandbox/SOUL.md`. Use the full path when downloading or uploading.
-
 ## Persistence Behavior
 
 Understanding when these files persist and when they are lost is critical.
 
-| Event | Workspace files |
-|---|---|
-| Sandbox restart | **Preserved:** the sandbox PVC retains its data. |
-| `nemoclaw <name> destroy` | **Lost:** the sandbox and its PVC are deleted. |
+### Survives: Sandbox Restart
+
+Sandbox restarts (`openshell sandbox restart`) preserve workspace files.
+The sandbox uses a **Persistent Volume Claim (PVC)** that outlives individual container restarts.
+
+### Lost: Sandbox Destroy
+
+Running `nemoclaw <name> destroy` **deletes the sandbox and its PVC**.
+All workspace files are permanently lost unless you back them up first.
 
 > **Warning:** Always back up your workspace files before running `nemoclaw <name> destroy`.
-> See Back Up and Restore (see the `nemoclaw-user-workspace` skill) for instructions.
+> See Backup and Restore (see the `nemoclaw-user-workspace` skill) for instructions.
 
 ## Editing Workspace Files
 
 The agent reads these files at the start of every session.
 You can edit them in two ways:
 
-1. **Let the agent do it:** Ask your agent to update its persona, memory, or user context during a session.
-2. **Edit manually:** Use `openshell sandbox connect` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
-
-## Prerequisites
-
-- A running NemoClaw sandbox (for backup) or a freshly created sandbox (for restore).
-- The OpenShell CLI on your `PATH`.
-- The sandbox name (shown by `nemoclaw list`).
+1. **Let the agent do it** — Ask your agent to update its persona, memory, or user context.
+2. **Edit manually** — Use `openshell sandbox shell` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
 
 Workspace files define your agent's personality, memory, and user context.
 They persist across sandbox restarts but are **permanently deleted** when you run `nemoclaw <name> destroy`.
@@ -80,9 +74,9 @@ This guide covers manual backup with CLI commands and an automated script.
 
 ## Step 1: When to Back Up
 
-- Before running `nemoclaw <name> destroy`.
-- Before major NemoClaw version upgrades.
-- Periodically, if you have invested time customizing your agent.
+- **Before running `nemoclaw <name> destroy`**
+- Before major NemoClaw version upgrades
+- Periodically, if you've invested time customizing your agent
 
 ## Step 2: Manual Backup
 
@@ -148,7 +142,7 @@ $ ./scripts/backup-workspace.sh restore my-assistant 20260320-120000
 List backed-up files to confirm completeness:
 
 ```console
-$ ls ~/.nemoclaw/backups/20260320-120000/
+$ ls -la ~/.nemoclaw/backups/20260320-120000/
 AGENTS.md
 IDENTITY.md
 MEMORY.md
@@ -157,16 +151,6 @@ USER.md
 memory/
 ```
 
-## Step 6: Inspecting Files Inside the Sandbox
-
-Connect to the sandbox to list or view workspace files directly:
-
-```console
-$ openshell sandbox connect my-assistant
-$ ls -la /sandbox/.openclaw/workspace/
-```
-
 ## Related Skills
 
 - `nemoclaw-user-reference` — Commands reference
-- `nemoclaw-user-monitor-sandbox` — Monitor Sandbox Activity

--- a/.agents/skills/nemoclaw-user-workspace/references/workspace-files.md
+++ b/.agents/skills/nemoclaw-user-workspace/references/workspace-files.md
@@ -2,21 +2,19 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Workspace Files
 
-OpenClaw stores agent identity, behavior, and memory in a set of Markdown files inside the sandbox.
-These files live at `/sandbox/.openclaw/workspace/` and are read by the agent at the start of every session.
+OpenClaw stores its personality, user context, and behavioral configuration in a set of Markdown files inside the sandbox.
+These files live at `/sandbox/.openclaw/workspace/` and are collectively called **workspace files**.
 
 ## File Reference
 
-Each file controls a distinct aspect of the agent's behavior and memory.
-
-| File | Purpose | Upstream Docs |
-|---|---|---|
-| `SOUL.md` | Core personality, tone, and behavioral rules. | [SOUL template](https://docs.openclaw.ai/reference/templates/SOUL) |
-| `USER.md` | Preferences, context, and facts the agent learns about you. | [USER template](https://docs.openclaw.ai/reference/templates/USER) |
-| `IDENTITY.md` | Agent name, creature type, emoji, and self-presentation. | [IDENTITY template](https://docs.openclaw.ai/reference/templates/IDENTITY) |
-| `AGENTS.md` | Multi-agent coordination, memory conventions, and safety guidelines. | [AGENTS template](https://docs.openclaw.ai/reference/templates/AGENTS) |
-| `MEMORY.md` | Curated long-term memory distilled from daily notes. | — |
-| `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. | — |
+| File | Purpose |
+|---|---|
+| `SOUL.md` | Defines the agent's persona, tone, and communication style. |
+| `USER.md` | Stores information about the human the agent assists. |
+| `IDENTITY.md` | Short identity card — name, language, emoji, creature type. |
+| `AGENTS.md` | Behavioral rules, memory conventions, safety guidelines, and session workflow. |
+| `MEMORY.md` | Curated long-term memory distilled from daily notes. |
+| `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. |
 
 ## Where They Live
 
@@ -34,30 +32,32 @@ All workspace files reside inside the sandbox filesystem:
     └── 2026-03-19.md
 ```
 
-> **Note:** The workspace directory is hidden (`.openclaw`).
-> The files are not at `/sandbox/SOUL.md`. Use the full path when downloading or uploading.
-
 ## Persistence Behavior
 
 Understanding when these files persist and when they are lost is critical.
 
-| Event | Workspace files |
-|---|---|
-| Sandbox restart | **Preserved:** the sandbox PVC retains its data. |
-| `nemoclaw <name> destroy` | **Lost:** the sandbox and its PVC are deleted. |
+### Survives: Sandbox Restart
+
+Sandbox restarts (`openshell sandbox restart`) preserve workspace files.
+The sandbox uses a **Persistent Volume Claim (PVC)** that outlives individual container restarts.
+
+### Lost: Sandbox Destroy
+
+Running `nemoclaw <name> destroy` **deletes the sandbox and its PVC**.
+All workspace files are permanently lost unless you back them up first.
 
 > **Warning:** Always back up your workspace files before running `nemoclaw <name> destroy`.
-> See Back Up and Restore (see the `nemoclaw-user-workspace` skill) for instructions.
+> See Backup and Restore (see the `nemoclaw-user-workspace` skill) for instructions.
 
 ## Editing Workspace Files
 
 The agent reads these files at the start of every session.
 You can edit them in two ways:
 
-1. **Let the agent do it:** Ask your agent to update its persona, memory, or user context during a session.
-2. **Edit manually:** Use `openshell sandbox connect` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
+1. **Let the agent do it** — Ask your agent to update its persona, memory, or user context.
+2. **Edit manually** — Use `openshell sandbox shell` to open a terminal inside the sandbox and edit files directly, or use `openshell sandbox upload` to push edited files from your host.
 
 ## Next Steps
 
-- Back Up and Restore workspace files (see the `nemoclaw-user-workspace` skill)
+- Backup and Restore workspace files (see the `nemoclaw-user-workspace` skill)
 - Commands reference (see the `nemoclaw-user-reference` skill)

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -431,6 +431,12 @@ describe("runner", () => {
     });
 
     it("does not leak parent secrets into subprocess env", async () => {
+      const prevMyApiKey = process.env.MY_API_KEY;
+      const prevGithubToken = process.env.GITHUB_TOKEN;
+      const prevAwsKey = process.env.AWS_ACCESS_KEY_ID;
+      const prevNvidiaKey = process.env.NVIDIA_API_KEY;
+      const prevProxy = process.env.HTTPS_PROXY;
+      const prevOsDebug = process.env.OPENSHELL_DEBUG;
       process.env.MY_API_KEY = "secret-key-123";
       process.env.GITHUB_TOKEN = "ghp_leaked";
       process.env.AWS_ACCESS_KEY_ID = "AKIA_leaked";
@@ -463,12 +469,18 @@ describe("runner", () => {
         expect(subEnv.HTTPS_PROXY).toBe("http://proxy.corp:8080");
         expect(subEnv.OPENSHELL_DEBUG).toBe("1");
       } finally {
-        delete process.env.MY_API_KEY;
-        delete process.env.GITHUB_TOKEN;
-        delete process.env.AWS_ACCESS_KEY_ID;
-        delete process.env.NVIDIA_API_KEY;
-        delete process.env.HTTPS_PROXY;
-        delete process.env.OPENSHELL_DEBUG;
+        if (prevMyApiKey === undefined) delete process.env.MY_API_KEY;
+        else process.env.MY_API_KEY = prevMyApiKey;
+        if (prevGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+        else process.env.GITHUB_TOKEN = prevGithubToken;
+        if (prevAwsKey === undefined) delete process.env.AWS_ACCESS_KEY_ID;
+        else process.env.AWS_ACCESS_KEY_ID = prevAwsKey;
+        if (prevNvidiaKey === undefined) delete process.env.NVIDIA_API_KEY;
+        else process.env.NVIDIA_API_KEY = prevNvidiaKey;
+        if (prevProxy === undefined) delete process.env.HTTPS_PROXY;
+        else process.env.HTTPS_PROXY = prevProxy;
+        if (prevOsDebug === undefined) delete process.env.OPENSHELL_DEBUG;
+        else process.env.OPENSHELL_DEBUG = prevOsDebug;
       }
     });
 

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -435,6 +435,8 @@ describe("runner", () => {
       process.env.GITHUB_TOKEN = "ghp_leaked";
       process.env.AWS_ACCESS_KEY_ID = "AKIA_leaked";
       process.env.NVIDIA_API_KEY = "nvapi-leaked";
+      process.env.HTTPS_PROXY = "http://proxy.corp:8080";
+      process.env.OPENSHELL_DEBUG = "1";
       try {
         await actionApply("default", minimalBlueprint());
 
@@ -456,11 +458,17 @@ describe("runner", () => {
         // Allowed system vars should still be present
         expect(subEnv).toHaveProperty("PATH");
         expect(subEnv).toHaveProperty("HOME");
+
+        // Proxy, TLS, and openshell vars must pass through
+        expect(subEnv.HTTPS_PROXY).toBe("http://proxy.corp:8080");
+        expect(subEnv.OPENSHELL_DEBUG).toBe("1");
       } finally {
         delete process.env.MY_API_KEY;
         delete process.env.GITHUB_TOKEN;
         delete process.env.AWS_ACCESS_KEY_ID;
         delete process.env.NVIDIA_API_KEY;
+        delete process.env.HTTPS_PROXY;
+        delete process.env.OPENSHELL_DEBUG;
       }
     });
 

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -430,7 +430,7 @@ describe("runner", () => {
       expect(providerCall[1]).not.toContain("--credential");
     });
 
-    it("does not leak parent secrets into subprocess env (NVBug 6010004)", async () => {
+    it("does not leak parent secrets into subprocess env", async () => {
       process.env.MY_API_KEY = "secret-key-123";
       process.env.GITHUB_TOKEN = "ghp_leaked";
       process.env.AWS_ACCESS_KEY_ID = "AKIA_leaked";

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -430,6 +430,40 @@ describe("runner", () => {
       expect(providerCall[1]).not.toContain("--credential");
     });
 
+    it("does not leak parent secrets into subprocess env (NVBug 6010004)", async () => {
+      process.env.MY_API_KEY = "secret-key-123";
+      process.env.GITHUB_TOKEN = "ghp_leaked";
+      process.env.AWS_ACCESS_KEY_ID = "AKIA_leaked";
+      process.env.NVIDIA_API_KEY = "nvapi-leaked";
+      try {
+        await actionApply("default", minimalBlueprint());
+
+        const providerCall = mockExeca.mock.calls.find(
+          (c) => Array.isArray(c[1]) && c[1].includes("provider"),
+        );
+        if (!providerCall) throw new Error("provider create call not found");
+        const subEnv = providerCall[2].env;
+
+        // The explicitly injected credential must be present
+        expect(subEnv.OPENAI_API_KEY).toBe("secret-key-123");
+
+        // Secrets from the parent process must NOT be present
+        expect(subEnv).not.toHaveProperty("GITHUB_TOKEN");
+        expect(subEnv).not.toHaveProperty("AWS_ACCESS_KEY_ID");
+        expect(subEnv).not.toHaveProperty("NVIDIA_API_KEY");
+        expect(subEnv).not.toHaveProperty("MY_API_KEY");
+
+        // Allowed system vars should still be present
+        expect(subEnv).toHaveProperty("PATH");
+        expect(subEnv).toHaveProperty("HOME");
+      } finally {
+        delete process.env.MY_API_KEY;
+        delete process.env.GITHUB_TOKEN;
+        delete process.env.AWS_ACCESS_KEY_ID;
+        delete process.env.NVIDIA_API_KEY;
+      }
+    });
+
     it("falls back to credential_default when env var is unset", async () => {
       const bp = {
         components: {

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -21,63 +21,8 @@ import { execa } from "execa";
 import YAML from "yaml";
 
 import { validateEndpointUrl } from "./ssrf.js";
+import { buildSubprocessEnv } from "../lib/subprocess-env.js";
 import { DASHBOARD_PORT } from "../lib/ports.js";
-
-// ── Subprocess environment allowlist ───────────────────────────
-// Only these env vars (or prefixes) are forwarded to subprocesses
-// spawned by the runner.  Everything else — including secrets like
-// NVIDIA_API_KEY, GITHUB_TOKEN, AWS_ACCESS_KEY_ID — is stripped.
-// Credentials needed by the subprocess are injected explicitly via
-// the `credEnv` overlay.  See: NVBug 6010004.
-
-const ALLOWED_ENV_NAMES = new Set([
-  "HOME",
-  "USER",
-  "LOGNAME",
-  "SHELL",
-  "PATH",
-  "TERM",
-  "TMPDIR",
-  "TMP",
-  "TEMP",
-  "LANG",
-  "NODE_ENV",
-  "HOSTNAME",
-  // Proxy — required behind corporate firewalls
-  "HTTP_PROXY",
-  "HTTPS_PROXY",
-  "NO_PROXY",
-  "http_proxy",
-  "https_proxy",
-  "no_proxy",
-  // TLS — custom CA bundles in enterprise environments
-  "SSL_CERT_FILE",
-  "SSL_CERT_DIR",
-  "NODE_EXTRA_CA_CERTS",
-  // Rust diagnostics — openshell is a Rust binary
-  "RUST_LOG",
-  "RUST_BACKTRACE",
-  // Container and orchestration runtimes
-  "DOCKER_HOST",
-  "KUBECONFIG",
-  "SSH_AUTH_SOCK",
-]);
-
-const ALLOWED_ENV_PREFIXES = ["LC_", "XDG_", "OPENSHELL_", "GRPC_"];
-
-function buildSubprocessEnv(extra?: Record<string, string>): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value === undefined) continue;
-    if (ALLOWED_ENV_NAMES.has(key) || ALLOWED_ENV_PREFIXES.some((p) => key.startsWith(p))) {
-      env[key] = value;
-    }
-  }
-  if (extra) {
-    Object.assign(env, extra);
-  }
-  return env;
-}
 
 type Action = "plan" | "apply" | "status" | "rollback";
 

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -43,9 +43,27 @@ const ALLOWED_ENV_NAMES = new Set([
   "LANG",
   "NODE_ENV",
   "HOSTNAME",
+  // Proxy — required behind corporate firewalls
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+  // TLS — custom CA bundles in enterprise environments
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "NODE_EXTRA_CA_CERTS",
+  // Rust diagnostics — openshell is a Rust binary
+  "RUST_LOG",
+  "RUST_BACKTRACE",
+  // Container and orchestration runtimes
+  "DOCKER_HOST",
+  "KUBECONFIG",
+  "SSH_AUTH_SOCK",
 ]);
 
-const ALLOWED_ENV_PREFIXES = ["LC_", "XDG_"];
+const ALLOWED_ENV_PREFIXES = ["LC_", "XDG_", "OPENSHELL_", "GRPC_"];
 
 function buildSubprocessEnv(extra?: Record<string, string>): Record<string, string> {
   const env: Record<string, string> = {};

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -23,6 +23,44 @@ import YAML from "yaml";
 import { validateEndpointUrl } from "./ssrf.js";
 import { DASHBOARD_PORT } from "../lib/ports.js";
 
+// ── Subprocess environment allowlist ───────────────────────────
+// Only these env vars (or prefixes) are forwarded to subprocesses
+// spawned by the runner.  Everything else — including secrets like
+// NVIDIA_API_KEY, GITHUB_TOKEN, AWS_ACCESS_KEY_ID — is stripped.
+// Credentials needed by the subprocess are injected explicitly via
+// the `credEnv` overlay.  See: NVBug 6010004.
+
+const ALLOWED_ENV_NAMES = new Set([
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "PATH",
+  "TERM",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "LANG",
+  "NODE_ENV",
+  "HOSTNAME",
+]);
+
+const ALLOWED_ENV_PREFIXES = ["LC_", "XDG_"];
+
+function buildSubprocessEnv(extra?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (ALLOWED_ENV_NAMES.has(key) || ALLOWED_ENV_PREFIXES.some((p) => key.startsWith(p))) {
+      env[key] = value;
+    }
+  }
+  if (extra) {
+    Object.assign(env, extra);
+  }
+  return env;
+}
+
 type Action = "plan" | "apply" | "status" | "rollback";
 
 // ── Logging helpers ─────────────────────────────────────────────
@@ -294,7 +332,7 @@ export async function actionApply(
     reject: false,
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, ...credEnv },
+    env: buildSubprocessEnv(credEnv),
   });
 
   progress(70, "Setting inference route");

--- a/nemoclaw/src/lib/subprocess-env.ts
+++ b/nemoclaw/src/lib/subprocess-env.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Subprocess environment allowlist.
+ *
+ * Subprocesses spawned by the CLI or plugin must NOT inherit the full
+ * parent process.env — that leaks secrets (NVIDIA_API_KEY, GITHUB_TOKEN,
+ * AWS_ACCESS_KEY_ID, etc.) to child processes where they can be read and
+ * exfiltrated. Instead, only forward the categories below.
+ *
+ * Credentials needed by a subprocess are injected explicitly via the
+ * `extra` parameter.
+ *
+ * See: NVBug 6010004
+ *
+ * NOTE: src/lib/subprocess-env.ts is a mirror of this file for the CLI
+ * project. Keep them in sync.
+ */
+
+// ── Allowed individual names ───────────────────────────────────
+
+const SYSTEM = ["HOME", "USER", "LOGNAME", "SHELL", "PATH", "TERM", "HOSTNAME", "NODE_ENV"];
+
+const TEMP = ["TMPDIR", "TMP", "TEMP"];
+
+const LOCALE = ["LANG"]; // LC_* handled via prefix
+
+const PROXY = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"];
+
+const TLS = ["SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS"];
+
+const TOOLCHAIN = ["DOCKER_HOST", "KUBECONFIG", "SSH_AUTH_SOCK", "RUST_LOG", "RUST_BACKTRACE"];
+
+const ALLOWED_ENV_NAMES = new Set([...SYSTEM, ...TEMP, ...LOCALE, ...PROXY, ...TLS, ...TOOLCHAIN]);
+
+// ── Allowed prefixes ───────────────────────────────────────────
+
+const ALLOWED_ENV_PREFIXES = ["LC_", "XDG_", "OPENSHELL_", "GRPC_"];
+
+// ── Public API ─────────────────────────────────────────────────
+
+export function buildSubprocessEnv(extra?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (ALLOWED_ENV_NAMES.has(key) || ALLOWED_ENV_PREFIXES.some((p) => key.startsWith(p))) {
+      env[key] = value;
+    }
+  }
+  if (extra) {
+    Object.assign(env, extra);
+  }
+  return env;
+}

--- a/nemoclaw/src/lib/subprocess-env.ts
+++ b/nemoclaw/src/lib/subprocess-env.ts
@@ -12,7 +12,7 @@
  * Credentials needed by a subprocess are injected explicitly via the
  * `extra` parameter.
  *
- * See: NVBug 6010004
+ * See: #1874
  *
  * NOTE: src/lib/subprocess-env.ts is a mirror of this file for the CLI
  * project. Keep them in sync.

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -54,6 +54,7 @@ const {
   saveCredential,
 } = require("./credentials");
 const registry = require("./registry");
+const { buildSubprocessEnv } = require("./subprocess-env");
 const nim = require("./nim");
 const onboardSession = require("./onboard-session");
 const policies = require("./policies");
@@ -2674,28 +2675,16 @@ async function createSandbox(
     messagingAllowedIds,
     discordGuilds,
   );
-  // Only pass non-sensitive env vars to the sandbox. Credentials flow through
-  // OpenShell providers — the gateway injects them as placeholders and the L7
-  // proxy rewrites Authorization headers with real secrets at egress.
+  // Only pass non-sensitive env vars to the sandbox creation subprocess.
+  // Credentials flow through OpenShell providers — the gateway injects them
+  // as placeholders and the L7 proxy rewrites Authorization headers with
+  // real secrets at egress.
   // See: crates/openshell-sandbox/src/secrets.rs (placeholder rewriting),
-  //      crates/openshell-router/src/backend.rs (inference auth injection).
+  //      crates/openshell-router/src/backend.rs (inference auth injection),
+  //      src/lib/subprocess-env.ts (allowlist definition),
+  //      NVBug 6010004 (original security report).
   const envArgs = [formatEnvAssignment("CHAT_UI_URL", chatUiUrl)];
-  const blockedSandboxEnvNames = new Set([
-    // Derived from REMOTE_PROVIDER_CONFIG to prevent drift
-    ...Object.values(REMOTE_PROVIDER_CONFIG)
-      .map((cfg) => cfg.credentialEnv)
-      .filter(Boolean),
-    // Additional credentials not in REMOTE_PROVIDER_CONFIG
-    "BEDROCK_API_KEY",
-    "DISCORD_BOT_TOKEN",
-    "SLACK_BOT_TOKEN",
-    "SLACK_APP_TOKEN",
-    "TELEGRAM_BOT_TOKEN",
-    webSearch.BRAVE_API_KEY_ENV,
-  ]);
-  const sandboxEnv = Object.fromEntries(
-    Object.entries(process.env).filter(([name]) => !blockedSandboxEnvNames.has(name)),
-  );
+  const sandboxEnv = buildSubprocessEnv();
   // Run without piping through awk — the pipe masked non-zero exit codes
   // from openshell because bash returns the status of the last pipeline
   // command (awk, always 0) unless pipefail is set. Removing the pipe

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -54,7 +54,6 @@ const {
   saveCredential,
 } = require("./credentials");
 const registry = require("./registry");
-const { buildSubprocessEnv } = require("./subprocess-env");
 const nim = require("./nim");
 const onboardSession = require("./onboard-session");
 const policies = require("./policies");
@@ -2675,16 +2674,33 @@ async function createSandbox(
     messagingAllowedIds,
     discordGuilds,
   );
-  // Only pass non-sensitive env vars to the sandbox creation subprocess.
-  // Credentials flow through OpenShell providers — the gateway injects them
-  // as placeholders and the L7 proxy rewrites Authorization headers with
-  // real secrets at egress.
+  // Only pass non-sensitive env vars to the sandbox. Credentials flow through
+  // OpenShell providers — the gateway injects them as placeholders and the L7
+  // proxy rewrites Authorization headers with real secrets at egress.
   // See: crates/openshell-sandbox/src/secrets.rs (placeholder rewriting),
-  //      crates/openshell-router/src/backend.rs (inference auth injection),
-  //      src/lib/subprocess-env.ts (allowlist definition),
-  //      NVBug 6010004 (original security report).
+  //      crates/openshell-router/src/backend.rs (inference auth injection).
+  //
+  // TODO: migrate this blocklist to the shared allowlist in
+  // src/lib/subprocess-env.ts once the sandbox create path has been validated
+  // end-to-end with the stricter filtering. The allowlist rejects unknown
+  // env vars by default, which is safer but needs careful rollout.
   const envArgs = [formatEnvAssignment("CHAT_UI_URL", chatUiUrl)];
-  const sandboxEnv = buildSubprocessEnv();
+  const blockedSandboxEnvNames = new Set([
+    // Derived from REMOTE_PROVIDER_CONFIG to prevent drift
+    ...Object.values(REMOTE_PROVIDER_CONFIG)
+      .map((cfg) => cfg.credentialEnv)
+      .filter(Boolean),
+    // Additional credentials not in REMOTE_PROVIDER_CONFIG
+    "BEDROCK_API_KEY",
+    "DISCORD_BOT_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "TELEGRAM_BOT_TOKEN",
+    webSearch.BRAVE_API_KEY_ENV,
+  ]);
+  const sandboxEnv = Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => !blockedSandboxEnvNames.has(name)),
+  );
   // Run without piping through awk — the pipe masked non-zero exit codes
   // from openshell because bash returns the status of the last pipeline
   // command (awk, always 0) unless pipefail is set. Removing the pipe

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -14,6 +14,7 @@ import {
 import { join } from "node:path";
 
 import { DASHBOARD_PORT } from "./ports";
+import { buildSubprocessEnv } from "./subprocess-env";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -126,7 +127,7 @@ function startService(
   const subprocess = spawn(command, args, {
     detached: true,
     stdio: ["ignore", logFd, logFd],
-    env: { ...process.env, ...env },
+    env: buildSubprocessEnv(env),
   });
   closeSync(logFd);
 

--- a/src/lib/subprocess-env.ts
+++ b/src/lib/subprocess-env.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Subprocess environment allowlist.
+ *
+ * Subprocesses spawned by the CLI or plugin must NOT inherit the full
+ * parent process.env — that leaks secrets (NVIDIA_API_KEY, GITHUB_TOKEN,
+ * AWS_ACCESS_KEY_ID, etc.) to child processes where they can be read and
+ * exfiltrated. Instead, only forward the categories below.
+ *
+ * Credentials needed by a subprocess are injected explicitly via the
+ * `extra` parameter.
+ *
+ * See: NVBug 6010004
+ *
+ * NOTE: nemoclaw/src/lib/subprocess-env.ts is a mirror of this file for
+ * the plugin project. Keep them in sync.
+ */
+
+// ── Allowed individual names ───────────────────────────────────
+
+const SYSTEM = ["HOME", "USER", "LOGNAME", "SHELL", "PATH", "TERM", "HOSTNAME", "NODE_ENV"];
+
+const TEMP = ["TMPDIR", "TMP", "TEMP"];
+
+const LOCALE = ["LANG"]; // LC_* handled via prefix
+
+const PROXY = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"];
+
+const TLS = ["SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS"];
+
+const TOOLCHAIN = ["DOCKER_HOST", "KUBECONFIG", "SSH_AUTH_SOCK", "RUST_LOG", "RUST_BACKTRACE"];
+
+const ALLOWED_ENV_NAMES = new Set([...SYSTEM, ...TEMP, ...LOCALE, ...PROXY, ...TLS, ...TOOLCHAIN]);
+
+// ── Allowed prefixes ───────────────────────────────────────────
+
+const ALLOWED_ENV_PREFIXES = ["LC_", "XDG_", "OPENSHELL_", "GRPC_"];
+
+// ── Public API ─────────────────────────────────────────────────
+
+export function buildSubprocessEnv(extra?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    if (ALLOWED_ENV_NAMES.has(key) || ALLOWED_ENV_PREFIXES.some((p) => key.startsWith(p))) {
+      env[key] = value;
+    }
+  }
+  if (extra) {
+    Object.assign(env, extra);
+  }
+  return env;
+}

--- a/src/lib/subprocess-env.ts
+++ b/src/lib/subprocess-env.ts
@@ -12,7 +12,7 @@
  * Credentials needed by a subprocess are injected explicitly via the
  * `extra` parameter.
  *
- * See: NVBug 6010004
+ * See: #1874
  *
  * NOTE: nemoclaw/src/lib/subprocess-env.ts is a mirror of this file for
  * the plugin project. Keep them in sync.

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from "vitest";
 
 const ONBOARD_JS = path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts");
 const RUNNER_TS = path.join(import.meta.dirname, "..", "nemoclaw", "src", "blueprint", "runner.ts");
+const SERVICES_TS = path.join(import.meta.dirname, "..", "src", "lib", "services.ts");
 
 // Matches --credential followed by a value containing "=" (i.e. KEY=VALUE).
 // Catches quoted KEY=VALUE patterns in JS and Python f-string interpolation.
@@ -73,28 +74,32 @@ describe("credential exposure in process arguments", () => {
     expect(src).not.toMatch(/"--credential",\s*process\.env\./);
   });
 
-  it("onboard.js does not embed sandbox secrets in the sandbox create command line", () => {
+  it("onboard.js uses buildSubprocessEnv allowlist, not a hand-rolled blocklist", () => {
     const src = fs.readFileSync(ONBOARD_JS, "utf-8");
 
-    // sandboxEnv must be built with a blocklist that strips all credential env vars.
-    // The blocklist derives provider keys from REMOTE_PROVIDER_CONFIG and adds
-    // messaging tokens explicitly. Verify both mechanisms are present.
-    const blocklistMatch = src.match(/const blockedSandboxEnvNames = new Set\(\[([\s\S]*?)\]\);/);
-    expect(blocklistMatch).not.toBeNull();
-    const blocklist = blocklistMatch[1];
-    // Provider credentials are derived from REMOTE_PROVIDER_CONFIG
-    expect(blocklist).toContain("REMOTE_PROVIDER_CONFIG");
-    // Messaging and additional credentials are listed explicitly
-    expect(blocklist).toContain('"BEDROCK_API_KEY"');
-    expect(blocklist).toContain('"DISCORD_BOT_TOKEN"');
-    expect(blocklist).toContain('"SLACK_BOT_TOKEN"');
-    expect(blocklist).toContain('"SLACK_APP_TOKEN"');
-    expect(blocklist).toContain('"TELEGRAM_BOT_TOKEN"');
+    // sandboxEnv must be built via the shared allowlist (buildSubprocessEnv),
+    // not a hand-rolled blocklist. The allowlist approach is more secure because
+    // it rejects unknown/future secrets by default.  See: NVBug 6010004.
+    expect(src).toMatch(/buildSubprocessEnv/);
+    expect(src).toMatch(/sandboxEnv\s*=\s*buildSubprocessEnv\(/);
+    // The old blocklist pattern must not be present
+    expect(src).not.toMatch(/blockedSandboxEnvNames/);
+    // Secrets must not be pushed into envArgs
     expect(src).toMatch(/streamSandboxCreate\(createCommand, sandboxEnv(?:, \{)?/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("NVIDIA_API_KEY"/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("DISCORD_BOT_TOKEN"/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_BOT_TOKEN"/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_APP_TOKEN"/);
+  });
+
+  it("services.ts must not spread full process.env into subprocess", () => {
+    const src = fs.readFileSync(SERVICES_TS, "utf-8");
+
+    const spreadRe = /env:\s*\{[^}]*\.\.\.process\.env/;
+    const violations = src.split("\n").filter(
+      (line) => spreadRe.test(line) && !line.trimStart().startsWith("//"),
+    );
+    expect(violations).toEqual([]);
   });
 
   it("onboard curl probes use explicit timeouts", () => {

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -43,13 +43,11 @@ describe("credential exposure in process arguments", () => {
   it("runner.ts must not spread full process.env into subprocess", () => {
     const src = fs.readFileSync(RUNNER_TS, "utf-8");
 
-    // Match { ...process.env } or { ...process.env, ... } as execa env option.
-    // The runner must use buildSubprocessEnv() with an allowlist instead.
-    const spreadRe = /env:\s*\{[^}]*\.\.\.process\.env/;
-    const violations = src.split("\n").filter(
-      (line) => spreadRe.test(line) && !line.trimStart().startsWith("//"),
-    );
-    expect(violations).toEqual([]);
+    // Strip comments so that documented bad patterns don't trigger false positives.
+    // Scan the full source (not line-by-line) to catch multiline spreads.
+    const uncommented = src.replace(/\/\/.*$/gm, "");
+    const spreadRe = /env\s*:\s*\{[\s\S]*?\.\.\.process\.env/;
+    expect(uncommented).not.toMatch(spreadRe);
   });
 
   it("runner.ts must not pass KEY=VALUE to --credential", () => {
@@ -104,11 +102,9 @@ describe("credential exposure in process arguments", () => {
   it("services.ts must not spread full process.env into subprocess", () => {
     const src = fs.readFileSync(SERVICES_TS, "utf-8");
 
-    const spreadRe = /env:\s*\{[^}]*\.\.\.process\.env/;
-    const violations = src.split("\n").filter(
-      (line) => spreadRe.test(line) && !line.trimStart().startsWith("//"),
-    );
-    expect(violations).toEqual([]);
+    const uncommented = src.replace(/\/\/.*$/gm, "");
+    const spreadRe = /env\s*:\s*\{[\s\S]*?\.\.\.process\.env/;
+    expect(uncommented).not.toMatch(spreadRe);
   });
 
   it("onboard curl probes use explicit timeouts", () => {

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -39,6 +39,18 @@ describe("credential exposure in process arguments", () => {
     expect(violations).toEqual([]);
   });
 
+  it("runner.ts must not spread full process.env into subprocess (NVBug 6010004)", () => {
+    const src = fs.readFileSync(RUNNER_TS, "utf-8");
+
+    // Match { ...process.env } or { ...process.env, ... } as execa env option.
+    // The runner must use buildSubprocessEnv() with an allowlist instead.
+    const spreadRe = /env:\s*\{[^}]*\.\.\.process\.env/;
+    const violations = src.split("\n").filter(
+      (line) => spreadRe.test(line) && !line.trimStart().startsWith("//"),
+    );
+    expect(violations).toEqual([]);
+  });
+
   it("runner.ts must not pass KEY=VALUE to --credential", () => {
     const src = fs.readFileSync(RUNNER_TS, "utf-8");
     const lines = src.split("\n");

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -40,7 +40,7 @@ describe("credential exposure in process arguments", () => {
     expect(violations).toEqual([]);
   });
 
-  it("runner.ts must not spread full process.env into subprocess (NVBug 6010004)", () => {
+  it("runner.ts must not spread full process.env into subprocess", () => {
     const src = fs.readFileSync(RUNNER_TS, "utf-8");
 
     // Match { ...process.env } or { ...process.env, ... } as execa env option.
@@ -74,17 +74,26 @@ describe("credential exposure in process arguments", () => {
     expect(src).not.toMatch(/"--credential",\s*process\.env\./);
   });
 
-  it("onboard.js uses buildSubprocessEnv allowlist, not a hand-rolled blocklist", () => {
+  it("onboard.js does not embed sandbox secrets in the sandbox create command line", () => {
     const src = fs.readFileSync(ONBOARD_JS, "utf-8");
 
-    // sandboxEnv must be built via the shared allowlist (buildSubprocessEnv),
-    // not a hand-rolled blocklist. The allowlist approach is more secure because
-    // it rejects unknown/future secrets by default.  See: NVBug 6010004.
-    expect(src).toMatch(/buildSubprocessEnv/);
-    expect(src).toMatch(/sandboxEnv\s*=\s*buildSubprocessEnv\(/);
-    // The old blocklist pattern must not be present
-    expect(src).not.toMatch(/blockedSandboxEnvNames/);
-    // Secrets must not be pushed into envArgs
+    // sandboxEnv must be built with a blocklist that strips all credential env vars.
+    // The blocklist derives provider keys from REMOTE_PROVIDER_CONFIG and adds
+    // messaging tokens explicitly. Verify both mechanisms are present.
+    //
+    // TODO: migrate to the shared allowlist in subprocess-env.ts
+    // once the sandbox create path has been validated end-to-end.
+    const blocklistMatch = src.match(/const blockedSandboxEnvNames = new Set\(\[([\s\S]*?)\]\);/);
+    expect(blocklistMatch).not.toBeNull();
+    const blocklist = blocklistMatch[1];
+    // Provider credentials are derived from REMOTE_PROVIDER_CONFIG
+    expect(blocklist).toContain("REMOTE_PROVIDER_CONFIG");
+    // Messaging and additional credentials are listed explicitly
+    expect(blocklist).toContain('"BEDROCK_API_KEY"');
+    expect(blocklist).toContain('"DISCORD_BOT_TOKEN"');
+    expect(blocklist).toContain('"SLACK_BOT_TOKEN"');
+    expect(blocklist).toContain('"SLACK_APP_TOKEN"');
+    expect(blocklist).toContain('"TELEGRAM_BOT_TOKEN"');
     expect(src).toMatch(/streamSandboxCreate\(createCommand, sandboxEnv(?:, \{)?/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("NVIDIA_API_KEY"/);
     expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("DISCORD_BOT_TOKEN"/);


### PR DESCRIPTION
## Summary

- Introduce `subprocess-env.ts` — a shared module (mirrored in both CLI and plugin projects) that exports `buildSubprocessEnv()`. Defines an env var allowlist structured by category (system, temp, locale, proxy, TLS, toolchain) with prefix groups (LC_, XDG_, OPENSHELL_, GRPC_).
- Apply the allowlist to two subprocess spawn sites:
  - `nemoclaw/src/blueprint/runner.ts` — provider create (the original bug target)
  - `src/lib/services.ts` — cloudflared spawn (same vulnerable `{ ...process.env }` pattern)
- `src/lib/onboard.ts` — **intentionally left on its existing blocklist** to avoid regression risk on the highest-traffic code path. A TODO marks the future migration.
- Static analysis guards in `credential-exposure.test.ts` now cover all three call sites, preventing `...process.env` from creeping back into runner.ts or services.ts
- Runtime regression test in `runner.test.ts` asserts secrets are stripped and proxy/openshell vars pass through

## Test plan

- [x] `make check` — all hooks pass
- [x] `npm test` — all 1528 tests pass
- [x] New test: `runner.test.ts` "does not leak parent secrets into subprocess env"
- [x] New test: `credential-exposure.test.ts` guards for runner.ts and services.ts
- [ ] Manual: verify `nemoclaw apply` configures inference provider correctly
- [ ] Manual: verify behind a corporate proxy (HTTPS_PROXY passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced allowlisted subprocess environment builder so spawned processes receive a filtered env plus explicit credentials.

* **Bug Fixes**
  * Subprocess environment isolation: parent-process secrets are no longer forwarded; only explicit credentials and allowlisted system vars are passed.

* **Tests**
  * Added regression checks to detect full-process env spreading and a test ensuring env filtering and test-env cleanup.

* **Documentation**
  * Clarified destroy warning (includes persistent volume) and updated workspace file, persistence, backup, and "shell" usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->