### PR TITLE
fix(channels): pre-validate Slack auth to prevent gateway crash

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -526,15 +526,25 @@ except Exception as e:
 PYAUTHTEST
   ) || auth_result="network_error:python3_failed"
 
+  # Definitive auth failures that warrant disabling the channel. Transient
+  # or service-side errors (ratelimited, request_timeout, service_unavailable,
+  # internal_error, fatal_error) should NOT disable — the gateway may succeed
+  # if the issue resolves by the time it connects.
+  # Ref: https://docs.slack.dev/reference/methods/auth.test
+  local _fatal_auth_errors="account_inactive invalid_auth not_authed token_expired token_revoked missing_scope not_allowed_token_type"
+
   case "$auth_result" in
     ok)
       printf '[channels] Slack bot token validated successfully\n' >&2
       ;;
     error:*)
       local slack_error="${auth_result#error:}"
-      printf '[channels] [slack][default] provider failed to start: %s — channel disabled\n' "$slack_error" >&2
 
-      python3 - "$config_file" <<'PYSLACKDISABLE'
+      # shellcheck disable=SC2076  # we want literal match, not pattern
+      if [[ " $_fatal_auth_errors " =~ " $slack_error " ]]; then
+        printf '[channels] [slack][default] provider failed to start: %s — channel disabled\n' "$slack_error" >&2
+
+        python3 - "$config_file" <<'PYSLACKDISABLE'
 import json, sys
 
 config_file = sys.argv[1]
@@ -550,8 +560,11 @@ with open(config_file, "w") as f:
     json.dump(cfg, f, indent=2)
 PYSLACKDISABLE
 
-      (cd /sandbox/.openclaw && sha256sum openclaw.json >"$hash_file")
-      printf '[channels] Config hash recomputed after disabling Slack channel\n' >&2
+        (cd /sandbox/.openclaw && sha256sum openclaw.json >"$hash_file")
+        printf '[channels] Config hash recomputed after disabling Slack channel\n' >&2
+      else
+        printf '[channels] Slack auth.test returned transient error: %s — channel left enabled\n' "$slack_error" >&2
+      fi
       ;;
     network_error:*)
       printf '[channels] Could not reach Slack API for token validation (%s) — channel left enabled\n' "${auth_result#network_error:}" >&2

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -465,6 +465,100 @@ PYSLACK
   printf '[channels] Config hash recomputed after Slack token override\n' >&2
 }
 
