### PR TITLE
fix(onboard): add gateway start timeout and increase health poll window (#1830)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -269,6 +269,7 @@ function repairRecordedSandbox(sandboxName) {
 
 const { streamSandboxCreate } = sandboxCreateStream;
 
+/** Spawn `openshell gateway start` and stream its output with progress heartbeats. */
 function streamGatewayStart(command, env = process.env) {
   const child = spawn("bash", ["-lc", command], {
     cwd: ROOT,
@@ -2524,6 +2525,7 @@ async function preflight() {
 
 // ── Step 2: Gateway ──────────────────────────────────────────────
 
+/** Start the OpenShell gateway with retry logic and post-start health polling. */
 async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
   step(2, 8, "Starting OpenShell gateway");
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -384,11 +384,18 @@ function streamGatewayStart(command, env = process.env) {
 
   // Hard timeout to prevent indefinite hangs if the openshell process
   // never exits (e.g. Docker daemon unresponsive, k3s restart loop). (#1830)
+  // On timeout, send SIGTERM and let the `close` event resolve the promise
+  // so the child has actually exited before the caller proceeds to retry.
   const GATEWAY_START_TIMEOUT = envInt("NEMOCLAW_GATEWAY_START_TIMEOUT", 600) * 1000;
+  let killedByTimeout = false;
   const killTimer = setTimeout(() => {
+    killedByTimeout = true;
     lines.push("[NemoClaw] Gateway start timed out — killing process.");
     child.kill("SIGTERM");
-    finish({ status: 1, output: lines.join("\n") });
+    // If SIGTERM is ignored, force-kill after 10s.
+    setTimeout(() => {
+      if (!settled) child.kill("SIGKILL");
+    }, 10_000).unref?.();
   }, GATEWAY_START_TIMEOUT);
   killTimer.unref?.();
 
@@ -402,7 +409,8 @@ function streamGatewayStart(command, env = process.env) {
     });
     child.on("close", (code) => {
       clearTimeout(killTimer);
-      finish({ status: code ?? 1, output: lines.join("\n") });
+      const exitCode = killedByTimeout ? 1 : (code ?? 1);
+      finish({ status: exitCode, output: lines.join("\n") });
     });
   });
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -381,14 +381,26 @@ function streamGatewayStart(command, env = process.env) {
   }, 5000);
   heartbeatTimer.unref?.();
 
+  // Hard timeout to prevent indefinite hangs if the openshell process
+  // never exits (e.g. Docker daemon unresponsive, k3s restart loop). (#1830)
+  const GATEWAY_START_TIMEOUT = envInt("NEMOCLAW_GATEWAY_START_TIMEOUT", 600) * 1000;
+  const killTimer = setTimeout(() => {
+    lines.push("[NemoClaw] Gateway start timed out — killing process.");
+    child.kill("SIGTERM");
+    finish({ status: 1, output: lines.join("\n") });
+  }, GATEWAY_START_TIMEOUT);
+  killTimer.unref?.();
+
   return new Promise((resolve) => {
     resolvePromise = resolve;
     child.on("error", (error) => {
+      clearTimeout(killTimer);
       const detail = error?.message || String(error);
       lines.push(detail);
       finish({ status: 1, output: lines.join("\n") });
     });
     child.on("close", (code) => {
+      clearTimeout(killTimer);
       finish({ status: code ?? 1, output: lines.join("\n") });
     });
   });
@@ -2595,8 +2607,11 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
 
         // ARM64 (e.g. Raspberry Pi) needs more time: k3s takes 90-180s to init
         const isArm64 = process.arch === "arm64";
-        const healthPollCount = envInt("NEMOCLAW_HEALTH_POLL_COUNT", isArm64 ? 30 : 5);
-        const healthPollInterval = envInt("NEMOCLAW_HEALTH_POLL_INTERVAL", isArm64 ? 10 : 2);
+        // After openshell gateway start returns (container HEALTHY at Layer 1),
+        // poll application-layer connectivity (Layer 2: gRPC, TLS, port mapping).
+        // 60s default gives enough buffer for gRPC init and TLS handshake. (#1830)
+        const healthPollCount = envInt("NEMOCLAW_HEALTH_POLL_COUNT", isArm64 ? 30 : 12);
+        const healthPollInterval = envInt("NEMOCLAW_HEALTH_POLL_INTERVAL", isArm64 ? 10 : 5);
         for (let i = 0; i < healthPollCount; i++) {
           // Ensure the gateway is selected before each probe (non-TTY environments
           // like ARM64 may not have it selected automatically)


### PR DESCRIPTION
fix(onboard): add gateway start timeout and increase health poll window (#1830)
## Summary  

  Two defensive improvements to gateway startup: (1) add a hard timeout to `streamGatewayStart` to prevent NemoClaw from hanging indefinitely if the `openshell gateway start` process never exits, and (2) increase the post-start health poll window from 10s to 60s to give the application-layer connectivity check (gRPC,   
  TLS, port mapping) more time after the container reports healthy.
                                                                                                                                                                                                                                                                                                                                 
  ## Related Issue

  Fixes #1830

  ## Changes

  - Add a 600s configurable hard timeout (`NEMOCLAW_GATEWAY_START_TIMEOUT`) to `streamGatewayStart()` that kills the child process if it hasn't exited. Covers edge cases where Docker daemon is unresponsive or k3s enters a restart loop that never terminates.                                                                
  - Increase x86 post-start health poll defaults from 5×2s=10s to 12×5s=60s. Gateway startup involves two health-check layers: Layer 1 (Docker container healthcheck, handled inside `openshell gateway start`) confirms k3s/pods/TLS are ready; Layer 2 (NemoClaw's post-start poll via `openshell status` + `gateway info`)
  confirms the host-side CLI can connect over gRPC. The previous 10s window was tight for Layer 2 propagation. ARM64 defaults (30×10s=300s) are unchanged.                                                                                                                                                                       
  - All poll values remain overridable via `NEMOCLAW_HEALTH_POLL_COUNT` and `NEMOCLAW_HEALTH_POLL_INTERVAL`.
                                                                                                                                                                                                                                                                                                                                 
  ## Type of Change
                                                                                                                                                                                                                                                                                                                                 
  - [x] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates
  - [ ] Doc only (prose changes, no code sample modifications)                                                                                                                                                                                                                                                                   
  - [ ] Doc only (includes code sample changes)
                                                                                                                                                                                                                                                                                                                                 
  ## Verification 

  - [ ] `npx prek run --all-files` passes
  - [ ] `npm test` passes
  - [ ] Tests added or updated for new or changed behavior
  - [x] No secrets, API keys, or credentials committed                                                                                                                                                                                                                                                                           
  - [ ] Docs updated for user-facing behavior changes
  - [ ] `make docs` builds without warnings (doc changes only)                                                                                                                                                                                                                                                                   
  - [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
  - [ ] New doc pages include SPDX header and frontmatter (new pages only)                                                                                                                                                                                                                                                       
   
  ## AI Disclosure                                                                                                                                                                                                                                                                                                               
                  
  - [x] AI-assisted — tool: Claude Code                                                                                                                                                                                                                                                                                          
   
  ## Root Cause Analysis                                                                                                                                                                                                                                                                                                         
                  
  Full analysis of the #1830 failure scenario, based on reading OpenShell source code (`crates/openshell-bootstrap/src/runtime.rs`, `lib.rs`, `docker.rs`):                                                                                                                                                                      
   
  ### Two-Layer Health Checking Architecture                                                                                                                                                                                                                                                                                     
                  
  **Layer 1 — Container health (inside OpenShell):** `wait_for_gateway_ready()` polls Docker container HEALTHCHECK status for up to 360s (180×2s). The healthcheck script verifies DNS, k8s API, StatefulSet readiness, TLS secrets, and NodePort connectivity. Docker HEALTHCHECK config: `interval=5s, timeout=5s,             
  start-period=20s, retries=60` — container stays `starting` for up to 320s before becoming `unhealthy`.
                                                                                                                                                                                                                                                                                                                                 
  **Layer 2 — Application connectivity (inside NemoClaw):** Post-start poll checks `openshell status` (gRPC connectivity) and `openshell gateway info` (metadata). Container HEALTHY ≠ CLI connected — gRPC init, TLS handshake, and port mapping propagation may need additional seconds.                                       
   
  ### Why the 15+ minute hang occurs on slow environments                                                                                                                                                                                                                                                                        
                  
  On slow environments (macOS + Docker Desktop, first-run image pulls):                                                                                                                                                                                                                                                          
   
  1. `openshell gateway start` creates container + volume                                                                                                                                                                                                                                                                        
  2. k3s initialization exceeds Docker's 320s healthcheck window → container becomes `unhealthy`
  3. OpenShell's `wait_for_gateway_ready()` sees unhealthy → returns error                                                                                                                                                                                                                                                       
  4. OpenShell's auto-cleanup (`destroy_gateway_resources()`, added in #464) deletes container + volume + network + image
  5. NemoClaw's post-start poll finds empty environment → fails                                                                                                                                                                                                                                                                  
  6. NemoClaw's `destroyGateway()` is a no-op (OpenShell already cleaned up)                                                                                                                                                                                                                                                     
  7. Retry starts from scratch — must re-pull images, recreate volume, re-init k3s                                                                                                                                                                                                                                               
  8. 3 attempts × ~350s each = 15+ minutes                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                 
  **The cache loss happens inside OpenShell's auto-cleanup, not in NemoClaw's `destroyGateway()`.** The root constraint is Docker's 320s healthcheck window being insufficient for slow first-run environments.                                                                                                                  
                                                                                                                                                                                                                                                                                                                                 
  ### What this PR fixes vs. what requires OpenShell changes                                                                                                                                                                                                                                                                     
                  
  | Issue | Root cause | Fixed here? |                                                                                                                                                                                                                                                                                           
  |-------|-----------|-------------|
 fix(onboard): add gateway start timeout and increase health poll window (#1830)
 | Cache destroyed on retry | OpenShell auto-cleanup deletes volume on fresh deploy failure. The 320s Docker healthcheck window and 360s OpenShell poll are reasonable for most environments — the issue only occurs when first-run image pulls + k3s init exceed this window on slow systems. | No — happens inside OpenShell  
  before NemoClaw runs |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
  | streamGatewayStart hangs forever | No timeout if openshell process never exits | **Yes** — 600s hard timeout |                                                                                                                                                                                                               
  | Layer 2 poll too short | 10s may not cover gRPC/TLS propagation | **Yes** — increased to 60s |                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                 
  ### Reproduction                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                 
  Reproduced on Ubuntu 24.04 with network throttling (200kbit). Confirmed via `docker ps` that container was `health: starting` during `openshell gateway start` but gone after it returned non-zero — OpenShell's auto-cleanup removed it before NemoClaw's post-start poll ran.                                                
   
  ### Verification of fix                                                                                                                                                                                                                                                                                                        
                  
  Tested on Ubuntu 24.04 (clean install, no cached images):                                                                                                                                                                                                                                                                      
                  
      [2/8] Starting OpenShell gateway                                                                                                                                                                                                                                                                                           
      Using pinned OpenShell gateway image: ghcr.io/nvidia/openshell/cluster:0.0.26
      Starting gateway cluster...                                                                                                                                                                                                                                                                                                
      Still starting gateway cluster... (5s elapsed)
      ...                                                                                                                                                                                                                                                                                                                        
      Still starting OpenShell gateway pod... (200s elapsed)
      Waiting for gateway health...                                                                                                                                                                                                                                                                                              
      Waiting for gateway health...
      ✓ Gateway is healthy
                                                                                                                                                                                                                                                                                                                                 
  Gateway started successfully. Layer 2 poll passed within 2 iterations (~10s).                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a hard timeout to gateway startup to prevent indefinite waits, terminate stalled launches, and ensure failures are reported.
  * Adjusted gateway health-check polling defaults for more reliable readiness detection across different platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>