### PR TITLE
fix(e2e): stabilize nightly — PONG retry + landlock PATH

### DIFF
--- a/test/e2e/e2e-cloud-experimental/checks/04-landlock-readonly.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/04-landlock-readonly.sh
@@ -47,7 +47,7 @@ info "Running Landlock read-only checks in sandbox: $SANDBOX_NAME"
 
 # ── 1: Cannot create files in /sandbox (Landlock read_only) ───────
 info "1. Cannot create files in /sandbox"
-OUT=$(sandbox_exec "touch /sandbox/landlock-test 2>&1 || echo BLOCKED")
+OUT=$(sandbox_exec "touch /sandbox/landlock-test 2>&1 || echo BLOCKED" || true)
 if echo "$OUT" | grep -qi "BLOCKED\|Permission denied\|Read-only\|EACCES"; then
   pass "sandbox home is Landlock read-only"
 else
@@ -56,7 +56,7 @@ fi
 
 # ── 2: Cannot modify .bashrc (sandbox-owned but Landlock read_only) ─
 info "2. Cannot modify .bashrc (Landlock protects sandbox-owned files)"
-OUT=$(sandbox_exec "echo 'malicious' >> /sandbox/.bashrc 2>&1 || echo BLOCKED")
+OUT=$(sandbox_exec "echo 'malicious' >> /sandbox/.bashrc 2>&1 || echo BLOCKED" || true)
 if echo "$OUT" | grep -qi "BLOCKED\|Permission denied\|Read-only\|EACCES"; then
   pass ".bashrc is Landlock read-only despite sandbox ownership"
 else
@@ -65,7 +65,7 @@ fi
 
 # ── 3: Cannot modify .profile (sandbox-owned but Landlock read_only) ─
 info "3. Cannot modify .profile (Landlock protects sandbox-owned files)"
-OUT=$(sandbox_exec "echo 'malicious' >> /sandbox/.profile 2>&1 || echo BLOCKED")
+OUT=$(sandbox_exec "echo 'malicious' >> /sandbox/.profile 2>&1 || echo BLOCKED" || true)
 if echo "$OUT" | grep -qi "BLOCKED\|Permission denied\|Read-only\|EACCES"; then
   pass ".profile is Landlock read-only despite sandbox ownership"
 else
@@ -74,7 +74,7 @@ fi
 
 # ── 4: Cannot write to .openclaw/openclaw.json ────────────────────
 info "4. Cannot write to openclaw.json (Landlock + DAC)"
-OUT=$(sandbox_exec "echo '{}' > /sandbox/.openclaw/openclaw.json 2>&1 || echo BLOCKED")
+OUT=$(sandbox_exec "echo '{}' > /sandbox/.openclaw/openclaw.json 2>&1 || echo BLOCKED" || true)
 if echo "$OUT" | grep -qi "BLOCKED\|Permission denied\|Read-only\|EACCES"; then
   pass "openclaw.json is read-only under Landlock"
 else
@@ -83,7 +83,7 @@ fi
 
 # ── 5: Cannot create new files in .openclaw dir ──────────────────
 info "5. Cannot create files in .openclaw (Landlock read_only)"
-OUT=$(sandbox_exec "touch /sandbox/.openclaw/evil 2>&1 || echo BLOCKED")
+OUT=$(sandbox_exec "touch /sandbox/.openclaw/evil 2>&1 || echo BLOCKED" || true)
 if echo "$OUT" | grep -qi "BLOCKED\|Permission denied\|Read-only\|EACCES"; then
   pass ".openclaw dir is Landlock read-only"
 else
@@ -92,7 +92,7 @@ fi
 
 # ── 6: CAN write to .openclaw-data (Landlock read_write) ─────────
 info "6. Can write to .openclaw-data (Landlock read_write)"
-OUT=$(sandbox_exec "touch /sandbox/.openclaw-data/landlock-test && echo OK || echo FAILED")
+OUT=$(sandbox_exec "touch /sandbox/.openclaw-data/landlock-test && echo OK || echo FAILED" || true)
 if echo "$OUT" | grep -q "OK"; then
   pass ".openclaw-data is writable under Landlock"
 else
