### PR TITLE
fix(onboard): forward enabled messaging channels into policy preset suggestions

### DIFF
--- a/src/lib/onboard-session.test.ts
+++ b/src/lib/onboard-session.test.ts
@@ -122,6 +122,29 @@ describe("onboard session", () => {
     expect(loaded.metadata.token).toBeUndefined();
   });
 
+  it("persists messagingChannels across save/load roundtrips", () => {
+    const created = session.createSession();
+    created.messagingChannels = ["telegram", "slack"];
+    session.saveSession(created);
+
+    const loaded = session.loadSession();
+    expect(loaded.messagingChannels).toEqual(["telegram", "slack"]);
+  });
+
+  it("filters non-string entries out of persisted messagingChannels", () => {
+    const created = session.createSession();
+    created.messagingChannels = ["telegram", 42, null, "discord"];
+    session.saveSession(created);
+
+    const loaded = session.loadSession();
+    expect(loaded.messagingChannels).toEqual(["telegram", "discord"]);
+  });
+
+  it("defaults messagingChannels to null for fresh sessions", () => {
+    const fresh = session.createSession();
+    expect(fresh.messagingChannels).toBeNull();
+  });
+
   it("persists and clears web search config through safe session updates", () => {
     session.saveSession(session.createSession());
     session.markStepComplete("provider_selection", {

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -59,6 +59,7 @@ export interface Session {
   nimContainer: string | null;
   webSearchConfig: WebSearchConfig | null;
   policyPresets: string[] | null;
+  messagingChannels: string[] | null;
   metadata: SessionMetadata;
   steps: Record<string, StepState>;
 }
@@ -88,6 +89,7 @@ export interface SessionUpdates {
   nimContainer?: string;
   webSearchConfig?: WebSearchConfig | null;
   policyPresets?: string[];
+  messagingChannels?: string[];
   metadata?: { gatewayName?: string; fromDockerfile?: string | null };
 }
 
@@ -203,6 +205,9 @@ export function createSession(overrides: Partial<Session> = {}): Session {
     policyPresets: Array.isArray(overrides.policyPresets)
       ? overrides.policyPresets.filter((value) => typeof value === "string")
       : null,
+    messagingChannels: Array.isArray(overrides.messagingChannels)
+      ? overrides.messagingChannels.filter((value) => typeof value === "string")
+      : null,
     metadata: {
       gatewayName: overrides.metadata?.gatewayName || "nemoclaw",
       fromDockerfile: overrides.metadata?.fromDockerfile || null,
@@ -239,6 +244,9 @@ export function normalizeSession(data: unknown): Session | null {
         : null,
     policyPresets: Array.isArray(d.policyPresets)
       ? (d.policyPresets as unknown[]).filter((value) => typeof value === "string") as string[]
+      : null,
+    messagingChannels: Array.isArray(d.messagingChannels)
+      ? (d.messagingChannels as unknown[]).filter((value) => typeof value === "string") as string[]
       : null,
     lastStepStarted: typeof d.lastStepStarted === "string" ? d.lastStepStarted : null,
     lastCompletedStep: typeof d.lastCompletedStep === "string" ? d.lastCompletedStep : null,
@@ -549,6 +557,9 @@ export function filterSafeUpdates(updates: SessionUpdates): Partial<Session> {
   }
   if (Array.isArray(updates.policyPresets)) {
     safe.policyPresets = updates.policyPresets.filter((value) => typeof value === "string");
+  }
+  if (Array.isArray(updates.messagingChannels)) {
+    safe.messagingChannels = updates.messagingChannels.filter((value) => typeof value === "string");
   }
   if (isObject(updates.metadata) && typeof updates.metadata.gatewayName === "string") {
     safe.metadata = {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4688,6 +4688,7 @@ async function setupMessagingChannels() {
         console.log(`  ✓ ${ch.name} token saved`);
       } else {
         console.log(`  Skipped ${ch.name} (no token entered)`);
+        enabled.delete(ch.name);
         continue;
       }
     }
@@ -4743,19 +4744,23 @@ async function setupMessagingChannels() {
   }
   console.log("");
 
+  // Channels where the user declined to enter a token were dropped from
+  // `enabled` inside the per-channel loop, so only channels with credentials
+  // configured remain in the Set.
+
   // Preflight: verify Telegram API is reachable from the host before sandbox creation.
   // The non-interactive branch above already ran this probe and returned early,
   // so this second call only fires on the interactive path — guard explicitly
   // to make the no-double-probe invariant visible at the call site.
   if (
     !isNonInteractive() &&
-    selected.includes("telegram") &&
+    enabled.has("telegram") &&
     getMessagingToken("TELEGRAM_BOT_TOKEN")
   ) {
     await checkTelegramReachability(getMessagingToken("TELEGRAM_BOT_TOKEN"));
   }
 
-  return selected;
+  return Array.from(enabled);
 }
 
 function getSuggestedPolicyPresets({ enabledChannels = null, webSearchConfig = null, provider = null } = {}) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5212,6 +5212,23 @@ async function presetsCheckboxSelector(allPresets, initialSelected) {
   });
 }
 
+function computeSetupPresetSuggestions(tierName, options = {}) {
+  const { enabledChannels = null, webSearchConfig = null, provider = null } = options;
+  const known = Array.isArray(options.knownPresetNames) ? new Set(options.knownPresetNames) : null;
+  const suggestions = tiers.resolveTierPresets(tierName).map((p) => p.name);
+  const add = (name) => {
+    if (suggestions.includes(name)) return;
+    if (known && !known.has(name)) return;
+    suggestions.push(name);
+  };
+  if (webSearchConfig) add("brave");
+  if (provider && LOCAL_INFERENCE_PROVIDERS.includes(provider)) add("local-inference");
+  if (Array.isArray(enabledChannels)) {
+    for (const channel of enabledChannels) add(channel);
+  }
+  return suggestions;
+}
+
 // eslint-disable-next-line complexity
 async function setupPoliciesWithSelection(sandboxName, options = {}) {
   const selectedPresets = Array.isArray(options.selectedPresets) ? options.selectedPresets : null;
@@ -5244,14 +5261,12 @@ async function setupPoliciesWithSelection(sandboxName, options = {}) {
   // Tier selection — determines the default preset list for this install.
   const tierName = await selectPolicyTier();
   registry.updateSandbox(sandboxName, { policyTier: tierName });
-  // Seed suggestions from the tier's default preset names (for non-interactive path).
-  const suggestions = tiers.resolveTierPresets(tierName).map((p) => p.name);
-  // Allow credential-based overrides on top of the tier (additive only).
-  if (webSearchConfig && !suggestions.includes("brave")) suggestions.push("brave");
-  // Auto-suggest local-inference preset when a local provider is selected
-  if (provider && LOCAL_INFERENCE_PROVIDERS.includes(provider) && !suggestions.includes("local-inference")) {
-    suggestions.push("local-inference");
-  }
+  const suggestions = computeSetupPresetSuggestions(tierName, {
+    enabledChannels,
+    webSearchConfig,
+    provider,
+    knownPresetNames: allPresets.map((p) => p.name),
+  });
 
   if (isNonInteractive()) {
     const policyMode = (process.env.NEMOCLAW_POLICY_MODE || "suggested").trim().toLowerCase();
@@ -6155,6 +6170,7 @@ module.exports = {
   isOpenclawReady,
   arePolicyPresetsApplied,
   getSuggestedPolicyPresets,
+  computeSetupPresetSuggestions,
   LOCAL_INFERENCE_PROVIDERS,
   presetsCheckboxSelector,
   selectPolicyTier,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6222,6 +6222,9 @@ async function onboard(opts = {}) {
     const recordedPolicyPresets = Array.isArray(latestSession?.policyPresets)
       ? latestSession.policyPresets
       : null;
+    const recordedMessagingChannels = Array.isArray(latestSession?.messagingChannels)
+      ? latestSession.messagingChannels
+      : [];
     if (dangerouslySkipPermissions) {
       step(8, 8, "Policy presets");
       if (!waitForSandboxReady(sandboxName)) {
@@ -6258,7 +6261,10 @@ async function onboard(opts = {}) {
             Array.isArray(recordedPolicyPresets) && recordedPolicyPresets.length > 0
               ? recordedPolicyPresets
               : null,
-          enabledChannels: selectedMessagingChannels,
+          enabledChannels:
+            selectedMessagingChannels.length > 0
+              ? selectedMessagingChannels
+              : recordedMessagingChannels,
           webSearchConfig,
           provider,
           onSelection: (policyPresets) => {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -54,7 +54,7 @@ import { stageOptimizedSandboxBuildContext } from "../dist/lib/sandbox-build-con
 import { buildWebSearchDockerConfig } from "../dist/lib/web-search";
 
 const require = createRequire(import.meta.url);
-const { getSuggestedPolicyPresets } = require("../dist/lib/onboard.js");
+const { getSuggestedPolicyPresets, computeSetupPresetSuggestions } = require("../dist/lib/onboard.js");
 
 describe("onboard helpers", () => {
   it("classifies sandbox create timeout failures and tracks upload progress", () => {
@@ -159,6 +159,85 @@ describe("onboard helpers", () => {
     expect(getSuggestedPolicyPresets({ provider: "openai-api" })).not.toContain("local-inference");
     expect(getSuggestedPolicyPresets({ provider: null })).not.toContain("local-inference");
     expect(getSuggestedPolicyPresets({})).not.toContain("local-inference");
+  });
+
+  describe("computeSetupPresetSuggestions", () => {
+    const known = [
+      "npm", "pypi", "huggingface", "brew", "brave",
+      "slack", "discord", "telegram", "jira", "outlook",
+      "local-inference",
+    ];
+
+    it("returns balanced tier defaults without messaging presets when no channels enabled", () => {
+      const suggestions = computeSetupPresetSuggestions("balanced", {
+        enabledChannels: [],
+        knownPresetNames: known,
+      });
+      expect(suggestions).toEqual(["npm", "pypi", "huggingface", "brew", "brave"]);
+    });
+
+    it("forwards enabled messaging channels into the balanced tier suggestions", () => {
+      const suggestions = computeSetupPresetSuggestions("balanced", {
+        enabledChannels: ["telegram"],
+        knownPresetNames: known,
+      });
+      expect(suggestions).toContain("telegram");
+      expect(suggestions).toContain("npm");
+      expect(suggestions).toContain("brave");
+    });
+
+    it("forwards multiple messaging channels", () => {
+      const suggestions = computeSetupPresetSuggestions("balanced", {
+        enabledChannels: ["discord", "slack"],
+        knownPresetNames: known,
+      });
+      expect(suggestions).toContain("discord");
+      expect(suggestions).toContain("slack");
+    });
+
+    it("does not duplicate a channel already present in the tier (open tier)", () => {
+      const suggestions = computeSetupPresetSuggestions("open", {
+        enabledChannels: ["telegram", "slack"],
+        knownPresetNames: known,
+      });
+      expect(suggestions.filter((n) => n === "telegram")).toHaveLength(1);
+      expect(suggestions.filter((n) => n === "slack")).toHaveLength(1);
+    });
+
+    it("drops channel names that are not known presets", () => {
+      const suggestions = computeSetupPresetSuggestions("balanced", {
+        enabledChannels: ["telegram", "not-a-real-preset"],
+        knownPresetNames: known,
+      });
+      expect(suggestions).toContain("telegram");
+      expect(suggestions).not.toContain("not-a-real-preset");
+    });
+
+    it("still adds brave when webSearchConfig is provided", () => {
+      const suggestions = computeSetupPresetSuggestions("restricted", {
+        webSearchConfig: { provider: "brave" },
+        knownPresetNames: known,
+      });
+      expect(suggestions).toContain("brave");
+    });
+
+    it("adds local-inference for local providers", () => {
+      const suggestions = computeSetupPresetSuggestions("balanced", {
+        provider: "ollama-local",
+        knownPresetNames: known,
+      });
+      expect(suggestions).toContain("local-inference");
+    });
+
+    it("ignores enabledChannels when null (non-explicit selection)", () => {
+      const suggestions = computeSetupPresetSuggestions("balanced", {
+        enabledChannels: null,
+        knownPresetNames: known,
+      });
+      expect(suggestions).not.toContain("telegram");
+      expect(suggestions).not.toContain("slack");
+      expect(suggestions).not.toContain("discord");
+    });
   });
 
   it("patches the staged Dockerfile with the selected model and chat UI URL", () => {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -5,7 +5,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -15,6 +14,7 @@ import {
   buildSandboxConfigSyncScript,
   classifySandboxCreateFailure,
   compactText,
+  computeSetupPresetSuggestions,
   formatEnvAssignment,
   getDashboardAccessInfo,
   getDashboardForwardStartCommand,
@@ -34,6 +34,7 @@ import {
   getResumeSandboxConflict,
   getSandboxStateFromOutputs,
   getStableGatewayImageRef,
+  getSuggestedPolicyPresets,
   isGatewayHealthy,
   classifyValidationFailure,
   hasResponsesToolCall,
@@ -52,9 +53,6 @@ import {
 } from "../dist/lib/onboard";
 import { stageOptimizedSandboxBuildContext } from "../dist/lib/sandbox-build-context";
 import { buildWebSearchDockerConfig } from "../dist/lib/web-search";
-
-const require = createRequire(import.meta.url);
-const { getSuggestedPolicyPresets, computeSetupPresetSuggestions } = require("../dist/lib/onboard.js");
 
 describe("onboard helpers", () => {
   it("classifies sandbox create timeout failures and tracks upload progress", () => {


### PR DESCRIPTION
The Balanced tier omits messaging presets by default, so a user who enabled telegram, slack, or discord in the messaging step would still see the matching preset unchecked at the policy step. Extract the seed-suggestions logic from setupPoliciesWithSelection into a pure helper and forward enabledChannels alongside the existing brave and local-inference additions.

Closes #2014

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [X] AI-assisted — tool: <!-- e.g., Claude Code, Cursor, GitHub Copilot -->

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced setup suggestions to include selected messaging channels, web-search and local-inference options, and to prefer newly selected channels when resuming setup.
  * Sessions now persist nullable messaging channel selections and sanitize non-string entries.

* **Bug Fixes**
  * Messaging reachability checks (e.g., Telegram) now run only when a token-backed channel remains enabled.

* **Tests**
  * Added unit tests for suggestion logic, channel inclusion/deduplication/filtering, and session persistence/round-trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->