### PR TITLE
fix: revert base image digest pinning that broke all e2e tests

### DIFF
--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -96,8 +96,8 @@ retry() {
 # Brev VMs sometimes have unattended-upgrades running at boot.
 wait_for_apt_lock() {
   local max_wait=120 elapsed=0
-  while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 ||
-    fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
+  while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 \
+    || fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
     if ((elapsed >= max_wait)); then
       warn "apt lock not released after ${max_wait}s — proceeding anyway"
       return 0
@@ -155,8 +155,8 @@ else
   NODESOURCE_URL="https://deb.nodesource.com/setup_22.x"
   NODESOURCE_SHA256="575583bbac2fccc0b5edd0dbc03e222d9f9dc8d724da996d22754d6411104fd1"
   ns_tmp="$(mktemp)"
-  curl -fsSL "$NODESOURCE_URL" -o "$ns_tmp" ||
-    {
+  curl -fsSL "$NODESOURCE_URL" -o "$ns_tmp" \
+    || {
       rm -f "$ns_tmp"
       fail "Failed to download NodeSource installer"
     }
@@ -192,9 +192,9 @@ if command -v openshell >/dev/null 2>&1; then
     info "OpenShell CLI $_installed_ver does not match pinned ${_pinned_ver} — reinstalling..."
     ARCH="$(uname -m)"
     case "$ARCH" in
-    x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
-    aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
-    *) fail "Unsupported architecture: $ARCH" ;;
+      x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
+      aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
+      *) fail "Unsupported architecture: $ARCH" ;;
     esac
     tmpdir="$(mktemp -d)"
     retry 3 10 "download openshell" \
@@ -209,9 +209,9 @@ else
   info "Installing OpenShell CLI ${OPENSHELL_VERSION}..."
   ARCH="$(uname -m)"
   case "$ARCH" in
-  x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
-  aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
-  *) fail "Unsupported architecture: $ARCH" ;;
+    x86_64 | amd64) ASSET="openshell-x86_64-unknown-linux-musl.tar.gz" ;;
+    aarch64 | arm64) ASSET="openshell-aarch64-unknown-linux-musl.tar.gz" ;;
+    *) fail "Unsupported architecture: $ARCH" ;;
   esac
   tmpdir="$(mktemp -d)"
   retry 3 10 "download openshell" \
@@ -260,8 +260,8 @@ else
   # Use sg docker to ensure docker group is active without re-login
   for image in "${DOCKER_IMAGES[@]}"; do
     info "  Pulling $image..."
-    sg docker -c "docker pull $image" 2>&1 | tail -1 ||
-      warn "  Failed to pull $image (will be pulled at test time)"
+    sg docker -c "docker pull $image" 2>&1 | tail -1 \
+      || warn "  Failed to pull $image (will be pulled at test time)"
   done
 
   # The openshell/cluster image tag should match the CLI version.
@@ -271,8 +271,8 @@ else
   info "  Pulling $CLUSTER_IMAGE..."
   if ! sg docker -c "docker pull $CLUSTER_IMAGE" 2>&1 | tail -1; then
     warn "  Could not pull $CLUSTER_IMAGE — trying :latest"
-    sg docker -c "docker pull ghcr.io/nvidia/openshell/cluster:latest" 2>&1 | tail -1 ||
-      warn "  Failed to pull openshell/cluster (will be pulled at test time)"
+    sg docker -c "docker pull ghcr.io/nvidia/openshell/cluster:latest" 2>&1 | tail -1 \
+      || warn "  Failed to pull openshell/cluster (will be pulled at test time)"
   fi
 
   info "Docker images pre-pulled"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1272,13 +1272,6 @@ except Exception:
     warn "Skipping onboarding — this shell still cannot resolve 'nemoclaw'."
   fi
 
-  # Post-upgrade: check for stale sandboxes and offer to rebuild them.
-  # See: https://github.com/NVIDIA/NemoClaw/issues/1904
-  if [ "${_has_sandboxes:-0}" -gt 0 ] 2>/dev/null && command_exists nemoclaw; then
-    info "Checking for sandboxes that need upgrading…"
-    nemoclaw upgrade-sandboxes 2>&1 || warn "Sandbox upgrade check failed (non-fatal). Run 'nemoclaw upgrade-sandboxes' manually."
-  fi
-
   print_done
   post_install_message
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -450,28 +450,6 @@ function getBlueprintMinOpenshellVersion(rootDir = ROOT) {
   return getBlueprintVersionField("min_openshell_version", rootDir);
 }
 
-/**
- * Read the pinned base-image digest from nemoclaw-blueprint/blueprint.yaml.
- * Returns a validated "sha256:<hex64>" string, or null when the blueprint is
- * missing, the field is absent, or the value fails validation. See #1904.
- */
-function getBlueprintBaseImageDigest(rootDir = ROOT) {
-  try {
-    const YAML = require("yaml");
-    const blueprintPath = path.join(rootDir, "nemoclaw-blueprint", "blueprint.yaml");
-    if (!fs.existsSync(blueprintPath)) return null;
-    const raw = fs.readFileSync(blueprintPath, "utf8");
-    const parsed = YAML.parse(raw);
-    const value = parsed && parsed.digest;
-    if (typeof value !== "string") return null;
-    const trimmed = value.trim();
-    if (!/^sha256:[0-9a-f]{64}$/.test(trimmed)) return null;
-    return trimmed;
-  } catch {
-    return null;
-  }
-}
-
 function getBlueprintMaxOpenshellVersion(rootDir = ROOT) {
   return getBlueprintVersionField("max_openshell_version", rootDir);
 }
@@ -1085,15 +1063,6 @@ function patchStagedDockerfile(
     dockerfile = dockerfile.replace(
       /^ARG NEMOCLAW_DISCORD_GUILDS_B64=.*$/m,
       `ARG NEMOCLAW_DISCORD_GUILDS_B64=${encodeDockerJsonArg(discordGuilds)}`,
-    );
-  }
-  // Pin the base image to the digest declared in blueprint.yaml so Docker
-  // cannot silently reuse a stale :latest tag from the local cache. See #1904.
-  const blueprintDigest = getBlueprintBaseImageDigest(ROOT);
-  if (blueprintDigest) {
-    dockerfile = dockerfile.replace(
-      /^ARG BASE_IMAGE=.*$/m,
-      `ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base@${blueprintDigest}`,
     );
   }
   fs.writeFileSync(dockerfilePath, dockerfile);
@@ -2744,14 +2713,6 @@ async function createSandbox(
     messagingAllowedIds,
     discordGuilds,
   );
-  // Pre-pull the digest-pinned base image so `docker build` does not silently
-  // reuse a stale :latest from the local layer cache. See #1904.
-  const blueprintDigest = getBlueprintBaseImageDigest(ROOT);
-  if (blueprintDigest) {
-    const pinnedRef = `ghcr.io/nvidia/nemoclaw/sandbox-base@${blueprintDigest}`;
-    console.log(`  Pulling base image (${blueprintDigest.slice(0, 19)}...)...`);
-    run(["docker", "pull", pinnedRef], { ignoreError: true });
-  }
   // Only pass non-sensitive env vars to the sandbox. Credentials flow through
   // OpenShell providers — the gateway injects them as placeholders and the L7
   // proxy rewrites Authorization headers with real secrets at egress.
