### PR TITLE
fix(scripts): harden kubelet detection and daemon.json manipulation

### DIFF
--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -290,6 +290,9 @@ check_local_provider_health() {
 detect_kubelet_conflict() {
   KUBELET_CONFLICT_DETAIL=""
 
+  # Kubelet conflicts only apply on Linux (cgroup namespace sharing).
+  [ "$(uname -s)" = "Linux" ] || return 1
+
   if pgrep -x kubelet >/dev/null 2>&1 || pgrep -x kubelite >/dev/null 2>&1 || pgrep -x k3s >/dev/null 2>&1; then
     KUBELET_CONFLICT_DETAIL="kubelet process detected"
     return 0

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -7,7 +7,7 @@ socket_exists() {
 
   if [ -n "${NEMOCLAW_TEST_SOCKET_PATHS:-}" ]; then
     case ":$NEMOCLAW_TEST_SOCKET_PATHS:" in
-      *":$socket_path:"*) return 0 ;;
+    *":$socket_path:"*) return 0 ;;
     esac
     return 1
   fi
@@ -74,21 +74,21 @@ docker_host_runtime() {
   local docker_host="${1:-${DOCKER_HOST:-}}"
 
   case "$docker_host" in
-    unix://*"/.colima/default/docker.sock" | unix://*"/.config/colima/default/docker.sock")
-      printf 'colima\n'
-      ;;
-    unix://*"/podman/machine/podman.sock" | unix://*"/podman/podman.sock")
-      printf 'podman\n'
-      ;;
-    unix://*"/.docker/run/docker.sock")
-      printf 'docker-desktop\n'
-      ;;
-    "")
-      return 1
-      ;;
-    *)
-      printf 'custom\n'
-      ;;
+  unix://*"/.colima/default/docker.sock" | unix://*"/.config/colima/default/docker.sock")
+    printf 'colima\n'
+    ;;
+  unix://*"/podman/machine/podman.sock" | unix://*"/podman/podman.sock")
+    printf 'podman\n'
+    ;;
+  unix://*"/.docker/run/docker.sock")
+    printf 'docker-desktop\n'
+    ;;
+  "")
+    return 1
+    ;;
+  *)
+    printf 'custom\n'
+    ;;
   esac
 }
 
@@ -238,10 +238,10 @@ select_openshell_cluster_container() {
 _validate_port() {
   local name="$1" value="$2"
   case "$value" in
-    '' | *[!0-9]*)
-      printf 'Invalid %s=%s (expected 1024-65535)\n' "$name" "$value" >&2
-      return 1
-      ;;
+  '' | *[!0-9]*)
+    printf 'Invalid %s=%s (expected 1024-65535)\n' "$name" "$value" >&2
+    return 1
+    ;;
   esac
   [ "$value" -ge 1024 ] && [ "$value" -le 65535 ] || {
     printf 'Invalid %s=%s (expected 1024-65535)\n' "$name" "$value" >&2
@@ -257,9 +257,9 @@ get_local_provider_base_url() {
   _validate_port NEMOCLAW_VLLM_PORT "$vllm_port" || return 1
   _validate_port NEMOCLAW_OLLAMA_PORT "$ollama_port" || return 1
   case "$provider" in
-    vllm-local) printf 'http://host.openshell.internal:%s/v1\n' "$vllm_port" ;;
-    ollama-local) printf 'http://host.openshell.internal:%s/v1\n' "$ollama_port" ;;
-    *) return 1 ;;
+  vllm-local) printf 'http://host.openshell.internal:%s/v1\n' "$vllm_port" ;;
+  ollama-local) printf 'http://host.openshell.internal:%s/v1\n' "$ollama_port" ;;
+  *) return 1 ;;
   esac
 }
 
@@ -271,15 +271,15 @@ check_local_provider_health() {
   _validate_port NEMOCLAW_VLLM_PORT "$vllm_port" || return 1
   _validate_port NEMOCLAW_OLLAMA_PORT "$ollama_port" || return 1
   case "$provider" in
-    vllm-local)
-      curl -sf "http://localhost:${vllm_port}/v1/models" >/dev/null 2>&1
-      ;;
-    ollama-local)
-      curl -sf "http://localhost:${ollama_port}/api/tags" >/dev/null 2>&1
-      ;;
-    *)
-      return 1
-      ;;
+  vllm-local)
+    curl -sf "http://localhost:${vllm_port}/v1/models" >/dev/null 2>&1
+    ;;
+  ollama-local)
+    curl -sf "http://localhost:${ollama_port}/api/tags" >/dev/null 2>&1
+    ;;
+  *)
+    return 1
+    ;;
   esac
 }
 

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -7,7 +7,7 @@ socket_exists() {
 
   if [ -n "${NEMOCLAW_TEST_SOCKET_PATHS:-}" ]; then
     case ":$NEMOCLAW_TEST_SOCKET_PATHS:" in
-    *":$socket_path:"*) return 0 ;;
+      *":$socket_path:"*) return 0 ;;
     esac
     return 1
   fi
