### PR TITLE
docs(quickstart): add Reconfigure or Recover section to Next Steps

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -153,6 +153,50 @@ For troubleshooting installation or onboarding issues, see the [Troubleshooting 
 - [Deploy to a remote GPU instance](../deployment/deploy-to-remote-gpu.md) for always-on operation.
 - [Monitor sandbox activity](../monitoring/monitor-sandbox-activity.md) through the OpenShell TUI.
 
+## Reconfigure or Recover
+
+Recover from a misconfigured sandbox without re-running the full onboard wizard or destroying workspace state.
+
+### Change inference model or API
+
+Change the active model or provider at runtime without rebuilding the sandbox:
+
+```console
+$ openshell inference set -g nemoclaw -m <model> -p <provider>
+```
+
+See [Switch inference providers](../inference/switch-inference-providers.md) for provider-specific model IDs and API compatibility notes.
+
+### Reset a stored credential
+
+If an API key was entered incorrectly during onboarding, clear the stored value and re-enter it on the next onboard run:
+
+```console
+$ nemoclaw credentials list           # see which keys are stored
+$ nemoclaw credentials reset <KEY>    # clear a single key, e.g. NVIDIA_API_KEY
+$ nemoclaw onboard                    # re-run to re-enter the cleared key
+```
+
+The credentials command is documented in full at [Commands &rarr; `nemoclaw credentials reset`](../reference/commands.md#nemoclaw-credentials-reset-key).
+
+### Rebuild a sandbox while preserving workspace state
+
+If you changed the underlying Dockerfile, upgraded OpenClaw, or want to pick up a new base image without losing your sandbox's workspace files, use `rebuild` instead of destroying and recreating:
+
+```console
+$ nemoclaw <sandbox-name> rebuild
+```
+
+Rebuild preserves the mounted workspace and registered policies while recreating the container. See [Commands &rarr; `nemoclaw <name> rebuild`](../reference/commands.md#nemoclaw-name-rebuild) for flag details.
+
+### Add a network preset after onboarding
+
+Apply an additional preset (e.g. Telegram, GitHub) to a running sandbox without re-onboarding:
+
+```console
+$ nemoclaw <sandbox-name> policy-add
+```
+
 ## Troubleshooting
 
 If you run into issues during installation or onboarding, refer to the [Troubleshooting guide](../reference/troubleshooting.md) for common error messages and resolution steps.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -197,6 +197,8 @@ Apply an additional preset (e.g. Telegram, GitHub) to a running sandbox without 
 $ nemoclaw <sandbox-name> policy-add
 ```
 
+See [Commands &rarr; `nemoclaw <name> policy-add`](../reference/commands.md#nemoclaw-name-policy-add) for usage details and flags.
+
 ## Troubleshooting
 
 If you run into issues during installation or onboarding, refer to the [Troubleshooting guide](../reference/troubleshooting.md) for common error messages and resolution steps.


### PR DESCRIPTION
## Summary

Recovery commands were documented only in the full CLI reference (`docs/reference/commands.md`) and never cross-linked from the quickstart's Next Steps section. A user who misconfigured an API key during onboarding, wanted to pick up a new base image without destroying their workspace, or needed to add a network preset after onboarding had no entry point from the get-started path.

This PR adds a "Reconfigure or Recover" section between Next Steps and Troubleshooting with four concrete recovery patterns — each a small code block plus a link into the full commands reference.

## Changes

New section `## Reconfigure or Recover` in `docs/get-started/quickstart.md` with four subsections:

1. **Change inference model or API** — `openshell inference set -g nemoclaw -m <model> -p <provider>` → links to [switch-inference-providers.md](https://github.com/NVIDIA/NemoClaw/blob/main/docs/inference/switch-inference-providers.md).
2. **Reset a stored credential** — `nemoclaw credentials list` / `reset <KEY>` / `onboard` flow → links to [`commands.md#nemoclaw-credentials-reset-key`](https://github.com/NVIDIA/NemoClaw/blob/main/docs/reference/commands.md).
3. **Rebuild a sandbox while preserving workspace state** — `nemoclaw <sandbox-name> rebuild` → links to [`commands.md#nemoclaw-name-rebuild`](https://github.com/NVIDIA/NemoClaw/blob/main/docs/reference/commands.md).
4. **Add a network preset after onboarding** — `nemoclaw <sandbox-name> policy-add`.

The anchor slugs (`nemoclaw-credentials-reset-key`, `nemoclaw-name-rebuild`) match the current MyST markdown build output from the referenced headings.

No commands or behavior changed — this is a discoverability fix.

## Testing

Docs-only. Verified:
- [x] All four commands exist in the CLI today (`nemoclaw credentials list/reset`, `nemoclaw <name> rebuild`, `nemoclaw <name> policy-add`, `openshell inference set`)
- [x] Anchor slugs land on the right subheadings in `docs/reference/commands.md` (`### nemoclaw credentials reset <KEY>` at line 560, `### nemoclaw <name> rebuild` at line 403)

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is signed (SSH)
- [x] DCO Signed-off-by trailer present

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Reconfigure or Recover" section to Quickstart with four operational workflows: change active inference model/provider at runtime, reset stored onboarding credentials, rebuild an existing sandbox while preserving workspace and policies, and apply additional network presets to a running sandbox.
  * Added cross-links to related command and inference reference pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->