### PR TITLE
fix(docs): sync CLI help text with commands.md headings

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -348,7 +348,7 @@ The command is a static reference; it does not consult credentials or the runnin
 $ nemoclaw my-assistant channels list
 ```
 
-### `nemoclaw <name> channels add <channel>`
+### `nemoclaw <name> channels add`
 
 Store credentials for a messaging channel (`telegram`, `discord`, or `slack`) and rebuild the sandbox so the image picks up the new channel.
 The command prompts for any missing token, persists it under `~/.nemoclaw/credentials.json`, then asks whether to rebuild immediately.
@@ -365,7 +365,7 @@ $ nemoclaw my-assistant channels add telegram
 Slack requires both `SLACK_BOT_TOKEN` (bot user OAuth) and `SLACK_APP_TOKEN` (app-level Socket Mode token); the command prompts for each in turn.
 When `NEMOCLAW_NON_INTERACTIVE=1` is set, any missing token fails fast and no rebuild prompt is shown — instead, the change is queued and you are told to run `nemoclaw <name> rebuild` manually.
 
-### `nemoclaw <name> channels remove <channel>`
+### `nemoclaw <name> channels remove`
 
 Clear the stored credentials for a messaging channel and rebuild the sandbox so the image drops the channel.
 Running `remove` for a channel that was never configured is a no-op against the credentials file and still triggers the rebuild prompt.
@@ -382,7 +382,7 @@ As with `channels add`, `NEMOCLAW_NON_INTERACTIVE=1` skips the rebuild prompt an
 
 Host-side removal is the supported path because `/sandbox/.openclaw/openclaw.json` is read-only at runtime; `openclaw channels remove` cannot modify the baked config from inside the sandbox.
 
-### `nemoclaw <name> skill install <path>`
+### `nemoclaw <name> skill install`
 
 Deploy a skill directory to a running sandbox.
 The command validates the `SKILL.md` frontmatter (a `name` field is required), uploads all non-dot files preserving subdirectory structure, and performs agent-specific post-install steps.
@@ -469,7 +469,7 @@ List available snapshots for a sandbox with timestamps and item counts.
 $ nemoclaw my-assistant snapshot list
 ```
 
-### `nemoclaw <name> snapshot restore [timestamp]`
+### `nemoclaw <name> snapshot restore`
 
 Restore sandbox state from a snapshot.
 The sandbox must be running before you restore.
@@ -517,6 +517,19 @@ Show the sandbox list and the status of host auxiliary services (for example clo
 $ nemoclaw status
 ```
 
+### `nemoclaw setup`
+
+:::{warning}
+The `nemoclaw setup` command is deprecated.
+Use `nemoclaw onboard` instead.
+:::
+
+This command remains as a compatibility alias to `nemoclaw onboard`.
+
+```console
+$ nemoclaw setup
+```
+
 ### `nemoclaw setup-spark`
 
 :::{warning}
@@ -557,7 +570,7 @@ Values are not printed.
 $ nemoclaw credentials list
 ```
 
-### `nemoclaw credentials reset <KEY>`
+### `nemoclaw credentials reset`
 
 Remove a stored credential by name.
 After removal, re-running `nemoclaw onboard` re-prompts for that key.

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2822,7 +2822,7 @@ function help() {
 
   ${G}Getting Started:${R}
     ${B}nemoclaw onboard${R}                 Configure inference endpoint and credentials
-    nemoclaw onboard ${D}--from <Dockerfile>${R}  Use a custom Dockerfile for the sandbox image
+      ${D}--from <Dockerfile>${R}            Use a custom Dockerfile for the sandbox image
                                     ${D}(non-interactive: ${NOTICE_ACCEPT_FLAG} or ${NOTICE_ACCEPT_ENV}=1)${R}
 
   ${G}Sandbox Management:${R}
@@ -2841,13 +2841,13 @@ function help() {
 
   ${G}Policy Presets:${R}
     nemoclaw <name> policy-add [preset]    Add a network or filesystem policy preset ${D}(--yes, --dry-run)${R}
-    nemoclaw <name> policy-remove [preset] Remove an applied policy preset ${D}(--yes, --dry-run)${R}
+    nemoclaw <name> policy-remove [preset]  Remove an applied policy preset ${D}(--yes, --dry-run)${R}
     nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
   ${G}Messaging Channels:${R}
     nemoclaw <name> channels list            List supported messaging channels
     nemoclaw <name> channels add <channel>   Save credentials and rebuild ${D}(telegram|discord|slack)${R}
-    nemoclaw <name> channels remove <channel> Clear credentials and rebuild
+    nemoclaw <name> channels remove <channel>  Clear credentials and rebuild
 
   ${G}Compatibility Commands:${R}
     nemoclaw setup                   Deprecated alias for ${B}nemoclaw onboard${R}
@@ -2866,7 +2866,7 @@ function help() {
 
   ${G}Credentials:${R}
     nemoclaw credentials list        List stored credential keys
-    nemoclaw credentials reset <KEY> Remove a stored credential so onboard re-prompts
+    nemoclaw credentials reset <KEY>  Remove a stored credential so onboard re-prompts
 
   ${G}Backup:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade


### PR DESCRIPTION
## Summary

Sync CLI `--help` text with `docs/reference/commands.md` headings so the
`check-docs.sh` parity check passes in the nightly-e2e `cloud-experimental-e2e`
job.

### Root cause

The normalisation Perl in `check-docs.sh` strips inline descriptions from
`--help` lines only when they are preceded by **two or more spaces**. Three help
lines used a single-space separator, so the description text leaked into the
normalised command string. Additionally, five `commands.md` headings included
trailing positional arguments (`<channel>`, `<path>`, `[timestamp]`, `<KEY>`)
that the normaliser strips from help output, and two entries (`onboard --from`,
`setup`) had no matching doc heading.

### Changes

**`src/nemoclaw.ts` (help text)**
- Indent the `--from <Dockerfile>` line so it no longer starts with `nemoclaw`
  and is not parsed as a separate command.
- Add a second space before inline descriptions on `policy-remove [preset]`,
  `channels remove <channel>`, and `credentials reset <KEY>`.

**`docs/reference/commands.md` (headings)**
- Remove trailing positional arguments from five headings (`channels add`,
  `channels remove`, `skill install`, `snapshot restore`, `credentials reset`)
  to match the normalised help output.
- Add a `### \`nemoclaw setup\`` heading for the deprecated alias (previously
  present in `--help` but missing from docs).

### Nightly run

- **Run:** https://github.com/NVIDIA/NemoClaw/actions/runs/24757302596
- **Job:** `cloud-experimental-e2e` — Step 4 (`check-docs.sh`)
- **Commit:** `68fa01ccfcbf25a59bede65b586ed072678d6b2a`

## Test plan

- [ ] `bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli` passes locally
- [ ] Nightly re-run shows `check-docs.sh` step green

Signed-off-by: Hai Nguyen <haingu@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #2263