### PR TITLE
fix(e2e): set alternate dashboard port for multi-sandbox test

### DIFF
--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -540,7 +540,7 @@ test_sbx_10_multi_sandbox_metadata() {
   require_sandbox "$SANDBOX_A" "TC-SBX-10" || return
 
   log "  Onboarding second sandbox '$SANDBOX_B'..."
-  if ! onboard_sandbox "$SANDBOX_B"; then
+  if ! CHAT_UI_URL="http://127.0.0.1:18790" onboard_sandbox "$SANDBOX_B"; then
     fail "TC-SBX-10: Multi-Sandbox" "Sandbox '$SANDBOX_B' failed to onboard"
     return
   fi


### PR DESCRIPTION
## Summary
- TC-SBX-10 fails because PR #2086 added a port-collision guard in `ensureDashboardForward()` but the E2E test was not updated to use a different `CHAT_UI_URL` for sandbox B
- Sets `CHAT_UI_URL=http://127.0.0.1:18790` when onboarding the second sandbox

## Test plan
- [ ] Nightly E2E `sandbox-operations-e2e` job passes (TC-SBX-10, TC-SBX-11)

Fixes regression from #2086.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure configuration for sandbox operations.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal testing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->