### PR TITLE
fix(security): prevent prototype pollution via unsanitized config path [MEDIUM]

### DIFF
--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -1427,7 +1427,7 @@ describe("commands/migration-state", () => {
       "rejects unsafe path segment: %s",
       (segment) => {
         const doc: Record<string, unknown> = {};
-        expect(() => setConfigValue(doc, `${segment}.polluted`, "true")).toThrow(
+        expect(() => { setConfigValue(doc, `${segment}.polluted`, "true"); }).toThrow(
           /Unsafe config path segment/,
         );
       },
@@ -1436,7 +1436,7 @@ describe("commands/migration-state", () => {
     it("rejects __proto__ in nested position", () => {
       const doc: Record<string, unknown> = {};
       expect(() =>
-        setConfigValue(doc, "agents.__proto__.isAdmin", "true"),
+        { setConfigValue(doc, "agents.__proto__.isAdmin", "true"); },
       ).toThrow(/Unsafe config path segment/);
     });
 
@@ -1444,7 +1444,7 @@ describe("commands/migration-state", () => {
       "rejects unsafe segment in nested path: %s",
       (configPath) => {
         const doc: Record<string, unknown> = {};
-        expect(() => setConfigValue(doc, configPath, "true")).toThrow(
+        expect(() => { setConfigValue(doc, configPath, "true"); }).toThrow(
           /Unsafe config path segment/,
         );
       },
@@ -1453,7 +1453,9 @@ describe("commands/migration-state", () => {
     it("allows legitimate dotted paths", () => {
       const doc: Record<string, unknown> = {};
       setConfigValue(doc, "agents.list[0].workspace", "/tmp/ws");
-      expect((doc as any).agents.list[0].workspace).toBe("/tmp/ws");
+      const agents = doc.agents as Record<string, unknown>;
+      const list = agents.list as Record<string, unknown>[];
+      expect(list[0].workspace).toBe("/tmp/ws");
     });
 
     it("allows simple top-level keys", () => {

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { PluginLogger } from "../index.js";
+import { setConfigValue } from "./migration-state.js";
 
 // ---------------------------------------------------------------------------
 // fs mock — thin in-memory store keyed by absolute path
@@ -1416,6 +1417,49 @@ describe("commands/migration-state", () => {
           process.env.HOME = origHome;
         }
       }
+    });
+  });
+
+  // ── setConfigValue prototype pollution guard ─────────────────────
+
+  describe("setConfigValue", () => {
+    it.each(["__proto__", "constructor", "prototype"])(
+      "rejects unsafe path segment: %s",
+      (segment) => {
+        const doc: Record<string, unknown> = {};
+        expect(() => setConfigValue(doc, `${segment}.polluted`, "true")).toThrow(
+          /Unsafe config path segment/,
+        );
+      },
+    );
+
+    it("rejects __proto__ in nested position", () => {
+      const doc: Record<string, unknown> = {};
+      expect(() =>
+        setConfigValue(doc, "agents.__proto__.isAdmin", "true"),
+      ).toThrow(/Unsafe config path segment/);
+    });
+
+    it.each(["foo.prototype.bar", "foo.constructor.bar"])(
+      "rejects unsafe segment in nested path: %s",
+      (configPath) => {
+        const doc: Record<string, unknown> = {};
+        expect(() => setConfigValue(doc, configPath, "true")).toThrow(
+          /Unsafe config path segment/,
+        );
+      },
+    );
+
+    it("allows legitimate dotted paths", () => {
+      const doc: Record<string, unknown> = {};
+      setConfigValue(doc, "agents.list[0].workspace", "/tmp/ws");
+      expect((doc as any).agents.list[0].workspace).toBe("/tmp/ws");
+    });
+
+    it("allows simple top-level keys", () => {
+      const doc: Record<string, unknown> = {};
+      setConfigValue(doc, "theme", "dark");
+      expect(doc.theme).toBe("dark");
     });
   });
 });

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -1423,30 +1423,41 @@ describe("commands/migration-state", () => {
   // ── setConfigValue prototype pollution guard ─────────────────────
 
   describe("setConfigValue", () => {
+    const expectPrototypeClean = (): void => {
+      const probe: Record<string, unknown> = {};
+      for (const key of ["polluted", "isAdmin", "bar"]) {
+        expect(Object.prototype.hasOwnProperty.call(Object.prototype, key)).toBe(false);
+        expect(probe[key]).toBeUndefined();
+      }
+    };
+
     it.each(["__proto__", "constructor", "prototype"])(
       "rejects unsafe path segment: %s",
       (segment) => {
         const doc: Record<string, unknown> = {};
-        expect(() => { setConfigValue(doc, `${segment}.polluted`, "true"); }).toThrow(
-          /Unsafe config path segment/,
-        );
+        expect(() => {
+          setConfigValue(doc, `${segment}.polluted`, "true");
+        }).toThrow(/Unsafe config path segment/);
+        expectPrototypeClean();
       },
     );
 
     it("rejects __proto__ in nested position", () => {
       const doc: Record<string, unknown> = {};
-      expect(() =>
-        { setConfigValue(doc, "agents.__proto__.isAdmin", "true"); },
-      ).toThrow(/Unsafe config path segment/);
+      expect(() => {
+        setConfigValue(doc, "agents.__proto__.isAdmin", "true");
+      }).toThrow(/Unsafe config path segment/);
+      expectPrototypeClean();
     });
 
     it.each(["foo.prototype.bar", "foo.constructor.bar"])(
       "rejects unsafe segment in nested path: %s",
       (configPath) => {
         const doc: Record<string, unknown> = {};
-        expect(() => { setConfigValue(doc, configPath, "true"); }).toThrow(
-          /Unsafe config path segment/,
-        );
+        expect(() => {
+          setConfigValue(doc, configPath, "true");
+        }).toThrow(/Unsafe config path segment/);
+        expectPrototypeClean();
       },
     );
 

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -603,9 +603,7 @@ export function setConfigValue(
 
   for (const token of tokens) {
     if (UNSAFE_PROPERTY_NAMES.has(token)) {
-      throw new Error(
-        `Unsafe config path segment '${token}' in ${configPath}`,
-      );
+      throw new Error(`Unsafe config path segment '${token}' in ${configPath}`);
     }
   }
 

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -588,7 +588,10 @@ function resolveConfigSourcePath(manifest: SnapshotManifest, snapshotDir: string
   return path.join(snapshotDir, "openclaw", "openclaw.json");
 }
 
-function setConfigValue(
+const UNSAFE_PROPERTY_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
+/** @visibleForTesting */
+export function setConfigValue(
   document: Record<string, unknown>,
   configPath: string,
   value: string,
@@ -596,6 +599,14 @@ function setConfigValue(
   const tokens = configPath.match(/[^.[\]]+/g);
   if (!tokens || tokens.length === 0) {
     throw new Error(`Invalid config path: ${configPath}`);
+  }
+
+  for (const token of tokens) {
+    if (UNSAFE_PROPERTY_NAMES.has(token)) {
+      throw new Error(
+        `Unsafe config path segment '${token}' in ${configPath}`,
+      );
+    }
   }
 
   let current: unknown = document;


### PR DESCRIPTION
## Security Finding: Prototype Pollution via Unsanitized Config Path

**Severity:** MEDIUM
**Reported by:** FailSafe Security Researcher
**Component:** `nemoclaw/src/commands/migration-state.ts` — `setConfigValue()`

### Description

The `setConfigValue()` function tokenizes a dot-separated configuration path and iteratively traverses or builds an object structure to set a value. The function did not sanitize path tokens against dangerous JavaScript property names such as `__proto__`, `constructor`, or `prototype`, allowing an attacker to pollute `Object.prototype` through a crafted snapshot manifest.

### Fix

Add a denylist check (`__proto__`, `constructor`, `prototype`) before using each token as a property key. Throws an error if any token matches a dangerous key.

### Tests

- Unsafe paths (`__proto__`, `constructor`, `prototype`) in both top-level and nested positions are rejected
- Prototype stays clean after rejection (no partial mutation)
- Legitimate paths still work

Supersedes #1558. Closes #1553.

Co-authored-by: failsafesecurity <failsafesecurity@users.noreply.github.com>
Co-authored-by: Joshua Medvinsky <joshua-medvinsky@users.noreply.github.com>
Co-authored-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration settings validation now properly rejects invalid path segments to ensure system integrity and stability
* **Tests**
  * Added comprehensive test coverage for configuration path validation, including edge cases and boundary conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->