### PR TITLE
fix(sandbox): block --local agent and add crash recovery hint

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -486,14 +486,18 @@ openclaw() {
       return 1
       ;;
     agent)
-      # Warn when --local is used — it bypasses gateway protections including
-      # secret scanning, network policy, and inference auth. Ref: #1632
+      # Block --local inside sandbox — it bypasses gateway protections and can
+      # crash the container's main process, bricking the sandbox. Ref: #1632, #2016
       local _arg
       for _arg in "$@"; do
         if [ "$_arg" = "--local" ]; then
-          echo "[SECURITY] Warning: 'openclaw agent --local' bypasses the NemoClaw gateway." >&2
-          echo "[SECURITY] Secret scanning, network policy, and inference auth are NOT enforced in local mode." >&2
-          break
+          echo "Error: 'openclaw agent --local' is not supported inside NemoClaw sandboxes." >&2
+          echo "The --local flag bypasses the gateway's security protections (secret scanning," >&2
+          echo "network policy, inference auth) and can crash the sandbox." >&2
+          echo "" >&2
+          echo "Instead, run without --local to use the gateway's managed inference route:" >&2
+          echo "  openclaw agent --agent main -m \"hello\"" >&2
+          return 1
         fi
       done
       ;;

--- a/src/lib/gateway-state.ts
+++ b/src/lib/gateway-state.ts
@@ -125,10 +125,6 @@ export function getGatewayReuseState(
   return "missing";
 }
 
