### PR TITLE
[Auto-diagnosis] fix(e2e): surface CLI error output in snapshot-commands test

### DIFF
--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -150,17 +150,12 @@ run_cli_check() {
     if (/^\s*nemoclaw\s+(.+)/) {
       my $c = $1;
       $c =~ s/\s{2,}.*$//;
-      # Strip single-space-separated descriptions (uppercase start after arg)
-      $c =~ s/\s+[A-Z][a-z].*$//;
       $c =~ s/\s+$//;
       $c =~ s/\s*\[[^\]]*\]\s*$//;
       $c =~ s/\s*--output\s+FILE\s*$//;
       while ($c =~ s/\s+<[^>]+>\s*$//) {}
       my $k = "nemoclaw $c";
       $k =~ s/^nemoclaw debug.*/nemoclaw debug/;
-      # Skip deprecated aliases and flag variants not in commands.md
-      next if $k eq "nemoclaw setup";
-      next if $k =~ /\s--from$/;
       print "$k\n";
     }
   ' | LC_ALL=C sort -u >"$_tmp/help.txt"
@@ -174,15 +169,7 @@ run_cli_check() {
   log '[cli] phase 2/2: extract ### `nemoclaw …` headings from commands reference'
   # Allow optional MyST suffix on the same line, e.g. ### `nemoclaw onboard` {#anchor}
   grep -E '^### `nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
-    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) {
-      my $c = $1;
-      $c =~ s/\s{2,}.*$//;
-      $c =~ s/\s+$//;
-      $c =~ s/\s*\[[^\]]*\]\s*$//;
-      $c =~ s/\s*--output\s+FILE\s*$//;
-      while ($c =~ s/\s+<[^>]+>\s*$//) {}
-      print "$c\n";
-    }
+    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) { print "$1\n"; }
   ' | LC_ALL=C sort -u >"$_tmp/doc.txt"
 
   local _n_doc

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -150,12 +150,17 @@ run_cli_check() {
     if (/^\s*nemoclaw\s+(.+)/) {
       my $c = $1;
       $c =~ s/\s{2,}.*$//;
+      # Strip single-space-separated descriptions (uppercase start after arg)
+      $c =~ s/\s+[A-Z][a-z].*$//;
       $c =~ s/\s+$//;
       $c =~ s/\s*\[[^\]]*\]\s*$//;
       $c =~ s/\s*--output\s+FILE\s*$//;
       while ($c =~ s/\s+<[^>]+>\s*$//) {}
       my $k = "nemoclaw $c";
       $k =~ s/^nemoclaw debug.*/nemoclaw debug/;
+      # Skip deprecated aliases and flag variants not in commands.md
+      next if $k eq "nemoclaw setup";
+      next if $k =~ /\s--from$/;
       print "$k\n";
     }
   ' | LC_ALL=C sort -u >"$_tmp/help.txt"
@@ -169,7 +174,15 @@ run_cli_check() {
   log '[cli] phase 2/2: extract ### `nemoclaw …` headings from commands reference'
   # Allow optional MyST suffix on the same line, e.g. ### `nemoclaw onboard` {#anchor}
   grep -E '^### `nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
-    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) { print "$1\n"; }
+    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) {
+      my $c = $1;
+      $c =~ s/\s{2,}.*$//;
+      $c =~ s/\s+$//;
+      $c =~ s/\s*\[[^\]]*\]\s*$//;
+      $c =~ s/\s*--output\s+FILE\s*$//;
+      while ($c =~ s/\s+<[^>]+>\s*$//) {}
+      print "$c\n";
+    }
   ' | LC_ALL=C sort -u >"$_tmp/doc.txt"
 
   local _n_doc

--- a/test/e2e/test-snapshot-commands.sh
+++ b/test/e2e/test-snapshot-commands.sh
@@ -101,8 +101,13 @@ pass "Marker file written"
 # ── Phase 3: snapshot create ────────────────────────────────────────
 info "Phase 3: Creating snapshot..."
 
-SNAPSHOT_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot create 2>&1)
+SNAPSHOT_EXIT=0
+SNAPSHOT_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot create 2>&1) || SNAPSHOT_EXIT=$?
 echo "$SNAPSHOT_OUTPUT"
