### PR TITLE
fix(inference): migrate GLM-5 model references to GLM-5.1 (#1744)

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
@@ -39,7 +39,7 @@ Ollama appears when it is installed or running on the host.
 
 | Option | Description | Curated models |
 |--------|-------------|----------------|
-| NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, Kimi K2.5, GLM-5, MiniMax M2.5, GPT-OSS 120B |
+| NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, Kimi K2.5, GLM-5.1, MiniMax M2.5, GPT-OSS 120B |
 | OpenAI | Routes to the OpenAI API. Set `OPENAI_API_KEY`. | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro-2026-03-05` |
 | Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. If the endpoint also supports `/responses` with OpenClaw-style tool calling, NemoClaw can use that path; otherwise it falls back to `/chat/completions`. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
 | Anthropic | Routes to the Anthropic Messages API. Set `ANTHROPIC_API_KEY`. | `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-6` |

--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -70,7 +70,7 @@ Respond to the wizard as follows.
 
 1. At the `Choose [1]:` prompt, press Enter (or type `1`) to select **NVIDIA Endpoints**.
 2. At the `NVIDIA_API_KEY:` prompt, paste your key if it is not already exported.
-3. At the `Choose model [1]:` prompt, pick a curated model from the list (for example, **Nemotron 3 Super 120B**, **Kimi K2.5**, **GLM-5**, **MiniMax M2.5**, or **GPT-OSS 120B**), or pick **Other...** to enter any model ID from the [NVIDIA Endpoints catalog](https://build.nvidia.com).
+3. At the `Choose model [1]:` prompt, pick a curated model from the list (for example, **Nemotron 3 Super 120B**, **Kimi K2.5**, **GLM-5.1**, **MiniMax M2.5**, or **GPT-OSS 120B**), or pick **Other...** to enter any model ID from the [NVIDIA Endpoints catalog](https://build.nvidia.com).
 
 NemoClaw validates the model against the catalog API before creating the sandbox.
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -88,7 +88,7 @@ Respond to the wizard as follows.
 
 1. At the `Choose [1]:` prompt, press Enter (or type `1`) to select **NVIDIA Endpoints**.
 2. At the `NVIDIA_API_KEY:` prompt, paste your key if it is not already exported.
-3. At the `Choose model [1]:` prompt, pick a curated model from the list (for example, **Nemotron 3 Super 120B**, **Kimi K2.5**, **GLM-5**, **MiniMax M2.5**, or **GPT-OSS 120B**), or pick **Other...** to enter any model ID from the [NVIDIA Endpoints catalog](https://build.nvidia.com).
+3. At the `Choose model [1]:` prompt, pick a curated model from the list (for example, **Nemotron 3 Super 120B**, **Kimi K2.5**, **GLM-5.1**, **MiniMax M2.5**, or **GPT-OSS 120B**), or pick **Other...** to enter any model ID from the [NVIDIA Endpoints catalog](https://build.nvidia.com).
 
 NemoClaw validates the model against the catalog API before creating the sandbox.
 

--- a/docs/inference/inference-options.md
+++ b/docs/inference/inference-options.md
@@ -59,7 +59,7 @@ Ollama appears when it is installed or running on the host.
 
 | Option | Description | Curated models |
 |--------|-------------|----------------|
-| NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, Kimi K2.5, GLM-5, MiniMax M2.5, GPT-OSS 120B |
+| NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, Kimi K2.5, GLM-5.1, MiniMax M2.5, GPT-OSS 120B |
 | OpenAI | Routes to the OpenAI API. Set `OPENAI_API_KEY`. | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro-2026-03-05` |
 | Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. If the endpoint also supports `/responses` with OpenClaw-style tool calling, NemoClaw can use that path; otherwise it falls back to `/chat/completions`. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
 | Anthropic | Routes to the Anthropic Messages API. Set `ANTHROPIC_API_KEY`. | `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-6` |

--- a/src/lib/inference-config.test.ts
+++ b/src/lib/inference-config.test.ts
@@ -21,7 +21,7 @@ describe("inference selection config", () => {
     expect(CLOUD_MODEL_OPTIONS.map((option: { id: string }) => option.id)).toEqual([
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
-      "z-ai/glm5",
+      "z-ai/glm-5.1",
       "minimaxai/minimax-m2.5",
       "openai/gpt-oss-120b",
     ]);

--- a/src/lib/inference-config.ts
+++ b/src/lib/inference-config.ts
@@ -13,7 +13,7 @@ export const DEFAULT_CLOUD_MODEL = "nvidia/nemotron-3-super-120b-a12b";
 export const CLOUD_MODEL_OPTIONS = [
   { id: "nvidia/nemotron-3-super-120b-a12b", label: "Nemotron 3 Super 120B" },
   { id: "moonshotai/kimi-k2.5", label: "Kimi K2.5" },
-  { id: "z-ai/glm5", label: "GLM-5" },
+  { id: "z-ai/glm-5.1", label: "GLM-5" },
   { id: "minimaxai/minimax-m2.5", label: "MiniMax M2.5" },
   { id: "openai/gpt-oss-120b", label: "GPT-OSS 120B" },
 ];

--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -344,7 +344,7 @@ describe("inventory commands", () => {
           },
           {
             name: "beta",
-            model: "z-ai/glm5",
+            model: "z-ai/glm-5.1",
           },
         ],
         defaultSandbox: "alpha",
@@ -361,7 +361,7 @@ describe("inventory commands", () => {
     expect(lines).toContain("      (onboarded: nvidia/nemotron-3-super-120b-a12b)");
     // Non-default sandbox keeps its stored model — the gateway only applies
     // to whichever sandbox is currently connected.
-    expect(lines).toContain("    beta (z-ai/glm5)");
+    expect(lines).toContain("    beta (z-ai/glm-5.1)");
     expect(showServiceStatus).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -399,7 +399,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 if echo "$url" | grep -q '/v1/models$'; then
-  body='{"data":[{"id":"moonshotai/kimi-k2.5"},{"id":"z-ai/glm5"}]}'
+  body='{"data":[{"id":"moonshotai/kimi-k2.5"},{"id":"z-ai/glm-5.1"}]}'
 fi
 printf '%s' "$body" > "$outfile"
 printf '%s' "$status"
@@ -411,7 +411,7 @@ printf '%s' "$status"
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
-const answers = ["1", "7", "bad/model", "z-ai/glm5"];
+const answers = ["1", "7", "bad/model", "z-ai/glm-5.1"];
 const messages = [];
 
 credentials.prompt = async (message) => {
@@ -463,7 +463,7 @@ const { setupNim } = require(${onboardPath});
 
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.result.model, "z-ai/glm5");
+    assert.equal(payload.result.model, "z-ai/glm-5.1");
     assert.equal(
       payload.messages.filter((message: string) => /NVIDIA Endpoints model id:/.test(message))
         .length,


### PR DESCRIPTION
## Summary
Swap every curated `z-ai/glm5` reference to `z-ai/glm-5.1` ahead of the May 9, 2026 full-deprecation date. The successor is already served at the same provider prefix, so this is a straight id/label rename.

Fixes #1744.

## Files changed
- `src/lib/inference-config.ts` — `CLOUD_MODEL_OPTIONS` picker entry
- `src/lib/inference-config.test.ts` — id-list assertion
- `src/lib/inventory-commands.test.ts` — sandbox-list fixtures
- `test/onboard-selection.test.ts` — mocked `/v1/models` response + selection answers + expected model
- `docs/inference/inference-options.md` — NVIDIA Endpoints example list
- `.agents/skills/nemoclaw-user-configure-inference/SKILL.md`
- `.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md`

## Why now
Per the deprecation notice (issue #1744):
- **Apr 9, 2026** — Deprecation notice + banner live (gateway redirect active during migration window)
- **May 9, 2026** — GLM-5 fully shut down
- Successor: [GLM-5.1](https://build.nvidia.com/z-ai/glm-5.1)

Landing this before May 9 ensures the curated picker and docs no longer suggest a model that will return hard errors post-T0.

## Migration note for existing users
Users with sandboxes already pinned to `z-ai/glm5` will keep working via the gateway redirect through the migration window. A rebuild after this PR lands will pick up the new default automatically.

## Test plan
- [x] `npm run build:cli` — clean
- [x] `npx vitest run src/lib/inference-config.test.ts src/lib/inventory-commands.test.ts` — 22/22 pass
- [x] No remaining `glm5` or `GLM-5` (pre-.1) references anywhere in the tree
- [x] No code-path changes — purely a string rename

Signed-off-by: Colin McDonough <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Replaced NVIDIA Endpoints curated model GLM-5 with GLM-5.1 across configuration, tests, onboarding/selection flows, documentation, and quickstart examples to keep model identifiers consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->