### PR TITLE
refactor(sandbox): extract shared entrypoint library to fix Hermes vulnerability (#2277)

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -16,6 +16,13 @@
 
 set -euo pipefail
 
+# ── Source shared sandbox initialisation library ─────────────────
+# Single source of truth for security-sensitive primitives shared with
+# scripts/nemoclaw-start.sh (OpenClaw). Ref: #2277
+_SANDBOX_INIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../scripts/lib"
+# shellcheck source=scripts/lib/sandbox-init.sh
+source "${_SANDBOX_INIT_DIR}/sandbox-init.sh"
+
 # Harden: limit process count to prevent fork bombs
 if ! ulimit -Su 512 2>/dev/null; then
   echo "[SECURITY] Could not set soft nproc limit (container runtime may restrict ulimit)" >&2
@@ -27,19 +34,8 @@ fi
 # SECURITY: Lock down PATH
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-# ── Drop unnecessary Linux capabilities ──────────────────────────
-if [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ] && command -v capsh >/dev/null 2>&1; then
-  if capsh --has-p=cap_setpcap 2>/dev/null; then
-    export NEMOCLAW_CAPS_DROPPED=1
-    exec capsh \
-      --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
-      -- -c 'exec /usr/local/bin/nemoclaw-start "$@"' -- "$@"
-  else
-    echo "[SECURITY] CAP_SETPCAP not available — runtime already restricts capabilities" >&2
-  fi
-elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
-  echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2
-fi
+# ── Drop unnecessary Linux capabilities (shared) ────────────────
+drop_capabilities /usr/local/bin/nemoclaw-start "$@"
 
 # Normalize the self-wrapper bootstrap (same as OpenClaw entrypoint).
 if [ "${1:-}" = "env" ]; then
@@ -83,18 +79,7 @@ HERMES="$(command -v hermes)" # Resolve once, use absolute path everywhere
 HERMES_IMMUTABLE="/sandbox/.hermes"
 HERMES_WRITABLE="/sandbox/.hermes-data"
 
-# ── Config integrity check ──────────────────────────────────────
-verify_config_integrity() {
-  local hash_file="${HERMES_IMMUTABLE}/.config-hash"
-  if [ ! -f "$hash_file" ]; then
-    echo "[SECURITY] Config hash file missing — refusing to start without integrity verification" >&2
-    return 1
-  fi
-  if ! (cd "${HERMES_IMMUTABLE}" && sha256sum -c "$hash_file" --status 2>/dev/null); then
-    echo "[SECURITY] Hermes config integrity check FAILED — config may have been tampered with" >&2
-    return 1
-  fi
-}
+# verify_config_integrity is provided by sandbox-init.sh (parameterized).
 
 # Copy verified immutable config into the writable HERMES_HOME so the
 # gateway process can read it alongside its own state files.
@@ -146,66 +131,23 @@ GUARD
       printf '\n%s\n' "$snippet" >>"$rc_file"
     fi
   done
+  # SECURITY FIX: Lock .bashrc/.profile after all mutations are complete.
+  # This was missing in Hermes (unlike OpenClaw which had it via #2125),
+  # leaving rc files writable by the sandbox user. Ref: #2277
+  lock_rc_files "$_SANDBOX_HOME"
 }
 
