### PR TITLE
fix(cli): add tunnel stop + per-channel stop/start (#2103)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3382,6 +3382,15 @@ async function createSandbox(
         )
       : null;
 
+  // Drop channels the operator disabled via `nemoclaw <sandbox> channels stop`.
+  // Credentials stay in the keychain; the bridge simply isn't registered with
+  // the gateway on the next rebuild. `channels start` removes the entry and
+  // the bridge comes back.
+  const disabledEnvKeys = new Set(
+    MESSAGING_CHANNELS.filter((c) => registry.getDisabledChannels(sandboxName).includes(c.name))
+      .flatMap((c) => (c.appTokenEnvKey ? [c.envKey, c.appTokenEnvKey] : [c.envKey])),
+  );
+
   const messagingTokenDefs = [
     {
       name: `${sandboxName}-discord-bridge`,
@@ -3403,7 +3412,9 @@ async function createSandbox(
       envKey: "TELEGRAM_BOT_TOKEN",
       token: getMessagingToken("TELEGRAM_BOT_TOKEN"),
     },
-  ].filter(({ envKey }) => !enabledEnvKeys || enabledEnvKeys.has(envKey));
+  ]
+    .filter(({ envKey }) => !enabledEnvKeys || enabledEnvKeys.has(envKey))
+    .filter(({ envKey }) => !disabledEnvKeys.has(envKey));
 
   if (webSearchConfig) {
     messagingTokenDefs.push({

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3386,8 +3386,9 @@ async function createSandbox(
   // Credentials stay in the keychain; the bridge simply isn't registered with
   // the gateway on the next rebuild. `channels start` removes the entry and
   // the bridge comes back.
+  const disabledChannels = registry.getDisabledChannels(sandboxName);
   const disabledEnvKeys = new Set(
-    MESSAGING_CHANNELS.filter((c) => registry.getDisabledChannels(sandboxName).includes(c.name))
+    MESSAGING_CHANNELS.filter((c) => disabledChannels.includes(c.name))
       .flatMap((c) => (c.appTokenEnvKey ? [c.envKey, c.appTokenEnvKey] : [c.envKey])),
   );
 
@@ -3966,6 +3967,7 @@ async function createSandbox(
     providerCredentialHashes:
       Object.keys(providerCredentialHashes).length > 0 ? providerCredentialHashes : undefined,
     messagingChannels: activeMessagingChannels,
+    disabledChannels: disabledChannels.length > 0 ? [...disabledChannels] : undefined,
   });
 
   // Restore workspace state if we backed it up during credential rotation.

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -172,6 +172,10 @@ export function registerSandbox(entry: SandboxEntry): void {
       imageTag: entry.imageTag || null,
       providerCredentialHashes: entry.providerCredentialHashes || undefined,
       messagingChannels: entry.messagingChannels || [],
+      disabledChannels:
+        Array.isArray(entry.disabledChannels) && entry.disabledChannels.length > 0
+          ? [...entry.disabledChannels]
+          : undefined,
     };
     if (!data.defaultSandbox) {
       data.defaultSandbox = entry.name;

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -21,6 +21,7 @@ export interface SandboxEntry {
   imageTag?: string | null;
   providerCredentialHashes?: Record<string, string>;
   messagingChannels?: string[];
+  disabledChannels?: string[];
 }
 
 export interface SandboxRegistry {
@@ -227,5 +228,24 @@ export function setDefault(name: string): boolean {
 export function clearAll(): void {
   withLock(() => {
     save({ sandboxes: {}, defaultSandbox: null });
+  });
+}
+
+export function getDisabledChannels(name: string): string[] {
+  const data = load();
+  return data.sandboxes[name]?.disabledChannels ?? [];
+}
+
+export function setChannelDisabled(name: string, channel: string, disabled: boolean): boolean {
+  return withLock(() => {
+    const data = load();
+    const entry = data.sandboxes[name];
+    if (!entry) return false;
+    const current = new Set(entry.disabledChannels ?? []);
+    if (disabled) current.add(channel);
+    else current.delete(channel);
+    entry.disabledChannels = current.size > 0 ? Array.from(current).sort() : undefined;
+    save(data);
+    return true;
   });
 }

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1866,6 +1866,14 @@ async function sandboxChannelsSetEnabled(sandboxName, args, disabled) {
   }
 
   const normalized = channelArg.trim().toLowerCase();
+  const alreadyDisabled = registry.getDisabledChannels(sandboxName).includes(normalized);
+  if (alreadyDisabled === disabled) {
+    console.log(
+      `  Channel '${normalized}' is already ${disabled ? "disabled" : "enabled"} for '${sandboxName}'. Nothing to do.`,
+    );
+    return;
+  }
+
   if (dryRun) {
     console.log(
       `  --dry-run: would ${verb} channel '${normalized}' for '${sandboxName}'.`,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -94,6 +94,7 @@ const GLOBAL_COMMANDS = new Set([
   "setup-spark",
   "start",
   "stop",
+  "tunnel",
   "status",
   "debug",
   "uninstall",

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -952,6 +952,21 @@ function stop() {
   });
 }
 
+async function tunnel(args) {
+  const sub = args[0];
+  switch (sub) {
+    case "start":
+      await start();
+      return;
+    case "stop":
+      stop();
+      return;
+    default:
+      console.error(`  Usage: nemoclaw tunnel <start|stop>`);
+      process.exit(1);
+  }
+}
+
 function debug(args) {
   const { runDebug } = require("./lib/debug");
   const getDefaultSandbox = (): string | undefined => {
@@ -1830,6 +1845,48 @@ async function sandboxChannelsRemove(sandboxName, args = []) {
   clearChannelTokens(channel);
   console.log(`  ${G}✓${R} Cleared stored ${channelArg} credentials.`);
   await promptAndRebuild(sandboxName, `remove '${channelArg}'`);
+}
+
+async function sandboxChannelsSetEnabled(sandboxName, args, disabled) {
+  const verb = disabled ? "stop" : "start";
+  const dryRun = args.includes("--dry-run");
+  const channelArg = args.find((arg) => !arg.startsWith("-"));
+  if (!channelArg) {
+    console.error(`  Usage: nemoclaw <sandbox> channels ${verb} <channel> [--dry-run]`);
+    console.error(`  Valid channels: ${knownChannelNames().join(", ")}`);
+    process.exit(1);
+  }
+
+  const channel = getChannelDef(channelArg);
+  if (!channel) {
+    console.error(`  Unknown channel '${channelArg}'.`);
+    console.error(`  Valid channels: ${knownChannelNames().join(", ")}`);
+    process.exit(1);
+  }
+
+  const normalized = channelArg.trim().toLowerCase();
+  if (dryRun) {
+    console.log(
+      `  --dry-run: would ${verb} channel '${normalized}' for '${sandboxName}'.`,
+    );
+    return;
+  }
+
+  if (!registry.setChannelDisabled(sandboxName, normalized, disabled)) {
+    console.error(`  Sandbox '${sandboxName}' not found in the registry.`);
+    process.exit(1);
+  }
+  const state = disabled ? "disabled" : "enabled";
+  console.log(`  ${G}✓${R} Marked ${normalized} ${state} for '${sandboxName}'.`);
+  await promptAndRebuild(sandboxName, `${verb} '${normalized}'`);
+}
+
+async function sandboxChannelsStop(sandboxName, args = []) {
+  await sandboxChannelsSetEnabled(sandboxName, args, true);
+}
+
+async function sandboxChannelsStart(sandboxName, args = []) {
+  await sandboxChannelsSetEnabled(sandboxName, args, false);
 }
 
 /**
@@ -2845,9 +2902,11 @@ function help() {
     nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
   ${G}Messaging Channels:${R}
-    nemoclaw <name> channels list            List supported messaging channels
-    nemoclaw <name> channels add <channel>   Save credentials and rebuild ${D}(telegram|discord|slack)${R}
+    nemoclaw <name> channels list             List supported messaging channels
+    nemoclaw <name> channels add <channel>    Save credentials and rebuild ${D}(telegram|discord|slack)${R}
     nemoclaw <name> channels remove <channel> Clear credentials and rebuild
+    nemoclaw <name> channels stop <channel>   Disable channel (keeps credentials)
+    nemoclaw <name> channels start <channel>  Re-enable a previously stopped channel
 
   ${G}Compatibility Commands:${R}
     nemoclaw setup                   Deprecated alias for ${B}nemoclaw onboard${R}
@@ -2855,8 +2914,10 @@ function help() {
     nemoclaw deploy <instance>       Deprecated Brev-specific bootstrap path
 
   ${G}Services:${R}
-    nemoclaw start                   Start auxiliary services ${D}(Telegram, tunnel)${R}
-    nemoclaw stop                    Stop all services
+    nemoclaw tunnel start            Start the cloudflared public-URL tunnel
+    nemoclaw tunnel stop             Stop the cloudflared public-URL tunnel
+    nemoclaw start                   ${D}Deprecated alias for 'tunnel start'${R}
+    nemoclaw stop                    ${D}Deprecated alias for 'tunnel stop'${R}
     nemoclaw status                  Show sandbox list and service status
 
   Troubleshooting:
@@ -2917,10 +2978,19 @@ const [cmd, ...args] = process.argv.slice(2);
         await deploy(args[0]);
         break;
       case "start":
+        console.error(
+          `  ${YW}Deprecated:${R} 'nemoclaw start' is now 'nemoclaw tunnel start'. See 'nemoclaw help'.`,
+        );
         await start();
         break;
       case "stop":
+        console.error(
+          `  ${YW}Deprecated:${R} 'nemoclaw stop' is now 'nemoclaw tunnel stop'. See 'nemoclaw help'.`,
+        );
         stop();
+        break;
+      case "tunnel":
+        await tunnel(args);
         break;
       case "status":
         showStatus();
@@ -3095,12 +3165,20 @@ const [cmd, ...args] = process.argv.slice(2);
           case "remove":
             await sandboxChannelsRemove(cmd, channelsArgs);
             break;
+          case "stop":
+            await sandboxChannelsStop(cmd, channelsArgs);
+            break;
+          case "start":
+            await sandboxChannelsStart(cmd, channelsArgs);
+            break;
           default:
             console.error(`  Unknown channels subcommand: ${channelsSub}`);
-            console.error("  Usage: nemoclaw <name> channels <list|add|remove> [args]");
+            console.error("  Usage: nemoclaw <name> channels <list|add|remove|stop|start> [args]");
             console.error("    list                  List supported messaging channels");
             console.error("    add <channel>         Store credentials and rebuild the sandbox");
             console.error("    remove <channel>      Clear credentials and rebuild the sandbox");
+            console.error("    stop <channel>        Disable channel without wiping credentials");
+            console.error("    start <channel>       Re-enable a previously stopped channel");
             process.exit(1);
         }
         break;

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -209,6 +209,16 @@ describe("registry", () => {
   it("setChannelDisabled returns false when sandbox is missing", () => {
     expect(registry.setChannelDisabled("missing", "telegram", true)).toBe(false);
   });
+
+  it("registerSandbox preserves disabledChannels when re-registering", () => {
+    registry.registerSandbox({ name: "s1" });
+    registry.setChannelDisabled("s1", "telegram", true);
+    registry.registerSandbox({
+      name: "s1",
+      disabledChannels: registry.getDisabledChannels("s1"),
+    });
+    expect(registry.getDisabledChannels("s1")).toEqual(["telegram"]);
+  });
 });
 
 describe("atomic writes", () => {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -183,6 +183,32 @@ describe("registry", () => {
     const { sandboxes } = registry.listSandboxes();
     expect(sandboxes.length).toBe(0);
   });
+
+  it("setChannelDisabled toggles a channel on and off for a sandbox", () => {
+    registry.registerSandbox({ name: "s1" });
+    expect(registry.getDisabledChannels("s1")).toEqual([]);
+
+    expect(registry.setChannelDisabled("s1", "telegram", true)).toBe(true);
+    expect(registry.getDisabledChannels("s1")).toEqual(["telegram"]);
+
+    expect(registry.setChannelDisabled("s1", "discord", true)).toBe(true);
+    expect(registry.getDisabledChannels("s1")).toEqual(["discord", "telegram"]);
+
+    registry.setChannelDisabled("s1", "telegram", false);
+    expect(registry.getDisabledChannels("s1")).toEqual(["discord"]);
+  });
+
+  it("setChannelDisabled clears the disabledChannels field when empty", () => {
+    registry.registerSandbox({ name: "s1" });
+    registry.setChannelDisabled("s1", "telegram", true);
+    registry.setChannelDisabled("s1", "telegram", false);
+    const persisted = JSON.parse(fs.readFileSync(regFile, "utf-8"));
+    expect(persisted.sandboxes.s1.disabledChannels).toBeUndefined();
+  });
+
+  it("setChannelDisabled returns false when sandbox is missing", () => {
+    expect(registry.setChannelDisabled("missing", "telegram", true)).toBe(false);
+  });
 });
 
 describe("atomic writes", () => {


### PR DESCRIPTION
## Summary

Fixes #2103 where `nemoclaw stop` lied — it only stopped the cloudflared tunnel, not Telegram/Discord bridges, which moved inside the sandbox in #1081 and couldn't be paused without destroying the sandbox.

- **Rename** `nemoclaw stop/start` → `nemoclaw tunnel stop/start`. Legacy `stop`/`start` kept as deprecated aliases that print a warning and delegate.
- **New** `nemoclaw <sandbox> channels stop <channel>` and `channels start <channel>`. Marks the channel disabled in the per-sandbox registry, rebuilds, and the onboard code skips registering that bridge with the gateway. Credentials stay in the keychain — non-destructive, unlike `channels remove`.

## Why rebuild and not `openshell sandbox exec`

Aaron floated the shields-down exec-into-sandbox pattern in the #2103 thread. On closer look, that path doesn't work cleanly for this:
- `openclaw.json` is read-only at runtime (Landlock + `root:root 444`), and NemoClaw's sandbox entrypoint explicitly intercepts `openclaw channels add/remove` from inside with a host-side-only error.
- `openclaw gateway stop` is too coarse — kills every channel plus agent comms.
- SIGTERM on the bridge process works but doesn't persist across a gateway restart.
- No per-channel runtime CLI exists in OpenClaw today.

So this PR mirrors `channels remove`'s config-patch + rebuild plumbing. A rebuild takes a few minutes and preserves workspace data, which is strictly better than the current "delete the sandbox" workaround.

## Note on #2103's policy-remove claim

#2103's issue body said "No remove/delete/revoke logic exists anywhere in `policies.ts`." That's stale — `removePreset()` at `src/lib/policies.ts:278` and the `nemoclaw <sandbox> policy-remove <preset>` CLI dispatch at `src/nemoclaw.ts:3088` already exist. No code change needed for that line item.

## Test plan

- [x] `npx vitest run --project cli` — 1740 passed, 7 skipped (3 new registry tests for `setChannelDisabled`/`getDisabledChannels`)
- [x] `npm run typecheck:cli` clean
- [x] Manual: help text renders new commands, `nemoclaw stop` prints deprecation + still works, `nemoclaw tunnel stop` works directly, `nemoclaw tunnel bogus` prints usage
- [x] Manual: `nemoclaw <sandbox> channels stop telegram` with fake registry → registry gains `disabledChannels: ["telegram"]`; `channels start telegram` removes the entry; dry-run honored; unknown channel rejected
- [ ] Not yet validated against a live sandbox rebuild (the onboard-side filter that excludes `disabledChannels` from `messagingTokenDefs` is a one-liner, but hasn't been E2E-tested end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tunnel start|stop` command for service management
  * Added `channels start|stop` commands to enable/disable specific messaging channels in sandboxes

* **Deprecations**
  * Marked `nemoclaw start|stop` as deprecated; use `tunnel start|stop` instead

* **Tests**
  * Added test coverage for channel enable/disable functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->