### PR TITLE
fix(e2e): prevent set -e from swallowing snapshot command output

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -348,7 +348,7 @@ The command is a static reference; it does not consult credentials or the runnin
 $ nemoclaw my-assistant channels list
 ```
 
-### `nemoclaw <name> channels add <channel>`
+### `nemoclaw <name> channels add`
 
 Store credentials for a messaging channel (`telegram`, `discord`, or `slack`) and rebuild the sandbox so the image picks up the new channel.
 The command prompts for any missing token, persists it under `~/.nemoclaw/credentials.json`, then asks whether to rebuild immediately.
@@ -365,7 +365,7 @@ $ nemoclaw my-assistant channels add telegram
 Slack requires both `SLACK_BOT_TOKEN` (bot user OAuth) and `SLACK_APP_TOKEN` (app-level Socket Mode token); the command prompts for each in turn.
 When `NEMOCLAW_NON_INTERACTIVE=1` is set, any missing token fails fast and no rebuild prompt is shown — instead, the change is queued and you are told to run `nemoclaw <name> rebuild` manually.
 
-### `nemoclaw <name> channels remove <channel>`
+### `nemoclaw <name> channels remove`
 
 Clear the stored credentials for a messaging channel and rebuild the sandbox so the image drops the channel.
 Running `remove` for a channel that was never configured is a no-op against the credentials file and still triggers the rebuild prompt.
@@ -382,7 +382,7 @@ As with `channels add`, `NEMOCLAW_NON_INTERACTIVE=1` skips the rebuild prompt an
 
 Host-side removal is the supported path because `/sandbox/.openclaw/openclaw.json` is read-only at runtime; `openclaw channels remove` cannot modify the baked config from inside the sandbox.
 
-### `nemoclaw <name> skill install <path>`
+### `nemoclaw <name> skill install`
 
 Deploy a skill directory to a running sandbox.
 The command validates the `SKILL.md` frontmatter (a `name` field is required), uploads all non-dot files preserving subdirectory structure, and performs agent-specific post-install steps.
@@ -469,7 +469,7 @@ List available snapshots for a sandbox with timestamps and item counts.
 $ nemoclaw my-assistant snapshot list
 ```
 
-### `nemoclaw <name> snapshot restore [timestamp]`
+### `nemoclaw <name> snapshot restore`
 
 Restore sandbox state from a snapshot.
 The sandbox must be running before you restore.
@@ -517,6 +517,19 @@ Show the sandbox list and the status of host auxiliary services (for example clo
 $ nemoclaw status
 ```
 
+### `nemoclaw setup`
+
+:::{warning}
+The `nemoclaw setup` command is deprecated.
+Use `nemoclaw onboard` instead.
+:::
+
+This command remains as a compatibility alias to `nemoclaw onboard`.
+
+```console
+$ nemoclaw setup
+```
+
 ### `nemoclaw setup-spark`
 
 :::{warning}
@@ -557,7 +570,7 @@ Values are not printed.
 $ nemoclaw credentials list
 ```
 
-### `nemoclaw credentials reset <KEY>`
+### `nemoclaw credentials reset`
 
 Remove a stored credential by name.
 After removal, re-running `nemoclaw onboard` re-prompts for that key.

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2822,7 +2822,7 @@ function help() {
 
   ${G}Getting Started:${R}
     ${B}nemoclaw onboard${R}                 Configure inference endpoint and credentials
-    nemoclaw onboard ${D}--from <Dockerfile>${R}  Use a custom Dockerfile for the sandbox image
+      ${D}--from <Dockerfile>${R}            Use a custom Dockerfile for the sandbox image
                                     ${D}(non-interactive: ${NOTICE_ACCEPT_FLAG} or ${NOTICE_ACCEPT_ENV}=1)${R}
 
   ${G}Sandbox Management:${R}
@@ -2841,13 +2841,13 @@ function help() {
 
   ${G}Policy Presets:${R}
     nemoclaw <name> policy-add [preset]    Add a network or filesystem policy preset ${D}(--yes, --dry-run)${R}
-    nemoclaw <name> policy-remove [preset] Remove an applied policy preset ${D}(--yes, --dry-run)${R}
+    nemoclaw <name> policy-remove [preset]  Remove an applied policy preset ${D}(--yes, --dry-run)${R}
     nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
   ${G}Messaging Channels:${R}
     nemoclaw <name> channels list            List supported messaging channels
     nemoclaw <name> channels add <channel>   Save credentials and rebuild ${D}(telegram|discord|slack)${R}
-    nemoclaw <name> channels remove <channel> Clear credentials and rebuild
+    nemoclaw <name> channels remove <channel>  Clear credentials and rebuild
 
   ${G}Compatibility Commands:${R}
     nemoclaw setup                   Deprecated alias for ${B}nemoclaw onboard${R}
@@ -2866,7 +2866,7 @@ function help() {
 
   ${G}Credentials:${R}
     nemoclaw credentials list        List stored credential keys
-    nemoclaw credentials reset <KEY> Remove a stored credential so onboard re-prompts
+    nemoclaw credentials reset <KEY>  Remove a stored credential so onboard re-prompts
 
   ${G}Backup:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade

--- a/test/e2e/test-snapshot-commands.sh
+++ b/test/e2e/test-snapshot-commands.sh
@@ -101,7 +101,7 @@ pass "Marker file written"
 # ── Phase 3: snapshot create ────────────────────────────────────────
 info "Phase 3: Creating snapshot..."
 
-SNAPSHOT_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot create 2>&1)
+SNAPSHOT_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot create 2>&1) || true
 echo "$SNAPSHOT_OUTPUT"
 
 if echo "$SNAPSHOT_OUTPUT" | grep -q "Snapshot created"; then
@@ -117,7 +117,7 @@ info "Snapshot path: ${SNAPSHOT_PATH:-unknown}"
 # ── Phase 4: snapshot list ──────────────────────────────────────────
 info "Phase 4: Listing snapshots..."
 
-LIST_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot list 2>&1)
+LIST_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot list 2>&1) || true
 echo "$LIST_OUTPUT"
 
 if echo "$LIST_OUTPUT" | grep -q "snapshot(s)"; then
