### PR TITLE
fix(e2e): use --name flag in landlock sandbox exec (#1851)

### DIFF
--- a/test/e2e/e2e-cloud-experimental/checks/04-landlock-readonly.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/04-landlock-readonly.sh
@@ -40,7 +40,7 @@ fail_test() {
 
 # Helper: run a command inside the sandbox via openshell
 sandbox_exec() {
-  openshell sandbox exec "$SANDBOX_NAME" -- bash -c "$1" 2>&1
+  openshell sandbox exec --name "$SANDBOX_NAME" -- bash -c "$1" 2>&1
 }
 
 info "Running Landlock read-only checks in sandbox: $SANDBOX_NAME"

--- a/test/e2e/test-sandbox-rebuild.sh
+++ b/test/e2e/test-sandbox-rebuild.sh
@@ -96,12 +96,12 @@ fi
 # ── Step 3: Write marker files into sandbox ─────────────────────────
 info "Step 3: Writing marker files into sandbox workspace..."
 
-openshell sandbox exec "$SANDBOX_NAME" -- \
+openshell sandbox exec --name "$SANDBOX_NAME" -- \
   sh -c "mkdir -p /sandbox/.openclaw-data/workspace && echo '${MARKER_CONTENT}' > ${MARKER_FILE}" \
   || fail "Failed to write marker file"
 
 # Verify the marker file was written
-VERIFY=$(openshell sandbox exec "$SANDBOX_NAME" -- cat "$MARKER_FILE" 2>/dev/null || true)
+VERIFY=$(openshell sandbox exec --name "$SANDBOX_NAME" -- cat "$MARKER_FILE" 2>/dev/null || true)
 [ "$VERIFY" = "$MARKER_CONTENT" ] || fail "Marker file verification failed: got '$VERIFY'"
 
 pass "Marker file written and verified"
@@ -144,7 +144,7 @@ pass "Rebuild completed"
 # ── Step 6: Verify marker files survived ────────────────────────────
 info "Step 6: Verifying marker files survived rebuild..."
 
-RESTORED=$(openshell sandbox exec "$SANDBOX_NAME" -- cat "$MARKER_FILE" 2>/dev/null || true)
+RESTORED=$(openshell sandbox exec --name "$SANDBOX_NAME" -- cat "$MARKER_FILE" 2>/dev/null || true)
 if [ "$RESTORED" = "$MARKER_CONTENT" ]; then
   pass "Marker file survived rebuild"
 else


### PR DESCRIPTION
## Summary

`04-landlock-readonly.sh` has exited 127 on **every nightly since April 8** when it was added in PR #1121. This is one of the three root causes keeping the nightly E2E red for 24+ consecutive days.

## Root Cause

The `sandbox_exec()` helper calls:
```bash
openshell sandbox exec "$SANDBOX_NAME" -- bash -c "..."
```

But `openshell 0.0.26` requires the `--name` flag:
```bash
openshell sandbox exec --name "$SANDBOX_NAME" -- bash -c "..."
```

Without `--name`, the sandbox name (`e2e-cloud-experimental`) is parsed as the **command to execute**, producing `command not found` → exit 127.

## Fix

One-line change in `sandbox_exec()`:
```diff
-  openshell sandbox exec "$SANDBOX_NAME" -- bash -c "$1" 2>&1
+  openshell sandbox exec --name "$SANDBOX_NAME" -- bash -c "$1" 2>&1
```

## Verification

Reproduced and verified the fix on a DGX Spark running the E2E suite:
- Before fix: `04-landlock-readonly: EXIT CODE: 127`
- After fix: `openshell sandbox exec --name e2e-debug -- echo "hello from sandbox"` → `hello from sandbox`

Closes #1851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized how sandbox instances are invoked in end-to-end tests to ensure consistent execution and verification across checks and rebuild scenarios.
  * Internal test-only changes; no user-facing behavior, API, or public interface modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->