### PR TITLE
fix(onboard): classify expired API key as credential error

### DIFF
--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -58,6 +58,45 @@ describe("classifyValidationFailure", () => {
     });
   });
 
+  it("classifies 400 + expired key message as credential (#1942 — Gemini)", () => {
+    // Gemini returns HTTP 400 with this exact message when the API key has expired.
+    // Must classify as "credential" so the onboard wizard prompts to re-enter the
+    // key instead of looping back to provider selection.
+    expect(
+      classifyValidationFailure({
+        httpStatus: 400,
+        message: "API key expired. Please renew the API key.",
+      }),
+    ).toEqual({
+      kind: "credential",
+      retry: "credential",
+    });
+  });
+
+  it("classifies 400 + API_KEY_INVALID message as credential (#1942 — Gemini)", () => {
+    // Gemini also uses "API_KEY_INVALID" as the status string for revoked keys.
+    expect(
+      classifyValidationFailure({
+        httpStatus: 400,
+        message: "API_KEY_INVALID: API key not valid. Please pass a valid API key.",
+      }),
+    ).toEqual({
+      kind: "credential",
+      retry: "credential",
+    });
+  });
+
+  it("classifies 400 without credential message as model (regression guard)", () => {
+    // HTTP 400 without a credential-bearing message still routes to "model"
+    // so existing gemini model-selection retry behavior stays intact.
+    expect(
+      classifyValidationFailure({ httpStatus: 400, message: "model xyz not found" }),
+    ).toEqual({
+      kind: "model",
+      retry: "model",
+    });
+  });
+
   it("classifies model-not-found message as model", () => {
     expect(classifyValidationFailure({ message: "model xyz not found" })).toEqual({
       kind: "model",

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -86,6 +86,21 @@ describe("classifyValidationFailure", () => {
     });
   });
 
+  it("classifies bare 'API key not valid' message as credential (#1942 — Gemini .message only)", () => {
+    // When the message field is extracted without the API_KEY_INVALID status
+    // prefix, the bare wording must still classify as credential. Flagged by
+    // CodeRabbit on #2132.
+    expect(
+      classifyValidationFailure({
+        httpStatus: 400,
+        message: "API key not valid. Please pass a valid API key.",
+      }),
+    ).toEqual({
+      kind: "credential",
+      retry: "credential",
+    });
+  });
+
   it("classifies 400 without credential message as model (regression guard)", () => {
     // HTTP 400 without a credential-bearing message still routes to "model"
     // so existing gemini model-selection retry behavior stays intact.

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -38,7 +38,7 @@ export function classifyValidationFailure({
   // this check the onboard flow skips the key re-entry prompt and loops
   // back to provider selection. See #1942.
   if (
-    /api key expired|api[_ ]key[_ ]invalid|unauthorized|forbidden|invalid api key|invalid_auth|permission/i.test(
+    /api key (expired|not valid)|api[_ ]key[_ ]invalid|unauthorized|forbidden|invalid api key|invalid_auth|permission/i.test(
       normalized,
     )
   ) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -32,6 +32,18 @@ export function classifyValidationFailure({
   if (httpStatus === 401 || httpStatus === 403) {
     return { kind: "credential", retry: "credential" };
   }
+  // Credential-bearing error messages take precedence over the HTTP 400
+  // "model" default because some providers (notably Google Gemini) return
+  // HTTP 400 with "API key expired. Please renew the API key." — without
+  // this check the onboard flow skips the key re-entry prompt and loops
+  // back to provider selection. See #1942.
+  if (
+    /api key expired|api[_ ]key[_ ]invalid|unauthorized|forbidden|invalid api key|invalid_auth|permission/i.test(
+      normalized,
+    )
+  ) {
+    return { kind: "credential", retry: "credential" };
+  }
   if (httpStatus === 400) {
     return { kind: "model", retry: "model" };
   }
@@ -40,9 +52,6 @@ export function classifyValidationFailure({
   }
   if (httpStatus === 404 || httpStatus === 405) {
     return { kind: "endpoint", retry: "selection" };
-  }
-  if (/unauthorized|forbidden|invalid api key|invalid_auth|permission/i.test(normalized)) {
-    return { kind: "credential", retry: "credential" };
   }
   return { kind: "unknown", retry: "selection" };
 }


### PR DESCRIPTION
## Summary

When a Gemini onboard validates with an expired API key, the provider returns HTTP 400 with `"API key expired. Please renew the API key."`. The current classifier checks `httpStatus === 400` first and returns `{ kind: "model", retry: "model" }`, so the expired-key case never reaches the credential-message regex. In the Gemini validation flow (no `allowModelRetry`), `kind: "model"` falls through to `unknown`, and the onboard wizard loops back to provider selection without offering to re-enter the key.

## Related Issue

Closes #1942

## Changes

- `src/lib/validation.ts` — move the credential-bearing message check **before** the `httpStatus === 400 → model` default. Extend the credential regex to include `api key expired` and `api[_ ]key[_ ]invalid` so Gemini's `API_KEY_INVALID` status classification also lands as `credential`.
- Inline comment documents why the order matters and cites #1942.
- HTTP 400 without a credential-bearing message still classifies as `model` — regression guard test added.

## Testing

- [x] `src/lib/validation.test.ts` — 41 tests pass (+3 new: expired key, API_KEY_INVALID, regression guard)
- [x] `src/lib/validation-recovery.test.ts` — 5 tests pass
- [x] Build + typecheck clean

Executed:
- Targeted `npx vitest run src/lib/validation.test.ts src/lib/validation-recovery.test.ts` in the `nemoclaw-test` Docker environment

## Prior art

Prior fix attempt [#1944](https://github.com/NVIDIA/NemoClaw/pull/1944) was closed by its author on 2026-04-18 to reduce PR volume — the issue remained open. This PR replays the same core reorder with a slightly broader credential regex (covering both `API key expired` and `API_KEY_INVALID` forms Gemini uses) and preserves the existing test style.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commits are signed (SSH)
- [x] DCO Signed-off-by trailer present

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error classification now prioritizes credential-related messages so API key/credential failures (expired, invalid, unauthorized) are reported as credential issues rather than being misclassified as model errors, improving clarity and retry guidance.

* **Tests**
  * Added tests covering credential-related 400 responses and a regression case to ensure unrelated model errors remain classified correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->