### PR TITLE
fix(cli): fail fast on unsupported onboarding hosts

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2495,6 +2495,17 @@ async function preflight() {
   step(1, 8, "Preflight checks");
 
   const host = assessHost();
+  if (host.hostSupport && host.hostSupport.status === "error") {
+    console.error(`  ${host.hostSupport.message}`);
+    printRemediationActions(planHostRemediation(host));
+    process.exit(1);
+  }
+  if (host.hostSupport && host.hostSupport.status === "warning") {
+    console.log(`  ⚠ ${host.hostSupport.message}`);
+  }
+  if (host.hostSupport && host.hostSupport.status === "ok") {
+    console.log(`  ✓ ${host.hostSupport.message}`);
+  }
 
   // Docker / runtime
   if (!host.dockerReachable) {

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   assessHost,
   checkPortAvailable,
+  classifyHostSupport,
   getMemoryInfo,
   ensureSwap,
   planHostRemediation,
@@ -330,6 +331,8 @@ describe("assessHost", () => {
     });
 
     expect(result.isWsl).toBe(true);
+    expect(result.hostSupport?.status).toBe("warning");
+    expect(result.hostSupport?.code).toBe("CAVEATED_PLATFORM");
     expect(result.notes).toContain("Running under WSL");
   });
 
@@ -344,9 +347,128 @@ describe("assessHost", () => {
     expect(result.isHeadlessLikely).toBe(true);
     expect(result.notes).toContain("Headless environment likely");
   });
