### PR TITLE
docs(quickstart): add Update to the Latest Version section

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -376,27 +376,39 @@ $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 ### Upgrade your sandboxes to the new image
 
-Re-running the installer updates the CLI, but existing sandboxes continue running on whatever base image you used to create them.
-Use [`nemoclaw upgrade-sandboxes`](../reference/commands.md#nemoclaw-upgrade-sandboxes) to rebuild any sandbox whose base image is older than the one currently pinned by NemoClaw:
+Re-running the installer updates the CLI, but existing sandboxes continue running on whatever base image you used to create them. The upgrade flow is non-destructive by default — NemoClaw automatically preserves your workspace data — but a manual snapshot before any major upgrade gives you a fast undo button.
+
+**Safe upgrade flow:**
 
 ```console
-$ nemoclaw upgrade-sandboxes --check    # list stale sandboxes without rebuilding
-$ nemoclaw upgrade-sandboxes            # rebuild with confirmation prompt
-$ nemoclaw upgrade-sandboxes --auto     # rebuild without prompting
+$ nemoclaw <sandbox-name> snapshot create --name pre-upgrade   # optional, recommended
+$ nemoclaw upgrade-sandboxes --check                            # list stale sandboxes without rebuilding
+$ nemoclaw upgrade-sandboxes                                    # rebuild with confirmation
 ```
 
-Each rebuild follows the same backup-and-restore flow as [`nemoclaw <name> rebuild`](../reference/commands.md#nemoclaw-name-rebuild). NemoClaw reapplies workspace files, credentials, and policy presets to the new sandbox automatically.
-See [Backup and Restore](../workspace/backup-restore.md) for the full state-preservation guarantees.
+For scripted use, replace the rebuild command with `nemoclaw upgrade-sandboxes --auto` to skip the confirmation prompt.
 
-:::{tip} Manual snapshot for major upgrades
-For releases that change schemas or break compatibility, take a manual snapshot first:
+If anything looks wrong after the upgrade, roll back to the snapshot:
 
 ```console
-$ nemoclaw my-assistant snapshot create
+$ nemoclaw <sandbox-name> snapshot restore pre-upgrade
 ```
 
-If the upgrade goes badly, roll back with `nemoclaw my-assistant snapshot restore`.
-See [Commands &rarr; `nemoclaw <name> snapshot create`](../reference/commands.md#nemoclaw-name-snapshot-create) for details.
+#### What changes during a rebuild
+
+Each rebuild **destroys the existing container and creates a new one** on the upgraded base image. NemoClaw protects your data through the same backup-and-restore flow as [`nemoclaw <name> rebuild`](../reference/commands.md#nemoclaw-name-rebuild):
+
+- **Preserved automatically.** Before deleting the old container, NemoClaw snapshots the workspace state directories defined in the agent manifest (typically `/sandbox/.openclaw/workspace/`) and restores them into the new container. Stored credentials (`~/.nemoclaw/credentials.json`) and registered policy presets live on the host the entire time, so they are never at risk and are re-applied to the new sandbox automatically.
+- **Not preserved.** Anything written outside the workspace state directories: packages installed inside the running container with `apt`/`pip`, files in non-workspace paths, and in-memory or process state. If you have customized the running container at runtime, capture that as `Dockerfile` changes (for `nemoclaw onboard --from`) or a manual `openshell sandbox download` before the rebuild starts.
+
+Aborts before the destroy step are non-destructive. The flow refuses to proceed past preflight if a credential is missing (see below) or past backup if the snapshot fails (with `"Aborting rebuild to prevent data loss"`), so a botched run leaves the original sandbox intact and ready to retry.
+
+See [Backup and Restore](../workspace/backup-restore.md) for the full list of state-preservation guarantees, snapshot retention, and instructions for manual backups when the auto-flow is not enough.
+
+:::{note} If the rebuild aborts with `Missing credential: <KEY>`
+The rebuild preflight reads the provider credential recorded by your last `nemoclaw onboard` session. If you have switched providers since onboarding (for example, from a remote API to a local Ollama setup) the preflight may still reference the old key and fail before any destroy step runs.
+
+To recover: re-run `nemoclaw onboard` and select your current provider — that refreshes the session metadata. Your existing container keeps serving traffic until the new image is ready.
 :::
 
 ## Uninstall

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -363,7 +363,7 @@ Refer to [`nemoclaw <name> policy-add`](../reference/commands.md#nemoclaw-name-p
 
 ## Update to the Latest Version
 
-When a new NemoClaw release becomes available, two things need to update: the `nemoclaw` CLI on your host, and the sandbox images your agents are running in.
+When a new NemoClaw release becomes available, update the `nemoclaw` CLI on your host and check existing sandboxes for stale agent/runtime versions.
 
 ### Update the NemoClaw CLI
 
@@ -374,21 +374,22 @@ Before it onboards anything, the installer calls [`nemoclaw backup-all`](../refe
 $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
-### Upgrade your sandboxes to the new image
+### Upgrade sandboxes with stale agent and runtime versions
 
-Re-running the installer updates the CLI, but existing sandboxes continue running on whatever base image you used to create them. The upgrade flow is non-destructive by default — NemoClaw automatically preserves your workspace data — but a manual snapshot before any major upgrade gives you a fast undo button.
+The installer checks registered sandboxes after onboarding succeeds and runs `nemoclaw upgrade-sandboxes --auto` for stale running sandboxes. Use `upgrade-sandboxes` directly to verify the result, rebuild when you skipped the installer or onboarding step, or handle sandboxes that were stopped or could not be version-checked. The upgrade flow is non-destructive by default because NemoClaw preserves manifest-defined workspace state, but a manual snapshot before any major upgrade gives you a state restore point.
 
 **Safe upgrade flow:**
 
 ```console
 $ nemoclaw <sandbox-name> snapshot create --name pre-upgrade   # optional, recommended
-$ nemoclaw upgrade-sandboxes --check                            # list stale sandboxes without rebuilding
-$ nemoclaw upgrade-sandboxes                                    # rebuild with confirmation
+$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash          # updates CLI; auto-upgrades stale running sandboxes
+$ nemoclaw upgrade-sandboxes --check                            # verify or list remaining stale/unknown sandboxes
+$ nemoclaw upgrade-sandboxes                                    # manually rebuild remaining stale running sandboxes
 ```
 
-For scripted use, replace the rebuild command with `nemoclaw upgrade-sandboxes --auto` to skip the confirmation prompt.
+For scripted manual rebuilds, use `nemoclaw upgrade-sandboxes --auto` to skip the confirmation prompt.
 
-If anything looks wrong after the upgrade, roll back to the snapshot:
+If the upgraded sandbox needs its workspace state reverted, restore the pre-upgrade snapshot into the running sandbox. This restores saved state directories only; it does not downgrade the sandbox image or agent/runtime:
 
 ```console
 $ nemoclaw <sandbox-name> snapshot restore pre-upgrade
@@ -396,10 +397,10 @@ $ nemoclaw <sandbox-name> snapshot restore pre-upgrade
 
 #### What changes during a rebuild
 
-Each rebuild **destroys the existing container and creates a new one** on the upgraded base image. NemoClaw protects your data through the same backup-and-restore flow as [`nemoclaw <name> rebuild`](../reference/commands.md#nemoclaw-name-rebuild):
+Each rebuild destroys the existing container and creates a new one. NemoClaw protects your data through the same backup-and-restore flow as [`nemoclaw <name> rebuild`](../reference/commands.md#nemoclaw-name-rebuild):
 
-- **Preserved automatically.** Before deleting the old container, NemoClaw snapshots the workspace state directories defined in the agent manifest (typically `/sandbox/.openclaw/workspace/`) and restores them into the new container. Stored credentials (`~/.nemoclaw/credentials.json`) and registered policy presets live on the host the entire time, so they are never at risk and are re-applied to the new sandbox automatically.
-- **Not preserved.** Anything written outside the workspace state directories: packages installed inside the running container with `apt`/`pip`, files in non-workspace paths, and in-memory or process state. If you have customized the running container at runtime, capture that as `Dockerfile` changes (for `nemoclaw onboard --from`) or a manual `openshell sandbox download` before the rebuild starts.
+- NemoClaw preserves manifest-defined workspace state. Before deleting the old container, NemoClaw snapshots the state directories defined in the agent manifest (typically `/sandbox/.openclaw/workspace/`) and restores them into the new container. Stored credentials (`~/.nemoclaw/credentials.json`) and registered policy presets live on the host and are re-applied to the new sandbox automatically.
+- NemoClaw does not preserve runtime changes outside the workspace state directories. This includes packages installed inside the running container with `apt` or `pip`, files in non-workspace paths, and in-memory or process state. If you have customized the running container at runtime, capture that as `Dockerfile` changes (for `nemoclaw onboard --from`) or a manual `openshell sandbox download` before the rebuild starts.
 
 Aborts before the destroy step are non-destructive. The flow refuses to proceed past preflight if a credential is missing (see below) or past backup if the snapshot fails (with `"Aborting rebuild to prevent data loss"`), so a botched run leaves the original sandbox intact and ready to retry.
 
@@ -408,7 +409,7 @@ See [Backup and Restore](../workspace/backup-restore.md) for the full list of st
 :::{note} If the rebuild aborts with `Missing credential: <KEY>`
 The rebuild preflight reads the provider credential recorded by your last `nemoclaw onboard` session. If you have switched providers since onboarding (for example, from a remote API to a local Ollama setup) the preflight may still reference the old key and fail before any destroy step runs.
 
-To recover: re-run `nemoclaw onboard` and select your current provider — that refreshes the session metadata. Your existing container keeps serving traffic until the new image is ready.
+To recover, re-run `nemoclaw onboard` and select your current provider. This refreshes the session metadata. Your existing container keeps serving traffic until the new image is ready.
 :::
 
 ## Uninstall

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -361,6 +361,44 @@ $ nemoclaw <sandbox-name> policy-add
 
 Refer to [`nemoclaw <name> policy-add`](../reference/commands.md#nemoclaw-name-policy-add) for usage details and flags.
 
+## Update to the Latest Version
+
+When a new NemoClaw release becomes available, two things need to update: the `nemoclaw` CLI on your host, and the sandbox images your agents are running in.
+
+### Update the NemoClaw CLI
+
+Re-run the installer.
+Before it onboards anything, the installer calls [`nemoclaw backup-all`](../reference/commands.md#nemoclaw-backup-all) automatically, storing a snapshot of each running sandbox in `~/.nemoclaw/rebuild-backups/` as a safety net.
+
+```console
+$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
+### Upgrade your sandboxes to the new image
+
+Re-running the installer updates the CLI, but existing sandboxes continue running on whatever base image you used to create them.
+Use [`nemoclaw upgrade-sandboxes`](../reference/commands.md#nemoclaw-upgrade-sandboxes) to rebuild any sandbox whose base image is older than the one currently pinned by NemoClaw:
+
+```console
+$ nemoclaw upgrade-sandboxes --check    # list stale sandboxes without rebuilding
+$ nemoclaw upgrade-sandboxes            # rebuild with confirmation prompt
+$ nemoclaw upgrade-sandboxes --auto     # rebuild without prompting
+```
+
+Each rebuild follows the same backup-and-restore flow as [`nemoclaw <name> rebuild`](../reference/commands.md#nemoclaw-name-rebuild). NemoClaw reapplies workspace files, credentials, and policy presets to the new sandbox automatically.
+See [Backup and Restore](../workspace/backup-restore.md) for the full state-preservation guarantees.
+
+:::{tip} Manual snapshot for major upgrades
+For releases that change schemas or break compatibility, take a manual snapshot first:
+
+```console
+$ nemoclaw my-assistant snapshot create
+```
+
+If the upgrade goes badly, roll back with `nemoclaw my-assistant snapshot restore`.
+See [Commands &rarr; `nemoclaw <name> snapshot create`](../reference/commands.md#nemoclaw-name-snapshot-create) for details.
+:::
+
 ## Uninstall
 
 To remove NemoClaw and all resources created during setup, run the CLI's built-in uninstall command:


### PR DESCRIPTION
## Summary

- Adds a new `## Update to the Latest Version` H2 section to [`docs/get-started/quickstart.md`](https://github.com/NVIDIA/NemoClaw/blob/main/docs/get-started/quickstart.md), positioned between *Chat with the Agent* and *Uninstall*.
- Covers the two steps a user needs to upgrade an existing install: re-run the installer (CLI update) and `nemoclaw upgrade-sandboxes` (bulk rebuild of stale sandbox images).
- Calls out the `nemoclaw backup-all` that the installer runs automatically so users understand the built-in safety net, plus a `{tip}` admonition for a manual `snapshot create` / `snapshot restore` rollback on schema-breaking releases.

## Problem

Users asking how to update NemoClaw have to piece the flow together from three disconnected places:

1. [`docs/reference/commands.md`](https://github.com/NVIDIA/NemoClaw/blob/main/docs/reference/commands.md) has reference entries for `rebuild`, `upgrade-sandboxes`, `backup-all`, and `snapshot create/list/restore`, but reference-style flag tables aren't a walkthrough.
2. [`docs/workspace/backup-restore.md`](https://github.com/NVIDIA/NemoClaw/blob/main/docs/workspace/backup-restore.md) says to back up *"Before major NemoClaw version upgrades"* but never shows what upgrading actually looks like.
3. [`docs/reference/troubleshooting.md`](https://github.com/NVIDIA/NemoClaw/blob/main/docs/reference/troubleshooting.md) mentions re-running the installer only in error-recovery contexts.

Most notably, `nemoclaw upgrade-sandboxes` (the command purpose-built for the upgrade scenario) is documented in the command reference but not referenced from any tutorial, how-to, or quickstart page. A user who only reads `quickstart.md` has no guided path from *"a new release came out"* to *"my sandbox is on it"*.

No `docs/**/*upgrade*` or `docs/**/*update*` file exists.

## Change

New 38-line H2 section in `quickstart.md` that:

- Frames the two things that move on a new release — the host CLI and the sandbox base image — and why both need updating.
- Shows the installer re-run command and notes that `backup-all` runs automatically before onboarding.
- Shows `upgrade-sandboxes` with its three common invocations (`--check`, default, `--auto`) and explicitly cross-links to the existing `rebuild` reference entry so the state-preservation guarantees (workspace files, credentials, policy presets) are documented in one place only.
- Adds a `{tip}` block for manual `snapshot create` / `snapshot restore` when a release notes mentions schema or compatibility breaks.

Every command mention cross-links to its existing anchor in [`docs/reference/commands.md`](https://github.com/NVIDIA/NemoClaw/blob/main/docs/reference/commands.md) so flag details are not duplicated and anchor slugs (`nemoclaw-name-rebuild`, `nemoclaw-upgrade-sandboxes`, `nemoclaw-backup-all`, `nemoclaw-name-snapshot-create`) follow the existing MyST convention used in #2224.

## Test plan

- [x] `markdownlint-cli2 docs/get-started/quickstart.md` clean (0 errors).
- [x] All cross-link anchors verified present in `docs/reference/commands.md`:
  - `#nemoclaw-backup-all` — line 468
  - `#nemoclaw-upgrade-sandboxes` — line 449
  - `#nemoclaw-name-rebuild` — line 427
  - `#nemoclaw-name-snapshot-create` — line 479
- [x] Cross-link to `../workspace/backup-restore.md` verified.
- [x] `commitlint` passes on the commit header (under 100 chars).
- [x] DCO trailer present, SSH-signed.

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New Quickstart for keeping NemoClaw current: re-run the installer to refresh the CLI and create an automatic safety backup.
  * Documented sandbox upgrade flow: detect stale sandboxes, check mode, interactive confirm or unattended (--auto) rebuild, and automatic reapplication of workspace files, credentials, and policy presets.
  * Clarified rebuild/rollback semantics: old container replaced, workspace preserved, non-workspace/in-memory state not preserved; restore via snapshot.
  * Added preflight/backup abort guidance and troubleshooting for missing credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->