### PR TITLE
fix(dashboard): inject NEMOCLAW_DASHBOARD_PORT into sandbox so gateway uses configured port (#1925)

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -131,6 +131,31 @@ $ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard
 
 See Environment Variables (see the `nemoclaw-user-reference` skill) for the full list of port overrides.
 
+### Running multiple sandboxes simultaneously
+
+Each sandbox requires its own dashboard port.
+If you onboard a second sandbox without overriding the port, onboarding fails because port `18789` is already claimed by the first sandbox.
+
+Assign a distinct port to each sandbox at onboard time:
+
+```console
+$ nemoclaw onboard                              # first sandbox — uses default 18789
+$ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard  # second sandbox — uses 19000
+```
+
+Each sandbox then has its own SSH tunnel and its own dashboard URL:
+
+```text
+http://localhost:18789   ← first sandbox
+http://localhost:19000   ← second sandbox
+```
+
+You can verify which tunnel belongs to which sandbox with:
+
+```console
+$ openshell forward list
+```
+
 ## Onboarding
 
 ### Cgroup v2 errors during onboard

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -459,6 +459,26 @@ $ openshell term
 To permanently allow an endpoint, add it to the network policy.
 Refer to Customize the Network Policy (see the `nemoclaw-user-manage-policy` skill) for details.
 
+### Dashboard not reachable after setting `NEMOCLAW_DASHBOARD_PORT`
+
+If you ran `NEMOCLAW_DASHBOARD_PORT=<port> nemoclaw onboard` and onboarding completed
+but the dashboard URL is unreachable (browser shows connection refused or the page fails
+to load), the sandbox was most likely created with an older NemoClaw version that had a
+bug where `NEMOCLAW_DASHBOARD_PORT` was parsed on the host but not passed into the sandbox
+at startup. The gateway inside the sandbox continued listening on the default port 18789
+while the SSH tunnel forwarded the custom port — leaving nothing at the other end of the
+tunnel.
+
+Re-run onboarding on the current NemoClaw release with the desired port. This rebuilds
+the sandbox image with the gateway bound to the configured port:
+
+```console
+$ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard
+```
+
+If you need to run multiple sandboxes at different ports at the same time, see
+[Running multiple sandboxes simultaneously](#running-multiple-sandboxes-simultaneously).
+
 ### Blueprint run failed
 
 View the error output for the failed blueprint run:

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -157,6 +157,31 @@ $ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard
 
 See [Environment Variables](commands.md#environment-variables) for the full list of port overrides.
 
+### Running multiple sandboxes simultaneously
+
+Each sandbox requires its own dashboard port.
+If you onboard a second sandbox without overriding the port, onboarding fails because port `18789` is already claimed by the first sandbox.
+
+Assign a distinct port to each sandbox at onboard time:
+
+```console
+$ nemoclaw onboard                              # first sandbox — uses default 18789
+$ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard  # second sandbox — uses 19000
+```
+
+Each sandbox then has its own SSH tunnel and its own dashboard URL:
+
+```
+http://localhost:18789   ← first sandbox
+http://localhost:19000   ← second sandbox
+```
+
+You can verify which tunnel belongs to which sandbox with:
+
+```console
+$ openshell forward list
+```
+
 ## Onboarding
 
 ### Cgroup v2 errors during onboard

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -489,6 +489,26 @@ $ openshell term
 To permanently allow an endpoint, add it to the network policy.
 Refer to [Customize the Network Policy](../network-policy/customize-network-policy.md) for details.
 
+### Dashboard not reachable after setting `NEMOCLAW_DASHBOARD_PORT`
+
+If you ran `NEMOCLAW_DASHBOARD_PORT=<port> nemoclaw onboard` and onboarding completed
+but the dashboard URL is unreachable (browser shows connection refused or the page fails
+to load), the sandbox was most likely created with an older NemoClaw version that had a
+bug where `NEMOCLAW_DASHBOARD_PORT` was parsed on the host but not passed into the sandbox
+at startup. The gateway inside the sandbox continued listening on the default port 18789
+while the SSH tunnel forwarded the custom port — leaving nothing at the other end of the
+tunnel.
+
+Re-run onboarding on the current NemoClaw release with the desired port. This rebuilds
+the sandbox image with the gateway bound to the configured port:
+
+```console
+$ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard
+```
+
+If you need to run multiple sandboxes at different ports at the same time, see
+[Running multiple sandboxes simultaneously](#running-multiple-sandboxes-simultaneously).
+
 ### Blueprint run failed
 
 View the error output for the failed blueprint run:

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -171,7 +171,7 @@ $ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard  # second sandbox — uses 1900
 
 Each sandbox then has its own SSH tunnel and its own dashboard URL:
 
-```
+```text
 http://localhost:18789   ← first sandbox
 http://localhost:19000   ← second sandbox
 ```

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -960,7 +960,7 @@ harden_openclaw_symlinks
 # SECURITY: The sandbox user cannot kill this process because it runs
 # under a different UID. The fake-HOME attack no longer works because
 # the agent cannot restart the gateway with a tampered config.
-nohup gosu gateway "$OPENCLAW" gateway run >/tmp/gateway.log 2>&1 &
+nohup gosu gateway "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
 GATEWAY_PID=$!
 echo "[gateway] openclaw gateway launched as 'gateway' user (pid $GATEWAY_PID)" >&2
 trap cleanup SIGTERM SIGINT

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -172,7 +172,16 @@ else
     exit 1
   fi
 fi
-CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:${_DASHBOARD_PORT}}"
+# When NEMOCLAW_DASHBOARD_PORT is explicitly set (injected at sandbox create time
+# via envArgs in onboard.ts), unconditionally override CHAT_UI_URL so the gateway
+# starts on the configured port even if the Docker image has a different value
+# baked in. Without this, the Docker ENV takes precedence and the gateway listens
+# on the wrong port while the SSH tunnel forwards the custom port. (#1925)
+if [ -n "${NEMOCLAW_DASHBOARD_PORT:-}" ]; then
+  CHAT_UI_URL="http://127.0.0.1:${_DASHBOARD_PORT}"
+else
+  CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:${_DASHBOARD_PORT}}"
+fi
 PUBLIC_PORT="$_DASHBOARD_PORT"
 OPENCLAW="$(command -v openclaw)" # Resolve once, use absolute path everywhere
 _SANDBOX_HOME="/sandbox"          # Home dir for the sandbox user (useradd -d /sandbox in Dockerfile.base)

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -901,7 +901,7 @@ if [ "$(id -u)" -ne 0 ]; then
   chmod 600 /tmp/auto-pair.log
 
   # Start gateway in background, auto-pair, then wait
-  nohup "$OPENCLAW" gateway run >/tmp/gateway.log 2>&1 &
+  nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
   GATEWAY_PID=$!
   echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)" >&2
   trap cleanup SIGTERM SIGINT

--- a/src/lib/agent-runtime.test.ts
+++ b/src/lib/agent-runtime.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+// Import from compiled dist/ so coverage is attributed correctly.
+import { buildRecoveryScript } from "../../dist/lib/agent-runtime";
+import type { AgentDefinition } from "./agent-defs";
+
+// Test fixture — only fields read by buildRecoveryScript are needed.
+// Cast via unknown to avoid requiring the full AgentDefinition shape.
+const minimalAgent = {
+  name: "test-agent",
+  displayName: "Test Agent",
+  binary_path: "/usr/local/bin/test-agent",
+  gateway_command: "test-agent gateway run",
+  healthProbe: { url: "http://127.0.0.1:19000/" },
+} as unknown as AgentDefinition;
+
+describe("buildRecoveryScript", () => {
+  it("returns null for null agent (OpenClaw inline script handles it)", () => {
+    expect(buildRecoveryScript(null, 18789)).toBeNull();
+  });
+
+  it("embeds the port in the gateway launch command (#1925)", () => {
+    const script = buildRecoveryScript(minimalAgent, 19000);
+    expect(script).toContain("--port 19000");
+  });
+
+  it("embeds the default port when called with default value", () => {
+    const script = buildRecoveryScript(minimalAgent, 18789);
+    expect(script).toContain("--port 18789");
+  });
+
+  it("uses the agent gateway_command, not a hardcoded openclaw", () => {
+    const script = buildRecoveryScript(minimalAgent, 19000);
+    expect(script).toContain("test-agent gateway run --port 19000");
+  });
+
+  it("falls back to openclaw gateway run when gateway_command is absent", () => {
+    const agent = { ...minimalAgent, gateway_command: undefined } as unknown as AgentDefinition;
+    const script = buildRecoveryScript(agent, 19000);
+    expect(script).toContain("openclaw gateway run --port 19000");
+  });
+});

--- a/src/lib/agent-runtime.ts
+++ b/src/lib/agent-runtime.ts
@@ -53,7 +53,7 @@ export function getHealthProbeUrl(agent: AgentDefinition | null): string {
  * Returns the script string, or null if agent is null (use existing inline
  * OpenClaw script instead).
  */
-export function buildRecoveryScript(agent: AgentDefinition | null): string | null {
+export function buildRecoveryScript(agent: AgentDefinition | null, port: number): string | null {
   if (!agent) return null;
 
   const probeUrl = getHealthProbeUrl(agent);
@@ -70,7 +70,7 @@ export function buildRecoveryScript(agent: AgentDefinition | null): string | nul
     "touch /tmp/gateway.log; chmod 600 /tmp/gateway.log;",
     `AGENT_BIN=${shellQuote(binaryPath as string)}; if [ ! -x "$AGENT_BIN" ]; then AGENT_BIN="$(command -v ${shellQuote((binaryPath as string).split("/").pop()!)})"; fi;`,
     'if [ -z "$AGENT_BIN" ]; then echo AGENT_MISSING; exit 1; fi;',
-    `nohup ${gatewayCmd} > /tmp/gateway.log 2>&1 &`,
+    `nohup ${gatewayCmd} --port ${port} > /tmp/gateway.log 2>&1 &`,
     "GPID=$!; sleep 2;",
     'if kill -0 "$GPID" 2>/dev/null; then echo "GATEWAY_PID=$GPID"; else echo GATEWAY_FAILED; cat /tmp/gateway.log 2>/dev/null | tail -5; fi',
   ].join(" ");

--- a/src/lib/dashboard.test.ts
+++ b/src/lib/dashboard.test.ts
@@ -113,4 +113,11 @@ describe("buildControlUiUrls", () => {
     const urls = buildControlUiUrls("tok");
     expect(urls).toHaveLength(1);
   });
+
+  it("uses the configured port in the displayed URL when NEMOCLAW_DASHBOARD_PORT overrides the default (#1925)", () => {
+    // getDashboardAccessInfo passes dashboardPort explicitly so the URL shown to
+    // the user reflects the custom port — not the default 18789.
+    const urls = buildControlUiUrls("my-token", 19000);
+    expect(urls).toEqual(["http://127.0.0.1:19000/#token=my-token"]);
+  });
 });

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4780,10 +4780,22 @@ function ensureDashboardForward(sandboxName, chatUiUrl = `http://127.0.0.1:${CON
   // Use stdio "ignore" to prevent spawnSync from waiting on inherited pipe fds.
   // The --background flag forks a child that inherits stdout/stderr; if those are
   // pipes, spawnSync blocks until the background process exits (never).
-  runOpenshell(["forward", "start", "--background", forwardTarget, sandboxName], {
+  // Use stdio "ignore" to prevent spawnSync from waiting on inherited pipe fds.
+  // The --background flag forks a child that inherits stdout/stderr; if those are
+  // pipes, spawnSync blocks until the background process exits (never).
+  const fwdResult = runOpenshell(["forward", "start", "--background", forwardTarget, sandboxName], {
     ignoreError: true,
     stdio: ["ignore", "ignore", "ignore"],
   });
+  // A non-zero exit from the parent means forward start rejected before forking —
+  // typically because the port is already bound by another process (e.g. a local
+  // Docker test container with -p PORT:PORT). The error is otherwise swallowed by
+  // ignoreError + stdio:ignore, leaving the dashboard URL silently unreachable (#1925).
+  if (fwdResult && fwdResult.status !== 0) {
+    console.warn(`! Port ${portToStop} forward did not start — port may be in use by another process.`);
+    console.warn(`  Check: docker ps --format 'table {{.Names}}\\t{{.Ports}}' | grep ${portToStop}`);
+    console.warn(`  Free the port, then reconnect: nemoclaw ${sandboxName} connect`);
+  }
 }
 
 function findOpenclawJsonPath(dir) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2787,6 +2787,13 @@ async function createSandbox(
   // subprocesses (gateway start, openshell CLI) but the sandbox should
   // never have access to the host's Kubernetes cluster or SSH agent.
   const envArgs = [formatEnvAssignment("CHAT_UI_URL", chatUiUrl)];
+  // Pass the configured dashboard port into the sandbox so nemoclaw-start.sh
+  // can unconditionally override CHAT_UI_URL even when the Docker image was
+  // built with a different default. Without this, the baked-in Docker ENV
+  // value takes precedence and the gateway starts on the wrong port. (#1925)
+  if (process.env.NEMOCLAW_DASHBOARD_PORT) {
+    envArgs.push(formatEnvAssignment("NEMOCLAW_DASHBOARD_PORT", String(DASHBOARD_PORT)));
+  }
   if (webSearchConfig?.fetchEnabled) {
     const braveKey =
       getCredential(webSearch.BRAVE_API_KEY_ENV) || process.env[webSearch.BRAVE_API_KEY_ENV];

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4780,9 +4780,6 @@ function ensureDashboardForward(sandboxName, chatUiUrl = `http://127.0.0.1:${CON
   // Use stdio "ignore" to prevent spawnSync from waiting on inherited pipe fds.
   // The --background flag forks a child that inherits stdout/stderr; if those are
   // pipes, spawnSync blocks until the background process exits (never).
-  // Use stdio "ignore" to prevent spawnSync from waiting on inherited pipe fds.
-  // The --background flag forks a child that inherits stdout/stderr; if those are
-  // pipes, spawnSync blocks until the background process exits (never).
   const fwdResult = runOpenshell(["forward", "start", "--background", forwardTarget, sandboxName], {
     ignoreError: true,
     stdio: ["ignore", "ignore", "ignore"],

--- a/src/lib/ports.ts
+++ b/src/lib/ports.ts
@@ -30,16 +30,16 @@ export function parsePort(envVar: string, fallback: number): number {
 
 /** OpenShell gateway port (default 8080, override via NEMOCLAW_GATEWAY_PORT). */
 export const GATEWAY_PORT = parsePort("NEMOCLAW_GATEWAY_PORT", 8080);
-/** Dashboard UI port (default 18789, override via NEMOCLAW_DASHBOARD_PORT). This is the host-side port. */
-export const DASHBOARD_PORT = parsePort("NEMOCLAW_DASHBOARD_PORT", 18789);
 /**
  * The default port the OpenClaw dashboard listens on inside the sandbox.
- * The sandbox image is built with CHAT_UI_URL=http://127.0.0.1:DASHBOARD_PORT (patched
- * by patchStagedDockerfile), so the gateway starts on whichever port was configured
- * via NEMOCLAW_DASHBOARD_PORT at onboard time. This constant represents the hardcoded
- * default when no override is set.
+ * The sandbox image is built with CHAT_UI_URL=http://127.0.0.1:SANDBOX_DASHBOARD_PORT
+ * (patched by patchStagedDockerfile), so the gateway starts on whichever port was
+ * configured via NEMOCLAW_DASHBOARD_PORT at onboard time. This constant represents
+ * the hardcoded default when no override is set.
  */
 export const SANDBOX_DASHBOARD_PORT = 18789;
+/** Dashboard UI port (default SANDBOX_DASHBOARD_PORT, override via NEMOCLAW_DASHBOARD_PORT). This is the host-side port. */
+export const DASHBOARD_PORT = parsePort("NEMOCLAW_DASHBOARD_PORT", SANDBOX_DASHBOARD_PORT);
 /** vLLM / NIM inference port (default 8000, override via NEMOCLAW_VLLM_PORT). */
 export const VLLM_PORT = parsePort("NEMOCLAW_VLLM_PORT", 8000);
 /** Ollama inference port (default 11434, override via NEMOCLAW_OLLAMA_PORT). */

--- a/src/lib/ports.ts
+++ b/src/lib/ports.ts
@@ -37,7 +37,7 @@ export const GATEWAY_PORT = parsePort("NEMOCLAW_GATEWAY_PORT", 8080);
  * configured via NEMOCLAW_DASHBOARD_PORT at onboard time. This constant represents
  * the hardcoded default when no override is set.
  */
-export const SANDBOX_DASHBOARD_PORT = 18789;
+const SANDBOX_DASHBOARD_PORT = 18789;
 /** Dashboard UI port (default SANDBOX_DASHBOARD_PORT, override via NEMOCLAW_DASHBOARD_PORT). This is the host-side port. */
 export const DASHBOARD_PORT = parsePort("NEMOCLAW_DASHBOARD_PORT", SANDBOX_DASHBOARD_PORT);
 /** vLLM / NIM inference port (default 8000, override via NEMOCLAW_VLLM_PORT). */

--- a/src/lib/ports.ts
+++ b/src/lib/ports.ts
@@ -30,8 +30,16 @@ export function parsePort(envVar: string, fallback: number): number {
 
 /** OpenShell gateway port (default 8080, override via NEMOCLAW_GATEWAY_PORT). */
 export const GATEWAY_PORT = parsePort("NEMOCLAW_GATEWAY_PORT", 8080);
-/** Dashboard UI port (default 18789, override via NEMOCLAW_DASHBOARD_PORT). */
+/** Dashboard UI port (default 18789, override via NEMOCLAW_DASHBOARD_PORT). This is the host-side port. */
 export const DASHBOARD_PORT = parsePort("NEMOCLAW_DASHBOARD_PORT", 18789);
+/**
+ * The default port the OpenClaw dashboard listens on inside the sandbox.
+ * The sandbox image is built with CHAT_UI_URL=http://127.0.0.1:DASHBOARD_PORT (patched
+ * by patchStagedDockerfile), so the gateway starts on whichever port was configured
+ * via NEMOCLAW_DASHBOARD_PORT at onboard time. This constant represents the hardcoded
+ * default when no override is set.
+ */
+export const SANDBOX_DASHBOARD_PORT = 18789;
 /** vLLM / NIM inference port (default 8000, override via NEMOCLAW_VLLM_PORT). */
 export const VLLM_PORT = parsePort("NEMOCLAW_VLLM_PORT", 8000);
 /** Ollama inference port (default 11434, override via NEMOCLAW_OLLAMA_PORT). */

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -237,7 +237,7 @@ function isSandboxGatewayRunning(sandboxName) {
  */
 function recoverSandboxProcesses(sandboxName) {
   const agent = agentRuntime.getSessionAgent(sandboxName);
-  const agentScript = agentRuntime.buildRecoveryScript(agent, DASHBOARD_PORT);
+  const agentScript = agentRuntime.buildRecoveryScript(agent, agent?.forwardPort ?? DASHBOARD_PORT);
   // The recovery script runs as the sandbox user (non-root). This matches
   // the non-root fallback path in nemoclaw-start.sh — no privilege
   // separation, but the gateway runs and inference works.

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -237,7 +237,7 @@ function isSandboxGatewayRunning(sandboxName) {
  */
 function recoverSandboxProcesses(sandboxName) {
   const agent = agentRuntime.getSessionAgent(sandboxName);
-  const agentScript = agentRuntime.buildRecoveryScript(agent);
+  const agentScript = agentRuntime.buildRecoveryScript(agent, DASHBOARD_PORT);
   // The recovery script runs as the sandbox user (non-root). This matches
   // the non-root fallback path in nemoclaw-start.sh — no privilege
   // separation, but the gateway runs and inference works.
@@ -258,7 +258,7 @@ function recoverSandboxProcesses(sandboxName) {
       // Resolve and start gateway
       'OPENCLAW="$(command -v openclaw)";',
       'if [ -z "$OPENCLAW" ]; then echo OPENCLAW_MISSING; exit 1; fi;',
-      'nohup "$OPENCLAW" gateway run > /tmp/gateway.log 2>&1 &',
+      `nohup "$OPENCLAW" gateway run --port ${DASHBOARD_PORT} > /tmp/gateway.log 2>&1 &`,
       "GPID=$!; sleep 2;",
       // Verify the gateway actually started (didn't crash immediately)
       'if kill -0 "$GPID" 2>/dev/null; then echo "GATEWAY_PID=$GPID"; else echo GATEWAY_FAILED; cat /tmp/gateway.log 2>/dev/null | tail -5; fi',

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -14,7 +14,7 @@ describe("nemoclaw-start non-root fallback", () => {
 
     expect(src).toMatch(/if \[ "\$\(id -u\)" -ne 0 \]; then/);
     expect(src).toMatch(/touch \/tmp\/gateway\.log/);
-    expect(src).toMatch(/nohup "\$OPENCLAW" gateway run >\/tmp\/gateway\.log 2>&1 &/);
+    expect(src).toMatch(/nohup "\$OPENCLAW" gateway run --port "\$\{_DASHBOARD_PORT\}" >\/tmp\/gateway\.log 2>&1 &/);
   });
 
   it("exits on config integrity failure in non-root mode", () => {
@@ -530,6 +530,17 @@ describe("nemoclaw-start CHAT_UI_URL override for configurable dashboard port (#
     expect(ifElseBlock).toBeTruthy();
     expect(ifElseBlock[1]).toContain(
       'CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:${_DASHBOARD_PORT}}"',
+    );
+  });
+
+  it("passes --port to openclaw gateway run in root path (gosu gateway) (#1925)", () => {
+    // The root path (run as root, then gosu'd to the gateway user) must also
+    // pass --port so the gateway binds to the configured port. Without this,
+    // a user with NEMOCLAW_DASHBOARD_PORT set would get a gateway on 18789
+    // even though the SSH tunnel forwards the custom port.
+    const rootBlock = src.split(/# ── Root path/)[1] || "";
+    expect(rootBlock).toMatch(
+      /nohup gosu gateway "\$OPENCLAW" gateway run --port "\$\{_DASHBOARD_PORT\}" >\/tmp\/gateway\.log 2>&1 &/,
     );
   });
 });

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -502,3 +502,34 @@ describe("nemoclaw-start signal handling", () => {
     expect(src).toMatch(/AUTO_PAIR_PID=\$!/);
   });
 });
+
+describe("nemoclaw-start CHAT_UI_URL override for configurable dashboard port (#1925)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("unconditionally sets CHAT_UI_URL when NEMOCLAW_DASHBOARD_PORT is injected", () => {
+    // When the var is present (injected via envArgs in onboard.ts), the gateway
+    // must use the configured port even if the Docker image has a different
+    // CHAT_UI_URL baked in as a Docker ENV directive.
+    const overrideBlock = src.match(
+      /if \[ -n "\$\{NEMOCLAW_DASHBOARD_PORT:-\}" \]; then([\s\S]*?)else/,
+    );
+    expect(overrideBlock).toBeTruthy();
+    // Plain assignment — the Docker ENV value cannot take precedence
+    expect(overrideBlock[1]).toContain('CHAT_UI_URL="http://127.0.0.1:${_DASHBOARD_PORT}"');
+    // Must NOT use :- in this branch — that would let the baked-in Docker ENV win
+    // and restart the gateway on the wrong port (#1925)
+    expect(overrideBlock[1]).not.toMatch(/CHAT_UI_URL=.*:-/);
+  });
+
+  it("falls back to baked-in CHAT_UI_URL when NEMOCLAW_DASHBOARD_PORT is absent", () => {
+    // When no port override was injected (default install), honour whatever
+    // CHAT_UI_URL was baked into the Docker image at onboard time.
+    const ifElseBlock = src.match(
+      /if \[ -n "\$\{NEMOCLAW_DASHBOARD_PORT:-\}" \]; then[\s\S]*?else([\s\S]*?)fi/,
+    );
+    expect(ifElseBlock).toBeTruthy();
+    expect(ifElseBlock[1]).toContain(
+      'CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:${_DASHBOARD_PORT}}"',
+    );
+  });
+});

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -429,8 +429,10 @@ describe("onboard helpers", () => {
     });
 
     expect(command).toContain("--background");
-    // Default port — forward same port on both sides.
+    // Default port — forward same port on both sides using the bare port number.
+    // Must not regress to all-interfaces (0.0.0.0:18789) or port:port (18789:18789) forms.
     expect(command).toContain("18789");
+    expect(command).not.toContain("0.0.0.0:18789");
     expect(command).not.toContain("18789:18789");
     expect(command).toContain("the-crucible");
   });

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -412,7 +412,38 @@ describe("onboard helpers", () => {
     expect(command).toContain("forward");
     expect(command).toContain("start");
     expect(command).toContain("--background");
+    // On WSL, bind to all interfaces so the Windows-side browser can reach the port.
+    // The sandbox image is built with CHAT_UI_URL=http://127.0.0.1:19999, so the
+    // gateway listens on 19999 inside the sandbox — openshell maps host:19999 →
+    // sandbox:19999 (same port both sides, the only mapping openshell supports).
     expect(command).toContain("0.0.0.0:19999");
+    expect(command).toContain("the-crucible");
+  });
+
+  it("uses the default port as-is when NEMOCLAW_DASHBOARD_PORT is not overridden", () => {
+    const command = getDashboardForwardStartCommand("the-crucible", {
+      chatUiUrl: "http://127.0.0.1:18789",
+      openshellBinary: "/usr/bin/openshell",
+    });
+
+    expect(command).toContain("--background");
+    // Default port — forward same port on both sides.
+    expect(command).toContain("18789");
+    expect(command).not.toContain("18789:18789");
+    expect(command).toContain("the-crucible");
+  });
+
+  it("forwards a custom port as-is on non-WSL loopback", () => {
+    const command = getDashboardForwardStartCommand("the-crucible", {
+      chatUiUrl: "http://127.0.0.1:19000",
+      openshellBinary: "/usr/bin/openshell",
+    });
+
+    expect(command).toContain("--background");
+    // The gateway is configured to listen on the same port (via CHAT_UI_URL baked at
+    // onboard time), so host:19000 → sandbox:19000 is the correct mapping.
+    expect(command).toContain("19000");
+    expect(command).not.toContain("19000:18789");
     expect(command).toContain("the-crucible");
   });
 

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -444,7 +444,11 @@ describe("onboard helpers", () => {
     expect(command).toContain("--background");
     // The gateway is configured to listen on the same port (via CHAT_UI_URL baked at
     // onboard time), so host:19000 → sandbox:19000 is the correct mapping.
+    // Non-WSL loopback must use the plain port — not the all-interfaces (0.0.0.0:19000)
+    // form and not any port:port variant (openshell does not support asymmetric mapping).
     expect(command).toContain("19000");
+    expect(command).not.toContain("0.0.0.0:19000");
+    expect(command).not.toContain("19000:19000");
     expect(command).not.toContain("19000:18789");
     expect(command).toContain("the-crucible");
   });
@@ -2532,6 +2536,10 @@ const { createSandbox } = require(${onboardPath});
     assert.ok(
       !payload.commands.some((entry) => entry.command.includes("19000:18789")),
       "forward must not use asymmetric 19000:18789 mapping",
+    );
+    assert.ok(
+      !payload.commands.some((entry) => entry.command.includes("19000:19000")),
+      "forward must not use port:port form (openshell does not support it)",
     );
   });
 

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -2414,6 +2414,125 @@ const { createSandbox } = require(${onboardPath});
     );
   });
 
+  it("injects NEMOCLAW_DASHBOARD_PORT into sandbox create envArgs when set (#1925)", async () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-dashboard-port-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "dashboard-port-envargs.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+    const preflightPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "preflight.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const preflight = require(${preflightPath});
+const credentials = require(${credentialsPath});
+const childProcess = require("node:child_process");
+const { EventEmitter } = require("node:events");
+
+const commands = [];
+runner.run = (command, opts = {}) => {
+  commands.push({ command, env: opts.env || null });
+  return { status: 0 };
+};
+runner.runCapture = (command) => {
+  if (command.includes("'sandbox' 'get' 'my-assistant'")) return "";
+  if (command.includes("'sandbox' 'list'")) return "my-assistant Ready";
+  // Custom port: dashboard readiness curl uses 19000 (DASHBOARD_PORT from env)
+  if (command.includes("sandbox exec 'my-assistant' curl -sf http://localhost:19000/")) return "ok";
+  if (command.includes("'forward' 'list'")) return "19000 -> my-assistant:19000";
+  return "";
+};
+registry.registerSandbox = () => true;
+registry.removeSandbox = () => true;
+preflight.checkPortAvailable = async () => ({ ok: true });
+credentials.prompt = async () => "";
+
+childProcess.spawn = (...args) => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  commands.push({ command: args[1][1], env: args[2]?.env || null });
+  process.nextTick(() => {
+    child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
+    child.emit("close", 0);
+  });
+  return child;
+};
+
+const { createSandbox } = require(${onboardPath});
+
+(async () => {
+  process.env.OPENSHELL_GATEWAY = "nemoclaw";
+  const sandboxName = await createSandbox(null, "gpt-5.4");
+  console.log(JSON.stringify({ sandboxName, commands }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    // Strip CHAT_UI_URL so createSandbox falls back to http://127.0.0.1:19000.
+    // Without this, a CHAT_UI_URL set in the developer's shell or CI would be
+    // inherited, causing chatUiUrl to use the wrong port and making the forward
+    // command assertion below fail spuriously.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { CHAT_UI_URL: _stripped, ...inheritedEnv } = process.env;
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...inheritedEnv,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_DASHBOARD_PORT: "19000",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payloadLine = result.stdout
+      .trim()
+      .split("\n")
+      .slice()
+      .reverse()
+      .find((line) => line.startsWith("{") && line.endsWith("}"));
+    assert.ok(payloadLine, `expected JSON payload in stdout:\n${result.stdout}`);
+    const payload = JSON.parse(payloadLine);
+    const createCommand = payload.commands.find((entry) =>
+      entry.command.includes("'sandbox' 'create'"),
+    );
+    assert.ok(createCommand, "expected sandbox create command");
+    // Part 1 of fix (#1925): NEMOCLAW_DASHBOARD_PORT must be in envArgs so
+    // nemoclaw-start.sh can unconditionally override CHAT_UI_URL at runtime,
+    // overriding whatever value the Docker image had baked in.
+    assert.match(createCommand.command, /'NEMOCLAW_DASHBOARD_PORT=19000'/);
+    // Forward must use same-port mapping (openshell does not support asymmetric)
+    assert.ok(
+      payload.commands.some(
+        (entry) =>
+          entry.command.includes("'forward' 'start' '--background' '19000' 'my-assistant'") ||
+          entry.command.includes(
+            "'forward' 'start' '--background' '0.0.0.0:19000' 'my-assistant'",
+          ),
+      ),
+      "expected dashboard forward for port 19000",
+    );
+    assert.ok(
+      !payload.commands.some((entry) => entry.command.includes("19000:18789")),
+      "forward must not use asymmetric 19000:18789 mapping",
+    );
+  });
+
   it(
     "creates providers for messaging tokens and attaches them to the sandbox",
     { timeout: 60_000 },


### PR DESCRIPTION
## Summary

Fixes #1925.

Setting `NEMOCLAW_DASHBOARD_PORT` to a custom value had no effect — the SSH tunnel forwarded the correct host port, but the OpenClaw gateway inside the sandbox was still listening on the default port (`18789`), so the tunnel connected to nothing.

The bug has three independent failure points, all of which must be fixed.

### Failure point 1 — `NEMOCLAW_DASHBOARD_PORT` was never passed into the container

`createSandbox()` builds an `envArgs` array injected at container start time. Only `CHAT_UI_URL` was in that array; `NEMOCLAW_DASHBOARD_PORT` was absent, so the script inside the container had no way to know a custom port was requested.

### Failure point 2 — the shell fallback could not override the Docker `ENV`

`nemoclaw-start.sh` used `CHAT_UI_URL=${CHAT_UI_URL:-http://127.0.0.1:${_DASHBOARD_PORT}}`. The `:-` operator only fires when the variable is unset or empty. When the Docker image was built, `CHAT_UI_URL` was baked in as an `ENV` directive by `patchStagedDockerfile`, so the fallback never fired and the gateway always started on the port from the image.

### Failure point 3 — `openclaw gateway run` was not told which port to bind

The gateway binary reads its listen port from the `--port` flag, not from `CHAT_UI_URL` or `openclaw.json`. Without `--port`, the gateway always defaulted to `18789` regardless of any env var. `nemoclaw-start.sh` has two gateway launch lines (non-root path line 904 and root path line 963); both were missing `--port`. Recovery scripts in `nemoclaw.ts` and `agent-runtime.ts` also lacked `--port`, meaning a crashed gateway would restart on the wrong port even after the initial start was correct.

> **Note:** The initial fix only patched line 963 (root/local-test path). End-to-end verification via `nemoclaw onboard` revealed the gateway was still on 18789 because openshell always takes the non-root path (line 904, reached after `exec gosu sandbox` re-enters the script with `NEMOCLAW_CMD` non-empty). Line 904 and the recovery scripts were patched in follow-up commits.

### Fix

**`src/lib/onboard.ts`** — inject `NEMOCLAW_DASHBOARD_PORT` into the container via `envArgs`:

```typescript
if (process.env.NEMOCLAW_DASHBOARD_PORT) {
  envArgs.push(formatEnvAssignment("NEMOCLAW_DASHBOARD_PORT", String(DASHBOARD_PORT)));
}
```

**`scripts/nemoclaw-start.sh`** — unconditionally override `CHAT_UI_URL` when `NEMOCLAW_DASHBOARD_PORT` is present; pass `--port` on both gateway launch lines:

```bash
if [ -n "${NEMOCLAW_DASHBOARD_PORT:-}" ]; then
  CHAT_UI_URL="http://127.0.0.1:${_DASHBOARD_PORT}"
else
  CHAT_UI_URL="${CHAT_UI_URL:-http://127.0.0.1:${_DASHBOARD_PORT}}"
fi
# ...
nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &          # line 904 non-root
nohup gosu gateway "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &  # line 963 root
```

**`src/lib/agent-runtime.ts`** and **`src/nemoclaw.ts`** — pass port to recovery scripts so a crashed gateway restarts on the configured port, not the hardcoded default.

Data flow after fix:

```
NEMOCLAW_DASHBOARD_PORT=19000
  → onboard.ts: injected into container via envArgs
  → nemoclaw-start.sh: detects var, overrides CHAT_UI_URL unconditionally
  → openclaw gateway run --port 19000
  → gateway listens on ws://127.0.0.1:19000 inside sandbox
  → openshell forward start 19000 sandbox-name
  → tunnel: host:19000 → sandbox:19000 ✓
```

## Changes

| File | Change |
|------|--------|
| `src/lib/ports.ts` | Consolidate `18789` default into `SANDBOX_DASHBOARD_PORT`; remove duplicate literal |
| `src/lib/onboard.ts` | Inject `NEMOCLAW_DASHBOARD_PORT` into sandbox `envArgs` when set |
| `scripts/nemoclaw-start.sh` | (1) Unconditionally override `CHAT_UI_URL`; (2) `--port "${_DASHBOARD_PORT}"` on both gateway launch lines (904 non-root, 963 root) |
| `src/lib/agent-runtime.ts` | Add `port` parameter to `buildRecoveryScript`; embed `--port` in recovery command |
| `src/nemoclaw.ts` | Pass `DASHBOARD_PORT` to `buildRecoveryScript`; add `--port` to inline OpenClaw recovery script |
| `test/onboard.test.ts` | Fix forward-command assertions + new integration test for `envArgs` injection |
| `test/nemoclaw-start.test.ts` | Tests for `CHAT_UI_URL` override logic; `--port` assertions for both non-root (line 904) and root (line 963) gateway launch lines |
| `src/lib/agent-runtime.test.ts` | New test file: `buildRecoveryScript` port embedding |
| `src/lib/dashboard.test.ts` | New test for `buildControlUiUrls` with custom port |
| `docs/reference/troubleshooting.md` | Add multi-sandbox section; add runtime entry for `NEMOCLAW_DASHBOARD_PORT` not reachable |

## Test plan

- [x] `NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard` — `openshell sandbox exec -- grep "listening on" /tmp/gateway.log` shows `ws://127.0.0.1:19000`; dashboard URL opens in browser
- [x] `openshell forward list` shows port 19000 forwarded after onboard
- [ ] Default (no env var) — dashboard responds on port 18789, no regression
- [ ] Two sandboxes simultaneously — each on its own port, `openshell forward list` shows both
- [x] `npx vitest run --project cli test/onboard.test.ts` — all cases pass
- [x] `npx vitest run --project cli test/nemoclaw-start.test.ts` — all cases pass
- [x] `npx vitest run --project cli src/lib/agent-runtime.test.ts` — all cases pass
- [x] `npx vitest run --project plugin src/lib/dashboard.test.ts` — custom-port URL test passes

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox startups now accept a configurable dashboard port so each sandbox can run on a custom port.

* **Bug Fixes**
  * Improved detection and user-facing warnings when dashboard port forwarding fails.
  * Gateway startup and recovery now consistently honor the configured dashboard port.

* **Documentation**
  * Added troubleshooting for multi-sandbox port conflicts and unreachable dashboards after port changes.

* **Tests**
  * Expanded tests covering port propagation, forwarding commands, generated URLs, and startup/recovery behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->