### PR TITLE
fix(install): prevent recursive npm link in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ts-migration:guard": "tsx scripts/check-legacy-migrated-paths.ts",
     "type-safety:hotspots": "tsx scripts/type-safety-hotspots.ts",
     "bump:version": "tsx scripts/bump-version.ts",
-    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then npm link 2>/dev/null || true; if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
+    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then npm link --ignore-scripts 2>/dev/null || true; if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "git describe --tags --match 'v*' | sed 's/^v//' > .version && test -s .version && cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- PR #2116 added `npm link` to the `prepare` lifecycle script
- When the E2E installer calls `npm link` (scripts/install.sh:924), it triggers `prepare`, which runs another `npm link`, which triggers `prepare` again — **infinite recursion**
- All 15 nightly E2E jobs hang with ~14 orphan `npm link` processes each until the job timeout kills them
- Adds `--ignore-scripts` to the `npm link` in `prepare` to break the cycle

## Test plan
- [ ] `npm install && npm link` in a fresh clone completes without hanging
- [ ] Nightly E2E jobs get past the "Linking NemoClaw CLI" step

Fixes regression from #2116.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build process configuration to optimize dependency handling during package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->