### PR TITLE
fix(e2e): use non-interactive policy-add in network policy tests

### DIFF
--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -142,33 +142,19 @@ preflight() {
   log "Pre-flight complete"
 }
 
-# Apply a network policy preset using expect to handle interactive prompts.
+# Apply a network policy preset by name (non-interactive).
 apply_preset() {
   local preset_name="$1"
-  local preset_list preset_num
-  preset_list=$(nemoclaw "$SANDBOX_NAME" policy-add </dev/null 2>&1) || true
-  log "  DEBUG preset_list output: ${preset_list:0:500}"
-  preset_num=$(echo "$preset_list" | grep -oE '[0-9]+\) [^ ]+ '"$preset_name" | grep -oE '^[0-9]+') || true
-  if [[ -z "$preset_num" ]]; then
-    log "  Could not find '$preset_name' in preset list"
+  log "  Applying preset '$preset_name'..."
+  local output exit_code=0
+  output=$(nemoclaw "$SANDBOX_NAME" policy-add "$preset_name" --yes 2>&1) || exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    log "  policy-add failed (exit $exit_code): ${output:0:300}"
     return 1
   fi
-  log "  Applying preset '$preset_name' (#$preset_num) via expect..."
-  local exit_code=0
-  set +e
-  expect <<EOF 2>&1 | tee -a "$LOG_FILE"
-set timeout 30
-spawn nemoclaw $SANDBOX_NAME policy-add
-expect "Choose preset*"
-send "$preset_num\r"
-expect "*Y/n*"
-send "Y\r"
-expect eof
-EOF
-  exit_code=${PIPESTATUS[0]}
-  set -e
+  log "  Applied preset '$preset_name'"
   sleep 3
-  return "$exit_code"
+  return 0
 }
 
 # Execute a command inside the sandbox via SSH.
@@ -340,23 +326,8 @@ fetch('$target_url', {signal: AbortSignal.timeout(15000)})
   log "  Before dry-run: $before"
 
   log "  Step 2: Running policy-add --dry-run slack..."
-  local slack_list slack_num
-  slack_list=$(nemoclaw "$SANDBOX_NAME" policy-add --dry-run </dev/null 2>&1) || true
-  slack_num=$(echo "$slack_list" | grep -oE '[0-9]+\) [^ ]+ slack ' | grep -oE '^[0-9]+') || true
-  if [[ -z "$slack_num" ]]; then
-    fail "TC-NET-04: Setup" "Could not find slack in preset list"
-    return
-  fi
   local dry_output
