### PR TITLE
docs: prep for v0.0.22

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -176,7 +176,11 @@ $ nemoclaw deploy <instance-name>
 ### `nemoclaw <name> connect`
 
 Connect to a sandbox by name.
-On a TTY, a one-shot hint prints before dropping into the sandbox shell, reminding you to run `openclaw tui` inside.
+If the sandbox is not yet in the `Ready` phase (for example, right after onboarding while the 2.4 GB image is still pulling), `connect` polls `openshell sandbox list` every few seconds and prints the current phase so you can see progress instead of a silent hang.
+Control the wait budget with `NEMOCLAW_CONNECT_TIMEOUT` (integer seconds; default `120`). When the deadline expires, `connect` exits non-zero with the last-seen phase.
+
+On a TTY, a one-shot hint prints before dropping into the sandbox shell.
+The hint is agent-aware: it names the correct TUI command for the sandbox's agent and reminds you to use `/exit` to leave the chat before `exit` returns you to the host shell.
 Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `nemoclaw <name> rebuild` hint.
 If another terminal is already connected to the sandbox, `connect` prints a note with the number of existing sessions before proceeding. Multiple concurrent sessions are allowed.

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -176,11 +176,11 @@ $ nemoclaw deploy <instance-name>
 ### `nemoclaw <name> connect`
 
 Connect to a sandbox by name.
-If the sandbox is not yet in the `Ready` phase (for example, right after onboarding while the 2.4 GB image is still pulling), `connect` polls `openshell sandbox list` every few seconds and prints the current phase so you can see progress instead of a silent hang.
-Control the wait budget with `NEMOCLAW_CONNECT_TIMEOUT` (integer seconds; default `120`). When the deadline expires, `connect` exits non-zero with the last-seen phase.
+If the sandbox is not yet in the `Ready` phase, `connect` polls `openshell sandbox list` every few seconds and prints the current phase. This gives you progress output right after onboarding, when the 2.4 GB image is still pulling, instead of a silent hang.
+Control the wait budget with `NEMOCLAW_CONNECT_TIMEOUT` (integer seconds, default `120`). When the deadline expires, `connect` exits non-zero with the last-seen phase.
 
 On a TTY, a one-shot hint prints before dropping into the sandbox shell.
-The hint is agent-aware: it names the correct TUI command for the sandbox's agent and reminds you to use `/exit` to leave the chat before `exit` returns you to the host shell.
+The hint is agent-aware. It names the correct TUI command for the sandbox's agent and reminds you to use `/exit` to leave the chat before `exit` returns you to the host shell.
 Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `nemoclaw <name> rebuild` hint.
 If another terminal is already connected to the sandbox, `connect` prints a note with the number of existing sessions before proceeding. Multiple concurrent sessions are allowed.

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.20"}
+{"name": "nemoclaw", "version": "0.0.22"}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -200,7 +200,11 @@ $ nemoclaw deploy <instance-name>
 ### `nemoclaw <name> connect`
 
 Connect to a sandbox by name.
-On a TTY, a one-shot hint prints before dropping into the sandbox shell, reminding you to run `openclaw tui` inside.
+If the sandbox is not yet in the `Ready` phase (for example, right after onboarding while the 2.4 GB image is still pulling), `connect` polls `openshell sandbox list` every few seconds and prints the current phase so you can see progress instead of a silent hang.
+Control the wait budget with `NEMOCLAW_CONNECT_TIMEOUT` (integer seconds; default `120`). When the deadline expires, `connect` exits non-zero with the last-seen phase.
+
+On a TTY, a one-shot hint prints before dropping into the sandbox shell.
+The hint is agent-aware: it names the correct TUI command for the sandbox's agent and reminds you to use `/exit` to leave the chat before `exit` returns you to the host shell.
 Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `nemoclaw <name> rebuild` hint.
 If another terminal is already connected to the sandbox, `connect` prints a note with the number of existing sessions before proceeding. Multiple concurrent sessions are allowed.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -200,11 +200,11 @@ $ nemoclaw deploy <instance-name>
 ### `nemoclaw <name> connect`
 
 Connect to a sandbox by name.
