### PR TITLE
fix(k8s): replace privileged DinD with rootless DinD

### DIFF
--- a/k8s/nemoclaw-k8s.yaml
+++ b/k8s/nemoclaw-k8s.yaml
@@ -9,25 +9,54 @@ metadata:
   labels:
     app: nemoclaw
 spec:
+  securityContext:
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
   automountServiceAccountToken: false
   enableServiceLinks: false
   containers:
     # Docker daemon (DinD)
     - name: dind
-      image: docker:24-dind
+      image: docker:24-dind-rootless
       securityContext:
-        privileged: true
+        privileged: false
+        runAsUser: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: true  # required for newuidmap/newgidmap
+        seccompProfile:
+          type: Unconfined  # required for user namespace setup by rootlesskit
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - SETUID     # newuidmap
+            - SETGID     # newgidmap
+            - SETFCAP    # file capabilities during image builds
+            - NET_ADMIN  # k3s/flannel CNI network setup
+            - NET_RAW    # k3s/flannel VXLAN and kube-proxy
       env:
         - name: DOCKER_TLS_CERTDIR
           value: ""
-      command: ["dockerd", "--host=unix:///var/run/docker.sock"]
+        # Rootlesskit: use the pod network namespace directly instead of
+        # creating an isolated slirp4netns namespace.  Without this, k3s
+        # and the socat proxy live in different network namespaces and
+        # inference routing from the sandbox to host.openshell.internal
+        # breaks.
+        - name: DOCKERD_ROOTLESS_ROOTLESSKIT_NET
+          value: "host"
+        # Rootlesskit: propagate mount events from the pod into the
+        # rootless mount namespace so k3s can bind-mount volumes into
+        # sandbox containers.
+        - name: DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS
+          value: "--propagation=rslave"
       volumeMounts:
         - name: docker-storage
-          mountPath: /var/lib/docker
+          mountPath: /home/rootless/.local/share/docker
         - name: docker-socket
-          mountPath: /var/run
+          mountPath: /run/user/1000
         - name: docker-config
-          mountPath: /etc/docker
+          mountPath: /home/rootless/.config/docker
       resources:
         requests:
           memory: "8Gi"
@@ -90,7 +119,7 @@ spec:
           exec sleep infinity
       env:
         - name: DOCKER_HOST
-          value: unix:///var/run/docker.sock
+          value: unix:///run/user/1000/docker.sock
         # Dynamo endpoint (raw host:port for socat) - UPDATE THIS FOR YOUR CLUSTER
         - name: DYNAMO_HOST
           value: "vllm-disagg-frontend.dynamo.svc.cluster.local:8000"
@@ -117,9 +146,7 @@ spec:
           value: "1"
       volumeMounts:
         - name: docker-socket
-          mountPath: /var/run
-        - name: docker-config
-          mountPath: /etc/docker
+          mountPath: /run/user/1000
       resources:
         requests:
           memory: "4Gi"
@@ -129,10 +156,15 @@ spec:
     # Configure Docker daemon for cgroup v2
     - name: init-docker-config
       image: busybox
-      command: ["sh", "-c", "echo '{\"default-cgroupns-mode\":\"host\"}' > /etc/docker/daemon.json"]
+      command:
+        - sh
+        - -c
+        - |
+          mkdir -p /config/docker
+          echo '{"default-cgroupns-mode":"host"}' > /config/docker/daemon.json
       volumeMounts:
         - name: docker-config
-          mountPath: /etc/docker
+          mountPath: /config/docker
 
   volumes:
     - name: docker-storage

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -138,7 +138,7 @@ function verifyGatewayContainerRunning() {
     `docker inspect --type container --format '{{.State.Running}}' ${containerName}`,
     { ignoreError: true, suppressOutput: true },
   );
-  if (result.status === 0 && (result.stdout || "").trim() === "true") {
+  if (result.status === 0 && (result.stdout || "").toString().trim() === "true") {
     return "running";
   }
   // Container exists but is stopped (exit 0, Running !== "true")


### PR DESCRIPTION
## Summary

- Replaces the privileged DinD sidecar in `k8s/nemoclaw-k8s.yaml` with rootless Docker-in-Docker (`docker:24-dind-rootless`), eliminating trivial host escape via `nsenter`
- Updates all volume mount paths, socket paths, daemon config paths, and env vars for rootless operation
- Adds rootlesskit env vars (`DOCKERD_ROOTLESS_ROOTLESSKIT_NET=host`, `--propagation=rslave`) to ensure k3s networking and mount propagation work inside the pod

### Security changes

| Before | After |
|--------|-------|
| `privileged: true` | `privileged: false`, UID 1000, `runAsNonRoot: true` |
| All capabilities | Drop ALL, add SETUID/SETGID/SETFCAP/NET_ADMIN/NET_RAW |
| No seccomp | Pod-level RuntimeDefault; dind Unconfined (rootlesskit requires it) |
| No fsGroup | `fsGroup: 1000` for emptyDir volume ownership |

### Known limitations of rootless DinD

- overlay2 requires kernel 5.11+ (older nodes fall back to fuse-overlayfs)
- No `--net=host` for inner containers
- No privileged port binding (< 1024) inside DinD — NemoClaw uses only ports >= 1024

## Test plan

- [ ] Trigger nightly E2E suite on this branch (all jobs)
- [ ] Verify pod starts and all containers reach Running
- [ ] Verify host escape PoC fails: `kubectl exec -it nemoclaw -c dind -- nsenter --target 1 --mount --uts --ipc --net --pid -- bash` → "Operation not permitted"
- [ ] Verify Docker connectivity from workspace: `kubectl exec -it nemoclaw -c workspace -- docker info`
- [ ] Verify NemoClaw installer completes end-to-end
- [ ] Verify inference routing through socat proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to rootless Docker deployment for improved security isolation, running containers as non-root with tighter capability controls and relocated Docker socket/state to user-specific locations to preserve workflows.
* **Bug Fixes**
  * Improved runtime detection used during onboarding to more reliably determine local Docker status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->