### PR TITLE
fix(security): add SHA-256 integrity verification for k8s installer download

### DIFF
--- a/.github/workflows/installer-hash-check.yaml
+++ b/.github/workflows/installer-hash-check.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Weekly check that the pinned NemoClaw installer SHA-256 in k8s/nemoclaw-k8s.yaml
+# still matches the upstream script at https://www.nvidia.com/nemoclaw.sh.
+# Fails with an actionable message when the upstream script has changed.
+
+name: installer-hash-check
+
+on:
+  schedule:
+    # Every Monday at 09:30 UTC (offset from docker-pin-check at 09:00)
+    - cron: "30 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-hash:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Verify installer hash is current
+        run: bash scripts/check-installer-hash.sh

--- a/.github/workflows/installer-hash-check.yaml
+++ b/.github/workflows/installer-hash-check.yaml
@@ -1,15 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Weekly check that the pinned NemoClaw installer SHA-256 in k8s/nemoclaw-k8s.yaml
+# Verifies the pinned NemoClaw installer SHA-256 in k8s/nemoclaw-k8s.yaml
 # still matches the upstream script at https://www.nvidia.com/nemoclaw.sh.
-# Fails with an actionable message when the upstream script has changed.
+# Runs on every PR and push to main, plus a weekly scheduled check.
 
 name: installer-hash-check
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
   schedule:
-    # Every Monday at 09:30 UTC (offset from docker-pin-check at 09:00)
+    # Weekly fallback in case upstream changes between PRs
     - cron: "30 9 * * 1"
   workflow_dispatch:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check lint format lint-ts format-ts docs docs-strict docs-live docs-clean
+.PHONY: check lint format lint-ts format-ts check-installer-hash docs docs-strict docs-live docs-clean
 
 check:
 	npx prek run --all-files
@@ -17,6 +17,11 @@ format-cli:
 
 format-ts:
 	cd nemoclaw && npm run lint:fix && npm run format
+
+# --- Integrity checks ---
+
+check-installer-hash:
+	bash scripts/check-installer-hash.sh
 
 # --- Documentation ---
 

--- a/k8s/nemoclaw-k8s.yaml
+++ b/k8s/nemoclaw-k8s.yaml
@@ -77,10 +77,29 @@ spec:
           # Run official NemoClaw installer
           echo "[4/4] Running NemoClaw installer..."
           umask 077
+
+          # Preflight: ensure sha256sum is available for integrity verification
+          command -v sha256sum >/dev/null 2>&1 || {
+            echo "FATAL: sha256sum not found — cannot verify installer integrity. Aborting."
+            exit 1
+          }
+
+          # Expected SHA-256 of the installer script — update when upgrading
+          # To refresh: scripts/check-installer-hash.sh --update
+          NEMOCLAW_INSTALLER_SHA256="1ae2bc0a538637272167cda8338b322cbb475b731cae14b0833e5a9dadcbad91"
+
           curl --proto '=https' --tlsv1.2 --fail --show-error --silent \
             --location \
             --output /tmp/nemoclaw-install.sh \
             https://www.nvidia.com/nemoclaw.sh
+
+          # Verify integrity before execution
+          echo "${NEMOCLAW_INSTALLER_SHA256}  /tmp/nemoclaw-install.sh" | sha256sum -c - || {
+            echo "FATAL: Installer checksum mismatch — possible tampering. Aborting."
+            rm -f /tmp/nemoclaw-install.sh
+            exit 1
+          }
+
           chmod 700 /tmp/nemoclaw-install.sh
           bash /tmp/nemoclaw-install.sh
           rm -f /tmp/nemoclaw-install.sh

