### PR TITLE
[Auto-diagnosis] fix check-docs CLI/doc heading normalization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -398,17 +398,6 @@ RUN chown root:root /sandbox/.nemoclaw \
     && touch /sandbox/.nemoclaw/config.json \
     && chown sandbox:sandbox /sandbox/.nemoclaw/config.json
 
-# DAC-protect /sandbox home directory: under Landlock best_effort, kernels
-# without Landlock support fall back to DAC-only enforcement. Root ownership
-# with sticky bit prevents the sandbox user from creating new files directly
-# in the home directory while still allowing access to writable subdirectories
-# (.openclaw-data, .nemoclaw/state, /tmp). The sticky bit survives any chown
-# by OpenShell's prepare_filesystem() and prevents sandbox from renaming or
-# deleting root-owned entries.
-# Ref: https://github.com/NVIDIA/NemoClaw/issues/804
-RUN chown root:root /sandbox \
-    && chmod 1755 /sandbox
-
 # Entrypoint runs as root to start the gateway as the gateway user,
 # then drops to sandbox for agent commands. See nemoclaw-start.sh.
 ENTRYPOINT ["/usr/local/bin/nemoclaw-start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -398,6 +398,17 @@ RUN chown root:root /sandbox/.nemoclaw \
     && touch /sandbox/.nemoclaw/config.json \
     && chown sandbox:sandbox /sandbox/.nemoclaw/config.json
 
+# DAC-protect /sandbox home directory: under Landlock best_effort, kernels
+# without Landlock support fall back to DAC-only enforcement. Root ownership
+# with sticky bit prevents the sandbox user from creating new files directly
+# in the home directory while still allowing access to writable subdirectories
+# (.openclaw-data, .nemoclaw/state, /tmp). The sticky bit survives any chown
+# by OpenShell's prepare_filesystem() and prevents sandbox from renaming or
+# deleting root-owned entries.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/804
+RUN chown root:root /sandbox \
+    && chmod 1755 /sandbox
+
 # Entrypoint runs as root to start the gateway as the gateway user,
 # then drops to sandbox for agent commands. See nemoclaw-start.sh.
 ENTRYPOINT ["/usr/local/bin/nemoclaw-start"]

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2525,7 +2525,7 @@ function help() {
 
   ${G}Policy Presets:${R}
     nemoclaw <name> policy-add [preset]    Add a network or filesystem policy preset ${D}(--yes, --dry-run)${R}
-    nemoclaw <name> policy-remove [preset] Remove an applied policy preset ${D}(--yes, --dry-run)${R}
+    nemoclaw <name> policy-remove [preset]  Remove an applied policy preset ${D}(--yes, --dry-run)${R}
     nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
   ${G}Compatibility Commands:${R}
@@ -2545,7 +2545,7 @@ function help() {
 
   ${G}Credentials:${R}
     nemoclaw credentials list        List stored credential keys
-    nemoclaw credentials reset <KEY> Remove a stored credential so onboard re-prompts
+    nemoclaw credentials reset <KEY>  Remove a stored credential so onboard re-prompts
 
   ${G}Backup:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -156,6 +156,7 @@ run_cli_check() {
       while ($c =~ s/\s+<[^>]+>\s*$//) {}
       my $k = "nemoclaw $c";
       $k =~ s/^nemoclaw debug.*/nemoclaw debug/;
+      $k =~ s/^(nemoclaw onboard) --from.*/$1/;
       print "$k\n";
     }
   ' | LC_ALL=C sort -u >"$_tmp/help.txt"
@@ -168,8 +169,13 @@ run_cli_check() {
   # log text: backticks are documentation markers, not command substitution
   log '[cli] phase 2/2: extract ### `nemoclaw …` headings from commands reference'
   # Allow optional MyST suffix on the same line, e.g. ### `nemoclaw onboard` {#anchor}
-  grep -E '^### `nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
-    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) { print "$1\n"; }
+  grep -E '^### (Legacy )?\`nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
+    if (/^### (?:Legacy )?\`([^\`]+)\`/) {
+      my $c = $1;
+      $c =~ s/\s*\[[^\]]*\]\s*$//;
+      while ($c =~ s/\s+<[^>]+>\s*$//) {}
+      print "$c\n";
+    }
   ' | LC_ALL=C sort -u >"$_tmp/doc.txt"
 
   local _n_doc


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The cloud-experimental-e2e `check-docs` test fails because CLI help output and
docs reference headings are normalized differently. Two `policy-remove` and
`credentials reset` help lines lack the double-space separator the phase-1
`\s{2,}` regex expects, phase-1 does not collapse `nemoclaw onboard --from*`
variants, and phase-2 misses `Legacy`-prefixed headings and does not strip
trailing `[arg]`/`<arg>` from doc headings.

Fixes cloud-experimental-e2e check-docs failure in nightly run 24705240158.

## Related Issue
Fixes #2238

## Changes
- `src/nemoclaw.ts` — add double-space separator on `policy-remove` and `credentials reset` help lines so the normalizer regex matches.
- `test/e2e/e2e-cloud-experimental/check-docs.sh` — collapse `nemoclaw onboard --from*` variants to `nemoclaw onboard`; broaden phase-2 grep to match `Legacy`-prefixed headings; strip trailing `[arg]`/`<arg>` from doc headings.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (`nemoclaw-diagnosis` skill)

---
Signed-off-by: Hai Nguyen <haingu@nvidia.com>