+# validate_hermes_symlinks / harden_hermes_symlinks — thin wrappers
+# around shared library functions for backward compatibility with callsites.
 validate_hermes_symlinks() {
-  local entry name target expected
-  for entry in /sandbox/.hermes/*; do
-    [ -L "$entry" ] || continue
-    name="$(basename "$entry")"
-    target="$(readlink -f "$entry" 2>/dev/null || true)"
-    expected="/sandbox/.hermes-data/$name"
-    if [ "$target" != "$expected" ]; then
-      echo "[SECURITY] Symlink $entry points to unexpected target: $target (expected $expected)" >&2
-      return 1
-    fi
-  done
+  validate_config_symlinks /sandbox/.hermes /sandbox/.hermes-data
 }
 
 harden_hermes_symlinks() {
-  local entry hardened failed
-  hardened=0
-  failed=0
-
-  if ! command -v chattr >/dev/null 2>&1; then
-    echo "[SECURITY] chattr not available — relying on DAC + Landlock for .hermes hardening" >&2
-    return 0
-  fi
-
-  if chattr +i /sandbox/.hermes 2>/dev/null; then
-    hardened=$((hardened + 1))
-  else
-    failed=$((failed + 1))
-  fi
-
-  for entry in /sandbox/.hermes/*; do
-    [ -L "$entry" ] || continue
-    if chattr +i "$entry" 2>/dev/null; then
-      hardened=$((hardened + 1))
-    else
-      failed=$((failed + 1))
-    fi
-  done
-
-  if [ "$failed" -gt 0 ]; then
-    echo "[SECURITY] Immutable hardening applied to $hardened path(s); $failed path(s) could not be hardened — continuing with DAC + Landlock" >&2
-  elif [ "$hardened" -gt 0 ]; then
-    echo "[SECURITY] Immutable hardening applied to /sandbox/.hermes and validated symlinks" >&2
-  fi
+  harden_config_symlinks /sandbox/.hermes /sandbox/.hermes
 }
 
-configure_messaging_channels() {
-  # Channel entries are baked into config.yaml at image build time via
-  # NEMOCLAW_MESSAGING_CHANNELS_B64. Placeholder tokens flow through to
-  # the L7 proxy for rewriting at egress.
-  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] || [ -n "${DISCORD_BOT_TOKEN:-}" ] || [ -n "${SLACK_BOT_TOKEN:-}" ] || return 0
-
-  echo "[channels] Messaging channels active (baked at build time):" >&2
-  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && echo "[channels]   telegram" >&2
-  [ -n "${DISCORD_BOT_TOKEN:-}" ] && echo "[channels]   discord" >&2
-  [ -n "${SLACK_BOT_TOKEN:-}" ] && echo "[channels]   slack" >&2
-  return 0
-}
+# configure_messaging_channels is provided by sandbox-init.sh (shared).
 
 print_dashboard_urls() {
   local local_url
@@ -262,16 +204,10 @@ start_decode_proxy() {
   echo "[gateway] decode-proxy failed to start — placeholder rewriting may not work" >&2
 }
 
-# Forward SIGTERM/SIGINT to child processes for graceful shutdown.
-cleanup() {
-  echo "[gateway] received signal, forwarding to children..." >&2
-  local gateway_status=0
-  kill -TERM "$GATEWAY_PID" 2>/dev/null || true
-  [ -n "${SOCAT_PID:-}" ] && kill -TERM "$SOCAT_PID" 2>/dev/null || true
-  [ -n "${DECODE_PROXY_PID:-}" ] && kill -TERM "$DECODE_PROXY_PID" 2>/dev/null || true
-  wait "$GATEWAY_PID" 2>/dev/null || gateway_status=$?
-  exit "$gateway_status"
-}
+# cleanup_on_signal is provided by sandbox-init.sh. It reads
+# SANDBOX_CHILD_PIDS (array of all PIDs) and SANDBOX_WAIT_PID (the
+# primary process whose exit status is returned).
+# Each code path below sets these before registering the trap.
 
 # ── Proxy environment ────────────────────────────────────────────
 PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
@@ -285,18 +221,6 @@ export http_proxy="$_PROXY_URL"
 export https_proxy="$_PROXY_URL"
 export no_proxy="$_NO_PROXY_VAL"
 
-_PROXY_MARKER_BEGIN="# nemoclaw-proxy-config begin"
-_PROXY_MARKER_END="# nemoclaw-proxy-config end"
-_PROXY_SNIPPET="${_PROXY_MARKER_BEGIN}
-export HTTP_PROXY=\"$_PROXY_URL\"
-export HTTPS_PROXY=\"$_PROXY_URL\"
-export NO_PROXY=\"$_NO_PROXY_VAL\"
-export http_proxy=\"$_PROXY_URL\"
-export https_proxy=\"$_PROXY_URL\"
-export no_proxy=\"$_NO_PROXY_VAL\"
-export HERMES_HOME=\"${HERMES_WRITABLE}\"
-${_PROXY_MARKER_END}"
-
 if [ "$(id -u)" -eq 0 ]; then
   _SANDBOX_HOME=$(getent passwd sandbox 2>/dev/null | cut -d: -f6)
   _SANDBOX_HOME="${_SANDBOX_HOME:-/sandbox}"
@@ -304,27 +228,24 @@ else
   _SANDBOX_HOME="${HOME:-/sandbox}"
 fi
 
-_write_proxy_snippet() {
-  local target="$1"
-  if [ -f "$target" ] && grep -qF "$_PROXY_MARKER_BEGIN" "$target" 2>/dev/null; then
-    local tmp
-    tmp="$(mktemp)"
-    awk -v b="$_PROXY_MARKER_BEGIN" -v e="$_PROXY_MARKER_END" \
-      '$0==b{s=1;next} $0==e{s=0;next} !s' "$target" >"$tmp"
-    printf '%s\n' "$_PROXY_SNIPPET" >>"$tmp"
-    cat "$tmp" >"$target"
-    rm -f "$tmp"
-    return 0
-  fi
-  printf '\n%s\n' "$_PROXY_SNIPPET" >>"$target"
-}
-
-# Write proxy snippet — may fail after capsh drops cap_dac_override
-# (root can no longer write sandbox-owned files). Non-fatal.
-if [ -w "$_SANDBOX_HOME" ]; then
-  _write_proxy_snippet "${_SANDBOX_HOME}/.bashrc" 2>/dev/null || true
-  _write_proxy_snippet "${_SANDBOX_HOME}/.profile" 2>/dev/null || true
-fi
+# SECURITY FIX: Write proxy config to a standalone file via
+# emit_sandbox_sourced_file() (root:root 444) instead of appending
+# inline to .bashrc/.profile. The old approach left .bashrc writable
+# by the sandbox user — same vulnerability class as #2181.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/2277
+_PROXY_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
+{
+  cat <<PROXYEOF
+# Proxy configuration (overrides narrow OpenShell defaults on connect)
+export HTTP_PROXY="$_PROXY_URL"
+export HTTPS_PROXY="$_PROXY_URL"
+export NO_PROXY="$_NO_PROXY_VAL"
+export http_proxy="$_PROXY_URL"
+export https_proxy="$_PROXY_URL"
+export no_proxy="$_NO_PROXY_VAL"
+export HERMES_HOME="${HERMES_WRITABLE}"
+PROXYEOF
+} | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"
 
 # ── Main ─────────────────────────────────────────────────────────
 
@@ -336,7 +257,7 @@ if [ "$(id -u)" -ne 0 ]; then
   export HOME=/sandbox
   export HERMES_HOME="${HERMES_WRITABLE}"
 
-  if ! verify_config_integrity; then
+  if ! verify_config_integrity "${HERMES_IMMUTABLE}"; then
     echo "[SECURITY] Config integrity check failed — refusing to start (non-root mode)" >&2
     exit 1
   fi
@@ -351,6 +272,10 @@ if [ "$(id -u)" -ne 0 ]; then
   touch /tmp/gateway.log
   chmod 600 /tmp/gateway.log
 
+  # Defence-in-depth: verify /tmp file permissions before launching services.
+  # shellcheck disable=SC2119
+  validate_tmp_permissions
+
   # Start decode proxy and Hermes gateway
   start_decode_proxy
   HERMES_HOME="${HERMES_WRITABLE}" \
@@ -361,8 +286,12 @@ if [ "$(id -u)" -ne 0 ]; then
     nohup "$HERMES" gateway run >/tmp/gateway.log 2>&1 &
   GATEWAY_PID=$!
   echo "[gateway] hermes gateway launched (pid $GATEWAY_PID)" >&2
-  trap cleanup SIGTERM SIGINT
+  SANDBOX_CHILD_PIDS=("$GATEWAY_PID")
+  [ -n "${DECODE_PROXY_PID:-}" ] && SANDBOX_CHILD_PIDS+=("$DECODE_PROXY_PID")
+  SANDBOX_WAIT_PID="$GATEWAY_PID"
+  trap cleanup_on_signal SIGTERM SIGINT
   start_socat_forwarder
+  [ -n "${SOCAT_PID:-}" ] && SANDBOX_CHILD_PIDS+=("$SOCAT_PID")
   print_dashboard_urls
 
   wait "$GATEWAY_PID"
@@ -371,7 +300,7 @@ fi
 
 # ── Root path (full privilege separation via gosu) ─────────────
 
-verify_config_integrity
+verify_config_integrity "${HERMES_IMMUTABLE}"
 deploy_config_to_writable
 install_configure_guard
 configure_messaging_channels
@@ -391,6 +320,10 @@ validate_hermes_symlinks
 # Lock .hermes directory after validation.
 harden_hermes_symlinks
 
+# Defence-in-depth: verify /tmp file permissions before launching services.
+# shellcheck disable=SC2119
+validate_tmp_permissions
+
 # Start the gateway as the 'gateway' user.
 # Start decode proxy and gateway
 start_decode_proxy
@@ -402,8 +335,12 @@ HERMES_HOME="${HERMES_WRITABLE}" \
   nohup gosu gateway "$HERMES" gateway run >/tmp/gateway.log 2>&1 &
 GATEWAY_PID=$!
 echo "[gateway] hermes gateway launched as 'gateway' user (pid $GATEWAY_PID)" >&2
-trap cleanup SIGTERM SIGINT
+SANDBOX_CHILD_PIDS=("$GATEWAY_PID")
+[ -n "${DECODE_PROXY_PID:-}" ] && SANDBOX_CHILD_PIDS+=("$DECODE_PROXY_PID")
+SANDBOX_WAIT_PID="$GATEWAY_PID"
+trap cleanup_on_signal SIGTERM SIGINT
 start_socat_forwarder
+[ -n "${SOCAT_PID:-}" ] && SANDBOX_CHILD_PIDS+=("$SOCAT_PID")
 print_dashboard_urls
 
 # Keep container running by waiting on the gateway process.

--- a/bin/lib/runner.js
+++ b/bin/lib/runner.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/scripts/lib/sandbox-init.sh
+++ b/scripts/lib/sandbox-init.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared sandbox entrypoint primitives for NemoClaw agent types.
+#
+# Sourced by scripts/nemoclaw-start.sh (OpenClaw) and agents/hermes/start.sh
+# (Hermes) to provide a single source of truth for security-sensitive
+# initialisation functions. Prevents drift between entrypoints — every
+# security fix applied here protects both agents automatically.
+#
+# Usage (from an entrypoint script):
+#   SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+#   # shellcheck source=scripts/lib/sandbox-init.sh
+#   source "${SCRIPT_DIR}/../scripts/lib/sandbox-init.sh"  # adjust path
+#
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/2277
+
+# Guard against double-sourcing.
+[ -z "${_SANDBOX_INIT_LOADED:-}" ] || return 0
+_SANDBOX_INIT_LOADED=1
+
+# ── /tmp trust boundary map ──────────────────────────────────────
+# Files in /tmp that cross user boundaries. Every file sourced by
+# .bashrc/.profile MUST be root-owned 444 in root mode.
+#
+# File                         Owner      Mode  Writer   Reader    Sourced?
+# /tmp/nemoclaw-proxy-env.sh   root       444   root     sandbox   YES (.bashrc/.profile)
+# /tmp/gateway.log             gateway    600   gateway  gateway   no
+# /tmp/auto-pair.log           sandbox    600   sandbox  sandbox   no
+# /tmp/.npm-cache/             sandbox    755   sandbox  sandbox   no (tool data)
+# /tmp/.cache/                 sandbox    755   sandbox  sandbox   no (tool data)
+# /tmp/.config/                sandbox    755   sandbox  sandbox   no (tool data)
+# /tmp/.gnupg/                 sandbox    700   sandbox  sandbox   no (key data)
+#
+# In non-root mode privilege separation is disabled — all files are
+# owned by sandbox. chmod 444 is best-effort (owner can chmod back).
+# This is an accepted limitation documented in the OpenShell security model.
+#
+# See also: https://github.com/NVIDIA/NemoClaw/issues/2181
+# Future: adopt s6-overlay fix-attrs.d/ for declarative enforcement.
+# ─────────────────────────────────────────────────────────────────
+
+# ── Secure file helpers ──────────────────────────────────────────
+# Centralized primitives for creating files that cross trust boundaries
+# in /tmp. Using these helpers instead of ad-hoc chmod/chown ensures
+# consistent security posture and prevents the class of bug in #2181.
+#
+# Future: these map directly to s6-overlay fix-attrs.d/ entries when
+# the entrypoint is decomposed.
+
+# Write a file that the sandbox user can SOURCE but not MODIFY.
+# Reads content from stdin. Caller usage:
+#   emit_sandbox_sourced_file /path <<'EOF'
+#   export FOO="bar"
+#   EOF
+#
+# Or pipe into it:
+#   generate_content | emit_sandbox_sourced_file /path
+#
+# Root mode:  root:root 444 — sandbox cannot chmod (not owner).
+# Non-root:   sandbox:sandbox 444 — best-effort (owner can chmod back;
+#             accepted limitation since privilege separation is disabled).
+emit_sandbox_sourced_file() {
+  local path="$1"
+  # Remove any pre-existing file/symlink to prevent symlink-following attacks.
+  # rm -f works because: root can remove anything; in non-root mode the owner
+  # can remove their own file in sticky-bit /tmp.
+  rm -f "$path" 2>/dev/null || true
+  cat >"$path"
+  if [ "$(id -u)" -eq 0 ]; then
+    chown root:root "$path"
+  fi
+  chmod 444 "$path"
+}
+
+# Verify that trust-boundary files in /tmp have the expected permissions
+# BEFORE handing off to the sandbox user. Call this after all init work
+# and before launching services. Defence-in-depth: catches regressions
+# even if a new file is added without using the helper above.
+#
+# Usage:
+#   validate_tmp_permissions                          # default sourced + log files
+#   validate_tmp_permissions /tmp/custom-sourced.sh   # additional sourced files
+#
+# Positional args are additional sourced files to check (444 required).
+# shellcheck disable=SC2120
+validate_tmp_permissions() {
+  local failed=0
+
+  # Files sourced by sandbox (.bashrc/.profile) — must not be writable.
+  local sourced_files=("/tmp/nemoclaw-proxy-env.sh")
+  sourced_files+=("$@")
+
+  for f in "${sourced_files[@]}"; do
+    [ -f "$f" ] || continue
+    local perms owner
+    perms="$(stat -c '%a' "$f" 2>/dev/null || stat -f '%Lp' "$f" 2>/dev/null || echo "unknown")"
+    owner="$(stat -c '%U' "$f" 2>/dev/null || stat -f '%Su' "$f" 2>/dev/null || echo "unknown")"
+    if [ "$(id -u)" -eq 0 ] && { [ "$owner" != "root" ] || [ "$perms" != "444" ]; }; then
+      echo "[SECURITY] $f has unsafe permissions: owner=$owner mode=$perms (expected root:444)" >&2
+      failed=1
+    elif [ "$(id -u)" -ne 0 ] && [ "$perms" != "444" ]; then
+      echo "[SECURITY] $f has unsafe permissions: mode=$perms (expected 444)" >&2
+      failed=1
+    fi
+  done
+
+  # Restricted log files — must be 600
+  for f in /tmp/gateway.log /tmp/auto-pair.log; do
+    [ -f "$f" ] || continue
+    local perms
+    perms="$(stat -c '%a' "$f" 2>/dev/null || stat -f '%Lp' "$f" 2>/dev/null || echo "unknown")"
+    if [ "$perms" != "600" ]; then
+      echo "[SECURITY] $f has unexpected permissions: mode=$perms (expected 600)" >&2
+      failed=1
+    fi
+  done
+
+  return $failed
+}
+
+# ── Capability dropping ──────────────────────────────────────────
+# CIS Docker Benchmark 5.3: containers should not run with default caps.
+# OpenShell manages the container runtime so we cannot pass --cap-drop=ALL
+# to docker run. Instead, drop dangerous capabilities from the bounding set
+# at startup using capsh. The bounding set limits what caps any child process
+# (gateway, sandbox, agent) can ever acquire.
+#
+# Kept: cap_chown, cap_setuid, cap_setgid, cap_fowner, cap_kill
+#   — required by the entrypoint for gosu privilege separation and chown.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/797
+#
+# Usage:
+#   drop_capabilities /usr/local/bin/nemoclaw-start "$@"
+#
+# The first argument is the absolute path to the entrypoint script to
+# re-exec via capsh. Remaining arguments are forwarded.
+drop_capabilities() {
+  local entrypoint="$1"
+  shift
+
+  if [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ] && command -v capsh >/dev/null 2>&1; then
+    # capsh --drop requires CAP_SETPCAP in the bounding set. OpenShell's
+    # sandbox runtime may strip it, so check before attempting the drop.
+    if capsh --has-p=cap_setpcap 2>/dev/null; then
+      export NEMOCLAW_CAPS_DROPPED=1
+      exec capsh \
+        --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
+        -- -c "exec $entrypoint \"\$@\"" -- "$@"
+    else
+      echo "[SECURITY] CAP_SETPCAP not available — runtime already restricts capabilities" >&2
+    fi
+  elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
+    echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2
+  fi
+}
+
+# ── Config integrity check ──────────────────────────────────────
+# The config hash was pinned at build time. If it doesn't match,
+# someone (or something) has tampered with the config.
+#
+# Usage:
+#   verify_config_integrity /sandbox/.openclaw    # OpenClaw
+#   verify_config_integrity /sandbox/.hermes      # Hermes
+#
+# The config_dir must contain a .config-hash file with sha256sum output.
+verify_config_integrity() {
+  local config_dir="$1"
+  local hash_file="${config_dir}/.config-hash"
+
+  if [ ! -f "$hash_file" ]; then
+    echo "[SECURITY] Config hash file missing (${hash_file}) — refusing to start without integrity verification" >&2
+    return 1
+  fi
+  if ! (cd "$config_dir" && sha256sum -c "$hash_file" --status 2>/dev/null); then
+    echo "[SECURITY] Config integrity check FAILED in ${config_dir} — config may have been tampered with" >&2
+    return 1
+  fi
+}
+
+# ── RC file locking ──────────────────────────────────────────────
+# Lock .bashrc and .profile to 444 after all mutations (proxy snippets,
+# configure guard, gateway token export) are complete. This prevents the
+# sandbox user from injecting code that runs on every `nemoclaw connect`.
+#
+# SECURITY: This fixes the Hermes vulnerability where .bashrc/.profile
+# were never locked (unlike OpenClaw which had this via #2125).
+#
+# Usage:
+#   lock_rc_files /sandbox   # locks /sandbox/.bashrc and /sandbox/.profile
+lock_rc_files() {
+  local home_dir="$1"
+
+  for rc_file in "${home_dir}/.bashrc" "${home_dir}/.profile"; do
+    if [ -f "$rc_file" ]; then
+      chmod 444 "$rc_file"
+    fi
+  done
+}
+
+# ── Cleanup / signal forwarding ──────────────────────────────────
+# Forward SIGTERM/SIGINT to child processes for graceful shutdown.
+# The entrypoint is PID 1 — without a trap, signals interrupt wait and
+# children are orphaned until Docker sends SIGKILL after the grace period.
+#
+# Usage:
+#   # After starting processes, register their PIDs:
+#   SANDBOX_CHILD_PIDS=("$GATEWAY_PID" "$AUTO_PAIR_PID")
+#   SANDBOX_WAIT_PID="$GATEWAY_PID"
+#   trap cleanup_on_signal SIGTERM SIGINT
+#
+# SANDBOX_CHILD_PIDS: array of PIDs to kill on signal (best-effort).
+# SANDBOX_WAIT_PID: the primary PID whose exit status is returned.
+cleanup_on_signal() {
+  echo "[gateway] received signal, forwarding to children..." >&2
+  local primary_status=0
+
+  for pid in "${SANDBOX_CHILD_PIDS[@]}"; do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+
+  if [ -n "${SANDBOX_WAIT_PID:-}" ]; then
+    wait "$SANDBOX_WAIT_PID" 2>/dev/null || primary_status=$?
+  fi
+
+  # Wait for remaining children (best-effort, don't fail on already-exited)
+  for pid in "${SANDBOX_CHILD_PIDS[@]}"; do
+    [ "$pid" = "${SANDBOX_WAIT_PID:-}" ] && continue
+    wait "$pid" 2>/dev/null || true
+  done
+
+  exit "$primary_status"
+}
+
+# ── Symlink validation ───────────────────────────────────────────
+# Verify ALL symlinks in a config directory point to the expected
+# writable data directory. Dynamic scan so future symlinks are
+# covered automatically.
+#
+# Usage:
+#   validate_config_symlinks /sandbox/.openclaw /sandbox/.openclaw-data
+#   validate_config_symlinks /sandbox/.hermes /sandbox/.hermes-data
+validate_config_symlinks() {
+  local config_dir="$1"
+  local data_dir="$2"
+  local entry name target expected
+
+  for entry in "${config_dir}"/*; do
+    [ -L "$entry" ] || continue
+    name="$(basename "$entry")"
+    target="$(readlink -f "$entry" 2>/dev/null || true)"
+    expected="${data_dir}/${name}"
+    if [ "$target" != "$expected" ]; then
+      echo "[SECURITY] Symlink $entry points to unexpected target: $target (expected $expected)" >&2
+      return 1
+    fi
+  done
+}
+
+# Lock a config directory and its symlinks with the immutable flag so
+# they cannot be swapped at runtime even if DAC or Landlock are bypassed.
+# chattr requires cap_linux_immutable which the entrypoint has as root;
+# the sandbox user cannot remove the flag.
+#
+# Usage:
+#   harden_config_symlinks /sandbox/.openclaw
+#   harden_config_symlinks /sandbox/.hermes
+harden_config_symlinks() {
+  local config_dir="$1"
+  local label="${2:-${config_dir}}"
+  local entry hardened failed
+  hardened=0
+  failed=0
+
+  if ! command -v chattr >/dev/null 2>&1; then
+    echo "[SECURITY] chattr not available — relying on DAC + Landlock for ${label} hardening" >&2
+    return 0
+  fi
+
+  if chattr +i "$config_dir" 2>/dev/null; then
+    hardened=$((hardened + 1))
+  else
+    failed=$((failed + 1))
+  fi
+
+  for entry in "${config_dir}"/*; do
+    [ -L "$entry" ] || continue
+    if chattr +i "$entry" 2>/dev/null; then
+      hardened=$((hardened + 1))
+    else
+      failed=$((failed + 1))
+    fi
+  done
+
+  if [ "$failed" -gt 0 ]; then
+    echo "[SECURITY] Immutable hardening applied to $hardened path(s); $failed path(s) could not be hardened — continuing with DAC + Landlock" >&2
+  elif [ "$hardened" -gt 0 ]; then
+    echo "[SECURITY] Immutable hardening applied to ${label} and validated symlinks" >&2
+  fi
+}
+
+# ── Messaging channels ──────────────────────────────────────────
+# Channel entries are baked into the config at image build time via
+# NEMOCLAW_MESSAGING_CHANNELS_B64. Placeholder tokens flow through
+# to the L7 proxy for rewriting at egress. Real tokens are never
+# visible inside the sandbox.
+#
+# This function just logs which channels are active. Runtime patching
+# of config files is not possible — Landlock enforces read-only at
+# the kernel level.
+configure_messaging_channels() {
+  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] || [ -n "${DISCORD_BOT_TOKEN:-}" ] || [ -n "${SLACK_BOT_TOKEN:-}" ] || return 0
+
+  echo "[channels] Messaging channels active (baked at build time):" >&2
+  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && echo "[channels]   telegram" >&2
+  [ -n "${DISCORD_BOT_TOKEN:-}" ] && echo "[channels]   discord" >&2
+  [ -n "${SLACK_BOT_TOKEN:-}" ] && echo "[channels]   slack" >&2
+  return 0
+}

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -31,6 +31,13 @@
 
 set -euo pipefail
 
+# ── Source shared sandbox initialisation library ─────────────────
+# Single source of truth for security-sensitive primitives shared with
+# agents/hermes/start.sh. Ref: https://github.com/NVIDIA/NemoClaw/issues/2277
+_SANDBOX_INIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"
+# shellcheck source=scripts/lib/sandbox-init.sh
+source "${_SANDBOX_INIT_DIR}/sandbox-init.sh"
+
 # Harden: limit process count to prevent fork bombs (ref: #809)
 # Best-effort: some container runtimes (e.g., brev) restrict ulimit
 # modification, returning "Invalid argument". Warn but don't block startup.
@@ -94,30 +101,8 @@ else
   install -d -m 700 /tmp/.gnupg
 fi
 
-# ── Drop unnecessary Linux capabilities ──────────────────────────
-# CIS Docker Benchmark 5.3: containers should not run with default caps.
-# OpenShell manages the container runtime so we cannot pass --cap-drop=ALL
-# to docker run. Instead, drop dangerous capabilities from the bounding set
-# at startup using capsh. The bounding set limits what caps any child process
-# (gateway, sandbox, agent) can ever acquire.
-#
-# Kept: cap_chown, cap_setuid, cap_setgid, cap_fowner, cap_kill
-#   — required by the entrypoint for gosu privilege separation and chown.
-# Ref: https://github.com/NVIDIA/NemoClaw/issues/797
-if [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ] && command -v capsh >/dev/null 2>&1; then
-  # capsh --drop requires CAP_SETPCAP in the bounding set. OpenShell's
-  # sandbox runtime may strip it, so check before attempting the drop.
-  if capsh --has-p=cap_setpcap 2>/dev/null; then
-    export NEMOCLAW_CAPS_DROPPED=1
-    exec capsh \
-      --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
-      -- -c 'exec /usr/local/bin/nemoclaw-start "$@"' -- "$@"
-  else
-    echo "[SECURITY] CAP_SETPCAP not available — runtime already restricts capabilities" >&2
-  fi
-elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
-  echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2
-fi
+# ── Drop unnecessary Linux capabilities (shared) ────────────────
+drop_capabilities /usr/local/bin/nemoclaw-start "$@"
 
 # Normalize the sandbox-create bootstrap wrapper. Onboard launches the
 # container as `env CHAT_UI_URL=... nemoclaw-start`, but this script is already
@@ -186,23 +171,8 @@ PUBLIC_PORT="$_DASHBOARD_PORT"
 OPENCLAW="$(command -v openclaw)" # Resolve once, use absolute path everywhere
 _SANDBOX_HOME="/sandbox"          # Home dir for the sandbox user (useradd -d /sandbox in Dockerfile.base)
 
-# ── Config integrity check ──────────────────────────────────────
-# The config hash was pinned at build time. If it doesn't match,
-# someone (or something) has tampered with the config.
-
-verify_config_integrity() {
-  local hash_file="/sandbox/.openclaw/.config-hash"
-  if [ ! -f "$hash_file" ]; then
-    echo "[SECURITY] Config hash file missing — refusing to start without integrity verification" >&2
-    return 1
-  fi
-  if ! (cd /sandbox/.openclaw && sha256sum -c "$hash_file" --status 2>/dev/null); then
-    echo "[SECURITY] openclaw.json integrity check FAILED — config may have been tampered with" >&2
-    echo "[SECURITY] Expected hash: $(cat "$hash_file")" >&2
-    echo "[SECURITY] Actual hash:   $(sha256sum /sandbox/.openclaw/openclaw.json)" >&2
-    return 1
-  fi
-}
+# ── Config integrity check (delegates to shared library) ────────
+# verify_config_integrity is provided by sandbox-init.sh (parameterized).
 
 # ── Runtime model/provider override ──────────────────────────────
 # Patches openclaw.json at startup when NEMOCLAW_MODEL_OVERRIDE is set,
@@ -552,55 +522,17 @@ GUARD
   done
   # Final lock after all rc-file mutations (export_gateway_token + this
   # function) are complete so Landlock read_only enforcement holds.
-  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
-    [ -f "$rc_file" ] && chmod 444 "$rc_file"
-  done
+  lock_rc_files "$_SANDBOX_HOME"
 }
 
+# validate_openclaw_symlinks / harden_openclaw_symlinks — thin wrappers
+# around shared library functions for backward compatibility with callsites.
 validate_openclaw_symlinks() {
-  local entry name target expected
-  for entry in /sandbox/.openclaw/*; do
-    [ -L "$entry" ] || continue
-    name="$(basename "$entry")"
-    target="$(readlink -f "$entry" 2>/dev/null || true)"
-    expected="/sandbox/.openclaw-data/$name"
-    if [ "$target" != "$expected" ]; then
-      echo "[SECURITY] Symlink $entry points to unexpected target: $target (expected $expected)" >&2
-      return 1
-    fi
-  done
+  validate_config_symlinks /sandbox/.openclaw /sandbox/.openclaw-data
 }
 
 harden_openclaw_symlinks() {
-  local entry hardened failed
-  hardened=0
-  failed=0
-
-  if ! command -v chattr >/dev/null 2>&1; then
-    echo "[SECURITY] chattr not available — relying on DAC + Landlock for .openclaw hardening" >&2
-    return 0
-  fi
-
-  if chattr +i /sandbox/.openclaw 2>/dev/null; then
-    hardened=$((hardened + 1))
-  else
-    failed=$((failed + 1))
-  fi
-
-  for entry in /sandbox/.openclaw/*; do
-    [ -L "$entry" ] || continue
-    if chattr +i "$entry" 2>/dev/null; then
-      hardened=$((hardened + 1))
-    else
-      failed=$((failed + 1))
-    fi
-  done
-
-  if [ "$failed" -gt 0 ]; then
-    echo "[SECURITY] Immutable hardening applied to $hardened path(s); $failed path(s) could not be hardened — continuing with DAC + Landlock" >&2
-  elif [ "$hardened" -gt 0 ]; then
-    echo "[SECURITY] Immutable hardening applied to /sandbox/.openclaw and validated symlinks" >&2
-  fi
+  harden_config_symlinks /sandbox/.openclaw /sandbox/.openclaw
 }
 
 # Write an auth profile JSON for the NVIDIA API key so the gateway can authenticate.
@@ -633,24 +565,7 @@ harden_auth_profiles() {
   fi
 }
 
-configure_messaging_channels() {
-  # Channel entries are baked into openclaw.json at image build time via
-  # NEMOCLAW_MESSAGING_CHANNELS_B64 (see Dockerfile). Placeholder tokens
-  # (openshell:resolve:env:*) flow through to API calls where the L7 proxy
-  # rewrites them with real secrets at egress. Real tokens are never visible
-  # inside the sandbox.
-  #
-  # Runtime patching of /sandbox/.openclaw/openclaw.json is not possible:
-  # Landlock enforces read-only on /sandbox/.openclaw/ at the kernel level,
-  # regardless of DAC (file ownership/chmod). Writes fail with EPERM.
-  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] || [ -n "${DISCORD_BOT_TOKEN:-}" ] || [ -n "${SLACK_BOT_TOKEN:-}" ] || return 0
-
-  echo "[channels] Messaging channels active (baked at build time):" >&2
-  [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && echo "[channels]   telegram (native)" >&2
-  [ -n "${DISCORD_BOT_TOKEN:-}" ] && echo "[channels]   discord (native)" >&2
-  [ -n "${SLACK_BOT_TOKEN:-}" ] && echo "[channels]   slack (native)" >&2
-  return 0
-}
+# configure_messaging_channels is provided by sandbox-init.sh (shared).
 
 # Print the local and remote dashboard URLs, appending the auth token if available.
 print_dashboard_urls() {
@@ -801,17 +716,16 @@ fi
 # config to /tmp/nemoclaw-proxy-env.sh. The pre-built .bashrc and .profile
 # source this file automatically.
 #
-# SECURITY: /tmp has the sticky bit, so when running as root the sandbox user
-# cannot delete or replace this root-owned file. In non-root mode privilege
-# separation is already disabled, so this is an accepted limitation.
+# SECURITY: The proxy-env file is written via emit_sandbox_sourced_file()
+# which ensures root:root 444 in root mode (sandbox cannot modify) and
+# best-effort 444 in non-root mode. The /tmp sticky bit prevents the
+# sandbox user from deleting or replacing the root-owned file.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/2181
 #
 # Both uppercase and lowercase variants are required: Node.js undici prefers
 # lowercase (no_proxy) over uppercase (NO_PROXY) when both are set.
 # curl/wget use uppercase.  gRPC C-core uses lowercase.
 _PROXY_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
-# Remove any pre-existing file/symlink to prevent symlink-following attacks,
-# then write a fresh file.
-rm -f "$_PROXY_ENV_FILE" 2>/dev/null || true
 {
   cat <<PROXYEOF
 # Proxy configuration (overrides narrow OpenShell defaults on connect)
@@ -833,25 +747,12 @@ PROXYEOF
   for _redir in "${_TOOL_REDIRECTS[@]}"; do
     echo "export ${_redir?}"
   done
-} >"$_PROXY_ENV_FILE"
-chmod 644 "$_PROXY_ENV_FILE"
+} | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"
 
-# Forward SIGTERM/SIGINT to child processes for graceful shutdown.
-# This script is PID 1 — without a trap, signals interrupt wait and
-# children are orphaned until Docker sends SIGKILL after the grace period.
-cleanup() {
-  echo "[gateway] received signal, forwarding to children..." >&2
-  local gateway_status=0
-  kill -TERM "$GATEWAY_PID" 2>/dev/null || true
-  if [ -n "${AUTO_PAIR_PID:-}" ]; then
-    kill -TERM "$AUTO_PAIR_PID" 2>/dev/null || true
-  fi
-  wait "$GATEWAY_PID" 2>/dev/null || gateway_status=$?
-  if [ -n "${AUTO_PAIR_PID:-}" ]; then
-    wait "$AUTO_PAIR_PID" 2>/dev/null || true
-  fi
-  exit "$gateway_status"
-}
+# cleanup_on_signal is provided by sandbox-init.sh. It reads
+# SANDBOX_CHILD_PIDS (array of all PIDs) and SANDBOX_WAIT_PID (the
+# primary process whose exit status is returned).
+# Each code path below sets these before registering the trap.
 # ── Main ─────────────────────────────────────────────────────────
 
 echo 'Setting up NemoClaw...' >&2
@@ -870,7 +771,7 @@ fi
 if [ "$(id -u)" -ne 0 ]; then
   echo "[gateway] Running as non-root (uid=$(id -u)) — privilege separation disabled" >&2
   export HOME=/sandbox
-  if ! verify_config_integrity; then
+  if ! verify_config_integrity /sandbox/.openclaw; then
     echo "[SECURITY] Config integrity check failed — refusing to start (non-root mode)" >&2
     exit 1
   fi
@@ -957,12 +858,19 @@ if [ "$(id -u)" -ne 0 ]; then
   touch /tmp/auto-pair.log
   chmod 600 /tmp/auto-pair.log
 
+  # Defence-in-depth: verify /tmp file permissions before launching services.
+  # shellcheck disable=SC2119
+  validate_tmp_permissions
+
   # Start gateway in background, auto-pair, then wait
   nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
   GATEWAY_PID=$!
   echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)" >&2
-  trap cleanup SIGTERM SIGINT
   start_auto_pair
+  SANDBOX_CHILD_PIDS=("$GATEWAY_PID")
+  [ -n "${AUTO_PAIR_PID:-}" ] && SANDBOX_CHILD_PIDS+=("$AUTO_PAIR_PID")
+  SANDBOX_WAIT_PID="$GATEWAY_PID"
+  trap cleanup_on_signal SIGTERM SIGINT
   print_dashboard_urls
 
   wait "$GATEWAY_PID"
@@ -972,7 +880,7 @@ fi
 # ── Root path (full privilege separation via gosu) ─────────────
 
 # Verify config integrity before starting anything
-verify_config_integrity
+verify_config_integrity /sandbox/.openclaw
 apply_model_override
 apply_cors_override
 export_gateway_token
@@ -1013,6 +921,10 @@ validate_openclaw_symlinks
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/1019
 harden_openclaw_symlinks
 
+# Defence-in-depth: verify /tmp file permissions before launching services.
+# shellcheck disable=SC2119
+validate_tmp_permissions
+
 # Start the gateway as the 'gateway' user.
 # SECURITY: The sandbox user cannot kill this process because it runs
 # under a different UID. The fake-HOME attack no longer works because
@@ -1020,9 +932,12 @@ harden_openclaw_symlinks
 nohup gosu gateway "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
 GATEWAY_PID=$!
 echo "[gateway] openclaw gateway launched as 'gateway' user (pid $GATEWAY_PID)" >&2
-trap cleanup SIGTERM SIGINT
 
 start_auto_pair
+SANDBOX_CHILD_PIDS=("$GATEWAY_PID")
+[ -n "${AUTO_PAIR_PID:-}" ] && SANDBOX_CHILD_PIDS+=("$AUTO_PAIR_PID")
+SANDBOX_WAIT_PID="$GATEWAY_PID"
+trap cleanup_on_signal SIGTERM SIGINT
 print_dashboard_urls
 
 # Keep container running by waiting on the gateway process.

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -22,8 +22,8 @@ describe("nemoclaw-start non-root fallback", () => {
   it("exits on config integrity failure in non-root mode", () => {
     const src = fs.readFileSync(START_SCRIPT, "utf-8");
 
-    // Non-root block must call verify_config_integrity and exit 1 on failure
-    expect(src).toMatch(/if ! verify_config_integrity; then\s+.*exit 1/s);
+    // Non-root block must call verify_config_integrity (with config dir) and exit 1 on failure
+    expect(src).toMatch(/if ! verify_config_integrity\b.*; then\s+.*exit 1/s);
     // Must not contain the old "proceeding anyway" fallback
     expect(src).not.toMatch(/proceeding anyway/i);
   });
@@ -50,9 +50,11 @@ describe("nemoclaw-start non-root fallback", () => {
     expect(nonRootBlock).toBeTruthy();
     const block = nonRootBlock[1];
 
-    // Only check top-level echo lines that are NOT inside { } > file redirects.
-    // Filter out lines inside brace-group redirects (proxy-env.sh, etc.)
-    const braceStripped = block.replace(/\{[\s\S]*?\}\s*>\s*"[^"]*"/g, "");
+    // Only check top-level echo lines that are NOT inside { } > file redirects
+    // or { } | emit_sandbox_sourced_file pipe patterns (proxy-env.sh, etc.)
+    const braceStripped = block
+      .replace(/\{[\s\S]*?\}\s*>\s*"[^"]*"/g, "")
+      .replace(/\{[\s\S]*?\}\s*\|\s*emit_sandbox_sourced_file\b[^\n]*/g, "");
     const echoLines = braceStripped.match(/^\s*echo\s+.+$/gm) || [];
     expect(echoLines.length).toBeGreaterThan(0);
     for (const line of echoLines) {
@@ -535,51 +537,32 @@ describe("nemoclaw-start auto-pair client whitelisting (#117)", () => {
 describe("nemoclaw-start signal handling", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 
-  it("defines cleanup() as a single top-level function", () => {
-    const matches = src.match(/^cleanup\(\)/gm);
-    expect(matches).toHaveLength(1);
+  it("uses shared cleanup_on_signal from sandbox-init.sh", () => {
+    // cleanup_on_signal is provided by sandbox-init.sh; the entrypoint
+    // must NOT define its own cleanup() — it uses the shared version.
+    const localCleanup = src.match(/^cleanup\(\)/gm);
+    expect(localCleanup).toBeNull();
+    // Must reference cleanup_on_signal in trap registrations
+    expect(src).toContain("trap cleanup_on_signal SIGTERM SIGINT");
   });
 
-  it("cleanup() forwards SIGTERM to both GATEWAY_PID and AUTO_PAIR_PID", () => {
-    const cleanup = src.match(/cleanup\(\) \{[\s\S]*?^}/m)?.[0];
-    expect(cleanup).toBeDefined();
-    expect(cleanup).toMatch(/kill -TERM "\$GATEWAY_PID"/);
-    expect(cleanup).toMatch(/kill -TERM "\$AUTO_PAIR_PID"/);
-  });
-
-  it("cleanup() waits for both child processes", () => {
-    const cleanup = src.match(/cleanup\(\) \{[\s\S]*?^}/m)?.[0];
-    expect(cleanup).toMatch(/wait "\$GATEWAY_PID"/);
-    expect(cleanup).toMatch(/wait "\$AUTO_PAIR_PID"/);
-  });
-
-  it("cleanup() exits with the gateway exit status", () => {
-    const cleanup = src.match(/cleanup\(\) \{[\s\S]*?^}/m)?.[0];
-    expect(cleanup).toMatch(/exit "\$gateway_status"/);
-  });
-
-  it("registers trap before start_auto_pair in non-root path", () => {
-    // trap must appear before start_auto_pair within the non-root block.
-    // Use the Root path comment as boundary instead of ^fi$ which matches
-    // nested fi inside helper functions.
+  it("sets SANDBOX_CHILD_PIDS and SANDBOX_WAIT_PID before trap in non-root path", () => {
     const nonRootBlock = src.match(/if \[ "\$\(id -u\)" -ne 0 \]; then[\s\S]*?# ── Root path/)?.[0];
     expect(nonRootBlock).toBeDefined();
-    const trapIdx = nonRootBlock.indexOf("trap cleanup SIGTERM SIGINT");
-    // Match the call site "start_auto_pair\n" (not the function definition "start_auto_pair() {")
-    const autoIdx = nonRootBlock.search(/^\s*start_auto_pair\s*$/m);
-    expect(trapIdx).toBeGreaterThan(-1);
-    expect(autoIdx).toBeGreaterThan(-1);
-    expect(trapIdx).toBeLessThan(autoIdx);
+    expect(nonRootBlock).toContain("SANDBOX_CHILD_PIDS=");
+    expect(nonRootBlock).toContain("SANDBOX_WAIT_PID=");
+    const pidsIdx = nonRootBlock.indexOf("SANDBOX_CHILD_PIDS=");
+    const trapIdx = nonRootBlock.indexOf("trap cleanup_on_signal");
+    expect(pidsIdx).toBeLessThan(trapIdx);
   });
 
-  it("registers trap before start_auto_pair in root path", () => {
-    // In the root path (after the non-root block), trap must precede start_auto_pair
+  it("sets SANDBOX_CHILD_PIDS and SANDBOX_WAIT_PID before trap in root path", () => {
     const rootBlock = src.split(/# ── Root path/)[1] || "";
-    const trapIdx = rootBlock.indexOf("trap cleanup SIGTERM SIGINT");
-    const autoIdx = rootBlock.indexOf("start_auto_pair");
-    expect(trapIdx).toBeGreaterThan(-1);
-    expect(autoIdx).toBeGreaterThan(-1);
-    expect(trapIdx).toBeLessThan(autoIdx);
+    expect(rootBlock).toContain("SANDBOX_CHILD_PIDS=");
+    expect(rootBlock).toContain("SANDBOX_WAIT_PID=");
+    const pidsIdx = rootBlock.indexOf("SANDBOX_CHILD_PIDS=");
+    const trapIdx = rootBlock.indexOf("trap cleanup_on_signal");
+    expect(pidsIdx).toBeLessThan(trapIdx);
   });
 
   it("captures AUTO_PAIR_PID from background process", () => {

--- a/test/sandbox-init.test.ts
+++ b/test/sandbox-init.test.ts
@@ -1,0 +1,507 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  symlinkSync,
+  lstatSync,
+  chmodSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SANDBOX_INIT = join(import.meta.dirname, "../scripts/lib/sandbox-init.sh");
+
+/**
+ * Run a bash snippet that sources sandbox-init.sh and executes the given body.
+ * Returns { stdout, stderr } as trimmed strings.
+ */
+function runWithLib(
+  body: string,
+  opts: { env?: Record<string, string>; expectFail?: boolean } = {},
+) {
+  const script = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `source ${JSON.stringify(SANDBOX_INIT)}`,
+    body,
+  ].join("\n");
+  const tmpFile = join(tmpdir(), `sandbox-init-test-${process.pid}-${Date.now()}.sh`);
+  try {
+    writeFileSync(tmpFile, script, { mode: 0o700 });
+    const result = execFileSync("bash", [tmpFile], {
+      encoding: "utf-8",
+      env: { ...process.env, ...opts.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { stdout: result.trim(), stderr: "" };
+  } catch (e: any) {
+    if (opts.expectFail) {
+      return {
+        stdout: (e.stdout || "").toString().trim(),
+        stderr: (e.stderr || "").toString().trim(),
+      };
+    }
+    throw e;
+  } finally {
+    try {
+      execFileSync("rm", ["-f", tmpFile]);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+describe("scripts/lib/sandbox-init.sh", () => {
+  describe("emit_sandbox_sourced_file", () => {
+    let workDir: string;
+
+    beforeEach(() => {
+      workDir = mkdtempSync(join(tmpdir(), "sandbox-init-emit-"));
+    });
+
+    afterEach(() => {
+      execFileSync("rm", ["-rf", workDir]);
+    });
+
+    it("creates a file with 444 permissions", () => {
+      const target = join(workDir, "test-sourced.sh");
+      runWithLib(`echo 'export FOO=bar' | emit_sandbox_sourced_file ${JSON.stringify(target)}`);
+
+      expect(existsSync(target)).toBe(true);
+      const content = readFileSync(target, "utf-8");
+      expect(content).toContain("export FOO=bar");
+
+      // Check permissions — 444 in octal
+      const perms = execFileSync("stat", ["-f", "%Lp", target], { encoding: "utf-8" }).trim();
+      expect(perms).toBe("444");
+    });
+
+    it("overwrites existing file cleanly", () => {
+      const target = join(workDir, "overwrite.sh");
+      writeFileSync(target, "OLD CONTENT");
+      runWithLib(`echo 'NEW CONTENT' | emit_sandbox_sourced_file ${JSON.stringify(target)}`);
+
+      const content = readFileSync(target, "utf-8");
+      expect(content).toContain("NEW CONTENT");
+      expect(content).not.toContain("OLD CONTENT");
+    });
+
+    it("removes symlink before writing (anti-symlink attack)", () => {
+      const target = join(workDir, "proxy-env.sh");
+      const sensitive = join(workDir, "sensitive-data");
+      writeFileSync(sensitive, "SECRET_DATA");
+      symlinkSync(sensitive, target);
+
+      runWithLib(`echo 'export X=1' | emit_sandbox_sourced_file ${JSON.stringify(target)}`);
+
+      // Target should now be a regular file, not a symlink
+      const stat = lstatSync(target);
+      expect(stat.isSymbolicLink()).toBe(false);
+      // Sensitive file should be untouched
+      expect(readFileSync(sensitive, "utf-8")).toBe("SECRET_DATA");
+    });
+
+    it("accepts heredoc input", () => {
+      const target = join(workDir, "heredoc.sh");
+      runWithLib(`
+emit_sandbox_sourced_file ${JSON.stringify(target)} <<'EOF'
+export A="hello"
+export B="world"
+EOF
+      `);
+
+      const content = readFileSync(target, "utf-8");
+      expect(content).toContain('export A="hello"');
+      expect(content).toContain('export B="world"');
+    });
+  });
+
+  describe("validate_tmp_permissions", () => {
+    let workDir: string;
+    let origProxyEnv: string | null;
+
+    beforeEach(() => {
+      workDir = mkdtempSync(join(tmpdir(), "sandbox-init-validate-"));
+      // Save and remove any existing proxy-env.sh to avoid false positives
+      origProxyEnv = existsSync("/tmp/nemoclaw-proxy-env.sh")
+        ? readFileSync("/tmp/nemoclaw-proxy-env.sh", "utf-8")
+        : null;
+    });
+
+    afterEach(() => {
+      execFileSync("rm", ["-rf", workDir]);
+      // Restore if we had one
+      if (origProxyEnv !== null) {
+        writeFileSync("/tmp/nemoclaw-proxy-env.sh", origProxyEnv);
+      }
+    });
+
+    it("passes when no monitored files exist", () => {
+      // validate_tmp_permissions should succeed when files don't exist
+      // (they're skipped via [ -f "$f" ] || continue)
+      runWithLib(`
+        # Temporarily move proxy-env.sh out of the way if it exists
+        [ -f /tmp/nemoclaw-proxy-env.sh ] && mv /tmp/nemoclaw-proxy-env.sh /tmp/nemoclaw-proxy-env.sh.bak.$$ 2>/dev/null || true
+        [ -f /tmp/gateway.log ] && mv /tmp/gateway.log /tmp/gateway.log.bak.$$ 2>/dev/null || true
+        [ -f /tmp/auto-pair.log ] && mv /tmp/auto-pair.log /tmp/auto-pair.log.bak.$$ 2>/dev/null || true
+        validate_tmp_permissions
+        # Restore
+        [ -f /tmp/nemoclaw-proxy-env.sh.bak.$$ ] && mv /tmp/nemoclaw-proxy-env.sh.bak.$$ /tmp/nemoclaw-proxy-env.sh 2>/dev/null || true
+        [ -f /tmp/gateway.log.bak.$$ ] && mv /tmp/gateway.log.bak.$$ /tmp/gateway.log 2>/dev/null || true
+        [ -f /tmp/auto-pair.log.bak.$$ ] && mv /tmp/auto-pair.log.bak.$$ /tmp/auto-pair.log 2>/dev/null || true
+        echo "PASSED"
+      `);
+    });
+
+    it("detects bad permissions on sourced files", () => {
+      const testFile = join(workDir, "bad-sourced.sh");
+      writeFileSync(testFile, "# bad permissions");
+      chmodSync(testFile, 0o644); // writable — should fail
+
+      const { stderr } = runWithLib(
+        `validate_tmp_permissions ${JSON.stringify(testFile)}`,
+        { expectFail: true },
+      );
+      expect(stderr).toContain("unsafe permissions");
+    });
+
+    it("passes with correct 444 permissions on sourced files", () => {
+      const testFile = join(workDir, "good-sourced.sh");
+      writeFileSync(testFile, "# good permissions");
+      chmodSync(testFile, 0o444);
+
+      // Need to temporarily hide the default monitored files
+      runWithLib(`
+        [ -f /tmp/nemoclaw-proxy-env.sh ] && mv /tmp/nemoclaw-proxy-env.sh /tmp/nemoclaw-proxy-env.sh.bak.$$ 2>/dev/null || true
+        [ -f /tmp/gateway.log ] && mv /tmp/gateway.log /tmp/gateway.log.bak.$$ 2>/dev/null || true
+        [ -f /tmp/auto-pair.log ] && mv /tmp/auto-pair.log /tmp/auto-pair.log.bak.$$ 2>/dev/null || true
+        validate_tmp_permissions ${JSON.stringify(testFile)}
+        [ -f /tmp/nemoclaw-proxy-env.sh.bak.$$ ] && mv /tmp/nemoclaw-proxy-env.sh.bak.$$ /tmp/nemoclaw-proxy-env.sh 2>/dev/null || true
+        [ -f /tmp/gateway.log.bak.$$ ] && mv /tmp/gateway.log.bak.$$ /tmp/gateway.log 2>/dev/null || true
+        [ -f /tmp/auto-pair.log.bak.$$ ] && mv /tmp/auto-pair.log.bak.$$ /tmp/auto-pair.log 2>/dev/null || true
+        echo "PASSED"
+      `);
+    });
+  });
+
+  describe("verify_config_integrity", () => {
+    let workDir: string;
+
+    beforeEach(() => {
+      workDir = mkdtempSync(join(tmpdir(), "sandbox-init-integrity-"));
+    });
+
+    afterEach(() => {
+      execFileSync("rm", ["-rf", workDir]);
+    });
+
+    it("fails when hash file is missing", () => {
+      const { stderr } = runWithLib(
+        `verify_config_integrity ${JSON.stringify(workDir)}`,
+        { expectFail: true },
+      );
+      expect(stderr).toContain("Config hash file missing");
+    });
+
+    it("passes when config matches hash", () => {
+      const configFile = join(workDir, "config.json");
+      writeFileSync(configFile, '{"test": true}');
+      // Generate hash
+      execFileSync("bash", [
+        "-c",
+        `cd ${JSON.stringify(workDir)} && sha256sum config.json > .config-hash`,
+      ]);
+
+      runWithLib(`
+        verify_config_integrity ${JSON.stringify(workDir)}
+        echo "INTEGRITY_OK"
+      `);
+    });
+
+    it("fails when config is tampered", () => {
+      const configFile = join(workDir, "config.json");
+      writeFileSync(configFile, '{"test": true}');
+      execFileSync("bash", [
+        "-c",
+        `cd ${JSON.stringify(workDir)} && sha256sum config.json > .config-hash`,
+      ]);
+      // Tamper with config
+      writeFileSync(configFile, '{"test": false, "injected": "malicious"}');
+
+      const { stderr } = runWithLib(
+        `verify_config_integrity ${JSON.stringify(workDir)}`,
+        { expectFail: true },
+      );
+      expect(stderr).toContain("integrity check FAILED");
+    });
+  });
+
+  describe("lock_rc_files", () => {
+    let workDir: string;
+
+    beforeEach(() => {
+      workDir = mkdtempSync(join(tmpdir(), "sandbox-init-lock-"));
+    });
+
+    afterEach(() => {
+      // Need to make writable before cleanup
+      try {
+        chmodSync(join(workDir, ".bashrc"), 0o644);
+      } catch {
+        /* ignore */
+      }
+      try {
+        chmodSync(join(workDir, ".profile"), 0o644);
+      } catch {
+        /* ignore */
+      }
+      execFileSync("rm", ["-rf", workDir]);
+    });
+
+    it("sets .bashrc and .profile to 444", () => {
+      writeFileSync(join(workDir, ".bashrc"), "# bashrc");
+      writeFileSync(join(workDir, ".profile"), "# profile");
+
+      runWithLib(`lock_rc_files ${JSON.stringify(workDir)}`);
+
+      const bashrcPerms = execFileSync("stat", ["-f", "%Lp", join(workDir, ".bashrc")], {
+        encoding: "utf-8",
+      }).trim();
+      const profilePerms = execFileSync("stat", ["-f", "%Lp", join(workDir, ".profile")], {
+        encoding: "utf-8",
+      }).trim();
+      expect(bashrcPerms).toBe("444");
+      expect(profilePerms).toBe("444");
+    });
+
+    it("is a no-op when files do not exist", () => {
+      // Should not throw
+      runWithLib(`lock_rc_files ${JSON.stringify(workDir)}`);
+    });
+  });
+
+  describe("drop_capabilities", () => {
+    it("function is defined and callable", () => {
+      // We can't test actual capsh on macOS, but verify the function exists
+      // and handles the no-capsh case gracefully. Capture stderr via redirect.
+      const { stdout } = runWithLib(
+        `
+        # Hide capsh from PATH so the function falls through
+        drop_capabilities /usr/local/bin/fake-entrypoint 2>&1
+        echo "FALLTHROUGH_OK"
+      `,
+        { env: { PATH: "/usr/bin:/bin", NEMOCLAW_CAPS_DROPPED: "" } },
+      );
+      expect(stdout).toContain("capsh not available");
+      expect(stdout).toContain("FALLTHROUGH_OK");
+    });
+
+    it("skips when NEMOCLAW_CAPS_DROPPED=1", () => {
+      const { stdout } = runWithLib(
+        `
+        NEMOCLAW_CAPS_DROPPED=1
+        drop_capabilities /usr/local/bin/fake-entrypoint
+        echo "SKIPPED_OK"
+      `,
+      );
+      expect(stdout).toContain("SKIPPED_OK");
+    });
+  });
+
+  describe("validate_config_symlinks", () => {
+    let workDir: string;
+
+    beforeEach(() => {
+      workDir = mkdtempSync(join(tmpdir(), "sandbox-init-symlinks-"));
+      mkdirSync(join(workDir, "config"));
+      mkdirSync(join(workDir, "data"));
+    });
+
+    afterEach(() => {
+      execFileSync("rm", ["-rf", workDir]);
+    });
+
+    it("passes when symlinks point to expected targets", () => {
+      const dataFile = join(workDir, "data", "agents");
+      writeFileSync(dataFile, "data");
+      symlinkSync(dataFile, join(workDir, "config", "agents"));
+
+      // Use realpath to resolve macOS /var → /private/var symlinks so
+      // the expected path matches what readlink -f returns inside bash.
+      const resolvedConfig = execFileSync("realpath", [join(workDir, "config")], {
+        encoding: "utf-8",
+      }).trim();
+      const resolvedData = execFileSync("realpath", [join(workDir, "data")], {
+        encoding: "utf-8",
+      }).trim();
+
+      runWithLib(`
+        validate_config_symlinks ${JSON.stringify(resolvedConfig)} ${JSON.stringify(resolvedData)}
+        echo "SYMLINKS_OK"
+      `);
+    });
+
+    it("fails when symlink points to unexpected target", () => {
+      const badTarget = join(workDir, "malicious");
+      writeFileSync(badTarget, "evil");
+      symlinkSync(badTarget, join(workDir, "config", "agents"));
+
+      const { stderr } = runWithLib(
+        `validate_config_symlinks ${JSON.stringify(join(workDir, "config"))} ${JSON.stringify(join(workDir, "data"))}`,
+        { expectFail: true },
+      );
+      expect(stderr).toContain("unexpected target");
+    });
+
+    it("passes when directory has no symlinks", () => {
+      writeFileSync(join(workDir, "config", "regular-file"), "not a symlink");
+
+      runWithLib(`
+        validate_config_symlinks ${JSON.stringify(join(workDir, "config"))} ${JSON.stringify(join(workDir, "data"))}
+        echo "NO_SYMLINKS_OK"
+      `);
+    });
+  });
+
+  describe("configure_messaging_channels", () => {
+    it("returns silently when no tokens are set", () => {
+      const { stderr } = runWithLib("configure_messaging_channels", {
+        env: {
+          TELEGRAM_BOT_TOKEN: "",
+          DISCORD_BOT_TOKEN: "",
+          SLACK_BOT_TOKEN: "",
+        },
+      });
+      expect(stderr).not.toContain("[channels]");
+    });
+
+    it("logs active channels when tokens are present", () => {
+      // Since configure_messaging_channels writes to stderr, we need to capture it
+      const script = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `source ${JSON.stringify(SANDBOX_INIT)}`,
+        "configure_messaging_channels",
+      ].join("\n");
+      const tmpFile = join(tmpdir(), `sandbox-init-channels-${process.pid}.sh`);
+      try {
+        writeFileSync(tmpFile, script, { mode: 0o700 });
+        const result = execFileSync("bash", [tmpFile], {
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            TELEGRAM_BOT_TOKEN: "fake-token",
+            DISCORD_BOT_TOKEN: "",
+            SLACK_BOT_TOKEN: "fake-slack",
+          },
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (e: any) {
+        // This shouldn't fail, but if it does we want the stderr
+        const stderr = (e.stderr || "").toString();
+        expect(stderr).toContain("telegram");
+        expect(stderr).toContain("slack");
+        expect(stderr).not.toContain("discord");
+      }
+    });
+  });
+
+  describe("cleanup_on_signal", () => {
+    it("function is defined and uses SANDBOX_CHILD_PIDS", () => {
+      // Verify the function exists and handles empty PID list gracefully
+      const { stdout } = runWithLib(`
+        SANDBOX_CHILD_PIDS=()
+        SANDBOX_WAIT_PID=""
+        # Override exit so we can test
+        exit() { echo "EXIT_\$1"; }
+        cleanup_on_signal
+      `);
+      expect(stdout).toContain("EXIT_0");
+    });
+  });
+
+  describe("double-source guard", () => {
+    it("does not redefine functions when sourced twice", () => {
+      runWithLib(`
+        # Source again — should be a no-op
+        source ${JSON.stringify(SANDBOX_INIT)}
+        # Functions should still work
+        echo "test" | emit_sandbox_sourced_file /dev/null 2>/dev/null || true
+        echo "DOUBLE_SOURCE_OK"
+      `);
+    });
+  });
+
+  describe("both entrypoints source the shared library", () => {
+    it("nemoclaw-start.sh sources sandbox-init.sh", () => {
+      const src = readFileSync(
+        join(import.meta.dirname, "../scripts/nemoclaw-start.sh"),
+        "utf-8",
+      );
+      expect(src).toContain("source");
+      expect(src).toContain("sandbox-init.sh");
+    });
+
+    it("hermes start.sh sources sandbox-init.sh", () => {
+      const src = readFileSync(
+        join(import.meta.dirname, "../agents/hermes/start.sh"),
+        "utf-8",
+      );
+      expect(src).toContain("source");
+      expect(src).toContain("sandbox-init.sh");
+    });
+
+    it("hermes start.sh calls lock_rc_files (vulnerability fix)", () => {
+      const src = readFileSync(
+        join(import.meta.dirname, "../agents/hermes/start.sh"),
+        "utf-8",
+      );
+      expect(src).toContain("lock_rc_files");
+    });
+
+    it("hermes start.sh uses emit_sandbox_sourced_file for proxy config", () => {
+      const src = readFileSync(
+        join(import.meta.dirname, "../agents/hermes/start.sh"),
+        "utf-8",
+      );
+      expect(src).toContain("emit_sandbox_sourced_file");
+      // Should NOT contain the old inline _write_proxy_snippet pattern
+      expect(src).not.toContain("_write_proxy_snippet");
+      expect(src).not.toContain("_PROXY_MARKER_BEGIN");
+    });
+
+    it("hermes start.sh calls validate_tmp_permissions", () => {
+      const src = readFileSync(
+        join(import.meta.dirname, "../agents/hermes/start.sh"),
+        "utf-8",
+      );
+      expect(src).toContain("validate_tmp_permissions");
+    });
+
+    it("nemoclaw-start.sh uses emit_sandbox_sourced_file for proxy-env.sh", () => {
+      const src = readFileSync(
+        join(import.meta.dirname, "../scripts/nemoclaw-start.sh"),
+        "utf-8",
+      );
+      expect(src).toContain("emit_sandbox_sourced_file");
+      // Should NOT contain old chmod 644 for proxy-env
+      expect(src).not.toMatch(/chmod 644.*\$_PROXY_ENV_FILE/);
+    });
+
+    it("nemoclaw-start.sh uses parameterized verify_config_integrity", () => {
+      const src = readFileSync(
+        join(import.meta.dirname, "../scripts/nemoclaw-start.sh"),
+        "utf-8",
+      );
+      expect(src).toContain("verify_config_integrity /sandbox/.openclaw");
+    });
+  });
+});

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -201,6 +201,10 @@ describe("service environment", () => {
   });
 
   describe("proxy environment variables (issue #626)", () => {
+    // The proxy persistence block calls emit_sandbox_sourced_file from the
+    // shared library. Wrappers that execute the extracted block must source it.
+    const sandboxInitSource = `source ${JSON.stringify(join(import.meta.dirname, "../scripts/lib/sandbox-init.sh"))}`;
+
     function extractToolRedirects() {
       const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
       const block = execFileSync("sed", ["-n", "/^_TOOL_REDIRECTS=/,/^done$/p", scriptPath], {
@@ -313,21 +317,24 @@ describe("service environment", () => {
         const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
         const persistBlock = execFileSync(
           "sed",
-          ["-n", "/^_PROXY_URL=/,/^chmod 644/p", scriptPath],
+          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
           { encoding: "utf-8" },
         );
         if (!persistBlock.trim()) {
           throw new Error(
             "Failed to extract proxy persistence block from scripts/nemoclaw-start.sh — " +
-              "the _PROXY_URL..chmod block may have been moved or renamed",
+              "the _PROXY_ENV_FILE..emit_sandbox_sourced_file block may have been moved or renamed",
           );
         }
         const toolRedirects = extractToolRedirects();
         const wrapper = [
           "#!/usr/bin/env bash",
+          sandboxInitSource,
           toolRedirects,
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
+          '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
           // Override the hardcoded path to use our temp dir
           persistBlock
             .trimEnd()
@@ -354,6 +361,11 @@ describe("service environment", () => {
         expect(envFile).toContain("GNUPGHOME=/tmp/.gnupg");
         expect(envFile).toContain("PYTHON_HISTORY=/tmp/.python_history");
         expect(envFile).toContain("npm_config_prefix=/tmp/npm-global");
+        // Permission should be 444 (hardened via emit_sandbox_sourced_file)
+        const perms = execFileSync("stat", ["-f", "%Lp", join(fakeDataDir, "proxy-env.sh")], {
+          encoding: "utf-8",
+        }).trim();
+        expect(perms).toBe("444");
       } finally {
         try {
           unlinkSync(tmpFile);
@@ -376,21 +388,24 @@ describe("service environment", () => {
         const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
         const persistBlock = execFileSync(
           "sed",
-          ["-n", "/^_PROXY_URL=/,/^chmod 644/p", scriptPath],
+          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
           { encoding: "utf-8" },
         );
         if (!persistBlock.trim()) {
           throw new Error(
             "Failed to extract proxy persistence block from scripts/nemoclaw-start.sh — " +
-              "the _PROXY_URL..chmod block may have been moved or renamed",
+              "the _PROXY_ENV_FILE..emit_sandbox_sourced_file block may have been moved or renamed",
           );
         }
         const toolRedirects = extractToolRedirects();
         const wrapper = [
           "#!/usr/bin/env bash",
+          sandboxInitSource,
           toolRedirects,
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
+          '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
           persistBlock
             .trimEnd()
             .replaceAll("/tmp/nemoclaw-proxy-env.sh", `${fakeDataDir}/proxy-env.sh`),
@@ -428,22 +443,25 @@ describe("service environment", () => {
         const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
         const persistBlock = execFileSync(
           "sed",
-          ["-n", "/^_PROXY_URL=/,/^chmod 644/p", scriptPath],
+          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
           { encoding: "utf-8" },
         );
         if (!persistBlock.trim()) {
           throw new Error(
             "Failed to extract proxy persistence block from scripts/nemoclaw-start.sh — " +
-              "the _PROXY_URL..chmod block may have been moved or renamed",
+              "the _PROXY_ENV_FILE..emit_sandbox_sourced_file block may have been moved or renamed",
           );
         }
         const toolRedirects = extractToolRedirects();
         const makeWrapper = (host) =>
           [
             "#!/usr/bin/env bash",
+            sandboxInitSource,
             toolRedirects,
             `PROXY_HOST="${host}"`,
             'PROXY_PORT="3128"',
+            '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
+            '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
             persistBlock
               .trimEnd()
               .replaceAll("/tmp/nemoclaw-proxy-env.sh", `${fakeDataDir}/proxy-env.sh`),
@@ -481,13 +499,13 @@ describe("service environment", () => {
         const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
         const persistBlock = execFileSync(
           "sed",
-          ["-n", "/^_PROXY_URL=/,/^chmod 644/p", scriptPath],
+          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
           { encoding: "utf-8" },
         );
         if (!persistBlock.trim()) {
           throw new Error(
             "Failed to extract proxy persistence block from scripts/nemoclaw-start.sh — " +
-              "the _PROXY_URL..chmod block may have been moved or renamed",
+              "the _PROXY_ENV_FILE..emit_sandbox_sourced_file block may have been moved or renamed",
           );
         }
         const sensitiveFile = join(fakeDataDir, "sensitive");
@@ -497,9 +515,12 @@ describe("service environment", () => {
         const toolRedirects = extractToolRedirects();
         const wrapper = [
           "#!/usr/bin/env bash",
+          sandboxInitSource,
           toolRedirects,
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
+          '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
           persistBlock.trimEnd().replaceAll("/tmp/nemoclaw-proxy-env.sh", proxyEnvPath),
         ].join("\n");
         writeFileSync(tmpFile, wrapper, { mode: 0o700 });
@@ -571,26 +592,29 @@ describe("service environment", () => {
         const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
         const persistBlock = execFileSync(
           "sed",
-          ["-n", "/^_PROXY_URL=/,/^chmod 644/p", scriptPath],
+          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
           { encoding: "utf-8" },
         );
         if (!persistBlock.trim()) {
           throw new Error(
-            "sed anchors (_PROXY_URL=…chmod 644) not found in nemoclaw-start.sh — test cannot run",
+            "sed anchors (_PROXY_ENV_FILE=…emit_sandbox_sourced_file) not found in nemoclaw-start.sh — test cannot run",
           );
         }
         const wrapper = [
           "#!/usr/bin/env bash",
           "set -euo pipefail",
-          `PROXY_HOST="10.200.0.1"`,
-          `PROXY_PORT="3128"`,
-          `NODE_USE_ENV_PROXY=1`,
-          `_TOOL_REDIRECTS=()`,
+          sandboxInitSource,
+          'PROXY_HOST="10.200.0.1"',
+          'PROXY_PORT="3128"',
+          '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          'NODE_USE_ENV_PROXY=1',
+          '_TOOL_REDIRECTS=()',
+          `_AXIOS_FIX_SCRIPT="${fakeFixScript}"`,
           "set +u  # array expansion safe on macOS bash",
           persistBlock
             .trimEnd()
-            .replaceAll("/tmp/nemoclaw-proxy-env.sh", `${fakeDataDir}/proxy-env.sh`)
-            .replaceAll("/opt/nemoclaw-blueprint/scripts/axios-proxy-fix.js", fakeFixScript),
+            .replaceAll("/tmp/nemoclaw-proxy-env.sh", `${fakeDataDir}/proxy-env.sh`),
         ].join("\n");
         // Create a fake fix script so the -f check passes
         writeFileSync(fakeFixScript, "// fake", { mode: 0o644 });
@@ -619,7 +643,7 @@ describe("service environment", () => {
         const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
         const persistBlock = execFileSync(
           "sed",
-          ["-n", "/^_PROXY_URL=/,/^chmod 644/p", scriptPath],
+          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
           { encoding: "utf-8" },
         );
         if (!persistBlock.trim()) {
@@ -628,15 +652,18 @@ describe("service environment", () => {
         const wrapper = [
           "#!/usr/bin/env bash",
           "set -euo pipefail",
-          `PROXY_HOST="10.200.0.1"`,
-          `PROXY_PORT="3128"`,
+          sandboxInitSource,
+          'PROXY_HOST="10.200.0.1"',
+          'PROXY_PORT="3128"',
+          '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
           // NODE_USE_ENV_PROXY intentionally NOT set
-          `_TOOL_REDIRECTS=()`,
+          '_TOOL_REDIRECTS=()',
+          `_AXIOS_FIX_SCRIPT="${fakeFixScript}"`,
           "set +u  # array expansion safe on macOS bash",
           persistBlock
             .trimEnd()
-            .replaceAll("/tmp/nemoclaw-proxy-env.sh", `${fakeDataDir}/proxy-env.sh`)
-            .replaceAll("/opt/nemoclaw-blueprint/scripts/axios-proxy-fix.js", fakeFixScript),
+            .replaceAll("/tmp/nemoclaw-proxy-env.sh", `${fakeDataDir}/proxy-env.sh`),
         ].join("\n");
         writeFileSync(fakeFixScript, "// fake", { mode: 0o644 });
         writeFileSync(tmpFile, wrapper, { mode: 0o700 });


### PR DESCRIPTION
## Summary

Extract common entrypoint functions from `scripts/nemoclaw-start.sh` (OpenClaw) and `agents/hermes/start.sh` (Hermes) into a shared shell library (`scripts/lib/sandbox-init.sh`). This fixes an active Hermes vulnerability (same class as #2181), prevents the two entrypoints from drifting further apart, and establishes reusable primitives for future agent types.

## Related Issue

Fixes #2277

## Changes

- **`scripts/lib/sandbox-init.sh`** (new): Shared library with security primitives — `emit_sandbox_sourced_file()`, `validate_tmp_permissions()`, `drop_capabilities()`, `verify_config_integrity()`, `lock_rc_files()`, `cleanup_on_signal()`, `validate_config_symlinks()`, `harden_config_symlinks()`, `configure_messaging_channels()`
- **`agents/hermes/start.sh`**: Sources shared library. **Security fix**: `.bashrc`/`.profile` now locked to 444 via `lock_rc_files()` (was wide open). Proxy config now uses `emit_sandbox_sourced_file` (root:root 444) instead of inline append to writable `.bashrc`. `validate_tmp_permissions()` gate added before service launch.
- **`scripts/nemoclaw-start.sh`**: Sources shared library. Replaced inline capsh block, `verify_config_integrity()`, symlink validation, messaging channels, cleanup, and proxy-env writing with shared versions. Proxy-env.sh now written via `emit_sandbox_sourced_file` (444 instead of 644).
- **`test/sandbox-init.test.ts`** (new): 28 tests covering all shared library functions independently
- **`test/nemoclaw-start.test.ts`**: Updated tests for shared `cleanup_on_signal` pattern (replaces inline `cleanup()`)
- **`test/service-env.test.ts`**: Updated sed extraction anchors for `emit_sandbox_sourced_file` pattern; added 444 permission assertion

### Hermes vulnerability fix summary

| Control | Before | After |
|---|---|---|
| `.bashrc`/`.profile` locked? | **No — wide open** | ✅ chmod 444 via `lock_rc_files` |
| Proxy config | **Inline in writable .bashrc** | ✅ Standalone 444 file via `emit_sandbox_sourced_file` |
| `/tmp` permission validation | **Missing** | ✅ `validate_tmp_permissions` before service launch |
| Future fixes auto-applied? | **No — manual port** | ✅ Both source same library |

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes (shellcheck, shfmt, eslint, prettier, gitleaks all pass; test runner has pre-existing Docker-dependent failures on main)
- [x] `npm test` passes (sandbox-init 28/28, service-env 34/34, nemoclaw-start 68/68; pre-existing install-preflight failures unrelated to this PR)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (pi agent)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened configuration integrity verification during startup
  * Enhanced file permission hardening for initialization and runtime files
  * Added defense-in-depth validation checks

* **Reliability Improvements**
  * Improved graceful shutdown signal handling
  * More robust error detection during initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->