### PR TITLE
fix(policy): add tls: terminate to telegram preset

### DIFF
--- a/nemoclaw-blueprint/policies/presets/telegram.yaml
+++ b/nemoclaw-blueprint/policies/presets/telegram.yaml
@@ -12,6 +12,7 @@ network_policies:
       - host: api.telegram.org
         port: 443
         protocol: rest
+        tls: terminate
         enforcement: enforce
         rules:
           - allow: { method: GET, path: "/bot*/**" }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -606,18 +606,26 @@ describe("policies", () => {
       }
     });
 
-    it("messaging WebSocket presets use tls: skip, not terminate", () => {
-      for (const name of ["discord", "slack"]) {
-        const content = policies.loadPreset(name);
+    it("messaging WebSocket presets keep tls: skip on gateway endpoints", () => {
+      const cases = [
+        { preset: "discord", pattern: /host:\s*gateway\.discord\.gg[\s\S]*?tls:\s*skip/ },
+        { preset: "slack", pattern: /host:\s*wss-primary\.slack\.com[\s\S]*?tls:\s*skip/ },
+        { preset: "slack", pattern: /host:\s*wss-backup\.slack\.com[\s\S]*?tls:\s*skip/ },
+      ];
+
+      for (const { preset, pattern } of cases) {
+        const content = policies.loadPreset(preset);
         expect(content).toBeTruthy();
-        expect(content.includes("tls: terminate")).toBe(false);
+        expect(content).toMatch(pattern);
       }
     });
 
     it("telegram REST preset uses tls: terminate for L7 proxy", () => {
       const content = policies.loadPreset("telegram");
       expect(content).toBeTruthy();
-      expect(content.includes("tls: terminate")).toBe(true);
+      expect(content).toMatch(
+        /host:\s*api\.telegram\.org[\s\S]*?protocol:\s*rest[\s\S]*?tls:\s*terminate/,
+      );
     });
 
     it("pypi preset allows HEAD for pip lazy-wheel metadata checks", () => {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -606,12 +606,18 @@ describe("policies", () => {
       }
     });
 
-    it("messaging REST presets do not pin deprecated tls termination", () => {
-      for (const name of ["discord", "slack", "telegram"]) {
+    it("messaging WebSocket presets use tls: skip, not terminate", () => {
+      for (const name of ["discord", "slack"]) {
         const content = policies.loadPreset(name);
         expect(content).toBeTruthy();
         expect(content.includes("tls: terminate")).toBe(false);
       }
+    });
+
+    it("telegram REST preset uses tls: terminate for L7 proxy", () => {
+      const content = policies.loadPreset("telegram");
+      expect(content).toBeTruthy();
+      expect(content.includes("tls: terminate")).toBe(true);
     });
 
     it("pypi preset allows HEAD for pip lazy-wheel metadata checks", () => {


### PR DESCRIPTION
## Summary
- The `telegram.yaml` preset was missing `tls: terminate` on the `api.telegram.org` endpoint
- The baseline `openclaw-sandbox.yaml` has it, but the preset omitted it
- After PR #2098 changed gateway TLS field handling, the omission causes 403 on live policy-add (TC-NET-03)

## Test plan
- [ ] Nightly E2E `network-policy-e2e` job passes (TC-NET-03)

Fixes regression from #2098.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Telegram network preset now uses TLS termination for connections to api.telegram.org:443, changing TLS handling for that endpoint.
* **Tests**
  * Test suite updated to reflect TLS behavior: gateway/WebSocket presets assert TLS is skipped, and Telegram preset asserts TLS termination for REST endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->