### PR TITLE
fix(hermes): stabilize Telegram by upgrading to Hermes v2026.4.13

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -16,27 +16,11 @@ RUN (apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
     && apt-get autoremove --purge -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Patch: disable Hermes's TelegramFallbackTransport inside the sandbox.
-# The fallback transport rewrites api.telegram.org to raw IPs, which
-# OpenShell's L7 proxy rejects (hostname-based policy). Without it,
-# python-telegram-bot uses default httpx transport which respects
-# HTTPS_PROXY and routes through the proxy correctly.
-# Must run as root before USER sandbox.
-# Replace _fallback_ips method to always return empty list, which
-# skips the entire fallback transport code path.
-RUN python3 -c "\
-import pathlib, re; \
-p = pathlib.Path('/usr/local/lib/python3.11/dist-packages/gateway/platforms/telegram.py'); \
-src = p.read_text(); \
-patched = src.replace( \
-    'fallback_ips = self._fallback_ips()', \
-    'fallback_ips = []  # NemoClaw: disabled for sandbox proxy compatibility'); \
-patched = patched.replace( \
-    'if not fallback_ips:', \
-    'if False:  # NemoClaw: skip fallback discovery'); \
-assert 'NemoClaw: disabled' in patched, 'Patch failed: _fallback_ips line not found'; \
-p.write_text(patched); \
-print('[patch] Disabled TelegramFallbackTransport for sandbox proxy compatibility')"
+# Hermes v2026.4.13+ auto-detects HTTPS_PROXY and skips fallback-IP
+# transport when a proxy is present. The sandbox proxy chain
+# (decode-proxy → OpenShell L7 proxy) handles credential placeholder
+# rewriting and hostname-based policy enforcement. No monkey patch needed.
+ENV HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1
 
 # Copy NemoClaw plugin for Hermes (Python-based)
 COPY agents/hermes/plugin/ /opt/nemoclaw-hermes-plugin/

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -22,8 +22,8 @@ FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Hermes version pinned for reproducibility.
-# Calver tag v2026.4.8 = semver 0.8.0.
-ARG HERMES_VERSION=v2026.4.8
+# Calver tag v2026.4.13 = semver 0.9.0.
+ARG HERMES_VERSION=v2026.4.13
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3=3.11.2-1+b1 \


### PR DESCRIPTION
## Summary

- Upgrades Hermes from v2026.4.8 to v2026.4.13
- Removes the fragile build-time monkey patch that string-replaced `gateway/platforms/telegram.py` to disable `TelegramFallbackTransport`
- Sets `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1` — v2026.4.13 natively supports this env var and also auto-detects `HTTPS_PROXY`, skipping fallback transport when a proxy is present

The monkey patch was failing with `FileNotFoundError` during docker build, breaking both `hermes-e2e` and `rebuild-hermes-e2e`.

## Test plan

- [x] `docker build` the Hermes sandbox image succeeds (no more `FileNotFoundError`)
- [x] Telegram messages route through the sandbox proxy chain (decode-proxy → OpenShell L7 proxy)
- [x] Credential placeholder rewriting (`openshell:resolve:env:TELEGRAM_BOT_TOKEN`) works at egress
- [x] hermes-e2e and rebuild-hermes-e2e pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Hermes agent to v2026.4.13 to pick up the latest release.
  * Telegram fallback IP behavior is now configurable at runtime via HERMES_TELEGRAM_DISABLE_FALLBACK_IPS, allowing toggling fallback discovery without rebuilding images.
  * Replaced prior build-time source patching with an environment-driven approach for more predictable image creation and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->