+
+  it("classifies macOS Apple Silicon as caveated", () => {
+    const result = assessHost({
+      platform: "darwin",
+      arch: "arm64",
+      env: {},
+      dockerInfoOutput: "",
+      commandExistsImpl: () => false,
+    });
+
+    expect(result.hostSupport?.status).toBe("warning");
+    expect(result.hostSupport?.code).toBe("CAVEATED_PLATFORM");
+  });
+
+  it("classifies macOS Intel as unsupported", () => {
+    const result = assessHost({
+      platform: "darwin",
+      arch: "x64",
+      env: {},
+      dockerInfoOutput: "",
+      commandExistsImpl: () => false,
+    });
+
+    expect(result.hostSupport?.status).toBe("error");
+    expect(result.hostSupport?.code).toBe("UNSUPPORTED_ARCH");
+  });
+
+  it("classifies native Windows as unsupported", () => {
+    const result = assessHost({
+      platform: "win32",
+      env: {},
+      commandExistsImpl: () => false,
+    });
+
+    expect(result.hostSupport?.status).toBe("error");
+    expect(result.hostSupport?.code).toBe("UNSUPPORTED_PLATFORM");
+  });
+});
+
+describe("classifyHostSupport", () => {
+  it("marks Linux as tested", () => {
+    const result = classifyHostSupport({ platform: "linux", isWsl: false });
+    expect(result.status).toBe("ok");
+    expect(result.code).toBe("TESTED_PLATFORM");
+  });
+
+  it("marks WSL as caveated", () => {
+    const result = classifyHostSupport({ platform: "linux", isWsl: true });
+    expect(result.status).toBe("warning");
+    expect(result.code).toBe("CAVEATED_PLATFORM");
+  });
 });
 
 describe("planHostRemediation", () => {
+  it("returns a blocking unsupported-host action for native Windows", () => {
+    const actions = planHostRemediation({
+      platform: "win32",
+      isWsl: false,
+      runtime: "unknown",
+      packageManager: "unknown",
+      systemctlAvailable: false,
+      dockerServiceActive: null,
+      dockerServiceEnabled: null,
+      dockerInstalled: false,
+      dockerRunning: false,
+      dockerReachable: false,
+      nodeInstalled: true,
+      openshellInstalled: true,
+      dockerCgroupVersion: "unknown",
+      dockerDefaultCgroupnsMode: "unknown",
+      requiresHostCgroupnsFix: false,
+      isUnsupportedRuntime: false,
+      isHeadlessLikely: false,
+      hasNvidiaGpu: false,
+      hostSupport: {
+        status: "error",
+        code: "UNSUPPORTED_PLATFORM",
+        message: "Native Windows host detected: run NemoClaw inside WSL2 with Docker Desktop backend.",
+      },
+      notes: [],
+    });
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0].id).toBe("unsupported_host_platform");
+    expect(actions[0].blocking).toBe(true);
+    expect(actions[0].commands.join("\n")).toMatch(/WSL2/);
+  });
+
+  it("adds a non-blocking caveat action for macOS Apple Silicon", () => {
+    const actions = planHostRemediation({
+      platform: "darwin",
+      arch: "arm64",
+      isWsl: false,
+      runtime: "docker-desktop",
+      packageManager: "brew",
+      systemctlAvailable: false,
+      dockerServiceActive: null,
+      dockerServiceEnabled: null,
+      dockerInstalled: true,
+      dockerRunning: true,
+      dockerReachable: true,
+      nodeInstalled: true,
+      openshellInstalled: true,
+      dockerCgroupVersion: "unknown",
+      dockerDefaultCgroupnsMode: "unknown",
+      requiresHostCgroupnsFix: false,
+      isUnsupportedRuntime: false,
+      isHeadlessLikely: false,
+      hasNvidiaGpu: false,
+      hostSupport: {
+        status: "warning",
+        code: "CAVEATED_PLATFORM",
+        message: "macOS (Apple Silicon) host detected: tested with limitations.",
+      },
+      notes: [],
+    });
+
+    const caveat = actions.find((action: { id: string }) => action.id === "host_platform_caveat");
+    expect(caveat).toBeTruthy();
+    expect(caveat?.blocking).toBe(false);
+  });
+
   it("recommends starting docker when installed but unreachable and service inactive", () => {
     const actions = planHostRemediation({
       platform: "linux",

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -85,8 +85,23 @@ export type PackageManager = "apt" | "dnf" | "yum" | "brew" | "pacman" | "unknow
 
 export type RemediationKind = "info" | "manual" | "auto" | "sudo";
 
+export type HostSupportStatus = "ok" | "warning" | "error";
+
+export type HostSupportCode =
+  | "TESTED_PLATFORM"
+  | "CAVEATED_PLATFORM"
+  | "UNSUPPORTED_PLATFORM"
+  | "UNSUPPORTED_ARCH";
+
+export interface HostSupportAssessment {
+  status: HostSupportStatus;
+  code: HostSupportCode;
+  message: string;
+}
+
 export interface HostAssessment {
   platform: NodeJS.Platform | string;
+  arch?: string;
   isWsl: boolean;
   runtime: ContainerRuntime;
   packageManager?: PackageManager;
@@ -105,6 +120,7 @@ export interface HostAssessment {
   isUnsupportedRuntime: boolean;
   isHeadlessLikely: boolean;
   hasNvidiaGpu: boolean;
+  hostSupport?: HostSupportAssessment;
   notes: string[];
 }
 
@@ -119,6 +135,7 @@ export interface RemediationAction {
 
 export interface AssessHostOpts {
   platform?: NodeJS.Platform;
+  arch?: string;
   env?: NodeJS.ProcessEnv;
   release?: string;
   procVersion?: string;
@@ -246,8 +263,91 @@ function parseSystemctlState(value = ""): boolean | null {
   return null;
 }
 
+function hostSupportCommands(hostSupport: HostSupportAssessment): string[] {
+  if (hostSupport.code === "UNSUPPORTED_PLATFORM") {
+    return [
+      "Use a tested platform from docs/get-started/quickstart.md.",
+      "If you are on Windows, run NemoClaw inside WSL2 with Docker Desktop backend.",
+      "Then rerun `nemoclaw onboard`.",
+    ];
+  }
+
+  if (hostSupport.code === "UNSUPPORTED_ARCH") {
+    return [
+      "Use macOS on Apple Silicon or Linux from the tested platform matrix.",
+      "Then rerun `nemoclaw onboard`.",
+    ];
+  }
+
+  if (hostSupport.code === "CAVEATED_PLATFORM") {
+    return [
+      "Continue if this setup matches your environment, or switch to the primary Linux + Docker path.",
+      "If onboarding fails, follow the troubleshooting guide and rerun `nemoclaw onboard`.",
+    ];
+  }
+
+  return [];
+}
+
+export function classifyHostSupport(opts: {
+  platform: NodeJS.Platform | string;
+  arch?: string;
+  isWsl?: boolean;
+}): HostSupportAssessment {
+  const platform = opts.platform;
+  const arch = String(opts.arch || "");
+  const isWsl = Boolean(opts.isWsl);
+
+  if (platform === "linux" && !isWsl) {
+    return {
+      status: "ok",
+      code: "TESTED_PLATFORM",
+      message: "Linux host detected: tested platform.",
+    };
+  }
+
+  if (platform === "linux" && isWsl) {
+    return {
+      status: "warning",
+      code: "CAVEATED_PLATFORM",
+      message: "Windows WSL2 host detected: tested with limitations.",
+    };
+  }
+
+  if (platform === "darwin" && arch === "arm64") {
+    return {
+      status: "warning",
+      code: "CAVEATED_PLATFORM",
+      message: "macOS (Apple Silicon) host detected: tested with limitations.",
+    };
+  }
+
+  if (platform === "darwin" && !arch) {
+    return {
+      status: "warning",
+      code: "CAVEATED_PLATFORM",
+      message: "macOS host detected: tested with limitations on Apple Silicon.",
+    };
+  }
+
+  if (platform === "darwin") {
+    return {
+      status: "error",
+      code: "UNSUPPORTED_ARCH",
+      message: "macOS Intel host detected: unsupported platform for NemoClaw onboarding.",
+    };
+  }
+
+  return {
+    status: "error",
+    code: "UNSUPPORTED_PLATFORM",
+    message: `${platform} host detected: unsupported platform for NemoClaw onboarding.`,
+  };
+}
+
 export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   const platform = opts.platform ?? process.platform;
+  const arch = opts.arch ?? process.arch;
   const env = opts.env ?? process.env;
   const runCaptureImpl =
     opts.runCaptureImpl ??
@@ -302,9 +402,12 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     platform === "linux" && systemctlAvailable && dockerInstalled
       ? parseSystemctlState(runCaptureImpl("systemctl is-enabled docker", { ignoreError: true }))
       : null;
+  const isWsl = detectWsl({ platform, env, release, procVersion });
+  const hostSupport = classifyHostSupport({ platform, arch, isWsl });
   const assessment: HostAssessment = {
     platform,
-    isWsl: detectWsl({ platform, env, release, procVersion }),
+    arch,
+    isWsl,
     runtime,
     packageManager,
     systemctlAvailable,
@@ -323,6 +426,7 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     isUnsupportedRuntime: runtime === "podman",
     isHeadlessLikely: isHeadlessLikely(env),
     hasNvidiaGpu,
+    hostSupport,
     notes: [],
   };
 
@@ -341,6 +445,36 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
 
 export function planHostRemediation(assessment: HostAssessment): RemediationAction[] {
   const actions: RemediationAction[] = [];
+  const hostSupport =
+    assessment.hostSupport ??
+    classifyHostSupport({
+      platform: assessment.platform,
+      arch: assessment.arch,
+      isWsl: assessment.isWsl,
+    });
+
+  if (hostSupport.status === "error") {
+    actions.push({
+      id: "unsupported_host_platform",
+      title: "Use a tested host platform",
+      kind: "manual",
+      reason: hostSupport.message,
+      commands: hostSupportCommands(hostSupport),
+      blocking: true,
+    });
+    return actions;
+  }
+
+  if (hostSupport.status === "warning") {
+    actions.push({
+      id: "host_platform_caveat",
+      title: "Host platform is tested with limitations",
+      kind: "info",
+      reason: hostSupport.message,
+      commands: hostSupportCommands(hostSupport),
+      blocking: false,
+    });
+  }
 
   if (!assessment.dockerInstalled) {
     const installCommands: Record<PackageManager, string> = {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -5199,4 +5199,19 @@ const { createSandbox } = require(${onboardPath});
       "pullAndResolveBaseImageDigest must be called BEFORE patchStagedDockerfile — regression #1904",
     );
   });
+
+  it("fails fast on unsupported host platform before Docker reachability checks", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+    const hostSupportCheck = source.indexOf('host.hostSupport && host.hostSupport.status === "error"');
+    assert.ok(hostSupportCheck !== -1, "unsupported host-support check not found in preflight()");
+    const dockerCheck = source.indexOf("if (!host.dockerReachable)");
+    assert.ok(dockerCheck !== -1, "docker reachability check not found in preflight()");
+    assert.ok(
+      hostSupportCheck < dockerCheck,
+      "unsupported host-support check must run before docker reachability checks",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- revive the intent of closed #1461 on top of current `main` architecture (`src/lib/*`)
- classify host platform support in preflight as `ok` / `warning` / `error`
- fail fast in onboarding when host support is `error`, before Docker reachability checks
- keep caveated hosts non-blocking with explicit guidance

## Why this is a new PR
#1461 was closed on 2026-04-08 pending final policy decisions around supported / unsupported-warn / unsupported-err host behavior. This PR applies a narrowed implementation that matches current repo structure and current tested/caveated policy framing.

## Scope
- `src/lib/preflight.ts`
- `src/lib/onboard.ts`
- `src/lib/preflight.test.ts`
- `test/onboard.test.ts`

## Validation
- `npm run build:cli`
- `npx vitest run src/lib/preflight.test.ts`
- `npx vitest run test/onboard.test.ts -t "fails fast on unsupported host platform before Docker reachability checks"`
- `npx vitest run test/install-preflight.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host platform and architecture validation during preflight checks to detect compatibility status.
  * Unsupported platforms now fail immediately with remediation guidance.
  * Caveated platforms (such as WSL or Apple Silicon macOS) display informational warnings.

* **Tests**
  * Added comprehensive platform compatibility test coverage for macOS, Windows, WSL, and Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->