### PR TITLE
docs(network-policy): warn that policy set replaces the live policy

### DIFF
--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -125,28 +125,67 @@ $ nemoclaw <name> status
 
 Dynamic changes apply a policy update to a running sandbox without restarting it.
 
-### Create a Policy File
+> [!WARNING]
+> `openshell policy set` **replaces** the sandbox's live policy with the contents of the file you provide; it does not merge.
+> A running sandbox's live policy is the baseline from `openclaw-sandbox.yaml` plus every preset that was layered on during onboarding.
+> Applying a file that contains only the baseline (or only a single preset) silently drops every other preset that was in effect.
 
-Create a YAML file with the endpoints to add.
-Follow the same format as the baseline policy in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`.
-Add a top-level `version` field (for example, `version: 1`).
-OpenShell rejects policy YAML that omits this field.
+### Option 1: Drop a Preset File and Use `policy-add` (Recommended)
 
-### Apply the Policy
+This is the non-destructive path and the only flow NemoClaw supports out of the box for merging new entries into a running policy.
 
-Use the OpenShell CLI to apply the policy update:
+1. Create a preset-format YAML file under `nemoclaw-blueprint/policies/presets/`, for example `nemoclaw-blueprint/policies/presets/influxdb.yaml`:
+
+   ```yaml
+   preset:
+     name: influxdb
+     description: "InfluxDB time-series database"
+   network_policies:
+     influxdb:
+       name: influxdb
+       endpoints:
+         - host: influxdb.internal.example.com
+           port: 8086
+           protocol: rest
+           enforcement: enforce
+           tls: terminate
+           rules:
+             - allow: { method: GET, path: "/**" }
+             - allow: { method: POST, path: "/api/v2/write" }
+       binaries:
+         - { path: /usr/bin/curl }
+   ```
+
+2. Apply it to the running sandbox:
+
+   ```console
+   $ nemoclaw my-assistant policy-add
+   ```
+
+   NemoClaw reads the live policy via `openshell policy get --full`, structurally merges your preset's `network_policies` into it, and writes the merged result back.
+   Existing presets and the baseline remain in place.
+   The preset file under `presets/` also persists across sandbox recreations.
+
+### Option 2: Snapshot, Edit, and Set via OpenShell
+
+Use this path only when you cannot add a file under the NemoClaw source tree.
+You must start from the **live** policy, not from `openclaw-sandbox.yaml`, so the presets layered on at onboarding are preserved in the file you apply.
 
 ```console
-$ openshell policy set --policy <policy-file> <sandbox-name>
+$ openshell policy get --full my-assistant > live-policy.yaml
 ```
 
-The change takes effect immediately.
+Edit `live-policy.yaml` to add your entries under `network_policies:`, keeping the existing `version` field intact, then apply:
+
+```console
+$ openshell policy set --policy live-policy.yaml my-assistant
+```
 
 ### Scope of Dynamic Changes
 
 Dynamic changes apply only to the current session.
-When the sandbox stops, the running policy resets to the baseline defined in the policy file.
-To make changes permanent, update the static policy file and re-run setup.
+When the sandbox stops, the running policy resets to the baseline composed from `openclaw-sandbox.yaml` plus the presets recorded for the sandbox.
+To make a custom policy survive a sandbox recreation, ship the preset file in the repository (Option 1 above — the file under `presets/` persists) or edit `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.
 
 ### Approve Requests Interactively
 

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -92,28 +92,67 @@ $ nemoclaw <name> status
 
 Dynamic changes apply a policy update to a running sandbox without restarting it.
 
-### Create a Policy File
+> [!WARNING]
+> `openshell policy set` **replaces** the sandbox's live policy with the contents of the file you provide; it does not merge.
+> A running sandbox's live policy is the baseline from `openclaw-sandbox.yaml` plus every preset that was layered on during onboarding.
+> Applying a file that contains only the baseline (or only a single preset) silently drops every other preset that was in effect.
 
