### PR TITLE
fix(onboard): persist model and provider to sandbox registry after creation

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5251,6 +5251,7 @@ async function onboard(opts = {}) {
         agent,
         dangerouslySkipPermissions,
       );
+      registry.updateSandbox(sandboxName, { model, provider });
       onboardSession.markStepComplete("sandbox", { sandboxName, provider, model, nimContainer });
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fix `nemoclaw list` showing `model: unknown  provider: unknown` after onboard.
`registry.updateSandbox()` at Step 4 (inference setup) runs before the sandbox
entry exists in the registry. `updateSandbox` silently returns `false` when the
entry is not found, so the model and provider are never saved.
`registerSandbox()` at Step 6 (create sandbox) later creates the entry without
model or provider.
Add `registry.updateSandbox(sandboxName, { model, provider })` after
`createSandbox()` returns, so the update runs after the entry exists.

## Related Issue
issue [1881](https://github.com/NVIDIA/NemoClaw/issues/1881)

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [x] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [x] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Truong Nguyen <tgnguyen@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured sandbox model and provider metadata are reliably saved when a sandbox is created or reused, including cases where later setup steps are skipped or resumed—preventing loss of configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->