### PR TITLE
feat(policies): add mnemo-cortex preset for local memory coprocessor access

### DIFF
--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -182,6 +182,7 @@ Available presets:
 | `github` | GitHub and GitHub REST API |
 | `huggingface` | Hugging Face Hub (download-only) and inference router |
 | `jira` | Atlassian Jira API |
+| `mnemo-cortex` | Mnemo Cortex memory coprocessor (host-local, plain HTTP) |
 | `npm` | npm and Yarn registries |
 | `outlook` | Microsoft 365 and Outlook |
 | `pypi` | Python Package Index |

--- a/nemoclaw-blueprint/policies/presets/mnemo-cortex.yaml
+++ b/nemoclaw-blueprint/policies/presets/mnemo-cortex.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Mnemo Cortex memory coprocessor access preset.
+#
+# Mnemo Cortex (https://github.com/GuyMannDude/mnemo-cortex) is a local-first,
+# multi-agent memory layer for OpenClaw. It runs on the host at port 50001 as a
+# plain-HTTP service and exposes session memory, recall/search, and the
+# Developer's Passport user-working-style APIs via REST (and via an MCP bridge
+# that node subprocesses inside the sandbox typically consume).
+#
+# This preset is opt-in; it is not included in any policy tier. Apply with:
+#
+#     nemoclaw <sandbox-name> policy-add mnemo-cortex
+#
+# For a remote Mnemo deployment (not host-local), write a custom policy using
+# this file as a template and substitute the host/port for your deployment.
+
+preset:
+  name: mnemo-cortex
+  description: "Mnemo Cortex memory coprocessor access via host gateway"
+
+network_policies:
+  mnemo_cortex:
+    name: mnemo_cortex
+    endpoints:
+      - host: host.openshell.internal
+        port: 50001
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }


### PR DESCRIPTION
## Summary

Adds a `mnemo-cortex` network-policy preset so sandboxed OpenClaw agents can reach [Mnemo Cortex](https://github.com/GuyMannDude/mnemo-cortex) — a local-first, multi-agent memory layer — running on the host at port 50001.

## Why

Mnemo users (agents inside a NemoClaw sandbox needing persistent memory) currently have to hand-apply a custom policy via `openshell policy set` each time the sandbox is rebuilt. There's no preset on disk, so the Mnemo rule vanishes on every NemoClaw upgrade and `nemoclaw <name> rebuild` — silent breakage for the agent.

A discoverable preset restores the upgrade-safe path documented in `docs/network-policy/customize-network-policy.md`:

```console
$ nemoclaw <sandbox-name> policy-add mnemo-cortex
```

Rebuild then preserves the policy automatically.

## Shape

The preset is a **structural clone of `local-inference.yaml`**:

| | `local-inference` | `mnemo-cortex` (this PR) |
|---|---|---|
| Host | `host.openshell.internal` | `host.openshell.internal` |
| Protocol | `rest` (plain HTTP) | `rest` (plain HTTP) |
| Ports | 11434, 11435, 8000 | 50001 |
| Rules | GET + POST | GET + POST |
| Binaries | `openclaw`, `claude` | `openclaw`, `node` |
| Tier membership | none (opt-in) | none (opt-in) |

The only structural differences are the port and the binary allow-list (`node` instead of `claude` — Mnemo's canonical access path from within a sandbox is a Node-based MCP bridge subprocess).

## Changes

- **New**: `nemoclaw-blueprint/policies/presets/mnemo-cortex.yaml`
- **Doc**: row added to the "Available presets" table in `docs/network-policy/customize-network-policy.md`

## Testing

Not live-tested against a running sandbox in this PR (openshell CLI isn't trivially reachable from the host in a vanilla `openshell-cluster-nemoclaw` container). The preset mirrors the shape and semantics of `local-inference.yaml` (applied to live sandboxes successfully — merged in NVIDIA/NemoClaw#TODO), so the access pattern is already established. Happy to work with a maintainer on any additional verification they'd like.

## Notes

- Opt-in only; not added to any policy tier (Restricted/Balanced/Open). Mnemo access is a deliberate choice, not a default.
- Preset comment links to the Mnemo Cortex repo for context; the preset itself carries the standard NVIDIA Apache-2.0 header.
- Remote-HTTPS Mnemo deployments are out of scope for this preset — the file comment directs users to write a custom policy for those cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the new `mnemo-cortex` network policy preset to the docs.

* **New Features**
  * Introduced the `mnemo-cortex` preset: exposes a host-local plain-HTTP endpoint via the host gateway and permits GET/POST requests to any path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->