### PR TITLE
docs: update commands reference for 0.0.23 release

### DIFF
--- a/.agents/skills/nemoclaw-user-deploy-remote/SKILL.md
+++ b/.agents/skills/nemoclaw-user-deploy-remote/SKILL.md
@@ -56,7 +56,7 @@ The legacy compatibility flow performs the following steps on the VM:
 1. Installs Docker and the NVIDIA Container Toolkit if a GPU is present.
 2. Installs the OpenShell CLI.
 3. Runs `nemoclaw onboard` (the setup wizard) to create the gateway, register providers, and launch the sandbox.
-4. Starts optional host auxiliary services (for example the cloudflared tunnel) when `cloudflared` is available. Channel messaging is configured during onboarding and runs through OpenShell-managed processes, not through `nemoclaw start`.
+4. Starts optional host auxiliary services (for example the cloudflared tunnel) when `cloudflared` is available. Channel messaging is configured during onboarding and runs through OpenShell-managed processes, not through `nemoclaw tunnel start`.
 
 By default, the compatibility wrapper asks Brev to provision on `gcp`. Override this with `NEMOCLAW_BREV_PROVIDER` if you need a different Brev cloud provider.
 
@@ -141,7 +141,7 @@ $ nemoclaw deploy <instance-name>
 Telegram, Discord, and Slack reach your agent through OpenShell-managed processes and gateway constructs.
 NemoClaw configures those channels during `nemoclaw onboard`. Tokens are registered with OpenShell providers, channel configuration is baked into the sandbox image, and runtime delivery stays under OpenShell control.
 
-`nemoclaw start` does not start Telegram (or other chat bridges). It only starts optional host services such as the cloudflared tunnel when that binary is present.
+`nemoclaw tunnel start` does not start Telegram (or other chat bridges). It only starts optional host services such as the cloudflared tunnel when that binary is present. (`nemoclaw start` is kept as a deprecated alias.)
 For details, refer to Commands (use the `nemoclaw-user-reference` skill).
 
 ## Step 9: Create a Telegram Bot
