### PR TITLE
fix: add auth proxy port to local-inference policy (#709)

### DIFF
--- a/nemoclaw-blueprint/policies/presets/local-inference.yaml
+++ b/nemoclaw-blueprint/policies/presets/local-inference.yaml
@@ -17,6 +17,13 @@ network_policies:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
       - host: host.openshell.internal
+        port: 11435
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: host.openshell.internal
         port: 8000
         protocol: rest
         enforcement: enforce

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1912,7 +1912,10 @@ function startOllamaAuthProxy(): void {
   const pid = spawnOllamaAuthProxy(ollamaProxyToken);
   sleep(1);
   if (!isOllamaProxyProcess(pid)) {
-    console.error(`  Warning: Ollama auth proxy did not start on :${OLLAMA_PROXY_PORT}`);
+    console.error(`  Error: Ollama auth proxy failed to start on :${OLLAMA_PROXY_PORT}`);
+    console.error(`  Containers will not be able to reach Ollama without the proxy.`);
+    console.error(`  Check if port ${OLLAMA_PROXY_PORT} is already in use: lsof -ti :${OLLAMA_PROXY_PORT}`);
+    process.exit(1);
   }
 }
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1901,7 +1901,7 @@ function killStaleProxy(): void {
   }
 }
 
-function startOllamaAuthProxy(): void {
+function startOllamaAuthProxy(): boolean {
   const crypto = require("crypto");
   killStaleProxy();
 
@@ -1915,8 +1915,9 @@ function startOllamaAuthProxy(): void {
     console.error(`  Error: Ollama auth proxy failed to start on :${OLLAMA_PROXY_PORT}`);
     console.error(`  Containers will not be able to reach Ollama without the proxy.`);
     console.error(`  Check if port ${OLLAMA_PROXY_PORT} is already in use: lsof -ti :${OLLAMA_PROXY_PORT}`);
-    process.exit(1);
+    return false;
   }
+  return true;
 }
 
 /**
@@ -4147,7 +4148,9 @@ async function setupNim(gpu) {
           // WSL2 doesn't need the proxy — Docker can reach the host directly.
           console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT}`);
         } else {
-          startOllamaAuthProxy();
+          if (!startOllamaAuthProxy()) {
+            process.exit(1);
+          }
           console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT} (proxy on :${OLLAMA_PROXY_PORT})`);
         }
         provider = "ollama-local";
@@ -4207,7 +4210,9 @@ async function setupNim(gpu) {
         // Shell required: backgrounding (&), env var prefix, output redirection.
         run(`OLLAMA_HOST=0.0.0.0:${OLLAMA_PORT} ollama serve > /dev/null 2>&1 &`, { ignoreError: true });
         sleep(2);
-        startOllamaAuthProxy();
+        if (!startOllamaAuthProxy()) {
+          process.exit(1);
+        }
         console.log(`  ✓ Using Ollama on localhost:${OLLAMA_PORT} (proxy on :${OLLAMA_PROXY_PORT})`);
         provider = "ollama-local";
         credentialEnv = "OPENAI_API_KEY";

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -611,6 +611,7 @@ runner.runCapture = (command) => {
   if (cmd.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now";
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
   if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
   return "";
 };
 
@@ -708,6 +709,7 @@ runner.runCapture = (command) => {
   if (cmd.includes("ollama list")) return "nemotron-3-nano:30b  abc  24 GB  now";
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
   if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
   return "";
 };
 
@@ -811,6 +813,7 @@ runner.runCapture = (command) => {
   if (cmd.includes("ollama list")) return "";
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
   if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
   return "";
 };
 
@@ -921,6 +924,7 @@ runner.runCapture = (command) => {
   if (cmd.includes("ollama list")) return "";
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
   if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
   return "";
 };
 

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -155,10 +155,11 @@ describe("policies", () => {
       }
     });
 
-    it("local-inference preset targets host.openshell.internal on Ollama and vLLM ports", () => {
+    it("local-inference preset targets host.openshell.internal on Ollama, proxy, and vLLM ports", () => {
       const content = policies.loadPreset("local-inference");
       expect(content).toContain("host.openshell.internal");
       expect(content).toContain("port: 11434");
+      expect(content).toContain("port: 11435");
       expect(content).toContain("port: 8000");
     });
 


### PR DESCRIPTION
## Summary

Fixes the remaining open issue in #709 — local Ollama inference from inside sandbox containers returns HTTP 403/401 even with `local-inference` policy enabled.

**Root cause:** PR #1922 introduced an authenticated reverse proxy on port **11435**, but PR #2000's `local-inference` policy preset only allows port **11434** (direct Ollama) and **8000** (vLLM). On non-WSL Linux systems, container traffic is routed to port 11435 (`src/lib/local-inference.ts:21`), which the policy blocks.

**Changes:**
- **`local-inference.yaml`**: Add port 11435 (auth proxy) endpoint so containers can reach the proxy on non-WSL systems
- **`onboard.ts`**: Upgrade proxy startup failure from a soft warning to a hard error with actionable diagnostics — prevents onboarding from completing with a broken provider config
- **`policies.test.ts`**: Assert port 11435 is present in the preset to prevent regression

## Test plan

- [x] All 79 policy tests pass (including updated port assertion)
- [x] All 34 local-inference unit tests pass
- [x] 125/129 onboard tests pass (4 pre-existing timeout failures in unrelated `--from` test)
- [x] Ollama proxy recovery tests pass
- [ ] Manual: onboard with Local Ollama on Linux Docker CE, verify inference works through proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional local inference network endpoint (host internal, port 11435).

* **Bug Fixes**
  * Onboarding now fails gracefully when the local auth proxy cannot start and logs actionable diagnostic hints.

* **Tests**
  * Updated tests and mocks to validate the new endpoint and the revised onboarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->