### PR TITLE
fix(connect): show agent-specific command and /exit hint (Fixes #2079)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -260,7 +260,9 @@ print_done() {
       printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$(detect_shell_profile)"
     fi
     printf "  %s$%s nemoclaw %s connect\n" "$C_GREEN" "$C_RESET" "$sandbox_name"
-    if [[ "$agent_name" == "openclaw" || -z "$agent_name" ]]; then
+    if [[ "$agent_name" == "hermes" ]]; then
+      printf "  %ssandbox@%s$%s hermes\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
+    else
       printf "  %ssandbox@%s$%s openclaw tui\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
     fi
   elif [[ "$NEMOCLAW_READY_NOW" == true ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -260,11 +260,19 @@ print_done() {
       printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$(detect_shell_profile)"
     fi
     printf "  %s$%s nemoclaw %s connect\n" "$C_GREEN" "$C_RESET" "$sandbox_name"
-    if [[ "$agent_name" == "hermes" ]]; then
-      printf "  %ssandbox@%s$%s hermes\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
-    else
-      printf "  %ssandbox@%s$%s openclaw tui\n" "$C_GREEN" "$sandbox_name" "$C_RESET"
-    fi
+    local agent_cmd
+    case "$agent_name" in
+      hermes)
+        agent_cmd="hermes"
+        ;;
+      "" | openclaw)
+        agent_cmd="openclaw tui"
+        ;;
+      *)
+        agent_cmd="$agent_name"
+        ;;
+    esac
+    printf "  %ssandbox@%s$%s %s\n" "$C_GREEN" "$sandbox_name" "$C_RESET" "$agent_cmd"
   elif [[ "$NEMOCLAW_READY_NOW" == true ]]; then
     printf "  ${C_GREEN}NemoClaw CLI is installed.${C_RESET}\n"
     printf "  ${C_DIM}Onboarding has not run yet.${C_RESET}\n"

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1230,11 +1230,12 @@ async function sandboxConnect(sandboxName, { dangerouslySkipPermissions = false 
     !["1", "true"].includes(String(process.env.NEMOCLAW_NO_CONNECT_HINT || ""))
   ) {
     console.log("");
+    const agentCmd = sb?.agent === "hermes" ? "hermes" : "openclaw tui";
     console.log(`  ${G}✓${R} Connecting to sandbox '${sandboxName}'`);
     console.log(
-      `  ${D}Inside the sandbox, run \`openclaw tui\` to start chatting with the agent.${R}`,
+      `  ${D}Inside the sandbox, run \`${agentCmd}\` to start chatting with the agent.${R}`,
     );
-    console.log(`  ${D}Type \`exit\` (or Ctrl-D) to return to the host shell.${R}`);
+    console.log(`  ${D}Type \`/exit\` to leave the chat, then \`exit\` to return to the host shell.${R}`);
     console.log("");
   }
   const result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1230,7 +1230,8 @@ async function sandboxConnect(sandboxName, { dangerouslySkipPermissions = false 
     !["1", "true"].includes(String(process.env.NEMOCLAW_NO_CONNECT_HINT || ""))
   ) {
     console.log("");
-    const agentCmd = sb?.agent === "hermes" ? "hermes" : "openclaw tui";
+    const agentName = sb?.agent || "openclaw";
+    const agentCmd = agentName === "openclaw" ? "openclaw tui" : agentName;
     console.log(`  ${G}✓${R} Connecting to sandbox '${sandboxName}'`);
     console.log(
       `  ${D}Inside the sandbox, run \`${agentCmd}\` to start chatting with the agent.${R}`,


### PR DESCRIPTION
## Summary

Fixes #2079 — the connect hint showed incorrect instructions after connecting to a sandbox.

### Problems
1. **Wrong TUI command**: Always showed `openclaw tui` regardless of which agent the sandbox runs. For hermes sandboxes, the correct command is `hermes`.
2. **Missing /exit hint**: The exit hint only mentioned `exit` (shell exit), but users who launched the TUI first need `/exit` to leave the chat before `exit` returns them to the host shell.

### Changes
- **`src/nemoclaw.ts`**: Derive the TUI command from the sandbox registry's `agent` field (`hermes` → `hermes`, others → `openclaw tui`). Updated exit hint to mention `/exit` for leaving the chat.
- **`scripts/install.sh`**: Show agent-specific command in post-onboard hint (was only shown for openclaw agent, now shown for all agents with correct command).

### Testing
- Ran full test suite — 0 new failures (38 pre-existing failures unchanged)
- No test assertions reference the hint text (tests suppress via `NEMOCLAW_NO_CONNECT_HINT=1`)

Signed-off-by: kagura-agent <kagura-agent@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox connection hint now always shows a single connect command reflecting the configured agent (Hermes, OpenClaw tui, or the agent's name).

* **Documentation**
  * Clarified exit instructions: use "/exit" to leave the in-sandbox chat, then "exit" to return to the host shell.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->