### PR TITLE
fix(install): guard npm link in prepare with NEMOCLAW_INSTALLING

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ts-migration:guard": "tsx scripts/check-legacy-migrated-paths.ts",
     "type-safety:hotspots": "tsx scripts/type-safety-hotspots.ts",
     "bump:version": "tsx scripts/bump-version.ts",
-    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
+    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then if [ -z \"${NEMOCLAW_INSTALLING:-}\" ]; then npm link 2>/dev/null || true; fi; if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "git describe --tags --match 'v*' | sed 's/^v//' > .version && test -s .version && cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ts-migration:guard": "tsx scripts/check-legacy-migrated-paths.ts",
     "type-safety:hotspots": "tsx scripts/type-safety-hotspots.ts",
     "bump:version": "tsx scripts/bump-version.ts",
-    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && npm install --omit=dev --ignore-scripts 2>/dev/null || true && if [ -d .git ]; then if [ -z \"${NEMOCLAW_INSTALLING:-}\" ]; then npm link 2>/dev/null || true; fi; if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
+    "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && (npm install --omit=dev --ignore-scripts 2>/dev/null || true) && if [ -d .git ]; then if [ -z \"${NEMOCLAW_INSTALLING:-}\" ]; then npm link 2>/dev/null || true; fi; if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "git describe --tags --match 'v*' | sed 's/^v//' > .version && test -s .version && cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },
   "dependencies": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -923,6 +923,9 @@ install_nemoclaw() {
   local repo_root package_json
   repo_root="$(resolve_repo_root)"
   package_json="${repo_root}/package.json"
+  # Tell prepare not to run npm link — the installer handles linking explicitly.
+  export NEMOCLAW_INSTALLING=1
+
   if is_source_checkout "$repo_root"; then
     info "NemoClaw package.json found in the selected source checkout — installing from source…"
     NEMOCLAW_SOURCE_ROOT="$repo_root"
@@ -933,7 +936,7 @@ install_nemoclaw() {
     spin "Installing NemoClaw dependencies" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm install --ignore-scripts"
     spin "Building NemoClaw CLI modules" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm run --if-present build:cli"
     spin "Building NemoClaw plugin" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\"/nemoclaw && npm install --ignore-scripts && npm run build"
-    spin "Linking NemoClaw CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link --ignore-scripts"
+    spin "Linking NemoClaw CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link"
   else
     if [[ -f "$package_json" ]]; then
       info "Installer payload is not a persistent source checkout — installing from GitHub…"
@@ -966,7 +969,7 @@ install_nemoclaw() {
     spin "Installing NemoClaw dependencies" bash -c "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
     spin "Building NemoClaw CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"
     spin "Building NemoClaw plugin" bash -c "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
-    spin "Linking NemoClaw CLI" bash -c "cd \"$nemoclaw_src\" && npm link --ignore-scripts"
+    spin "Linking NemoClaw CLI" bash -c "cd \"$nemoclaw_src\" && npm link"
   fi
 
   refresh_path

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -63,10 +63,11 @@ info "1. Gateway user exists with separate UID"
 OUT=$(run_as_root "id gateway && id sandbox")
 GW_UID=$(echo "$OUT" | grep "^uid=" | head -1 | sed 's/uid=\([0-9]*\).*/\1/')
 SB_UID=$(echo "$OUT" | grep "^uid=" | tail -1 | sed 's/uid=\([0-9]*\).*/\1/')
-if [ -n "$GW_UID" ] && [ -n "$SB_UID" ] && [ "$GW_UID" != "$SB_UID" ]; then
+SB_GID=$(echo "$OUT" | grep "^uid=" | tail -1 | sed 's/.*gid=\([0-9]*\).*/\1/')
+if [ -n "$GW_UID" ] && [ -n "$SB_UID" ] && [ -n "$SB_GID" ] && [ "$GW_UID" != "$SB_UID" ]; then
   pass "gateway (uid=$GW_UID) and sandbox (uid=$SB_UID) are different users"
 else
-  fail "gateway and sandbox UIDs not distinct: $OUT"
+  fail "gateway and sandbox IDs not distinct or incomplete: $OUT"
 fi
 
 # ── Test 2: openclaw.json is not writable by sandbox user ────────
@@ -368,10 +369,12 @@ fi
 
 # ── Test 25: Non-root mode executes without gosu ──────────────────
 # The entrypoint detects uid != 0, skips gosu, and execs the command directly.
-# Verifies the non-root fallback path works after read-only /sandbox (#804).
+# Use the image's actual sandbox uid/gid here: the system-assigned sandbox uid
+# is not guaranteed to be 1000 on every runner, and the non-root fallback is
+# designed to run as that sandbox user.
 
 info "25. Non-root mode executes command without gosu"
-OUT=$(docker run --rm --user 1000:1000 "$IMAGE" echo "NON_ROOT_EXEC_OK" 2>&1 || true)
+OUT=$(docker run --rm --user "${SB_UID}:${SB_GID}" "$IMAGE" echo "NON_ROOT_EXEC_OK" 2>&1 || true)
 if echo "$OUT" | grep -q "NON_ROOT_EXEC_OK"; then
   pass "non-root mode executed command directly (no gosu)"
 else


### PR DESCRIPTION
## Summary
- Re-adds `npm link` to `prepare` for the dev workflow (#2116's original goal: `npm install` in a fresh clone auto-links `nemoclaw` globally)
- Gates it with `NEMOCLAW_INSTALLING` env var so the installer skips it — the installer sets this var before any npm calls and handles linking explicitly
- Dev clones: `npm install` → prepare runs → `npm link` fires (no installer env var)
- Installer: `NEMOCLAW_INSTALLING=1` is exported → prepare skips `npm link` → installer calls `npm link` itself after building

## Test plan
- [ ] Fresh clone + `npm install` → `nemoclaw --version` works (dev path)
- [ ] `bash scripts/install.sh --non-interactive` completes without hanging (installer path)
- [ ] Nightly E2E jobs get past "Linking NemoClaw CLI" in seconds

Supersedes #2116, #2134.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now tolerates non-critical failures during preparation, reducing setup interruptions.
  * CLI linking is more reliable across different install scenarios.
  * An install-time environment flag is set to ensure consistent behavior during source or remote installs.

* **Tests**
  * End-to-end gateway isolation tests updated to detect and run using dynamically discovered sandbox user/group IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->