### PR TITLE
fix(ci): revert #2186 and use direct symlink for nemoclaw CLI on Brev

### DIFF
--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -249,17 +249,6 @@ npm run build 2>&1 | tail -3
 cd "$NEMOCLAW_CLONE_DIR"
 info "Plugin built"
 
-# Create the global nemoclaw symlink once during setup. This runs here
-# (before any test) so the cold-path npm link cost is absorbed by the
-# launchable's own readiness window rather than a later test's tight
-# execSync timeout. When the test suite rsyncs PR branch code over this
-# clone, a subsequent `npm link` is a fast no-op against the existing
-# symlink. See PR #1888 regression commentary.
-info "Linking nemoclaw CLI globally..."
-sudo npm link 2>&1 | tail -3
-sudo chown -R "$TARGET_USER":"$TARGET_USER" "$NEMOCLAW_CLONE_DIR"
-info "nemoclaw CLI linked"
-
 # ══════════════════════════════════════════════════════════════════════
 # 6. Pre-pull Docker images
 # ══════════════════════════════════════════════════════════════════════

--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -249,6 +249,16 @@ npm run build 2>&1 | tail -3
 cd "$NEMOCLAW_CLONE_DIR"
 info "Plugin built"
 
+# Expose the nemoclaw CLI on PATH. Earlier this was `sudo npm link`, but
+# on cold CPU Brev that routinely hangs inside npm's global-prefix
+# housekeeping and `sudo chown -R node_modules` traversal (≥20 min in
+# CI). npm link just creates two symlinks in the end; do them directly
+# so setup stays deterministic and fast.
+info "Linking nemoclaw CLI (direct symlink)..."
+sudo ln -sf "$NEMOCLAW_CLONE_DIR/bin/nemoclaw.js" /usr/local/bin/nemoclaw
+sudo chmod +x "$NEMOCLAW_CLONE_DIR/bin/nemoclaw.js"
+info "nemoclaw CLI linked at /usr/local/bin/nemoclaw"
+
 # ══════════════════════════════════════════════════════════════════════
 # 6. Pre-pull Docker images
 # ══════════════════════════════════════════════════════════════════════

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -426,9 +426,7 @@ function bootstrapLaunchable(elapsed) {
   // Install nemoclaw CLI.
   // Use `sudo npm link` because Node.js is installed system-wide via
   // nodesource (global prefix is /usr), so creating the global symlink
-  // requires elevated permissions. The launchable setup script already
-  // runs this once during its readiness window, so this invocation is a
-  // fast idempotent no-op against the existing symlink on Brev CPU runs.
+  // requires elevated permissions.
   console.log(`[${elapsed()}] Installing nemoclaw CLI (npm link)...`);
   ssh(
     `source ~/.nvm/nvm.sh 2>/dev/null || true && cd ${resolvedRemoteDir} && sudo npm link && sudo chown -R $(whoami):$(whoami) ${resolvedRemoteDir}`,

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -423,15 +423,17 @@ function bootstrapLaunchable(elapsed) {
   );
   console.log(`[${elapsed()}] Plugin built`);
 
-  // Install nemoclaw CLI.
-  // Use `sudo npm link` because Node.js is installed system-wide via
-  // nodesource (global prefix is /usr), so creating the global symlink
-  // requires elevated permissions.
-  console.log(`[${elapsed()}] Installing nemoclaw CLI (npm link)...`);
+  // Expose the nemoclaw CLI on PATH. The launchable setup script already
+  // creates /usr/local/bin/nemoclaw → $NEMOCLAW_CLONE_DIR/bin/nemoclaw.js
+  // as a direct symlink, and rsync above preserves that path, so this is
+  // an idempotent re-link to make local dev runs (that skip the launchable)
+  // still work. Avoid `sudo npm link` on cold CPU Brev — it routinely
+  // hangs inside npm's global-prefix housekeeping.
+  console.log(`[${elapsed()}] Linking nemoclaw CLI (direct symlink)...`);
   ssh(
-    `source ~/.nvm/nvm.sh 2>/dev/null || true && cd ${resolvedRemoteDir} && sudo npm link && sudo chown -R $(whoami):$(whoami) ${resolvedRemoteDir}`,
+    `sudo ln -sf ${resolvedRemoteDir}/bin/nemoclaw.js /usr/local/bin/nemoclaw && sudo chmod +x ${resolvedRemoteDir}/bin/nemoclaw.js`,
     {
-      timeout: 120_000,
+      timeout: 30_000,
       stream: true,
     },
   );


### PR DESCRIPTION
## Summary
Reverts #2186 (which made Brev E2E failures 10× slower) and replaces \`sudo npm link\` with a direct \`sudo ln -sf\` symlink in both the launchable setup and the in-test bootstrap path. \`npm link\` is overkill for what we actually need and hangs indefinitely on cold CPU Brev instances. Direct symlink is O(1) and deterministic.

## Related Issue
Regression from my own #2186. Surfaced while validating #2183 (ollama E2E).

## Changes
This PR contains two commits:

1. **Revert #2186.** Restores the launchable setup to its pre-\`sudo npm link\` state. This alone would leave non-full suites broken by the original pre-existing #1888 issue, but without burning a 20-min Brev instance per run.
2. **Replace \`sudo npm link\` with direct symlink.**
   - \`scripts/brev-launchable-ci-cpu.sh\` — after plugin build, create \`/usr/local/bin/nemoclaw → \$NEMOCLAW_CLONE_DIR/bin/nemoclaw.js\` via \`sudo ln -sf\`. Drop \`sudo chown -R\` (only the single symlink is root-owned now, not node_modules).
   - \`test/e2e/brev-e2e.test.ts\` — replace the in-test \`sudo npm link\` with the same direct-symlink approach. Idempotent re-link so local dev runs that skip the launchable still work.

## Evidence
- **Before #2186 (2026-04-14):** non-full suites failed at ~2 min with a clear \`sudo npm link ETIMEDOUT\` (pre-existing #1888 regression, but cheap to fail).
- **After #2186 (today):** non-full suites hang on \`sudo npm link\` inside the launchable until the 20-min outer cap trips. 10× longer to fail, 10× more Brev credit per failed run. Evidence: [run 24737205166](https://github.com/NVIDIA/NemoClaw/actions/runs/24737205166) — stuck on \`Linking nemoclaw CLI globally...\` from 808s to 1198s with no progress.
- \`npm link\` does two things: \`/usr/local/lib/node_modules/<name>\` symlink + \`/usr/local/bin/<bin>\` symlink. We only need the second one. Replacing with \`sudo ln -sf\` bypasses npm's global-prefix housekeeping and the \`sudo chown -R node_modules\` traversal that likely drove the hang.

## Type of Change
- [x] Code change (bug fix)

## Verification
- [x] \`bash -n\` on the launchable script — syntax OK
- [x] \`npm run typecheck:cli\` — passes
- [x] Pre-push hooks — passes (modulo the pre-existing flaky \`test/install-preflight.test.ts:107\`, resolves on retry, unrelated)
- [ ] **End-to-end Brev E2E run** — to be validated via \`gh workflow run e2e-brev.yaml --ref revert/2186-brev-npm-link-launchable --field test_suite=credential-sanitization\` (any non-\`full\` suite proves the bootstrap now completes). Will attach run URL before merge.

## Retro note
Shipped #2186 without running the Brev suite end-to-end — exact failure mode I had flagged on #2123 earlier the same day. This PR is validated the right way before merge.

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Optimized NemoClaw CLI installation mechanism with deterministic symlink approach, reducing environment setup initialization time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->