### PR TITLE
fix(upgrade): pin base image via pull-then-inspect and rebuild stale sandboxes

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -379,6 +379,35 @@ jobs:
           path: /tmp/nemoclaw-e2e-install.log
           if-no-files-found: ignore
 
+  # ── Shields & config lifecycle E2E ───────────────────────────
+  # Validates shields down/up controls config mutability, config get/set/
+  # rotate-token, audit trail, and auto-restore timer.
+  shields-config-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run shields & config E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-shields"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-shields-config.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shields-config-install-log
+          path: /tmp/nemoclaw-e2e-shields-install.log
+          if-no-files-found: ignore
+
   # ── OpenClaw rebuild upgrade E2E ─────────────────────────────
   # Reproduces NVBug 6076156: onboard with an older OpenClaw version,
   # then rebuild to verify workspace state survives the upgrade.
@@ -406,6 +435,38 @@ jobs:
         with:
           name: rebuild-openclaw-install-log
           path: /tmp/nemoclaw-e2e-install.log
+          if-no-files-found: ignore
+
+  # ── Issue #1904: stale sandbox after NemoClaw upgrade ────────
+  # Exact reproduction of the reporter's scenario: install an older
+  # NemoClaw, create a sandbox, upgrade to current, verify the old
+  # sandbox is detected as stale and rebuilt with the new image.
+  upgrade-stale-sandbox-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run upgrade stale sandbox E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-upgrade-stale"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-upgrade-stale-sandbox.sh
+
+      - name: Upload install logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upgrade-stale-sandbox-logs
+          path: |
+            /tmp/nemoclaw-e2e-old-install.log
+            /tmp/nemoclaw-e2e-upgrade-install.log
           if-no-files-found: ignore
 
   # ── Hermes rebuild upgrade E2E ──────────────────────────────
@@ -489,8 +550,8 @@ jobs:
 
   notify-on-failure:
     runs-on: ubuntu-latest
-    needs: [cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e, sandbox-survival-e2e, hermes-e2e, skip-permissions-e2e, sandbox-operations-e2e, inference-routing-e2e, snapshot-commands-e2e, rebuild-openclaw-e2e, rebuild-hermes-e2e, gpu-e2e]
-    if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.messaging-providers-e2e.result == 'failure' || needs.sandbox-survival-e2e.result == 'failure' || needs.hermes-e2e.result == 'failure' || needs.skip-permissions-e2e.result == 'failure' || needs.sandbox-operations-e2e.result == 'failure' || needs.inference-routing-e2e.result == 'failure' || needs.snapshot-commands-e2e.result == 'failure' || needs.rebuild-openclaw-e2e.result == 'failure' || needs.rebuild-hermes-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
+    needs: [cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e, sandbox-survival-e2e, hermes-e2e, skip-permissions-e2e, sandbox-operations-e2e, inference-routing-e2e, snapshot-commands-e2e, rebuild-openclaw-e2e, upgrade-stale-sandbox-e2e, rebuild-hermes-e2e, gpu-e2e]
+    if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.messaging-providers-e2e.result == 'failure' || needs.sandbox-survival-e2e.result == 'failure' || needs.hermes-e2e.result == 'failure' || needs.skip-permissions-e2e.result == 'failure' || needs.sandbox-operations-e2e.result == 'failure' || needs.inference-routing-e2e.result == 'failure' || needs.snapshot-commands-e2e.result == 'failure' || needs.rebuild-openclaw-e2e.result == 'failure' || needs.upgrade-stale-sandbox-e2e.result == 'failure' || needs.rebuild-hermes-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
     permissions:
       issues: write
     steps:

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+test/e2e/test-inference-routing.sh:generic-api-key:304

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1265,6 +1265,12 @@ except Exception:
     if run_installer_host_preflight; then
       run_onboard
       ONBOARD_RAN=true
