### PR TITLE
fix(sandbox): upgrade stale OpenClaw in base image before patching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN npm ci --omit=dev
 # (already COPYed to /opt/nemoclaw-blueprint/ above).
 # hadolint ignore=DL3059,DL4006
 RUN set -eu; \
-    MIN_VER=$(grep 'min_openclaw_version' /opt/nemoclaw-blueprint/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
+    MIN_VER=$(grep -m 1 'min_openclaw_version' /opt/nemoclaw-blueprint/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
     [ -n "$MIN_VER" ] || { echo "ERROR: Could not parse min_openclaw_version from blueprint.yaml" >&2; exit 1; }; \
     CUR_VER=$(openclaw --version 2>/dev/null | awk '{print $2}' || echo "0.0.0"); \
     if [ "$(printf '%s\n%s' "$MIN_VER" "$CUR_VER" | sort -V | head -n1)" = "$MIN_VER" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,8 @@ RUN npm ci --omit=dev
 # The minimum required version comes from nemoclaw-blueprint/blueprint.yaml
 # (already COPYed to /opt/nemoclaw-blueprint/ above).
 # hadolint ignore=DL3059,DL4006
-RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
-    set -eu; \
-    MIN_VER=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
+RUN set -eu; \
+    MIN_VER=$(grep 'min_openclaw_version' /opt/nemoclaw-blueprint/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
     [ -n "$MIN_VER" ] || { echo "ERROR: Could not parse min_openclaw_version from blueprint.yaml" >&2; exit 1; }; \
     CUR_VER=$(openclaw --version 2>/dev/null | awk '{print $2}' || echo "0.0.0"); \
     if [ "$(printf '%s\n%s' "$MIN_VER" "$CUR_VER" | sort -V | head -n1)" = "$MIN_VER" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
     MIN_VER=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
     [ -n "$MIN_VER" ] || { echo "ERROR: Could not parse min_openclaw_version from blueprint.yaml" >&2; exit 1; }; \
     CUR_VER=$(openclaw --version 2>/dev/null | awk '{print $2}' || echo "0.0.0"); \
-    if [ "$(printf '%s\n%s' "$MIN_VER" "$CUR_VER" | sort -V | head -n1)" != "$MIN_VER" ]; then \
+    if [ "$(printf '%s\n%s' "$MIN_VER" "$CUR_VER" | sort -V | head -n1)" = "$MIN_VER" ]; then \
         echo "INFO: OpenClaw $CUR_VER is current (>= $MIN_VER), no upgrade needed"; \
     else \
         echo "INFO: Base image has OpenClaw $CUR_VER, upgrading to $MIN_VER (minimum required)"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,29 @@ COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
 WORKDIR /opt/nemoclaw
 RUN npm ci --omit=dev
 
+# Upgrade OpenClaw if the base image is stale.
+#
+# The GHCR base image (sandbox-base:latest) may lag behind the version pinned
+# in Dockerfile.base. When that happens the fetch-guard patches below fail
+# because the target functions don't exist in the older OpenClaw. Rather than
+# silently skipping patches (leaving the sandbox unpatched), upgrade OpenClaw
+# in-place so every build gets the version the patches expect.
+#
+# The minimum required version comes from nemoclaw-blueprint/blueprint.yaml
+# (already COPYed to /opt/nemoclaw-blueprint/ above).
+# hadolint ignore=DL3059,DL4006
+RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
+    set -eu; \
+    MIN_VER=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
+    [ -n "$MIN_VER" ] || { echo "ERROR: Could not parse min_openclaw_version from blueprint.yaml" >&2; exit 1; }; \
+    CUR_VER=$(openclaw --version 2>/dev/null | awk '{print $2}' || echo "0.0.0"); \
+    if [ "$(printf '%s\n%s' "$MIN_VER" "$CUR_VER" | sort -V | head -n1)" != "$MIN_VER" ]; then \
+        echo "INFO: OpenClaw $CUR_VER is current (>= $MIN_VER), no upgrade needed"; \
+    else \
+        echo "INFO: Base image has OpenClaw $CUR_VER, upgrading to $MIN_VER (minimum required)"; \
+        npm install -g "openclaw@${MIN_VER}"; \
+    fi
+
 # Patch OpenClaw media fetch for proxy-only sandbox (NVIDIA/NemoClaw#1755).
 #
 # NemoClaw forces all sandbox egress through the OpenShell L7 proxy
@@ -93,19 +116,20 @@ RUN npm ci --omit=dev
 # the next maintainer reviewing an OPENCLAW_VERSION bump knows to revisit.
 # hadolint ignore=SC2016,DL3059,DL4006
 RUN set -eu; \
+    OC_DIST=/usr/local/lib/node_modules/openclaw/dist; \
     # --- Patch 1: rewrite fetch-guard export --- \
-    fg_export="$(grep -RIlE --include='*.js' 'export \{[^}]*withStrictGuardedFetchMode as [a-z]' /usr/local/lib/node_modules/openclaw/dist/)"; \
+    fg_export="$(grep -RIlE --include='*.js' 'export \{[^}]*withStrictGuardedFetchMode as [a-z]' "$OC_DIST")"; \
     test -n "$fg_export"; \
     for f in $fg_export; do \
         grep -q 'withTrustedEnvProxyGuardedFetchMode' "$f" || { echo "ERROR: $f missing withTrustedEnvProxyGuardedFetchMode"; exit 1; }; \
     done; \
     printf '%s\n' "$fg_export" | xargs sed -i -E 's|withStrictGuardedFetchMode as ([a-z])|withTrustedEnvProxyGuardedFetchMode as \1|g'; \
-    if grep -REq --include='*.js' 'withStrictGuardedFetchMode as [a-z]' /usr/local/lib/node_modules/openclaw/dist/; then echo "ERROR: Patch 1 left strict-mode export alias" >&2; exit 1; fi; \
+    if grep -REq --include='*.js' 'withStrictGuardedFetchMode as [a-z]' "$OC_DIST"; then echo "ERROR: Patch 1 left strict-mode export alias" >&2; exit 1; fi; \
     # --- Patch 2: neutralize assertExplicitProxyAllowed --- \
-    fg_assert="$(grep -RIlE --include='*.js' 'async function assertExplicitProxyAllowed' /usr/local/lib/node_modules/openclaw/dist/)"; \
+    fg_assert="$(grep -RIlE --include='*.js' 'async function assertExplicitProxyAllowed' "$OC_DIST")"; \
     test -n "$fg_assert"; \
     printf '%s\n' "$fg_assert" | xargs sed -i -E 's|(async function assertExplicitProxyAllowed\([^)]*\) \{)|\1 if (process.env.OPENSHELL_SANDBOX === "1") return; /* nemoclaw: env-gated bypass, see Dockerfile */ |'; \
-    grep -REq --include='*.js' 'assertExplicitProxyAllowed\([^)]*\) \{ if \(process\.env\.OPENSHELL_SANDBOX === "1"\) return; /\* nemoclaw' /usr/local/lib/node_modules/openclaw/dist/
+    grep -REq --include='*.js' 'assertExplicitProxyAllowed\([^)]*\) \{ if \(process\.env\.OPENSHELL_SANDBOX === "1"\) return; /\* nemoclaw' "$OC_DIST"
 
 # Set up blueprint for local resolution.
 # Blueprints are immutable at runtime; DAC protection (root ownership) is applied

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,13 @@ RUN set -eu; \
 #   target hostname allowlist for the proxy hostname check (or exposes config
 #   to disable the check).
 #
+# SYNC WITH OPENCLAW: these patches grep for specific exports and function
+# definitions in the compiled OpenClaw dist (withStrictGuardedFetchMode,
+# assertExplicitProxyAllowed). If OpenClaw renames, removes, or restructures
+# either symbol in a future release, the grep will fail and the build will
+# abort. When bumping OPENCLAW_VERSION, verify both symbols still exist in
+# the new dist and update the regex / sed replacement accordingly.
+#
 # Both patches fail-close: if grep finds no targets, the build aborts so
 # the next maintainer reviewing an OPENCLAW_VERSION bump knows to revisit.
 # hadolint ignore=SC2016,DL3059,DL4006

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,13 @@ RUN set -eu; \
         echo "INFO: OpenClaw $CUR_VER is current (>= $MIN_VER), no upgrade needed"; \
     else \
         echo "INFO: Base image has OpenClaw $CUR_VER, upgrading to $MIN_VER (minimum required)"; \
-        npm install -g "openclaw@${MIN_VER}"; \
+        # npm 10's atomic-move install can hit EROFS on overlayfs when the
+        # prior install spans multiple image layers (e.g. openclaw was
+        # baked into sandbox-base, then we upgrade on top here). Clearing
+        # at the shell level first gives npm a clean slate and avoids the
+        # rmdir failure inside npm's own install path.
+        rm -rf /usr/local/lib/node_modules/openclaw /usr/local/bin/openclaw; \
+        npm install -g --no-audit --no-fund --no-progress "openclaw@${MIN_VER}"; \
     fi
 
 # Patch OpenClaw media fetch for proxy-only sandbox (NVIDIA/NemoClaw#1755).

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -161,7 +161,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
     echo "$OPENCLAW_VERSION" | grep -qxE '[0-9]+(\.[0-9]+)*' \
     || { echo "Error: OPENCLAW_VERSION='$OPENCLAW_VERSION' is invalid (expected e.g. 2026.3.11)."; exit 1; }; \
-    OPENCLAW_MIN_VERSION=$(grep 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
+    OPENCLAW_MIN_VERSION=$(grep -m 1 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
     [ -n "$OPENCLAW_MIN_VERSION" ] \
     || { echo "Error: Could not parse min_openclaw_version from nemoclaw-blueprint/blueprint.yaml"; exit 1; }; \
     if [ "$(printf '%s\n%s' "$OPENCLAW_MIN_VERSION" "$OPENCLAW_VERSION" | sort -V | head -n1)" != "$OPENCLAW_MIN_VERSION" ]; then \

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -17,6 +17,10 @@ describe("fetch-guard patch regression guard", () => {
     expect(src).toContain("openclaw --version");
     // Must upgrade when stale
     expect(src).toContain('npm install -g "openclaw@${MIN_VER}"');
+    // The "current" branch must fire when MIN_VER is the smallest (= not !=)
+    expect(src).toContain(
+      '| sort -V | head -n1)" = "$MIN_VER" ]; then',
+    );
   });
 
   it("Patch 1 rewrites withStrictGuardedFetchMode export with fail-close", () => {

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("fetch-guard patch regression guard", () => {
+  it("Dockerfile upgrades stale OpenClaw in base image before patching", () => {
+    const dockerfile = path.join(import.meta.dirname, "..", "Dockerfile");
+    const src = fs.readFileSync(dockerfile, "utf-8");
+
+    // Must read min version from blueprint
+    expect(src).toContain("min_openclaw_version");
+    // Must check installed version against minimum
+    expect(src).toContain("openclaw --version");
+    // Must upgrade when stale
+    expect(src).toContain('npm install -g "openclaw@${MIN_VER}"');
+  });
+
+  it("Patch 1 rewrites withStrictGuardedFetchMode export with fail-close", () => {
+    const dockerfile = path.join(import.meta.dirname, "..", "Dockerfile");
+    const src = fs.readFileSync(dockerfile, "utf-8");
+
+    expect(src).toContain("withStrictGuardedFetchMode as [a-z]");
+    expect(src).toContain("withTrustedEnvProxyGuardedFetchMode");
+    expect(src).toContain("Patch 1 left strict-mode export alias");
+  });
+
+  it("Patch 2 injects env-gated bypass for assertExplicitProxyAllowed", () => {
+    const dockerfile = path.join(import.meta.dirname, "..", "Dockerfile");
+    const src = fs.readFileSync(dockerfile, "utf-8");
+
+    expect(src).toContain("assertExplicitProxyAllowed");
+    expect(src).toContain('OPENSHELL_SANDBOX === "1"');
+  });
+});

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,37 +5,33 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+const dockerfileSrc = fs.readFileSync(
+  path.join(import.meta.dirname, "..", "Dockerfile"),
+  "utf-8",
+);
+
 describe("fetch-guard patch regression guard", () => {
   it("Dockerfile upgrades stale OpenClaw in base image before patching", () => {
-    const dockerfile = path.join(import.meta.dirname, "..", "Dockerfile");
-    const src = fs.readFileSync(dockerfile, "utf-8");
-
     // Must read min version from blueprint
-    expect(src).toContain("min_openclaw_version");
+    expect(dockerfileSrc).toContain("min_openclaw_version");
     // Must check installed version against minimum
-    expect(src).toContain("openclaw --version");
+    expect(dockerfileSrc).toContain("openclaw --version");
     // Must upgrade when stale (any npm flags between `-g` and the target
     // are fine — we've needed to add --no-audit/--no-fund/--no-progress
     // for memory/IO reasons and may need more).
-    expect(src).toMatch(/npm install -g .*"openclaw@\$\{MIN_VER\}"/);
+    expect(dockerfileSrc).toMatch(/npm install -g .*"openclaw@\$\{MIN_VER\}"/);
     // The "current" branch must fire when MIN_VER is the smallest (= not !=)
-    expect(src).toContain('| sort -V | head -n1)" = "$MIN_VER" ]; then');
+    expect(dockerfileSrc).toContain('| sort -V | head -n1)" = "$MIN_VER" ]; then');
   });
 
   it("Patch 1 rewrites withStrictGuardedFetchMode export with fail-close", () => {
-    const dockerfile = path.join(import.meta.dirname, "..", "Dockerfile");
-    const src = fs.readFileSync(dockerfile, "utf-8");
-
-    expect(src).toContain("withStrictGuardedFetchMode as [a-z]");
-    expect(src).toContain("withTrustedEnvProxyGuardedFetchMode");
-    expect(src).toContain("Patch 1 left strict-mode export alias");
+    expect(dockerfileSrc).toContain("withStrictGuardedFetchMode as [a-z]");
+    expect(dockerfileSrc).toContain("withTrustedEnvProxyGuardedFetchMode");
+    expect(dockerfileSrc).toContain("Patch 1 left strict-mode export alias");
   });
 
   it("Patch 2 injects env-gated bypass for assertExplicitProxyAllowed", () => {
-    const dockerfile = path.join(import.meta.dirname, "..", "Dockerfile");
-    const src = fs.readFileSync(dockerfile, "utf-8");
-
-    expect(src).toContain("assertExplicitProxyAllowed");
-    expect(src).toContain('OPENSHELL_SANDBOX === "1"');
+    expect(dockerfileSrc).toContain("assertExplicitProxyAllowed");
+    expect(dockerfileSrc).toContain('OPENSHELL_SANDBOX === "1"');
   });
 });

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -20,9 +20,7 @@ describe("fetch-guard patch regression guard", () => {
     // for memory/IO reasons and may need more).
     expect(src).toMatch(/npm install -g .*"openclaw@\$\{MIN_VER\}"/);
     // The "current" branch must fire when MIN_VER is the smallest (= not !=)
-    expect(src).toContain(
-      '| sort -V | head -n1)" = "$MIN_VER" ]; then',
-    );
+    expect(src).toContain('| sort -V | head -n1)" = "$MIN_VER" ]; then');
   });
 
   it("Patch 1 rewrites withStrictGuardedFetchMode export with fail-close", () => {

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -15,8 +15,10 @@ describe("fetch-guard patch regression guard", () => {
     expect(src).toContain("min_openclaw_version");
     // Must check installed version against minimum
     expect(src).toContain("openclaw --version");
-    // Must upgrade when stale
-    expect(src).toContain('npm install -g "openclaw@${MIN_VER}"');
+    // Must upgrade when stale (any npm flags between `-g` and the target
+    // are fine — we've needed to add --no-audit/--no-fund/--no-progress
+    // for memory/IO reasons and may need more).
+    expect(src).toMatch(/npm install -g .*"openclaw@\$\{MIN_VER\}"/);
     // The "current" branch must fire when MIN_VER is the smallest (= not !=)
     expect(src).toContain(
       '| sort -V | head -n1)" = "$MIN_VER" ]; then',


### PR DESCRIPTION
## Summary

- Adds a version-check step in the Dockerfile that detects when the GHCR `sandbox-base:latest` image has an older OpenClaw than `min_openclaw_version` from `blueprint.yaml`, and upgrades it in-place before the fetch-guard patches run
- Extracts repeated `/usr/local/lib/node_modules/openclaw/dist` path into `OC_DIST` variable in the patch step
- Adds `test/fetch-guard-patch-regression.test.ts` regression guard

Fixes the build failure where the `:latest` base image contains OpenClaw 2026.3.11 but the fetch-guard patches target functions added in 2026.4.2 (`assertExplicitProxyAllowed`, `withStrictGuardedFetchMode` export pattern).

## Test plan

- [x] `npx vitest run test/fetch-guard-patch-regression.test.ts` — new test passes
- [x] `npm test` — 98 files pass, no new failures (1 pre-existing `migration-state.test.ts` failure from missing `json5` dep)
- [x] All pre-commit and pre-push hooks pass
- [ ] QA: `nemoclaw onboard --non-interactive` succeeds with stale base image (Truong to verify)
- [ ] CI: nightly E2E passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container build now validates and enforces a minimum tool version, performing a conditional in-place upgrade when needed and failing early if the requirement is not parseable.
  * Patch application updated to discover installation locations dynamically, improving reliability of the build-time patching steps.

* **Tests**
  * Added regression tests that verify the build-time version checks and confirm the presence and correct application of the expected patches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->