### PR TITLE
fix(install): invoke install-openshell.sh from install_nemoclaw

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1021,6 +1021,16 @@ install_nemoclaw() {
     spin "Building NemoClaw CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"
     spin "Building NemoClaw plugin" bash -c "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
     spin "Linking NemoClaw CLI" bash -c "cd \"$nemoclaw_src\" && npm link"
+
+    # Install/upgrade the OpenShell CLI on the GitHub-clone path (curl|bash).
+    # Without this, install.sh defers the openshell version gate entirely to
+    # `nemoclaw onboard`, so any later skip of onboard (preflight blocking,
+    # interrupted session) leaves openshell stale below blueprint's
+    # min_openshell_version even though the new NemoClaw declared a higher
+    # floor. The source-checkout branch intentionally skips this — a developer
+    # running ./scripts/install.sh manages their own openshell. The script is
+    # idempotent on the happy path. See #2272.
+    spin "Installing OpenShell CLI" bash "${NEMOCLAW_SOURCE_ROOT}/scripts/install-openshell.sh"
   fi
 
   # Install/upgrade the OpenShell CLI now rather than deferring to `nemoclaw

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1033,14 +1033,6 @@ install_nemoclaw() {
     spin "Installing OpenShell CLI" bash "${NEMOCLAW_SOURCE_ROOT}/scripts/install-openshell.sh"
   fi
 
-  # Install/upgrade the OpenShell CLI now rather than deferring to `nemoclaw
-  # onboard`. The onboard path is skipped when host preflight blocks, so a
-  # curl|bash upgrade could leave openshell stale below blueprint's
-  # min_openshell_version while nemoclaw itself moves to the new version. The
-  # script is idempotent — it exits 0 if the installed version is already in
-  # range — so calling it every install is free on the happy path. See #2272.
-  spin "Installing OpenShell CLI" bash "${NEMOCLAW_SOURCE_ROOT}/scripts/install-openshell.sh"
-
   refresh_path
   ensure_nemoclaw_shim || true
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -982,6 +982,14 @@ install_nemoclaw() {
     spin "Linking NemoClaw CLI" bash -c "cd \"$nemoclaw_src\" && npm link"
   fi
 
+  # Install/upgrade the OpenShell CLI now rather than deferring to `nemoclaw
+  # onboard`. The onboard path is skipped when host preflight blocks, so a
+  # curl|bash upgrade could leave openshell stale below blueprint's
+  # min_openshell_version while nemoclaw itself moves to the new version. The
+  # script is idempotent — it exits 0 if the installed version is already in
+  # range — so calling it every install is free on the happy path. See #2272.
+  spin "Installing OpenShell CLI" bash "${NEMOCLAW_SOURCE_ROOT}/scripts/install-openshell.sh"
+
   refresh_path
   ensure_nemoclaw_shim || true
 }


### PR DESCRIPTION
install.sh previously delegated all OpenShell CLI install/upgrade to `nemoclaw onboard`. When onboard is skipped (host preflight blocks, user aborts, interrupted session) the version gate never runs, so a curl|bash upgrade could leave openshell stale even though the new NemoClaw release declares a higher min_openshell_version.

Run install-openshell.sh at the tail of install_nemoclaw instead. The script is idempotent — it exits 0 if the installed version is already within [MIN_VERSION, MAX_VERSION], so calling it every install is free on the happy path. The onboard-side check at onboard.ts:2664-2706 stays in place as a safety net for direct `nemoclaw onboard` invocations outside the installer.

Fixes #2272.

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [X] AI-assisted — tool: Claude Code<!-- e.g., Claude Code, Cursor, GitHub Copilot -->

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now runs the OpenShell CLI installation/upgrade during initial setup so it’s available immediately instead of waiting for a later onboarding step.
  * OpenShell installation/upgrade is attempted on every install to ensure the CLI is present and kept up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->