### PR TITLE
fix(skill-install): refresh OpenClaw skills after update (Fixes #1911)

### DIFF
--- a/src/lib/skill-install.test.ts
+++ b/src/lib/skill-install.test.ts
@@ -10,6 +10,7 @@ import {
   parseFrontmatter,
   resolveSkillPaths,
   collectFiles,
+  postInstall,
   validateRelativePath,
   shellQuote,
 } from "../../dist/lib/skill-install";
@@ -245,5 +246,36 @@ describe("resolveSkillPaths", () => {
     expect(paths.mirrorDir).toBeNull();
     expect(paths.sessionFile).toBeNull();
     expect(paths.isOpenClaw).toBe(false);
+  });
+});
+
+describe("postInstall", () => {
+  it("refreshes OpenClaw sessions after mirroring an updated skill", () => {
+    const skillDir = mkdtempSync(join(tmpdir(), "skill-postinstall-"));
+    const commands: string[] = [];
+    try {
+      writeFileSync(skillDir + "/SKILL.md", "---\nname: weather\n---\n# Weather\n");
+      const result = postInstall(
+        { configFile: "/tmp/ssh-config", sandboxName: "alpha" },
+        resolveSkillPaths(null, "weather"),
+        skillDir,
+        {
+          sshExecImpl: (_ctx, command) => {
+            commands.push(command);
+            return { status: 0, stdout: "", stderr: "" };
+          },
+        },
+      );
+
+      expect(result).toEqual({ success: true, messages: [] });
+      expect(commands.some((command) => command.includes("$HOME/.openclaw/skills/weather"))).toBe(
+        true,
+      );
+      expect(commands).toContain(
+        "printf '{}' > '/sandbox/.openclaw-data/agents/main/sessions/sessions.json'",
+      );
+    } finally {
+      rmSync(skillDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/skill-install.ts
+++ b/src/lib/skill-install.ts
@@ -274,9 +274,13 @@ export function postInstall(
   ctx: SshContext,
   paths: SkillPaths,
   localSkillDir: string,
-  opts: { skipRefresh?: boolean } = {},
+  opts: {
+    skipRefresh?: boolean;
+    sshExecImpl?: typeof sshExec;
+  } = {},
 ): { success: boolean; messages: string[] } {
   const messages: string[] = [];
+  const runSsh = opts.sshExecImpl ?? sshExec;
 
   if (paths.isOpenClaw) {
     // Mirror to $HOME/.openclaw/skills/ — OpenClaw resolves skills from
@@ -295,7 +299,7 @@ export function postInstall(
         // mirrorDir contains $HOME which must expand, so we use double
         // quotes (not shellQuote). Safe because validateRelativePath
         // restricts filenames to [A-Za-z0-9._-/] before we reach here.
-        const result = sshExec(
+        const result = runSsh(
           ctx,
           `mkdir -p "${mirrorSubdir}" && cat > "${mirrorFile}"`,
           { input: content },
@@ -309,11 +313,10 @@ export function postInstall(
       }
     }
 
-    // Clear sessions.json so OpenClaw re-discovers skills on next session.
-    // Skip on updates — the agent already knows the skill, and clearing
-    // sessions would destroy chat history unnecessarily.
+    // Clear sessions.json so OpenClaw re-discovers skills on the next
+    // session even after an in-place skill update.
     if (paths.sessionFile && !opts.skipRefresh) {
-      const refreshResult = sshExec(ctx, `printf '{}' > ${shellQuote(paths.sessionFile)}`);
+      const refreshResult = runSsh(ctx, `printf '{}' > ${shellQuote(paths.sessionFile)}`);
       if (!refreshResult || refreshResult.status !== 0) {
         messages.push("Warning: failed to clear sessions (agent may need manual restart)");
       }

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1341,6 +1341,10 @@ function sandboxPolicyList(sandboxName) {
   console.log("");
 }
 
+/**
+ * Install or update a local skill directory into a live sandbox and perform
+ * any agent-specific post-install refresh needed for the new content to load.
+ */
 async function sandboxSkillInstall(sandboxName, args = []) {
   const sub = args[0];
   if (!sub || sub === "help" || sub === "--help" || sub === "-h") {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1462,9 +1462,9 @@ async function sandboxSkillInstall(sandboxName, args = []) {
     console.log(`  ${G}✓${R} Uploaded ${uploaded} file(s) to sandbox`);
 
     // 7. Post-install (OpenClaw mirror + refresh, or restart hint).
-    //    Skip session refresh on updates — the agent already knows the skill;
-    //    clearing sessions would destroy chat history unnecessarily.
-    const post = skillInstall.postInstall(ctx, paths, skillDir, { skipRefresh: isUpdate });
+    //    OpenClaw caches skill content per session, so always refresh the
+    //    session index after an install/update to avoid stale SKILL.md data.
+    const post = skillInstall.postInstall(ctx, paths, skillDir);
     for (const msg of post.messages) {
       if (msg.startsWith("Warning:")) {
         console.error(`  ${YW}${msg}${R}`);


### PR DESCRIPTION
fix(skill-install): refresh OpenClaw sessions after skill updates (Fixes #1911)

## Summary

Fixes #1911.

OpenClaw was writing the updated `SKILL.md` into the sandbox, but `nemoclaw <sandbox> skill install` still skipped the session refresh on updates. That left the agent serving stale skill content for an existing session even though the on-disk skill had changed.

This change keeps the existing mirror step and always clears the OpenClaw session index after install or update so the next session reloads the latest skill content.

## Changes

- `src/nemoclaw.ts`: stop telling post-install to skip the OpenClaw refresh on updates.
- `src/lib/skill-install.ts`: keep the mirror step and always clear `sessions.json` for OpenClaw installs unless a caller explicitly opts out.
- `src/lib/skill-install.test.ts`: add coverage that the OpenClaw post-install flow mirrors the skill and refreshes the session index.

## Testing

- `npm run build:cli`
- `npm run typecheck:cli`
- `npm test -- src/lib/skill-install.test.ts`
- `npm test`

## Evidence it works

- The new post-install test verifies that updating an OpenClaw skill now issues the session refresh command instead of leaving the old session index in place.
- The touched-path build and unit test pass locally.
- Full `npm test` still hits unrelated pre-existing suite failures in this environment, including:
  - `test/install-preflight.test.ts`
  - `test/legacy-path-guard.test.ts`
  - `src/lib/preflight.test.ts`
  - `src/lib/sandbox-version.test.ts`
  - `test/security-c2-dockerfile-injection.test.ts`

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session and index data are now refreshed consistently for both installations and updates, preventing stale metadata.

* **Improvements**
  * Mirror-related post-install commands run more reliably; command execution is now pluggable to improve flexibility and testing.

* **Tests**
  * New test coverage verifies post-install behavior, including session refresh and mirror command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->