### PR TITLE
fix(upgrade): pin base image via pull-then-inspect and rebuild stale sandboxes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1265,6 +1265,12 @@ except Exception:
     if run_installer_host_preflight; then
       run_onboard
       ONBOARD_RAN=true
+      # After onboard, check for stale sandboxes that need rebuilding (#1904).
+      # Uses --auto so it runs non-interactively in piped/CI contexts.
+      if [ "${_has_sandboxes:-0}" -gt 0 ] 2>/dev/null && command_exists nemoclaw; then
+        info "Checking for sandboxes that need upgrading…"
+        nemoclaw upgrade-sandboxes --auto 2>&1 || warn "Sandbox upgrade check failed (non-fatal)."
+      fi
     else
       warn "Skipping onboarding until the host prerequisites above are fixed."
     fi

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -454,6 +454,48 @@ function getBlueprintMaxOpenshellVersion(rootDir = ROOT) {
   return getBlueprintVersionField("max_openshell_version", rootDir);
 }
 
+// ── Base image digest resolution ────────────────────────────────
+// Pulls the sandbox-base image from GHCR and inspects it to get the
+// actual repo digest. This avoids the registry mismatch that broke
+// e2e tests in #1937 — the digest always comes from the same registry
+// we're pinning to. See #1904.
+
+const SANDBOX_BASE_IMAGE = "ghcr.io/nvidia/nemoclaw/sandbox-base";
+const SANDBOX_BASE_TAG = "latest";
+
+/**
+ * Pull sandbox-base:latest from GHCR and resolve its repo digest.
+ * Returns { digest, ref } on success, or null when the pull or
+ * inspect fails (offline, GHCR outage, local-only build).
+ */
+function pullAndResolveBaseImageDigest() {
+  const imageWithTag = `${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG}`;
+  try {
+    run(["docker", "pull", imageWithTag], { suppressOutput: true });
+  } catch {
+    // Pull failed — caller should fall back to unpin :latest
+    return null;
+  }
+
+  let inspectOutput;
+  try {
+    inspectOutput = runCapture(
+      ["docker", "inspect", "--format", "{{index .RepoDigests 0}}", imageWithTag],
+      { ignoreError: false },
+    );
+  } catch {
+    return null;
+  }
+
+  // inspectOutput looks like "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:abc123..."
+  const match = (inspectOutput || "").match(/sha256:[0-9a-f]{64}/);
+  if (!match) return null;
+
+  const digest = match[0];
+  const ref = `${SANDBOX_BASE_IMAGE}@${digest}`;
+  return { digest, ref };
+}
+
 function getStableGatewayImageRef(versionOutput = null) {
   const version = getInstalledOpenshellVersion(versionOutput);
   if (!version) return null;
@@ -991,10 +1033,17 @@ function patchStagedDockerfile(
   messagingChannels = [],
   messagingAllowedIds = {},
   discordGuilds = {},
+  baseImageRef = null,
 ) {
   const { providerKey, primaryModelRef, inferenceBaseUrl, inferenceApi, inferenceCompat } =
     getSandboxInferenceConfig(model, provider, preferredInferenceApi);
   let dockerfile = fs.readFileSync(dockerfilePath, "utf8");
+  // Pin the base image to a specific digest when available (#1904).
+  // The ref must come from pullAndResolveBaseImageDigest() — never from
+  // blueprint.yaml, whose digest belongs to a different registry.
+  if (baseImageRef) {
+    dockerfile = dockerfile.replace(/^ARG BASE_IMAGE=.*$/m, `ARG BASE_IMAGE=${baseImageRef}`);
+  }
   dockerfile = dockerfile.replace(/^ARG NEMOCLAW_MODEL=.*$/m, `ARG NEMOCLAW_MODEL=${model}`);
   dockerfile = dockerfile.replace(
     /^ARG NEMOCLAW_PROVIDER_KEY=.*$/m,
@@ -2734,6 +2783,15 @@ async function createSandbox(
       };
     }
   }
+  // Pull the base image and resolve its digest so the Dockerfile is pinned to
+  // exactly what we just fetched. This prevents stale :latest tags from
+  // silently reusing a cached old image after NemoClaw upgrades (#1904).
+  const resolved = pullAndResolveBaseImageDigest();
+  if (resolved) {
+    console.log(`  Pinning base image to ${resolved.digest.slice(0, 19)}...`);
+  } else {
+    console.warn("  Warning: could not pull base image from registry; using cached :latest.");
+  }
   patchStagedDockerfile(
     stagedDockerfile,
     model,
@@ -2745,6 +2803,7 @@ async function createSandbox(
     activeMessagingChannels,
     messagingAllowedIds,
     discordGuilds,
+    resolved ? resolved.ref : null,
   );
   // Only pass non-sensitive env vars to the sandbox. Credentials flow through
   // OpenShell providers — the gateway injects them as placeholders and the L7
@@ -5468,6 +5527,9 @@ module.exports = {
   getInstalledOpenshellVersion,
   getBlueprintMinOpenshellVersion,
   getBlueprintMaxOpenshellVersion,
+  pullAndResolveBaseImageDigest,
+  SANDBOX_BASE_IMAGE,
+  SANDBOX_BASE_TAG,
   versionGte,
   getRequestedModelHint,
   getRequestedProviderHint,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -80,6 +80,7 @@ const GLOBAL_COMMANDS = new Set([
   "uninstall",
   "credentials",
   "backup-all",
+  "upgrade-sandboxes",
   "help",
   "--help",
   "-h",
@@ -1601,24 +1602,33 @@ function _rebuildLog(msg) {
   console.error(`  ${D}[rebuild ${new Date().toISOString()}] ${msg}${R}`);
 }
 
-async function sandboxRebuild(sandboxName, args = []) {
+async function sandboxRebuild(sandboxName, args = [], opts = {}) {
   const verbose =
     args.includes("--verbose") ||
     args.includes("-v") ||
     process.env.NEMOCLAW_REBUILD_VERBOSE === "1";
   const log = verbose ? _rebuildLog : () => {};
   const skipConfirm = args.includes("--yes") || args.includes("--force");
+  // When called from upgradeSandboxes in a loop, throwOnError prevents
+  // process.exit from aborting the entire batch on the first failure.
+  const bail = opts.throwOnError
+    ? (msg, code = 1) => {
+        throw new Error(msg);
+      }
+    : (_msg, code = 1) => process.exit(code);
   const sb = registry.getSandbox(sandboxName);
   if (!sb) {
     console.error(`  Sandbox '${sandboxName}' not found in registry.`);
-    process.exit(1);
+    bail(`Sandbox '${sandboxName}' not found in registry.`);
+    return;
   }
 
   // Multi-agent guard (temporary — until swarm lands)
   if (sb.agents && sb.agents.length > 1) {
     console.error("  Multi-agent sandbox rebuild is not yet supported.");
     console.error("  Back up state manually and recreate with `nemoclaw onboard`.");
-    process.exit(1);
+    bail("Multi-agent sandbox rebuild is not yet supported.");
+    return;
   }
 
   const agent = agentRuntime.getSessionAgent(sandboxName);
@@ -1660,7 +1670,8 @@ async function sandboxRebuild(sandboxName, args = []) {
   if (!liveNames.has(sandboxName)) {
     console.error(`  Sandbox '${sandboxName}' is not running. Cannot back up state.`);
     console.error("  Start it first or recreate with `nemoclaw onboard --recreate-sandbox`.");
-    process.exit(1);
+    bail(`Sandbox '${sandboxName}' is not running.`);
+    return;
   }
 
   // Step 2: Backup
@@ -1679,7 +1690,8 @@ async function sandboxRebuild(sandboxName, args = []) {
       console.error(`  Failed: ${backup.failedDirs.join(", ")}`);
     }
     console.error("  Aborting rebuild to prevent data loss.");
-    process.exit(1);
+    bail("Failed to back up sandbox state.");
+    return;
   }
   console.log(`  ${G}\u2713${R} State backed up (${backup.backedUpDirs.length} directories)`);
   console.log(`    Backup: ${backup.manifest.backupPath}`);
@@ -1705,7 +1717,8 @@ async function sandboxRebuild(sandboxName, args = []) {
   if (deleteResult.status !== 0 && !alreadyGone) {
     console.error("  Failed to delete sandbox. Aborting rebuild.");
     console.error("  State backup is preserved at: " + backup.manifest.backupPath);
-    process.exit(deleteResult.status || 1);
+    bail("Failed to delete sandbox.", deleteResult.status || 1);
+    return;
   }
   registry.removeSandbox(sandboxName);
   log(
@@ -1811,6 +1824,95 @@ async function sandboxRebuild(sandboxName, args = []) {
     );
     console.log(`    Backup available at: ${backup.manifest.backupPath}`);
   }
+}
+
+// ── Upgrade sandboxes (#1904) ────────────────────────────────────
+// Detect sandboxes running stale agent versions and offer to rebuild them.
+
+async function upgradeSandboxes(args = []) {
+  const checkOnly = args.includes("--check");
+  const auto = args.includes("--auto");
+  const skipConfirm = auto || args.includes("--yes");
+
+  const sandboxes = registry.listSandboxes().sandboxes;
+  if (sandboxes.length === 0) {
+    console.log("  No sandboxes found in the registry.");
+    return;
+  }
+
+  // Query live sandboxes so we can tell the user which are running
+  const liveResult = captureOpenshell(["sandbox", "list"], { ignoreError: true });
+  if (liveResult.status !== 0) {
+    console.error("  Failed to query running sandboxes from OpenShell.");
+    console.error("  Ensure OpenShell is running: openshell status");
+    return;
+  }
+  const liveNames = parseLiveSandboxNames(liveResult.output || "");
+
+  // Classify sandboxes as stale or current
+  const stale = [];
+  for (const sb of sandboxes) {
+    const versionCheck = sandboxVersion.checkAgentVersion(sb.name);
+    if (versionCheck.isStale) {
+      stale.push({
+        name: sb.name,
+        current: versionCheck.sandboxVersion,
+        expected: versionCheck.expectedVersion,
+        running: liveNames.has(sb.name),
+      });
+    }
+  }
+
+  if (stale.length === 0) {
+    console.log("  All sandboxes are up to date.");
+    return;
+  }
+
+  console.log(`\n  ${B}Stale sandboxes:${R}`);
+  for (const s of stale) {
+    const status = s.running ? `${G}running${R}` : `${D}stopped${R}`;
+    console.log(`    ${s.name}  v${s.current || "?"} → v${s.expected}  (${status})`);
+  }
+  console.log("");
+
+  if (checkOnly) {
+    console.log(`  ${stale.length} sandbox(es) need upgrading.`);
+    console.log("  Run `nemoclaw upgrade-sandboxes` to rebuild them.");
+    return;
+  }
+
+  const rebuildable = stale.filter((s) => s.running);
+  const stopped = stale.filter((s) => !s.running);
+  if (stopped.length > 0) {
+    console.log(`  ${D}Skipping ${stopped.length} stopped sandbox(es) — start them first.${R}`);
+  }
+  if (rebuildable.length === 0) {
+    console.log("  No running stale sandboxes to rebuild.");
+    return;
+  }
+
+  let rebuilt = 0;
+  let failed = 0;
+  for (const s of rebuildable) {
+    if (!skipConfirm) {
+      const answer = await askPrompt(`  Rebuild '${s.name}'? [y/N]: `);
+      if (answer.trim().toLowerCase() !== "y" && answer.trim().toLowerCase() !== "yes") {
+        console.log(`  Skipped '${s.name}'.`);
+        continue;
+      }
+    }
+    try {
+      await sandboxRebuild(s.name, ["--yes"], { throwOnError: true });
+      rebuilt++;
+    } catch (err) {
+      console.error(`  ${YW}\u26a0${R} Failed to rebuild '${s.name}': ${err.message}`);
+      failed++;
+    }
+  }
+
+  console.log("");
+  if (rebuilt > 0) console.log(`  ${G}\u2713${R} ${rebuilt} sandbox(es) rebuilt.`);
+  if (failed > 0) console.log(`  ${YW}\u26a0${R} ${failed} sandbox(es) failed — see errors above.`);
 }
 
 // ── Pre-upgrade backup ───────────────────────────────────────────
@@ -2033,6 +2135,9 @@ function help() {
   ${G}Backup:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade
 
+  ${G}Upgrade:${R}
+    nemoclaw upgrade-sandboxes       Detect and rebuild stale sandboxes ${D}(--check, --auto)${R}
+
   Cleanup:
     nemoclaw uninstall [flags]       Run uninstall.sh (local only; no remote fallback)
 
@@ -2097,6 +2202,9 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       case "backup-all":
         backupAll();
+        break;
+      case "upgrade-sandboxes":
+        await upgradeSandboxes(args);
         break;
       case "--version":
       case "-v": {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2189,4 +2189,126 @@ describe("list shows live gateway inference", () => {
     expect(r.out).toContain("llama3.2:1b");
     expect(r.out).toContain("ollama-local");
   });
+
+  // ── Issue #1904: sandbox not upgraded after NemoClaw upgrade ───
+  // Original report: user upgrades NemoClaw from v0.0.11→v0.0.15 via
+  // curl|bash. Existing sandbox still runs old OpenClaw (2026.3.11)
+  // because Docker cached the stale :latest image. upgrade-sandboxes
+  // --check should detect the version mismatch and report it.
+
+  it(
+    "upgrade-sandboxes --check detects a stale sandbox after NemoClaw upgrade (#1904)",
+    { timeout: 15000 },
+    () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-upgrade-sandboxes-"));
+      const localBin = path.join(home, "bin");
+      const nemoclawDir = path.join(home, ".nemoclaw");
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.mkdirSync(nemoclawDir, { recursive: true });
+
+      // Registry with a sandbox that has an old agentVersion (the pre-upgrade state)
+      fs.writeFileSync(
+        path.join(nemoclawDir, "sandboxes.json"),
+        JSON.stringify({
+          sandboxes: {
+            "my-agent": {
+              name: "my-agent",
+              model: "nvidia/nemotron-3-super-120b-a12b",
+              provider: "nvidia-prod",
+              gpuEnabled: false,
+              policies: [],
+              agentVersion: "2026.3.11",
+            },
+          },
+          defaultSandbox: "my-agent",
+        }),
+        { mode: 0o600 },
+      );
+
+      // Fake openshell that reports the sandbox as running
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/usr/bin/env bash",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+          '  echo "my-agent   Running   openclaw"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "openshell 0.0.24"',
+          "  exit 0",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const r = runWithEnv("upgrade-sandboxes --check 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+
+      expect(r.code).toBe(0);
+      // Should report the stale sandbox with version info
+      expect(r.out).toContain("my-agent");
+      expect(r.out).toContain("2026.3.11");
+      expect(r.out).toMatch(/stale|need upgrading/i);
+    },
+  );
+
+  it(
+    "upgrade-sandboxes --check reports all-current when no sandboxes are stale (#1904)",
+    { timeout: 15000 },
+    () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-upgrade-current-"));
+      const localBin = path.join(home, "bin");
+      const nemoclawDir = path.join(home, ".nemoclaw");
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.mkdirSync(nemoclawDir, { recursive: true });
+
+      // Registry with a sandbox at the current version — should NOT be stale
+      fs.writeFileSync(
+        path.join(nemoclawDir, "sandboxes.json"),
+        JSON.stringify({
+          sandboxes: {
+            "my-agent": {
+              name: "my-agent",
+              model: "nvidia/nemotron-3-super-120b-a12b",
+              provider: "nvidia-prod",
+              gpuEnabled: false,
+              policies: [],
+              agentVersion: "9999.12.31",
+            },
+          },
+          defaultSandbox: "my-agent",
+        }),
+        { mode: 0o600 },
+      );
+
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/usr/bin/env bash",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+          '  echo "my-agent   Running   openclaw"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "openshell 0.0.24"',
+          "  exit 0",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const r = runWithEnv("upgrade-sandboxes --check 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.out).toContain("up to date");
+    },
+  );
 });

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -41,6 +41,8 @@ import {
   normalizeProviderBaseUrl,
   parsePolicyPresetEnv,
   patchStagedDockerfile,
+  pullAndResolveBaseImageDigest,
+  SANDBOX_BASE_IMAGE,
   printSandboxCreateRecoveryHints,
   resolveDashboardForwardTarget,
   summarizeCurlFailure,
@@ -4514,6 +4516,214 @@ const { createSandbox } = require(${onboardPath});
     assert.ok(
       updateAfterCreate !== -1,
       "registry.updateSandbox(model, provider) must appear AFTER createSandbox() — regression #1881",
+    );
+  });
+
+  // ── Base image digest pinning (#1904) ──────────────────────────
+
+  it("patchStagedDockerfile rewrites ARG BASE_IMAGE when baseImageRef is provided", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-base-image-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    const fakeRef =
+      "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-pin",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        fakeRef,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      assert.match(patched, /^ARG BASE_IMAGE=ghcr\.io\/nvidia\/nemoclaw\/sandbox-base@sha256:a{64}$/m);
+      // Model patching still works alongside base image pinning
+      assert.match(patched, /^ARG NEMOCLAW_MODEL=gpt-5\.4$/m);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patchStagedDockerfile preserves ARG BASE_IMAGE when baseImageRef is null", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-base-image-null-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-nopin",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        null,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      assert.match(
+        patched,
+        /^ARG BASE_IMAGE=ghcr\.io\/nvidia\/nemoclaw\/sandbox-base:latest$/m,
+        "BASE_IMAGE should remain unchanged when baseImageRef is null",
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patchStagedDockerfile is safe when Dockerfile has no ARG BASE_IMAGE line", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-no-base-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    const fakeRef =
+      "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-nobase",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        fakeRef,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      // No ARG BASE_IMAGE in original, so the ref should not appear
+      assert.ok(!patched.includes("ARG BASE_IMAGE="), "Should not inject BASE_IMAGE when line is absent");
+      // Other patching should still work
+      assert.match(patched, /^ARG NEMOCLAW_MODEL=gpt-5\.4$/m);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("regression #1904: BASE_IMAGE must reference sandbox-base, not openshell-community", () => {
+    // This is the exact bug that broke all e2e tests in PR #1937:
+    // the code read a digest from blueprint.yaml (openshell-community registry)
+    // and applied it to nemoclaw/sandbox-base (different registry).
+    // Verify that patchStagedDockerfile only writes refs to sandbox-base.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-regression-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    const correctRef =
+      "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-regression",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        correctRef,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      const baseLine = patched.split("\n").find((l) => l.startsWith("ARG BASE_IMAGE="));
+      assert.ok(baseLine, "ARG BASE_IMAGE line must exist");
+      assert.ok(
+        baseLine.includes("nemoclaw/sandbox-base"),
+        `BASE_IMAGE must reference nemoclaw/sandbox-base, got: ${baseLine}`,
+      );
+      assert.ok(
+        !baseLine.includes("openshell-community"),
+        `BASE_IMAGE must NOT reference openshell-community — regression #1937. Got: ${baseLine}`,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("regression #1904: pullAndResolveBaseImageDigest uses sandbox-base registry", () => {
+    // Structural check: verify the constant matches the Dockerfile default
+    // and does NOT reference the openshell-community registry.
+    assert.ok(
+      SANDBOX_BASE_IMAGE.includes("nemoclaw/sandbox-base"),
+      `SANDBOX_BASE_IMAGE must reference nemoclaw/sandbox-base, got: ${SANDBOX_BASE_IMAGE}`,
+    );
+    assert.ok(
+      !SANDBOX_BASE_IMAGE.includes("openshell-community"),
+      `SANDBOX_BASE_IMAGE must NOT reference openshell-community, got: ${SANDBOX_BASE_IMAGE}`,
+    );
+  });
+
+  it("regression #1904: createSandbox calls pullAndResolveBaseImageDigest before patchStagedDockerfile", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+    const pullPos = source.indexOf("pullAndResolveBaseImageDigest()");
+    assert.ok(pullPos !== -1, "pullAndResolveBaseImageDigest() call not found in onboard.ts");
+    const patchPos = source.indexOf("patchStagedDockerfile(", pullPos);
+    assert.ok(
+      patchPos > pullPos,
+      "pullAndResolveBaseImageDigest must be called BEFORE patchStagedDockerfile — regression #1904",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Re-implements digest pinning and `upgrade-sandboxes` reverted in #1938
- Fixes the root cause: original PR read a digest from `blueprint.yaml` (belongs to `ghcr.io/nvidia/openshell-community`) and applied it to `ghcr.io/nvidia/nemoclaw/sandbox-base` — a different registry. Docker digests are repo-specific, so every sandbox creation failed with "manifest unknown"
- New approach: `pullAndResolveBaseImageDigest()` pulls `sandbox-base:latest` from GHCR, then `docker inspect` extracts the actual repo digest. The digest is self-consistent by construction — it always comes from the same registry we pin to
- Falls back to unpinned `:latest` when GHCR is unreachable (offline/firewall users)
- Re-adds `nemoclaw upgrade-sandboxes` command with `--check`/`--auto`/`--yes` flags and fixes from CodeRabbit review (sandbox list error handling, `throwOnError` for batch rebuilds, `--auto` in install.sh)

Closes #1904

## Test plan

- [x] 8 new unit tests (6 in onboard.test.ts, 2 CLI integration tests in cli.test.ts)
- [x] Regression guard: verifies `ARG BASE_IMAGE` references `nemoclaw/sandbox-base`, NOT `openshell-community`
- [x] Structural test: `pullAndResolveBaseImageDigest()` called before `patchStagedDockerfile()`
- [x] CLI test: `upgrade-sandboxes --check` detects stale sandbox (original reporter scenario from #1904)
- [x] CLI test: `upgrade-sandboxes --check` reports all-current when no sandboxes are stale
- [ ] Nightly cloud e2e: verify sandbox creation succeeds with digest pinning (the exact scenario that broke in #1937)
- [ ] Manual: verify `nemoclaw upgrade-sandboxes --check` on a real environment with a stale sandbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sandboxes are now automatically checked for staleness and rebuilt after onboarding completes
  * New `upgrade-sandboxes` command detects and rebuilds sandboxes with outdated versions; supports `--check` (report-only) and `--auto` (skip confirmations) modes
  * Docker base images are now pinned to specific digest versions for reproducible builds

* **Tests**
  * Added integration tests for sandbox upgrade detection and base image pinning behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->