### PR TITLE
fix(onboard): probe gateway container before trusting stale health metadata

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -126,7 +126,7 @@ const BACK_TO_SELECTION = "__NEMOCLAW_BACK_TO_SELECTION__";
  *
  * Returns "running" | "missing" | "unknown".
  * - "running"  — container exists and State.Running is true
- * - "missing"  — docker reports "No such object" (container was removed)
+ * - "missing"  — container was removed or exists but is stopped (not reusable)
  * - "unknown"  — any other failure (daemon down, timeout, etc.)
  *
  * Callers should only trigger stale-metadata cleanup on "missing", not on
@@ -141,6 +141,10 @@ function verifyGatewayContainerRunning() {
   );
   if (result.status === 0 && (result.stdout || "").trim() === "true") {
     return "running";
+  }
+  // Container exists but is stopped (exit 0, Running !== "true")
+  if (result.status === 0) {
+    return "missing";
   }
   const stderr = (result.stderr || "").toString();
   if (stderr.includes("No such object") || stderr.includes("No such container")) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -118,6 +118,21 @@ const RESET = USE_COLOR ? "\x1b[0m" : "";
 let OPENSHELL_BIN = null;
 const GATEWAY_NAME = "nemoclaw";
 const BACK_TO_SELECTION = "__NEMOCLAW_BACK_TO_SELECTION__";
+
+/**
+ * Probe whether the gateway Docker container is actually running.
+ * openshell CLI metadata can be stale after a manual `docker rm`, so this
+ * verifies the container is live before trusting a "healthy" reuse state.
+ * See #2020.
+ */
+function verifyGatewayContainerRunning() {
+  const containerName = `openshell-cluster-${GATEWAY_NAME}`;
+  const result = run(
+    `docker inspect --type container --format '{{.State.Running}}' ${containerName} 2>/dev/null`,
+    { ignoreError: true, suppressOutput: true },
+  );
+  return result.status === 0 && (result.stdout || "").trim() === "true";
+}
 const OPENCLAW_LAUNCH_AGENT_PLIST = "~/Library/LaunchAgents/ai.openclaw.gateway.plist";
 
 const BUILD_ENDPOINT_URL = "https://integrate.api.nvidia.com/v1";
@@ -2352,7 +2367,19 @@ async function preflight() {
     ignoreError: true,
   });
   const activeGatewayInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
-  const gatewayReuseState = getGatewayReuseState(gatewayStatus, gwInfo, activeGatewayInfo);
+  let gatewayReuseState = getGatewayReuseState(gatewayStatus, gwInfo, activeGatewayInfo);
+
+  // Verify the gateway container is actually running — openshell CLI metadata
+  // can be stale after a manual `docker rm`. See #2020.
+  if (gatewayReuseState === "healthy" && !verifyGatewayContainerRunning()) {
+    console.log("  Gateway metadata is stale (container not running). Cleaning up...");
+    runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+    runOpenshell(["gateway", "destroy", "-g", GATEWAY_NAME], { ignoreError: true });
+    registry.clearAll();
+    gatewayReuseState = "missing";
+    console.log("  ✓ Stale gateway metadata cleaned up");
+  }
+
   if (gatewayReuseState === "stale" || gatewayReuseState === "active-unnamed") {
     console.log("  Cleaning up previous NemoClaw session...");
     runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
@@ -5820,7 +5847,19 @@ async function onboard(opts = {}) {
       ignoreError: true,
     });
     const activeGatewayInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
