### PR TITLE
fix(cli): auto-detect sandbox name from registry in nemoclaw debug (#1728)

### DIFF
--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -7,6 +7,7 @@ import { platform, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
 import { DASHBOARD_PORT } from "./ports";
+import { listSandboxes } from "./registry";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -141,6 +142,22 @@ function collectShell(collectDir: string, label: string, shellCmd: string): void
 // ---------------------------------------------------------------------------
 
 function detectSandboxName(): string {
+  // First, check the local registry for the default sandbox. This is
+  // the authoritative source — it reflects the user's actual onboard
+  // choices and survives gateway restarts. Falling back to "default"
+  // without checking the registry was the bug in #1728: debug always
+  // targeted a sandbox named "default" even though the user's sandbox
+  // was named something else (e.g. "my-assistant").
+  try {
+    const registry = listSandboxes();
+    if (registry.defaultSandbox) return registry.defaultSandbox;
+    const names = registry.sandboxes.map((s) => s.name).filter(Boolean);
+    if (names.length > 0) return names[0];
+  } catch {
+    /* registry unreadable — fall through to openshell probe */
+  }
+
+  // Fallback: ask the live gateway directly
   if (!commandExists("openshell")) return "default";
   try {
     const output = execFileSync("openshell", ["sandbox", "list"], {


### PR DESCRIPTION
## Summary
- `detectSandboxName()` in `src/lib/debug.ts` now checks the local registry (`sandboxes.json`) for `defaultSandbox` before falling back to `openshell sandbox list` and then the hardcoded `"default"`.

Fixes #1728.

## Why
`nemoclaw debug --quick` always collected diagnostics for a sandbox named `"default"` because `detectSandboxName()` only tried `openshell sandbox list` (which may return nothing or time out) and then fell back to the literal string `"default"`. The user's actual sandbox (e.g. `"my-assistant"`) was ignored. The docs say sandbox name is "auto-detected" but the implementation never checked the authoritative source — the local registry.

## Test plan
- [x] `npm run build:cli` — compiles cleanly.
- [ ] Manual: `nemoclaw debug --quick` with a sandbox named anything other than "default" — should now target the correct sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox detection now prefers local registry configuration over live gateway probing, falls back to previous discovery methods when local data is missing or fails, and includes more robust error handling to avoid incorrect or missing sandbox names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: ColinM-sys <cmcdonough@50words.com>