### PR TITLE
fix(security): reject symlinks on ~/.nemoclaw to prevent credential hijack

### DIFF
--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -13,7 +13,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, sep } from "node:path";
 
@@ -21,6 +21,7 @@ import { execa } from "execa";
 import YAML from "yaml";
 
 import { validateEndpointUrl } from "./ssrf.js";
+import { safeMkdirSync } from "../lib/safe-dir.js";
 import { buildSubprocessEnv } from "../lib/subprocess-env.js";
 import { DASHBOARD_PORT } from "../lib/ports.js";
 
@@ -321,7 +322,7 @@ export async function actionApply(
 
   progress(85, "Saving run state");
   const stateDir = join(homedir(), ".nemoclaw", "state", "runs", rid);
-  mkdirSync(stateDir, { recursive: true });
+  safeMkdirSync(stateDir);
   writeFileSync(
     join(stateDir, "plan.json"),
     JSON.stringify(

--- a/nemoclaw/src/blueprint/snapshot.ts
+++ b/nemoclaw/src/blueprint/snapshot.ts
@@ -12,19 +12,13 @@
  */
 
 import type { Dirent } from "node:fs";
-import {
-  cpSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  renameSync,
-  writeFileSync,
-} from "node:fs";
+import { cpSync, existsSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, relative } from "node:path";
 
 import { execa } from "execa";
+
+import { safeMkdirSync } from "../lib/safe-dir.js";
 
 const HOME = homedir();
 const OPENCLAW_DIR = join(HOME, ".openclaw");
@@ -61,7 +55,7 @@ export function createSnapshot(): string | null {
 
   const timestamp = compactTimestamp();
   const snapshotDir = join(SNAPSHOTS_DIR, timestamp);
-  mkdirSync(snapshotDir, { recursive: true });
+  safeMkdirSync(snapshotDir);
 
   const dest = join(snapshotDir, "openclaw");
   cpSync(OPENCLAW_DIR, dest, { recursive: true });

--- a/nemoclaw/src/blueprint/state.ts
+++ b/nemoclaw/src/blueprint/state.ts
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
-const STATE_DIR = join(process.env.HOME ?? "/tmp", ".nemoclaw", "state");
+import { safeMkdirSync } from "../lib/safe-dir.js";
+
+const STATE_DIR = join(homedir(), ".nemoclaw", "state");
 
 export interface NemoClawState {
   lastRunId: string | null;
@@ -24,7 +27,7 @@ let stateDirCreated = false;
 function ensureStateDir(): void {
   if (stateDirCreated) return;
   if (!existsSync(STATE_DIR)) {
-    mkdirSync(STATE_DIR, { recursive: true });
+    safeMkdirSync(STATE_DIR);
   }
   stateDirCreated = true;
 }

--- a/nemoclaw/src/lib/safe-dir.ts
+++ b/nemoclaw/src/lib/safe-dir.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { lstatSync, mkdirSync } from "node:fs";
+
+/**
+ * Reject a path that is a symbolic link.
+ *
+ * Prevents symlink attacks where an attacker creates ~/.nemoclaw (or a
+ * subdirectory) as a symlink to an attacker-controlled location before the
+ * user first runs NemoClaw, causing credentials and state to be written
+ * outside the intended directory.
+ *
+ * @throws if the path exists and is a symbolic link.
+ */
+function rejectSymlink(dirPath: string): void {
+  try {
+    const stat = lstatSync(dirPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(
+        `Refusing to use ${dirPath}: path is a symbolic link. ` +
+          "This may indicate a symlink attack. Remove the symlink and retry.",
+      );
+    }
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+}
+
+/**
+ * Create a directory after verifying it is not a symlink.
+ *
+ * Drop-in replacement for `mkdirSync(path, { recursive: true })` that
+ * checks the target path with `lstat()` before creating it.
+ */
+export function safeMkdirSync(dirPath: string, options?: { mode?: number }): void {
+  rejectSymlink(dirPath);
+  mkdirSync(dirPath, { recursive: true, ...options });
+}

--- a/nemoclaw/src/lib/safe-dir.ts
+++ b/nemoclaw/src/lib/safe-dir.ts
@@ -2,37 +2,56 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { lstatSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve, sep } from "node:path";
 
 /**
- * Reject a path that is a symbolic link.
+ * Reject symlinks in the path tree between `dirPath` and the user's home dir.
  *
- * Prevents symlink attacks where an attacker creates ~/.nemoclaw (or a
- * subdirectory) as a symlink to an attacker-controlled location before the
- * user first runs NemoClaw, causing credentials and state to be written
- * outside the intended directory.
+ * Walks from `dirPath` upward, stopping at $HOME. For each component:
+ *   - If it exists as a symlink: throw (attack detected).
+ *   - If it exists as a real directory: stop (trusted anchor).
+ *   - If it doesn't exist (ENOENT): continue upward.
  *
- * @throws if the path exists and is a symbolic link.
+ * Stops at $HOME because system-level symlinks above it (e.g. /tmp -> /private/tmp
+ * on macOS, /var -> /private/var) are trusted OS infrastructure. Paths outside
+ * $HOME (e.g. tmpdir fallback) skip the check entirely — those are low-trust
+ * shared directories where the threat model is different.
+ *
+ * @throws if any path component at or below $HOME is a symbolic link.
  */
 function rejectSymlink(dirPath: string): void {
-  try {
-    const stat = lstatSync(dirPath);
-    if (stat.isSymbolicLink()) {
-      throw new Error(
-        `Refusing to use ${dirPath}: path is a symbolic link. ` +
-          "This may indicate a symlink attack. Remove the symlink and retry.",
-      );
+  const home = resolve(homedir());
+  let current = resolve(dirPath);
+  let parent = dirname(current);
+  while (current !== parent) {
+    // Only check paths at or below $HOME — above is trusted OS infrastructure.
+    if (!current.startsWith(home + sep) && current !== home) break;
+    try {
+      const stat = lstatSync(current);
+      if (stat.isSymbolicLink()) {
+        throw new Error(
+          `Refusing to use ${dirPath}: ${current} is a symbolic link. ` +
+            "This may indicate a symlink attack. Remove the symlink and retry.",
+        );
+      }
+      // Exists as a real directory — trusted anchor, stop walking.
+      break;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      // Doesn't exist yet — will be created by mkdirSync. Check parent.
     }
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-    throw err;
+    if (current === home) break; // checked $HOME itself, don't go above
+    current = parent;
+    parent = dirname(current);
   }
 }
 
 /**
- * Create a directory after verifying it is not a symlink.
+ * Create a directory after verifying no path component is a symlink.
  *
  * Drop-in replacement for `mkdirSync(path, { recursive: true })` that
- * checks the target path with `lstat()` before creating it.
+ * checks path components (at or below $HOME) with `lstat()` before creating.
  */
 export function safeMkdirSync(dirPath: string, options?: { mode?: number }): void {
   rejectSymlink(dirPath);

--- a/nemoclaw/src/onboard/config.ts
+++ b/nemoclaw/src/onboard/config.ts
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
-let configDir = join(process.env.HOME ?? tmpdir(), ".nemoclaw");
+import { safeMkdirSync } from "../lib/safe-dir.js";
+
+let configDir = join(homedir(), ".nemoclaw");
 
 export type EndpointType =
   | "build"
@@ -73,11 +75,11 @@ function ensureConfigDir(): void {
   if (configDirCreated) return;
   if (!existsSync(configDir)) {
     try {
-      mkdirSync(configDir, { recursive: true });
+      safeMkdirSync(configDir);
     } catch {
       configDir = join(tmpdir(), ".nemoclaw");
       if (!existsSync(configDir)) {
-        mkdirSync(configDir, { recursive: true });
+        safeMkdirSync(configDir);
       }
     }
   }

--- a/nemoclaw/src/onboard/config.ts
+++ b/nemoclaw/src/onboard/config.ts
@@ -73,15 +73,20 @@ let configDirCreated = false;
 
 function ensureConfigDir(): void {
   if (configDirCreated) return;
-  if (!existsSync(configDir)) {
-    try {
-      safeMkdirSync(configDir);
-    } catch {
-      configDir = join(tmpdir(), ".nemoclaw");
-      if (!existsSync(configDir)) {
-        safeMkdirSync(configDir);
-      }
+  try {
+    safeMkdirSync(configDir);
+  } catch (error: unknown) {
+    // Never swallow symlink errors — they indicate an attack.
+    if (error instanceof Error && /symbolic link/i.test(error.message)) {
+      throw error;
     }
+    // Fall back to tmpdir only for permission/filesystem errors.
+    const code = (error as NodeJS.ErrnoException).code;
+    if (!code || !["EACCES", "EPERM", "EROFS"].includes(code)) {
+      throw error;
+    }
+    configDir = join(tmpdir(), ".nemoclaw");
+    safeMkdirSync(configDir);
   }
   configDirCreated = true;
 }

--- a/src/lib/config-io.ts
+++ b/src/lib/config-io.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { safeMkdirSync } from "./safe-dir";
 import { shellQuote } from "./shell-quote";
 
 function buildRemediation(): string {
@@ -82,7 +83,7 @@ export class ConfigPermissionError extends Error {
 
 export function ensureConfigDir(dirPath: string): void {
   try {
-    fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+    safeMkdirSync(dirPath, { mode: 0o700 });
 
     const stat = fs.statSync(dirPath);
     if ((stat.mode & 0o077) !== 0) {

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -8,12 +8,14 @@
  */
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import type { WebSearchConfig } from "./web-search";
+import { safeMkdirSync } from "./safe-dir";
 
 export const SESSION_VERSION = 1;
-export const SESSION_DIR = path.join(process.env.HOME || "/tmp", ".nemoclaw");
+export const SESSION_DIR = path.join(os.homedir(), ".nemoclaw");
 export const SESSION_FILE = path.join(SESSION_DIR, "onboard-session.json");
 export const LOCK_FILE = path.join(SESSION_DIR, "onboard.lock");
 const VALID_STEP_STATES = new Set(["pending", "in_progress", "complete", "failed", "skipped"]);
@@ -94,7 +96,7 @@ export interface SessionUpdates {
 // ── Helpers ──────────────────────────────────────────────────────
 
 function ensureSessionDir(): void {
-  fs.mkdirSync(SESSION_DIR, { recursive: true, mode: 0o700 });
+  safeMkdirSync(SESSION_DIR, { mode: 0o700 });
 }
 
 export function sessionPath(): string {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -12,6 +12,7 @@ const os = require("os");
 const path = require("path");
 const { spawn, spawnSync } = require("child_process");
 const pRetry = require("p-retry");
+const { safeMkdirSync } = require("./safe-dir");
 
 /** Parse a numeric env var, returning `fallback` when unset or non-finite. */
 function envInt(name, fallback) {
@@ -1631,7 +1632,7 @@ let ollamaProxyToken: string | null = null;
 
 function ensureProxyStateDir(): void {
   if (!fs.existsSync(PROXY_STATE_DIR)) {
-    fs.mkdirSync(PROXY_STATE_DIR, { recursive: true });
+    safeMkdirSync(PROXY_STATE_DIR);
   }
 }
 

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { ensureConfigDir, readConfigFile, writeConfigFile } from "./config-io";
@@ -27,7 +28,7 @@ export interface SandboxRegistry {
   defaultSandbox: string | null;
 }
 
-export const REGISTRY_FILE = path.join(process.env.HOME || "/tmp", ".nemoclaw", "sandboxes.json");
+export const REGISTRY_FILE = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
 export const LOCK_DIR = `${REGISTRY_FILE}.lock`;
 export const LOCK_OWNER = path.join(LOCK_DIR, "owner");
 export const LOCK_STALE_MS = 10_000;

--- a/src/lib/safe-dir.ts
+++ b/src/lib/safe-dir.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { lstatSync, mkdirSync } from "node:fs";
+
+/**
+ * Reject a path that is a symbolic link.
+ *
+ * Prevents symlink attacks where an attacker creates ~/.nemoclaw (or a
+ * subdirectory) as a symlink to an attacker-controlled location before the
+ * user first runs NemoClaw, causing credentials and state to be written
+ * outside the intended directory.
+ *
+ * @throws if the path exists and is a symbolic link.
+ */
+function rejectSymlink(dirPath: string): void {
+  try {
+    const stat = lstatSync(dirPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(
+        `Refusing to use ${dirPath}: path is a symbolic link. ` +
+          "This may indicate a symlink attack. Remove the symlink and retry.",
+      );
+    }
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+}
+
+/**
+ * Create a directory after verifying it is not a symlink.
+ *
+ * Drop-in replacement for `mkdirSync(path, { recursive: true })` that
+ * checks the target path with `lstat()` before creating it.
+ */
+export function safeMkdirSync(dirPath: string, options?: { mode?: number }): void {
+  rejectSymlink(dirPath);
+  mkdirSync(dirPath, { recursive: true, ...options });
+}

--- a/src/lib/safe-dir.ts
+++ b/src/lib/safe-dir.ts
@@ -2,37 +2,56 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { lstatSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve, sep } from "node:path";
 
 /**
- * Reject a path that is a symbolic link.
+ * Reject symlinks in the path tree between `dirPath` and the user's home dir.
  *
- * Prevents symlink attacks where an attacker creates ~/.nemoclaw (or a
- * subdirectory) as a symlink to an attacker-controlled location before the
- * user first runs NemoClaw, causing credentials and state to be written
- * outside the intended directory.
+ * Walks from `dirPath` upward, stopping at $HOME. For each component:
+ *   - If it exists as a symlink: throw (attack detected).
+ *   - If it exists as a real directory: stop (trusted anchor).
+ *   - If it doesn't exist (ENOENT): continue upward.
  *
- * @throws if the path exists and is a symbolic link.
+ * Stops at $HOME because system-level symlinks above it (e.g. /tmp -> /private/tmp
+ * on macOS, /var -> /private/var) are trusted OS infrastructure. Paths outside
+ * $HOME (e.g. tmpdir fallback) skip the check entirely — those are low-trust
+ * shared directories where the threat model is different.
+ *
+ * @throws if any path component at or below $HOME is a symbolic link.
  */
 function rejectSymlink(dirPath: string): void {
-  try {
-    const stat = lstatSync(dirPath);
-    if (stat.isSymbolicLink()) {
-      throw new Error(
-        `Refusing to use ${dirPath}: path is a symbolic link. ` +
-          "This may indicate a symlink attack. Remove the symlink and retry.",
-      );
+  const home = resolve(homedir());
+  let current = resolve(dirPath);
+  let parent = dirname(current);
+  while (current !== parent) {
+    // Only check paths at or below $HOME — above is trusted OS infrastructure.
+    if (!current.startsWith(home + sep) && current !== home) break;
+    try {
+      const stat = lstatSync(current);
+      if (stat.isSymbolicLink()) {
+        throw new Error(
+          `Refusing to use ${dirPath}: ${current} is a symbolic link. ` +
+            "This may indicate a symlink attack. Remove the symlink and retry.",
+        );
+      }
+      // Exists as a real directory — trusted anchor, stop walking.
+      break;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      // Doesn't exist yet — will be created by mkdirSync. Check parent.
     }
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-    throw err;
+    if (current === home) break; // checked $HOME itself, don't go above
+    current = parent;
+    parent = dirname(current);
   }
 }
 
 /**
- * Create a directory after verifying it is not a symlink.
+ * Create a directory after verifying no path component is a symlink.
  *
  * Drop-in replacement for `mkdirSync(path, { recursive: true })` that
- * checks the target path with `lstat()` before creating it.
+ * checks path components (at or below $HOME) with `lstat()` before creating.
  */
 export function safeMkdirSync(dirPath: string, options?: { mode?: number }): void {
   rejectSymlink(dirPath);

--- a/src/lib/usage-notice.ts
+++ b/src/lib/usage-notice.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 
 import noticeConfig from "../../bin/lib/usage-notice.json";
+import { safeMkdirSync } from "./safe-dir";
 
 export const NOTICE_ACCEPT_FLAG = "--yes-i-accept-third-party-software";
 export const NOTICE_ACCEPT_ENV = "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE";
@@ -61,7 +62,7 @@ export function hasAcceptedUsageNotice(version: string): boolean {
 export function saveUsageNoticeAcceptance(version: string): void {
   const stateFile = getUsageNoticeStateFile();
   const dir = path.dirname(stateFile);
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  safeMkdirSync(dir, { mode: 0o700 });
   fs.chmodSync(dir, 0o700);
   fs.writeFileSync(
     stateFile,


### PR DESCRIPTION
## Summary
- Add `safeMkdirSync()` utility that checks `lstat()` before `mkdirSync()` and throws if the target path is a symbolic link
- Apply to all `~/.nemoclaw` directory creation paths across both CLI and plugin (8 vulnerable locations)
- Also fix remaining `process.env.HOME||"/tmp"` patterns with `os.homedir()`

## Why
`mkdirSync(~/.nemoclaw, { recursive: true })` does not check whether the path already exists as a symlink. An attacker who creates `~/.nemoclaw` as a symlink to an attacker-controlled directory before the user first runs NemoClaw causes credentials, state, and config to be written to the attacker's location. Combined with plaintext credential storage, API keys are directly readable.

## What changed
- **New**: `src/lib/safe-dir.ts` and `nemoclaw/src/lib/safe-dir.ts` — `safeMkdirSync()` utility (lstat check + mkdirSync)
- **CLI side**: `config-io.ts`, `onboard-session.ts`, `onboard.ts`, `usage-notice.ts` — replaced bare `mkdirSync` with `safeMkdirSync`
- **Plugin side**: `state.ts`, `config.ts`, `runner.ts`, `snapshot.ts` — replaced bare `mkdirSync` with `safeMkdirSync`
- **Bonus**: `registry.ts` and `onboard-session.ts` — fixed `process.env.HOME||"/tmp"` → `os.homedir()`

## Test plan
- [x] `npm run build` (plugin) — compiles cleanly
- [x] `npm run typecheck:cli` — passes
- [x] `vitest run --project plugin` — 334 tests pass
- [x] All pre-commit, commit-msg, and pre-push hooks pass
- [ ] Manual: `ln -s /tmp/test ~/.nemoclaw && nemoclaw onboard` — verify error: "path is a symbolic link"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened directory creation to reject unsafe/symlinked paths, reducing risk of directory traversal or symlink attacks.
  * Standardized use of the OS home directory for config, state, session, and registry locations instead of environment fallbacks.
  * More consistent, reliable path handling and tighter error handling during initialization and onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->