### PR TITLE
fix(e2e): capture full snapshot timestamp including milliseconds

### DIFF
--- a/test/e2e/test-snapshot-commands.sh
+++ b/test/e2e/test-snapshot-commands.sh
@@ -127,7 +127,7 @@ else
 fi
 
 # Extract the timestamp from list output for targeted restore later
-SNAPSHOT_TIMESTAMP=$(echo "$LIST_OUTPUT" | grep -oE "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}" | head -1 || true)
+SNAPSHOT_TIMESTAMP=$(echo "$LIST_OUTPUT" | grep -oE "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]+Z" | head -1 || true)
 [ -n "${SNAPSHOT_TIMESTAMP}" ] || fail "Failed to parse a snapshot timestamp from list output: ${LIST_OUTPUT}"
 info "Snapshot timestamp: ${SNAPSHOT_TIMESTAMP}"
 


### PR DESCRIPTION
## Summary
- `sandbox-state.ts` generates timestamps like `2026-04-21T00-20-58-197Z` (with ms + Z suffix)
- The E2E regex only captured up to seconds (`HH-MM-SS`), truncating the timestamp
- When two snapshots are created within the same second, the partial match is ambiguous and restore fails
- Updates regex to match the full format including milliseconds and trailing Z

## Test plan
- [ ] Nightly E2E `snapshot-commands-e2e` job passes (Phase 7)

Pre-existing bug, not a regression from today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced snapshot timestamp extraction validation in end-to-end tests to ensure accurate parsing of ISO-8601 formatted timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->