### PR TITLE
fix: reject unrecognized config paths in config set (Fixes #2019)

### DIFF
--- a/src/lib/sandbox-config.ts
+++ b/src/lib/sandbox-config.ts
@@ -114,6 +114,24 @@ function setDotpath(obj: Record<string, unknown>, dotpath: string, value: unknow
 }
 
 /**
+ * Return true when every segment in a dotpath is an own property on the
+ * current config object, which keeps config set constrained to recognized keys.
+ */
+function isRecognizedConfigPath(obj: unknown, dotpath: string): boolean {
+  if (!dotpath || typeof dotpath !== "string") return false;
+  const keys = dotpath.split(".");
+  if (keys.some((key) => !key)) return false;
+
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (current == null || typeof current !== "object" || Array.isArray(current)) return false;
+    if (!Object.prototype.hasOwnProperty.call(current as Record<string, unknown>, key)) return false;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return true;
+}
+
+/**
  * Parse a config file's raw text according to its format.
  */
 function parseConfig(raw: string, format: string): Record<string, unknown> {
@@ -305,6 +323,11 @@ function configSet(sandboxName: string, opts: ConfigSetOpts = {}): void {
   if (opts.key.startsWith("gateway.") || opts.key === "gateway") {
     console.error("  Cannot modify the gateway section directly.");
     console.error("  Use `nemoclaw config rotate-token` for credential changes.");
+    process.exit(1);
+  }
+
+  if (!isRecognizedConfigPath(config, opts.key)) {
+    console.error(`  Key validation failed: "${opts.key}" is not a recognized ${target.agentName} config path.`);
     process.exit(1);
   }
 
@@ -522,6 +545,7 @@ export {
   resolveAgentConfig,
   extractDotpath,
   setDotpath,
+  isRecognizedConfigPath,
   validateUrlValue,
   readStdin,
 };

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -1,10 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createRequire } from "node:module";
 import { describe, it, expect } from "vitest";
 
 // Build must run before these tests (imports from dist/)
-const { extractDotpath, setDotpath, validateUrlValue, resolveAgentConfig } = require("../dist/lib/sandbox-config");
+const require = createRequire(import.meta.url);
+const {
+  extractDotpath,
+  isRecognizedConfigPath,
+  setDotpath,
+  validateUrlValue,
+  resolveAgentConfig,
+} = require("../dist/lib/sandbox-config");
 
 describe("resolveAgentConfig", () => {
   it("returns openclaw defaults for unknown sandbox", () => {
@@ -77,6 +85,47 @@ describe("config set helpers", () => {
       const obj: Record<string, unknown> = { a: { existing: true } };
       setDotpath(obj, "a.newKey", "added");
       expect(obj.a).toEqual({ existing: true, newKey: "added" });
+    });
+  });
+
+  describe("isRecognizedConfigPath", () => {
+    it("accepts an existing top-level key", () => {
+      expect(isRecognizedConfigPath({ version: 1 }, "version")).toBe(true);
+    });
+
+    it("accepts an existing nested key path", () => {
+      expect(
+        isRecognizedConfigPath(
+          { agents: { defaults: { model: { primary: "gpt-5.4" } } } },
+          "agents.defaults.model.primary",
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts existing keys whose value is null", () => {
+      expect(isRecognizedConfigPath({ provider: { endpoint: null } }, "provider.endpoint")).toBe(true);
+    });
+
+    it("rejects an unknown top-level key", () => {
+      expect(isRecognizedConfigPath({ version: 1 }, "inference.endpoint")).toBe(false);
+    });
+
+    it("rejects an unknown nested key", () => {
+      expect(
+        isRecognizedConfigPath(
+          { agents: { defaults: { model: { primary: "gpt-5.4" } } } },
+          "agents.defaults.model.secondary",
+        ),
+      ).toBe(false);
+    });
+
+    it("rejects malformed dotpaths", () => {
+      expect(isRecognizedConfigPath({ version: 1 }, "agents..defaults")).toBe(false);
+    });
+
+    it("rejects prototype-inherited keys", () => {
+      expect(isRecognizedConfigPath({}, "toString")).toBe(false);
+      expect(isRecognizedConfigPath({ safe: {} }, "safe.constructor")).toBe(false);
     });
   });
 

--- a/test/e2e/test-shields-config.sh
+++ b/test/e2e/test-shields-config.sh
@@ -270,7 +270,7 @@ section "Phase 5: config set"
 
 # Set a test key
 CONFIG_SET_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" config set \
-  --key "nemoclaw_e2e_test" --value '"shields-config-e2e"' 2>&1)
+  --key "agents.defaults.model.primary" --value '"shields-config-e2e"' 2>&1)
 echo "$CONFIG_SET_OUTPUT"
 
 if echo "$CONFIG_SET_OUTPUT" | grep -q "Config updated\|config updated"; then
@@ -280,7 +280,7 @@ else
 fi
 
 # Verify the change is visible via config get
-VERIFY_SET=$(nemoclaw "${SANDBOX_NAME}" config get --key nemoclaw_e2e_test 2>&1)
+VERIFY_SET=$(nemoclaw "${SANDBOX_NAME}" config get --key agents.defaults.model.primary 2>&1)
 if echo "$VERIFY_SET" | grep -q "shields-config-e2e"; then
   pass "config set change visible in config get"
 else
@@ -298,7 +298,7 @@ fi
 
 # Verify SSRF validation on URLs
 SSRF_SET=$(nemoclaw "${SANDBOX_NAME}" config set \
-  --key "test_url" --value '"http://127.0.0.1:8080/steal"' 2>&1 || true)
+  --key "agents.defaults.model.primary" --value '"http://127.0.0.1:8080/steal"' 2>&1 || true)
 if echo "$SSRF_SET" | grep -qi "private\|validation failed"; then
   pass "config set blocks private IP URLs (SSRF)"
 else
@@ -377,7 +377,7 @@ fi
 # ══════════════════════════════════════════════════════════════════
 section "Phase 8: Config changes persist"
 
-PERSIST_CHECK=$(nemoclaw "${SANDBOX_NAME}" config get --key nemoclaw_e2e_test 2>&1)
+PERSIST_CHECK=$(nemoclaw "${SANDBOX_NAME}" config get --key agents.defaults.model.primary 2>&1)
 if echo "$PERSIST_CHECK" | grep -q "shields-config-e2e"; then
   pass "Config changes survived shields up (persisted)"
 else


### PR DESCRIPTION
Fixes #2019

## Summary

`nemoclaw <name> config set` was accepting arbitrary dotpaths and writing them straight into `openclaw.json`. That made it easy to create config keys that OpenClaw does not recognize, which then breaks agent startup.

This change makes `config set` reject unrecognized config paths before it writes anything.

## Changes

- `src/lib/sandbox-config.ts`: added `isRecognizedConfigPath()` and made `configSet()` fail fast when the requested dotpath is not already present in the current agent config.
- `test/config-set.test.ts`: added regression coverage for recognized and unrecognized config paths.
- `test/e2e/test-shields-config.sh`: updated the config-set smoke path to mutate a real existing config field instead of relying on creating a brand-new top-level key.

## Testing

- `npm run build:cli`
- `npm run typecheck:cli`
- `npm test -- test/config-set.test.ts test/config-rotate-token.test.ts`

## Evidence It Works

- `config set --key inference.endpoint ...` now fails with a key validation error instead of corrupting `openclaw.json`.
- The focused config helper tests pass, including the new path-recognition regression coverage.

## Notes

- I also ran `npm test`. In this worktree it still reproduces unrelated existing failures in `test/legacy-path-guard.test.ts`, `src/lib/preflight.test.ts`, `src/lib/sandbox-version.test.ts`, and `test/install-preflight.test.ts`.

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration commands now validate that dot-path keys are well-formed and recognized; invalid keys produce a clear error and terminate the operation.

* **Tests**
  * Added unit tests for valid/invalid configuration paths and updated end-to-end tests to verify the new validation and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->