### PR TITLE
docs: catch up documentation for v0.0.16 changes

### DIFF
--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -86,6 +86,12 @@ If you only need one of the built-in presets, use `nemoclaw <name> policy-add` i
 $ nemoclaw my-assistant policy-add
 ```
 
+To remove a previously applied preset, use `nemoclaw <name> policy-remove`:
+
+```console
+$ nemoclaw my-assistant policy-remove
+```
+
 Use a manual YAML edit when you need to allow custom hosts that are not covered by a preset, such as an internal API or a weather service.
 
 Each entry in the `network` section defines an endpoint group with the following fields:

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -50,6 +50,13 @@ $ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <
 > **Warning:** For NemoClaw-managed environments, use `nemoclaw onboard` when you need to create or recreate the OpenShell gateway or sandbox.
 > Avoid `openshell self-update`, `npm update -g openshell`, `openshell gateway start --recreate`, or `openshell sandbox create` directly unless you intend to manage OpenShell separately and then rerun `nemoclaw onboard`.
 
+The installer detects existing sandbox sessions before onboarding and prints a warning if any are found.
+To make the installer abort instead of continuing, set `NEMOCLAW_SINGLE_SESSION=1`:
+
+```console
+$ NEMOCLAW_SINGLE_SESSION=1 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
 The wizard prompts for a provider first, then collects the provider credential if needed.
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.
 Credentials are stored in `~/.nemoclaw/credentials.json`. For file permissions, plaintext storage behavior, and hardening guidance, see Credential Storage (see the `nemoclaw-user-configure-security` skill).
@@ -163,6 +170,7 @@ $ nemoclaw deploy <instance-name>
 Connect to a sandbox by name.
 On a TTY, a one-shot hint prints before dropping into the sandbox shell, reminding you to run `openclaw tui` inside.
 Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
+If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `nemoclaw <name> rebuild` hint.
 
 ```console
 $ nemoclaw my-assistant connect
@@ -173,6 +181,9 @@ $ nemoclaw my-assistant connect
 Show sandbox status, health, and inference configuration.
 For local Ollama and local vLLM routes, the command also probes the host-side health endpoint and reports whether the backend is reachable.
 If the backend is down, the output includes an `Inference: unreachable` line with the local URL and a remediation hint.
+
+The Policy section displays the live enforced policy (fetched via `openshell policy get --full`), which reflects presets added or removed after sandbox creation.
+If the sandbox is running an outdated agent version, the output includes an `Update` line with the available version and a `nemoclaw <name> rebuild` hint.
 
 ```console
 $ nemoclaw my-assistant status
@@ -194,7 +205,8 @@ This removes the sandbox from the registry.
 
 > **Warning:** This command permanently deletes the sandbox **and its persistent volume**.
 > All workspace files (see the `nemoclaw-user-workspace` skill) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
-> Back up your workspace first — see Backup and Restore (see the `nemoclaw-user-workspace` skill).
+> Back up your workspace first with `nemoclaw <name> snapshot create` or see Backup and Restore (see the `nemoclaw-user-workspace` skill).
+> If you want to upgrade the sandbox while preserving state, use `nemoclaw <name> rebuild` instead.
 
 ```console
 $ nemoclaw my-assistant destroy
@@ -228,6 +240,21 @@ List available policy presets and show which ones are applied to the sandbox.
 $ nemoclaw my-assistant policy-list
 ```
 
