### PR TITLE
fix(security): prevent DNS rebinding SSRF bypass in validateEndpointUrl

### DIFF
--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -73,7 +73,7 @@ vi.mock("execa", () => ({
 
 vi.mock("./ssrf.js", () => ({
   // eslint-disable-next-line @typescript-eslint/require-await
-  validateEndpointUrl: vi.fn(async (url: string) => url),
+  validateEndpointUrl: vi.fn(async (url: string) => ({ url, pinnedUrl: url })),
 }));
 
 const { validateEndpointUrl } = await import("./ssrf.js");

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -133,13 +133,19 @@ async function resolveRunConfig(
 
   let inferenceCfg = { ...inferenceProfiles[profile] };
   if (endpointUrl) {
-    await validateEndpointUrl(endpointUrl);
-    inferenceCfg = { ...inferenceCfg, endpoint: endpointUrl };
+    const validated = await validateEndpointUrl(endpointUrl);
+    // Use DNS-pinned URL for HTTP (full SSRF/rebinding protection). For HTTPS,
+    // keep the original hostname — TLS certificate validation prevents rebinding
+    // since the attacker cannot present a valid cert for the target.
+    const safe = endpointUrl.startsWith("https:") ? validated.url : validated.pinnedUrl;
+    inferenceCfg = { ...inferenceCfg, endpoint: safe };
   }
 
   // Validate the final endpoint (whether from CLI override or blueprint profile)
   if (inferenceCfg.endpoint) {
-    await validateEndpointUrl(inferenceCfg.endpoint);
+    const validated = await validateEndpointUrl(inferenceCfg.endpoint);
+    const safe = inferenceCfg.endpoint.startsWith("https:") ? validated.url : validated.pinnedUrl;
+    inferenceCfg = { ...inferenceCfg, endpoint: safe };
   }
 
   const sandboxCfg = blueprint.components?.sandbox ?? {};

--- a/nemoclaw/src/blueprint/ssrf.test.ts
+++ b/nemoclaw/src/blueprint/ssrf.test.ts
@@ -83,16 +83,16 @@ describe("validateEndpointUrl", () => {
 
   it("allows https", async () => {
     mockPublicDns();
-    await expect(validateEndpointUrl("https://api.nvidia.com/v1")).resolves.toBe(
-      "https://api.nvidia.com/v1",
-    );
+    const result = await validateEndpointUrl("https://api.nvidia.com/v1");
+    expect(result.url).toBe("https://api.nvidia.com/v1");
+    expect(result.pinnedUrl).toBe("https://93.184.216.34/v1");
   });
 
   it("allows http", async () => {
     mockPublicDns();
-    await expect(validateEndpointUrl("http://api.nvidia.com/v1")).resolves.toBe(
-      "http://api.nvidia.com/v1",
-    );
+    const result = await validateEndpointUrl("http://api.nvidia.com/v1");
+    expect(result.url).toBe("http://api.nvidia.com/v1");
+    expect(result.pinnedUrl).toBe("http://93.184.216.34/v1");
   });
 
   it("rejects file:// scheme", async () => {
@@ -170,19 +170,25 @@ describe("validateEndpointUrl", () => {
   it("allows NVIDIA API endpoint", async () => {
     mockPublicDns();
     const url = "https://integrate.api.nvidia.com/v1";
-    await expect(validateEndpointUrl(url)).resolves.toBe(url);
+    const result = await validateEndpointUrl(url);
+    expect(result.url).toBe(url);
+    expect(result.pinnedUrl).toBe("https://93.184.216.34/v1");
   });
 
   it("allows URL with port", async () => {
     mockPublicDns();
     const url = "https://api.example.com:8443/v1";
-    await expect(validateEndpointUrl(url)).resolves.toBe(url);
+    const result = await validateEndpointUrl(url);
+    expect(result.url).toBe(url);
+    expect(result.pinnedUrl).toBe("https://93.184.216.34:8443/v1");
   });
 
   it("preserves URL path", async () => {
     mockPublicDns();
     const url = "https://api.example.com/v1/chat/completions";
-    await expect(validateEndpointUrl(url)).resolves.toBe(url);
+    const result = await validateEndpointUrl(url);
+    expect(result.url).toBe(url);
+    expect(result.pinnedUrl).toBe("https://93.184.216.34/v1/chat/completions");
   });
 });
 
@@ -269,9 +275,41 @@ describe("validateEndpointUrl – DNS rebinding", () => {
       { address: "93.184.216.34", family: 4 },
       { address: "2607:f8b0:4004:800::200e", family: 6 },
     ]);
-    await expect(validateEndpointUrl("https://cdn.example.com/v1")).resolves.toBe(
-      "https://cdn.example.com/v1",
-    );
+    const result = await validateEndpointUrl("https://cdn.example.com/v1");
+    expect(result.url).toBe("https://cdn.example.com/v1");
+    expect(result.pinnedUrl).toBe("https://93.184.216.34/v1");
+  });
+});
+
+describe("validateEndpointUrl – DNS pinning", () => {
+  it("pins HTTP URL to resolved IP (prevents rebinding)", async () => {
+    mockPublicDns();
+    const result = await validateEndpointUrl("http://attacker.com:8080/v1");
+    // pinnedUrl has IP instead of hostname — downstream connects to validated IP
+    expect(result.pinnedUrl).toBe("http://93.184.216.34:8080/v1");
+    // original URL preserved for reference
+    expect(result.url).toBe("http://attacker.com:8080/v1");
+  });
+
+  it("pins HTTPS URL to resolved IP", async () => {
+    mockPublicDns();
+    const result = await validateEndpointUrl("https://api.example.com/v1");
+    expect(result.pinnedUrl).toBe("https://93.184.216.34/v1");
+  });
+
+  it("pins IPv6 address with brackets", async () => {
+    mockLookup.mockResolvedValue([{ address: "2607:f8b0:4004:800::200e", family: 6 }]);
+    const result = await validateEndpointUrl("https://ipv6host.example.com/v1");
+    expect(result.pinnedUrl).toBe("https://[2607:f8b0:4004:800::200e]/v1");
+  });
+
+  it("uses first resolved address for pinning", async () => {
+    mockLookup.mockResolvedValue([
+      { address: "1.2.3.4", family: 4 },
+      { address: "5.6.7.8", family: 4 },
+    ]);
+    const result = await validateEndpointUrl("http://multi.example.com/v1");
+    expect(result.pinnedUrl).toBe("http://1.2.3.4/v1");
   });
 });
 
@@ -285,19 +323,22 @@ describe("validateEndpointUrl – URL parsing edge cases", () => {
   it("allows URL with query parameters", async () => {
     mockPublicDns();
     const url = "https://api.example.com/v1?key=abc&model=gpt";
-    await expect(validateEndpointUrl(url)).resolves.toBe(url);
+    const result = await validateEndpointUrl(url);
+    expect(result.url).toBe(url);
   });
 
   it("allows URL with fragment", async () => {
     mockPublicDns();
     const url = "https://api.example.com/v1#section";
-    await expect(validateEndpointUrl(url)).resolves.toBe(url);
+    const result = await validateEndpointUrl(url);
+    expect(result.url).toBe(url);
   });
 
   it("allows URL with userinfo/basic auth", async () => {
     mockPublicDns();
     // URL parser extracts hostname correctly even with userinfo
     const url = "https://user:pass@api.example.com/v1";
-    await expect(validateEndpointUrl(url)).resolves.toBe(url);
+    const result = await validateEndpointUrl(url);
+    expect(result.url).toBe(url);
   });
 });

--- a/nemoclaw/src/blueprint/ssrf.ts
+++ b/nemoclaw/src/blueprint/ssrf.ts
@@ -120,7 +120,24 @@ export function isPrivateIp(addr: string): boolean {
   return false;
 }
 
-export async function validateEndpointUrl(url: string): Promise<string> {
+/**
+ * Result of endpoint URL validation with DNS pinning.
+ *
+ * `url` is the original URL (hostname intact).
+ * `pinnedUrl` has the hostname replaced with the first resolved IP, preventing
+ * DNS rebinding TOCTOU attacks where an attacker returns a public IP at
+ * validation time and a private IP at connection time.
+ *
+ * Callers should use `pinnedUrl` for HTTP endpoints (full protection) and `url`
+ * for HTTPS endpoints (TLS certificate validation prevents rebinding since the
+ * attacker cannot present a valid cert for the rebinding target).
+ */
+export interface ValidatedEndpoint {
+  url: string;
+  pinnedUrl: string;
+}
+
+export async function validateEndpointUrl(url: string): Promise<ValidatedEndpoint> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -156,5 +173,11 @@ export async function validateEndpointUrl(url: string): Promise<string> {
     }
   }
 
-  return url;
+  // DNS pinning: replace hostname with the first validated IP to prevent
+  // TOCTOU rebinding between validation and connection time.
+  const pinned = new URL(url);
+  const first = addresses[0];
+  pinned.hostname = first.family === 6 ? `[${first.address}]` : first.address;
+
+  return { url, pinnedUrl: pinned.toString() };
 }


### PR DESCRIPTION
## Summary
- Add DNS pinning to `validateEndpointUrl()` to prevent TOCTOU DNS rebinding attacks (CWE-918)
- The function now returns a `ValidatedEndpoint` with both the original URL and a DNS-pinned URL (hostname replaced with the first resolved IP)
- For HTTP endpoints: callers use the pinned URL (full rebinding protection)
- For HTTPS endpoints: callers keep the original hostname (TLS certificate validation prevents rebinding since the attacker cannot present a valid cert for the target)

## Why
`validateEndpointUrl()` resolved DNS at validation time but returned the original hostname URL. An attacker controlling a DNS server could return a public IP on the first query (passing validation) and a private IP on the second query (at connection time), redirecting inference requests to localhost, cloud metadata endpoints (`169.254.169.254`), or other internal services. This leaks API credentials (`OPENAI_API_KEY`, `NVIDIA_API_KEY`) and intercepts all inference traffic.

Note: The `0.0.0.0/8` blocklist gap (Bypass 1 from the report) was previously fixed on `main`. This PR addresses the remaining DNS rebinding TOCTOU (Bypass 2).

## What changed
- `nemoclaw/src/blueprint/ssrf.ts` — `validateEndpointUrl()` returns `ValidatedEndpoint` with `{ url, pinnedUrl }`; builds pinned URL by replacing hostname with first resolved IP (IPv6 addresses bracketed per URL spec)
- `nemoclaw/src/blueprint/runner.ts` — `resolveProfile()` uses pinned URL for HTTP, original URL for HTTPS
- `nemoclaw/src/blueprint/ssrf.test.ts` — updated assertions for new return type; added DNS pinning test suite (HTTP, HTTPS, IPv6, multi-address)
- `nemoclaw/src/blueprint/runner.test.ts` — updated mock to return `ValidatedEndpoint` shape

## Test plan
- [x] `npm run build` (plugin) — compiles cleanly
- [x] `vitest run --project plugin` — 334 tests pass
- [x] All pre-commit hooks pass (prettier, eslint, gitleaks, etc.)
- [x] Pre-push TypeScript type-check passes
- [ ] Manual: `nemoclaw blueprint apply --endpoint http://zero.ports.sh:8080/v1` — verify the pinned URL uses resolved IP, not hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced endpoint validation with DNS pinning support for improved URL resolution handling.

* **Tests**
  * Updated validation tests to verify new endpoint validation contract with pinned URL support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->