### PR TITLE
fix(install): pass --ignore-scripts to npm link in installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ts-migration:guard": "tsx scripts/check-legacy-migrated-paths.ts",
     "type-safety:hotspots": "tsx scripts/type-safety-hotspots.ts",
     "bump:version": "tsx scripts/bump-version.ts",
-    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then npm link --ignore-scripts 2>/dev/null || true; if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
+    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "git describe --tags --match 'v*' | sed 's/^v//' > .version && test -s .version && cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -933,7 +933,7 @@ install_nemoclaw() {
     spin "Installing NemoClaw dependencies" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm install --ignore-scripts"
     spin "Building NemoClaw CLI modules" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm run --if-present build:cli"
     spin "Building NemoClaw plugin" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\"/nemoclaw && npm install --ignore-scripts && npm run build"
-    spin "Linking NemoClaw CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link"
+    spin "Linking NemoClaw CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link --ignore-scripts"
   else
     if [[ -f "$package_json" ]]; then
       info "Installer payload is not a persistent source checkout — installing from GitHub…"
@@ -966,7 +966,7 @@ install_nemoclaw() {
     spin "Installing NemoClaw dependencies" bash -c "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
     spin "Building NemoClaw CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"
     spin "Building NemoClaw plugin" bash -c "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
-    spin "Linking NemoClaw CLI" bash -c "cd \"$nemoclaw_src\" && npm link"
+    spin "Linking NemoClaw CLI" bash -c "cd \"$nemoclaw_src\" && npm link --ignore-scripts"
   fi
 
   refresh_path


### PR DESCRIPTION
## Summary
- The installer already runs `build:cli`, `npm install`, and plugin build before calling `npm link`
- Without `--ignore-scripts`, `npm link` triggers the `prepare` lifecycle (added in #2116) which redundantly re-runs `build:cli` and `npm install --omit=dev`, hanging all E2E jobs for 15+ minutes
- Adds `--ignore-scripts` to both `npm link` call sites in `scripts/install.sh`

#2134 fixed the recursion within `prepare` itself, but the installer still triggers `prepare` unnecessarily — this is the companion fix.

## Test plan
- [ ] Nightly E2E jobs get past "Linking NemoClaw CLI" in seconds, not minutes
- [ ] `bash scripts/install.sh` from a source checkout completes normally

Fixes regression from #2116.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modified CLI linking step to run with script execution suppressed, reducing side effects during installation.
  * Scoped pre-commit hook setup so the hook installer and its fallback message run only when inside a repository, avoiding unexpected hook attempts outside a repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->