+# ── Slack auth pre-validation ────────────────────────────────────
+# Pre-validates the resolved Slack bot token against the Slack auth.test
+# API before launching the gateway. If the token is invalid (e.g., revoked
+# or expired), the Slack channel is disabled in openclaw.json so the
+# gateway starts without it — preventing an unhandled promise rejection
+# from @slack/web-api that would crash the entire gateway process.
+# Node v22 treats unhandled rejections as fatal, taking down inference,
+# chat, and TUI along with the failed channel.
+#
+# Network errors (proxy not ready, Slack API unreachable) are treated as
+# transient: the channel is left enabled and the gateway is allowed to
+# retry on its own. Only a definitive auth failure disables the channel.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/2340
+
+validate_slack_auth() {
+  [ -n "${SLACK_BOT_TOKEN:-}" ] || return 0
+
+  # Only validate tokens with the correct prefix — if the prefix is wrong,
+  # apply_slack_token_override already skipped placeholder resolution and
+  # Bolt's synchronous format check will reject the token without an
+  # unhandled promise rejection.
+  case "${SLACK_BOT_TOKEN}" in
+    xoxb-*) ;;
+    *) return 0 ;;
+  esac
+
+  local config_file="/sandbox/.openclaw/openclaw.json"
+  local hash_file="/sandbox/.openclaw/.config-hash"
+
+  # SECURITY: Refuse to write through symlinks to prevent symlink-following attacks.
+  if [ -L "$config_file" ] || [ -L "$hash_file" ]; then
+    printf '[SECURITY] Refusing Slack auth validation — config or hash path is a symlink\n' >&2
+    return 1
+  fi
+
+  printf '[channels] Validating Slack bot token against auth.test...\n' >&2
+
+  local auth_result
+  auth_result=$(
+    SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN" python3 <<'PYAUTHTEST'
+import json, os, sys, urllib.request
+
+token = os.environ["SLACK_BOT_TOKEN"]
+try:
+    req = urllib.request.Request(
+        "https://slack.com/api/auth.test",
+        headers={"Authorization": "Bearer " + token,
+                 "Content-Type": "application/x-www-form-urlencoded"},
+        data=b"",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        data = json.loads(resp.read())
+    if data.get("ok"):
+        print("ok")
+    else:
+        print("error:" + data.get("error", "unknown"))
+except Exception as e:
+    print("network_error:" + str(e)[:200])
+PYAUTHTEST
+  ) || auth_result="network_error:python3_failed"
+
+  case "$auth_result" in
+    ok)
+      printf '[channels] Slack bot token validated successfully\n' >&2
+      ;;
+    error:*)
+      local slack_error="${auth_result#error:}"
+      printf '[channels] [slack][default] provider failed to start: %s — channel disabled\n' "$slack_error" >&2
+
+      python3 - "$config_file" <<'PYSLACKDISABLE'
+import json, sys
+
+config_file = sys.argv[1]
+with open(config_file) as f:
+    cfg = json.load(f)
+
+slack = cfg.get("channels", {}).get("slack", {})
+for acct in slack.get("accounts", {}).values():
+    if isinstance(acct, dict):
+        acct["enabled"] = False
+
+with open(config_file, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYSLACKDISABLE
+
+      (cd /sandbox/.openclaw && sha256sum openclaw.json >"$hash_file")
+      printf '[channels] Config hash recomputed after disabling Slack channel\n' >&2
+      ;;
+    network_error:*)
+      printf '[channels] Could not reach Slack API for token validation (%s) — channel left enabled\n' "${auth_result#network_error:}" >&2
+      ;;
+  esac
+}
+
 _read_gateway_token() {
   python3 - <<'PYTOKEN'
 import json
@@ -996,6 +1090,7 @@ if [ "$(id -u)" -ne 0 ]; then
   apply_model_override
   apply_cors_override
   apply_slack_token_override
+  validate_slack_auth
   export_gateway_token
   install_configure_guard
   configure_messaging_channels
@@ -1111,6 +1206,7 @@ verify_config_integrity /sandbox/.openclaw
 apply_model_override
 apply_cors_override
 apply_slack_token_override
+validate_slack_auth
 export_gateway_token
 install_configure_guard
 

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -29,6 +29,10 @@
  *   BREV_MIN_DISK          — Minimum disk size in GB (default: 50)
  *   TELEGRAM_BOT_TOKEN       — Telegram bot token for messaging-providers test (fake OK)
  *   DISCORD_BOT_TOKEN        — Discord bot token for messaging-providers test (fake OK)
+ *   SLACK_BOT_TOKEN          — Slack bot token for messaging-providers test (fake OK)
+ *   SLACK_APP_TOKEN          — Slack app token for messaging-providers test (fake OK)
+ *   SLACK_BOT_TOKEN_REVOKED  — Revoked xoxb- token to test auth pre-validation (#2340)
+ *   SLACK_APP_TOKEN_REVOKED  — Paired xapp- token for the revoked bot token
  *   TELEGRAM_BOT_TOKEN_REAL  — Real Telegram token for optional live round-trip
  *   DISCORD_BOT_TOKEN_REAL   — Real Discord token for optional live round-trip
  *   TELEGRAM_CHAT_ID_E2E     — Telegram chat ID for optional sendMessage test
@@ -143,6 +147,10 @@ function sshEnv(cmd, { timeout = 600_000, stream = false } = {}) {
   for (const key of [
     "TELEGRAM_BOT_TOKEN",
     "DISCORD_BOT_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "SLACK_BOT_TOKEN_REVOKED",
+    "SLACK_APP_TOKEN_REVOKED",
     "TELEGRAM_BOT_TOKEN_REAL",
     "DISCORD_BOT_TOKEN_REAL",
     "TELEGRAM_CHAT_ID_E2E",

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -42,6 +42,10 @@
 #   TELEGRAM_ALLOWED_IDS                   — comma-separated Telegram user IDs for DM allowlisting
 #   TELEGRAM_BOT_TOKEN_REAL                — optional: enables Phase 6 real round-trip
 #   DISCORD_BOT_TOKEN_REAL                 — optional: enables Phase 6 real round-trip
+#   SLACK_BOT_TOKEN                        — defaults to fake token (xoxb-fake-...)
+#   SLACK_APP_TOKEN                        — defaults to fake token (xapp-fake-...)
+#   SLACK_BOT_TOKEN_REVOKED                — optional: revoked xoxb- token to test auth pre-validation (#2340)
+#   SLACK_APP_TOKEN_REVOKED                — optional: paired xapp- token for the revoked bot token
 #   TELEGRAM_CHAT_ID_E2E                   — optional: enables sendMessage test
 #   NEMOCLAW_E2E_STRICT_DISCORD_GATEWAY    — fail instead of skip on known Discord gateway blockers
 #
@@ -94,9 +98,13 @@ SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-msg-provider}"
 # Default to fake tokens if not provided
 TELEGRAM_TOKEN="${TELEGRAM_BOT_TOKEN:-test-fake-telegram-token-e2e}"
 DISCORD_TOKEN="${DISCORD_BOT_TOKEN:-test-fake-discord-token-e2e}"
+SLACK_TOKEN="${SLACK_BOT_TOKEN:-xoxb-fake-slack-token-e2e}"
+SLACK_APP="${SLACK_APP_TOKEN:-xapp-fake-slack-app-token-e2e}"
 TELEGRAM_IDS="${TELEGRAM_ALLOWED_IDS:-123456789,987654321}"
 export TELEGRAM_BOT_TOKEN="$TELEGRAM_TOKEN"
 export DISCORD_BOT_TOKEN="$DISCORD_TOKEN"
+export SLACK_BOT_TOKEN="$SLACK_TOKEN"
+export SLACK_APP_TOKEN="$SLACK_APP"
 export TELEGRAM_ALLOWED_IDS="$TELEGRAM_IDS"
 
 # Run a command inside the sandbox via stdin (avoids exposing sensitive args in process list)
@@ -160,6 +168,8 @@ pass "Docker is running"
 
 info "Telegram token: ${TELEGRAM_TOKEN:0:10}... (${#TELEGRAM_TOKEN} chars)"
 info "Discord token: ${DISCORD_TOKEN:0:10}... (${#DISCORD_TOKEN} chars)"
+info "Slack bot token: ${SLACK_TOKEN:0:10}... (${#SLACK_TOKEN} chars)"
+info "Slack app token: ${SLACK_APP:0:10}... (${#SLACK_APP} chars)"
 info "Sandbox name: $SANDBOX_NAME"
 STRICT_DISCORD_GATEWAY="${NEMOCLAW_E2E_STRICT_DISCORD_GATEWAY:-0}"
 
@@ -1039,9 +1049,137 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════
-# Phase 7: Cleanup
+# Phase 7: Slack auth pre-validation (#2340)
+#
+# Validates that validate_slack_auth() correctly pre-validates tokens
+# and disables the Slack channel when auth fails, rather than letting
+# the gateway crash from an unhandled promise rejection.
+#
+# The sandbox was installed with fake Slack tokens (xoxb-fake-...) in
+# Phase 1. These tokens have the right prefix but are invalid, so
+# validate_slack_auth should have:
+#   1. Called Slack's auth.test API
+#   2. Received an auth error (invalid_auth or not_authed)
+#   3. Disabled the Slack channel in openclaw.json
+#   4. Logged the failure and continued starting the gateway
+#
+# The gateway should still be running (inference/chat/TUI alive).
 # ══════════════════════════════════════════════════════════════════
-section "Phase 7: Cleanup"
+section "Phase 7: Slack auth pre-validation (#2340)"
+
+# S1: Gateway process is still running (not crashed by Slack auth failure)
+gw_status=$(sandbox_exec "cat /proc/1/stat 2>/dev/null | awk '{print \$3}'" 2>/dev/null || true)
+if [ -n "$gw_status" ] && [ "$gw_status" != "Z" ]; then
+  pass "S1: Gateway process is alive (state: $gw_status) — Slack auth failure did not crash it"
+else
+  fail "S1: Gateway process is not running (state: ${gw_status:-unknown}) — may have crashed"
+fi
+
+# S2: Gateway log contains the pre-validation attempt
+gw_log=$(sandbox_exec "cat /tmp/gateway.log 2>/dev/null" 2>/dev/null || true)
+if echo "$gw_log" | grep -q "Validating Slack bot token"; then
+  pass "S2: Gateway log shows Slack token pre-validation was attempted"
+elif [ -z "$gw_log" ]; then
+  skip "S2: Could not read gateway log"
+else
+  # Validation may have run but logged to stderr (entrypoint, not gateway log).
+  # Check entrypoint output via docker logs as fallback.
+  container_log=$(docker logs "$(docker ps -qf "name=$SANDBOX_NAME" | head -1)" 2>&1 || true)
+  if echo "$container_log" | grep -q "Validating Slack bot token"; then
+    pass "S2: Container log shows Slack token pre-validation was attempted"
+  else
+    fail "S2: No evidence of Slack token pre-validation in gateway or container logs"
+  fi
+fi
+
+# S3: Slack channel is disabled in openclaw.json after auth failure
+slack_enabled=$(sandbox_exec "python3 -c \"
+import json
+try:
+    cfg = json.load(open('/sandbox/.openclaw/openclaw.json'))
+    acct = cfg.get('channels', {}).get('slack', {}).get('accounts', {}).get('default', {})
+    print(acct.get('enabled', 'MISSING'))
+except Exception as e:
+    print('ERROR: ' + str(e))
+\"" 2>/dev/null || true)
+
+if [ "$slack_enabled" = "False" ]; then
+  pass "S3: Slack channel is disabled in openclaw.json (auth failure handled correctly)"
+elif [ "$slack_enabled" = "True" ]; then
+  # Channel still enabled — validation may not have reached Slack API (network).
+  # Check if the log says it was a network error (acceptable) vs auth error (bug).
+  all_logs="${gw_log}${container_log:-}"
+  if echo "$all_logs" | grep -q "channel left enabled"; then
+    skip "S3: Slack channel left enabled (network error reaching Slack API during validation)"
+  else
+    fail "S3: Slack channel is still enabled — validate_slack_auth did not disable it on auth failure"
+  fi
+elif [ "$slack_enabled" = "MISSING" ]; then
+  skip "S3: No Slack channel in openclaw.json (Slack may not have been configured)"
+else
+  fail "S3: Unexpected Slack enabled state: ${slack_enabled:0:200}"
+fi
+
+# S4: Log contains the expected auth error message
+all_logs="${gw_log}${container_log:-}"
+if echo "$all_logs" | grep -q "provider failed to start:.*channel disabled"; then
+  pass "S4: Log confirms Slack channel was disabled due to auth failure"
+elif echo "$all_logs" | grep -q "channel left enabled"; then
+  skip "S4: Slack validation hit a transient/network error (channel left enabled)"
+elif echo "$all_logs" | grep -q "Slack bot token validated successfully"; then
+  skip "S4: Slack token unexpectedly passed validation (token may be valid)"
+else
+  fail "S4: No Slack auth validation result found in logs"
+fi
+
+# S5: Optional — test with a known-revoked token if provided
+if [ -n "${SLACK_BOT_TOKEN_REVOKED:-}" ]; then
+  info "Re-onboarding with revoked Slack token to verify auth pre-validation..."
+
+  # Destroy and re-onboard with the revoked token
+  nemoclaw "$SANDBOX_NAME" destroy --yes 2>/dev/null || true
+  openshell sandbox delete "$SANDBOX_NAME" 2>/dev/null || true
+
+  export SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN_REVOKED"
+  export SLACK_APP_TOKEN="${SLACK_APP_TOKEN_REVOKED:-$SLACK_APP}"
+  export NEMOCLAW_RECREATE_SANDBOX=1
+
+  REVOKED_LOG="/tmp/nemoclaw-e2e-revoked-slack.log"
+  bash install.sh --non-interactive >"$REVOKED_LOG" 2>&1 || true
+
+  # Read the gateway log from the new sandbox
+  revoked_gw_log=$(sandbox_exec "cat /tmp/gateway.log 2>/dev/null" 2>/dev/null || true)
+  revoked_container_log=$(docker logs "$(docker ps -qf "name=$SANDBOX_NAME" | head -1)" 2>&1 || true)
+  revoked_all_logs="${revoked_gw_log}${revoked_container_log}"
+
+  # S5a: Revoked token should trigger auth failure
+  if echo "$revoked_all_logs" | grep -q "provider failed to start:.*channel disabled"; then
+    pass "S5: Revoked Slack token correctly detected and channel disabled"
+  elif echo "$revoked_all_logs" | grep -q "channel left enabled"; then
+    skip "S5: Could not reach Slack API to validate revoked token (network)"
+  else
+    fail "S5: Revoked Slack token was not caught by validate_slack_auth"
+  fi
+
+  # S5b: Gateway should still be running
+  revoked_gw_status=$(sandbox_exec "cat /proc/1/stat 2>/dev/null | awk '{print \$3}'" 2>/dev/null || true)
+  if [ -n "$revoked_gw_status" ] && [ "$revoked_gw_status" != "Z" ]; then
+    pass "S5b: Gateway survived revoked Slack token (process alive)"
+  else
+    fail "S5b: Gateway crashed with revoked Slack token"
+  fi
+
+  # Restore original tokens for cleanup
+  export SLACK_BOT_TOKEN="$SLACK_TOKEN"
+  export SLACK_APP_TOKEN="$SLACK_APP"
+else
+  skip "S5: SLACK_BOT_TOKEN_REVOKED not set — skipping revoked-token test"
+fi
+
+# ══════════════════════════════════════════════════════════════════
+# Phase 8: Cleanup
+# ══════════════════════════════════════════════════════════════════
+section "Phase 8: Cleanup"
 
 info "Destroying sandbox '$SANDBOX_NAME'..."
 nemoclaw "$SANDBOX_NAME" destroy --yes 2>/dev/null || true

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -168,8 +168,8 @@ pass "Docker is running"
 
 info "Telegram token: ${TELEGRAM_TOKEN:0:10}... (${#TELEGRAM_TOKEN} chars)"
 info "Discord token: ${DISCORD_TOKEN:0:10}... (${#DISCORD_TOKEN} chars)"
-info "Slack bot token: ${SLACK_TOKEN:0:10}... (${#SLACK_TOKEN} chars)"
-info "Slack app token: ${SLACK_APP:0:10}... (${#SLACK_APP} chars)"
+info "Slack bot token: configured (${#SLACK_TOKEN} chars)"
+info "Slack app token: configured (${#SLACK_APP} chars)"
 info "Sandbox name: $SANDBOX_NAME"
 STRICT_DISCORD_GATEWAY="${NEMOCLAW_E2E_STRICT_DISCORD_GATEWAY:-0}"
 
@@ -1067,12 +1067,20 @@ fi
 # ══════════════════════════════════════════════════════════════════
 section "Phase 7: Slack auth pre-validation (#2340)"
 
-# S1: Gateway process is still running (not crashed by Slack auth failure)
-gw_status=$(sandbox_exec "cat /proc/1/stat 2>/dev/null | awk '{print \$3}'" 2>/dev/null || true)
-if [ -n "$gw_status" ] && [ "$gw_status" != "Z" ]; then
-  pass "S1: Gateway process is alive (state: $gw_status) — Slack auth failure did not crash it"
+# S1: Gateway is serving on port 18789 (not crashed by Slack auth failure)
+# Probing the port is more accurate than checking PID 1 — the entrypoint can
+# survive even if the gateway child process dies (#2340).
+gw_port=$(sandbox_exec 'node -e "
+const net = require(\"net\");
+const sock = net.connect(18789, \"127.0.0.1\");
+sock.on(\"connect\", () => { console.log(\"OPEN\"); sock.end(); });
+sock.on(\"error\", () => console.log(\"CLOSED\"));
+setTimeout(() => { console.log(\"TIMEOUT\"); sock.destroy(); }, 5000);
+"' 2>/dev/null || true)
+if echo "$gw_port" | grep -q "OPEN"; then
+  pass "S1: Gateway is serving on port 18789 — Slack auth failure did not take it down"
 else
-  fail "S1: Gateway process is not running (state: ${gw_status:-unknown}) — may have crashed"
+  fail "S1: Gateway is not serving on port 18789 (${gw_port:0:200})"
 fi
 
 # S2: Gateway log contains the pre-validation attempt
@@ -1097,7 +1105,8 @@ slack_enabled=$(sandbox_exec "python3 -c \"
 import json
 try:
     cfg = json.load(open('/sandbox/.openclaw/openclaw.json'))
-    acct = cfg.get('channels', {}).get('slack', {}).get('accounts', {}).get('default', {})
+    accounts = cfg.get('channels', {}).get('slack', {}).get('accounts', {})
+    acct = accounts.get('default') or accounts.get('main') or next((v for v in accounts.values() if isinstance(v, dict)), {})
     print(acct.get('enabled', 'MISSING'))
 except Exception as e:
     print('ERROR: ' + str(e))
@@ -1161,12 +1170,18 @@ if [ -n "${SLACK_BOT_TOKEN_REVOKED:-}" ]; then
     fail "S5: Revoked Slack token was not caught by validate_slack_auth"
   fi
 
-  # S5b: Gateway should still be running
-  revoked_gw_status=$(sandbox_exec "cat /proc/1/stat 2>/dev/null | awk '{print \$3}'" 2>/dev/null || true)
-  if [ -n "$revoked_gw_status" ] && [ "$revoked_gw_status" != "Z" ]; then
-    pass "S5b: Gateway survived revoked Slack token (process alive)"
+  # S5b: Gateway should still be serving
+  revoked_gw_port=$(sandbox_exec 'node -e "
+const net = require(\"net\");
+const sock = net.connect(18789, \"127.0.0.1\");
+sock.on(\"connect\", () => { console.log(\"OPEN\"); sock.end(); });
+sock.on(\"error\", () => console.log(\"CLOSED\"));
+setTimeout(() => { console.log(\"TIMEOUT\"); sock.destroy(); }, 5000);
+"' 2>/dev/null || true)
+  if echo "$revoked_gw_port" | grep -q "OPEN"; then
+    pass "S5b: Gateway survived revoked Slack token (port 18789 open)"
   else
-    fail "S5b: Gateway crashed with revoked Slack token"
+    fail "S5b: Gateway not serving after revoked Slack token (${revoked_gw_port:0:200})"
   fi
 
   # Restore original tokens for cleanup

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -539,7 +539,27 @@ describe("Slack auth pre-validation (#2340)", () => {
     expect(fn[1]).toContain("Config hash recomputed after disabling Slack channel");
   });
 
-  it("does not disable the channel on network errors (transient failures)", () => {
+  it("only disables on definitive auth errors, not transient API errors", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    // Must define a list of fatal auth errors
+    expect(fn[1]).toContain("_fatal_auth_errors");
+    // Must include the key definitive errors from Slack docs
+    for (const err of [
+      "invalid_auth",
+      "token_expired",
+      "token_revoked",
+      "not_authed",
+      "account_inactive",
+    ]) {
+      expect(fn[1]).toContain(err);
+    }
+    // Transient errors must get a different log message and stay enabled
+    expect(fn[1]).toContain("transient error");
+    expect(fn[1]).toContain("channel left enabled");
+  });
+
+  it("does not disable the channel on network errors", () => {
     const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
     expect(fn).toBeTruthy();
     expect(fn[1]).toContain("network_error:");

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -426,11 +426,11 @@ describe("runtime CORS origin override (#719)", () => {
     const nonRootBlock = src.match(/if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)# ── Root path/);
     expect(nonRootBlock).toBeTruthy();
     expect(nonRootBlock[1]).toMatch(
-      /apply_model_override[\s\S]*?apply_cors_override[\s\S]*?apply_slack_token_override[\s\S]*?export_gateway_token/,
+      /apply_model_override[\s\S]*?apply_cors_override[\s\S]*?apply_slack_token_override[\s\S]*?validate_slack_auth[\s\S]*?export_gateway_token/,
     );
 
     const rootBlock = src.match(
-      /# ── Root path[\s\S]*?apply_model_override\n\s*apply_cors_override\n\s*apply_slack_token_override\n\s*export_gateway_token/,
+      /# ── Root path[\s\S]*?apply_model_override\n\s*apply_cors_override\n\s*apply_slack_token_override\n\s*validate_slack_auth\n\s*export_gateway_token/,
     );
     expect(rootBlock).toBeTruthy();
   });
@@ -472,6 +472,85 @@ describe("runtime CORS origin override (#719)", () => {
     const fn = src.match(/apply_cors_override\(\) \{([\s\S]*?)^}/m);
     expect(fn).toBeTruthy();
     expect(fn[1]).toContain("control characters");
+  });
+});
+
+describe("Slack auth pre-validation (#2340)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("defines validate_slack_auth function", () => {
+    expect(src).toMatch(/validate_slack_auth\(\) \{/);
+  });
+
+  it("calls validate_slack_auth after apply_slack_token_override in both paths", () => {
+    const nonRootBlock = src.match(
+      /if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)# ── Root path/,
+    );
+    expect(nonRootBlock).toBeTruthy();
+    expect(nonRootBlock[1]).toMatch(
+      /apply_slack_token_override[\s\S]*?validate_slack_auth[\s\S]*?export_gateway_token/,
+    );
+
+    const rootBlock = src.match(
+      /# ── Root path[\s\S]*?apply_slack_token_override\n\s*validate_slack_auth\n\s*export_gateway_token/,
+    );
+    expect(rootBlock).toBeTruthy();
+  });
+
+  it("is a no-op when SLACK_BOT_TOKEN is not set", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toMatch(/\[ -n "\$\{SLACK_BOT_TOKEN:-\}" \] \|\| return 0/);
+  });
+
+  it("only validates tokens with xoxb- prefix", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("xoxb-*");
+  });
+
+  it("guards against symlink attacks on config and hash files", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain('-L "$config_file"');
+    expect(fn[1]).toContain('-L "$hash_file"');
+    expect(fn[1]).toContain("Refusing Slack auth validation");
+  });
+
+  it("calls Slack auth.test API via python3 urllib", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("https://slack.com/api/auth.test");
+    expect(fn[1]).toContain("urllib.request");
+  });
+
+  it("disables the Slack channel on auth failure instead of crashing", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain('acct["enabled"] = False');
+    expect(fn[1]).toContain("provider failed to start");
+    expect(fn[1]).toContain("channel disabled");
+  });
+
+  it("recomputes config hash after disabling the channel", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("sha256sum openclaw.json");
+    expect(fn[1]).toContain("Config hash recomputed after disabling Slack channel");
+  });
+
+  it("does not disable the channel on network errors (transient failures)", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("network_error:");
+    expect(fn[1]).toContain("channel left enabled");
+  });
+
+  it("handles python3 failure gracefully", () => {
+    const fn = src.match(/validate_slack_auth\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    // || fallback ensures set -e does not kill the script if python3 fails
+    expect(fn[1]).toContain('|| auth_result="network_error:python3_failed"');
   });
 });
 


### PR DESCRIPTION
## Summary

- Pre-validates Slack bot tokens against the `auth.test` API before launching the OpenClaw gateway, preventing an unhandled promise rejection from `@slack/web-api` that crashes the entire process (Node v22 fatal unhandled rejection)
- On auth failure (e.g., `invalid_auth` from revoked/expired tokens), disables the Slack channel in `openclaw.json` so the gateway starts without it — keeping inference, chat, and TUI alive
- Network errors (proxy not ready, Slack API unreachable) are treated as transient: channel stays enabled, gateway retries on its own

Closes #2340

## Test plan

- [x] All 78 `nemoclaw-start.test.ts` tests pass (9 new + 69 existing including 1 updated)
- [x] shellcheck passes with no warnings
- [x] `tsc` build succeeds
- [ ] E2E: deploy sandbox with valid Slack tokens → gateway starts with Slack enabled, log shows `Slack bot token validated successfully`
- [ ] E2E: deploy sandbox with revoked Slack tokens → gateway starts without Slack, log shows `[slack][default] provider failed to start: invalid_auth — channel disabled`
- [ ] E2E: deploy sandbox with no Slack tokens → no validation attempt, gateway starts normally
- [ ] E2E: deploy sandbox with Slack tokens but proxy down → log shows `channel left enabled`, gateway attempts normal startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup Slack pre-validation: checks bot tokens (only bot-format), refuses symlinked config/hash inputs, disables Slack integrations on definitive auth failures and updates config integrity, treats transient/network/API issues as non-blocking (logged, Slack left enabled).

* **Tests**
  * Unit, integration, and e2e updates to verify validation placement, token-format gating, symlink protection, definitive vs transient outcomes, fallback handling, masked credential handling, and revoked-token scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->