@@ -74,21 +74,21 @@ docker_host_runtime() {
   local docker_host="${1:-${DOCKER_HOST:-}}"
 
   case "$docker_host" in
-  unix://*"/.colima/default/docker.sock" | unix://*"/.config/colima/default/docker.sock")
-    printf 'colima\n'
-    ;;
-  unix://*"/podman/machine/podman.sock" | unix://*"/podman/podman.sock")
-    printf 'podman\n'
-    ;;
-  unix://*"/.docker/run/docker.sock")
-    printf 'docker-desktop\n'
-    ;;
-  "")
-    return 1
-    ;;
-  *)
-    printf 'custom\n'
-    ;;
+    unix://*"/.colima/default/docker.sock" | unix://*"/.config/colima/default/docker.sock")
+      printf 'colima\n'
+      ;;
+    unix://*"/podman/machine/podman.sock" | unix://*"/podman/podman.sock")
+      printf 'podman\n'
+      ;;
+    unix://*"/.docker/run/docker.sock")
+      printf 'docker-desktop\n'
+      ;;
+    "")
+      return 1
+      ;;
+    *)
+      printf 'custom\n'
+      ;;
   esac
 }
 
@@ -156,8 +156,8 @@ first_non_loopback_nameserver() {
     return 1
   fi
 
-  printf '%s\n' "$resolv_conf" |
-    awk '$1 == "nameserver" && $2 !~ /^127\./ { print $2; exit }'
+  printf '%s\n' "$resolv_conf" \
+    | awk '$1 == "nameserver" && $2 !~ /^127\./ { print $2; exit }'
 }
 
 get_colima_vm_nameserver() {
@@ -238,10 +238,10 @@ select_openshell_cluster_container() {
 _validate_port() {
   local name="$1" value="$2"
   case "$value" in
-  '' | *[!0-9]*)
-    printf 'Invalid %s=%s (expected 1024-65535)\n' "$name" "$value" >&2
-    return 1
-    ;;
+    '' | *[!0-9]*)
+      printf 'Invalid %s=%s (expected 1024-65535)\n' "$name" "$value" >&2
+      return 1
+      ;;
   esac
   [ "$value" -ge 1024 ] && [ "$value" -le 65535 ] || {
     printf 'Invalid %s=%s (expected 1024-65535)\n' "$name" "$value" >&2
@@ -257,9 +257,9 @@ get_local_provider_base_url() {
   _validate_port NEMOCLAW_VLLM_PORT "$vllm_port" || return 1
   _validate_port NEMOCLAW_OLLAMA_PORT "$ollama_port" || return 1
   case "$provider" in
-  vllm-local) printf 'http://host.openshell.internal:%s/v1\n' "$vllm_port" ;;
-  ollama-local) printf 'http://host.openshell.internal:%s/v1\n' "$ollama_port" ;;
-  *) return 1 ;;
+    vllm-local) printf 'http://host.openshell.internal:%s/v1\n' "$vllm_port" ;;
+    ollama-local) printf 'http://host.openshell.internal:%s/v1\n' "$ollama_port" ;;
+    *) return 1 ;;
   esac
 }
 
@@ -271,15 +271,15 @@ check_local_provider_health() {
   _validate_port NEMOCLAW_VLLM_PORT "$vllm_port" || return 1
   _validate_port NEMOCLAW_OLLAMA_PORT "$ollama_port" || return 1
   case "$provider" in
-  vllm-local)
-    curl -sf "http://localhost:${vllm_port}/v1/models" >/dev/null 2>&1
-    ;;
-  ollama-local)
-    curl -sf "http://localhost:${ollama_port}/api/tags" >/dev/null 2>&1
-    ;;
-  *)
-    return 1
-    ;;
+    vllm-local)
+      curl -sf "http://localhost:${vllm_port}/v1/models" >/dev/null 2>&1
+      ;;
+    ollama-local)
+      curl -sf "http://localhost:${ollama_port}/api/tags" >/dev/null 2>&1
+      ;;
+    *)
+      return 1
+      ;;
   esac
 }
 

--- a/scripts/setup-spark.sh
+++ b/scripts/setup-spark.sh
@@ -112,27 +112,33 @@ if [ -f "$DAEMON_JSON" ]; then
     else
       info "Updating Docker daemon cgroupns mode to 'host'..."
       python3 -c "
