### PR TITLE
docs: catch up documentation for v0.0.15 changes

### DIFF
--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -157,6 +157,9 @@ This is useful when you want to test a destination before deciding whether it be
 NemoClaw ships preset policy files for common integrations in `nemoclaw-blueprint/policies/presets/`.
 Apply a preset as-is or use it as a starting template for a custom policy.
 
+During onboarding, the policy tier (see the `nemoclaw-user-reference` skill) you select determines which presets are enabled by default.
+You can add or remove individual presets in the interactive preset screen that follows tier selection.
+
 Available presets:
 
 | Preset | Endpoints |

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -44,7 +44,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--dangerously-skip-permissions] [--yes-i-accept-third-party-software]
+$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--yes-i-accept-third-party-software]
 ```
 
 > **Warning:** For NemoClaw-managed environments, use `nemoclaw onboard` when you need to create or recreate the OpenShell gateway or sandbox.
@@ -54,6 +54,24 @@ The wizard prompts for a provider first, then collects the provider credential i
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.
 Credentials are stored in `~/.nemoclaw/credentials.json`. For file permissions, plaintext storage behavior, and hardening guidance, see Credential Storage (see the `nemoclaw-user-configure-security` skill).
 The legacy `nemoclaw setup` command is deprecated; use `nemoclaw onboard` instead.
+
+After provider selection, the wizard prompts for a **policy tier** that controls the default set of network policy presets applied to the sandbox.
+Three tiers are available:
+
+| Tier | Description |
+|------|-------------|
+| Restricted | Base sandbox only. No third-party network access beyond inference and core agent tooling. |
+| Balanced (default) | Full dev tooling and web search. Package installs, model downloads, and inference. No messaging platform access. |
+| Open | Broad access across third-party services including messaging and productivity. |
+
+After selecting a tier, the wizard shows a combined preset and access-mode screen where you can include or exclude individual presets and toggle each between read and read-write access.
+For details on tiers and the presets each includes, see Network Policies (see the `nemoclaw-user-reference` skill).
+
+In non-interactive mode, set the tier with `NEMOCLAW_POLICY_TIER` (default: `balanced`):
+
+```console
+$ NEMOCLAW_POLICY_TIER=restricted nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
+```
 
 If you enable Brave Search during onboarding, NemoClaw currently stores the Brave API key in the sandbox's OpenClaw configuration.
 That means the OpenClaw agent can read the key.
@@ -84,6 +102,7 @@ $ BRAVE_API_KEY=... \
 The wizard prompts for a sandbox name.
 Names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.
 Uppercase letters are automatically lowercased.
+Names that match global CLI commands (`status`, `list`, `debug`, etc.) are rejected to avoid routing conflicts.
 
 If you enable Slack during onboarding, the wizard collects both the Bot Token (`SLACK_BOT_TOKEN`) and the App-Level Token (`SLACK_APP_TOKEN`).
 Socket Mode requires both tokens.
@@ -209,6 +228,24 @@ List available policy presets and show which ones are applied to the sandbox.
 $ nemoclaw my-assistant policy-list
 ```
 
+### `nemoclaw <name> skill install <path>`
+
+Deploy a skill directory to a running sandbox.
+The command validates the `SKILL.md` frontmatter (a `name` field is required), uploads all non-dot files preserving subdirectory structure, and performs agent-specific post-install steps.
+
+```console
+$ nemoclaw my-assistant skill install ./my-skill/
+```
+
+The skill directory must contain a `SKILL.md` file with YAML frontmatter that includes a `name` field.
+Skill names must contain only alphanumeric characters, dots, hyphens, and underscores.
+
+Files with names starting with `.` (dotfiles) are skipped and listed in the output.
+Files with unsafe path characters are rejected to prevent shell injection.
+
+If the skill already exists on the sandbox, the command updates it in place and preserves chat history.
+For new installs, the agent session index is refreshed so the agent discovers the skill on the next session.
+
 ### `openshell term`
 
 Open the OpenShell TUI to monitor sandbox activity and approve network egress requests.
@@ -307,6 +344,29 @@ The CLI uses the local `uninstall.sh` first and falls back to the hosted script 
 ```console
 $ nemoclaw uninstall [--yes] [--keep-openshell] [--delete-models]
 ```
