### PR TITLE
fix: use named exec for bridge health probe (Fixes #2018)

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1047,6 +1047,10 @@ async function credentialsCommand(args) {
   process.exit(1);
 }
 
+/**
+ * Inspect gateway logs for known Telegram conflict signatures without blocking
+ * the broader status command when the probe cannot run.
+ */
 function checkMessagingBridgeHealth(sandboxName, channels) {
   // Only Telegram currently emits a recognizable conflict signature in the
   // gateway log. Discord/Slack have similar single-consumer constraints but
@@ -1058,7 +1062,7 @@ function checkMessagingBridgeHealth(sandboxName, channels) {
   try {
     const result = spawnSync(
       getOpenshellBinary(),
-      ["sandbox", "exec", sandboxName, "sh", "-c", script],
+      ["sandbox", "exec", "-n", sandboxName, "--", "sh", "-c", script],
       { encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
     );
     const count = Number.parseInt((result.stdout || "").trim(), 10);
@@ -1106,12 +1110,15 @@ function backfillAndFindOverlaps() {
   }
 }
 
+/**
+ * Read a short tail of the gateway log for degraded messaging diagnostics.
+ */
 function readGatewayLog(sandboxName) {
   const { spawnSync } = require("child_process");
   try {
     const result = spawnSync(
       getOpenshellBinary(),
-      ["sandbox", "exec", sandboxName, "sh", "-c", "tail -n 10 /tmp/gateway.log 2>/dev/null"],
+      ["sandbox", "exec", "-n", sandboxName, "--", "sh", "-c", "tail -n 10 /tmp/gateway.log 2>/dev/null"],
       { encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
     );
     const output = (result.stdout || "").trim();

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -295,6 +295,66 @@ describe("CLI dispatch", () => {
     expect(fs.readFileSync(markerFile, "utf8")).not.toContain("--follow");
   });
 
+  it("uses named sandbox exec for bridge status helpers", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-status-messaging-"));
+    const localBin = path.join(home, "bin");
+    const registryDir = path.join(home, ".nemoclaw");
+    const markerFile = path.join(home, "openshell.log");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify({
+        sandboxes: {
+          alpha: {
+            name: "alpha",
+            model: "test-model",
+            provider: "nvidia-prod",
+            gpuEnabled: false,
+            policies: [],
+            messagingChannels: ["telegram"],
+            agent: "hermes",
+          },
+        },
+        defaultSandbox: "alpha",
+      }),
+      { mode: 0o600 },
+    );
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        `marker_file=${JSON.stringify(markerFile)}`,
+        'printf \'%s\\n\' "$*" >> "$marker_file"',
+        'if [ "$1" = "sandbox" ] && [ "$2" = "exec" ]; then',
+        '  if [ "$8" = "tail -n 200 /tmp/gateway.log 2>/dev/null | grep -cE \\"getUpdates conflict|409[[:space:]:]+Conflict\\" || true" ]; then',
+        "    echo 1",
+        "    exit 0",
+        "  fi",
+        '  if [ "$8" = "tail -n 10 /tmp/gateway.log 2>/dev/null" ]; then',
+        "    echo 'getUpdates conflict'",
+        "    exit 0",
+        "  fi",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("status", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    const log = fs.readFileSync(markerFile, "utf8");
+    expect(r.code).toBe(0);
+    expect(log).toContain(
+      'sandbox exec -n alpha -- sh -c tail -n 200 /tmp/gateway.log 2>/dev/null | grep -cE "getUpdates conflict|409[[:space:]:]+Conflict" || true',
+    );
+    expect(log).toContain("sandbox exec -n alpha -- sh -c tail -n 10 /tmp/gateway.log 2>/dev/null");
+    expect(log).not.toContain("sandbox exec alpha sh -c");
+  });
+
   it("destroys the gateway runtime when the last sandbox is removed", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-destroy-last-"));
     const localBin = path.join(home, "bin");


### PR DESCRIPTION
Fixes #2018

## Summary

`checkMessagingBridgeHealth()` was calling `openshell sandbox exec` with the sandbox name as a positional argument. That form silently misses the intended sandbox on current OpenShell, so the Telegram conflict probe never checks the right target.

This change switches the probe to the named-sandbox form that OpenShell expects.

## Changes

- `src/nemoclaw.ts`: changed the bridge-health probe to use `openshell sandbox exec -n <sandbox> -- sh -c ...`.
- `test/cli.test.ts`: added a CLI regression test that drives `nemoclaw status` with a fake `openshell` binary and verifies the exact argv shape used for the bridge-health exec call.

## Testing

- `npm run build:cli`
- `npm run typecheck:cli`
- `npm test -- test/cli.test.ts`

## Evidence It Works

- The new CLI regression test confirms the status path now invokes `sandbox exec -n alpha -- sh -c ...`.
- The focused CLI suite passes with the new coverage in place.

## Notes

- I also ran `npm test`. In this worktree it still reproduces unrelated existing failures in `test/legacy-path-guard.test.ts`, `src/lib/preflight.test.ts`, `src/lib/sandbox-version.test.ts`, and `test/install-preflight.test.ts`.

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted internal messaging-bridge health check and gateway log handling to use a consistent named-sandbox invocation format.
* **Documentation**
  * Updated documentation for gateway log reading and health-check probe behavior.
* **Tests**
  * Added a CLI test verifying status/health-check uses the named-sandbox execution form and exits successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->