### PR TITLE
fix(status): surface Telegram 409 conflicts by passing sandbox name via --name flag (Fixes #2018)

### DIFF
--- a/src/lib/messaging-bridge-health.test.ts
+++ b/src/lib/messaging-bridge-health.test.ts
@@ -93,6 +93,33 @@ describe("checkMessagingBridgeHealth", () => {
     expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
   });
 
+  it("returns empty when spawnSync reports a non-zero exit status (exec failed)", () => {
+    spawnSyncMock.mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: "",
+      stderr: "/bin/bash: alpha: command not found\n",
+      status: 127,
+      signal: null,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
+  });
+
+  it("returns empty when spawnSync returns an error object (e.g. timeout)", () => {
+    spawnSyncMock.mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: null,
+      stderr: null,
+      status: null,
+      signal: "SIGTERM",
+      error: new Error("spawnSync timed out"),
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
+  });
+
   // Regression for #2018: `openshell sandbox exec` requires the --name/-n
   // flag. Passing the sandbox name as a positional causes the name to be
   // interpreted as the first word of the command and fails with exit 127.

--- a/src/lib/messaging-bridge-health.test.ts
+++ b/src/lib/messaging-bridge-health.test.ts
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./resolve-openshell.js", () => ({
+  resolveOpenshell: vi.fn(() => "/usr/local/bin/openshell"),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawnSync: vi.fn() };
+});
+
+import { checkMessagingBridgeHealth } from "./messaging-bridge-health.js";
+import { spawnSync } from "node:child_process";
+import { resolveOpenshell } from "./resolve-openshell.js";
+
+const spawnSyncMock = vi.mocked(spawnSync);
+const resolveOpenshellMock = vi.mocked(resolveOpenshell);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resolveOpenshellMock.mockReturnValue("/usr/local/bin/openshell");
+});
+
+describe("checkMessagingBridgeHealth", () => {
+  it("returns empty and does not spawn when channels does not include telegram", () => {
+    const result = checkMessagingBridgeHealth("alpha", ["discord", "slack"]);
+    expect(result).toEqual([]);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("returns empty and does not spawn when channels is null/undefined", () => {
+    expect(checkMessagingBridgeHealth("alpha", null)).toEqual([]);
+    expect(checkMessagingBridgeHealth("alpha", undefined)).toEqual([]);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when openshell binary cannot be resolved", () => {
+    resolveOpenshellMock.mockReturnValue(null);
+    const result = checkMessagingBridgeHealth("alpha", ["telegram"]);
+    expect(result).toEqual([]);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a conflict entry when gateway log reports N conflicts", () => {
+    spawnSyncMock.mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: "32\n",
+      stderr: "",
+      status: 0,
+      signal: null,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    const result = checkMessagingBridgeHealth("alpha", ["telegram"]);
+    expect(result).toEqual([{ channel: "telegram", conflicts: 32 }]);
+  });
+
+  it("returns empty when the conflict count is zero", () => {
+    spawnSyncMock.mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: "0\n",
+      stderr: "",
+      status: 0,
+      signal: null,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    const result = checkMessagingBridgeHealth("alpha", ["telegram"]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when the count is non-numeric", () => {
+    spawnSyncMock.mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: "\n",
+      stderr: "",
+      status: 0,
+      signal: null,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
+  });
+
+  it("returns empty when spawnSync throws", () => {
+    spawnSyncMock.mockImplementation(() => {
+      throw new Error("spawn EPIPE");
+    });
+
+    expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
+  });
+
+  // Regression for #2018: `openshell sandbox exec` requires the --name/-n
+  // flag. Passing the sandbox name as a positional causes the name to be
+  // interpreted as the first word of the command and fails with exit 127.
+  describe("argv shape (#2018 regression)", () => {
+    beforeEach(() => {
+      spawnSyncMock.mockReturnValue({
+        pid: 0,
+        output: [],
+        stdout: "5\n",
+        stderr: "",
+        status: 0,
+        signal: null,
+      } as unknown as ReturnType<typeof spawnSync>);
+    });
+
+    it("passes the sandbox name via --name/-n, not as a positional", () => {
+      checkMessagingBridgeHealth("tele-brev", ["telegram"]);
+
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      const [binary, args] = spawnSyncMock.mock.calls[0];
+      expect(binary).toBe("/usr/local/bin/openshell");
+
+      const argsArray = args as string[];
+      expect(argsArray).toContain("-n");
+      const nameFlagIdx = argsArray.indexOf("-n");
+      expect(argsArray[nameFlagIdx + 1]).toBe("tele-brev");
+
+      // Pre-fix, args were ["sandbox", "exec", "<name>", "sh", "-c", <script>].
+      // Ensure the sandbox name is not directly adjacent to "exec" (positional).
+      const execIdx = argsArray.indexOf("exec");
+      expect(argsArray[execIdx + 1]).not.toBe("tele-brev");
+    });
+
+    it("separates the command from flags with `--`", () => {
+      checkMessagingBridgeHealth("tele-brev", ["telegram"]);
+      const [, args] = spawnSyncMock.mock.calls[0];
+      const argsArray = args as string[];
+      const sepIdx = argsArray.indexOf("--");
+      expect(sepIdx).toBeGreaterThan(-1);
+      expect(argsArray[sepIdx + 1]).toBe("sh");
+      expect(argsArray[sepIdx + 2]).toBe("-c");
+    });
+  });
+});

--- a/src/lib/messaging-bridge-health.test.ts
+++ b/src/lib/messaging-bridge-health.test.ts
@@ -19,6 +19,19 @@ import { resolveOpenshell } from "./resolve-openshell.js";
 const spawnSyncMock = vi.mocked(spawnSync);
 const resolveOpenshellMock = vi.mocked(resolveOpenshell);
 
+type SpawnResult = ReturnType<typeof spawnSync>;
+function mockSpawn(overrides: Partial<SpawnResult> = {}): void {
+  spawnSyncMock.mockReturnValue({
+    pid: 0,
+    output: [],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+    ...overrides,
+  } as unknown as SpawnResult);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   resolveOpenshellMock.mockReturnValue("/usr/local/bin/openshell");
@@ -45,43 +58,19 @@ describe("checkMessagingBridgeHealth", () => {
   });
 
   it("returns a conflict entry when gateway log reports N conflicts", () => {
-    spawnSyncMock.mockReturnValue({
-      pid: 0,
-      output: [],
-      stdout: "32\n",
-      stderr: "",
-      status: 0,
-      signal: null,
-    } as unknown as ReturnType<typeof spawnSync>);
-
-    const result = checkMessagingBridgeHealth("alpha", ["telegram"]);
-    expect(result).toEqual([{ channel: "telegram", conflicts: 32 }]);
+    mockSpawn({ stdout: "32\n" });
+    expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([
+      { channel: "telegram", conflicts: 32 },
+    ]);
   });
 
   it("returns empty when the conflict count is zero", () => {
-    spawnSyncMock.mockReturnValue({
-      pid: 0,
-      output: [],
-      stdout: "0\n",
-      stderr: "",
-      status: 0,
-      signal: null,
-    } as unknown as ReturnType<typeof spawnSync>);
-
-    const result = checkMessagingBridgeHealth("alpha", ["telegram"]);
-    expect(result).toEqual([]);
+    mockSpawn({ stdout: "0\n" });
+    expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
   });
 
   it("returns empty when the count is non-numeric", () => {
-    spawnSyncMock.mockReturnValue({
-      pid: 0,
-      output: [],
-      stdout: "\n",
-      stderr: "",
-      status: 0,
-      signal: null,
-    } as unknown as ReturnType<typeof spawnSync>);
-
+    mockSpawn({ stdout: "\n" });
     expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
   });
 
@@ -89,34 +78,22 @@ describe("checkMessagingBridgeHealth", () => {
     spawnSyncMock.mockImplementation(() => {
       throw new Error("spawn EPIPE");
     });
-
     expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
   });
 
   it("returns empty when spawnSync reports a non-zero exit status (exec failed)", () => {
-    spawnSyncMock.mockReturnValue({
-      pid: 0,
-      output: [],
-      stdout: "",
-      stderr: "/bin/bash: alpha: command not found\n",
-      status: 127,
-      signal: null,
-    } as unknown as ReturnType<typeof spawnSync>);
-
+    mockSpawn({ stderr: "/bin/bash: alpha: command not found\n", status: 127 });
     expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
   });
 
   it("returns empty when spawnSync returns an error object (e.g. timeout)", () => {
-    spawnSyncMock.mockReturnValue({
-      pid: 0,
-      output: [],
-      stdout: null,
-      stderr: null,
+    mockSpawn({
+      stdout: null as unknown as string,
+      stderr: null as unknown as string,
       status: null,
       signal: "SIGTERM",
       error: new Error("spawnSync timed out"),
-    } as unknown as ReturnType<typeof spawnSync>);
-
+    });
     expect(checkMessagingBridgeHealth("alpha", ["telegram"])).toEqual([]);
   });
 
@@ -124,16 +101,7 @@ describe("checkMessagingBridgeHealth", () => {
   // flag. Passing the sandbox name as a positional causes the name to be
   // interpreted as the first word of the command and fails with exit 127.
   describe("argv shape (#2018 regression)", () => {
-    beforeEach(() => {
-      spawnSyncMock.mockReturnValue({
-        pid: 0,
-        output: [],
-        stdout: "5\n",
-        stderr: "",
-        status: 0,
-        signal: null,
-      } as unknown as ReturnType<typeof spawnSync>);
-    });
+    beforeEach(() => mockSpawn({ stdout: "5\n" }));
 
     it("passes the sandbox name via --name/-n, not as a positional", () => {
       checkMessagingBridgeHealth("tele-brev", ["telegram"]);
@@ -143,8 +111,8 @@ describe("checkMessagingBridgeHealth", () => {
       expect(binary).toBe("/usr/local/bin/openshell");
 
       const argsArray = args as string[];
-      expect(argsArray).toContain("-n");
       const nameFlagIdx = argsArray.indexOf("-n");
+      expect(nameFlagIdx).toBeGreaterThan(-1);
       expect(argsArray[nameFlagIdx + 1]).toBe("tele-brev");
 
       // Pre-fix, args were ["sandbox", "exec", "<name>", "sh", "-c", <script>].

--- a/src/lib/messaging-bridge-health.ts
+++ b/src/lib/messaging-bridge-health.ts
@@ -1,16 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Messaging-channel bridge health probe.
-//
-// Scans the gateway log inside the sandbox for conflict signatures that
-// indicate another consumer is holding the messaging provider's long-poll
-// (Telegram's single-getUpdates-consumer constraint is the canonical case).
-// Results surface as a "degraded" warning in `nemoclaw <sandbox> status`.
-//
-// Only Telegram currently emits a recognisable signature — Discord/Slack
-// have similar single-consumer constraints but log differently, and the
-// regex can be extended when those patterns are known.
 
 import { spawnSync } from "node:child_process";
 import { resolveOpenshell } from "./resolve-openshell.js";

--- a/src/lib/messaging-bridge-health.ts
+++ b/src/lib/messaging-bridge-health.ts
@@ -43,6 +43,7 @@ export function checkMessagingBridgeHealth(
       timeout: 3000,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    if (result.error || result.status !== 0) return [];
     const count = Number.parseInt((result.stdout || "").trim(), 10);
     if (!Number.isFinite(count) || count === 0) return [];
     return [{ channel: "telegram", conflicts: count }];

--- a/src/lib/messaging-bridge-health.ts
+++ b/src/lib/messaging-bridge-health.ts
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
+import type { MessagingBridgeHealth } from "./inventory-commands.js";
 import { resolveOpenshell } from "./resolve-openshell.js";
-
-export interface BridgeConflict {
-  channel: string;
-  conflicts: number;
-}
 
 const CONFLICT_SCRIPT =
   'tail -n 200 /tmp/gateway.log 2>/dev/null | grep -cE "getUpdates conflict|409[[:space:]:]+Conflict" || true';
@@ -15,7 +11,7 @@ const CONFLICT_SCRIPT =
 export function checkMessagingBridgeHealth(
   sandboxName: string,
   channels: readonly string[] | null | undefined,
-): BridgeConflict[] {
+): MessagingBridgeHealth[] {
   if (!Array.isArray(channels) || !channels.includes("telegram")) return [];
 
   const binary = resolveOpenshell();

--- a/src/lib/messaging-bridge-health.ts
+++ b/src/lib/messaging-bridge-health.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Messaging-channel bridge health probe.
+//
+// Scans the gateway log inside the sandbox for conflict signatures that
+// indicate another consumer is holding the messaging provider's long-poll
+// (Telegram's single-getUpdates-consumer constraint is the canonical case).
+// Results surface as a "degraded" warning in `nemoclaw <sandbox> status`.
+//
+// Only Telegram currently emits a recognisable signature — Discord/Slack
+// have similar single-consumer constraints but log differently, and the
+// regex can be extended when those patterns are known.
+
+import { spawnSync } from "node:child_process";
+import { resolveOpenshell } from "./resolve-openshell.js";
+
+export interface BridgeConflict {
+  channel: string;
+  conflicts: number;
+}
+
+const CONFLICT_SCRIPT =
+  'tail -n 200 /tmp/gateway.log 2>/dev/null | grep -cE "getUpdates conflict|409[[:space:]:]+Conflict" || true';
+
+export function checkMessagingBridgeHealth(
+  sandboxName: string,
+  channels: readonly string[] | null | undefined,
+): BridgeConflict[] {
+  if (!Array.isArray(channels) || !channels.includes("telegram")) return [];
+
+  const binary = resolveOpenshell();
+  if (!binary) return [];
+
+  // `openshell sandbox exec` requires --name/-n for the sandbox name; a
+  // positional there gets parsed as the first word of the command and
+  // fails with exit 127 (#2018).
+  const args = ["sandbox", "exec", "-n", sandboxName, "--", "sh", "-c", CONFLICT_SCRIPT];
+
+  try {
+    const result = spawnSync(binary, args, {
+      encoding: "utf-8",
+      timeout: 3000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const count = Number.parseInt((result.stdout || "").trim(), 10);
+    if (!Number.isFinite(count) || count === 0) return [];
+    return [{ channel: "telegram", conflicts: count }];
+  } catch {
+    return [];
+  }
+}

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1091,7 +1091,7 @@ function readGatewayLog(sandboxName) {
   try {
     const result = spawnSync(
       getOpenshellBinary(),
-      ["sandbox", "exec", sandboxName, "sh", "-c", "tail -n 10 /tmp/gateway.log 2>/dev/null"],
+      ["sandbox", "exec", "-n", sandboxName, "--", "sh", "-c", "tail -n 10 /tmp/gateway.log 2>/dev/null"],
       { encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
     );
     const output = (result.stdout || "").trim();

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1047,27 +1047,7 @@ async function credentialsCommand(args) {
   process.exit(1);
 }
 
-function checkMessagingBridgeHealth(sandboxName, channels) {
-  // Only Telegram currently emits a recognizable conflict signature in the
-  // gateway log. Discord/Slack have similar single-consumer constraints but
-  // log differently; we can extend the regex when those patterns are known.
-  if (!Array.isArray(channels) || !channels.includes("telegram")) return [];
-  const { spawnSync } = require("child_process");
-  const script =
-    'tail -n 200 /tmp/gateway.log 2>/dev/null | grep -cE "getUpdates conflict|409[[:space:]:]+Conflict" || true';
-  try {
-    const result = spawnSync(
-      getOpenshellBinary(),
-      ["sandbox", "exec", sandboxName, "sh", "-c", script],
-      { encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
-    );
-    const count = Number.parseInt((result.stdout || "").trim(), 10);
-    if (!Number.isFinite(count) || count === 0) return [];
-    return [{ channel: "telegram", conflicts: count }];
-  } catch {
-    return [];
-  }
-}
+const { checkMessagingBridgeHealth } = require("./lib/messaging-bridge-health");
 
 function makeConflictProbe() {
   // Upfront liveness check so we can distinguish "provider not attached" from

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1094,6 +1094,7 @@ function readGatewayLog(sandboxName) {
       ["sandbox", "exec", "-n", sandboxName, "--", "sh", "-c", "tail -n 10 /tmp/gateway.log 2>/dev/null"],
       { encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
     );
+    if (result.error || result.status !== 0) return null;
     const output = (result.stdout || "").trim();
     return output || null;
   } catch {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`checkMessagingBridgeHealth()` invoked `openshell sandbox exec` with the sandbox name as a positional argument. `openshell sandbox exec` requires `--name`/`-n` — the positional was parsed as the first word of the command and exited 127. The function's catch-all swallowed the error, so the "degraded" warning for Telegram 409 conflicts never appeared in `nemoclaw <sandbox> status`.

## Related Issue

Fixes #2018

## Changes

- Extract `checkMessagingBridgeHealth` from the IIFE-style `src/nemoclaw.ts` into a new `src/lib/messaging-bridge-health.ts` so the argv shape is unit-testable.
- Use the correct `openshell sandbox exec -n <name> -- sh -c <script>` form.
- Use `resolveOpenshell()` directly and return an empty list if the binary is missing (matches the pattern in `sandbox-state.ts` / `sandbox-version.ts`), instead of relying on the caller's cached helper that hard-exits.
- Add `src/lib/messaging-bridge-health.test.ts` with 9 unit tests: happy path, zero-count, non-numeric stdout, `spawnSync` throws, non-Telegram channels, null/undefined channels, missing binary, and two regression tests that pin the argv shape (both fail on the pre-fix arguments).

### Note for reviewer

The same `sandbox exec <name> …` positional pattern appears in a few other places:

- `src/lib/agent-onboard.ts:135,177` — agent readiness probes
- `src/lib/sandbox-state.ts:388` — post-restore `chown` during rebuild

Those are outside this issue's scope; flagging in case you want a follow-up.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool:

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: sanketsh4h <sanketshah5135@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a messaging-bridge health check that reports Telegram conflict counts when present.

* **Refactor**
  * Moves bridge health logic into a dedicated module and improves reliability, error handling, and sandboxed invocation.

* **Tests**
  * Adds comprehensive tests covering success, failure, parsing, argument construction, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->