### PR TITLE
fix(gateway-state): restore column-agnostic Ready check in isSandboxReady

### DIFF
--- a/src/lib/gateway-state.ts
+++ b/src/lib/gateway-state.ts
@@ -44,9 +44,13 @@ export function parseSandboxStatus(output: string, sandboxName: string): string 
 /**
  * Check if a sandbox is in Ready state from `openshell sandbox list` output.
  * Strips ANSI codes and exact-matches the sandbox name in the first column.
+ * Checks all columns for "Ready" (not just column 2) because the column
+ * layout of `openshell sandbox list` varies across OpenShell versions.
  */
 export function isSandboxReady(output: string, sandboxName: string): boolean {
-  return parseSandboxStatus(output, sandboxName) === "Ready";
+  const cols = parseSandboxRow(output, sandboxName);
+  if (!cols) return false;
+  return cols.includes("Ready") && !cols.includes("NotReady");
 }
 
 /**


### PR DESCRIPTION
## Summary
- PR #466 refactored `isSandboxReady` to delegate to `parseSandboxStatus`, which hardcodes the status to column 2 (`cols[1]`). The previous implementation used `cols.includes("Ready")` to check all columns.
- When `openshell sandbox list` outputs the status in a column other than the second, the readyCheck never returns true, causing `openshell sandbox create` to hang indefinitely after image upload — the sandbox becomes Ready but NemoClaw never detects it.
- This broke every nightly E2E test. Bisected to `49ec8955` (#466) with confirmed good run on the prior commit.
- Restores the column-agnostic `cols.includes("Ready") && !cols.includes("NotReady")` check while keeping the `parseSandboxRow` helper.

## Bisect results
| Commit | Result |
|--------|--------|
| `bd82e1f0` (pre-#466) | Pass |
| `ff18fb8f` (midpoint) | Pass |
| `49ec8955` (#466) | Fail — sandbox hangs |
| `37ca70e6` (pre-#466, docs) | Pass |

## Test plan
- [x] `vitest run test/onboard-readiness.test.ts` — 34 passed
- [ ] Nightly E2E on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox readiness detection to be more resilient across different versions of the sandbox management tool, ensuring reliable status parsing regardless of column layout variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->