### PR TITLE
fix(sandbox): chmod 444 rc files after entrypoint writes

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -461,10 +461,6 @@ ${marker_end}"
       printf '\n%s\n' "$snippet" >>"$rc_file"
     fi
   done
-  # Lock rc files read-only so Landlock enforcement holds
-  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
-    [ -f "$rc_file" ] && chmod 444 "$rc_file"
-  done
 }
 
 install_configure_guard() {
@@ -538,6 +534,8 @@ GUARD
       printf '\n%s\n' "$snippet" >>"$rc_file"
     fi
   done
+  # Final lock after all rc-file mutations (export_gateway_token + this
+  # function) are complete so Landlock read_only enforcement holds.
   for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
     [ -f "$rc_file" ] && chmod 444 "$rc_file"
   done

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -461,6 +461,10 @@ ${marker_end}"
       printf '\n%s\n' "$snippet" >>"$rc_file"
     fi
   done
+  # Lock rc files read-only so Landlock enforcement holds
+  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
+    [ -f "$rc_file" ] && chmod 444 "$rc_file"
+  done
 }
 
 install_configure_guard() {
@@ -533,6 +537,9 @@ GUARD
     elif [ -w "$rc_file" ] || [ -w "$(dirname "$rc_file")" ]; then
       printf '\n%s\n' "$snippet" >>"$rc_file"
     fi
+  done
+  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
+    [ -f "$rc_file" ] && chmod 444 "$rc_file"
   done
 }
 


### PR DESCRIPTION
## Summary
- `export_gateway_token` and `install_configure_guard` write to `.bashrc`/`.profile` but never lock them read-only afterward
- The Landlock policy declares `/sandbox` as `read_only`, but the files retain default umask permissions (644), failing the `04-landlock-readonly` E2E assertion
- Adds `chmod 444` after both write loops

## Test plan
- [ ] Nightly E2E `cloud-experimental-e2e` job passes (04-landlock-readonly)

Fixes regression from #2081.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Shell configuration files are now set to read-only at the end of setup steps (after gateway token injection and install/configure guard), preventing accidental edits and ensuring configuration stability across completion of the setup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->