### PR TITLE
fix(security): migrate docker shell strings to argv arrays in agent-onboard

### DIFF
--- a/src/lib/agent-onboard.ts
+++ b/src/lib/agent-onboard.ts
@@ -55,13 +55,14 @@ export function createAgentSandbox(agent: AgentDefinition): {
 
   if (baseDockerfile) {
     const baseImageTag = `ghcr.io/nvidia/nemoclaw/${agent.name}-sandbox-base:latest`;
-    const inspectResult = run(`docker image inspect ${shellQuote(baseImageTag)} >/dev/null 2>&1`, {
+    const inspectResult = run(["docker", "image", "inspect", baseImageTag], {
       ignoreError: true,
+      stdio: ["ignore", "ignore", "ignore"],
     });
     if (inspectResult.status !== 0) {
       console.log(`  Building ${agent.displayName} base image (first time only)...`);
       run(
-        `docker build -f ${shellQuote(baseDockerfile)} -t ${shellQuote(baseImageTag)} ${shellQuote(ROOT)}`,
+        ["docker", "build", "-f", baseDockerfile, "-t", baseImageTag, ROOT],
         { stdio: ["ignore", "inherit", "inherit"] },
       );
       console.log(`  \u2713 Base image built: ${baseImageTag}`);
@@ -156,6 +157,10 @@ export async function handleAgentSetup(
     const script = buildSandboxConfigSyncScript(sandboxConfig);
     const scriptFile = writeSandboxConfigSyncFile(script);
     try {
+      // NOTE: This call retains the shell string form because it requires stdin
+      // redirection (< scriptFile) which cannot be expressed as a pure argv array
+      // without access to the openshell binary path. A full migration requires
+      // exposing getOpenshellBinary() or runOpenshell() in the OnboardContext.
       run(
         `${openshellShellCommand(["sandbox", "connect", sandboxName])} < ${shellQuote(scriptFile)}`,
         { stdio: ["ignore", "ignore", "inherit"] },


### PR DESCRIPTION
## Summary\n\nPartial migration of shell-string `run()` calls to argv arrays in `src/lib/agent-onboard.ts`, as tracked in #1889.\n\n## Changes\n\nConverts 2 of 3 shell-string calls to structurally safe argv arrays:\n- `docker image inspect` — no longer uses shell interpolation\n- `docker build` — no longer uses shell interpolation\n\nThe third call (`openshell sandbox connect` with stdin `<` redirection) retains shell form because it requires stdin redirection and the openshell binary path is not directly accessible from the `OnboardContext`. A full migration of this callsite requires exposing `getOpenshellBinary()` or `runOpenshell()` in the context.\n\nPartial fix for #1889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains internal maintenance and code improvements with no user-facing changes. Updates to underlying infrastructure components enhance reliability and code quality without affecting end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->