### PR TITLE
fix(onboard): convert stdout Buffer to string in gateway container probe

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -138,7 +138,7 @@ function verifyGatewayContainerRunning() {
     `docker inspect --type container --format '{{.State.Running}}' ${containerName}`,
     { ignoreError: true, suppressOutput: true },
   );
-  if (result.status === 0 && (result.stdout || "").trim() === "true") {
+  if (result.status === 0 && String(result.stdout || "").trim() === "true") {
     return "running";
   }
   // Container exists but is stopped (exit 0, Running !== "true")


### PR DESCRIPTION
## Summary

One-line fix — verifyGatewayContainerRunning() crashes with TypeError on second sandbox onboard because result.stdout is a Buffer, not a string.

## Related Issue

Regression from PR #2032.
Detailed issue at [2054](https://github.com/NVIDIA/NemoClaw/issues/2054)

## Changes

- Wrap result.stdout with String() before calling .trim() in verifyGatewayContainerRunning()

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes

## AI Disclosure

- [x] AI-assisted — tool: Cursor

---

Signed-off-by: Truong Nguyen <tgnguyen@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of gateway container status verification by enhancing string type handling during status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->