-Create a YAML file with the endpoints to add.
-Follow the same format as the baseline policy in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`.
-Add a top-level `version` field (for example, `version: 1`).
-OpenShell rejects policy YAML that omits this field.
+### Option 1: Drop a Preset File and Use `policy-add` (Recommended)
 
-### Apply the Policy
+This is the non-destructive path and the only flow NemoClaw supports out of the box for merging new entries into a running policy.
 
-Use the OpenShell CLI to apply the policy update:
+1. Create a preset-format YAML file under `nemoclaw-blueprint/policies/presets/`, for example `nemoclaw-blueprint/policies/presets/influxdb.yaml`:
+
+   ```yaml
+   preset:
+     name: influxdb
+     description: "InfluxDB time-series database"
+   network_policies:
+     influxdb:
+       name: influxdb
+       endpoints:
+         - host: influxdb.internal.example.com
+           port: 8086
+           protocol: rest
+           enforcement: enforce
+           tls: terminate
+           rules:
+             - allow: { method: GET, path: "/**" }
+             - allow: { method: POST, path: "/api/v2/write" }
+       binaries:
+         - { path: /usr/bin/curl }
+   ```
+
+2. Apply it to the running sandbox:
+
+   ```console
+   $ nemoclaw my-assistant policy-add
+   ```
+
+   NemoClaw reads the live policy via `openshell policy get --full`, structurally merges your preset's `network_policies` into it, and writes the merged result back.
+   Existing presets and the baseline remain in place.
+   The preset file under `presets/` also persists across sandbox recreations.
+
+### Option 2: Snapshot, Edit, and Set via OpenShell
+
+Use this path only when you cannot add a file under the NemoClaw source tree.
+You must start from the **live** policy, not from `openclaw-sandbox.yaml`, so the presets layered on at onboarding are preserved in the file you apply.
 
 ```console
-$ openshell policy set --policy <policy-file> <sandbox-name>
+$ openshell policy get --full my-assistant > live-policy.yaml
 ```
 
-The change takes effect immediately.
+Edit `live-policy.yaml` to add your entries under `network_policies:`, keeping the existing `version` field intact, then apply:
+
+```console
+$ openshell policy set --policy live-policy.yaml my-assistant
+```
 
 ### Scope of Dynamic Changes
 
 Dynamic changes apply only to the current session.
-When the sandbox stops, the running policy resets to the baseline defined in the policy file.
-To make changes permanent, update the static policy file and re-run setup.
+When the sandbox stops, the running policy resets to the baseline composed from `openclaw-sandbox.yaml` plus the presets recorded for the sandbox.
+To make a custom policy survive a sandbox recreation, ship the preset file in the repository (Option 1 above — the file under `presets/` persists) or edit `openclaw-sandbox.yaml` and re-run `nemoclaw onboard`.
 
 ### Approve Requests Interactively
 


### PR DESCRIPTION
The Dynamic Changes section previously told users to copy openclaw-sandbox.yaml, add their endpoints, and run openshell policy set on the result. That silently replaces the live policy with a file that contains only the baseline, dropping every preset that was layered on at onboarding. Users running a Balanced tier sandbox would lose npm, pypi, huggingface, brew, and brave in one command, which is exactly the foot-gun reported on #2232.

Rewrite the section as two clearly-labelled options: drop a preset file under nemoclaw-blueprint/policies/presets/ and run nemoclaw <name> policy-add (non-destructive, merges via policy get + policy set), or snapshot the live policy with openshell policy get --full first and edit that before applying. Call out explicitly that openshell policy set is a replace, not a merge.

Fixes #2232

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [X] Doc only (prose changes, no code sample modifications)
- [X] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [X] Docs updated for user-facing behavior changes
- [X] `make docs` builds without warnings (doc changes only)
- [X] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [X] AI-assisted — tool: Claude Code<!-- e.g., Claude Code, Cursor, GitHub Copilot -->

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced two clear workflows for customizing network policies: preset-based and direct edit options
  * Added explicit warnings about policy replacement behavior and potential preset loss
  * Updated guidance on sandbox reset behavior and how changes persist across recreations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->