### PR TITLE
chore(install): bump OpenShell version to 0.0.32

### DIFF
--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version: "0.1.0"
-min_openshell_version: "0.0.29"
-max_openshell_version: "0.0.29"
+min_openshell_version: "0.0.32"
+max_openshell_version: "0.0.32"
 min_openclaw_version: "2026.4.2"
 # Mirrors the components.sandbox.image manifest digest below. Lets a
 # downstream consumer (or release tooling) verify the blueprint declares

--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -28,7 +28,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/<ref>/scripts/brev-launchable-ci-cpu.sh | bash
 #
 # Environment overrides:
-#   OPENSHELL_VERSION     — OpenShell CLI release tag (default: v0.0.29)
+#   OPENSHELL_VERSION     — OpenShell CLI release tag (default: v0.0.32)
 #   NEMOCLAW_REF          — NemoClaw git ref to clone (default: main)
 #   NEMOCLAW_CLONE_DIR    — Where to clone NemoClaw (default: ~/NemoClaw)
 #   SKIP_DOCKER_PULL      — Set to 1 to skip Docker image pre-pulls
@@ -40,7 +40,7 @@
 set -euo pipefail
 
 # ── Configuration ────────────────────────────────────────────────────
-OPENSHELL_VERSION="${OPENSHELL_VERSION:-v0.0.29}"
+OPENSHELL_VERSION="${OPENSHELL_VERSION:-v0.0.32}"
 NEMOCLAW_REF="${NEMOCLAW_REF:-main}"
 TARGET_USER="${SUDO_USER:-$(id -un)}"
 TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -36,10 +36,10 @@ info "Detected $OS_LABEL ($ARCH_LABEL)"
 # Minimum version required for Landlock filesystem policy enforcement
 # (NVIDIA/OpenShell#810 fixes the drop_privileges/Landlock ordering bug
 # that caused /sandbox to remain writable on 0.0.26).
-MIN_VERSION="0.0.29"
+MIN_VERSION="0.0.32"
 # Maximum version validated for this NemoClaw release. Newer OpenShell builds
 # may change sandbox semantics; upgrade NemoClaw before upgrading past this.