--- a/scripts/check-installer-hash.sh
+++ b/scripts/check-installer-hash.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verifies that the SHA-256 hash pinned in k8s/nemoclaw-k8s.yaml matches
+# the current https://www.nvidia.com/nemoclaw.sh installer script.
+#
+# Usage:
+#   scripts/check-installer-hash.sh            # exit 0 if current, 1 if stale
+#   scripts/check-installer-hash.sh --update   # rewrite the hash in the manifest
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MANIFEST="${REPO_ROOT}/k8s/nemoclaw-k8s.yaml"
+INSTALLER_URL="https://www.nvidia.com/nemoclaw.sh"
+
+case "${1:-}" in
+  "" | --update) ;;
+  *)
+    echo "Usage: scripts/check-installer-hash.sh [--update]" >&2
+    exit 2
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Extract the pinned hash from the manifest
+# ---------------------------------------------------------------------------
+pinned_hash() {
+  sed -n 's/.*NEMOCLAW_INSTALLER_SHA256="\([a-f0-9]\{64\}\)".*/\1/p' "$MANIFEST" | head -1
+}
+
+# ---------------------------------------------------------------------------
+# Download the installer and compute its SHA-256
+# ---------------------------------------------------------------------------
+fetch_upstream_hash() {
+  local tmpfile
+  tmpfile=$(mktemp)
+  trap 'rm -f "$tmpfile"' RETURN
+
+  curl --proto '=https' --tlsv1.2 -fsSL \
+    --connect-timeout 10 --max-time 30 \
+    --retry 3 --retry-delay 1 --retry-all-errors \
+    -o "$tmpfile" "$INSTALLER_URL"
+
+  sha256sum "$tmpfile" | cut -d' ' -f1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+pinned=$(pinned_hash)
+
+if [[ -z "$pinned" ]]; then
+  echo "ERROR: no NEMOCLAW_INSTALLER_SHA256 found in ${MANIFEST}" >&2
+  exit 1
+fi
+
+echo "Fetching upstream installer from ${INSTALLER_URL}..."
+upstream=$(fetch_upstream_hash)
+
+if [[ "$pinned" == "$upstream" ]]; then
+  echo "OK: installer hash is up-to-date (${pinned})"
+  exit 0
+fi
+
+if [[ "${1:-}" != "--update" ]]; then
+  echo "STALE: pinned installer hash does not match upstream."
+  echo ""
+  echo "  pinned:   ${pinned}"
+  echo "  upstream: ${upstream}"
+  echo ""
+  echo "To update, run:"
+  echo ""
+  echo "  scripts/check-installer-hash.sh --update"
+  echo ""
+  exit 1
+fi
+
+# Perform the replacement
+sed -i.bak "s/${pinned}/${upstream}/" "$MANIFEST"
+rm -f "${MANIFEST}.bak"
+
+echo "Updated ${MANIFEST}: NEMOCLAW_INSTALLER_SHA256"
+echo "  old: ${pinned}"
+echo "  new: ${upstream}"


### PR DESCRIPTION
## Summary
- Adds SHA-256 checksum verification before executing the downloaded `nemoclaw.sh` installer in the k8s workspace container, preventing MITM/CDN compromise from delivering arbitrary code
- Adds a `sha256sum` preflight check so the pod fails fast with a clear error if the binary is missing
- Adds `scripts/check-installer-hash.sh` and a weekly CI workflow to catch hash staleness before it causes runtime failures
- Adds `make check-installer-hash` Makefile target for local verification

## Test plan
- [ ] Apply manifest with correct hash — pod starts normally, installer runs
- [ ] Change hash to a wrong value — pod aborts with "checksum mismatch", installer does NOT execute
- [ ] Run `scripts/check-installer-hash.sh` — should report OK
- [ ] Run `scripts/check-installer-hash.sh --update` with a stale hash — should rewrite the manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now verifies a pinned SHA-256 checksum and will abort if the checksum does not match.

* **Chores**
  * Added an automated workflow to validate the pinned installer hash on PRs, pushes to main, weekly schedule, and manual runs.
  * Added a local command to check or update the pinned installer hash and integrated it into the build tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->