### PR TITLE
feat(onboard): add review summary + Y/n gate before destructive sandbox build

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3306,13 +3306,23 @@ async function promptValidatedSandboxName() {
 /**
  * Render the configuration summary shown before the destructive sandbox build.
  * Extracted from confirmOnboardConfiguration() for direct unit testing — see #2165.
+ *
+ * Fields:
+ * - credentialEnv:    env-var name of the API key (e.g. "NVIDIA_API_KEY").
+ *                     Rendered with the fixed credentials.json location so
+ *                     users can see where the key was stored.
+ * - notes:            additional bullet lines shown under the summary
+ *                     (e.g. "~6 minutes on this host"). Each note rendered
+ *                     as "Note: <text>" so it's visually distinct.
  */
 function formatOnboardConfigSummary({
   provider,
   model,
+  credentialEnv = null,
   webSearchConfig,
   enabledChannels,
   sandboxName,
+  notes = [],
 }) {
   const bar = `  ${"─".repeat(50)}`;
   const messaging =
@@ -3320,6 +3330,12 @@ function formatOnboardConfigSummary({
       ? enabledChannels.join(", ")
       : "none";
   const webSearch = webSearchConfig && webSearchConfig.fetchEnabled === true ? "enabled" : "disabled";
+  const apiKeyLine = credentialEnv
+    ? `  API key:       ${credentialEnv} (stored in ~/.nemoclaw/credentials.json)`
+    : `  API key:       (not required for ${provider ?? "this provider"})`;
+  const noteLines = (Array.isArray(notes) ? notes : [])
+    .filter((n) => typeof n === "string" && n.length > 0)
+    .map((n) => `  Note:          ${n}`);
   return [
     "",
     bar,
@@ -3327,9 +3343,11 @@ function formatOnboardConfigSummary({
     bar,
     `  Provider:      ${provider ?? "(unset)"}`,
     `  Model:         ${model ?? "(unset)"}`,
+    apiKeyLine,
     `  Web search:    ${webSearch}`,
     `  Messaging:     ${messaging}`,
     `  Sandbox name:  ${sandboxName}`,
+    ...noteLines,
     bar,
   ].join("\n");
 }
@@ -6675,10 +6693,12 @@ async function onboard(opts = {}) {
         formatOnboardConfigSummary({
           provider,
           model,
+          credentialEnv,
           webSearchConfig,
           enabledChannels:
             selectedMessagingChannels.length > 0 ? selectedMessagingChannels : null,
           sandboxName,
+          notes: ["Sandbox build takes ~6 minutes on this host."],
         }),
       );
       console.log("  Web search and messaging channels will be prompted next.");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3303,6 +3303,37 @@ async function promptValidatedSandboxName() {
 
 // ── Step 5: Sandbox ──────────────────────────────────────────────
 
+/**
+ * Render the configuration summary shown before the destructive sandbox build.
+ * Extracted from confirmOnboardConfiguration() for direct unit testing — see #2165.
+ */
+function formatOnboardConfigSummary({
+  provider,
+  model,
+  webSearchConfig,
+  enabledChannels,
+  sandboxName,
+}) {
+  const bar = `  ${"─".repeat(50)}`;
+  const messaging =
+    Array.isArray(enabledChannels) && enabledChannels.length > 0
+      ? enabledChannels.join(", ")
+      : "none";
+  const webSearch = webSearchConfig && webSearchConfig.fetchEnabled === true ? "enabled" : "disabled";
+  return [
+    "",
+    bar,
+    "  Review configuration",
+    bar,
+    `  Provider:      ${provider ?? "(unset)"}`,
+    `  Model:         ${model ?? "(unset)"}`,
+    `  Web search:    ${webSearch}`,
+    `  Messaging:     ${messaging}`,
+    `  Sandbox name:  ${sandboxName}`,
+    bar,
+  ].join("\n");
+}
+
 // eslint-disable-next-line complexity
 async function createSandbox(
   gpu,
@@ -3322,6 +3353,24 @@ async function createSandbox(
     sandboxNameOverride ?? (await promptValidatedSandboxName()),
     "sandbox name",
   );
+
+  // Show a review summary and a Y/n gate before any destructive action
+  // (docker build, provider creation, credential persistence). Non-interactive
+  // runs opt out of the gate — they still see the summary for log clarity.
+  // See #2165.
+  console.log(formatOnboardConfigSummary({
+    provider, model, webSearchConfig, enabledChannels, sandboxName,
+  }));
+  if (!isNonInteractive() && !dangerouslySkipPermissions) {
+    const answer = (await promptOrDefault("  Apply this configuration? [Y/n]: ", null, "y"))
+      .trim()
+      .toLowerCase();
+    if (answer === "n" || answer === "no") {
+      console.log("  Aborted. Re-run `nemoclaw onboard` to start over.");
+      process.exit(0);
+    }
+  }
+
   const effectivePort = agent ? agent.forwardPort : CONTROL_UI_PORT;
   const chatUiUrl = process.env.CHAT_UI_URL || `http://127.0.0.1:${effectivePort}`;
 
@@ -6834,6 +6883,7 @@ module.exports = {
   setupInference,
   setupMessagingChannels,
   setupNim,
+  formatOnboardConfigSummary,
   isInferenceRouteReady,
   isNonInteractive,
   isOpenclawReady,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3354,34 +3354,6 @@ async function createSandbox(
     "sandbox name",
   );
 
-  // Show a review summary and a Y/n gate before the ~6-minute sandbox build.
-  // Scope note: credentials entered in earlier steps (Brave API key, messaging
-  // tokens, provider API keys) have already been persisted to
-  // ~/.nemoclaw/credentials.json by setupInference/setupMessagingChannels.
-  // The gate prevents the long destructive operations (docker build, provider
-  // creation on the gateway, sandbox registration) that the reporter of #2165
-  // wanted to guard. Users can clear persisted credentials with
-  // `nemoclaw credentials reset <KEY>` if they abort. Non-interactive runs
-  // opt out of the gate but still see the summary for log clarity.
-  console.log(formatOnboardConfigSummary({
-    provider, model, webSearchConfig, enabledChannels, sandboxName,
-  }));
-  if (!isNonInteractive() && !dangerouslySkipPermissions) {
-    const answer = (await promptOrDefault("  Apply this configuration? [Y/n]: ", null, "y"))
-      .trim()
-      .toLowerCase();
-    if (answer === "n" || answer === "no") {
-      console.log("  Aborted. Re-run `nemoclaw onboard` to start over.");
-      console.log(
-        "  Credentials entered so far are stored in ~/.nemoclaw/credentials.json —",
-      );
-      console.log(
-        "  clear them with `nemoclaw credentials reset <KEY>` if you no longer want them.",
-      );
-      process.exit(0);
-    }
-  }
-
   const effectivePort = agent ? agent.forwardPort : CONTROL_UI_PORT;
   const chatUiUrl = process.env.CHAT_UI_URL || `http://127.0.0.1:${effectivePort}`;
 
@@ -6689,6 +6661,43 @@ async function onboard(opts = {}) {
           }
         }
       }
+      // Prompt for the sandbox name before configureWebSearch and
+      // setupMessagingChannels so the review gate below can run BEFORE any
+      // credentials for Brave Search or messaging tokens are persisted.
+      // Scope note: inference credentials collected in the earlier step are
+      // already on disk; clear them with `nemoclaw credentials reset <KEY>`
+      // if the user aborts. See #2165 (reporter) and #2221 (CodeRabbit).
+      if (!sandboxName) {
+        sandboxName = await promptValidatedSandboxName();
+      }
+
+      console.log(
+        formatOnboardConfigSummary({
+          provider,
+          model,
+          webSearchConfig,
+          enabledChannels:
+            selectedMessagingChannels.length > 0 ? selectedMessagingChannels : null,
+          sandboxName,
+        }),
+      );
+      console.log("  Web search and messaging channels will be prompted next.");
+      if (!isNonInteractive() && !dangerouslySkipPermissions) {
+        const answer = (await promptOrDefault("  Apply this configuration? [Y/n]: ", null, "y"))
+          .trim()
+          .toLowerCase();
+        if (answer === "n" || answer === "no") {
+          console.log("  Aborted. Re-run `nemoclaw onboard` to start over.");
+          console.log(
+            "  Inference credentials entered so far are stored in ~/.nemoclaw/credentials.json —",
+          );
+          console.log(
+            "  clear them with `nemoclaw credentials reset <KEY>` if you no longer want them.",
+          );
+          process.exit(0);
+        }
+      }
+
       let nextWebSearchConfig = webSearchConfig;
       if (nextWebSearchConfig) {
         note("  [resume] Revalidating Brave Search configuration for sandbox recreation.");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3354,10 +3354,15 @@ async function createSandbox(
     "sandbox name",
   );
 
-  // Show a review summary and a Y/n gate before any destructive action
-  // (docker build, provider creation, credential persistence). Non-interactive
-  // runs opt out of the gate — they still see the summary for log clarity.
-  // See #2165.
+  // Show a review summary and a Y/n gate before the ~6-minute sandbox build.
+  // Scope note: credentials entered in earlier steps (Brave API key, messaging
+  // tokens, provider API keys) have already been persisted to
+  // ~/.nemoclaw/credentials.json by setupInference/setupMessagingChannels.
+  // The gate prevents the long destructive operations (docker build, provider
+  // creation on the gateway, sandbox registration) that the reporter of #2165
+  // wanted to guard. Users can clear persisted credentials with
+  // `nemoclaw credentials reset <KEY>` if they abort. Non-interactive runs
+  // opt out of the gate but still see the summary for log clarity.
   console.log(formatOnboardConfigSummary({
     provider, model, webSearchConfig, enabledChannels, sandboxName,
   }));
@@ -3367,6 +3372,12 @@ async function createSandbox(
       .toLowerCase();
     if (answer === "n" || answer === "no") {
       console.log("  Aborted. Re-run `nemoclaw onboard` to start over.");
+      console.log(
+        "  Credentials entered so far are stored in ~/.nemoclaw/credentials.json —",
+      );
+      console.log(
+        "  clear them with `nemoclaw credentials reset <KEY>` if you no longer want them.",
+      );
       process.exit(0);
     }
   }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6627,6 +6627,43 @@ async function onboard(opts = {}) {
         break;
       }
 
+      // Prompt for the sandbox name and show the review gate BEFORE
+      // setupInference runs upsertProvider / `inference set` on the gateway.
+      // On retry (inferenceResult.retry === "selection") the user is re-prompted
+      // for provider/model above and sees this gate again with the new config.
+      // See #2221 (CodeRabbit).
+      if (!sandboxName) {
+        sandboxName = await promptValidatedSandboxName();
+      }
+      console.log(
+        formatOnboardConfigSummary({
+          provider,
+          model,
+          credentialEnv,
+          webSearchConfig,
+          enabledChannels:
+            selectedMessagingChannels.length > 0 ? selectedMessagingChannels : null,
+          sandboxName,
+          notes: ["Sandbox build takes ~6 minutes on this host."],
+        }),
+      );
+      console.log("  Web search and messaging channels will be prompted next.");
+      if (!isNonInteractive() && !dangerouslySkipPermissions) {
+        const answer = (await promptOrDefault("  Apply this configuration? [Y/n]: ", null, "y"))
+          .trim()
+          .toLowerCase();
+        if (answer === "n" || answer === "no") {
+          console.log("  Aborted. Re-run `nemoclaw onboard` to start over.");
+          console.log(
+            "  Credentials entered so far are stored in ~/.nemoclaw/credentials.json —",
+          );
+          console.log(
+            "  clear them with `nemoclaw credentials reset <KEY>` if you no longer want them.",
+          );
+          process.exit(0);
+        }
+      }
+
       startRecordedStep("inference", { sandboxName, provider, model });
       const inferenceResult = await setupInference(
         sandboxName,
@@ -6679,45 +6716,6 @@ async function onboard(opts = {}) {
           }
         }
       }
-      // Prompt for the sandbox name before configureWebSearch and
-      // setupMessagingChannels so the review gate below can run BEFORE any
-      // credentials for Brave Search or messaging tokens are persisted.
-      // Scope note: inference credentials collected in the earlier step are
-      // already on disk; clear them with `nemoclaw credentials reset <KEY>`
-      // if the user aborts. See #2165 (reporter) and #2221 (CodeRabbit).
-      if (!sandboxName) {
-        sandboxName = await promptValidatedSandboxName();
-      }
-
-      console.log(
-        formatOnboardConfigSummary({
-          provider,
-          model,
-          credentialEnv,
-          webSearchConfig,
-          enabledChannels:
-            selectedMessagingChannels.length > 0 ? selectedMessagingChannels : null,
-          sandboxName,
-          notes: ["Sandbox build takes ~6 minutes on this host."],
-        }),
-      );
-      console.log("  Web search and messaging channels will be prompted next.");
-      if (!isNonInteractive() && !dangerouslySkipPermissions) {
-        const answer = (await promptOrDefault("  Apply this configuration? [Y/n]: ", null, "y"))
-          .trim()
-          .toLowerCase();
-        if (answer === "n" || answer === "no") {
-          console.log("  Aborted. Re-run `nemoclaw onboard` to start over.");
-          console.log(
-            "  Inference credentials entered so far are stored in ~/.nemoclaw/credentials.json —",
-          );
-          console.log(
-            "  clear them with `nemoclaw credentials reset <KEY>` if you no longer want them.",
-          );
-          process.exit(0);
-        }
-      }
-
       let nextWebSearchConfig = webSearchConfig;
       if (nextWebSearchConfig) {
         note("  [resume] Revalidating Brave Search configuration for sandbox recreation.");

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -5370,22 +5370,33 @@ const { createSandbox } = require(${onboardPath});
     const summary = formatOnboardConfigSummary({
       provider: "gemini-api",
       model: "gemini-2.5-flash",
+      credentialEnv: "GEMINI_API_KEY",
       webSearchConfig: { fetchEnabled: true },
       enabledChannels: ["telegram", "slack"],
       sandboxName: "my-assistant",
+      notes: ["Sandbox build takes ~6 minutes on this host."],
     });
 
     assert.ok(summary.includes("Review configuration"), "summary has review heading");
     assert.ok(summary.includes("gemini-api"), "summary includes provider");
     assert.ok(summary.includes("gemini-2.5-flash"), "summary includes model");
+    assert.ok(
+      summary.includes("GEMINI_API_KEY (stored in ~/.nemoclaw/credentials.json)"),
+      "summary shows API key env var + storage location",
+    );
     assert.ok(summary.includes("enabled"), "summary includes web-search enabled");
     assert.ok(summary.includes("telegram, slack"), "summary lists enabled channels");
     assert.ok(summary.includes("my-assistant"), "summary shows sandbox name");
+    assert.ok(
+      summary.includes("Note:          Sandbox build takes ~6 minutes on this host."),
+      "summary renders notes under sandbox name",
+    );
 
     // No messaging, no web search → "none" / "disabled"
     const bareSummary = formatOnboardConfigSummary({
       provider: "nvidia-prod",
       model: "nvidia/nemotron-3-super-120b-a12b",
+      credentialEnv: "NVIDIA_API_KEY",
       webSearchConfig: null,
       enabledChannels: [],
       sandboxName: "test",
@@ -5394,6 +5405,20 @@ const { createSandbox } = require(${onboardPath});
     assert.ok(
       bareSummary.includes("Web search:    disabled"),
       "null webSearch renders as 'disabled'",
+    );
+
+    // No credentialEnv → "(not required for <provider>)" placeholder
+    const localSummary = formatOnboardConfigSummary({
+      provider: "ollama-local",
+      model: "llama3:8b",
+      credentialEnv: null,
+      webSearchConfig: null,
+      enabledChannels: [],
+      sandboxName: "local",
+    });
+    assert.ok(
+      localSummary.includes("(not required for ollama-local)"),
+      "null credentialEnv falls back to a provider-specific message",
     );
 
     // Missing provider/model → "(unset)" placeholder, not "undefined"

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -5364,4 +5364,51 @@ const { createSandbox } = require(${onboardPath});
       "pullAndResolveBaseImageDigest must be called BEFORE patchStagedDockerfile — regression #1904",
     );
   });
+
+  it("formatOnboardConfigSummary renders all collected fields (#2165)", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const onboardPath = path.join(repoRoot, "dist", "lib", "onboard.js");
+    delete require.cache[onboardPath];
+    const { formatOnboardConfigSummary } = require(onboardPath);
+
+    const summary = formatOnboardConfigSummary({
+      provider: "gemini-api",
+      model: "gemini-2.5-flash",
+      webSearchConfig: { fetchEnabled: true },
+      enabledChannels: ["telegram", "slack"],
+      sandboxName: "my-assistant",
+    });
+
+    assert.ok(summary.includes("Review configuration"), "summary has review heading");
+    assert.ok(summary.includes("gemini-api"), "summary includes provider");
+    assert.ok(summary.includes("gemini-2.5-flash"), "summary includes model");
+    assert.ok(summary.includes("enabled"), "summary includes web-search enabled");
+    assert.ok(summary.includes("telegram, slack"), "summary lists enabled channels");
+    assert.ok(summary.includes("my-assistant"), "summary shows sandbox name");
+
+    // No messaging, no web search → "none" / "disabled"
+    const bareSummary = formatOnboardConfigSummary({
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      webSearchConfig: null,
+      enabledChannels: [],
+      sandboxName: "test",
+    });
+    assert.ok(bareSummary.includes("Messaging:     none"), "empty channels renders as 'none'");
+    assert.ok(
+      bareSummary.includes("Web search:    disabled"),
+      "null webSearch renders as 'disabled'",
+    );
+
+    // Missing provider/model → "(unset)" placeholder, not "undefined"
+    const orphanSummary = formatOnboardConfigSummary({
+      provider: null,
+      model: null,
+      webSearchConfig: null,
+      enabledChannels: null,
+      sandboxName: "orphan",
+    });
+    assert.ok(!orphanSummary.includes("undefined"), "null fields never render as 'undefined'");
+    assert.ok(orphanSummary.includes("(unset)"), "null fields fall back to '(unset)'");
+  });
 });

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -50,6 +50,7 @@ import {
   summarizeProbeFailure,
   shouldIncludeBuildContextPath,
   writeSandboxConfigSyncFile,
+  formatOnboardConfigSummary,
 } from "../dist/lib/onboard";
 import { stageOptimizedSandboxBuildContext } from "../dist/lib/sandbox-build-context";
 import { buildWebSearchDockerConfig } from "../dist/lib/web-search";
@@ -5366,11 +5367,6 @@ const { createSandbox } = require(${onboardPath});
   });
 
   it("formatOnboardConfigSummary renders all collected fields (#2165)", () => {
-    const repoRoot = path.join(import.meta.dirname, "..");
-    const onboardPath = path.join(repoRoot, "dist", "lib", "onboard.js");
-    delete require.cache[onboardPath];
-    const { formatOnboardConfigSummary } = require(onboardPath);
-
     const summary = formatOnboardConfigSummary({
       provider: "gemini-api",
       model: "gemini-2.5-flash",


### PR DESCRIPTION
## Summary

`nemoclaw onboard` collected 8 inputs then immediately began a ~6-minute sandbox image build + provider/credential persistence with **no final confirmation**. Users who hit Enter by reflex at the sandbox-name prompt (where `[my-assistant]` is pre-filled) were locked into a build they did not intend to start.

This PR adds a compact summary + `[Y/n]` gate right after the sandbox-name prompt in `createSandbox()`, before any destructive action (docker build, `patchStagedDockerfile`, provider creation).

### Before

```
  [6/8] Creating sandbox
  ──────────────────────────────────────────────
  Sandbox name (lowercase, starts with letter, hyphens ok) [my-assistant]:
  ← Enter pressed →
  [7/8] Building sandbox image...   ← 6 minutes locked in
```

### After

```
  [6/8] Creating sandbox
  ──────────────────────────────────────────────
  Sandbox name (lowercase, starts with letter, hyphens ok) [my-assistant]:
  ← Enter pressed →

  ──────────────────────────────────────────────────
  Review configuration
  ──────────────────────────────────────────────────
  Provider:      gemini-api
  Model:         gemini-2.5-flash
  Web search:    disabled
  Messaging:     none
  Sandbox name:  my-assistant
  ──────────────────────────────────────────────────
  Apply this configuration? [Y/n]:
```

Default is `Y` so a confident user still just hits Enter once. Answering `n`/`no` prints `"Aborted. Re-run nemoclaw onboard to start over."` and exits `0` (clean abort, not an error).

Non-interactive runs (`NEMOCLAW_NON_INTERACTIVE=1`, or `--dangerously-skip-permissions`) still print the summary for log clarity but skip the gate — automated flows opted out of prompts.

## Related Issue

Closes #2165 (priority:high, `Getting Started` label)

## Changes

- **`src/lib/onboard.ts`** — added `formatOnboardConfigSummary()` (pure, exported for testing) and an inline confirm prompt in `createSandbox()` right after the sandbox-name validation. Non-interactive / dangerouslySkipPermissions skip the prompt but still emit the summary.

## Testing

- [x] `npx vitest run test/onboard.test.ts` — 134 tests pass (+1 for new summary test)
- [x] `npx vitest run test/runner.test.ts` — 60/60 pass (exercises create-sandbox e2e)
- [x] `npm run build:cli` + `npm run typecheck:cli` clean

Executed:
- New test covers: full-field render (provider/model/web/messaging/sandbox name), empty channels → `"none"`, null webSearch → `"disabled"`, and null-field → `"(unset)"` fallback (guards against stringified `"undefined"` leaking).

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Commit is signed (SSH)
- [x] DCO Signed-off-by trailer present

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration review summary showing provider, model, API credential hint (or "not required"), web search status, messaging channels (or "none"), sandbox name (prompted if missing), and optional notes.
  * Interactive confirmation prompt lets users approve or abort applying the configuration; abort prints guidance and exits onboarding (non-interactive runs skip the prompt but still display the summary).

* **Tests**
  * Added tests validating the configuration summary formatting and placeholder rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->