### PR TITLE
fix: prompt for NGC API key when pulling local NIM images

### DIFF
--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -309,8 +309,10 @@ describe("nim", () => {
       }
     });
 
-    it("returns true when auths has https://nvcr.io with token field", () => {
-      const restore = mockDockerConfig(JSON.stringify({ auths: { "https://nvcr.io": { token: "abc123" } } }));
+    it("returns true when auths has https://nvcr.io with auth field", () => {
+      const restore = mockDockerConfig(
+        JSON.stringify({ auths: { "https://nvcr.io": { auth: "dXNlcjpwYXNz" } } }),
+      );
       try {
         expect(nim.isNgcLoggedIn()).toBe(true);
       } finally {
@@ -347,6 +349,37 @@ describe("nim", () => {
 
     it("returns false when auths is empty and no credHelpers", () => {
       const restore = mockDockerConfig(JSON.stringify({ auths: {} }));
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns true when empty nvcr.io marker exists and credsStore is set (Docker Desktop)", () => {
+      const restore = mockDockerConfig(
+        JSON.stringify({ credsStore: "desktop", auths: { "nvcr.io": {} } }),
+      );
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(true);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns false when credsStore is set but no nvcr.io marker (not logged in)", () => {
+      const restore = mockDockerConfig(
+        JSON.stringify({ credsStore: "desktop", auths: {} }),
+      );
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns false when empty nvcr.io marker exists but no credsStore", () => {
+      const restore = mockDockerConfig(JSON.stringify({ auths: { "nvcr.io": {} } }));
       try {
         expect(nim.isNgcLoggedIn()).toBe(false);
       } finally {

--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -268,4 +268,90 @@ describe("nim", () => {
       }
     });
   });
+
+  describe("isNgcLoggedIn", () => {
+    const fs = require("fs");
+    const os = require("os");
+
+    function mockDockerConfig(config: string | null) {
+      const origReadFileSync = fs.readFileSync;
+      const origHomedir = os.homedir;
+      os.homedir = () => "/mock-home";
+      if (config === null) {
+        fs.readFileSync = () => { throw new Error("ENOENT"); };
+      } else {
+        fs.readFileSync = (p: string, ...args: unknown[]) => {
+          if (typeof p === "string" && p.includes(".docker/config.json")) return config;
+          return origReadFileSync(p, ...args);
+        };
+      }
+      return () => {
+        fs.readFileSync = origReadFileSync;
+        os.homedir = origHomedir;
+      };
+    }
+
+    it("returns true when credHelpers has nvcr.io", () => {
+      const restore = mockDockerConfig(JSON.stringify({ credHelpers: { "nvcr.io": "secretservice" } }));
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(true);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns true when auths has nvcr.io with auth field", () => {
+      const restore = mockDockerConfig(JSON.stringify({ auths: { "nvcr.io": { auth: "dXNlcjpwYXNz" } } }));
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(true);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns true when auths has https://nvcr.io with token field", () => {
+      const restore = mockDockerConfig(JSON.stringify({ auths: { "https://nvcr.io": { token: "abc123" } } }));
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(true);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns false when auths has nvcr.io but empty entry", () => {
+      const restore = mockDockerConfig(JSON.stringify({ auths: { "nvcr.io": {} } }));
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns false when config file is missing", () => {
+      const restore = mockDockerConfig(null);
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns false when config has malformed JSON", () => {
+      const restore = mockDockerConfig("not json");
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    it("returns false when auths is empty and no credHelpers", () => {
+      const restore = mockDockerConfig(JSON.stringify({ auths: {} }));
+      try {
+        expect(nim.isNgcLoggedIn()).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+  });
 });

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -177,9 +177,9 @@ export function detectGpu(): GpuDetection | null {
 }
 
 // Check if Docker has stored credentials for nvcr.io.
-// When credsStore is set (e.g., Docker Desktop), credentials are in the OS
-// keychain and not visible in config.json. Returns false in that case,
-// causing a redundant but harmless re-prompt.
+// Docker Desktop (macOS/Windows/WSL) stores creds in the OS keychain and
+// leaves an empty marker entry { "nvcr.io": {} } in auths after a successful
+// login. That marker plus a global credsStore is treated as logged in.
 export function isNgcLoggedIn(): boolean {
   try {
     const os = require("os");
@@ -191,7 +191,9 @@ export function isNgcLoggedIn(): boolean {
     if (parsed?.credHelpers?.["nvcr.io"]) return true;
     const auths = parsed?.auths || {};
     const entry = auths["nvcr.io"] || auths["https://nvcr.io"];
-    return Boolean(entry && (entry.auth || entry.token));
+    if (entry?.auth) return true;
+    if (entry && parsed?.credsStore) return true;
+    return false;
   } catch {
     return false;
   }

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -176,6 +176,10 @@ export function detectGpu(): GpuDetection | null {
   return null;
 }
 
+// Check if Docker has stored credentials for nvcr.io.
+// When credsStore is set (e.g., Docker Desktop), credentials are in the OS
+// keychain and not visible in config.json. Returns false in that case,
+// causing a redundant but harmless re-prompt.
 export function isNgcLoggedIn(): boolean {
   try {
     const os = require("os");
@@ -193,6 +197,7 @@ export function isNgcLoggedIn(): boolean {
   }
 }
 
+// NGC expects literal "$oauthtoken" as the username for API key authentication.
 export function dockerLoginNgc(apiKey: string): boolean {
   const { spawnSync } = require("child_process");
   const result = spawnSync("docker", ["login", "nvcr.io", "-u", "$oauthtoken", "--password-stdin"], {
@@ -200,6 +205,13 @@ export function dockerLoginNgc(apiKey: string): boolean {
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "pipe"],
   });
+  if (result.error) {
+    console.error(`  Docker error: ${result.error.message}`);
+    return false;
+  }
+  if (result.status !== 0 && result.stderr) {
+    console.error(`  Docker login error: ${result.stderr.trim()}`);
+  }
   return result.status === 0;
 }
 

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -180,9 +180,14 @@ export function isNgcLoggedIn(): boolean {
   try {
     const os = require("os");
     const fs = require("fs");
-    const config = os.homedir() + "/.docker/config.json";
+    const path = require("path");
+    const config = path.join(os.homedir(), ".docker", "config.json");
     const data = fs.readFileSync(config, "utf-8");
-    return data.includes("nvcr.io");
+    const parsed = JSON.parse(data);
+    if (parsed?.credHelpers?.["nvcr.io"]) return true;
+    const auths = parsed?.auths || {};
+    const entry = auths["nvcr.io"] || auths["https://nvcr.io"];
+    return Boolean(entry && (entry.auth || entry.token));
   } catch {
     return false;
   }

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -176,6 +176,28 @@ export function detectGpu(): GpuDetection | null {
   return null;
 }
 
+export function isNgcLoggedIn(): boolean {
+  try {
+    const os = require("os");
+    const fs = require("fs");
+    const config = os.homedir() + "/.docker/config.json";
+    const data = fs.readFileSync(config, "utf-8");
+    return data.includes("nvcr.io");
+  } catch {
+    return false;
+  }
+}
+
+export function dockerLoginNgc(apiKey: string): boolean {
+  const { spawnSync } = require("child_process");
+  const result = spawnSync("docker", ["login", "nvcr.io", "-u", "$oauthtoken", "--password-stdin"], {
+    input: apiKey,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return result.status === 0;
+}
+
 export function pullNimImage(model: string): string {
   const image = getImageForModel(model);
   if (!image) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3957,11 +3957,17 @@ async function setupNim(gpu) {
 
           // Ensure Docker is logged in to NGC registry before pulling NIM images.
           if (!nim.isNgcLoggedIn()) {
+            if (isNonInteractive()) {
+              console.error(
+                "  Docker is not logged in to nvcr.io. In non-interactive mode, run `docker login nvcr.io` first and retry.",
+              );
+              process.exit(1);
+            }
             console.log("");
             console.log("  NGC API Key required to pull NIM images.");
             console.log("  Get one from: https://org.ngc.nvidia.com/setup/api-key");
             console.log("");
-            let ngcKey = await prompt("  NGC API Key: ", { secret: true });
+            let ngcKey = normalizeCredentialValue(await prompt("  NGC API Key: ", { secret: true }));
             if (!ngcKey) {
               console.error("  NGC API Key is required for Local NIM.");
               process.exit(1);
@@ -3969,7 +3975,7 @@ async function setupNim(gpu) {
             if (!nim.dockerLoginNgc(ngcKey)) {
               console.error("  Failed to login to NGC registry. Check your API key and try again.");
               console.log("");
-              ngcKey = await prompt("  NGC API Key: ", { secret: true });
+              ngcKey = normalizeCredentialValue(await prompt("  NGC API Key: ", { secret: true }));
               if (!ngcKey || !nim.dockerLoginNgc(ngcKey)) {
                 console.error("  NGC login failed. Cannot pull NIM images.");
                 process.exit(1);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3955,6 +3955,28 @@ async function setupNim(gpu) {
           }
           model = sel.name;
 
+          // Ensure Docker is logged in to NGC registry before pulling NIM images.
+          if (!nim.isNgcLoggedIn()) {
+            console.log("");
+            console.log("  NGC API Key required to pull NIM images.");
+            console.log("  Get one from: https://org.ngc.nvidia.com/setup/api-key");
+            console.log("");
+            let ngcKey = await prompt("  NGC API Key: ", { secret: true });
+            if (!ngcKey) {
+              console.error("  NGC API Key is required for Local NIM.");
+              process.exit(1);
+            }
+            if (!nim.dockerLoginNgc(ngcKey)) {
+              console.error("  Failed to login to NGC registry. Check your API key and try again.");
+              console.log("");
+              ngcKey = await prompt("  NGC API Key: ", { secret: true });
+              if (!ngcKey || !nim.dockerLoginNgc(ngcKey)) {
+                console.error("  NGC login failed. Cannot pull NIM images.");
+                process.exit(1);
+              }
+            }
+          }
+
           console.log(`  Pulling NIM image for ${model}...`);
           nim.pullNimImage(model);
 

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -3066,6 +3066,7 @@ nimMod.pullNimImage = () => {};
 nimMod.containerName = () => "nemoclaw-nim-test";
 nimMod.startNimContainerByName = () => "container-123";
 nimMod.waitForNimHealth = () => true;
+nimMod.isNgcLoggedIn = () => true;
 
 // Select option 7 (nim-local), then model 1
 const answers = ["7", "1"];


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Local NIM onboarding fails at the image pull step because `docker pull nvcr.io/nim/...` requires NGC registry authentication. This  adds an NGC API key prompt during onboard that runs `docker login nvcr.io --password-stdin` before pulling the NIM image. The key is masked during input and handled securely via stdin. 

## Related Issue
Based on the investigation in PR #236.

## Changes
 - `src/lib/nim.ts`: Add `isNgcLoggedIn()` to check if Docker is already authenticated with nvcr.io, and `dockerLoginNgc()` to login  securely via `--password-stdin`.                                                                                                    
  - `src/lib/onboard.ts`: Prompt for NGC API key before NIM image pull when not already logged in. Masked input, one retry on failure.
  - `test/onboard-selection.test.ts`: Mock `isNgcLoggedIn` in NIM-local selection test. 

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup wizard enforces NGC Docker authentication for NIM model setup: interactive mode prompts for an NGC API key (one retry); non-interactive mode prints login instructions and exits.

* **Bug Fixes / Reliability**
  * Improved detection and login handling for NGC Docker credentials so image pulls proceed only after successful authentication and failures are reported.

* **Tests**
  * Added unit tests for NGC auth detection and updated onboarding tests to cover authenticated flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->