+      # After onboard, check for stale sandboxes that need rebuilding (#1904).
+      # Uses --auto so it runs non-interactively in piped/CI contexts.
+      if [ "${_has_sandboxes:-0}" -gt 0 ] 2>/dev/null && command_exists nemoclaw; then
+        info "Checking for sandboxes that need upgrading…"
+        nemoclaw upgrade-sandboxes --auto 2>&1 || warn "Sandbox upgrade check failed (non-fatal)."
+      fi
     else
       warn "Skipping onboarding until the host prerequisites above are fixed."
     fi

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2830,8 +2830,8 @@ async function createSandbox(
     console.log(`  Pinning base image to ${resolved.digest.slice(0, 19)}...`);
   } else {
     // Check if the image exists locally before falling back to unpinned :latest.
-    // On a first-time install behind a firewall, there's no cached image and the
-    // build would fail later with a confusing Docker error.
+    // On a first-time install behind a firewall with no cached image, warn early
+    // so the user knows the build will likely fail.
     const localCheck = runCapture(
       ["docker", "image", "inspect", `${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG}`],
       { ignoreError: true },
@@ -2839,11 +2839,10 @@ async function createSandbox(
     if (localCheck) {
       console.warn("  Warning: could not pull base image from registry; using cached :latest.");
     } else {
-      console.error(`  Error: base image ${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG} is not available.`);
-      console.error("  Cannot pull from registry and no local cache exists.");
-      console.error("  Check your network connection or pull the image manually:");
-      console.error(`    docker pull ${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG}`);
-      process.exit(1);
+      console.warn(`  Warning: base image ${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG} is not available locally.`);
+      console.warn("  The build will fail unless Docker can pull the image during build.");
+      console.warn("  If offline, pull the image manually first:");
+      console.warn(`    docker pull ${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG}`);
     }
   }
   patchStagedDockerfile(

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -455,6 +455,57 @@ function getBlueprintMaxOpenshellVersion(rootDir = ROOT) {
   return getBlueprintVersionField("max_openshell_version", rootDir);
 }
 
+// ── Base image digest resolution ────────────────────────────────
+// Pulls the sandbox-base image from GHCR and inspects it to get the
+// actual repo digest. This avoids the registry mismatch that broke
+// e2e tests in #1937 — the digest always comes from the same registry
+// we're pinning to. See #1904.
+
+const SANDBOX_BASE_IMAGE = "ghcr.io/nvidia/nemoclaw/sandbox-base";
+const SANDBOX_BASE_TAG = "latest";
+
+/**
+ * Pull sandbox-base:latest from GHCR and resolve its repo digest.
+ * Returns { digest, ref } on success, or null when the pull or
+ * inspect fails (offline, GHCR outage, local-only build).
+ */
+function pullAndResolveBaseImageDigest() {
+  const imageWithTag = `${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG}`;
+  try {
+    run(["docker", "pull", imageWithTag], { suppressOutput: true });
+  } catch {
+    // Pull failed — caller should fall back to unpin :latest
+    return null;
+  }
+
+  let inspectOutput;
+  try {
+    inspectOutput = runCapture(
+      ["docker", "inspect", "--format", "{{json .RepoDigests}}", imageWithTag],
+      { ignoreError: false },
+    );
+  } catch {
+    return null;
+  }
+
+  // RepoDigests is a JSON array like ["ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:abc..."].
+  // Filter to the entry matching our registry — index ordering is not guaranteed.
+  let repoDigests;
+  try {
+    repoDigests = JSON.parse(inspectOutput || "[]");
+  } catch {
+    return null;
+  }
+  const repoDigest = Array.isArray(repoDigests)
+    ? repoDigests.find((entry) => entry.startsWith(`${SANDBOX_BASE_IMAGE}@sha256:`))
+    : null;
+  if (!repoDigest) return null;
+
+  const digest = repoDigest.slice(repoDigest.indexOf("@") + 1);
+  const ref = `${SANDBOX_BASE_IMAGE}@${digest}`;
+  return { digest, ref };
+}
+
 function getStableGatewayImageRef(versionOutput = null) {
   const version = getInstalledOpenshellVersion(versionOutput);
   if (!version) return null;
@@ -992,10 +1043,17 @@ function patchStagedDockerfile(
   messagingChannels = [],
   messagingAllowedIds = {},
   discordGuilds = {},
+  baseImageRef = null,
 ) {
   const { providerKey, primaryModelRef, inferenceBaseUrl, inferenceApi, inferenceCompat } =
     getSandboxInferenceConfig(model, provider, preferredInferenceApi);
   let dockerfile = fs.readFileSync(dockerfilePath, "utf8");
+  // Pin the base image to a specific digest when available (#1904).
+  // The ref must come from pullAndResolveBaseImageDigest() — never from
+  // blueprint.yaml, whose digest belongs to a different registry.
+  if (baseImageRef) {
+    dockerfile = dockerfile.replace(/^ARG BASE_IMAGE=.*$/m, `ARG BASE_IMAGE=${baseImageRef}`);
+  }
   dockerfile = dockerfile.replace(/^ARG NEMOCLAW_MODEL=.*$/m, `ARG NEMOCLAW_MODEL=${model}`);
   dockerfile = dockerfile.replace(
     /^ARG NEMOCLAW_PROVIDER_KEY=.*$/m,
@@ -2756,6 +2814,15 @@ async function createSandbox(
       };
     }
   }
+  // Pull the base image and resolve its digest so the Dockerfile is pinned to
+  // exactly what we just fetched. This prevents stale :latest tags from
+  // silently reusing a cached old image after NemoClaw upgrades (#1904).
+  const resolved = pullAndResolveBaseImageDigest();
+  if (resolved) {
+    console.log(`  Pinning base image to ${resolved.digest.slice(0, 19)}...`);
+  } else {
+    console.warn("  Warning: could not pull base image from registry; using cached :latest.");
+  }
   patchStagedDockerfile(
     stagedDockerfile,
     model,
@@ -2767,6 +2834,7 @@ async function createSandbox(
     activeMessagingChannels,
     messagingAllowedIds,
     discordGuilds,
+    resolved ? resolved.ref : null,
   );
   // Only pass non-sensitive env vars to the sandbox. Credentials flow through
   // OpenShell providers — the gateway injects them as placeholders and the L7
@@ -5487,6 +5555,9 @@ module.exports = {
   getInstalledOpenshellVersion,
   getBlueprintMinOpenshellVersion,
   getBlueprintMaxOpenshellVersion,
+  pullAndResolveBaseImageDigest,
+  SANDBOX_BASE_IMAGE,
+  SANDBOX_BASE_TAG,
   versionGte,
   getRequestedModelHint,
   getRequestedProviderHint,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1051,8 +1051,16 @@ function patchStagedDockerfile(
   // Pin the base image to a specific digest when available (#1904).
   // The ref must come from pullAndResolveBaseImageDigest() — never from
   // blueprint.yaml, whose digest belongs to a different registry.
+  // Only rewrite when the current value already points at our sandbox-base
+  // image — custom --from Dockerfiles may use a different base.
   if (baseImageRef) {
-    dockerfile = dockerfile.replace(/^ARG BASE_IMAGE=.*$/m, `ARG BASE_IMAGE=${baseImageRef}`);
+    dockerfile = dockerfile.replace(/^ARG BASE_IMAGE=(.*)$/m, (line, currentValue) => {
+      const trimmed = String(currentValue).trim();
+      if (trimmed.startsWith(`${SANDBOX_BASE_IMAGE}:`) || trimmed.startsWith(`${SANDBOX_BASE_IMAGE}@`)) {
+        return `ARG BASE_IMAGE=${baseImageRef}`;
+      }
+      return line;
+    });
   }
   dockerfile = dockerfile.replace(/^ARG NEMOCLAW_MODEL=.*$/m, `ARG NEMOCLAW_MODEL=${model}`);
   dockerfile = dockerfile.replace(
@@ -2821,7 +2829,22 @@ async function createSandbox(
   if (resolved) {
     console.log(`  Pinning base image to ${resolved.digest.slice(0, 19)}...`);
   } else {
-    console.warn("  Warning: could not pull base image from registry; using cached :latest.");
+    // Check if the image exists locally before falling back to unpinned :latest.
+    // On a first-time install behind a firewall, there's no cached image and the
+    // build would fail later with a confusing Docker error.
+    const localCheck = runCapture(
+      ["docker", "image", "inspect", `${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG}`],
+      { ignoreError: true },
+    );
+    if (localCheck) {
+      console.warn("  Warning: could not pull base image from registry; using cached :latest.");
+    } else {
+      console.error(`  Error: base image ${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG} is not available.`);
+      console.error("  Cannot pull from registry and no local cache exists.");
+      console.error("  Check your network connection or pull the image manually:");
+      console.error(`    docker pull ${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG}`);
+      process.exit(1);
+    }
   }
   patchStagedDockerfile(
     stagedDockerfile,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -80,6 +80,7 @@ const GLOBAL_COMMANDS = new Set([
   "uninstall",
   "credentials",
   "backup-all",
+  "upgrade-sandboxes",
   "help",
   "--help",
   "-h",
@@ -1601,24 +1602,33 @@ function _rebuildLog(msg) {
   console.error(`  ${D}[rebuild ${new Date().toISOString()}] ${msg}${R}`);
 }
 
-async function sandboxRebuild(sandboxName, args = []) {
+async function sandboxRebuild(sandboxName, args = [], opts = {}) {
   const verbose =
     args.includes("--verbose") ||
     args.includes("-v") ||
     process.env.NEMOCLAW_REBUILD_VERBOSE === "1";
   const log = verbose ? _rebuildLog : () => {};
   const skipConfirm = args.includes("--yes") || args.includes("--force");
+  // When called from upgradeSandboxes in a loop, throwOnError prevents
+  // process.exit from aborting the entire batch on the first failure.
+  const bail = opts.throwOnError
+    ? (msg, code = 1) => {
+        throw new Error(msg);
+      }
+    : (_msg, code = 1) => process.exit(code);
   const sb = registry.getSandbox(sandboxName);
   if (!sb) {
     console.error(`  Sandbox '${sandboxName}' not found in registry.`);
-    process.exit(1);
+    bail(`Sandbox '${sandboxName}' not found in registry.`);
+    return;
   }
 
   // Multi-agent guard (temporary — until swarm lands)
   if (sb.agents && sb.agents.length > 1) {
     console.error("  Multi-agent sandbox rebuild is not yet supported.");
     console.error("  Back up state manually and recreate with `nemoclaw onboard`.");
-    process.exit(1);
+    bail("Multi-agent sandbox rebuild is not yet supported.");
+    return;
   }
 
   const agent = agentRuntime.getSessionAgent(sandboxName);
@@ -1660,7 +1670,8 @@ async function sandboxRebuild(sandboxName, args = []) {
   if (!liveNames.has(sandboxName)) {
     console.error(`  Sandbox '${sandboxName}' is not running. Cannot back up state.`);
     console.error("  Start it first or recreate with `nemoclaw onboard --recreate-sandbox`.");
-    process.exit(1);
+    bail(`Sandbox '${sandboxName}' is not running.`);
+    return;
   }
 
   // Step 2: Backup
@@ -1679,7 +1690,8 @@ async function sandboxRebuild(sandboxName, args = []) {
       console.error(`  Failed: ${backup.failedDirs.join(", ")}`);
     }
     console.error("  Aborting rebuild to prevent data loss.");
-    process.exit(1);
+    bail("Failed to back up sandbox state.");
+    return;
   }
   console.log(`  ${G}\u2713${R} State backed up (${backup.backedUpDirs.length} directories)`);
   console.log(`    Backup: ${backup.manifest.backupPath}`);
@@ -1705,7 +1717,8 @@ async function sandboxRebuild(sandboxName, args = []) {
   if (deleteResult.status !== 0 && !alreadyGone) {
     console.error("  Failed to delete sandbox. Aborting rebuild.");
     console.error("  State backup is preserved at: " + backup.manifest.backupPath);
-    process.exit(deleteResult.status || 1);
+    bail("Failed to delete sandbox.", deleteResult.status || 1);
+    return;
   }
   registry.removeSandbox(sandboxName);
   log(
@@ -1811,6 +1824,117 @@ async function sandboxRebuild(sandboxName, args = []) {
     );
     console.log(`    Backup available at: ${backup.manifest.backupPath}`);
   }
+}
+
+// ── Upgrade sandboxes (#1904) ────────────────────────────────────
+// Detect sandboxes running stale agent versions and offer to rebuild them.
+
+async function upgradeSandboxes(args = []) {
+  const checkOnly = args.includes("--check");
+  const auto = args.includes("--auto");
+  const skipConfirm = auto || args.includes("--yes");
+
+  const sandboxes = registry.listSandboxes().sandboxes;
+  if (sandboxes.length === 0) {
+    console.log("  No sandboxes found in the registry.");
+    return;
+  }
+
+  // Query live sandboxes so we can tell the user which are running
+  const liveResult = captureOpenshell(["sandbox", "list"], { ignoreError: true });
+  if (liveResult.status !== 0) {
+    console.error("  Failed to query running sandboxes from OpenShell.");
+    console.error("  Ensure OpenShell is running: openshell status");
+    process.exit(liveResult.status || 1);
+  }
+  const liveNames = parseLiveSandboxNames(liveResult.output || "");
+
+  // Classify sandboxes as stale, unknown, or current
+  const stale = [];
+  const unknown = [];
+  for (const sb of sandboxes) {
+    const versionCheck = sandboxVersion.checkAgentVersion(sb.name);
+    if (versionCheck.isStale) {
+      stale.push({
+        name: sb.name,
+        current: versionCheck.sandboxVersion,
+        expected: versionCheck.expectedVersion,
+        running: liveNames.has(sb.name),
+      });
+    } else if (versionCheck.detectionMethod === "unavailable") {
+      unknown.push({
+        name: sb.name,
+        expected: versionCheck.expectedVersion,
+        running: liveNames.has(sb.name),
+      });
+    }
+  }
+
+  if (stale.length === 0 && unknown.length === 0) {
+    console.log("  All sandboxes are up to date.");
+    return;
+  }
+
+  if (stale.length > 0) {
+    console.log(`\n  ${B}Stale sandboxes:${R}`);
+    for (const s of stale) {
+      const status = s.running ? `${G}running${R}` : `${D}stopped${R}`;
+      console.log(`    ${s.name}  v${s.current || "?"} → v${s.expected}  (${status})`);
+    }
+  }
+  if (unknown.length > 0) {
+    console.log(`\n  ${YW}Unknown version:${R}`);
+    for (const s of unknown) {
+      const status = s.running ? `${G}running${R}` : `${D}stopped${R}`;
+      console.log(`    ${s.name}  v? → v${s.expected}  (${status})`);
+    }
+  }
+  console.log("");
+
+  if (checkOnly) {
+    if (stale.length > 0) console.log(`  ${stale.length} sandbox(es) need upgrading.`);
+    if (unknown.length > 0) {
+      console.log(
+        `  ${unknown.length} sandbox(es) could not be version-checked; start them and rerun, or rebuild manually.`,
+      );
+    }
+    console.log("  Run `nemoclaw upgrade-sandboxes` to rebuild them.");
+    return;
+  }
+
+  const rebuildable = stale.filter((s) => s.running);
+  const stopped = stale.filter((s) => !s.running);
+  if (stopped.length > 0) {
+    console.log(`  ${D}Skipping ${stopped.length} stopped sandbox(es) — start them first.${R}`);
+  }
+  if (rebuildable.length === 0) {
+    console.log("  No running stale sandboxes to rebuild.");
+    return;
+  }
+
+  let rebuilt = 0;
+  let failed = 0;
+  for (const s of rebuildable) {
+    if (!skipConfirm) {
+      const answer = await askPrompt(`  Rebuild '${s.name}'? [y/N]: `);
+      if (answer.trim().toLowerCase() !== "y" && answer.trim().toLowerCase() !== "yes") {
+        console.log(`  Skipped '${s.name}'.`);
+        continue;
+      }
+    }
+    try {
+      await sandboxRebuild(s.name, ["--yes"], { throwOnError: true });
+      rebuilt++;
+    } catch (err) {
+      console.error(`  ${YW}\u26a0${R} Failed to rebuild '${s.name}': ${err.message}`);
+      failed++;
+    }
+  }
+
+  console.log("");
+  if (rebuilt > 0) console.log(`  ${G}\u2713${R} ${rebuilt} sandbox(es) rebuilt.`);
+  if (failed > 0) console.log(`  ${YW}\u26a0${R} ${failed} sandbox(es) failed — see errors above.`);
+  if (failed > 0) process.exit(1);
 }
 
 // ── Pre-upgrade backup ───────────────────────────────────────────
@@ -2033,6 +2157,9 @@ function help() {
   ${G}Backup:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade
 
+  ${G}Upgrade:${R}
+    nemoclaw upgrade-sandboxes       Detect and rebuild stale sandboxes ${D}(--check, --auto)${R}
+
   Cleanup:
     nemoclaw uninstall [flags]       Run uninstall.sh (local only; no remote fallback)
 
@@ -2097,6 +2224,9 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       case "backup-all":
         backupAll();
+        break;
+      case "upgrade-sandboxes":
+        await upgradeSandboxes(args);
         break;
       case "--version":
       case "-v": {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2189,4 +2189,126 @@ describe("list shows live gateway inference", () => {
     expect(r.out).toContain("llama3.2:1b");
     expect(r.out).toContain("ollama-local");
   });
+
+  // ── Issue #1904: sandbox not upgraded after NemoClaw upgrade ───
+  // Original report: user upgrades NemoClaw from v0.0.11→v0.0.15 via
+  // curl|bash. Existing sandbox still runs old OpenClaw (2026.3.11)
+  // because Docker cached the stale :latest image. upgrade-sandboxes
+  // --check should detect the version mismatch and report it.
+
+  it(
+    "upgrade-sandboxes --check detects a stale sandbox after NemoClaw upgrade (#1904)",
+    { timeout: 15000 },
+    () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-upgrade-sandboxes-"));
+      const localBin = path.join(home, "bin");
+      const nemoclawDir = path.join(home, ".nemoclaw");
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.mkdirSync(nemoclawDir, { recursive: true });
+
+      // Registry with a sandbox that has an old agentVersion (the pre-upgrade state)
+      fs.writeFileSync(
+        path.join(nemoclawDir, "sandboxes.json"),
+        JSON.stringify({
+          sandboxes: {
+            "my-agent": {
+              name: "my-agent",
+              model: "nvidia/nemotron-3-super-120b-a12b",
+              provider: "nvidia-prod",
+              gpuEnabled: false,
+              policies: [],
+              agentVersion: "2026.3.11",
+            },
+          },
+          defaultSandbox: "my-agent",
+        }),
+        { mode: 0o600 },
+      );
+
+      // Fake openshell that reports the sandbox as running
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/usr/bin/env bash",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+          '  echo "my-agent   Running   openclaw"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "openshell 0.0.24"',
+          "  exit 0",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const r = runWithEnv("upgrade-sandboxes --check 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+
+      expect(r.code).toBe(0);
+      // Should report the stale sandbox with version info
+      expect(r.out).toContain("my-agent");
+      expect(r.out).toContain("2026.3.11");
+      expect(r.out).toMatch(/stale|need upgrading/i);
+    },
+  );
+
+  it(
+    "upgrade-sandboxes --check reports all-current when no sandboxes are stale (#1904)",
+    { timeout: 15000 },
+    () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-upgrade-current-"));
+      const localBin = path.join(home, "bin");
+      const nemoclawDir = path.join(home, ".nemoclaw");
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.mkdirSync(nemoclawDir, { recursive: true });
+
+      // Registry with a sandbox at the current version — should NOT be stale
+      fs.writeFileSync(
+        path.join(nemoclawDir, "sandboxes.json"),
+        JSON.stringify({
+          sandboxes: {
+            "my-agent": {
+              name: "my-agent",
+              model: "nvidia/nemotron-3-super-120b-a12b",
+              provider: "nvidia-prod",
+              gpuEnabled: false,
+              policies: [],
+              agentVersion: "9999.12.31",
+            },
+          },
+          defaultSandbox: "my-agent",
+        }),
+        { mode: 0o600 },
+      );
+
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/usr/bin/env bash",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+          '  echo "my-agent   Running   openclaw"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "openshell 0.0.24"',
+          "  exit 0",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const r = runWithEnv("upgrade-sandboxes --check 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.out).toContain("up to date");
+    },
+  );
 });

--- a/test/e2e/test-upgrade-stale-sandbox.sh
+++ b/test/e2e/test-upgrade-stale-sandbox.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Issue #1904 reproduction — "sandbox OpenClaw version is not upgraded
+# after NemoClaw upgrade".
+#
+#   1. Install current NemoClaw via install.sh (sets up gateway + OpenShell)
+#   2. Delete the sandbox install.sh created (keep the gateway)
+#   3. Build a base image with an OLDER OpenClaw version (2026.3.11)
+#   4. Create a sandbox from that old image via openshell directly
+#   5. Register it in NemoClaw's registry with the old agentVersion
+#   6. Run `nemoclaw upgrade-sandboxes --check`
+#   7. Verify it detects the sandbox as stale
+#   8. Run `nemoclaw <name> rebuild --yes` to upgrade
+#   9. Verify the sandbox now runs the current OpenClaw version
+#  10. Verify `upgrade-sandboxes --check` reports clean
+#
+# Prerequisites:
+#   - Docker running
+#   - NVIDIA_API_KEY set (real key, starts with nvapi-)
+
+set -euo pipefail
+
+OLD_OPENCLAW_VERSION="2026.3.11"
+SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-upgrade-stale}"
+REGISTRY_FILE="$HOME/.nemoclaw/sandboxes.json"
+SESSION_FILE="$HOME/.nemoclaw/onboard-session.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() {
+  echo -e "${RED}[FAIL]${NC} $1" >&2
+  echo -e "${YELLOW}[DIAG]${NC} --- Failure diagnostics ---" >&2
+  echo -e "${YELLOW}[DIAG]${NC} Registry: $(cat "${REGISTRY_FILE}" 2>/dev/null || echo 'not found')" >&2
+  echo -e "${YELLOW}[DIAG]${NC} Sandboxes: $(openshell sandbox list 2>&1 || echo 'openshell unavailable')" >&2
+  echo -e "${YELLOW}[DIAG]${NC} Docker images: $(docker images --format '{{.Repository}}:{{.Tag}} {{.ID}}' | grep -Ei 'sandbox|nemoclaw|openclaw' | head -10 || true)" >&2
+  echo -e "${YELLOW}[DIAG]${NC} --- End diagnostics ---" >&2
+  exit 1
+}
+info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+diag() { echo -e "${YELLOW}[DIAG]${NC} $1"; }
+
+# ── Preflight ───────────────────────────────────────────────────────
+[ -n "${NVIDIA_API_KEY:-}" ] || fail "NVIDIA_API_KEY is required"
+[ "${NEMOCLAW_NON_INTERACTIVE:-}" = "1" ] || fail "NEMOCLAW_NON_INTERACTIVE=1 is required"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+export NEMOCLAW_REBUILD_VERBOSE=1
+
+info "Issue #1904 reproduction (old OpenClaw: ${OLD_OPENCLAW_VERSION}, sandbox: ${SANDBOX_NAME})"
+
+# ── Phase 1: Install current NemoClaw ────────────────────────────────
+info "Phase 1: Installing current NemoClaw via install.sh..."
+
+export NEMOCLAW_NON_INTERACTIVE=1
+export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1
+export NEMOCLAW_SANDBOX_NAME="${SANDBOX_NAME}"
+export NEMOCLAW_RECREATE_SANDBOX=1
+
+INSTALL_LOG="/tmp/nemoclaw-e2e-upgrade-install.log"
+if ! bash "${REPO_ROOT}/install.sh" --non-interactive >"$INSTALL_LOG" 2>&1; then
+  info "install.sh exited non-zero (may be expected). Checking..."
+fi
+
+# Source shell profile to pick up nvm/PATH changes
+if [ -f "$HOME/.bashrc" ]; then
+  # shellcheck source=/dev/null
+  source "$HOME/.bashrc" 2>/dev/null || true
+fi
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+fi
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+command -v nemoclaw >/dev/null 2>&1 || fail "nemoclaw not found on PATH after install"
+command -v openshell >/dev/null 2>&1 || fail "openshell not found on PATH after install"
+pass "NemoClaw installed"
+
+# ── Phase 2: Delete sandbox, build old base image ────────────────────
+info "Phase 2: Replacing sandbox with old OpenClaw ${OLD_OPENCLAW_VERSION}..."
+
+# Delete the sandbox that install.sh created — we'll make our own old one.
+openshell sandbox delete "${SANDBOX_NAME}" 2>/dev/null || true
+diag "Deleted Phase 1 sandbox, gateway preserved"
+
+OLD_BASE_TAG="nemoclaw-old-base:e2e-upgrade-stale"
+BLUEPRINT="${REPO_ROOT}/nemoclaw-blueprint/blueprint.yaml"
+BLUEPRINT_BAK="${BLUEPRINT}.bak"
+
+# Temporarily lower min_openclaw_version so the old version builds.
+cp "${BLUEPRINT}" "${BLUEPRINT_BAK}"
+sed "s/min_openclaw_version:.*/min_openclaw_version: \"${OLD_OPENCLAW_VERSION}\"/" "${BLUEPRINT}" >"${BLUEPRINT}.tmp"
+mv "${BLUEPRINT}.tmp" "${BLUEPRINT}"
+
+docker build \
+  --build-arg "OPENCLAW_VERSION=${OLD_OPENCLAW_VERSION}" \
+  -f "${REPO_ROOT}/Dockerfile.base" \
+  -t "${OLD_BASE_TAG}" \
+  "${REPO_ROOT}"
+BUILD_RC=$?
+
+mv "${BLUEPRINT_BAK}" "${BLUEPRINT}"
+[ "$BUILD_RC" -eq 0 ] || fail "Failed to build old base image"
+
+pass "Old base image built (OpenClaw ${OLD_OPENCLAW_VERSION})"
+
+# ── Phase 3: Create old sandbox via openshell ────────────────────────
+info "Phase 3: Creating sandbox with old OpenClaw..."
+
+TESTDIR=$(mktemp -d)
+cat >"${TESTDIR}/Dockerfile" <<DOCKERFILE
+FROM ${OLD_BASE_TAG}
+USER sandbox
+WORKDIR /sandbox
+RUN mkdir -p /sandbox/.openclaw-data/workspace /sandbox/.openclaw && echo '{}' > /sandbox/.openclaw/openclaw.json
+CMD ["/bin/bash"]
+DOCKERFILE
+
+openshell sandbox create --name "${SANDBOX_NAME}" --from "${TESTDIR}/Dockerfile" --gateway nemoclaw --no-tty -- true
+rm -rf "${TESTDIR}"
+
+# Wait for Ready
+for _i in $(seq 1 30); do
+  if openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready"; then
+    break
+  fi
+  sleep 5
+done
+openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready" \
+  || fail "Sandbox did not become Ready"
+
+SANDBOX_VERSION=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- openclaw --version 2>&1) \
+  || fail "Failed to read OpenClaw version from old sandbox"
+info "Old sandbox OpenClaw version: ${SANDBOX_VERSION}"
+
+pass "Old sandbox created (OpenClaw ${OLD_OPENCLAW_VERSION})"
+
+# ── Phase 4: Register with old agentVersion ──────────────────────────
+info "Phase 4: Registering sandbox with old agentVersion..."
+
+python3 -c "
+import json
+reg = {'sandboxes': {'${SANDBOX_NAME}': {
+    'name': '${SANDBOX_NAME}',
+    'createdAt': '$(date -u +%Y-%m-%dT%H:%M:%SZ)',
+    'model': 'nvidia/nemotron-3-super-120b-a12b',
+    'provider': 'nvidia-prod',
+    'gpuEnabled': False,
+    'policies': [],
+    'policyTier': None,
+    'agent': None,
+    'agentVersion': '${OLD_OPENCLAW_VERSION}'
+}}, 'defaultSandbox': '${SANDBOX_NAME}'}
+with open('${REGISTRY_FILE}', 'w') as f:
+    json.dump(reg, f, indent=2)
+
+sess_path = '${SESSION_FILE}'
+try:
+    with open(sess_path) as f:
+        sess = json.load(f)
+except Exception:
+    sess = {}
+sess['sandboxName'] = '${SANDBOX_NAME}'
+sess['status'] = 'complete'
+with open(sess_path, 'w') as f:
+    json.dump(sess, f, indent=2)
+print('Registry and session updated')
+"
+
+pass "Sandbox registered with agentVersion=${OLD_OPENCLAW_VERSION}"
+
+# ── Phase 5: Verify upgrade-sandboxes detects the stale sandbox ──────
+info "Phase 5: Running upgrade-sandboxes --check..."
+
+CHECK_OUTPUT=$(nemoclaw upgrade-sandboxes --check 2>&1 || true)
+echo "$CHECK_OUTPUT"
+
+if echo "$CHECK_OUTPUT" | grep -qi "stale\|need upgrading"; then
+  pass "Phase 5: upgrade-sandboxes --check detected stale sandbox"
+elif echo "$CHECK_OUTPUT" | grep -qi "up to date"; then
+  fail "upgrade-sandboxes --check says all up to date — stale sandbox NOT detected (#1904)"
+else
+  fail "upgrade-sandboxes --check produced unexpected output"
+fi
+
+# ── Phase 6: Rebuild and verify new version ──────────────────────────
+info "Phase 6: Rebuilding sandbox..."
+
+nemoclaw "${SANDBOX_NAME}" rebuild --yes 2>&1 || fail "Sandbox rebuild failed"
+
+for _i in $(seq 1 30); do
+  if openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready"; then
+    break
+  fi
+  sleep 5
+done
+
+NEW_OPENCLAW_VERSION=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- openclaw --version 2>&1) \
+  || fail "Failed to read OpenClaw version after rebuild"
+info "New sandbox OpenClaw version: ${NEW_OPENCLAW_VERSION}"
+
+if echo "${NEW_OPENCLAW_VERSION}" | grep -q "${OLD_OPENCLAW_VERSION}"; then
+  fail "Sandbox still running old OpenClaw ${OLD_OPENCLAW_VERSION} after rebuild — #1904 NOT fixed"
+fi
+
+pass "Phase 6: Sandbox upgraded from OpenClaw ${OLD_OPENCLAW_VERSION} to ${NEW_OPENCLAW_VERSION}"
+
+# ── Phase 7: Verify clean ────────────────────────────────────────────
+info "Phase 7: Verifying upgrade-sandboxes --check is clean..."
+
+RECHECK_OUTPUT=$(nemoclaw upgrade-sandboxes --check 2>&1 || true)
+echo "$RECHECK_OUTPUT"
+
+if echo "$RECHECK_OUTPUT" | grep -qi "up to date"; then
+  pass "Phase 7: All sandboxes up to date after rebuild"
+else
+  fail "Phase 7: upgrade-sandboxes --check did not report 'up to date' after rebuild"
+fi
+
+echo ""
+echo -e "${GREEN}═══════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  Issue #1904 E2E PASSED${NC}"
+echo -e "${GREEN}  Old: OpenClaw ${OLD_OPENCLAW_VERSION}${NC}"
+echo -e "${GREEN}  New: OpenClaw ${NEW_OPENCLAW_VERSION}${NC}"
+echo -e "${GREEN}═══════════════════════════════════════════════════════════${NC}"

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -4700,6 +4700,56 @@ const { createSandbox } = require(${onboardPath});
     }
   });
 
+  it("patchStagedDockerfile does NOT overwrite custom --from BASE_IMAGE that differs from sandbox-base", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-custom-base-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    const customBase = "my-registry.example.com/my-custom-image:v2";
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        `ARG BASE_IMAGE=${customBase}`,
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    const sandboxRef =
+      "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-custom",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        sandboxRef,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      const baseLine = patched.split("\n").find((l) => l.startsWith("ARG BASE_IMAGE="));
+      assert.ok(baseLine, "ARG BASE_IMAGE line must exist");
+      assert.ok(
+        baseLine.includes(customBase),
+        `Custom --from BASE_IMAGE must be preserved, got: ${baseLine}`,
+      );
+      assert.ok(
+        !baseLine.includes("sandbox-base"),
+        `Custom --from BASE_IMAGE must NOT be overwritten with sandbox-base, got: ${baseLine}`,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("regression #1904: pullAndResolveBaseImageDigest uses sandbox-base registry", () => {
     // Structural check: verify the constant matches the Dockerfile default
     // and does NOT reference the openshell-community registry.

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -41,6 +41,8 @@ import {
   normalizeProviderBaseUrl,
   parsePolicyPresetEnv,
   patchStagedDockerfile,
+  pullAndResolveBaseImageDigest,
+  SANDBOX_BASE_IMAGE,
   printSandboxCreateRecoveryHints,
   resolveDashboardForwardTarget,
   summarizeCurlFailure,
@@ -4514,6 +4516,214 @@ const { createSandbox } = require(${onboardPath});
     assert.ok(
       updateAfterCreate !== -1,
       "registry.updateSandbox(model, provider) must appear AFTER createSandbox() — regression #1881",
+    );
+  });
+
+  // ── Base image digest pinning (#1904) ──────────────────────────
+
+  it("patchStagedDockerfile rewrites ARG BASE_IMAGE when baseImageRef is provided", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-base-image-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    const fakeRef =
+      "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-pin",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        fakeRef,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      assert.match(patched, /^ARG BASE_IMAGE=ghcr\.io\/nvidia\/nemoclaw\/sandbox-base@sha256:a{64}$/m);
+      // Model patching still works alongside base image pinning
+      assert.match(patched, /^ARG NEMOCLAW_MODEL=gpt-5\.4$/m);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patchStagedDockerfile preserves ARG BASE_IMAGE when baseImageRef is null", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-base-image-null-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-nopin",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        null,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      assert.match(
+        patched,
+        /^ARG BASE_IMAGE=ghcr\.io\/nvidia\/nemoclaw\/sandbox-base:latest$/m,
+        "BASE_IMAGE should remain unchanged when baseImageRef is null",
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patchStagedDockerfile is safe when Dockerfile has no ARG BASE_IMAGE line", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-no-base-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    const fakeRef =
+      "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-nobase",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        fakeRef,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      // No ARG BASE_IMAGE in original, so the ref should not appear
+      assert.ok(!patched.includes("ARG BASE_IMAGE="), "Should not inject BASE_IMAGE when line is absent");
+      // Other patching should still work
+      assert.match(patched, /^ARG NEMOCLAW_MODEL=gpt-5\.4$/m);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("regression #1904: BASE_IMAGE must reference sandbox-base, not openshell-community", () => {
+    // This is the exact bug that broke all e2e tests in PR #1937:
+    // the code read a digest from blueprint.yaml (openshell-community registry)
+    // and applied it to nemoclaw/sandbox-base (different registry).
+    // Verify that patchStagedDockerfile only writes refs to sandbox-base.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-regression-"));
+    const dockerfilePath = path.join(tmpDir, "Dockerfile");
+    fs.writeFileSync(
+      dockerfilePath,
+      [
+        "ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+        "ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b",
+        "ARG NEMOCLAW_PROVIDER_KEY=nvidia",
+        "ARG NEMOCLAW_PRIMARY_MODEL_REF=nvidia/nemotron-3-super-120b-a12b",
+        "ARG CHAT_UI_URL=http://127.0.0.1:18789",
+        "ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=",
+        "ARG NEMOCLAW_WEB_SEARCH_ENABLED=0",
+        "ARG NEMOCLAW_BUILD_ID=default",
+      ].join("\n"),
+    );
+
+    const correctRef =
+      "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    try {
+      patchStagedDockerfile(
+        dockerfilePath,
+        "gpt-5.4",
+        "http://127.0.0.1:19999",
+        "build-regression",
+        "openai-api",
+        null,
+        null,
+        [],
+        {},
+        {},
+        correctRef,
+      );
+      const patched = fs.readFileSync(dockerfilePath, "utf8");
+      const baseLine = patched.split("\n").find((l) => l.startsWith("ARG BASE_IMAGE="));
+      assert.ok(baseLine, "ARG BASE_IMAGE line must exist");
+      assert.ok(
+        baseLine.includes("nemoclaw/sandbox-base"),
+        `BASE_IMAGE must reference nemoclaw/sandbox-base, got: ${baseLine}`,
+      );
+      assert.ok(
+        !baseLine.includes("openshell-community"),
+        `BASE_IMAGE must NOT reference openshell-community — regression #1937. Got: ${baseLine}`,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("regression #1904: pullAndResolveBaseImageDigest uses sandbox-base registry", () => {
+    // Structural check: verify the constant matches the Dockerfile default
+    // and does NOT reference the openshell-community registry.
+    assert.ok(
+      SANDBOX_BASE_IMAGE.includes("nemoclaw/sandbox-base"),
+      `SANDBOX_BASE_IMAGE must reference nemoclaw/sandbox-base, got: ${SANDBOX_BASE_IMAGE}`,
+    );
+    assert.ok(
+      !SANDBOX_BASE_IMAGE.includes("openshell-community"),
+      `SANDBOX_BASE_IMAGE must NOT reference openshell-community, got: ${SANDBOX_BASE_IMAGE}`,
+    );
+  });
+
+  it("regression #1904: createSandbox calls pullAndResolveBaseImageDigest before patchStagedDockerfile", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+    const pullPos = source.indexOf("pullAndResolveBaseImageDigest()");
+    assert.ok(pullPos !== -1, "pullAndResolveBaseImageDigest() call not found in onboard.ts");
+    const patchPos = source.indexOf("patchStagedDockerfile(", pullPos);
+    assert.ok(
+      patchPos > pullPos,
+      "pullAndResolveBaseImageDigest must be called BEFORE patchStagedDockerfile — regression #1904",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Re-implements digest pinning and `upgrade-sandboxes` reverted in #1938
- Fixes the root cause: original PR read a digest from `blueprint.yaml` (belongs to `ghcr.io/nvidia/openshell-community`) and applied it to `ghcr.io/nvidia/nemoclaw/sandbox-base` — a different registry. Docker digests are repo-specific, so every sandbox creation failed with "manifest unknown"
- New approach: `pullAndResolveBaseImageDigest()` pulls `sandbox-base:latest` from GHCR, then `docker inspect` extracts the actual repo digest. The digest is self-consistent by construction — it always comes from the same registry we pin to
- Falls back to unpinned `:latest` when GHCR is unreachable (offline/firewall users)
- Re-adds `nemoclaw upgrade-sandboxes` command with `--check`/`--auto`/`--yes` flags and fixes from CodeRabbit review (sandbox list error handling, `throwOnError` for batch rebuilds, `--auto` in install.sh)

Closes #1904

## Test plan

- [x] 8 new unit tests (6 in onboard.test.ts, 2 CLI integration tests in cli.test.ts)
- [x] Regression guard: verifies `ARG BASE_IMAGE` references `nemoclaw/sandbox-base`, NOT `openshell-community`
- [x] Structural test: `pullAndResolveBaseImageDigest()` called before `patchStagedDockerfile()`
- [x] CLI test: `upgrade-sandboxes --check` detects stale sandbox (original reporter scenario from #1904)
- [x] CLI test: `upgrade-sandboxes --check` reports all-current when no sandboxes are stale
- [x] Nightly cloud e2e: verify sandbox creation succeeds with digest pinning (the exact scenario that broke in #1937)
- [ ] Manual: verify `nemoclaw upgrade-sandboxes --check` on a real environment with a stale sandbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to detect and batch-upgrade stale sandboxes (report-only and auto/yes modes).
  * Installer now performs a post-onboarding scan and can trigger non-blocking sandbox upgrades.

* **Improvements**
  * Sandbox base images are pinned to resolved digests when available for more reproducible builds.
  * Rebuild flow updated to continue processing multiple sandboxes and surface per-sandbox failures without aborting the whole run.

* **Tests**
  * New unit/integration and end-to-end tests covering detection, reporting, upgrade, and rebuild workflows.

* **Chores**
  * Nightly workflow extended with new E2E jobs; CI failure artifacts and notifications updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->