### PR TITLE
fix(onboard): url-encode API key in Gemini query-param auth

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1271,7 +1271,7 @@ function probeResponsesToolCalling(endpointUrl, model, apiKey, options = {}) {
     ? ["-H", `Authorization: Bearer ${normalizedKey}`]
     : [];
   const url = useQueryParam && normalizedKey
-    ? `${baseUrl}/responses?key=${normalizedKey}`
+    ? `${baseUrl}/responses?key=${encodeURIComponent(normalizedKey)}`
     : `${baseUrl}/responses`;
   const result = runCurlProbe([
     "-sS",
@@ -1327,7 +1327,7 @@ function probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options = {}) {
     ? ["-H", `Authorization: Bearer ${normalizedKey}`]
     : [];
   const appendKey = (path) =>
-    useQueryParam && normalizedKey ? `${baseUrl}${path}?key=${normalizedKey}` : `${baseUrl}${path}`;
+    useQueryParam && normalizedKey ? `${baseUrl}${path}?key=${encodeURIComponent(normalizedKey)}` : `${baseUrl}${path}`;
 
   const responsesProbe =
     options.requireResponsesToolCalling === true

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -126,12 +126,12 @@ export function fetchOpenAiLikeModels(
   const useQueryParam = options.authMode === "query-param";
   const normalizedKey = apiKey ? normalizeCredentialValue(apiKey) : "";
   const baseUrl = `${String(endpointUrl).replace(/\/+$/, "")}/models`;
-  const url = useQueryParam && normalizedKey ? `${baseUrl}?key=${normalizedKey}` : baseUrl;
+  const url = useQueryParam && normalizedKey ? `${baseUrl}?key=${encodeURIComponent(normalizedKey)}` : baseUrl;
   try {
     const result = runCurlProbeImpl([
       "-sS",
       ...getCurlTimingArgs(),
-      ...(!useQueryParam && apiKey ? ["-H", `Authorization: Bearer ${normalizedKey}`] : []),
+      ...(!useQueryParam && normalizedKey ? ["-H", `Authorization: Bearer ${normalizedKey}`] : []),
       url,
     ]);
     return toModelCatalogFetchResult(result);

--- a/test/gemini-probe-auth.test.ts
+++ b/test/gemini-probe-auth.test.ts
@@ -34,9 +34,9 @@ describe("Gemini dual-auth credential fix (issue #1960)", () => {
       expect(onboardSrc).toMatch(/authMode.*===.*"query-param"/);
     });
 
-    it("appends ?key= to the URL when using query-param auth", () => {
-      // The compiled code must build URLs with ?key= for query-param mode
-      expect(onboardSrc).toMatch(/\?key=/);
+    it("appends ?key= to the URL with encodeURIComponent when using query-param auth", () => {
+      // The compiled code must URL-encode the key when building ?key= URLs
+      expect(onboardSrc).toMatch(/\?key=.*encodeURIComponent/);
     });
 
     it("getProbeAuthMode returns query-param for gemini-api", () => {


### PR DESCRIPTION
## Summary

Follow-up to #2003 addressing CodeRabbit review feedback:

- Apply `encodeURIComponent()` to the API key in all three `?key=` URL constructions (`probeResponsesToolCalling`, `probeOpenAiLikeEndpoint.appendKey`, `fetchOpenAiLikeModels`) to prevent malformed URLs if the key contains reserved characters
- Fix the Bearer-header guard in `fetchOpenAiLikeModels` to check `normalizedKey` instead of raw `apiKey` for consistency with the other probe functions

## Test plan

- [x] Updated `test/gemini-probe-auth.test.ts` to verify compiled source uses `encodeURIComponent` in `?key=` construction
- [x] Existing `provider-models.test.ts` Gemini tests still pass (alphanumeric keys are unaffected by encoding)
- [x] Existing `onboard-selection.test.ts` Gemini tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API keys supplied via query parameters are now properly URL-encoded to ensure secure and correct handling of special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->