### PR TITLE
fix(uninstall): source nvm in non-interactive shells to find npm

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -420,6 +420,18 @@ is_installer_managed_nemoclaw_shim() {
 }
 
 remove_nemoclaw_cli() {
+  # Source nvm if available (curl|bash runs non-interactive, nvm not auto-loaded)
+  if [ -z "$(command -v npm 2>/dev/null)" ]; then
+    for nvm_script in "$HOME/.nvm/nvm.sh" "${NVM_DIR:-}/nvm.sh"; do
+      if [ -f "$nvm_script" ]; then
+        . "$nvm_script" --no-use 2>/dev/null
+        # Activate the default or current nvm alias so npm is on PATH
+        nvm use default >/dev/null 2>&1 || nvm use current >/dev/null 2>&1 || true
+        break
+      fi
+    done
+  fi
+
   if command -v npm >/dev/null 2>&1; then
     npm unlink -g nemoclaw >/dev/null 2>&1 || true
     if npm uninstall -g --loglevel=error nemoclaw >/dev/null 2>&1; then
@@ -429,6 +441,16 @@ remove_nemoclaw_cli() {
     fi
   else
     warn "npm not found; skipping nemoclaw npm uninstall."
+  fi
+
+  # Fallback: if nemoclaw binary is still on PATH, remove it directly
+  if command -v nemoclaw >/dev/null 2>&1; then
+    local nemoclaw_bin
+    nemoclaw_bin="$(command -v nemoclaw)"
+    if [ -f "$nemoclaw_bin" ]; then
+      remove_path "$nemoclaw_bin"
+      info "Removed leftover nemoclaw binary at $nemoclaw_bin"
+    fi
   fi
 
   if [ -L "${NEMOCLAW_SHIM_DIR}/nemoclaw" ]; then


### PR DESCRIPTION
## Summary\n\nWhen running `curl -fsSL .../uninstall.sh | bash`, nvm is not sourced in the non-interactive shell, so `npm` is not on PATH. The `remove_nemoclaw_cli()` function skips CLI removal with "npm not found".\n\n## Changes\n\n1. **Auto-detect nvm**: Before the npm check, attempts to source `$HOME/.nvm/nvm.sh` or `$NVM_DIR/nvm.sh` and activate the default node version\n2. **Fallback removal**: After npm uninstall, if `nemoclaw` is still on PATH, directly removes the binary\n\nFixes #1959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the uninstall process for the CLI tool to better handle Node/NVM environments, ensuring complete removal of all associated files and binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->