### PR TITLE
feat(cli): add type-safety hotspot report

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -350,6 +350,18 @@ The status command detects the sandbox context and reports "active (inside sandb
 
 Run `openshell sandbox list` on the host to check the underlying sandbox state.
 
+### `openclaw update` hangs or times out inside the sandbox
+
+This is expected for the current NemoClaw deployment model.
+NemoClaw installs `openclaw` into the sandbox image at build time, so the CLI is image-pinned rather than updated in place inside a running sandbox.
+
+Do not run `openclaw update` inside the sandbox.
+Instead:
+
+1. Upgrade to a NemoClaw release that includes the newer `openclaw` version.
+2. If you build NemoClaw from source, bump the pinned `openclaw` version in `Dockerfile.base` and rebuild the sandbox base image.
+3. Run `nemoclaw <name> rebuild` to recreate the sandbox with the updated image. The rebuild command automatically backs up workspace state before destroying the old sandbox and restores it afterward.
+
 ### Inference requests time out
 
 Verify that the inference provider endpoint is reachable from the host.

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -350,18 +350,6 @@ The status command detects the sandbox context and reports "active (inside sandb
 
 Run `openshell sandbox list` on the host to check the underlying sandbox state.
 
-### `openclaw update` hangs or times out inside the sandbox
-
-This is expected for the current NemoClaw deployment model.
-NemoClaw installs `openclaw` into the sandbox image at build time, so the CLI is image-pinned rather than updated in place inside a running sandbox.
-
-Do not run `openclaw update` inside the sandbox.
-Instead:
-
-1. Upgrade to a NemoClaw release that includes the newer `openclaw` version.
-2. If you build NemoClaw from source, bump the pinned `openclaw` version in `Dockerfile.base` and rebuild the sandbox base image.
-3. Back up any workspace files you need, then recreate the sandbox so it uses the rebuilt image.
-
 ### Inference requests time out
 
 Verify that the inference provider endpoint is reachable from the host.

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -350,6 +350,18 @@ The status command detects the sandbox context and reports "active (inside sandb
 
 Run `openshell sandbox list` on the host to check the underlying sandbox state.
 
+### `openclaw update` hangs or times out inside the sandbox
+
+This is expected for the current NemoClaw deployment model.
+NemoClaw installs `openclaw` into the sandbox image at build time, so the CLI is image-pinned rather than updated in place inside a running sandbox.
+
+Do not run `openclaw update` inside the sandbox.
+Instead:
+
+1. Upgrade to a NemoClaw release that includes the newer `openclaw` version.
+2. If you build NemoClaw from source, bump the pinned `openclaw` version in `Dockerfile.base` and rebuild the sandbox base image.
+3. Back up any workspace files you need, then recreate the sandbox so it uses the rebuilt image.
+
 ### Inference requests time out
 
 Verify that the inference provider endpoint is reachable from the host.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -390,7 +390,7 @@ Instead:
 
 1. Upgrade to a NemoClaw release that includes the newer `openclaw` version.
 2. If you build NemoClaw from source, bump the pinned `openclaw` version in `Dockerfile.base` and rebuild the sandbox base image.
-3. Back up any workspace files you need, then recreate the sandbox so it uses the rebuilt image.
+3. Run `nemoclaw <name> rebuild` to recreate the sandbox with the updated image. The rebuild command automatically backs up workspace state before destroying the old sandbox and restores it afterward.
 
 ### Inference requests time out
 

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -306,6 +306,21 @@ describe("commands/migration-state", () => {
       expect(result.externalRoots.some((r) => r.kind === "skillsExtraDir")).toBe(true);
     });
 
