### PR TITLE
fix(security): unify --dangerously-skip-permissions with shields-down state

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -63,6 +63,7 @@ const registry = require("./registry");
 const nim = require("./nim");
 const onboardSession = require("./onboard-session");
 const policies = require("./policies");
+const shields = require("./shields");
 const tiers = require("./tiers");
 const { ensureUsageNoticeConsent } = require("./usage-notice");
 const {
@@ -6212,7 +6213,7 @@ async function onboard(opts = {}) {
         console.error(`\n  ✗ Sandbox '${sandboxName}' not ready after creation. Giving up.`);
         process.exit(1);
       }
-      policies.applyPermissivePolicy(sandboxName);
+      shields.shieldsDownPermanent(sandboxName);
       onboardSession.markStepComplete("policies", {
         sandboxName,
         provider,

--- a/src/lib/shields.ts
+++ b/src/lib/shields.ts
@@ -3,7 +3,9 @@
 //
 // Host-side shields management: down, up, status.
 //
-// Shields provide time-bounded policy relaxation with automatic restore.
+// Shields provide time-bounded or permanent policy relaxation.
+// Time-bounded shields have automatic restore; permanent shields
+// (--dangerously-skip-permissions) persist until explicitly raised.
 // The sandbox cannot lower or raise its own shields — all mutations are
 // host-initiated (security invariant).
 
@@ -61,6 +63,7 @@ interface ShieldsState {
   shieldsDownReason?: string | null;
   shieldsDownPolicy?: string | null;
   shieldsPolicySnapshotPath?: string | null;
+  permanent?: boolean;
   updatedAt?: string;
 }
 
@@ -123,6 +126,25 @@ function killTimer(sandboxName: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Config unlock — shared between shields-down and dangerously-skip-permissions
+//
+// Sets permissions to sandbox:sandbox 0600/0700, matching what OpenClaw
+// writes natively (mode 384 = 0o600). This keeps `openclaw doctor` happy.
+// ---------------------------------------------------------------------------
+
+function unlockAgentConfig(sandboxName: string, target: { configPath: string; configDir: string }): void {
+  try {
+    kubectlExec(sandboxName, ["chattr", "-i", target.configPath]);
+    kubectlExec(sandboxName, ["chown", "sandbox:sandbox", target.configPath]);
+    kubectlExec(sandboxName, ["chmod", "600", target.configPath]);
+    kubectlExec(sandboxName, ["chown", "sandbox:sandbox", target.configDir]);
+    kubectlExec(sandboxName, ["chmod", "700", target.configDir]);
+  } catch {
+    console.error("  Warning: Could not unlock config file. Config may remain read-only.");
+  }
+}
+
+// ---------------------------------------------------------------------------
 // shields down
 // ---------------------------------------------------------------------------
 
@@ -140,10 +162,17 @@ function shieldsDown(sandboxName: string, opts: ShieldsDownOpts = {}): void {
 
   const state = loadShieldsState(sandboxName);
   if (state.shieldsDown) {
-    console.error(
-      `  Shields are already DOWN for ${sandboxName} (since ${state.shieldsDownAt}).`,
-    );
-    console.error("  Run `nemoclaw shields up` first, or use --extend (not yet implemented).");
+    if (state.permanent) {
+      console.error(
+        `  Shields are permanently DOWN for ${sandboxName} (--dangerously-skip-permissions).`,
+      );
+      console.error("  Run `nemoclaw shields up` first to restore, then try again.");
+    } else {
+      console.error(
+        `  Shields are already DOWN for ${sandboxName} (since ${state.shieldsDownAt}).`,
+      );
+      console.error("  Run `nemoclaw shields up` first, or use --extend (not yet implemented).");
+    }
     process.exit(1);
   }
 
@@ -192,15 +221,13 @@ function shieldsDown(sandboxName: string, opts: ShieldsDownOpts = {}): void {
   //     runs inside the Landlock context and can't bypass any of them.
   //     kubectl exec bypasses Landlock (starts a new process outside the sandbox's
   //     Landlock domain), so we route through docker exec → kubectl exec.
+  //
+  //     Permissions are set to sandbox:sandbox 0600/0700 to match what
+  //     OpenClaw natively creates (mode 384 = 0o600) so `openclaw doctor`
+  //     sees the expected owner and mode without recommending fixes.
   const target = resolveAgentConfig(sandboxName);
   console.log(`  Unlocking ${target.agentName} config (${target.configPath})...`);
-  try {
-    kubectlExec(sandboxName, ["chattr", "-i", target.configPath]);
-    kubectlExec(sandboxName, ["chmod", "666", target.configPath]);
-    kubectlExec(sandboxName, ["chmod", "777", target.configDir]);
-  } catch {
-    console.error("  Warning: Could not unlock config file. Config may remain read-only.");
-  }
+  unlockAgentConfig(sandboxName, target);
 
   // 3. Update state
   const now = new Date().toISOString();
@@ -249,6 +276,7 @@ function shieldsDown(sandboxName: string, opts: ShieldsDownOpts = {}): void {
     try {
       run(buildPolicySetCommand(snapshotPath, sandboxName), { ignoreError: true });
       kubectlExec(sandboxName, ["chmod", "444", target.configPath]);
+      kubectlExec(sandboxName, ["chown", "root:root", target.configPath]);
       kubectlExec(sandboxName, ["chattr", "+i", target.configPath]);
     } catch {
       // Best effort rollback
@@ -299,17 +327,26 @@ function shieldsUp(sandboxName: string): void {
 
   const snapshotPath = state.shieldsPolicySnapshotPath;
   if (!snapshotPath || !fs.existsSync(snapshotPath)) {
-    console.error("  No policy snapshot found. Cannot restore — manual intervention required.");
-    console.error("  Apply your intended policy with: openshell policy set --policy <file>");
-    process.exit(1);
+    if (state.permanent) {
+      // Permanent shields may not have a snapshot (best-effort capture).
+      // Warn but proceed — re-lock the config and clear the state.
+      console.error("  No policy snapshot found. Skipping policy restore.");
+      console.error("  You may need to re-apply your intended policy manually.");
+    } else {
+      console.error("  No policy snapshot found. Cannot restore — manual intervention required.");
+      console.error("  Apply your intended policy with: openshell policy set --policy <file>");
+      process.exit(1);
+    }
   }
 
   // 1. Kill auto-restore timer if running
   killTimer(sandboxName);
 
-  // 2. Restore policy from snapshot
-  console.log("  Restoring policy from snapshot...");
-  run(buildPolicySetCommand(snapshotPath, sandboxName));
+  // 2. Restore policy from snapshot (if available)
+  if (snapshotPath && fs.existsSync(snapshotPath)) {
+    console.log("  Restoring policy from snapshot...");
+    run(buildPolicySetCommand(snapshotPath, sandboxName));
+  }
 
   // 2b. Re-lock config file to read-only.
   //     Restore the Dockerfile's original permissions and immutable bit.
@@ -338,6 +375,7 @@ function shieldsUp(sandboxName: string): void {
     shieldsDownTimeout: null,
     shieldsDownReason: null,
     shieldsDownPolicy: null,
+    permanent: false,
     // Keep snapshotPath for forensics — don't clear it
   });
 
@@ -384,15 +422,100 @@ function shieldsStatus(sandboxName: string): void {
       ? Math.max(0, state.shieldsDownTimeout - elapsed)
       : null;
 
-  console.log("  Shields: DOWN");
+  console.log(`  Shields: DOWN${state.permanent ? " (permanent)" : ""}`);
   console.log(`  Since:   ${state.shieldsDownAt ?? "unknown"}`);
-  if (remaining !== null) {
+  if (state.permanent) {
+    console.log("  Timeout: none (--dangerously-skip-permissions)");
+  } else if (remaining !== null) {
     const mins = Math.floor(remaining / 60);
     const secs = remaining % 60;
     console.log(`  Timeout: ${mins}m ${secs}s remaining`);
   }
   console.log(`  Reason:  ${state.shieldsDownReason ?? "not specified"}`);
   console.log(`  Policy:  ${state.shieldsDownPolicy ?? "permissive"}`);
+}
+
+// ---------------------------------------------------------------------------
+// shields down permanent — used by --dangerously-skip-permissions
+//
+// Puts the sandbox into permanent shields-down state: permissive policy,
+// config file unlocked with doctor-aligned permissions, no auto-restore.
+// Idempotent — safe to call on every connect when the registry flag is set.
+// ---------------------------------------------------------------------------
+
+function shieldsDownPermanent(sandboxName: string): void {
+  validateName(sandboxName, "sandbox name");
+
+  const state = loadShieldsState(sandboxName);
+
+  // Already permanently down — idempotent no-op.
+  if (state.shieldsDown && state.permanent) {
+    return;
+  }
+
+  // If shields are down with a timer, kill the timer and upgrade to permanent.
+  if (state.shieldsDown && !state.permanent) {
+    killTimer(sandboxName);
+    saveShieldsState(sandboxName, {
+      permanent: true,
+      shieldsDownTimeout: null,
+      shieldsDownReason: "dangerously-skip-permissions (upgraded from timed)",
+    });
+
+    appendAuditEntry({
+      action: "shields_down_permanent",
+      sandbox: sandboxName,
+      timestamp: new Date().toISOString(),
+      reason: "upgraded from timed to permanent (--dangerously-skip-permissions)",
+    });
+    return;
+  }
+
+  // Shields are up — do the full shields-down sequence without a timer.
+
+  // 1. Capture current policy snapshot (for shields-up restore later)
+  let snapshotPath: string | null = null;
+  try {
+    const rawPolicy = runCapture(buildPolicyGetCommand(sandboxName), { ignoreError: true });
+    const policyYaml = parseCurrentPolicy(rawPolicy);
+    if (policyYaml) {
+      const ts = Date.now();
+      snapshotPath = path.join(STATE_DIR, `policy-snapshot-${ts}.yaml`);
+      fs.mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(snapshotPath, policyYaml, { mode: 0o600 });
+    }
+  } catch {
+    // Non-fatal — snapshot is best-effort for permanent mode
+  }
+
+  // 2. Apply permissive policy
+  const policies = require("./policies");
+  policies.applyPermissivePolicy(sandboxName);
+
+  // 3. Unlock config with doctor-aligned permissions
+  const target = resolveAgentConfig(sandboxName);
+  unlockAgentConfig(sandboxName, target);
+
+  // 4. Save permanent shields-down state
+  const now = new Date().toISOString();
+  saveShieldsState(sandboxName, {
+    shieldsDown: true,
+    shieldsDownAt: now,
+    shieldsDownTimeout: null,
+    shieldsDownReason: "dangerously-skip-permissions",
+    shieldsDownPolicy: "permissive",
+    shieldsPolicySnapshotPath: snapshotPath,
+    permanent: true,
+  });
+
+  // 5. Audit log
+  appendAuditEntry({
+    action: "shields_down_permanent",
+    sandbox: sandboxName,
+    timestamp: now,
+    reason: "dangerously-skip-permissions",
+    policy_snapshot: snapshotPath ?? undefined,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -409,6 +532,7 @@ function isShieldsDown(sandboxName: string): boolean {
 
 export {
   shieldsDown,
+  shieldsDownPermanent,
   shieldsUp,
   shieldsStatus,
   isShieldsDown,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1162,10 +1162,14 @@ async function sandboxConnect(sandboxName, { dangerouslySkipPermissions = false 
     /* non-fatal — don't block connect on version check failure */
   }
 
-  if (dangerouslySkipPermissions) {
+  // Check both the CLI flag and the registry for dangerously-skip-permissions.
+  // The registry flag persists from onboard, so subsequent connects without
+  // the CLI flag still enter permanent shields-down state.
+  const sb = registry.getSandbox(sandboxName);
+  const effectiveSkipPerms = dangerouslySkipPermissions || sb?.dangerouslySkipPermissions;
+  if (effectiveSkipPerms) {
     printDangerouslySkipPermissionsWarning();
-    const policies = require("./lib/policies");
-    policies.applyPermissivePolicy(sandboxName);
+    shields.shieldsDownPermanent(sandboxName);
   }
   checkAndRecoverSandboxProcesses(sandboxName);
   // Ensure Ollama auth proxy is running (recovers from host reboots)
@@ -1251,7 +1255,9 @@ async function sandboxStatus(sandboxName) {
     console.log(`    GPU:      ${sb.gpuEnabled ? "yes" : "no"}`);
     console.log(`    Policies: ${(sb.policies || []).join(", ") || "none"}`);
     if (sb.dangerouslySkipPermissions) {
-      console.log(`    Permissions: dangerously-skip-permissions (open)`);
+      console.log(`    Permissions: dangerously-skip-permissions (shields permanently down)`);
+    } else if (shields.isShieldsDown(sandboxName)) {
+      console.log(`    Permissions: shields down (check \`shields status\` for details)`);
     }
 
     // Agent version check

--- a/test/e2e/test-shields-config.sh
+++ b/test/e2e/test-shields-config.sh
@@ -201,15 +201,31 @@ else
   fail "shields down did not report success: ${SHIELDS_DOWN_OUTPUT}"
 fi
 
-# Check permissions changed
+# Check permissions changed — should be sandbox:sandbox 600/700 (doctor-aligned)
 PERMS_DOWN=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- \
-  stat -c '%a' "${CONFIG_PATH}" 2>/dev/null || true)
+  stat -c '%a %U:%G' "${CONFIG_PATH}" 2>/dev/null || true)
 info "Config perms (shields DOWN): ${PERMS_DOWN}"
 
-if echo "$PERMS_DOWN" | grep -q "666\|664\|644"; then
-  pass "Config file permissions relaxed (${PERMS_DOWN})"
+if [ "$(echo "$PERMS_DOWN" | awk '{print $1}')" = "600" ]; then
+  pass "Config file mode is 600 (doctor-aligned, ${PERMS_DOWN})"
 else
-  fail "Config file permissions not relaxed after shields down: ${PERMS_DOWN}"
+  fail "Config file should be mode 600 after shields down: ${PERMS_DOWN}"
+fi
+
+if [ "$(echo "$PERMS_DOWN" | awk '{print $2}')" = "sandbox:sandbox" ]; then
+  pass "Config file owned by sandbox:sandbox after shields down"
+else
+  fail "Config file should be owned by sandbox:sandbox: ${PERMS_DOWN}"
+fi
+
+DIR_PERMS_DOWN=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- \
+  stat -c '%a %U:%G' "$(dirname "${CONFIG_PATH}")" 2>/dev/null || true)
+info "Config dir perms (shields DOWN): ${DIR_PERMS_DOWN}"
+
+if [ "$(echo "$DIR_PERMS_DOWN" | awk '{print $1}')" = "700" ]; then
+  pass "Config directory mode is 700 (doctor-aligned)"
+else
+  fail "Config directory should be mode 700 after shields down: ${DIR_PERMS_DOWN}"
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/test/e2e/test-skip-permissions-policy.sh
+++ b/test/e2e/test-skip-permissions-policy.sh
@@ -233,6 +233,52 @@ else
   fail "nemoclaw status failed: ${status_output:0:200}"
 fi
 
+# 3d: shields status must show DOWN (permanent)
+info "Checking shields status..."
+shields_output=$(nemoclaw "$SANDBOX_NAME" shields status 2>&1)
+echo "$shields_output" | while IFS= read -r line; do info "  $line"; done
+
+if echo "$shields_output" | grep -q "Shields: DOWN"; then
+  pass "shields status reports DOWN"
+else
+  fail "shields status should show DOWN when --dangerously-skip-permissions is active"
+fi
+
+if echo "$shields_output" | grep -qi "permanent"; then
+  pass "shields status shows permanent mode"
+else
+  fail "shields status should show permanent mode"
+fi
+
+# 3e: Config file permissions must be sandbox:sandbox 0600 (doctor-aligned)
+info "Checking config file permissions inside sandbox..."
+PERMS_OUTPUT=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- \
+  stat -c '%a %U:%G' /sandbox/.openclaw/openclaw.json 2>/dev/null || true)
+info "Config perms: ${PERMS_OUTPUT}"
+
+if [ "$(echo "$PERMS_OUTPUT" | awk '{print $1}')" = "600" ]; then
+  pass "Config file mode is 600 (matches openclaw doctor expectations)"
+else
+  fail "Config file mode should be 600 (got: ${PERMS_OUTPUT})"
+fi
+
+if [ "$(echo "$PERMS_OUTPUT" | awk '{print $2}')" = "sandbox:sandbox" ]; then
+  pass "Config file owned by sandbox:sandbox"
+else
+  fail "Config file should be owned by sandbox:sandbox (got: ${PERMS_OUTPUT})"
+fi
+
+# 3f: Config directory permissions must be sandbox:sandbox 0700
+DIR_PERMS=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- \
+  stat -c '%a %U:%G' /sandbox/.openclaw 2>/dev/null || true)
+info "Config dir perms: ${DIR_PERMS}"
+
+if [ "$(echo "$DIR_PERMS" | awk '{print $1}')" = "700" ]; then
+  pass "Config directory mode is 700"
+else
+  fail "Config directory mode should be 700 (got: ${DIR_PERMS})"
+fi
+
 # ══════════════════════════════════════════════════════════════════
 # Phase 4: Verify outbound HTTPS from inside sandbox
 # ══════════════════════════════════════════════════════════════════

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -2144,18 +2144,19 @@ const { setupInference } = require(${onboardPath});
     );
   });
 
-  it("activates permissive policy via policy set when dangerouslySkipPermissions is true", () => {
+  it("enters permanent shields-down state when dangerouslySkipPermissions is true", () => {
     const source = fs.readFileSync(
       path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
       "utf-8",
     );
 
-    // The dangerouslySkipPermissions branch must call applyPermissivePolicy to
-    // activate the policy via `openshell policy set --wait`.  Without this,
-    // the base policy from sandbox create stays in Pending status (#897).
+    // The dangerouslySkipPermissions branch must call shields.shieldsDownPermanent
+    // to activate the permissive policy, unlock the config file with doctor-aligned
+    // permissions, and record permanent shields-down state. This replaced the
+    // previous policies.applyPermissivePolicy call to unify the shields state machine.
     assert.match(
       source,
-      /if \(dangerouslySkipPermissions\) \{\s*step\(8, 8, "Policy presets"\);\s*if \(!waitForSandboxReady\(sandboxName\)\) \{[\s\S]*?\}\s*policies\.applyPermissivePolicy\(sandboxName\);/,
+      /if \(dangerouslySkipPermissions\) \{\s*step\(8, 8, "Policy presets"\);\s*if \(!waitForSandboxReady\(sandboxName\)\) \{[\s\S]*?\}\s*shields\.shieldsDownPermanent\(sandboxName\);/,
     );
     // Must NOT just print a skip message without activating the policy.
     assert.doesNotMatch(


### PR DESCRIPTION
## Summary

- `--dangerously-skip-permissions` now enters **permanent shields-down state** instead of only applying the permissive network policy
- Config file inside sandbox set to `sandbox:sandbox 0600/0700` matching what OpenClaw natively writes (`mode: 384`), so `openclaw doctor` no longer recommends chmod fixes
- `shields status` correctly reports DOWN (permanent) when the flag is active
- `sandboxConnect` checks the registry on every connect, not just when the CLI flag is passed

## Problem

Three independent issues with `--dangerously-skip-permissions`:

1. **Config file stayed locked** — only the network policy was relaxed, but `openclaw.json` remained `root:root 0444` inside the sandbox. `openclaw doctor` would ask the user to chmod.
2. **Shields state was disconnected** — `shields status` reported UP even in permissive mode because `--dangerously-skip-permissions` and `shields down` were independent code paths.
3. **Wrong permissions when unlocked** — `shields down` used `chmod 666`/`chmod 777` (world-writable) instead of `sandbox:sandbox 0600/0700`, which still didn't match doctor expectations.

## Changes

- **shields.ts**: Extract `unlockAgentConfig()` using `sandbox:sandbox 0600/0700`; add `shieldsDownPermanent()` (idempotent, no timer); update status/up for permanent state
- **nemoclaw.ts**: `sandboxConnect` checks registry + CLI flag, calls `shieldsDownPermanent()`; status distinguishes permanent vs timed shields-down
- **onboard.ts**: Replaces `applyPermissivePolicy()` with `shieldsDownPermanent()`
- **test/onboard.test.ts**: Updated source-match test for new call
- **test/e2e/**: Both skip-permissions and shields-config E2E tests verify doctor-aligned permissions with exact field matching

## Test plan

- [x] E2E: `skip-permissions-e2e` passed on [run 24609204912](https://github.com/NVIDIA/NemoClaw/actions/runs/24609204912)
- [x] E2E: `shields-config-e2e` passed on [run 24609204912](https://github.com/NVIDIA/NemoClaw/actions/runs/24609204912)
- [ ] Inside sandbox, run `openclaw doctor` — verify no permission complaints
- [ ] Run `shields up` after permanent — verify config re-locks
- [ ] Run `shields down --timeout 5m` after permanent — verify "permanently DOWN" error

Supersedes #2058 and #2059 (wrong git identity).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permanent shields-down mode for enhanced sandbox protection control.

* **Bug Fixes**
  * Onboarding now applies permanent shields-down instead of previous permission-handling approach.
  * Config file and directory permissions are now enforced to stricter, more secure standards (read/write only by sandbox owner).

* **Tests**
  * Updated tests to verify permanent shields-down behavior and stricter permission requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->