### PR TITLE
fix(uninstall): clean up orphaned openshell processes on uninstall (#1940)

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -294,10 +294,11 @@ stop_orphaned_openshell_processes() {
   local -a pids=()
   local pid
 
-  # Scope to the invoking user to avoid killing other users' processes
-  # on shared systems (e.g. when running via sudo). (#1940)
+  # Scope to the original invoking user to avoid killing other users' processes
+  # on shared systems. Under sudo, SUDO_USER holds the real caller; fall back
+  # to LOGNAME, then id -un. (#1940)
   local _user
-  _user="$(id -un 2>/dev/null || echo "")"
+  _user="${SUDO_USER:-${LOGNAME:-$(id -un 2>/dev/null || echo "")}}"
   local -a _pgrep_user=()
   if [ -n "$_user" ]; then
     _pgrep_user=(-u "$_user")
@@ -309,13 +310,15 @@ stop_orphaned_openshell_processes() {
     pids+=("$pid")
   done < <(pgrep "${_pgrep_user[@]}" -f "openshell (sandbox create|ssh-proxy)" 2>/dev/null || true)
 
-  # Also collect ssh processes whose command line references openshell
-  # (these are the SSH sessions spawned by openshell sandbox create).
+  # Also collect ssh processes whose command line references openshell.
+  # Match "openshell ssh-proxy" or "openshell-" (gateway name pattern) to
+  # avoid false positives on unrelated ssh sessions. User scoping via
+  # _pgrep_user provides an additional safety net.
   while IFS= read -r pid; do
     [ -n "$pid" ] || continue
     local cmd
     cmd="$(ps -p "$pid" -o args= 2>/dev/null)" || continue
-    if [[ "$cmd" == *openshell* ]]; then
+    if [[ "$cmd" == *"openshell ssh-proxy"* ]] || [[ "$cmd" == *"openshell-"* ]]; then
       pids+=("$pid")
     fi
   done < <(pgrep "${_pgrep_user[@]}" -x ssh 2>/dev/null || true)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -292,11 +292,20 @@ stop_orphaned_openshell_processes() {
   local -a pids=()
   local pid
 
+  # Scope to the invoking user to avoid killing other users' processes
+  # on shared systems (e.g. when running via sudo). (#1940)
+  local _user
+  _user="$(id -un 2>/dev/null || echo "")"
+  local -a _pgrep_user=()
+  if [ -n "$_user" ]; then
+    _pgrep_user=(-u "$_user")
+  fi
+
   # Collect openshell sandbox create, ssh-proxy, and related ssh processes.
   while IFS= read -r pid; do
     [ -n "$pid" ] || continue
     pids+=("$pid")
-  done < <(pgrep -f "openshell (sandbox create|ssh-proxy)" 2>/dev/null || true)
+  done < <(pgrep "${_pgrep_user[@]}" -f "openshell (sandbox create|ssh-proxy)" 2>/dev/null || true)
 
   # Also collect ssh processes whose command line references openshell
   # (these are the SSH sessions spawned by openshell sandbox create).
@@ -307,7 +316,7 @@ stop_orphaned_openshell_processes() {
     if [[ "$cmd" == *openshell* ]]; then
       pids+=("$pid")
     fi
-  done < <(pgrep -x ssh 2>/dev/null || true)
+  done < <(pgrep "${_pgrep_user[@]}" -x ssh 2>/dev/null || true)
 
   # Deduplicate
   local -A seen=()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -243,6 +243,7 @@ remove_file_with_optional_sudo() {
   info "Removed $path"
 }
 
+# Stop NemoClaw helper services (e.g. Telegram bridge, cloudflared).
 stop_helper_services() {
   if [ -x "$SCRIPT_DIR/scripts/start-services.sh" ]; then
     run_optional "Stopped NemoClaw helper services" "$SCRIPT_DIR/scripts/start-services.sh" --stop
@@ -251,6 +252,7 @@ stop_helper_services() {
   remove_glob_paths "${TMP_ROOT}/nemoclaw-services-*"
 }
 
+# Stop openshell port-forward processes on the dashboard port.
 stop_openshell_forward_processes() {
   if ! command -v pgrep >/dev/null 2>&1; then
     warn "pgrep not found; skipping local OpenShell forward process cleanup."
@@ -342,6 +344,7 @@ stop_orphaned_openshell_processes() {
   done
 }
 
+# Remove OpenShell sandboxes, providers, and gateway.
 remove_openshell_resources() {
   if ! command -v openshell >/dev/null 2>&1; then
     warn "openshell not found; skipping gateway/provider/sandbox cleanup."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -314,9 +314,9 @@ stop_orphaned_openshell_processes() {
   # Match "openshell ssh-proxy" or "openshell-" (gateway name pattern) to
   # avoid false positives on unrelated ssh sessions. User scoping via
   # _pgrep_user provides an additional safety net.
+  local cmd
   while IFS= read -r pid; do
     [ -n "$pid" ] || continue
-    local cmd
     cmd="$(ps -p "$pid" -o args= 2>/dev/null)" || continue
     if [[ "$cmd" == *"openshell ssh-proxy"* ]] || [[ "$cmd" == *"openshell-"* ]]; then
       pids+=("$pid")

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -281,6 +281,58 @@ stop_openshell_forward_processes() {
   done
 }
 
+# Kill orphaned openshell processes left behind after uninstall —
+# sandbox create, ssh-proxy, and related ssh sessions. (#1940)
+stop_orphaned_openshell_processes() {
+  if ! command -v pgrep >/dev/null 2>&1; then
+    warn "pgrep not found; skipping orphaned openshell process cleanup."
+    return 0
+  fi
+
+  local -a pids=()
+  local pid
+
+  # Collect openshell sandbox create, ssh-proxy, and related ssh processes.
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    pids+=("$pid")
+  done < <(pgrep -f "openshell (sandbox create|ssh-proxy)" 2>/dev/null || true)
+
+  # Also collect ssh processes whose command line references openshell
+  # (these are the SSH sessions spawned by openshell sandbox create).
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    local cmd
+    cmd="$(ps -p "$pid" -o args= 2>/dev/null)" || continue
+    if [[ "$cmd" == *openshell* ]]; then
+      pids+=("$pid")
+    fi
+  done < <(pgrep -x ssh 2>/dev/null || true)
+
+  # Deduplicate
+  local -A seen=()
+  local -a unique_pids=()
+  for pid in "${pids[@]}"; do
+    if [ -z "${seen[$pid]:-}" ]; then
+      seen[$pid]=1
+      unique_pids+=("$pid")
+    fi
+  done
+
+  if [ "${#unique_pids[@]}" -eq 0 ]; then
+    info "No orphaned openshell processes found"
+    return 0
+  fi
+
+  for pid in "${unique_pids[@]}"; do
+    if kill "$pid" >/dev/null 2>&1 || kill -9 "$pid" >/dev/null 2>&1; then
+      info "Stopped orphaned openshell process $pid"
+    else
+      warn "Failed to stop orphaned openshell process $pid"
+    fi
+  done
+}
+
 remove_openshell_resources() {
   if ! command -v openshell >/dev/null 2>&1; then
     warn "openshell not found; skipping gateway/provider/sandbox cleanup."
@@ -629,6 +681,7 @@ main() {
   step 1 "Stopping services"
   stop_helper_services
   stop_openshell_forward_processes
+  stop_orphaned_openshell_processes
 
   step 2 "OpenShell resources"
   remove_openshell_resources


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                 
  `nemoclaw uninstall` only kills `openshell forward` processes but leaves behind `openshell sandbox create`, `openshell ssh-proxy`, and their child `ssh` sessions. These orphaned processes accumulate across onboard/destroy cycles.                                                                                          
                                                                                                                                                                                                                                                                                                                                 
  ## Fix                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                 
  Add `stop_orphaned_openshell_processes()` to the uninstall flow (step 1) that finds and kills all openshell-related processes:                                                                                                                                                                                                 
  - `openshell sandbox create` and `openshell ssh-proxy` via `pgrep -f`                                                                                                                                                                                                                                                          
  - `ssh` sessions spawned by openshell (verified via `ps -p <PID> -o args=` containing "openshell")                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                 
  ## Reproduction & Verification                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                 
  **Before fix** — orphaned processes remain after uninstall:                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                 
      $ nemoclaw uninstall
      [1/6] Stopping services                                                                                                                                                                                                                                                                                                    
      [uninstall] No local OpenShell forward processes found
      ...                                                                                                                                                                                                                                                                                                                        
      $ ps -ef | grep openshell | grep -v grep
      openshell sandbox create --from ... --name lyy ...                                                                                                                                                                                                                                                                         
      ssh -o ProxyCommand=/...openshell ssh-proxy ...   
      openshell ssh-proxy --gateway ...                                                                                                                                                                                                                                                                                          
      (18 orphaned processes)                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                 
  **After fix** — all processes cleaned up:                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                 
      $ nemoclaw uninstall
      [1/6] Stopping services                                                                                                                                                                                                                                                                                                    
      [uninstall] No local OpenShell forward processes found
      [uninstall] Stopped orphaned openshell process 350520 
      [uninstall] Stopped orphaned openshell process 355434
      ... (18 processes killed)                                                                                                                                                                                                                                                                                                  
      $ ps -ef | grep openshell | grep -v grep
      (empty — all cleaned up)                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                 
  ## Test plan
                                                                                                                                                                                                                                                                                                                                 
  - [x] Reproduced on Ubuntu 24.04 (NemoClaw v0.1.0, OpenShell 0.0.26)
  - [x] Verified 18 orphaned openshell processes cleaned up after uninstall                                                                                                                                                                                                                                                      
  - [x] Verified `ps -ef | grep openshell` returns empty after fix         
  - [x] Only kills openshell-related processes (ssh sessions verified via cmdline)                                                                                                                                                                                                                                               
  - [ ] Existing test suite passes   


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstall now stops remaining helper services and removes related temporary service artifacts.
  * Detects and terminates orphaned OpenShell-related background processes owned by the invoking user; deduplicates targets, attempts graceful shutdown before forcing termination, and provides clearer info/warn logging of outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>