### PR TITLE
fix(ci): bump wsl-e2e NEMOCLAW_EXEC_TIMEOUT to 60s (Fixes #2204)

### DIFF
--- a/.github/workflows/wsl-e2e.yaml
+++ b/.github/workflows/wsl-e2e.yaml
@@ -159,7 +159,10 @@ jobs:
           $script = @"
           set -euo pipefail
           cd '$env:WSL_WORKDIR'
-          export NEMOCLAW_EXEC_TIMEOUT=30000
+          # WSL process-spawn overhead pushes CLI runtime close to the test
+          # budget; keep exec timeout aligned with the vitest test timeout so
+          # tests that legitimately consume their full budget aren't killed.
+          export NEMOCLAW_EXEC_TIMEOUT=60000
           export NEMOCLAW_TEST_TIMEOUT=60000
           npx vitest run --testTimeout 60000
           "@


### PR DESCRIPTION
## Summary

Fixes the lingering `sandbox-stuck-recovery.test.ts > connect times out with guidance when sandbox is stuck in Provisioning` failure on `wsl-e2e` that has been red on `main` since #466 merged. My earlier #2198 fixed the sibling tests but this one kept hitting the CI test-budget ceiling.

Fixes #2204.

## Root cause

Not a mock-script bug — the mocks for `sandbox list` already return the phase string that `parseSandboxStatus` expects, and the tests pass cleanly on macOS and the Linux `checks` job.

The failure is WSL-specific timing:

- `NEMOCLAW_EXEC_TIMEOUT=30000` caps each outer `spawnSync` to the CLI at 30 seconds.
- WSL process-spawn overhead is high: each mocked `openshell` invocation is a fresh Node.js child process, and the CLI makes 4+ of these (`sandbox get`, `policy get --full`, `inference get`, first `sandbox list`) before the readiness poll loop from #466 starts.
- The 3 sibling tests in `sandbox-stuck-recovery.test.ts` that skip the poll loop were passing at **26–28s** on WSL — already within a few seconds of the ceiling.
- The failing test is the only one that sets `NEMOCLAW_CONNECT_TIMEOUT=3`, so it actually enters the poll loop (pre-poll + 3s sleep + final poll + "Timed out" print). That pushes total runtime past 30s on WSL runners, so the outer `spawnSync` kills the CLI before the "Timed out" guidance prints.

The `Status: unknown` artifact mentioned in #2204 is the CLI's display fallback `parseSandboxStatus(poll, ...) || "unknown"` kicking in after the child was killed mid-poll — not a missing subcommand in the mocks.

## Changes

- `.github/workflows/wsl-e2e.yaml`: bump `NEMOCLAW_EXEC_TIMEOUT` from `30000` to `60000`, aligned with the existing `NEMOCLAW_TEST_TIMEOUT=60000`. Short comment explains why WSL needs the larger ceiling.

## Why this is the right fix

- **Zero impact on fast runners.** Tests that finish in a few seconds on macOS/Linux return early; they don't pay for the larger ceiling.
- **No product-code change.** Only the WSL CI outer-spawn budget moves.
- **Targeted to the actual bottleneck.** The CLI isn't hanging — it's slow on WSL spawn. Bumping the budget matches the structural overhead.

## Considered and rejected

- **Patching the mocks** (the #2204 hypothesis). No new subcommand is invoked; the mocks are correct.
- **Reducing pre-poll overhead in product code** (e.g. skipping `policy get --full` on connect). Out of scope, risks regressing real behavior.
- **Dropping `NEMOCLAW_CONNECT_TIMEOUT` from the test.** The test asserts timeout behavior — it must enter the poll.
- **Bumping `macos-e2e`.** Not needed; those jobs pass comfortably.

## Type of Change

- [x] Code change (bug fix — CI config only)

## Verification

- [x] Local \`npx vitest run test/sandbox-stuck-recovery.test.ts test/sandbox-connect-inference.test.ts --project cli\` — 7/7 pass in 7.6s
- [x] \`npx prek run --files .github/workflows/wsl-e2e.yaml\` — clean
- [ ] **Real validation: this PR's \`wsl-e2e\` check must go green.**

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows Subsystem for Linux (WSL) test reliability by adjusting execution timeout settings to account for system overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->