### PR TITLE
fix(test): run TC-SBX-06 recovery in background to prevent pipe hang

### DIFF
--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -12,9 +12,9 @@
 # Test ordering:
 #   Phase 1 — Basic operations (sandbox A alive)
 #   Phase 2 — Non-destructive recovery (sandbox A alive)
-#   Phase 3 — Destructive gateway kill (destroys sandbox A, then re-onboards)
-#   Phase 4 — Multi-sandbox (onboards sandbox B alongside re-onboarded A)
-#   Phase 5 — Cleanup verification
+#   Phase 3 — Multi-sandbox (onboards sandbox B alongside A)
+#   Phase 4 — Cleanup verification (destroys sandbox B)
+#   Phase 5 — Gateway kill recovery (destructive — runs last)
 # =============================================================================
 
 set -euo pipefail
@@ -460,11 +460,11 @@ test_sbx_05_destroy_cleanup() {
 }
 
 # =============================================================================
-# Phase 3: Destructive gateway kill (destroys sandbox A, then re-onboards)
+# Phase 5: Gateway kill recovery (destructive — runs last)
 # =============================================================================
 
 test_sbx_06_gateway_recovery() {
-  log "=== TC-SBX-06: Gateway Auto-Recovery (destructive) ==="
+  log "=== TC-SBX-06: Gateway Auto-Recovery ==="
   require_sandbox "$SANDBOX_A" "TC-SBX-06" || return
 
   local container="openshell-cluster-nemoclaw"
@@ -477,37 +477,62 @@ test_sbx_06_gateway_recovery() {
   docker kill "$container" 2>/dev/null || true
   sleep 5
 
-  # Verify the container is actually stopped
   local container_state
   container_state=$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo "removed")
-  log "  Gateway container state after kill: $container_state"
+  log "  Container state after kill: $container_state"
   if [[ "$container_state" == "true" ]]; then
-    skip "TC-SBX-06" "Container still running after docker kill — cannot test recovery"
+    skip "TC-SBX-06" "Container still running after docker kill"
     return
   fi
 
-  log "  Running nemoclaw status (expect recovery attempt — may take several minutes)..."
-  local status_output status_exit=0
-  status_output=$($TIMEOUT_CMD 600 nemoclaw "$SANDBOX_A" status 2>&1) || status_exit=$?
-  log "  Status output (exit $status_exit): $(echo "$status_output" | head -5)"
+  local status_output
+  status_output=$(mktemp /tmp/sbx06-status-output.XXXXXX)
 
-  if echo "$status_output" | grep -qiE "recover|healthy|Ready|running|gateway"; then
-    pass "TC-SBX-06: Status handled gateway kill gracefully"
-  else
-    fail "TC-SBX-06: Gateway Recovery (status)" "No recovery indication (exit $status_exit). Output: $(echo "$status_output" | head -5)"
+  log "  Running nemoclaw status in background..."
+  nemoclaw "$SANDBOX_A" status >"$status_output" 2>&1 &
+  local status_pid=$!
+
+  local recovered=false
+  local docker_restarted=false
+  for i in $(seq 1 40); do
+    sleep 15
+    local cstate
+    cstate=$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo "removed")
+    [[ "$cstate" == "true" ]] && docker_restarted=true
+
+    if ! kill -0 "$status_pid" 2>/dev/null; then
+      local exit_code=0
+      wait "$status_pid" 2>/dev/null || exit_code=$?
+      log "  nemoclaw status exited with code $exit_code after $((i * 15))s"
+      if [[ $exit_code -eq 0 ]]; then
+        recovered=true
+      fi
+      break
+    fi
+    log "  [${i}] +$((i * 15))s | container: $cstate"
+  done
+
+  if kill -0 "$status_pid" 2>/dev/null; then
+    log "  nemoclaw status still running after 10 min — killing"
+    kill "$status_pid" 2>/dev/null || true
+    wait "$status_pid" 2>/dev/null || true
   fi
 
-  # Re-onboard to restore sandbox A for subsequent tests
-  log "  Re-onboarding sandbox A after gateway destruction..."
-  if onboard_sandbox "$SANDBOX_A"; then
-    pass "TC-SBX-06: Re-onboard after gateway kill succeeded"
+  log "  Output:"
+  head -20 "$status_output" 2>/dev/null | while IFS= read -r line; do log "    $line"; done
+  rm -f "$status_output"
+
+  if $recovered; then
+    pass "TC-SBX-06: Gateway recovered after docker kill"
+  elif ! $docker_restarted; then
+    skip "TC-SBX-06" "Docker did not restart gateway container on this runner"
   else
-    fail "TC-SBX-06: Re-onboard" "Could not re-onboard after gateway kill"
+    fail "TC-SBX-06: Gateway Recovery" "nemoclaw status did not recover the gateway"
   fi
 }
 
 # =============================================================================
-# Phase 4: Multi-sandbox (onboards sandbox B alongside A)
+# Phase 3: Multi-sandbox (onboards sandbox B alongside A)
 # =============================================================================
 
 test_sbx_10_multi_sandbox_metadata() {
@@ -677,15 +702,15 @@ main() {
   test_sbx_07_registry_rebuild
   test_sbx_08_process_recovery
 
-  # Phase 3: Destructive gateway kill (destroys + re-onboards sandbox A)
-  test_sbx_06_gateway_recovery
-
-  # Phase 4: Multi-sandbox (onboards sandbox B)
+  # Phase 3: Multi-sandbox (onboards sandbox B alongside A)
   test_sbx_10_multi_sandbox_metadata
   test_sbx_11_network_isolation
 
-  # Phase 5: Cleanup verification (destroys sandbox B)
+  # Phase 4: Cleanup verification (destroys sandbox B)
   test_sbx_05_destroy_cleanup "$SANDBOX_B"
+
+  # Phase 5: Gateway kill recovery (destructive — runs last)
+  test_sbx_06_gateway_recovery
 
   # Report — teardown runs via EXIT trap, no need to call explicitly
   trap - EXIT


### PR DESCRIPTION
## Summary

Fix TC-SBX-06 (gateway auto-recovery after `docker kill`) to avoid hanging the CI pipeline. Move it to the final test phase and run `nemoclaw status` in background with a poll loop.

## Related Issue

Fixes #[1909](https://github.com/NVIDIA/NemoClaw/issues/1909)

## Changes

- Move TC-SBX-06 to Phase 5 (last) so all other tests complete first
- Replace `$()` subshell capture with background execution + file redirect to avoid pipe hangs from orphaned child processes
- Three-way result: PASS (recovered), SKIP (Docker didn't restart container), FAIL (Docker restarted but nemoclaw couldn't recover)

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npx prek run --all-files` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Verified on CI: 15/15 PASS on ubuntu-latest (4 vCPU)

## AI Disclosure

- [x] AI-assisted — tool: Cursor

---

Signed-off-by: Truong Nguyen <tgnguyen@nvidia.com>