### PR TITLE
fix(onboard): persist model and provider to registry after sandbox creation

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5275,6 +5275,10 @@ async function onboard(opts = {}) {
         agent,
         dangerouslySkipPermissions,
       );
+      // Persist model and provider after the sandbox entry exists in the registry.
+      // updateSandbox() silently no-ops when the entry is missing, so this must
+      // run after createSandbox() / registerSandbox() — not before. Fixes #1881.
+      registry.updateSandbox(sandboxName, { model, provider });
       onboardSession.markStepComplete("sandbox", { sandboxName, provider, model, nimContainer });
     }
 

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -4500,4 +4500,24 @@ const { createSandbox } = require(${onboardPath});
     assert.match(fnBody, /isNonInteractive\(\)/);
     assert.match(fnBody, /process\.exit\(1\)/);
   });
+
+  it("regression #1881: registry.updateSandbox(model/provider) is called AFTER createSandbox", () => {
+    // updateSandbox() silently no-ops when the entry does not exist yet.
+    // This asserts that the model/provider update comes AFTER createSandbox()
+    // returns, not before registerSandbox() is called (the original bug).
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+    const createSandboxPos = source.indexOf("sandboxName = await createSandbox(");
+    assert.ok(createSandboxPos !== -1, "createSandbox call not found in onboard.ts");
+    const updateAfterCreate = source.indexOf(
+      "registry.updateSandbox(sandboxName, { model, provider })",
+      createSandboxPos,
+    );
+    assert.ok(
+      updateAfterCreate !== -1,
+      "registry.updateSandbox(model, provider) must appear AFTER createSandbox() — regression #1881",
+    );
+  });
 });


### PR DESCRIPTION
## Problem

After `nemoclaw onboard`, `nemoclaw list` shows `model: unknown  provider: unknown` for all sandboxes. The registry has `model: null` and `provider: null` even though onboard correctly displayed the configured values.

## Root cause

`registry.updateSandbox(sandboxName, { model, provider })` was called at line 3643 (Step 4: inference setup) — **before** `registry.registerSandbox()` at line 2827 (Step 6: create sandbox). Since `updateSandbox()` silently returns `false` when the entry doesn't exist (`registry.ts:177`), the values were never persisted.

## Fix

Added a `registry.updateSandbox(sandboxName, { model, provider })` call immediately after `createSandbox()` returns. At that point the registry entry is guaranteed to exist.

## Testing

- `nemoclaw onboard` → `nemoclaw list` now shows the correct model and provider
- `~/.nemoclaw/sandboxes.json` stores the configured values instead of `null`

Fixes #1881

Signed-off-by: Benedikt Schackenberg <6381261+BenediktSchackenberg@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures sandbox model and provider settings are persisted immediately after sandbox creation so configurations are reliably saved during onboarding.

* **Tests**
  * Added a regression test to verify the onboarding flow persists settings in the correct sequence to prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->