### PR TITLE
Redact messaging tokens in onboarding session and CLI output

### DIFF
--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -11,6 +11,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import type { WebSearchConfig } from "./web-search";
+import { redact } from "./runner";
 
 export const SESSION_VERSION = 1;
 export const SESSION_DIR = path.join(process.env.HOME || "/tmp", ".nemoclaw");
@@ -207,16 +208,8 @@ function parseLockInfo(value: unknown): LockInfo | null {
 
 export function redactSensitiveText(value: unknown): string | null {
   if (typeof value !== "string") return null;
-  return value
-    .replace(
-      /(NVIDIA_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|COMPATIBLE_API_KEY|COMPATIBLE_ANTHROPIC_API_KEY|BRAVE_API_KEY)=\S+/gi,
-      "$1=<REDACTED>",
-    )
-    .replace(/Bearer\s+\S+/gi, "Bearer <REDACTED>")
-    .replace(/nvapi-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
-    .replace(/ghp_[A-Za-z0-9]{20,}/g, "<REDACTED>")
-    .replace(/sk-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
-    .slice(0, 240);
+  // Use central production-grade redaction patterns from runner.ts
+  return redact(value).slice(0, 500);
 }
 
 export function sanitizeFailure(

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -18,12 +18,16 @@ export const TOKEN_PREFIX_PATTERNS: RegExp[] = [
   /nvcf-[A-Za-z0-9_-]{10,}/g,
   /ghp_[A-Za-z0-9_-]{10,}/g,
   /(?:github_pat_)[A-Za-z0-9_]{30,}/g,
+  /xoxb-[A-Za-z0-9-]{10,}/g,
+  /xapp-[A-Za-z0-9-]{10,}/g,
+  /\d+:[A-Za-z0-9_-]{20,}/g,
 ];
 
 /** Context-anchored patterns (require a prefix like KEY=, Bearer, etc.). */
 export const CONTEXT_PATTERNS: RegExp[] = [
   /(?<=Bearer\s+)[A-Za-z0-9_.+/=-]{10,}/gi,
   /(?<=(?:_KEY|API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[=: ]['"]?)[A-Za-z0-9_.+/=-]{10,}/gi,
+  /(?<=[A-Z0-9_]+_(?:KEY|TOKEN|SECRET)[=: ]['"]?)[A-Za-z0-9_.+/=-]{10,}/gi,
 ];
 
 /** All secret patterns combined. */


### PR DESCRIPTION
## Summary
This PR fixes a silent credential leak in the onboarding process. Previously, Slack, Discord, and Telegram tokens entered during onboarding were missed by the redaction system and persisted in plain text to `~/.nemoclaw/onboard-session.json` and CLI outputs.

## Related Issue
Fixes # (add your issue number here)

## Changes
- Updated `src/lib/secret-patterns.ts` to include standalone regex patterns for Slack tokens (`xoxb-`, `xapp-`), Telegram bot tokens, and a generic `_TOKEN=` catch-all.
- Refactored `redactSensitiveText` in `src/lib/onboard-session.ts` to delegate to the central `redact()` function from `src/lib/runner.ts`, ensuring consistency across logs and sessions.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Siddhartha Singh <siddharthagithub0007@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sensitive data redaction to detect and protect additional token formats and patterns, strengthening security.
  * Increased maximum display length for redacted content from 240 to 500 characters for better context visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->