### PR TITLE
[Auto-diagnosis] Harden /sandbox DAC permissions for Landlock fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -398,6 +398,17 @@ RUN chown root:root /sandbox/.nemoclaw \
     && touch /sandbox/.nemoclaw/config.json \
     && chown sandbox:sandbox /sandbox/.nemoclaw/config.json
 
+# DAC-protect /sandbox home directory: under Landlock best_effort, kernels
+# without Landlock support fall back to DAC-only enforcement. Root ownership
+# with sticky bit prevents the sandbox user from creating new files directly
+# in the home directory while still allowing access to writable subdirectories
+# (.openclaw-data, .nemoclaw/state, /tmp). The sticky bit survives any chown
+# by OpenShell's prepare_filesystem() and prevents sandbox from renaming or
+# deleting root-owned entries.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/804
+RUN chown root:root /sandbox \
+    && chmod 1755 /sandbox
+
 # Entrypoint runs as root to start the gateway as the gateway user,
 # then drops to sandbox for agent commands. See nemoclaw-start.sh.
 ENTRYPOINT ["/usr/local/bin/nemoclaw-start"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The `04-landlock-readonly` test in `cloud-experimental-e2e` fails because `/sandbox` is writable when Landlock `best_effort` mode degrades on CI runners without Landlock kernel support. This change sets root ownership and a sticky bit on `/sandbox` so the sandbox user cannot create new files in the home directory even without Landlock enforcement.

Fixes cloud-experimental-e2e `04-landlock-readonly` test 1 failure in nightly run 24705240158.

## Related Issue
Fixes #2237

## Changes
- `Dockerfile` — added `chown root:root /sandbox && chmod 1755 /sandbox` after the `.nemoclaw` hardening block so DAC prevents file creation in `/sandbox` when Landlock is unavailable.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (`nemoclaw-diagnosis` skill)

---
Signed-off-by: Hai Nguyen <haingu@nvidia.com>