@@ -101,7 +101,7 @@ fi
 
 # ── 7: CAN write to .nemoclaw/state (Landlock read_write via parent) ─
 info "7. Can write to .nemoclaw/state (Landlock read_write)"
-OUT=$(sandbox_exec "touch /sandbox/.nemoclaw/state/landlock-test && echo OK || echo FAILED")
+OUT=$(sandbox_exec "touch /sandbox/.nemoclaw/state/landlock-test && echo OK || echo FAILED" || true)
 if echo "$OUT" | grep -q "OK"; then
   pass ".nemoclaw/state is writable under Landlock"
 else
@@ -110,7 +110,7 @@ fi
 
 # ── 8: CAN write to /tmp (Landlock read_write) ───────────────────
 info "8. Can write to /tmp (Landlock read_write)"
-OUT=$(sandbox_exec "touch /tmp/landlock-test && echo OK || echo FAILED")
+OUT=$(sandbox_exec "touch /tmp/landlock-test && echo OK || echo FAILED" || true)
 if echo "$OUT" | grep -q "OK"; then
   pass "/tmp is writable under Landlock"
 else

--- a/test/e2e/test-e2e-cloud-experimental.sh
+++ b/test/e2e/test-e2e-cloud-experimental.sh
@@ -515,6 +515,11 @@ if ! e2e_cloud_experimental_phase_enabled phase5; then
 else
   export SANDBOX_NAME CLOUD_EXPERIMENTAL_MODEL REPO NVIDIA_API_KEY
 
