### PR TITLE
fix(security): warn when Ollama binds to 0.0.0.0 during onboard

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3343,6 +3343,14 @@ async function setupNim(gpu) {
           const ollamaEnv = isWsl() ? "" : `OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} `;
           run(`${ollamaEnv}ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
           sleep(2);
+          if (!isWsl()) {
+            console.log("");
+            console.log("  ⚠ Ollama is binding to 0.0.0.0 so the sandbox can reach it via Docker.");
+            console.log("    This exposes the Ollama API to your local network (no auth required).");
+            console.log("    On public WiFi, any device on the same network can send prompts to your GPU.");
+            console.log("    See: CNVD-2025-04094, CVE-2024-37032");
+            console.log("");
+          }
         }
         console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT}`);
         provider = "ollama-local";
@@ -3401,6 +3409,12 @@ async function setupNim(gpu) {
         console.log("  Starting Ollama...");
         run(`OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
         sleep(2);
+        console.log("");
+        console.log("  ⚠ Ollama is binding to 0.0.0.0 so the sandbox can reach it via Docker.");
+        console.log("    This exposes the Ollama API to your local network (no auth required).");
+        console.log("    On public WiFi, any device on the same network can send prompts to your GPU.");
+        console.log("    See: CNVD-2025-04094, CVE-2024-37032");
+        console.log("");
         console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT}`);
         provider = "ollama-local";
         credentialEnv = "OPENAI_API_KEY";

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1504,6 +1504,15 @@ async function promptOllamaModel(gpu = null) {
   return promptManualModelId("  Ollama model id: ", "Ollama");
 }
 
+function printOllamaExposureWarning() {
+  console.log("");
+  console.log("  ⚠ Ollama is binding to 0.0.0.0 so the sandbox can reach it via Docker.");
+  console.log("    This exposes the Ollama API to your local network (no auth required).");
+  console.log("    On public WiFi, any device on the same network can send prompts to your GPU.");
+  console.log("    See: CNVD-2025-04094, CVE-2024-37032");
+  console.log("");
+}
+
 function pullOllamaModel(model) {
   const result = spawnSync("bash", ["-c", `ollama pull ${shellQuote(model)}`], {
     cwd: ROOT,
@@ -3343,14 +3352,7 @@ async function setupNim(gpu) {
           const ollamaEnv = isWsl() ? "" : `OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} `;
           run(`${ollamaEnv}ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
           sleep(2);
-          if (!isWsl()) {
-            console.log("");
-            console.log("  ⚠ Ollama is binding to 0.0.0.0 so the sandbox can reach it via Docker.");
-            console.log("    This exposes the Ollama API to your local network (no auth required).");
-            console.log("    On public WiFi, any device on the same network can send prompts to your GPU.");
-            console.log("    See: CNVD-2025-04094, CVE-2024-37032");
-            console.log("");
-          }
+          if (!isWsl()) printOllamaExposureWarning();
         }
         console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT}`);
         provider = "ollama-local";
@@ -3409,12 +3411,7 @@ async function setupNim(gpu) {
         console.log("  Starting Ollama...");
         run(`OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
         sleep(2);
-        console.log("");
-        console.log("  ⚠ Ollama is binding to 0.0.0.0 so the sandbox can reach it via Docker.");
-        console.log("    This exposes the Ollama API to your local network (no auth required).");
-        console.log("    On public WiFi, any device on the same network can send prompts to your GPU.");
-        console.log("    See: CNVD-2025-04094, CVE-2024-37032");
-        console.log("");
+        printOllamaExposureWarning();
         console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT}`);
         provider = "ollama-local";
         credentialEnv = "OPENAI_API_KEY";


### PR DESCRIPTION
## Summary
- Add a user-visible warning during `nemoclaw onboard` when Ollama is started with `OLLAMA_HOST=0.0.0.0`, informing the user that their inference API is exposed to the local network without authentication.
- Warning appears at both Ollama startup sites (existing install + brew install paths). Suppressed on WSL where Ollama binds to 127.0.0.1.

## Why
NemoClaw's onboard flow forces `OLLAMA_HOST=0.0.0.0:11434` so the Docker sandbox can reach the host. This silently exposes the **unauthenticated** Ollama API to the entire local network. On public WiFi (airports, coffee shops, hackathons), any adjacent device can:

- Enumerate installed models (`GET /api/tags`)
- Send arbitrary prompts and receive responses (`POST /api/generate`)
- Consume GPU resources (denial of service)
- Extract model metadata (`POST /api/show`)

Ollama's lack of authentication is well-documented:
- **CNVD-2025-04094** — Ollama unauthorized access due to misconfiguration
- **CVE-2024-37032** ("Probllama") — Ollama remote code execution
- **CVE-2024-39720 through CVE-2024-39722** — additional Ollama CVEs
- **175,000+ exposed Ollama servers** found in internet-wide scans ([source](https://securityboulevard.com/2026/03/exposed-ollama-servers-security-risks-of-publicly-accessible-llm-infrastructure/))

NemoClaw is actively creating this exposure by overriding `OLLAMA_HOST` during automated onboard. The user is never warned.

## What changed
- `src/lib/onboard.ts` — added a warning block after each `OLLAMA_HOST=0.0.0.0` startup call, referencing the known CVEs and explaining the risk.

## What this does NOT change
- The binding behavior itself is unchanged. Docker requires `0.0.0.0` to reach the host from inside the container.
- A future PR should add a firewall rule or Docker network bridge to restrict access to localhost + the container bridge IP.

## Test plan
- [x] `npm run build:cli` — compiles cleanly.
- [ ] Manual: `nemoclaw onboard` with Ollama selected shows the warning on non-WSL systems.
- [ ] Manual: WSL onboard does not show the warning (Ollama binds to 127.0.0.1 there).

## Discovery
Identified during a code audit on 2026-04-07 (finding N-3 in my audit notes). The Ollama 0.0.0.0 exposure class has known CVEs but NemoClaw's role in forcing the insecure configuration has not been previously reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show a console security warning when the local Ollama service is started and is reachable from the local network (bound to 0.0.0.0).
  * Suppress the warning when running under WSL.
  * On macOS, display the warning unconditionally after the service starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: ColinM-sys <cmcdonough@50words.com>