### PR TITLE
fix(onboard): resolve dual auth credential conflict in Gemini validation probe

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1242,6 +1242,13 @@ function shouldRequireResponsesToolCalling(provider) {
   );
 }
 
+// Google Gemini rejects requests that carry both an Authorization: Bearer
+// header and a ?key= query parameter ("Multiple authentication credentials
+// received"). Send the API key as ?key= only for Gemini. See issue #1960.
+function getProbeAuthMode(provider) {
+  return provider === "gemini-api" ? "query-param" : undefined;
+}
+
 // shouldSkipResponsesProbe and isNvcfFunctionNotFoundForAccount /
 // nvcfFunctionNotFoundMessage — see validation import above. They live in
 // src/lib/validation.ts so they can be unit-tested independently.
@@ -1256,13 +1263,22 @@ function getValidationProbeCurlArgs(opts) {
   return ["--connect-timeout", "10", "--max-time", "15"];
 }
 
-function probeResponsesToolCalling(endpointUrl, model, apiKey) {
+function probeResponsesToolCalling(endpointUrl, model, apiKey, options = {}) {
+  const useQueryParam = options.authMode === "query-param";
+  const normalizedKey = apiKey ? normalizeCredentialValue(apiKey) : "";
+  const baseUrl = String(endpointUrl).replace(/\/+$/, "");
+  const authHeader = !useQueryParam && normalizedKey
+    ? ["-H", `Authorization: Bearer ${normalizedKey}`]
+    : [];
+  const url = useQueryParam && normalizedKey
+    ? `${baseUrl}/responses?key=${normalizedKey}`
+    : `${baseUrl}/responses`;
   const result = runCurlProbe([
     "-sS",
     ...getValidationProbeCurlArgs(),
     "-H",
     "Content-Type: application/json",
-    ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
+    ...authHeader,
     "-d",
     JSON.stringify({
       model,
@@ -1284,7 +1300,7 @@ function probeResponsesToolCalling(endpointUrl, model, apiKey) {
         },
       ],
     }),
-    `${String(endpointUrl).replace(/\/+$/, "")}/responses`,
+    url,
   ]);
 
   if (!result.ok) {
@@ -1304,12 +1320,21 @@ function probeResponsesToolCalling(endpointUrl, model, apiKey) {
 }
 
 function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
+  const useQueryParam = options.authMode === "query-param";
+  const normalizedKey = apiKey ? normalizeCredentialValue(apiKey) : "";
+  const baseUrl = String(endpointUrl).replace(/\/+$/, "");
+  const authHeader = !useQueryParam && normalizedKey
+    ? ["-H", `Authorization: Bearer ${normalizedKey}`]
+    : [];
+  const appendKey = (path) =>
+    useQueryParam && normalizedKey ? `${baseUrl}${path}?key=${normalizedKey}` : `${baseUrl}${path}`;
+
   const responsesProbe =
     options.requireResponsesToolCalling === true
       ? {
           name: "Responses API with tool calling",
           api: "openai-responses",
-          execute: () => probeResponsesToolCalling(endpointUrl, model, apiKey),
+          execute: () => probeResponsesToolCalling(endpointUrl, model, apiKey, { authMode: options.authMode }),
         }
       : {
           name: "Responses API",
@@ -1320,15 +1345,13 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
               ...getValidationProbeCurlArgs(),
               "-H",
               "Content-Type: application/json",
-              ...(apiKey
-                ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`]
-                : []),
+              ...authHeader,
               "-d",
               JSON.stringify({
                 model,
                 input: "Reply with exactly: OK",
               }),
-              `${String(endpointUrl).replace(/\/+$/, "")}/responses`,
+              appendKey("/responses"),
             ]),
         };
 
@@ -1341,13 +1364,13 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
         ...getValidationProbeCurlArgs(),
         "-H",
         "Content-Type: application/json",
-        ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
+        ...authHeader,
         "-d",
         JSON.stringify({
           model,
           messages: [{ role: "user", content: "Reply with exactly: OK" }],
         }),
-        `${String(endpointUrl).replace(/\/+$/, "")}/chat/completions`,
+        appendKey("/chat/completions"),
       ]),
   };
 
@@ -1372,14 +1395,14 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
           ...getValidationProbeCurlArgs(),
           "-H",
           "Content-Type: application/json",
-          ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
+          ...authHeader,
           "-d",
           JSON.stringify({
             model,
             input: "Reply with exactly: OK",
             stream: true,
           }),
-          `${String(endpointUrl).replace(/\/+$/, "")}/responses`,
+          appendKey("/responses"),
         ]);
         if (!streamResult.ok && streamResult.missingEvents.length > 0) {
           // Backend responds but lacks required streaming events — fall back
@@ -3695,12 +3718,14 @@ async function setupNim(gpu) {
           const defaultModel = requestedModel || _envModelRemote || remoteConfig.defaultModel;
           let modelValidator = null;
           if (selected.key === "openai" || selected.key === "gemini") {
+            const modelAuthMode = getProbeAuthMode(provider);
             modelValidator = (candidate) =>
               validateOpenAiLikeModel(
                 remoteConfig.label,
                 endpointUrl,
                 candidate,
                 getCredential(credentialEnv),
+                ...(modelAuthMode ? [{ authMode: modelAuthMode }] : []),
               );
           } else if (selected.key === "anthropic") {
             modelValidator = (candidate) =>
@@ -3825,6 +3850,7 @@ async function setupNim(gpu) {
                   {
                     requireResponsesToolCalling: shouldRequireResponsesToolCalling(provider),
                     skipResponsesProbe: shouldSkipResponsesProbe(provider),
+                    authMode: getProbeAuthMode(provider),
                   },
                 );
                 if (validation.ok) {
@@ -3856,6 +3882,7 @@ async function setupNim(gpu) {
               {
                 requireResponsesToolCalling: shouldRequireResponsesToolCalling(provider),
                 skipResponsesProbe: shouldSkipResponsesProbe(provider),
+                authMode: getProbeAuthMode(provider),
               },
             );
             if (validation.ok) {
@@ -6120,5 +6147,6 @@ module.exports = {
   writeSandboxConfigSyncFile,
   patchStagedDockerfile,
   ensureOllamaAuthProxy,
+  getProbeAuthMode,
   getValidationProbeCurlArgs,
 };

--- a/src/lib/provider-models.test.ts
+++ b/src/lib/provider-models.test.ts
@@ -189,4 +189,77 @@ describe("provider model helpers", () => {
       message: "Unexpected model catalog response: expected a top-level data array",
     });
   });
+
+  it("sends API key as ?key= query param when authMode is query-param (Gemini)", () => {
+    const result = fetchOpenAiLikeModels(
+      "https://generativelanguage.googleapis.com/v1beta/openai/",
+      "AIzaFakeKey123",
+      {
+        authMode: "query-param",
+        runCurlProbeImpl: (argv) => {
+          const url = argv.at(-1);
+          expect(url).toBe(
+            "https://generativelanguage.googleapis.com/v1beta/openai/models?key=AIzaFakeKey123",
+          );
+          expect(argv.join(" ")).not.toContain("Authorization: Bearer");
+          return {
+            ok: true,
+            httpStatus: 200,
+            curlStatus: 0,
+            body: JSON.stringify({ data: [{ id: "gemini-2.5-flash" }] }),
+            stderr: "",
+            message: "",
+          };
+        },
+      },
+    );
+
+    expect(result).toEqual({ ok: true, ids: ["gemini-2.5-flash"] });
+  });
+
+  it("uses Bearer header by default even when an API key is provided", () => {
+    fetchOpenAiLikeModels("https://api.openai.com/v1", "sk-test", {
+      runCurlProbeImpl: (argv) => {
+        const url = argv.at(-1);
+        expect(url).toBe("https://api.openai.com/v1/models");
+        expect(url).not.toContain("?key=");
+        expect(argv).toContain("Authorization: Bearer sk-test");
+        return {
+          ok: true,
+          httpStatus: 200,
+          curlStatus: 0,
+          body: JSON.stringify({ data: [{ id: "gpt-4.1" }] }),
+          stderr: "",
+          message: "",
+        };
+      },
+    });
+  });
+
+  it("validates Gemini models with query-param auth when authMode is passed through", () => {
+    const result = validateOpenAiLikeModel(
+      "Google Gemini",
+      "https://generativelanguage.googleapis.com/v1beta/openai/",
+      "gemini-2.5-flash",
+      "AIzaFakeKey123",
+      {
+        authMode: "query-param",
+        runCurlProbeImpl: (argv) => {
+          const url = argv.at(-1);
+          expect(url).toContain("?key=AIzaFakeKey123");
+          expect(argv.join(" ")).not.toContain("Authorization: Bearer");
+          return {
+            ok: true,
+            httpStatus: 200,
+            curlStatus: 0,
+            body: JSON.stringify({ data: [{ id: "gemini-2.5-flash" }] }),
+            stderr: "",
+            message: "",
+          };
+        },
+      },
+    );
+
+    expect(result).toEqual({ ok: true, validated: true });
+  });
 });

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -14,6 +14,10 @@ export const BUILD_ENDPOINT_URL = "https://integrate.api.nvidia.com/v1";
 export interface ProviderModelOptions {
   runCurlProbeImpl?: (argv: string[]) => CurlProbeResult;
   buildEndpointUrl?: string;
+  /** When "query-param", send the API key as a ?key= URL parameter instead of
+   *  an Authorization: Bearer header. Required for Google Gemini which rejects
+   *  requests carrying both auth methods. See issue #1960. */
+  authMode?: "bearer" | "query-param";
 }
 
 function parseModelIds(body: string, itemKeys: string[] = ["id"]): string[] {
@@ -119,12 +123,16 @@ export function fetchOpenAiLikeModels(
   options: ProviderModelOptions = {},
 ): ModelCatalogFetchResult {
   const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
+  const useQueryParam = options.authMode === "query-param";
+  const normalizedKey = apiKey ? normalizeCredentialValue(apiKey) : "";
+  const baseUrl = `${String(endpointUrl).replace(/\/+$/, "")}/models`;
+  const url = useQueryParam && normalizedKey ? `${baseUrl}?key=${normalizedKey}` : baseUrl;
   try {
     const result = runCurlProbeImpl([
       "-sS",
       ...getCurlTimingArgs(),
-      ...(apiKey ? ["-H", `Authorization: Bearer ${normalizeCredentialValue(apiKey)}`] : []),
-      `${String(endpointUrl).replace(/\/+$/, "")}/models`,
+      ...(!useQueryParam && apiKey ? ["-H", `Authorization: Bearer ${normalizedKey}`] : []),
+      url,
     ]);
     return toModelCatalogFetchResult(result);
   } catch (error) {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -216,6 +216,10 @@ describe("shouldSkipResponsesProbe", () => {
     expect(shouldSkipResponsesProbe("nvidia-prod")).toBe(true);
   });
 
+  it("skips the Responses probe for gemini-api (Gemini does not support /v1/responses)", () => {
+    expect(shouldSkipResponsesProbe("gemini-api")).toBe(true);
+  });
+
   it("does not skip the Responses probe for other providers", () => {
     expect(shouldSkipResponsesProbe("openai-api")).toBe(false);
     expect(shouldSkipResponsesProbe("anthropic-api")).toBe(false);

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -121,12 +121,13 @@ export function nvcfFunctionNotFoundMessage(model: string): string {
  * Whether the wizard should skip probing the OpenAI Responses API entirely
  * for the given inference provider. NVIDIA Build does not expose
  * `/v1/responses` for any model — every probe to that path returns
- * "404 page not found". Skipping the probe removes wasted round-trips and
- * stops the failure-message noise from leaking into chat-completions errors.
- * See issue #1601 (Bug 1).
+ * "404 page not found". Google Gemini also does not support the Responses
+ * API. Skipping the probe removes wasted round-trips and stops the
+ * failure-message noise from leaking into chat-completions errors.
+ * See issue #1601 (Bug 1) and issue #1960.
  */
 export function shouldSkipResponsesProbe(provider: string): boolean {
-  return provider === "nvidia-prod";
+  return provider === "nvidia-prod" || provider === "gemini-api";
 }
 
 /**

--- a/test/gemini-probe-auth.test.ts
+++ b/test/gemini-probe-auth.test.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { getProbeAuthMode } from "../dist/lib/onboard";
+
+describe("Gemini dual-auth credential fix (issue #1960)", () => {
+  describe("getProbeAuthMode", () => {
+    it("returns 'query-param' for gemini-api provider", () => {
+      expect(getProbeAuthMode("gemini-api")).toBe("query-param");
+    });
+
+    it("returns undefined for non-Gemini providers", () => {
+      expect(getProbeAuthMode("openai-api")).toBeUndefined();
+      expect(getProbeAuthMode("nvidia-prod")).toBeUndefined();
+      expect(getProbeAuthMode("anthropic-prod")).toBeUndefined();
+      expect(getProbeAuthMode("compatible-endpoint")).toBeUndefined();
+      expect(getProbeAuthMode("")).toBeUndefined();
+    });
+  });
+
+  describe("compiled probe uses ?key= for Gemini instead of Bearer header", () => {
+    const onboardSrc = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "dist", "lib", "onboard.js"),
+      "utf-8",
+    );
+
+    it("contains query-param auth mode logic in probeOpenAiLikeEndpoint", () => {
+      // The probe function must check for authMode === "query-param"
+      expect(onboardSrc).toMatch(/authMode.*===.*"query-param"/);
+    });
+
+    it("appends ?key= to the URL when using query-param auth", () => {
+      // The compiled code must build URLs with ?key= for query-param mode
+      expect(onboardSrc).toMatch(/\?key=/);
+    });
+
+    it("getProbeAuthMode returns query-param for gemini-api", () => {
+      expect(onboardSrc).toMatch(/gemini-api.*\?.*query-param|query-param.*gemini-api/);
+    });
+  });
+});

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -35,13 +35,20 @@ while [ "$#" -gt 0 ]; do
     *) url="$1"; shift ;;
   esac
 done
-if echo "$url" | grep -q '/models$'; then
+# Also extract auth from ?key= query parameter (Gemini uses this instead of Bearer header)
+url_auth=""
+if echo "$url" | grep -q '[?&]key='; then
+  url_auth=$(echo "$url" | sed 's/.*[?&]key=\\([^&]*\\).*/\\1/')
+fi
+# Strip query params for URL path matching
+url_path=$(echo "$url" | sed 's/?.*//')
+if echo "$url_path" | grep -q '/models$'; then
   body='{"data":[${models.map((model) => `{"id":"${model}"}`).join(",")}]}'
   status="200"
-elif echo "$auth" | grep -q '${goodToken}' && echo "$url" | grep -q '/responses$'; then
+elif (echo "$auth" | grep -q '${goodToken}' || echo "$url_auth" | grep -q '${goodToken}') && echo "$url_path" | grep -q '/responses$'; then
   body='{"id":"resp_123"}'
   status="200"
-elif echo "$auth" | grep -q '${goodToken}' && echo "$url" | grep -q '/chat/completions$'; then
+elif (echo "$auth" | grep -q '${goodToken}' || echo "$url_auth" | grep -q '${goodToken}') && echo "$url_path" | grep -q '/chat/completions$'; then
   body='{"id":"chatcmpl-123"}'
   status="200"
 fi
@@ -483,7 +490,7 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
-if echo "$url" | grep -q '/chat/completions$'; then
+if echo "$url" | grep -q '/chat/completions'; then
   status="200"
   body='{"choices":[{"message":{"content":"OK"}}]}'
 fi


### PR DESCRIPTION
## Summary

- Switch Gemini validation probes to use `?key=` query-param auth instead of `Authorization: Bearer` header, fixing HTTP 400 "Multiple authentication credentials received" during `nemoclaw onboard`
- Add `gemini-api` to `shouldSkipResponsesProbe()` — Gemini doesn't support the Responses API, so skip that probe to avoid noisy 404s
- Add `authMode` option to `ProviderModelOptions` so `fetchOpenAiLikeModels` also uses query-param auth for Gemini model validation

Fixes #1960

## Test plan

- [x] New `test/gemini-probe-auth.test.ts` — verifies `getProbeAuthMode` returns `"query-param"` for gemini-api and compiled probe contains query-param logic
- [x] New tests in `provider-models.test.ts` — mock `runCurlProbe` for Gemini and verify only `?key=` is used (no Bearer header)
- [x] Updated `validation.test.ts` — `shouldSkipResponsesProbe("gemini-api")` returns `true`
- [x] Updated `onboard-selection.test.ts` fake curl helpers to handle `?key=` URL params
- [x] All 1756 tests pass (only pre-existing `json5` import failure in plugin remains)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for query-parameter-based API authentication in addition to bearer token methods.
  * Improved Google Gemini API provider integration with optimized authentication handling.

* **Bug Fixes**
  * Fixed endpoint validation to properly skip unsupported Responses probe for Gemini API.

* **Tests**
  * Added comprehensive test coverage for dual authentication modes.
  * Added validation tests for Gemini-specific provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->