### PR TITLE
fix: catch permission errors when copying custom Dockerfile build context (#1808)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2558,13 +2558,23 @@ async function createSandbox(
     buildCtx = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-"));
     stagedDockerfile = path.join(buildCtx, "Dockerfile");
     // Copy the entire parent directory as build context.
-    fs.cpSync(path.dirname(fromResolved), buildCtx, {
-      recursive: true,
-      filter: (src) => {
-        const base = path.basename(src);
-        return !["node_modules", ".git", ".venv", "__pycache__"].includes(base);
-      },
-    });
+    try {
+      fs.cpSync(path.dirname(fromResolved), buildCtx, {
+        recursive: true,
+        filter: (src) => {
+          const base = path.basename(src);
+          return !["node_modules", ".git", ".venv", "__pycache__"].includes(base);
+        },
+      });
+    } catch (err) {
+      if (err.code === "EACCES") {
+        console.error(`  Permission denied while copying build context from: ${path.dirname(fromResolved)}`);
+        console.error("  The --from flag uses the Dockerfile's parent directory as the Docker build context.");
+        console.error("  Move your Dockerfile to a dedicated directory and retry.");
+        process.exit(1);
+      }
+      throw err;
+    }
     // If the caller pointed at a file not named "Dockerfile", copy it to the
     // location openshell expects (buildCtx/Dockerfile).
     if (path.basename(fromResolved) !== "Dockerfile") {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
When `nemoclaw onboard --from Dockerfile` is run in a directory with unreadable files (e.g., a user's home directory on WSL with Windows system files), the build context copy crashes with a raw Node.js stack trace. This catches the `EACCES`  error and shows a clear message telling the user to move the Dockerfile to a dedicated directory.             

## Related Issue
Fixes #1808

## Changes
 - `src/lib/onboard.ts`: Wrap the build context `fs.cpSync` call in a try/catch. On `EACCES`, print an actionable error  message and exit instead of crashing with a stack trace.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for permission-denied scenarios during the build process. When a permission issue occurs, users now receive a clear error message with actionable guidance on how to resolve the problem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->