### PR TITLE
fix(onboard): classify expired API key as credential error (fixes #1942)

### DIFF
--- a/src/lib/validation-recovery.test.ts
+++ b/src/lib/validation-recovery.test.ts
@@ -52,4 +52,15 @@ describe("validation-recovery helpers", () => {
       retry: "model",
     });
   });
+
+  it("classifies expired API key (HTTP 400) as credential recovery", () => {
+    expect(
+      getProbeRecovery({
+        failures: [
+          { httpStatus: 404, message: "not found" },
+          { httpStatus: 400, message: "API key expired. Please renew the API key." },
+        ],
+      }),
+    ).toEqual({ kind: "credential", retry: "credential" });
+  });
 });

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -58,6 +58,30 @@ describe("classifyValidationFailure", () => {
     });
   });
 
+  it("classifies 400 with 'API key expired' as credential (Gemini expired key)", () => {
+    expect(
+      classifyValidationFailure({
+        httpStatus: 400,
+        message: 'API key expired. Please renew the API key.',
+      }),
+    ).toEqual({
+      kind: "credential",
+      retry: "credential",
+    });
+  });
+
+  it("classifies 400 with unrelated message as model", () => {
+    expect(
+      classifyValidationFailure({
+        httpStatus: 400,
+        message: 'Invalid model configuration',
+      }),
+    ).toEqual({
+      kind: "model",
+      retry: "model",
+    });
+  });
+
   it("classifies model-not-found message as model", () => {
     expect(classifyValidationFailure({ message: "model xyz not found" })).toEqual({
       kind: "model",

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -32,6 +32,9 @@ export function classifyValidationFailure({
   if (httpStatus === 401 || httpStatus === 403) {
     return { kind: "credential", retry: "credential" };
   }
+  if (/unauthorized|forbidden|invalid api key|invalid_auth|permission|api key expired/i.test(normalized)) {
+    return { kind: "credential", retry: "credential" };
+  }
   if (httpStatus === 400) {
     return { kind: "model", retry: "model" };
   }
@@ -40,9 +43,6 @@ export function classifyValidationFailure({
   }
   if (httpStatus === 404 || httpStatus === 405) {
     return { kind: "endpoint", retry: "selection" };
-  }
-  if (/unauthorized|forbidden|invalid api key|invalid_auth|permission/i.test(normalized)) {
-    return { kind: "credential", retry: "credential" };
   }
   return { kind: "unknown", retry: "selection" };
 }


### PR DESCRIPTION
## Problem

When a user enters an expired Google Gemini API key during onboard, the wizard loops back to provider selection without offering to re-enter the key (#1942).

**Root cause:** `classifyValidationFailure()` checks HTTP status 400 → `kind: "model"` before checking the response message. Gemini returns HTTP 400 with `"API key expired. Please renew the API key."`, so the credential message regex never gets a chance to match.

In the validation flow for Gemini (which uses `validateOpenAiLikeSelection` without `allowModelRetry`), `kind: "model"` falls through to `{ kind: "unknown", retry: "selection" }` in `getProbeRecovery()`, skipping the key re-entry prompt.

## Fix

1. Move the credential message regex check **before** the HTTP 400 status check in `classifyValidationFailure()`
2. Add `api key expired` to the credential regex pattern

This ensures expired/invalid API keys are classified as `kind: "credential"` regardless of HTTP status code, so `promptValidationRecovery()` correctly offers retry/back/exit.

## Changes

- `src/lib/validation.ts` — reorder checks: credential message regex before HTTP 400
- `src/lib/validation.test.ts` — add tests for HTTP 400 + expired key message, and HTTP 400 + unrelated message
- `src/lib/validation-recovery.test.ts` — add probe-level test for expired key recovery

## Testing

All 45 validation + recovery tests pass. The 5 pre-existing preflight failures (detecting running gateway) are unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to recognize expired API key responses as credential failures, enabling proper credential recovery handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->