### PR TITLE
fix(onboard): auto-cleanup orphaned SSH port-forward on re-onboard (#1950)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2042,15 +2042,23 @@ async function preflight() {
         continue;
       }
       // Auto-cleanup orphaned SSH port-forward from a previous NemoClaw session
-      // (e.g. dashboard forward left behind after destroy). (#1950)
+      // (e.g. dashboard forward left behind after destroy). Only kill the process
+      // if its command line contains "openshell" to avoid killing unrelated SSH
+      // tunnels the user may have set up on the same port. (#1950)
       if (port === DASHBOARD_PORT && portCheck.process === "ssh" && portCheck.pid) {
-        console.log(`  Cleaning up orphaned SSH port-forward on port ${port} (PID ${portCheck.pid})...`);
-        run(`kill ${portCheck.pid} 2>/dev/null || true`, { ignoreError: true });
-        sleep(1);
-        portCheck = await checkPortAvailable(port);
-        if (portCheck.ok) {
-          console.log(`  ✓ Port ${port} available after orphaned forward cleanup (${label})`);
-          continue;
+        const cmdline = runCapture(
+          `cat /proc/${portCheck.pid}/cmdline 2>/dev/null | tr '\\0' ' '`,
+          { ignoreError: true },
+        ).trim();
+        if (cmdline.includes("openshell")) {
+          console.log(`  Cleaning up orphaned SSH port-forward on port ${port} (PID ${portCheck.pid})...`);
+          run(`kill ${portCheck.pid} 2>/dev/null || true`, { ignoreError: true });
+          sleep(1);
+          portCheck = await checkPortAvailable(port);
+          if (portCheck.ok) {
+            console.log(`  ✓ Port ${port} available after orphaned forward cleanup (${label})`);
+            continue;
+          }
         }
       }
       console.error("");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2046,8 +2046,9 @@ async function preflight() {
       // if its command line contains "openshell" to avoid killing unrelated SSH
       // tunnels the user may have set up on the same port. (#1950)
       if (port === DASHBOARD_PORT && portCheck.process === "ssh" && portCheck.pid) {
+        // Use `ps` to get the command line — works on Linux, macOS, and WSL.
         const cmdline = runCapture(
-          `cat /proc/${portCheck.pid}/cmdline 2>/dev/null | tr '\\0' ' '`,
+          `ps -p ${portCheck.pid} -o args= 2>/dev/null`,
           { ignoreError: true },
         ).trim();
         if (cmdline.includes("openshell")) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2035,11 +2035,23 @@ async function preflight() {
     { port: DASHBOARD_PORT, label: "NemoClaw dashboard" },
   ];
   for (const { port, label } of requiredPorts) {
-    const portCheck = await checkPortAvailable(port);
+    let portCheck = await checkPortAvailable(port);
     if (!portCheck.ok) {
       if ((port === GATEWAY_PORT || port === DASHBOARD_PORT) && gatewayReuseState === "healthy") {
         console.log(`  ✓ Port ${port} already owned by healthy NemoClaw runtime (${label})`);
         continue;
+      }
+      // Auto-cleanup orphaned SSH port-forward from a previous NemoClaw session
+      // (e.g. dashboard forward left behind after destroy). (#1950)
+      if (port === DASHBOARD_PORT && portCheck.process === "ssh" && portCheck.pid) {
+        console.log(`  Cleaning up orphaned SSH port-forward on port ${port} (PID ${portCheck.pid})...`);
+        run(`kill ${portCheck.pid} 2>/dev/null || true`, { ignoreError: true });
+        sleep(1);
+        portCheck = await checkPortAvailable(port);
+        if (portCheck.ok) {
+          console.log(`  ✓ Port ${port} available after orphaned forward cleanup (${label})`);
+          continue;
+        }
       }
       console.error("");
       console.error(`  !! Port ${port} is not available.`);


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                     
            
  Fixes #1950                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                 
  After destroying a sandbox and gateway, the SSH port-forward process for the dashboard (port 18789) is left running. Re-onboard fails at preflight with "Port 18789 is not available. Blocked by: ssh".                                                                                                                        
                                                                                                                                                                                                                                                                                                                                 
  ## Fix                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                 
  In the preflight port check, when port 18789 is blocked by an `ssh` process, automatically kill it and retry — similar to the orphaned gateway container cleanup in #1582.                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                 
  ## Reproduction & Verification
                                                                                                                                                                                                                                                                                                                                 
  **Before fix:**                                                                                                                                                                                                                                                                                                              
  [1/8] Preflight checks                                                                                                                                                                                                                                                                                                         
  ✓ Docker is running   
  ✓ Container runtime: docker                                                                                                                                                                                                                                                                                                    
  ✓ openshell CLI: openshell 0.0.26
  ✓ Port 8080 available (OpenShell gateway)

  !! Port 18789 is not available.                                                                                                                                                                                                                                                                                                
     NemoClaw dashboard needs this port.
     Blocked by: ssh (PID 3595441)                                                                                                                                                                                                                                                                                               
                  
  **After fix:**
  [1/8] Preflight checks
  ✓ Docker is running                                                                                                                                                                                                                                                                                                            
  ✓ Container runtime: docker
  ✓ openshell CLI: openshell 0.0.26                                                                                                                                                                                                                                                                                              
  ✓ Port 8080 available (OpenShell gateway)
  Cleaning up orphaned SSH port-forward on port 18789 (PID 3595441)...
  ✓ Port 18789 available after orphaned forward cleanup (NemoClaw dashboard)                                                                                                                                                                                                                                                     
   
  ## Test plan                                                                                                                                                                                                                                                                                                                   
                  
  - [x] Reproduced on Ubuntu 24.04 (NemoClaw v0.1.0, OpenShell 0.0.26)                                                                                                                                                                                                                                                           
  - [x] Verified auto-cleanup of orphaned SSH forward and successful re-onboard
  - [x] Verified non-SSH processes on port 18789 still trigger the original error                                                                                                                                                                                                                                                
  - [ ] Existing test suite passes                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                             

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard port conflict handling during onboarding: the installer now attempts to detect and clean up stale processes that block the required port, waits briefly, and retries.
  * If automatic recovery succeeds, setup continues; otherwise previous error reporting and exit behavior remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>