### PR TITLE
fix(test): update connect tests for readiness poll behavior from #466

### DIFF
--- a/test/reboot-identity-drift.test.ts
+++ b/test/reboot-identity-drift.test.ts
@@ -116,7 +116,7 @@ if (args[0] === "sandbox" && args[1] === "get" && args[2] === ${JSON.stringify(s
 }
 
 if (args[0] === "sandbox" && args[1] === "list") {
-  process.stdout.write("${sandboxName}\\n");
+  process.stdout.write("${sandboxName}   Ready   2m ago\\n");
   process.exit(0);
 }
 
@@ -201,7 +201,7 @@ if (args[0] === "sandbox" && args[1] === "get" && args[2] === ${JSON.stringify(s
 }
 
 if (args[0] === "sandbox" && args[1] === "list") {
-  process.stdout.write("${sandboxName}\\n");
+  process.stdout.write("${sandboxName}   Ready   2m ago\\n");
   process.exit(0);
 }
 

--- a/test/sandbox-connect-inference.test.ts
+++ b/test/sandbox-connect-inference.test.ts
@@ -74,7 +74,7 @@ if (args[0] === "sandbox" && args[1] === "get" && args[2] === ${JSON.stringify(s
 }
 
 if (args[0] === "sandbox" && args[1] === "list") {
-  process.stdout.write("${sandboxName}\\n");
+  process.stdout.write("${sandboxName}   Ready   2m ago\\n");
   process.exit(0);
 }
 

--- a/test/sandbox-stuck-recovery.test.ts
+++ b/test/sandbox-stuck-recovery.test.ts
@@ -64,7 +64,7 @@ if (args[0] === "sandbox" && args[1] === "get" && args[2] === ${JSON.stringify(s
 }
 
 if (args[0] === "sandbox" && args[1] === "list") {
-  process.stdout.write("${sandboxName}\\n");
+  process.stdout.write("${sandboxName}   ${phase}   1m ago\\n");
   process.exit(0);
 }
 
@@ -97,7 +97,12 @@ process.exit(0);
   return { tmpDir, sandboxName };
 }
 
-function runCli(tmpDir: string, sandboxName: string, subcommand: string) {
+function runCli(
+  tmpDir: string,
+  sandboxName: string,
+  subcommand: string,
+  extraEnv: Record<string, string> = {},
+) {
   const repoRoot = path.join(import.meta.dirname, "..");
   return spawnSync(
     process.execPath,
@@ -110,6 +115,7 @@ function runCli(tmpDir: string, sandboxName: string, subcommand: string) {
         HOME: tmpDir,
         PATH: "/usr/bin:/bin",
         NEMOCLAW_NO_CONNECT_HINT: "1",
+        ...extraEnv,
       },
       timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 15_000),
     },
@@ -118,18 +124,39 @@ function runCli(tmpDir: string, sandboxName: string, subcommand: string) {
 
 describe("sandbox stuck in non-Ready phase (#2016)", () => {
   it(
-    "connect exits with error and recovery hint when sandbox is stuck in Provisioning",
+    "connect times out with guidance when sandbox is stuck in Provisioning",
     { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
     () => {
       const { tmpDir, sandboxName } = setupFixture("stuck-sandbox", "Provisioning");
+
+      // Short connect timeout so the test doesn't wait 120s. Provisioning
+      // is not a terminal state, so the readiness poll introduced in #466
+      // waits until NEMOCLAW_CONNECT_TIMEOUT elapses.
+      const result = runCli(tmpDir, sandboxName, "connect", {
+        NEMOCLAW_CONNECT_TIMEOUT: "3",
+      });
+      expect(result.status).not.toBe(0);
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain(`Waiting for sandbox '${sandboxName}' to be ready`);
+      expect(combined).toContain("Timed out");
+      expect(combined).toContain("NEMOCLAW_CONNECT_TIMEOUT");
+    },
+  );
+
+  it(
+    "connect exits immediately with recovery hint when sandbox is in a terminal failure state",
+    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    () => {
+      const { tmpDir, sandboxName } = setupFixture("failed-sandbox", "Failed");
 
       const result = runCli(tmpDir, sandboxName, "connect");
       expect(result.status).not.toBe(0);
 
       const combined = (result.stdout || "") + (result.stderr || "");
-      expect(combined).toContain("stuck in 'Provisioning' phase");
-      expect(combined).toContain("process crash inside the sandbox");
-      expect(combined).toContain(`nemoclaw ${sandboxName} rebuild --yes`);
+      expect(combined).toContain("is in 'Failed' state");
+      expect(combined).toContain(`nemoclaw ${sandboxName} logs --follow`);
+      expect(combined).toContain(`nemoclaw ${sandboxName} status`);
     },
   );
 


### PR DESCRIPTION
## Summary

PR #466 (merged today at 19:01 UTC) changed `nemoclaw <name> connect` to poll `openshell sandbox list` for readiness instead of exiting immediately when the sandbox phase isn't Ready. Three pre-existing test files still encoded the old behavior and are now failing on every PR rebased onto main — including [post-merge CI on main itself](https://github.com/NVIDIA/NemoClaw/actions/runs/24740949920).

Observable in CI by:
- `test/sandbox-connect-inference.test.ts` — 2 assertions expecting `result.status === 0` get `null` (child process hits 15s spawnSync timeout)
- `test/sandbox-stuck-recovery.test.ts` — 2 failures (same timeout symptom + stale message assertions)
- `test/reboot-identity-drift.test.ts` — 4 failures (same timeout symptom)

## Root cause

The fake `openshell` binaries in these tests emit `sandbox list` output with only a name column:
```js
if (args[0] === "sandbox" && args[1] === "list") {
  process.stdout.write("${sandboxName}\n");
  process.exit(0);
}
```

The new readiness poll ([src/nemoclaw.ts](https://github.com/NVIDIA/NemoClaw/blob/main/src/nemoclaw.ts)) calls `parseSandboxStatus(output, name)` which needs `[name, status, age]` columns to extract a status. With only a name, it returns `null` → loop treats as `"unknown"` → polls until the test's spawnSync timeout kills the child.

## Changes

**1. `sandbox list` mocks updated** in all three files to emit a proper status column.
- `sandbox-connect-inference.test.ts` and `reboot-identity-drift.test.ts` always return `"${name}   Ready   2m ago"` (they test the happy path).
- `sandbox-stuck-recovery.test.ts` uses the parameterized `${phase}` its `setupFixture` already accepts.

**2. `sandbox-stuck-recovery.test.ts`: "stuck in Provisioning" test rewritten for the new behavior.**
The old assertions checked for `"stuck in 'Provisioning' phase"` + `"process crash inside the sandbox"` + `"rebuild --yes"` — messages that came from `ensureLiveSandboxOrExit`'s non-Ready branch. #466 bypasses that for `connect` via `{ allowNonReadyPhase: true }`, so those messages no longer fire. New assertions:
- `NEMOCLAW_CONNECT_TIMEOUT=3` via new `extraEnv` param on `runCli` so the readiness poll times out in 3s instead of 120s
- Asserts `"Waiting for sandbox '…' to be ready"` + `"Timed out"` + `"NEMOCLAW_CONNECT_TIMEOUT"` override hint

**3. `sandbox-stuck-recovery.test.ts`: companion test added** for the terminal-state exit path that #466 introduced but lacked a behavioral test. Failed phase should exit immediately with `logs --follow` and `status` recovery hints (covers the second branch of the TERMINAL check).

The `status` subcommand test in `sandbox-stuck-recovery.test.ts` is untouched — `status` still exits on non-Ready phases; #466 only changed `connect`.

## Testing

- Targeted: `npx vitest run test/reboot-identity-drift.test.ts test/sandbox-stuck-recovery.test.ts test/sandbox-connect-inference.test.ts` → 13 passed
- Full: `npm test` → 2061 passed, 12 skipped (was 4 failing on main post-#466)
- pre-commit hooks (prek): clean

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.

## Checklist

- [x] Tests added/updated for the behavior change introduced by #466.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated — N/A (no user-facing behavior change, just test realignment).

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated sandbox list command mock output to include status and timing details
  * Improved connection timeout error messages with helpful debugging command suggestions
  * Enhanced test infrastructure to support environment variable injection for connection timeout testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->