### PR TITLE
feat(sandbox): add procps for ps/top/kill debug tools (#2343)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         iproute2=6.1.0-3 \
         iptables=1.8.9-2 \
         libcap2-bin=1:2.66-4+deb12u2+b2 \
+        procps=2:4.0.2-3 \
     && rm -rf /var/lib/apt/lists/*
 
 # gosu for privilege separation (gateway vs sandbox user).


### PR DESCRIPTION
## Summary

Add `procps` to the sandbox base image so users can run `ps`, `top`, `kill`, `free`, `uptime`, and `vmstat` for debugging.

Fixes #2343.

## Why

Sandbox users reported that basic process-inspection commands were missing:

```
sandbox@xxx-nemoclaw-assistant:~$ ps
bash: ps: command not found
```

Without `ps` it is very hard to observe what is running inside the container. `procps` is the standard Debian package that delivers the full set of essential process/resource commands (`ps`, `top`, `kill`, `free`, `uptime`, `vmstat`) in a single ~1 MB package.

## Scope & Choices

- **Only one package added.** Kept the change minimal — the reporter asked for `ps`, and `procps` covers the common debug needs without dragging in additional surfaces (e.g. `psmisc`, `net-tools`). Follow-up packages can be requested in a separate issue.
- **Added to `Dockerfile.base`, not `Dockerfile`.** This is a cacheable, rarely-changing package, matching the policy documented at the top of `Dockerfile.base`.
- **Version pinned to `2:4.0.2-3`** (Debian bookworm candidate, confirmed via `apt-cache policy procps` on `node:22-slim`), consistent with every other apt package in the list.
- **Survives the final-image hardening step.** `Dockerfile` runs `apt-get remove --purge ... && apt-get autoremove --purge` to strip build tools and network probes. I simulated this end-to-end and `procps` is preserved, because it is explicitly installed and not a transitive dep of anything removed.

## Test plan

- [x] `hadolint Dockerfile.base` passes
- [x] `hadolint Dockerfile` passes
- [x] `docker build -f Dockerfile.base -t nemoclaw-base-test:2343 .` builds successfully
- [x] `docker run --rm nemoclaw-base-test:2343 bash -c 'ps aux'` lists processes
- [x] `which ps top kill free uptime vmstat` all resolve to `/usr/bin/`
- [x] Simulated the `Dockerfile` hardening step (`apt-get remove ... && autoremove --purge`) against the built base — `ps` still works afterwards
- [x] `prek` / commit-lint / DCO / gitleaks pre-commit hooks all pass
- [ ] CI `base-image.yaml` rebuild on merge

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image with an additional system utility package to support improved system monitoring and process management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->