### PR TITLE
fix(docs): align CLI help text with commands reference for check-docs parity

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -153,7 +153,7 @@ It verifies that Docker is reachable, warns on untested runtimes such as Podman,
 The preflight also enforces the OpenShell version range declared in the blueprint (`min_openshell_version` and `max_openshell_version`).
 If the installed OpenShell version falls outside this range, onboarding exits with an actionable error and a link to compatible releases.
 
-#### `--from <Dockerfile>`
+### `nemoclaw onboard --from`
 
 Build the sandbox image from a custom Dockerfile instead of the stock NemoClaw image.
 The entire parent directory of the specified file is used as the Docker build context, so any files your Dockerfile references (scripts, config, etc.) must live alongside it.
@@ -571,6 +571,14 @@ $ nemoclaw tunnel start
 
 `nemoclaw start` remains as a deprecated alias that prints a warning and delegates to `tunnel start`.
 
+### `nemoclaw start`
+
+Deprecated alias for `nemoclaw tunnel start`. Prints a warning and delegates.
+
+```console
+$ nemoclaw start
+```
+
 ### `nemoclaw tunnel stop`
 
 Stop host auxiliary services started by `nemoclaw tunnel start` (for example cloudflared). This does not affect messaging channels running inside the sandbox; use `nemoclaw <name> channels stop <channel>` to pause a specific bridge without destroying the sandbox.
@@ -581,12 +589,33 @@ $ nemoclaw tunnel stop
 
 `nemoclaw stop` remains as a deprecated alias that prints a warning and delegates to `tunnel stop`.
 
+### `nemoclaw stop`
+
+Deprecated alias for `nemoclaw tunnel stop`. Prints a warning and delegates.
+
+```console
+$ nemoclaw stop
+```
+
 ### `nemoclaw status`
 
 Show the sandbox list and the status of host auxiliary services (for example cloudflared).
 
 ```console
 $ nemoclaw status
+```
+
+### `nemoclaw setup`
+
+:::{warning}
+The `nemoclaw setup` command is deprecated.
+Use `nemoclaw onboard` instead.
+:::
+
+Compatibility alias for `nemoclaw onboard`.
+
+```console
+$ nemoclaw setup
 ```
 
 ### `nemoclaw setup-spark`

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2985,13 +2985,13 @@ function help() {
 
   ${G}Policy Presets:${R}
     nemoclaw <name> policy-add [preset]    Add a network or filesystem policy preset ${D}(--yes, --dry-run)${R}
-    nemoclaw <name> policy-remove [preset] Remove an applied policy preset ${D}(--yes, --dry-run)${R}
+    nemoclaw <name> policy-remove [preset]  Remove an applied policy preset ${D}(--yes, --dry-run)${R}
     nemoclaw <name> policy-list      List presets ${D}(● = applied)${R}
 
   ${G}Messaging Channels:${R}
     nemoclaw <name> channels list             List supported messaging channels
     nemoclaw <name> channels add <channel>    Save credentials and rebuild ${D}(telegram|discord|slack)${R}
-    nemoclaw <name> channels remove <channel> Clear credentials and rebuild
+    nemoclaw <name> channels remove <channel>  Clear credentials and rebuild
     nemoclaw <name> channels stop <channel>   Disable channel (keeps credentials)
     nemoclaw <name> channels start <channel>  Re-enable a previously stopped channel
 
@@ -3014,7 +3014,7 @@ function help() {
 
   ${G}Credentials:${R}
     nemoclaw credentials list        List stored credential keys
-    nemoclaw credentials reset <KEY> Remove a stored credential so onboard re-prompts
+    nemoclaw credentials reset <KEY>  Remove a stored credential so onboard re-prompts
 
   ${G}Backup:${R}
     nemoclaw backup-all              Back up all sandbox state before upgrade

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -169,7 +169,12 @@ run_cli_check() {
   log '[cli] phase 2/2: extract ### `nemoclaw …` headings from commands reference'
   # Allow optional MyST suffix on the same line, e.g. ### `nemoclaw onboard` {#anchor}
   grep -E '^### `nemoclaw ' "$COMMANDS_MD" | LC_ALL=C perl -CS -ne '
-    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) { print "$1\n"; }
+    if (/^### `([^`]+)`\s*(?:\{[^}]+\})?\s*$/) {
+      my $c = $1;
+      $c =~ s/\s*\[[^\]]*\]\s*$//;
+      while ($c =~ s/\s+<[^>]+>\s*$//) {}
+      print "$c\n";
+    }
   ' | LC_ALL=C sort -u >"$_tmp/doc.txt"
 
   local _n_doc


### PR DESCRIPTION
## Summary

The `check-docs` CI step (`cloud-experimental-e2e`) fails because the
CLI `--help` output and `docs/reference/commands.md` headings are out
of sync.

**Root causes (all three fixed here):**

1. **Single-space description separators in `help()`** —
   `channels remove`, `policy-remove`, and `credentials reset` used
   a single space before their description text. The `check-docs.sh`
   normalizer expects 2+ spaces as the delimiter, so description text
   leaked into the normalized command signature, producing phantom
   mismatches. Widened to 2 spaces.

2. **Inconsistent trailing-arg stripping** — the help-side normalizer
   strips trailing `<arg>` and `[optional]` placeholders, but the
   docs-side normalizer did not. Commands like
   `nemoclaw <name> channels add <channel>` (docs) normalized
   differently from `nemoclaw <name> channels add` (help). Added the
   same stripping to the docs perl extraction script.

3. **Missing `###` headings** — four commands present in `--help` had
   no level-3 heading in `docs/reference/commands.md`:
   `onboard --from`, `setup`, `start`, `stop`. Added headings for
   each (the latter three are deprecated aliases).

**Note:** The same `cloud-experimental-e2e` job also reports a Landlock
`/sandbox` writability failure in its step 3 (`04-landlock-readonly`).
That is an intermittent infrastructure-level issue unrelated to these
documentation changes and is tracked separately.

## Test plan

- [ ] Re-run `cloud-experimental-e2e` on this branch — the
      `check-docs.sh` step should pass
- [ ] Verify `nemoclaw --help` output still renders correctly
- [ ] Confirm no other `nightly-e2e` jobs regress

Signed-off-by: Hai Nguyen <haingu@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Fixes #2333