@@ -197,14 +197,16 @@ For a full first-time flow, refer to Quickstart (use the `nemoclaw-user-get-star
 After the sandbox is running, send a message to your bot in Telegram.
 If something fails, use `openshell term` on the host, check gateway logs, and verify network policy allows the Telegram API (see Customize the Network Policy (use the `nemoclaw-user-manage-policy` skill) and the `telegram` preset).
 
-## Step 13: `nemoclaw start` (cloudflared Only)
+## Step 13: `nemoclaw tunnel start` (cloudflared Only)
 
-`nemoclaw start` starts cloudflared when it is installed, which can expose the dashboard with a public URL.
-It does not affect Telegram connectivity.
+`nemoclaw tunnel start` starts cloudflared when it is installed, which can expose the dashboard with a public URL.
+It does not affect Telegram connectivity. The older `nemoclaw start` still works as a deprecated alias.
 
 ```console
-$ nemoclaw start
+$ nemoclaw tunnel start
 ```
+
+To pause the Telegram bridge without removing its credentials or destroying the sandbox, use `nemoclaw <name> channels stop telegram`. Re-enable it later with `nemoclaw <name> channels start telegram`.
 
 ## References
 

--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -92,6 +92,52 @@ curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uni
 
 For troubleshooting installation or onboarding issues, see the Troubleshooting guide (use the `nemoclaw-user-reference` skill).
 
+## Step 4: Reconfigure or Recover
+
+Recover from a misconfigured sandbox without re-running the full onboard wizard or destroying workspace state.
+
+### Change inference model or API
+
+Change the active model or provider at runtime without rebuilding the sandbox:
+
+```console
+$ openshell inference set -g nemoclaw -m <model> -p <provider>
+```
+
+See Switch inference providers (use the `nemoclaw-user-configure-inference` skill) for provider-specific model IDs and API compatibility notes.
+
+### Reset a stored credential
+
+If an API key was entered incorrectly during onboarding, clear the stored value and re-enter it on the next onboard run:
+
+```console
+$ nemoclaw credentials list           # see which keys are stored
+$ nemoclaw credentials reset <KEY>    # clear a single key, e.g. NVIDIA_API_KEY
+$ nemoclaw onboard                    # re-run to re-enter the cleared key
+```
+
+The credentials command is documented in full at Commands &rarr; `nemoclaw credentials reset` (use the `nemoclaw-user-reference` skill).
+
+### Rebuild a sandbox while preserving workspace state
+
+If you changed the underlying Dockerfile, upgraded OpenClaw, or want to pick up a new base image without losing your sandbox's workspace files, use `rebuild` instead of destroying and recreating:
+
+```console
+$ nemoclaw <sandbox-name> rebuild
+```
+
+Rebuild preserves the mounted workspace and registered policies while recreating the container. See Commands &rarr; `nemoclaw <name> rebuild` (use the `nemoclaw-user-reference` skill) for flag details.
+
+### Add a network preset after onboarding
+
+Apply an additional preset (e.g. Telegram, GitHub) to a running sandbox without re-onboarding:
+
+```console
+$ nemoclaw <sandbox-name> policy-add
+```
+
+See Commands &rarr; `nemoclaw <name> policy-add` (use the `nemoclaw-user-reference` skill) for usage details and flags.
+
 ## References
 
 - **Load [references/windows-setup.md](references/windows-setup.md)** when installing NemoClaw on Windows, enabling WSL 2, configuring Docker Desktop for Windows, or troubleshooting a Windows-specific install error. Includes Windows-only prerequisites that must be completed before the Quickstart.

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -44,7 +44,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--yes-i-accept-third-party-software]
+$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--agent <name>] [--dangerously-skip-permissions] [--yes-i-accept-third-party-software]
 ```
 
 > **Warning:** For NemoClaw-managed environments, use `nemoclaw onboard` when you need to create or recreate the OpenShell gateway or sandbox.
@@ -151,6 +151,28 @@ $ NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_FROM_DOCKERFILE=path/to/Dockerfile nemocla
 ```
 
 If a `--resume` is attempted with a different `--from` path than the original session, onboarding exits with a conflict error rather than silently building from the wrong image.
+
+#### `--dangerously-skip-permissions`
+
+> **Warning:** For development and testing only. This flag disables the sandbox's network policy and filesystem permission restrictions, so the OpenClaw agent inside the sandbox can reach any host and write anywhere in its home directory. Do not use this flag with production credentials or on hosts where other agents run.
+
+Replace the default balanced sandbox policy with the permissive policy bundled at `nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml`. Concretely, this means:
+
+- **Network:** all known endpoints open with no HTTP method or path filtering.
+- **Filesystem:** the sandbox home directory is writable (normally Landlock-restricted).
+- **Messaging / inference:** unchanged — still gated by the provider credentials you supply.
+
+```console
+$ nemoclaw onboard --dangerously-skip-permissions
+```
+
+Onboarding prints an explicit warning at start so the reduced security posture is visible in logs. The flag is also honored via `NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1` for non-interactive runs:
+
+```console
+$ NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1 nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
+```
+
+The flag is persisted on the sandbox registry entry, so `nemoclaw <sandbox> status` surfaces `Permissions: dangerously-skip-permissions (shields permanently down)` for sandboxes created this way. To tighten a sandbox after the fact, re-run `nemoclaw onboard` without the flag.
 
 ### `nemoclaw list`
 
@@ -356,6 +378,32 @@ As with `channels add`, `NEMOCLAW_NON_INTERACTIVE=1` skips the rebuild prompt an
 
 Host-side removal is the supported path because `/sandbox/.openclaw/openclaw.json` is read-only at runtime; `openclaw channels remove` cannot modify the baked config from inside the sandbox.
 
+### `nemoclaw <name> channels stop <channel>`
+
+Pause a single messaging bridge (`telegram`, `discord`, or `slack`) without clearing its credentials. The channel is marked disabled in the per-sandbox registry, and the sandbox is rebuilt so the onboard step skips registering the bridge with the gateway. Credentials stay in `~/.nemoclaw/credentials.json`, so a later `channels start` brings the bridge back without re-entering tokens.
+
+```console
+$ nemoclaw my-assistant channels stop telegram
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Report the channel that would be disabled without updating the registry or rebuilding |
+
+Use `channels stop` instead of `channels remove` when you want to pause a bridge temporarily. `channels remove` is destructive to credentials; `channels stop` is not.
+
+### `nemoclaw <name> channels start <channel>`
+
+Re-enable a channel previously paused with `channels stop`. The channel is removed from the disabled list, the sandbox is rebuilt, and the bridge registers with the gateway again using the stored credentials.
+
+```console
+$ nemoclaw my-assistant channels start telegram
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Report the channel that would be re-enabled without updating the registry or rebuilding |
+
 ### `nemoclaw <name> skill install <path>`
 
 Deploy a skill directory to a running sandbox.
@@ -435,24 +483,42 @@ Snapshots are stored in `~/.nemoclaw/rebuild-backups/<name>/`.
 $ nemoclaw my-assistant snapshot create
 ```
 
+| Flag | Description |
+|------|-------------|
+| `--name <label>` | Attach a human-readable label to the snapshot so you can restore by name later |
+
+Names must be 1 to 63 characters from `[A-Za-z0-9._-]`, start with an alphanumeric character, and cannot look like a version selector (`v1`, `v2`, ...). Duplicate names per sandbox are rejected; pick a different name or delete the existing snapshot first.
+
+```console
+$ nemoclaw my-assistant snapshot create --name before-upgrade
+```
+
 ### `nemoclaw <name> snapshot list`
 
-List available snapshots for a sandbox with timestamps and item counts.
+List available snapshots for a sandbox as a table of version, name, timestamp, and path.
+Versions (`v1`, `v2`, ...) are computed on read from timestamp-ascending order, so `v1` is the oldest snapshot and `vN` is the newest. Snapshots created before this feature landed are numbered retroactively.
 
 ```console
 $ nemoclaw my-assistant snapshot list
 ```
 
-### `nemoclaw <name> snapshot restore [timestamp]`
+### `nemoclaw <name> snapshot restore [selector]`
 
 Restore sandbox state from a snapshot.
 The sandbox must be running before you restore.
-If no timestamp is provided, the latest snapshot is used.
-Partial timestamp prefixes are accepted if they match exactly one snapshot.
+If no selector is provided, the latest snapshot is used.
 Restore performs a clean replacement of each state directory, removing files that were added after the snapshot was taken.
+
+The selector accepts any of:
+
+- A version (`v1`, `v2`, ..., `vN`) from `snapshot list`.
+- An exact name passed to `snapshot create --name`.
+- An exact or prefix timestamp (partial prefixes are accepted when they match exactly one snapshot).
 
 ```console
 $ nemoclaw my-assistant snapshot restore
+$ nemoclaw my-assistant snapshot restore v3
+$ nemoclaw my-assistant snapshot restore before-upgrade
 $ nemoclaw my-assistant snapshot restore 2026-04-14T
 ```
 
@@ -467,21 +533,25 @@ $ openshell term
 
 For a remote Brev instance, SSH to the instance and run `openshell term` there, or use a port-forward to the gateway.
 
-### `nemoclaw start`
+### `nemoclaw tunnel start`
 
 Start optional host auxiliary services. This is the cloudflared tunnel when `cloudflared` is installed (for a public URL to the dashboard). Channel messaging (Telegram, Discord, Slack) is not started here; it is configured during `nemoclaw onboard` and runs through OpenShell-managed constructs.
 
 ```console
-$ nemoclaw start
+$ nemoclaw tunnel start
 ```
 
-### `nemoclaw stop`
+`nemoclaw start` remains as a deprecated alias that prints a warning and delegates to `tunnel start`.
 
-Stop host auxiliary services started by `nemoclaw start` (for example cloudflared).
+### `nemoclaw tunnel stop`
+
+Stop host auxiliary services started by `nemoclaw tunnel start` (for example cloudflared). This does not affect messaging channels running inside the sandbox; use `nemoclaw <name> channels stop <channel>` to pause a specific bridge without destroying the sandbox.
 
 ```console
-$ nemoclaw stop
+$ nemoclaw tunnel stop
 ```
+
+`nemoclaw stop` remains as a deprecated alias that prints a warning and delegates to `tunnel stop`.
 
 ### `nemoclaw status`
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -312,13 +312,13 @@ Follow these steps to reconnect.
 
 1. Start host auxiliary services (if needed).
 
-   If you use the cloudflared tunnel started by `nemoclaw start`, start it again:
+   If you use the cloudflared tunnel started by `nemoclaw tunnel start`, start it again:
 
    ```console
-   $ nemoclaw start
+   $ nemoclaw tunnel start
    ```
 
-   Telegram, Discord, and Slack are handled by OpenShell-managed channel messaging configured at onboarding, not by a separate bridge process from `nemoclaw start`.
+   Telegram, Discord, and Slack are handled by OpenShell-managed channel messaging configured at onboarding, not by a separate bridge process from `nemoclaw tunnel start`. To pause a single bridge without destroying the sandbox, use `nemoclaw <name> channels stop <channel>`.
 
 > **If the sandbox does not recover:** If the sandbox remains missing after restarting the gateway, run `nemoclaw onboard` to recreate it.
 > The wizard prompts for confirmation before destroying an existing sandbox. If you confirm, it **destroys and recreates** the sandbox. Workspace files (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.

--- a/.agents/skills/nemoclaw-user-workspace/SKILL.md
+++ b/.agents/skills/nemoclaw-user-workspace/SKILL.md
@@ -30,9 +30,19 @@ $ nemoclaw my-assistant snapshot list
 $ nemoclaw my-assistant snapshot restore
 ```
 
-To restore a specific snapshot instead of the latest, pass a timestamp or prefix:
+`snapshot list` prints a table of version, name, timestamp, and path. Versions (`v1`, `v2`, ..., `vN`) are computed from the timestamp order, so `vN` is always the newest snapshot.
+
+To tag a snapshot with a human-readable label, pass `--name`:
 
 ```console
+$ nemoclaw my-assistant snapshot create --name before-upgrade
+```
+
+To restore a specific snapshot instead of the latest, pass a version, name, or timestamp prefix:
+
+```console
+$ nemoclaw my-assistant snapshot restore v3
+$ nemoclaw my-assistant snapshot restore before-upgrade
 $ nemoclaw my-assistant snapshot restore 2026-04-14T
 ```
 

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -65,7 +65,7 @@ The legacy compatibility flow performs the following steps on the VM:
 1. Installs Docker and the NVIDIA Container Toolkit if a GPU is present.
 2. Installs the OpenShell CLI.
 3. Runs `nemoclaw onboard` (the setup wizard) to create the gateway, register providers, and launch the sandbox.
-4. Starts optional host auxiliary services (for example the cloudflared tunnel) when `cloudflared` is available. Channel messaging is configured during onboarding and runs through OpenShell-managed processes, not through `nemoclaw start`.
+4. Starts optional host auxiliary services (for example the cloudflared tunnel) when `cloudflared` is available. Channel messaging is configured during onboarding and runs through OpenShell-managed processes, not through `nemoclaw tunnel start`.
 
 By default, the compatibility wrapper asks Brev to provision on `gcp`. Override this with `NEMOCLAW_BREV_PROVIDER` if you need a different Brev cloud provider.
 

--- a/docs/deployment/set-up-telegram-bridge.md
+++ b/docs/deployment/set-up-telegram-bridge.md
@@ -4,7 +4,7 @@ title:
   nav: "Set Up Telegram"
 description:
   main: "Connect Telegram to your sandboxed OpenClaw agent using OpenShell-managed channel messaging configured during onboarding."
-  agent: "Explains how Telegram reaches the sandboxed OpenClaw agent through OpenShell-managed processes and onboarding-time channel configuration. Use when setting up Telegram, a chat interface, or messaging integration without relying on nemoclaw start for bridges."
+  agent: "Explains how Telegram reaches the sandboxed OpenClaw agent through OpenShell-managed processes and onboarding-time channel configuration. Use when setting up Telegram, a chat interface, or messaging integration without relying on nemoclaw tunnel start for bridges."
 keywords: ["nemoclaw telegram", "telegram bot openclaw agent", "openshell channel messaging"]
 topics: ["generative_ai", "ai_agents"]
 tags: ["openclaw", "openshell", "telegram", "deployment", "nemoclaw"]
@@ -25,7 +25,7 @@ status: published
 Telegram, Discord, and Slack reach your agent through OpenShell-managed processes and gateway constructs.
 NemoClaw configures those channels during `nemoclaw onboard`. Tokens are registered with OpenShell providers, channel configuration is baked into the sandbox image, and runtime delivery stays under OpenShell control.
 
-`nemoclaw start` does not start Telegram (or other chat bridges). It only starts optional host services such as the cloudflared tunnel when that binary is present.
+`nemoclaw tunnel start` does not start Telegram (or other chat bridges). It only starts optional host services such as the cloudflared tunnel when that binary is present. (`nemoclaw start` is kept as a deprecated alias.)
 For details, refer to [Commands](../reference/commands.md).
 
 ## Prerequisites
@@ -86,17 +86,19 @@ For a full first-time flow, refer to [Quickstart](../get-started/quickstart.md).
 After the sandbox is running, send a message to your bot in Telegram.
 If something fails, use `openshell term` on the host, check gateway logs, and verify network policy allows the Telegram API (see [Customize the Network Policy](../network-policy/customize-network-policy.md) and the `telegram` preset).
 
-## `nemoclaw start` (cloudflared Only)
+## `nemoclaw tunnel start` (cloudflared Only)
 
-`nemoclaw start` starts cloudflared when it is installed, which can expose the dashboard with a public URL.
-It does not affect Telegram connectivity.
+`nemoclaw tunnel start` starts cloudflared when it is installed, which can expose the dashboard with a public URL.
+It does not affect Telegram connectivity. The older `nemoclaw start` still works as a deprecated alias.
 
 ```console
-$ nemoclaw start
+$ nemoclaw tunnel start
 ```
+
+To pause the Telegram bridge without removing its credentials or destroying the sandbox, use `nemoclaw <name> channels stop telegram`. Re-enable it later with `nemoclaw <name> channels start telegram`.
 
 ## Related Topics
 
 - [Deploy NemoClaw to a Remote GPU Instance](deploy-to-remote-gpu.md) for remote deployment with messaging.
 - [Architecture](../reference/architecture.md) for how providers, the gateway, and the sandbox fit together.
-- [Commands](../reference/commands.md) for `start`, `stop`, and `status`.
+- [Commands](../reference/commands.md) for `tunnel start`, `tunnel stop`, `channels start`, `channels stop`, and `status`.

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.22"}
+{"name": "nemoclaw", "version": "0.0.23"}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -406,6 +406,32 @@ As with `channels add`, `NEMOCLAW_NON_INTERACTIVE=1` skips the rebuild prompt an
 
 Host-side removal is the supported path because `/sandbox/.openclaw/openclaw.json` is read-only at runtime; `openclaw channels remove` cannot modify the baked config from inside the sandbox.
 
+### `nemoclaw <name> channels stop <channel>`
+
+Pause a single messaging bridge (`telegram`, `discord`, or `slack`) without clearing its credentials. The channel is marked disabled in the per-sandbox registry, and the sandbox is rebuilt so the onboard step skips registering the bridge with the gateway. Credentials stay in `~/.nemoclaw/credentials.json`, so a later `channels start` brings the bridge back without re-entering tokens.
+
+```console
+$ nemoclaw my-assistant channels stop telegram
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Report the channel that would be disabled without updating the registry or rebuilding |
+
+Use `channels stop` instead of `channels remove` when you want to pause a bridge temporarily. `channels remove` is destructive to credentials; `channels stop` is not.
+
+### `nemoclaw <name> channels start <channel>`
+
+Re-enable a channel previously paused with `channels stop`. The channel is removed from the disabled list, the sandbox is rebuilt, and the bridge registers with the gateway again using the stored credentials.
+
+```console
+$ nemoclaw my-assistant channels start telegram
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Report the channel that would be re-enabled without updating the registry or rebuilding |
+
 ### `nemoclaw <name> skill install <path>`
 
 Deploy a skill directory to a running sandbox.
@@ -485,24 +511,42 @@ Snapshots are stored in `~/.nemoclaw/rebuild-backups/<name>/`.
 $ nemoclaw my-assistant snapshot create
 ```
 
+| Flag | Description |
+|------|-------------|
+| `--name <label>` | Attach a human-readable label to the snapshot so you can restore by name later |
+
+Names must be 1 to 63 characters from `[A-Za-z0-9._-]`, start with an alphanumeric character, and cannot look like a version selector (`v1`, `v2`, ...). Duplicate names per sandbox are rejected; pick a different name or delete the existing snapshot first.
+
+```console
+$ nemoclaw my-assistant snapshot create --name before-upgrade
+```
+
 ### `nemoclaw <name> snapshot list`
 
-List available snapshots for a sandbox with timestamps and item counts.
+List available snapshots for a sandbox as a table of version, name, timestamp, and path.
+Versions (`v1`, `v2`, ...) are computed on read from timestamp-ascending order, so `v1` is the oldest snapshot and `vN` is the newest. Snapshots created before this feature landed are numbered retroactively.
 
 ```console
 $ nemoclaw my-assistant snapshot list
 ```
 
-### `nemoclaw <name> snapshot restore [timestamp]`
+### `nemoclaw <name> snapshot restore [selector]`
 
 Restore sandbox state from a snapshot.
 The sandbox must be running before you restore.
-If no timestamp is provided, the latest snapshot is used.
-Partial timestamp prefixes are accepted if they match exactly one snapshot.
+If no selector is provided, the latest snapshot is used.
 Restore performs a clean replacement of each state directory, removing files that were added after the snapshot was taken.
+
+The selector accepts any of:
+
+- A version (`v1`, `v2`, ..., `vN`) from `snapshot list`.
+- An exact name passed to `snapshot create --name`.
+- An exact or prefix timestamp (partial prefixes are accepted when they match exactly one snapshot).
 
 ```console
 $ nemoclaw my-assistant snapshot restore
+$ nemoclaw my-assistant snapshot restore v3
+$ nemoclaw my-assistant snapshot restore before-upgrade
 $ nemoclaw my-assistant snapshot restore 2026-04-14T
 ```
 
@@ -517,21 +561,25 @@ $ openshell term
 
 For a remote Brev instance, SSH to the instance and run `openshell term` there, or use a port-forward to the gateway.
 
-### `nemoclaw start`
+### `nemoclaw tunnel start`
 
 Start optional host auxiliary services. This is the cloudflared tunnel when `cloudflared` is installed (for a public URL to the dashboard). Channel messaging (Telegram, Discord, Slack) is not started here; it is configured during `nemoclaw onboard` and runs through OpenShell-managed constructs.
 
 ```console
-$ nemoclaw start
+$ nemoclaw tunnel start
 ```
 
-### `nemoclaw stop`
+`nemoclaw start` remains as a deprecated alias that prints a warning and delegates to `tunnel start`.
 
-Stop host auxiliary services started by `nemoclaw start` (for example cloudflared).
+### `nemoclaw tunnel stop`
+
+Stop host auxiliary services started by `nemoclaw tunnel start` (for example cloudflared). This does not affect messaging channels running inside the sandbox; use `nemoclaw <name> channels stop <channel>` to pause a specific bridge without destroying the sandbox.
 
 ```console
-$ nemoclaw stop
+$ nemoclaw tunnel stop
 ```
+
+`nemoclaw stop` remains as a deprecated alias that prints a warning and delegates to `tunnel stop`.
 
 ### `nemoclaw status`
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -338,13 +338,13 @@ Follow these steps to reconnect.
 
 1. Start host auxiliary services (if needed).
 
-   If you use the cloudflared tunnel started by `nemoclaw start`, start it again:
+   If you use the cloudflared tunnel started by `nemoclaw tunnel start`, start it again:
 
    ```console
-   $ nemoclaw start
+   $ nemoclaw tunnel start
    ```
 
-   Telegram, Discord, and Slack are handled by OpenShell-managed channel messaging configured at onboarding, not by a separate bridge process from `nemoclaw start`.
+   Telegram, Discord, and Slack are handled by OpenShell-managed channel messaging configured at onboarding, not by a separate bridge process from `nemoclaw tunnel start`. To pause a single bridge without destroying the sandbox, use `nemoclaw <name> channels stop <channel>`.
 
 :::{admonition} If the sandbox does not recover
 :class: warning

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
   {
     "preferred": true,
+    "version": "0.0.23",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.23/"
+  },
+  {
     "version": "0.0.22",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.22/"
   },

--- a/docs/workspace/backup-restore.md
+++ b/docs/workspace/backup-restore.md
@@ -44,9 +44,19 @@ $ nemoclaw my-assistant snapshot list
 $ nemoclaw my-assistant snapshot restore
 ```
 
-To restore a specific snapshot instead of the latest, pass a timestamp or prefix:
+`snapshot list` prints a table of version, name, timestamp, and path. Versions (`v1`, `v2`, ..., `vN`) are computed from the timestamp order, so `vN` is always the newest snapshot.
+
+To tag a snapshot with a human-readable label, pass `--name`:
 
 ```console
+$ nemoclaw my-assistant snapshot create --name before-upgrade
+```
+
+To restore a specific snapshot instead of the latest, pass a version, name, or timestamp prefix:
+
+```console
+$ nemoclaw my-assistant snapshot restore v3
+$ nemoclaw my-assistant snapshot restore before-upgrade
 $ nemoclaw my-assistant snapshot restore 2026-04-14T
 ```
 


### PR DESCRIPTION
## Summary
Catch up the user-facing docs for features and command renames merged since v0.0.22, and bump the doc-site version strings to 0.0.23.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
- `docs/reference/commands.md` — Documented `snapshot create --name`, the new version-aware `snapshot list` table, and version/name/timestamp selectors for `snapshot restore` (from #2184). Renamed `nemoclaw start`/`stop` sections to `nemoclaw tunnel start`/`stop` with a deprecation note on the legacy aliases, and added new `channels start`/`channels stop` per-channel subsections (from #2103).
- `docs/workspace/backup-restore.md` — Added `--name` and `v<N>` / name / timestamp selector examples for the snapshot commands.
- `docs/deployment/set-up-telegram-bridge.md`, `docs/deployment/deploy-to-remote-gpu.md`, `docs/reference/troubleshooting.md` — Switched references from `nemoclaw start` to `nemoclaw tunnel start`; noted `channels stop/start` as the non-destructive way to pause a bridge.
- `docs/project.json`, `docs/versions1.json` — Bumped preferred doc version to 0.0.23 and moved 0.0.22 into the version history list.
- `.agents/skills/nemoclaw-user-*` — Regenerated via `scripts/docs-to-skills.py` so downstream skills match the doc sources.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Note on `npm test`: the CLI suite hit a pre-existing environmental timeout in `test/cli.test.ts:60` (`bare unknown name surfaces sandbox-not-found`) reaching a non-running local gateway. The plugin and skills YAML suites pass. This PR touches only Markdown + JSON under `docs/` and autogenerated `.agents/skills/` output, so the failing test is unrelated.

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `channels stop/start` commands to pause and resume individual messaging bridges without destroying sandboxes
  * Introduced `--name` flag for creating labeled snapshots with improved restore selection (by version, name, or timestamp)
  * Added `--dangerously-skip-permissions` flag to `nemoclaw onboard`
  * Renamed host auxiliary commands to `nemoclaw tunnel start/stop` (legacy aliases retained for backward compatibility)

* **Documentation**
  * Expanded quickstart guide with recovery, reconfiguration, and credential reset workflows
  * Updated all documentation to reflect new command structure and bridge lifecycle operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->