### PR TITLE
fix(test): remove --local flag from TC-SBX-02 chat command

### DIFF
--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -292,7 +292,7 @@ test_sbx_02_connect_chat() {
 
   log "  Sending one-shot message to agent via SSH..."
   local reply
-  reply=$(sandbox_exec "openclaw agent --agent main --local -m 'Say exactly: HELLO_E2E' --session-id e2e-test" 2>&1) || true
+  reply=$(sandbox_exec "openclaw agent --agent main -m 'Say exactly: HELLO_E2E' --session-id e2e-test" 2>&1) || true
 
   if echo "$reply" | grep -qi "HELLO_E2E"; then
     pass "TC-SBX-02: Agent replied with expected token"


### PR DESCRIPTION
## Summary

Remove --local flag from the TC-SBX-02 chat test command. OpenClaw 2026.4.2 now blocks --local inside NemoClaw sandboxes. The agent uses the gateway inference route instead, which is the correct path.

## Related Issue

Issue [2061](https://github.com/NVIDIA/NemoClaw/issues/2061)

## Changes

- Remove --local from the openclaw agent command in test_sbx_02_connect_chat()

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npx prek run --all-files` passes
- [x] Tested locally: agent replies HELLO_E2E through the gateway route
- [x] No secrets, API keys, or credentials committed

## AI Disclosure

- [x] AI-assisted — tool: Cursor

---

Signed-off-by: Truong Nguyen <tgnguyen@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test configuration to reflect agent command behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->