### PR TITLE
fix(e2e): align CLI help spacing and check-docs normalization

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2841,13 +2841,13 @@ function help() {
 
   ${G}Policy Presets:${R}
     nemoclaw <name> policy-add [preset]    Add a network or filesystem policy preset ${D}(--yes, --dry-run)${R}
-    nemoclaw <name> policy-remove [preset] Remove an applied policy preset ${D}(--yes, --dry-run)${R}
+    nemoclaw <name> policy-remove [preset]  Remove an applied policy preset ${D}(--yes, --dry-run)${R}
     nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
   ${G}Messaging Channels:${R}
     nemoclaw <name> channels list            List supported messaging channels
     nemoclaw <name> channels add <channel>   Save credentials and rebuild ${D}(telegram|discord|slack)${R}
-    nemoclaw <name> channels remove <channel> Clear credentials and rebuild
+    nemoclaw <name> channels remove <channel>  Clear credentials and rebuild
 
   ${G}Compatibility Commands:${R}
     nemoclaw setup                   Deprecated alias for ${B}nemoclaw onboard${R}
@@ -2866,7 +2866,7 @@ function help() {
 
   ${G}Credentials:${R}
     nemoclaw credentials list        List stored credential keys
-    nemoclaw credentials reset <KEY> Remove a stored credential so onboard re-prompts
+    nemoclaw credentials reset <KEY>  Remove a stored credential so onboard re-prompts
 
   ${G}Backup:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -141,7 +141,7 @@ run_cli_check() {
   # shellcheck disable=SC2016
   # log text: backticks are documentation markers, not command substitution
   log '[cli]        vs: docs/reference/commands.md (### `nemoclaw …` headings only)'
-  log "[cli] excluded: openshell, /nemoclaw slash, deprecated nemoclaw setup (not in --help)"
+  log "[cli] excluded: openshell, /nemoclaw slash, deprecated nemoclaw setup/setup-spark, nemoclaw onboard variants"
 
   log "[cli] phase 1/2: extract normalized usage lines from --help"
   NO_COLOR=1 "$NODE" "$CLI_JS" --help 2>&1 | LC_ALL=C perl -CS -ne '
@@ -156,6 +156,8 @@ run_cli_check() {
       while ($c =~ s/\s+<[^>]+>\s*$//) {}
       my $k = "nemoclaw $c";
       $k =~ s/^nemoclaw debug.*/nemoclaw debug/;
+      $k =~ s/^nemoclaw onboard.*/nemoclaw onboard/;
+      next if $k =~ /^nemoclaw setup(?:-spark)?$/;
       print "$k\n";
     }
   ' | LC_ALL=C sort -u >"$_tmp/help.txt"
@@ -169,7 +171,13 @@ run_cli_check() {
   log '[cli] phase 2/2: extract ### `nemoclaw …` headings from commands reference'
   # Allow optional MyST suffix on the same line, e.g. ### `nemoclaw onboard` {#anchor}
   grep -E '^### `nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
-    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) { print "$1\n"; }
+    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) {
+      my $c = $1;
+      $c =~ s/\s*\[[^\]]*\]\s*$//;
+      while ($c =~ s/\s+<[^>]+>\s*$//) {}
+      next if $c =~ /^nemoclaw setup(?:-spark)?$/;
+      print "$c\n";
+    }
   ' | LC_ALL=C sort -u >"$_tmp/doc.txt"
 
   local _n_doc


### PR DESCRIPTION
## Summary

Fix the `check-docs.sh` CLI-vs-docs parity check that failed in nightly-e2e run [#24757302596](https://github.com/NVIDIA/NemoClaw/actions/runs/24757302596).

### Root cause

Two issues caused `cloud-experimental-e2e` step 4 (`Documentation checks`) to fail:

1. **Help text spacing**: Three lines in `src/nemoclaw.ts` (`policy-remove`, `channels remove`, `credentials reset`) had only 1 space between the command and its description text. The check script's `\s{2,}` regex requires ≥2 spaces to strip descriptions, so these lines kept description text in the normalized output.

2. **Normalization asymmetry**: The help-side extraction stripped trailing `<arg>` and `[arg]` placeholders, but the doc-side extraction did not. This caused mismatches like `channels add` (help) vs `channels add <channel>` (docs). Additionally, `nemoclaw onboard --from` appeared as a separate entry and deprecated `nemoclaw setup` had no doc heading.

### Changes

- `src/nemoclaw.ts`: Add a second space before description text on the three affected help lines so the `\s{2,}` regex fires correctly.
- `test/e2e/e2e-cloud-experimental/check-docs.sh`:
  - Doc-side Perl: strip trailing `<arg>` and `[arg]` from `### nemoclaw …` headings (matching help-side normalization).
  - Help-side Perl: collapse `nemoclaw onboard --from` variants to `nemoclaw onboard` (like `debug`), and exclude deprecated `setup`/`setup-spark` aliases.
  - Updated exclusion comment to reflect actual exclusions.

### Other nightly failures (not addressed here)

| Job | Class | Root cause |
|-----|-------|------------|
| `cloud-experimental-e2e` (step 3) | infra_flake | Landlock not enforcing read-only on `/sandbox` root — OpenShell-level issue |
| `hermes-e2e` | infra_flake | NVIDIA Endpoints HTTP 429 (rate limit) during endpoint validation |
| `snapshot-commands-e2e` | infra_flake | Likely same HTTP 429 during install → sandbox unregistered in CLI registry |

## Test plan

- [ ] Re-run `check-docs.sh --only-cli` against the patched help output to verify parity
- [ ] Verify `bash -n` passes on the modified shell script (validated locally)
- [ ] Nightly-e2e `cloud-experimental-e2e` step 4 should pass with this fix

Signed-off-by: Hai Nguyen <contact@juve.vn>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #2229