+    it("resolves external roots against the provided env", () => {
+      const env = { HOME: "/home/user", OPENCLAW_HOME: "/custom/home" };
+      addDir("/custom/home/.openclaw");
+      addFile(
+        "/custom/home/.openclaw/openclaw.json",
+        JSON.stringify({
+          skills: { load: { extraDirs: ["~/skills-extra"] } },
+        }),
+      );
+      addDir("/custom/home/skills-extra");
+
+      const result = detectHostOpenClaw(env);
+      expect(result.externalRoots[0]?.sourcePath).toBe("/custom/home/skills-extra");
+    });
+
     it("warns about symlinks in workspace", () => {
       const env = { HOME: "/home/user" };
       addDir("/home/user/.openclaw");

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -88,7 +88,44 @@ type CandidateRoot = {
   required: boolean;
 };
 
-type OpenClawConfigDocument = Record<string, unknown>;
+type UnknownRecord = { [key: string]: unknown };
+type OpenClawConfigDocument = UnknownRecord;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function readTrimmedString(value: unknown): string | null {
+  const trimmed = readString(value)?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function readRecord(value: unknown): UnknownRecord | null {
+  return isRecord(value) ? value : null;
+}
+
+function readRecordKey(
+  record: UnknownRecord | null | undefined,
+  key: string,
+): UnknownRecord | null {
+  return readRecord(record?.[key]);
+}
+
+function readArrayKey(record: UnknownRecord | null | undefined, key: string): unknown[] | null {
+  const value = record?.[key];
+  return Array.isArray(value) ? value : null;
+}
+
+function parseConfigDocument(value: unknown, context: string): OpenClawConfigDocument {
+  if (!isRecord(value)) {
+    throw new Error(`${context} is not a JSON object.`);
+  }
+  return value;
+}
 
 function resolveHostHome(env: NodeJS.ProcessEnv = process.env): string {
   const fallbackHome = env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
@@ -148,11 +185,7 @@ function loadConfigDocument(configPath: string): OpenClawConfigDocument | null {
     return null;
   }
   const raw = readFileSync(configPath, "utf-8");
-  const parsed: unknown = JSON5.parse(raw);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`Config at ${configPath} is not a JSON object.`);
-  }
-  return parsed as OpenClawConfigDocument;
+  return parseConfigDocument(JSON5.parse(raw), `Config at ${configPath}`);
 }
 
 function collectSymlinkPaths(rootPath: string): string[] {
@@ -234,29 +267,13 @@ function collectExternalRoots(
   const errors: string[] = [];
   const rootMap = new Map<string, CandidateRoot>();
 
-  const agents = config?.["agents"];
-  const agentDefaults =
-    agents && typeof agents === "object" && !Array.isArray(agents)
-      ? (agents as Record<string, unknown>)["defaults"]
-      : undefined;
-  const agentList =
-    agents && typeof agents === "object" && !Array.isArray(agents)
-      ? (agents as Record<string, unknown>)["list"]
-      : undefined;
-  const skills = config?.["skills"];
-  const skillLoad =
-    skills && typeof skills === "object" && !Array.isArray(skills)
-      ? (skills as Record<string, unknown>)["load"]
-      : undefined;
+  const agents = readRecordKey(config, "agents");
+  const agentDefaults = readRecordKey(agents, "defaults");
+  const agentList = readArrayKey(agents, "list");
+  const skillLoad = readRecordKey(readRecordKey(config, "skills"), "load");
 
-  const defaultsWorkspace =
-    agentDefaults && typeof agentDefaults === "object" && !Array.isArray(agentDefaults)
-      ? (agentDefaults as Record<string, unknown>)["workspace"]
-      : undefined;
-  const defaultWorkspace =
-    typeof defaultsWorkspace === "string" && defaultsWorkspace.trim()
-      ? defaultsWorkspace.trim()
-      : defaultWorkspacePath();
+  const defaultsWorkspace = readTrimmedString(agentDefaults?.workspace);
+  const defaultWorkspace = defaultsWorkspace ?? defaultWorkspacePath();
   registerRoot(rootMap, {
     pathValue: defaultWorkspace,
     kind: "workspace",
@@ -266,20 +283,19 @@ function collectExternalRoots(
     required: typeof defaultsWorkspace === "string" && defaultsWorkspace.trim().length > 0,
   });
 
-  if (Array.isArray(agentList)) {
+  if (agentList) {
     agentList.forEach((entry, index) => {
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      const agent = readRecord(entry);
+      if (!agent) {
         return;
       }
-      const agent = entry as Record<string, unknown>;
-      const agentId =
-        typeof agent["id"] === "string" && agent["id"].trim()
-          ? agent["id"].trim()
-          : `agent-${String(index)}`;
+      const agentId = readTrimmedString(agent.id) ?? `agent-${String(index)}`;
+      const workspace = readTrimmedString(agent.workspace);
+      const agentDir = readTrimmedString(agent.agentDir);
 
-      if (typeof agent["workspace"] === "string" && agent["workspace"].trim()) {
+      if (workspace) {
         registerRoot(rootMap, {
-          pathValue: agent["workspace"].trim(),
+          pathValue: workspace,
           kind: "workspace",
           label: `${agentId}-workspace`,
           bindingPath: `agents.list[${String(index)}].workspace`,
@@ -288,9 +304,9 @@ function collectExternalRoots(
         });
       }
 
-      if (typeof agent["agentDir"] === "string" && agent["agentDir"].trim()) {
+      if (agentDir) {
         registerRoot(rootMap, {
-          pathValue: agent["agentDir"].trim(),
+          pathValue: agentDir,
           kind: "agentDir",
           label: `${agentId}-agent-dir`,
           bindingPath: `agents.list[${String(index)}].agentDir`,
@@ -301,17 +317,15 @@ function collectExternalRoots(
     });
   }
 
-  const extraDirs =
-    skillLoad && typeof skillLoad === "object" && !Array.isArray(skillLoad)
-      ? (skillLoad as Record<string, unknown>)["extraDirs"]
-      : undefined;
-  if (Array.isArray(extraDirs)) {
+  const extraDirs = readArrayKey(skillLoad, "extraDirs");
+  if (extraDirs) {
     extraDirs.forEach((entry, index) => {
-      if (typeof entry !== "string" || !entry.trim()) {
+      const extraDir = readTrimmedString(entry);
+      if (!extraDir) {
         return;
       }
       registerRoot(rootMap, {
-        pathValue: entry.trim(),
+        pathValue: extraDir,
         kind: "skillsExtraDir",
         label: `skills-extra-${String(index + 1)}`,
         bindingPath: `skills.load.extraDirs[${String(index)}]`,
@@ -417,25 +431,12 @@ export function detectHostOpenClaw(env: NodeJS.ProcessEnv = process.env): HostOp
   warnings.push(...rootInfo.warnings);
   errors.push(...rootInfo.errors);
 
-  const workspaceDir =
-    config &&
-    typeof config["agents"] === "object" &&
-    config["agents"] &&
-    !Array.isArray(config["agents"]) &&
-    typeof (
-      (config["agents"] as Record<string, unknown>)["defaults"] as
-        | Record<string, unknown>
-        | undefined
-    )?.["workspace"] === "string"
-      ? resolveUserPath(
-          (
-            ((config["agents"] as Record<string, unknown>)["defaults"] as Record<string, unknown>)[
-              "workspace"
-            ] as string
-          ).trim(),
-          env,
-        )
-      : defaultWorkspacePath(env);
+  const defaultsWorkspace = readTrimmedString(
+    readRecordKey(readRecordKey(config, "agents"), "defaults")?.workspace,
+  );
+  const workspaceDir = defaultsWorkspace
+    ? resolveUserPath(defaultsWorkspace, env)
+    : defaultWorkspacePath(env);
 
   const extensionsDir = existsSync(path.join(stateDir, "extensions"))
     ? path.join(stateDir, "extensions")
@@ -521,9 +522,10 @@ function stripCredentials(obj: unknown): unknown {
   if (obj === null || obj === undefined) return obj;
   if (typeof obj !== "object") return obj;
   if (Array.isArray(obj)) return obj.map(stripCredentials);
+  if (!isRecord(obj)) return obj;
 
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+  const result: UnknownRecord = {};
+  for (const [key, value] of Object.entries(obj)) {
     if (isCredentialField(key)) {
       result[key] = "[STRIPPED_BY_MIGRATION]";
     } else {
@@ -538,13 +540,11 @@ function stripCredentials(obj: unknown): unknown {
  * config section (contains auth tokens — regenerated by sandbox entrypoint).
  */
 function sanitizeConfigFile(configPath: string): void {
-  if (!existsSync(configPath)) return;
-  const raw = readFileSync(configPath, "utf-8");
-  const parsed: unknown = JSON5.parse(raw);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
-  const config = parsed as Record<string, unknown>;
-  delete config["gateway"];
-  const sanitized = stripCredentials(config) as Record<string, unknown>;
+  const config = loadConfigDocument(configPath);
+  if (!config) return;
+  delete config.gateway;
+  const sanitized = stripCredentials(config);
+  if (!isRecord(sanitized)) return;
   writeFileSync(configPath, JSON.stringify(sanitized, null, 2));
   chmodSync(configPath, 0o600);
 }

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -229,8 +229,9 @@ function registerRoot(
     sandboxGroup: string;
     required: boolean;
   },
+  env: NodeJS.ProcessEnv = process.env,
 ): void {
-  const resolvedPath = resolveUserPath(params.pathValue);
+  const resolvedPath = resolveUserPath(params.pathValue, env);
   const normalized = normalizeHostPath(resolvedPath);
   const existing = rootMap.get(normalized);
   if (existing) {
@@ -262,6 +263,7 @@ function defaultWorkspacePath(env: NodeJS.ProcessEnv = process.env): string {
 function collectExternalRoots(
   config: OpenClawConfigDocument | null,
   stateDir: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): { roots: MigrationExternalRoot[]; warnings: string[]; errors: string[] } {
   const warnings: string[] = [];
   const errors: string[] = [];
@@ -273,15 +275,19 @@ function collectExternalRoots(
   const skillLoad = readRecordKey(readRecordKey(config, "skills"), "load");
 
   const defaultsWorkspace = readTrimmedString(agentDefaults?.workspace);
-  const defaultWorkspace = defaultsWorkspace ?? defaultWorkspacePath();
-  registerRoot(rootMap, {
-    pathValue: defaultWorkspace,
-    kind: "workspace",
-    label: "default-workspace",
-    bindingPath: "agents.defaults.workspace",
-    sandboxGroup: "workspaces",
-    required: typeof defaultsWorkspace === "string" && defaultsWorkspace.trim().length > 0,
-  });
+  const defaultWorkspace = defaultsWorkspace ?? defaultWorkspacePath(env);
+  registerRoot(
+    rootMap,
+    {
+      pathValue: defaultWorkspace,
+      kind: "workspace",
+      label: "default-workspace",
+      bindingPath: "agents.defaults.workspace",
+      sandboxGroup: "workspaces",
+      required: typeof defaultsWorkspace === "string" && defaultsWorkspace.trim().length > 0,
+    },
+    env,
+  );
 
   if (agentList) {
     agentList.forEach((entry, index) => {
@@ -294,25 +300,33 @@ function collectExternalRoots(
       const agentDir = readTrimmedString(agent.agentDir);
 
       if (workspace) {
-        registerRoot(rootMap, {
-          pathValue: workspace,
-          kind: "workspace",
-          label: `${agentId}-workspace`,
-          bindingPath: `agents.list[${String(index)}].workspace`,
-          sandboxGroup: "workspaces",
-          required: true,
-        });
+        registerRoot(
+          rootMap,
+          {
+            pathValue: workspace,
+            kind: "workspace",
+            label: `${agentId}-workspace`,
+            bindingPath: `agents.list[${String(index)}].workspace`,
+            sandboxGroup: "workspaces",
+            required: true,
+          },
+          env,
+        );
       }
 
       if (agentDir) {
-        registerRoot(rootMap, {
-          pathValue: agentDir,
-          kind: "agentDir",
-          label: `${agentId}-agent-dir`,
-          bindingPath: `agents.list[${String(index)}].agentDir`,
-          sandboxGroup: "agent-dirs",
-          required: true,
-        });
+        registerRoot(
+          rootMap,
+          {
+            pathValue: agentDir,
+            kind: "agentDir",
+            label: `${agentId}-agent-dir`,
+            bindingPath: `agents.list[${String(index)}].agentDir`,
+            sandboxGroup: "agent-dirs",
+            required: true,
+          },
+          env,
+        );
       }
     });
   }
@@ -324,14 +338,18 @@ function collectExternalRoots(
       if (!extraDir) {
         return;
       }
-      registerRoot(rootMap, {
-        pathValue: extraDir,
-        kind: "skillsExtraDir",
-        label: `skills-extra-${String(index + 1)}`,
-        bindingPath: `skills.load.extraDirs[${String(index)}]`,
-        sandboxGroup: "skills",
-        required: true,
-      });
+      registerRoot(
+        rootMap,
+        {
+          pathValue: extraDir,
+          kind: "skillsExtraDir",
+          label: `skills-extra-${String(index + 1)}`,
+          bindingPath: `skills.load.extraDirs[${String(index)}]`,
+          sandboxGroup: "skills",
+          required: true,
+        },
+        env,
+      );
     });
   }
 
@@ -427,7 +445,7 @@ export function detectHostOpenClaw(env: NodeJS.ProcessEnv = process.env): HostOp
     errors.push(`Failed to parse OpenClaw config at ${configPath}: ${msg}`);
   }
 
-  const rootInfo = collectExternalRoots(config, stateDir);
+  const rootInfo = collectExternalRoots(config, stateDir, env);
   warnings.push(...rootInfo.warnings);
   errors.push(...rootInfo.errors);
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ts-migration:assist": "tsx scripts/ts-migration-assist.ts",
     "ts-migration:bulk-fix-prs": "tsx scripts/ts-migration-bulk-fix-prs.ts",
     "ts-migration:guard": "tsx scripts/check-legacy-migrated-paths.ts",
+    "type-safety:hotspots": "tsx scripts/type-safety-hotspots.ts",
     "bump:version": "tsx scripts/bump-version.ts",
     "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "git describe --tags --match 'v*' | sed 's/^v//' > .version && test -s .version && cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"

--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -1,0 +1,1288 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const DEFAULT_PROJECTS = ["tsconfig.cli.json", "nemoclaw/tsconfig.json"] as const;
+const DEFAULT_TOP_FILES = 15;
+const DEFAULT_TOP_FUNCTIONS = 15;
+const DEFAULT_MIN_SCORE = 1;
+const COMMENT_DIRECTIVE_RE = /@ts-ignore|@ts-expect-error/g;
+
+type ProjectInfo = {
+  name: string;
+  compilerOptions: ts.CompilerOptions;
+  fileNames: string[];
+};
+
+type PatternCounts = {
+  explicitAnyCount: number;
+  unknownTypeCount: number;
+  recordStringUnknownCount: number;
+  typeAssertionCount: number;
+  nonNullAssertionCount: number;
+  parserBoundaryCount: number;
+  tsDirectiveCount: number;
+};
+
+export type FileHotspot = PatternCounts & {
+  filePath: string;
+  project: string;
+  loc: number;
+  exportCount: number;
+  weakExportCount: number;
+  fanIn: number;
+  importCount: number;
+  noCheck: boolean;
+  rawUnsafety: number;
+  impactMultiplier: number;
+  score: number;
+  reasons: string[];
+};
+
+export type FunctionHotspot = PatternCounts & {
+  displayName: string;
+  filePath: string;
+  line: number;
+  loc: number;
+  exported: boolean;
+  weakParameterCount: number;
+  weakReturnType: boolean;
+  missingReturnType: boolean;
+  fileFanIn: number;
+  noCheck: boolean;
+  rawUnsafety: number;
+  impactMultiplier: number;
+  score: number;
+  reasons: string[];
+};
+
+type ThemeSummary = {
+  id: string;
+  title: string;
+  detail: string;
+  count: number;
+  examples: string[];
+};
+
+type ReportSummary = PatternCounts & {
+  projectCount: number;
+  fileCount: number;
+  noCheckFileCount: number;
+  exportCount: number;
+  weakExportCount: number;
+  totalLoc: number;
+};
+
+export type HotspotReport = {
+  summary: ReportSummary;
+  files: FileHotspot[];
+  functions: FunctionHotspot[];
+  themes: ThemeSummary[];
+  scoring: {
+    description: string;
+  };
+};
+
+export type AnalyzeOptions = {
+  rootDir?: string;
+  projectPaths?: string[];
+  includeTests?: boolean;
+};
+
+type CliOptions = {
+  rootDir: string;
+  projectPaths: string[];
+  includeTests: boolean;
+  topFiles: number;
+  topFunctions: number;
+  minScore: number;
+  json: boolean;
+};
+
+type RawFunctionData = PatternCounts & {
+  displayName: string;
+  filePath: string;
+  line: number;
+  loc: number;
+  exported: boolean;
+  weakParameterCount: number;
+  weakReturnType: boolean;
+  missingReturnType: boolean;
+  noCheck: boolean;
+};
+
+type RawFileData = PatternCounts & {
+  absPath: string;
+  filePath: string;
+  project: string;
+  loc: number;
+  exportCount: number;
+  weakExportCount: number;
+  importSpecifiers: string[];
+  noCheck: boolean;
+  functions: RawFunctionData[];
+};
+
+type ReportableFunctionNode =
+  | ts.FunctionDeclaration
+  | ts.MethodDeclaration
+  | ts.GetAccessorDeclaration
+  | ts.SetAccessorDeclaration
+  | ts.ArrowFunction
+  | ts.FunctionExpression;
+
+function createPatternCounts(): PatternCounts {
+  return {
+    explicitAnyCount: 0,
+    unknownTypeCount: 0,
+    recordStringUnknownCount: 0,
+    typeAssertionCount: 0,
+    nonNullAssertionCount: 0,
+    parserBoundaryCount: 0,
+    tsDirectiveCount: 0,
+  };
+}
+
+function addPattern(target: PatternCounts, key: keyof PatternCounts, amount = 1): void {
+  target[key] += amount;
+}
+
+function roundScore(value: number): number {
+  return Math.round(value);
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural;
+}
+
+function toPosixRelative(rootDir: string, filePath: string): string {
+  return path.relative(rootDir, filePath).split(path.sep).join(path.posix.sep);
+}
+
+function countNonEmptyLines(text: string): number {
+  return text.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
+}
+
+function countMatches(text: string, re: RegExp): number {
+  const matches = text.match(re);
+  return matches ? matches.length : 0;
+}
+
+function hasLeadingTsNoCheck(text: string): boolean {
+  let offset = 0;
+  if (text.startsWith("#!")) {
+    const newline = text.indexOf("\n");
+    offset = newline === -1 ? text.length : newline + 1;
+  }
+
+  const ranges = ts.getLeadingCommentRanges(text, offset) ?? [];
+  return ranges.some((range) => text.slice(range.pos, range.end).includes("@ts-nocheck"));
+}
+
+function formatDiagnostics(diagnostics: readonly ts.Diagnostic[], rootDir: string): string {
+  return diagnostics
+    .map((diagnostic) => {
+      const prefix = diagnostic.file
+        ? `${toPosixRelative(rootDir, diagnostic.file.fileName)}:${String(
+            diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start ?? 0).line + 1,
+          )}`
+        : rootDir;
+      const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+      return `${prefix}: ${message}`;
+    })
+    .join("\n");
+}
+
+function loadProjectInfo(rootDir: string, projectPath: string): ProjectInfo {
+  const absProjectPath = path.resolve(rootDir, projectPath);
+  const loaded = ts.readConfigFile(absProjectPath, ts.sys.readFile);
+
+  if (loaded.error) {
+    throw new Error(
+      `Failed to read ${projectPath}:\n${formatDiagnostics([loaded.error], rootDir)}`,
+    );
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    loaded.config,
+    ts.sys,
+    path.dirname(absProjectPath),
+    undefined,
+    absProjectPath,
+  );
+
+  if (parsed.errors.length > 0) {
+    throw new Error(
+      `Failed to parse ${projectPath}:\n${formatDiagnostics(parsed.errors, rootDir)}`,
+    );
+  }
+
+  return {
+    name: toPosixRelative(rootDir, absProjectPath),
+    compilerOptions: parsed.options,
+    fileNames: parsed.fileNames.map((fileName) => path.resolve(fileName)),
+  };
+}
+
+function shouldIncludeFile(filePath: string, includeTests: boolean): boolean {
+  const normalized = filePath.split(path.sep).join(path.posix.sep);
+  if (!/\.[cm]?tsx?$/.test(normalized)) return false;
+  if (normalized.endsWith(".d.ts")) return false;
+  if (normalized.includes("/node_modules/") || normalized.includes("/dist/")) return false;
+  if (!includeTests && (/\.test\.[cm]?tsx?$/.test(normalized) || normalized.includes("/test/"))) {
+    return false;
+  }
+  return true;
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  return (ts.getCombinedModifierFlags(node as ts.Declaration) & ts.ModifierFlags.Export) !== 0;
+}
+
+function countExports(sourceFile: ts.SourceFile): number {
+  let count = 0;
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportAssignment(statement)) {
+      count += 1;
+      continue;
+    }
+
+    if (ts.isExportDeclaration(statement)) {
+      if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        count += statement.exportClause.elements.length;
+      } else {
+        count += 1;
+      }
+      continue;
+    }
+
+    if (!hasExportModifier(statement)) {
+      continue;
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      count += statement.declarationList.declarations.length;
+      continue;
+    }
+
+    if (
+      ts.isFunctionDeclaration(statement) ||
+      ts.isClassDeclaration(statement) ||
+      ts.isInterfaceDeclaration(statement) ||
+      ts.isTypeAliasDeclaration(statement) ||
+      ts.isEnumDeclaration(statement)
+    ) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+function getPropertyNameText(name: ts.PropertyName | ts.BindingName | undefined): string | null {
+  if (!name) return null;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+function getEnclosingClassName(node: ts.Node): string | null {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (ts.isClassDeclaration(current) && current.name) {
+      return current.name.text;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function getFunctionDisplayName(node: ReportableFunctionNode): string | null {
+  if (ts.isFunctionDeclaration(node)) {
+    return node.name?.text ?? null;
+  }
+
+  if (
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node)
+  ) {
+    const methodName = getPropertyNameText(node.name);
+    if (!methodName) return null;
+    const className = getEnclosingClassName(node);
+    return className ? `${className}.${methodName}` : methodName;
+  }
+
+  if (
+    (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+    ts.isVariableDeclaration(node.parent)
+  ) {
+    return getPropertyNameText(node.parent.name);
+  }
+
+  return null;
+}
+
+function isReportableFunction(node: ts.Node): node is ReportableFunctionNode {
+  if (
+    !ts.isFunctionDeclaration(node) &&
+    !ts.isMethodDeclaration(node) &&
+    !ts.isGetAccessorDeclaration(node) &&
+    !ts.isSetAccessorDeclaration(node) &&
+    !ts.isArrowFunction(node) &&
+    !ts.isFunctionExpression(node)
+  ) {
+    return false;
+  }
+
+  return Boolean(getFunctionDisplayName(node));
+}
+
+function isNodeExported(node: ReportableFunctionNode): boolean {
+  if (ts.isFunctionDeclaration(node)) {
+    return hasExportModifier(node);
+  }
+
+  if (
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node)
+  ) {
+    return hasExportModifier(node.parent);
+  }
+
+  if (
+    (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+    ts.isVariableDeclaration(node.parent)
+  ) {
+    const maybeStatement = node.parent.parent?.parent;
+    return Boolean(
+      maybeStatement && ts.isVariableStatement(maybeStatement) && hasExportModifier(maybeStatement),
+    );
+  }
+
+  return false;
+}
+
+function buildTypeAliasMap(sourceFile: ts.SourceFile): Map<string, ts.TypeNode> {
+  const aliases = new Map<string, ts.TypeNode>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isTypeAliasDeclaration(node)) {
+      aliases.set(node.name.text, node.type);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return aliases;
+}
+
+function containsWeakType(
+  typeNode: ts.TypeNode | undefined,
+  aliases: Map<string, ts.TypeNode>,
+  seen = new Set<string>(),
+): boolean {
+  if (!typeNode) return false;
+
+  switch (typeNode.kind) {
+    case ts.SyntaxKind.AnyKeyword:
+    case ts.SyntaxKind.UnknownKeyword:
+    case ts.SyntaxKind.ObjectKeyword:
+      return true;
+    default:
+      break;
+  }
+
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return containsWeakType(typeNode.type, aliases, seen);
+  }
+
+  if (ts.isArrayTypeNode(typeNode)) {
+    return containsWeakType(typeNode.elementType, aliases, seen);
+  }
+
+  if (ts.isTupleTypeNode(typeNode)) {
+    return typeNode.elements.some((element) =>
+      containsWeakType(
+        ts.isNamedTupleMember(element) ? element.type : element,
+        aliases,
+        new Set(seen),
+      ),
+    );
+  }
+
+  if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
+    return typeNode.types.some((part) => containsWeakType(part, aliases, new Set(seen)));
+  }
+
+  if (ts.isTypeLiteralNode(typeNode)) {
+    if (typeNode.members.length === 0) return true;
+    return typeNode.members.some((member) => {
+      if (
+        ts.isPropertySignature(member) ||
+        ts.isMethodSignature(member) ||
+        ts.isIndexSignatureDeclaration(member) ||
+        ts.isCallSignatureDeclaration(member) ||
+        ts.isConstructSignatureDeclaration(member)
+      ) {
+        return containsWeakType(member.type, aliases, new Set(seen));
+      }
+      return false;
+    });
+  }
+
+  if (ts.isTypeOperatorNode(typeNode)) {
+    return containsWeakType(typeNode.type, aliases, seen);
+  }
+
+  if (ts.isIndexedAccessTypeNode(typeNode)) {
+    return (
+      containsWeakType(typeNode.objectType, aliases, new Set(seen)) ||
+      containsWeakType(typeNode.indexType, aliases, new Set(seen))
+    );
+  }
+
+  if (ts.isMappedTypeNode(typeNode)) {
+    return Boolean(typeNode.type && containsWeakType(typeNode.type, aliases, seen));
+  }
+
+  if (ts.isConditionalTypeNode(typeNode)) {
+    return (
+      containsWeakType(typeNode.checkType, aliases, new Set(seen)) ||
+      containsWeakType(typeNode.extendsType, aliases, new Set(seen)) ||
+      containsWeakType(typeNode.trueType, aliases, new Set(seen)) ||
+      containsWeakType(typeNode.falseType, aliases, new Set(seen))
+    );
+  }
+
+  if (ts.isFunctionTypeNode(typeNode) || ts.isConstructorTypeNode(typeNode)) {
+    return (
+      typeNode.parameters.some((parameter) =>
+        containsWeakType(parameter.type, aliases, new Set(seen)),
+      ) || containsWeakType(typeNode.type, aliases, new Set(seen))
+    );
+  }
+
+  if (ts.isTypePredicateNode(typeNode)) {
+    return false;
+  }
+
+  if (ts.isTypeReferenceNode(typeNode)) {
+    if (isDirectRecordStringUnknown(typeNode, aliases)) {
+      return true;
+    }
+
+    const typeArguments = typeNode.typeArguments ?? [];
+    if (typeArguments.some((argument) => containsWeakType(argument, aliases, new Set(seen)))) {
+      return true;
+    }
+
+    if (ts.isIdentifier(typeNode.typeName)) {
+      const aliasName = typeNode.typeName.text;
+      const aliasType = aliases.get(aliasName);
+      if (aliasType && !seen.has(aliasName)) {
+        const nextSeen = new Set(seen);
+        nextSeen.add(aliasName);
+        return containsWeakType(aliasType, aliases, nextSeen);
+      }
+    }
+  }
+
+  return false;
+}
+
+function isDirectRecordStringUnknown(
+  node: ts.TypeReferenceNode,
+  aliases: Map<string, ts.TypeNode>,
+): boolean {
+  if (!ts.isIdentifier(node.typeName) || node.typeName.text !== "Record") {
+    return false;
+  }
+
+  if (!node.typeArguments || node.typeArguments.length !== 2) {
+    return false;
+  }
+
+  return (
+    node.typeArguments[0].kind === ts.SyntaxKind.StringKeyword &&
+    containsWeakType(node.typeArguments[1], aliases)
+  );
+}
+
+function isParserBoundaryCall(node: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(node.expression)) {
+    return false;
+  }
+
+  const owner = node.expression.expression;
+  const member = node.expression.name.text;
+  if (!ts.isIdentifier(owner)) {
+    return false;
+  }
+
+  return (
+    (owner.text === "JSON" && member === "parse") ||
+    (owner.text === "JSON5" && member === "parse") ||
+    (owner.text === "YAML" && member === "parse") ||
+    (owner.text === "yaml" && member === "load")
+  );
+}
+
+function collectImportSpecifiers(sourceFile: ts.SourceFile): string[] {
+  const specifiers = new Set<string>();
+
+  function maybeAdd(specifier: ts.Expression | undefined): void {
+    if (specifier && ts.isStringLiteralLike(specifier) && specifier.text.startsWith(".")) {
+      specifiers.add(specifier.text);
+    }
+  }
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      maybeAdd(node.moduleSpecifier);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      maybeAdd(node.moduleReference.expression);
+    } else if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "require" &&
+      node.arguments.length === 1
+    ) {
+      maybeAdd(node.arguments[0]);
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1
+    ) {
+      maybeAdd(node.arguments[0]);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return [...specifiers];
+}
+
+function resolveLocalImport(
+  project: ProjectInfo,
+  fromFile: string,
+  specifier: string,
+  analyzedFiles: Set<string>,
+): string | null {
+  const resolved = ts.resolveModuleName(specifier, fromFile, project.compilerOptions, ts.sys)
+    .resolvedModule?.resolvedFileName;
+
+  if (resolved) {
+    const absResolved = path.resolve(resolved);
+    if (analyzedFiles.has(absResolved)) {
+      return absResolved;
+    }
+  }
+
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  const candidates = new Set<string>([
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}.mts`,
+    `${base}.cts`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.tsx"),
+    path.join(base, "index.mts"),
+    path.join(base, "index.cts"),
+  ]);
+
+  if (specifier.endsWith(".js") || specifier.endsWith(".mjs") || specifier.endsWith(".cjs")) {
+    const withoutJs = base.replace(/\.[cm]?js$/, "");
+    candidates.add(`${withoutJs}.ts`);
+    candidates.add(`${withoutJs}.tsx`);
+    candidates.add(`${withoutJs}.mts`);
+    candidates.add(`${withoutJs}.cts`);
+  }
+
+  for (const candidate of candidates) {
+    const absCandidate = path.resolve(candidate);
+    if (analyzedFiles.has(absCandidate)) {
+      return absCandidate;
+    }
+  }
+
+  return null;
+}
+
+function createFunctionData(
+  node: ReportableFunctionNode,
+  sourceFile: ts.SourceFile,
+  aliases: Map<string, ts.TypeNode>,
+  filePath: string,
+  noCheck: boolean,
+): RawFunctionData {
+  const displayName = getFunctionDisplayName(node) ?? "<anonymous>";
+  const start = node.getStart(sourceFile);
+  const line = sourceFile.getLineAndCharacterOfPosition(start).line + 1;
+  const loc = countNonEmptyLines(sourceFile.text.slice(start, node.end));
+  const weakParameterCount = node.parameters.reduce((count, parameter) => {
+    return count + (containsWeakType(parameter.type, aliases) ? 1 : 0);
+  }, 0);
+
+  return {
+    ...createPatternCounts(),
+    displayName,
+    filePath,
+    line,
+    loc,
+    exported: isNodeExported(node),
+    weakParameterCount,
+    weakReturnType: containsWeakType(node.type, aliases),
+    missingReturnType: isNodeExported(node) && !node.type,
+    noCheck,
+  };
+}
+
+function computeFileRawUnsafety(file: RawFileData): number {
+  let raw = 0;
+  if (file.noCheck) raw += 70;
+  raw += file.tsDirectiveCount * 12;
+  raw += file.explicitAnyCount * 12;
+  raw += file.parserBoundaryCount * 9;
+  raw += file.recordStringUnknownCount * 6;
+  raw += file.typeAssertionCount * 3;
+  raw += file.nonNullAssertionCount;
+  raw += file.weakExportCount * 8;
+  raw += file.unknownTypeCount * 0.25;
+  return raw;
+}
+
+function computeFunctionRawUnsafety(fn: RawFunctionData): number {
+  let raw = 0;
+  if (fn.noCheck) raw += 8;
+  raw += fn.tsDirectiveCount * 12;
+  raw += fn.explicitAnyCount * 12;
+  raw += fn.parserBoundaryCount * 12;
+  raw += fn.recordStringUnknownCount * 6;
+  raw += fn.typeAssertionCount * 3;
+  raw += fn.nonNullAssertionCount;
+  raw += fn.weakParameterCount * 7;
+  raw += fn.weakReturnType ? 8 : 0;
+  raw += fn.missingReturnType ? 2 : 0;
+  raw += fn.unknownTypeCount * 0.25;
+  return raw;
+}
+
+function appendReason(reasons: string[], reason: string): void {
+  if (!reasons.includes(reason)) {
+    reasons.push(reason);
+  }
+}
+
+function buildFileReasons(file: RawFileData, fanIn: number): string[] {
+  const reasons: string[] = [];
+
+  if (file.noCheck) appendReason(reasons, "@ts-nocheck disables the checker");
+  if (fanIn > 0) appendReason(reasons, `fan-in ${String(fanIn)}`);
+  if (file.parserBoundaryCount > 0) {
+    appendReason(
+      reasons,
+      `${String(file.parserBoundaryCount)} JSON/YAML ${pluralize(file.parserBoundaryCount, "parse boundary", "parse boundaries")}`,
+    );
+  }
+  if (file.recordStringUnknownCount > 0) {
+    appendReason(reasons, `${String(file.recordStringUnknownCount)} Record<string, unknown>`);
+  }
+  if (file.typeAssertionCount > 0) {
+    appendReason(
+      reasons,
+      `${String(file.typeAssertionCount)} ${pluralize(file.typeAssertionCount, "cast")}`,
+    );
+  }
+  if (file.weakExportCount > 0) {
+    appendReason(
+      reasons,
+      `${String(file.weakExportCount)} weak exported ${pluralize(file.weakExportCount, "signature")}`,
+    );
+  }
+  if (file.tsDirectiveCount > 0) {
+    appendReason(
+      reasons,
+      `${String(file.tsDirectiveCount)} ${pluralize(file.tsDirectiveCount, "ts-ignore/expect-error")}`,
+    );
+  }
+  if (file.explicitAnyCount > 0) {
+    appendReason(
+      reasons,
+      `${String(file.explicitAnyCount)} explicit ${pluralize(file.explicitAnyCount, "any")}`,
+    );
+  }
+  if (file.nonNullAssertionCount > 0) {
+    appendReason(
+      reasons,
+      `${String(file.nonNullAssertionCount)} non-null ${pluralize(file.nonNullAssertionCount, "assertion")}`,
+    );
+  }
+
+  return reasons.slice(0, 5);
+}
+
+function buildFunctionReasons(fn: RawFunctionData, fileFanIn: number): string[] {
+  const reasons: string[] = [];
+
+  if (fn.noCheck) appendReason(reasons, "enclosing file is @ts-nocheck");
+  if (fn.exported) appendReason(reasons, "exported API");
+  if (fileFanIn > 0) appendReason(reasons, `file fan-in ${String(fileFanIn)}`);
+  if (fn.parserBoundaryCount > 0) {
+    appendReason(
+      reasons,
+      `${String(fn.parserBoundaryCount)} JSON/YAML ${pluralize(fn.parserBoundaryCount, "parse boundary", "parse boundaries")}`,
+    );
+  }
+  if (fn.recordStringUnknownCount > 0) {
+    appendReason(reasons, `${String(fn.recordStringUnknownCount)} Record<string, unknown>`);
+  }
+  if (fn.typeAssertionCount > 0) {
+    appendReason(
+      reasons,
+      `${String(fn.typeAssertionCount)} ${pluralize(fn.typeAssertionCount, "cast")}`,
+    );
+  }
+  if (fn.weakParameterCount > 0) {
+    appendReason(
+      reasons,
+      `${String(fn.weakParameterCount)} weak ${pluralize(fn.weakParameterCount, "parameter")}`,
+    );
+  }
+  if (fn.weakReturnType) appendReason(reasons, "weak return type");
+  if (fn.missingReturnType) appendReason(reasons, "exported with inferred return type");
+
+  return reasons.slice(0, 5);
+}
+
+function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): RawFileData {
+  const text = fs.readFileSync(absPath, "utf8");
+  const sourceFile = ts.createSourceFile(absPath, text, ts.ScriptTarget.Latest, true);
+  const aliases = buildTypeAliasMap(sourceFile);
+  const noCheck = hasLeadingTsNoCheck(text);
+  const fileMetrics = createPatternCounts();
+  const functions: RawFunctionData[] = [];
+  const functionStack: RawFunctionData[] = [];
+
+  addPattern(fileMetrics, "tsDirectiveCount", countMatches(text, COMMENT_DIRECTIVE_RE));
+
+  function applyPattern(key: keyof PatternCounts, amount = 1): void {
+    addPattern(fileMetrics, key, amount);
+    const current = functionStack[functionStack.length - 1];
+    if (current) {
+      addPattern(current, key, amount);
+    }
+  }
+
+  function visit(node: ts.Node): void {
+    if (isReportableFunction(node)) {
+      const fn = createFunctionData(
+        node,
+        sourceFile,
+        aliases,
+        toPosixRelative(rootDir, absPath),
+        noCheck,
+      );
+      functions.push(fn);
+      functionStack.push(fn);
+      ts.forEachChild(node, visit);
+      functionStack.pop();
+      return;
+    }
+
+    if (node.kind === ts.SyntaxKind.AnyKeyword) {
+      applyPattern("explicitAnyCount");
+    } else if (node.kind === ts.SyntaxKind.UnknownKeyword) {
+      applyPattern("unknownTypeCount");
+    }
+
+    if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
+      applyPattern("typeAssertionCount");
+    }
+
+    if (ts.isNonNullExpression(node)) {
+      applyPattern("nonNullAssertionCount");
+    }
+
+    if (ts.isTypeReferenceNode(node) && isDirectRecordStringUnknown(node, aliases)) {
+      applyPattern("recordStringUnknownCount");
+    }
+
+    if (ts.isCallExpression(node) && isParserBoundaryCall(node)) {
+      applyPattern("parserBoundaryCount");
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  const weakExportCount = functions.filter(
+    (fn) => fn.exported && (fn.weakParameterCount > 0 || fn.weakReturnType || fn.missingReturnType),
+  ).length;
+
+  return {
+    ...fileMetrics,
+    absPath,
+    filePath: toPosixRelative(rootDir, absPath),
+    project: project.name,
+    loc: countNonEmptyLines(text),
+    exportCount: countExports(sourceFile),
+    weakExportCount,
+    importSpecifiers: collectImportSpecifiers(sourceFile),
+    noCheck,
+    functions,
+  };
+}
+
+function buildThemes(files: FileHotspot[], summary: ReportSummary): ThemeSummary[] {
+  const themes: ThemeSummary[] = [];
+  const topNoCheck = files
+    .filter((file) => file.noCheck)
+    .slice(0, 3)
+    .map((file) => file.filePath);
+  if (summary.noCheckFileCount > 0) {
+    themes.push({
+      id: "no-check",
+      title: "Remove @ts-nocheck from high-traffic helpers",
+      detail: `${String(summary.noCheckFileCount)} files disable type checking entirely.`,
+      count: summary.noCheckFileCount,
+      examples: topNoCheck,
+    });
+  }
+
+  const parseExamples = files
+    .filter((file) => file.parserBoundaryCount > 0)
+    .slice(0, 3)
+    .map((file) => file.filePath);
+  if (summary.parserBoundaryCount > 0) {
+    themes.push({
+      id: "parse-boundaries",
+      title: "Type parsed JSON/YAML documents",
+      detail: `${String(summary.parserBoundaryCount)} parse boundaries pair with ${String(
+        summary.recordStringUnknownCount,
+      )} weak map/object types.`,
+      count: summary.parserBoundaryCount,
+      examples: parseExamples,
+    });
+  }
+
+  const exportExamples = files
+    .filter((file) => file.weakExportCount > 0)
+    .slice(0, 3)
+    .map((file) => file.filePath);
+  if (summary.weakExportCount > 0) {
+    themes.push({
+      id: "weak-exports",
+      title: "Tighten public module surfaces first",
+      detail: `${String(summary.weakExportCount)} exported functions still rely on weak signatures.`,
+      count: summary.weakExportCount,
+      examples: exportExamples,
+    });
+  }
+
+  const castExamples = files
+    .filter((file) => file.typeAssertionCount > 0)
+    .slice(0, 3)
+    .map((file) => file.filePath);
+  if (summary.typeAssertionCount > 0) {
+    themes.push({
+      id: "cast-heavy",
+      title: "Collapse repeated casts with one real type or guard",
+      detail: `${String(summary.typeAssertionCount)} casts show where one interface or decoder can remove many assertions.`,
+      count: summary.typeAssertionCount,
+      examples: castExamples,
+    });
+  }
+
+  return themes;
+}
+
+export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): HotspotReport {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const projectPaths = options.projectPaths?.length ? options.projectPaths : [...DEFAULT_PROJECTS];
+  const includeTests = options.includeTests ?? false;
+  const projects = projectPaths.map((projectPath) => loadProjectInfo(rootDir, projectPath));
+
+  const projectByFile = new Map<string, ProjectInfo>();
+  for (const project of projects) {
+    for (const fileName of project.fileNames) {
+      if (!shouldIncludeFile(fileName, includeTests)) {
+        continue;
+      }
+      if (!projectByFile.has(fileName)) {
+        projectByFile.set(fileName, project);
+      }
+    }
+  }
+
+  const analyzedFiles = new Set(projectByFile.keys());
+  if (analyzedFiles.size === 0) {
+    throw new Error("No TypeScript source files matched the selected projects.");
+  }
+
+  const rawFiles = [...analyzedFiles]
+    .sort((left, right) => left.localeCompare(right))
+    .map((absPath) => analyzeFile(absPath, rootDir, projectByFile.get(absPath)!));
+
+  const importersByFile = new Map<string, Set<string>>();
+  const importsFromFile = new Map<string, Set<string>>();
+  for (const file of rawFiles) {
+    importersByFile.set(file.absPath, new Set());
+    importsFromFile.set(file.absPath, new Set());
+  }
+
+  for (const file of rawFiles) {
+    const project = projectByFile.get(file.absPath)!;
+    const resolvedImports = importsFromFile.get(file.absPath)!;
+
+    for (const specifier of file.importSpecifiers) {
+      const resolved = resolveLocalImport(project, file.absPath, specifier, analyzedFiles);
+      if (!resolved || resolved === file.absPath) {
+        continue;
+      }
+      resolvedImports.add(resolved);
+      importersByFile.get(resolved)?.add(file.absPath);
+    }
+  }
+
+  const files: FileHotspot[] = rawFiles
+    .map((file) => {
+      const fanIn = importersByFile.get(file.absPath)?.size ?? 0;
+      const importCount = importsFromFile.get(file.absPath)?.size ?? 0;
+      const rawUnsafety = computeFileRawUnsafety(file);
+      const impactMultiplier =
+        1 + Math.min(fanIn, 8) * 0.12 + Math.min(file.exportCount, 10) * 0.04;
+      const score = roundScore(
+        (rawUnsafety * impactMultiplier * 10) / Math.sqrt(Math.max(file.loc, 1)),
+      );
+
+      return {
+        ...file,
+        fanIn,
+        importCount,
+        rawUnsafety,
+        impactMultiplier,
+        score,
+        reasons: buildFileReasons(file, fanIn),
+      };
+    })
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      if (right.fanIn !== left.fanIn) return right.fanIn - left.fanIn;
+      if (right.rawUnsafety !== left.rawUnsafety) return right.rawUnsafety - left.rawUnsafety;
+      return left.filePath.localeCompare(right.filePath);
+    });
+
+  const fanInByFile = new Map(files.map((file) => [file.filePath, file.fanIn]));
+  const functions: FunctionHotspot[] = rawFiles
+    .flatMap((file) => file.functions)
+    .map((fn) => {
+      const fileFanIn = fanInByFile.get(fn.filePath) ?? 0;
+      const rawUnsafety = computeFunctionRawUnsafety(fn);
+      const impactMultiplier = 1 + Math.min(fileFanIn, 8) * 0.1 + (fn.exported ? 0.35 : 0);
+      const score = roundScore(
+        (rawUnsafety * impactMultiplier * 10) / Math.sqrt(Math.max(fn.loc, 12)),
+      );
+
+      return {
+        ...fn,
+        fileFanIn,
+        rawUnsafety,
+        impactMultiplier,
+        score,
+        reasons: buildFunctionReasons(fn, fileFanIn),
+      };
+    })
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      if (right.fileFanIn !== left.fileFanIn) return right.fileFanIn - left.fileFanIn;
+      if (right.rawUnsafety !== left.rawUnsafety) return right.rawUnsafety - left.rawUnsafety;
+      if (left.filePath !== right.filePath) return left.filePath.localeCompare(right.filePath);
+      return left.line - right.line;
+    });
+
+  const summary = rawFiles.reduce<ReportSummary>(
+    (acc, file) => {
+      acc.fileCount += 1;
+      acc.totalLoc += file.loc;
+      acc.exportCount += file.exportCount;
+      acc.weakExportCount += file.weakExportCount;
+      if (file.noCheck) acc.noCheckFileCount += 1;
+      acc.explicitAnyCount += file.explicitAnyCount;
+      acc.unknownTypeCount += file.unknownTypeCount;
+      acc.recordStringUnknownCount += file.recordStringUnknownCount;
+      acc.typeAssertionCount += file.typeAssertionCount;
+      acc.nonNullAssertionCount += file.nonNullAssertionCount;
+      acc.parserBoundaryCount += file.parserBoundaryCount;
+      acc.tsDirectiveCount += file.tsDirectiveCount;
+      return acc;
+    },
+    {
+      ...createPatternCounts(),
+      projectCount: projects.length,
+      fileCount: 0,
+      noCheckFileCount: 0,
+      exportCount: 0,
+      weakExportCount: 0,
+      totalLoc: 0,
+    },
+  );
+
+  return {
+    summary,
+    files,
+    functions,
+    themes: buildThemes(files, summary),
+    scoring: {
+      description:
+        "Heuristic score increases with type escapes (@ts-nocheck, parse boundaries, casts, weak signatures) and reuse (fan-in/exports), then discounts larger files/functions.",
+    },
+  };
+}
+
+function pickFunctionsForDisplay(
+  functions: FunctionHotspot[],
+  topFunctions: number,
+  minScore: number,
+): FunctionHotspot[] {
+  const picked: FunctionHotspot[] = [];
+  const fileCounts = new Map<string, number>();
+
+  for (const fn of functions) {
+    if (fn.score < minScore) {
+      continue;
+    }
+    const seen = fileCounts.get(fn.filePath) ?? 0;
+    if (seen >= 2) {
+      continue;
+    }
+    picked.push(fn);
+    fileCounts.set(fn.filePath, seen + 1);
+    if (picked.length >= topFunctions) {
+      break;
+    }
+  }
+
+  return picked;
+}
+
+export function renderTextReport(
+  report: HotspotReport,
+  options: Pick<CliOptions, "topFiles" | "topFunctions" | "minScore"> = {
+    topFiles: DEFAULT_TOP_FILES,
+    topFunctions: DEFAULT_TOP_FUNCTIONS,
+    minScore: DEFAULT_MIN_SCORE,
+  },
+): string {
+  const topFiles = report.files
+    .filter((file) => file.score >= options.minScore)
+    .slice(0, options.topFiles);
+  const topFunctions = pickFunctionsForDisplay(
+    report.functions,
+    options.topFunctions,
+    options.minScore,
+  );
+  const lines: string[] = [];
+
+  lines.push("Type-safety hotspots (bang-for-buck heuristic)");
+  lines.push(
+    `Analyzed ${String(report.summary.fileCount)} files across ${String(
+      report.summary.projectCount,
+    )} project${report.summary.projectCount === 1 ? "" : "s"}.`,
+  );
+  lines.push(
+    `Totals: ${String(report.summary.noCheckFileCount)} @ts-nocheck file${
+      report.summary.noCheckFileCount === 1 ? "" : "s"
+    }, ${String(report.summary.typeAssertionCount)} casts, ${String(
+      report.summary.recordStringUnknownCount,
+    )} Record<string, unknown>, ${String(report.summary.parserBoundaryCount)} parse boundaries.`,
+  );
+  lines.push(`Heuristic: ${report.scoring.description}`);
+
+  if (report.themes.length > 0) {
+    lines.push("");
+    lines.push("Repo-wide themes");
+    for (const theme of report.themes.slice(0, 4)) {
+      const examples = theme.examples.length > 0 ? ` Examples: ${theme.examples.join(", ")}.` : "";
+      lines.push(`- ${theme.title}: ${theme.detail}${examples}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("Top files");
+  if (topFiles.length === 0) {
+    lines.push(`- No files scored at least ${String(options.minScore)}.`);
+  } else {
+    topFiles.forEach((file, index) => {
+      lines.push(`${String(index + 1)}. ${String(file.score)} — ${file.filePath}`);
+      lines.push(
+        `   loc ${String(file.loc)}, fan-in ${String(file.fanIn)}, exports ${String(
+          file.exportCount,
+        )}, raw ${formatNumber(file.rawUnsafety)}`,
+      );
+      lines.push(`   ${file.reasons.join("; ")}`);
+    });
+  }
+
+  lines.push("");
+  lines.push("Top functions");
+  if (topFunctions.length === 0) {
+    lines.push(`- No functions scored at least ${String(options.minScore)}.`);
+  } else {
+    topFunctions.forEach((fn, index) => {
+      lines.push(
+        `${String(index + 1)}. ${String(fn.score)} — ${fn.displayName} (${fn.filePath}:${String(fn.line)})`,
+      );
+      lines.push(
+        `   loc ${String(fn.loc)}, file fan-in ${String(fn.fileFanIn)}, raw ${formatNumber(
+          fn.rawUnsafety,
+        )}`,
+      );
+      lines.push(`   ${fn.reasons.join("; ")}`);
+    });
+  }
+
+  return lines.join("\n");
+}
+
+function parseInteger(flag: string, value: string | undefined): number {
+  if (!value) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Expected a non-negative integer for ${flag}, got '${value}'`);
+  }
+  return parsed;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const projectPaths: string[] = [];
+  const options: CliOptions = {
+    rootDir: process.cwd(),
+    projectPaths,
+    includeTests: false,
+    topFiles: DEFAULT_TOP_FILES,
+    topFunctions: DEFAULT_TOP_FUNCTIONS,
+    minScore: DEFAULT_MIN_SCORE,
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--root":
+        if (!argv[index + 1]) {
+          throw new Error("Missing value for --root");
+        }
+        options.rootDir = path.resolve(argv[index + 1]!);
+        index += 1;
+        break;
+      case "--project":
+        if (!argv[index + 1]) {
+          throw new Error("Missing value for --project");
+        }
+        projectPaths.push(argv[index + 1]!);
+        index += 1;
+        break;
+      case "--top-files":
+        options.topFiles = parseInteger(arg, argv[index + 1]);
+        index += 1;
+        break;
+      case "--top-functions":
+        options.topFunctions = parseInteger(arg, argv[index + 1]);
+        index += 1;
+        break;
+      case "--min-score":
+        options.minScore = parseInteger(arg, argv[index + 1]);
+        index += 1;
+        break;
+      case "--include-tests":
+        options.includeTests = true;
+        break;
+      case "--json":
+        options.json = true;
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (projectPaths.length === 0) {
+    options.projectPaths = [...DEFAULT_PROJECTS];
+  }
+
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`Usage: npm run type-safety:hotspots -- [options]
+
+Rank files and functions by a bang-for-buck heuristic for adding stronger types.
+
+Options:
+  --root <dir>             Repo root to analyze (default: cwd)
+  --project <path>         Tsconfig to analyze (repeatable)
+  --top-files <n>          Files to show in text output (default: ${String(DEFAULT_TOP_FILES)})
+  --top-functions <n>      Functions to show in text output (default: ${String(DEFAULT_TOP_FUNCTIONS)})
+  --min-score <n>          Minimum score to print in text output (default: ${String(DEFAULT_MIN_SCORE)})
+  --include-tests          Include *.test.ts files
+  --json                   Emit JSON instead of text
+  -h, --help               Show this help`);
+}
+
+export function main(argv = process.argv.slice(2)): void {
+  try {
+    const options = parseArgs(argv);
+    const report = analyzeTypeSafetyHotspots({
+      rootDir: options.rootDir,
+      projectPaths: options.projectPaths,
+      includeTests: options.includeTests,
+    });
+
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+
+    console.log(
+      renderTextReport(report, {
+        topFiles: options.topFiles,
+        topFunctions: options.topFunctions,
+        minScore: options.minScore,
+      }),
+    );
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+const THIS_FILE = fileURLToPath(import.meta.url);
+
+if (process.argv[1] && path.resolve(process.argv[1]) === THIS_FILE) {
+  main();
+}

--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -107,6 +107,8 @@ type CliOptions = {
 type RawFunctionData = PatternCounts & {
   displayName: string;
   filePath: string;
+  start: number;
+  end: number;
   line: number;
   loc: number;
   exported: boolean;
@@ -126,6 +128,12 @@ type RawFileData = PatternCounts & {
   importSpecifiers: string[];
   noCheck: boolean;
   functions: RawFunctionData[];
+};
+
+type CommentDirectiveOccurrence = {
+  pos: number;
+  end: number;
+  count: number;
 };
 
 type ReportableFunctionNode =
@@ -177,31 +185,38 @@ function countMatches(text: string, re: RegExp): number {
   return matches ? matches.length : 0;
 }
 
-function collectCommentText(text: string): string {
+function collectDirectiveCommentOccurrences(text: string): CommentDirectiveOccurrence[] {
   const scanner = ts.createScanner(
     ts.ScriptTarget.Latest,
     false,
     ts.LanguageVariant.Standard,
     text,
   );
-  let comments = "";
+  const occurrences: CommentDirectiveOccurrence[] = [];
 
   while (true) {
     const token = scanner.scan();
     if (token === ts.SyntaxKind.EndOfFileToken) {
-      return comments;
+      return occurrences;
     }
     if (
       token === ts.SyntaxKind.SingleLineCommentTrivia ||
       token === ts.SyntaxKind.MultiLineCommentTrivia
     ) {
-      comments += `${scanner.getTokenText()}\n`;
+      const count = countMatches(scanner.getTokenText(), COMMENT_DIRECTIVE_RE);
+      if (count > 0) {
+        occurrences.push({
+          pos: scanner.getTokenPos(),
+          end: scanner.getTextPos(),
+          count,
+        });
+      }
     }
   }
 }
 
-function countDirectiveComments(text: string): number {
-  return countMatches(collectCommentText(text), COMMENT_DIRECTIVE_RE);
+function countDirectiveComments(occurrences: readonly CommentDirectiveOccurrence[]): number {
+  return occurrences.reduce((count, occurrence) => count + occurrence.count, 0);
 }
 
 function hasLeadingTsNoCheck(text: string): boolean {
@@ -634,8 +649,7 @@ function isParserBoundaryCall(node: ts.CallExpression): boolean {
   return (
     (owner.text === "JSON" && member === "parse") ||
     (owner.text === "JSON5" && member === "parse") ||
-    (owner.text === "YAML" && member === "parse") ||
-    (owner.text === "yaml" && member === "load")
+    ((owner.text === "YAML" || owner.text === "yaml") && (member === "parse" || member === "load"))
   );
 }
 
@@ -734,8 +748,9 @@ function createFunctionData(
 ): RawFunctionData {
   const displayName = getFunctionDisplayName(node) ?? "<anonymous>";
   const start = node.getStart(sourceFile);
+  const end = node.end;
   const line = sourceFile.getLineAndCharacterOfPosition(start).line + 1;
-  const loc = countNonEmptyLines(sourceFile.text.slice(start, node.end));
+  const loc = countNonEmptyLines(sourceFile.text.slice(start, end));
   const weakParameterCount = node.parameters.reduce((count, parameter) => {
     return count + (containsWeakType(parameter.type, aliases) ? 1 : 0);
   }, 0);
@@ -744,6 +759,8 @@ function createFunctionData(
     ...createPatternCounts(),
     displayName,
     filePath,
+    start,
+    end,
     line,
     loc,
     exported: isNodeExported(node),
@@ -871,16 +888,35 @@ function buildFunctionReasons(fn: RawFunctionData, fileFanIn: number): string[] 
   return reasons.slice(0, 5);
 }
 
+function findInnermostContainingFunction(
+  functions: readonly RawFunctionData[],
+  occurrence: CommentDirectiveOccurrence,
+): RawFunctionData | null {
+  let innermost: RawFunctionData | null = null;
+
+  for (const fn of functions) {
+    if (occurrence.pos < fn.start || occurrence.end > fn.end) {
+      continue;
+    }
+    if (!innermost || fn.end - fn.start < innermost.end - innermost.start) {
+      innermost = fn;
+    }
+  }
+
+  return innermost;
+}
+
 function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): RawFileData {
   const text = fs.readFileSync(absPath, "utf8");
   const sourceFile = ts.createSourceFile(absPath, text, ts.ScriptTarget.Latest, true);
   const aliases = buildTypeAliasMap(sourceFile);
   const noCheck = hasLeadingTsNoCheck(text);
+  const directiveOccurrences = collectDirectiveCommentOccurrences(text);
   const fileMetrics = createPatternCounts();
   const functions: RawFunctionData[] = [];
   const functionStack: RawFunctionData[] = [];
 
-  addPattern(fileMetrics, "tsDirectiveCount", countDirectiveComments(text));
+  addPattern(fileMetrics, "tsDirectiveCount", countDirectiveComments(directiveOccurrences));
 
   function applyPattern(key: keyof PatternCounts, amount = 1): void {
     addPattern(fileMetrics, key, amount);
@@ -932,6 +968,13 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
   }
 
   visit(sourceFile);
+
+  for (const occurrence of directiveOccurrences) {
+    const containingFunction = findInnermostContainingFunction(functions, occurrence);
+    if (containingFunction) {
+      addPattern(containingFunction, "tsDirectiveCount", occurrence.count);
+    }
+  }
 
   const weakExportCount = functions.filter(
     (fn) => fn.exported && (fn.weakParameterCount > 0 || fn.weakReturnType || fn.missingReturnType),
@@ -1094,6 +1137,7 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
   const functions: FunctionHotspot[] = rawFiles
     .flatMap((file) => file.functions)
     .map((fn) => {
+      const { start: _start, end: _end, ...functionData } = fn;
       const fileFanIn = fanInByFile.get(fn.filePath) ?? 0;
       const rawUnsafety = computeFunctionRawUnsafety(fn);
       const impactMultiplier = 1 + Math.min(fileFanIn, 8) * 0.1 + (fn.exported ? 0.35 : 0);
@@ -1102,7 +1146,7 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
       );
 
       return {
-        ...fn,
+        ...functionData,
         fileFanIn,
         rawUnsafety,
         impactMultiplier,

--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -177,6 +177,33 @@ function countMatches(text: string, re: RegExp): number {
   return matches ? matches.length : 0;
 }
 
+function collectCommentText(text: string): string {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    false,
+    ts.LanguageVariant.Standard,
+    text,
+  );
+  let comments = "";
+
+  while (true) {
+    const token = scanner.scan();
+    if (token === ts.SyntaxKind.EndOfFileToken) {
+      return comments;
+    }
+    if (
+      token === ts.SyntaxKind.SingleLineCommentTrivia ||
+      token === ts.SyntaxKind.MultiLineCommentTrivia
+    ) {
+      comments += `${scanner.getTokenText()}\n`;
+    }
+  }
+}
+
+function countDirectiveComments(text: string): number {
+  return countMatches(collectCommentText(text), COMMENT_DIRECTIVE_RE);
+}
+
 function hasLeadingTsNoCheck(text: string): boolean {
   let offset = 0;
   if (text.startsWith("#!")) {
@@ -389,21 +416,140 @@ function buildTypeAliasMap(sourceFile: ts.SourceFile): Map<string, ts.TypeNode> 
   return aliases;
 }
 
+function isWeakKeywordType(typeNode: ts.TypeNode): boolean {
+  return (
+    typeNode.kind === ts.SyntaxKind.AnyKeyword ||
+    typeNode.kind === ts.SyntaxKind.UnknownKeyword ||
+    typeNode.kind === ts.SyntaxKind.ObjectKeyword
+  );
+}
+
+function containsWeakTypeInNodeList(
+  typeNodes: readonly ts.TypeNode[],
+  aliases: Map<string, ts.TypeNode>,
+  seen: ReadonlySet<string>,
+): boolean {
+  return typeNodes.some((typeNode) => containsWeakType(typeNode, aliases, new Set(seen)));
+}
+
+function containsWeakTypeInTupleType(
+  tupleType: ts.TupleTypeNode,
+  aliases: Map<string, ts.TypeNode>,
+  seen: ReadonlySet<string>,
+): boolean {
+  return tupleType.elements.some((element) =>
+    containsWeakType(
+      ts.isNamedTupleMember(element) ? element.type : element,
+      aliases,
+      new Set(seen),
+    ),
+  );
+}
+
+function containsWeakTypeInTypeLiteral(
+  typeLiteral: ts.TypeLiteralNode,
+  aliases: Map<string, ts.TypeNode>,
+  seen: ReadonlySet<string>,
+): boolean {
+  if (typeLiteral.members.length === 0) return true;
+
+  return typeLiteral.members.some((member) => {
+    if (
+      ts.isPropertySignature(member) ||
+      ts.isMethodSignature(member) ||
+      ts.isIndexSignatureDeclaration(member) ||
+      ts.isCallSignatureDeclaration(member) ||
+      ts.isConstructSignatureDeclaration(member)
+    ) {
+      return containsWeakType(member.type, aliases, new Set(seen));
+    }
+    return false;
+  });
+}
+
+function containsWeakTypeInIndexedAccessType(
+  indexedAccessType: ts.IndexedAccessTypeNode,
+  aliases: Map<string, ts.TypeNode>,
+  seen: ReadonlySet<string>,
+): boolean {
+  return (
+    containsWeakType(indexedAccessType.objectType, aliases, new Set(seen)) ||
+    containsWeakType(indexedAccessType.indexType, aliases, new Set(seen))
+  );
+}
+
+function containsWeakTypeInConditionalType(
+  conditionalType: ts.ConditionalTypeNode,
+  aliases: Map<string, ts.TypeNode>,
+  seen: ReadonlySet<string>,
+): boolean {
+  return containsWeakTypeInNodeList(
+    [
+      conditionalType.checkType,
+      conditionalType.extendsType,
+      conditionalType.trueType,
+      conditionalType.falseType,
+    ],
+    aliases,
+    seen,
+  );
+}
+
+function containsWeakTypeInSignatureType(
+  signatureType: ts.FunctionTypeNode | ts.ConstructorTypeNode,
+  aliases: Map<string, ts.TypeNode>,
+  seen: ReadonlySet<string>,
+): boolean {
+  return (
+    signatureType.parameters.some((parameter) =>
+      containsWeakType(parameter.type, aliases, new Set(seen)),
+    ) || containsWeakType(signatureType.type, aliases, new Set(seen))
+  );
+}
+
+function containsWeakTypeInTypeArguments(
+  typeArguments: readonly ts.TypeNode[] | undefined,
+  aliases: Map<string, ts.TypeNode>,
+  seen: ReadonlySet<string>,
+): boolean {
+  return typeArguments
+    ? typeArguments.some((argument) => containsWeakType(argument, aliases, new Set(seen)))
+    : false;
+}
+
+function containsWeakTypeInTypeReference(
+  typeReference: ts.TypeReferenceNode,
+  aliases: Map<string, ts.TypeNode>,
+  seen: ReadonlySet<string>,
+): boolean {
+  if (isDirectRecordStringUnknown(typeReference, aliases)) {
+    return true;
+  }
+
+  if (containsWeakTypeInTypeArguments(typeReference.typeArguments, aliases, seen)) {
+    return true;
+  }
+
+  if (ts.isIdentifier(typeReference.typeName)) {
+    const aliasName = typeReference.typeName.text;
+    const aliasType = aliases.get(aliasName);
+    if (aliasType && !seen.has(aliasName)) {
+      const nextSeen = new Set(seen);
+      nextSeen.add(aliasName);
+      return containsWeakType(aliasType, aliases, nextSeen);
+    }
+  }
+
+  return false;
+}
+
 function containsWeakType(
   typeNode: ts.TypeNode | undefined,
   aliases: Map<string, ts.TypeNode>,
   seen = new Set<string>(),
 ): boolean {
   if (!typeNode) return false;
-
-  switch (typeNode.kind) {
-    case ts.SyntaxKind.AnyKeyword:
-    case ts.SyntaxKind.UnknownKeyword:
-    case ts.SyntaxKind.ObjectKeyword:
-      return true;
-    default:
-      break;
-  }
+  if (isWeakKeywordType(typeNode)) return true;
 
   if (ts.isParenthesizedTypeNode(typeNode)) {
     return containsWeakType(typeNode.type, aliases, seen);
@@ -414,33 +560,15 @@ function containsWeakType(
   }
 
   if (ts.isTupleTypeNode(typeNode)) {
-    return typeNode.elements.some((element) =>
-      containsWeakType(
-        ts.isNamedTupleMember(element) ? element.type : element,
-        aliases,
-        new Set(seen),
-      ),
-    );
+    return containsWeakTypeInTupleType(typeNode, aliases, seen);
   }
 
   if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
-    return typeNode.types.some((part) => containsWeakType(part, aliases, new Set(seen)));
+    return containsWeakTypeInNodeList(typeNode.types, aliases, seen);
   }
 
   if (ts.isTypeLiteralNode(typeNode)) {
-    if (typeNode.members.length === 0) return true;
-    return typeNode.members.some((member) => {
-      if (
-        ts.isPropertySignature(member) ||
-        ts.isMethodSignature(member) ||
-        ts.isIndexSignatureDeclaration(member) ||
-        ts.isCallSignatureDeclaration(member) ||
-        ts.isConstructSignatureDeclaration(member)
-      ) {
-        return containsWeakType(member.type, aliases, new Set(seen));
-      }
-      return false;
-    });
+    return containsWeakTypeInTypeLiteral(typeNode, aliases, seen);
   }
 
   if (ts.isTypeOperatorNode(typeNode)) {
@@ -448,10 +576,7 @@ function containsWeakType(
   }
 
   if (ts.isIndexedAccessTypeNode(typeNode)) {
-    return (
-      containsWeakType(typeNode.objectType, aliases, new Set(seen)) ||
-      containsWeakType(typeNode.indexType, aliases, new Set(seen))
-    );
+    return containsWeakTypeInIndexedAccessType(typeNode, aliases, seen);
   }
 
   if (ts.isMappedTypeNode(typeNode)) {
@@ -459,20 +584,11 @@ function containsWeakType(
   }
 
   if (ts.isConditionalTypeNode(typeNode)) {
-    return (
-      containsWeakType(typeNode.checkType, aliases, new Set(seen)) ||
-      containsWeakType(typeNode.extendsType, aliases, new Set(seen)) ||
-      containsWeakType(typeNode.trueType, aliases, new Set(seen)) ||
-      containsWeakType(typeNode.falseType, aliases, new Set(seen))
-    );
+    return containsWeakTypeInConditionalType(typeNode, aliases, seen);
   }
 
   if (ts.isFunctionTypeNode(typeNode) || ts.isConstructorTypeNode(typeNode)) {
-    return (
-      typeNode.parameters.some((parameter) =>
-        containsWeakType(parameter.type, aliases, new Set(seen)),
-      ) || containsWeakType(typeNode.type, aliases, new Set(seen))
-    );
+    return containsWeakTypeInSignatureType(typeNode, aliases, seen);
   }
 
   if (ts.isTypePredicateNode(typeNode)) {
@@ -480,24 +596,7 @@ function containsWeakType(
   }
 
   if (ts.isTypeReferenceNode(typeNode)) {
-    if (isDirectRecordStringUnknown(typeNode, aliases)) {
-      return true;
-    }
-
-    const typeArguments = typeNode.typeArguments ?? [];
-    if (typeArguments.some((argument) => containsWeakType(argument, aliases, new Set(seen)))) {
-      return true;
-    }
-
-    if (ts.isIdentifier(typeNode.typeName)) {
-      const aliasName = typeNode.typeName.text;
-      const aliasType = aliases.get(aliasName);
-      if (aliasType && !seen.has(aliasName)) {
-        const nextSeen = new Set(seen);
-        nextSeen.add(aliasName);
-        return containsWeakType(aliasType, aliases, nextSeen);
-      }
-    }
+    return containsWeakTypeInTypeReference(typeNode, aliases, seen);
   }
 
   return false;
@@ -781,7 +880,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
   const functions: RawFunctionData[] = [];
   const functionStack: RawFunctionData[] = [];
 
-  addPattern(fileMetrics, "tsDirectiveCount", countMatches(text, COMMENT_DIRECTIVE_RE));
+  addPattern(fileMetrics, "tsDirectiveCount", countDirectiveComments(text));
 
   function applyPattern(key: keyof PatternCounts, amount = 1): void {
     addPattern(fileMetrics, key, amount);

--- a/src/lib/agent-defs.test.ts
+++ b/src/lib/agent-defs.test.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getAgentChoices, loadAgent, resolveAgentName } from "../../dist/lib/agent-defs";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.NEMOCLAW_AGENT;
+});
+
+describe("agent definitions", () => {
+  it("loads computed OpenClaw manifest properties", () => {
+    const openclaw = loadAgent("openclaw");
+
+    expect(openclaw.name).toBe("openclaw");
+    expect(openclaw.displayName).toBe("OpenClaw");
+    expect(openclaw.healthProbe.port).toBe(18789);
+    expect(openclaw.forwardPort).toBe(18789);
+    expect(openclaw.configPaths).toEqual({
+      immutableDir: "/sandbox/.openclaw",
+      writableDir: "/sandbox/.openclaw-data",
+      configFile: "openclaw.json",
+      envFile: null,
+      format: "json",
+    });
+    expect(openclaw.messagingPlatforms).toEqual(["telegram", "discord", "slack"]);
+    expect(openclaw.legacyPaths?.startScript).toContain("scripts/nemoclaw-start.sh");
+  });
+
+  it("loads Hermes manifest properties without falling back to OpenClaw defaults", () => {
+    const hermes = loadAgent("hermes");
+
+    expect(hermes.name).toBe("hermes");
+    expect(hermes.displayName).toBe("Hermes Agent");
+    expect(hermes.hasDevicePairing).toBe(false);
+    expect(hermes.configPaths).toEqual({
+      immutableDir: "/sandbox/.hermes",
+      writableDir: "/sandbox/.hermes-data",
+      configFile: "config.yaml",
+      envFile: ".env",
+      format: "yaml",
+    });
+    expect(hermes.healthProbe.url).toBe("http://localhost:8642/health");
+    expect(hermes.messagingPlatforms).toEqual(["telegram", "discord", "slack"]);
+  });
+
+  it("orders OpenClaw first in interactive choices", () => {
+    const choices = getAgentChoices();
+    expect(choices[0]?.name).toBe("openclaw");
+    expect(choices.map((choice) => choice.name)).toContain("hermes");
+  });
+
+  it("falls back to openclaw when session references an unknown agent", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(resolveAgentName({ session: { agent: "missing-agent" } })).toBe("openclaw");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("session references unknown agent 'missing-agent'"),
+    );
+  });
+});

--- a/src/lib/agent-defs.test.ts
+++ b/src/lib/agent-defs.test.ts
@@ -1,13 +1,36 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getAgentChoices, loadAgent, resolveAgentName } from "../../dist/lib/agent-defs";
+import {
+  AGENTS_DIR,
+  getAgentChoices,
+  loadAgent,
+  resolveAgentName,
+} from "../../dist/lib/agent-defs";
+
+const tempAgentDirs: string[] = [];
+
+function writeTempAgentManifest(name: string, contents: string): void {
+  const agentDir = path.join(AGENTS_DIR, name);
+  tempAgentDirs.push(agentDir);
+  fs.mkdirSync(agentDir, { recursive: true });
+  fs.writeFileSync(path.join(agentDir, "manifest.yaml"), contents);
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.NEMOCLAW_AGENT;
+  while (tempAgentDirs.length > 0) {
+    const agentDir = tempAgentDirs.pop();
+    if (agentDir) {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  }
 });
 
 describe("agent definitions", () => {
@@ -59,5 +82,34 @@ describe("agent definitions", () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("session references unknown agent 'missing-agent'"),
     );
+  });
+
+  it("rejects invalid forward_ports values in manifests", () => {
+    const agentName = `invalid-forward-port-${String(Date.now())}`;
+    writeTempAgentManifest(
+      agentName,
+      [`name: ${agentName}`, "display_name: Broken Ports", "forward_ports:", "  - 70000"].join(
+        "\n",
+      ),
+    );
+
+    expect(() => loadAgent(agentName)).toThrow(/forward_ports\[0\]/);
+  });
+
+  it("rejects invalid health_probe.port values in manifests", () => {
+    const agentName = `invalid-health-port-${String(Date.now())}`;
+    writeTempAgentManifest(
+      agentName,
+      [
+        `name: ${agentName}`,
+        "display_name: Broken Health Probe",
+        "health_probe:",
+        '  url: "http://localhost:9000/health"',
+        "  port: 0.5",
+        "  timeout_seconds: 30",
+      ].join("\n"),
+    );
+
+    expect(() => loadAgent(agentName)).toThrow(/health_probe\.port/);
   });
 });

--- a/src/lib/agent-defs.ts
+++ b/src/lib/agent-defs.ts
@@ -4,15 +4,18 @@
 // Agent definition loader — reads agents/*/manifest.yaml and provides
 // accessors for agent-specific configuration used during onboarding.
 
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const yaml = require("js-yaml");
+const yaml: { load(input: string): unknown } = require("js-yaml");
 
 import { ROOT } from "./runner";
 import { DASHBOARD_PORT } from "./ports";
 
 export const AGENTS_DIR = path.join(ROOT, "agents");
+
+type UnknownRecord = { [key: string]: unknown };
+type StringMap = { [key: string]: string };
 
 export interface AgentHealthProbe {
   url: string;
@@ -48,10 +51,10 @@ export interface AgentDefinition {
   phone_home_hosts?: string[];
   forward_ports?: number[];
   health_probe?: AgentHealthProbe;
-  config?: Record<string, unknown>;
+  config?: UnknownRecord;
   state_dirs?: string[];
   messaging_platforms?: { supported?: string[] };
-  _legacy_paths?: Record<string, string>;
+  _legacy_paths?: StringMap;
   agentDir: string;
   manifestPath: string;
   readonly displayName: string;
@@ -82,6 +85,93 @@ export interface AgentChoice {
 
 const _cache = new Map<string, AgentDefinition>();
 
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: UnknownRecord, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readBoolean(record: UnknownRecord, key: string): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function readObject(record: UnknownRecord, key: string): UnknownRecord | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function readStringArray(record: UnknownRecord, key: string): string[] | undefined {
+  const value = record[key];
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function readNumberArray(record: UnknownRecord, key: string): number[] | undefined {
+  const value = record[key];
+  if (!Array.isArray(value)) return undefined;
+  return value.filter(
+    (entry): entry is number => typeof entry === "number" && Number.isFinite(entry),
+  );
+}
+
+function readStringMap(record: UnknownRecord, key: string): StringMap | undefined {
+  const value = readObject(record, key);
+  if (!value) return undefined;
+
+  const result: StringMap = {};
+  for (const [entryKey, entryValue] of Object.entries(value)) {
+    if (typeof entryValue === "string") {
+      result[entryKey] = entryValue;
+    }
+  }
+  return result;
+}
+
+function readHealthProbe(record: UnknownRecord): AgentHealthProbe | undefined {
+  const healthProbe = readObject(record, "health_probe");
+  if (!healthProbe) return undefined;
+
+  const url = readString(healthProbe, "url");
+  const port = healthProbe.port;
+  const timeoutSeconds = healthProbe.timeout_seconds;
+
+  if (
+    typeof url === "string" &&
+    typeof port === "number" &&
+    Number.isFinite(port) &&
+    typeof timeoutSeconds === "number" &&
+    Number.isFinite(timeoutSeconds)
+  ) {
+    return {
+      url,
+      port,
+      timeout_seconds: timeoutSeconds,
+    };
+  }
+
+  return undefined;
+}
+
+function readMessagingPlatforms(record: UnknownRecord): { supported?: string[] } | undefined {
+  const messagingPlatforms = readObject(record, "messaging_platforms");
+  if (!messagingPlatforms) return undefined;
+
+  const supported = readStringArray(messagingPlatforms, "supported");
+  return supported ? { supported } : {};
+}
+
+function loadManifestRecord(manifestPath: string): UnknownRecord {
+  const parsed = yaml.load(fs.readFileSync(manifestPath, "utf8"));
+  if (!isRecord(parsed)) {
+    throw new Error(`Agent manifest must be a YAML object: ${manifestPath}`);
+  }
+  return parsed;
+}
+
 /**
  * List available agent names by scanning agents/ for directories with
  * a manifest.yaml file.
@@ -90,9 +180,9 @@ export function listAgents(): string[] {
   if (!fs.existsSync(AGENTS_DIR)) return [];
   return fs
     .readdirSync(AGENTS_DIR, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
-    .filter((d) => fs.existsSync(path.join(AGENTS_DIR, d.name, "manifest.yaml")))
-    .map((d) => d.name)
+    .filter((entry) => entry.isDirectory())
+    .filter((entry) => fs.existsSync(path.join(AGENTS_DIR, entry.name, "manifest.yaml")))
+    .map((entry) => entry.name)
     .sort();
 }
 
@@ -100,32 +190,59 @@ export function listAgents(): string[] {
  * Load and parse an agent manifest.
  */
 export function loadAgent(name: string): AgentDefinition {
-  if (_cache.has(name)) return _cache.get(name)!;
+  const cached = _cache.get(name);
+  if (cached) return cached;
 
   const manifestPath = path.join(AGENTS_DIR, name, "manifest.yaml");
   if (!fs.existsSync(manifestPath)) {
     throw new Error(`Agent '${name}' not found: ${manifestPath}`);
   }
 
-  const raw = yaml.load(fs.readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+  const raw = loadManifestRecord(manifestPath);
   const agentDir = path.join(AGENTS_DIR, name);
+  const manifestName = readString(raw, "name") ?? name;
+  const description = readString(raw, "description");
+  const displayName = readString(raw, "display_name");
+  const binaryPath = readString(raw, "binary_path");
+  const versionCommand = readString(raw, "version_command");
+  const expectedVersion = readString(raw, "expected_version");
+  const gatewayCommand = readString(raw, "gateway_command");
+  const forwardPorts = readNumberArray(raw, "forward_ports");
+  const healthProbe = readHealthProbe(raw);
+  const config = readObject(raw, "config");
+  const stateDirs = readStringArray(raw, "state_dirs");
+  const phoneHomeHosts = readStringArray(raw, "phone_home_hosts");
+  const messagingPlatforms = readMessagingPlatforms(raw);
+  const legacyPathConfig = readStringMap(raw, "_legacy_paths");
 
   const agent: AgentDefinition = {
-    // Raw manifest fields
     ...raw,
-
-    // Computed paths
+    name: manifestName,
+    description,
+    display_name: displayName,
+    binary_path: binaryPath,
+    version_command: versionCommand,
+    expected_version: expectedVersion,
+    gateway_command: gatewayCommand,
+    device_pairing: readBoolean(raw, "device_pairing"),
+    phone_home_hosts: phoneHomeHosts,
+    forward_ports: forwardPorts,
+    health_probe: healthProbe,
+    config,
+    state_dirs: stateDirs,
+    messaging_platforms: messagingPlatforms,
+    _legacy_paths: legacyPathConfig,
     agentDir,
     manifestPath,
 
     get displayName(): string {
-      return (raw.display_name as string) || (raw.name as string);
+      return displayName ?? manifestName;
     },
 
     get healthProbe(): AgentHealthProbe {
       return (
-        (raw.health_probe as AgentHealthProbe) || {
-          url: `http://localhost:${DASHBOARD_PORT}/`,
+        healthProbe ?? {
+          url: `http://localhost:${String(DASHBOARD_PORT)}/`,
           port: DASHBOARD_PORT,
           timeout_seconds: 30,
         }
@@ -133,88 +250,90 @@ export function loadAgent(name: string): AgentDefinition {
     },
 
     get forwardPort(): number {
-      const ports = (raw.forward_ports as number[]) || [];
-      return ports[0] || DASHBOARD_PORT;
+      return forwardPorts?.[0] ?? DASHBOARD_PORT;
     },
 
     get configPaths(): AgentConfigPaths {
-      const cfg = (raw.config as Record<string, string>) || {};
       return {
-        immutableDir: cfg.immutable_dir || "/sandbox/.openclaw",
-        writableDir: cfg.writable_dir || "/sandbox/.openclaw-data",
-        configFile: cfg.config_file || "openclaw.json",
-        envFile: cfg.env_file || null,
-        format: cfg.format || "json",
+        immutableDir: readString(config ?? {}, "immutable_dir") ?? "/sandbox/.openclaw",
+        writableDir: readString(config ?? {}, "writable_dir") ?? "/sandbox/.openclaw-data",
+        configFile: readString(config ?? {}, "config_file") ?? "openclaw.json",
+        envFile: readString(config ?? {}, "env_file") ?? null,
+        format: readString(config ?? {}, "format") ?? "json",
       };
     },
 
     get stateDirs(): string[] {
-      return (raw.state_dirs as string[]) || [];
+      return stateDirs ?? [];
     },
 
     get versionCommand(): string {
-      return (raw.version_command as string) || `${raw.binary_path || "unknown"} --version`;
+      return versionCommand ?? `${binaryPath ?? "unknown"} --version`;
     },
 
     get expectedVersion(): string | null {
-      return (raw.expected_version as string) || null;
+      return expectedVersion ?? null;
     },
 
     get hasDevicePairing(): boolean {
-      return raw.device_pairing === true;
+      return readBoolean(raw, "device_pairing") === true;
     },
 
     get phoneHomeHosts(): string[] {
-      return (raw.phone_home_hosts as string[]) || [];
+      return phoneHomeHosts ?? [];
     },
 
     get messagingPlatforms(): string[] {
-      const mp = (raw.messaging_platforms as { supported?: string[] }) || {};
-      return mp.supported || [];
+      return messagingPlatforms?.supported ?? [];
     },
 
     get dockerfileBasePath(): string | null {
-      const p = path.join(agentDir, "Dockerfile.base");
-      return fs.existsSync(p) ? p : null;
+      const dockerfileBase = path.join(agentDir, "Dockerfile.base");
+      return fs.existsSync(dockerfileBase) ? dockerfileBase : null;
     },
 
     get dockerfilePath(): string | null {
-      const p = path.join(agentDir, "Dockerfile");
-      return fs.existsSync(p) ? p : null;
+      const dockerfilePath = path.join(agentDir, "Dockerfile");
+      return fs.existsSync(dockerfilePath) ? dockerfilePath : null;
     },
 
     get startScriptPath(): string | null {
-      const p = path.join(agentDir, "start.sh");
-      return fs.existsSync(p) ? p : null;
+      const startScriptPath = path.join(agentDir, "start.sh");
+      return fs.existsSync(startScriptPath) ? startScriptPath : null;
     },
 
     get policyAdditionsPath(): string | null {
-      const p = path.join(agentDir, "policy-additions.yaml");
-      return fs.existsSync(p) ? p : null;
+      const policyAdditionsPath = path.join(agentDir, "policy-additions.yaml");
+      return fs.existsSync(policyAdditionsPath) ? policyAdditionsPath : null;
     },
 
     get policyPermissivePath(): string | null {
-      const p = path.join(agentDir, "policy-permissive.yaml");
-      return fs.existsSync(p) ? p : null;
+      const policyPermissivePath = path.join(agentDir, "policy-permissive.yaml");
+      return fs.existsSync(policyPermissivePath) ? policyPermissivePath : null;
     },
 
     get pluginDir(): string | null {
-      const p = path.join(agentDir, "plugin");
-      return fs.existsSync(p) ? p : null;
+      const pluginDir = path.join(agentDir, "plugin");
+      return fs.existsSync(pluginDir) ? pluginDir : null;
     },
 
     get legacyPaths(): AgentLegacyPaths | null {
-      if (!raw._legacy_paths) return null;
-      const lp = raw._legacy_paths as Record<string, string>;
+      if (!legacyPathConfig) return null;
       return {
-        dockerfileBase: lp.dockerfile_base ? path.join(ROOT, lp.dockerfile_base) : null,
-        dockerfile: lp.dockerfile ? path.join(ROOT, lp.dockerfile) : null,
-        startScript: lp.start_script ? path.join(ROOT, lp.start_script) : null,
-        policy: lp.policy ? path.join(ROOT, lp.policy) : null,
-        plugin: lp.plugin ? path.join(ROOT, lp.plugin) : null,
+        dockerfileBase: legacyPathConfig.dockerfile_base
+          ? path.join(ROOT, legacyPathConfig.dockerfile_base)
+          : null,
+        dockerfile: legacyPathConfig.dockerfile
+          ? path.join(ROOT, legacyPathConfig.dockerfile)
+          : null,
+        startScript: legacyPathConfig.start_script
+          ? path.join(ROOT, legacyPathConfig.start_script)
+          : null,
+        policy: legacyPathConfig.policy ? path.join(ROOT, legacyPathConfig.policy) : null,
+        plugin: legacyPathConfig.plugin ? path.join(ROOT, legacyPathConfig.plugin) : null,
       };
     },
-  } as AgentDefinition;
+  };
 
   _cache.set(name, agent);
   return agent;
@@ -226,18 +345,18 @@ export function loadAgent(name: string): AgentDefinition {
  */
 export function getAgentChoices(): AgentChoice[] {
   const agents = listAgents().map((name) => {
-    const a = loadAgent(name);
+    const agent = loadAgent(name);
     return {
-      name: a.name as string,
-      displayName: a.displayName,
-      description: (a.description as string) || "",
+      name: agent.name,
+      displayName: agent.displayName,
+      description: agent.description ?? "",
     };
   });
 
-  agents.sort((a, b) => {
-    if (a.name === "openclaw") return -1;
-    if (b.name === "openclaw") return 1;
-    return a.name.localeCompare(b.name);
+  agents.sort((left, right) => {
+    if (left.name === "openclaw") return -1;
+    if (right.name === "openclaw") return 1;
+    return left.name.localeCompare(right.name);
   });
 
   return agents;
@@ -273,7 +392,7 @@ export function resolveAgentName({
     return envAgent;
   }
 
-  if (session && session.agent) {
+  if (session?.agent) {
     const available = listAgents();
     if (!available.includes(session.agent)) {
       console.error(

--- a/src/lib/agent-defs.ts
+++ b/src/lib/agent-defs.ts
@@ -110,12 +110,27 @@ function readStringArray(record: UnknownRecord, key: string): string[] | undefin
   return value.filter((entry): entry is string => typeof entry === "string");
 }
 
-function readNumberArray(record: UnknownRecord, key: string): number[] | undefined {
+function isValidPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+function readPortArray(record: UnknownRecord, key: string): number[] | undefined {
   const value = record[key];
-  if (!Array.isArray(value)) return undefined;
-  return value.filter(
-    (entry): entry is number => typeof entry === "number" && Number.isFinite(entry),
-  );
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(`Agent manifest field '${key}' must be an array of TCP ports`);
+  }
+
+  const ports = value.map((entry, index) => {
+    if (!isValidPort(entry)) {
+      throw new Error(
+        `Agent manifest field '${key}[${String(index)}]' must be an integer TCP port between 1 and 65535`,
+      );
+    }
+    return entry;
+  });
+
+  return ports.length > 0 ? ports : undefined;
 }
 
 function readStringMap(record: UnknownRecord, key: string): StringMap | undefined {
@@ -139,10 +154,15 @@ function readHealthProbe(record: UnknownRecord): AgentHealthProbe | undefined {
   const port = healthProbe.port;
   const timeoutSeconds = healthProbe.timeout_seconds;
 
+  if (port !== undefined && !isValidPort(port)) {
+    throw new Error(
+      "Agent manifest field 'health_probe.port' must be an integer TCP port between 1 and 65535",
+    );
+  }
+
   if (
     typeof url === "string" &&
-    typeof port === "number" &&
-    Number.isFinite(port) &&
+    isValidPort(port) &&
     typeof timeoutSeconds === "number" &&
     Number.isFinite(timeoutSeconds)
   ) {
@@ -207,7 +227,7 @@ export function loadAgent(name: string): AgentDefinition {
   const versionCommand = readString(raw, "version_command");
   const expectedVersion = readString(raw, "expected_version");
   const gatewayCommand = readString(raw, "gateway_command");
-  const forwardPorts = readNumberArray(raw, "forward_ports");
+  const forwardPorts = readPortArray(raw, "forward_ports");
   const healthProbe = readHealthProbe(raw);
   const config = readObject(raw, "config");
   const stateDirs = readStringArray(raw, "state_dirs");

--- a/src/lib/onboard-session.test.ts
+++ b/src/lib/onboard-session.test.ts
@@ -349,4 +349,18 @@ describe("onboard session", () => {
     expect(summary.failure.message).toContain("Bearer <REDACTED>");
     expect(summary.failure.message).not.toContain("abcdefghijklmnopqrstuvwxyz");
   });
+
+  it("re-sanitizes in-memory failures in debug summaries", () => {
+    const rawSession = session.createSession({
+      failure: {
+        step: "provider_selection",
+        message: "Bearer abcdefghijklmnopqrstuvwxyz",
+        recordedAt: "2026-04-01T00:00:00.000Z",
+      },
+    });
+
+    const summary = session.summarizeForDebug(rawSession);
+    expect(summary.failure.message).toContain("Bearer <REDACTED>");
+    expect(summary.failure.message).not.toContain("abcdefghijklmnopqrstuvwxyz");
+  });
 });

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -16,12 +16,16 @@ export const SESSION_VERSION = 1;
 export const SESSION_DIR = path.join(process.env.HOME || "/tmp", ".nemoclaw");
 export const SESSION_FILE = path.join(SESSION_DIR, "onboard-session.json");
 export const LOCK_FILE = path.join(SESSION_DIR, "onboard.lock");
-const VALID_STEP_STATES = new Set(["pending", "in_progress", "complete", "failed", "skipped"]);
+const STEP_STATES = ["pending", "in_progress", "complete", "failed", "skipped"] as const;
+const VALID_STEP_STATES = new Set<string>(STEP_STATES);
+
+type UnknownRecord = { [key: string]: unknown };
+type StepStatus = (typeof STEP_STATES)[number];
 
 // ── Types ────────────────────────────────────────────────────────
 
 export interface StepState {
-  status: string;
+  status: StepStatus;
   startedAt: string | null;
   completedAt: string | null;
   error: string | null;
@@ -93,6 +97,28 @@ export interface SessionUpdates {
   metadata?: { gatewayName?: string; fromDockerfile?: string | null };
 }
 
+export interface DebugSessionSummary {
+  version: number;
+  sessionId: string;
+  status: string;
+  resumable: boolean;
+  mode: string;
+  startedAt: string;
+  updatedAt: string;
+  sandboxName: string | null;
+  provider: string | null;
+  model: string | null;
+  endpointUrl: string | null;
+  credentialEnv: string | null;
+  preferredInferenceApi: string | null;
+  nimContainer: string | null;
+  policyPresets: string[] | null;
+  lastStepStarted: string | null;
+  lastCompletedStep: string | null;
+  failure: SessionFailure | null;
+  steps: Record<string, StepState>;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────
 
 function ensureSessionDir(): void {
@@ -120,8 +146,63 @@ function defaultSteps(): Record<string, StepState> {
   };
 }
 
-export function isObject(value: unknown): value is Record<string, unknown> {
+export function isObject(value: unknown): value is UnknownRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function readStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function readStepStatus(value: unknown): StepStatus | null {
+  if (value === "pending") return value;
+  if (value === "in_progress") return value;
+  if (value === "complete") return value;
+  if (value === "failed") return value;
+  if (value === "skipped") return value;
+  return null;
+}
+
+function parseWebSearchConfig(value: unknown): WebSearchConfig | null {
+  return isObject(value) && value.fetchEnabled === true ? { fetchEnabled: true } : null;
+}
+
+function parseSessionMetadata(value: unknown): SessionMetadata | undefined {
+  if (!isObject(value)) return undefined;
+  return {
+    gatewayName: readString(value.gatewayName) ?? "nemoclaw",
+    fromDockerfile: readString(value.fromDockerfile),
+  };
+}
+
+function parseStepState(value: unknown): StepState | null {
+  if (!isObject(value)) return null;
+  const status = readStepStatus(value.status);
+  if (!status) return null;
+  return {
+    status,
+    startedAt: readString(value.startedAt),
+    completedAt: readString(value.completedAt),
+    error: redactSensitiveText(value.error),
+  };
+}
+
+function parseLockInfo(value: unknown): LockInfo | null {
+  if (!isObject(value) || typeof value.pid !== "number") return null;
+  return {
+    pid: value.pid,
+    startedAt: readString(value.startedAt),
+    command: readString(value.command),
+  };
 }
 
 export function redactSensitiveText(value: unknown): string | null {
@@ -142,17 +223,14 @@ export function sanitizeFailure(
   input: { step?: unknown; message?: unknown; recordedAt?: unknown } | null | undefined,
 ): SessionFailure | null {
   if (!input) return null;
-  const step = typeof input.step === "string" ? input.step : null;
+  const step = readString(input.step);
   const message = redactSensitiveText(input.message);
-  const recordedAt =
-    typeof input.recordedAt === "string" ? input.recordedAt : new Date().toISOString();
+  const recordedAt = readString(input.recordedAt) ?? new Date().toISOString();
   return step || message ? { step, message, recordedAt } : null;
 }
 
 export function validateStep(step: unknown): boolean {
-  if (!isObject(step)) return false;
-  if (!VALID_STEP_STATES.has(step.status as string)) return false;
-  return true;
+  return parseStepState(step) !== null;
 }
 
 export function redactUrl(value: unknown): string | null {
@@ -181,99 +259,70 @@ export function createSession(overrides: Partial<Session> = {}): Session {
   const now = new Date().toISOString();
   return {
     version: SESSION_VERSION,
-    sessionId: overrides.sessionId || `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    sessionId: overrides.sessionId ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
     resumable: true,
     status: "in_progress",
-    mode: overrides.mode || "interactive",
-    startedAt: overrides.startedAt || now,
-    updatedAt: overrides.updatedAt || now,
-    lastStepStarted: overrides.lastStepStarted || null,
-    lastCompletedStep: overrides.lastCompletedStep || null,
-    failure: overrides.failure || null,
-    agent: overrides.agent || null,
-    sandboxName: overrides.sandboxName || null,
-    provider: overrides.provider || null,
-    model: overrides.model || null,
-    endpointUrl: overrides.endpointUrl || null,
-    credentialEnv: overrides.credentialEnv || null,
-    preferredInferenceApi: overrides.preferredInferenceApi || null,
-    nimContainer: overrides.nimContainer || null,
-    webSearchConfig:
-      overrides.webSearchConfig && overrides.webSearchConfig.fetchEnabled === true
-        ? { fetchEnabled: true }
-        : null,
-    policyPresets: Array.isArray(overrides.policyPresets)
-      ? overrides.policyPresets.filter((value) => typeof value === "string")
-      : null,
-    messagingChannels: Array.isArray(overrides.messagingChannels)
-      ? overrides.messagingChannels.filter((value) => typeof value === "string")
-      : null,
+    mode: overrides.mode ?? "interactive",
+    startedAt: overrides.startedAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    lastStepStarted: overrides.lastStepStarted ?? null,
+    lastCompletedStep: overrides.lastCompletedStep ?? null,
+    failure: overrides.failure ?? null,
+    agent: overrides.agent ?? null,
+    sandboxName: overrides.sandboxName ?? null,
+    provider: overrides.provider ?? null,
+    model: overrides.model ?? null,
+    endpointUrl: overrides.endpointUrl ?? null,
+    credentialEnv: overrides.credentialEnv ?? null,
+    preferredInferenceApi: overrides.preferredInferenceApi ?? null,
+    nimContainer: overrides.nimContainer ?? null,
+    webSearchConfig: parseWebSearchConfig(overrides.webSearchConfig),
+    policyPresets: readStringArray(overrides.policyPresets),
+    messagingChannels: readStringArray(overrides.messagingChannels),
     metadata: {
-      gatewayName: overrides.metadata?.gatewayName || "nemoclaw",
-      fromDockerfile: overrides.metadata?.fromDockerfile || null,
+      gatewayName: overrides.metadata?.gatewayName ?? "nemoclaw",
+      fromDockerfile: overrides.metadata?.fromDockerfile ?? null,
     },
     steps: {
       ...defaultSteps(),
-      ...(overrides.steps || {}),
+      ...(overrides.steps ?? {}),
     },
   };
 }
 
 // eslint-disable-next-line complexity
 export function normalizeSession(data: unknown): Session | null {
-  if (!isObject(data) || (data as Record<string, unknown>).version !== SESSION_VERSION) return null;
-  const d = data as Record<string, unknown>;
-  const normalized = createSession({
-    sessionId: typeof d.sessionId === "string" ? d.sessionId : undefined,
-    mode: typeof d.mode === "string" ? d.mode : undefined,
-    startedAt: typeof d.startedAt === "string" ? d.startedAt : undefined,
-    updatedAt: typeof d.updatedAt === "string" ? d.updatedAt : undefined,
-    agent: typeof d.agent === "string" ? d.agent : null,
-    sandboxName: typeof d.sandboxName === "string" ? d.sandboxName : null,
-    provider: typeof d.provider === "string" ? d.provider : null,
-    model: typeof d.model === "string" ? d.model : null,
-    endpointUrl: typeof d.endpointUrl === "string" ? redactUrl(d.endpointUrl) : null,
-    credentialEnv: typeof d.credentialEnv === "string" ? d.credentialEnv : null,
-    preferredInferenceApi:
-      typeof d.preferredInferenceApi === "string" ? d.preferredInferenceApi : null,
-    nimContainer: typeof d.nimContainer === "string" ? d.nimContainer : null,
-    webSearchConfig:
-      isObject(d.webSearchConfig) &&
-      (d.webSearchConfig as Record<string, unknown>).fetchEnabled === true
-        ? { fetchEnabled: true }
-        : null,
-    policyPresets: Array.isArray(d.policyPresets)
-      ? (d.policyPresets as unknown[]).filter((value) => typeof value === "string") as string[]
-      : null,
-    messagingChannels: Array.isArray(d.messagingChannels)
-      ? (d.messagingChannels as unknown[]).filter((value) => typeof value === "string") as string[]
-      : null,
-    lastStepStarted: typeof d.lastStepStarted === "string" ? d.lastStepStarted : null,
-    lastCompletedStep: typeof d.lastCompletedStep === "string" ? d.lastCompletedStep : null,
-    failure: sanitizeFailure(d.failure as Record<string, unknown> | null),
-    metadata: isObject(d.metadata)
-      ? ({
-          gatewayName: (d.metadata as Record<string, unknown>).gatewayName,
-          fromDockerfile: (d.metadata as Record<string, unknown>).fromDockerfile || null,
-        } as SessionMetadata)
-      : undefined,
-  } as Partial<Session>);
-  normalized.resumable = d.resumable !== false;
-  normalized.status = typeof d.status === "string" ? d.status : normalized.status;
+  if (!isObject(data) || data.version !== SESSION_VERSION) return null;
 
-  if (isObject(d.steps)) {
-    for (const [name, step] of Object.entries(d.steps as Record<string, unknown>)) {
-      if (
-        Object.prototype.hasOwnProperty.call(normalized.steps, name) &&
-        validateStep(step)
-      ) {
-        const s = step as Record<string, unknown>;
-        normalized.steps[name] = {
-          status: s.status as string,
-          startedAt: typeof s.startedAt === "string" ? s.startedAt : null,
-          completedAt: typeof s.completedAt === "string" ? s.completedAt : null,
-          error: redactSensitiveText(s.error),
-        };
+  const normalized = createSession({
+    sessionId: readString(data.sessionId) ?? undefined,
+    mode: readString(data.mode) ?? undefined,
+    startedAt: readString(data.startedAt) ?? undefined,
+    updatedAt: readString(data.updatedAt) ?? undefined,
+    agent: readString(data.agent),
+    sandboxName: readString(data.sandboxName),
+    provider: readString(data.provider),
+    model: readString(data.model),
+    endpointUrl: typeof data.endpointUrl === "string" ? redactUrl(data.endpointUrl) : null,
+    credentialEnv: readString(data.credentialEnv),
+    preferredInferenceApi: readString(data.preferredInferenceApi),
+    nimContainer: readString(data.nimContainer),
+    webSearchConfig: parseWebSearchConfig(data.webSearchConfig),
+    policyPresets: readStringArray(data.policyPresets),
+    messagingChannels: readStringArray(data.messagingChannels),
+    lastStepStarted: readString(data.lastStepStarted),
+    lastCompletedStep: readString(data.lastCompletedStep),
+    failure: sanitizeFailure(isObject(data.failure) ? data.failure : null),
+    metadata: parseSessionMetadata(data.metadata),
+  });
+  normalized.resumable = data.resumable !== false;
+  normalized.status = readString(data.status) ?? normalized.status;
+
+  if (isObject(data.steps)) {
+    for (const [name, step] of Object.entries(data.steps)) {
+      const parsedStep = parseStepState(step);
+      if (Object.prototype.hasOwnProperty.call(normalized.steps, name) && parsedStep) {
+        normalized.steps[name] = parsedStep;
       }
     }
   }
@@ -320,13 +369,7 @@ export function clearSession(): void {
 
 function parseLockFile(contents: string): LockInfo | null {
   try {
-    const parsed = JSON.parse(contents);
-    if (typeof parsed?.pid !== "number") return null;
-    return {
-      pid: parsed.pid,
-      startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : null,
-      command: typeof parsed.command === "string" ? parsed.command : null,
-    };
+    return parseLockInfo(JSON.parse(contents));
   } catch {
     return null;
   }
@@ -338,7 +381,7 @@ function isProcessAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (error: unknown) {
-    return (error as NodeJS.ErrnoException)?.code === "EPERM";
+    return isErrnoException(error) && error.code === "EPERM";
   }
 }
 
@@ -378,7 +421,7 @@ export function acquireOnboardLock(command: string | null = null): LockResult {
       // resolves to the same file we created (fstat ino vs stat ino).
       fd = fs.openSync(LOCK_FILE, "wx", 0o600);
     } catch (error: unknown) {
-      if ((error as NodeJS.ErrnoException)?.code !== "EEXIST") {
+      if (!isErrnoException(error) || error.code !== "EEXIST") {
         throw error;
       }
 
@@ -395,7 +438,7 @@ export function acquireOnboardLock(command: string | null = null): LockResult {
         staleInode = stat.ino;
         existing = parseLockFile(fs.readFileSync(LOCK_FILE, "utf8"));
       } catch (readError: unknown) {
-        if ((readError as NodeJS.ErrnoException)?.code === "ENOENT") {
+        if (isErrnoException(readError) && readError.code === "ENOENT") {
           continue;
         }
         throw readError;
@@ -433,8 +476,16 @@ export function acquireOnboardLock(command: string | null = null): LockResult {
     try {
       fs.writeSync(fd, payload);
     } catch (writeError) {
-      try { fs.closeSync(fd); } catch { /* ignore */ }
-      try { fs.unlinkSync(LOCK_FILE); } catch { /* ignore */ }
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+      try {
+        fs.unlinkSync(LOCK_FILE);
+      } catch {
+        /* ignore */
+      }
       throw writeError;
     }
     heldLockFd = fd;
@@ -465,7 +516,7 @@ function unlinkIfInodeMatches(filePath: string, expectedInode: bigint | null): v
       return;
     }
   } catch (statError: unknown) {
-    if ((statError as NodeJS.ErrnoException)?.code === "ENOENT") {
+    if (isErrnoException(statError) && statError.code === "ENOENT") {
       return;
     }
     throw statError;
@@ -473,7 +524,7 @@ function unlinkIfInodeMatches(filePath: string, expectedInode: bigint | null): v
   try {
     fs.unlinkSync(filePath);
   } catch (unlinkError: unknown) {
-    if ((unlinkError as NodeJS.ErrnoException)?.code !== "ENOENT") {
+    if (!isErrnoException(unlinkError) || unlinkError.code !== "ENOENT") {
       throw unlinkError;
     }
   }
@@ -494,7 +545,7 @@ export function releaseOnboardLock(): void {
         const pathStat = fs.statSync(LOCK_FILE, { bigint: true });
         pathInode = pathStat.ino;
       } catch (error: unknown) {
-        if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        if (!isErrnoException(error) || error.code !== "ENOENT") {
           // Unexpected — fall through to closing the fd.
         }
       }
@@ -502,7 +553,7 @@ export function releaseOnboardLock(): void {
         try {
           fs.unlinkSync(LOCK_FILE);
         } catch (unlinkError: unknown) {
-          if ((unlinkError as NodeJS.ErrnoException)?.code !== "ENOENT") {
+          if (!isErrnoException(unlinkError) || unlinkError.code !== "ENOENT") {
             // Best effort — surfacing this would mask the real error.
           }
         }
@@ -511,7 +562,11 @@ export function releaseOnboardLock(): void {
       // fstat can fail if the fd was already closed somehow; nothing
       // safe to do beyond closing it below.
     } finally {
-      try { fs.closeSync(fd); } catch { /* ignore */ }
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // ignore
+      }
     }
     return;
   }
@@ -526,7 +581,7 @@ export function releaseOnboardLock(): void {
     try {
       existing = parseLockFile(fs.readFileSync(LOCK_FILE, "utf8"));
     } catch (error: unknown) {
-      if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return;
+      if (isErrnoException(error) && error.code === "ENOENT") return;
       throw error;
     }
     if (!existing) return;
@@ -564,7 +619,10 @@ export function filterSafeUpdates(updates: SessionUpdates): Partial<Session> {
   if (isObject(updates.metadata) && typeof updates.metadata.gatewayName === "string") {
     safe.metadata = {
       gatewayName: updates.metadata.gatewayName,
-      fromDockerfile: (typeof updates.metadata.fromDockerfile === "string" ? updates.metadata.fromDockerfile : null),
+      fromDockerfile:
+        typeof updates.metadata.fromDockerfile === "string"
+          ? updates.metadata.fromDockerfile
+          : null,
     };
   }
   return safe;
@@ -645,10 +703,9 @@ export function completeSession(updates: SessionUpdates = {}): Session {
   });
 }
 
-export function summarizeForDebug(session: Session | null = loadSession()): Record<
-  string,
-  unknown
-> | null {
+export function summarizeForDebug(
+  session: Session | null = loadSession(),
+): DebugSessionSummary | null {
   if (!session) return null;
   return {
     version: session.version,

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -725,7 +725,7 @@ export function summarizeForDebug(
     policyPresets: session.policyPresets,
     lastStepStarted: session.lastStepStarted,
     lastCompletedStep: session.lastCompletedStep,
-    failure: session.failure,
+    failure: sanitizeFailure(session.failure),
     steps: Object.fromEntries(
       Object.entries(session.steps).map(([name, step]) => [
         name,

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,11 +1,38 @@
-// @ts-nocheck
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const os = require("os");
-const path = require("path");
+import { existsSync as defaultExistsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-function isWsl(opts = {}) {
+export type ContainerRuntime = "podman" | "colima" | "docker-desktop" | "docker" | "unknown";
+
+export interface PlatformLookupOptions {
+  platform?: NodeJS.Platform;
+  home?: string;
+  uid?: number;
+}
+
+export interface WslDetectionOptions {
+  isWsl?: boolean;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  release?: string;
+  procVersion?: string;
+}
+
+export interface DockerHostDetectionOptions extends PlatformLookupOptions, WslDetectionOptions {
+  env?: NodeJS.ProcessEnv;
+  existsSync?: (filePath: string) => boolean;
+}
+
+export interface DockerHostDetection {
+  dockerHost: string;
+  source: "env" | "socket";
+  socketPath: string | null;
+}
+
+function isWsl(opts: WslDetectionOptions = {}): boolean {
   // Explicit override — lets tests pin behavior regardless of the host kernel.
   // Useful because the WSL detection below consults `os.release()`, which
   // returns a "microsoft"-tagged string on WSL2 hosts even when env vars are
@@ -28,7 +55,7 @@ function isWsl(opts = {}) {
   );
 }
 
-function inferContainerRuntime(info = "") {
+function inferContainerRuntime(info = ""): ContainerRuntime {
   const normalized = String(info).toLowerCase();
   if (!normalized.trim()) return "unknown";
   if (normalized.includes("podman")) return "podman";
@@ -38,14 +65,14 @@ function inferContainerRuntime(info = "") {
   return "unknown";
 }
 
-function shouldPatchCoredns(runtime, opts = {}) {
+function shouldPatchCoredns(runtime: ContainerRuntime, opts: WslDetectionOptions = {}): boolean {
   // CoreDNS patching is needed for Colima and Podman (both use custom network bridges).
   // On WSL2, the host DNS is not routable from k3s pods — skip and let setup-dns-proxy.sh handle it.
   if (isWsl(opts)) return false;
   return runtime === "colima" || runtime === "podman";
 }
 
-function getColimaDockerSocketCandidates(opts = {}) {
+function getColimaDockerSocketCandidates(opts: PlatformLookupOptions = {}): string[] {
   const home = opts.home ?? process.env.HOME ?? "/tmp";
   return [
     path.join(home, ".colima/default/docker.sock"),
@@ -53,12 +80,14 @@ function getColimaDockerSocketCandidates(opts = {}) {
   ];
 }
 
-function findColimaDockerSocket(opts = {}) {
-  const existsSync = opts.existsSync ?? require("fs").existsSync;
-  return getColimaDockerSocketCandidates(opts).find((socketPath) => existsSync(socketPath)) ?? null;
+function findColimaDockerSocket(
+  opts: PlatformLookupOptions & { existsSync?: (filePath: string) => boolean } = {},
+): string | null {
+  const fileExists = opts.existsSync ?? defaultExistsSync;
+  return getColimaDockerSocketCandidates(opts).find((socketPath) => fileExists(socketPath)) ?? null;
 }
 
-function getPodmanSocketCandidates(opts = {}) {
+function getPodmanSocketCandidates(opts: PlatformLookupOptions = {}): string[] {
   const home = opts.home ?? process.env.HOME ?? "/tmp";
   const platform = opts.platform ?? process.platform;
   const uid = opts.uid ?? process.getuid?.() ?? 1000;
@@ -70,10 +99,10 @@ function getPodmanSocketCandidates(opts = {}) {
     ];
   }
 
-  return [`/run/user/${uid}/podman/podman.sock`, "/run/podman/podman.sock"];
+  return [`/run/user/${String(uid)}/podman/podman.sock`, "/run/podman/podman.sock"];
 }
 
-function getDockerSocketCandidates(opts = {}) {
+function getDockerSocketCandidates(opts: PlatformLookupOptions = {}): string[] {
   const home = opts.home ?? process.env.HOME ?? "/tmp";
   const platform = opts.platform ?? process.platform;
 
@@ -96,7 +125,7 @@ function getDockerSocketCandidates(opts = {}) {
   return [];
 }
 
-function detectDockerHost(opts = {}) {
+function detectDockerHost(opts: DockerHostDetectionOptions = {}): DockerHostDetection | null {
   const env = opts.env ?? process.env;
   if (env.DOCKER_HOST) {
     return {
@@ -106,9 +135,9 @@ function detectDockerHost(opts = {}) {
     };
   }
 
-  const existsSync = opts.existsSync ?? require("fs").existsSync;
+  const fileExists = opts.existsSync ?? defaultExistsSync;
   for (const socketPath of getDockerSocketCandidates(opts)) {
-    if (existsSync(socketPath)) {
+    if (fileExists(socketPath)) {
       return {
         dockerHost: `unix://${socketPath}`,
         source: "socket",

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -99,7 +99,11 @@ function getPodmanSocketCandidates(opts: PlatformLookupOptions = {}): string[] {
     ];
   }
 
-  return [`/run/user/${String(uid)}/podman/podman.sock`, "/run/podman/podman.sock"];
+  if (platform === "linux") {
+    return [`/run/user/${String(uid)}/podman/podman.sock`, "/run/podman/podman.sock"];
+  }
+
+  return [];
 }
 
 function getDockerSocketCandidates(opts: PlatformLookupOptions = {}): string[] {

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -11,34 +10,129 @@
 // The base sandbox policy is always applied regardless of tier.
 // Tiers layer additional presets on top of that baseline.
 
-const fs = require("fs");
-const path = require("path");
-const YAML = require("yaml");
-const { ROOT } = require("./runner");
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+
+import { ROOT } from "./runner";
 
 const TIERS_FILE = path.join(ROOT, "nemoclaw-blueprint", "policies", "tiers.yaml");
+const ALLOWED_ACCESS: ReadonlySet<string> = new Set(["read", "read-write"]);
+type TierAccess = "read" | "read-write";
+
+export interface TierPreset {
+  name: string;
+  access: TierAccess;
+}
+
+export interface TierDefinition {
+  name: string;
+  label: string;
+  description: string;
+  presets: TierPreset[];
+}
+
+interface TierDocument {
+  tiers: TierDefinition[];
+}
+
+interface ResolveTierPresetOptions {
+  overrides?: Record<string, string>;
+  selected?: string[] | null;
+}
+
+type UnknownRecord = { [key: string]: unknown };
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: UnknownRecord, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function isTierAccess(value: string): value is TierAccess {
+  return ALLOWED_ACCESS.has(value);
+}
+
+function parseTierPreset(value: unknown, index: number, tierName: string): TierPreset {
+  if (!isRecord(value)) {
+    throw new Error(`tiers.yaml: tier '${tierName}' preset ${String(index)} is not an object`);
+  }
+
+  const name = readString(value, "name");
+  const access = readString(value, "access");
+
+  if (!name) {
+    throw new Error(`tiers.yaml: tier '${tierName}' preset ${String(index)} is missing name`);
+  }
+  if (!access || !isTierAccess(access)) {
+    throw new Error(
+      `tiers.yaml: tier '${tierName}' preset '${name}' has invalid access '${String(access)}'`,
+    );
+  }
+
+  return { name, access };
+}
+
+function parseTierDefinition(value: unknown, index: number): TierDefinition {
+  if (!isRecord(value)) {
+    throw new Error(`tiers.yaml: tier ${String(index)} is not an object`);
+  }
+
+  const name = readString(value, "name");
+  const label = readString(value, "label");
+  const description = readString(value, "description");
+  const presetsValue = value.presets;
+
+  if (!name) {
+    throw new Error(`tiers.yaml: tier ${String(index)} is missing name`);
+  }
+  if (!label) {
+    throw new Error(`tiers.yaml: tier '${name}' is missing label`);
+  }
+  if (!description) {
+    throw new Error(`tiers.yaml: tier '${name}' is missing description`);
+  }
+  if (!Array.isArray(presetsValue)) {
+    throw new Error(`tiers.yaml: tier '${name}' presets must be an array`);
+  }
+
+  return {
+    name,
+    label,
+    description,
+    presets: presetsValue.map((preset, presetIndex) => parseTierPreset(preset, presetIndex, name)),
+  };
+}
+
+function parseTierDocument(raw: string): TierDocument {
+  const parsed = YAML.parse(raw);
+  if (!isRecord(parsed) || !Array.isArray(parsed.tiers)) {
+    throw new Error(`tiers.yaml: expected a top-level 'tiers' array in ${TIERS_FILE}`);
+  }
+
+  return {
+    tiers: parsed.tiers.map((tier, index) => parseTierDefinition(tier, index)),
+  };
+}
 
 /**
  * Load and return all tier definitions from tiers.yaml.
  * Preserves the order defined in the file (restrictive → open).
- *
- * @returns {{ name: string, label: string, description: string, presets: Array<{name: string, access: string}> }[]}
  */
-function listTiers() {
+function listTiers(): TierDefinition[] {
   const content = fs.readFileSync(TIERS_FILE, "utf-8");
-  const parsed = YAML.parse(content);
-  return parsed.tiers;
+  return parseTierDocument(content).tiers;
 }
 
 /**
  * Return a single tier definition by name.
  * Returns null if the tier does not exist.
- *
- * @param {string} name
- * @returns {{ name: string, label: string, description: string, presets: Array<{name: string, access: string}> } | null}
  */
-function getTier(name) {
-  return listTiers().find((t) => t.name === name) ?? null;
+function getTier(name: string): TierDefinition | null {
+  return listTiers().find((tier) => tier.name === name) ?? null;
 }
 
 /**
@@ -50,35 +144,32 @@ function getTier(name) {
  *
  * Presets can also be excluded by passing a `selected` allowlist — only
  * presets whose names appear in the list are kept.
- *
- * @param {string} tierName
- * @param {{ overrides?: Record<string, string>, selected?: string[] | null }} [options]
- * @returns {{ name: string, access: string }[]}
  */
-function resolveTierPresets(tierName, options = {}) {
-  const overrides = options.overrides || {};
+function resolveTierPresets(
+  tierName: string,
+  options: ResolveTierPresetOptions = {},
+): TierPreset[] {
+  const overrides = options.overrides ?? {};
   const selected = options.selected === undefined ? null : options.selected;
   const tier = getTier(tierName);
   if (!tier) {
     throw new Error(`Unknown tier: ${tierName}`);
   }
 
-  let presets = tier.presets.map((p) => ({
-    name: p.name,
-    access: overrides[p.name] ?? p.access,
-  }));
+  let presets = tier.presets.map((preset): TierPreset => {
+    const override = overrides[preset.name];
+    return {
+      name: preset.name,
+      access: override && isTierAccess(override) ? override : preset.access,
+    };
+  });
 
   if (selected !== null) {
     const allowSet = new Set(selected);
-    presets = presets.filter((p) => allowSet.has(p.name));
+    presets = presets.filter((preset) => allowSet.has(preset.name));
   }
 
   return presets;
 }
 
-export {
-  TIERS_FILE,
-  listTiers,
-  getTier,
-  resolveTierPresets,
-};
+export { TIERS_FILE, listTiers, getTier, resolveTierPresets };

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -52,6 +52,10 @@ describe("platform helpers", () => {
         getPodmanSocketCandidates({ platform: "linux", home: "/tmp/test-home", uid: 1001 }),
       ).toEqual(["/run/user/1001/podman/podman.sock", "/run/podman/podman.sock"]);
     });
+
+    it("returns no Podman socket paths on unsupported platforms", () => {
+      expect(getPodmanSocketCandidates({ platform: "win32", home: "C:/Users/test" })).toEqual([]);
+    });
   });
 
   describe("getDockerSocketCandidates", () => {

--- a/test/policy-tiers.test.ts
+++ b/test/policy-tiers.test.ts
@@ -10,9 +10,9 @@
 //   - Preset deselection within a tier
 //   - Integration with the existing policies module
 
-import { describe, it, expect } from "vitest";
-import tiers from "../dist/lib/tiers";
+import { describe, expect, it } from "vitest";
 import policies from "../dist/lib/policies";
+import tiers from "../dist/lib/tiers";
 
 interface TierPreset {
   name: string;
@@ -30,6 +30,12 @@ interface Preset {
   name: string;
 }
 
+function mustGetTier(name: string): Tier {
+  const tier = tiers.getTier(name);
+  expect(tier).not.toBeNull();
+  return tier as Tier;
+}
+
 describe("tiers", () => {
   describe("listTiers", () => {
     it("returns exactly 3 tiers", () => {
@@ -37,7 +43,7 @@ describe("tiers", () => {
     });
 
     it("tiers are ordered restricted → balanced → open", () => {
-      const names = tiers.listTiers().map((t: Tier) => t.name);
+      const names = tiers.listTiers().map((tier: Tier) => tier.name);
       expect(names).toEqual(["restricted", "balanced", "open"]);
     });
 
@@ -51,28 +57,25 @@ describe("tiers", () => {
     });
 
     it("labels are human-readable capitalised strings", () => {
-      const labels = tiers.listTiers().map((t: Tier) => t.label);
+      const labels = tiers.listTiers().map((tier: Tier) => tier.label);
       expect(labels).toEqual(["Restricted", "Balanced", "Open"]);
     });
   });
 
   describe("getTier", () => {
     it("returns the restricted tier", () => {
-      const t = tiers.getTier("restricted");
-      expect(t).not.toBeNull();
-      expect(t.name).toBe("restricted");
+      const tier = mustGetTier("restricted");
+      expect(tier.name).toBe("restricted");
     });
 
     it("returns the balanced tier", () => {
-      const t = tiers.getTier("balanced");
-      expect(t).not.toBeNull();
-      expect(t.name).toBe("balanced");
+      const tier = mustGetTier("balanced");
+      expect(tier.name).toBe("balanced");
     });
 
     it("returns the open tier", () => {
-      const t = tiers.getTier("open");
-      expect(t).not.toBeNull();
-      expect(t.name).toBe("open");
+      const tier = mustGetTier("open");
+      expect(tier.name).toBe("open");
     });
 
     it("returns null for an unknown tier", () => {
@@ -82,13 +85,13 @@ describe("tiers", () => {
 
   describe("tier: restricted", () => {
     it("has no presets — base sandbox policy only", () => {
-      expect(tiers.getTier("restricted").presets).toHaveLength(0);
+      expect(mustGetTier("restricted").presets).toHaveLength(0);
     });
   });
 
   describe("tier: balanced", () => {
     it("includes npm, pypi, huggingface, brew, and brave", () => {
-      const names = tiers.getTier("balanced").presets.map((p: TierPreset) => p.name);
+      const names = mustGetTier("balanced").presets.map((preset: TierPreset) => preset.name);
       expect(names).toContain("npm");
       expect(names).toContain("pypi");
       expect(names).toContain("huggingface");
@@ -97,17 +100,17 @@ describe("tiers", () => {
     });
 
     it("has at least 5 presets", () => {
-      expect(tiers.getTier("balanced").presets.length).toBeGreaterThanOrEqual(5);
+      expect(mustGetTier("balanced").presets.length).toBeGreaterThanOrEqual(5);
     });
 
     it("all balanced presets are read-write", () => {
-      for (const preset of tiers.getTier("balanced").presets) {
+      for (const preset of mustGetTier("balanced").presets) {
         expect(preset.access).toBe("read-write");
       }
     });
 
     it("does not include messaging presets (slack, discord, telegram)", () => {
-      const names = tiers.getTier("balanced").presets.map((p: TierPreset) => p.name);
+      const names = mustGetTier("balanced").presets.map((preset: TierPreset) => preset.name);
       expect(names).not.toContain("slack");
       expect(names).not.toContain("discord");
       expect(names).not.toContain("telegram");
@@ -116,33 +119,37 @@ describe("tiers", () => {
 
   describe("tier: open", () => {
     it("has more presets than balanced", () => {
-      const balancedCount = tiers.getTier("balanced").presets.length;
-      const openCount = tiers.getTier("open").presets.length;
+      const balancedCount = mustGetTier("balanced").presets.length;
+      const openCount = mustGetTier("open").presets.length;
       expect(openCount).toBeGreaterThan(balancedCount);
     });
 
     it("all open presets are read-write", () => {
-      for (const preset of tiers.getTier("open").presets) {
+      for (const preset of mustGetTier("open").presets) {
         expect(preset.access).toBe("read-write");
       }
     });
 
     it("includes messaging presets (slack, discord, telegram)", () => {
-      const names = tiers.getTier("open").presets.map((p: TierPreset) => p.name);
+      const names = mustGetTier("open").presets.map((preset: TierPreset) => preset.name);
       expect(names).toContain("slack");
       expect(names).toContain("discord");
       expect(names).toContain("telegram");
     });
 
     it("includes productivity presets (jira, outlook)", () => {
-      const names = tiers.getTier("open").presets.map((p: TierPreset) => p.name);
+      const names = mustGetTier("open").presets.map((preset: TierPreset) => preset.name);
       expect(names).toContain("jira");
       expect(names).toContain("outlook");
     });
 
     it("open tier contains all balanced presets by name", () => {
-      const balancedNames = new Set(tiers.getTier("balanced").presets.map((p: TierPreset) => p.name));
-      const openNames = new Set(tiers.getTier("open").presets.map((p: TierPreset) => p.name));
+      const balancedNames = new Set(
+        mustGetTier("balanced").presets.map((preset: TierPreset) => preset.name),
+      );
+      const openNames = new Set(
+        mustGetTier("open").presets.map((preset: TierPreset) => preset.name),
+      );
       for (const name of balancedNames) {
         expect(openNames.has(name)).toBe(true);
       }
@@ -153,8 +160,8 @@ describe("tiers", () => {
     it("returns default presets for balanced with no overrides", () => {
       const resolved: TierPreset[] = tiers.resolveTierPresets("balanced");
       expect(resolved.length).toBeGreaterThanOrEqual(5);
-      for (const p of resolved) {
-        expect(p.access).toBe("read-write");
+      for (const preset of resolved) {
+        expect(preset.access).toBe("read-write");
       }
     });
 
@@ -162,10 +169,9 @@ describe("tiers", () => {
       const resolved: TierPreset[] = tiers.resolveTierPresets("balanced", {
         overrides: { npm: "read" },
       });
-      const npm = resolved.find((p: TierPreset) => p.name === "npm");
+      const npm = resolved.find((preset: TierPreset) => preset.name === "npm");
       expect(npm!.access).toBe("read");
-      // other presets unchanged
-      const pypi = resolved.find((p: TierPreset) => p.name === "pypi");
+      const pypi = resolved.find((preset: TierPreset) => preset.name === "pypi");
       expect(pypi!.access).toBe("read-write");
     });
 
@@ -174,7 +180,7 @@ describe("tiers", () => {
         selected: ["npm", "pypi"],
       });
       expect(resolved).toHaveLength(2);
-      const names = resolved.map((p: TierPreset) => p.name);
+      const names = resolved.map((preset: TierPreset) => preset.name);
       expect(names).toContain("npm");
       expect(names).toContain("pypi");
     });
@@ -211,17 +217,17 @@ describe("tiers", () => {
     });
 
     it("open tier resolve returns all open presets", () => {
-      const openTier = tiers.getTier("open");
+      const openTier = mustGetTier("open");
       const resolved: TierPreset[] = tiers.resolveTierPresets("open");
       expect(resolved).toHaveLength(openTier.presets.length);
     });
 
     it("each resolved preset has name and access fields", () => {
       for (const tier of tiers.listTiers()) {
-        for (const p of tiers.resolveTierPresets(tier.name)) {
-          expect(typeof p.name).toBe("string");
-          expect(typeof p.access).toBe("string");
-          expect(p.access.length).toBeGreaterThan(0);
+        for (const preset of tiers.resolveTierPresets(tier.name)) {
+          expect(typeof preset.name).toBe("string");
+          expect(typeof preset.access).toBe("string");
+          expect(preset.access.length).toBeGreaterThan(0);
         }
       }
     });
@@ -229,7 +235,7 @@ describe("tiers", () => {
 
   describe("integration: all tier presets exist on disk", () => {
     it("every preset referenced in tiers.yaml exists as a preset file", () => {
-      const available = new Set(policies.listPresets().map((p: Preset) => p.name));
+      const available = new Set(policies.listPresets().map((preset: Preset) => preset.name));
       for (const tier of tiers.listTiers()) {
         for (const preset of tier.presets) {
           expect(

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -67,6 +67,11 @@ export const template = ` +
       "src/commented.ts": `// @ts-ignore this is a real directive comment
 export const value = 1;
 `,
+      "src/function-commented.ts": `export function ignored(value: string): string {
+  // @ts-expect-error deliberately ignored in fixture
+  return value;
+}
+`,
     });
 
     const report = analyzeTypeSafetyHotspots({
@@ -77,12 +82,37 @@ export const value = 1;
     const disabled = report.files.find((file) => file.filePath === "src/disabled.ts");
     const stringy = report.files.find((file) => file.filePath === "src/stringy.ts");
     const commented = report.files.find((file) => file.filePath === "src/commented.ts");
+    const ignored = report.functions.find((fn) => fn.displayName === "ignored");
 
     expect(disabled?.noCheck).toBe(true);
     expect(stringy?.noCheck).toBe(false);
     expect(stringy?.tsDirectiveCount).toBe(0);
     expect(commented?.tsDirectiveCount).toBe(1);
+    expect(ignored?.tsDirectiveCount).toBe(1);
     expect(disabled?.score).toBeGreaterThan(0);
+  });
+
+  it("detects YAML.load as a parse boundary", () => {
+    const rootDir = makeProject({
+      "src/yamlish.ts": `export function loadConfig(raw: string) {
+  const YAML = { load(value: string): string { return value; } };
+  // @ts-ignore fixture suppression for hotspot scoring
+  return YAML.load(raw);
+}
+`,
+    });
+
+    const report = analyzeTypeSafetyHotspots({
+      rootDir,
+      projectPaths: ["tsconfig.json"],
+    });
+
+    const yamlish = report.files.find((file) => file.filePath === "src/yamlish.ts");
+    const loadConfig = report.functions.find((fn) => fn.displayName === "loadConfig");
+
+    expect(yamlish?.parserBoundaryCount).toBe(1);
+    expect(loadConfig?.parserBoundaryCount).toBe(1);
+    expect(loadConfig?.tsDirectiveCount).toBe(1);
   });
 
   it("ranks shared parse-boundary helpers as high-value typing targets", () => {

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { analyzeTypeSafetyHotspots, renderTextReport } from "../scripts/type-safety-hotspots";
+
+const tempDirs: string[] = [];
+
+function makeProject(files: Record<string, string>): string {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-type-hotspots-"));
+  tempDirs.push(rootDir);
+
+  fs.writeFileSync(
+    path.join(rootDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          strict: true,
+        },
+        include: ["src/**/*.ts"],
+      },
+      null,
+      2,
+    ),
+  );
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absPath = path.join(rootDir, relativePath);
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, content);
+  }
+
+  return rootDir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("type-safety hotspots tool", () => {
+  it("detects leading @ts-nocheck without false positives from string literals", () => {
+    const rootDir = makeProject({
+      "src/disabled.ts": `// @ts-nocheck
+export function disabled(value) {
+  return value?.flag;
+}
+`,
+      "src/stringy.ts": `export const banner = "// @ts-nocheck";
+`,
+    });
+
+    const report = analyzeTypeSafetyHotspots({
+      rootDir,
+      projectPaths: ["tsconfig.json"],
+    });
+
+    const disabled = report.files.find((file) => file.filePath === "src/disabled.ts");
+    const stringy = report.files.find((file) => file.filePath === "src/stringy.ts");
+
+    expect(disabled?.noCheck).toBe(true);
+    expect(stringy?.noCheck).toBe(false);
+    expect(disabled?.score).toBeGreaterThan(0);
+  });
+
+  it("ranks shared parse-boundary helpers as high-value typing targets", () => {
+    const rootDir = makeProject({
+      "src/config.ts": `export function normalizeConfig(raw: string) {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const metadata = ((parsed.metadata as Record<string, unknown>) || {}) as Record<string, unknown>;
+  const labels = Array.isArray(parsed.labels)
+    ? (parsed.labels as unknown[]).filter((value): value is string => typeof value === "string")
+    : [];
+
+  return {
+    name: (parsed.name as string) || "default",
+    enabled: parsed.enabled === true,
+    owner: (metadata.owner as string) || null,
+    labels,
+  };
+}
+`,
+      "src/use-a.ts": `import { normalizeConfig } from "./config";
+
+export const configA = normalizeConfig("{}");
+`,
+      "src/use-b.ts": `import { normalizeConfig } from "./config";
+
+export const configB = normalizeConfig("{}");
+`,
+      "src/other.ts": `export function identity(value: string): string {
+  return value;
+}
+`,
+    });
+
+    const report = analyzeTypeSafetyHotspots({
+      rootDir,
+      projectPaths: ["tsconfig.json"],
+    });
+
+    const configFile = report.files.find((file) => file.filePath === "src/config.ts");
+    const normalizeConfig = report.functions.find((fn) => fn.displayName === "normalizeConfig");
+    const textReport = renderTextReport(report, {
+      topFiles: 1,
+      topFunctions: 1,
+      minScore: 1,
+    });
+
+    expect(report.files[0]?.filePath).toBe("src/config.ts");
+    expect(configFile?.fanIn).toBe(2);
+    expect(configFile?.parserBoundaryCount).toBe(1);
+    expect(configFile?.recordStringUnknownCount).toBeGreaterThanOrEqual(2);
+    expect(normalizeConfig?.parserBoundaryCount).toBe(1);
+    expect(normalizeConfig?.score).toBeGreaterThan(0);
+    expect(report.themes.map((theme) => theme.id)).toContain("parse-boundaries");
+    expect(textReport).toContain("src/config.ts");
+    expect(textReport).toContain("normalizeConfig");
+  });
+});

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -58,7 +58,14 @@ export function disabled(value) {
   return value?.flag;
 }
 `,
-      "src/stringy.ts": `export const banner = "// @ts-nocheck";
+      "src/stringy.ts":
+        `export const banner = "// @ts-nocheck @ts-ignore";
+export const template = ` +
+        "String.raw`@ts-expect-error`" +
+        `;
+`,
+      "src/commented.ts": `// @ts-ignore this is a real directive comment
+export const value = 1;
 `,
     });
 
@@ -69,9 +76,12 @@ export function disabled(value) {
 
     const disabled = report.files.find((file) => file.filePath === "src/disabled.ts");
     const stringy = report.files.find((file) => file.filePath === "src/stringy.ts");
+    const commented = report.files.find((file) => file.filePath === "src/commented.ts");
 
     expect(disabled?.noCheck).toBe(true);
     expect(stringy?.noCheck).toBe(false);
+    expect(stringy?.tsDirectiveCount).toBe(0);
+    expect(commented?.tsDirectiveCount).toBe(1);
     expect(disabled?.score).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
## Summary
Add a `type-safety:hotspots` developer command that ranks files and functions by type-safety ROI, then use it to refactor the first wave of high-value hotspots it surfaced. This gives contributors a repeatable way to prioritize typing work and knocks down the initial top five hotspots the new tool identified.

## Changes
- add `scripts/type-safety-hotspots.ts` and `npm run type-safety:hotspots`, plus tests covering hotspot scoring and `@ts-nocheck` detection
- refactor the initial top five hotspots from the first report: `src/lib/onboard-session.ts`, `src/lib/tiers.ts`, `src/lib/platform.ts`, `nemoclaw/src/commands/migration-state.ts`, and `src/lib/agent-defs.ts`
- add typed parsing/helpers to reduce unchecked JSON/YAML access, remove `@ts-nocheck` from `tiers.ts` and `platform.ts`, and add `src/lib/agent-defs.test.ts`
- update `test/policy-tiers.test.ts` for the stricter nullable `getTier()` surface exposed by the new typing work
- regenerate the touched troubleshooting skill artifact via the repo hooks
- reduce the original hotspot scores reported by the new tool from `180/117/111/107/102` to `61/11/0/36/13` for `onboard-session`, `tiers`, `platform`, `migration-state`, and `agent-defs`

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: OpenAI Codex (pi coding agent)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified sandbox guidance for `openclaw update`, documenting cause and recommending rebuild/upgrade remediation that preserves workspace state.
* **Tests**
  * Expanded coverage: agent manifests, platform/socket detection, migration-state env handling, session redaction, and type-safety analyzer/reporting.
* **Improvements**
  * Hardened parsing/validation, stronger type/runtime checks, safer error handling, tighter session summaries, and refined platform/runtime detection.
* **Tools**
  * Added a type-safety analysis CLI and an npm script to run it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->