### PR TITLE
fix(snapshot): preflight sandbox liveness and clean restore

### DIFF
--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -342,6 +342,21 @@ export function restoreSandboxState(
       return { success: false, restoredDirs, failedDirs: [...localDirs] };
     }
 
+    // Remove existing state dirs before extracting so stale files from
+    // later snapshots don't persist after restoring an earlier one.
+    const rmCmd = localDirs
+      .map((d) => `rm -rf "${writableDir}/${d}"`)
+      .join(" && ");
+    _log(`Cleaning target dirs before restore: ${rmCmd}`);
+    const rmResult = spawnSync(
+      "ssh",
+      [...sshArgs(configFile, sandboxName), rmCmd],
+      { stdio: ["ignore", "pipe", "pipe"], timeout: 30000 },
+    );
+    if (rmResult.status !== 0) {
+      _log(`WARNING: pre-restore cleanup failed (exit ${rmResult.status}): ${(rmResult.stderr?.toString() || "").substring(0, 200)}`);
+    }
+
     const extractCmd = `tar -xf - -C ${writableDir}`;
     const sshResult = spawnSync(
       "ssh",

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1806,6 +1806,16 @@ function sandboxSnapshot(sandboxName, subArgs) {
       break;
     }
     case "restore": {
+      const isLive = captureOpenshell(["sandbox", "list"], { ignoreError: true });
+      if (isLive.status !== 0) {
+        console.error("  Failed to query live sandbox state from OpenShell.");
+        process.exit(1);
+      }
+      const liveNames = parseLiveSandboxNames(isLive.output || "");
+      if (!liveNames.has(sandboxName)) {
+        console.error(`  Sandbox '${sandboxName}' is not running. Cannot restore snapshot.`);
+        process.exit(1);
+      }
       const timestamp = subArgs[1] || null;
       let backupPath;
       if (timestamp) {


### PR DESCRIPTION
## Summary

Two fixes for `snapshot restore`:

1. **Preflight sandbox liveness before restore** — `restoreSandboxState()` returns success immediately when no state dirs are backed up, so a restore against a stopped or missing sandbox could silently report success. Now checks the sandbox is live before attempting restore, matching the existing `snapshot create` preflight.

2. **Clean target dirs before extracting to remove stale files** — `restoreSandboxState()` used `tar -xf` overlay semantics which only overwrites files present in the archive. Files added after a snapshot was taken would persist when restoring that earlier snapshot. Now removes the target state directories inside the sandbox before extracting so the restored state is an exact replica.

Closes #1902

## Test plan

- [x] All hooks pass (pre-commit, commit-msg, pre-push)
- [x] Nightly E2E triggered on this branch — validates Phase 7 (restore earlier snapshot, assert later files are gone)

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>