### PR TITLE
fix: standardize timeout/gtimeout handling

### DIFF
--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -41,6 +41,19 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 # ── Colors ───────────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -163,7 +176,7 @@ sandbox_exec() {
     return 1
   fi
   local result ssh_exit=0
-  result=$(${TIMEOUT_CMD:+$TIMEOUT_CMD 120} ssh -F "$ssh_cfg" \
+  result=$(run_with_timeout 120 ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 -o LogLevel=ERROR \
     "openshell-${SANDBOX_NAME}" "$cmd" 2>&1) || ssh_exit=$?
@@ -181,7 +194,7 @@ onboard_sandbox() {
     NEMOCLAW_NON_INTERACTIVE=1 \
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
     NEMOCLAW_POLICY_TIER="open" \
-    ${TIMEOUT_CMD:+$TIMEOUT_CMD 600} nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
+    run_with_timeout 600 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
     2>&1 | tee -a "$LOG_FILE" || {
     log "FATAL: Onboard failed for '$name'"
     return 1

--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -29,10 +29,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-3600}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -47,7 +47,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -22,27 +22,23 @@
 set -euo pipefail
 
 # ── Overall timeout ──────────────────────────────────────────────────────────
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
-  TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-3600}"
-  if command -v timeout >/dev/null 2>&1; then
-    exec timeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  fi
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
 fi
 
-# ── Config ───────────────────────────────────────────────────────────────────
-SANDBOX_NAME="e2e-deploy"
-LOG_FILE="test-deployment-services-$(date +%Y%m%d-%H%M%S).log"
-touch "$LOG_FILE"
-
-if command -v gtimeout >/dev/null 2>&1; then
-  TIMEOUT_CMD="gtimeout"
-elif command -v timeout >/dev/null 2>&1; then
-  TIMEOUT_CMD="timeout"
-else
-  TIMEOUT_CMD=""
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+  TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-3600}"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
+  fi
 fi
 
 # ── Colors ───────────────────────────────────────────────────────────────────

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -22,10 +22,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -41,7 +41,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -34,6 +34,20 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+# shellcheck disable=SC2329
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 PASS=0
 FAIL=0
 TOTAL=0

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -15,10 +15,23 @@
 
 set -uo pipefail
 
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
-  exec timeout -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
+  fi
 fi
 
 PASS=0