+
+## Environment Variables
+
+NemoClaw reads the following environment variables to configure service ports.
+Set them before running `nemoclaw onboard` or any command that starts services.
+All ports must be non-privileged integers between 1024 and 65535.
+
+| Variable | Default | Service |
+|----------|---------|---------|
+| `NEMOCLAW_GATEWAY_PORT` | 8080 | OpenShell gateway |
+| `NEMOCLAW_DASHBOARD_PORT` | 18789 | Dashboard UI |
+| `NEMOCLAW_VLLM_PORT` | 8000 | vLLM / NIM inference |
+| `NEMOCLAW_OLLAMA_PORT` | 11434 | Ollama inference |
+
+If a port value is not a valid integer or falls outside the allowed range, the CLI exits with an error.
+
+```console
+$ export NEMOCLAW_DASHBOARD_PORT=19000
+$ nemoclaw onboard
+```
+
+These overrides apply to onboarding, status checks, health probes, and the uninstaller.
+Defaults are unchanged when no variable is set.
 
 ### Legacy `nemoclaw setup`
 

--- a/.agents/skills/nemoclaw-user-reference/references/network-policies.md
+++ b/.agents/skills/nemoclaw-user-reference/references/network-policies.md
@@ -71,6 +71,32 @@ All endpoints use TLS termination and are enforced at port 443.
 > Apply the `github` preset during onboarding if your agent needs GitHub access.
 > See Customize the Network Policy (see the `nemoclaw-user-manage-policy` skill).
 
+(policy-tiers)=
+
+## Policy Tiers
+
+During onboarding, the wizard prompts for a policy tier that determines the default set of presets applied on top of the baseline policy.
+The baseline policy is always applied regardless of the selected tier.
+
+| Tier | Presets included | Description |
+|------|------------------|-------------|
+| Restricted | None | Base sandbox only. No third-party network access beyond inference and core agent tooling. |
+| Balanced (default) | npm, pypi, huggingface, brew, brave | Full dev tooling and web search. No messaging platform access. |
+| Open | npm, pypi, huggingface, brew, brave, slack, discord, telegram, jira, outlook | Broad access across third-party services including messaging and productivity. |
+
+After selecting a tier, a combined preset and access-mode screen lets you include or exclude individual presets and toggle each between read (GET only) and read-write (GET + POST/PUT/PATCH) access.
+Tier-default presets are pre-selected; additional presets can be added from the full list.
+
+Tier definitions are stored in `nemoclaw-blueprint/policies/tiers.yaml`.
+
+In non-interactive mode, set the tier with `NEMOCLAW_POLICY_TIER`:
+
+```console
+$ NEMOCLAW_POLICY_TIER=open nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
+```
+
+If the value does not match a known tier, onboarding exits with an error listing the valid options.
+
 ### Inference
 
 The baseline policy allows only the `local` inference route. External inference

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -111,8 +111,8 @@ If the L4T version is not recognized, the setup step is skipped and the installe
 
 ### Port already in use
 
-The NemoClaw gateway uses port `18789` by default.
-If another process is already bound to this port, onboarding fails.
+The NemoClaw dashboard uses port `18789` by default and the gateway uses port `8080`.
+If another process is already bound to one of these ports, onboarding fails.
 Identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```console
@@ -122,6 +122,14 @@ $ kill <PID>
 
 If the process does not exit, use `kill -9 <PID>` to force-terminate it.
 Then retry onboarding.
+
+Alternatively, override the conflicting port with an environment variable instead of stopping the other process:
+
+```console
+$ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard
+```
+
+See Environment Variables (see the `nemoclaw-user-reference` skill) for the full list of port overrides.
 
 ## Onboarding
 
@@ -158,7 +166,11 @@ The `install-openshell.sh` script also enforces this constraint and pins fresh i
 Sandbox names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.
 Uppercase letters are automatically lowercased.
 
-If the name does not match these rules, the wizard exits with an error.
+Names that collide with global CLI commands are also rejected.
+Reserved names include `onboard`, `list`, `deploy`, `setup`, `start`, `stop`, `status`, `debug`, `uninstall`, `credentials`, and `help`.
+Using a reserved name would cause the CLI to route to the global command instead of the sandbox.
+
+If the name does not match these rules or is reserved, the wizard exits with an error.
 Choose a name such as `my-assistant` or `dev1`.
 
 ### Sandbox creation fails on DGX

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -122,6 +122,9 @@ This is useful when you want to test a destination before deciding whether it be
 NemoClaw ships preset policy files for common integrations in `nemoclaw-blueprint/policies/presets/`.
 Apply a preset as-is or use it as a starting template for a custom policy.
 
+During onboarding, the [policy tier](../reference/network-policies.md#policy-tiers) you select determines which presets are enabled by default.
+You can add or remove individual presets in the interactive preset screen that follows tier selection.
+
 Available presets:
 
 | Preset | Endpoints |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -64,7 +64,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--dangerously-skip-permissions] [--yes-i-accept-third-party-software]
+$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--yes-i-accept-third-party-software]
 ```
 
 :::{warning}