@@ -5440,7 +5401,6 @@ module.exports = {
   getNavigationChoice,
   getSandboxInferenceConfig,
   getInstalledOpenshellVersion,
-  getBlueprintBaseImageDigest,
   getBlueprintMinOpenshellVersion,
   getBlueprintMaxOpenshellVersion,
   versionGte,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -503,7 +503,13 @@ function hydrateCredentialEnv(envName) {
   return value || null;
 }
 
-const { getCurlTimingArgs, summarizeCurlFailure, summarizeProbeFailure, runCurlProbe, runStreamingEventProbe } = httpProbe;
+const {
+  getCurlTimingArgs,
+  summarizeCurlFailure,
+  summarizeProbeFailure,
+  runCurlProbe,
+  runStreamingEventProbe,
+} = httpProbe;
 
 function getNavigationChoice(value = "") {
   const normalized = String(value || "")
@@ -799,8 +805,6 @@ function isAffirmativeAnswer(value) {
       .toLowerCase(),
   );
 }
-
-
 
 function validateBraveSearchApiKey(apiKey) {
   return runCurlProbe([
@@ -2318,11 +2322,14 @@ async function recoverGatewayRuntime() {
     return true;
   }
 
-  const startResult = runOpenshell(["gateway", "start", "--name", GATEWAY_NAME, "--port", String(GATEWAY_PORT)], {
-    ignoreError: true,
-    env: getGatewayStartEnv(),
-    suppressOutput: true,
-  });
+  const startResult = runOpenshell(
+    ["gateway", "start", "--name", GATEWAY_NAME, "--port", String(GATEWAY_PORT)],
+    {
+      ignoreError: true,
+      env: getGatewayStartEnv(),
+      suppressOutput: true,
+    },
+  );
   if (startResult.status !== 0) {
     const diagnostic = compactText(
       redact(`${startResult.stderr || ""} ${startResult.stdout || ""}`),
@@ -2373,9 +2380,18 @@ async function promptValidatedSandboxName() {
       // A sandbox named 'status' makes 'nemoclaw status connect' route to
       // the global status command instead of the sandbox.
       const RESERVED_NAMES = new Set([
-        "onboard", "list", "deploy", "setup", "setup-spark",
-        "start", "stop", "status", "debug", "uninstall",
-        "credentials", "help",
+        "onboard",
+        "list",
+        "deploy",
+        "setup",
+        "setup-spark",
+        "start",
+        "stop",
+        "status",
+        "debug",
+        "uninstall",
+        "credentials",
+        "help",
       ]);
       if (RESERVED_NAMES.has(sandboxName)) {
         console.error(`  Reserved name: '${sandboxName}' is a NemoClaw CLI command.`);
@@ -2577,8 +2593,12 @@ async function createSandbox(
       });
     } catch (err) {
       if (err.code === "EACCES") {
-        console.error(`  Permission denied while copying build context from: ${path.dirname(fromResolved)}`);
-        console.error("  The --from flag uses the Dockerfile's parent directory as the Docker build context.");
+        console.error(
+          `  Permission denied while copying build context from: ${path.dirname(fromResolved)}`,
+        );
+        console.error(
+          "  The --from flag uses the Dockerfile's parent directory as the Docker build context.",
+        );
         console.error("  Move your Dockerfile to a dedicated directory and retry.");
         process.exit(1);
       }
@@ -2600,7 +2620,12 @@ async function createSandbox(
 
   // Create sandbox (use -- echo to avoid dropping into interactive shell)
   // Pass the base policy so sandbox starts in proxy mode (required for policy updates later)
-  const globalPermissivePath = path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml");
+  const globalPermissivePath = path.join(
+    ROOT,
+    "nemoclaw-blueprint",
+    "policies",
+    "openclaw-sandbox-permissive.yaml",
+  );
   let basePolicyPath;
   if (dangerouslySkipPermissions) {
     // Permissive mode: use agent-specific permissive policy if available,
@@ -2608,7 +2633,12 @@ async function createSandbox(
     const agentPermissive = agent && agentOnboard.getAgentPermissivePolicyPath(agent);
     basePolicyPath = agentPermissive || globalPermissivePath;
   } else {
-    const defaultPolicyPath = path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml");
+    const defaultPolicyPath = path.join(
+      ROOT,
+      "nemoclaw-blueprint",
+      "policies",
+      "openclaw-sandbox.yaml",
+    );
     basePolicyPath = (agent && agentOnboard.getAgentPolicyPath(agent)) || defaultPolicyPath;
   }
   const createArgs = [
@@ -2638,7 +2668,9 @@ async function createSandbox(
     );
     process.exit(1);
   }
-  const tokensByEnvKey = Object.fromEntries(messagingTokenDefs.map(({ envKey, token }) => [envKey, token]));
+  const tokensByEnvKey = Object.fromEntries(
+    messagingTokenDefs.map(({ envKey, token }) => [envKey, token]),
+  );
   const activeMessagingChannels = [
     ...new Set(
       messagingTokenDefs
@@ -2647,7 +2679,8 @@ async function createSandbox(
           if (envKey === "DISCORD_BOT_TOKEN") return "discord";
           if (envKey === "SLACK_BOT_TOKEN") return "slack";
           // SLACK_APP_TOKEN alone does not enable slack; bot token is required.
-          if (envKey === "SLACK_APP_TOKEN") return tokensByEnvKey["SLACK_BOT_TOKEN"] ? "slack" : null;
+          if (envKey === "SLACK_APP_TOKEN")
+            return tokensByEnvKey["SLACK_BOT_TOKEN"] ? "slack" : null;
           if (envKey === "TELEGRAM_BOT_TOKEN") return "telegram";
           return null;
         })
@@ -2725,7 +2758,8 @@ async function createSandbox(
   // env vars by default, which is safer but needs careful rollout.
   const envArgs = [formatEnvAssignment("CHAT_UI_URL", chatUiUrl)];
   if (webSearchConfig?.fetchEnabled) {
-    const braveKey = getCredential(webSearch.BRAVE_API_KEY_ENV) || process.env[webSearch.BRAVE_API_KEY_ENV];
+    const braveKey =
+      getCredential(webSearch.BRAVE_API_KEY_ENV) || process.env[webSearch.BRAVE_API_KEY_ENV];
     if (braveKey) {
       envArgs.push(formatEnvAssignment(webSearch.BRAVE_API_KEY_ENV, braveKey));
     }
@@ -2855,7 +2889,7 @@ async function createSandbox(
     name: sandboxName,
     gpuEnabled: !!gpu,
     agent: agent ? agent.name : null,
-    agentVersion: fromDockerfile ? null : (effectiveAgent.expectedVersion || null),
+    agentVersion: fromDockerfile ? null : effectiveAgent.expectedVersion || null,
     dangerouslySkipPermissions: dangerouslySkipPermissions || undefined,
   });
 
@@ -2883,14 +2917,20 @@ async function createSandbox(
 
   try {
     if (process.platform === "darwin") {
-      const vmKernel = runCapture("docker info --format '{{.KernelVersion}}'", { ignoreError: true }).trim();
+      const vmKernel = runCapture("docker info --format '{{.KernelVersion}}'", {
+        ignoreError: true,
+      }).trim();
       if (vmKernel) {
         const parts = vmKernel.split(".");
         const major = parseInt(parts[0], 10);
         const minor = parseInt(parts[1], 10);
         if (!isNaN(major) && !isNaN(minor) && (major < 5 || (major === 5 && minor < 13))) {
-          console.warn(`  ⚠ Landlock: Docker VM kernel ${vmKernel} does not support Landlock (requires ≥5.13).`);
-          console.warn("    Sandbox filesystem restrictions will silently degrade (best_effort mode).");
+          console.warn(
+            `  ⚠ Landlock: Docker VM kernel ${vmKernel} does not support Landlock (requires ≥5.13).`,
+          );
+          console.warn(
+            "    Sandbox filesystem restrictions will silently degrade (best_effort mode).",
+          );
         }
       }
     } else if (process.platform === "linux") {
@@ -2901,7 +2941,9 @@ async function createSandbox(
         const minor = parseInt(parts[1], 10);
         if (!isNaN(major) && !isNaN(minor) && (major < 5 || (major === 5 && minor < 13))) {
           console.warn(`  ⚠ Landlock: Kernel ${uname} does not support Landlock (requires ≥5.13).`);
-          console.warn("    Sandbox filesystem restrictions will silently degrade (best_effort mode).");
+          console.warn(
+            "    Sandbox filesystem restrictions will silently degrade (best_effort mode).",
+          );
         }
       }
     }
@@ -2925,9 +2967,12 @@ async function setupNim(gpu) {
 
   // Detect local inference options
   const hasOllama = !!runCapture("command -v ollama", { ignoreError: true });
-  const ollamaRunning = !!runCapture(`curl -sf http://localhost:${OLLAMA_PORT}/api/tags 2>/dev/null`, {
-    ignoreError: true,
-  });
+  const ollamaRunning = !!runCapture(
+    `curl -sf http://localhost:${OLLAMA_PORT}/api/tags 2>/dev/null`,
+    {
+      ignoreError: true,
+    },
+  );
   const vllmRunning = !!runCapture(`curl -sf http://localhost:${VLLM_PORT}/v1/models 2>/dev/null`, {
     ignoreError: true,
   });
@@ -3428,7 +3473,9 @@ async function setupNim(gpu) {
         console.log("  Installing Ollama via Homebrew...");
         run("brew install ollama", { ignoreError: true });
         console.log("  Starting Ollama...");
-        run(`OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
+        run(`OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} ollama serve > /dev/null 2>&1 &`, {
+          ignoreError: true,
+        });
         sleep(2);
         printOllamaExposureWarning();
         console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT}`);
@@ -3487,9 +3534,12 @@ async function setupNim(gpu) {
         credentialEnv = "OPENAI_API_KEY";
         endpointUrl = getLocalProviderBaseUrl(provider);
         // Query vLLM for the actual model ID
-        const vllmModelsRaw = runCapture(`curl -sf http://localhost:${VLLM_PORT}/v1/models 2>/dev/null`, {
-          ignoreError: true,
-        });
+        const vllmModelsRaw = runCapture(
+          `curl -sf http://localhost:${VLLM_PORT}/v1/models 2>/dev/null`,
+          {
+            ignoreError: true,
+          },
+        );
         try {
           const vllmModels = JSON.parse(vllmModelsRaw);
           if (vllmModels.data && vllmModels.data.length > 0) {
@@ -3739,8 +3789,7 @@ const MESSAGING_CHANNELS = [
     help: "Slack API → Your Apps → OAuth & Permissions → Bot User OAuth Token (xoxb-...).",
     label: "Slack Bot Token",
     appTokenEnvKey: "SLACK_APP_TOKEN",
-    appTokenHelp:
-      "Slack API → Your Apps → Basic Information → App-Level Tokens (xapp-...).",
+    appTokenHelp: "Slack API → Your Apps → Basic Information → App-Level Tokens (xapp-...).",
     appTokenLabel: "Slack App Token (Socket Mode)",
   },
 ];
@@ -3899,9 +3948,7 @@ async function setupMessagingChannels() {
         console.log(`  ✓ ${ch.name} — reply mode already set: ${mode}`);
       } else {
         console.log(`  ${ch.requireMentionHelp}`);
-        const answer = (await prompt("  Reply only when @mentioned? [Y/n]: "))
-          .trim()
-          .toLowerCase();
+        const answer = (await prompt("  Reply only when @mentioned? [Y/n]: ")).trim().toLowerCase();
         process.env[ch.requireMentionEnvKey] = answer === "n" || answer === "no" ? "0" : "1";
         const mode =
           process.env[ch.requireMentionEnvKey] === "0" ? "all messages" : "@mentions only";
@@ -4137,7 +4184,8 @@ async function selectPolicyTier() {
     const answer = await prompt(
       `  Select tier [1-${allTiers.length}] (default: ${allTiers.indexOf(defaultTier) + 1} ${defaultTier.name}): `,
     );
-    const idx = answer.trim() === "" ? allTiers.indexOf(defaultTier) : parseInt(answer.trim(), 10) - 1;
+    const idx =
+      answer.trim() === "" ? allTiers.indexOf(defaultTier) : parseInt(answer.trim(), 10) - 1;
     const chosen = allTiers[idx] || defaultTier;
     console.log(`  Tier: ${chosen.label}`);
     return chosen.name;
@@ -4258,7 +4306,10 @@ async function selectTierPresetsAndAccess(tierName, allPresets, extraSelected = 
   ];
 
   // Initial inclusion: tier presets + any already-applied extras.
-  const included = new Set([...tierNames, ...extraSelected.filter((n) => ordered.find((p) => p.name === n))]);
+  const included = new Set([
+    ...tierNames,
+    ...extraSelected.filter((n) => ordered.find((p) => p.name === n)),
+  ]);
 
   // Access levels: tier defaults for tier presets, read-write default for others.
   const accessModes = {};
@@ -4280,7 +4331,9 @@ async function selectTierPresetsAndAccess(tierName, allPresets, extraSelected = 
 
   // ── Non-interactive: return tier defaults silently ─────────────────
   if (isNonInteractive()) {
-    return ordered.filter((p) => included.has(p.name)).map((p) => ({ name: p.name, access: accessModes[p.name] }));
+    return ordered
+      .filter((p) => included.has(p.name))
+      .map((p) => ({ name: p.name, access: accessModes[p.name] }));
   }
 
   // ── Fallback: non-TTY ─────────────────────────────────────────────
@@ -4312,7 +4365,9 @@ async function selectTierPresetsAndAccess(tierName, allPresets, extraSelected = 
         }
       }
     }
-    return ordered.filter((p) => included.has(p.name)).map((p) => ({ name: p.name, access: accessModes[p.name] }));
+    return ordered
+      .filter((p) => included.has(p.name))
+      .map((p) => ({ name: p.name, access: accessModes[p.name] }));
   }
 
   // ── Raw-mode TUI ─────────────────────────────────────────────────
@@ -4372,7 +4427,11 @@ async function selectTierPresetsAndAccess(tierName, allPresets, extraSelected = 
       if (key === "\r" || key === "\n") {
         cleanup();
         process.stdout.write("\n");
-        resolve(ordered.filter((p) => included.has(p.name)).map((p) => ({ name: p.name, access: accessModes[p.name] })));
+        resolve(
+          ordered
+            .filter((p) => included.has(p.name))
+            .map((p) => ({ name: p.name, access: accessModes[p.name] })),
+        );
       } else if (key === "\x03") {
         cleanup();
         process.exit(1);
@@ -4751,7 +4810,9 @@ function getDashboardForwardPort(
   chatUiUrl = process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`,
 ) {
   const forwardTarget = resolveDashboardForwardTarget(chatUiUrl);
-  return forwardTarget.includes(":") ? (forwardTarget.split(":").pop() ?? String(CONTROL_UI_PORT)) : forwardTarget;
+  return forwardTarget.includes(":")
+    ? (forwardTarget.split(":").pop() ?? String(CONTROL_UI_PORT))
+    : forwardTarget;
 }
 
 function getDashboardForwardTarget(
@@ -4763,7 +4824,8 @@ function getDashboardForwardTarget(
 }
 
 function getDashboardForwardStartCommand(sandboxName, options = {}) {
-  const chatUiUrl = options.chatUiUrl || process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`;
+  const chatUiUrl =
+    options.chatUiUrl || process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`;
   const forwardTarget = getDashboardForwardTarget(chatUiUrl, options);
   return `${openshellShellCommand(
     ["forward", "start", "--background", forwardTarget, sandboxName],
@@ -4796,7 +4858,8 @@ function getDashboardAccessInfo(sandboxName, options = {}) {
   const token = Object.prototype.hasOwnProperty.call(options, "token")
     ? options.token
     : fetchGatewayAuthTokenFromSandbox(sandboxName);
-  const chatUiUrl = options.chatUiUrl || process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`;
+  const chatUiUrl =
+    options.chatUiUrl || process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`;
   const dashboardPort = Number(getDashboardForwardPort(chatUiUrl));
   const dashboardAccess = buildControlUiUrls(token, dashboardPort).map((url, index) => ({
     label: index === 0 ? "Dashboard" : `Alt ${index}`,
@@ -4951,7 +5014,9 @@ async function onboard(opts = {}) {
     opts.dangerouslySkipPermissions || process.env.NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS === "1";
   if (dangerouslySkipPermissions) {
     console.error("");
-    console.error("  \u26a0  --dangerously-skip-permissions: sandbox security restrictions disabled.");
+    console.error(
+      "  \u26a0  --dangerously-skip-permissions: sandbox security restrictions disabled.",
+    );
     console.error("     Network:    all known endpoints open (no method/path filtering)");
     console.error("     Filesystem: sandbox home directory is writable");
     console.error("     Use for development/testing only.");

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -86,7 +86,6 @@ const GLOBAL_COMMANDS = new Set([
   "uninstall",
   "credentials",
   "backup-all",
-  "upgrade-sandboxes",
   "help",
   "--help",
   "-h",
@@ -1872,89 +1871,6 @@ function sandboxSnapshot(sandboxName, subArgs) {
 }
 
 /**
- * Check all registered sandboxes for stale agent versions and offer to rebuild
- * them. Called after install.sh upgrades NemoClaw so existing sandboxes pick up
- * the new OpenClaw base image instead of running on a stale Docker cache.
- * See #1904.
- */
-async function upgradeSandboxes(args = []) {
-  const autoRebuild = args.includes("--auto") || args.includes("--yes");
-  const checkOnly = args.includes("--check");
-  const { sandboxes } = registry.listSandboxes();
-  if (sandboxes.length === 0) {
-    console.log("  No sandboxes registered. Nothing to upgrade.");
-    return;
-  }
-
-  const liveList = captureOpenshell(["sandbox", "list"], { ignoreError: true });
-  const liveNames = parseLiveSandboxNames(liveList.output || "");
-
-  const stale = [];
-  const upToDate = [];
-  for (const sb of sandboxes) {
-    const result = sandboxVersion.checkAgentVersion(sb.name);
-    if (result.isStale) {
-      stale.push({ sb, result, live: liveNames.has(sb.name) });
-    } else {
-      upToDate.push(sb);
-    }
-  }
-
-  if (stale.length === 0) {
-    console.log(`  ${G}All ${sandboxes.length} sandbox(es) are up to date.${R}`);
-    return;
-  }
-
-  console.log(`  ${YW}${stale.length} sandbox(es) need upgrading:${R}`);
-  for (const { sb, result, live } of stale) {
-    const status = live ? `${G}running${R}` : `${D}stopped${R}`;
-    const cur = result.sandboxVersion || "unknown";
-    const exp = result.expectedVersion || "unknown";
-    console.log(`    ${B}${sb.name}${R}  ${cur} → ${exp}  (${status})`);
-  }
-  if (upToDate.length > 0) {
-    console.log(`  ${D}${upToDate.length} sandbox(es) already current.${R}`);
-  }
-
-  if (checkOnly) return;
-
-  let rebuilt = 0;
-  let skipped = 0;
-  let failed = 0;
-
-  for (const { sb, live } of stale) {
-    if (!live) {
-      console.log(`  ${D}Skipping '${sb.name}' — not running. Start it first, then re-run.${R}`);
-      skipped++;
-      continue;
-    }
-
-    let proceed = autoRebuild;
-    if (!proceed) {
-      const answer = await askPrompt(`  Rebuild '${sb.name}'? [y/N] `);
-      proceed = answer.toLowerCase() === "y" || answer.toLowerCase() === "yes";
-    }
-
-    if (!proceed) {
-      skipped++;
-      continue;
-    }
-
-    try {
-      console.log(`  Rebuilding '${sb.name}'...`);
-      await sandboxRebuild(sb.name, ["--yes"]);
-      rebuilt++;
-    } catch (err) {
-      console.error(`  ${_RD}Failed to rebuild '${sb.name}': ${err.message || err}${R}`);
-      failed++;
-    }
-  }
-
-  console.log("");
-  console.log(`  Upgrade summary: ${rebuilt} rebuilt, ${skipped} skipped, ${failed} failed`);
-}
-
-/**
  * Back up all registered sandboxes. Called by install.sh before upgrading
  * NemoClaw or OpenShell so sandbox state is recoverable if the upgrade
  * destroys sandbox contents.
@@ -2051,9 +1967,8 @@ function help() {
     nemoclaw credentials list        List stored credential keys
     nemoclaw credentials reset <KEY> Remove a stored credential so onboard re-prompts
 
-  ${G}Backup & Upgrade:${R}
+  ${G}Backup:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade
-    nemoclaw upgrade-sandboxes       Detect and rebuild stale sandboxes ${D}(--check, --auto)${R}
 
   Cleanup:
     nemoclaw uninstall [flags]       Run uninstall.sh (local only; no remote fallback)
@@ -2119,9 +2034,6 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       case "backup-all":
         backupAll();
-        break;
-      case "upgrade-sandboxes":
-        await upgradeSandboxes(args);
         break;
       case "--version":
       case "-v": {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -48,10 +48,7 @@ const onboardSession = require("./lib/onboard-session");
 const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
 const { NOTICE_ACCEPT_ENV, NOTICE_ACCEPT_FLAG } = require("./lib/usage-notice");
 const { runDebugCommand } = require("./lib/debug-command");
-const {
-  runDeprecatedOnboardAliasCommand,
-  runOnboardCommand,
-} = require("./lib/onboard-command");
+const { runDeprecatedOnboardAliasCommand, runOnboardCommand } = require("./lib/onboard-command");
 const {
   captureOpenshellCommand,
   getInstalledOpenshellVersion,
@@ -62,10 +59,7 @@ const {
 const { listSandboxesCommand, showStatusCommand } = require("./lib/inventory-commands");
 const { executeDeploy } = require("./lib/deploy");
 const { runStartCommand, runStopCommand } = require("./lib/services-command");
-const {
-  buildVersionedUninstallUrl,
-  runUninstallCommand,
-} = require("./lib/uninstall-command");
+const { buildVersionedUninstallUrl, runUninstallCommand } = require("./lib/uninstall-command");
 const agentRuntime = require("../bin/lib/agent-runtime");
 const sandboxVersion = require("./lib/sandbox-version");
 const sandboxState = require("./lib/sandbox-state");
@@ -309,7 +303,9 @@ function checkAndRecoverSandboxProcesses(sandboxName, { quiet = false } = {}) {
   const _recoveryAgent = agentRuntime.getSessionAgent(sandboxName);
   if (!quiet) {
     console.log("");
-    console.log(`  ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway is not running inside the sandbox (sandbox likely restarted).`);
+    console.log(
+      `  ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway is not running inside the sandbox (sandbox likely restarted).`,
+    );
     console.log("  Recovering...");
   }
 
@@ -327,11 +323,15 @@ function checkAndRecoverSandboxProcesses(sandboxName, { quiet = false } = {}) {
     }
     ensureSandboxPortForward(sandboxName);
     if (!quiet) {
-      console.log(`  ${G}✓${R} ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway restarted inside sandbox.`);
+      console.log(
+        `  ${G}✓${R} ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway restarted inside sandbox.`,
+      );
       console.log(`  ${G}✓${R} Dashboard port forward re-established.`);
     }
   } else if (!quiet) {
-    console.error(`  Could not restart ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway automatically.`);
+    console.error(
+      `  Could not restart ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway automatically.`,
+    );
     console.error("  Connect to the sandbox and run manually:");
     console.error(`    ${agentRuntime.getGatewayCommand(_recoveryAgent)}`);
   }
@@ -575,9 +575,10 @@ function getSandboxGatewayState(sandboxName) {
         // Extract YAML content from policy get --full (skip metadata header before "---").
         // Use a regex to handle varying line endings (\n, \r\n) and optional trailing whitespace.
         const delimIdx = livePolicy.output.search(/^---\s*$/m);
-        const yamlPart = delimIdx !== -1
-          ? livePolicy.output.slice(delimIdx).replace(/^---\s*[\r\n]+/, "")
-          : livePolicy.output;
+        const yamlPart =
+          delimIdx !== -1
+            ? livePolicy.output.slice(delimIdx).replace(/^---\s*[\r\n]+/, "")
+            : livePolicy.output;
         // Guard: only replace if the extracted content looks like policy YAML
         // (starts with a YAML key like "version:" or "network_policies:").
         // Avoids replacing with warnings or status text from unexpected output.
@@ -585,7 +586,10 @@ function getSandboxGatewayState(sandboxName) {
         const looksLikeError = /^(error|failed|invalid|warning|status)\b/i.test(trimmedYaml);
         if (trimmedYaml && !looksLikeError && /^[a-z_][a-z0-9_]*\s*:/m.test(trimmedYaml)) {
           // Add 2-space indent to match the original sandbox get output format.
-          const indented = trimmedYaml.split("\n").map((l) => (l ? "  " + l : l)).join("\n");
+          const indented = trimmedYaml
+            .split("\n")
+            .map((l) => (l ? "  " + l : l))
+            .join("\n");
           output = before + "\n\n" + indented + "\n";
         }
       }
@@ -818,7 +822,9 @@ function exitWithSpawnResult(result) {
 
 function printDangerouslySkipPermissionsWarning() {
   console.error("");
-  console.error("  \u26a0  --dangerously-skip-permissions: sandbox security restrictions disabled.");
+  console.error(
+    "  \u26a0  --dangerously-skip-permissions: sandbox security restrictions disabled.",
+  );
   console.error("     Network:    all known endpoints open (no method/path filtering)");
   console.error("     Filesystem: sandbox home directory is writable");
   console.error("     Use for development/testing only.");
@@ -903,14 +909,22 @@ function debug(args) {
     const { defaultSandbox, sandboxes } = registry.listSandboxes();
     if (!defaultSandbox) return undefined;
     if (!sandboxes.find((s) => s.name === defaultSandbox)) {
-      console.error(`${_RD}Warning:${R} default sandbox '${defaultSandbox}' is no longer in the registry.`);
-      console.error(`  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}nemoclaw onboard${R} again.\n`);
+      console.error(
+        `${_RD}Warning:${R} default sandbox '${defaultSandbox}' is no longer in the registry.`,
+      );
+      console.error(
+        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}nemoclaw onboard${R} again.\n`,
+      );
       return undefined;
     }
     const liveList = captureOpenshell(["sandbox", "list"], { ignoreError: true });
     if (liveList.status === 0 && !parseLiveSandboxNames(liveList.output).has(defaultSandbox)) {
-      console.error(`${_RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`);
-      console.error(`  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}nemoclaw onboard${R} again.\n`);
+      console.error(
+        `${_RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`,
+      );
+      console.error(
+        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}nemoclaw onboard${R} again.\n`,
+      );
       return undefined;
     }
     return defaultSandbox;
@@ -1050,7 +1064,9 @@ async function sandboxConnect(sandboxName, { dangerouslySkipPermissions = false 
         console.error(line);
       }
     }
-  } catch { /* non-fatal — don't block connect on version check failure */ }
+  } catch {
+    /* non-fatal — don't block connect on version check failure */
+  }
 
   if (dangerouslySkipPermissions) {
     printDangerouslySkipPermissionsWarning();
@@ -1063,10 +1079,15 @@ async function sandboxConnect(sandboxName, { dangerouslySkipPermissions = false 
   // `nemoclaw <name> connect` lands on a bare bash prompt and users
   // ask "now what?" — see #465. Suppress the hint when stdout isn't a
   // TTY so scripted callers don't get noise in their pipelines.
-  if (process.stdout.isTTY && !["1", "true"].includes(String(process.env.NEMOCLAW_NO_CONNECT_HINT || ""))) {
+  if (
+    process.stdout.isTTY &&
+    !["1", "true"].includes(String(process.env.NEMOCLAW_NO_CONNECT_HINT || ""))
+  ) {
     console.log("");
     console.log(`  ${G}✓${R} Connecting to sandbox '${sandboxName}'`);
-    console.log(`  ${D}Inside the sandbox, run \`openclaw tui\` to start chatting with the agent.${R}`);
+    console.log(
+      `  ${D}Inside the sandbox, run \`openclaw tui\` to start chatting with the agent.${R}`,
+    );
     console.log(`  ${D}Type \`exit\` (or Ctrl-D) to return to the host shell.${R}`);
     console.log("");
   }
@@ -1119,7 +1140,9 @@ async function sandboxStatus(sandboxName) {
         console.log(`    ${YW}Update:   v${versionCheck.expectedVersion} available${R}`);
         console.log(`              Run \`nemoclaw ${sandboxName} rebuild\` to upgrade`);
       }
-    } catch { /* non-fatal */ }
+    } catch {
+      /* non-fatal */
+    }
   }
 
   const lookup = await getReconciledSandboxGatewayState(sandboxName);
@@ -1321,8 +1344,12 @@ async function sandboxSkillInstall(sandboxName, args = []) {
     console.log("  Usage: nemoclaw <sandbox> skill install <path>");
     console.log("");
     console.log("  Deploy a skill directory to a running sandbox.");
-    console.log("  <path> must be a skill directory containing a SKILL.md (with 'name:' frontmatter),");
-    console.log("  or a direct path to a SKILL.md file. All non-dot files in the directory are uploaded.");
+    console.log(
+      "  <path> must be a skill directory containing a SKILL.md (with 'name:' frontmatter),",
+    );
+    console.log(
+      "  or a direct path to a SKILL.md file. All non-dot files in the directory are uploaded.",
+    );
     console.log("");
     return;
   }
@@ -1387,7 +1414,9 @@ async function sandboxSkillInstall(sandboxName, args = []) {
     process.exit(1);
   }
   if (collected.skippedDotfiles.length > 0) {
-    console.log(`  ${D}Skipping ${collected.skippedDotfiles.length} hidden path(s): ${collected.skippedDotfiles.join(", ")}${R}`);
+    console.log(
+      `  ${D}Skipping ${collected.skippedDotfiles.length} hidden path(s): ${collected.skippedDotfiles.join(", ")}${R}`,
+    );
   }
   const fileLabel = collected.files.length === 1 ? "1 file" : `${collected.files.length} files`;
   console.log(`  ${G}✓${R} Validated SKILL.md (name: ${frontmatter.name}, ${fileLabel})`);
@@ -1408,7 +1437,10 @@ async function sandboxSkillInstall(sandboxName, args = []) {
     process.exit(1);
   }
 
-  const tmpSshConfig = path.join(os.tmpdir(), `nemoclaw-ssh-skill-${process.pid}-${Date.now()}.conf`);
+  const tmpSshConfig = path.join(
+    os.tmpdir(),
+    `nemoclaw-ssh-skill-${process.pid}-${Date.now()}.conf`,
+  );
   fs.writeFileSync(tmpSshConfig, sshConfigResult.output, { mode: 0o600 });
 
   try {
@@ -1570,7 +1602,10 @@ function _rebuildLog(msg) {
 }
 
 async function sandboxRebuild(sandboxName, args = []) {
-  const verbose = args.includes("--verbose") || args.includes("-v") || process.env.NEMOCLAW_REBUILD_VERBOSE === "1";
+  const verbose =
+    args.includes("--verbose") ||
+    args.includes("-v") ||
+    process.env.NEMOCLAW_REBUILD_VERBOSE === "1";
   const log = verbose ? _rebuildLog : () => {};
   const skipConfirm = args.includes("--yes") || args.includes("--force");
   const sb = registry.getSandbox(sandboxName);
@@ -1617,7 +1652,9 @@ async function sandboxRebuild(sandboxName, args = []) {
   // Step 1: Ensure sandbox is live for backup
   log("Checking sandbox liveness: openshell sandbox list");
   const isLive = captureOpenshell(["sandbox", "list"], { ignoreError: true });
-  log(`openshell sandbox list exit=${isLive.status}, output=${(isLive.output || "").substring(0, 200)}`);
+  log(
+    `openshell sandbox list exit=${isLive.status}, output=${(isLive.output || "").substring(0, 200)}`,
+  );
   const liveNames = parseLiveSandboxNames(isLive.output || "");
   log(`Live sandboxes: ${Array.from(liveNames).join(", ") || "(none)"}`);
   if (!liveNames.has(sandboxName)) {
@@ -1630,7 +1667,9 @@ async function sandboxRebuild(sandboxName, args = []) {
   console.log("  Backing up sandbox state...");
   log(`Agent type: ${sb.agent || "openclaw"}, stateDirs from manifest`);
   const backup = sandboxState.backupSandboxState(sandboxName);
-  log(`Backup result: success=${backup.success}, backed=${backup.backedUpDirs.join(",")}, failed=${backup.failedDirs.join(",")}`);
+  log(
+    `Backup result: success=${backup.success}, backed=${backup.backedUpDirs.join(",")}, failed=${backup.failedDirs.join(",")}`,
+  );
   if (!backup.success) {
     console.error("  Failed to back up sandbox state.");
     if (backup.backedUpDirs.length > 0) {
@@ -1650,7 +1689,9 @@ async function sandboxRebuild(sandboxName, args = []) {
   // nulls session.sandboxName — both break the immediate onboard --resume.
   console.log("  Deleting old sandbox...");
   const sbMeta = registry.getSandbox(sandboxName);
-  log(`Registry entry: agent=${sbMeta?.agent}, agentVersion=${sbMeta?.agentVersion}, nimContainer=${sbMeta?.nimContainer}`);
+  log(
+    `Registry entry: agent=${sbMeta?.agent}, agentVersion=${sbMeta?.agentVersion}, nimContainer=${sbMeta?.nimContainer}`,
+  );
   if (sbMeta && sbMeta.nimContainer) nim.stopNimContainerByName(sbMeta.nimContainer);
   else nim.stopNimContainer(sandboxName);
 
@@ -1667,7 +1708,9 @@ async function sandboxRebuild(sandboxName, args = []) {
     process.exit(deleteResult.status || 1);
   }
   registry.removeSandbox(sandboxName);
-  log(`Registry after remove: ${JSON.stringify(registry.listSandboxes().sandboxes.map(s => s.name))}`);
+  log(
+    `Registry after remove: ${JSON.stringify(registry.listSandboxes().sandboxes.map((s) => s.name))}`,
+  );
   console.log(`  ${G}\u2713${R} Old sandbox deleted`);
 
   // Step 4: Recreate via onboard --resume
@@ -1677,7 +1720,9 @@ async function sandboxRebuild(sandboxName, args = []) {
   // Force the sandbox name so onboard recreates with the same name.
   // Mark session resumable and point at this sandbox; set env var as fallback.
   const sessionBefore = onboardSession.loadSession();
-  log(`Session before update: sandboxName=${sessionBefore?.sandboxName}, status=${sessionBefore?.status}, resumable=${sessionBefore?.resumable}, provider=${sessionBefore?.provider}, model=${sessionBefore?.model}`);
+  log(
+    `Session before update: sandboxName=${sessionBefore?.sandboxName}, status=${sessionBefore?.status}, resumable=${sessionBefore?.resumable}, provider=${sessionBefore?.provider}, model=${sessionBefore?.model}`,
+  );
 
   onboardSession.updateSession((s) => {
     s.sandboxName = sandboxName;
@@ -1688,8 +1733,12 @@ async function sandboxRebuild(sandboxName, args = []) {
   process.env.NEMOCLAW_SANDBOX_NAME = sandboxName;
 
   const sessionAfter = onboardSession.loadSession();
-  log(`Session after update: sandboxName=${sessionAfter?.sandboxName}, status=${sessionAfter?.status}, resumable=${sessionAfter?.resumable}, provider=${sessionAfter?.provider}, model=${sessionAfter?.model}`);
-  log(`Env: NEMOCLAW_SANDBOX_NAME=${process.env.NEMOCLAW_SANDBOX_NAME}, NEMOCLAW_RECREATE_SANDBOX=${process.env.NEMOCLAW_RECREATE_SANDBOX}`);
+  log(
+    `Session after update: sandboxName=${sessionAfter?.sandboxName}, status=${sessionAfter?.status}, resumable=${sessionAfter?.resumable}, provider=${sessionAfter?.provider}, model=${sessionAfter?.model}`,
+  );
+  log(
+    `Env: NEMOCLAW_SANDBOX_NAME=${process.env.NEMOCLAW_SANDBOX_NAME}, NEMOCLAW_RECREATE_SANDBOX=${process.env.NEMOCLAW_RECREATE_SANDBOX}`,
+  );
   log("Calling onboard({ resume: true, nonInteractive: true, recreateSandbox: true })");
 
   const { onboard } = require("./lib/onboard");
@@ -1706,7 +1755,9 @@ async function sandboxRebuild(sandboxName, args = []) {
   console.log("  Restoring workspace state...");
   log(`Restoring from: ${backup.manifest.backupPath} into sandbox: ${sandboxName}`);
   const restore = sandboxState.restoreSandboxState(sandboxName, backup.manifest.backupPath);
-  log(`Restore result: success=${restore.success}, restored=${restore.restoredDirs.join(",")}, failed=${restore.failedDirs.join(",")}`);
+  log(
+    `Restore result: success=${restore.success}, restored=${restore.restoredDirs.join(",")}, failed=${restore.failedDirs.join(",")}`,
+  );
   if (!restore.success) {
     console.error(`  Partial restore: ${restore.restoredDirs.join(", ") || "none"}`);
     console.error(`  Failed: ${restore.failedDirs.join(", ")}`);
@@ -1716,18 +1767,24 @@ async function sandboxRebuild(sandboxName, args = []) {
   }
 
   // Step 6: Post-restore agent-specific migration
-  const agentDef = agent ? require("./lib/agent-defs").loadAgent(agent.name) : require("./lib/agent-defs").loadAgent("openclaw");
+  const agentDef = agent
+    ? require("./lib/agent-defs").loadAgent(agent.name)
+    : require("./lib/agent-defs").loadAgent("openclaw");
   if (agentDef.name === "openclaw") {
     // openclaw doctor --fix validates and repairs directory structure.
     // Idempotent and safe — catches structural changes between OpenClaw versions
     // (new symlinks, new data dirs, etc.) that the restored state may be missing.
     log("Running openclaw doctor --fix inside sandbox for post-upgrade structure repair");
     const doctorResult = executeSandboxCommand(sandboxName, "openclaw doctor --fix");
-    log(`doctor --fix: exit=${doctorResult?.status}, stdout=${(doctorResult?.stdout || "").substring(0, 200)}`);
+    log(
+      `doctor --fix: exit=${doctorResult?.status}, stdout=${(doctorResult?.stdout || "").substring(0, 200)}`,
+    );
     if (doctorResult && doctorResult.status === 0) {
       console.log(`  ${G}\u2713${R} Post-upgrade structure check passed`);
     } else {
-      console.log(`  ${D}Post-upgrade structure check skipped (doctor returned ${doctorResult?.status ?? "null"})${R}`);
+      console.log(
+        `  ${D}Post-upgrade structure check skipped (doctor returned ${doctorResult?.status ?? "null"})${R}`,
+      );
     }
   }
   // Hermes: no explicit post-restore step needed. Hermes's SessionDB._init_schema()
@@ -1749,7 +1806,9 @@ async function sandboxRebuild(sandboxName, args = []) {
       console.log(`    Now running: ${agentName} v${versionCheck.expectedVersion}`);
     }
   } else {
-    console.log(`  ${YW}\u26a0${R} Sandbox '${sandboxName}' rebuilt but state restore was incomplete`);
+    console.log(
+      `  ${YW}\u26a0${R} Sandbox '${sandboxName}' rebuilt but state restore was incomplete`,
+    );
     console.log(`    Backup available at: ${backup.manifest.backupPath}`);
   }
 }
@@ -1775,7 +1834,9 @@ function sandboxSnapshot(sandboxName, subArgs) {
       console.log(`  Creating snapshot of '${sandboxName}'...`);
       const result = sandboxState.backupSandboxState(sandboxName);
       if (result.success) {
-        console.log(`  ${G}\u2713${R} Snapshot created (${result.backedUpDirs.length} directories)`);
+        console.log(
+          `  ${G}\u2713${R} Snapshot created (${result.backedUpDirs.length} directories)`,
+        );
         console.log(`    ${result.manifest.backupPath}`);
       } else {
         console.error("  Snapshot failed.");
@@ -1898,7 +1959,9 @@ function backupAll() {
     console.log(`  Backing up '${sb.name}'...`);
     const result = sandboxState.backupSandboxState(sb.name);
     if (result.success) {
-      console.log(`  ${G}\u2713${R} ${sb.name}: ${result.backedUpDirs.length} dirs → ${result.manifest.backupPath}`);
+      console.log(
+        `  ${G}\u2713${R} ${sb.name}: ${result.backedUpDirs.length} dirs → ${result.manifest.backupPath}`,
+      );
       backed++;
     } else {
       console.error(`  ${_RD}✗${R} ${sb.name}: backup failed (${result.failedDirs.join(", ")})`);
@@ -2095,7 +2158,9 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       default:
         console.error(`  Unknown action: ${action}`);
-        console.error(`  Valid actions: connect, status, logs, policy-add, policy-remove, policy-list, skill, snapshot, rebuild, destroy`);
+        console.error(
+          `  Valid actions: connect, status, logs, policy-add, policy-remove, policy-list, skill, snapshot, rebuild, destroy`,
+        );
         process.exit(1);
     }
     return;

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -878,12 +878,15 @@ describe("onboard helpers", () => {
     );
 
     // Primary start path (startGatewayWithOptions) builds gwArgs with --port.
-    assert.match(source, /const gwArgs = \["--name", GATEWAY_NAME, "--port", String\(GATEWAY_PORT\)\]/);
+    assert.match(
+      source,
+      /const gwArgs = \["--name", GATEWAY_NAME, "--port", String\(GATEWAY_PORT\)\]/,
+    );
 
     // Recovery start path (recoverGatewayRuntime) also passes --port.
     assert.match(
       source,
-      /runOpenshell\(\["gateway", "start", "--name", GATEWAY_NAME, "--port", String\(GATEWAY_PORT\)\]/,
+      /runOpenshell\(\s*\["gateway", "start", "--name", GATEWAY_NAME, "--port", String\(GATEWAY_PORT\)\]/,
     );
   });
 
@@ -2286,9 +2289,7 @@ const { createSandbox } = require(${onboardPath});
       payload.commands.some(
         (entry) =>
           entry.command.includes("'forward' 'start' '--background' '18789' 'my-assistant'") ||
-          entry.command.includes(
-            "'forward' 'start' '--background' '0.0.0.0:18789' 'my-assistant'",
-          ),
+          entry.command.includes("'forward' 'start' '--background' '0.0.0.0:18789' 'my-assistant'"),
       ),
       "expected dashboard forward (loopback or WSL 0.0.0.0)",
     );

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -16,7 +16,6 @@ import {
   classifySandboxCreateFailure,
   compactText,
   formatEnvAssignment,
-  getBlueprintBaseImageDigest,
   getDashboardAccessInfo,
   getDashboardForwardStartCommand,
   getNavigationChoice,
@@ -4515,109 +4514,5 @@ const { createSandbox } = require(${onboardPath});
       updateAfterCreate !== -1,
       "registry.updateSandbox(model, provider) must appear AFTER createSandbox() — regression #1881",
     );
-  });
-
-  // ── getBlueprintBaseImageDigest tests (#1904) ───────────────────
-
-  it("getBlueprintBaseImageDigest returns the sha256 digest from blueprint.yaml", () => {
-    const repoRoot = path.join(import.meta.dirname, "..");
-    const digest = getBlueprintBaseImageDigest(repoRoot);
-    assert.ok(digest !== null, "digest should not be null for the real blueprint");
-    assert.match(digest, /^sha256:[0-9a-f]{64}$/);
-  });
-
-  it("getBlueprintBaseImageDigest returns null when blueprint directory is missing", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-missing-"));
-    try {
-      assert.equal(getBlueprintBaseImageDigest(tmpDir), null);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  it("getBlueprintBaseImageDigest returns null when digest field is missing", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-nofield-"));
-    const bpDir = path.join(tmpDir, "nemoclaw-blueprint");
-    fs.mkdirSync(bpDir, { recursive: true });
-    fs.writeFileSync(path.join(bpDir, "blueprint.yaml"), 'version: "0.1.0"\n');
-    try {
-      assert.equal(getBlueprintBaseImageDigest(tmpDir), null);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  it("getBlueprintBaseImageDigest rejects malformed digest values", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-malformed-"));
-    const bpDir = path.join(tmpDir, "nemoclaw-blueprint");
-    fs.mkdirSync(bpDir, { recursive: true });
-    fs.writeFileSync(path.join(bpDir, "blueprint.yaml"), 'digest: "not-a-real-digest"\n');
-    try {
-      assert.equal(getBlueprintBaseImageDigest(tmpDir), null);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  it("patchStagedDockerfile rewrites ARG BASE_IMAGE with the blueprint digest", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-patch-"));
-    const dockerfilePath = path.join(tmpDir, "Dockerfile");
-    fs.writeFileSync(
-      dockerfilePath,
-      [
-        "ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
-        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
-        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
-        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
-        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
-        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
-        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
-        "ARG NEMOCLAW_BUILD_ID=default",
-      ].join("\n"),
-    );
-    try {
-      patchStagedDockerfile(dockerfilePath, "gpt-5.4", "http://127.0.0.1:19999", "build-digest-test", "openai-api");
-      const patched = fs.readFileSync(dockerfilePath, "utf8");
-      assert.match(patched, /^ARG BASE_IMAGE=ghcr\.io\/nvidia\/nemoclaw\/sandbox-base@sha256:/m);
-      assert.doesNotMatch(patched, /:latest/);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  it("patchStagedDockerfile preserves when Dockerfile has no ARG BASE_IMAGE line", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-digest-nobase-"));
-    const dockerfilePath = path.join(tmpDir, "Dockerfile");
-    fs.writeFileSync(
-      dockerfilePath,
-      [
-        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
-        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
-        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
-        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
-        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
-        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
-        "ARG NEMOCLAW_BUILD_ID=default",
-      ].join("\n"),
-    );
-    try {
-      patchStagedDockerfile(dockerfilePath, "gpt-5.4", "http://127.0.0.1:19999", "build-nobase", "openai-api");
-      const patched = fs.readFileSync(dockerfilePath, "utf8");
-      assert.doesNotMatch(patched, /BASE_IMAGE/);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  it("regression #1904: createSandbox pre-pulls the digest-pinned base image", () => {
-    const source = fs.readFileSync(path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"), "utf-8");
-    const patchPos = source.indexOf("patchStagedDockerfile(");
-    assert.ok(patchPos !== -1, "patchStagedDockerfile call not found in onboard.ts");
-    const prePullPos = source.indexOf('run(["docker", "pull", pinnedRef]', patchPos);
-    assert.ok(prePullPos !== -1, "docker pull with pinnedRef must appear after patchStagedDockerfile — regression #1904");
-    const sandboxCreatePos = source.indexOf('"sandbox",', prePullPos);
-    assert.ok(sandboxCreatePos !== -1, "sandbox create args not found after pre-pull");
-    const createArgPos = source.indexOf('"create",', sandboxCreatePos);
-    assert.ok(createArgPos !== -1, "pre-pull must appear before sandbox create command — regression #1904");
   });
 });


### PR DESCRIPTION
## Summary
- Reverts cf4941a4 ("fix(upgrade): pin base image digest and rebuild stale sandboxes")
- The digest in `blueprint.yaml` belongs to `ghcr.io/nvidia/openshell-community/sandboxes/openclaw` but the code applied it to `ghcr.io/nvidia/nemoclaw/sandbox-base` — a different registry repo
- Docker digests are repo-specific, so every sandbox creation fails with "manifest unknown"
- All 6 nightly e2e jobs fail identically: sandbox-survival, skip-permissions, hermes, rebuild-openclaw, cloud, messaging-providers

## What's removed
- `getBlueprintBaseImageDigest()` function and Dockerfile `BASE_IMAGE` patching in `onboard.ts`
- Pre-pull of digest-pinned base image before sandbox creation
- `nemoclaw upgrade-sandboxes` command in `nemoclaw.ts`
- Post-upgrade sandbox check in `install.sh`
- 7 related tests in `onboard.test.ts`

## Test plan
- [ ] CI passes on this branch
- [ ] Re-trigger nightly e2e after merge to confirm sandbox creation works again

Closes #1904 (will need to be re-opened with the correct registry approach)

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed automatic sandbox upgrade step from the installer; onboarding now completes without attempting conditional sandbox upgrades.
  * Removed the standalone sandbox upgrade CLI command.
  * Stopped pinning sandbox base images to digest values during sandbox creation.

* **Tests**
  * Updated tests to reflect removal of digest-pinning and sandbox upgrade behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->