-/**
- * Extract the sandbox phase from `openshell sandbox get` output.
- * Returns the phase string (e.g., "Ready", "Provisioning") or null if not found.
- */
 export function parseSandboxPhase(getOutput: string): string | null {
   if (typeof getOutput !== "string") return null;
   const clean = stripAnsi(getOutput);

--- a/src/lib/gateway-state.ts
+++ b/src/lib/gateway-state.ts
@@ -125,6 +125,17 @@ export function getGatewayReuseState(
   return "missing";
 }
 
+/**
+ * Extract the sandbox phase from `openshell sandbox get` output.
+ * Returns the phase string (e.g., "Ready", "Provisioning") or null if not found.
+ */
+export function parseSandboxPhase(getOutput: string): string | null {
+  if (typeof getOutput !== "string") return null;
+  const clean = stripAnsi(getOutput);
+  const match = clean.match(/^\s*Phase:\s+(\S+)/m);
+  return match ? match[1] : null;
+}
+
 export function getSandboxStateFromOutputs(
   sandboxName: string,
   getOutput = "",

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -737,7 +737,7 @@ async function ensureLiveSandboxOrExit(sandboxName) {
       );
       console.error("");
       console.error(
-        `  Run \`nemoclaw ${sandboxName} rebuild --yes\` to recreate the sandbox (workspace state will be preserved).`,
+        `  Run \`nemoclaw ${sandboxName} rebuild --yes\` to recreate the sandbox (--yes skips the confirmation prompt; workspace state will be preserved).`,
       );
       process.exit(1);
     }
@@ -1274,7 +1274,7 @@ async function sandboxStatus(sandboxName) {
       );
       console.log("");
       console.log(
-        `  Run \`nemoclaw ${sandboxName} rebuild --yes\` to recreate the sandbox (workspace state will be preserved).`,
+        `  Run \`nemoclaw ${sandboxName} rebuild --yes\` to recreate the sandbox (--yes skips the confirmation prompt; workspace state will be preserved).`,
       );
     }
   } else if (lookup.state === "missing") {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -67,6 +67,7 @@ const sandboxVersion = require("./lib/sandbox-version");
 const sandboxState = require("./lib/sandbox-state");
 const { ensureOllamaAuthProxy } = require("./lib/onboard");
 const skillInstall = require("./lib/skill-install");
+const { parseSandboxPhase } = require("./lib/gateway-state");
 
 // ── Global commands ──────────────────────────────────────────────
 
@@ -728,6 +729,18 @@ async function getReconciledSandboxGatewayState(sandboxName) {
 async function ensureLiveSandboxOrExit(sandboxName) {
   const lookup = await getReconciledSandboxGatewayState(sandboxName);
   if (lookup.state === "present") {
+    const phase = parseSandboxPhase(lookup.output || "");
+    if (phase && phase !== "Ready") {
+      console.error(`  Sandbox '${sandboxName}' is stuck in '${phase}' phase.`);
+      console.error(
+        "  This usually happens when a process crash inside the sandbox prevented clean startup.",
+      );
+      console.error("");
+      console.error(
+        `  Run \`nemoclaw ${sandboxName} rebuild --yes\` to recreate the sandbox (workspace state will be preserved).`,
+      );
+      process.exit(1);
+    }
     return lookup;
   }
   if (lookup.state === "missing") {
@@ -1252,6 +1265,18 @@ async function sandboxStatus(sandboxName) {
       console.log("");
     }
     console.log(lookup.output);
+    const phase = parseSandboxPhase(lookup.output || "");
+    if (phase && phase !== "Ready") {
+      console.log("");
+      console.log(`  Sandbox '${sandboxName}' is stuck in '${phase}' phase.`);
+      console.log(
+        "  This usually happens when a process crash inside the sandbox prevented clean startup.",
+      );
+      console.log("");
+      console.log(
+        `  Run \`nemoclaw ${sandboxName} rebuild --yes\` to recreate the sandbox (workspace state will be preserved).`,
+      );
+    }
   } else if (lookup.state === "missing") {
     registry.removeSandbox(sandboxName);
     const session = onboardSession.loadSession();

--- a/test/gateway-state.test.ts
+++ b/test/gateway-state.test.ts
@@ -13,6 +13,7 @@ import {
   hasStaleGateway,
   hasActiveGatewayInfo,
   getReportedGatewayName,
+  parseSandboxPhase,
 } from "../src/lib/gateway-state.js";
 
 // Realistic CLI outputs
@@ -181,6 +182,39 @@ describe("isGatewayHealthy", () => {
     // be treated as empty after stripping, triggering the ARM64 fallback.
     const ansiOnly = "\x1b[0m\x1b[32m";
     expect(isGatewayHealthy(ansiOnly, GW_INFO_NAMED, GW_INFO_ACTIVE)).toBe(true);
+  });
+});
+
+describe("parseSandboxPhase", () => {
+  it("extracts Ready phase from sandbox get output", () => {
+    const output = ["Sandbox:", "", "  Id: abc", "  Name: my-assistant", "  Phase: Ready"].join(
+      "\n",
+    );
+    expect(parseSandboxPhase(output)).toBe("Ready");
+  });
+
+  it("extracts Provisioning phase from sandbox get output", () => {
+    const output = [
+      "Sandbox:",
+      "",
+      "  Id: abc",
+      "  Name: my-assistant",
+      "  Phase: Provisioning",
+    ].join("\n");
+    expect(parseSandboxPhase(output)).toBe("Provisioning");
+  });
+
+  it("strips ANSI codes before parsing", () => {
+    const output = "  \x1b[1mPhase:\x1b[0m Ready";
+    expect(parseSandboxPhase(output)).toBe("Ready");
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseSandboxPhase("")).toBeNull();
+  });
+
+  it("returns null when no Phase line is present", () => {
+    expect(parseSandboxPhase("Sandbox:\n  Id: abc\n  Name: test")).toBeNull();
   });
 });
 

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -204,6 +204,45 @@ describe("nemoclaw-start configure guard (#1114)", () => {
   });
 });
 
