### PR TITLE
fix(policy): add tls: skip to brew preset endpoints (#2331)

### DIFF
--- a/nemoclaw-blueprint/policies/presets/brew.yaml
+++ b/nemoclaw-blueprint/policies/presets/brew.yaml
@@ -12,21 +12,27 @@ network_policies:
       - host: formulae.brew.sh
         port: 443
         access: full
+        tls: skip
       - host: github.com
         port: 443
         access: full
+        tls: skip
       - host: ghcr.io
         port: 443
         access: full
+        tls: skip
       - host: pkg-containers.githubusercontent.com
         port: 443
         access: full
+        tls: skip
       - host: objects.githubusercontent.com
         port: 443
         access: full
+        tls: skip
       - host: raw.githubusercontent.com
         port: 443
         access: full
+        tls: skip
     binaries:
       - { path: /usr/bin/curl }
       - { path: /usr/bin/git }


### PR DESCRIPTION
## Summary

Add `tls: skip` to all six endpoints in the `brew` policy preset so the L7 proxy performs L4 pass-through instead of TLS termination.

## Problem

After OpenShell v0.0.15+ began auto-terminating TLS on every detected TLS stream ([OpenShell#544](https://github.com/NVIDIA/OpenShell/pull/544)), `git` inside the sandbox fails with:

```
fatal: unable to access 'https://github.com/Homebrew/brew.git/':
server certificate verification failed. CAfile: none CRLfile: none
```

`curl` to the same host through the same proxy succeeds, and `git -c http.sslVerify=false` also succeeds — isolating the defect to the proxy's TLS termination presenting a certificate that git's OpenSSL cannot validate.

## Fix

Add `tls: skip` to all brew preset endpoints (`formulae.brew.sh`, `github.com`, `ghcr.io`, `pkg-containers.githubusercontent.com`, `objects.githubusercontent.com`, `raw.githubusercontent.com`). This restores L4 pass-through so git validates the real server certificates directly.

This follows the same pattern established in PR #2098 for Discord/Slack WebSocket endpoints.

## Test plan

- [x] `npx vitest run test/policies.test.ts` — 86 tests pass
- [ ] Nightly E2E: `brew` preset `git ls-remote` against whitelisted endpoint succeeds without `http.sslVerify=false`

Fixes #2331

Signed-off-by: kagura-agent <kagura-agent@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policy presets to modify TLS certificate verification behavior for connections to multiple package repository and external service endpoints supporting package management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->