### PR TITLE
fix: run npm link in prepare script for dev installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ This repo ships agent skills under `.agents/skills/`, organized into three audie
 
 | Task | Command |
 |------|---------|
-| Install all deps | `npm install && cd nemoclaw && npm install && npm run build && cd .. && cd nemoclaw-blueprint && uv sync && cd ..` |
+| Install all deps | `npm install && npm link && cd nemoclaw && npm install && npm run build && cd .. && cd nemoclaw-blueprint && uv sync && cd ..` |
 | Build plugin | `cd nemoclaw && npm run build` |
 | Watch mode | `cd nemoclaw && npm run dev` |
 | Run all tests | `npm test` |

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ts-migration:guard": "tsx scripts/check-legacy-migrated-paths.ts",
     "type-safety:hotspots": "tsx scripts/type-safety-hotspots.ts",
     "bump:version": "tsx scripts/bump-version.ts",
-    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
+    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then npm link 2>/dev/null || true; if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "git describe --tags --match 'v*' | sed 's/^v//' > .version && test -s .version && cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add `npm link` (gated behind `.git` check) to the `prepare` script so that `npm install` in a git clone automatically links the `nemoclaw` binary globally
- Update AGENTS.md quick reference to include `npm link` in the dev install command
- Mirrors what `scripts/install.sh` already does at the "Linking NemoClaw CLI" step

**Root cause:** The `prepare` script built the CLI to `dist/` but never ran `npm link`, so `bin/nemoclaw.js` only existed in `node_modules/.bin/` — not as a global command. On Brev, the shell profile still had `~/.local/bin` in PATH from a previous installer run, but the shim was gone after environment recreation.

## Test plan
- [ ] Clone repo fresh, run `npm install`, verify `nemoclaw --version` works
- [ ] Verify `npm install` still succeeds when npm global prefix is not writable (the `|| true` fallback)
- [ ] Verify the installer path (`curl | bash`) is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and installation instructions to include a package linking step.

* **Chores**
  * Enhanced the package initialization script to include automatic dependency linking during environment setup when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->