### PR TITLE
fix(hermes): ensure sandbox user can read blueprint files

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -32,6 +32,8 @@ RUN chmod 755 /usr/local/bin/nemoclaw-decode-proxy
 
 # Copy blueprint (shared infrastructure)
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
+# Ensure sandbox user can read blueprint files copied as root
+RUN chmod -R a+rX /opt/nemoclaw-blueprint/
 
 # Copy startup script
 COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh


### PR DESCRIPTION
## Summary

`COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/` places files owned by root. When the Dockerfile subsequently switches to `USER sandbox` and runs `cp -r /opt/nemoclaw-blueprint/*`, the sandbox user cannot read those files on systems where Docker's default umask results in restrictive permissions (e.g. `640` or tighter).

Add `RUN chmod -R a+rX /opt/nemoclaw-blueprint/` immediately after the `COPY` step to explicitly guarantee read permission for all users, making the build portable across different Docker/OS environments.

## Related Issue

Fixes #2191

## Changes

- `agents/hermes/Dockerfile`: add `chmod -R a+rX /opt/nemoclaw-blueprint/` after COPY

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

- [x] `make check` passes (including hadolint)
- [x] `npm test` passes
- [x] Docker build tested on brev (n2d-standard-4, Ubuntu) with both original and fixed Dockerfile
- [x] Fixed build: step `RUN chmod -R a+rX /opt/nemoclaw-blueprint/` executes and subsequent `cp` as sandbox user completes without error

## AI Disclosure

This fix was developed with AI assistance (Hermes Agent). The root cause analysis, code change, and verification were reviewed by the author.

## DCO Sign-Off

Signed-off-by: Tian Zhang <tiazhang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved permission configuration in Docker environment to ensure proper access to necessary files when running with restricted user privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->