### PR TITLE
feat(whatsapp): add WhatsApp channel support for sandbox onboarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,6 +250,20 @@ os.chmod(path, 0o600)"
 RUN openclaw doctor --fix > /dev/null 2>&1 || true \
     && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
+# Register bundled WhatsApp extension so openclaw channels login works
+# inside the sandbox without requiring npm or a writable config.
+# This adds the extension path to plugins.load.paths in openclaw.json,
+# the same mutation openclaw's interactive plugin installer would make.
+# Only applied when WhatsApp is selected during onboard.
+# hadolint ignore=DL4006,SC2015
+RUN WA_ENABLED="$(echo "$NEMOCLAW_MESSAGING_CHANNELS_B64" | base64 -d 2>/dev/null | grep -q '"whatsapp"' && echo 1 || echo 0)" \
+    && if [ "$WA_ENABLED" = "1" ]; then \
+         WA_EXT="/usr/local/lib/node_modules/openclaw/dist/extensions/whatsapp" \
+         && if [ -d "$WA_EXT" ] && [ -f "$WA_EXT/openclaw.plugin.json" ]; then \
+              node -e "const fs=require('fs'), p='$HOME/.openclaw/openclaw.json', c=JSON.parse(fs.readFileSync(p,'utf8')); c.plugins=c.plugins||{}; c.plugins.load=c.plugins.load||{}; c.plugins.load.paths=c.plugins.load.paths||[]; if(!c.plugins.load.paths.includes('$WA_EXT'))c.plugins.load.paths.push('$WA_EXT'); c.plugins.entries=c.plugins.entries||{}; c.plugins.entries.whatsapp=Object.assign(c.plugins.entries.whatsapp||{},{enabled:true}); c.channels=c.channels||{}; c.channels.whatsapp=Object.assign(c.channels.whatsapp||{},{enabled:true}); fs.writeFileSync(p,JSON.stringify(c,null,2))"; \
+            else echo "ERROR: WhatsApp selected but bundled extension not found at $WA_EXT" >&2; exit 1; fi; \
+       else echo "WhatsApp not selected — skipping plugin registration"; fi
+
 # Lock openclaw.json via DAC: chown to root so the sandbox user cannot modify
 # it at runtime.  This works regardless of Landlock enforcement status.
 # The Landlock policy (/sandbox/.openclaw in read_only) provides defense-in-depth
@@ -262,6 +276,33 @@ RUN openclaw doctor --fix > /dev/null 2>&1 || true \
 # The writable state lives in .openclaw-data, reached via the symlinks.
 # hadolint ignore=DL3002
 USER root
+
+# Patch OpenClaw WhatsApp extension to route WebSocket through the sandbox
+# proxy. Baileys' makeWASocket does not honor HTTPS_PROXY; without an explicit
+# agent the WebSocket connects directly and times out (408). The session chunk
+# is a pre-bundled .js file in dist/ with a hash in the filename; we find it
+# by grepping for the createWaSocket function. Requires root to write to the
+# globally-installed OpenClaw dist directory.
+# Fixed upstream in OpenClaw 2026.4.15+; remove this patch after version bump.
+# See #513.
+# hadolint ignore=DL4006,SC2015
+RUN WA_ENABLED="$(echo "$NEMOCLAW_MESSAGING_CHANNELS_B64" | base64 -d 2>/dev/null | grep -q '"whatsapp"' && echo 1 || echo 0)" \
+    && if [ "$WA_ENABLED" = "1" ]; then \
+         OC_DIST="/usr/local/lib/node_modules/openclaw/dist" \
+         && WA_CHUNK="$(grep -rl 'async function createWaSocket' "$OC_DIST"/session-*.js 2>/dev/null | head -1)" \
+         && echo "Patching WhatsApp proxy agent in: ${WA_CHUNK:-NOT FOUND}" \
+         && if [ -n "$WA_CHUNK" ] && grep -q 'markOnlineOnConnect: false' "$WA_CHUNK"; then \
+              sed -i 's|markOnlineOnConnect: false|markOnlineOnConnect: false, agent: process.env.HTTPS_PROXY ? new (__require("https-proxy-agent").HttpsProxyAgent)(process.env.HTTPS_PROXY) : undefined|' "$WA_CHUNK"; \
+              if grep -q 'HttpsProxyAgent' "$WA_CHUNK"; then \
+                echo "Patch applied successfully"; \
+              else \
+                echo "ERROR: Patch verification failed" >&2; exit 1; \
+              fi; \
+            elif node -e "const v=require('/usr/local/lib/node_modules/openclaw/package.json').version;process.exit(v>='2026.4.15'?0:1)"; then \
+              echo "OpenClaw $(node -e "process.stdout.write(require('/usr/local/lib/node_modules/openclaw/package.json').version)") has upstream proxy fix — skipping patch"; \
+            else \
+              echo "ERROR: WhatsApp proxy patch target not found — WebSocket will time out in sandbox" >&2; exit 1; fi; \
+       else echo "WhatsApp not selected — skipping proxy patch"; fi
 
 # Ensure .openclaw-data subdirs and symlinks exist for logs, credentials, and
 # sandbox. These are defined in Dockerfile.base but the GHCR base image may