+  # Ensure PATH includes /usr/local/bin and ~/.local/bin so child bash
+  # processes (checks/*.sh) can find openshell and other tools installed
+  # during Phase 3. Without this, check scripts exit 127. (#1969)
+  export PATH="/usr/local/bin:${HOME}/.local/bin:${PATH}"
+
   shopt -s nullglob
   case_scripts=("$E2E_CLOUD_EXPERIMENTAL_READY_DIR"/*.sh)
   shopt -u nullglob

--- a/test/e2e/test-full-e2e.sh
+++ b/test/e2e/test-full-e2e.sh
@@ -323,20 +323,22 @@ for pong_attempt in 1 2 3; do
   fi
   [ "$pong_attempt" -lt 3 ] || break
   sleep 5
-  # Re-fetch
+  # Re-fetch with verbose curl on retry to diagnose proxy issues (#1969)
   ssh_config="$(mktemp)"
   sandbox_response=""
   if openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_config" 2>/dev/null; then
+    info "Retry $((pong_attempt + 1)): using curl -v to capture proxy request/response headers"
     sandbox_response=$($TIMEOUT_CMD ssh -F "$ssh_config" \
       -o StrictHostKeyChecking=no \
       -o UserKnownHostsFile=/dev/null \
       -o ConnectTimeout=10 \
       -o LogLevel=ERROR \
       "openshell-${SANDBOX_NAME}" \
-      "curl -s --max-time 60 https://inference.local/v1/chat/completions \
+      "curl -v --max-time 60 https://inference.local/v1/chat/completions \
         -H 'Content-Type: application/json' \
         -d '{\"model\":\"nvidia/nemotron-3-super-120b-a12b\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
       2>&1) || true
+    info "Verbose response (first 500 chars): ${sandbox_response:0:500}"
   fi
   rm -f "$ssh_config"
 done

--- a/test/e2e/test-full-e2e.sh
+++ b/test/e2e/test-full-e2e.sh
@@ -309,6 +309,8 @@ rm -f "$ssh_config"
 
 # Retry sandbox inference up to 3 times — live models are not deterministic
 # and the gateway proxy can return unexpected responses on first attempt. (#1969)
+TIMEOUT_CMD="${TIMEOUT_CMD:-}"
+sandbox_content=""
 pong_ok=false
 for pong_attempt in 1 2 3; do
   if [ -n "$sandbox_response" ]; then

--- a/test/e2e/test-full-e2e.sh
+++ b/test/e2e/test-full-e2e.sh
@@ -307,16 +307,44 @@ if openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_config" 2>/dev/null; then
 fi
 rm -f "$ssh_config"
 
-if [ -n "$sandbox_response" ]; then
-  sandbox_content=$(echo "$sandbox_response" | parse_chat_content 2>/dev/null) || true
-  if grep -qi "PONG" <<<"$sandbox_content"; then
-    pass "[LIVE] Sandbox inference: model responded with PONG through sandbox"
-    info "Full path proven: user → sandbox → openshell gateway → NVIDIA Endpoints → response"
+# Retry sandbox inference up to 3 times — live models are not deterministic
+# and the gateway proxy can return unexpected responses on first attempt. (#1969)
+pong_ok=false
+for pong_attempt in 1 2 3; do
+  if [ -n "$sandbox_response" ]; then
+    sandbox_content=$(echo "$sandbox_response" | parse_chat_content 2>/dev/null) || true
+    if grep -qi "PONG" <<<"$sandbox_content"; then
+      pong_ok=true
+      break
+    fi
+    info "Sandbox inference attempt ${pong_attempt}/3: got '${sandbox_content:0:80}', retrying in 5s..."
   else
-    fail "[LIVE] Sandbox inference: expected PONG, got: ${sandbox_content:0:200}"
+    info "Sandbox inference attempt ${pong_attempt}/3: empty response, retrying in 5s..."
   fi
+  [ "$pong_attempt" -lt 3 ] || break
+  sleep 5
+  # Re-fetch
+  ssh_config="$(mktemp)"
+  sandbox_response=""
+  if openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_config" 2>/dev/null; then
+    sandbox_response=$($TIMEOUT_CMD ssh -F "$ssh_config" \
+      -o StrictHostKeyChecking=no \
+      -o UserKnownHostsFile=/dev/null \
+      -o ConnectTimeout=10 \
+      -o LogLevel=ERROR \
+      "openshell-${SANDBOX_NAME}" \
+      "curl -s --max-time 60 https://inference.local/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{\"model\":\"nvidia/nemotron-3-super-120b-a12b\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
+      2>&1) || true
+  fi
+  rm -f "$ssh_config"
+done
+if $pong_ok; then
+  pass "[LIVE] Sandbox inference: model responded with PONG through sandbox"
+  info "Full path proven: user → sandbox → openshell gateway → NVIDIA Endpoints → response"
 else
-  fail "[LIVE] Sandbox inference: no response from inference.local inside sandbox"
+  fail "[LIVE] Sandbox inference: expected PONG after 3 attempts, got: ${sandbox_content:0:200}"
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -322,6 +322,7 @@ baseline_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
 
 # Retry baseline inference up to 3 times — live models are not deterministic
 # and the gateway proxy can return unexpected responses on first attempt. (#1969)
+baseline_content=""
 pong_ok=false
 for pong_attempt in 1 2 3; do
   baseline_content=""
@@ -651,6 +652,7 @@ post_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
   2>&1) || true
 
 # Retry post-restart inference up to 3 times. (#1969)
+post_content=""
 pong_ok=false
 for pong_attempt in 1 2 3; do
   post_content=""

--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -320,15 +320,32 @@ baseline_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
     -d '{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
   2>&1) || true
 
-baseline_content=""
-if [ -n "$baseline_response" ]; then
-  baseline_content=$(echo "$baseline_response" | parse_chat_content 2>/dev/null) || true
-fi
-
-if grep -qi "PONG" <<<"$baseline_content"; then
+# Retry baseline inference up to 3 times — live models are not deterministic
+# and the gateway proxy can return unexpected responses on first attempt. (#1969)
+pong_ok=false
+for pong_attempt in 1 2 3; do
+  baseline_content=""
+  if [ -n "$baseline_response" ]; then
+    baseline_content=$(echo "$baseline_response" | parse_chat_content 2>/dev/null) || true
+  fi
+  if grep -qi "PONG" <<<"$baseline_content"; then
+    pong_ok=true
+    break
+  fi
+  info "Baseline attempt ${pong_attempt}/3: got '${baseline_content:0:80}', retrying in 5s..."
+  [ "$pong_attempt" -lt 3 ] || break
+  sleep 5
+  # shellcheck disable=SC2029
+  baseline_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
+    "curl -s --max-time 60 https://inference.local/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d '{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
+    2>&1) || true
+done
+if $pong_ok; then
   pass "[LIVE] Baseline: model responded with PONG through sandbox"
 else
-  fail "[LIVE] Baseline: expected PONG, got: ${baseline_content:0:200}"
+  fail "[LIVE] Baseline: expected PONG after 3 attempts, got: ${baseline_content:0:200}"
   info "Raw response: ${baseline_response:0:300}"
   info "Cannot establish baseline — aborting (survival test meaningless without it)"
   cleanup_ssh
@@ -633,17 +650,33 @@ post_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
     -d '{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
   2>&1) || true
 
-post_content=""
-if [ -n "$post_response" ]; then
-  post_content=$(echo "$post_response" | parse_chat_content 2>/dev/null) || true
-fi
-
-if grep -qi "PONG" <<<"$post_content"; then
+# Retry post-restart inference up to 3 times. (#1969)
+pong_ok=false
+for pong_attempt in 1 2 3; do
+  post_content=""
+  if [ -n "$post_response" ]; then
+    post_content=$(echo "$post_response" | parse_chat_content 2>/dev/null) || true
+  fi
+  if grep -qi "PONG" <<<"$post_content"; then
+    pong_ok=true
+    break
+  fi
+  info "Post-restart attempt ${pong_attempt}/3: got '${post_content:0:80}', retrying in 5s..."
+  [ "$pong_attempt" -lt 3 ] || break
+  sleep 5
+  # shellcheck disable=SC2029
+  post_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
+    "curl -s --max-time 60 https://inference.local/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d '{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
+    2>&1) || true
+done
+if $pong_ok; then
   pass "[LIVE] Post-restart: model responded with PONG through sandbox"
   info "Full path proven: user → sandbox → openshell gateway (resumed) → NVIDIA Endpoints → response"
   info "This proves #859's ask: reliable non-destructive gateway lifecycle with working inference"
 else
-  fail "[LIVE] Post-restart: expected PONG, got: ${post_content:0:200}"
+  fail "[LIVE] Post-restart: expected PONG after 3 attempts, got: ${post_content:0:200}"
   info "Raw response: ${post_response:0:300}"
 fi
 


### PR DESCRIPTION
## Summary

The nightly E2E has been failing for 10+ consecutive runs. Two independent fixes:

1. **PONG inference retry** — sandbox inference assertions now retry 3x with 5s backoff. Live models through the gateway proxy are not deterministic; a single attempt was too brittle for CI.

2. **Landlock PATH fix** — `04-landlock-readonly.sh` exited 127 because `openshell` was not on PATH in child bash processes. Exports PATH before Phase 5 check scripts and adds `|| true` to `sandbox_exec` calls for expected non-zero exits.

## Changes

- `test/e2e/test-full-e2e.sh` — 3-attempt retry for sandbox inference PONG
- `test/e2e/test-sandbox-survival.sh` — 3-attempt retry for baseline + post-restart PONG
- `test/e2e/test-e2e-cloud-experimental.sh` — export PATH before Phase 5 checks
- `test/e2e/e2e-cloud-experimental/checks/04-landlock-readonly.sh` — `|| true` on sandbox_exec calls

## Testing

- [x] All pre-commit hooks pass (shellcheck, shfmt, tests)
- [x] `npm test` — 1303 tests pass, no regressions
- [x] Retry logic simulated locally (fails-then-succeeds, all-fail cases verified)
- [ ] Nightly run on main — the real test (can only verify in CI environment)

Fixes #1969

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made sandbox checks tolerant of command failures to avoid premature termination while preserving existing pass/fail detection.
  * Updated test runner PATH so check scripts can locate newly installed tooling during test runs.
  * Added up-to-3 retry attempts with short delays, regenerated per-attempt configs, and improved diagnostics (truncated response previews and clearer info logs) for sandbox inference and survival checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->