### PR TITLE
fix(security): use os.homedir() instead of process.env.HOME for state paths

### DIFF
--- a/nemoclaw/src/blueprint/state.test.ts
+++ b/nemoclaw/src/blueprint/state.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type fs from "node:fs";
+import { homedir } from "node:os";
 import { loadState, saveState, clearState, type NemoClawState } from "./state.js";
 
 const store = new Map<string, string>();
@@ -24,7 +25,7 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
-const STATE_PATH = `${process.env.HOME ?? "/tmp"}/.nemoclaw/state/nemoclaw.json`;
+const STATE_PATH = `${homedir()}/.nemoclaw/state/nemoclaw.json`;
 
 describe("blueprint/state", () => {
   beforeEach(() => {

--- a/nemoclaw/src/blueprint/state.ts
+++ b/nemoclaw/src/blueprint/state.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
-const STATE_DIR = join(process.env.HOME ?? "/tmp", ".nemoclaw", "state");
+const STATE_DIR = join(homedir(), ".nemoclaw", "state");
 
 export interface NemoClawState {
   lastRunId: string | null;

--- a/nemoclaw/src/onboard/config.test.ts
+++ b/nemoclaw/src/onboard/config.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { homedir } from "node:os";
 import {
   describeOnboardEndpoint,
   describeOnboardProvider,
@@ -124,7 +125,7 @@ describe("onboard/config", () => {
 
     it("returns parsed config when file exists", () => {
       const config = makeConfig();
-      const configPath = `${process.env.HOME ?? "/tmp"}/.nemoclaw/config.json`;
+      const configPath = `${homedir()}/.nemoclaw/config.json`;
       store.set(configPath, JSON.stringify(config));
       expect(loadOnboardConfig()).toEqual(config);
     });

--- a/nemoclaw/src/onboard/config.ts
+++ b/nemoclaw/src/onboard/config.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
-let configDir = join(process.env.HOME ?? tmpdir(), ".nemoclaw");
+let configDir = join(homedir(), ".nemoclaw");
 
 export type EndpointType =
   | "build"


### PR DESCRIPTION
## Summary
- Replace `process.env.HOME ?? "/tmp"` with `os.homedir()` in `state.ts` and `config.ts`
- Eliminates unsafe `/tmp` fallback when HOME is unset and aligns with the pattern already used by `runner.ts` and `snapshot.ts`

## Why
`state.ts` and `config.ts` used `process.env.HOME` to construct state directory paths, falling back to `/tmp` (or `os.tmpdir()`) when HOME is unset. Two risks:

1. **HOME injection**: An attacker controlling the HOME variable (e.g. in a shared container) could redirect state files to an attacker-controlled path where pre-seeded state influences NemoClaw behavior
2. **World-writable fallback**: When HOME is unset, state files were created under `/tmp/.nemoclaw/`, which is world-readable on multi-user systems

`os.homedir()` falls back to the passwd database (`getpwuid`) when HOME is unset, never to `/tmp`.

## What changed
- `nemoclaw/src/blueprint/state.ts` — `process.env.HOME ?? "/tmp"` → `homedir()`
- `nemoclaw/src/onboard/config.ts` — `process.env.HOME ?? tmpdir()` → `homedir()`
- `nemoclaw/src/blueprint/state.test.ts` — updated path constant to use `homedir()`
- `nemoclaw/src/onboard/config.test.ts` — updated path constant to use `homedir()`

## Test plan
- [x] `npm run build` (plugin) — compiles cleanly
- [x] `vitest run --project plugin` — 334 tests pass
- [x] All pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of application configuration and state file storage by using the system's standard home directory detection method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->