### PR TITLE
fix(hermes): copy blueprint before dropping to USER sandbox

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -60,11 +60,16 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
     NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=${NEMOCLAW_MESSAGING_ALLOWED_IDS_B64}
 
 WORKDIR /sandbox
-USER sandbox
 
-# Set up blueprint for local resolution
+# Set up blueprint for local resolution. Must run as root because the
+# sandbox user cannot read /opt/nemoclaw-blueprint/* — COPY preserves
+# restrictive source permissions and the build context produces files
+# the sandbox user has no access to (#2191). Blueprints stay root-owned
+# and world-readable, matching the OpenClaw Dockerfile's handling.
 RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \
     && cp -r /opt/nemoclaw-blueprint/* /sandbox/.nemoclaw/blueprints/0.1.0/
+
+USER sandbox
 
 # Generate Hermes config.yaml and .env from build args.
 # config.yaml is immutable at runtime (Landlock read-only on /sandbox/.hermes).

--- a/test/hermes-dockerfile-blueprint-order.test.ts
+++ b/test/hermes-dockerfile-blueprint-order.test.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression test for #2191 — Hermes Dockerfile copied the shared blueprint
+// AFTER dropping to USER sandbox, which cannot read /opt/nemoclaw-blueprint/*
+// because COPY preserves restrictive source permissions. The build failed at:
+//
+//   cp: cannot open '/opt/nemoclaw-blueprint/blueprint.yaml' for reading:
+//   Permission denied
+//
+// The copy must happen while still running as root, matching the OpenClaw
+// Dockerfile's layout.
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const HERMES_DOCKERFILE = path.join(import.meta.dirname, "..", "agents", "hermes", "Dockerfile");
+
+function firstLineMatching(lines: string[], re: RegExp): number {
+  for (let i = 0; i < lines.length; i++) {
+    if (re.test(lines[i])) return i;
+  }
+  return -1;
+}
+
+describe("agents/hermes/Dockerfile blueprint copy ordering (#2191)", () => {
+  const source = fs.readFileSync(HERMES_DOCKERFILE, "utf-8");
+  const lines = source.split("\n");
+
+  it("copies /opt/nemoclaw-blueprint into /sandbox before dropping to USER sandbox", () => {
+    const blueprintCp = firstLineMatching(
+      lines,
+      /cp\s+-r\s+\/opt\/nemoclaw-blueprint\/\*\s+\/sandbox\/\.nemoclaw\/blueprints\//,
+    );
+    const userSandbox = firstLineMatching(lines, /^USER\s+sandbox\s*$/);
+
+    expect(blueprintCp).toBeGreaterThanOrEqual(0);
+    expect(userSandbox).toBeGreaterThanOrEqual(0);
+    expect(blueprintCp).toBeLessThan(userSandbox);
+  });
+});


### PR DESCRIPTION
Fixes #2191.

The Hermes sandbox Dockerfile copied `/opt/nemoclaw-blueprint/*` into `/sandbox/.nemoclaw/blueprints/0.1.0/` after switching to `USER sandbox`. `COPY` preserves restrictive source permissions, so the sandbox user could not read the files and the build failed at:

```
cp: cannot open '/opt/nemoclaw-blueprint/blueprint.yaml' for reading: Permission denied
```

The main NemoClaw `Dockerfile` handles the same blueprint by running `mkdir` + `cp -r` as root before the `USER` drop, leaving blueprints root-owned and world-readable. This aligns `agents/hermes/Dockerfile` with that pattern.

### Change

- Move the blueprint `mkdir` + `cp -r` above `USER sandbox`.
- Leave blueprints root-owned (matching the main Dockerfile).
- Add a regression test (`test/hermes-dockerfile-blueprint-order.test.ts`) that parses the Dockerfile and fails if the blueprint `cp` line appears at or after `USER sandbox`.

### Verification

Regression test fails on the unfixed Dockerfile and passes on the fixed one:

```
 FAIL  test/hermes-dockerfile-blueprint-order.test.ts
  AssertionError: expected 66 to be less than 62

 PASS  test/hermes-dockerfile-blueprint-order.test.ts
   copies /opt/nemoclaw-blueprint into /sandbox before dropping to USER sandbox
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hermes agent build configuration to properly handle blueprint staging with correct permission settings.

* **Tests**
  * Added regression test to verify correct ordering of blueprint staging and user permission restrictions in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->