-import json
+import json, os, tempfile
 with open('$DAEMON_JSON') as f:
     d = json.load(f)
 d['default-cgroupns-mode'] = 'host'
-with open('$DAEMON_JSON', 'w') as f:
+dirn = os.path.dirname('$DAEMON_JSON')
+fd, tmp = tempfile.mkstemp(dir=dirn, suffix='.tmp')
+with os.fdopen(fd, 'w') as f:
     json.dump(d, f, indent=2)
+os.replace(tmp, '$DAEMON_JSON')
 "
       NEEDS_RESTART=true
     fi
   else
     info "Adding cgroupns=host to Docker daemon config..."
     python3 -c "
-import json
+import json, os, tempfile
 try:
     with open('$DAEMON_JSON') as f:
         d = json.load(f)
-except:
+except (IOError, json.JSONDecodeError):
     d = {}
 d['default-cgroupns-mode'] = 'host'
-with open('$DAEMON_JSON', 'w') as f:
+dirn = os.path.dirname('$DAEMON_JSON')
+fd, tmp = tempfile.mkstemp(dir=dirn, suffix='.tmp')
+with os.fdopen(fd, 'w') as f:
     json.dump(d, f, indent=2)
+os.replace(tmp, '$DAEMON_JSON')
 "
     NEEDS_RESTART=true
   fi

--- a/test/runtime-shell.test.ts
+++ b/test/runtime-shell.test.ts
@@ -200,6 +200,45 @@ describe("shell runtime helpers", () => {
     expect(result.stdout.trim()).toBe("9.9.9.9");
   });
 
+  it("detect_kubelet_conflict skips on non-Linux (macOS)", () => {
+    const result = runShell(
+      `uname() { printf 'Darwin\\n'; }; source "${RUNTIME_SH}"; detect_kubelet_conflict`,
+    );
+    // Should return 1 (no conflict) on non-Linux
+    expect(result.status).toBe(1);
+  });
+
+  it("detect_kubelet_conflict returns 0 when kubelet process is found", () => {
+    const result = runShell(
+      `uname() { printf 'Linux\\n'; }
+       pgrep() { [[ "$2" == "kubelet" ]] && return 0 || return 1; }
+       source "${RUNTIME_SH}"; detect_kubelet_conflict
+       echo "$KUBELET_CONFLICT_DETAIL"`,
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("kubelet process detected");
+  });
+
+  it("detect_kubelet_conflict returns 1 when no kubelet is found", () => {
+    const result = runShell(
+      `uname() { printf 'Linux\\n'; }
+       pgrep() { return 1; }
+       command() { return 1; }
+       systemctl() { return 1; }
+       source "${RUNTIME_SH}"; detect_kubelet_conflict`,
+    );
+    expect(result.status).toBe(1);
+  });
+
+  it("warn_kubelet_conflict emits conflict detail to stderr", () => {
+    const result = runShell(
+      `warn() { echo >&2 "$1"; }; source "${RUNTIME_SH}"; warn_kubelet_conflict "MicroK8s is running"`,
+    );
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("MicroK8s is running");
+    expect(result.stderr).toContain("CrashLoopBackOff");
+  });
+
   it("does not consume installer stdin when reading the Colima VM nameserver", () => {
     const result = runShell(
       `function colima() { cat > /dev/null || true; printf 'nameserver 100.100.100.100\\n'; }


### PR DESCRIPTION
## Summary

Follow-up to #433. Addresses four items identified during regression risk review:

- Add Linux platform guard to `detect_kubelet_conflict()` so it safely returns "no conflict" when `runtime.sh` is sourced on macOS
- Replace bare `except:` in `setup-spark.sh` Python blocks with `except (IOError, json.JSONDecodeError):` to avoid swallowing `KeyboardInterrupt`/`SystemExit`
- Use atomic writes (`tempfile.mkstemp` + `os.replace`) for `daemon.json` manipulation to prevent corruption from partial writes or concurrent reads
- Add 4 tests for `detect_kubelet_conflict()` and `warn_kubelet_conflict()` in `runtime-shell.test.ts`

## Test plan

- [x] 4 new tests in `runtime-shell.test.ts` (all passing)
- [x] ShellCheck clean on both modified scripts
- [x] All 23 runtime-shell tests pass (16 existing + 4 new + 3 others)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker daemon configuration updates now use atomic file writes for safer upgrades.
  * Kubelet conflict detection now skips non-Linux systems to avoid inappropriate checks.
  * Error handling for configuration reads/parsing refined to catch specific errors.

* **Tests**
  * Added tests covering kubelet conflict detection across OS variations, process/service states, and warning output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->