### PR TITLE
fix(upgrade): pin base image digest and rebuild stale sandboxes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1272,6 +1272,13 @@ except Exception:
     warn "Skipping onboarding — this shell still cannot resolve 'nemoclaw'."
   fi
 
+  # Post-upgrade: check for stale sandboxes and offer to rebuild them.
+  # See: https://github.com/NVIDIA/NemoClaw/issues/1904
+  if [ "${_has_sandboxes:-0}" -gt 0 ] 2>/dev/null && command_exists nemoclaw; then
+    info "Checking for sandboxes that need upgrading…"
+    nemoclaw upgrade-sandboxes 2>&1 || warn "Sandbox upgrade check failed (non-fatal). Run 'nemoclaw upgrade-sandboxes' manually."
+  fi
+
   print_done
   post_install_message
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -450,6 +450,28 @@ function getBlueprintMinOpenshellVersion(rootDir = ROOT) {
   return getBlueprintVersionField("min_openshell_version", rootDir);
 }
 
+/**
+ * Read the pinned base-image digest from nemoclaw-blueprint/blueprint.yaml.
+ * Returns a validated "sha256:<hex64>" string, or null when the blueprint is
+ * missing, the field is absent, or the value fails validation. See #1904.
+ */
+function getBlueprintBaseImageDigest(rootDir = ROOT) {
+  try {
+    const YAML = require("yaml");
+    const blueprintPath = path.join(rootDir, "nemoclaw-blueprint", "blueprint.yaml");
+    if (!fs.existsSync(blueprintPath)) return null;
+    const raw = fs.readFileSync(blueprintPath, "utf8");
+    const parsed = YAML.parse(raw);
+    const value = parsed && parsed.digest;
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!/^sha256:[0-9a-f]{64}$/.test(trimmed)) return null;
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
 function getBlueprintMaxOpenshellVersion(rootDir = ROOT) {
   return getBlueprintVersionField("max_openshell_version", rootDir);
 }
@@ -1063,6 +1085,15 @@ function patchStagedDockerfile(
     dockerfile = dockerfile.replace(
       /^ARG NEMOCLAW_DISCORD_GUILDS_B64=.*$/m,
       `ARG NEMOCLAW_DISCORD_GUILDS_B64=${encodeDockerJsonArg(discordGuilds)}`,
+    );
+  }
+  // Pin the base image to the digest declared in blueprint.yaml so Docker
+  // cannot silently reuse a stale :latest tag from the local cache. See #1904.
+  const blueprintDigest = getBlueprintBaseImageDigest(ROOT);
+  if (blueprintDigest) {
+    dockerfile = dockerfile.replace(
+      /^ARG BASE_IMAGE=.*$/m,
+      `ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base@${blueprintDigest}`,
     );
   }
   fs.writeFileSync(dockerfilePath, dockerfile);
@@ -2694,6 +2725,14 @@ async function createSandbox(
     messagingAllowedIds,
     discordGuilds,
   );
+  // Pre-pull the digest-pinned base image so `docker build` does not silently
+  // reuse a stale :latest from the local layer cache. See #1904.
+  const blueprintDigest = getBlueprintBaseImageDigest(ROOT);
+  if (blueprintDigest) {
+    const pinnedRef = `ghcr.io/nvidia/nemoclaw/sandbox-base@${blueprintDigest}`;
+    console.log(`  Pulling base image (${blueprintDigest.slice(0, 19)}...)...`);
+    run(["docker", "pull", pinnedRef], { ignoreError: true });
+  }
   // Only pass non-sensitive env vars to the sandbox. Credentials flow through
   // OpenShell providers — the gateway injects them as placeholders and the L7
   // proxy rewrites Authorization headers with real secrets at egress.
@@ -5380,6 +5419,7 @@ module.exports = {
   getNavigationChoice,
   getSandboxInferenceConfig,
   getInstalledOpenshellVersion,
+  getBlueprintBaseImageDigest,
   getBlueprintMinOpenshellVersion,
   getBlueprintMaxOpenshellVersion,
   versionGte,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -86,6 +86,7 @@ const GLOBAL_COMMANDS = new Set([
   "uninstall",
   "credentials",
   "backup-all",
+  "upgrade-sandboxes",
   "help",
   "--help",
   "-h",
@@ -1861,6 +1862,89 @@ function sandboxSnapshot(sandboxName, subArgs) {
 }
 
 /**
+ * Check all registered sandboxes for stale agent versions and offer to rebuild
+ * them. Called after install.sh upgrades NemoClaw so existing sandboxes pick up
+ * the new OpenClaw base image instead of running on a stale Docker cache.
+ * See #1904.
+ */
+async function upgradeSandboxes(args = []) {
+  const autoRebuild = args.includes("--auto") || args.includes("--yes");
+  const checkOnly = args.includes("--check");
+  const { sandboxes } = registry.listSandboxes();
+  if (sandboxes.length === 0) {
+    console.log("  No sandboxes registered. Nothing to upgrade.");
+    return;
+  }
+
+  const liveList = captureOpenshell(["sandbox", "list"], { ignoreError: true });
+  const liveNames = parseLiveSandboxNames(liveList.output || "");
+
+  const stale = [];
+  const upToDate = [];
+  for (const sb of sandboxes) {
+    const result = sandboxVersion.checkAgentVersion(sb.name);
+    if (result.isStale) {
+      stale.push({ sb, result, live: liveNames.has(sb.name) });
+    } else {
+      upToDate.push(sb);
+    }
+  }
+
+  if (stale.length === 0) {
+    console.log(`  ${G}All ${sandboxes.length} sandbox(es) are up to date.${R}`);
+    return;
+  }
+
+  console.log(`  ${YW}${stale.length} sandbox(es) need upgrading:${R}`);
+  for (const { sb, result, live } of stale) {
+    const status = live ? `${G}running${R}` : `${D}stopped${R}`;
+    const cur = result.sandboxVersion || "unknown";
+    const exp = result.expectedVersion || "unknown";
+    console.log(`    ${B}${sb.name}${R}  ${cur} → ${exp}  (${status})`);
+  }
+  if (upToDate.length > 0) {
+    console.log(`  ${D}${upToDate.length} sandbox(es) already current.${R}`);
+  }
+
+  if (checkOnly) return;
+
+  let rebuilt = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const { sb, live } of stale) {
+    if (!live) {
+      console.log(`  ${D}Skipping '${sb.name}' — not running. Start it first, then re-run.${R}`);
+      skipped++;
+      continue;
+    }
+
+    let proceed = autoRebuild;
+    if (!proceed) {
+      const answer = await askPrompt(`  Rebuild '${sb.name}'? [y/N] `);
+      proceed = answer.toLowerCase() === "y" || answer.toLowerCase() === "yes";
+    }
+
+    if (!proceed) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      console.log(`  Rebuilding '${sb.name}'...`);
+      await sandboxRebuild(sb.name, ["--yes"]);
+      rebuilt++;
+    } catch (err) {
+      console.error(`  ${_RD}Failed to rebuild '${sb.name}': ${err.message || err}${R}`);
+      failed++;
+    }
+  }
+
+  console.log("");
+  console.log(`  Upgrade summary: ${rebuilt} rebuilt, ${skipped} skipped, ${failed} failed`);
+}
+
+/**
  * Back up all registered sandboxes. Called by install.sh before upgrading
  * NemoClaw or OpenShell so sandbox state is recoverable if the upgrade
  * destroys sandbox contents.
@@ -1957,8 +2041,9 @@ function help() {
     nemoclaw credentials list        List stored credential keys
     nemoclaw credentials reset <KEY> Remove a stored credential so onboard re-prompts
 
-  ${G}Backup:${R}
+  ${G}Backup & Upgrade:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade
+    nemoclaw upgrade-sandboxes       Detect and rebuild stale sandboxes ${D}(--check, --auto)${R}
 
   Cleanup:
     nemoclaw uninstall [flags]       Run uninstall.sh (local only; no remote fallback)
@@ -2024,6 +2109,9 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       case "backup-all":
         backupAll();
+        break;
+      case "upgrade-sandboxes":
+        await upgradeSandboxes(args);
         break;
       case "--version":
       case "-v": {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -16,6 +16,7 @@ import {
   classifySandboxCreateFailure,
   compactText,
   formatEnvAssignment,
+  getBlueprintBaseImageDigest,
   getDashboardAccessInfo,
   getDashboardForwardStartCommand,
   getNavigationChoice,
@@ -4514,5 +4515,109 @@ const { createSandbox } = require(${onboardPath});
       updateAfterCreate !== -1,
       "registry.updateSandbox(model, provider) must appear AFTER createSandbox() — regression #1881",
     );
+  });
+
+  // ── getBlueprintBaseImageDigest tests (#1904) ───────────────────
+
+  it("getBlueprintBaseImageDigest returns the sha256 digest from blueprint.yaml", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const digest = getBlueprintBaseImageDigest(repoRoot);
+    assert.ok(digest !== null, "digest should not be null for the real blueprint");
+    assert.match(digest, /^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("getBlueprintBaseImageDigest returns null when blueprint directory is missing", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-missing-"));
+    try {
+      assert.equal(getBlueprintBaseImageDigest(tmpDir), null);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("getBlueprintBaseImageDigest returns null when digest field is missing", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-nofield-"));
+    const bpDir = path.join(tmpDir, "nemoclaw-blueprint");
+    fs.mkdirSync(bpDir, { recursive: true });
+    fs.writeFileSync(path.join(bpDir, "blueprint.yaml"), 'version: "0.1.0"\n');
+    try {
+      assert.equal(getBlueprintBaseImageDigest(tmpDir), null);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("getBlueprintBaseImageDigest rejects malformed digest values", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-malformed-"));
+    const bpDir = path.join(tmpDir, "nemoclaw-blueprint");
+    fs.mkdirSync(bpDir, { recursive: true });
+    fs.writeFileSync(path.join(bpDir, "blueprint.yaml"), 'digest: "not-a-real-digest"\n');
+    try {
+      assert.equal(getBlueprintBaseImageDigest(tmpDir), null);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patchStagedDockerfile rewrites ARG BASE_IMAGE with the blueprint digest", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-patch-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+    try {
+      patchStagedDockerfile(dockerfilePath, "gpt-5.4", "http://127.0.0.1:19999", "build-digest-test", "openai-api");
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      assert.match(patched, /^ARG BASE_IMAGE=ghcr\.io\/nvidia\/nemoclaw\/sandbox-base@sha256:/m);
+      assert.doesNotMatch(patched, /:latest/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patchStagedDockerfile preserves when Dockerfile has no ARG BASE_IMAGE line", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-nobase-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+    try {
+      patchStagedDockerfile(dockerfilePath, "gpt-5.4", "http://127.0.0.1:19999", "build-nobase", "openai-api");
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      assert.doesNotMatch(patched, /BASE_IMAGE/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("regression #1904: createSandbox pre-pulls the digest-pinned base image", () => {
+    const source = fs.readFileSync(path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"), "utf-8");
+    const patchPos = source.indexOf("patchStagedDockerfile(");
+    assert.ok(patchPos !== -1, "patchStagedDockerfile call not found in onboard.ts");
+    const prePullPos = source.indexOf('run(["docker", "pull", pinnedRef]', patchPos);
+    assert.ok(prePullPos !== -1, "docker pull with pinnedRef must appear after patchStagedDockerfile — regression #1904");
+    const sandboxCreatePos = source.indexOf('"sandbox",', prePullPos);
+    assert.ok(sandboxCreatePos !== -1, "sandbox create args not found after pre-pull");
+    const createArgPos = source.indexOf('"create",', sandboxCreatePos);
+    assert.ok(createArgPos !== -1, "pre-pull must appear before sandbox create command — regression #1904");
   });
 });


### PR DESCRIPTION
## Summary
- Pins the sandbox base image to the sha256 digest from `blueprint.yaml` during Dockerfile patching so Docker must pull on cache miss instead of reusing a stale `:latest` tag
- Pre-pulls the digest-pinned image before sandbox creation for progress feedback and fail-fast on registry errors
- Adds `nemoclaw upgrade-sandboxes` command to detect and rebuild stale sandboxes after CLI upgrade (`--auto` for non-interactive, `--check` for report-only)
- Integrates `upgrade-sandboxes` into `install.sh` post-onboard flow so the upgrade path automatically catches stale sandboxes

## Test plan
- [x] 7 new unit tests for digest parsing, Dockerfile pinning, and pre-pull ordering (114/114 pass)
- [ ] Manual: upgrade from v0.0.11 → current, verify `nemoclaw upgrade-sandboxes` detects stale sandbox
- [ ] Manual: verify newly created sandboxes use the pinned digest image
- [ ] Manual: verify `--auto` flag rebuilds without prompting

Closes #1904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic sandbox upgrade during installation when sandboxes are detected.
  * New `nemoclaw upgrade-sandboxes` command to upgrade existing sandboxes with version checking and progress reporting (supports `--check`, `--auto`, `--yes` options).
  * Base image digest pinning for reproducible sandbox builds.

* **Tests**
  * Added comprehensive test coverage for blueprint digest handling and sandbox upgrade workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->