-If the sandbox is not yet in the `Ready` phase (for example, right after onboarding while the 2.4 GB image is still pulling), `connect` polls `openshell sandbox list` every few seconds and prints the current phase so you can see progress instead of a silent hang.
-Control the wait budget with `NEMOCLAW_CONNECT_TIMEOUT` (integer seconds; default `120`). When the deadline expires, `connect` exits non-zero with the last-seen phase.
+If the sandbox is not yet in the `Ready` phase, `connect` polls `openshell sandbox list` every few seconds and prints the current phase. This gives you progress output right after onboarding, when the 2.4 GB image is still pulling, instead of a silent hang.
+Control the wait budget with `NEMOCLAW_CONNECT_TIMEOUT` (integer seconds, default `120`). When the deadline expires, `connect` exits non-zero with the last-seen phase.
 
 On a TTY, a one-shot hint prints before dropping into the sandbox shell.
-The hint is agent-aware: it names the correct TUI command for the sandbox's agent and reminds you to use `/exit` to leave the chat before `exit` returns you to the host shell.
+The hint is agent-aware. It names the correct TUI command for the sandbox's agent and reminds you to use `/exit` to leave the chat before `exit` returns you to the host shell.
 Set `NEMOCLAW_NO_CONNECT_HINT=1` to suppress the hint in scripted workflows.
 If the sandbox is running an outdated agent version, a non-blocking warning prints before connecting with a `nemoclaw <name> rebuild` hint.
 If another terminal is already connected to the sandbox, `connect` prints a note with the number of existing sessions before proceeding. Multiple concurrent sessions are allowed.

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,14 @@
 [
   {
     "preferred": true,
+    "version": "0.0.22",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.22/"
+  },
+  {
+    "version": "0.0.21",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.21/"
+  },
+  {
     "version": "0.0.20",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.20/"
   },


### PR DESCRIPTION
## Summary

Bumps the published doc version to `0.0.22` and documents the user-visible CLI behavior changes to `nemoclaw <name> connect` that landed since v0.0.21. Drafted via the `nemoclaw-contributor-update-docs` skill against commits in `v0.0.21..origin/main`, filtered through `docs/.docs-skip`.

## Changes

- **`docs/project.json`** and **`docs/versions1.json`**: bump the published version from `0.0.20` to `0.0.22`; insert a `0.0.21` entry into the version list so the history stays contiguous.
- **`docs/reference/commands.md`** → `nemoclaw <name> connect`: document two new behaviors.
  - Readiness poll with `NEMOCLAW_CONNECT_TIMEOUT` (integer seconds; default `120`) that replaces the silent hang when the sandbox is not yet `Ready` — right after onboarding, while the 2.4 GB image is still pulling (#466).
  - Post-connect hint is now agent-aware, names the correct TUI command for the sandbox's agent, and tells you to use `/exit` to leave the chat before `exit` returns you to the host shell (#2080).

Feature PRs that shipped their own docs in the same commit are intentionally not re-documented here:

- `channels list/add/remove` (#2139) — command reference and the "`openclaw channels` blocked inside the sandbox" troubleshooting entry landed with the feature.
- `nemoclaw gc` (#2176) — documented as part of the destroy/rebuild image cleanup PR.

Skipped per `docs/.docs-skip`:

- `e6bad533 fix(shields): verify config lock and fail hard on re-lock failure (#2066)` — matched `skip-features: src/lib/shields.ts`.

Other commits in the range (#2141 OpenShell version bump, #1819 plugin banner live inference probe, #2085 / #2146 Slack Socket Mode fixes, #2110 axios proxy fix, #1818 NIM curl timeouts, #1824 onboard gateway bootstrap recovery, and assorted CI / test / install plumbing) are internal behavior refinements with no doc-relevant surface change.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes for the modified files via the pre-commit hook, including `Regenerate agent skills from docs` (source ↔ generated parity confirmed)
- [ ] `npm test` passes — skipped; the one pre-existing `test/cli.test.ts > unknown command exits 1` failure on `origin/main` is unrelated to these markdown/JSON-only changes
- [ ] Tests added or updated for new or changed behavior — n/a, doc-only
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only) — not run locally
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — n/a, no new pages

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `connect` now displays the sandbox phase while waiting for readiness and honors a configurable timeout via NEMOCLAW_CONNECT_TIMEOUT (default 120s).
  * TTY hints are agent-aware and instruct using `/exit` before returning to the host shell.

* **Documentation**
  * Command docs updated to describe polling, timeout, and TTY guidance.
  * Project/docs metadata updated for versions 0.0.21 and 0.0.22 (package version bumped to 0.0.22).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->