### PR TITLE
fix(e2e): repair check-docs normalizer and use non-interactive preset CLI

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -147,6 +147,8 @@ It verifies that Docker is reachable, warns on untested runtimes such as Podman,
 The preflight also enforces the OpenShell version range declared in the blueprint (`min_openshell_version` and `max_openshell_version`).
 If the installed OpenShell version falls outside this range, onboarding exits with an actionable error and a link to compatible releases.
 
+### `nemoclaw onboard --from`
+
 #### `--from <Dockerfile>`
 
 Build the sandbox image from a custom Dockerfile instead of the stock NemoClaw image.
@@ -510,7 +512,7 @@ $ nemoclaw onboard
 These overrides apply to onboarding, status checks, health probes, and the uninstaller.
 Defaults are unchanged when no variable is set.
 
-### Legacy `nemoclaw setup`
+### `nemoclaw setup`
 
 Deprecated. Use `nemoclaw onboard` instead.
 Running `nemoclaw setup` now delegates directly to `nemoclaw onboard`.

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -150,6 +150,7 @@ run_cli_check() {
     if (/^\s*nemoclaw\s+(.+)/) {
       my $c = $1;
       $c =~ s/\s{2,}.*$//;
+      $c =~ s/(\]|>)\s+[A-Z].*$/$1/;
       $c =~ s/\s+$//;
       $c =~ s/\s*\[[^\]]*\]\s*$//;
       $c =~ s/\s*--output\s+FILE\s*$//;
@@ -169,7 +170,12 @@ run_cli_check() {
   log '[cli] phase 2/2: extract ### `nemoclaw …` headings from commands reference'
   # Allow optional MyST suffix on the same line, e.g. ### `nemoclaw onboard` {#anchor}
   grep -E '^### `nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
-    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) { print "$1\n"; }
+    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) {
+      my $c = $1;
+      $c =~ s/\s*\[[^\]]*\]\s*$//;
+      while ($c =~ s/\s+<[^>]+>\s*$//) {}
+      print "$c\n";
+    }
   ' | LC_ALL=C sort -u >"$_tmp/doc.txt"
 
   local _n_doc

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -142,28 +142,13 @@ preflight() {
   log "Pre-flight complete"
 }
 
-# Apply a network policy preset using expect to handle interactive prompts.
+# Apply a network policy preset via the non-interactive CLI path.
 apply_preset() {
   local preset_name="$1"
-  local preset_list preset_num
-  preset_list=$(nemoclaw "$SANDBOX_NAME" policy-add </dev/null 2>&1) || true
-  preset_num=$(echo "$preset_list" | grep -oE '[0-9]+\) . '"$preset_name" | grep -oE '^[0-9]+') || true
-  if [[ -z "$preset_num" ]]; then
-    log "  Could not find '$preset_name' in preset list"
-    return 1
-  fi
-  log "  Applying preset '$preset_name' (#$preset_num) via expect..."
+  log "  Applying preset '$preset_name' via CLI..."
   local exit_code=0
   set +e
-  expect <<EOF 2>&1 | tee -a "$LOG_FILE"
-set timeout 30
-spawn nemoclaw $SANDBOX_NAME policy-add
-expect "Choose preset*"
-send "$preset_num\r"
-expect "*Y/n*"
-send "Y\r"
-expect eof
-EOF
+  nemoclaw "$SANDBOX_NAME" policy-add "$preset_name" --yes 2>&1 | tee -a "$LOG_FILE"
   exit_code=${PIPESTATUS[0]}
   set -e
   sleep 3
@@ -339,26 +324,11 @@ fetch('$target_url', {signal: AbortSignal.timeout(15000)})
   log "  Before dry-run: $before"
 
   log "  Step 2: Running policy-add --dry-run slack..."
-  local slack_list slack_num
-  slack_list=$(nemoclaw "$SANDBOX_NAME" policy-add --dry-run </dev/null 2>&1) || true
-  slack_num=$(echo "$slack_list" | grep -oE '[0-9]+\) . slack ' | grep -oE '^[0-9]+') || true
-  if [[ -z "$slack_num" ]]; then
-    fail "TC-NET-04: Setup" "Could not find slack in preset list"
-    return
-  fi
   local dry_output
-  dry_output=$(
-    expect <<EOF 2>&1
-set timeout 15
-spawn nemoclaw $SANDBOX_NAME policy-add --dry-run
-expect "Choose preset*"
-send "$slack_num\r"
-expect eof
-EOF
-  ) || true
+  dry_output=$(nemoclaw "$SANDBOX_NAME" policy-add slack --dry-run 2>&1) || true
   log "  Dry-run output: ${dry_output:0:300}"
 
-  if echo "$dry_output" | grep -qiE "slack\.com|dry.run|no changes"; then
+  if echo "$dry_output" | grep -qiE "slack\.com|dry.run|no changes|Would add"; then
     pass "TC-NET-04: Dry-run printed endpoint info"
   else
     fail "TC-NET-04: Dry-run output" "Expected endpoint info in output: ${dry_output:0:200}"


### PR DESCRIPTION
## Summary

- **check-docs.sh**: the Perl normalizer for `nemoclaw --help` output only stripped description text following 2+ spaces (`\s{2,}`). Some commands (e.g. `policy-remove`, `credentials reset`) have only 1 space before the description, causing mismatches. Added a second regex to strip descriptions after a single space when they start with an uppercase letter. Also added `<arg>`/`[arg]` stripping on the docs side so both normalizers agree.
- **commands.md**: added missing `nemoclaw onboard --from` heading and renamed `Legacy nemoclaw setup` to bare `nemoclaw setup` to match CLI help output.
- **test-network-policy.sh**: replaced the fragile interactive `apply_preset` function (which parsed `expect`-style output with Unicode markers via grep) with the non-interactive `nemoclaw policy-add <name> --yes` CLI path. Simplified TC-NET-04 dry-run assertion to use `--dry-run` flag directly.

## Failure details

- **Workflow run**: https://github.com/NVIDIA/NemoClaw/actions/runs/24705240158
- **Commit**: `e8e272ce52140244a9523d6f17990ebb6baff9e5`
- **Failed jobs**:
  - `cloud-experimental-e2e` — check-docs.sh normalizer mismatch (`config_error`)
  - `network-policy-e2e` — interactive preset parsing failure (`config_error`)
  - `token-rotation-e2e` — timeout during re-onboard (`infra_flake`, not fixed here)

## Test plan

- [ ] Re-run `check-docs.sh` locally against current `nemoclaw --help` output
- [ ] Verify `test-network-policy.sh` passes with `nemoclaw policy-add <preset> --yes`
- [ ] Confirm nightly-e2e passes on next scheduled run

Signed-off-by: Hai Nguyen <haingu@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Fixes #2159
