### PR TITLE
fix(test): prevent flaky tarball test race condition

### DIFF
--- a/src/lib/debug.test.ts
+++ b/src/lib/debug.test.ts
@@ -77,10 +77,14 @@ describe("createTarball", () => {
   it("creates tarball successfully and returns true for valid output path", () => {
     tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
     writeFileSync(join(tempDir, "dummy.txt"), "test data");
-    const output = join(tempDir, "output.tar.gz");
+    // Write output to a SEPARATE directory — writing into the source dir
+    // causes tar to see the file changing as it reads, returning exit 1.
+    const outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
+    const output = join(outputDir, "output.tar.gz");
     const ok = createTarball(tempDir, output);
     expect(ok).toBe(true);
     expect(process.exitCode).toBeUndefined();
     expect(existsSync(output)).toBe(true);
+    rmSync(outputDir, { recursive: true, force: true });
   });
 });

--- a/src/lib/debug.test.ts
+++ b/src/lib/debug.test.ts
@@ -56,6 +56,7 @@ describe("redact", () => {
 
 describe("createTarball", () => {
   let tempDir: string;
+  let outputDir: string;
 
   beforeEach(() => {
     process.exitCode = undefined;
@@ -63,6 +64,7 @@ describe("createTarball", () => {
 
   afterEach(() => {
     if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    if (outputDir) rmSync(outputDir, { recursive: true, force: true });
     process.exitCode = undefined;
   });
 
@@ -79,12 +81,11 @@ describe("createTarball", () => {
     writeFileSync(join(tempDir, "dummy.txt"), "test data");
     // Write output to a SEPARATE directory — writing into the source dir
     // causes tar to see the file changing as it reads, returning exit 1.
-    const outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
+    outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
     const output = join(outputDir, "output.tar.gz");
     const ok = createTarball(tempDir, output);
     expect(ok).toBe(true);
     expect(process.exitCode).toBeUndefined();
     expect(existsSync(output)).toBe(true);
-    rmSync(outputDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

The `createTarball` success test writes `output.tar.gz` into the same temp directory being archived. `tar` sees the file appear while reading the directory and exits with code 1 ("file changed as we read it"), causing intermittent CI failures on any PR that rebases onto main.

Fix: write output to a separate temp directory.

## Test plan

- [x] 10/10 debug tests pass
- [x] Race condition eliminated — output dir is separate from source dir

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by writing generated test artifacts to a separate temporary output directory instead of the archived source directory.
  * Enhanced cleanup to remove the separate output directory (recursive) after each test, ensuring no leftover artifacts remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->