### PR TITLE
fix(rebuild): forward stored --from Dockerfile path to onboard on rebuild

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2417,7 +2417,12 @@ async function sandboxRebuild(sandboxName, args = [], opts = {}) {
   log(
     `Env: NEMOCLAW_SANDBOX_NAME=${process.env.NEMOCLAW_SANDBOX_NAME}, NEMOCLAW_RECREATE_SANDBOX=${process.env.NEMOCLAW_RECREATE_SANDBOX}`,
   );
-  log("Calling onboard({ resume: true, nonInteractive: true, recreateSandbox: true })");
+
+  // Forward the stored --from Dockerfile path so onboard --resume uses the
+  // same custom image.  Without this, the conflict check rejects the resume
+  // because requestedFrom (null) !== recordedFrom (the stored path).  (#2301)
+  const storedFromDockerfile = sessionAfter?.metadata?.fromDockerfile || null;
+  log(`Calling onboard({ resume: true, nonInteractive: true, recreateSandbox: true, fromDockerfile: ${storedFromDockerfile} })`);
 
   const { onboard } = require("./lib/onboard");
   await onboard({
@@ -2425,6 +2430,7 @@ async function sandboxRebuild(sandboxName, args = [], opts = {}) {
     nonInteractive: true,
     recreateSandbox: true,
     agent: rebuildAgent,
+    fromDockerfile: storedFromDockerfile,
   });
 
   log("onboard() returned successfully");

--- a/test/repro-2201.test.ts
+++ b/test/repro-2201.test.ts
@@ -55,9 +55,11 @@ afterEach(() => {
 function createFixture({
   rebuildTarget,
   lastOnboarded,
+  fromDockerfile = null,
 }: {
   rebuildTarget: { name: string; agent: string | null };
   lastOnboarded: { name: string; agent: string | null };
+  fromDockerfile?: string | null;
 }) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-2201-"));
   tmpFixtures.push(tmpDir);
@@ -96,7 +98,7 @@ function createFixture({
       provider: "p", model: "m", endpointUrl: null, credentialEnv: null,
       preferredInferenceApi: null, nimContainer: null, webSearchConfig: null,
       policyPresets: [], messagingChannels: null,
-      metadata: { gatewayName: "nemoclaw", fromDockerfile: null },
+      metadata: { gatewayName: "nemoclaw", fromDockerfile: fromDockerfile },
       steps: {
         preflight:  { status: "complete", startedAt: null, completedAt: null, error: null },
         gateway:    { status: "complete", startedAt: null, completedAt: null, error: null },
@@ -188,9 +190,13 @@ function runRebuild(fixture: ReturnType<typeof createFixture>) {
   );
 }
 
-function readSessionAgent(fixture: ReturnType<typeof createFixture>): unknown {
+function readSession(fixture: ReturnType<typeof createFixture>): Record<string, unknown> {
   const p = path.join(fixture.nemoclawDir, "onboard-session.json");
-  return JSON.parse(fs.readFileSync(p, "utf-8")).agent;
+  return JSON.parse(fs.readFileSync(p, "utf-8"));
+}
+
+function readSessionAgent(fixture: ReturnType<typeof createFixture>): unknown {
+  return readSession(fixture).agent;
 }
 
 describe("Issue #2201: rebuild syncs agent from registry, not stale session", () => {
@@ -218,5 +224,25 @@ describe("Issue #2201: rebuild syncs agent from registry, not stale session", ()
       // With fix: session.agent = "hermes" (synced from hermes registry entry)
       // Without fix: session.agent stays null (from openclaw onboard)
       expect(readSessionAgent(f)).toBe("hermes");
+    });
+});
+
+describe("Issue #2301: rebuild forwards stored --from Dockerfile to onboard", () => {
+  it("rebuild does not hit fromDockerfile conflict when session has a stored --from path",
+    { timeout: 60_000 }, () => {
+      // Scenario: user onboarded with --from /path/to/Dockerfile, then
+      // runs rebuild.  Without the fix, onboard's conflict check sees
+      // requestedFrom=null vs recordedFrom="/path/to/Dockerfile" and
+      // exits with a conflict error.
+      const f = createFixture({
+        rebuildTarget: { name: "openclaw", agent: null },
+        lastOnboarded: { name: "openclaw", agent: null },
+        fromDockerfile: "/tmp/custom/Dockerfile",
+      });
+      const result = runRebuild(f);
+      // Without fix: exits with "Session was started with --from ..."
+      // With fix: rebuild proceeds past conflict check (may still fail
+      // later in the fake-env backup step — that's expected with stubs).
+      expect(result.stderr).not.toMatch(/Session was started with --from/);
     });
 });


### PR DESCRIPTION
## Summary

- `sandboxRebuild()` called `onboard({ resume: true })` without passing the session's stored `fromDockerfile`, causing the conflict check to reject the resume (`requestedFrom=null` vs `recordedFrom="/path/to/Dockerfile"`)
- This made `nemoclaw <name> rebuild` and `nemoclaw upgrade-sandboxes` fail unconditionally for any sandbox created with `--from`
- Fix reads the stored `fromDockerfile` from session metadata and passes it through to `onboard()`

Fixes #2301

## Test plan

- [x] New test: rebuild does not hit fromDockerfile conflict when session has a stored `--from` path
- [x] Existing #2201 regression tests still pass (agent syncing unaffected)
- [x] All 3 rebuild tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rebuild operations to properly preserve and use the stored Dockerfile source configuration, preventing errors when resuming sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->