### PR TITLE
fix(k8s): pin container images by sha256 digest (#1436)

### DIFF
--- a/k8s/nemoclaw-k8s.yaml
+++ b/k8s/nemoclaw-k8s.yaml
@@ -14,7 +14,9 @@ spec:
   containers:
     # Docker daemon (DinD)
     - name: dind
-      image: docker:24-dind
+      # Pinned by digest to prevent supply-chain attacks via mutable tag references.
+      # Tag: docker:24-dind (update digest when bumping the tag).
+      image: docker:24-dind@sha256:9b17a9f25adf17b88d0a013b4f00160754adf4b07ccbe9986664a49886c2c98e
       securityContext:
         privileged: true
       env:
@@ -35,7 +37,9 @@ spec:
 
     # Workspace - runs official NemoClaw installer
     - name: workspace
-      image: node:22
+      # Pinned by digest to prevent supply-chain attacks via mutable tag references.
+      # Tag: node:22 (update digest when bumping the tag).
+      image: node:22@sha256:ecabd1cb6956d7acfffe8af6bbfbe2df42362269fd28c227f36367213d0bb777
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -128,7 +132,9 @@ spec:
   initContainers:
     # Configure Docker daemon for cgroup v2
     - name: init-docker-config
-      image: busybox
+      # Pinned by digest to prevent supply-chain attacks via mutable tag references.
+      # Tag: busybox:latest (update digest when pinning to a different tag).
+      image: busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
       command: ["sh", "-c", "echo '{\"default-cgroupns-mode\":\"host\"}' > /etc/docker/daemon.json"]
       volumeMounts:
         - name: docker-config


### PR DESCRIPTION
## Summary
- Pin the three images in `k8s/nemoclaw-k8s.yaml` to sha256 digests:
  - `docker:24-dind` → `docker:24-dind@sha256:9b17a9f2...`
  - `node:22` → `node:22@sha256:ecabd1cb...`
  - `busybox` → `busybox@sha256:1487d0af...`
- Preserve the human-readable tag in a comment above each `image:` line so maintainers can refresh the digest when bumping versions.

Fixes #1436.

## Why
The K8s manifest referenced images by mutable tag. A compromised registry or tag overwrite would inject malicious code into the pod — supply-chain attack vector. The root `Dockerfile` already pins `node:22-slim@sha256:4f77a690...` by digest; this extends the same hardening to the K8s manifest.

## Test plan
- [x] `grep "image:" k8s/nemoclaw-k8s.yaml` shows all three images pinned by `@sha256:`
- [x] YAML is syntactically valid (no indentation/structure changes)
- [ ] Manual: `kubectl apply -f k8s/nemoclaw-k8s.yaml` pulls the pinned digests (verifiable in a dev cluster)

Digests captured from Docker Hub at commit time via authenticated Registry v2 HEAD requests.

Signed-off-by: Colin McDonough <cmcdonough@50words.com>