### PR TITLE
fix(cli): exit with non-zero code when debug tarball creation fails

### DIFF
--- a/src/lib/debug-command.test.ts
+++ b/src/lib/debug-command.test.ts
@@ -31,7 +31,7 @@ describe("debug command", () => {
   });
 
   it("runs the debug command with parsed options", () => {
-    const runDebug = vi.fn();
+    const runDebug = vi.fn().mockReturnValue(true);
     runDebugCommand(["--sandbox", "beta"], {
       getDefaultSandbox: () => "alpha",
       runDebug,
@@ -45,7 +45,7 @@ describe("debug command", () => {
   });
 
   it("--sandbox overrides the default sandbox", () => {
-    const runDebug = vi.fn();
+    const runDebug = vi.fn().mockReturnValue(true);
     runDebugCommand(["--sandbox", "mybox"], {
       getDefaultSandbox: () => "stale-default",
       runDebug,
@@ -59,7 +59,7 @@ describe("debug command", () => {
   });
 
   it("falls back to undefined when getDefaultSandbox returns undefined", () => {
-    const runDebug = vi.fn();
+    const runDebug = vi.fn().mockReturnValue(true);
     runDebugCommand(["--quick"], {
       getDefaultSandbox: () => undefined,
       runDebug,
@@ -70,6 +70,21 @@ describe("debug command", () => {
       }) as never,
     });
     expect(runDebug).toHaveBeenCalledWith({ quick: true, sandboxName: undefined });
+  });
+
+  it("exits with code 1 when runDebug returns false (tarball failure)", () => {
+    const runDebug = vi.fn().mockReturnValue(false);
+    expect(() =>
+      runDebugCommand(["--output", "/nonexistent/path/debug.tar.gz"], {
+        getDefaultSandbox: () => "alpha",
+        runDebug,
+        log: () => {},
+        error: () => {},
+        exit: ((code: number) => {
+          throw new Error(`exit:${code}`);
+        }) as never,
+      }),
+    ).toThrow("exit:1");
   });
 
   it("exits on invalid arguments", () => {

--- a/src/lib/debug-command.ts
+++ b/src/lib/debug-command.ts
@@ -5,7 +5,7 @@ import type { DebugOptions } from "./debug";
 
 export interface RunDebugCommandDeps {
   getDefaultSandbox: () => string | undefined;
-  runDebug: (options: DebugOptions) => void;
+  runDebug: (options: DebugOptions) => boolean;
   log?: (message?: string) => void;
   error?: (message?: string) => void;
   exit?: (code: number) => never;
@@ -68,6 +68,8 @@ export function parseDebugArgs(
 }
 
 export function runDebugCommand(args: string[], deps: RunDebugCommandDeps): void {
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
   const opts = parseDebugArgs(args, deps);
-  deps.runDebug(opts);
+  const ok = deps.runDebug(opts);
+  if (!ok) exit(1);
 }

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -446,23 +446,28 @@ function collectKernelMessages(collectDir: string): void {
 // Tarball
 // ---------------------------------------------------------------------------
 
-function createTarball(collectDir: string, output: string): void {
-  spawnSync("tar", ["czf", output, "-C", dirname(collectDir), basename(collectDir)], {
+function createTarball(collectDir: string, output: string): boolean {
+  const result = spawnSync("tar", ["czf", output, "-C", dirname(collectDir), basename(collectDir)], {
     stdio: "inherit",
     timeout: 60_000,
   });
+  if (result.status !== 0) {
+    warn(`Failed to create tarball at ${output} (tar exited with code ${result.status ?? "unknown"})`);
+    return false;
+  }
   info(`Tarball written to ${output}`);
   warn(
     "Known secrets are auto-redacted, but please review for any remaining sensitive data before sharing.",
   );
   info("Attach this file to your GitHub issue.");
+  return true;
 }
 
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
-export function runDebug(opts: DebugOptions = {}): void {
+export function runDebug(opts: DebugOptions = {}): boolean {
   const quick = opts.quick ?? false;
   const output = opts.output ?? "";
   // Compiled location: dist/lib/debug.js → repo root is 2 levels up
@@ -499,13 +504,15 @@ export function runDebug(opts: DebugOptions = {}): void {
 
     collectKernelMessages(collectDir);
 
+    let tarballOk = true;
     if (output) {
-      createTarball(collectDir, output);
+      tarballOk = createTarball(collectDir, output);
     }
 
     console.log("");
     info("Done. If filing a bug, run with --output and attach the tarball to your issue:");
     info("  nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz");
+    return tarballOk;
   } finally {
     rmSync(collectDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Changes
<!-- Bullet list of key changes. -->

- Check `spawnSync` return status in `createTarball()` — previously the exit code was ignored
- Return `boolean` from `runDebug()` to indicate success/failure
- Propagate tarball failure through `runDebugCommand()` → `process.exit(1)`
- Print a warning message when tar fails instead of the misleading "Tarball written to ..." success message

Fixes #1765

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [x] AI-assisted — tool: OpenClaw (Claude)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: swqa-saiy <swqa-saiy@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the debug command to properly detect and report when debug operations fail, ensuring the process exits with the correct error code for improved integration with command-line workflows and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->