### PR TITLE
fix(install): support Jetson BSP R39+ in host setup script

### DIFF
--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -26,15 +26,25 @@ get_jetpack_version() {
   revision="$(printf '%s\n' "$release_line" | sed -n 's/^.*REVISION: \([0-9][0-9]*\)\..*$/\1/p')"
   l4t_version="${release}.${revision}"
 
+  if [[ -z "$release" ]]; then
+    info "Jetson detected but could not parse L4T release — skipping host setup" >&2
+    return 0
+  fi
+
+  if ((release >= 39)); then
+    info "Jetson detected (L4T $l4t_version) — this version does not require any host setup" >&2
+    return 0
+  fi
+
   case "$l4t_version" in
     36.*)
       printf "%s" "jp6"
       ;;
     38.*)
-      printf "%s" "jp7"
+      printf "%s" "jp7-r38"
       ;;
     *)
-      info "Jetson detected (L4T $l4t_version) but version is not recognized — skipping host setup"
+      info "Jetson detected (L4T $l4t_version) but version is not recognized — skipping host setup" >&2
       ;;
   esac
 }
@@ -52,8 +62,8 @@ configure_jetson_host() {
       "${SUDO[@]}" update-alternatives --set iptables /usr/sbin/iptables-legacy
       "${SUDO[@]}" sed -i '/"iptables": false,/d; /"bridge": "none"/d; s/"default-runtime": "nvidia",/"default-runtime": "nvidia"/' /etc/docker/daemon.json
       ;;
-    jp7)
-      # JP7 (Thor) does not need iptables or Docker daemon.json changes.
+    jp7-r38)
+      # JP7 R38 does not need iptables or Docker daemon.json changes.
       ;;
     *)
       error "Unsupported Jetson version: $jetpack_version"


### PR DESCRIPTION
R39 and later BSP versions do not require any host customization. Detect the L4T release number arithmetically so future versions are handled automatically without needing script changes.

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `nemoclaw-contributor-update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/nemoclaw-contributor-update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Your Name <your-email@example.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup script version detection and mapping for Jetson 38-series devices so the correct JetPack variant is chosen.
  * Setup now handles unparseable or newer OS releases more gracefully, allowing the process to continue with safer defaults.
  * Updated no-op case handling to align with the new 38-series mapping and provide clearer failure messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->