--- a/nemoclaw-blueprint/policies/presets/whatsapp.yaml
+++ b/nemoclaw-blueprint/policies/presets/whatsapp.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: whatsapp
+  description: "WhatsApp Web access via Baileys (WebSocket + media)"
+
+network_policies:
+  whatsapp:
+    name: whatsapp
+    endpoints:
+      # WebSocket transport — must use access: full (CONNECT tunnel).
+      # WhatsApp Web requires HTTP/1.1 for the 101 Switching Protocols
+      # upgrade; the proxy's L7 relay breaks long-lived WebSocket
+      # connections. Same pattern as Discord gateway and Slack Socket
+      # Mode. See #513, #409.
+      - host: web.whatsapp.com
+        port: 443
+        access: full
+      # Noise protocol transport — binary framing, incompatible with
+      # the proxy's L7 HTTP relay. Requires CONNECT tunnel.
+      - host: g.whatsapp.net
+        port: 443
+        access: full
+      # Noise protocol fallback port (XMPP). Only preset using non-443
+      # port — required because WhatsApp Noise protocol falls back to
+      # 5222 when 443 is blocked.
+      - host: g.whatsapp.net
+        port: 5222
+        access: full
+      # Media CDN (upload/download attachments, profile pics).
+      # POST required for sending media via WhatsApp.
+      - host: mmg.whatsapp.net
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: media.whatsapp.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      # Static assets and config (read-only)
+      - host: static.whatsapp.net
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+      # Signal Protocol key distribution (standard HTTPS key exchange)
+      - host: pps.whatsapp.net
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      # Baileys version check — fetches latest protocol version from GitHub.
+      # Without this, Baileys falls back to a stale hardcoded version that
+      # WhatsApp rejects with 405 during the Noise handshake.
+      - host: raw.githubusercontent.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/WhiskeySockets/Baileys/master/src/Defaults/index.ts" }
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }

--- a/nemoclaw-blueprint/policies/tiers.yaml
+++ b/nemoclaw-blueprint/policies/tiers.yaml
@@ -39,5 +39,6 @@ tiers:
       - { name: slack,        access: read-write }
       - { name: discord,      access: read-write }
       - { name: telegram,     access: read-write }
+      - { name: whatsapp,    access: read-write }
       - { name: jira,         access: read-write }
       - { name: outlook,      access: read-write }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3200,6 +3200,14 @@ async function createSandbox(
         .filter(Boolean),
     ),
   ];
+  // WhatsApp uses QR pairing (no token), so add it if selected in step 5.
+  if (
+    Array.isArray(enabledChannels) &&
+    enabledChannels.includes("whatsapp") &&
+    !activeMessagingChannels.includes("whatsapp")
+  ) {
+    activeMessagingChannels.push("whatsapp");
+  }
   // Build allowed sender IDs map from env vars set during the messaging prompt.
   // Each channel with a userIdEnvKey in MESSAGING_CHANNELS may have a
   // comma-separated list of IDs (e.g. TELEGRAM_ALLOWED_IDS="123,456").
