### PR TITLE
fix(status): show live enforced policy instead of stale baseline (#1132)

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -567,8 +567,10 @@ function getSandboxGatewayState(sandboxName) {
         // plus the original colored "Policy:" header line.
         const before = rawLines.slice(0, policyLineIdx + 1).join("\n");
         // Extract YAML content from policy get --full (skip metadata header before "---").
-        const yamlPart = livePolicy.output.includes("---\n")
-          ? livePolicy.output.split("---\n").slice(1).join("---\n")
+        // Use a regex to handle varying line endings (\n, \r\n) and optional trailing whitespace.
+        const delimIdx = livePolicy.output.search(/^---\s*$/m);
+        const yamlPart = delimIdx !== -1
+          ? livePolicy.output.slice(delimIdx).replace(/^---\s*[\r\n]+/, "")
           : livePolicy.output;
         // Add 2-space indent to match the original sandbox get output format.
         const indented = yamlPart.trimEnd().split("\n").map((l) => (l ? "  " + l : l)).join("\n");

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -599,6 +599,7 @@ function getSandboxGatewayState(sandboxName) {
   return { state: "unknown_error", output };
 }
 
+/** Print troubleshooting hints based on gateway lifecycle state in the output. */
 function printGatewayLifecycleHint(output = "", sandboxName = "", writer = console.error) {
   const cleanOutput = stripAnsi(output);
   if (/No gateway configured/i.test(cleanOutput)) {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -577,7 +577,8 @@ function getSandboxGatewayState(sandboxName) {
         // (starts with a YAML key like "version:" or "network_policies:").
         // Avoids replacing with warnings or status text from unexpected output.
         const trimmedYaml = yamlPart.trim();
-        if (trimmedYaml && /^[a-z_][a-z0-9_]*\s*:/m.test(trimmedYaml)) {
+        const looksLikeError = /^(error|failed|invalid|warning|status)\b/i.test(trimmedYaml);
+        if (trimmedYaml && !looksLikeError && /^[a-z_][a-z0-9_]*\s*:/m.test(trimmedYaml)) {
           // Add 2-space indent to match the original sandbox get output format.
           const indented = trimmedYaml.split("\n").map((l) => (l ? "  " + l : l)).join("\n");
           output = before + "\n\n" + indented + "\n";

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -545,6 +545,7 @@ async function recoverNamedGatewayRuntime() {
   return { recovered: false, before, after, attempted: true };
 }
 
+/** Query sandbox presence and return its output with the live enforced policy. */
 function getSandboxGatewayState(sandboxName) {
   const result = captureOpenshell(["sandbox", "get", sandboxName]);
   let output = result.output;

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -547,8 +547,33 @@ async function recoverNamedGatewayRuntime() {
 
 function getSandboxGatewayState(sandboxName) {
   const result = captureOpenshell(["sandbox", "get", sandboxName]);
-  const output = result.output;
+  let output = result.output;
   if (result.status === 0) {
+    // `openshell sandbox get` returns the immutable baseline policy from sandbox
+    // creation, which does not include network_policies added later via
+    // `openshell policy set`. Replace the Policy section with the live policy
+    // from `policy get --full`, preserving the colored "Policy:" header and
+    // Sandbox info above it. (#1132)
+    const livePolicy = captureOpenshell(["policy", "get", "--full", sandboxName], {
+      ignoreError: true,
+    });
+    if (livePolicy.status === 0 && livePolicy.output.trim()) {
+      const rawLines = String(output).split("\n");
+      const cleanLines = stripAnsi(String(output)).split("\n");
+      const policyLineIdx = cleanLines.findIndex((l) => l.trim() === "Policy:");
+      if (policyLineIdx !== -1) {
+        // Keep everything before Policy (Sandbox info with colors),
+        // plus the original colored "Policy:" header line.
+        const before = rawLines.slice(0, policyLineIdx + 1).join("\n");
+        // Extract YAML content from policy get --full (skip metadata header before "---").
+        const yamlPart = livePolicy.output.includes("---\n")
+          ? livePolicy.output.split("---\n").slice(1).join("---\n")
+          : livePolicy.output;
+        // Add 2-space indent to match the original sandbox get output format.
+        const indented = yamlPart.trimEnd().split("\n").map((l) => (l ? "  " + l : l)).join("\n");
+        output = before + "\n\n" + indented + "\n";
+      }
+    }
     return { state: "present", output };
   }
   if (/\bNotFound\b|\bNot Found\b|sandbox not found/i.test(output)) {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -510,6 +510,7 @@ function getNamedGatewayLifecycleState() {
   return { state: "missing_named", status: status.output, gatewayInfo: gatewayInfo.output };
 }
 
+/** Attempt to recover the named NemoClaw gateway after a restart or connectivity loss. */
 async function recoverNamedGatewayRuntime() {
   const before = getNamedGatewayLifecycleState();
   if (before.state === "healthy_named") {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -573,9 +573,15 @@ function getSandboxGatewayState(sandboxName) {
         const yamlPart = delimIdx !== -1
           ? livePolicy.output.slice(delimIdx).replace(/^---\s*[\r\n]+/, "")
           : livePolicy.output;
-        // Add 2-space indent to match the original sandbox get output format.
-        const indented = yamlPart.trimEnd().split("\n").map((l) => (l ? "  " + l : l)).join("\n");
-        output = before + "\n\n" + indented + "\n";
+        // Guard: only replace if the extracted content looks like policy YAML
+        // (starts with a YAML key like "version:" or "network_policies:").
+        // Avoids replacing with warnings or status text from unexpected output.
+        const trimmedYaml = yamlPart.trim();
+        if (trimmedYaml && /^[a-z_][a-z0-9_]*\s*:/m.test(trimmedYaml)) {
+          // Add 2-space indent to match the original sandbox get output format.
+          const indented = trimmedYaml.split("\n").map((l) => (l ? "  " + l : l)).join("\n");
+          output = before + "\n\n" + indented + "\n";
+        }
       }
     }
     return { state: "present", output };


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                                     
                  
  Fixes #1132

  `nemoclaw status` displays policy details from `openshell sandbox get`, which returns the immutable baseline policy from sandbox creation time. Network policies added later via `nemoclaw policy-add` / `openshell policy set` are not reflected in this baseline, causing the Policy section to be missing actively enforced 
  policies.
                                                                                                                                                                                                                                                                                                                                 
  ## Root Cause   

  OpenShell maintains two separate storage locations for policy:

  1. **`sandbox.spec.policy` (baseline)** — Written once at sandbox creation. Used by `validate_static_fields_unchanged()` to ensure static fields (`filesystem_policy`, `landlock`, `process`) cannot be modified after creation, since these are kernel-level restrictions (Landlock, UID/GID) that are irreversible. Returned 
  by `openshell sandbox get`.
                                                                                                                                                                                                                                                                                                                                 
  2. **`sandbox_policies` table (runtime revisions)** — Updated on every `openshell policy set`. The sandbox proxy reads the latest revision to enforce network access rules. Returned by `openshell policy get --full`.                                                                                                         
   
  When `openshell policy set` is called, it validates the new policy against the baseline, writes a new revision to the runtime table, but intentionally does NOT update `sandbox.spec.policy` — preserving the immutable security baseline. This means `openshell sandbox get` never reflects post-creation policy changes.     
                  
  ## Fix                                                                                                                                                                                                                                                                                                                         
                  
  In `getSandboxGatewayState()`, after a successful `openshell sandbox get`, fetch the live policy via `openshell policy get --full` and replace the Policy section in the output. The Sandbox info and colored "Policy:" header are preserved from the original output.                                                         
   
  ## Reproduction & Verification                                                                                                                                                                                                                                                                                                 
                  
  **Before fix** — `nemoclaw status` Policy section missing slack after `policy-add`:

  | Check | Result |                                                                                                                                                                                                                                                                                                             
  |-------|--------|
  | `nemoclaw lyy policy-list` | ● slack (applied) |                                                                                                                                                                                                                                                                             
  | `nemoclaw lyy status` header | Policies: pypi, npm, slack |                                                                                                                                                                                                                                                                  
  | `openshell policy get --full lyy` | ✅ Contains slack endpoints |                                                                                                                                                                                                                                                            
  | Network access from sandbox via node | ✅ `api.slack.com` returns `{"ok":true}` |                                                                                                                                                                                                                                            
  | `nemoclaw lyy status` policy detail | ❌ **slack missing from network_policies** |                                                                                                                                                                                                                                           
  | `openshell sandbox get lyy` | ❌ **slack missing from network_policies** |                                                                                                                                                                                                                                                   

`nemoclaw status` Policy section missing slack after `policy-add`:                                                                                                                                                                                                                                            
                  
      Policies: pypi, npm, slack    ← header shows slack (from registry)                                                                                                                                                                                                                                                         
   
      Policy:                                                                                                                                                                                                                                                                                                                    
        network_policies:
          claude_code: ...
          npm_registry: ...
          nvidia: ...
          openclaw_api: ...
          openclaw_docs: ...
                                     ← slack missing from policy detail! 
                                                                                                                                                                                                                                                                                                                                 
  **After fix** — Policy detail section now shows all enforced policies including slack, pypi, npm_yarn (all policies added post-creation are visible).            
Policy section shows all enforced policies including slack:                                                                                                                                                                                                                                                    
                  
      Policies: pypi, npm, slack

      Policy:
        network_policies:
          claude_code: ...
          npm_registry: ...                                                                                                                                                                                                                                                                                                      
          npm_yarn: ...
          nvidia: ...                                                                                                                                                                                                                                                                                                            
          openclaw_api: ...
          openclaw_docs: ...
          pypi: ...
          slack:                     ← now visible
            name: slack
            endpoints:
            - host: slack.com                                                                                                                                                                                                                                                                                                    
            ...                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                                                                                                                                   
                  
  - [x] Reproduced on Ubuntu 24.04 (NemoClaw v0.1.0, OpenShell 0.0.20)                                                                                                                                                                                                                                                           
  - [x] Verified `nemoclaw policy-add` slack → `nemoclaw status` now shows slack in Policy detail
  - [x] Verified Sandbox info section preserved with colors                                                                                                                                                                                                                                                                      
  - [x] Verified OpenClaw/NIM status lines still display correctly
  - [x] Verified fallback: if `policy get --full` fails, original output shown unchanged
  - [ ] Existing test suite passes           

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic gateway recovery: the system can attempt to recover named gateways when their lifecycle isn't healthy and reports whether recovery was attempted and which recovery path was used.

* **Bug Fixes**
  * Sandbox details now display the live enforced policy YAML (replacing the previous static policy section) so shown policy matches current enforced configuration.

* **Documentation**
  * Added inline documentation for lifecycle hint output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>
