### PR TITLE
fix(status): use -n flag for sandbox exec in checkMessagingBridgeHealth

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1127,7 +1127,7 @@ function readGatewayLog(sandboxName) {
   try {
     const result = spawnSync(
       getOpenshellBinary(),
-      ["sandbox", "exec", sandboxName, "sh", "-c", "tail -n 10 /tmp/gateway.log 2>/dev/null"],
+      ["sandbox", "exec", "-n", sandboxName, "--", "sh", "-c", "tail -n 10 /tmp/gateway.log 2>/dev/null"],
       { encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
     );
     const output = (result.stdout || "").trim();

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1074,7 +1074,7 @@ function checkMessagingBridgeHealth(sandboxName, channels) {
   try {
     const result = spawnSync(
       getOpenshellBinary(),
-      ["sandbox", "exec", sandboxName, "sh", "-c", script],
+      ["sandbox", "exec", "-n", sandboxName, "--", "sh", "-c", script],
       { encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
     );
     const count = Number.parseInt((result.stdout || "").trim(), 10);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`checkMessagingBridgeHealth()` calls `openshell sandbox exec <sandboxName> sh -c <script>` with the sandbox name as a positional argument. However, `openshell sandbox exec` requires the `-n`/`--name` flag. Without it, the sandbox name is interpreted as the command to execute, causing exit code 127. The catch block silently swallows this error, so the Telegram 409 conflict degraded warning is never shown in `nemoclaw <sandbox> status` output.

## Related Issue

Fixes #2018

## Changes

- `src/nemoclaw.ts`: changed `["sandbox", "exec", sandboxName, "sh", "-c", script]` to `["sandbox", "exec", "-n", sandboxName, "--", "sh", "-c", script]`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Manually verified: `nemoclaw <sandbox> status` now surfaces the Telegram 409 degraded warning instead of silently swallowing exit 127.

## AI Disclosure

- [x] AI-assisted — tool: OpenClaw (Claude Opus 4.7 via GitHub Copilot)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal command-line argument handling for improved consistency. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->