@@ -4409,6 +4417,14 @@ const MESSAGING_CHANNELS = [
     appTokenHelp: "Slack API → Your Apps → Basic Information → App-Level Tokens (xapp-...).",
     appTokenLabel: "Slack App Token (Socket Mode)",
   },
+  {
+    name: "whatsapp",
+    envKey: "_WHATSAPP_QR_PAIRING",
+    description: "WhatsApp messaging (QR pairing)",
+    help: "WhatsApp uses QR code pairing — no token needed during onboard.",
+    label: "WhatsApp",
+    qrPairing: true,
+  },
 ];
 
 async function setupMessagingChannels() {
@@ -4452,7 +4468,7 @@ async function setupMessagingChannels() {
       output.write(`    [${i + 1}] ${marker} ${ch.name} — ${ch.description}${status}\n`);
     });
     output.write("\n");
-    output.write("  Press 1-3 to toggle, Enter when done: ");
+    output.write(`  Press 1-${MESSAGING_CHANNELS.length} to toggle, Enter when done: `);
   };
 
   showList();
@@ -4526,6 +4542,10 @@ async function setupMessagingChannels() {
     const ch = MESSAGING_CHANNELS.find((c) => c.name === name);
     if (!ch) {
       console.log(`  Unknown channel: ${name}`);
+      continue;
+    }
+    if (ch.qrPairing) {
+      console.log(`  ✓ ${ch.name} — QR pairing after onboard: openclaw channels login --channel ${ch.name}`);
       continue;
     }
     if (getMessagingToken(ch.envKey)) {
@@ -4622,6 +4642,11 @@ function getSuggestedPolicyPresets({ enabledChannels = null, webSearchConfig = n
   maybeSuggestMessagingPreset("telegram", "TELEGRAM_BOT_TOKEN");
   maybeSuggestMessagingPreset("slack", "SLACK_BOT_TOKEN");
   maybeSuggestMessagingPreset("discord", "DISCORD_BOT_TOKEN");
+
+  // WhatsApp has no env-key (QR pairing) — suggest preset only if explicitly selected.
+  if (usesExplicitMessagingSelection && enabledChannels.includes("whatsapp")) {
+    suggestions.push("whatsapp");
+  }
 
   if (webSearchConfig) suggestions.push("brave");
 
@@ -5311,10 +5336,15 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
   // extraSelected seeds the initial checked state beyond the tier defaults:
   // - presets already applied from a previous run
   // - credential-based additions from suggestions (e.g. brave when webSearchConfig is set)
+  // - messaging channels enabled in step 5 that have a matching preset
   const knownNames = new Set(allPresets.map((p) => p.name));
+  const channelPresets = Array.isArray(enabledChannels)
+    ? enabledChannels.filter((name) => knownNames.has(name))
+    : [];
   const extraSelected = [
     ...applied.filter((name) => knownNames.has(name)),
     ...suggestions.filter((name) => knownNames.has(name) && !applied.includes(name)),
+    ...channelPresets.filter((name) => !applied.includes(name) && !suggestions.includes(name)),
   ];
   const resolvedPresets = await selectTierPresetsAndAccess(tierName, allPresets, extraSelected);
   const interactiveChoice = resolvedPresets.map((p) => p.name);
@@ -5532,7 +5562,7 @@ function getDashboardGuidanceLines(dashboardAccess = [], options = {}) {
   return guidance;
 }
 
-function printDashboard(sandboxName, model, provider, nimContainer = null, agent = null) {
+function printDashboard(sandboxName, model, provider, nimContainer = null, agent = null, messagingChannels = []) {
   const nimStat = nimContainer ? nim.nimStatusByName(nimContainer) : nim.nimStatus(sandboxName);
   const nimLabel = nimStat.running ? "running" : "not running";
 
@@ -5603,6 +5633,13 @@ function printDashboard(sandboxName, model, provider, nimContainer = null, agent
     console.log(
       `               append  #token=<token>  to the URL, or see /tmp/gateway.log inside the sandbox.`,
     );
+  }
+  if (Array.isArray(messagingChannels) && messagingChannels.includes("whatsapp")) {
+    console.log("");
+    console.log("  WhatsApp — complete pairing inside the sandbox:");
+    console.log(`    nemoclaw ${sandboxName} connect`);
+    console.log("    openclaw channels login --channel whatsapp");
+    console.log("    # Scan the QR code with your phone to finish pairing");
   }
   console.log(`  ${"─".repeat(50)}`);
   console.log("");
@@ -6090,7 +6127,11 @@ async function onboard(opts = {}) {
 
     onboardSession.completeSession({ sandboxName, provider, model });
     completed = true;
-    printDashboard(sandboxName, model, provider, nimContainer, agent);
+    const dashboardChannels =
+      selectedMessagingChannels.length > 0
+        ? selectedMessagingChannels
+        : registry.getSandbox(sandboxName)?.messagingChannels || session?.messagingChannels || [];
+    printDashboard(sandboxName, model, provider, nimContainer, agent, dashboardChannels);
   } finally {
     releaseOnboardLock();
   }

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1629,7 +1629,7 @@ function cleanupSandboxServices(sandboxName, { stopHostServices = false } = {}) 
   }
 
   // Delete messaging providers created during onboard.
-  for (const suffix of ["telegram-bridge", "discord-bridge", "slack-bridge"]) {
+  for (const suffix of ["telegram-bridge", "discord-bridge", "slack-bridge", "whatsapp-bridge"]) {
     runOpenshell(["provider", "delete", `${sandboxName}-${suffix}`], { ignoreError: true });
   }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -682,6 +682,7 @@ describe("CLI dispatch", () => {
     expect(log).toContain("provider delete alpha-telegram-bridge");
     expect(log).toContain("provider delete alpha-discord-bridge");
     expect(log).toContain("provider delete alpha-slack-bridge");
+    expect(log).toContain("provider delete alpha-whatsapp-bridge");
   });
 
   it("passes plain logs through without the tail flag", () => {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -96,9 +96,9 @@ selectFromList(items, options)
 
 describe("policies", () => {
   describe("listPresets", () => {
-    it("returns all 12 presets", () => {
+    it("returns all 13 presets", () => {
       const presets = policies.listPresets();
-      expect(presets.length).toBe(12);
+      expect(presets.length).toBe(13);
     });
 
     it("each preset has name and description", () => {
@@ -126,6 +126,7 @@ describe("policies", () => {
         "pypi",
         "slack",
         "telegram",
+        "whatsapp",
       ];
       expect(names).toEqual(expected);
     });

--- a/test/policy-tiers.test.ts
+++ b/test/policy-tiers.test.ts
@@ -127,11 +127,12 @@ describe("tiers", () => {
       }
     });
 
-    it("includes messaging presets (slack, discord, telegram)", () => {
+    it("includes messaging presets (slack, discord, telegram, whatsapp)", () => {
       const names = tiers.getTier("open").presets.map((p: TierPreset) => p.name);
       expect(names).toContain("slack");
       expect(names).toContain("discord");
       expect(names).toContain("telegram");
+      expect(names).toContain("whatsapp");
     });
 
     it("includes productivity presets (jira, outlook)", () => {

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -341,3 +341,61 @@ describe("huggingface preset", () => {
     }
   });
 });
+
+describe("whatsapp preset", () => {
+  const WHATSAPP_PRESET_PATH = new URL(
+    "../nemoclaw-blueprint/policies/presets/whatsapp.yaml",
+    import.meta.url,
+  );
+  const whatsappPreset = YAML.parse(
+    readFileSync(WHATSAPP_PRESET_PATH, "utf-8"),
+  ) as Record<string, unknown>;
+
+  type Rule = { allow?: { method?: string; path?: string } };
+  type Endpoint = { host?: string; port?: number; access?: string; protocol?: string; enforcement?: string; rules?: Rule[] };
+
+  function presetEndpoints(): Endpoint[] {
+    const np = whatsappPreset.network_policies as Record<string, unknown> | undefined;
+    if (!np) return [];
+    const wa = np.whatsapp as { endpoints?: unknown } | undefined;
+    return Array.isArray(wa?.endpoints) ? (wa!.endpoints as Endpoint[]) : [];
+  }
+
+  it("regression #513: whatsapp preset file exists and parses", () => {
+    expect(whatsappPreset).toEqual(expect.objectContaining({}));
+    const meta = whatsappPreset.preset as { name?: unknown } | undefined;
+    expect(meta?.name).toBe("whatsapp");
+    const np = whatsappPreset.network_policies as Record<string, unknown> | undefined;
+    expect(np && "whatsapp" in np).toBe(true);
+  });
+
+  it("regression #513: web.whatsapp.com uses access:full for WebSocket", () => {
+    const endpoints = presetEndpoints();
+    const ws = endpoints.find((ep) => ep.host === "web.whatsapp.com");
+    expect(ws).toBeDefined();
+    expect(ws!.access).toBe("full");
+    // Must NOT have protocol:rest — that breaks WebSocket
+    expect(ws!.protocol).toBeUndefined();
+  });
+
+  it("regression #513: g.whatsapp.net uses access:full for Noise protocol", () => {
+    const endpoints = presetEndpoints();
+    const noise443 = endpoints.find((ep) => ep.host === "g.whatsapp.net" && ep.port === 443);
+    const noise5222 = endpoints.find((ep) => ep.host === "g.whatsapp.net" && ep.port === 5222);
+    expect(noise443).toBeDefined();
+    expect(noise443!.access).toBe("full");
+    expect(noise5222).toBeDefined();
+    expect(noise5222!.access).toBe("full");
+  });
+
+  it("media and static endpoints use protocol:rest with L7 enforcement", () => {
+    const l7Hosts = ["mmg.whatsapp.net", "media.whatsapp.com", "static.whatsapp.net", "pps.whatsapp.net"];
+    for (const host of l7Hosts) {
+      const ep = presetEndpoints().find((e) => e.host === host);
+      expect(ep).toBeDefined();
+      expect(ep!.protocol).toBe("rest");
+      expect(ep!.enforcement).toBe("enforce");
+      expect(ep!.access).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Add WhatsApp as a messaging channel option during nemoclaw onboard. WhatsApp uses QR code pairing (no token), so the onboard flow skips the token prompt and prints pairing instructions in the summary.

Changes:
- Add whatsapp.yaml network policy preset with security-hardened endpoints (3/8 access:full for WebSocket/Noise, 5/8 L7-enforced)
- Add WhatsApp to onboard channel selector and policy auto-suggestion
- Register WhatsApp plugin in sandbox image when channel is selected
- Patch Baileys proxy agent in sandbox image for OpenClaw 2026.4.2 (fixed upstream in 2026.4.15+; patch self-skips after version bump)
- Add whatsapp-bridge to sandbox destroy cleanup
- Add regression tests for preset, tier, and cleanup

Closes #513

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [x] AI-assisted — tool: <!-- e.g., Claude Code, Cursor, GitHub Copilot -->

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Your Name <your-email@example.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WhatsApp as a messaging channel with QR-code pairing and dashboard pairing instructions; onboarding supports selecting WhatsApp and seeds matching policy presets

* **Chores**
  * Build now conditionally includes WhatsApp support and optional HTTPS proxy handling for WhatsApp sessions
  * Sandbox cleanup now removes WhatsApp provider entries
  * Policy tiers updated to expose WhatsApp in the open tier

* **Tests**
  * Updated/added tests to cover the new WhatsApp preset and provider cleanup behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->