### PR TITLE
fix(sandbox): allow intra-sandbox symlinks in safeTarExtract audit (#2268)

### DIFF
--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -180,9 +180,19 @@ export function validateTarEntries(
 
 /**
  * Walk a directory and return violations for any symlinks whose
- * resolved targets escape rootPath.
+ * resolved targets don't land within any of the allowed roots.
+ *
+ * `allowedRoots` always includes the extraction directory (the local host
+ * path). Callers pass additional roots — notably `/sandbox` — to permit
+ * legitimate intra-sandbox symlinks baked into the sandbox base image
+ * (e.g. `/sandbox/.openclaw` → `/sandbox/.openclaw-data`). Those look
+ * like "escapes" relative to the extraction temp dir on the host, but
+ * are intra-sandbox once the backup is restored. See issue #2268.
  */
-function auditExtractedSymlinks(dirPath: string, rootPath: string): string[] {
+function auditExtractedSymlinks(
+  dirPath: string,
+  allowedRoots: string[],
+): string[] {
   const violations: string[] = [];
   if (!existsSync(dirPath)) return violations;
 
@@ -194,7 +204,10 @@ function auditExtractedSymlinks(dirPath: string, rootPath: string): string[] {
         if (stat.isSymbolicLink()) {
           const linkTarget = readlinkSync(fullPath);
           const resolvedTarget = path.resolve(path.dirname(fullPath), linkTarget);
-          if (!isWithinRoot(resolvedTarget, rootPath)) {
+          const inAnyAllowedRoot = allowedRoots.some((root) =>
+            isWithinRoot(resolvedTarget, root),
+          );
+          if (!inAnyAllowedRoot) {
             violations.push(`symlink escape: ${fullPath} -> ${linkTarget} (resolves to ${resolvedTarget})`);
           }
         } else if (stat.isDirectory()) {
@@ -282,8 +295,11 @@ export function safeTarExtract(
   }
 
   // Phase 3: Post-extraction symlink audit (symlink targets are not
-  // visible in `tar -tf` output, so we must check after extraction)
-  const symlinkViolations = auditExtractedSymlinks(targetDir, targetDir);
+  // visible in `tar -tf` output, so we must check after extraction).
+  // Allow targets inside either the host extraction dir OR the canonical
+  // sandbox root (/sandbox) — the latter covers legitimate intra-sandbox
+  // symlinks baked into the base image (see #2268).
+  const symlinkViolations = auditExtractedSymlinks(targetDir, [targetDir, "/sandbox"]);
   if (symlinkViolations.length > 0) {
     // Nuke the extraction — do not leave attacker-controlled symlinks on host
     try {

--- a/test/security-sandbox-tar-traversal.test.ts
+++ b/test/security-sandbox-tar-traversal.test.ts
@@ -321,6 +321,65 @@ describe("Fix: safeTarExtract blocks malicious archives and extracts safe ones",
       fs.rmSync(workDir, { recursive: true, force: true });
     }
   });
+
+  // Regression for #2268 — the sandbox base image places intra-sandbox
+  // symlinks like /sandbox/.openclaw → /sandbox/.openclaw-data. When the
+  // backup tar is extracted on the host, those absolute symlinks point
+  // OUTSIDE the extraction temp dir, but INSIDE the canonical sandbox
+  // root — which is where they'll be legitimately resolved on restore.
+  // Treating them as escape violations breaks every rebuild / snapshot
+  // create on v0.0.22.
+  it("allows symlinks whose target resolves within /sandbox (intra-sandbox layout)", async () => {
+    const { safeTarExtract } = await loadSandboxState();
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sandbox-link-"));
+    try {
+      const targetDir = path.join(workDir, "backup");
+      fs.mkdirSync(targetDir, { recursive: true });
+
+      const tar = buildTar([
+        { path: "sandbox/.openclaw-data/", type: "5" },
+        {
+          path: "sandbox/.openclaw",
+          type: "2",
+          linkTarget: "/sandbox/.openclaw-data",
+        },
+      ]);
+
+      const result = safeTarExtract(tar, targetDir);
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  // Security guardrail: /sandbox/ is allowed, but a crafted symlink whose
+  // target *looks* absolute must not escape beyond the sandbox root.
+  // /sandbox/../etc/passwd resolves to /etc/passwd — still must be blocked.
+  it("blocks symlinks that escape /sandbox even with an absolute target", async () => {
+    const { safeTarExtract } = await loadSandboxState();
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sandbox-escape-"));
+    try {
+      const targetDir = path.join(workDir, "backup");
+      fs.mkdirSync(targetDir, { recursive: true });
+
+      const tar = buildTar([
+        {
+          path: "evil-abs-link",
+          type: "2",
+          linkTarget: "/etc/passwd",
+        },
+      ]);
+
+      const result = safeTarExtract(tar, targetDir);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("symlink");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("Fix: rejectHardLinks blocks hard-link entries at validation time", () => {


### PR DESCRIPTION
## Summary

Closes #2268 — P1 regression in v0.0.22.

\`safeTarExtract\`'s post-extraction symlink audit (added in #2163 to block tar path-traversal attacks) flagged every symlink whose target resolved outside the extraction temp directory. The sandbox base image legitimately ships intra-sandbox symlinks like \`/sandbox/.openclaw → /sandbox/.openclaw-data\` — those resolve *outside* the host temp dir but *inside* the canonical \`/sandbox\` root, where they'll be correctly resolved when the backup is restored into a fresh sandbox.

Result: the audit nuked every backup, breaking \`nemoclaw rebuild\` and \`nemoclaw snapshot create\` on v0.0.22. The only workaround was \`destroy + onboard\` (loses all state).

## Fix

- \`auditExtractedSymlinks(dirPath, allowedRoots: string[])\` — now takes an array of allowed roots instead of a single one
- \`safeTarExtract\` passes \`[targetDir, "/sandbox"]\` so intra-sandbox absolute symlinks are honored while genuine escape attempts (e.g. symlink to \`/etc/passwd\` or \`../../.ssh/authorized_keys\`) still abort the extraction

The security guardrail is intact: \`/sandbox\` is a subtree root, so crafted symlinks with absolute targets outside \`/sandbox\` (e.g. \`/etc/passwd\`) are still rejected.

## Test plan

- [x] New test: \`allows symlinks whose target resolves within /sandbox (intra-sandbox layout)\` — locks the regression fix
- [x] New test: \`blocks symlinks that escape /sandbox even with an absolute target\` — confirms \`/etc/passwd\` symlinks still rejected
- [x] Existing \`blocks symlink escaping target directory\` (relative \`../../\`) still passes
- [x] All 21 sandbox-tar security tests pass
- [x] Full CLI suite: 1783 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Bug Fixes**
  * Improved symlink validation during tar archive extraction to correctly allow absolute symlink targets that resolve within the sandbox environment.
  * Enhanced security checks now reject symlinks with targets outside permitted directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->