--- a/test/e2e/test-inference-routing.sh
+++ b/test/e2e/test-inference-routing.sh
@@ -49,6 +49,19 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -182,7 +195,7 @@ sandbox_exec() {
     return 1
   fi
   local result ssh_exit=0
-  result=$($TIMEOUT_CMD 60 ssh -F "$ssh_cfg" \
+  result=$(run_with_timeout 60 ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 -o LogLevel=ERROR \
     "openshell-${SANDBOX_NAME}" "$cmd" 2>&1) || ssh_exit=$?
@@ -317,7 +330,7 @@ test_inf_06_invalid_api_key() {
     NEMOCLAW_NON_INTERACTIVE=1 \
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
     NEMOCLAW_SANDBOX_NAME="e2e-invalid-key" \
-    $TIMEOUT_CMD 120 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
+    run_with_timeout 120 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
     2>&1) || exit_code=$?
 
   # 1. Exit code should be non-zero (onboard should fail)
@@ -381,7 +394,7 @@ test_inf_07_unreachable_endpoint() {
     NEMOCLAW_ENDPOINT_URL="https://nemoclaw-e2e.invalid/v1" \
     NEMOCLAW_MODEL="test-model" \
     COMPATIBLE_API_KEY="fake-key-for-unreachable-test" \
-    $TIMEOUT_CMD 120 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
+    run_with_timeout 120 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
     2>&1) || exit_code=$?
 
   # 1. Exit code should be non-zero
@@ -450,7 +463,7 @@ test_inf_02_openai() {
     NEMOCLAW_PROVIDER="openai" \
     NEMOCLAW_MODEL="$model" \
     OPENAI_API_KEY="$api_key" \
-    $TIMEOUT_CMD 300 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
+    run_with_timeout 300 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
     2>&1 | redact_stream "$api_key" | tee -a "$LOG_FILE" || onboard_exit=$?
 
   if [[ $onboard_exit -ne 0 ]]; then
@@ -469,7 +482,7 @@ test_inf_02_openai() {
 
   log "  Sending test prompt through sandbox inference proxy..."
   local response
-  response=$($TIMEOUT_CMD 90 ssh -F "$ssh_cfg" \
+  response=$(run_with_timeout 90 ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 -o LogLevel=ERROR \
     "openshell-${sbx_name}" \
@@ -526,7 +539,7 @@ test_inf_03_anthropic() {
     NEMOCLAW_PROVIDER="anthropic" \
     NEMOCLAW_MODEL="$model" \
     ANTHROPIC_API_KEY="$api_key" \
-    $TIMEOUT_CMD 300 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
+    run_with_timeout 300 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
     2>&1 | redact_stream "$api_key" | tee -a "$LOG_FILE" || onboard_exit=$?
 
   if [[ $onboard_exit -ne 0 ]]; then
@@ -545,7 +558,7 @@ test_inf_03_anthropic() {
 
   log "  Sending test prompt through sandbox inference proxy (Anthropic Messages API)..."
   local response
-  response=$($TIMEOUT_CMD 90 ssh -F "$ssh_cfg" \
+  response=$(run_with_timeout 90 ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 -o LogLevel=ERROR \
     "openshell-${sbx_name}" \
@@ -615,7 +628,7 @@ test_inf_09_compatible_endpoint() {
     NEMOCLAW_ENDPOINT_URL="$endpoint_url" \
     NEMOCLAW_MODEL="$endpoint_model" \
     COMPATIBLE_API_KEY="$endpoint_key" \
-    $TIMEOUT_CMD 300 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
+    run_with_timeout 300 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
     2>&1 | redact_stream "$endpoint_key" | tee -a "$LOG_FILE" || onboard_exit=$?
 
   if [[ $onboard_exit -ne 0 ]]; then
@@ -636,7 +649,7 @@ test_inf_09_compatible_endpoint() {
   # Send a prompt through the inference proxy inside the sandbox
   log "  Sending test prompt through sandbox inference proxy..."
   local response
-  response=$($TIMEOUT_CMD 90 ssh -F "$ssh_cfg" \
+  response=$(run_with_timeout 90 ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 -o LogLevel=ERROR \
     "openshell-${sbx_name}" \

--- a/test/e2e/test-inference-routing.sh
+++ b/test/e2e/test-inference-routing.sh
@@ -37,10 +37,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-1200}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -55,7 +55,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-inference-routing.sh
+++ b/test/e2e/test-inference-routing.sh
@@ -30,24 +30,23 @@
 set -euo pipefail
 
 # ── Overall timeout ──────────────────────────────────────────────────────────
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
-  TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-1200}"
-  if command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  elif command -v timeout >/dev/null 2>&1; then
-    exec timeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  fi
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
 fi
 
-# macOS uses gtimeout (from coreutils); Linux uses timeout
-if command -v gtimeout &>/dev/null; then
-  TIMEOUT_CMD="gtimeout"
-elif command -v timeout &>/dev/null; then
-  TIMEOUT_CMD="timeout"
-else
-  echo "ERROR: Neither timeout nor gtimeout found. Install coreutils: brew install coreutils"
-  exit 1
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+  TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-1200}"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
+  fi
 fi
 
 RED='\033[0;31m'

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -32,10 +32,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-3600}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -50,7 +50,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -127,10 +127,11 @@ preflight() {
   install_nemoclaw
   if ! command -v expect >/dev/null 2>&1; then
     log "Installing expect..."
-    sudo apt-get update -qq && sudo apt-get install -y -qq expect >/dev/null 2>&1
+    if ! (sudo apt-get update -qq && sudo apt-get install -y -qq expect >/dev/null 2>&1); then
+      log "WARNING: failed to install expect — interactive tests will skip"
+    fi
     if ! command -v expect >/dev/null 2>&1; then
-      log "ERROR: failed to install expect"
-      exit 1
+      log "WARNING: expect not available — interactive tests will skip"
     fi
   fi
   if ! command -v python3 >/dev/null 2>&1; then
@@ -138,27 +139,40 @@ preflight() {
     exit 1
   fi
   log "nemoclaw: $(nemoclaw --version 2>/dev/null || echo unknown)"
-  log "expect: $(command -v expect 2>/dev/null || echo 'not available')"
   log "python3: $(python3 --version 2>/dev/null || echo unknown)"
   log "Pre-flight complete"
 }
 
-# Apply a network policy preset using expect to handle interactive prompts.
+# Apply a network policy preset by name (non-interactive).
 apply_preset() {
   local preset_name="$1"
+  log "  Applying preset '$preset_name' (non-interactive)..."
+  local exit_code=0
+  nemoclaw "$SANDBOX_NAME" policy-add "$preset_name" --yes 2>&1 | tee -a "$LOG_FILE" || exit_code=$?
+  sleep 3
+  return "$exit_code"
+}
+
+# Apply a network policy preset via interactive prompts using expect.
+apply_preset_interactive() {
+  local preset_name="$1"
+  if ! command -v expect >/dev/null 2>&1; then
+    log "  expect not available — cannot test interactive mode"
+    return 2
+  fi
   local preset_list preset_num
-  preset_list=$(nemoclaw "$SANDBOX_NAME" policy-add </dev/null 2>&1) || true
-  preset_num=$(echo "$preset_list" | grep -oE '[0-9]+\) . '"$preset_name" | grep -oE '^[0-9]+') || true
+  preset_list=$(NEMOCLAW_NON_INTERACTIVE='' nemoclaw "$SANDBOX_NAME" policy-add </dev/null 2>&1) || true
+  preset_num=$(echo "$preset_list" | grep -oE '[0-9]+\).*'"$preset_name" | grep -oE '^[0-9]+') || true
   if [[ -z "$preset_num" ]]; then
-    log "  Could not find '$preset_name' in preset list"
+    log "  Could not find '$preset_name' in interactive preset list"
     return 1
   fi
-  log "  Applying preset '$preset_name' (#$preset_num) via expect..."
+  log "  Applying preset '$preset_name' (#$preset_num) via interactive expect..."
   local exit_code=0
   set +e
-  expect <<EOF 2>&1 | tee -a "$LOG_FILE"
+  NEMOCLAW_NON_INTERACTIVE='' expect <<EOF 2>&1 | tee -a "$LOG_FILE"
 set timeout 30
-spawn nemoclaw $SANDBOX_NAME policy-add
+spawn env NEMOCLAW_NON_INTERACTIVE= nemoclaw $SANDBOX_NAME policy-add
 expect "Choose preset*"
 send "$preset_num\r"
 expect "*Y/n*"
@@ -291,14 +305,22 @@ fetch('$target_url', {signal: AbortSignal.timeout(15000)})
 \"" 2>&1) || true
   log "  Before policy-add: $before"
 
-  if echo "$before" | grep -qE "STATUS_[23]"; then
+  if echo "$before" | grep -qE "STATUS_[2-4][0-9][0-9]"; then
     skip "TC-NET-03" "api.telegram.org already reachable before policy-add (preset may be pre-applied)"
     return
   fi
 
-  log "  Step 2: Adding telegram preset..."
-  if ! apply_preset "telegram"; then
-    fail "TC-NET-03: Setup" "Could not apply telegram preset"
+  log "  Step 2: Adding telegram preset (interactive mode)..."
+  local interactive_rc=0
+  apply_preset_interactive "telegram" || interactive_rc=$?
+  if [[ $interactive_rc -eq 2 ]]; then
+    log "  Interactive mode unavailable (expect missing) — falling back to non-interactive..."
+    if ! apply_preset "telegram"; then
+      fail "TC-NET-03: Setup" "Could not apply telegram preset"
+      return
+    fi
+  elif [[ $interactive_rc -ne 0 ]]; then
+    fail "TC-NET-03: Interactive policy-add" "interactive flow failed (exit $interactive_rc)"
     return
   fi
 
@@ -313,12 +335,12 @@ fetch('$target_url', {signal: AbortSignal.timeout(30000)})
 \"" 2>&1) || true
   log "  After policy-add: $after"
 
-  if echo "$after" | grep -qE "STATUS_2"; then
+  if echo "$after" | grep -qE "STATUS_[2-4][0-9][0-9]"; then
     pass "TC-NET-03: Endpoint reachable after live policy-add ($after)"
-  elif echo "$after" | grep -qE "STATUS_403"; then
-    fail "TC-NET-03: Live policy-add" "api.telegram.org still blocked with 403 after policy-add"
+  elif echo "$after" | grep -qE "ERROR_"; then
+    fail "TC-NET-03: Live policy-add" "api.telegram.org still proxy-blocked after policy-add ($after)"
   else
-    fail "TC-NET-03: Live policy-add" "api.telegram.org still blocked after policy-add ($after)"
+    fail "TC-NET-03: Live policy-add" "Unexpected response after policy-add ($after)"
   fi
 }
 
@@ -340,26 +362,11 @@ fetch('$target_url', {signal: AbortSignal.timeout(15000)})
   log "  Before dry-run: $before"
 
   log "  Step 2: Running policy-add --dry-run slack..."
-  local slack_list slack_num
-  slack_list=$(nemoclaw "$SANDBOX_NAME" policy-add --dry-run </dev/null 2>&1) || true
-  slack_num=$(echo "$slack_list" | grep -oE '[0-9]+\) . slack ' | grep -oE '^[0-9]+') || true
-  if [[ -z "$slack_num" ]]; then
-    fail "TC-NET-04: Setup" "Could not find slack in preset list"
-    return
-  fi
-  local dry_output
-  dry_output=$(
-    expect <<EOF 2>&1
-set timeout 15
-spawn nemoclaw $SANDBOX_NAME policy-add --dry-run
-expect "Choose preset*"
-send "$slack_num\r"
-expect eof
-EOF
-  ) || true
-  log "  Dry-run output: ${dry_output:0:300}"
+  local dry_output dry_rc=0
+  dry_output=$(nemoclaw "$SANDBOX_NAME" policy-add slack --dry-run 2>&1) || dry_rc=$?
+  log "  Dry-run output (exit $dry_rc): ${dry_output:0:300}"
 
-  if echo "$dry_output" | grep -qiE "slack\.com|dry.run|no changes"; then
+  if [[ $dry_rc -eq 0 ]] && echo "$dry_output" | grep -qiE "slack\.com|would be opened"; then
     pass "TC-NET-04: Dry-run printed endpoint info"
   else
     fail "TC-NET-04: Dry-run output" "Expected endpoint info in output: ${dry_output:0:200}"

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -44,6 +44,19 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 # ── Config ───────────────────────────────────────────────────────────────────
 SANDBOX_NAME="e2e-net-policy"
 LOG_FILE="test-network-policy-$(date +%Y%m%d-%H%M%S).log"
@@ -197,7 +210,7 @@ sandbox_exec() {
     return 1
   fi
   local result ssh_exit=0
-  result=$(${TIMEOUT_CMD:+$TIMEOUT_CMD 120} ssh -F "$ssh_cfg" \
+  result=$(run_with_timeout 120 ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 -o LogLevel=ERROR \
     "openshell-${SANDBOX_NAME}" "$cmd" 2>&1) || ssh_exit=$?
@@ -225,7 +238,7 @@ setup_sandbox() {
     NEMOCLAW_NON_INTERACTIVE=1 \
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
     NEMOCLAW_POLICY_TIER="restricted" \
-    ${TIMEOUT_CMD:+$TIMEOUT_CMD 600} nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
+    run_with_timeout 600 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software \
     2>&1 | tee -a "$LOG_FILE" || {
     log "FATAL: Onboard failed"
     exit 1

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -25,27 +25,28 @@
 set -euo pipefail
 
 # ── Overall timeout ──────────────────────────────────────────────────────────
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-3600}"
-  if command -v timeout >/dev/null 2>&1; then
-    exec timeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
   fi
 fi
 
 # ── Config ───────────────────────────────────────────────────────────────────
 SANDBOX_NAME="e2e-net-policy"
 LOG_FILE="test-network-policy-$(date +%Y%m%d-%H%M%S).log"
-
-if command -v gtimeout >/dev/null 2>&1; then
-  TIMEOUT_CMD="gtimeout"
-elif command -v timeout >/dev/null 2>&1; then
-  TIMEOUT_CMD="timeout"
-else
-  TIMEOUT_CMD=""
-fi
 
 # ── Colors ───────────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'

--- a/test/e2e/test-onboard-resume.sh
+++ b/test/e2e/test-onboard-resume.sh
@@ -41,6 +41,19 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 PASS=0
 FAIL=0
 SKIP=0

--- a/test/e2e/test-onboard-resume.sh
+++ b/test/e2e/test-onboard-resume.sh
@@ -29,10 +29,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-600}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -47,7 +47,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-onboard-resume.sh
+++ b/test/e2e/test-onboard-resume.sh
@@ -22,18 +22,22 @@
 
 set -uo pipefail
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
-  TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-600}"
-  TIMEOUT_BIN=""
-  if command -v timeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="timeout"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="gtimeout"
-  fi
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
 
-  if [ -n "$TIMEOUT_BIN" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+  TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-600}"
+  if [ -n "$TIMEOUT_CMD" ]; then
     export NEMOCLAW_E2E_NO_TIMEOUT=1
-    exec "$TIMEOUT_BIN" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
   fi
 fi
 

--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -27,10 +27,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-1800}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -45,7 +45,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -39,6 +39,19 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 # ── Config ───────────────────────────────────────────────────────────────────
 SANDBOX_A="test-sbx-a"
 SANDBOX_B="test-sbx-b"
@@ -103,7 +116,7 @@ sandbox_exec_for() {
     return 1
   fi
   local result exit_code=0
-  result=$($TIMEOUT_CMD 60 ssh -F "$ssh_cfg" \
+  result=$(run_with_timeout 60 ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 -o LogLevel=ERROR \
     "openshell-${name}" "$cmd" 2>&1) || exit_code=$?
@@ -331,7 +344,7 @@ test_sbx_04_log_streaming() {
   require_sandbox "$SANDBOX_A" "TC-SBX-04" || return
 
   local output logs_exit=0
-  output=$($TIMEOUT_CMD 10 nemoclaw "$SANDBOX_A" logs 2>&1) || logs_exit=$?
+  output=$(run_with_timeout 10 nemoclaw "$SANDBOX_A" logs 2>&1) || logs_exit=$?
 
   if [[ $logs_exit -ne 0 ]]; then
     fail "TC-SBX-04: Log Streaming" "nemoclaw logs exited with code $logs_exit"
@@ -341,7 +354,7 @@ test_sbx_04_log_streaming() {
     fail "TC-SBX-04: Log Streaming" "nemoclaw logs succeeded but produced no output"
   fi
 
-  $TIMEOUT_CMD 5 nemoclaw "$SANDBOX_A" logs --follow &>/dev/null &
+  run_with_timeout 5 nemoclaw "$SANDBOX_A" logs --follow &>/dev/null &
   local pid=$!
   sleep 3
 
@@ -378,7 +391,7 @@ test_sbx_07_registry_rebuild() {
   rm -f "$registry"
 
   local output
-  output=$($TIMEOUT_CMD 60 nemoclaw list 2>&1) || true
+  output=$(run_with_timeout 60 nemoclaw list 2>&1) || true
 
   if echo "$output" | grep -q "$SANDBOX_A"; then
     pass "TC-SBX-07: Registry rebuilt — '$SANDBOX_A' found after deletion"
@@ -407,7 +420,7 @@ test_sbx_08_process_recovery() {
 
   log "  Running nemoclaw status (expect process recovery)..."
   local status_output status_exit=0
-  status_output=$($TIMEOUT_CMD 120 nemoclaw "$SANDBOX_A" status 2>&1) || status_exit=$?
+  status_output=$(run_with_timeout 120 nemoclaw "$SANDBOX_A" status 2>&1) || status_exit=$?
 
   if [[ $status_exit -ne 0 ]]; then
     fail "TC-SBX-08: Process Recovery (status)" "nemoclaw status exited with code $status_exit"

--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -20,13 +20,22 @@
 set -euo pipefail
 
 # ── Overall timeout (prevents hung CI jobs) ──────────────────────────────────
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-1800}"
-  if command -v timeout >/dev/null 2>&1; then
-    exec timeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
   fi
 fi
 
@@ -34,16 +43,6 @@ fi
 SANDBOX_A="test-sbx-a"
 SANDBOX_B="test-sbx-b"
 LOG_FILE="test-sandbox-operations-$(date +%Y%m%d-%H%M%S).log"
-
-# macOS uses gtimeout (from coreutils); Linux uses timeout
-if command -v gtimeout &>/dev/null; then
-  TIMEOUT_CMD="gtimeout"
-elif command -v timeout &>/dev/null; then
-  TIMEOUT_CMD="timeout"
-else
-  echo "ERROR: Neither timeout nor gtimeout found. Install coreutils: brew install coreutils"
-  exit 1
-fi
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -47,10 +47,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -65,7 +65,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -59,6 +59,19 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 PASS=0
 FAIL=0
 SKIP=0
@@ -114,7 +127,7 @@ MIN_OPENSHELL="0.0.24"
 MODEL="nvidia/nemotron-3-super-120b-a12b"
 
 # SSH helper — sets up SSH config and common options for sandbox access
-# Sets: ssh_config, SSH_OPTS, SSH_TARGET, TIMEOUT_CMD
+# Sets: ssh_config, SSH_OPTS, SSH_TARGET
 setup_ssh() {
   ssh_config="$(mktemp)"
   if ! openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_config" 2>/dev/null; then
@@ -124,9 +137,6 @@ setup_ssh() {
   fi
   SSH_OPTS=(-F "$ssh_config" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o LogLevel=ERROR)
   SSH_TARGET="openshell-${SANDBOX_NAME}"
-  TIMEOUT_CMD=""
-  command -v timeout >/dev/null 2>&1 && TIMEOUT_CMD="timeout 90"
-  command -v gtimeout >/dev/null 2>&1 && TIMEOUT_CMD="gtimeout 90"
   return 0
 }
 
@@ -323,7 +333,7 @@ fi
 # 4b: Live inference through sandbox
 info "[LIVE] Baseline inference: user → sandbox → gateway → NVIDIA Endpoints..."
 # shellcheck disable=SC2029  # client-side expansion is intentional
-baseline_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
+baseline_response=$(run_with_timeout 90 ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
   "curl -s --max-time 60 https://inference.local/v1/chat/completions \
     -H 'Content-Type: application/json' \
     -d '{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
@@ -346,7 +356,7 @@ for pong_attempt in 1 2 3; do
   [ "$pong_attempt" -lt 3 ] || break
   sleep 5
   # shellcheck disable=SC2029
-  baseline_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
+  baseline_response=$(run_with_timeout 90 ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
     "curl -s --max-time 60 https://inference.local/v1/chat/completions \
       -H 'Content-Type: application/json' \
       -d '{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
@@ -654,7 +664,7 @@ section "Phase 10: Live inference after restart (THE definitive test)"
 
 info "[LIVE] Post-restart inference: user → sandbox → gateway → NVIDIA Endpoints..."
 # shellcheck disable=SC2029
-post_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
+post_response=$(run_with_timeout 90 ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
   "curl -s --max-time 60 https://inference.local/v1/chat/completions \
     -H 'Content-Type: application/json' \
     -d '{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \
@@ -676,7 +686,7 @@ for pong_attempt in 1 2 3; do
   [ "$pong_attempt" -lt 3 ] || break
   sleep 5
   # shellcheck disable=SC2029
-  post_response=$($TIMEOUT_CMD ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
+  post_response=$(run_with_timeout 90 ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
     "curl -s --max-time 60 https://inference.local/v1/chat/completions \
       -H 'Content-Type: application/json' \
       -d '{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":100}'" \

--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -40,13 +40,22 @@
 
 set -uo pipefail
 
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
-  if command -v timeout >/dev/null 2>&1; then
-    exec timeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
   fi
 fi
 

--- a/test/e2e/test-shields-config.sh
+++ b/test/e2e/test-shields-config.sh
@@ -37,10 +37,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -55,7 +55,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-shields-config.sh
+++ b/test/e2e/test-shields-config.sh
@@ -49,6 +49,19 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 PASS=0
 FAIL=0
 TOTAL=0

--- a/test/e2e/test-shields-config.sh
+++ b/test/e2e/test-shields-config.sh
@@ -30,13 +30,22 @@
 
 set -uo pipefail
 
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
-  if command -v timeout >/dev/null 2>&1; then
-    exec timeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
   fi
 fi
 

--- a/test/e2e/test-skip-permissions-policy.sh
+++ b/test/e2e/test-skip-permissions-policy.sh
@@ -41,10 +41,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -60,7 +60,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-skip-permissions-policy.sh
+++ b/test/e2e/test-skip-permissions-policy.sh
@@ -53,6 +53,20 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+# shellcheck disable=SC2329
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 PASS=0
 FAIL=0
 TOTAL=0

--- a/test/e2e/test-skip-permissions-policy.sh
+++ b/test/e2e/test-skip-permissions-policy.sh
@@ -34,13 +34,22 @@
 
 set -uo pipefail
 
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
-  if command -v timeout >/dev/null 2>&1; then
-    exec timeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    exec gtimeout -s TERM "$TIMEOUT_SECONDS" bash "$0" "$@"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
   fi
 fi
 

--- a/test/e2e/test-token-rotation.sh
+++ b/test/e2e/test-token-rotation.sh
@@ -36,7 +36,7 @@ elif command -v gtimeout >/dev/null 2>&1; then
 fi
 
 if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
-  TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
+  TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-2400}"
   if [ -n "$TIMEOUT_CMD" ]; then
     export NEMOCLAW_E2E_NO_TIMEOUT=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"

--- a/test/e2e/test-token-rotation.sh
+++ b/test/e2e/test-token-rotation.sh
@@ -42,6 +42,19 @@ if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   fi
 fi
 
+# Run with $TIMEOUT_CMD if set; run directly if empty (NEMOCLAW_E2E_NO_TIMEOUT bypass).
+# Avoids `$TIMEOUT_CMD 60 ssh …` becoming `60 ssh …` → "60: command not found".
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
 PASS=0
 FAIL=0
 TOTAL=0

--- a/test/e2e/test-token-rotation.sh
+++ b/test/e2e/test-token-rotation.sh
@@ -35,10 +35,10 @@ elif command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD="gtimeout"
 fi
 
-if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ "${NEMOCLAW_E2E_TIMEOUT_WRAPPED:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-2400}"
   if [ -n "$TIMEOUT_CMD" ]; then
-    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    export NEMOCLAW_E2E_TIMEOUT_WRAPPED=1
     exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
   else
     echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
@@ -53,7 +53,7 @@ fi
 run_with_timeout() {
   local seconds="$1"
   shift
-  if [ -n "$TIMEOUT_CMD" ]; then
+  if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ] && [ -n "$TIMEOUT_CMD" ]; then
     "$TIMEOUT_CMD" "$seconds" "$@"
   else
     "$@"

--- a/test/e2e/test-token-rotation.sh
+++ b/test/e2e/test-token-rotation.sh
@@ -23,10 +23,23 @@
 
 set -uo pipefail
 
-if [ -z "${NEMOCLAW_E2E_NO_TIMEOUT:-}" ]; then
-  export NEMOCLAW_E2E_NO_TIMEOUT=1
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+
+if [ "${NEMOCLAW_E2E_NO_TIMEOUT:-0}" != "1" ]; then
   TIMEOUT_SECONDS="${NEMOCLAW_E2E_TIMEOUT_SECONDS:-900}"
-  exec timeout -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  if [ -n "$TIMEOUT_CMD" ]; then
+    export NEMOCLAW_E2E_NO_TIMEOUT=1
+    exec "$TIMEOUT_CMD" -s TERM "$TIMEOUT_SECONDS" "$0" "$@"
+  else
+    echo "ERROR: 'timeout' not found. Install coreutils (macOS: 'brew install coreutils')" >&2
+    echo "       or bypass with NEMOCLAW_E2E_NO_TIMEOUT=1" >&2
+    exit 127
+  fi
 fi
 
 PASS=0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Standardize the `timeout`/`gtimeout` detection preamble across all 10 e2e test scripts. Fixes a hard crash on macOS without GNU coreutils (`exec: timeout: not found`) by detecting both binaries up-front, failing fast with actionable remediation when neither is available, and consolidating ad-hoc per-file patterns into a single shared shape.

## Related Issue
Closes #2160

## Changes
- **Move `timeout`/`gtimeout` detection above the self-wrap block** so `TIMEOUT_CMD` is set on every invocation — including the re-execed run after `exec timeout … "$0" "$@"`. Previously the variable was scoped inside the wrap block; on the re-execed run it was unset, causing `set -u` crashes (`test-sandbox-operations.sh`, `test-inference-routing.sh`) or silent loss of per-call timeouts (`test-network-policy.sh`, `test-deployment-services.sh`).
- **Fail-fast with exit 127** and actionable guidance when neither `timeout` nor `gtimeout` is available, instead of crashing with `exec: not found` or silently dropping the timeout protection:

## Type of Change
- [x] Code change (feature, bug fix, or refactor)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Hung Le <hple@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized e2e timeout detection and consistent re-exec wrapping using the system timeout utility.
  * Added a helper to run commands under timeout and updated test call sites.
  * Bypass now requires an explicit opt-in to skip timeouts, preventing recursive wrapping.
  * Prints clear guidance and aborts when timeouts are enabled but no timeout utility is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->