### PR TITLE
fix(destroy): clean up orphaned sandbox Docker images

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -492,7 +492,7 @@ The `destroy` and `rebuild` commands clean up the image automatically, but image
 This command lists all `openshell/sandbox-from:*` images, cross-references the sandbox registry, and removes any that are no longer associated with a registered sandbox.
 
 ```console
-$ nemoclaw gc [--dry-run] [--yes]
+$ nemoclaw gc [--dry-run] [--yes|--force]
 ```
 
 | Flag | Description |

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -204,7 +204,7 @@ $ nemoclaw my-assistant logs [--follow]
 
 ### `nemoclaw <name> destroy`
 
-Stop the NIM container and delete the sandbox.
+Stop the NIM container, remove the host-side Docker image built during onboard, and delete the sandbox.
 This removes the sandbox from the registry.
 
 > **Warning:** This command permanently deletes the sandbox **and its persistent volume**.
@@ -323,7 +323,7 @@ For new installs, the agent session index is refreshed so the agent discovers th
 ### `nemoclaw <name> rebuild`
 
 Upgrade a sandbox to the current agent version while preserving workspace state.
-The command backs up workspace state, destroys the old sandbox, recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
+The command backs up workspace state, destroys the old sandbox (including its host-side Docker image), recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
 Credentials are stripped from backups before storage.
 
 ```console
@@ -483,6 +483,22 @@ $ nemoclaw credentials reset NVIDIA_API_KEY
 | Flag | Description |
 |------|-------------|
 | `--yes`, `-y` | Skip the confirmation prompt |
+
+### `nemoclaw gc`
+
+Remove orphaned sandbox Docker images from the host.
+Each `nemoclaw onboard` builds an `openshell/sandbox-from:<timestamp>` image (~765 MB).
+The `destroy` and `rebuild` commands clean up the image automatically, but images from older NemoClaw versions or interrupted operations may remain.
+This command lists all `openshell/sandbox-from:*` images, cross-references the sandbox registry, and removes any that are no longer associated with a registered sandbox.
+
+```console
+$ nemoclaw gc [--dry-run] [--yes]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | List orphaned images without removing them |
+| `--yes`, `--force` | Skip the confirmation prompt |
 
 ### `nemoclaw uninstall`
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -520,7 +520,7 @@ The `destroy` and `rebuild` commands clean up the image automatically, but image
 This command lists all `openshell/sandbox-from:*` images, cross-references the sandbox registry, and removes any that are no longer associated with a registered sandbox.
 
 ```console
-$ nemoclaw gc [--dry-run] [--yes]
+$ nemoclaw gc [--dry-run] [--yes|--force]
 ```
 
 | Flag | Description |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -228,7 +228,7 @@ $ nemoclaw my-assistant logs [--follow]
 
 ### `nemoclaw <name> destroy`
 
-Stop the NIM container and delete the sandbox.
+Stop the NIM container, remove the host-side Docker image built during onboard, and delete the sandbox.
 This removes the sandbox from the registry.
 
 :::{warning}
@@ -349,7 +349,7 @@ For new installs, the agent session index is refreshed so the agent discovers th
 ### `nemoclaw <name> rebuild`
 
 Upgrade a sandbox to the current agent version while preserving workspace state.
-The command backs up workspace state, destroys the old sandbox, recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
+The command backs up workspace state, destroys the old sandbox (including its host-side Docker image), recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
 Credentials are stripped from backups before storage.
 
 ```console
@@ -511,6 +511,22 @@ $ nemoclaw credentials reset NVIDIA_API_KEY
 | Flag | Description |
 |------|-------------|
 | `--yes`, `-y` | Skip the confirmation prompt |
+
+### `nemoclaw gc`
+
+Remove orphaned sandbox Docker images from the host.
+Each `nemoclaw onboard` builds an `openshell/sandbox-from:<timestamp>` image (~765 MB).
+The `destroy` and `rebuild` commands clean up the image automatically, but images from older NemoClaw versions or interrupted operations may remain.
+This command lists all `openshell/sandbox-from:*` images, cross-references the sandbox registry, and removes any that are no longer associated with a registered sandbox.
+
+```console
+$ nemoclaw gc [--dry-run] [--yes]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | List orphaned images without removing them |
+| `--yes`, `--force` | Skip the confirmation prompt |
 
 ### `nemoclaw uninstall`
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3398,8 +3398,12 @@ async function createSandbox(
 
     note(`  Deleting and recreating sandbox '${sandboxName}'...`);
 
-    // Destroy old sandbox
+    // Destroy old sandbox and clean up its host-side Docker image.
+    const oldEntry = registry.getSandbox(sandboxName);
     runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
+    if (oldEntry?.imageTag) {
+      run(["docker", "rmi", oldEntry.imageTag], { ignoreError: true });
+    }
     registry.removeSandbox(sandboxName);
   }
 
