### PR TITLE
docs: use ~/nemoclaw instead of hardcoded /home/ubuntu (#1319)

### DIFF
--- a/.agents/skills/nemoclaw-user-deploy-remote/SKILL.md
+++ b/.agents/skills/nemoclaw-user-deploy-remote/SKILL.md
@@ -71,7 +71,7 @@ $ nemoclaw deploy <instance-name>
 SSH to the instance and run the OpenShell TUI to monitor activity and approve network requests:
 
 ```console
-$ ssh <instance-name> 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell term'
+$ ssh <instance-name> 'cd ~/nemoclaw && set -a && . .env && set +a && openshell term'
 ```
 
 ## Step 5: Verify Inference

--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -30,7 +30,7 @@ $ openshell term
 For a remote sandbox, pass the instance name:
 
 ```console
-$ ssh my-gpu-box 'cd /home/ubuntu/nemoclaw && . .env && openshell term'
+$ ssh my-gpu-box 'cd ~/nemoclaw && . .env && openshell term'
 ```
 
 The TUI displays the sandbox state, active inference provider, and a live feed of network activity.

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -350,6 +350,18 @@ The status command detects the sandbox context and reports "active (inside sandb
 
 Run `openshell sandbox list` on the host to check the underlying sandbox state.
 
+### `openclaw update` hangs or times out inside the sandbox
+
+This is expected for the current NemoClaw deployment model.
+NemoClaw installs `openclaw` into the sandbox image at build time, so the CLI is image-pinned rather than updated in place inside a running sandbox.
+
+Do not run `openclaw update` inside the sandbox.
+Instead:
+
+1. Upgrade to a NemoClaw release that includes the newer `openclaw` version.
+2. If you build NemoClaw from source, bump the pinned `openclaw` version in `Dockerfile.base` and rebuild the sandbox base image.
+3. Back up any workspace files you need, then recreate the sandbox so it uses the rebuilt image.
+
 ### Inference requests time out
 
 Verify that the inference provider endpoint is reachable from the host.

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -83,7 +83,7 @@ $ nemoclaw deploy <instance-name>
 SSH to the instance and run the OpenShell TUI to monitor activity and approve network requests:
 
 ```console
-$ ssh <instance-name> 'cd /home/ubuntu/nemoclaw && set -a && . .env && set +a && openshell term'
+$ ssh <instance-name> 'cd ~/nemoclaw && set -a && . .env && set +a && openshell term'
 ```
 
 ## Verify Inference

--- a/docs/network-policy/approve-network-requests.md
+++ b/docs/network-policy/approve-network-requests.md
@@ -41,7 +41,7 @@ $ openshell term
 For a remote sandbox, pass the instance name:
 
 ```console
-$ ssh my-gpu-box 'cd /home/ubuntu/nemoclaw && . .env && openshell term'
+$ ssh my-gpu-box 'cd ~/nemoclaw && . .env && openshell term'
 ```
 
 The TUI displays the sandbox state, active inference provider, and a live feed of network activity.


### PR DESCRIPTION
## Summary
Post-deploy SSH examples in the docs told users to \`cd /home/ubuntu/nemoclaw\`, which fails on Brev providers that use non-ubuntu usernames (e.g., \`shadeform\` on shadecloud). Swaps in \`~/nemoclaw\` so the remote shell expands \`\$HOME\` to whatever the provider assigns.

## Related Issue
Fixes #1319. The CLI itself was already fixed in #1470 (\`src/lib/deploy.ts:381\` detects remote \`\$HOME\` via \`ssh ... 'echo \$HOME'\`). This PR cleans up the residual doc paths that would still break a shadecloud user following the written instructions.

## Changes
- \`docs/deployment/deploy-to-remote-gpu.md\`: \`/home/ubuntu/nemoclaw\` → \`~/nemoclaw\`
- \`docs/network-policy/approve-network-requests.md\`: same
- Regenerated \`.agents/skills/nemoclaw-user-deploy-remote/SKILL.md\` and \`.agents/skills/nemoclaw-user-manage-policy/SKILL.md\` via \`scripts/docs-to-skills.py\`
- Regen also picked up prior drift in \`.agents/skills/nemoclaw-user-reference/references/troubleshooting.md\` (source doc already had an \`openclaw update\` entry; the skill was stale)

## Type of Change
- [x] Doc only (includes code sample changes)

## Verification
- [x] \`npx prek run --all-files\` passes (pre-commit + pre-push hooks green on this branch)
- [ ] \`npm test\` — N/A for doc-only change
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized deployment command examples to use home-relative paths for improved portability.
  * Added troubleshooting guidance explaining expected behavior when running updates in sandbox environments, with recommended alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->