### PR TITLE
fix(security): use argv arrays for docker/curl/openshell to prevent shell injection

### DIFF
--- a/src/lib/local-inference.test.ts
+++ b/src/lib/local-inference.test.ts
@@ -86,35 +86,35 @@ describe("local inference helpers", () => {
 
   it("validates a reachable local provider", () => {
     let callCount = 0;
-    const mockArgvCapture = () => {
+    const mockCapture = () => {
       callCount += 1;
       return '{"models":[]}';
     };
-    const result = validateLocalProvider("ollama-local", () => "", mockArgvCapture);
+    const result = validateLocalProvider("ollama-local", mockCapture);
     expect(result).toEqual({ ok: true });
     expect(callCount).toBe(2);
   });
 
   it("returns a clear error when ollama-local is unavailable", () => {
-    const result = validateLocalProvider("ollama-local", () => "", () => "");
+    const result = validateLocalProvider("ollama-local", () => "");
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/http:\/\/localhost:11434/);
   });
 
   it("returns a clear error when ollama-local is not reachable from containers", () => {
     let callCount = 0;
-    const mockArgvCapture = () => {
+    const mockCapture = () => {
       callCount += 1;
       return callCount === 1 ? '{"models":[]}' : "";
     };
-    const result = validateLocalProvider("ollama-local", () => "", mockArgvCapture);
+    const result = validateLocalProvider("ollama-local", mockCapture);
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/host\.openshell\.internal:11434/);
     expect(result.message).toMatch(/0\.0\.0\.0:11434/);
   });
 
   it("returns a clear error when vllm-local is unavailable", () => {
-    const result = validateLocalProvider("vllm-local", () => "", () => "");
+    const result = validateLocalProvider("vllm-local", () => "");
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/http:\/\/localhost:8000/);
   });
@@ -163,26 +163,26 @@ describe("local inference helpers", () => {
 
   it("returns a clear error when vllm-local is not reachable from containers", () => {
     let callCount = 0;
-    const mockArgvCapture = () => {
+    const mockCapture = () => {
       callCount += 1;
       return callCount === 1 ? '{"data":[]}' : "";
     };
-    const result = validateLocalProvider("vllm-local", () => "", mockArgvCapture);
+    const result = validateLocalProvider("vllm-local", mockCapture);
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/host\.openshell\.internal:8000/);
   });
 
   it("treats unknown local providers as already valid", () => {
-    expect(validateLocalProvider("custom-provider", () => "", () => "")).toEqual({ ok: true });
+    expect(validateLocalProvider("custom-provider", () => "")).toEqual({ ok: true });
   });
 
   it("skips health check entirely for unknown providers", () => {
     let callCount = 0;
-    const mockArgvCapture = () => {
+    const mockCapture = () => {
       callCount += 1;
       return callCount <= 1 ? "ok" : "";
     };
-    const result = validateLocalProvider("custom-provider", () => "", mockArgvCapture);
+    const result = validateLocalProvider("custom-provider", mockCapture);
     // custom-provider has no health check command, so it returns ok immediately
     expect(result).toEqual({ ok: true });
   });
@@ -204,14 +204,8 @@ describe("local inference helpers", () => {
   });
 
   it("returns parsed ollama model options when available", () => {
-    const mockArgvCapture = () => "";
-    const mockArgvCaptureList = () => "nemotron-3-nano:30b  abc  24 GB  now\nqwen3:32b  def  20 GB  now";
-    expect(
-      getOllamaModelOptions(
-        () => "",
-        mockArgvCaptureList,
-      ),
-    ).toEqual(["nemotron-3-nano:30b", "qwen3:32b"]);
+    const mockCapture = () => "nemotron-3-nano:30b  abc  24 GB  now\nqwen3:32b  def  20 GB  now";
+    expect(getOllamaModelOptions(mockCapture)).toEqual(["nemotron-3-nano:30b", "qwen3:32b"]);
   });
 
   it("parses installed models from Ollama /api/tags output", () => {
@@ -234,38 +228,28 @@ describe("local inference helpers", () => {
 
   it("prefers Ollama /api/tags over parsing the CLI list output", () => {
     let call = 0;
-    const mockArgvCapture = () => {
+    const mockCapture = () => {
       call += 1;
       if (call === 1) {
         return JSON.stringify({ models: [{ name: "qwen2.5:7b" }] });
       }
       return "";
     };
-    expect(
-      getOllamaModelOptions(() => "", mockArgvCapture),
-    ).toEqual(["qwen2.5:7b"]);
+    expect(getOllamaModelOptions(mockCapture)).toEqual(["qwen2.5:7b"]);
   });
 
   it("returns no installed ollama models when list output is empty", () => {
-    expect(getOllamaModelOptions(() => "", () => "")).toEqual([]);
+    expect(getOllamaModelOptions(() => "")).toEqual([]);
   });
 
   it("prefers the default ollama model when present", () => {
-    const mockArgvCapture = () => "qwen3:32b  abc  20 GB  now\nnemotron-3-nano:30b  def  24 GB  now";
-    expect(
-      getDefaultOllamaModel(
-        () => "",
-        null,
-        mockArgvCapture,
-      ),
-    ).toBe(DEFAULT_OLLAMA_MODEL);
+    const mockCapture = () => "qwen3:32b  abc  20 GB  now\nnemotron-3-nano:30b  def  24 GB  now";
+    expect(getDefaultOllamaModel(null, mockCapture)).toBe(DEFAULT_OLLAMA_MODEL);
   });
 
   it("falls back to the first listed ollama model when the default is absent", () => {
-    const mockArgvCapture = () => "qwen3:32b  abc  20 GB  now\ngemma3:4b  def  3 GB  now";
-    expect(
-      getDefaultOllamaModel(() => "", null, mockArgvCapture),
-    ).toBe("qwen3:32b");
+    const mockCapture = () => "qwen3:32b  abc  20 GB  now\ngemma3:4b  def  3 GB  now";
+    expect(getDefaultOllamaModel(null, mockCapture)).toBe("qwen3:32b");
   });
 
   it("falls back to bootstrap model options when no Ollama models are installed", () => {
@@ -276,7 +260,7 @@ describe("local inference helpers", () => {
     expect(
       getBootstrapOllamaModelOptions({ totalMemoryMB: LARGE_OLLAMA_MIN_MEMORY_MB }),
     ).toEqual(["qwen2.5:7b", DEFAULT_OLLAMA_MODEL]);
-    expect(getDefaultOllamaModel(() => "", { totalMemoryMB: 16384 }, () => "")).toBe("qwen2.5:7b");
+    expect(getDefaultOllamaModel({ totalMemoryMB: 16384 }, () => "")).toBe("qwen2.5:7b");
   });
 
   it("builds a background warmup command for ollama models", () => {
@@ -309,13 +293,14 @@ describe("local inference helpers", () => {
   });
 
   it("fails ollama model validation when the probe times out or returns nothing", () => {
-    const result = validateOllamaModel("nemotron-3-nano:30b", () => "", () => "");
+    const result = validateOllamaModel("nemotron-3-nano:30b", () => "");
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/did not answer the local probe in time/);
   });
 
   it("fails ollama model validation when Ollama returns an error payload", () => {
-    const result = validateOllamaModel("gabegoodhart/minimax-m2.1:latest", () => "",
+    const result = validateOllamaModel(
+      "gabegoodhart/minimax-m2.1:latest",
       () => JSON.stringify({ error: "model requires more system memory" }),
     );
     expect(result.ok).toBe(false);
@@ -323,13 +308,14 @@ describe("local inference helpers", () => {
   });
 
   it("passes ollama model validation when the probe returns a normal payload", () => {
-    const result = validateOllamaModel("nemotron-3-nano:30b", () => "",
+    const result = validateOllamaModel(
+      "nemotron-3-nano:30b",
       () => JSON.stringify({ model: "nemotron-3-nano:30b", response: "hello", done: true }),
     );
     expect(result).toEqual({ ok: true });
   });
 
   it("treats non-JSON probe output as success once the model responds", () => {
-    expect(validateOllamaModel("nemotron-3-nano:30b", () => "", () => "ok")).toEqual({ ok: true });
+    expect(validateOllamaModel("nemotron-3-nano:30b", () => "ok")).toEqual({ ok: true });
   });
 });

--- a/src/lib/local-inference.test.ts
+++ b/src/lib/local-inference.test.ts
@@ -55,8 +55,8 @@ describe("local inference helpers", () => {
       "http://localhost:11434/api/tags",
     );
     expect(getLocalProviderLabel("ollama-local")).toBe("Local Ollama");
-    expect(getLocalProviderHealthCheck("ollama-local")).toBe(
-      "curl -sf http://localhost:11434/api/tags 2>/dev/null",
+    expect(getLocalProviderHealthCheck("ollama-local")).toEqual(
+      ["curl", "-sf", "http://localhost:11434/api/tags"],
     );
   });
 
@@ -64,49 +64,57 @@ describe("local inference helpers", () => {
     expect(getLocalProviderValidationBaseUrl("ollama-local")).toBe("http://localhost:11434/v1");
     expect(getLocalProviderHealthEndpoint("vllm-local")).toBe("http://localhost:8000/v1/models");
     expect(getLocalProviderLabel("vllm-local")).toBe("Local vLLM");
-    expect(getLocalProviderHealthCheck("vllm-local")).toBe(
-      "curl -sf http://localhost:8000/v1/models 2>/dev/null",
+    expect(getLocalProviderHealthCheck("vllm-local")).toEqual(
+      ["curl", "-sf", "http://localhost:8000/v1/models"],
     );
-    expect(getLocalProviderContainerReachabilityCheck("vllm-local")).toBe(
-      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:8000/v1/models 2>/dev/null`,
-    );
+    expect(getLocalProviderContainerReachabilityCheck("vllm-local")).toEqual([
+      "docker", "run", "--rm",
+      "--add-host", "host.openshell.internal:host-gateway",
+      CONTAINER_REACHABILITY_IMAGE,
+      "-sf", "http://host.openshell.internal:8000/v1/models",
+    ]);
   });
 
   it("returns the expected container reachability command for ollama-local", () => {
-    expect(getLocalProviderContainerReachabilityCheck("ollama-local")).toBe(
-      `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:11434/api/tags 2>/dev/null`,
-    );
+    expect(getLocalProviderContainerReachabilityCheck("ollama-local")).toEqual([
+      "docker", "run", "--rm",
+      "--add-host", "host.openshell.internal:host-gateway",
+      CONTAINER_REACHABILITY_IMAGE,
+      "-sf", "http://host.openshell.internal:11434/api/tags",
+    ]);
   });
 
   it("validates a reachable local provider", () => {
     let callCount = 0;
-    const result = validateLocalProvider("ollama-local", () => {
+    const mockArgvCapture = () => {
       callCount += 1;
       return '{"models":[]}';
-    });
+    };
+    const result = validateLocalProvider("ollama-local", () => "", mockArgvCapture);
     expect(result).toEqual({ ok: true });
     expect(callCount).toBe(2);
   });
 
   it("returns a clear error when ollama-local is unavailable", () => {
-    const result = validateLocalProvider("ollama-local", () => "");
+    const result = validateLocalProvider("ollama-local", () => "", () => "");
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/http:\/\/localhost:11434/);
   });
 
   it("returns a clear error when ollama-local is not reachable from containers", () => {
     let callCount = 0;
-    const result = validateLocalProvider("ollama-local", () => {
+    const mockArgvCapture = () => {
       callCount += 1;
       return callCount === 1 ? '{"models":[]}' : "";
-    });
+    };
+    const result = validateLocalProvider("ollama-local", () => "", mockArgvCapture);
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/host\.openshell\.internal:11434/);
     expect(result.message).toMatch(/0\.0\.0\.0:11434/);
   });
 
   it("returns a clear error when vllm-local is unavailable", () => {
-    const result = validateLocalProvider("vllm-local", () => "");
+    const result = validateLocalProvider("vllm-local", () => "", () => "");
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/http:\/\/localhost:8000/);
   });
@@ -155,24 +163,26 @@ describe("local inference helpers", () => {
 
   it("returns a clear error when vllm-local is not reachable from containers", () => {
     let callCount = 0;
-    const result = validateLocalProvider("vllm-local", () => {
+    const mockArgvCapture = () => {
       callCount += 1;
       return callCount === 1 ? '{"data":[]}' : "";
-    });
+    };
+    const result = validateLocalProvider("vllm-local", () => "", mockArgvCapture);
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/host\.openshell\.internal:8000/);
   });
 
   it("treats unknown local providers as already valid", () => {
-    expect(validateLocalProvider("custom-provider", () => "")).toEqual({ ok: true });
+    expect(validateLocalProvider("custom-provider", () => "", () => "")).toEqual({ ok: true });
   });
 
   it("skips health check entirely for unknown providers", () => {
     let callCount = 0;
-    const result = validateLocalProvider("custom-provider", () => {
+    const mockArgvCapture = () => {
       callCount += 1;
       return callCount <= 1 ? "ok" : "";
-    });
+    };
+    const result = validateLocalProvider("custom-provider", () => "", mockArgvCapture);
     // custom-provider has no health check command, so it returns ok immediately
     expect(result).toEqual({ ok: true });
   });
@@ -194,9 +204,12 @@ describe("local inference helpers", () => {
   });
 
   it("returns parsed ollama model options when available", () => {
+    const mockArgvCapture = () => "";
+    const mockArgvCaptureList = () => "nemotron-3-nano:30b  abc  24 GB  now\nqwen3:32b  def  20 GB  now";
     expect(
       getOllamaModelOptions(
-        () => "nemotron-3-nano:30b  abc  24 GB  now\nqwen3:32b  def  20 GB  now",
+        () => "",
+        mockArgvCaptureList,
       ),
     ).toEqual(["nemotron-3-nano:30b", "qwen3:32b"]);
   });
@@ -221,32 +234,37 @@ describe("local inference helpers", () => {
 
   it("prefers Ollama /api/tags over parsing the CLI list output", () => {
     let call = 0;
+    const mockArgvCapture = () => {
+      call += 1;
+      if (call === 1) {
+        return JSON.stringify({ models: [{ name: "qwen2.5:7b" }] });
+      }
+      return "";
+    };
     expect(
-      getOllamaModelOptions(() => {
-        call += 1;
-        if (call === 1) {
-          return JSON.stringify({ models: [{ name: "qwen2.5:7b" }] });
-        }
-        return "";
-      }),
+      getOllamaModelOptions(() => "", mockArgvCapture),
     ).toEqual(["qwen2.5:7b"]);
   });
 
   it("returns no installed ollama models when list output is empty", () => {
-    expect(getOllamaModelOptions(() => "")).toEqual([]);
+    expect(getOllamaModelOptions(() => "", () => "")).toEqual([]);
   });
 
   it("prefers the default ollama model when present", () => {
+    const mockArgvCapture = () => "qwen3:32b  abc  20 GB  now\nnemotron-3-nano:30b  def  24 GB  now";
     expect(
       getDefaultOllamaModel(
-        () => "qwen3:32b  abc  20 GB  now\nnemotron-3-nano:30b  def  24 GB  now",
+        () => "",
+        null,
+        mockArgvCapture,
       ),
     ).toBe(DEFAULT_OLLAMA_MODEL);
   });
 
   it("falls back to the first listed ollama model when the default is absent", () => {
+    const mockArgvCapture = () => "qwen3:32b  abc  20 GB  now\ngemma3:4b  def  3 GB  now";
     expect(
-      getDefaultOllamaModel(() => "qwen3:32b  abc  20 GB  now\ngemma3:4b  def  3 GB  now"),
+      getDefaultOllamaModel(() => "", null, mockArgvCapture),
     ).toBe("qwen3:32b");
   });
 
@@ -258,50 +276,60 @@ describe("local inference helpers", () => {
     expect(
       getBootstrapOllamaModelOptions({ totalMemoryMB: LARGE_OLLAMA_MIN_MEMORY_MB }),
     ).toEqual(["qwen2.5:7b", DEFAULT_OLLAMA_MODEL]);
-    expect(getDefaultOllamaModel(() => "", { totalMemoryMB: 16384 })).toBe("qwen2.5:7b");
+    expect(getDefaultOllamaModel(() => "", { totalMemoryMB: 16384 }, () => "")).toBe("qwen2.5:7b");
   });
 
   it("builds a background warmup command for ollama models", () => {
     const command = getOllamaWarmupCommand("nemotron-3-nano:30b");
-    expect(command).toMatch(/^nohup curl -s http:\/\/localhost:11434\/api\/generate /);
-    expect(command).toMatch(/"model":"nemotron-3-nano:30b"/);
-    expect(command).toMatch(/"keep_alive":"15m"/);
+    expect(command).toEqual(expect.arrayContaining(["bash", "-c"]));
+    expect(command[2]).toMatch(/^nohup curl -s http:\/\/localhost:11434\/api\/generate /);
+    expect(command[2]).toMatch(/"model":"nemotron-3-nano:30b"/);
+    expect(command[2]).toMatch(/"keep_alive":"15m"/);
   });
 
   it("supports custom probe and warmup tuning", () => {
-    expect(getOllamaWarmupCommand("qwen2.5:7b", "30m")).toMatch(/"keep_alive":"30m"/);
-    expect(getOllamaProbeCommand("qwen2.5:7b", 30, "5m")).toMatch(/--max-time 30/);
-    expect(getOllamaProbeCommand("qwen2.5:7b", 30, "5m")).toMatch(/"keep_alive":"5m"/);
+    const warmup = getOllamaWarmupCommand("qwen2.5:7b", "30m");
+    expect(warmup[2]).toMatch(/"keep_alive":"30m"/);
+    const probe1 = getOllamaProbeCommand("qwen2.5:7b", 30, "5m");
+    expect(probe1).toContain("--max-time");
+    expect(probe1).toContain("30");
+    const payload1 = probe1[probe1.length - 1];
+    expect(payload1).toMatch(/"keep_alive":"5m"/);
   });
 
-  it("builds a foreground probe command for ollama models", () => {
+  it("builds a foreground probe command as an argv array", () => {
     const command = getOllamaProbeCommand("nemotron-3-nano:30b");
-    expect(command).toMatch(/^curl -sS --max-time 120 http:\/\/localhost:11434\/api\/generate /);
-    expect(command).toMatch(/"model":"nemotron-3-nano:30b"/);
+    expect(command[0]).toBe("curl");
+    expect(command).toContain("-sS");
+    expect(command).toContain("--max-time");
+    expect(command).toContain("120");
+    expect(command).toContain("http://localhost:11434/api/generate");
+    const payload = command[command.length - 1];
+    expect(payload).toMatch(/"model":"nemotron-3-nano:30b"/);
   });
 
   it("fails ollama model validation when the probe times out or returns nothing", () => {
-    const result = validateOllamaModel("nemotron-3-nano:30b", () => "");
+    const result = validateOllamaModel("nemotron-3-nano:30b", () => "", () => "");
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/did not answer the local probe in time/);
   });
 
   it("fails ollama model validation when Ollama returns an error payload", () => {
-    const result = validateOllamaModel("gabegoodhart/minimax-m2.1:latest", () =>
-      JSON.stringify({ error: "model requires more system memory" }),
+    const result = validateOllamaModel("gabegoodhart/minimax-m2.1:latest", () => "",
+      () => JSON.stringify({ error: "model requires more system memory" }),
     );
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/requires more system memory/);
   });
 
   it("passes ollama model validation when the probe returns a normal payload", () => {
-    const result = validateOllamaModel("nemotron-3-nano:30b", () =>
-      JSON.stringify({ model: "nemotron-3-nano:30b", response: "hello", done: true }),
+    const result = validateOllamaModel("nemotron-3-nano:30b", () => "",
+      () => JSON.stringify({ model: "nemotron-3-nano:30b", response: "hello", done: true }),
     );
     expect(result).toEqual({ ok: true });
   });
 
   it("treats non-JSON probe output as success once the model responds", () => {
-    expect(validateOllamaModel("nemotron-3-nano:30b", () => "ok")).toEqual({ ok: true });
+    expect(validateOllamaModel("nemotron-3-nano:30b", () => "", () => "ok")).toEqual({ ok: true });
   });
 });

--- a/src/lib/local-inference.ts
+++ b/src/lib/local-inference.ts
@@ -10,7 +10,7 @@ import type { CurlProbeResult } from "./http-probe";
 import { runCurlProbe } from "./http-probe";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { shellQuote } = require("./runner");
+const { shellQuote, runArgvCapture } = require("./runner");
 
 import { VLLM_PORT, OLLAMA_PORT } from "./ports";
 
@@ -75,9 +75,9 @@ export function getLocalProviderHealthEndpoint(provider: string): string | null 
   }
 }
 
-export function getLocalProviderHealthCheck(provider: string): string | null {
+export function getLocalProviderHealthCheck(provider: string): string[] | null {
   const endpoint = getLocalProviderHealthEndpoint(provider);
-  return endpoint ? `curl -sf ${endpoint} 2>/dev/null` : null;
+  return endpoint ? ["curl", "-sf", endpoint] : null;
 }
 
 export function getLocalProviderLabel(provider: string): string | null {
@@ -146,27 +146,41 @@ export function probeLocalProviderHealth(
   };
 }
 
-export function getLocalProviderContainerReachabilityCheck(provider: string): string | null {
+export function getLocalProviderContainerReachabilityCheck(provider: string): string[] | null {
   switch (provider) {
     case "vllm-local":
-      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:${VLLM_PORT}/v1/models 2>/dev/null`;
+      return [
+        "docker", "run", "--rm",
+        "--add-host", "host.openshell.internal:host-gateway",
+        CONTAINER_REACHABILITY_IMAGE,
+        "-sf", `http://host.openshell.internal:${VLLM_PORT}/v1/models`,
+      ];
     case "ollama-local":
-      return `docker run --rm --add-host host.openshell.internal:host-gateway ${CONTAINER_REACHABILITY_IMAGE} -sf http://host.openshell.internal:${OLLAMA_PORT}/api/tags 2>/dev/null`;
+      return [
+        "docker", "run", "--rm",
+        "--add-host", "host.openshell.internal:host-gateway",
+        CONTAINER_REACHABILITY_IMAGE,
+        "-sf", `http://host.openshell.internal:${OLLAMA_PORT}/api/tags`,
+      ];
     default:
       return null;
   }
 }
 
+export type RunArgvCaptureFn = (cmd: string[], opts?: { ignoreError?: boolean }) => string;
+
 export function validateLocalProvider(
   provider: string,
   runCapture: RunCaptureFn,
+  runArgvCaptureImpl?: RunArgvCaptureFn,
 ): ValidationResult {
+  const argvCapture = runArgvCaptureImpl ?? runArgvCapture;
   const command = getLocalProviderHealthCheck(provider);
   if (!command) {
     return { ok: true };
   }
 
-  const output = runCapture(command, { ignoreError: true });
+  const output = argvCapture(command, { ignoreError: true });
   if (!output) {
     switch (provider) {
       case "vllm-local":
@@ -190,7 +204,7 @@ export function validateLocalProvider(
     return { ok: true };
   }
 
-  const containerOutput = runCapture(containerCommand, { ignoreError: true });
+  const containerOutput = argvCapture(containerCommand, { ignoreError: true });
   if (containerOutput) {
     return { ok: true };
   }
@@ -237,8 +251,9 @@ export function parseOllamaTags(output: unknown): string[] {
   }
 }
 
-export function getOllamaModelOptions(runCapture: RunCaptureFn): string[] {
-  const tagsOutput = runCapture(`curl -sf http://localhost:${OLLAMA_PORT}/api/tags 2>/dev/null`, {
+export function getOllamaModelOptions(runCapture: RunCaptureFn, runArgvCaptureImpl?: RunArgvCaptureFn): string[] {
+  const argvCapture = runArgvCaptureImpl ?? runArgvCapture;
+  const tagsOutput = argvCapture(["curl", "-sf", `http://localhost:${OLLAMA_PORT}/api/tags`], {
     ignoreError: true,
   });
   const tagsParsed = parseOllamaTags(tagsOutput);
@@ -246,7 +261,7 @@ export function getOllamaModelOptions(runCapture: RunCaptureFn): string[] {
     return tagsParsed;
   }
 
-  const listOutput = runCapture("ollama list 2>/dev/null", { ignoreError: true });
+  const listOutput = argvCapture(["ollama", "list"], { ignoreError: true });
   return parseOllamaList(listOutput);
 }
 
@@ -261,8 +276,9 @@ export function getBootstrapOllamaModelOptions(gpu: GpuInfo | null): string[] {
 export function getDefaultOllamaModel(
   runCapture: RunCaptureFn,
   gpu: GpuInfo | null = null,
+  runArgvCaptureImpl?: RunArgvCaptureFn,
 ): string {
-  const models = getOllamaModelOptions(runCapture);
+  const models = getOllamaModelOptions(runCapture, runArgvCaptureImpl);
   if (models.length === 0) {
     const bootstrap = getBootstrapOllamaModelOptions(gpu);
     return bootstrap[0];
@@ -270,35 +286,47 @@ export function getDefaultOllamaModel(
   return models.includes(DEFAULT_OLLAMA_MODEL) ? DEFAULT_OLLAMA_MODEL : models[0];
 }
 
-export function getOllamaWarmupCommand(model: string, keepAlive = "15m"): string {
+export function getOllamaWarmupCommand(model: string, keepAlive = "15m"): string[] {
   const payload = JSON.stringify({
     model,
     prompt: "hello",
     stream: false,
     keep_alive: keepAlive,
   });
-  return `nohup curl -s http://localhost:${OLLAMA_PORT}/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} >/dev/null 2>&1 &`;
+  // backgrounding (nohup ... &) requires a shell wrapper
+  return [
+    "bash", "-c",
+    `nohup curl -s http://localhost:${OLLAMA_PORT}/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} >/dev/null 2>&1 &`,
+  ];
 }
 
 export function getOllamaProbeCommand(
   model: string,
   timeoutSeconds = 120,
   keepAlive = "15m",
-): string {
+): string[] {
   const payload = JSON.stringify({
     model,
     prompt: "hello",
     stream: false,
     keep_alive: keepAlive,
   });
-  return `curl -sS --max-time ${timeoutSeconds} http://localhost:${OLLAMA_PORT}/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} 2>/dev/null`;
+  return [
+    "curl", "-sS",
+    "--max-time", String(timeoutSeconds),
+    `http://localhost:${OLLAMA_PORT}/api/generate`,
+    "-H", "Content-Type: application/json",
+    "-d", payload,
+  ];
 }
 
 export function validateOllamaModel(
   model: string,
   runCapture: RunCaptureFn,
+  runArgvCaptureImpl?: RunArgvCaptureFn,
 ): ValidationResult {
-  const output = runCapture(getOllamaProbeCommand(model), { ignoreError: true });
+  const argvCapture = runArgvCaptureImpl ?? runArgvCapture;
+  const output = argvCapture(getOllamaProbeCommand(model), { ignoreError: true });
   if (!output) {
     return {
       ok: false,

--- a/src/lib/local-inference.ts
+++ b/src/lib/local-inference.ts
@@ -10,7 +10,7 @@ import type { CurlProbeResult } from "./http-probe";
 import { runCurlProbe } from "./http-probe";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { shellQuote, runArgvCapture } = require("./runner");
+const { shellQuote, runCapture } = require("./runner");
 
 import { VLLM_PORT, OLLAMA_PORT } from "./ports";
 
@@ -20,7 +20,7 @@ export const DEFAULT_OLLAMA_MODEL = "nemotron-3-nano:30b";
 export const SMALL_OLLAMA_MODEL = "qwen2.5:7b";
 export const LARGE_OLLAMA_MIN_MEMORY_MB = 32768;
 
-export type RunCaptureFn = (cmd: string, opts?: { ignoreError?: boolean }) => string;
+export type RunCaptureFn = (cmd: string | string[], opts?: { ignoreError?: boolean }) => string;
 
 export interface GpuInfo {
   totalMemoryMB: number;
@@ -167,20 +167,17 @@ export function getLocalProviderContainerReachabilityCheck(provider: string): st
   }
 }
 
-export type RunArgvCaptureFn = (cmd: string[], opts?: { ignoreError?: boolean }) => string;
-
 export function validateLocalProvider(
   provider: string,
-  runCapture: RunCaptureFn,
-  runArgvCaptureImpl?: RunArgvCaptureFn,
+  runCaptureImpl?: RunCaptureFn,
 ): ValidationResult {
-  const argvCapture = runArgvCaptureImpl ?? runArgvCapture;
+  const capture = runCaptureImpl ?? runCapture;
   const command = getLocalProviderHealthCheck(provider);
   if (!command) {
     return { ok: true };
   }
 
-  const output = argvCapture(command, { ignoreError: true });
+  const output = capture(command, { ignoreError: true });
   if (!output) {
     switch (provider) {
       case "vllm-local":
@@ -204,7 +201,7 @@ export function validateLocalProvider(
     return { ok: true };
   }
 
-  const containerOutput = argvCapture(containerCommand, { ignoreError: true });
+  const containerOutput = capture(containerCommand, { ignoreError: true });
   if (containerOutput) {
     return { ok: true };
   }
@@ -251,9 +248,9 @@ export function parseOllamaTags(output: unknown): string[] {
   }
 }
 
-export function getOllamaModelOptions(runCapture: RunCaptureFn, runArgvCaptureImpl?: RunArgvCaptureFn): string[] {
-  const argvCapture = runArgvCaptureImpl ?? runArgvCapture;
-  const tagsOutput = argvCapture(["curl", "-sf", `http://localhost:${OLLAMA_PORT}/api/tags`], {
+export function getOllamaModelOptions(runCaptureImpl?: RunCaptureFn): string[] {
+  const capture = runCaptureImpl ?? runCapture;
+  const tagsOutput = capture(["curl", "-sf", `http://localhost:${OLLAMA_PORT}/api/tags`], {
     ignoreError: true,
   });
   const tagsParsed = parseOllamaTags(tagsOutput);
@@ -261,7 +258,7 @@ export function getOllamaModelOptions(runCapture: RunCaptureFn, runArgvCaptureIm
     return tagsParsed;
   }
 
-  const listOutput = argvCapture(["ollama", "list"], { ignoreError: true });
+  const listOutput = capture(["ollama", "list"], { ignoreError: true });
   return parseOllamaList(listOutput);
 }
 
@@ -274,11 +271,10 @@ export function getBootstrapOllamaModelOptions(gpu: GpuInfo | null): string[] {
 }
 
 export function getDefaultOllamaModel(
-  runCapture: RunCaptureFn,
   gpu: GpuInfo | null = null,
-  runArgvCaptureImpl?: RunArgvCaptureFn,
+  runCaptureImpl?: RunCaptureFn,
 ): string {
-  const models = getOllamaModelOptions(runCapture, runArgvCaptureImpl);
+  const models = getOllamaModelOptions(runCaptureImpl);
   if (models.length === 0) {
     const bootstrap = getBootstrapOllamaModelOptions(gpu);
     return bootstrap[0];
@@ -325,11 +321,10 @@ export function getOllamaProbeCommand(
 
 export function validateOllamaModel(
   model: string,
-  runCapture: RunCaptureFn,
-  runArgvCaptureImpl?: RunArgvCaptureFn,
+  runCaptureImpl?: RunCaptureFn,
 ): ValidationResult {
-  const argvCapture = runArgvCaptureImpl ?? runArgvCapture;
-  const output = argvCapture(getOllamaProbeCommand(model), { ignoreError: true });
+  const capture = runCaptureImpl ?? runCapture;
+  const output = capture(getOllamaProbeCommand(model), { ignoreError: true });
   if (!output) {
     return {
       ok: false,

--- a/src/lib/local-inference.ts
+++ b/src/lib/local-inference.ts
@@ -293,7 +293,10 @@ export function getOllamaWarmupCommand(model: string, keepAlive = "15m"): string
     stream: false,
     keep_alive: keepAlive,
   });
-  // backgrounding (nohup ... &) requires a shell wrapper
+  // backgrounding (nohup ... &) and output redirection require a shell wrapper.
+  // The payload is safe: model name is JSON-serialized (escaping all special
+  // chars) then shellQuote'd (single-quoted), so injection through model
+  // names is not feasible. This is the one intentional bash -c exception.
   return [
     "bash", "-c",
     `nohup curl -s http://localhost:${OLLAMA_PORT}/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} >/dev/null 2>&1 &`,

--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -16,14 +16,10 @@ function loadNimWithMockedRunner(runCapture: Mock) {
   const runner = require(RUNNER_PATH);
   const originalRun = runner.run;
   const originalRunCapture = runner.runCapture;
-  const originalRunArgv = runner.runArgv;
-  const originalRunArgvCapture = runner.runArgvCapture;
 
   delete require.cache[NIM_DIST_PATH];
   runner.run = vi.fn();
-  runner.runArgv = vi.fn();
   runner.runCapture = runCapture;
-  runner.runArgvCapture = runCapture;
   const nimModule = require(NIM_DIST_PATH);
 
   return {
@@ -32,8 +28,6 @@ function loadNimWithMockedRunner(runCapture: Mock) {
       delete require.cache[NIM_DIST_PATH];
       runner.run = originalRun;
       runner.runCapture = originalRunCapture;
-      runner.runArgv = originalRunArgv;
-      runner.runArgvCapture = originalRunArgvCapture;
     },
   };
 }

--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -94,10 +94,10 @@ describe("nim", () => {
 
     it("detects GB10 unified-memory GPUs as Spark-capable NVIDIA devices", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        const cmdStr = Array.isArray(cmd) ? cmd.join(" ") : cmd;
-        if (cmdStr.includes("memory.total")) return "";
-        if (cmdStr.includes("query-gpu=name")) return "NVIDIA GB10";
-        if (cmdStr.includes("free") && cmdStr.includes("-m")) return "              total        used        free      shared  buff/cache   available\nMem:         131072       10240       90000        1024       30832      119808\nSwap:             0           0           0";
+        expect(Array.isArray(cmd)).toBe(true);
+        if (cmd.some((a: string) => a.includes("memory.total"))) return "";
+        if (cmd.some((a: string) => a.includes("query-gpu=name"))) return "NVIDIA GB10";
+        if (cmd[0] === "free" && cmd[1] === "-m") return "              total        used        free      shared  buff/cache   available\nMem:         131072       10240       90000        1024       30832      119808\nSwap:             0           0           0";
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
@@ -120,10 +120,10 @@ describe("nim", () => {
 
     it("detects Orin unified-memory GPUs without marking them as Spark", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        const cmdStr = Array.isArray(cmd) ? cmd.join(" ") : cmd;
-        if (cmdStr.includes("memory.total")) return "";
-        if (cmdStr.includes("query-gpu=name")) return "NVIDIA Jetson AGX Orin";
-        if (cmdStr.includes("free") && cmdStr.includes("-m")) return "              total        used        free      shared  buff/cache   available\nMem:          32768        5120       20000         512       7148       27136\nSwap:             0           0           0";
+        expect(Array.isArray(cmd)).toBe(true);
+        if (cmd.some((a: string) => a.includes("memory.total"))) return "";
+        if (cmd.some((a: string) => a.includes("query-gpu=name"))) return "NVIDIA Jetson AGX Orin";
+        if (cmd[0] === "free" && cmd[1] === "-m") return "              total        used        free      shared  buff/cache   available\nMem:          32768        5120       20000         512       7148       27136\nSwap:             0           0           0";
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
@@ -146,10 +146,10 @@ describe("nim", () => {
 
     it("marks low-memory unified-memory NVIDIA devices as not NIM-capable", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        const cmdStr = Array.isArray(cmd) ? cmd.join(" ") : cmd;
-        if (cmdStr.includes("memory.total")) return "";
-        if (cmdStr.includes("query-gpu=name")) return "NVIDIA Xavier";
-        if (cmdStr.includes("free") && cmdStr.includes("-m")) return "              total        used        free      shared  buff/cache   available\nMem:           4096        1024        2048         256       1024        2816\nSwap:             0           0           0";
+        expect(Array.isArray(cmd)).toBe(true);
+        if (cmd.some((a: string) => a.includes("memory.total"))) return "";
+        if (cmd.some((a: string) => a.includes("query-gpu=name"))) return "NVIDIA Xavier";
+        if (cmd[0] === "free" && cmd[1] === "-m") return "              total        used        free      shared  buff/cache   available\nMem:           4096        1024        2048         256       1024        2816\nSwap:             0           0           0";
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
@@ -177,23 +177,23 @@ describe("nim", () => {
   });
 
   describe("nimStatusByName", () => {
-    /** Normalize a mock command arg (string or argv array) to a joined string for matching. */
-    function cmdStr(cmd: string | string[]): string {
-      return Array.isArray(cmd) ? cmd.join(" ") : cmd;
+    /** Check if an argv array contains a specific element. */
+    function hasArg(cmd: string | string[], arg: string): boolean {
+      return Array.isArray(cmd) ? cmd.includes(arg) : cmd.includes(arg);
     }
 
     it("uses provided port directly", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        const s = cmdStr(cmd);
-        if (s.includes("docker") && s.includes("inspect")) return "running";
-        if (s.includes("http://localhost:9000/v1/models")) return '{"data":[]}';
+        expect(Array.isArray(cmd)).toBe(true);
+        if (cmd[0] === "docker" && cmd.includes("inspect")) return "running";
+        if (cmd[0] === "curl" && hasArg(cmd, "http://localhost:9000/v1/models")) return '{"data":[]}';
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
 
       try {
         const st = nimModule.nimStatusByName("foo", 9000);
-        const commands = runCapture.mock.calls.map(([c]: [string | string[]]) => cmdStr(c));
+        const commands = runCapture.mock.calls.map(([c]: [string | string[]]) => c);
 
         expect(st).toMatchObject({
           running: true,
@@ -201,8 +201,8 @@ describe("nim", () => {
           container: "foo",
           state: "running",
         });
-        expect(commands.some((c: string) => c.includes("docker port"))).toBe(false);
-        expect(commands.some((c: string) => c.includes("http://localhost:9000/v1/models"))).toBe(
+        expect(commands.some((c: string[]) => c[0] === "docker" && c.includes("port"))).toBe(false);
+        expect(commands.some((c: string[]) => c.includes("http://localhost:9000/v1/models"))).toBe(
           true,
         );
       } finally {
@@ -213,20 +213,20 @@ describe("nim", () => {
     it("uses published docker port when no port is provided", () => {
       for (const mapping of ["0.0.0.0:9000", "127.0.0.1:9000", "[::]:9000", ":::9000"]) {
         const runCapture = vi.fn((cmd: string | string[]) => {
-          const s = cmdStr(cmd);
-          if (s.includes("docker") && s.includes("inspect")) return "running";
-          if (s.includes("docker") && s.includes("port")) return mapping;
-          if (s.includes("http://localhost:9000/v1/models")) return '{"data":[]}';
+          expect(Array.isArray(cmd)).toBe(true);
+          if (cmd[0] === "docker" && cmd.includes("inspect")) return "running";
+          if (cmd[0] === "docker" && cmd.includes("port")) return mapping;
+          if (cmd[0] === "curl" && hasArg(cmd, "http://localhost:9000/v1/models")) return '{"data":[]}';
           return "";
         });
         const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
 
         try {
           const st = nimModule.nimStatusByName("foo");
-          const commands = runCapture.mock.calls.map(([c]: [string | string[]]) => cmdStr(c));
+          const commands = runCapture.mock.calls.map(([c]: [string | string[]]) => c);
 
           expect(st).toMatchObject({ running: true, healthy: true, container: "foo", state: "running" });
-          expect(commands.some((c: string) => c.includes("docker port"))).toBe(true);
+          expect(commands.some((c: string[]) => c[0] === "docker" && c.includes("port"))).toBe(true);
         } finally {
           restore();
         }
@@ -235,10 +235,10 @@ describe("nim", () => {
 
     it("falls back to 8000 when docker port lookup fails", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        const s = cmdStr(cmd);
-        if (s.includes("docker") && s.includes("inspect")) return "running";
-        if (s.includes("docker") && s.includes("port")) return "";
-        if (s.includes("http://localhost:8000/v1/models")) return '{"data":[]}';
+        expect(Array.isArray(cmd)).toBe(true);
+        if (cmd[0] === "docker" && cmd.includes("inspect")) return "running";
+        if (cmd[0] === "docker" && cmd.includes("port")) return "";
+        if (cmd[0] === "curl" && hasArg(cmd, "http://localhost:8000/v1/models")) return '{"data":[]}';
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
@@ -253,8 +253,8 @@ describe("nim", () => {
 
     it("does not run health check when container is not running", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        const s = cmdStr(cmd);
-        if (s.includes("docker") && s.includes("inspect")) return "exited";
+        expect(Array.isArray(cmd)).toBe(true);
+        if (cmd[0] === "docker" && cmd.includes("inspect")) return "exited";
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);

--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -16,10 +16,14 @@ function loadNimWithMockedRunner(runCapture: Mock) {
   const runner = require(RUNNER_PATH);
   const originalRun = runner.run;
   const originalRunCapture = runner.runCapture;
+  const originalRunArgv = runner.runArgv;
+  const originalRunArgvCapture = runner.runArgvCapture;
 
   delete require.cache[NIM_DIST_PATH];
   runner.run = vi.fn();
+  runner.runArgv = vi.fn();
   runner.runCapture = runCapture;
+  runner.runArgvCapture = runCapture;
   const nimModule = require(NIM_DIST_PATH);
 
   return {
@@ -28,6 +32,8 @@ function loadNimWithMockedRunner(runCapture: Mock) {
       delete require.cache[NIM_DIST_PATH];
       runner.run = originalRun;
       runner.runCapture = originalRunCapture;
+      runner.runArgv = originalRunArgv;
+      runner.runArgvCapture = originalRunArgvCapture;
     },
   };
 }
@@ -93,10 +99,11 @@ describe("nim", () => {
     });
 
     it("detects GB10 unified-memory GPUs as Spark-capable NVIDIA devices", () => {
-      const runCapture = vi.fn((cmd: string) => {
-        if (cmd.includes("memory.total")) return "";
-        if (cmd.includes("query-gpu=name")) return "NVIDIA GB10";
-        if (cmd.includes("free -m")) return "131072";
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        const cmdStr = Array.isArray(cmd) ? cmd.join(" ") : cmd;
+        if (cmdStr.includes("memory.total")) return "";
+        if (cmdStr.includes("query-gpu=name")) return "NVIDIA GB10";
+        if (cmdStr.includes("free") && cmdStr.includes("-m")) return "              total        used        free      shared  buff/cache   available\nMem:         131072       10240       90000        1024       30832      119808\nSwap:             0           0           0";
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
@@ -118,10 +125,11 @@ describe("nim", () => {
     });
 
     it("detects Orin unified-memory GPUs without marking them as Spark", () => {
-      const runCapture = vi.fn((cmd: string) => {
-        if (cmd.includes("memory.total")) return "";
-        if (cmd.includes("query-gpu=name")) return "NVIDIA Jetson AGX Orin";
-        if (cmd.includes("free -m")) return "32768";
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        const cmdStr = Array.isArray(cmd) ? cmd.join(" ") : cmd;
+        if (cmdStr.includes("memory.total")) return "";
+        if (cmdStr.includes("query-gpu=name")) return "NVIDIA Jetson AGX Orin";
+        if (cmdStr.includes("free") && cmdStr.includes("-m")) return "              total        used        free      shared  buff/cache   available\nMem:          32768        5120       20000         512       7148       27136\nSwap:             0           0           0";
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
@@ -143,10 +151,11 @@ describe("nim", () => {
     });
 
     it("marks low-memory unified-memory NVIDIA devices as not NIM-capable", () => {
-      const runCapture = vi.fn((cmd: string) => {
-        if (cmd.includes("memory.total")) return "";
-        if (cmd.includes("query-gpu=name")) return "NVIDIA Xavier";
-        if (cmd.includes("free -m")) return "4096";
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        const cmdStr = Array.isArray(cmd) ? cmd.join(" ") : cmd;
+        if (cmdStr.includes("memory.total")) return "";
+        if (cmdStr.includes("query-gpu=name")) return "NVIDIA Xavier";
+        if (cmdStr.includes("free") && cmdStr.includes("-m")) return "              total        used        free      shared  buff/cache   available\nMem:           4096        1024        2048         256       1024        2816\nSwap:             0           0           0";
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
@@ -174,17 +183,23 @@ describe("nim", () => {
   });
 
   describe("nimStatusByName", () => {
+    /** Normalize a mock command arg (string or argv array) to a joined string for matching. */
+    function cmdStr(cmd: string | string[]): string {
+      return Array.isArray(cmd) ? cmd.join(" ") : cmd;
+    }
+
     it("uses provided port directly", () => {
-      const runCapture = vi.fn((cmd: string) => {
-        if (cmd.includes("docker inspect")) return "running";
-        if (cmd.includes("http://localhost:9000/v1/models")) return '{"data":[]}';
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        const s = cmdStr(cmd);
+        if (s.includes("docker") && s.includes("inspect")) return "running";
+        if (s.includes("http://localhost:9000/v1/models")) return '{"data":[]}';
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
 
       try {
         const st = nimModule.nimStatusByName("foo", 9000);
-        const commands = runCapture.mock.calls.map(([cmd]: [string]) => cmd);
+        const commands = runCapture.mock.calls.map(([c]: [string | string[]]) => cmdStr(c));
 
         expect(st).toMatchObject({
           running: true,
@@ -192,8 +207,8 @@ describe("nim", () => {
           container: "foo",
           state: "running",
         });
-        expect(commands.some((cmd: string) => cmd.includes("docker port"))).toBe(false);
-        expect(commands.some((cmd: string) => cmd.includes("http://localhost:9000/v1/models"))).toBe(
+        expect(commands.some((c: string) => c.includes("docker port"))).toBe(false);
+        expect(commands.some((c: string) => c.includes("http://localhost:9000/v1/models"))).toBe(
           true,
         );
       } finally {
@@ -203,20 +218,21 @@ describe("nim", () => {
 
     it("uses published docker port when no port is provided", () => {
       for (const mapping of ["0.0.0.0:9000", "127.0.0.1:9000", "[::]:9000", ":::9000"]) {
-        const runCapture = vi.fn((cmd: string) => {
-          if (cmd.includes("docker inspect")) return "running";
-          if (cmd.includes("docker port")) return mapping;
-          if (cmd.includes("http://localhost:9000/v1/models")) return '{"data":[]}';
+        const runCapture = vi.fn((cmd: string | string[]) => {
+          const s = cmdStr(cmd);
+          if (s.includes("docker") && s.includes("inspect")) return "running";
+          if (s.includes("docker") && s.includes("port")) return mapping;
+          if (s.includes("http://localhost:9000/v1/models")) return '{"data":[]}';
           return "";
         });
         const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
 
         try {
           const st = nimModule.nimStatusByName("foo");
-          const commands = runCapture.mock.calls.map(([cmd]: [string]) => cmd);
+          const commands = runCapture.mock.calls.map(([c]: [string | string[]]) => cmdStr(c));
 
           expect(st).toMatchObject({ running: true, healthy: true, container: "foo", state: "running" });
-          expect(commands.some((cmd: string) => cmd.includes("docker port"))).toBe(true);
+          expect(commands.some((c: string) => c.includes("docker port"))).toBe(true);
         } finally {
           restore();
         }
@@ -224,10 +240,11 @@ describe("nim", () => {
     });
 
     it("falls back to 8000 when docker port lookup fails", () => {
-      const runCapture = vi.fn((cmd: string) => {
-        if (cmd.includes("docker inspect")) return "running";
-        if (cmd.includes("docker port")) return "";
-        if (cmd.includes("http://localhost:8000/v1/models")) return '{"data":[]}';
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        const s = cmdStr(cmd);
+        if (s.includes("docker") && s.includes("inspect")) return "running";
+        if (s.includes("docker") && s.includes("port")) return "";
+        if (s.includes("http://localhost:8000/v1/models")) return '{"data":[]}';
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
@@ -241,8 +258,9 @@ describe("nim", () => {
     });
 
     it("does not run health check when container is not running", () => {
-      const runCapture = vi.fn((cmd: string) => {
-        if (cmd.includes("docker inspect")) return "exited";
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        const s = cmdStr(cmd);
+        if (s.includes("docker") && s.includes("inspect")) return "exited";
         return "";
       });
       const { nimModule, restore } = loadNimWithMockedRunner(runCapture);

--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -94,7 +94,7 @@ describe("nim", () => {
 
     it("detects GB10 unified-memory GPUs as Spark-capable NVIDIA devices", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        expect(Array.isArray(cmd)).toBe(true);
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
         if (cmd.some((a: string) => a.includes("memory.total"))) return "";
         if (cmd.some((a: string) => a.includes("query-gpu=name"))) return "NVIDIA GB10";
         if (cmd[0] === "free" && cmd[1] === "-m") return "              total        used        free      shared  buff/cache   available\nMem:         131072       10240       90000        1024       30832      119808\nSwap:             0           0           0";
@@ -120,7 +120,7 @@ describe("nim", () => {
 
     it("detects Orin unified-memory GPUs without marking them as Spark", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        expect(Array.isArray(cmd)).toBe(true);
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
         if (cmd.some((a: string) => a.includes("memory.total"))) return "";
         if (cmd.some((a: string) => a.includes("query-gpu=name"))) return "NVIDIA Jetson AGX Orin";
         if (cmd[0] === "free" && cmd[1] === "-m") return "              total        used        free      shared  buff/cache   available\nMem:          32768        5120       20000         512       7148       27136\nSwap:             0           0           0";
@@ -146,7 +146,7 @@ describe("nim", () => {
 
     it("marks low-memory unified-memory NVIDIA devices as not NIM-capable", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        expect(Array.isArray(cmd)).toBe(true);
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
         if (cmd.some((a: string) => a.includes("memory.total"))) return "";
         if (cmd.some((a: string) => a.includes("query-gpu=name"))) return "NVIDIA Xavier";
         if (cmd[0] === "free" && cmd[1] === "-m") return "              total        used        free      shared  buff/cache   available\nMem:           4096        1024        2048         256       1024        2816\nSwap:             0           0           0";
@@ -184,7 +184,7 @@ describe("nim", () => {
 
     it("uses provided port directly", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        expect(Array.isArray(cmd)).toBe(true);
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
         if (cmd[0] === "docker" && cmd.includes("inspect")) return "running";
         if (cmd[0] === "curl" && hasArg(cmd, "http://localhost:9000/v1/models")) return '{"data":[]}';
         return "";
@@ -201,8 +201,8 @@ describe("nim", () => {
           container: "foo",
           state: "running",
         });
-        expect(commands.some((c: string[]) => c[0] === "docker" && c.includes("port"))).toBe(false);
-        expect(commands.some((c: string[]) => c.includes("http://localhost:9000/v1/models"))).toBe(
+        expect(commands.some((c) => c[0] === "docker" && c.includes("port"))).toBe(false);
+        expect(commands.some((c) => c.includes("http://localhost:9000/v1/models"))).toBe(
           true,
         );
       } finally {
@@ -213,7 +213,7 @@ describe("nim", () => {
     it("uses published docker port when no port is provided", () => {
       for (const mapping of ["0.0.0.0:9000", "127.0.0.1:9000", "[::]:9000", ":::9000"]) {
         const runCapture = vi.fn((cmd: string | string[]) => {
-          expect(Array.isArray(cmd)).toBe(true);
+          if (!Array.isArray(cmd)) throw new Error("expected argv array");
           if (cmd[0] === "docker" && cmd.includes("inspect")) return "running";
           if (cmd[0] === "docker" && cmd.includes("port")) return mapping;
           if (cmd[0] === "curl" && hasArg(cmd, "http://localhost:9000/v1/models")) return '{"data":[]}';
@@ -226,7 +226,7 @@ describe("nim", () => {
           const commands = runCapture.mock.calls.map(([c]: [string | string[]]) => c);
 
           expect(st).toMatchObject({ running: true, healthy: true, container: "foo", state: "running" });
-          expect(commands.some((c: string[]) => c[0] === "docker" && c.includes("port"))).toBe(true);
+          expect(commands.some((c) => c[0] === "docker" && c.includes("port"))).toBe(true);
         } finally {
           restore();
         }
@@ -235,7 +235,7 @@ describe("nim", () => {
 
     it("falls back to 8000 when docker port lookup fails", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        expect(Array.isArray(cmd)).toBe(true);
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
         if (cmd[0] === "docker" && cmd.includes("inspect")) return "running";
         if (cmd[0] === "docker" && cmd.includes("port")) return "";
         if (cmd[0] === "curl" && hasArg(cmd, "http://localhost:8000/v1/models")) return '{"data":[]}';
@@ -253,7 +253,7 @@ describe("nim", () => {
 
     it("does not run health check when container is not running", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
-        expect(Array.isArray(cmd)).toBe(true);
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
         if (cmd[0] === "docker" && cmd.includes("inspect")) return "exited";
         return "";
       });

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -4,7 +4,7 @@
 // NIM container management — pull, start, stop, health-check NIM images.
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { run, runCapture, runArgv, runArgvCapture } = require("./runner");
+const { run, runCapture } = require("./runner");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const nimImages = require("../../bin/lib/nim-images.json");
 
@@ -61,7 +61,7 @@ export function canRunNimWithMemory(totalMemoryMB: number): boolean {
 export function detectGpu(): GpuDetection | null {
   // Try NVIDIA first — query VRAM
   try {
-    const output = runArgvCapture(
+    const output = runCapture(
       ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
       { ignoreError: true },
     );
@@ -87,7 +87,7 @@ export function detectGpu(): GpuDetection | null {
 
   // Fallback: unified-memory NVIDIA devices
   try {
-    const nameOutput = runArgvCapture(
+    const nameOutput = runCapture(
       ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader,nounits"],
       { ignoreError: true },
     );
@@ -101,7 +101,7 @@ export function detectGpu(): GpuDetection | null {
     if (unifiedGpuNames.length > 0) {
       let totalMemoryMB = 0;
       try {
-        const freeOut = runArgvCapture(["free", "-m"], { ignoreError: true });
+        const freeOut = runCapture(["free", "-m"], { ignoreError: true });
         if (freeOut) {
           const memLine = freeOut.split("\n").find((l: string) => l.includes("Mem:"));
           if (memLine) {
@@ -133,7 +133,7 @@ export function detectGpu(): GpuDetection | null {
   // macOS: detect Apple Silicon or discrete GPU
   if (process.platform === "darwin") {
     try {
-      const spOutput = runArgvCapture(["system_profiler", "SPDisplaysDataType"], {
+      const spOutput = runCapture(["system_profiler", "SPDisplaysDataType"], {
         ignoreError: true,
       });
       if (spOutput) {
@@ -150,7 +150,7 @@ export function detectGpu(): GpuDetection | null {
             if (vramMatch[2].toUpperCase() === "GB") memoryMB *= 1024;
           } else {
             try {
-              const memBytes = runArgvCapture(["sysctl", "-n", "hw.memsize"], { ignoreError: true });
+              const memBytes = runCapture(["sysctl", "-n", "hw.memsize"], { ignoreError: true });
               if (memBytes) memoryMB = Math.floor(parseInt(memBytes, 10) / 1024 / 1024);
             } catch {
               /* ignored */
@@ -183,7 +183,7 @@ export function pullNimImage(model: string): string {
     process.exit(1);
   }
   console.log(`  Pulling NIM image: ${image}`);
-  runArgv(["docker", "pull", image]);
+  run(["docker", "pull", image]);
   return image;
 }
 
@@ -199,10 +199,10 @@ export function startNimContainerByName(name: string, model: string, port = VLLM
     process.exit(1);
   }
 
-  runArgv(["docker", "rm", "-f", name], { ignoreError: true });
+  run(["docker", "rm", "-f", name], { ignoreError: true });
 
   console.log(`  Starting NIM container: ${name}`);
-  runArgv([
+  run([
     "docker", "run", "-d", "--gpus", "all",
     "-p", `${Number(port)}:8000`,
     "--name", name,
@@ -220,7 +220,7 @@ export function waitForNimHealth(port = VLLM_PORT, timeout = 300): boolean {
 
   while ((Date.now() - start) / 1000 < timeout) {
     try {
-      const result = runArgvCapture(["curl", "-sf", `http://localhost:${hostPort}/v1/models`], {
+      const result = runCapture(["curl", "-sf", `http://localhost:${hostPort}/v1/models`], {
         ignoreError: true,
       });
       if (result) {
@@ -244,8 +244,8 @@ export function stopNimContainer(sandboxName: string): void {
 
 export function stopNimContainerByName(name: string): void {
   console.log(`  Stopping NIM container: ${name}`);
-  runArgv(["docker", "stop", name], { ignoreError: true });
-  runArgv(["docker", "rm", name], { ignoreError: true });
+  run(["docker", "stop", name], { ignoreError: true });
+  run(["docker", "rm", name], { ignoreError: true });
 }
 
 export function nimStatus(sandboxName: string, port?: number): NimStatus {
@@ -255,7 +255,7 @@ export function nimStatus(sandboxName: string, port?: number): NimStatus {
 
 export function nimStatusByName(name: string, port?: number): NimStatus {
   try {
-    const state = runArgvCapture(
+    const state = runCapture(
       ["docker", "inspect", "--format", "{{.State.Status}}", name],
       { ignoreError: true },
     );
@@ -265,13 +265,13 @@ export function nimStatusByName(name: string, port?: number): NimStatus {
     if (state === "running") {
       let resolvedHostPort = port != null ? Number(port) : 0;
       if (!resolvedHostPort) {
-        const mapping = runArgvCapture(["docker", "port", name, "8000"], {
+        const mapping = runCapture(["docker", "port", name, "8000"], {
           ignoreError: true,
         });
         const m = mapping && mapping.match(/:(\d+)\s*$/);
         resolvedHostPort = m ? Number(m[1]) : VLLM_PORT;
       }
-      const health = runArgvCapture(
+      const health = runCapture(
         ["curl", "-sf", `http://localhost:${resolvedHostPort}/v1/models`],
         { ignoreError: true },
       );

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -4,7 +4,7 @@
 // NIM container management — pull, start, stop, health-check NIM images.
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { run, runCapture, runArgv, runArgvCapture, shellQuote } = require("./runner");
+const { run, runCapture, runArgv, runArgvCapture } = require("./runner");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const nimImages = require("../../bin/lib/nim-images.json");
 

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -4,7 +4,7 @@
 // NIM container management — pull, start, stop, health-check NIM images.
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { run, runCapture, shellQuote } = require("./runner");
+const { run, runCapture, runArgv, runArgvCapture, shellQuote } = require("./runner");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const nimImages = require("../../bin/lib/nim-images.json");
 
@@ -61,8 +61,8 @@ export function canRunNimWithMemory(totalMemoryMB: number): boolean {
 export function detectGpu(): GpuDetection | null {
   // Try NVIDIA first — query VRAM
   try {
-    const output = runCapture(
-      "nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits",
+    const output = runArgvCapture(
+      ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
       { ignoreError: true },
     );
     if (output) {
@@ -87,8 +87,8 @@ export function detectGpu(): GpuDetection | null {
 
   // Fallback: unified-memory NVIDIA devices
   try {
-    const nameOutput = runCapture(
-      "nvidia-smi --query-gpu=name --format=csv,noheader,nounits",
+    const nameOutput = runArgvCapture(
+      ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader,nounits"],
       { ignoreError: true },
     );
     const gpuNames = nameOutput
@@ -101,8 +101,14 @@ export function detectGpu(): GpuDetection | null {
     if (unifiedGpuNames.length > 0) {
       let totalMemoryMB = 0;
       try {
-        const memLine = runCapture("free -m | awk '/Mem:/ {print $2}'", { ignoreError: true });
-        if (memLine) totalMemoryMB = parseInt(memLine.trim(), 10) || 0;
+        const freeOut = runArgvCapture(["free", "-m"], { ignoreError: true });
+        if (freeOut) {
+          const memLine = freeOut.split("\n").find((l: string) => l.includes("Mem:"));
+          if (memLine) {
+            const parts = memLine.split(/\s+/);
+            totalMemoryMB = parseInt(parts[1], 10) || 0;
+          }
+        }
       } catch {
         /* ignored */
       }
@@ -127,7 +133,7 @@ export function detectGpu(): GpuDetection | null {
   // macOS: detect Apple Silicon or discrete GPU
   if (process.platform === "darwin") {
     try {
-      const spOutput = runCapture("system_profiler SPDisplaysDataType 2>/dev/null", {
+      const spOutput = runArgvCapture(["system_profiler", "SPDisplaysDataType"], {
         ignoreError: true,
       });
       if (spOutput) {
@@ -144,7 +150,7 @@ export function detectGpu(): GpuDetection | null {
             if (vramMatch[2].toUpperCase() === "GB") memoryMB *= 1024;
           } else {
             try {
-              const memBytes = runCapture("sysctl -n hw.memsize", { ignoreError: true });
+              const memBytes = runArgvCapture(["sysctl", "-n", "hw.memsize"], { ignoreError: true });
               if (memBytes) memoryMB = Math.floor(parseInt(memBytes, 10) / 1024 / 1024);
             } catch {
               /* ignored */
@@ -177,7 +183,7 @@ export function pullNimImage(model: string): string {
     process.exit(1);
   }
   console.log(`  Pulling NIM image: ${image}`);
-  run(`docker pull ${shellQuote(image)}`);
+  runArgv(["docker", "pull", image]);
   return image;
 }
 
@@ -193,13 +199,16 @@ export function startNimContainerByName(name: string, model: string, port = VLLM
     process.exit(1);
   }
 
-  const qn = shellQuote(name);
-  run(`docker rm -f ${qn} 2>/dev/null || true`, { ignoreError: true });
+  runArgv(["docker", "rm", "-f", name], { ignoreError: true });
 
   console.log(`  Starting NIM container: ${name}`);
-  run(
-    `docker run -d --gpus all -p ${Number(port)}:8000 --name ${qn} --shm-size 16g ${shellQuote(image)}`,
-  );
+  runArgv([
+    "docker", "run", "-d", "--gpus", "all",
+    "-p", `${Number(port)}:8000`,
+    "--name", name,
+    "--shm-size", "16g",
+    image,
+  ]);
   return name;
 }
 
@@ -211,7 +220,7 @@ export function waitForNimHealth(port = VLLM_PORT, timeout = 300): boolean {
 
   while ((Date.now() - start) / 1000 < timeout) {
     try {
-      const result = runCapture(`curl -sf http://localhost:${hostPort}/v1/models`, {
+      const result = runArgvCapture(["curl", "-sf", `http://localhost:${hostPort}/v1/models`], {
         ignoreError: true,
       });
       if (result) {
@@ -234,10 +243,9 @@ export function stopNimContainer(sandboxName: string): void {
 }
 
 export function stopNimContainerByName(name: string): void {
-  const qn = shellQuote(name);
   console.log(`  Stopping NIM container: ${name}`);
-  run(`docker stop ${qn} 2>/dev/null || true`, { ignoreError: true });
-  run(`docker rm ${qn} 2>/dev/null || true`, { ignoreError: true });
+  runArgv(["docker", "stop", name], { ignoreError: true });
+  runArgv(["docker", "rm", name], { ignoreError: true });
 }
 
 export function nimStatus(sandboxName: string, port?: number): NimStatus {
@@ -247,9 +255,8 @@ export function nimStatus(sandboxName: string, port?: number): NimStatus {
 
 export function nimStatusByName(name: string, port?: number): NimStatus {
   try {
-    const qn = shellQuote(name);
-    const state = runCapture(
-      `docker inspect --format '{{.State.Status}}' ${qn} 2>/dev/null`,
+    const state = runArgvCapture(
+      ["docker", "inspect", "--format", "{{.State.Status}}", name],
       { ignoreError: true },
     );
     if (!state) return { running: false, container: name };
@@ -258,14 +265,14 @@ export function nimStatusByName(name: string, port?: number): NimStatus {
     if (state === "running") {
       let resolvedHostPort = port != null ? Number(port) : 0;
       if (!resolvedHostPort) {
-        const mapping = runCapture(`docker port ${qn} 8000 2>/dev/null`, {
+        const mapping = runArgvCapture(["docker", "port", name, "8000"], {
           ignoreError: true,
         });
         const m = mapping && mapping.match(/:(\d+)\s*$/);
         resolvedHostPort = m ? Number(m[1]) : VLLM_PORT;
       }
-      const health = runCapture(
-        `curl -sf http://localhost:${resolvedHostPort}/v1/models 2>/dev/null`,
+      const health = runArgvCapture(
+        ["curl", "-sf", `http://localhost:${resolvedHostPort}/v1/models`],
         { ignoreError: true },
       );
       healthy = !!health;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1479,9 +1479,9 @@ const { shouldIncludeBuildContextPath, copyBuildContextDir, printSandboxCreateRe
 // classifySandboxCreateFailure — see validation import above
 
 async function promptOllamaModel(gpu = null) {
-  const installed = getOllamaModelOptions(runCapture);
+  const installed = getOllamaModelOptions();
   const options = installed.length > 0 ? installed : getBootstrapOllamaModelOptions(gpu);
-  const defaultModel = getDefaultOllamaModel(runCapture, gpu);
+  const defaultModel = getDefaultOllamaModel(gpu);
   const defaultIndex = Math.max(0, options.indexOf(defaultModel));
 
   console.log("");
@@ -1537,7 +1537,7 @@ function prepareOllamaModel(model, installedModels = []) {
 
   console.log(`  Loading Ollama model: ${model}`);
   run(getOllamaWarmupCommand(model), { ignoreError: true });
-  return validateOllamaModel(model, runCapture);
+  return validateOllamaModel(model);
 }
 
 function getRequestedSandboxNameHint() {
@@ -3349,9 +3349,9 @@ async function setupNim(gpu) {
         credentialEnv = "OPENAI_API_KEY";
         endpointUrl = getLocalProviderBaseUrl(provider);
         while (true) {
-          const installedModels = getOllamaModelOptions(runCapture);
+          const installedModels = getOllamaModelOptions();
           if (isNonInteractive()) {
-            model = requestedModel || getDefaultOllamaModel(runCapture, gpu);
+            model = requestedModel || getDefaultOllamaModel(gpu);
           } else {
             model = await promptOllamaModel(gpu);
           }
@@ -3406,9 +3406,9 @@ async function setupNim(gpu) {
         credentialEnv = "OPENAI_API_KEY";
         endpointUrl = getLocalProviderBaseUrl(provider);
         while (true) {
-          const installedModels = getOllamaModelOptions(runCapture);
+          const installedModels = getOllamaModelOptions();
           if (isNonInteractive()) {
-            model = requestedModel || getDefaultOllamaModel(runCapture, gpu);
+            model = requestedModel || getDefaultOllamaModel(gpu);
           } else {
             model = await promptOllamaModel(gpu);
           }
@@ -3604,7 +3604,7 @@ async function setupInference(
       process.exit(applyResult.status || 1);
     }
   } else if (provider === "vllm-local") {
-    const validation = validateLocalProvider(provider, runCapture);
+    const validation = validateLocalProvider(provider);
     if (!validation.ok) {
       console.error(`  ${validation.message}`);
       process.exit(1);
@@ -3629,7 +3629,7 @@ async function setupInference(
       String(LOCAL_INFERENCE_TIMEOUT_SECS),
     ]);
   } else if (provider === "ollama-local") {
-    const validation = validateLocalProvider(provider, runCapture);
+    const validation = validateLocalProvider(provider);
     if (!validation.ok) {
       console.error(`  ${validation.message}`);
       console.error("  On macOS, local inference also depends on OpenShell host routing support.");
@@ -3656,7 +3656,7 @@ async function setupInference(
     ]);
     console.log(`  Priming Ollama model: ${model}`);
     run(getOllamaWarmupCommand(model), { ignoreError: true });
-    const probe = validateOllamaModel(model, runCapture);
+    const probe = validateOllamaModel(model);
     if (!probe.ok) {
       console.error(`  ${probe.message}`);
       process.exit(1);

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -14,11 +14,6 @@ const registry = require("./registry");
 const { loadAgent } = require("./agent-defs");
 
 const PRESETS_DIR = path.join(ROOT, "nemoclaw-blueprint", "policies", "presets");
-function getOpenshellCommand() {
-  const binary = process.env.NEMOCLAW_OPENSHELL_BIN;
-  if (!binary) return "openshell";
-  return shellQuote(binary);
-}
 
 function listPresets() {
   if (!fs.existsSync(PRESETS_DIR)) return [];

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -9,7 +9,7 @@ const path = require("path");
 const os = require("os");
 const readline = require("readline");
 const YAML = require("yaml");
-const { ROOT, run, runCapture, shellQuote } = require("./runner");
+const { ROOT, run, runArgv, runArgvCapture, runCapture, shellQuote } = require("./runner");
 const registry = require("./registry");
 const { loadAgent } = require("./agent-defs");
 
@@ -99,17 +99,19 @@ function parseCurrentPolicy(raw) {
 }
 
 /**
- * Build the openshell policy set command with properly quoted arguments.
+ * Build the openshell policy set command as an argv array.
  */
 function buildPolicySetCommand(policyFile, sandboxName) {
-  return `${getOpenshellCommand()} policy set --policy ${shellQuote(policyFile)} --wait ${shellQuote(sandboxName)}`;
+  const binary = process.env.NEMOCLAW_OPENSHELL_BIN || "openshell";
+  return [binary, "policy", "set", "--policy", policyFile, "--wait", sandboxName];
 }
 
 /**
- * Build the openshell policy get command with properly quoted arguments.
+ * Build the openshell policy get command as an argv array.
  */
 function buildPolicyGetCommand(sandboxName) {
-  return `${getOpenshellCommand()} policy get --full ${shellQuote(sandboxName)} 2>/dev/null`;
+  const binary = process.env.NEMOCLAW_OPENSHELL_BIN || "openshell";
+  return [binary, "policy", "get", "--full", sandboxName];
 }
 
 /**
@@ -245,7 +247,7 @@ function applyPreset(sandboxName, presetName, _options = {}) {
   // Get current policy YAML from sandbox
   let rawPolicy = "";
   try {
-    rawPolicy = runCapture(buildPolicyGetCommand(sandboxName), { ignoreError: true });
+    rawPolicy = runArgvCapture(buildPolicyGetCommand(sandboxName), { ignoreError: true });
   } catch {
     /* ignored */
   }
@@ -263,7 +265,7 @@ function applyPreset(sandboxName, presetName, _options = {}) {
   fs.writeFileSync(tmpFile, merged, { encoding: "utf-8", mode: 0o600 });
 
   try {
-    run(buildPolicySetCommand(tmpFile, sandboxName));
+    runArgv(buildPolicySetCommand(tmpFile, sandboxName));
 
     console.log(`  Applied preset: ${presetName}`);
   } finally {
@@ -383,7 +385,7 @@ function applyPermissivePolicy(sandboxName) {
   }
 
   console.log("  Applying permissive policy (--dangerously-skip-permissions)...");
-  run(buildPolicySetCommand(policyPath, sandboxName));
+  runArgv(buildPolicySetCommand(policyPath, sandboxName));
   console.log("  Applied permissive policy.");
 
   const sandbox = registry.getSandbox(sandboxName);

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -9,7 +9,7 @@ const path = require("path");
 const os = require("os");
 const readline = require("readline");
 const YAML = require("yaml");
-const { ROOT, run, runArgv, runArgvCapture, runCapture, shellQuote } = require("./runner");
+const { ROOT, run, runCapture } = require("./runner");
 const registry = require("./registry");
 const { loadAgent } = require("./agent-defs");
 
@@ -242,7 +242,7 @@ function applyPreset(sandboxName, presetName, _options = {}) {
   // Get current policy YAML from sandbox
   let rawPolicy = "";
   try {
-    rawPolicy = runArgvCapture(buildPolicyGetCommand(sandboxName), { ignoreError: true });
+    rawPolicy = runCapture(buildPolicyGetCommand(sandboxName), { ignoreError: true });
   } catch {
     /* ignored */
   }
@@ -260,7 +260,7 @@ function applyPreset(sandboxName, presetName, _options = {}) {
   fs.writeFileSync(tmpFile, merged, { encoding: "utf-8", mode: 0o600 });
 
   try {
-    runArgv(buildPolicySetCommand(tmpFile, sandboxName));
+    run(buildPolicySetCommand(tmpFile, sandboxName));
 
     console.log(`  Applied preset: ${presetName}`);
   } finally {
@@ -380,7 +380,7 @@ function applyPermissivePolicy(sandboxName) {
   }
 
   console.log("  Applying permissive policy (--dangerously-skip-permissions)...");
-  runArgv(buildPolicySetCommand(policyPath, sandboxName));
+  run(buildPolicySetCommand(policyPath, sandboxName));
   console.log("  Applied permissive policy.");
 
   const sandbox = registry.getSandbox(sandboxName);

--- a/src/lib/runner-argv.test.ts
+++ b/src/lib/runner-argv.test.ts
@@ -34,6 +34,12 @@ describe("runArgv", () => {
     expect(result.status).toBe(0);
   });
 
+  it("rejects shell: true to prevent security bypass", () => {
+    expect(() => runner.runArgv(["echo", "hi"], { shell: true })).toThrow(
+      /shell option is forbidden/,
+    );
+  });
+
   it("does not interpret shell metacharacters in arguments", () => {
     // If shell interpretation occurred, $(whoami) would be expanded
     const result = runner.runArgvCapture(
@@ -69,6 +75,12 @@ describe("runArgvCapture", () => {
 
   it("throws on failure without ignoreError", () => {
     expect(() => runner.runArgvCapture(["false"])).toThrow();
+  });
+
+  it("rejects shell: true to prevent security bypass", () => {
+    expect(() => runner.runArgvCapture(["echo", "hi"], { shell: true })).toThrow(
+      /shell option is forbidden/,
+    );
   });
 
   it("prevents shell injection via argument values", () => {

--- a/src/lib/runner-argv.test.ts
+++ b/src/lib/runner-argv.test.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const runner = require("../../dist/lib/runner");
+
+describe("runArgv", () => {
+  it("executes a simple command and returns result", () => {
+    const result = runner.runArgv(["echo", "hello"], { suppressOutput: true });
+    expect(result.status).toBe(0);
+  });
+
+  it("throws when command is not an array", () => {
+    expect(() => runner.runArgv("echo hello")).toThrow(/must be a non-empty array/);
+  });
+
+  it("throws when command is an empty array", () => {
+    expect(() => runner.runArgv([])).toThrow(/must be a non-empty array/);
+  });
+
+  it("returns non-zero status with ignoreError", () => {
+    const result = runner.runArgv(["false"], { ignoreError: true, suppressOutput: true });
+    expect(result.status).not.toBe(0);
+  });
+
+  it("passes extra env vars to the child process", () => {
+    const result = runner.runArgv(
+      ["bash", "-c", "echo $NEMOCLAW_TEST_VAR"],
+      { env: { NEMOCLAW_TEST_VAR: "injection-safe" }, suppressOutput: true },
+    );
+    expect(result.status).toBe(0);
+  });
+
+  it("does not interpret shell metacharacters in arguments", () => {
+    // If shell interpretation occurred, $(whoami) would be expanded
+    const result = runner.runArgvCapture(
+      ["echo", "$(whoami)", "&&", "rm", "-rf", "/"],
+      { ignoreError: true },
+    );
+    // echo receives literal argv — no shell expansion
+    expect(result).toContain("$(whoami)");
+    expect(result).toContain("&&");
+    expect(result).toContain("rm");
+  });
+});
+
+describe("runArgvCapture", () => {
+  it("captures stdout from a simple command", () => {
+    const output = runner.runArgvCapture(["echo", "hello world"]);
+    expect(output).toBe("hello world");
+  });
+
+  it("trims whitespace from output", () => {
+    const output = runner.runArgvCapture(["echo", "  trimmed  "]);
+    expect(output).toBe("trimmed");
+  });
+
+  it("throws when command is not an array", () => {
+    expect(() => runner.runArgvCapture("echo hello")).toThrow(/must be a non-empty array/);
+  });
+
+  it("returns empty string on failure with ignoreError", () => {
+    const output = runner.runArgvCapture(["false"], { ignoreError: true });
+    expect(output).toBe("");
+  });
+
+  it("throws on failure without ignoreError", () => {
+    expect(() => runner.runArgvCapture(["false"])).toThrow();
+  });
+
+  it("prevents shell injection via argument values", () => {
+    // Dangerous sandbox name that would cause injection with shell strings
+    const maliciousName = 'alpha"; rm -rf / #';
+    const output = runner.runArgvCapture(["echo", maliciousName]);
+    // With argv, the string is passed literally — no shell interpretation
+    expect(output).toBe(maliciousName);
+  });
+
+  it("prevents injection via dollar-sign expansion", () => {
+    const output = runner.runArgvCapture(["echo", "${HOME}"]);
+    // Literal ${HOME}, not expanded
+    expect(output).toBe("${HOME}");
+  });
+
+  it("prevents injection via backtick expansion", () => {
+    const output = runner.runArgvCapture(["echo", "`whoami`"]);
+    // Literal backticks, not expanded
+    expect(output).toBe("`whoami`");
+  });
+
+  it("handles arguments with spaces and special characters", () => {
+    const output = runner.runArgvCapture(["echo", "hello world", "foo bar"]);
+    expect(output).toBe("hello world foo bar");
+  });
+
+  it("passes extra env to the child process", () => {
+    const output = runner.runArgvCapture(
+      ["bash", "-c", "echo $TEST_ARGV_ENV"],
+      { env: { TEST_ARGV_ENV: "captured" } },
+    );
+    expect(output).toBe("captured");
+  });
+});
+
+describe("shell injection regression tests", () => {
+  it("sandbox names with shell metacharacters are safe with runArgv", () => {
+    // These names would cause injection if passed through bash -c
+    const dangerousNames = [
+      'my-sandbox; rm -rf /',
+      'test$(whoami)',
+      'sandbox`id`',
+      "sandbox' || echo pwned",
+      'sandbox" && echo pwned',
+      'sandbox\necho pwned',
+    ];
+
+    for (const name of dangerousNames) {
+      const output = runner.runArgvCapture(["echo", name], { ignoreError: true });
+      // Each name should be passed literally, not interpreted
+      expect(output).toContain(name.split("\n")[0]);
+    }
+  });
+
+  it("model names with shell metacharacters are safe with runArgvCapture", () => {
+    const output = runner.runArgvCapture(
+      ["echo", 'nvidia/model;curl http://evil.com'],
+    );
+    expect(output).toBe('nvidia/model;curl http://evil.com');
+  });
+});

--- a/src/lib/runner-argv.test.ts
+++ b/src/lib/runner-argv.test.ts
@@ -7,42 +7,39 @@ import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const runner = require("../../dist/lib/runner");
 
-describe("runArgv", () => {
+describe("run with argv array", () => {
   it("executes a simple command and returns result", () => {
-    const result = runner.runArgv(["echo", "hello"], { suppressOutput: true });
+    const result = runner.run(["echo", "hello"], { suppressOutput: true });
     expect(result.status).toBe(0);
   });
 
-  it("throws when command is not an array", () => {
-    expect(() => runner.runArgv("echo hello")).toThrow(/must be a non-empty array/);
-  });
-
-  it("throws when command is an empty array", () => {
-    expect(() => runner.runArgv([])).toThrow(/must be a non-empty array/);
+  it("throws when argv array is empty", () => {
+    expect(() => runner.run([])).toThrow(/must not be empty/);
   });
 
   it("returns non-zero status with ignoreError", () => {
-    const result = runner.runArgv(["false"], { ignoreError: true, suppressOutput: true });
+    const result = runner.run(["false"], { ignoreError: true, suppressOutput: true });
     expect(result.status).not.toBe(0);
   });
 
   it("passes extra env vars to the child process", () => {
-    const result = runner.runArgv(
-      ["bash", "-c", "echo $NEMOCLAW_TEST_VAR"],
+    const result = runner.run(
+      ["env"],
       { env: { NEMOCLAW_TEST_VAR: "injection-safe" }, suppressOutput: true },
     );
     expect(result.status).toBe(0);
+    expect(result.stdout.toString()).toContain("NEMOCLAW_TEST_VAR=injection-safe");
   });
 
   it("rejects shell: true to prevent security bypass", () => {
-    expect(() => runner.runArgv(["echo", "hi"], { shell: true })).toThrow(
+    expect(() => runner.run(["echo", "hi"], { shell: true })).toThrow(
       /shell option is forbidden/,
     );
   });
 
   it("does not interpret shell metacharacters in arguments", () => {
     // If shell interpretation occurred, $(whoami) would be expanded
-    const result = runner.runArgvCapture(
+    const result = runner.runCapture(
       ["echo", "$(whoami)", "&&", "rm", "-rf", "/"],
       { ignoreError: true },
     );
@@ -51,34 +48,49 @@ describe("runArgv", () => {
     expect(result).toContain("&&");
     expect(result).toContain("rm");
   });
+
+  it("still works with string commands (legacy path)", () => {
+    const result = runner.run("echo hello", { suppressOutput: true });
+    expect(result.status).toBe(0);
+  });
+
+  it("surfaces ENOENT error for missing executables", () => {
+    const result = runner.run(
+      ["nonexistent-binary-xyz-12345"],
+      { ignoreError: true, suppressOutput: true },
+    );
+    // spawnSync sets result.error for missing executables
+    expect(result.error).toBeDefined();
+    expect(result.error.code).toBe("ENOENT");
+  });
 });
 
-describe("runArgvCapture", () => {
+describe("runCapture with argv array", () => {
   it("captures stdout from a simple command", () => {
-    const output = runner.runArgvCapture(["echo", "hello world"]);
+    const output = runner.runCapture(["echo", "hello world"]);
     expect(output).toBe("hello world");
   });
 
   it("trims whitespace from output", () => {
-    const output = runner.runArgvCapture(["echo", "  trimmed  "]);
+    const output = runner.runCapture(["echo", "  trimmed  "]);
     expect(output).toBe("trimmed");
   });
 
-  it("throws when command is not an array", () => {
-    expect(() => runner.runArgvCapture("echo hello")).toThrow(/must be a non-empty array/);
+  it("throws when argv array is empty", () => {
+    expect(() => runner.runCapture([])).toThrow(/must not be empty/);
   });
 
   it("returns empty string on failure with ignoreError", () => {
-    const output = runner.runArgvCapture(["false"], { ignoreError: true });
+    const output = runner.runCapture(["false"], { ignoreError: true });
     expect(output).toBe("");
   });
 
   it("throws on failure without ignoreError", () => {
-    expect(() => runner.runArgvCapture(["false"])).toThrow();
+    expect(() => runner.runCapture(["false"])).toThrow();
   });
 
   it("rejects shell: true to prevent security bypass", () => {
-    expect(() => runner.runArgvCapture(["echo", "hi"], { shell: true })).toThrow(
+    expect(() => runner.runCapture(["echo", "hi"], { shell: true })).toThrow(
       /shell option is forbidden/,
     );
   });
@@ -86,39 +98,53 @@ describe("runArgvCapture", () => {
   it("prevents shell injection via argument values", () => {
     // Dangerous sandbox name that would cause injection with shell strings
     const maliciousName = 'alpha"; rm -rf / #';
-    const output = runner.runArgvCapture(["echo", maliciousName]);
+    const output = runner.runCapture(["echo", maliciousName]);
     // With argv, the string is passed literally — no shell interpretation
     expect(output).toBe(maliciousName);
   });
 
   it("prevents injection via dollar-sign expansion", () => {
-    const output = runner.runArgvCapture(["echo", "${HOME}"]);
+    const output = runner.runCapture(["echo", "${HOME}"]);
     // Literal ${HOME}, not expanded
     expect(output).toBe("${HOME}");
   });
 
   it("prevents injection via backtick expansion", () => {
-    const output = runner.runArgvCapture(["echo", "`whoami`"]);
+    const output = runner.runCapture(["echo", "`whoami`"]);
     // Literal backticks, not expanded
     expect(output).toBe("`whoami`");
   });
 
   it("handles arguments with spaces and special characters", () => {
-    const output = runner.runArgvCapture(["echo", "hello world", "foo bar"]);
+    const output = runner.runCapture(["echo", "hello world", "foo bar"]);
     expect(output).toBe("hello world foo bar");
   });
 
   it("passes extra env to the child process", () => {
-    const output = runner.runArgvCapture(
-      ["bash", "-c", "echo $TEST_ARGV_ENV"],
+    const output = runner.runCapture(
+      ["env"],
       { env: { TEST_ARGV_ENV: "captured" } },
     );
-    expect(output).toBe("captured");
+    expect(output).toContain("TEST_ARGV_ENV=captured");
+  });
+
+  it("still works with string commands (legacy path)", () => {
+    const output = runner.runCapture("echo hello");
+    expect(output).toBe("hello");
+  });
+
+  it("throws ENOENT for missing executables", () => {
+    expect(() => runner.runCapture(["nonexistent-binary-xyz-12345"])).toThrow();
+  });
+
+  it("returns empty string for missing executables with ignoreError", () => {
+    const output = runner.runCapture(["nonexistent-binary-xyz-12345"], { ignoreError: true });
+    expect(output).toBe("");
   });
 });
 
 describe("shell injection regression tests", () => {
-  it("sandbox names with shell metacharacters are safe with runArgv", () => {
+  it("sandbox names with shell metacharacters are safe with argv arrays", () => {
     // These names would cause injection if passed through bash -c
     const dangerousNames = [
       'my-sandbox; rm -rf /',
@@ -130,14 +156,14 @@ describe("shell injection regression tests", () => {
     ];
 
     for (const name of dangerousNames) {
-      const output = runner.runArgvCapture(["echo", name], { ignoreError: true });
+      const output = runner.runCapture(["echo", name], { ignoreError: true });
       // Each name should be passed literally, not interpreted
       expect(output).toContain(name.split("\n")[0]);
     }
   });
 
-  it("model names with shell metacharacters are safe with runArgvCapture", () => {
-    const output = runner.runArgvCapture(
+  it("model names with shell metacharacters are safe with argv arrays", () => {
+    const output = runner.runCapture(
       ["echo", 'nvidia/model;curl http://evil.com'],
     );
     expect(output).toBe('nvidia/model;curl http://evil.com');

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -179,6 +179,12 @@ function runArgv(cmd, opts = {}) {
   const exe = cmd[0];
   const args = cmd.slice(1);
   const { ignoreError, suppressOutput, env: extraEnv, stdio: stdioCfg, ...spawnOpts } = opts;
+
+  // Guard: re-enabling shell interpretation would defeat the purpose of runArgv.
+  if (spawnOpts.shell) {
+    throw new Error("runArgv: shell option is forbidden — use run() for shell commands");
+  }
+
   const stdio = stdioCfg ?? ["ignore", "pipe", "pipe"];
 
   const result = spawnSync(exe, args, {
@@ -213,6 +219,11 @@ function runArgvCapture(cmd, opts = {}) {
   const exe = cmd[0];
   const args = cmd.slice(1);
   const { ignoreError, env: extraEnv, stdio: _stdio, encoding: _encoding, ...spawnOpts } = opts;
+
+  // Guard: re-enabling shell interpretation would defeat the purpose of runArgvCapture.
+  if (spawnOpts.shell) {
+    throw new Error("runArgvCapture: shell option is forbidden — use runCapture() for shell commands");
+  }
 
   try {
     const result = spawnSync(exe, args, {

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -164,6 +164,78 @@ function writeRedactedResult(result, stdio) {
 }
 
 /**
+ * Run a command as an argv array, bypassing the shell entirely.
+ * This eliminates shell injection risks by passing arguments directly
+ * to the child process via execve(2).
+ *
+ * @param cmd - Array where cmd[0] is the executable and cmd[1..] are arguments.
+ * @param opts - Options forwarded to spawnSync, plus ignoreError/suppressOutput.
+ */
+function runArgv(cmd, opts = {}) {
+  if (!Array.isArray(cmd) || cmd.length === 0) {
+    throw new Error(`runArgv: command must be a non-empty array, got: ${typeof cmd}`);
+  }
+
+  const exe = cmd[0];
+  const args = cmd.slice(1);
+  const { ignoreError, suppressOutput, env: extraEnv, stdio: stdioCfg, ...spawnOpts } = opts;
+  const stdio = stdioCfg ?? ["ignore", "pipe", "pipe"];
+
+  const result = spawnSync(exe, args, {
+    ...spawnOpts,
+    stdio,
+    cwd: ROOT,
+    env: { ...process.env, ...extraEnv },
+  });
+  if (!suppressOutput) {
+    writeRedactedResult(result, stdio);
+  }
+  if (result.status !== 0 && !ignoreError) {
+    const cmdStr = cmd.join(" ");
+    console.error(`  Command failed (exit ${result.status}): ${redact(cmdStr).slice(0, 80)}`);
+    process.exit(result.status || 1);
+  }
+  return result;
+}
+
+/**
+ * Run a command as an argv array and return its stdout as a trimmed string.
+ * Bypasses the shell entirely — no expansion, no injection risk.
+ *
+ * @param cmd - Array where cmd[0] is the executable and cmd[1..] are arguments.
+ * @param opts - Options forwarded to spawnSync, plus ignoreError.
+ */
+function runArgvCapture(cmd, opts = {}) {
+  if (!Array.isArray(cmd) || cmd.length === 0) {
+    throw new Error(`runArgvCapture: command must be a non-empty array, got: ${typeof cmd}`);
+  }
+
+  const exe = cmd[0];
+  const args = cmd.slice(1);
+  const { ignoreError, env: extraEnv, stdio: _stdio, encoding: _encoding, ...spawnOpts } = opts;
+
+  try {
+    const result = spawnSync(exe, args, {
+      ...spawnOpts,
+      cwd: ROOT,
+      env: { ...process.env, ...extraEnv },
+      stdio: ["pipe", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+
+    if (result.status !== 0 && !ignoreError) {
+      throw new Error(`Command failed with status ${result.status}`);
+    }
+
+    const stdout = result.stdout || "";
+    return (typeof stdout === "string" ? stdout : stdout.toString("utf-8")).trim();
+  } catch (err) {
+    if (ignoreError) return "";
+    throw redactError(err);
+  }
+}
+
+/**
  * Shell-quote a value for safe interpolation into bash -c strings.
  * Wraps in single quotes and escapes embedded single quotes.
  */
@@ -195,6 +267,8 @@ export {
   SCRIPTS,
   redact,
   run,
+  runArgv,
+  runArgvCapture,
   runCapture,
   runInteractive,
   shellQuote,

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -15,10 +15,20 @@ if (dockerHost) {
 }
 
 /**
- * Run a shell command via bash, streaming stdout/stderr (redacted) to the terminal.
+ * Run a command, streaming stdout/stderr (redacted) to the terminal.
  * Exits the process on failure unless opts.ignoreError is true.
+ *
+ * Accepts two forms:
+ *   run("bash -c string")  — legacy: passes the string to bash for interpretation
+ *   run(["docker", "rm", name])  — safe: calls spawnSync(exe, args) with no shell
+ *
+ * When an argv array is passed, the shell option is forbidden to prevent
+ * callers from accidentally re-enabling shell interpretation.
  */
 function run(cmd, opts = {}) {
+  if (Array.isArray(cmd)) {
+    return runArrayCmd(cmd, opts);
+  }
   const stdio = opts.stdio ?? ["ignore", "pipe", "pipe"];
   const result = spawnSync("bash", ["-c", cmd], {
     ...opts,
@@ -31,6 +41,50 @@ function run(cmd, opts = {}) {
   }
   if (result.status !== 0 && !opts.ignoreError) {
     console.error(`  Command failed (exit ${result.status}): ${redact(cmd).slice(0, 80)}`);
+    process.exit(result.status || 1);
+  }
+  return result;
+}
+
+/**
+ * Internal: execute an argv array via spawnSync with no shell.
+ * Shared by run() and kept separate for clarity.
+ */
+function runArrayCmd(cmd, opts = {}) {
+  if (cmd.length === 0) {
+    throw new Error("run: argv array must not be empty");
+  }
+
+  const exe = cmd[0];
+  const args = cmd.slice(1);
+  const { ignoreError, suppressOutput, env: extraEnv, stdio: stdioCfg, ...spawnOpts } = opts;
+
+  // Guard: re-enabling shell interpretation defeats the purpose of argv arrays.
+  if (spawnOpts.shell) {
+    throw new Error("run: shell option is forbidden when passing an argv array");
+  }
+
+  const stdio = stdioCfg ?? ["ignore", "pipe", "pipe"];
+
+  const result = spawnSync(exe, args, {
+    ...spawnOpts,
+    stdio,
+    cwd: ROOT,
+    env: { ...process.env, ...extraEnv },
+  });
+  if (!suppressOutput) {
+    writeRedactedResult(result, stdio);
+  }
+  // Check result.error first — spawnSync sets this (with status === null) when
+  // the executable is missing (ENOENT), the call times out, or the spawn fails.
+  if (result.error && !ignoreError) {
+    const cmdStr = cmd.join(" ");
+    console.error(`  Command failed: ${redact(cmdStr).slice(0, 80)}: ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.status !== 0 && !ignoreError) {
+    const cmdStr = cmd.join(" ");
+    console.error(`  Command failed (exit ${result.status}): ${redact(cmdStr).slice(0, 80)}`);
     process.exit(result.status || 1);
   }
   return result;
@@ -59,10 +113,20 @@ function runInteractive(cmd, opts = {}) {
 }
 
 /**
- * Run a shell command and return its stdout as a trimmed string.
+ * Run a command and return its stdout as a trimmed string.
  * Throws a redacted error on failure, or returns '' when opts.ignoreError is true.
+ *
+ * Accepts two forms:
+ *   runCapture("some shell command")  — legacy: passes the string to execSync (shell)
+ *   runCapture(["curl", "-sf", url])  — safe: calls spawnSync(exe, args) with no shell
+ *
+ * When an argv array is passed, the shell option is forbidden to prevent
+ * callers from accidentally re-enabling shell interpretation.
  */
 function runCapture(cmd, opts = {}) {
+  if (Array.isArray(cmd)) {
+    return runArrayCapture(cmd, opts);
+  }
   try {
     return execSync(cmd, {
       ...opts,
@@ -73,6 +137,50 @@ function runCapture(cmd, opts = {}) {
     }).trim();
   } catch (err) {
     if (opts.ignoreError) return "";
+    throw redactError(err);
+  }
+}
+
+/**
+ * Internal: capture stdout from an argv array via spawnSync with no shell.
+ * Shared by runCapture() and kept separate for clarity.
+ */
+function runArrayCapture(cmd, opts = {}) {
+  if (cmd.length === 0) {
+    throw new Error("runCapture: argv array must not be empty");
+  }
+
+  const exe = cmd[0];
+  const args = cmd.slice(1);
+  const { ignoreError, env: extraEnv, stdio: _stdio, encoding: _encoding, ...spawnOpts } = opts;
+
+  // Guard: re-enabling shell interpretation defeats the purpose of argv arrays.
+  if (spawnOpts.shell) {
+    throw new Error("runCapture: shell option is forbidden when passing an argv array");
+  }
+
+  try {
+    const result = spawnSync(exe, args, {
+      ...spawnOpts,
+      cwd: ROOT,
+      env: { ...process.env, ...extraEnv },
+      stdio: ["pipe", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+
+    // Check result.error first — spawnSync sets this (with status === null) when
+    // the executable is missing (ENOENT), the call times out, or the spawn fails.
+    if (result.error && !ignoreError) {
+      throw result.error;
+    }
+    if (result.status !== 0 && !ignoreError) {
+      throw new Error(`Command failed with status ${result.status}`);
+    }
+
+    const stdout = result.stdout || "";
+    return (typeof stdout === "string" ? stdout : stdout.toString("utf-8")).trim();
+  } catch (err) {
+    if (ignoreError) return "";
     throw redactError(err);
   }
 }
@@ -164,89 +272,6 @@ function writeRedactedResult(result, stdio) {
 }
 
 /**
- * Run a command as an argv array, bypassing the shell entirely.
- * This eliminates shell injection risks by passing arguments directly
- * to the child process via execve(2).
- *
- * @param cmd - Array where cmd[0] is the executable and cmd[1..] are arguments.
- * @param opts - Options forwarded to spawnSync, plus ignoreError/suppressOutput.
- */
-function runArgv(cmd, opts = {}) {
-  if (!Array.isArray(cmd) || cmd.length === 0) {
-    throw new Error(`runArgv: command must be a non-empty array, got: ${typeof cmd}`);
-  }
-
-  const exe = cmd[0];
-  const args = cmd.slice(1);
-  const { ignoreError, suppressOutput, env: extraEnv, stdio: stdioCfg, ...spawnOpts } = opts;
-
-  // Guard: re-enabling shell interpretation would defeat the purpose of runArgv.
-  if (spawnOpts.shell) {
-    throw new Error("runArgv: shell option is forbidden — use run() for shell commands");
-  }
-
-  const stdio = stdioCfg ?? ["ignore", "pipe", "pipe"];
-
-  const result = spawnSync(exe, args, {
-    ...spawnOpts,
-    stdio,
-    cwd: ROOT,
-    env: { ...process.env, ...extraEnv },
-  });
-  if (!suppressOutput) {
-    writeRedactedResult(result, stdio);
-  }
-  if (result.status !== 0 && !ignoreError) {
-    const cmdStr = cmd.join(" ");
-    console.error(`  Command failed (exit ${result.status}): ${redact(cmdStr).slice(0, 80)}`);
-    process.exit(result.status || 1);
-  }
-  return result;
-}
-
-/**
- * Run a command as an argv array and return its stdout as a trimmed string.
- * Bypasses the shell entirely — no expansion, no injection risk.
- *
- * @param cmd - Array where cmd[0] is the executable and cmd[1..] are arguments.
- * @param opts - Options forwarded to spawnSync, plus ignoreError.
- */
-function runArgvCapture(cmd, opts = {}) {
-  if (!Array.isArray(cmd) || cmd.length === 0) {
-    throw new Error(`runArgvCapture: command must be a non-empty array, got: ${typeof cmd}`);
-  }
-
-  const exe = cmd[0];
-  const args = cmd.slice(1);
-  const { ignoreError, env: extraEnv, stdio: _stdio, encoding: _encoding, ...spawnOpts } = opts;
-
-  // Guard: re-enabling shell interpretation would defeat the purpose of runArgvCapture.
-  if (spawnOpts.shell) {
-    throw new Error("runArgvCapture: shell option is forbidden — use runCapture() for shell commands");
-  }
-
-  try {
-    const result = spawnSync(exe, args, {
-      ...spawnOpts,
-      cwd: ROOT,
-      env: { ...process.env, ...extraEnv },
-      stdio: ["pipe", "pipe", "pipe"],
-      encoding: "utf-8",
-    });
-
-    if (result.status !== 0 && !ignoreError) {
-      throw new Error(`Command failed with status ${result.status}`);
-    }
-
-    const stdout = result.stdout || "";
-    return (typeof stdout === "string" ? stdout : stdout.toString("utf-8")).trim();
-  } catch (err) {
-    if (ignoreError) return "";
-    throw redactError(err);
-  }
-}
-
-/**
  * Shell-quote a value for safe interpolation into bash -c strings.
  * Wraps in single quotes and escapes embedded single quotes.
  */
@@ -278,8 +303,6 @@ export {
   SCRIPTS,
   redact,
   run,
-  runArgv,
-  runArgvCapture,
   runCapture,
   runInteractive,
   shellQuote,

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -170,10 +170,12 @@ function runArrayCapture(cmd, opts = {}) {
 
     // Check result.error first — spawnSync sets this (with status === null) when
     // the executable is missing (ENOENT), the call times out, or the spawn fails.
-    if (result.error && !ignoreError) {
+    if (result.error) {
+      if (ignoreError) return "";
       throw result.error;
     }
-    if (result.status !== 0 && !ignoreError) {
+    if (result.status !== 0) {
+      if (ignoreError) return "";
       throw new Error(`Command failed with status ${result.status}`);
     }
 

--- a/test/onboard-readiness.test.ts
+++ b/test/onboard-readiness.test.ts
@@ -83,7 +83,7 @@ describe("WSL sandbox name handling", () => {
   it("buildPolicySetCommand preserves hyphenated sandbox name", () => {
     const cmd = buildPolicySetCommand("/tmp/policy.yaml", "my-assistant");
     expect(cmd).toContain("my-assistant");
-    expect(cmd.indexOf("my-assistant")).toBe(cmd.length - 1);
+    expect(cmd[cmd.length - 1]).toBe("my-assistant");
   });
 
   it("buildPolicyGetCommand preserves hyphenated sandbox name", () => {

--- a/test/onboard-readiness.test.ts
+++ b/test/onboard-readiness.test.ts
@@ -82,25 +82,25 @@ describe("sandbox readiness parsing", () => {
 describe("WSL sandbox name handling", () => {
   it("buildPolicySetCommand preserves hyphenated sandbox name", () => {
     const cmd = buildPolicySetCommand("/tmp/policy.yaml", "my-assistant");
-    expect(cmd.includes("'my-assistant'")).toBeTruthy();
-    expect(!cmd.includes(" my-assistant ")).toBeTruthy();
+    expect(cmd).toContain("my-assistant");
+    expect(cmd.indexOf("my-assistant")).toBe(cmd.length - 1);
   });
 
   it("buildPolicyGetCommand preserves hyphenated sandbox name", () => {
     const cmd = buildPolicyGetCommand("my-assistant");
-    expect(cmd.includes("'my-assistant'")).toBeTruthy();
+    expect(cmd).toContain("my-assistant");
   });
 
   it("buildPolicySetCommand preserves multi-hyphen names", () => {
     const cmd = buildPolicySetCommand("/tmp/p.yaml", "my-dev-assistant-v2");
-    expect(cmd.includes("'my-dev-assistant-v2'")).toBeTruthy();
+    expect(cmd).toContain("my-dev-assistant-v2");
   });
 
   it("buildPolicySetCommand preserves single-char name", () => {
     // If WSL truncates "my-assistant" to "m", the single-char name should
-    // still be quoted and passed through unchanged
+    // still be passed through unchanged as an argv element
     const cmd = buildPolicySetCommand("/tmp/p.yaml", "m");
-    expect(cmd.includes("'m'")).toBeTruthy();
+    expect(cmd).toContain("m");
   });
 
   it("applyPreset rejects truncated/invalid sandbox name", () => {

--- a/test/onboard-readiness.test.ts
+++ b/test/onboard-readiness.test.ts
@@ -80,9 +80,10 @@ describe("sandbox readiness parsing", () => {
 // Regression tests: WSL truncates hyphenated sandbox names during shell
 // argument parsing (e.g. "my-assistant" → "m").
 describe("WSL sandbox name handling", () => {
-  it("buildPolicySetCommand preserves hyphenated sandbox name", () => {
+  it("buildPolicySetCommand preserves hyphenated sandbox name as a separate argv element", () => {
     const cmd = buildPolicySetCommand("/tmp/policy.yaml", "my-assistant");
     expect(cmd).toContain("my-assistant");
+    // The sandbox name must be a discrete argv element, not concatenated into a shell string
     expect(cmd[cmd.length - 1]).toBe("my-assistant");
   });
 

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -132,10 +132,11 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "/usr/bin/ollama";
-  if (command.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
-  if (command.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now\\nqwen3:32b  def  20 GB  now";
-  if (command.includes("localhost:8000/v1/models")) return "";
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
+  if (cmd.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now\\nqwen3:32b  def  20 GB  now";
+  if (cmd.includes("localhost:8000/v1/models")) return "";
   return "";
 };
 registry.updateSandbox = (_name, update) => updates.push(update);
@@ -305,9 +306,10 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => { process.env.NVIDIA_API_KEY = "nvapi-test"; };
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "";
-  if (command.includes("localhost:11434/api/tags")) return "";
-  if (command.includes("localhost:8000/v1/models")) return "";
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "";
+  if (cmd.includes("localhost:11434/api/tags")) return "";
+  if (cmd.includes("localhost:8000/v1/models")) return "";
   return "";
 };
 
@@ -398,9 +400,10 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => { process.env.NVIDIA_API_KEY = "nvapi-test"; };
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "";
-  if (command.includes("localhost:11434/api/tags")) return "";
-  if (command.includes("localhost:8000/v1/models")) return "";
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "";
+  if (cmd.includes("localhost:11434/api/tags")) return "";
+  if (cmd.includes("localhost:8000/v1/models")) return "";
   return "";
 };
 
@@ -583,15 +586,16 @@ credentials.prompt = async (message) => {
   return answers.shift() || "";
 };
 runner.run = (command, opts = {}) => {
-  commands.push(command);
+  commands.push(Array.isArray(command) ? command.join(" ") : command);
   return { status: 0 };
 };
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "/usr/bin/ollama";
-  if (command.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
-  if (command.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now";
-  if (command.includes("localhost:8000/v1/models")) return "";
-  if (command.includes("api/generate")) return '{"response":"hello"}';
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
+  if (cmd.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now";
+  if (cmd.includes("localhost:8000/v1/models")) return "";
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
   return "";
 };
 
@@ -681,11 +685,12 @@ credentials.prompt = async (message) => {
 credentials.ensureApiKey = async () => { process.env.NVIDIA_API_KEY = "nvapi-good"; };
 runner.run = () => ({ status: 0 });
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "/usr/bin/ollama";
-  if (command.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
-  if (command.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now";
-  if (command.includes("localhost:8000/v1/models")) return "";
-  if (command.includes("api/generate")) return '{"response":"hello"}';
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
+  if (cmd.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now";
+  if (cmd.includes("localhost:8000/v1/models")) return "";
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
   return "";
 };
 
@@ -781,11 +786,12 @@ credentials.prompt = async (message) => {
   return answers.shift() || "";
 };
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "/usr/bin/ollama";
-  if (command.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [] });
-  if (command.includes("ollama list")) return "";
-  if (command.includes("localhost:8000/v1/models")) return "";
-  if (command.includes("api/generate")) return '{"response":"hello"}';
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [] });
+  if (cmd.includes("ollama list")) return "";
+  if (cmd.includes("localhost:8000/v1/models")) return "";
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
   return "";
 };
 
@@ -888,11 +894,12 @@ credentials.prompt = async (message) => {
   return answers.shift() || "";
 };
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "/usr/bin/ollama";
-  if (command.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [] });
-  if (command.includes("ollama list")) return "";
-  if (command.includes("localhost:8000/v1/models")) return "";
-  if (command.includes("api/generate")) return '{"response":"hello"}';
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [] });
+  if (cmd.includes("ollama list")) return "";
+  if (cmd.includes("localhost:8000/v1/models")) return "";
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
   return "";
 };
 
@@ -2725,9 +2732,10 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "";
-  if (command.includes("localhost:11434")) return "";
-  if (command.includes("localhost:8000/v1/models")) return JSON.stringify({ data: [{ id: "meta-llama/Llama-3.3-70B-Instruct" }] });
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "";
+  if (cmd.includes("localhost:11434")) return "";
+  if (cmd.includes("localhost:8000/v1/models")) return JSON.stringify({ data: [{ id: "meta-llama/Llama-3.3-70B-Instruct" }] });
   return "";
 };
 
@@ -2834,9 +2842,10 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
-  if (command.includes("command -v ollama")) return "";
-  if (command.includes("localhost:11434")) return "";
-  if (command.includes("localhost:8000/v1/models")) return "";
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "";
+  if (cmd.includes("localhost:11434")) return "";
+  if (cmd.includes("localhost:8000/v1/models")) return "";
   return "";
 };
 

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -132,6 +132,8 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
   if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
@@ -306,6 +308,8 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => { process.env.NVIDIA_API_KEY = "nvapi-test"; };
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "";
   if (cmd.includes("localhost:11434/api/tags")) return "";
@@ -400,6 +404,8 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => { process.env.NVIDIA_API_KEY = "nvapi-test"; };
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "";
   if (cmd.includes("localhost:11434/api/tags")) return "";
@@ -590,6 +596,8 @@ runner.run = (command, opts = {}) => {
   return { status: 0 };
 };
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
   if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
@@ -685,6 +693,8 @@ credentials.prompt = async (message) => {
 credentials.ensureApiKey = async () => { process.env.NVIDIA_API_KEY = "nvapi-good"; };
 runner.run = () => ({ status: 0 });
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
   if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [{ name: "nemotron-3-nano:30b" }] });
@@ -786,6 +796,8 @@ credentials.prompt = async (message) => {
   return answers.shift() || "";
 };
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
   if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [] });
@@ -894,6 +906,8 @@ credentials.prompt = async (message) => {
   return answers.shift() || "";
 };
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
   if (cmd.includes("localhost:11434/api/tags")) return JSON.stringify({ models: [] });
@@ -2732,6 +2746,8 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "";
   if (cmd.includes("localhost:11434")) return "";
@@ -2842,6 +2858,8 @@ credentials.prompt = async (message) => {
 };
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
+  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
+  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "";
   if (cmd.includes("localhost:11434")) return "";

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -257,20 +257,21 @@ describe("policies", () => {
   });
 
   describe("buildPolicySetCommand", () => {
-    it("shell-quotes sandbox name to prevent injection", () => {
+    it("returns an argv array with sandbox name as a separate element", () => {
       const cmd = policies.buildPolicySetCommand("/tmp/policy.yaml", "my-assistant");
-      expect(cmd).toBe("openshell policy set --policy '/tmp/policy.yaml' --wait 'my-assistant'");
+      expect(cmd).toEqual(["openshell", "policy", "set", "--policy", "/tmp/policy.yaml", "--wait", "my-assistant"]);
     });
 
-    it("escapes shell metacharacters in sandbox name", () => {
+    it("preserves shell metacharacters literally in sandbox name (no injection)", () => {
       const cmd = policies.buildPolicySetCommand("/tmp/policy.yaml", "test; whoami");
-      expect(cmd.includes("'test; whoami'")).toBeTruthy();
+      expect(cmd).toContain("test; whoami");
+      // The metacharacters are a literal argv element, not shell-interpreted
     });
 
     it("places --wait before the sandbox name", () => {
       const cmd = policies.buildPolicySetCommand("/tmp/policy.yaml", "test-box");
       const waitIdx = cmd.indexOf("--wait");
-      const nameIdx = cmd.indexOf("'test-box'");
+      const nameIdx = cmd.indexOf("test-box");
       expect(waitIdx < nameIdx).toBeTruthy();
     });
 
@@ -278,10 +279,7 @@ describe("policies", () => {
       process.env.NEMOCLAW_OPENSHELL_BIN = "/tmp/fake path/openshell";
       try {
         const cmd = policies.buildPolicySetCommand("/tmp/policy.yaml", "my-assistant");
-        assert.equal(
-          cmd,
-          "'/tmp/fake path/openshell' policy set --policy '/tmp/policy.yaml' --wait 'my-assistant'",
-        );
+        expect(cmd).toEqual(["/tmp/fake path/openshell", "policy", "set", "--policy", "/tmp/policy.yaml", "--wait", "my-assistant"]);
       } finally {
         delete process.env.NEMOCLAW_OPENSHELL_BIN;
       }
@@ -289,9 +287,9 @@ describe("policies", () => {
   });
 
   describe("buildPolicyGetCommand", () => {
-    it("shell-quotes sandbox name", () => {
+    it("returns an argv array with sandbox name as a separate element", () => {
       const cmd = policies.buildPolicyGetCommand("my-assistant");
-      expect(cmd).toBe("openshell policy get --full 'my-assistant' 2>/dev/null");
+      expect(cmd).toEqual(["openshell", "policy", "get", "--full", "my-assistant"]);
     });
   });
 


### PR DESCRIPTION
## Rationale

Supersedes #171 which targeted the now-deleted `bin/lib/*.js` files. This PR implements the same security improvement against the current TypeScript codebase (`src/lib/*.ts`).

Executing commands as strings through `bash -c` is vulnerable to injection attacks if any part of the command contains untrusted input (sandbox names, model names, policy paths). This PR adds `runArgv()` and `runArgvCapture()` to `runner.ts` that call `spawnSync(exe, args)` directly, bypassing the shell entirely.

## Changes

### Core: `src/lib/runner.ts`
- Added `runArgv(cmd, opts)` — executes argv arrays with redacted output, no shell
- Added `runArgvCapture(cmd, opts)` — captures stdout from argv arrays, no shell
- Both validate input is a non-empty array and throw on misuse
- Existing `run()`/`runCapture()` preserved for backward compat with `onboard.ts` (5400 lines, to be converted in a follow-up)

### Converted callsites

**`src/lib/nim.ts`** — all external commands converted:
- `nvidia-smi`, `system_profiler`, `sysctl`, `free` (GPU detection)
- `docker pull/run/rm/stop/inspect/port` (NIM container lifecycle)
- `curl` (health checks)
- Eliminated shell pipe (`free -m | awk`) by parsing `free -m` output in JS

**`src/lib/local-inference.ts`** — health/reachability commands now return argv arrays:
- `getLocalProviderHealthCheck()` → `string[]` (was `string`)
- `getLocalProviderContainerReachabilityCheck()` → `string[]` (was `string`)
- `getOllamaProbeCommand()` → `string[]` (was `string`)
- `getOllamaWarmupCommand()` → `string[]` (still uses `bash -c` for backgrounding, but payload is shell-quoted)
- `validateLocalProvider()` and `validateOllamaModel()` accept optional argv capture injection for testing

**`src/lib/policies.ts`** — command builders now return argv arrays:
- `buildPolicySetCommand()` → `string[]` (was shell-quoted string)
- `buildPolicyGetCommand()` → `string[]` (was shell-quoted string)
- Callers (`applyPreset`, `applyPermissivePolicy`) switched to `runArgv`/`runArgvCapture`

### Test coverage

**New: `src/lib/runner-argv.test.ts`** — 18 tests:
- Basic execution and stdout capture
- Input validation (non-array, empty array)
- Error handling (`ignoreError`, throws)
- **Shell injection regression tests**: \$(whoami), backticks, `&&`, quote breakout, \${HOME} expansion — all verified as literal strings with no shell interpretation
- Env passthrough

**Updated: 5 existing test files** (153 tests passing):
- `src/lib/local-inference.test.ts` — assertions updated for array return types
- `src/lib/nim.test.ts` — mocks updated to handle array commands, `free -m` mock returns realistic output
- `test/policies.test.ts` — assertions updated for argv arrays
- `test/onboard-readiness.test.ts` — WSL name preservation tests updated

## Verification

- [x] `npm run build:cli` — clean TypeScript compilation
- [x] `vitest run src/lib/runner-argv.test.ts` — 18/18 pass
- [x] `vitest run src/lib/local-inference.test.ts` — 34/34 pass
- [x] `vitest run src/lib/nim.test.ts` — 16/16 pass
- [x] `vitest run test/policies.test.ts` — 62/62 pass
- [x] `vitest run test/onboard-readiness.test.ts` — 23/23 pass

## What's left for follow-up

- `src/lib/onboard.ts` (5400 lines) still uses string-based `run()`/`runCapture()` — converting all callsites is a separate, larger PR
- `src/lib/preflight.ts` still uses `command -v` via shell strings
- `runInteractive()` still uses `bash -c`

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched command execution to explicit argv-style invocation for safer, literal argument handling and to remove shell interpolation.

* **Behavior**
  * Health, probe, container, model and GPU probes now produce and consume structured argv commands; warmup/probe actions run via argv-capable paths and fall back more robustly.

* **Tests**
  * Updated and added tests to validate argv inputs, input validation, shell-prohibition, legacy string support, and varied success/failure behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->