### PR TITLE
[Auto-diagnosis] fix(e2e): normalize both sides of check-docs CLI parity check

### DIFF
--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -150,12 +150,17 @@ run_cli_check() {
     if (/^\s*nemoclaw\s+(.+)/) {
       my $c = $1;
       $c =~ s/\s{2,}.*$//;
+      # Strip single-space-separated descriptions (uppercase start after arg)
+      $c =~ s/\s+[A-Z][a-z].*$//;
       $c =~ s/\s+$//;
       $c =~ s/\s*\[[^\]]*\]\s*$//;
       $c =~ s/\s*--output\s+FILE\s*$//;
       while ($c =~ s/\s+<[^>]+>\s*$//) {}
       my $k = "nemoclaw $c";
       $k =~ s/^nemoclaw debug.*/nemoclaw debug/;
+      # Skip deprecated aliases and flag variants not in commands.md
+      next if $k eq "nemoclaw setup";
+      next if $k =~ /\s--from$/;
       print "$k\n";
     }
   ' | LC_ALL=C sort -u >"$_tmp/help.txt"
@@ -169,7 +174,15 @@ run_cli_check() {
   log '[cli] phase 2/2: extract ### `nemoclaw …` headings from commands reference'
   # Allow optional MyST suffix on the same line, e.g. ### `nemoclaw onboard` {#anchor}
   grep -E '^### `nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
-    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) { print "$1\n"; }
+    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) {
+      my $c = $1;
+      $c =~ s/\s{2,}.*$//;
+      $c =~ s/\s+$//;
+      $c =~ s/\s*\[[^\]]*\]\s*$//;
+      $c =~ s/\s*--output\s+FILE\s*$//;
+      while ($c =~ s/\s+<[^>]+>\s*$//) {}
+      print "$c\n";
+    }
   ' | LC_ALL=C sort -u >"$_tmp/doc.txt"
 
   local _n_doc


### PR DESCRIPTION
## Summary

The `check-docs.sh` CLI parity check fails because it normalizes
`--help` output (stripping `<args>`, `[args]`, descriptions) but
compares the raw `commands.md` headings without the same normalization.

**Root cause:** Three normalization asymmetries between the help and doc sides:

1. **Arg stripping**: Help side strips trailing `<arg>` and `[arg]`
   placeholders; doc side preserves them in headings like
   `### \`nemoclaw <name> channels add <channel>\``.
2. **Description leakage**: Some help lines have descriptions separated by
   only one space after the last argument (e.g.,
   `channels remove <channel> Clear credentials…`), so the `\s{2,}` regex
   doesn't strip them.
3. **Excluded commands**: `nemoclaw setup` (deprecated alias) and
   `nemoclaw onboard --from` (flag variant documented under `####`) appear in
   help but have no standalone `###` heading in `commands.md`.

**Changes:**

- Apply identical `<arg>` / `[arg]` stripping to the doc-side extraction
- Add single-space description stripping via `[A-Z][a-z]` heuristic on the
  help side
- Exclude `nemoclaw setup` and `--from` flag variants from comparison

**Workflow run:** https://github.com/NVIDIA/NemoClaw/actions/runs/24757302596
**Failed job:** cloud-experimental-e2e (step 4 — Documentation checks)

Fixes #2250

Signed-off-by: Hai Nguyen <haingu@nvidia.com>