@@ -3589,11 +3593,12 @@ async function createSandbox(
       console.warn(`    docker pull ${SANDBOX_BASE_IMAGE}:${SANDBOX_BASE_TAG}`);
     }
   }
+  const buildId = String(Date.now());
   patchStagedDockerfile(
     stagedDockerfile,
     model,
     chatUiUrl,
-    String(Date.now()),
+    buildId,
     provider,
     preferredInferenceApi,
     webSearchConfig,
@@ -3759,6 +3764,7 @@ async function createSandbox(
     gpuEnabled: !!gpu,
     agent: agent ? agent.name : null,
     agentVersion: fromDockerfile ? null : effectiveAgent.expectedVersion || null,
+    imageTag: `openshell/sandbox-from:${buildId}`,
     dangerouslySkipPermissions: dangerouslySkipPermissions || undefined,
     providerCredentialHashes:
       Object.keys(providerCredentialHashes).length > 0 ? providerCredentialHashes : undefined,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3401,7 +3401,10 @@ async function createSandbox(
     // Destroy old sandbox and clean up its host-side Docker image.
     runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
     if (previousEntry?.imageTag) {
-      run(["docker", "rmi", previousEntry.imageTag], { ignoreError: true });
+      const rmiResult = run(["docker", "rmi", previousEntry.imageTag], { ignoreError: true, suppressOutput: true });
+      if (rmiResult.status !== 0) {
+        console.warn(`  Warning: failed to remove old sandbox image '${previousEntry.imageTag}'.`);
+      }
     }
     registry.removeSandbox(sandboxName);
   }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3399,10 +3399,9 @@ async function createSandbox(
     note(`  Deleting and recreating sandbox '${sandboxName}'...`);
 
     // Destroy old sandbox and clean up its host-side Docker image.
-    const oldEntry = registry.getSandbox(sandboxName);
     runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
-    if (oldEntry?.imageTag) {
-      run(["docker", "rmi", oldEntry.imageTag], { ignoreError: true });
+    if (previousEntry?.imageTag) {
+      run(["docker", "rmi", previousEntry.imageTag], { ignoreError: true });
     }
     registry.removeSandbox(sandboxName);
   }

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -18,6 +18,7 @@ export interface SandboxEntry {
   agent?: string | null;
   dangerouslySkipPermissions?: boolean;
   agentVersion?: string | null;
+  imageTag?: string | null;
   providerCredentialHashes?: Record<string, string>;
   messagingChannels?: string[];
 }
@@ -167,6 +168,7 @@ export function registerSandbox(entry: SandboxEntry): void {
       dangerouslySkipPermissions:
         entry.dangerouslySkipPermissions === true ? true : undefined,
       agentVersion: entry.agentVersion || null,
+      imageTag: entry.imageTag || null,
       providerCredentialHashes: entry.providerCredentialHashes || undefined,
       messagingChannels: entry.messagingChannels || [],
     };

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -99,6 +99,7 @@ const GLOBAL_COMMANDS = new Set([
   "credentials",
   "backup-all",
   "upgrade-sandboxes",
+  "gc",
   "help",
   "--help",
   "-h",
@@ -1973,6 +1974,21 @@ function cleanupSandboxServices(sandboxName, { stopHostServices = false } = {}) 
   }
 }
 
+/**
+ * Remove the host-side Docker image that was built for a sandbox during onboard.
+ * Must be called before registry.removeSandbox() since the imageTag is stored there.
+ */
+function removeSandboxImage(sandboxName) {
+  const sb = registry.getSandbox(sandboxName);
+  if (!sb?.imageTag) return;
+  try {
+    run(["docker", "rmi", sb.imageTag], { ignoreError: true });
+    console.log(`  Removed Docker image ${sb.imageTag}`);
+  } catch {
+    // Image may already be gone or in use — ignore.
+  }
+}
+
 async function sandboxDestroy(sandboxName, args = []) {
   const skipConfirm = args.includes("--yes") || args.includes("--force");
 
@@ -2032,6 +2048,7 @@ async function sandboxDestroy(sandboxName, args = []) {
     !!registry.getSandbox(sandboxName);
 
   cleanupSandboxServices(sandboxName, { stopHostServices: shouldStopHostServices });
+  removeSandboxImage(sandboxName);
 
   const removed = registry.removeSandbox(sandboxName);
   const session = onboardSession.loadSession();
@@ -2200,6 +2217,7 @@ async function sandboxRebuild(sandboxName, args = [], opts = {}) {
     bail("Failed to delete sandbox.", deleteResult.status || 1);
     return;
   }
+  removeSandboxImage(sandboxName);
   registry.removeSandbox(sandboxName);
   log(
     `Registry after remove: ${JSON.stringify(registry.listSandboxes().sandboxes.map((s) => s.name))}`,
@@ -2618,6 +2636,95 @@ function backupAll() {
   }
 }
 
+// ── Garbage collection ──────────────────────────────────────────
+
+async function garbageCollectImages(args = []) {
+  const dryRun = args.includes("--dry-run");
+  const skipConfirm = args.includes("--yes") || args.includes("--force");
+
+  // 1. List all openshell/sandbox-from images on the host
+  const imagesResult = spawnSync(
+    "docker",
+    ["images", "--filter", "reference=openshell/sandbox-from", "--format", "{{.Repository}}:{{.Tag}}\t{{.Size}}"],
+    { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (imagesResult.status !== 0) {
+    console.error("  Failed to query Docker images. Is Docker running?");
+    process.exit(1);
+  }
+
+  const allImages = (imagesResult.stdout || "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [tag, size] = line.split("\t");
+      return { tag, size: size || "unknown" };
+    });
+
+  if (allImages.length === 0) {
+    console.log("  No sandbox images found on the host.");
+    return;
+  }
+
+  // 2. Determine which images are in use by live or registered sandboxes
+  const registeredTags = new Set();
+  const { sandboxes } = registry.listSandboxes();
+  for (const sb of sandboxes) {
+    if (sb.imageTag) registeredTags.add(sb.imageTag);
+  }
+
+  // 3. Cross-reference to find orphans
+  const orphans = allImages.filter((img) => !registeredTags.has(img.tag));
+
+  if (orphans.length === 0) {
+    console.log(`  All ${allImages.length} sandbox image(s) are in use. Nothing to clean up.`);
+    return;
+  }
+
+  // 4. Display what will be removed
+  console.log(`  Found ${orphans.length} orphaned sandbox image(s):\n`);
+  for (const img of orphans) {
+    console.log(`    ${img.tag}  ${D}(${img.size})${R}`);
+  }
+  console.log("");
+
+  if (dryRun) {
+    console.log(`  --dry-run: would remove ${orphans.length} image(s).`);
+    return;
+  }
+
+  // 5. Confirm
+  if (!skipConfirm) {
+    const answer = await askPrompt(`  Remove ${orphans.length} orphaned image(s)? [y/N]: `);
+    if (answer.trim().toLowerCase() !== "y" && answer.trim().toLowerCase() !== "yes") {
+      console.log("  Cancelled.");
+      return;
+    }
+  }
+
+  // 6. Remove orphans
+  let removed = 0;
+  let failed = 0;
+  for (const img of orphans) {
+    const rmiResult = spawnSync("docker", ["rmi", img.tag], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (rmiResult.status === 0) {
+      console.log(`  ${G}✓${R} Removed ${img.tag}`);
+      removed++;
+    } else {
+      console.error(`  ${YW}⚠${R} Failed to remove ${img.tag}`);
+      failed++;
+    }
+  }
+
+  console.log("");
+  if (removed > 0) console.log(`  ${G}✓${R} Removed ${removed} orphaned image(s).`);
+  if (failed > 0) console.log(`  ${YW}⚠${R} Failed to remove ${failed} image(s).`);
+}
+
 // ── Help ─────────────────────────────────────────────────────────
 
 function help() {
@@ -2679,7 +2786,8 @@ function help() {
   ${G}Upgrade:${R}
     nemoclaw upgrade-sandboxes       Detect and rebuild stale sandboxes ${D}(--check, --auto)${R}
 
-  Cleanup:
+  ${G}Cleanup:${R}
+    nemoclaw gc                      Remove orphaned sandbox Docker images ${D}(--yes, --dry-run)${R}
     nemoclaw uninstall [flags]       Run uninstall.sh (local only; no remote fallback)
 
   ${G}Uninstall flags:${R}
@@ -2746,6 +2854,9 @@ const [cmd, ...args] = process.argv.slice(2);
         break;
       case "upgrade-sandboxes":
         await upgradeSandboxes(args);
+        break;
+      case "gc":
+        await garbageCollectImages(args);
         break;
       case "--version":
       case "-v": {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2713,7 +2713,10 @@ async function garbageCollectImages(args = []) {
       console.log(`  ${G}✓${R} Removed ${img.tag}`);
       removed++;
     } else {
-      console.error(`  ${YW}⚠${R} Failed to remove ${img.tag}`);
+      const details = `${rmiResult.stderr || rmiResult.stdout || ""}`.trim();
+      console.error(
+        `  ${YW}⚠${R} Failed to remove ${img.tag}${details ? `: ${details}` : ""}`,
+      );
       failed++;
     }
   }
@@ -2721,6 +2724,7 @@ async function garbageCollectImages(args = []) {
   console.log("");
   if (removed > 0) console.log(`  ${G}✓${R} Removed ${removed} orphaned image(s).`);
   if (failed > 0) console.log(`  ${YW}⚠${R} Failed to remove ${failed} image(s).`);
+  if (failed > 0) process.exit(1);
 }
 
 // ── Help ─────────────────────────────────────────────────────────

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1984,6 +1984,8 @@ function removeSandboxImage(sandboxName) {
   const result = run(["docker", "rmi", sb.imageTag], { ignoreError: true });
   if (result.status === 0) {
     console.log(`  Removed Docker image ${sb.imageTag}`);
+  } else {
+    console.warn(`  ${YW}⚠${R} Failed to remove Docker image ${sb.imageTag}; run 'nemoclaw gc' to clean up.`);
   }
 }
 
@@ -2789,7 +2791,7 @@ function help() {
     nemoclaw upgrade-sandboxes       Detect and rebuild stale sandboxes ${D}(--check, --auto)${R}
 
   ${G}Cleanup:${R}
-    nemoclaw gc                      Remove orphaned sandbox Docker images ${D}(--yes, --dry-run)${R}
+    nemoclaw gc                      Remove orphaned sandbox Docker images ${D}(--yes|--force, --dry-run)${R}
     nemoclaw uninstall [flags]       Run uninstall.sh (local only; no remote fallback)
 
   ${G}Uninstall flags:${R}

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1981,11 +1981,9 @@ function cleanupSandboxServices(sandboxName, { stopHostServices = false } = {}) 
 function removeSandboxImage(sandboxName) {
   const sb = registry.getSandbox(sandboxName);
   if (!sb?.imageTag) return;
-  try {
-    run(["docker", "rmi", sb.imageTag], { ignoreError: true });
+  const result = run(["docker", "rmi", sb.imageTag], { ignoreError: true });
+  if (result.status === 0) {
     console.log(`  Removed Docker image ${sb.imageTag}`);
-  } catch {
-    // Image may already be gone or in use — ignore.
   }
 }
 

--- a/test/image-cleanup.test.ts
+++ b/test/image-cleanup.test.ts
@@ -1,0 +1,134 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verify that sandbox lifecycle operations clean up host-side Docker images.
+// See: https://github.com/NVIDIA/NemoClaw/issues/2086
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+describe("image cleanup: sandbox destroy removes Docker image (#2086)", () => {
+  const nemoclawSrc = fs.readFileSync(path.join(ROOT, "src/nemoclaw.ts"), "utf-8");
+
+  it("removeSandboxImage() helper exists and calls docker rmi", () => {
+    expect(nemoclawSrc).toContain("function removeSandboxImage(");
+    expect(nemoclawSrc).toMatch(/docker.*rmi/);
+  });
+
+  it("sandboxDestroy calls removeSandboxImage before registry.removeSandbox", () => {
+    // Extract the sandboxDestroy function body
+    const destroyMatch = nemoclawSrc.match(
+      /async function sandboxDestroy[\s\S]*?^}/m,
+    );
+    expect(destroyMatch).toBeTruthy();
+    const destroyBody = destroyMatch[0];
+
+    // removeSandboxImage must appear before registry.removeSandbox
+    const removeImageIdx = destroyBody.indexOf("removeSandboxImage(");
+    const removeRegistryIdx = destroyBody.indexOf("registry.removeSandbox(");
+    expect(removeImageIdx).toBeGreaterThan(-1);
+    expect(removeRegistryIdx).toBeGreaterThan(-1);
+    expect(removeImageIdx).toBeLessThan(removeRegistryIdx);
+  });
+
+  it("sandboxRebuild calls removeSandboxImage before registry.removeSandbox", () => {
+    const rebuildMatch = nemoclawSrc.match(
+      /async function sandboxRebuild[\s\S]*?^  console\.log\(`\s*\$\{G\}.*Sandbox.*rebuilt/m,
+    );
+    expect(rebuildMatch).toBeTruthy();
+    const rebuildBody = rebuildMatch[0];
+
+    const removeImageIdx = rebuildBody.indexOf("removeSandboxImage(");
+    const removeRegistryIdx = rebuildBody.indexOf("registry.removeSandbox(");
+    expect(removeImageIdx).toBeGreaterThan(-1);
+    expect(removeRegistryIdx).toBeGreaterThan(-1);
+    expect(removeImageIdx).toBeLessThan(removeRegistryIdx);
+  });
+
+  it("removeSandboxImage gracefully handles missing imageTag", () => {
+    // The function should check for imageTag before attempting removal
+    const fnMatch = nemoclawSrc.match(
+      /function removeSandboxImage[\s\S]*?^}/m,
+    );
+    expect(fnMatch).toBeTruthy();
+    expect(fnMatch[0]).toContain("imageTag");
+  });
+});
+
+describe("image cleanup: onboard records imageTag in registry (#2086)", () => {
+  const onboardSrc = fs.readFileSync(path.join(ROOT, "src/lib/onboard.ts"), "utf-8");
+
+  it("buildId is captured before patchStagedDockerfile", () => {
+    // buildId should be a named variable, not an inline Date.now()
+    expect(onboardSrc).toContain("const buildId = String(Date.now())");
+  });
+
+  it("registerSandbox includes imageTag with buildId", () => {
+    expect(onboardSrc).toMatch(/imageTag:\s*`openshell\/sandbox-from:\$\{buildId\}`/);
+  });
+
+  it("onboard recreate path cleans up old image", () => {
+    // When recreating, the old image should be removed
+    expect(onboardSrc).toMatch(/oldEntry\?\.imageTag/);
+    expect(onboardSrc).toMatch(/docker.*rmi.*oldEntry\.imageTag/);
+  });
+});
+
+describe("image cleanup: registry stores imageTag (#2086)", () => {
+  const registrySrc = fs.readFileSync(path.join(ROOT, "src/lib/registry.ts"), "utf-8");
+
+  it("SandboxEntry interface includes imageTag field", () => {
+    expect(registrySrc).toMatch(/imageTag\?:\s*string\s*\|\s*null/);
+  });
+
+  it("registerSandbox persists imageTag", () => {
+    // The registerSandbox function should include imageTag in the stored entry
+    const registerMatch = registrySrc.match(
+      /function registerSandbox[\s\S]*?^}/m,
+    );
+    expect(registerMatch).toBeTruthy();
+    expect(registerMatch[0]).toContain("imageTag");
+  });
+});
+
+describe("image cleanup: gc command exists (#2086)", () => {
+  const nemoclawSrc = fs.readFileSync(path.join(ROOT, "src/nemoclaw.ts"), "utf-8");
+
+  it("gc is a global command", () => {
+    const globalBlock = nemoclawSrc.match(/GLOBAL_COMMANDS\s*=\s*new Set\(\[[\s\S]*?\]\)/);
+    expect(globalBlock).toBeTruthy();
+    expect(globalBlock[0]).toContain('"gc"');
+  });
+
+  it("gc command is dispatched in the CLI switch", () => {
+    expect(nemoclawSrc).toContain('case "gc"');
+    expect(nemoclawSrc).toContain("garbageCollectImages");
+  });
+
+  it("garbageCollectImages lists sandbox-from images and cross-references registry", () => {
+    const gcMatch = nemoclawSrc.match(
+      /async function garbageCollectImages[\s\S]*?^}/m,
+    );
+    expect(gcMatch).toBeTruthy();
+    const gcBody = gcMatch[0];
+
+    // Must query docker for sandbox-from images
+    expect(gcBody).toContain("openshell/sandbox-from");
+    // Must consult the registry for in-use tags
+    expect(gcBody).toContain("registry.listSandboxes");
+    // Must support --dry-run
+    expect(gcBody).toContain("dry-run");
+    // Must support --yes
+    expect(gcBody).toContain("--yes");
+  });
+
+  it("gc appears in help text", () => {
+    const helpMatch = nemoclawSrc.match(/function help\(\)[\s\S]*?^}/m);
+    expect(helpMatch).toBeTruthy();
+    expect(helpMatch[0]).toContain("nemoclaw gc");
+  });
+});

--- a/test/image-cleanup.test.ts
+++ b/test/image-cleanup.test.ts
@@ -21,9 +21,7 @@ describe("image cleanup: sandbox destroy removes Docker image (#2086)", () => {
 
   it("sandboxDestroy calls removeSandboxImage before registry.removeSandbox", () => {
     // Extract the sandboxDestroy function body
-    const destroyMatch = nemoclawSrc.match(
-      /async function sandboxDestroy[\s\S]*?^}/m,
-    );
+    const destroyMatch = nemoclawSrc.match(/async function sandboxDestroy[\s\S]*?^}/m);
     expect(destroyMatch).toBeTruthy();
     const destroyBody = destroyMatch[0];
 
@@ -37,7 +35,7 @@ describe("image cleanup: sandbox destroy removes Docker image (#2086)", () => {
 
   it("sandboxRebuild calls removeSandboxImage before registry.removeSandbox", () => {
     const rebuildMatch = nemoclawSrc.match(
-      /async function sandboxRebuild[\s\S]*?^  console\.log\(`\s*\$\{G\}.*Sandbox.*rebuilt/m,
+      /async function sandboxRebuild[\s\S]*?^\s*console\.log\(`\s*\$\{G\}.*Sandbox.*rebuilt/m,
     );
     expect(rebuildMatch).toBeTruthy();
     const rebuildBody = rebuildMatch[0];
@@ -51,9 +49,7 @@ describe("image cleanup: sandbox destroy removes Docker image (#2086)", () => {
 
   it("removeSandboxImage gracefully handles missing imageTag", () => {
     // The function should check for imageTag before attempting removal
-    const fnMatch = nemoclawSrc.match(
-      /function removeSandboxImage[\s\S]*?^}/m,
-    );
+    const fnMatch = nemoclawSrc.match(/function removeSandboxImage[\s\S]*?^}/m);
     expect(fnMatch).toBeTruthy();
     expect(fnMatch[0]).toContain("imageTag");
   });
@@ -73,8 +69,8 @@ describe("image cleanup: onboard records imageTag in registry (#2086)", () => {
 
   it("onboard recreate path cleans up old image", () => {
     // When recreating, the old image should be removed
-    expect(onboardSrc).toMatch(/oldEntry\?\.imageTag/);
-    expect(onboardSrc).toMatch(/docker.*rmi.*oldEntry\.imageTag/);
+    expect(onboardSrc).toMatch(/previousEntry\?\.imageTag/);
+    expect(onboardSrc).toMatch(/docker.*rmi.*previousEntry\.imageTag/);
   });
 });
 
@@ -87,9 +83,7 @@ describe("image cleanup: registry stores imageTag (#2086)", () => {
 
   it("registerSandbox persists imageTag", () => {
     // The registerSandbox function should include imageTag in the stored entry
-    const registerMatch = registrySrc.match(
-      /function registerSandbox[\s\S]*?^}/m,
-    );
+    const registerMatch = registrySrc.match(/function registerSandbox[\s\S]*?^}/m);
     expect(registerMatch).toBeTruthy();
     expect(registerMatch[0]).toContain("imageTag");
   });
@@ -110,9 +104,7 @@ describe("image cleanup: gc command exists (#2086)", () => {
   });
 
   it("garbageCollectImages lists sandbox-from images and cross-references registry", () => {
-    const gcMatch = nemoclawSrc.match(
-      /async function garbageCollectImages[\s\S]*?^}/m,
-    );
+    const gcMatch = nemoclawSrc.match(/async function garbageCollectImages[\s\S]*?^}/m);
     expect(gcMatch).toBeTruthy();
     const gcBody = gcMatch[0];
 

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -153,6 +153,29 @@ describe("registry", () => {
     });
   });
 
+  it("stores imageTag at registration time", () => {
+    registry.registerSandbox({
+      name: "tagged",
+      imageTag: "openshell/sandbox-from:1776766054",
+    });
+    const sb = registry.getSandbox("tagged");
+    expect(sb.imageTag).toBe("openshell/sandbox-from:1776766054");
+    const data = JSON.parse(fs.readFileSync(regFile, "utf-8"));
+    expect(data.sandboxes.tagged.imageTag).toBe("openshell/sandbox-from:1776766054");
+  });
+
+  it("imageTag defaults to null when not provided", () => {
+    registry.registerSandbox({ name: "no-tag" });
+    const sb = registry.getSandbox("no-tag");
+    expect(sb.imageTag).toBe(null);
+  });
+
+  it("imageTag can be updated via updateSandbox", () => {
+    registry.registerSandbox({ name: "updatable" });
+    registry.updateSandbox("updatable", { imageTag: "openshell/sandbox-from:9999" });
+    expect(registry.getSandbox("updatable").imageTag).toBe("openshell/sandbox-from:9999");
+  });
+
   it("handles corrupt registry file gracefully", () => {
     fs.mkdirSync(path.dirname(regFile), { recursive: true });
     fs.writeFileSync(regFile, "NOT JSON");


### PR DESCRIPTION
## Summary
- Track sandbox Docker image tags in the registry (`imageTag` field on `SandboxEntry`) so they can be cleaned up on `destroy` and `rebuild`
- Add `nemoclaw gc` command to find and remove orphaned `openshell/sandbox-from:*` images not associated with any registered sandbox
- Fix `removeSandboxImage()` to only report success when `docker rmi` actually succeeds, and remove redundant registry lookup in the onboard recreate path

## Test plan
- [x] `test/image-cleanup.test.ts` — 13 structural tests verifying cleanup wiring (all pass)
- [x] `test/registry.test.ts` — 3 new tests for `imageTag` storage, default null, and `updateSandbox` (all pass)
- [x] Full test suite: 1947 passed, 7 failed (all 7 are pre-existing environment failures on main)
- [x] Pre-commit hooks pass (lint, format, gitleaks, markdownlint, commitlint)
- [ ] Manual: run `nemoclaw gc --dry-run` on a host with orphaned images
- [ ] Manual: verify `nemoclaw <name> destroy` removes the sandbox image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `nemoclaw gc` with `--dry-run`, `--yes`, and `--force` to discover and remove orphaned sandbox images.

* **Improvements**
  * `nemoclaw <name> destroy` now also removes the host-side Docker image produced during onboarding.
  * `nemoclaw <name> rebuild` removes the old sandbox image before recreating.
  * Sandbox records now track image tags to enable cleanup.

* **Documentation**
  * Updated command reference and help text.

* **Tests**
  * Added tests for image-tag tracking, teardown/recreate cleanup, and the `gc` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->