### PR TITLE
test(e2e): use sandbox uid for non-root isolation check

### DIFF
--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -63,10 +63,11 @@ info "1. Gateway user exists with separate UID"
 OUT=$(run_as_root "id gateway && id sandbox")
 GW_UID=$(echo "$OUT" | grep "^uid=" | head -1 | sed 's/uid=\([0-9]*\).*/\1/')
 SB_UID=$(echo "$OUT" | grep "^uid=" | tail -1 | sed 's/uid=\([0-9]*\).*/\1/')
-if [ -n "$GW_UID" ] && [ -n "$SB_UID" ] && [ "$GW_UID" != "$SB_UID" ]; then
+SB_GID=$(echo "$OUT" | grep "^uid=" | tail -1 | sed 's/.*gid=\([0-9]*\).*/\1/')
+if [ -n "$GW_UID" ] && [ -n "$SB_UID" ] && [ -n "$SB_GID" ] && [ "$GW_UID" != "$SB_UID" ]; then
   pass "gateway (uid=$GW_UID) and sandbox (uid=$SB_UID) are different users"
 else
-  fail "gateway and sandbox UIDs not distinct: $OUT"
+  fail "gateway and sandbox IDs not distinct or incomplete: $OUT"
 fi
 
 # ── Test 2: openclaw.json is not writable by sandbox user ────────
@@ -368,10 +369,12 @@ fi
 
 # ── Test 25: Non-root mode executes without gosu ──────────────────
 # The entrypoint detects uid != 0, skips gosu, and execs the command directly.
-# Verifies the non-root fallback path works after read-only /sandbox (#804).
+# Use the image's actual sandbox uid/gid here: the system-assigned sandbox uid
+# is not guaranteed to be 1000 on every runner, and the non-root fallback is
+# designed to run as that sandbox user.
 
 info "25. Non-root mode executes command without gosu"
-OUT=$(docker run --rm --user 1000:1000 "$IMAGE" echo "NON_ROOT_EXEC_OK" 2>&1 || true)
+OUT=$(docker run --rm --user "${SB_UID}:${SB_GID}" "$IMAGE" echo "NON_ROOT_EXEC_OK" 2>&1 || true)
 if echo "$OUT" | grep -q "NON_ROOT_EXEC_OK"; then
   pass "non-root mode executed command directly (no gosu)"
 else


### PR DESCRIPTION
## Summary
This PR stabilizes the gateway isolation E2E by launching the non-root fallback check as the image's actual sandbox user instead of assuming uid 1000. The sandbox uid/gid are system-assigned in the image build and can vary across runners, so the hardcoded user caused the check to fail on unrelated PRs even though the entrypoint logic was unchanged.

## Changes
- capture the sandbox gid alongside the sandbox uid in `test/e2e-gateway-isolation.sh`
- run the non-root entrypoint check with `${SB_UID}:${SB_GID}` instead of a hardcoded `1000:1000`
- document why the non-root fallback test must use the image's real sandbox identity

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: OpenAI Codex

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced gateway isolation validation to verify both user and group IDs are properly distinct
  * Updated non-root container tests to use dynamically detected system credentials instead of hardcoded values, improving test reliability across different runner environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->