### PR TITLE
fix(onboard): warn that dashboard URL is printed only once

### DIFF
--- a/src/lib/agent-onboard.test.ts
+++ b/src/lib/agent-onboard.test.ts
@@ -76,14 +76,16 @@ describe("printDashboardUi — regression for #2078 (port 8642 is not a chat UI)
     expect(noteSpy).not.toHaveBeenCalled();
   });
 
-  it("keeps the existing tokenized URL wording for UI-kind agents", () => {
+  it("prints tokenized URL with save-now warning for UI-kind agents", () => {
     printDashboardUi("sandbox-y", "tok", uiAgent, {
       note: noteSpy,
       buildControlUiUrls: buildUrlsLoopback,
     });
 
     const output = logSpy.mock.calls.map((args) => String(args[0])).join("\n");
-    expect(output).toContain("Ficticious UI (tokenized URL; treat it like a password)");
+    expect(output).toContain(
+      "Ficticious UI (tokenized URL; treat it like a password; save it now - it will not be printed again)",
+    );
     expect(output).toContain("Port 19000 must be forwarded before opening this URL.");
     expect(output).toContain("http://127.0.0.1:19000/#token=tok");
   });

--- a/src/lib/agent-onboard.ts
+++ b/src/lib/agent-onboard.ts
@@ -252,7 +252,9 @@ export function printDashboardUi(
   }
 
   if (token) {
-    console.log(`  ${info.displayName} ${label} (tokenized URL; treat it like a password)`);
+    console.log(
+      `  ${info.displayName} ${label} (tokenized URL; treat it like a password; save it now - it will not be printed again)`,
+    );
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(token, info.port)) {
       console.log(`  ${url}`);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6270,7 +6270,9 @@ function printDashboard(sandboxName, model, provider, nimContainer = null, agent
       },
     });
   } else if (token) {
-    console.log("  OpenClaw UI (tokenized URL; treat it like a password)");
+    console.log(
+      "  OpenClaw UI (tokenized URL; treat it like a password; save it now - it will not be printed again)",
+    );
     for (const line of guidanceLines) {
       console.log(`  ${line}`);
     }


### PR DESCRIPTION
Add "save it now — will not be printed again" to the tokenized dashboard URL line in both onboard print paths (OpenClaw in onboard.ts, agent UI in agent-onboard.ts). Treat the URL as a one-shot credential (GitHub-PAT style) rather than exposing it through `nemoclaw status`, which would widen incidental leakage via CI logs and issue-paste output.

Fixes #2167

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [x] AI-assisted — tool: <!-- e.g., Claude Code, Cursor, GitHub Copilot -->

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Your Name <your-email@example.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved guidance in onboarding console messages regarding tokenized URLs. When users encounter the authentication token during the setup process, they are now explicitly instructed to save it immediately and clearly informed that the token will not be printed again in the future. This applies to both agent and gateway UI setup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->