### PR TITLE
test(cli): regression test for non-string gatewayName normalization

### DIFF
--- a/src/lib/onboard-session.test.ts
+++ b/src/lib/onboard-session.test.ts
@@ -172,6 +172,17 @@ describe("onboard session", () => {
     expect(loaded.metadata.token).toBeUndefined();
   });
 
+  it("drops non-string gatewayName during normalization", () => {
+    fs.mkdirSync(path.dirname(session.SESSION_FILE), { recursive: true });
+    fs.writeFileSync(
+      session.SESSION_FILE,
+      JSON.stringify({ version: 1, metadata: { gatewayName: 123 } }),
+    );
+    const loaded = session.loadSession();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.metadata.gatewayName).toBe("nemoclaw");
+  });
+
   it("returns null for corrupt session data", () => {
     fs.mkdirSync(path.dirname(session.SESSION_FILE), { recursive: true });
     fs.writeFileSync(session.SESSION_FILE, "not-json");


### PR DESCRIPTION
## Summary

- Adds a regression test verifying that a numeric `gatewayName` in session metadata is normalized to the default `"nemoclaw"` string
- Extracted from #1286 by @latenighthackathon, which could not be merged due to fork branch protection preventing conflict resolution

Supersedes #1286 — the code fix landed in #2082 via `parseSessionMetadata`/`readString`; this PR carries forward the regression test.

### Credit

Test authored by @latenighthackathon in #1286. Their other merged contributions to NemoClaw include #1125, #1133, #1137, #1220, #1302, #1358, #1392, #1597, #1602, #1772, #1773, #1774, #1846.

## Test plan

- [x] `npx vitest run src/lib/onboard-session.test.ts` — all 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)