### PR TITLE
fix(security): replace sandbox env blocklist with subprocess allowlist

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -28,6 +28,7 @@ const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 
 const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/g;
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("./runner");
 const { stageOptimizedSandboxBuildContext } = require("./sandbox-build-context");
+const { buildSubprocessEnv } = require("./subprocess-env");
 const { DASHBOARD_PORT, GATEWAY_PORT, VLLM_PORT, OLLAMA_PORT } = require("./ports");
 const {
   getDefaultOllamaModel,
@@ -2699,27 +2700,24 @@ async function createSandbox(
   // See: crates/openshell-sandbox/src/secrets.rs (placeholder rewriting),
   //      crates/openshell-router/src/backend.rs (inference auth injection).
   //
-  // TODO: migrate this blocklist to the shared allowlist in
-  // src/lib/subprocess-env.ts once the sandbox create path has been validated
-  // end-to-end with the stricter filtering. The allowlist rejects unknown
-  // env vars by default, which is safer but needs careful rollout.
+  // Use the shared allowlist (subprocess-env.ts) instead of the old
+  // blocklist. The blocklist only blocked 12 specific credential names
+  // and passed EVERYTHING else — including GITHUB_TOKEN,
+  // AWS_SECRET_ACCESS_KEY, SSH_AUTH_SOCK, KUBECONFIG, NPM_TOKEN, and
+  // any CI/CD secrets that happened to be in the host environment.
+  // The allowlist inverts the default: only known-safe env vars are
+  // forwarded, everything else is dropped.
+  //
+  // For the sandbox specifically, we also strip KUBECONFIG and
+  // SSH_AUTH_SOCK — the generic allowlist includes these for host-side
+  // subprocesses (gateway start, openshell CLI) but the sandbox should
+  // never have access to the host's Kubernetes cluster or SSH agent.
   const envArgs = [formatEnvAssignment("CHAT_UI_URL", chatUiUrl)];
-  const blockedSandboxEnvNames = new Set([
-    // Derived from REMOTE_PROVIDER_CONFIG to prevent drift
-    ...Object.values(REMOTE_PROVIDER_CONFIG)
-      .map((cfg) => cfg.credentialEnv)
-      .filter(Boolean),
-    // Additional credentials not in REMOTE_PROVIDER_CONFIG
-    "BEDROCK_API_KEY",
-    "DISCORD_BOT_TOKEN",
-    "SLACK_BOT_TOKEN",
-    "SLACK_APP_TOKEN",
-    "TELEGRAM_BOT_TOKEN",
-    webSearch.BRAVE_API_KEY_ENV,
-  ]);
-  const sandboxEnv = Object.fromEntries(
-    Object.entries(process.env).filter(([name]) => !blockedSandboxEnvNames.has(name)),
-  );
+  const sandboxEnv = buildSubprocessEnv();
+  // Remove host-infrastructure credentials that the generic allowlist
+  // permits for host-side processes but that must not enter the sandbox.
+  delete sandboxEnv.KUBECONFIG;
+  delete sandboxEnv.SSH_AUTH_SOCK;
   // Run without piping through awk — the pipe masked non-zero exit codes
   // from openshell because bash returns the status of the last pipeline
   // command (awk, always 0) unless pipefail is set. Removing the pipe

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -72,31 +72,23 @@ describe("credential exposure in process arguments", () => {
     expect(src).not.toMatch(/"--credential",\s*process\.env\./);
   });
 
-  it("onboard.js does not embed sandbox secrets in the sandbox create command line", () => {
+  it("onboard.ts uses subprocess allowlist (not blocklist) for sandbox env", () => {
     const src = fs.readFileSync(ONBOARD_JS, "utf-8");
 
-    // sandboxEnv must be built with a blocklist that strips all credential env vars.
-    // The blocklist derives provider keys from REMOTE_PROVIDER_CONFIG and adds
-    // messaging tokens explicitly. Verify both mechanisms are present.
-    //
-    // TODO: migrate to the shared allowlist in subprocess-env.ts
-    // once the sandbox create path has been validated end-to-end.
-    const blocklistMatch = src.match(/const blockedSandboxEnvNames = new Set\(\[([\s\S]*?)\]\);/);
-    expect(blocklistMatch).not.toBeNull();
-    const blocklist = blocklistMatch[1];
-    // Provider credentials are derived from REMOTE_PROVIDER_CONFIG
-    expect(blocklist).toContain("REMOTE_PROVIDER_CONFIG");
-    // Messaging and additional credentials are listed explicitly
-    expect(blocklist).toContain('"BEDROCK_API_KEY"');
-    expect(blocklist).toContain('"DISCORD_BOT_TOKEN"');
-    expect(blocklist).toContain('"SLACK_BOT_TOKEN"');
-    expect(blocklist).toContain('"SLACK_APP_TOKEN"');
-    expect(blocklist).toContain('"TELEGRAM_BOT_TOKEN"');
+    // The sandbox create path must use the shared subprocess-env.ts
+    // allowlist, NOT the old blocklist. The allowlist inverts the
+    // default: only known-safe env vars are forwarded, everything
+    // else (credentials, CI secrets, SSH agent, etc.) is dropped.
+    expect(src).toMatch(/buildSubprocessEnv\(\)/);
+    // The old blocklist pattern must NOT be present
+    expect(src).not.toMatch(/blockedSandboxEnvNames/);
+    // KUBECONFIG and SSH_AUTH_SOCK must be explicitly deleted from
+    // the sandbox env even though the generic allowlist permits them
+    // for host-side processes.
+    expect(src).toMatch(/delete sandboxEnv\.KUBECONFIG/);
+    expect(src).toMatch(/delete sandboxEnv\.SSH_AUTH_SOCK/);
+    // sandboxEnv must still be passed to streamSandboxCreate
     expect(src).toMatch(/streamSandboxCreate\(createCommand, sandboxEnv(?:, \{)?/);
-    expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("NVIDIA_API_KEY"/);
-    expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("DISCORD_BOT_TOKEN"/);
-    expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_BOT_TOKEN"/);
-    expect(src).not.toMatch(/envArgs\.push\(formatEnvAssignment\("SLACK_APP_TOKEN"/);
   });
 
   it("services.ts must not spread full process.env into subprocess", () => {


### PR DESCRIPTION
## Summary
- Replace the 12-entry env var blocklist in the sandbox creation path with the shared `subprocess-env.ts` allowlist. The blocklist passed the host's entire `process.env` into the sandbox minus only 12 specific names. The allowlist inverts the default: only known-safe variables are forwarded.
- Additionally strip `KUBECONFIG` and `SSH_AUTH_SOCK` from the sandbox environment — the generic allowlist includes these for host-side processes but the sandbox should never have access to the host's Kubernetes cluster or SSH agent.

## Why
The sandbox runs an AI agent with code execution. The blocklist only blocked 12 credential names and leaked **everything else** into the sandbox, including:

- `GITHUB_TOKEN` (confirmed absent from blocklist)
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`
- `SSH_AUTH_SOCK` (host SSH agent access)
- `KUBECONFIG` (host Kubernetes cluster access)
- `NPM_TOKEN`, `DOCKER_PASSWORD`
- `DATABASE_URL`, `REDIS_URL`, `MONGO_URI`
- Any CI/CD secrets (`GITLAB_TOKEN`, `CIRCLECI_TOKEN`, etc.)

A prompt-injected or compromised agent could read these via `process.env` and exfiltrate them through any allowed egress channel.

The correct fix — `subprocess-env.ts` — already exists in the codebase (PR #1874) and is applied to `blueprint/runner.ts` and `services.ts`. The sandbox creation path was explicitly left on the old blocklist with a TODO comment (lines 2702-2705). This PR completes that migration for the highest-impact code path.

## What changed
- `src/lib/onboard.ts` — import `buildSubprocessEnv` from `subprocess-env.ts`, replace the blocklist + `process.env` filter with `buildSubprocessEnv()`, delete `KUBECONFIG` and `SSH_AUTH_SOCK` from the result.

## Test plan
- [x] `npm run build:cli` — compiles cleanly.
- [ ] Manual: `nemoclaw onboard` with Ollama — verify sandbox can still reach inference (the allowlist includes `HOME`, `PATH`, `TERM`, proxy vars, and TLS vars which are sufficient).
- [ ] Manual: set `GITHUB_TOKEN=test123` in host env, onboard, exec into sandbox, verify `echo $GITHUB_TOKEN` is empty.

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox environment isolation so host-level access credentials are no longer forwarded into sandboxes; KUBECONFIG and SSH_AUTH_SOCK are explicitly excluded.
  * Replaced legacy blocklist handling with a consistent allowlist-based environment snapshot for more predictable and secure sandbox startups.

* **Tests**
  * Updated regression tests to verify the allowlist-based environment behavior and explicit exclusion of host credential variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->