### PR TITLE
fix(security): add missing provider token patterns to secret redaction

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -123,6 +123,9 @@ fi
 
 # Redact known sensitive patterns (API keys, tokens, passwords in env/args).
 # Keep in sync with src/lib/secret-patterns.ts — consistency test enforces this.
+# Notable tokens covered:
+#   - xoxe.xoxp- = Slack config token prefix
+#   - AKIA = long-term AWS access key; ASIA = temporary/session AWS key
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/1736
 redact() {
   sed -E \
@@ -135,9 +138,7 @@ redact() {
     -e 's/sk-[A-Za-z0-9_-]{20,}/<REDACTED>/g' \
     -e 's/xoxb-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/xoxp-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
-    `# xoxe.xoxp- = Slack config token prefix` \
     -e 's/xoxe\.xoxp-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
-    `# AWS access key IDs: AKIA = long-term, ASIA = temporary/session` \
     -e 's/AKIA[A-Z0-9]{16}/<REDACTED>/g' \
     -e 's/ASIA[A-Z0-9]{16}/<REDACTED>/g' \
     -e 's/hf_[A-Za-z0-9]{10,}/<REDACTED>/g' \

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -131,6 +131,16 @@ redact() {
     -e 's/nvcf-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/ghp_[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/github_pat_[A-Za-z0-9_]{30,}/<REDACTED>/g' \
+    -e 's/sk-proj-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    -e 's/sk-[A-Za-z0-9_-]{20,}/<REDACTED>/g' \
+    -e 's/xoxb-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    -e 's/xoxp-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    -e 's/AKIA[A-Z0-9]{16}/<REDACTED>/g' \
+    -e 's/hf_[A-Za-z0-9]{10,}/<REDACTED>/g' \
+    -e 's/glpat-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    -e 's/gsk_[A-Za-z0-9]{10,}/<REDACTED>/g' \
+    -e 's/pypi-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    -e 's/sk-ant-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/(Bearer )[^ ]+/\1<REDACTED>/gi'
 }
 

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -135,7 +135,11 @@ redact() {
     -e 's/sk-[A-Za-z0-9_-]{20,}/<REDACTED>/g' \
     -e 's/xoxb-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/xoxp-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    `# xoxe.xoxp- = Slack config token prefix` \
+    -e 's/xoxe\.xoxp-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
+    `# AWS access key IDs: AKIA = long-term, ASIA = temporary/session` \
     -e 's/AKIA[A-Z0-9]{16}/<REDACTED>/g' \
+    -e 's/ASIA[A-Z0-9]{16}/<REDACTED>/g' \
     -e 's/hf_[A-Za-z0-9]{10,}/<REDACTED>/g' \
     -e 's/glpat-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/gsk_[A-Za-z0-9]{10,}/<REDACTED>/g' \

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -14,10 +14,31 @@
 
 /** Token-prefix patterns that match standalone (no context needed). */
 export const TOKEN_PREFIX_PATTERNS: RegExp[] = [
+  // NVIDIA
   /nvapi-[A-Za-z0-9_-]{10,}/g,
   /nvcf-[A-Za-z0-9_-]{10,}/g,
+  // GitHub
   /ghp_[A-Za-z0-9_-]{10,}/g,
   /(?:github_pat_)[A-Za-z0-9_]{30,}/g,
+  // OpenAI
+  /sk-proj-[A-Za-z0-9_-]{10,}/g,
+  /sk-[A-Za-z0-9_-]{20,}/g,
+  // Slack
+  /xoxb-[A-Za-z0-9_-]{10,}/g,
+  /xoxp-[A-Za-z0-9_-]{10,}/g,
+  /xoxe\.xoxp-[A-Za-z0-9_-]{10,}/g,
+  // AWS access key IDs (always start with AKIA)
+  /AKIA[A-Z0-9]{16}/g,
+  // HuggingFace
+  /hf_[A-Za-z0-9]{10,}/g,
+  // GitLab
+  /glpat-[A-Za-z0-9_-]{10,}/g,
+  // Groq
+  /gsk_[A-Za-z0-9]{10,}/g,
+  // PyPI
+  /pypi-[A-Za-z0-9_-]{10,}/g,
+  // Anthropic
+  /sk-ant-[A-Za-z0-9_-]{10,}/g,
 ];
 
 /** Context-anchored patterns (require a prefix like KEY=, Bearer, etc.). */
@@ -41,4 +62,14 @@ export const EXPECTED_SHELL_PREFIXES = [
   "nvcf-",
   "ghp_",
   "github_pat_",
+  "sk-proj-",
+  "sk-",
+  "xoxb-",
+  "xoxp-",
+  "AKIA",
+  "hf_",
+  "glpat-",
+  "gsk_",
+  "pypi-",
+  "sk-ant-",
 ];

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -27,8 +27,8 @@ export const TOKEN_PREFIX_PATTERNS: RegExp[] = [
   /xoxb-[A-Za-z0-9_-]{10,}/g,
   /xoxp-[A-Za-z0-9_-]{10,}/g,
   /xoxe\.xoxp-[A-Za-z0-9_-]{10,}/g,
-  // AWS access key IDs (always start with AKIA)
-  /AKIA[A-Z0-9]{16}/g,
+  // AWS access key IDs (AKIA = long-term, ASIA = temporary/session)
+  /A(?:K|S)IA[A-Z0-9]{16}/g,
   // HuggingFace
   /hf_[A-Za-z0-9]{10,}/g,
   // GitLab
@@ -68,6 +68,7 @@ export const EXPECTED_SHELL_PREFIXES = [
   "xoxp-",
   "xoxe.xoxp-",
   "AKIA",
+  "ASIA",
   "hf_",
   "glpat-",
   "gsk_",

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -66,6 +66,7 @@ export const EXPECTED_SHELL_PREFIXES = [
   "sk-",
   "xoxb-",
   "xoxp-",
+  "xoxe.xoxp-",
   "AKIA",
   "hf_",
   "glpat-",


### PR DESCRIPTION
## Summary
- Add 10 new token-prefix patterns to `secret-patterns.ts` covering OpenAI, Anthropic, Slack, AWS, HuggingFace, GitLab, Groq, and PyPI.
- Mirror all new patterns in `scripts/debug.sh` per the single-source-of-truth contract.

## Why
The redaction system only caught NVIDIA and GitHub tokens. Every other provider's API keys passed through unredacted. Verified locally:

```
# BEFORE (unredacted — leaked to terminal/logs)
Your key is sk-proj-abc123def456ghi789jkl012mno345pqr678

# AFTER (redacted)
Your key is sk-p****
```

NemoClaw explicitly supports OpenAI, Anthropic, Slack, and HuggingFace as providers. Their tokens appear in error messages, subprocess output, and `nemoclaw debug` dumps — all of which flow through `redact()`. CWE-532 (Insertion of Sensitive Information into Log File).

## What changed
- `src/lib/secret-patterns.ts` — added 10 new prefix patterns to `TOKEN_PREFIX_PATTERNS` and corresponding entries to `EXPECTED_SHELL_PREFIXES`
- `scripts/debug.sh` — added matching sed patterns to `redact()`

## Test plan
- [x] `npm run build:cli` — compiles cleanly
- [x] Local verification: all 7 tested token formats (OpenAI, Slack, AWS, HuggingFace, GitLab, Groq, Anthropic) now redacted
- [ ] `test/secret-redaction.test.ts` consistency check should pass (verifies shell prefixes match TS prefixes)

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded secret-masking to cover additional API keys and tokens (OpenAI sk-proj/sk, Slack xoxb/xoxp/xoxe.xoxp, AWS AKIA/ASIA, Hugging Face, GitLab, Groq, PyPI, Anthropic), improving protection in debug output and logs.
  * Aligned runtime redaction patterns so masking is consistent across tools while preserving existing env/arg and Bearer token redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->