### PR TITLE
ci: enable copy-pr-bot and add self-hosted runner PR workflow

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# copy-pr-bot configuration
+# See: https://docs.gha-runners.nvidia.com/platform/apps/copy-pr-bot/
+#
+# This enables copy-pr-bot to automatically push PR code to pull-request/*
+# branches when the PR comes from a trusted user with signed commits.
+# Untrusted PRs require a maintainer to comment "/ok to test <SHA>".
+
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true

--- a/.github/workflows/pr-self-hosted.yaml
+++ b/.github/workflows/pr-self-hosted.yaml
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Self-hosted runner PR workflow — triggered by copy-pr-bot.
+#
+# copy-pr-bot pushes PR code to pull-request/<number> branches only after
+# a maintainer has vetted the changes (or the author is a trusted NVIDIA
+# employee with signed commits). This ensures community PRs never run on
+# self-hosted runners without explicit maintainer approval.
+#
+# Lightweight checks (lint, unit tests) still run on GitHub-hosted runners
+# via the regular pr.yaml workflow, which triggers on pull_request events.
+#
+# See: https://docs.gha-runners.nvidia.com/platform/onboarding/pull-request-testing/
+
+name: pr-self-hosted
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  get-pr-info:
+    runs-on: ubuntu-latest
+    outputs:
+      pr-info: ${{ steps.get-pr-info.outputs.pr-info }}
+    steps:
+      - id: get-pr-info
+        uses: nv-gha-runners/get-pr-info@main
+
+  build-sandbox-images:
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Pull base image from GHCR (fall back to local build)
+        run: |
+          if docker pull ghcr.io/nvidia/nemoclaw/sandbox-base:latest 2>/dev/null; then
+            echo "BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest" >> "$GITHUB_ENV"
+          else
+            echo "::warning::GHCR base image not available, building locally"
+            docker build -f Dockerfile.base -t nemoclaw-sandbox-base-local .
+            echo "BASE_IMAGE=nemoclaw-sandbox-base-local" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build production image
+        run: docker build --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} -t nemoclaw-production .
+
+      - name: Build sandbox test image (fixtures layered on production)
+        run: docker build -f test/Dockerfile.sandbox --build-arg BASE_IMAGE=nemoclaw-production -t nemoclaw-sandbox-test .
+
+      - name: Save images to tarballs
+        run: |
+          docker save nemoclaw-sandbox-test | gzip > /tmp/sandbox-test-image.tar.gz
+          docker save nemoclaw-production | gzip > /tmp/isolation-image.tar.gz
+
+      - name: Upload sandbox test image
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandbox-test-image
+          path: /tmp/sandbox-test-image.tar.gz
+          retention-days: 1
+
+      - name: Upload isolation image
+        uses: actions/upload-artifact@v4
+        with:
+          name: isolation-image
+          path: /tmp/isolation-image.tar.gz
+          retention-days: 1
+
+  test-e2e-sandbox:
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 15
+    needs: build-sandbox-images
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sandbox-test-image
+          path: /tmp
+
+      - name: Load image
+        run: gunzip -c /tmp/sandbox-test-image.tar.gz | docker load
+
+      - name: Run sandbox E2E tests
+        run: docker run --rm -v "${{ github.workspace }}/test:/opt/test" nemoclaw-sandbox-test /opt/test/e2e-test.sh
+
+  test-e2e-gateway-isolation:
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 15
+    needs: build-sandbox-images
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: isolation-image
+          path: /tmp
+
+      - name: Load image
+        run: gunzip -c /tmp/isolation-image.tar.gz | docker load
+
+      - name: Run gateway isolation E2E tests
+        run: NEMOCLAW_TEST_IMAGE=nemoclaw-production bash test/e2e-gateway-isolation.sh

--- a/.github/workflows/pr-self-hosted.yaml
+++ b/.github/workflows/pr-self-hosted.yaml
@@ -34,14 +34,14 @@ jobs:
       pr-info: ${{ steps.get-pr-info.outputs.pr-info }}
     steps:
       - id: get-pr-info
-        uses: nv-gha-runners/get-pr-info@main
+        uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
 
   build-sandbox-images:
     runs-on: linux-amd64-cpu4
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Pull base image from GHCR (fall back to local build)
         run: |
@@ -65,14 +65,14 @@ jobs:
           docker save nemoclaw-production | gzip > /tmp/isolation-image.tar.gz
 
       - name: Upload sandbox test image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sandbox-test-image
           path: /tmp/sandbox-test-image.tar.gz
           retention-days: 1
 
       - name: Upload isolation image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: isolation-image
           path: /tmp/isolation-image.tar.gz
@@ -84,10 +84,10 @@ jobs:
     needs: build-sandbox-images
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sandbox-test-image
           path: /tmp
@@ -104,10 +104,10 @@ jobs:
     needs: build-sandbox-images
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: isolation-image
           path: /tmp


### PR DESCRIPTION
## Summary

Enable NVIDIA GHA self-hosted runners for PR testing by adding:

1. **`.github/copy-pr-bot.yaml`** — activates copy-pr-bot on this repo
2. **`.github/workflows/pr-self-hosted.yaml`** — runs heavier CI jobs on self-hosted runners

## How it works

- **Lightweight checks** (lint, unit tests) continue to run on GitHub-hosted runners via `pr.yaml`, triggered by `pull_request` events — unchanged, runs for all PRs
- **Heavier jobs** (sandbox image builds, E2E sandbox tests, gateway isolation tests) now run on NVIDIA self-hosted runners (`linux-amd64-cpu4`), triggered only when copy-pr-bot pushes to `pull-request/*` branches

### Security model (copy-pr-bot)

| PR author | What happens |
|-----------|-------------|
| NVIDIA employee with signed commits | Auto-synced to `pull-request/<number>` → self-hosted CI runs |
| Community contributor | copy-pr-bot **does NOT** sync → self-hosted CI never runs |
| After maintainer comments `/ok to test <SHA>` | copy-pr-bot syncs → self-hosted CI runs |

This ensures **community PRs never execute on self-hosted runners without explicit maintainer approval**.

### copy-pr-bot config

```yaml
enabled: true
auto_sync_draft: false    # don't sync draft PRs
auto_sync_ready: true     # auto-sync ready-for-review PRs from trusted users
```

## Onboarding checklist

Per [GHA Runners onboarding guide](https://docs.gha-runners.nvidia.com/platform/onboarding/overview/):

- [x] Step 1: Review Before You Begin
- [x] Step 2: Fill out intake form
- [x] Step 3: copy-pr-bot config (this PR)
- [ ] Step 4: Install `nvidia-runner-mgmt` GitHub app (org-level, separate from this PR)
- [ ] Step 5: Request runner group access in `nv-gha-runners/enterprise-runner-configuration`

## Testing

This PR is additive-only — no existing workflows are modified. The new `pr-self-hosted.yaml` workflow will only activate once copy-pr-bot is installed and this config is merged to `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI configuration to enable a pull-request copy bot with draft/ready sync controls.
  * Added a self-hosted CI workflow that fetches PR metadata, builds and uploads container images, and runs end-to-end sandbox and isolation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->