+### `nemoclaw <name> policy-remove`
+
+Remove a previously applied policy preset from a sandbox.
+The command lists only the presets currently applied, prompts you to select one, shows the endpoints that would be removed, and asks for confirmation before narrowing egress.
+
+```console
+$ nemoclaw my-assistant policy-remove
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Preview which endpoints would be removed without applying changes |
+
+Unchecking a preset in the onboard TUI checkbox also removes it from the sandbox.
+
 ### `nemoclaw <name> skill install <path>`
 
 Deploy a skill directory to a running sandbox.
@@ -245,6 +272,63 @@ Files with unsafe path characters are rejected to prevent shell injection.
 
 If the skill already exists on the sandbox, the command updates it in place and preserves chat history.
 For new installs, the agent session index is refreshed so the agent discovers the skill on the next session.
+
+### `nemoclaw <name> rebuild`
+
+Upgrade a sandbox to the current agent version while preserving workspace state.
+The command backs up workspace state, destroys the old sandbox, recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
+Credentials are stripped from backups before storage.
+
+```console
+$ nemoclaw my-assistant rebuild [--yes] [--verbose]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--yes`, `--force` | Skip the confirmation prompt |
+| `--verbose` | Log SSH commands, exit codes, and session state (also enabled by `NEMOCLAW_REBUILD_VERBOSE=1`) |
+
+The sandbox must be running for the backup step to succeed.
+After restore, the command runs `openclaw doctor --fix` for cross-version structure repair.
+
+### `nemoclaw backup-all`
+
+Back up all registered running sandboxes to `~/.nemoclaw/rebuild-backups/`.
+Sandboxes that are not running are skipped.
+
+```console
+$ nemoclaw backup-all
+```
+
+The installer calls `backup-all` automatically before onboarding to protect against data loss during OpenShell upgrades.
+
+### `nemoclaw <name> snapshot create`
+
+Create a timestamped snapshot of sandbox state.
+Snapshots are stored in `~/.nemoclaw/rebuild-backups/<name>/`.
+
+```console
+$ nemoclaw my-assistant snapshot create
+```
+
+### `nemoclaw <name> snapshot list`
+
+List available snapshots for a sandbox with timestamps and item counts.
+
+```console
+$ nemoclaw my-assistant snapshot list
+```
+
+### `nemoclaw <name> snapshot restore [timestamp]`
+
+Restore sandbox state from a snapshot.
+If no timestamp is provided, the latest snapshot is used.
+Partial timestamp prefixes are accepted if they match exactly one snapshot.
+
+```console
+$ nemoclaw my-assistant snapshot restore
+$ nemoclaw my-assistant snapshot restore 2026-04-14T
+```
 
 ### `openshell term`
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -256,6 +256,24 @@ Follow these steps to reconnect.
 > The wizard prompts for confirmation before destroying an existing sandbox. If you confirm, it **destroys and recreates** the sandbox. Workspace files (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
 > Back up your workspace first by following the instructions at Back Up and Restore (see the `nemoclaw-user-workspace` skill).
 
+### Sandbox is running an outdated agent version
+
+After upgrading NemoClaw, `nemoclaw <name> connect` and `nemoclaw <name> status` warn if the sandbox is running an older agent version than the current image.
+
+To upgrade the sandbox while preserving workspace state, run:
+
+```console
+$ nemoclaw <name> rebuild
+```
+
+The rebuild command backs up state, destroys the old sandbox, recreates it with the current image, and restores state.
+Create a snapshot before rebuilding if you want an additional safety net:
+
+```console
+$ nemoclaw <name> snapshot create
+$ nemoclaw <name> rebuild
+```
+
 ### Sandbox shows as stopped
 
 The sandbox may have been stopped or deleted.

--- a/.agents/skills/nemoclaw-user-workspace/SKILL.md
+++ b/.agents/skills/nemoclaw-user-workspace/SKILL.md
@@ -70,7 +70,7 @@ You can edit them in two ways:
 Workspace files define your agent's personality, memory, and user context.
 They persist across sandbox restarts but are **permanently deleted** when you run `nemoclaw <name> destroy`.
 
-This guide covers manual backup with CLI commands and an automated script.
+This guide covers snapshot commands, manual backup with CLI commands, and an automated script.
 
 ## Step 1: When to Back Up
 
@@ -78,7 +78,27 @@ This guide covers manual backup with CLI commands and an automated script.
 - Before major NemoClaw version upgrades
 - Periodically, if you've invested time customizing your agent
 
-## Step 2: Manual Backup
+## Step 2: Snapshot Commands
+
+The fastest way to back up and restore sandbox state is with the built-in snapshot commands.
+Snapshots capture all workspace state directories defined in the agent manifest and store them in `~/.nemoclaw/rebuild-backups/<name>/`.
+
+```console
+$ nemoclaw my-assistant snapshot create
+$ nemoclaw my-assistant snapshot list
+$ nemoclaw my-assistant snapshot restore
+```
+
+To restore a specific snapshot instead of the latest, pass a timestamp or prefix:
+
+```console
+$ nemoclaw my-assistant snapshot restore 2026-04-14T
+```
+
+The `nemoclaw <name> rebuild` command uses the same snapshot mechanism automatically.
+For full details, see the Commands reference (see the `nemoclaw-user-reference` skill).
+
+## Step 3: Manual Backup
 
 Use `openshell sandbox download` to copy files from the sandbox to your host.
 
@@ -95,7 +115,7 @@ $ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/MEMORY.md "
 $ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/memory/ "$BACKUP_DIR/memory/"
 ```
 
-## Step 3: Manual Restore
+## Step 4: Manual Restore
 
 Use `openshell sandbox upload` to push files back into a sandbox.
 
