### PR TITLE
fix(e2e): fall back to sidecar for openshell version in sandbox-survival test

### DIFF
--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -248,6 +248,12 @@ if ! command -v openshell >/dev/null 2>&1; then
 fi
 
 OPENSHELL_VERSION=$(openshell --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+# Fallback: some OpenShell builds (e.g. 0.0.29) report "m-dev" instead of a
+# parseable semver. Read the sidecar file written by install-openshell.sh.
+if [ -z "$OPENSHELL_VERSION" ]; then
+  _SIDECAR="$(dirname "$(command -v openshell)")/.openshell-installed-version"
+  OPENSHELL_VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "$_SIDECAR" 2>/dev/null | head -1 || true)
+fi
 if version_gte "$OPENSHELL_VERSION" "$MIN_OPENSHELL"; then
   pass "openshell $OPENSHELL_VERSION >= $MIN_OPENSHELL (gateway resume + SSH secret + state persistence)"
 else


### PR DESCRIPTION
## Summary
- OpenShell 0.0.29 reports `openshell m-dev` instead of a parseable semver
- `test-sandbox-survival.sh` version gate only parsed `openshell --version`, got empty string, failed with "openshell < 0.0.24"
- Adds the same sidecar fallback (`.openshell-installed-version`) that `install-openshell.sh` already uses
- Test-only change, no production code affected

## Test plan
- [x] Only `test-sandbox-survival.sh` has this version gate (other E2E tests just log the version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test reliability by improving OpenShell version detection. The version validation process now includes a fallback mechanism to retrieve version information from an alternative source, ensuring tests run successfully even when the standard version retrieval method is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->