@@ -76,6 +76,24 @@ The wizard prompts for a provider first, then collects the provider credential i
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.
 Credentials are stored in `~/.nemoclaw/credentials.json`. For file permissions, plaintext storage behavior, and hardening guidance, see [Credential Storage](../security/credential-storage.md).
 The legacy `nemoclaw setup` command is deprecated; use `nemoclaw onboard` instead.
+
+After provider selection, the wizard prompts for a **policy tier** that controls the default set of network policy presets applied to the sandbox.
+Three tiers are available:
+
+| Tier | Description |
+|------|-------------|
+| Restricted | Base sandbox only. No third-party network access beyond inference and core agent tooling. |
+| Balanced (default) | Full dev tooling and web search. Package installs, model downloads, and inference. No messaging platform access. |
+| Open | Broad access across third-party services including messaging and productivity. |
+
+After selecting a tier, the wizard shows a combined preset and access-mode screen where you can include or exclude individual presets and toggle each between read and read-write access.
+For details on tiers and the presets each includes, see [Network Policies](network-policies.md#policy-tiers).
+
+In non-interactive mode, set the tier with `NEMOCLAW_POLICY_TIER` (default: `balanced`):
+
+```console
+$ NEMOCLAW_POLICY_TIER=restricted nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
+```
 
 If you enable Brave Search during onboarding, NemoClaw currently stores the Brave API key in the sandbox's OpenClaw configuration.
 That means the OpenClaw agent can read the key.
@@ -106,6 +124,7 @@ $ BRAVE_API_KEY=... \
 The wizard prompts for a sandbox name.
 Names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.
 Uppercase letters are automatically lowercased.
+Names that match global CLI commands (`status`, `list`, `debug`, etc.) are rejected to avoid routing conflicts.
 
 If you enable Slack during onboarding, the wizard collects both the Bot Token (`SLACK_BOT_TOKEN`) and the App-Level Token (`SLACK_APP_TOKEN`).
 Socket Mode requires both tokens.
@@ -235,6 +254,24 @@ List available policy presets and show which ones are applied to the sandbox.
 $ nemoclaw my-assistant policy-list
 ```
 
+### `nemoclaw <name> skill install <path>`
+
+Deploy a skill directory to a running sandbox.
+The command validates the `SKILL.md` frontmatter (a `name` field is required), uploads all non-dot files preserving subdirectory structure, and performs agent-specific post-install steps.
+
+```console
+$ nemoclaw my-assistant skill install ./my-skill/
+```
+
+The skill directory must contain a `SKILL.md` file with YAML frontmatter that includes a `name` field.
+Skill names must contain only alphanumeric characters, dots, hyphens, and underscores.
+
+Files with names starting with `.` (dotfiles) are skipped and listed in the output.
+Files with unsafe path characters are rejected to prevent shell injection.
+
+If the skill already exists on the sandbox, the command updates it in place and preserves chat history.
+For new installs, the agent session index is refreshed so the agent discovers the skill on the next session.
+
 ### `openshell term`
 
 Open the OpenShell TUI to monitor sandbox activity and approve network egress requests.
@@ -335,6 +372,29 @@ The CLI uses the local `uninstall.sh` first and falls back to the hosted script 
 ```console
 $ nemoclaw uninstall [--yes] [--keep-openshell] [--delete-models]
 ```
+
+## Environment Variables
+
+NemoClaw reads the following environment variables to configure service ports.
+Set them before running `nemoclaw onboard` or any command that starts services.
+All ports must be non-privileged integers between 1024 and 65535.
+
+| Variable | Default | Service |
+|----------|---------|---------|
+| `NEMOCLAW_GATEWAY_PORT` | 8080 | OpenShell gateway |
+| `NEMOCLAW_DASHBOARD_PORT` | 18789 | Dashboard UI |
+| `NEMOCLAW_VLLM_PORT` | 8000 | vLLM / NIM inference |
+| `NEMOCLAW_OLLAMA_PORT` | 11434 | Ollama inference |
+
+If a port value is not a valid integer or falls outside the allowed range, the CLI exits with an error.
+
+```console
+$ export NEMOCLAW_DASHBOARD_PORT=19000
+$ nemoclaw onboard
+```
+
+These overrides apply to onboarding, status checks, health probes, and the uninstaller.
+Defaults are unchanged when no variable is set.
 
 ### Legacy `nemoclaw setup`
 

--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -93,6 +93,32 @@ Apply the `github` preset during onboarding if your agent needs GitHub access.
 See [Customize the Network Policy](../network-policy/customize-network-policy.md).
 :::
 
+(policy-tiers)=
+
+## Policy Tiers
+
+During onboarding, the wizard prompts for a policy tier that determines the default set of presets applied on top of the baseline policy.
+The baseline policy is always applied regardless of the selected tier.
+
+| Tier | Presets included | Description |
+|------|------------------|-------------|
+| Restricted | None | Base sandbox only. No third-party network access beyond inference and core agent tooling. |
+| Balanced (default) | npm, pypi, huggingface, brew, brave | Full dev tooling and web search. No messaging platform access. |
+| Open | npm, pypi, huggingface, brew, brave, slack, discord, telegram, jira, outlook | Broad access across third-party services including messaging and productivity. |
+
+After selecting a tier, a combined preset and access-mode screen lets you include or exclude individual presets and toggle each between read (GET only) and read-write (GET + POST/PUT/PATCH) access.
+Tier-default presets are pre-selected; additional presets can be added from the full list.
+
+Tier definitions are stored in `nemoclaw-blueprint/policies/tiers.yaml`.
+
+In non-interactive mode, set the tier with `NEMOCLAW_POLICY_TIER`:
+
+```console
+$ NEMOCLAW_POLICY_TIER=open nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
+```
+
+If the value does not match a known tier, onboarding exits with an error listing the valid options.
+
 ### Inference
 
 The baseline policy allows only the `local` inference route. External inference

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -137,8 +137,8 @@ If the L4T version is not recognized, the setup step is skipped and the installe
 
 ### Port already in use
 
-The NemoClaw gateway uses port `18789` by default.
-If another process is already bound to this port, onboarding fails.
+The NemoClaw dashboard uses port `18789` by default and the gateway uses port `8080`.
+If another process is already bound to one of these ports, onboarding fails.
 Identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```console
@@ -148,6 +148,14 @@ $ kill <PID>
 
 If the process does not exit, use `kill -9 <PID>` to force-terminate it.
 Then retry onboarding.
+
+Alternatively, override the conflicting port with an environment variable instead of stopping the other process:
+
+```console
+$ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard
+```
+
+See [Environment Variables](commands.md#environment-variables) for the full list of port overrides.
 
 ## Onboarding
 
@@ -184,7 +192,11 @@ The `install-openshell.sh` script also enforces this constraint and pins fresh i
 Sandbox names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.
 Uppercase letters are automatically lowercased.
 
-If the name does not match these rules, the wizard exits with an error.
+Names that collide with global CLI commands are also rejected.
+Reserved names include `onboard`, `list`, `deploy`, `setup`, `start`, `stop`, `status`, `debug`, `uninstall`, `credentials`, and `help`.
+Using a reserved name would cause the CLI to route to the global command instead of the sandbox.
+
+If the name does not match these rules or is reserved, the wizard exits with an error.
 Choose a name such as `my-assistant` or `dev1`.
 
 ### Sandbox creation fails on DGX

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,18 @@
 [
   {
     "preferred": true,
+    "version": "0.0.15",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.15/"
+  },
+  {
+    "version": "0.0.14",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.14/"
+  },
+  {
+    "version": "0.0.13",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.13/"
+  },
+  {
     "version": "0.0.12",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.12/"
   },


### PR DESCRIPTION
## Summary
- Document tier-based policy selector (Restricted/Balanced/Open) in commands, network policies, and customize-network-policy pages (from #1753)
- Document configurable port overrides via environment variables (`NEMOCLAW_GATEWAY_PORT`, `NEMOCLAW_DASHBOARD_PORT`, `NEMOCLAW_VLLM_PORT`, `NEMOCLAW_OLLAMA_PORT`) (from #1645)
- Document `nemoclaw <sandbox> skill install <path>` command (from #1845, #1856)
- Document reserved sandbox name validation — CLI command collision check (from #1773)
- Bump doc version switcher through 0.0.15
- Remove `--dangerously-skip-permissions` from onboard usage synopsis (docs-skip violation)
- Regenerate agent skills from updated docs

## Test plan
- [x] `make docs` builds without warnings
- [x] All pre-commit hooks pass
- [ ] Verify rendered pages in docs build output
- [ ] Cross-references resolve correctly (`policy-tiers` anchor, `environment-variables` section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)