@@ -111,7 +131,7 @@ $ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/MEMORY.md" /sandbox/.openclaw
 $ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/memory/" /sandbox/.openclaw/workspace/memory/
 ```
 
-## Step 4: Using the Backup Script
+## Step 5: Using the Backup Script
 
 The repository includes a convenience script at `scripts/backup-workspace.sh`.
 
@@ -137,7 +157,7 @@ Restore from a specific timestamp:
 $ ./scripts/backup-workspace.sh restore my-assistant 20260320-120000
 ```
 
-## Step 5: Verifying a Backup
+## Step 6: Verifying a Backup
 
 List backed-up files to confirm completeness:
 

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -51,6 +51,12 @@ If you only need one of the built-in presets, use `nemoclaw <name> policy-add` i
 $ nemoclaw my-assistant policy-add
 ```
 
+To remove a previously applied preset, use `nemoclaw <name> policy-remove`:
+
+```console
+$ nemoclaw my-assistant policy-remove
+```
+
 Use a manual YAML edit when you need to allow custom hosts that are not covered by a preset, such as an internal API or a weather service.
 
 Each entry in the `network` section defines an endpoint group with the following fields:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -194,6 +194,7 @@ $ nemoclaw deploy <instance-name>
 Connect to a sandbox by name.
 On a TTY, a one-shot hint prints before dropping into the sandbox shell, reminding you to run `openclaw tui` inside.
 Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
+If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `nemoclaw <name> rebuild` hint.
 
 ```console
 $ nemoclaw my-assistant connect
@@ -204,6 +205,9 @@ $ nemoclaw my-assistant connect
 Show sandbox status, health, and inference configuration.
 For local Ollama and local vLLM routes, the command also probes the host-side health endpoint and reports whether the backend is reachable.
 If the backend is down, the output includes an `Inference: unreachable` line with the local URL and a remediation hint.
+
+The Policy section displays the live enforced policy (fetched via `openshell policy get --full`), which reflects presets added or removed after sandbox creation.
+If the sandbox is running an outdated agent version, the output includes an `Update` line with the available version and a `nemoclaw <name> rebuild` hint.
 
 ```console
 $ nemoclaw my-assistant status
@@ -226,7 +230,8 @@ This removes the sandbox from the registry.
 :::{warning}
 This command permanently deletes the sandbox **and its persistent volume**.
 All [workspace files](../workspace/workspace-files.md) (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
-Back up your workspace first — see [Backup and Restore](../workspace/backup-restore.md).
+Back up your workspace first with `nemoclaw <name> snapshot create` or see [Backup and Restore](../workspace/backup-restore.md).
+If you want to upgrade the sandbox while preserving state, use `nemoclaw <name> rebuild` instead.
 :::
 
 ```console
@@ -261,6 +266,21 @@ List available policy presets and show which ones are applied to the sandbox.
 $ nemoclaw my-assistant policy-list
 ```
 
+### `nemoclaw <name> policy-remove`
+
+Remove a previously applied policy preset from a sandbox.
+The command lists only the presets currently applied, prompts you to select one, shows the endpoints that would be removed, and asks for confirmation before narrowing egress.
+
+```console
+$ nemoclaw my-assistant policy-remove
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Preview which endpoints would be removed without applying changes |
+
+Unchecking a preset in the onboard TUI checkbox also removes it from the sandbox.
+
 ### `nemoclaw <name> skill install <path>`
 
 Deploy a skill directory to a running sandbox.
@@ -278,6 +298,63 @@ Files with unsafe path characters are rejected to prevent shell injection.
 
 If the skill already exists on the sandbox, the command updates it in place and preserves chat history.
 For new installs, the agent session index is refreshed so the agent discovers the skill on the next session.
