### PR TITLE
fix(debug): drop redundant output hint (Fixes #1732)

### DIFF
--- a/src/lib/debug.test.ts
+++ b/src/lib/debug.test.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-// Import from compiled dist/ so coverage is attributed correctly.
-import { redact, createTarball } from "../../dist/lib/debug";
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+// Import from compiled dist/ so coverage is attributed correctly.
+import { createTarball, getDebugCompletionMessages, redact } from "../../dist/lib/debug";
 
 describe("redact", () => {
   it("redacts NVIDIA_API_KEY=value patterns", () => {
@@ -54,6 +54,7 @@ describe("redact", () => {
   });
 });
 
+<<<<<<< HEAD
 describe("createTarball", () => {
   let tempDir: string;
   let outputDir: string;
@@ -87,5 +88,18 @@ describe("createTarball", () => {
     expect(ok).toBe(true);
     expect(process.exitCode).toBeUndefined();
     expect(existsSync(output)).toBe(true);
+  });
+});
+
+describe("getDebugCompletionMessages", () => {
+  it("suggests --output when no tarball path is provided", () => {
+    expect(getDebugCompletionMessages()).toEqual([
+      "Done. If filing a bug, run with --output and attach the tarball to your issue:",
+      "  nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz",
+    ]);
+  });
+
+  it("omits the redundant --output hint when a tarball was already written", () => {
+    expect(getDebugCompletionMessages("/tmp/nemoclaw-debug.tar.gz")).toEqual([]);
   });
 });

--- a/src/lib/debug.test.ts
+++ b/src/lib/debug.test.ts
@@ -54,7 +54,6 @@ describe("redact", () => {
   });
 });
 
-<<<<<<< HEAD
 describe("createTarball", () => {
   let tempDir: string;
   let outputDir: string;

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -451,6 +451,10 @@ function collectKernelMessages(collectDir: string): void {
 // Tarball
 // ---------------------------------------------------------------------------
 
+/**
+ * Archive the collected diagnostics into a tarball and print the sharing
+ * guidance that goes with the generated file.
+ */
 export function createTarball(collectDir: string, output: string): boolean {
   const result = spawnSync("tar", ["czf", output, "-C", dirname(collectDir), basename(collectDir)], {
     stdio: "inherit",
@@ -472,10 +476,30 @@ export function createTarball(collectDir: string, output: string): boolean {
   return true;
 }
 
+/**
+ * Return the final user-facing completion lines for the debug command.
+ * When a tarball was already written, the tarball creation step has already
+ * printed the attachment guidance, so we do not repeat it here.
+ */
+export function getDebugCompletionMessages(output?: string): string[] {
+  if (output) {
+    return [];
+  }
+
+  return [
+    "Done. If filing a bug, run with --output and attach the tarball to your issue:",
+    "  nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz",
+  ];
+}
+
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
+/**
+ * Collect local and sandbox diagnostics for a NemoClaw environment and
+ * optionally bundle the results into a tarball for issue reporting.
+ */
 export function runDebug(opts: DebugOptions = {}): void {
   const quick = opts.quick ?? false;
   const output = opts.output ?? "";
@@ -520,8 +544,9 @@ export function runDebug(opts: DebugOptions = {}): void {
 
     if (tarballOk) {
       console.log("");
-      info("Done. If filing a bug, run with --output and attach the tarball to your issue:");
-      info("  nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz");
+      for (const message of getDebugCompletionMessages(output)) {
+        info(message);
+      }
     }
   } finally {
     rmSync(collectDir, { recursive: true, force: true });


### PR DESCRIPTION
fix(debug): drop redundant --output hint after tarball creation (Fixes #1732)

## Summary

Fixes #1732.

`nemoclaw debug --output ...` already tells the user where the tarball was written, warns about redaction, and says to attach that file to the issue. The command then printed a second message telling the user to run the same command with `--output`, which was redundant and confusing.

This change makes the completion text depend on whether a tarball was already written. When `--output` is present, the command now ends with a short confirmation instead of repeating the `--output` example.

## Changes

- `src/lib/debug.ts`: add a small helper for the final debug messages and use it from `runDebug()`.
- `src/lib/debug.test.ts`: add coverage for the completion message with and without `--output`.

## Testing

- `npm run build:cli`
- `npm run typecheck:cli`
- `npm test -- src/lib/debug.test.ts src/lib/debug-command.test.ts`
- `npm test`

## Evidence it works

- The new helper test verifies that `nemoclaw debug --output ...` no longer prints the redundant suggestion to rerun with `--output`.
- The touched-path build and unit tests pass locally.
- Full `npm test` still hits unrelated pre-existing suite failures in this environment, including:
  - `test/install-preflight.test.ts`
  - `test/legacy-path-guard.test.ts`
  - `src/lib/preflight.test.ts`
  - `src/lib/sandbox-version.test.ts`

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying final completion guidance is shown when no output path is provided and suppressed when an output path is present.

* **Refactor**
  * Made completion guidance generation dynamic so final instructions are conditionally shown only when an output path wasn’t specified, replacing previous unconditional messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->