@@ -153,7 +153,7 @@ openshell sandbox exec --name "${SANDBOX_NAME}" -- \
 # ── Phase 6: snapshot restore (latest) ──────────────────────────────
 info "Phase 6: Restoring latest snapshot..."
 
-RESTORE_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot restore 2>&1)
+RESTORE_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot restore 2>&1) || true
 echo "$RESTORE_OUTPUT"
 
 if ! echo "$RESTORE_OUTPUT" | grep -q "Restored"; then
@@ -167,7 +167,7 @@ pass "Latest snapshot restored expected state"
 # ── Phase 7: snapshot restore with timestamp (first snapshot) ───────
 info "Phase 7: Restoring first snapshot by timestamp..."
 
-TARGETED_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot restore "${SNAPSHOT_TIMESTAMP}" 2>&1)
+TARGETED_OUTPUT=$(nemoclaw "${SANDBOX_NAME}" snapshot restore "${SNAPSHOT_TIMESTAMP}" 2>&1) || true
 echo "$TARGETED_OUTPUT"
 
 if ! echo "$TARGETED_OUTPUT" | grep -q "Restored"; then


### PR DESCRIPTION
## Summary

Fix the `snapshot-commands-e2e` test so failed `nemoclaw` commands surface
their error output instead of silently terminating the script.

### Root cause

The test script runs under `set -euo pipefail`. When a `nemoclaw` subcommand
exits non-zero inside a `$()` command substitution, `set -e` kills the script
at the assignment line — before `echo "$OUTPUT"` or the `fail()` handler can
run. The CI log shows only `Process completed with exit code 1` with zero
diagnostic context, making the underlying failure impossible to triage.

### Changes

Append `|| true` to the four `nemoclaw` command substitutions so the exit
code is absorbed into `$?` without triggering `set -e`. The captured output
is then echoed and inspected by the existing `grep` + `fail()` checks, which
produce proper diagnostics.

Affected calls:
- `nemoclaw <name> snapshot create`
- `nemoclaw <name> snapshot list`
- `nemoclaw <name> snapshot restore`
- `nemoclaw <name> snapshot restore <timestamp>`

### Nightly run

- **Run:** https://github.com/NVIDIA/NemoClaw/actions/runs/24757302596
- **Job:** `snapshot-commands-e2e` — Step 3 (`test-snapshot-commands.sh`)
- **Commit:** `68fa01ccfcbf25a59bede65b586ed072678d6b2a`

## Test plan

- [ ] Re-run `snapshot-commands-e2e` — on failure the log now shows the
      `nemoclaw` CLI error message (e.g. "Snapshot failed", "Sandbox not
      running") before the `[FAIL]` diagnostic block
- [ ] On success the test still passes (grep matches, `fail()` is not called)

Signed-off-by: Hai Nguyen <haingu@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #2264