+
+### `nemoclaw <name> rebuild`
+
+Upgrade a sandbox to the current agent version while preserving workspace state.
+The command backs up workspace state, destroys the old sandbox, recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
+Credentials are stripped from backups before storage.
+
+```console
+$ nemoclaw my-assistant rebuild [--yes] [--verbose]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--yes`, `--force` | Skip the confirmation prompt |
+| `--verbose` | Log SSH commands, exit codes, and session state (also enabled by `NEMOCLAW_REBUILD_VERBOSE=1`) |
+
+The sandbox must be running for the backup step to succeed.
+After restore, the command runs `openclaw doctor --fix` for cross-version structure repair.
+
+### `nemoclaw backup-all`
+
+Back up all registered running sandboxes to `~/.nemoclaw/rebuild-backups/`.
+Sandboxes that are not running are skipped.
+
+```console
+$ nemoclaw backup-all
+```
+
+The installer calls `backup-all` automatically before onboarding to protect against data loss during OpenShell upgrades.
+
+### `nemoclaw <name> snapshot create`
+
+Create a timestamped snapshot of sandbox state.
+Snapshots are stored in `~/.nemoclaw/rebuild-backups/<name>/`.
+
+```console
+$ nemoclaw my-assistant snapshot create
+```
+
+### `nemoclaw <name> snapshot list`
+
+List available snapshots for a sandbox with timestamps and item counts.
+
+```console
+$ nemoclaw my-assistant snapshot list
+```
+
+### `nemoclaw <name> snapshot restore [timestamp]`
+
+Restore sandbox state from a snapshot.
+If no timestamp is provided, the latest snapshot is used.
+Partial timestamp prefixes are accepted if they match exactly one snapshot.
+
+```console
+$ nemoclaw my-assistant snapshot restore
+$ nemoclaw my-assistant snapshot restore 2026-04-14T
+```
 
 ### `openshell term`
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -286,6 +286,24 @@ The wizard prompts for confirmation before destroying an existing sandbox. If yo
 Back up your workspace first by following the instructions at [Back Up and Restore](../workspace/backup-restore.md).
 :::
 
+### Sandbox is running an outdated agent version
+
+After upgrading NemoClaw, `nemoclaw <name> connect` and `nemoclaw <name> status` warn if the sandbox is running an older agent version than the current image.
+
+To upgrade the sandbox while preserving workspace state, run:
+
+```console
+$ nemoclaw <name> rebuild
+```
+
+The rebuild command backs up state, destroys the old sandbox, recreates it with the current image, and restores state.
+Create a snapshot before rebuilding if you want an additional safety net:
+
+```console
+$ nemoclaw <name> snapshot create
+$ nemoclaw <name> rebuild
+```
+
 ### Sandbox shows as stopped
 
 The sandbox may have been stopped or deleted.

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
   {
     "preferred": true,
+    "version": "0.0.16",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.16/"
+  },
+  {
     "version": "0.0.15",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.15/"
   },

--- a/docs/workspace/backup-restore.md
+++ b/docs/workspace/backup-restore.md
@@ -23,13 +23,33 @@ status: published
 Workspace files define your agent's personality, memory, and user context.
 They persist across sandbox restarts but are **permanently deleted** when you run `nemoclaw <name> destroy`.
 
-This guide covers manual backup with CLI commands and an automated script.
+This guide covers snapshot commands, manual backup with CLI commands, and an automated script.
 
 ## When to Back Up
 
 - **Before running `nemoclaw <name> destroy`**
 - Before major NemoClaw version upgrades
 - Periodically, if you've invested time customizing your agent
+
+## Snapshot Commands
+
+The fastest way to back up and restore sandbox state is with the built-in snapshot commands.
+Snapshots capture all workspace state directories defined in the agent manifest and store them in `~/.nemoclaw/rebuild-backups/<name>/`.
+
+```console
+$ nemoclaw my-assistant snapshot create
+$ nemoclaw my-assistant snapshot list
+$ nemoclaw my-assistant snapshot restore
+```
+
+To restore a specific snapshot instead of the latest, pass a timestamp or prefix:
+
+```console
+$ nemoclaw my-assistant snapshot restore 2026-04-14T
+```
+
+The `nemoclaw <name> rebuild` command uses the same snapshot mechanism automatically.
+For full details, see the [Commands reference](../reference/commands.md).
 
 ## Manual Backup
 


### PR DESCRIPTION
## Summary
- Document `nemoclaw <name> snapshot create/list/restore` commands (from #1892)
- Document `nemoclaw <name> policy-remove` command (from #1822)
- Document `nemoclaw <name> rebuild` command with version staleness detection (from #1870)
- Document `nemoclaw backup-all` command (from #1870)
- Update `status` to mention live enforced policy display (from #1896)
- Update `connect` and `status` to mention version staleness warnings (from #1870)
- Update `destroy` to reference snapshots and rebuild as alternatives
- Add snapshot commands section to backup-restore page
- Add `policy-remove` to customize-network-policy page
- Add "Sandbox is running an outdated agent version" troubleshooting entry
- Bump doc version switcher through 0.0.16
- Regenerate agent skills from updated docs

## Test plan
- [x] `make docs` builds without warnings
- [x] All pre-commit hooks pass
- [ ] Verify rendered pages in docs build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for policy preset removal command with selection flow
  * Documented new rebuild command for sandbox upgrades while preserving workspace state
  * Introduced snapshot commands for creating, listing, and restoring workspace backups
  * Added bulk backup capability for multiple sandboxes
  * Enhanced agent version warnings in connect and status commands with remediation guidance
  * Expanded troubleshooting guide with outdated agent version resolution steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->