### PR TITLE
fix(policy): restore L4 tunnel for WebSocket hosts via tls: skip

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -242,13 +242,14 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
-      # WebSocket gateway — must use access: full (CONNECT tunnel) instead
-      # of protocol: rest. The proxy's HTTP idle timeout (~2 min) kills
-      # long-lived WebSocket connections; a CONNECT tunnel avoids
-      # HTTP-level timeouts entirely. Matches presets/discord.yaml. See #409.
+      # WebSocket gateway — pure L4 CONNECT tunnel. OpenShell v0.0.15+
+      # auto-terminates TLS unconditionally (NVIDIA/OpenShell#544), which
+      # also applies to WSS. tls: skip restores the pre-v0.0.15 pass-
+      # through behaviour needed here. Matches presets/discord.yaml.
       - host: gateway.discord.gg
         port: 443
         access: full
+        tls: skip
       - host: cdn.discordapp.com
         port: 443
         protocol: rest

--- a/nemoclaw-blueprint/policies/presets/discord.yaml
+++ b/nemoclaw-blueprint/policies/presets/discord.yaml
@@ -22,13 +22,14 @@ network_policies:
           # Reaction DELETE requires an extra path segment: /reactions/{emoji}/@me or /{user_id}
           - allow: { method: DELETE, path: "/api/v*/channels/*/messages/*" }
           - allow: { method: DELETE, path: "/api/v*/channels/*/messages/*/reactions/*/*" }
-      # WebSocket gateway — must use access: full (CONNECT tunnel) instead
-      # of protocol: rest. The proxy's HTTP idle timeout (~2 min) kills
-      # long-lived WebSocket connections; a CONNECT tunnel avoids
-      # HTTP-level timeouts entirely. See #409.
+      # WebSocket gateway — pure L4 CONNECT tunnel. OpenShell v0.0.15+
+      # auto-terminates TLS unconditionally (NVIDIA/OpenShell#544), which
+      # also applies to WSS. tls: skip restores the pre-v0.0.15 pass-
+      # through behaviour needed here.
       - host: gateway.discord.gg
         port: 443
         access: full
+        tls: skip
       - host: cdn.discordapp.com
         port: 443
         protocol: rest

--- a/nemoclaw-blueprint/policies/presets/slack.yaml
+++ b/nemoclaw-blueprint/policies/presets/slack.yaml
@@ -30,14 +30,18 @@ network_policies:
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
-      # Socket Mode WebSocket — requires CONNECT tunnel to avoid
-      # HTTP idle timeout killing the persistent connection. See #409.
+      # Socket Mode WebSocket — pure L4 CONNECT tunnel. OpenShell v0.0.15+
+      # auto-terminates TLS unconditionally (NVIDIA/OpenShell#544), which
+      # also applies to WSS. tls: skip restores the pre-v0.0.15 pass-
+      # through behaviour needed here.
       - host: wss-primary.slack.com
         port: 443
         access: full
+        tls: skip
       - host: wss-backup.slack.com
         port: 443
         access: full
+        tls: skip
     binaries:
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }

--- a/schemas/blueprint.schema.json
+++ b/schemas/blueprint.schema.json
@@ -137,7 +137,7 @@
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "protocol": { "type": "string", "enum": ["rest"] },
         "enforcement": { "type": "string", "enum": ["enforce", "audit"] },
-        "tls": { "type": "string", "enum": ["terminate", "passthrough"] },
+        "tls": { "type": "string", "enum": ["terminate", "passthrough", "skip"] },
         "access": { "type": "string", "enum": ["full"] },
         "rules": {
           "type": "array",

--- a/schemas/policy-preset.schema.json
+++ b/schemas/policy-preset.schema.json
@@ -49,7 +49,7 @@
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "protocol": { "type": "string", "enum": ["rest"] },
         "enforcement": { "type": "string", "enum": ["enforce", "audit"] },
-        "tls": { "type": "string", "enum": ["terminate", "passthrough"] },
+        "tls": { "type": "string", "enum": ["terminate", "passthrough", "skip"] },
         "access": { "type": "string", "enum": ["full"] },
         "rules": {
           "type": "array",

--- a/schemas/sandbox-policy.schema.json
+++ b/schemas/sandbox-policy.schema.json
@@ -74,7 +74,7 @@
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "protocol": { "type": "string", "enum": ["rest"] },
         "enforcement": { "type": "string", "enum": ["enforce", "audit"] },
-        "tls": { "type": "string", "enum": ["terminate", "passthrough"] },
+        "tls": { "type": "string", "enum": ["terminate", "passthrough", "skip"] },
         "access": { "type": "string", "enum": ["full"] },
         "rules": {
           "type": "array",


### PR DESCRIPTION
OpenShell [v0.0.15+ auto-terminates TLS unconditionally](https://github.com/NVIDIA/OpenShell/pull/544) on every detected TLS stream, which also applies to WSS. Without an explicit opt-out, messaging WebSocket endpoints (previously shipping as pure L4 CONNECT tunnels via `access: full`) are now MITMed, and the Discord client consistently loses its gateway connection with close code 1006.

Add `tls: skip` to the affected endpoints to restore the pre-v0.0.15 pass-through behaviour:
  - discord preset: gateway.discord.gg
  - slack preset:   wss-primary.slack.com, wss-backup.slack.com
  - baseline openclaw-sandbox.yaml: gateway.discord.gg

Extend the policy schemas to accept `skip` in the `tls` enum.

Fixes #2092.
Fixes #1738.

Related to #2085.

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [X] AI-assisted — tool: Claude Code<!-- e.g., Claude Code, Cursor, GitHub Copilot -->

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS handling for Discord and Slack WebSocket connections to prevent timeout issues and restore proper pass-through behavior for long-lived secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->