-  dry_output=$(
-    expect <<EOF 2>&1
-set timeout 15
-spawn nemoclaw $SANDBOX_NAME policy-add --dry-run
-expect "Choose preset*"
-send "$slack_num\r"
-expect eof
-EOF
-  ) || true
+  dry_output=$(nemoclaw "$SANDBOX_NAME" policy-add slack --dry-run 2>&1) || true
   log "  Dry-run output: ${dry_output:0:300}"
 
   if echo "$dry_output" | grep -qiE "slack\.com|dry.run|no changes"; then

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -147,6 +147,7 @@ apply_preset() {
   local preset_name="$1"
   local preset_list preset_num
   preset_list=$(nemoclaw "$SANDBOX_NAME" policy-add </dev/null 2>&1) || true
+  log "  DEBUG preset_list output: ${preset_list:0:500}"
   preset_num=$(echo "$preset_list" | grep -oE '[0-9]+\) [^ ]+ '"$preset_name" | grep -oE '^[0-9]+') || true
   if [[ -z "$preset_num" ]]; then
     log "  Could not find '$preset_name' in preset list"

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -266,7 +266,7 @@ test_net_02_whitelist_access() {
 test_net_03_live_policy_add() {
   log "=== TC-NET-03: Live Policy-Add Without Restart ==="
 
-  local target_url="https://api.telegram.org/"
+  local target_url="https://api.telegram.org/bot000000000:fake/getMe"
 
   log "  Step 1: Verify api.telegram.org is blocked before policy-add..."
   local before
@@ -277,7 +277,7 @@ fetch('$target_url', {signal: AbortSignal.timeout(15000)})
 \"" 2>&1) || true
   log "  Before policy-add: $before"
 
-  if echo "$before" | grep -qE "STATUS_[23]"; then
+  if echo "$before" | grep -qE "STATUS_[24]" && ! echo "$before" | grep -qE "STATUS_403"; then
     skip "TC-NET-03" "api.telegram.org already reachable before policy-add (preset may be pre-applied)"
     return
   fi
@@ -299,7 +299,7 @@ fetch('$target_url', {signal: AbortSignal.timeout(30000)})
 \"" 2>&1) || true
   log "  After policy-add: $after"
 
-  if echo "$after" | grep -qE "STATUS_2"; then
+  if echo "$after" | grep -qE "STATUS_[24]" && ! echo "$after" | grep -qE "STATUS_403"; then
     pass "TC-NET-03: Endpoint reachable after live policy-add ($after)"
   elif echo "$after" | grep -qE "STATUS_403"; then
     fail "TC-NET-03: Live policy-add" "api.telegram.org still blocked with 403 after policy-add"

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -147,7 +147,7 @@ apply_preset() {
   local preset_name="$1"
   local preset_list preset_num
   preset_list=$(nemoclaw "$SANDBOX_NAME" policy-add </dev/null 2>&1) || true
-  preset_num=$(echo "$preset_list" | grep -oE '[0-9]+\) . '"$preset_name" | grep -oE '^[0-9]+') || true
+  preset_num=$(echo "$preset_list" | grep -oE '[0-9]+\) [^ ]+ '"$preset_name" | grep -oE '^[0-9]+') || true
   if [[ -z "$preset_num" ]]; then
     log "  Could not find '$preset_name' in preset list"
     return 1
@@ -341,7 +341,7 @@ fetch('$target_url', {signal: AbortSignal.timeout(15000)})
   log "  Step 2: Running policy-add --dry-run slack..."
   local slack_list slack_num
   slack_list=$(nemoclaw "$SANDBOX_NAME" policy-add --dry-run </dev/null 2>&1) || true
-  slack_num=$(echo "$slack_list" | grep -oE '[0-9]+\) . slack ' | grep -oE '^[0-9]+') || true
+  slack_num=$(echo "$slack_list" | grep -oE '[0-9]+\) [^ ]+ slack ' | grep -oE '^[0-9]+') || true
   if [[ -z "$slack_num" ]]; then
     fail "TC-NET-04: Setup" "Could not find slack in preset list"
     return


### PR DESCRIPTION
## Summary
- `sandboxPolicyAdd` checks `NEMOCLAW_NON_INTERACTIVE` and exits immediately with "Non-interactive mode requires a preset name" when no preset argument is given
- The nightly E2E workflow sets `NEMOCLAW_NON_INTERACTIVE=1`, so `apply_preset()` — which scraped the interactive menu via `nemoclaw policy-add </dev/null` — never worked. The command exited before printing the menu.
- TC-NET-02 through TC-NET-05 have been broken since the test was added in #2091

## Changes
- Replace the expect-based interactive menu scraping with direct CLI syntax: `nemoclaw <sandbox> policy-add <preset> --yes`
- Fix TC-NET-04 dry-run to also use `policy-add slack --dry-run` directly
- Remove ~30 lines of unnecessary expect/grep plumbing

## Type of Change
- [x] Code change (feature, bug fix, or refactor)

## Verification
- [x] Confirmed `NEMOCLAW_NON_INTERACTIVE=1` causes early exit in `sandboxPolicyAdd` (src/nemoclaw.ts:1556)
- [x] `policy-add <preset> --yes` bypasses both the interactive menu and confirmation prompt
- [x] No secrets, API keys, or credentials committed

## Test plan
- [ ] Nightly E2E: TC-NET-02, TC-NET-03, TC-NET-04, TC-NET-05 should pass

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved network policy tests by switching preset application to a non-interactive mode, removing fragile prompt handling.
  * Simplified dry-run preset checks to a direct execution path for more deterministic behavior.
  * Strengthened reachability evaluation and pass/fail criteria (explicitly excluding forbidden responses) to reduce flakiness and improve result accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->