### PR TITLE
fix(onboard): persist per-sandbox dashboard ports for multi-sandbox UI access

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5523,7 +5523,7 @@ function getDashboardAccessInfo(sandboxName, options = {}) {
   const storedPort = getSandboxDashboardPort(sandboxName);
   const chatUiUrl =
     options.chatUiUrl || process.env.CHAT_UI_URL || `http://127.0.0.1:${storedPort}`;
-  const dashboardPort = Number(getDashboardForwardPort(chatUiUrl || `http://127.0.0.1:${storedPort}`));
+  const dashboardPort = Number(getDashboardForwardPort(chatUiUrl));
   const dashboardAccess = buildControlUiUrls(token, dashboardPort).map((url, index) => ({
     label: index === 0 ? "Dashboard" : `Alt ${index}`,
     url: buildAuthenticatedDashboardUrl(url, null),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -30,7 +30,14 @@ const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/g;
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("./runner");
 const { stageOptimizedSandboxBuildContext } = require("./sandbox-build-context");
 const { buildSubprocessEnv } = require("./subprocess-env");
-const { DASHBOARD_PORT, GATEWAY_PORT, VLLM_PORT, OLLAMA_PORT, OLLAMA_PROXY_PORT } = require("./ports");
+const {
+  DEFAULT_DASHBOARD_PORT,
+  DASHBOARD_PORT,
+  GATEWAY_PORT,
+  VLLM_PORT,
+  OLLAMA_PORT,
+  OLLAMA_PROXY_PORT,
+} = require("./ports");
 const {
   getDefaultOllamaModel,
   getBootstrapOllamaModelOptions,
@@ -2812,6 +2819,44 @@ async function promptValidatedSandboxName() {
   process.exit(1);
 }
 
+function getSandboxDashboardPort(sandboxName) {
+  const sandbox = registry.getSandbox(sandboxName);
+  const rawPort =
+    sandbox && sandbox.dashboardPort ? Number(sandbox.dashboardPort) : DEFAULT_DASHBOARD_PORT;
+  return Number.isFinite(rawPort) && rawPort > 0 ? rawPort : DEFAULT_DASHBOARD_PORT;
+}
+
+function findDashboardPortConflict(sandboxName, dashboardPort) {
+  const sandboxes = registry.listSandboxes().sandboxes || [];
+  return (
+    sandboxes.find((entry) => {
+      if (!entry || entry.name === sandboxName) return false;
+      const entryPort =
+        entry.dashboardPort != null && entry.dashboardPort !== ""
+          ? Number(entry.dashboardPort)
+          : DEFAULT_DASHBOARD_PORT;
+      return Number.isFinite(entryPort) && entryPort === dashboardPort;
+    }) || null
+  );
+}
+
+function assertDashboardPortConflictFree(sandboxName, dashboardPort) {
+  const conflictingSandbox = findDashboardPortConflict(sandboxName, dashboardPort);
+  if (!conflictingSandbox) {
+    return;
+  }
+
+  console.error(
+    `  Sandbox '${conflictingSandbox.name}' already uses dashboard port ${dashboardPort}.`,
+  );
+  console.error(
+    "  Reusing that port would repoint the OpenClaw UI at the new sandbox and invalidate the other sandbox's URL.",
+  );
+  console.error("  Re-run onboarding with a distinct port, for example:");
+  console.error(`    NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard`);
+  process.exit(1);
+}
+
 // ── Step 5: Sandbox ──────────────────────────────────────────────
 
 // eslint-disable-next-line complexity
@@ -2832,6 +2877,7 @@ async function createSandbox(
   const sandboxName = sandboxNameOverride || (await promptValidatedSandboxName());
   const effectivePort = agent ? agent.forwardPort : CONTROL_UI_PORT;
   const chatUiUrl = process.env.CHAT_UI_URL || `http://127.0.0.1:${effectivePort}`;
+  const dashboardPort = Number(getDashboardForwardPort(chatUiUrl));
 
   // Check whether messaging providers will be needed — this must happen before
   // the sandbox reuse decision so we can detect stale sandboxes that were created
@@ -2927,6 +2973,10 @@ async function createSandbox(
 
   // Reconcile local registry state with the live OpenShell gateway state.
   const liveExists = pruneStaleSandboxEntry(sandboxName);
+
+  if (!liveExists) {
+    assertDashboardPortConflictFree(sandboxName, dashboardPort);
+  }
 
   // Declared outside the liveExists block so it is accessible during
   // post-creation restore (the sandbox create path runs after the block).
@@ -3412,6 +3462,7 @@ async function createSandbox(
     model: model || null,
     provider: provider || null,
     gpuEnabled: !!gpu,
+    dashboardPort,
     agent: agent ? agent.name : null,
     agentVersion: fromDockerfile ? null : effectiveAgent.expectedVersion || null,
     dangerouslySkipPermissions: dangerouslySkipPermissions || undefined,
@@ -5469,9 +5520,10 @@ function getDashboardAccessInfo(sandboxName, options = {}) {
   const token = Object.prototype.hasOwnProperty.call(options, "token")
     ? options.token
     : fetchGatewayAuthTokenFromSandbox(sandboxName);
+  const storedPort = getSandboxDashboardPort(sandboxName);
   const chatUiUrl =
-    options.chatUiUrl || process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`;
-  const dashboardPort = Number(getDashboardForwardPort(chatUiUrl));
+    options.chatUiUrl || process.env.CHAT_UI_URL || `http://127.0.0.1:${storedPort}`;
+  const dashboardPort = Number(getDashboardForwardPort(chatUiUrl || `http://127.0.0.1:${storedPort}`));
   const dashboardAccess = buildControlUiUrls(token, dashboardPort).map((url, index) => ({
     label: index === 0 ? "Dashboard" : `Alt ${index}`,
     url: buildAuthenticatedDashboardUrl(url, null),
@@ -6112,6 +6164,7 @@ module.exports = {
   providerExistsInGateway,
   parsePolicyPresetEnv,
   pruneStaleSandboxEntry,
+  findDashboardPortConflict,
   repairRecordedSandbox,
   recoverGatewayRuntime,
   resolveDashboardForwardTarget,

--- a/src/lib/ports.ts
+++ b/src/lib/ports.ts
@@ -37,9 +37,9 @@ export const GATEWAY_PORT = parsePort("NEMOCLAW_GATEWAY_PORT", 8080);
  * configured via NEMOCLAW_DASHBOARD_PORT at onboard time. This constant represents
  * the hardcoded default when no override is set.
  */
-const SANDBOX_DASHBOARD_PORT = 18789;
-/** Dashboard UI port (default SANDBOX_DASHBOARD_PORT, override via NEMOCLAW_DASHBOARD_PORT). This is the host-side port. */
-export const DASHBOARD_PORT = parsePort("NEMOCLAW_DASHBOARD_PORT", SANDBOX_DASHBOARD_PORT);
+export const DEFAULT_DASHBOARD_PORT = 18789;
+/** Dashboard UI port (default DEFAULT_DASHBOARD_PORT, override via NEMOCLAW_DASHBOARD_PORT). This is the host-side port. */
+export const DASHBOARD_PORT = parsePort("NEMOCLAW_DASHBOARD_PORT", DEFAULT_DASHBOARD_PORT);
 /** vLLM / NIM inference port (default 8000, override via NEMOCLAW_VLLM_PORT). */
 export const VLLM_PORT = parsePort("NEMOCLAW_VLLM_PORT", 8000);
 /** Ollama inference port (default 11434, override via NEMOCLAW_OLLAMA_PORT). */

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -13,6 +13,7 @@ export interface SandboxEntry {
   nimContainer?: string | null;
   provider?: string | null;
   gpuEnabled?: boolean;
+  dashboardPort?: number | null;
   policies?: string[];
   policyTier?: string | null;
   agent?: string | null;
@@ -161,6 +162,7 @@ export function registerSandbox(entry: SandboxEntry): void {
       nimContainer: entry.nimContainer || null,
       provider: entry.provider || null,
       gpuEnabled: entry.gpuEnabled || false,
+      dashboardPort: entry.dashboardPort || null,
       policies: entry.policies || [],
       policyTier: entry.policyTier || null,
       agent: entry.agent || null,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -242,8 +242,9 @@ function isSandboxGatewayRunning(sandboxName) {
 function recoverSandboxProcesses(sandboxName) {
   const agent = agentRuntime.getSessionAgent(sandboxName);
   const sandbox = registry.getSandbox(sandboxName);
-  const dashboardPort =
+  const rawPort =
     sandbox?.dashboardPort != null ? Number(sandbox.dashboardPort) : DEFAULT_DASHBOARD_PORT;
+  const dashboardPort = Number.isFinite(rawPort) ? rawPort : DEFAULT_DASHBOARD_PORT;
   const agentScript = agentRuntime.buildRecoveryScript(agent, agent?.forwardPort ?? dashboardPort);
   // The recovery script runs as the sandbox user (non-root). This matches
   // the non-root fallback path in nemoclaw-start.sh — no privilege
@@ -286,11 +287,11 @@ function recoverSandboxProcesses(sandboxName) {
 function ensureSandboxPortForward(sandboxName) {
   const agent = agentRuntime.getSessionAgent(sandboxName);
   const sandbox = registry.getSandbox(sandboxName);
+  const rawPort =
+    sandbox?.dashboardPort != null ? Number(sandbox.dashboardPort) : DEFAULT_DASHBOARD_PORT;
   const port = agent
     ? String(agent.forwardPort)
-    : String(
-        sandbox?.dashboardPort != null ? Number(sandbox.dashboardPort) : DEFAULT_DASHBOARD_PORT,
-      );
+    : String(Number.isFinite(rawPort) ? rawPort : DEFAULT_DASHBOARD_PORT);
   runOpenshell(["forward", "stop", port], { ignoreError: true });
   runOpenshell(["forward", "start", "--background", port, sandboxName], {
     ignoreError: true,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -6,7 +6,7 @@ const { execFileSync, spawnSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { DASHBOARD_PORT } = require("./lib/ports");
+const { DEFAULT_DASHBOARD_PORT, DASHBOARD_PORT } = require("./lib/ports");
 
 // ---------------------------------------------------------------------------
 // Color / style — respects NO_COLOR and non-TTY environments.
@@ -241,7 +241,10 @@ function isSandboxGatewayRunning(sandboxName) {
  */
 function recoverSandboxProcesses(sandboxName) {
   const agent = agentRuntime.getSessionAgent(sandboxName);
-  const agentScript = agentRuntime.buildRecoveryScript(agent, agent?.forwardPort ?? DASHBOARD_PORT);
+  const sandbox = registry.getSandbox(sandboxName);
+  const dashboardPort =
+    sandbox?.dashboardPort != null ? Number(sandbox.dashboardPort) : DEFAULT_DASHBOARD_PORT;
+  const agentScript = agentRuntime.buildRecoveryScript(agent, agent?.forwardPort ?? dashboardPort);
   // The recovery script runs as the sandbox user (non-root). This matches
   // the non-root fallback path in nemoclaw-start.sh — no privilege
   // separation, but the gateway runs and inference works.
@@ -252,7 +255,7 @@ function recoverSandboxProcesses(sandboxName) {
       "[ -f ~/.bashrc ] && . ~/.bashrc 2>/dev/null;",
       // Re-check liveness before touching anything — another caller may have
       // already recovered the gateway between our initial check and now (TOCTOU).
-      `if curl -sf --max-time 3 http://127.0.0.1:${DASHBOARD_PORT}/ > /dev/null 2>&1; then echo ALREADY_RUNNING; exit 0; fi;`,
+      `if curl -sf --max-time 3 http://127.0.0.1:${dashboardPort}/ > /dev/null 2>&1; then echo ALREADY_RUNNING; exit 0; fi;`,
       // Clean stale lock files from the previous run (gateway checks these)
       "rm -rf /tmp/openclaw-*/gateway.*.lock 2>/dev/null;",
       // Clean stale temp files from the previous run
@@ -262,7 +265,7 @@ function recoverSandboxProcesses(sandboxName) {
       // Resolve and start gateway
       'OPENCLAW="$(command -v openclaw)";',
       'if [ -z "$OPENCLAW" ]; then echo OPENCLAW_MISSING; exit 1; fi;',
-      `nohup "$OPENCLAW" gateway run --port ${DASHBOARD_PORT} > /tmp/gateway.log 2>&1 &`,
+      `nohup "$OPENCLAW" gateway run --port ${dashboardPort} > /tmp/gateway.log 2>&1 &`,
       "GPID=$!; sleep 2;",
       // Verify the gateway actually started (didn't crash immediately)
       'if kill -0 "$GPID" 2>/dev/null; then echo "GATEWAY_PID=$GPID"; else echo GATEWAY_FAILED; cat /tmp/gateway.log 2>/dev/null | tail -5; fi',
@@ -282,7 +285,12 @@ function recoverSandboxProcesses(sandboxName) {
  */
 function ensureSandboxPortForward(sandboxName) {
   const agent = agentRuntime.getSessionAgent(sandboxName);
-  const port = agent ? String(agent.forwardPort) : DASHBOARD_FORWARD_PORT;
+  const sandbox = registry.getSandbox(sandboxName);
+  const port = agent
+    ? String(agent.forwardPort)
+    : String(
+        sandbox?.dashboardPort != null ? Number(sandbox.dashboardPort) : DEFAULT_DASHBOARD_PORT,
+      );
   runOpenshell(["forward", "stop", port], { ignoreError: true });
   runOpenshell(["forward", "start", "--background", port, sandboxName], {
     ignoreError: true,

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -2736,6 +2736,120 @@ const { createSandbox } = require(${onboardPath});
     },
   );
 
+  it("fails fast when another sandbox already owns the requested dashboard port", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-dashboard-conflict-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "dashboard-port-conflict-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, ".nemoclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".nemoclaw", "sandboxes.json"),
+      JSON.stringify({
+        sandboxes: {
+          first: {
+            name: "first",
+            model: "nvidia/nemotron-3-super-120b-a12b",
+            provider: "nvidia-prod",
+          },
+        },
+        defaultSandbox: "first",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(fakeBin, "openshell"),
+      `#!/usr/bin/env bash
+if [ "$1" = "sandbox" ] && [ "$2" = "get" ]; then
+  exit 1
+fi
+if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then
+  exit 0
+fi
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const script = `
+const { createSandbox } = require(${onboardPath});
+
+(async () => {
+  await createSandbox(null, "gpt-5.4", "nvidia-prod", null, "second");
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+      },
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Sandbox 'first' already uses dashboard port 18789\./);
+    assert.match(
+      result.stderr,
+      /NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard/,
+    );
+  });
+
+  it("treats legacy sandbox entries without dashboardPort as default 18789", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-legacy-dashboard-port-"));
+    const scriptPath = path.join(tmpDir, "legacy-dashboard-port-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    fs.mkdirSync(path.join(tmpDir, ".nemoclaw"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".nemoclaw", "sandboxes.json"),
+      JSON.stringify({
+        sandboxes: {
+          first: {
+            name: "first",
+            model: "nvidia/nemotron-3-super-120b-a12b",
+            provider: "nvidia-prod",
+          },
+        },
+        defaultSandbox: "first",
+      }),
+    );
+
+    const script = `
+const { findDashboardPortConflict } = require(${onboardPath});
+
+const legacyConflict = findDashboardPortConflict("second", 18789);
+const customConflict = findDashboardPortConflict("second", 19000);
+console.log(JSON.stringify({
+  legacyConflict: legacyConflict ? legacyConflict.name : null,
+  customConflict: customConflict ? customConflict.name : null,
+}));
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        NEMOCLAW_DASHBOARD_PORT: "19000",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.equal(payload.legacyConflict, "first");
+    assert.equal(payload.customConflict, null);
+  });
+
   it("aborts onboard when a messaging provider upsert fails", { timeout: 60_000 }, async () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-provider-fail-"));

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -2312,11 +2312,14 @@ const { createSandbox } = require(${onboardPath});
 `;
     fs.writeFileSync(scriptPath, script);
 
+    // Ensure host shell env cannot change the requested dashboard port in this test.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { NEMOCLAW_DASHBOARD_PORT: _ignoredDashboardPort, ...inheritedEnv } = process.env;
     const result = spawnSync(process.execPath, [scriptPath], {
       cwd: repoRoot,
       encoding: "utf-8",
       env: {
-        ...process.env,
+        ...inheritedEnv,
         HOME: tmpDir,
         PATH: `${fakeBin}:${process.env.PATH || ""}`,
         NEMOCLAW_NON_INTERACTIVE: "1",

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -42,10 +42,12 @@ describe("registry", () => {
     registry.registerSandbox({
       name: "alpha",
       gpuEnabled: false,
+      dashboardPort: 19000,
       model: "nvidia/nemotron-3-super-120b-a12b",
       provider: "nvidia-prod",
     });
     const data = JSON.parse(fs.readFileSync(regFile, "utf-8"));
+    expect(data.sandboxes.alpha.dashboardPort).toBe(19000);
     expect(data.sandboxes.alpha.model).toBe("nvidia/nemotron-3-super-120b-a12b");
     expect(data.sandboxes.alpha.provider).toBe("nvidia-prod");
   });


### PR DESCRIPTION
## Summary

This change prevents multi-sandbox onboard flows from reusing the same dashboard port and silently repointing the OpenClaw UI at the most recently created sandbox.

It persists a `dashboardPort` per sandbox in the registry, fails fast when a new sandbox tries to claim a port already owned by another sandbox, and preserves backward compatibility for legacy sandbox entries that do not yet have a `dashboardPort` field.

Fixes #1179.

## What changed

- persist `dashboardPort` in sandbox registry entries
- detect dashboard port conflicts before creating a new sandbox
- show a clear onboarding error instead of silently reusing an existing dashboard forward
- use stored per-sandbox dashboard ports for reconnect/recovery flows
- treat legacy sandbox entries without `dashboardPort` as the historical default port `18789`
- add regression coverage for:
  - dashboard port conflict detection
  - legacy registry entries without `dashboardPort`

## Test plan

- `npm run build:cli`
- local targeted verification of legacy registry fallback:
  - legacy sandbox entries conflict with `18789`
  - legacy sandbox entries do not falsely conflict with `19000`
- Brev validation:
  - confirmed second onboard on default dashboard port is blocked with a clear conflict message
  - confirmed legacy sandbox entries without `dashboardPort` do not falsely block onboarding on a new port
  - confirmed new sandboxes can be created on distinct ports (`19000`, `19001`)
  - confirmed `openshell forward list` shows separate forwards for:
    - existing sandbox on `18789`
    - new sandbox on `19000`
    - new sandbox on `19001`
  - confirmed registry persists `dashboardPort` for newly created sandboxes

## Notes

A separate OpenShell policy application issue was observed during Brev validation (`openshell policy set ... -> Unimplemented`), but it occurs after sandbox creation and forward setup and is not part of this fix.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-sandbox dashboard port persisted in the registry so each sandbox can have its own dashboard port.
  * Onboarding enforces dashboard-port uniqueness to prevent conflicts.
  * Recovery and port-forwarding now honor per-sandbox dashboard ports (with a sensible default fallback).

* **Tests**
  * Added tests for port-conflict detection, onboarding failure on conflict, and registry compatibility with default ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->