### PR TITLE
feat(ci): add macOS e2e testing workflow

### DIFF
--- a/.github/workflows/macos-e2e.yaml
+++ b/.github/workflows/macos-e2e.yaml
@@ -30,11 +30,6 @@ jobs:
   macos-e2e:
     runs-on: macos-26
     timeout-minutes: 30
-    env:
-      NEMOCLAW_NON_INTERACTIVE: "1"
-      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
-      NEMOCLAW_RECREATE_SANDBOX: "1"
-      NEMOCLAW_SANDBOX_NAME: "e2e-macos"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -87,6 +82,10 @@ jobs:
         env:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-macos"
         run: bash test/e2e/test-full-e2e.sh
 
       - name: Explain skipped full E2E

--- a/.github/workflows/macos-e2e.yaml
+++ b/.github/workflows/macos-e2e.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-e2e-logs
           path: |

--- a/.github/workflows/macos-e2e.yaml
+++ b/.github/workflows/macos-e2e.yaml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: macos-e2e
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "bin/**"
+      - "nemoclaw/**"
+      - "scripts/**"
+      - "src/**"
+      - "test/**"
+      - ".github/workflows/macos-e2e.yaml"
+      - "package.json"
+      - "vitest.config.ts"
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos-e2e:
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      NEMOCLAW_NON_INTERACTIVE: "1"
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+      NEMOCLAW_RECREATE_SANDBOX: "1"
+      NEMOCLAW_SANDBOX_NAME: "e2e-macos"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Show environment
+        run: |
+          set -euo pipefail
+          echo "Runner: $(uname -a)"
+          echo "Arch:   $(uname -m)"
+          sw_vers
+          node --version
+          npm --version
+
+      - name: Install root dependencies
+        run: npm install --ignore-scripts
+
+      - name: Build CLI TypeScript modules
+        run: npm run build:cli
+
+      - name: Install and build plugin
+        run: |
+          set -euo pipefail
+          cd nemoclaw
+          npm install --ignore-scripts
+          npm run build
+
+      - name: Run vitest suite
+        run: npx vitest run --testTimeout 60000
+
+      - name: Detect Docker availability
+        id: docker
+        run: |
+          if docker info >/dev/null 2>&1; then
+            echo "docker_ok=true" >> "$GITHUB_OUTPUT"
+            echo "Docker is available"
+            docker version
+          else
+            echo "docker_ok=false" >> "$GITHUB_OUTPUT"
+            echo "Docker is not available on this runner"
+          fi
+
+      - name: Run macOS full E2E
+        if: steps.docker.outputs.docker_ok == 'true'
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-full-e2e.sh
+
+      - name: Explain skipped full E2E
+        if: steps.docker.outputs.docker_ok != 'true'
+        run: |
+          echo 'Skipping macOS full E2E because Docker is unavailable on this runner.'
+          echo 'The workflow still validated the NemoClaw build and vitest suite on macOS (Apple Silicon).'

--- a/.github/workflows/macos-e2e.yaml
+++ b/.github/workflows/macos-e2e.yaml
@@ -14,6 +14,8 @@ on:
       - "test/**"
       - ".github/workflows/macos-e2e.yaml"
       - "package.json"
+      - "package-lock.json"
+      - "nemoclaw/package-lock.json"
       - "vitest.config.ts"
   push:
     branches:

--- a/.github/workflows/macos-e2e.yaml
+++ b/.github/workflows/macos-e2e.yaml
@@ -20,6 +20,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/workflows/docs-preview-*.yaml"
+      - "ISSUE_TEMPLATE/**"
+      - ".github/ISSUE_TEMPLATE/**"
 
 permissions:
   contents: read
@@ -34,10 +40,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "22"
           cache: npm
@@ -61,7 +67,7 @@ jobs:
         run: |
           set -euo pipefail
           cd nemoclaw
-          npm install --ignore-scripts
+          npm ci --ignore-scripts
           npm run build
 
       - name: Run vitest suite
@@ -95,3 +101,12 @@ jobs:
         run: |
           echo 'Skipping macOS full E2E because Docker is unavailable on this runner.'
           echo 'The workflow still validated the NemoClaw build and vitest suite on macOS (Apple Silicon).'
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-e2e-logs
+          path: |
+            /tmp/nemoclaw-e2e-*.log
+          if-no-files-found: ignore

--- a/.github/workflows/macos-e2e.yaml
+++ b/.github/workflows/macos-e2e.yaml
@@ -50,7 +50,7 @@ jobs:
           npm --version
 
       - name: Install root dependencies
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Build CLI TypeScript modules
         run: npm run build:cli


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that validates the NemoClaw build and vitest suite on the `macos-26` (Apple Silicon) runner image, mirroring the WSL E2E pattern from #1715.

## Related Issue

Closes #1715 follow-up — extends cross-platform CI coverage to macOS.

## Changes

- Add `.github/workflows/macos-e2e.yaml` with:
  - `macos-26` runner targeting Apple Silicon
  - Node.js 22 setup with npm caching
  - Full CLI + plugin build (`build:cli` and `nemoclaw/npm run build`)
  - `vitest run` with 60 s per-test timeout as the primary gate
  - Conditional Docker detection and full E2E execution when available
  - `src/**` in path triggers (CLI tests import from `dist/` compiled from `src/`)
  - 30-minute job timeout, concurrency group with cancel-in-progress
  - Triggers on PRs (code paths), pushes to main, and manual dispatch

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a macOS end-to-end testing workflow that builds the project, runs unit tests, and conditionally executes full E2E tests when Docker is available.
  * Runs on macOS with a 30-minute timeout, supports manual and CI triggers, enforces concurrency with cancellation, uses Node 22 + Vitest, caches npm, and uploads E2E logs as artifacts on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->