### PR TITLE
fix(security): reject symlinks on config directory path

### DIFF
--- a/src/lib/config-io.test.ts
+++ b/src/lib/config-io.test.ts
@@ -35,6 +35,35 @@ describe("config-io", () => {
     expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
   });
 
+  it("rejects a symlink in place of the config directory", () => {
+    const tmp = makeTempDir();
+    const attackerDir = path.join(tmp, "attacker");
+    fs.mkdirSync(attackerDir);
+    const symlinkPath = path.join(tmp, ".nemoclaw");
+    fs.symlinkSync(attackerDir, symlinkPath);
+
+    expect(() => ensureConfigDir(symlinkPath)).toThrow(/symbolic link/);
+    expect(() => ensureConfigDir(symlinkPath)).toThrow(/symlink attack/);
+  });
+
+  it("rejects a symlink in an ancestor of the config directory", () => {
+    const tmp = makeTempDir();
+    const attackerDir = path.join(tmp, "attacker");
+    fs.mkdirSync(attackerDir);
+    const symlinkPath = path.join(tmp, ".nemoclaw");
+    fs.symlinkSync(attackerDir, symlinkPath);
+    const nestedDir = path.join(symlinkPath, "state");
+
+    expect(() => ensureConfigDir(nestedDir)).toThrow(/symbolic link/);
+  });
+
+  it("allows a normal directory (no symlinks)", () => {
+    const dir = path.join(makeTempDir(), ".nemoclaw");
+    ensureConfigDir(dir);
+    expect(fs.existsSync(dir)).toBe(true);
+    expect(fs.lstatSync(dir).isSymbolicLink()).toBe(false);
+  });
+
   it("tightens pre-existing weak directory permissions to 0o700", () => {
     const dir = path.join(makeTempDir(), "config");
     fs.mkdirSync(dir, { mode: 0o755 });

--- a/src/lib/config-io.test.ts
+++ b/src/lib/config-io.test.ts
@@ -36,7 +36,10 @@ describe("config-io", () => {
   });
 
   it("rejects a symlink in place of the config directory", () => {
-    const tmp = makeTempDir();
+    // Place temp dir under HOME so rejectSymlinksOnPath inspects it.
+    const home = process.env.HOME || os.homedir();
+    const tmp = fs.mkdtempSync(path.join(home, ".nemoclaw-test-"));
+    tmpDirs.push(tmp);
     const attackerDir = path.join(tmp, "attacker");
     fs.mkdirSync(attackerDir);
     const symlinkPath = path.join(tmp, ".nemoclaw");
@@ -47,7 +50,9 @@ describe("config-io", () => {
   });
 
   it("rejects a symlink in an ancestor of the config directory", () => {
-    const tmp = makeTempDir();
+    const home = process.env.HOME || os.homedir();
+    const tmp = fs.mkdtempSync(path.join(home, ".nemoclaw-test-"));
+    tmpDirs.push(tmp);
     const attackerDir = path.join(tmp, "attacker");
     fs.mkdirSync(attackerDir);
     const symlinkPath = path.join(tmp, ".nemoclaw");
@@ -58,7 +63,10 @@ describe("config-io", () => {
   });
 
   it("allows a normal directory (no symlinks)", () => {
-    const dir = path.join(makeTempDir(), ".nemoclaw");
+    const home = process.env.HOME || os.homedir();
+    const tmp = fs.mkdtempSync(path.join(home, ".nemoclaw-test-"));
+    tmpDirs.push(tmp);
+    const dir = path.join(tmp, ".nemoclaw");
     ensureConfigDir(dir);
     expect(fs.existsSync(dir)).toBe(true);
     expect(fs.lstatSync(dir).isSymbolicLink()).toBe(false);

--- a/src/lib/config-io.ts
+++ b/src/lib/config-io.ts
@@ -80,7 +80,43 @@ export class ConfigPermissionError extends Error {
   }
 }
 
+/**
+ * Reject a path if it — or any ancestor up to the user's home — is a symlink.
+ * This prevents an attacker from planting e.g. ~/.nemoclaw as a symlink to an
+ * attacker-controlled directory, which would cause credentials to be written
+ * to the wrong location.
+ */
+function rejectSymlinksOnPath(dirPath: string): void {
+  const home = process.env.HOME || os.homedir();
+  const resolved = path.resolve(dirPath);
+  const resolvedHome = path.resolve(home);
+
+  // Walk from dirPath up to (but not including) HOME, checking each component.
+  let current = resolved;
+  while (current.length > resolvedHome.length && current !== path.dirname(current)) {
+    try {
+      const stat = fs.lstatSync(current);
+      if (stat.isSymbolicLink()) {
+        const target = fs.readlinkSync(current);
+        throw new Error(
+          `Refusing to use config directory: ${current} is a symbolic link ` +
+            `(target: ${target}). This may indicate a symlink attack. ` +
+            `Remove the symlink and retry: rm ${current}`,
+        );
+      }
+    } catch (error) {
+      // ENOENT is fine — the directory doesn't exist yet; keep walking up
+      // to check ancestors that DO exist (an ancestor might be a symlink).
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    current = path.dirname(current);
+  }
+}
+
 export function ensureConfigDir(dirPath: string): void {
+  // SECURITY: Block symlink attacks before creating or writing to the directory.
+  rejectSymlinksOnPath(dirPath);
+
   try {
     fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
 

--- a/src/lib/config-io.ts
+++ b/src/lib/config-io.ts
@@ -91,9 +91,19 @@ function rejectSymlinksOnPath(dirPath: string): void {
   const resolved = path.resolve(dirPath);
   const resolvedHome = path.resolve(home);
 
-  // Walk from dirPath up to (but not including) HOME, checking each component.
+  // Only check the path components between HOME and dirPath — those are
+  // the user-controllable segments where a symlink attack could be planted.
+  // System-level symlinks above HOME (e.g. /var -> private/var on macOS)
+  // are legitimate and must not trigger rejection.
+  const relToHome = path.relative(resolvedHome, resolved);
+  if (relToHome === "" || relToHome.startsWith("..") || path.isAbsolute(relToHome)) {
+    // dirPath is not under HOME — nothing user-controllable to check.
+    return;
+  }
+
+  // Walk from dirPath up to (but not including) HOME.
   let current = resolved;
-  while (current.length > resolvedHome.length && current !== path.dirname(current)) {
+  while (current !== resolvedHome && current !== path.dirname(current)) {
     try {
       const stat = fs.lstatSync(current);
       if (stat.isSymbolicLink()) {
@@ -101,7 +111,7 @@ function rejectSymlinksOnPath(dirPath: string): void {
         throw new Error(
           `Refusing to use config directory: ${current} is a symbolic link ` +
             `(target: ${target}). This may indicate a symlink attack. ` +
-            `Remove the symlink and retry: rm ${current}`,
+            `Remove the symlink and retry: rm ${shellQuote(current)}`,
         );
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

- Mitigates a symlink attack on the `~/.nemoclaw` credentials directory: an attacker who plants `~/.nemoclaw` as a symlink to an attacker-controlled directory before the user's first run could hijack credential writes
- Adds `rejectSymlinksOnPath()` in `ensureConfigDir()` that walks from the target directory up to `$HOME`, using `lstatSync()` on each component to detect symlinks without following them
- Aborts with a descriptive error if any path component is a symbolic link, preventing credential write hijack

## Test plan

- [x] New test: rejects a direct symlink in place of the config directory
- [x] New test: rejects a symlink in an ancestor of the config directory
- [x] New test: allows a normal (non-symlink) directory without error
- [x] All 11 config-io tests pass
- [x] Full test suite: 2062 passed, 0 regressions (5 pre-existing infra failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration-directory creation and validation to detect and reject symlinked path components under the home directory, causing early failure when such symlinks are encountered.

* **Tests**
  * Added tests covering symlink-in-target, symlink-in-ancestor, and normal-directory success cases; verifies created config paths are not symbolic links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->