+describe("nemoclaw-start configure guard blocks --local (#2016)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("blocks openclaw agent --local with a hard error and return 1", () => {
+    const guardBlock = src.match(
+      /install_configure_guard\(\) \{([\s\S]*?)^validate_openclaw_symlinks/m,
+    );
+    expect(guardBlock).toBeTruthy();
+    const body = guardBlock[1];
+    // Must contain the agent) case that checks for --local
+    expect(body).toContain("agent)");
+    expect(body).toContain('"--local"');
+    // Must print an error (not a warning) and return 1
+    expect(body).toMatch(/echo "Error:.*--local.*not supported inside NemoClaw sandboxes/);
+    expect(body).toMatch(/return 1/);
+    // Must NOT contain the old warning pattern
+    expect(body).not.toContain("[SECURITY] Warning");
+  });
+
+  it("suggests the correct alternative command without --local", () => {
+    const guardBlock = src.match(
+      /install_configure_guard\(\) \{([\s\S]*?)^validate_openclaw_symlinks/m,
+    );
+    expect(guardBlock).toBeTruthy();
+    expect(guardBlock[1]).toContain("openclaw agent --agent main");
+  });
+
+  it("allows openclaw agent without --local to pass through", () => {
+    const guardBlock = src.match(
+      /install_configure_guard\(\) \{([\s\S]*?)^validate_openclaw_symlinks/m,
+    );
+    expect(guardBlock).toBeTruthy();
+    const body = guardBlock[1];
+    // The agent) case only returns 1 inside the --local check.
+    // After the for loop, execution falls through to `command openclaw "$@"`.
+    expect(body).toContain('command openclaw "$@"');
+  });
+});
+
 describe("runtime model override (#759)", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 

--- a/test/sandbox-stuck-recovery.test.ts
+++ b/test/sandbox-stuck-recovery.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,18 +5,19 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-/**
- * Tests for #2016 — recovery hint when sandbox is stuck in non-Ready phase.
- *
- * Creates a fake openshell binary that reports a sandbox in "Provisioning"
- * phase, then verifies that `nemoclaw connect` and `nemoclaw status` print
- * the recovery guidance instead of proceeding or silently failing.
- */
+const tmpFixtures: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpFixtures.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function setupFixture(sandboxName: string, phase: string) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-stuck-"));
+  tmpFixtures.push(tmpDir);
   const homeLocalBin = path.join(tmpDir, ".local", "bin");
   const registryDir = path.join(tmpDir, ".nemoclaw");
   const openshellPath = path.join(homeLocalBin, "openshell");

--- a/test/sandbox-stuck-recovery.test.ts
+++ b/test/sandbox-stuck-recovery.test.ts
@@ -1,0 +1,162 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tests for #2016 — recovery hint when sandbox is stuck in non-Ready phase.
+ *
+ * Creates a fake openshell binary that reports a sandbox in "Provisioning"
+ * phase, then verifies that `nemoclaw connect` and `nemoclaw status` print
+ * the recovery guidance instead of proceeding or silently failing.
+ */
+
+function setupFixture(sandboxName: string, phase: string) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-stuck-"));
+  const homeLocalBin = path.join(tmpDir, ".local", "bin");
+  const registryDir = path.join(tmpDir, ".nemoclaw");
+  const openshellPath = path.join(homeLocalBin, "openshell");
+
+  fs.mkdirSync(homeLocalBin, { recursive: true });
+  fs.mkdirSync(registryDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(registryDir, "sandboxes.json"),
+    JSON.stringify({
+      defaultSandbox: sandboxName,
+      sandboxes: {
+        [sandboxName]: {
+          name: sandboxName,
+          model: "nvidia/test-model",
+          provider: "nvidia-prod",
+          gpuEnabled: false,
+          policies: [],
+        },
+      },
+    }),
+    { mode: 0o600 },
+  );
+
+  // Fake openshell binary — reports sandbox in the specified phase
+  fs.writeFileSync(
+    openshellPath,
+    `#!${process.execPath}
+const args = process.argv.slice(2);
+
+if (args[0] === "status") {
+  process.stdout.write("Gateway: nemoclaw\\nStatus: Connected\\n");
+  process.exit(0);
+}
+
+if (args[0] === "gateway" && args[1] === "info") {
+  process.stdout.write("Gateway: nemoclaw\\nGateway endpoint: https://127.0.0.1:8080\\n");
+  process.exit(0);
+}
+
+if (args[0] === "sandbox" && args[1] === "get" && args[2] === ${JSON.stringify(sandboxName)}) {
+  process.stdout.write("Sandbox:\\n\\n  Id: abc\\n  Name: ${sandboxName}\\n  Phase: ${phase}\\n");
+  process.exit(0);
+}
+
+if (args[0] === "sandbox" && args[1] === "list") {
+  process.stdout.write("${sandboxName}\\n");
+  process.exit(0);
+}
+
+if (args[0] === "policy" && args[1] === "get") {
+  process.exit(1);
+}
+
+if (args[0] === "inference" && args[1] === "get") {
+  process.stdout.write("Gateway inference:\\n  Provider: nvidia-prod\\n  Model: nvidia/test-model\\n");
+  process.exit(0);
+}
+
+if (args[0] === "sandbox" && args[1] === "connect") {
+  process.exit(0);
+}
+
+if (args[0] === "logs") {
+  process.exit(0);
+}
+
+if (args[0] === "forward") {
+  process.exit(0);
+}
+
+process.exit(0);
+`,
+    { mode: 0o755 },
+  );
+
+  return { tmpDir, sandboxName };
+}
+
+function runCli(tmpDir: string, sandboxName: string, subcommand: string) {
+  const repoRoot = path.join(import.meta.dirname, "..");
+  return spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "bin", "nemoclaw.js"), sandboxName, subcommand],
+    {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: "/usr/bin:/bin",
+        NEMOCLAW_NO_CONNECT_HINT: "1",
+      },
+      timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 15_000),
+    },
+  );
+}
+
+describe("sandbox stuck in non-Ready phase (#2016)", () => {
+  it(
+    "connect exits with error and recovery hint when sandbox is stuck in Provisioning",
+    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    () => {
+      const { tmpDir, sandboxName } = setupFixture("stuck-sandbox", "Provisioning");
+
+      const result = runCli(tmpDir, sandboxName, "connect");
+      expect(result.status).not.toBe(0);
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("stuck in 'Provisioning' phase");
+      expect(combined).toContain("process crash inside the sandbox");
+      expect(combined).toContain(`nemoclaw ${sandboxName} rebuild --yes`);
+    },
+  );
+
+  it(
+    "status shows recovery hint when sandbox is stuck in Provisioning",
+    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    () => {
+      const { tmpDir, sandboxName } = setupFixture("stuck-status", "Provisioning");
+
+      const result = runCli(tmpDir, sandboxName, "status");
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("stuck in 'Provisioning' phase");
+      expect(combined).toContain(`nemoclaw ${sandboxName} rebuild --yes`);
+    },
+  );
+
+  it(
+    "connect succeeds when sandbox phase is Ready",
+    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    () => {
+      const { tmpDir, sandboxName } = setupFixture("ready-sandbox", "Ready");
+
+      const result = runCli(tmpDir, sandboxName, "connect");
+      expect(result.status).toBe(0);
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).not.toContain("stuck in");
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- **Blocks `openclaw agent --local` inside sandboxes** — changes the configure guard from a warning to a hard error (`return 1`) with clear guidance to use the gateway-routed alternative instead. The `--local` flag bypasses security protections and can crash the container's main process, permanently bricking the sandbox.
- **Adds stuck-sandbox recovery hints** — when a sandbox is stuck in a non-Ready phase (e.g. "Provisioning" after a crash), `nemoclaw connect` now exits with a recovery message instead of failing with an opaque gRPC error, and `nemoclaw status` shows the same hint.
- **Adds `parseSandboxPhase` classifier** to `gateway-state.ts` for extracting sandbox phase from `openshell sandbox get` output.

Fixes #2016

## Test plan
- [x] `parseSandboxPhase` unit tests: Ready, Provisioning, ANSI stripping, empty/missing input
- [x] Configure guard static analysis tests: hard error + return 1, suggests alternative, allows agent without --local
- [x] Integration tests with fake openshell binary: connect fails with hint on Provisioning, status shows hint, connect succeeds when Ready
- [ ] Manual: run `openclaw agent --local` inside a sandbox → verify blocked with error message
- [ ] Manual: crash a sandbox, then `nemoclaw <name> connect` → verify recovery hint printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox detection: commands now detect non-Ready (e.g., Provisioning) sandboxes, fail connect attempts, and show troubleshooting text plus an explicit rebuild command.
  * Status output includes additional diagnostic guidance when a sandbox is stuck.

* **Security**
  * Blocked unsupported agent --local invocations inside sandboxes with a clear error and immediate failure to prevent bypass/crash scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->