### PR TITLE
fix(dns): retry DNS verification and extend proxy readiness wait for Jetson

### DIFF
--- a/scripts/setup-dns-proxy.sh
+++ b/scripts/setup-dns-proxy.sh
@@ -164,7 +164,7 @@ kctl exec -n openshell "$POD" -- \
 _dns_ready=0
 for _i in $(seq 1 10); do
   if kctl exec -n openshell "$POD" -- \
-    sh -c "echo -ne '\x00\x1e\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x06google\x03com\x00\x00\x01\x00\x01' \
+    sh -c "printf '%b' '\x00\x1e\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x06google\x03com\x00\x00\x01\x00\x01' \
       | timeout 1 socat - UDP:${VETH_GW}:53 2>/dev/null" | grep -q .; then
     _dns_ready=1
     break

--- a/scripts/setup-dns-proxy.sh
+++ b/scripts/setup-dns-proxy.sh
@@ -158,7 +158,22 @@ kctl exec -n openshell "$POD" -- \
   sh -c "nohup python3 -u /tmp/dns-proxy.py '${DNS_UPSTREAM}' '${VETH_GW}' \
     > /tmp/dns-proxy.log 2>&1 &"
 
-sleep 2
+# Wait for forwarder to actually be serving (up to 10s).
+# The PID file is written before the socket is bound, so we probe
+# with a real DNS query instead of just checking the file. See #2017.
+_dns_ready=0
+for _i in $(seq 1 10); do
+  if kctl exec -n openshell "$POD" -- \
+    sh -c "echo -ne '\x00\x1e\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x06google\x03com\x00\x00\x01\x00\x01' \
+      | timeout 1 socat - UDP:${VETH_GW}:53 2>/dev/null" | grep -q .; then
+    _dns_ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "$_dns_ready" -eq 0 ]; then
+  echo "WARNING: DNS forwarder not responding after 10s — verification may fail"
+fi
 
 # ── Step 4: Allow UDP DNS in sandbox iptables ───────────────────────
 #
@@ -272,12 +287,19 @@ if [ -n "$SANDBOX_NS" ]; then
   fi
 
   # 6d. Actual DNS resolution from sandbox (getent hosts)
-  DNS_RESULT="$(sb_exec getent hosts github.com 2>/dev/null || true)"
+  # Retry up to 3 times — on slower hardware (Jetson ARM64) the forwarder
+  # may need a few extra seconds after binding. See #2017.
+  DNS_RESULT=""
+  for _dns_try in 1 2 3; do
+    DNS_RESULT="$(sb_exec getent hosts github.com 2>/dev/null || true)"
+    [ -n "$DNS_RESULT" ] && break
+    [ "$_dns_try" -lt 3 ] && sleep 2
+  done
   if [ -n "$DNS_RESULT" ]; then
     echo "  [PASS] getent hosts github.com -> ${DNS_RESULT}"
     VERIFY_PASS=$((VERIFY_PASS + 1))
   else
-    echo "  [FAIL] getent hosts github.com returned empty (DNS not resolving)"
+    echo "  [FAIL] getent hosts github.com returned empty after 3 attempts (DNS not resolving)"
     VERIFY_FAIL=$((VERIFY_FAIL + 1))
   fi
 else


### PR DESCRIPTION
## Summary

- **Fixes #2017** — DNS verification fails on Jetson Orin (aarch64) due to a timing race between the DNS forwarder binding its UDP socket and the `getent hosts` check firing.
- Replaces the fixed `sleep 2` after forwarder launch with a readiness poll (up to 10s) that sends a real DNS query via socat to confirm the forwarder is actually serving.
- Adds retry logic (3 attempts, 2s apart) to the `getent hosts github.com` verification so transient startup delays on slower hardware don't cause a spurious FAIL.

## Regression risk

Low. Both changes degrade gracefully — if socat is missing or the probe fails, the script falls through with a warning (same as before, just slower). No changes to the forwarder, iptables rules, resolv.conf rewriting, or CoreDNS discovery. DNS failure remains a warning, not a fatal error.

## Test plan

- [ ] Run `nemoclaw onboard` on Jetson Orin (aarch64) — all 4 DNS verification checks should pass
- [ ] Run `nemoclaw onboard` on x86 — verify no regression, readiness poll exits quickly (~1-2s)
- [ ] Test with a pod image that lacks socat — readiness poll should fall through with WARNING after 10s, getent retry should still pass
- [ ] Test with DNS genuinely broken — verify FAIL is reported after 3 retry attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced fixed startup delay with active DNS readiness checks and bounded retry loops for the DNS forwarder and runtime resolution.
  * Improved retry behavior and updated reporting when DNS remains unresponsive after multiple attempts, yielding more reliable network initialization and clearer warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->