### PR TITLE
docs: catch up reference and troubleshooting docs for v0.0.21

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -374,6 +374,11 @@ $ NEMOCLAW_EXPERIMENTAL=1 nemoclaw onboard
 Select **Local NVIDIA NIM [experimental]** from the provider list.
 NemoClaw filters available models by GPU VRAM, pulls the NIM container image, starts it, and waits for it to become healthy before continuing.
 
+NIM container images are hosted on `nvcr.io` and require NGC registry authentication before `docker pull` succeeds.
+If Docker is not already logged in to `nvcr.io`, onboard prompts for an [NGC API key](https://org.ngc.nvidia.com/setup/api-key) and runs `docker login nvcr.io` over `--password-stdin` so the key is never written to disk or shell history.
+The prompt masks the key during input and retries once on a bad key before failing.
+In non-interactive mode, onboard exits with login instructions if Docker is not already authenticated; run `docker login nvcr.io` yourself, then re-run `nemoclaw onboard --non-interactive`.
+
 > **Note:** NIM uses vLLM internally.
 > The same `chat/completions` API path restriction applies.
 

--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -188,6 +188,18 @@ $ openshell policy set --policy nemoclaw-blueprint/policies/presets/pypi.yaml my
 
 To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.
 
+For scripted workflows, `policy-add` and `policy-remove` accept the preset name as a positional argument:
+
+```console
+$ nemoclaw my-assistant policy-add pypi --yes
+$ nemoclaw my-assistant policy-remove pypi --yes
+```
+
+Set `NEMOCLAW_NON_INTERACTIVE=1` instead of `--yes` to drive the same flow from an environment variable.
+See Commands (use the `nemoclaw-user-reference` skill) for the full flag reference.
+
+`nemoclaw <name> rebuild` reapplies every policy preset to the recreated sandbox, so presets survive an agent-version upgrade without manual reapplication.
+
 ## Related Skills
 
 - `nemoclaw-user-reference` — Network Policies (use the `nemoclaw-user-reference` skill) for the full baseline policy reference

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -149,6 +149,7 @@ If a `--resume` is attempted with a different `--from` path than the original se
 ### `nemoclaw list`
 
 List all registered sandboxes with their model, provider, and policy presets.
+Sandboxes with an active SSH session are marked with a `●` indicator so you can tell at a glance which sandbox you are already connected to in another terminal.
 
 ```console
 $ nemoclaw list
@@ -172,6 +173,11 @@ Connect to a sandbox by name.
 On a TTY, a one-shot hint prints before dropping into the sandbox shell, reminding you to run `openclaw tui` inside.
 Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `nemoclaw <name> rebuild` hint.
+If another terminal is already connected to the sandbox, `connect` prints a note with the number of existing sessions before proceeding. Multiple concurrent sessions are allowed.
+
+After a host reboot, the OpenShell gateway rotates its SSH host keys.
+`connect` detects the resulting identity drift, prunes stale `openshell-*` entries from `~/.ssh/known_hosts`, and retries automatically.
+You no longer need to re-run `nemoclaw onboard` after a reboot in this case.
 
 ```console
 $ nemoclaw my-assistant connect
@@ -180,8 +186,20 @@ $ nemoclaw my-assistant connect
 ### `nemoclaw <name> status`
 
 Show sandbox status, health, and inference configuration.
-For local Ollama and local vLLM routes, the command also probes the host-side health endpoint and reports whether the backend is reachable.
-If the backend is down, the output includes an `Inference: unreachable` line with the local URL and a remediation hint.
+
+The command probes every inference provider and reports one of three states on the `Inference` line:
+
+| State | Meaning |
+|-------|---------|
+| `healthy` | The provider endpoint returned a reachable response. |
+| `unreachable` | The probe failed. The output includes the endpoint URL and a remediation hint. |
+| `not probed` | The endpoint URL is not known (for example, `compatible-*` providers). |
+
+Local providers (Ollama, vLLM) probe the host-side health endpoint.
+Remote providers (NVIDIA Endpoints, OpenAI, Anthropic, Gemini) use a lightweight reachability check; any HTTP response, including `401` or `403`, counts as reachable.
+No API keys are sent.
+
+A `Connected` line reports whether the sandbox has any active SSH sessions and, if so, how many.
 
 The Policy section displays the live enforced policy (fetched via `openshell policy get --full`), which reflects presets added or removed after sandbox creation.
 If the sandbox is running an outdated agent version, the output includes an `Update` line with the available version and a `nemoclaw <name> rebuild` hint.
@@ -212,6 +230,9 @@ This removes the sandbox from the registry.
 > Back up your workspace first with `nemoclaw <name> snapshot create` or see Backup and Restore (use the `nemoclaw-user-workspace` skill).
 > If you want to upgrade the sandbox while preserving state, use `nemoclaw <name> rebuild` instead.
 
+If another terminal has an active SSH session to the sandbox, `destroy` prints an active-session warning and requires a second confirmation before it proceeds.
+Pass `--yes` or `--force` to skip the prompt in scripted workflows.
+
 ```console
 $ nemoclaw my-assistant destroy
 ```
@@ -226,8 +247,19 @@ Before applying, the command shows which endpoints the preset would open and pro
 $ nemoclaw my-assistant policy-add
 ```
 
+To apply a specific preset without the interactive picker, pass its name as a positional argument:
+
+```console
+$ nemoclaw my-assistant policy-add pypi --yes
+```
+
+The positional form is required in scripted workflows.
+Set `NEMOCLAW_NON_INTERACTIVE=1` instead of `--yes` if you want the same behavior from an environment variable.
+If the preset name is unknown or already applied, the command exits non-zero with a clear error.
+
 | Flag | Description |
 |------|-------------|
+| `--yes`, `--force` | Skip the confirmation prompt (requires a preset name) |
 | `--dry-run` | Preview the endpoints a preset would open without applying changes |
 
 Use `--dry-run` to audit a preset before applying it:
@@ -239,6 +271,8 @@ $ nemoclaw my-assistant policy-add --dry-run
 ### `nemoclaw <name> policy-list`
 
 List available policy presets and show which ones are applied to the sandbox.
+The command cross-references the local registry against the live gateway state (via `openshell policy get`), so it flags presets that are applied in one place but not the other.
+This catches desync caused by external edits to the gateway policy or stale registry entries after a manual rollback.
 
 ```console
 $ nemoclaw my-assistant policy-list
@@ -253,8 +287,18 @@ The command lists only the presets currently applied, prompts you to select one,
 $ nemoclaw my-assistant policy-remove
 ```
 
+To remove a specific preset non-interactively, pass its name as a positional argument:
+
+```console
+$ nemoclaw my-assistant policy-remove pypi --yes
+```
+
+Set `NEMOCLAW_NON_INTERACTIVE=1` as an alternative to `--yes`.
+If the preset is unknown or not currently applied, the command exits non-zero with a clear error.
+
 | Flag | Description |
 |------|-------------|
+| `--yes`, `--force` | Skip the confirmation prompt (requires a preset name) |
 | `--dry-run` | Preview which endpoints would be removed without applying changes |
 
 Unchecking a preset in the onboard TUI checkbox also removes it from the sandbox.
@@ -325,6 +369,7 @@ For new installs, the agent session index is refreshed so the agent discovers th
 Upgrade a sandbox to the current agent version while preserving workspace state.
 The command backs up workspace state, destroys the old sandbox (including its host-side Docker image), recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
 Credentials are stripped from backups before storage.
+Policy presets applied to the old sandbox are reapplied to the new one so your egress rules survive the rebuild.
 
 ```console
 $ nemoclaw my-assistant rebuild [--yes] [--verbose]
@@ -334,6 +379,9 @@ $ nemoclaw my-assistant rebuild [--yes] [--verbose]
 |------|-------------|
 | `--yes`, `--force` | Skip the confirmation prompt |
 | `--verbose` | Log SSH commands, exit codes, and session state (also enabled by `NEMOCLAW_REBUILD_VERBOSE=1`) |
+
+If another terminal has an active SSH session to the sandbox, `rebuild` prints an active-session warning and requires confirmation before destroying the sandbox.
+Pass `--yes` or `--force` to skip the prompt in scripted workflows.
 
 The sandbox must be running for the backup step to succeed.
 After restore, the command runs `openclaw doctor --fix` for cross-version structure repair.

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -135,7 +135,8 @@ See Environment Variables (use the `nemoclaw-user-reference` skill) for the full
 ### Running multiple sandboxes simultaneously
 
 Each sandbox requires its own dashboard port.
-If you onboard a second sandbox without overriding the port, onboarding fails because port `18789` is already claimed by the first sandbox.
+If you onboard a second sandbox without overriding the port, onboarding fails with a clear error because port `18789` is already forwarded to the first sandbox.
+`onboard` checks `openshell forward list` before starting a new forward, so a second onboard cannot silently take over the first sandbox's port.
 
 Assign a distinct port to each sandbox at onboard time:
 
@@ -305,6 +306,10 @@ Follow these steps to reconnect.
    $ nemoclaw <name> connect
    ```
 
+   The gateway usually rotates its SSH host keys across a reboot.
+   `connect` detects the resulting identity drift, prunes the stale `openshell-*` entries from `~/.ssh/known_hosts`, and retries automatically.
+   You do not need to edit `known_hosts` by hand or re-run `nemoclaw onboard` in this case.
+
 1. Start host auxiliary services (if needed).
 
    If you use the cloudflared tunnel started by `nemoclaw start`, start it again:
@@ -436,6 +441,18 @@ $ nemoclaw <sandbox> channels remove <telegram|discord|slack>
 
 `channels add` stores credentials under `~/.nemoclaw/credentials.json` and `channels remove` clears them; both offer to rebuild the sandbox so the image reflects the new channel set.
 In non-interactive mode (`NEMOCLAW_NON_INTERACTIVE=1`), the commands stage the change and leave the rebuild to a follow-up `nemoclaw <sandbox> rebuild`.
+
+### `openclaw config set` or `unset` is blocked inside the sandbox
+
+This is expected.
+The sandbox's OpenClaw configuration (`/sandbox/.openclaw/openclaw.json`) is baked into the container image at build time and mounted read-only at runtime.
+NemoClaw's sandbox entrypoint installs a guard that intercepts `openclaw config set` and `openclaw config unset` and prints an actionable error instead of letting the call fail with a raw permission error.
+
+Rebuild the sandbox from the host to change its OpenClaw configuration:
+
+```console
+$ nemoclaw <sandbox> rebuild
+```
 
 ### `openclaw doctor --fix` cannot repair Discord channel config inside the sandbox
 

--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -234,6 +234,11 @@ $ NEMOCLAW_EXPERIMENTAL=1 nemoclaw onboard
 Select **Local NVIDIA NIM [experimental]** from the provider list.
 NemoClaw filters available models by GPU VRAM, pulls the NIM container image, starts it, and waits for it to become healthy before continuing.
 
+NIM container images are hosted on `nvcr.io` and require NGC registry authentication before `docker pull` succeeds.
+If Docker is not already logged in to `nvcr.io`, onboard prompts for an [NGC API key](https://org.ngc.nvidia.com/setup/api-key) and runs `docker login nvcr.io` over `--password-stdin` so the key is never written to disk or shell history.
+The prompt masks the key during input and retries once on a bad key before failing.
+In non-interactive mode, onboard exits with login instructions if Docker is not already authenticated; run `docker login nvcr.io` yourself, then re-run `nemoclaw onboard --non-interactive`.
+
 :::{note}
 NIM uses vLLM internally.
 The same `chat/completions` API path restriction applies.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -155,6 +155,18 @@ $ openshell policy set --policy nemoclaw-blueprint/policies/presets/pypi.yaml my
 
 To include a preset in the baseline, merge its entries into `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.
 
+For scripted workflows, `policy-add` and `policy-remove` accept the preset name as a positional argument:
+
+```console
+$ nemoclaw my-assistant policy-add pypi --yes
+$ nemoclaw my-assistant policy-remove pypi --yes
+```
+
+Set `NEMOCLAW_NON_INTERACTIVE=1` instead of `--yes` to drive the same flow from an environment variable.
+See [Commands](../reference/commands.md#nemoclaw-name-policy-add) for the full flag reference.
+
+`nemoclaw <name> rebuild` reapplies every policy preset to the recreated sandbox, so presets survive an agent-version upgrade without manual reapplication.
+
 ## Related Topics
 
 - [Approve or Deny Agent Network Requests](approve-network-requests.md) for real-time operator approval.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -171,6 +171,7 @@ If a `--resume` is attempted with a different `--from` path than the original se
 ### `nemoclaw list`
 
 List all registered sandboxes with their model, provider, and policy presets.
+Sandboxes with an active SSH session are marked with a `●` indicator so you can tell at a glance which sandbox you are already connected to in another terminal.
 
 ```console
 $ nemoclaw list
@@ -196,6 +197,11 @@ Connect to a sandbox by name.
 On a TTY, a one-shot hint prints before dropping into the sandbox shell, reminding you to run `openclaw tui` inside.
 Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `nemoclaw <name> rebuild` hint.
+If another terminal is already connected to the sandbox, `connect` prints a note with the number of existing sessions before proceeding. Multiple concurrent sessions are allowed.
+
+After a host reboot, the OpenShell gateway rotates its SSH host keys.
+`connect` detects the resulting identity drift, prunes stale `openshell-*` entries from `~/.ssh/known_hosts`, and retries automatically.
+You no longer need to re-run `nemoclaw onboard` after a reboot in this case.
 
 ```console
 $ nemoclaw my-assistant connect
@@ -204,8 +210,20 @@ $ nemoclaw my-assistant connect
 ### `nemoclaw <name> status`
 
 Show sandbox status, health, and inference configuration.
-For local Ollama and local vLLM routes, the command also probes the host-side health endpoint and reports whether the backend is reachable.
-If the backend is down, the output includes an `Inference: unreachable` line with the local URL and a remediation hint.
+
+The command probes every inference provider and reports one of three states on the `Inference` line:
+
+| State | Meaning |
+|-------|---------|
+| `healthy` | The provider endpoint returned a reachable response. |
+| `unreachable` | The probe failed. The output includes the endpoint URL and a remediation hint. |
+| `not probed` | The endpoint URL is not known (for example, `compatible-*` providers). |
+
+Local providers (Ollama, vLLM) probe the host-side health endpoint.
+Remote providers (NVIDIA Endpoints, OpenAI, Anthropic, Gemini) use a lightweight reachability check; any HTTP response, including `401` or `403`, counts as reachable.
+No API keys are sent.
+
+A `Connected` line reports whether the sandbox has any active SSH sessions and, if so, how many.
 
 The Policy section displays the live enforced policy (fetched via `openshell policy get --full`), which reflects presets added or removed after sandbox creation.
 If the sandbox is running an outdated agent version, the output includes an `Update` line with the available version and a `nemoclaw <name> rebuild` hint.
@@ -238,6 +256,9 @@ Back up your workspace first with `nemoclaw <name> snapshot create` or see [Back
 If you want to upgrade the sandbox while preserving state, use `nemoclaw <name> rebuild` instead.
 :::
 
+If another terminal has an active SSH session to the sandbox, `destroy` prints an active-session warning and requires a second confirmation before it proceeds.
+Pass `--yes` or `--force` to skip the prompt in scripted workflows.
+
 ```console
 $ nemoclaw my-assistant destroy
 ```
@@ -252,8 +273,19 @@ Before applying, the command shows which endpoints the preset would open and pro
 $ nemoclaw my-assistant policy-add
 ```
 
+To apply a specific preset without the interactive picker, pass its name as a positional argument:
+
+```console
+$ nemoclaw my-assistant policy-add pypi --yes
+```
+
+The positional form is required in scripted workflows.
+Set `NEMOCLAW_NON_INTERACTIVE=1` instead of `--yes` if you want the same behavior from an environment variable.
+If the preset name is unknown or already applied, the command exits non-zero with a clear error.
+
 | Flag | Description |
 |------|-------------|
+| `--yes`, `--force` | Skip the confirmation prompt (requires a preset name) |
 | `--dry-run` | Preview the endpoints a preset would open without applying changes |
 
 Use `--dry-run` to audit a preset before applying it:
@@ -265,6 +297,8 @@ $ nemoclaw my-assistant policy-add --dry-run
 ### `nemoclaw <name> policy-list`
 
 List available policy presets and show which ones are applied to the sandbox.
+The command cross-references the local registry against the live gateway state (via `openshell policy get`), so it flags presets that are applied in one place but not the other.
+This catches desync caused by external edits to the gateway policy or stale registry entries after a manual rollback.
 
 ```console
 $ nemoclaw my-assistant policy-list
@@ -279,8 +313,18 @@ The command lists only the presets currently applied, prompts you to select one,
 $ nemoclaw my-assistant policy-remove
 ```
 
+To remove a specific preset non-interactively, pass its name as a positional argument:
+
+```console
+$ nemoclaw my-assistant policy-remove pypi --yes
+```
+
+Set `NEMOCLAW_NON_INTERACTIVE=1` as an alternative to `--yes`.
+If the preset is unknown or not currently applied, the command exits non-zero with a clear error.
+
 | Flag | Description |
 |------|-------------|
+| `--yes`, `--force` | Skip the confirmation prompt (requires a preset name) |
 | `--dry-run` | Preview which endpoints would be removed without applying changes |
 
 Unchecking a preset in the onboard TUI checkbox also removes it from the sandbox.
@@ -351,6 +395,7 @@ For new installs, the agent session index is refreshed so the agent discovers th
 Upgrade a sandbox to the current agent version while preserving workspace state.
 The command backs up workspace state, destroys the old sandbox (including its host-side Docker image), recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
 Credentials are stripped from backups before storage.
+Policy presets applied to the old sandbox are reapplied to the new one so your egress rules survive the rebuild.
 
 ```console
 $ nemoclaw my-assistant rebuild [--yes] [--verbose]
@@ -360,6 +405,9 @@ $ nemoclaw my-assistant rebuild [--yes] [--verbose]
 |------|-------------|
 | `--yes`, `--force` | Skip the confirmation prompt |
 | `--verbose` | Log SSH commands, exit codes, and session state (also enabled by `NEMOCLAW_REBUILD_VERBOSE=1`) |
+
+If another terminal has an active SSH session to the sandbox, `rebuild` prints an active-session warning and requires confirmation before destroying the sandbox.
+Pass `--yes` or `--force` to skip the prompt in scripted workflows.
 
 The sandbox must be running for the backup step to succeed.
 After restore, the command runs `openclaw doctor --fix` for cross-version structure repair.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -161,7 +161,8 @@ See [Environment Variables](commands.md#environment-variables) for the full list
 ### Running multiple sandboxes simultaneously
 
 Each sandbox requires its own dashboard port.
-If you onboard a second sandbox without overriding the port, onboarding fails because port `18789` is already claimed by the first sandbox.
+If you onboard a second sandbox without overriding the port, onboarding fails with a clear error because port `18789` is already forwarded to the first sandbox.
+`onboard` checks `openshell forward list` before starting a new forward, so a second onboard cannot silently take over the first sandbox's port.
 
 Assign a distinct port to each sandbox at onboard time:
 
@@ -331,6 +332,10 @@ Follow these steps to reconnect.
    $ nemoclaw <name> connect
    ```
 
+   The gateway usually rotates its SSH host keys across a reboot.
+   `connect` detects the resulting identity drift, prunes the stale `openshell-*` entries from `~/.ssh/known_hosts`, and retries automatically.
+   You do not need to edit `known_hosts` by hand or re-run `nemoclaw onboard` in this case.
+
 1. Start host auxiliary services (if needed).
 
    If you use the cloudflared tunnel started by `nemoclaw start`, start it again:
@@ -466,6 +471,18 @@ $ nemoclaw <sandbox> channels remove <telegram|discord|slack>
 
 `channels add` stores credentials under `~/.nemoclaw/credentials.json` and `channels remove` clears them; both offer to rebuild the sandbox so the image reflects the new channel set.
 In non-interactive mode (`NEMOCLAW_NON_INTERACTIVE=1`), the commands stage the change and leave the rebuild to a follow-up `nemoclaw <sandbox> rebuild`.
+
+### `openclaw config set` or `unset` is blocked inside the sandbox
+
+This is expected.
+The sandbox's OpenClaw configuration (`/sandbox/.openclaw/openclaw.json`) is baked into the container image at build time and mounted read-only at runtime.
+NemoClaw's sandbox entrypoint installs a guard that intercepts `openclaw config set` and `openclaw config unset` and prints an actionable error instead of letting the call fail with a raw permission error.
+
+Rebuild the sandbox from the host to change its OpenClaw configuration:
+
+```console
+$ nemoclaw <sandbox> rebuild
+```
 
 ### `openclaw doctor --fix` cannot repair Discord channel config inside the sandbox
 


### PR DESCRIPTION
## Summary

Catches up the user-facing reference and troubleshooting docs with the CLI and policy behavior changes that landed in v0.0.21. Drafted via the `nemoclaw-contributor-update-docs` skill against commits in `v0.0.20..v0.0.21`, filtered through `docs/.docs-skip`.

## Changes

- **`docs/reference/commands.md`**
  - `nemoclaw list`: session indicator (●) for connected sandboxes (#2117).
  - `nemoclaw <name> connect`: active-session note; auto-recovery from SSH identity drift after a host reboot (#2117, #2064).
  - `nemoclaw <name> status`: three-state Inference line (`healthy` / `unreachable` / `not probed`) covering both local and remote providers; new `Connected` line (#2002, #2117).
  - `nemoclaw <name> destroy` and `rebuild`: active-session warning with second confirm; rebuild reapplies policy presets to the recreated sandbox (#2117, #2026).
  - `nemoclaw <name> policy-add` and `policy-remove`: positional preset argument and non-interactive flow via `--yes`/`--force`/`NEMOCLAW_NON_INTERACTIVE=1` (#2070).
  - `nemoclaw <name> policy-list`: registry-vs-gateway desync detection (#2089).
- **`docs/reference/troubleshooting.md`**
  - `Reconnect after a host reboot`: now reflects automatic stale `known_hosts` pruning on `connect` (#2064).
  - `Running multiple sandboxes simultaneously`: onboard's forward-port collision guard (#2086).
  - New section: `openclaw config set` or `unset` is blocked inside the sandbox (#2081).
- **`docs/network-policy/customize-network-policy.md`**: non-interactive `policy-add`/`policy-remove` form; preset preservation across rebuild (#2070, #2026).
- **`docs/inference/use-local-inference.md`**: NIM section now covers the NGC API key prompt with masked input and `docker login nvcr.io --password-stdin` behavior (#2043).
- **Generated skills regenerated** to pick up the source changes (`.agents/skills/nemoclaw-user-reference/references/{commands,troubleshooting}.md`, plus minor heading-flow deltas elsewhere). The pre-commit `Regenerate agent skills from docs` hook ran and confirmed source ↔ generated parity.

Commits skipped per `docs/.docs-skip` or no doc impact: `bbbaa0fb` (skip-features), `7cb482cb` (skip-features), `8dee23fd` (skip-terms), plus the usual CI / test / refactor / install-plumbing churn.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes for the modified files (the one failing test, `test/cli.test.ts > unknown command exits 1`, also fails on `origin/main` and is unrelated to these markdown-only changes)
- [ ] `npm test` passes — skipped; same pre-existing CLI-dispatch test failure unrelated to docs
- [ ] Tests added or updated for new or changed behavior — n/a, doc-only
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only) — not run locally
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — n/a, no new pages

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-session SSH connections with concurrent session support.
  * Three-state inference health reporting (healthy/unreachable/not probed) across all providers.
  * Automatic SSH host key rotation detection and recovery.
  * Non-interactive policy preset management via positional arguments.
  * Session indicators in sandbox list view.

* **Bug Fixes**
  * Protected destructive operations with active-session warnings.
  * Policy presets now preserved during sandbox rebuilds.

* **Documentation**
  * NGC registry authentication requirements for container images.
  * Multi-sandbox onboarding and reconnection guidance.
  * Troubleshooting updates for port conflicts and SSH issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->