### PR TITLE
fix(hermes): label port 8642 as OpenAI-compatible API, not chat UI (#2078)

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -41,6 +41,11 @@ RUN chmod 755 /usr/local/bin/nemoclaw-start
 ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b
 ARG NEMOCLAW_PROVIDER_KEY=custom
 ARG NEMOCLAW_INFERENCE_BASE_URL=https://inference.local/v1
+# CHAT_UI_URL is a legacy name shared with the OpenClaw build arg. For
+# Hermes this URL points at the OpenAI-compatible API server (port 8642,
+# exposing /v1 and /health), NOT a browser chat UI. Callers authenticate
+# via a bearer token in the Authorization header. See
+# agents/hermes/manifest.yaml (dashboard.kind: api).
 ARG CHAT_UI_URL=http://127.0.0.1:8642
 ARG NEMOCLAW_MESSAGING_CHANNELS_B64=W10=
 ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=

--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -28,9 +28,17 @@ health_probe:
   timeout_seconds: 90
 
 # ── Dashboard / UI ──────────────────────────────────────────────
-# Hermes exposes an OpenAI-compatible API, not a web dashboard.
-# Any OpenAI-compatible frontend (Open WebUI, LobeChat, etc.) can
-# connect at http://localhost:8642/v1.
+# Hermes exposes an OpenAI-compatible API on port 8642 — NOT a web
+# dashboard. Any OpenAI-compatible frontend (Open WebUI, LobeChat,
+# etc.) can connect at http://localhost:8642/v1. Auth is via a bearer
+# token in the Authorization header, not a URL fragment.
+#
+# The optional `hermes dashboard` web UI (pip install hermes-agent[web])
+# listens on a different port and is not installed by default.
+dashboard:
+  kind: api                    # "ui" or "api"
+  label: "OpenAI-compatible API"
+  path: "/v1"                  # appended to the base URL when displayed
 forward_ports:
   - 8642
 

--- a/src/lib/agent-defs.ts
+++ b/src/lib/agent-defs.ts
@@ -150,11 +150,12 @@ export function loadAgent(name: string): AgentDefinition {
       const d = (raw.dashboard as Partial<AgentDashboard>) || {};
       const kind: AgentDashboardKind = d.kind === "api" ? "api" : "ui";
       const defaultLabel = kind === "api" ? "API" : "UI";
+      const normalizedLabel = typeof d.label === "string" ? d.label.trim() : "";
       const rawPath = typeof d.path === "string" ? d.path.trim() : "";
       const path = rawPath ? (rawPath.startsWith("/") ? rawPath : `/${rawPath}`) : "/";
       return {
         kind,
-        label: typeof d.label === "string" && d.label.trim() ? d.label : defaultLabel,
+        label: normalizedLabel || defaultLabel,
         path,
       };
     },

--- a/src/lib/agent-defs.ts
+++ b/src/lib/agent-defs.ts
@@ -28,6 +28,14 @@ export interface AgentConfigPaths {
   format: string;
 }
 
+export type AgentDashboardKind = "ui" | "api";
+
+export interface AgentDashboard {
+  kind: AgentDashboardKind;
+  label: string;
+  path: string;
+}
+
 export interface AgentLegacyPaths {
   dockerfileBase: string | null;
   dockerfile: string | null;
@@ -57,6 +65,7 @@ export interface AgentDefinition {
   readonly displayName: string;
   readonly healthProbe: AgentHealthProbe;
   readonly forwardPort: number;
+  readonly dashboard: AgentDashboard;
   readonly configPaths: AgentConfigPaths;
   readonly stateDirs: string[];
   readonly versionCommand: string;
@@ -135,6 +144,19 @@ export function loadAgent(name: string): AgentDefinition {
     get forwardPort(): number {
       const ports = (raw.forward_ports as number[]) || [];
       return ports[0] || DASHBOARD_PORT;
+    },
+
+    get dashboard(): AgentDashboard {
+      const d = (raw.dashboard as Partial<AgentDashboard>) || {};
+      const kind: AgentDashboardKind = d.kind === "api" ? "api" : "ui";
+      const defaultLabel = kind === "api" ? "API" : "UI";
+      const rawPath = typeof d.path === "string" ? d.path.trim() : "";
+      const path = rawPath ? (rawPath.startsWith("/") ? rawPath : `/${rawPath}`) : "/";
+      return {
+        kind,
+        label: typeof d.label === "string" && d.label.trim() ? d.label : defaultLabel,
+        path,
+      };
     },
 
     get configPaths(): AgentConfigPaths {

--- a/src/lib/agent-onboard.test.ts
+++ b/src/lib/agent-onboard.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
 // Import from compiled dist/ so coverage is attributed correctly.
 import { printDashboardUi } from "../../dist/lib/agent-onboard";
 import type { AgentDefinition } from "./agent-defs";
@@ -41,6 +41,10 @@ describe("printDashboardUi — regression for #2078 (port 8642 is not a chat UI)
 
   afterEach(() => {
     logSpy.mockClear();
+  });
+
+  afterAll(() => {
+    logSpy.mockRestore();
   });
 
   it("labels an API-kind agent as the API — not a UI — and does not embed a token in the URL", () => {

--- a/src/lib/agent-onboard.test.ts
+++ b/src/lib/agent-onboard.test.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+// Import from compiled dist/ so coverage is attributed correctly.
+import { printDashboardUi } from "../../dist/lib/agent-onboard";
+import type { AgentDefinition } from "./agent-defs";
+
+// Test fixtures — only the fields printDashboardUi reads are populated.
+// Cast via unknown to avoid requiring the full AgentDefinition shape.
+const apiAgent = {
+  name: "hermes",
+  displayName: "Hermes Agent",
+  forwardPort: 8642,
+  dashboard: { kind: "api", label: "OpenAI-compatible API", path: "/v1" },
+} as unknown as AgentDefinition;
+
+const uiAgent = {
+  name: "ficticious-ui",
+  displayName: "Ficticious",
+  forwardPort: 19000,
+  dashboard: { kind: "ui", label: "UI", path: "/" },
+} as unknown as AgentDefinition;
+
+// Regression fixture for issue #2078 — matches the text a user sees when
+// no token is available and prevents the wording from regressing to
+// something that implies port 8642 is a browser UI.
+const buildUrlsLoopback = (token: string | null, port: number): string[] => {
+  const hash = token ? `#token=${token}` : "";
+  return [`http://127.0.0.1:${port}/${hash}`];
+};
+
+describe("printDashboardUi — regression for #2078 (port 8642 is not a chat UI)", () => {
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  const noteSpy = vi.fn();
+
+  beforeEach(() => {
+    logSpy.mockClear();
+    noteSpy.mockReset();
+  });
+
+  afterEach(() => {
+    logSpy.mockClear();
+  });
+
+  it("labels an API-kind agent as the API — not a UI — and does not embed a token in the URL", () => {
+    printDashboardUi("sandbox-x", "secret-token", apiAgent, {
+      note: noteSpy,
+      buildControlUiUrls: buildUrlsLoopback,
+    });
+
+    const output = logSpy.mock.calls.map((args) => String(args[0])).join("\n");
+    expect(output).toContain("Hermes Agent OpenAI-compatible API");
+    expect(output).not.toContain("UI (tokenized URL");
+    expect(output).toContain("Port 8642 must be forwarded before connecting.");
+    expect(output).toContain("http://127.0.0.1:8642/v1");
+    // Token-in-URL-fragment auth does not apply to the OpenAI API endpoint.
+    expect(output).not.toContain("#token=secret-token");
+  });
+
+  it("prints the API URL consistently whether or not a gateway token was read", () => {
+    printDashboardUi("sandbox-x", null, apiAgent, {
+      note: noteSpy,
+      buildControlUiUrls: buildUrlsLoopback,
+    });
+
+    const output = logSpy.mock.calls.map((args) => String(args[0])).join("\n");
+    expect(output).toContain("Hermes Agent OpenAI-compatible API");
+    expect(output).toContain("http://127.0.0.1:8642/v1");
+    // The API endpoint does not require the gateway token — don't confuse
+    // the user with the OpenClaw-style "token missing" warning.
+    expect(noteSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing tokenized URL wording for UI-kind agents", () => {
+    printDashboardUi("sandbox-y", "tok", uiAgent, {
+      note: noteSpy,
+      buildControlUiUrls: buildUrlsLoopback,
+    });
+
+    const output = logSpy.mock.calls.map((args) => String(args[0])).join("\n");
+    expect(output).toContain("Ficticious UI (tokenized URL; treat it like a password)");
+    expect(output).toContain("Port 19000 must be forwarded before opening this URL.");
+    expect(output).toContain("http://127.0.0.1:19000/#token=tok");
+  });
+});

--- a/src/lib/agent-onboard.ts
+++ b/src/lib/agent-onboard.ts
@@ -215,6 +215,11 @@ export function getAgentDashboardInfo(agent: AgentDefinition): {
 
 /**
  * Print the dashboard UI section for a non-OpenClaw agent.
+ *
+ * When the agent manifest declares `dashboard.kind: api`, we print the
+ * endpoint as an API (no tokenized URL fragment — the caller authenticates
+ * via a header) and use the manifest-supplied label/path. Otherwise we fall
+ * back to the original UI-style output used by browser dashboards.
  */
 export function printDashboardUi(
   _sandboxName: string,
@@ -226,15 +231,31 @@ export function printDashboardUi(
   },
 ): void {
   const info = getAgentDashboardInfo(agent);
+  const { kind, label, path } = agent.dashboard;
+
+  if (kind === "api") {
+    console.log(`  ${info.displayName} ${label}`);
+    console.log(`  Port ${info.port} must be forwarded before connecting.`);
+    const seen = new Set<string>();
+    for (const baseUrl of deps.buildControlUiUrls(null, info.port)) {
+      const withoutHash = baseUrl.split("#")[0].replace(/\/$/, "");
+      const url = path && path !== "/" ? `${withoutHash}${path}` : `${withoutHash}/`;
+      if (seen.has(url)) continue;
+      seen.add(url);
+      console.log(`  ${url}`);
+    }
+    return;
+  }
+
   if (token) {
-    console.log(`  ${info.displayName} UI (tokenized URL; treat it like a password)`);
+    console.log(`  ${info.displayName} ${label} (tokenized URL; treat it like a password)`);
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(token, info.port)) {
       console.log(`  ${url}`);
     }
   } else {
     deps.note("  Could not read gateway token from the sandbox (download failed).");
-    console.log(`  ${info.displayName} UI`);
+    console.log(`  ${info.displayName} ${label}`);
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(null, info.port)) {
       console.log(`  ${url}`);


### PR DESCRIPTION
## Summary

Fixes #2078. Onboarding told users "Hermes Agent UI" with a tokenized URL for port 8642, but that port serves the OpenAI-compatible API — not a browser dashboard — and the endpoint authenticates via a bearer header, so the URL-fragment token was misleading as well.

- Added a `dashboard` descriptor (`kind` / `label` / `path`) to `agents/hermes/manifest.yaml` so we can describe what a forward port actually serves.
- Branched `printDashboardUi` (`src/lib/agent-onboard.ts`) on the new kind. For `api`-kind agents we print the label (`"OpenAI-compatible API"`), drop the `#token=…` fragment, append the configured path (`/v1`), and switch the verb to "connecting" instead of "opening this URL".
- UI-kind agents render identically to before (default kind when the manifest omits `dashboard`).
- Kept the legacy `CHAT_UI_URL` build arg for OpenClaw interop with a comment explaining what it actually points at for Hermes.

### Before → after

Before:
```
  Hermes Agent UI (tokenized URL; treat it like a password)
  Port 8642 must be forwarded before opening this URL.
  http://127.0.0.1:8642/#token=abc123def456
```

After:
```
  Hermes Agent OpenAI-compatible API
  Port 8642 must be forwarded before connecting.
  http://127.0.0.1:8642/v1
```

Reproduced locally by running `printDashboardUi` against the real loaded manifest — no Docker / sandbox needed.

## Test plan

- [x] `npm run build:cli`
- [x] `npm run typecheck:cli`
- [x] New regression tests in `src/lib/agent-onboard.test.ts` covering the api-kind and ui-kind branches (3 cases, all passing)
- [x] `agent-runtime` tests unchanged (5/5 still passing)
- [ ] CI full suite
- [ ] Manual onboard of a Hermes sandbox to confirm the rendered text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable agent dashboards with explicit kind (UI or API) and normalized path handling
  * UI display now shows a label and path for API-style dashboards; Hermes registered as OpenAI-compatible API

* **Documentation**
  * Clarified Bearer token authentication and endpoint/path expectations for API dashboards
  * Added notes about port-forwarding and separate Hermes web UI availability

* **Tests**
  * Added regression tests covering dashboard output for API vs UI agents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>
