### PR TITLE
fix(policy): move /sandbox/.openclaw to read_write for OpenShell 0.0.29 Landlock

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -30,10 +30,10 @@ filesystem_policy:
     - /etc
     - /var/log
     - /sandbox
-    - /sandbox/.openclaw
   read_write:
     - /tmp
     - /dev/null
+    - /sandbox/.openclaw
     - /sandbox/.openclaw-data
     - /sandbox/.nemoclaw
 

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -35,14 +35,16 @@ filesystem_policy:
                                     # their own runtime environment. Writable state
                                     # is restricted to /sandbox/.openclaw-data.
                                     # Ref: https://github.com/NVIDIA/NemoClaw/issues/804
-    - /sandbox/.openclaw            # Immutable gateway config — prevents agent
-                                    # from tampering with auth tokens or CORS.
-                                    # Writable state (agents, plugins) lives in
-                                    # /sandbox/.openclaw-data via symlinks.
-                                    # Ref: https://github.com/NVIDIA/NemoClaw/issues/514
   read_write:
     - /tmp
     - /dev/null
+    - /sandbox/.openclaw            # Gateway config dir — must be writable so the
+                                    # entrypoint can patch openclaw.json at startup
+                                    # (model override, CORS, Slack token resolution)
+                                    # before Landlock restrict_self(). Protected at
+                                    # runtime by root:root 444 + chattr +i (shields).
+                                    # Moved from read_only for OpenShell >= 0.0.29
+                                    # where two-phase Landlock is enforced (#2141).
     - /sandbox/.openclaw-data       # Writable agent/plugin state (symlinked from .openclaw)
     - /sandbox/.nemoclaw            # Plugin state and config (state.ts, config.ts).
                                     # Blueprints are root-owned; sticky bit (1755)


### PR DESCRIPTION
## Summary
- OpenShell 0.0.29 (PR OpenShell#810) fixes the two-phase Landlock privilege ordering bug — `prepare()` now opens PathFds as root before `drop_privileges()`, then `enforce()` calls `restrict_self()`. Landlock is now actually enforced.
- The entrypoint (`nemoclaw-start.sh`) writes to `/sandbox/.openclaw/openclaw.json` at startup for model override, CORS override, Slack token resolution, and config hash recomputation. With `/sandbox/.openclaw` in `read_only`, these writes fail with `EACCES` under enforced Landlock, crashing the entrypoint and preventing the sandbox from reaching Ready.
- This caused every nightly E2E test to hang indefinitely at "Still uploading image into OpenShell gateway..." (the sandbox never became Ready, so the readyCheck poll never returned true)
- Moves `/sandbox/.openclaw` from `read_only` to `read_write` in both default and permissive policies
- Runtime agent-tamper protection is maintained by `root:root 444` + `chattr +i` (managed by shields), which are orthogonal to Landlock

## Test plan
- [ ] Nightly E2E run on this branch with OpenShell 0.0.29 — sandboxes should reach Ready
- [ ] `nemoclaw <name> status --json` should show `/sandbox/.openclaw` in `read_write`
- [ ] Shields up/down continues to lock/unlock config via `chattr +i`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Enhanced sandbox configuration handling by enabling write access to configuration files during startup, allowing proper initialization of model settings, CORS configuration, and authentication parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->