-MAX_VERSION="0.0.29"
+MAX_VERSION="0.0.32"
 # Pin fresh installs to this version instead of pulling "latest".
 PIN_VERSION="$MAX_VERSION"
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2689,7 +2689,7 @@ async function preflight() {
       // Source of truth: min_openshell_version in nemoclaw-blueprint/blueprint.yaml.
       // Fall back to the Landlock-enforcement floor (also MIN_VERSION in
       // scripts/install-openshell.sh) if the blueprint cannot be read.
-      const minOpenshellVersion = getBlueprintMinOpenshellVersion() ?? "0.0.29";
+      const minOpenshellVersion = getBlueprintMinOpenshellVersion() ?? "0.0.32";
       const needsUpgrade = !versionGte(currentVersion, minOpenshellVersion);
       if (needsUpgrade) {
         console.log(

--- a/test/install-openshell-version-check.test.ts
+++ b/test/install-openshell-version-check.test.ts
@@ -59,10 +59,10 @@ exit 1`,
 }
 
 describe("install-openshell.sh version check", () => {
-  it("exits cleanly when openshell 0.0.29 is already installed", () => {
-    const result = runWithInstalledVersion("0.0.29");
+  it("exits cleanly when openshell 0.0.32 is already installed", () => {
+    const result = runWithInstalledVersion("0.0.32");
     expect(result.status).toBe(0);
-    expect(result.stdout).toMatch(/already installed.*0\.0\.29/);
+    expect(result.stdout).toMatch(/already installed.*0\.0\.32/);
   });
 
   it("triggers upgrade when openshell 0.0.28 is installed (below MIN_VERSION)", () => {
@@ -85,7 +85,7 @@ describe("install-openshell.sh version check", () => {
   });
 
   it("fails with a clear error when openshell is above MAX_VERSION", () => {
-    const result = runWithInstalledVersion("0.0.30");
+    const result = runWithInstalledVersion("0.0.33");
     expect(result.status).toBe(1);
     expect(result.stdout).toMatch(/above the maximum/);
   });
@@ -96,13 +96,13 @@ describe("install-openshell.sh version check", () => {
     expect(result.stdout).toMatch(/above the maximum/);
   });
 
-  it("exits cleanly when openshell reports m-dev but sidecar records 0.0.29", () => {
+  it("exits cleanly when openshell reports m-dev but sidecar records 0.0.32", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openshell-mdev-"));
     try {
       const fakeBin = path.join(tmp, "bin");
       fs.mkdirSync(fakeBin);
 
-      // Fake openshell that reports "m-dev" (as openshell 0.0.29 does in practice)
+      // Fake openshell that reports "m-dev" (as some OpenShell dev builds do)
       writeExecutable(
         path.join(fakeBin, "openshell"),
         `#!/usr/bin/env bash
@@ -111,7 +111,7 @@ exit 99`,
       );
 
       // Sidecar file written by a previous install
-      fs.writeFileSync(path.join(fakeBin, ".openshell-installed-version"), "0.0.29\n");
+      fs.writeFileSync(path.join(fakeBin, ".openshell-installed-version"), "0.0.32\n");
 
       writeExecutable(path.join(fakeBin, "curl"), `#!/usr/bin/env bash\nexit 1`);
       writeExecutable(path.join(fakeBin, "gh"), `#!/usr/bin/env bash\nexit 1`);
@@ -121,7 +121,7 @@ exit 99`,
         encoding: "utf8",
       });
       expect(result.status).toBe(0);
-      expect(result.stdout).toMatch(/already installed.*0\.0\.29/);
+      expect(result.stdout).toMatch(/already installed.*0\.0\.32/);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -929,13 +929,13 @@ describe("onboard helpers", () => {
       path.join(blueprintDir, "blueprint.yaml"),
       [
         'version: "0.1.0"',
-        'min_openshell_version: "0.0.29"',
-        'max_openshell_version: "0.0.29"',
+        'min_openshell_version: "0.0.32"',
+        'max_openshell_version: "0.0.32"',
         'min_openclaw_version: "2026.3.0"',
       ].join("\n"),
     );
     try {
-      expect(getBlueprintMaxOpenshellVersion(tmpDir)).toBe("0.0.29");
+      expect(getBlueprintMaxOpenshellVersion(tmpDir)).toBe("0.0.32");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
Bumps the pinned OpenShell version range from `0.0.29` → `0.0.32` so fresh NemoClaw installs pick up sandbox hardening and TLS improvements from the last three OpenShell releases.

## Notable upstream changes

**0.0.30** ([NVIDIA/OpenShell@v0.0.29...v0.0.30](https://github.com/NVIDIA/OpenShell/compare/v0.0.29...v0.0.30))
- Network policy deny rules ([OpenShell#822](https://github.com/NVIDIA/OpenShell/pull/822))
- Preserve ownership on existing `read_write` paths ([OpenShell#827](https://github.com/NVIDIA/OpenShell/pull/827))
- Disable child core dumps ([OpenShell#821](https://github.com/NVIDIA/OpenShell/pull/821))
- Escape control characters in SSE error formatting ([OpenShell#842](https://github.com/NVIDIA/OpenShell/pull/842))
- Fix silent truncation of large streaming inference responses ([OpenShell#834](https://github.com/NVIDIA/OpenShell/pull/834))

**0.0.31** ([NVIDIA/OpenShell@v0.0.30...v0.0.31](https://github.com/NVIDIA/OpenShell/compare/v0.0.30...v0.0.31))
- Inference routed-request header allowlist ([OpenShell#826](https://github.com/NVIDIA/OpenShell/pull/826))

**0.0.32** ([NVIDIA/OpenShell@v0.0.31...v0.0.32](https://github.com/NVIDIA/OpenShell/compare/v0.0.31...v0.0.32))
- **Load system CA certificates for upstream TLS connections** ([OpenShell#862](https://github.com/NVIDIA/OpenShell/pull/862))
- Publish standalone `openshell-gateway` binaries ([OpenShell#853](https://github.com/NVIDIA/OpenShell/pull/853))

## Changes
- `nemoclaw-blueprint/blueprint.yaml`: `min_openshell_version` and `max_openshell_version` → `0.0.32`
- `scripts/install-openshell.sh`: `MIN_VERSION` and `MAX_VERSION` → `0.0.32` (`PIN_VERSION` follows `MAX`)
- `scripts/brev-launchable-ci-cpu.sh`: default `OPENSHELL_VERSION` → `v0.0.32`
- `src/lib/onboard.ts`: blueprint-fallback min version → `0.0.32`
- `test/onboard.test.ts`, `test/install-openshell-version-check.test.ts`: fixtures updated; "above MAX" test case moved from `0.0.30` to `0.0.33`

Historical `m-dev` comments referencing `0.0.29` left in place — they describe a self-report quirk the sidecar fallback still handles.

## Why not 0.0.33+?
`0.0.34` introduced incremental sandbox policy updates and L7 request-target canonicalization — changes with larger surface area against how NemoClaw delivers policy via gRPC. Worth a follow-up PR rather than bundling here. `0.0.35` released hours before this PR was cut — too fresh.

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.

## Testing
- [x] `npx vitest run test/install-openshell-version-check.test.ts` — 9 passed
- [x] pre-commit hooks (prek) clean: shellcheck, commitlint, gitleaks, YAML validator, CLI test suite
- [ ] Nightly E2E on this branch — will be kicked off after PR opens

## Notes
- No user-facing CLI behavior changes — just the pinned version range.
- Two pre-existing failures in `test/onboard.test.ts` reproduce on clean `main` and are unrelated to this bump.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenShell version constraints and default pinned version to v0.0.32 across configuration, install, and onboarding flows.

* **Tests**
  * Updated test fixtures and expectations to match the new OpenShell version (v0.0.32).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->