+
+if [ "$SNAPSHOT_EXIT" -ne 0 ]; then
+  fail "snapshot create exited ${SNAPSHOT_EXIT}: ${SNAPSHOT_OUTPUT}"
+fi
 
 if echo "$SNAPSHOT_OUTPUT" | grep -q "Snapshot created"; then
   pass "snapshot create succeeded"
@@ -142,7 +147,10 @@ openshell sandbox exec --name "${SANDBOX_NAME}" -- \
 GONE=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- cat "${MARKER_FILE}" 2>/dev/null || echo "GONE")
 [ "$GONE" = "GONE" ] || fail "First marker should be deleted but got: ${GONE}"
 
-nemoclaw "${SANDBOX_NAME}" snapshot create >/dev/null 2>&1 || fail "Second snapshot create failed"
+SECOND_SNAP_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot create 2>&1) || {
+  echo "$SECOND_SNAP_OUTPUT"
+  fail "Second snapshot create failed: ${SECOND_SNAP_OUTPUT}"
+}
 pass "State modified, second snapshot created"
 
 # Perturb workspace so restore has to do real work
@@ -153,8 +161,13 @@ openshell sandbox exec --name "${SANDBOX_NAME}" -- \
 # ── Phase 6: snapshot restore (latest) ──────────────────────────────
 info "Phase 6: Restoring latest snapshot..."
 
-RESTORE_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot restore 2>&1)
+RESTORE_EXIT=0
+RESTORE_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot restore 2>&1) || RESTORE_EXIT=$?
 echo "$RESTORE_OUTPUT"
+
+if [ "$RESTORE_EXIT" -ne 0 ]; then
+  fail "snapshot restore exited ${RESTORE_EXIT}: ${RESTORE_OUTPUT}"
+fi
 
 if ! echo "$RESTORE_OUTPUT" | grep -q "Restored"; then
   fail "snapshot restore failed: ${RESTORE_OUTPUT}"
@@ -167,8 +180,13 @@ pass "Latest snapshot restored expected state"
 # ── Phase 7: snapshot restore with timestamp (first snapshot) ───────
 info "Phase 7: Restoring first snapshot by timestamp..."
 
-TARGETED_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot restore "${SNAPSHOT_TIMESTAMP}" 2>&1)
+TARGETED_EXIT=0
+TARGETED_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot restore "${SNAPSHOT_TIMESTAMP}" 2>&1) || TARGETED_EXIT=$?
 echo "$TARGETED_OUTPUT"
+
+if [ "$TARGETED_EXIT" -ne 0 ]; then
+  fail "Targeted snapshot restore exited ${TARGETED_EXIT}: ${TARGETED_OUTPUT}"
+fi
 
 if ! echo "$TARGETED_OUTPUT" | grep -q "Restored"; then
   fail "Targeted snapshot restore failed: ${TARGETED_OUTPUT}"


### PR DESCRIPTION
## Summary

The snapshot-commands E2E test swallows all CLI diagnostic output when
`nemoclaw snapshot create` exits non-zero, making failures
undiagnosable from CI logs.

**Root cause:** The test uses `SNAPSHOT_OUTPUT=$(nemoclaw ... 2>&1)` with
`set -euo pipefail`. When the subshell command fails, `set -e` kills the
script at the assignment line before `echo "$SNAPSHOT_OUTPUT"` runs. The
captured error message (e.g., "Sandbox not running" or "Snapshot failed")
is lost — the CI log shows only `##[error] Process completed with exit
code 1`.

**Changes:**

- Capture exit code separately via `|| EXIT=$?` to prevent `set -e`
  from killing the script before output is displayed
- Echo the captured output before calling `fail()` so CI logs contain
  the CLI's error message for post-mortem diagnosis
- Apply the same pattern to all four nemoclaw snapshot subcommand calls:
  first create, second create, latest restore, and targeted restore

**Workflow run:** https://github.com/NVIDIA/NemoClaw/actions/runs/24757302596
**Failed job:** snapshot-commands-e2e (step 3 — Run snapshot commands E2E test)

Fixes #2251

Signed-off-by: Hai Nguyen <haingu@nvidia.com>