### PR TITLE
fix(onboard): use Bearer auth when probing Gemini OpenAI-compat endpoint

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1333,11 +1333,16 @@ function shouldRequireResponsesToolCalling(provider) {
   );
 }
 
-// Google Gemini rejects requests that carry both an Authorization: Bearer
-// header and a ?key= query parameter ("Multiple authentication credentials
-// received"). Send the API key as ?key= only for Gemini. See issue #1960.
-function getProbeAuthMode(provider) {
-  return provider === "gemini-api" ? "query-param" : undefined;
+// The Gemini OpenAI-compat endpoint at /v1beta/openai/ requires
+// `Authorization: Bearer <KEY>` and rejects `?key=<KEY>` with HTTP 400
+// "Missing or invalid Authorization header." The dual-auth rejection
+// described in #1960 applies to the native /v1beta/models/...:generateContent
+// endpoint, which the onboarder probes do not use. Both callers of this
+// helper (probeOpenAiLikeEndpoint, probeResponsesToolCalling) target the
+// OpenAI-compat URL, so returning undefined for every provider is correct:
+// probes default to Bearer auth and Gemini onboarding succeeds.
+function getProbeAuthMode(_provider) {
+  return undefined;
 }
 
 // shouldSkipResponsesProbe and isNvcfFunctionNotFoundForAccount /

--- a/test/gemini-probe-auth.test.ts
+++ b/test/gemini-probe-auth.test.ts
@@ -3,44 +3,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import fs from "node:fs";
-import path from "node:path";
 
 import { getProbeAuthMode } from "../dist/lib/onboard";
 
-describe("Gemini dual-auth credential fix (issue #1960)", () => {
-  describe("getProbeAuthMode", () => {
-    it("returns 'query-param' for gemini-api provider", () => {
-      expect(getProbeAuthMode("gemini-api")).toBe("query-param");
-    });
-
-    it("returns undefined for non-Gemini providers", () => {
-      expect(getProbeAuthMode("openai-api")).toBeUndefined();
-      expect(getProbeAuthMode("nvidia-prod")).toBeUndefined();
-      expect(getProbeAuthMode("anthropic-prod")).toBeUndefined();
-      expect(getProbeAuthMode("compatible-endpoint")).toBeUndefined();
-      expect(getProbeAuthMode("")).toBeUndefined();
-    });
+// The onboarder's Gemini validation probes target the OpenAI-compat
+// endpoint at https://generativelanguage.googleapis.com/v1beta/openai/.
+// That endpoint requires `Authorization: Bearer <KEY>` and rejects
+// `?key=<KEY>` with HTTP 400 "Missing or invalid Authorization header."
+//
+// The dual-auth rejection described in #1960 applies to Gemini's native
+// /v1beta/models/...:generateContent endpoint, which is not used by the
+// onboarder probes. getProbeAuthMode therefore returns undefined for
+// every provider so probes default to Bearer auth.
+describe("getProbeAuthMode — Bearer auth for OpenAI-compat probes", () => {
+  it("returns undefined for gemini-api so probes send Authorization: Bearer", () => {
+    expect(getProbeAuthMode("gemini-api")).toBeUndefined();
   });
 
-  describe("compiled probe uses ?key= for Gemini instead of Bearer header", () => {
-    const onboardSrc = fs.readFileSync(
-      path.join(import.meta.dirname, "..", "dist", "lib", "onboard.js"),
-      "utf-8",
-    );
-
-    it("contains query-param auth mode logic in probeOpenAiLikeEndpoint", () => {
-      // The probe function must check for authMode === "query-param"
-      expect(onboardSrc).toMatch(/authMode.*===.*"query-param"/);
-    });
-
-    it("appends ?key= to the URL with encodeURIComponent when using query-param auth", () => {
-      // The compiled code must URL-encode the key when building ?key= URLs
-      expect(onboardSrc).toMatch(/\?key=.*encodeURIComponent/);
-    });
-
-    it("getProbeAuthMode returns query-param for gemini-api", () => {
-      expect(onboardSrc).toMatch(/gemini-api.*\?.*query-param|query-param.*gemini-api/);
-    });
+  it("returns undefined for non-Gemini providers", () => {
+    expect(getProbeAuthMode("openai-api")).toBeUndefined();
+    expect(getProbeAuthMode("nvidia-prod")).toBeUndefined();
+    expect(getProbeAuthMode("anthropic-prod")).toBeUndefined();
+    expect(getProbeAuthMode("compatible-endpoint")).toBeUndefined();
+    expect(getProbeAuthMode("")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

The Gemini OpenAI-compat probe endpoint at `/v1beta/openai/` requires `Authorization: Bearer <KEY>` and rejects `?key=<KEY>` with HTTP 400 "Missing or invalid Authorization header." The onboarder currently sends `?key=` for Gemini, which blocks every Gemini onboarding run. This change makes `getProbeAuthMode` return `undefined` for every provider so probes default to Bearer auth.

## Related Issue

Fixes #2093

## Changes

- `src/lib/onboard.ts` — `getProbeAuthMode` unconditionally returns `undefined`; comment rewritten to explain that the #1960 dual-auth rejection applies to Gemini's native endpoint, not the OpenAI-compat shim that the probes target.
- `test/gemini-probe-auth.test.ts` — replaces the assertions that pinned the old (buggy) `"query-param"` return value with ones that pin the corrected Bearer-auth behavior. Drops the three compiled-source regex checks since they guarded the old behavior and carry no regression value for the fix.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Evidence

<details>
<summary>Direct reproduction against Google (click to expand)</summary>

With a known-good AI Studio key:

```bash
# Current behavior — FAILS:
$ curl -sS "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions?key=$KEY" \
    -H "Content-Type: application/json" \
    -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}]}'
# → HTTP 400  "Missing or invalid Authorization header."

# With this fix — SUCCEEDS:
$ curl -sS "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions" \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}]}'
# → HTTP 200
```

</details>

<details>
<summary>Safety: no regression to #1960</summary>

The comment on the old helper referenced #1960 ("Gemini rejects requests that carry both `Authorization: Bearer` and `?key=`"). That rejection is produced by Gemini's **native** `/v1beta/models/...:generateContent` endpoint, which the onboarder probes do not hit. Both callers of `getProbeAuthMode` — `probeOpenAiLikeEndpoint` and `probeResponsesToolCalling` — target only the OpenAI-compat URL (`GEMINI_ENDPOINT_URL` at `src/lib/onboard.ts:159`). So returning `undefined` for `gemini-api` cannot re-trigger the #1960 dual-auth error.

</details>

## Verification

- [x] `npx prek run --all-files` passes (hadolint skipped — no Dockerfile changes)
- [x] `npm test` passes (101 test files, 1854 tests passing, 2 files + 12 tests skipped — matches baseline)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes — N/A (internal helper)
- [ ] `make docs` builds without warnings — N/A
- [ ] Doc pages follow the style guide — N/A
- [ ] New doc pages include SPDX header and frontmatter — N/A

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

Signed-off-by: Jeff J Hunter <support@aipersonamethod.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gemini API endpoint probing now uses Bearer Authorization headers instead of sending API keys via URL query parameters.

* **Tests**
  * Test suite updated to reflect the new probing authentication behavior and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->