### PR TITLE
fix(e2e): normalize both sides of check-docs CLI parity check

### DIFF
--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -154,6 +154,12 @@ run_cli_check() {
       $c =~ s/\s*\[[^\]]*\]\s*$//;
       $c =~ s/\s*--output\s+FILE\s*$//;
       while ($c =~ s/\s+<[^>]+>\s*$//) {}
+      # Strip residual description text after last arg (single-space separated,
+      # starts with a capitalized word — e.g. "Remove an applied policy preset")
+      $c =~ s/\s+[A-Z][a-z].*$//;
+      # Re-strip trailing <arg>/[arg] exposed by description removal
+      $c =~ s/\s*\[[^\]]*\]\s*$//;
+      while ($c =~ s/\s+<[^>]+>\s*$//) {}
       my $k = "nemoclaw $c";
       $k =~ s/^nemoclaw debug.*/nemoclaw debug/;
       print "$k\n";
@@ -169,7 +175,13 @@ run_cli_check() {
   log '[cli] phase 2/2: extract ### `nemoclaw …` headings from commands reference'
   # Allow optional MyST suffix on the same line, e.g. ### `nemoclaw onboard` {#anchor}
   grep -E '^### `nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
-    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) { print "$1\n"; }
+    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) {
+      my $c = $1;
+      # Strip trailing <arg> and [arg] placeholders (same as help side)
+      $c =~ s/\s*\[[^\]]*\]\s*$//;
+      while ($c =~ s/\s+<[^>]+>\s*$//) {}
+      print "$c\n";
+    }
   ' | LC_ALL=C sort -u >"$_tmp/doc.txt"
 
   local _n_doc


### PR DESCRIPTION
## Problem

The CLI parity check in `check-docs.sh` applies asymmetric normalization to
the two sides it compares, causing false mismatches in the nightly E2E run.

**Help side** (phase 1) strips trailing `<arg>`/`[arg]` placeholders and
descriptions separated by 2+ spaces, but:
1. Descriptions separated by a **single space** after the last argument (e.g.
   `channels remove <channel> Clear credentials and rebuild`) slip through
   the `\s{2,}` regex.
2. After description removal, newly-exposed trailing `<arg>`/`[arg]`
   placeholders are not re-stripped.

**Doc side** (phase 2) extracts `### \`nemoclaw …\`` headings **verbatim**
without stripping argument placeholders, so headings like
`nemoclaw <name> channels add <channel>` never match the stripped help output.

## Fix

- **Help side:** Add a post-strip pass that removes residual description text
  starting with a capitalized word (`/\s+[A-Z][a-z].*$/`), then re-strip
  any `<arg>`/`[arg]` placeholders exposed by the description removal.
- **Doc side:** Strip trailing `<arg>` and `[arg]` placeholders from
  headings, applying the same normalization as the help side.

## Testing

Verified both normalization paths produce identical output for all commands
listed in the issue's CI mismatch log.

Closes #2250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing and documentation validation processes to improve consistency checks between CLI help text and reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->