-    const gatewayReuseState = getGatewayReuseState(gatewayStatus, gatewayInfo, activeGatewayInfo);
+    let gatewayReuseState = getGatewayReuseState(gatewayStatus, gatewayInfo, activeGatewayInfo);
+
+    // Verify the gateway container is actually running — openshell CLI metadata
+    // can be stale after a manual `docker rm`. See #2020.
+    if (gatewayReuseState === "healthy" && !verifyGatewayContainerRunning()) {
+      console.log("  Gateway metadata is stale (container not running). Cleaning up...");
+      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+      runOpenshell(["gateway", "destroy", "-g", GATEWAY_NAME], { ignoreError: true });
+      registry.clearAll();
+      gatewayReuseState = "missing";
+      console.log("  ✓ Stale gateway metadata cleaned up");
+    }
+
     const canReuseHealthyGateway = gatewayReuseState === "healthy";
     const resumeGateway =
       resume && session?.steps?.gateway?.status === "complete" && canReuseHealthyGateway;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2374,7 +2374,7 @@ async function preflight() {
   if (gatewayReuseState === "healthy" && !verifyGatewayContainerRunning()) {
     console.log("  Gateway metadata is stale (container not running). Cleaning up...");
     runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
-    runOpenshell(["gateway", "destroy", "-g", GATEWAY_NAME], { ignoreError: true });
+    destroyGateway();
     registry.clearAll();
     gatewayReuseState = "missing";
     console.log("  ✓ Stale gateway metadata cleaned up");
@@ -5925,7 +5925,7 @@ async function onboard(opts = {}) {
     if (gatewayReuseState === "healthy" && !verifyGatewayContainerRunning()) {
       console.log("  Gateway metadata is stale (container not running). Cleaning up...");
       runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
-      runOpenshell(["gateway", "destroy", "-g", GATEWAY_NAME], { ignoreError: true });
+      destroyGateway();
       registry.clearAll();
       gatewayReuseState = "missing";
       console.log("  ✓ Stale gateway metadata cleaned up");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -123,15 +123,30 @@ const BACK_TO_SELECTION = "__NEMOCLAW_BACK_TO_SELECTION__";
  * Probe whether the gateway Docker container is actually running.
  * openshell CLI metadata can be stale after a manual `docker rm`, so this
  * verifies the container is live before trusting a "healthy" reuse state.
- * See #2020.
+ *
+ * Returns "running" | "missing" | "unknown".
+ * - "running"  — container exists and State.Running is true
+ * - "missing"  — docker reports "No such object" (container was removed)
+ * - "unknown"  — any other failure (daemon down, timeout, etc.)
+ *
+ * Callers should only trigger stale-metadata cleanup on "missing", not on
+ * "unknown", to avoid destroying a healthy gateway when Docker is temporarily
+ * unavailable.  See #2020.
  */
 function verifyGatewayContainerRunning() {
   const containerName = `openshell-cluster-${GATEWAY_NAME}`;
   const result = run(
-    `docker inspect --type container --format '{{.State.Running}}' ${containerName} 2>/dev/null`,
+    `docker inspect --type container --format '{{.State.Running}}' ${containerName}`,
     { ignoreError: true, suppressOutput: true },
   );
-  return result.status === 0 && (result.stdout || "").trim() === "true";
+  if (result.status === 0 && (result.stdout || "").trim() === "true") {
+    return "running";
+  }
+  const stderr = (result.stderr || "").toString();
+  if (stderr.includes("No such object") || stderr.includes("No such container")) {
+    return "missing";
+  }
+  return "unknown";
 }
 const OPENCLAW_LAUNCH_AGENT_PLIST = "~/Library/LaunchAgents/ai.openclaw.gateway.plist";
 
@@ -2371,13 +2386,18 @@ async function preflight() {
 
   // Verify the gateway container is actually running — openshell CLI metadata
   // can be stale after a manual `docker rm`. See #2020.
-  if (gatewayReuseState === "healthy" && !verifyGatewayContainerRunning()) {
-    console.log("  Gateway metadata is stale (container not running). Cleaning up...");
-    runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
-    destroyGateway();
-    registry.clearAll();
-    gatewayReuseState = "missing";
-    console.log("  ✓ Stale gateway metadata cleaned up");
+  if (gatewayReuseState === "healthy") {
+    const containerState = verifyGatewayContainerRunning();
+    if (containerState === "missing") {
+      console.log("  Gateway metadata is stale (container not running). Cleaning up...");
+      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+      destroyGateway();
+      registry.clearAll();
+      gatewayReuseState = "missing";
+      console.log("  ✓ Stale gateway metadata cleaned up");
+    } else if (containerState === "unknown") {
+      console.log("  Warning: could not verify gateway container state (Docker may be unavailable). Proceeding with cached health status.");
+    }
   }
 
   if (gatewayReuseState === "stale" || gatewayReuseState === "active-unnamed") {
@@ -5922,13 +5942,18 @@ async function onboard(opts = {}) {
 
     // Verify the gateway container is actually running — openshell CLI metadata
     // can be stale after a manual `docker rm`. See #2020.
-    if (gatewayReuseState === "healthy" && !verifyGatewayContainerRunning()) {
-      console.log("  Gateway metadata is stale (container not running). Cleaning up...");
-      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
-      destroyGateway();
-      registry.clearAll();
-      gatewayReuseState = "missing";
-      console.log("  ✓ Stale gateway metadata cleaned up");
+    if (gatewayReuseState === "healthy") {
+      const containerState = verifyGatewayContainerRunning();
+      if (containerState === "missing") {
+        console.log("  Gateway metadata is stale (container not running). Cleaning up...");
+        runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+        destroyGateway();
+        registry.clearAll();
+        gatewayReuseState = "missing";
+        console.log("  ✓ Stale gateway metadata cleaned up");
+      } else if (containerState === "unknown") {
+        console.log("  Warning: could not verify gateway container state (Docker may be unavailable). Proceeding with cached health status.");
+      }
     }
 
     const canReuseHealthyGateway = gatewayReuseState === "healthy";

--- a/test/gateway-liveness-probe.test.ts
+++ b/test/gateway-liveness-probe.test.ts
@@ -45,18 +45,25 @@ describe("gateway liveness probe (#2020)", () => {
     expect(mainFlowProbe).toBeTruthy();
   });
 
-  it("downgrades to 'missing' when container is not running", () => {
-    // Both probe sites must set gatewayReuseState = "missing" on failure
-    const downgrades = content.match(/!verifyGatewayContainerRunning\(\)/g);
+  it("returns tri-state: running, missing, or unknown", () => {
+    // The helper must distinguish container-removed from Docker-unavailable
+    expect(content).toContain('return "running"');
+    expect(content).toContain('return "missing"');
+    expect(content).toContain('return "unknown"');
+  });
+
+  it("only downgrades to 'missing' when container is confirmed missing", () => {
+    // Both probe sites must check containerState === "missing" before cleanup
+    const downgrades = content.match(/containerState === "missing"/g);
     expect(downgrades).toBeTruthy();
     expect(downgrades.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("cleans up stale metadata when container is not running", () => {
-    // After detecting a stale container, the code must clean up forwarding
+  it("cleans up stale metadata when container is confirmed missing", () => {
+    // After detecting a removed container, the code must clean up forwarding
     // and destroy the gateway via the shared destroyGateway() helper.
     const cleanupAfterProbe = content.match(
-      /!verifyGatewayContainerRunning\(\)[\s\S]*?forward.*stop[\s\S]*?destroyGateway\(\)/,
+      /containerState === "missing"[\s\S]*?forward.*stop[\s\S]*?destroyGateway\(\)/,
     );
     expect(cleanupAfterProbe).toBeTruthy();
   });

--- a/test/gateway-liveness-probe.test.ts
+++ b/test/gateway-liveness-probe.test.ts
@@ -37,7 +37,9 @@ describe("gateway liveness probe (#2020)", () => {
 
   it("main onboard flow probes the container before canReuseHealthyGateway", () => {
     // The main onboard flow must also probe before setting canReuseHealthyGateway.
-    const mainFlowProbe = content.match(
+    // Scope to the onboard() function so the regex can't accidentally match the preflight block.
+    const onboardSection = content.slice(content.indexOf("async function onboard("));
+    const mainFlowProbe = onboardSection.match(
       /let gatewayReuseState = getGatewayReuseState[\s\S]*?verifyGatewayContainerRunning\(\)[\s\S]*?const canReuseHealthyGateway/,
     );
     expect(mainFlowProbe).toBeTruthy();
@@ -52,21 +54,27 @@ describe("gateway liveness probe (#2020)", () => {
 
   it("cleans up stale metadata when container is not running", () => {
     // After detecting a stale container, the code must clean up forwarding
-    // and destroy the gateway — same as the existing stale path.
+    // and destroy the gateway via the shared destroyGateway() helper.
     const cleanupAfterProbe = content.match(
-      /!verifyGatewayContainerRunning\(\)[\s\S]*?forward.*stop[\s\S]*?gateway.*destroy/,
+      /!verifyGatewayContainerRunning\(\)[\s\S]*?forward.*stop[\s\S]*?destroyGateway\(\)/,
     );
     expect(cleanupAfterProbe).toBeTruthy();
   });
 
   it("does not modify isGatewayHealthy() in gateway-state.ts", () => {
-    // isGatewayHealthy() must remain a pure function — no I/O
+    // isGatewayHealthy() must remain a pure function — no I/O.
+    // Scope the check to the function body so unrelated helpers don't cause false failures.
     const gsContent = fs.readFileSync(
       path.join(ROOT, "src/lib/gateway-state.ts"),
       "utf-8",
     );
-    expect(gsContent).not.toContain("docker");
-    expect(gsContent).not.toContain("spawn");
-    expect(gsContent).not.toContain("exec");
+    const fnMatch = gsContent.match(
+      /(?:function isGatewayHealthy|const isGatewayHealthy\b)[\s\S]*?\n\}/,
+    );
+    expect(fnMatch).toBeTruthy();
+    const fnBody = fnMatch[0];
+    expect(fnBody).not.toContain("docker");
+    expect(fnBody).not.toContain("spawn");
+    expect(fnBody).not.toContain("exec");
   });
 });

--- a/test/gateway-liveness-probe.test.ts
+++ b/test/gateway-liveness-probe.test.ts
@@ -1,0 +1,72 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verify that onboarding probes the gateway Docker container before trusting
+// "healthy" metadata from the openshell CLI. Without this, a stale local
+// state file causes step 2 to skip gateway startup even when the container
+// has been removed, leading to "Connection refused" in step 4.
+//
+// See: https://github.com/NVIDIA/NemoClaw/issues/2020
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+describe("gateway liveness probe (#2020)", () => {
+  const content = fs.readFileSync(path.join(ROOT, "src/lib/onboard.ts"), "utf-8");
+
+  it("verifyGatewayContainerRunning() helper exists and checks Docker state", () => {
+    expect(content).toContain("function verifyGatewayContainerRunning()");
+    // Must use docker inspect to probe container state
+    expect(content).toContain("docker inspect --type container");
+    // Must check .State.Running, not just container existence
+    expect(content).toContain("{{.State.Running}}");
+  });
+
+  it("preflight probes the container when gatewayReuseState is 'healthy'", () => {
+    // The preflight section must call the probe before entering the port loop.
+    // Find the first gatewayReuseState assignment and the port loop.
+    const preflightProbe = content.match(
+      /let gatewayReuseState = getGatewayReuseState[\s\S]*?verifyGatewayContainerRunning\(\)[\s\S]*?gatewayReuseState = "missing"/,
+    );
+    expect(preflightProbe).toBeTruthy();
+  });
+
+  it("main onboard flow probes the container before canReuseHealthyGateway", () => {
+    // The main onboard flow must also probe before setting canReuseHealthyGateway.
+    const mainFlowProbe = content.match(
+      /let gatewayReuseState = getGatewayReuseState[\s\S]*?verifyGatewayContainerRunning\(\)[\s\S]*?const canReuseHealthyGateway/,
+    );
+    expect(mainFlowProbe).toBeTruthy();
+  });
+
+  it("downgrades to 'missing' when container is not running", () => {
+    // Both probe sites must set gatewayReuseState = "missing" on failure
+    const downgrades = content.match(/!verifyGatewayContainerRunning\(\)/g);
+    expect(downgrades).toBeTruthy();
+    expect(downgrades.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("cleans up stale metadata when container is not running", () => {
+    // After detecting a stale container, the code must clean up forwarding
+    // and destroy the gateway — same as the existing stale path.
+    const cleanupAfterProbe = content.match(
+      /!verifyGatewayContainerRunning\(\)[\s\S]*?forward.*stop[\s\S]*?gateway.*destroy/,
+    );
+    expect(cleanupAfterProbe).toBeTruthy();
+  });
+
+  it("does not modify isGatewayHealthy() in gateway-state.ts", () => {
+    // isGatewayHealthy() must remain a pure function — no I/O
+    const gsContent = fs.readFileSync(
+      path.join(ROOT, "src/lib/gateway-state.ts"),
+      "utf-8",
+    );
+    expect(gsContent).not.toContain("docker");
+    expect(gsContent).not.toContain("spawn");
+    expect(gsContent).not.toContain("exec");
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixes #2020**: `nemoclaw onboard` step 2 skipped gateway startup when openshell CLI metadata reported "healthy" but the Docker container had been removed, causing "Connection refused" in step 4
- Adds `verifyGatewayContainerRunning()` helper that runs `docker inspect` to check actual container state before trusting a "healthy" reuse decision
- Applies the probe in both the preflight port check and the main onboard gateway-reuse flow, downgrading to `"missing"` and cleaning up stale metadata when the container is dead

## Test plan

- [ ] New `test/gateway-liveness-probe.test.ts` validates the probe helper exists, is called in both code paths, downgrades state correctly, and confirms `gateway-state.ts` remains pure (no I/O)
- [ ] Existing `test/gateway-state.test.ts` passes unchanged (pure classifier tests)
- [ ] Manual: remove gateway container (`docker rm openshell-cluster-nemoclaw`), run `nemoclaw onboard` — should detect stale metadata and start a fresh gateway instead of skipping
- [ ] Manual: with a healthy gateway running, `nemoclaw onboard` should still reuse it (happy path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway reliability: added a runtime liveness check before reusing a gateway; stops forwarding, clears stale local state, and prevents reuse when the gateway is missing. Unclear probe results emit a warning and retain the cached healthy status.

* **Tests**
  * Added tests validating the liveness check, the ordering of recovery/cleanup actions, and behavior for running/missing/unknown probe outcomes; also verifies health-check helpers are free of side-effecting runtime probes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->