### PR TITLE
chore(ci): add conventional commit prefix to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build(deps)"


### PR DESCRIPTION
## Summary

Dependabot PRs fail commit-lint because the auto-generated message ("Bump X from Y to Z") lacks the conventional commit prefix. This adds `commit-message.prefix: "build(deps)"` so future PRs generate `build(deps): bump X from Y to Z`.

Fixes the commit-lint failure on #1926, #1927, #1928, #1929, #1930 (existing PRs still need admin squash-merge, but future ones will pass automatically).

## Test plan

- [x] 2-line config change, no code impact

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation: weekly dependency update commits now use a consistent commit-message prefix ("chore(deps)") to improve repo history clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->