### PR TITLE
docs(reference): document --dangerously-skip-permissions onboard flag

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -64,7 +64,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--yes-i-accept-third-party-software]
+$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--dangerously-skip-permissions] [--yes-i-accept-third-party-software]
 ```
 
 :::{warning}
@@ -173,6 +173,30 @@ $ NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_FROM_DOCKERFILE=path/to/Dockerfile nemocla
 ```
 
 If a `--resume` is attempted with a different `--from` path than the original session, onboarding exits with a conflict error rather than silently building from the wrong image.
+
+#### `--dangerously-skip-permissions`
+
+:::{warning}
+For development and testing only. This flag disables the sandbox's network policy and filesystem permission restrictions, so the OpenClaw agent inside the sandbox can reach any host and write anywhere in its home directory. Do not use this flag with production credentials or on hosts where other agents run.
+:::
+
+Replace the default balanced sandbox policy with the permissive policy bundled at `nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml`. Concretely, this means:
+
+- **Network:** all known endpoints open with no HTTP method or path filtering.
+- **Filesystem:** the sandbox home directory is writable (normally Landlock-restricted).
+- **Messaging / inference:** unchanged — still gated by the provider credentials you supply.
+
+```console
+$ nemoclaw onboard --dangerously-skip-permissions
+```
+
+Onboarding prints an explicit warning at start so the reduced security posture is visible in logs. The flag is also honored via `NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1` for non-interactive runs:
+
+```console
+$ NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
+```
+
+The flag is persisted on the sandbox registry entry, so `nemoclaw <sandbox> status` surfaces `Permissions: dangerously-skip-permissions (shields permanently down)` for sandboxes created this way. To tighten a sandbox after the fact, re-run `nemoclaw onboard` without the flag.
 
 ### `nemoclaw list`
 


### PR DESCRIPTION
## Summary

The `--dangerously-skip-permissions` flag is accepted by `nemoclaw onboard` (usage line in [`src/lib/onboard-command.ts:39`](https://github.com/NVIDIA/NemoClaw/blob/main/src/lib/onboard-command.ts#L39), parse in [`src/lib/onboard.ts:6301`](https://github.com/NVIDIA/NemoClaw/blob/main/src/lib/onboard.ts#L6301)) and is surfaced on `nemoclaw <sandbox> status` for sandboxes created with it — but it has no entry in the reference docs. A user reading `docs/reference/commands.md` has no way to learn what the flag disables, when it is intended for use, or the security implications.

## Changes

Add a subsection under `nemoclaw onboard` (after `--from`) that:

- Leads with a warning that the flag is development-only and unsafe for production credentials or shared hosts.
- Enumerates the concrete effects: network policy (all endpoints open, no method/path filtering), filesystem (sandbox home writable, normally Landlock-restricted), and what stays gated (messaging and inference credentials).
- Covers both the flag form and the `NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1` env var form for non-interactive runs.
- Notes that the flag is persisted on the registry entry and surfaced by `nemoclaw <sandbox> status` (`Permissions: dangerously-skip-permissions (shields permanently down)`), and that re-running `nemoclaw onboard` without the flag restores the default policy.
- Adds the flag to the top-level usage line for completeness.

## Testing

Docs-only. Verified:

- [x] The policy path cited (`nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml`) exists and is used when the flag is set — [`src/lib/onboard.ts:3640`](https://github.com/NVIDIA/NemoClaw/blob/main/src/lib/onboard.ts#L3640).
- [x] The env var form is honored — [`src/lib/onboard.ts:6302`](https://github.com/NVIDIA/NemoClaw/blob/main/src/lib/onboard.ts#L6302).
- [x] The status-command surfacing is real — [`src/nemoclaw.ts:1443`](https://github.com/NVIDIA/NemoClaw/blob/main/src/nemoclaw.ts#L1443).

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed (SSH)
- [x] DCO Signed-off-by trailer present

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Documented new `--dangerously-skip-permissions` flag for `nemoclaw onboard` command, disabling network and filesystem restrictions in development/testing environments
* Added `NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1` environment variable for non-interactive setups
* Documented how to check permissions status and restore normal restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->