### PR TITLE
fix(onboard): redact messaging tokens in session failures

### DIFF
--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -131,6 +131,7 @@ redact() {
     -e 's/nvcf-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/ghp_[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/github_pat_[A-Za-z0-9_]{30,}/<REDACTED>/g' \
+    -e 's/sk-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/(xox[bpas]|xapp)-[A-Za-z0-9-]{10,}/<REDACTED>/g' \
     -e 's/\bbot[0-9]{8,10}:[A-Za-z0-9_-]{35}\b/bot<REDACTED>/g' \
     -e 's/\b[0-9]{8,10}:[A-Za-z0-9_-]{35}\b/<REDACTED>/g' \

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -131,6 +131,10 @@ redact() {
     -e 's/nvcf-[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/ghp_[A-Za-z0-9_-]{10,}/<REDACTED>/g' \
     -e 's/github_pat_[A-Za-z0-9_]{30,}/<REDACTED>/g' \
+    -e 's/(xox[bpas]|xapp)-[A-Za-z0-9-]{10,}/<REDACTED>/g' \
+    -e 's/\bbot[0-9]{8,10}:[A-Za-z0-9_-]{35}\b/bot<REDACTED>/g' \
+    -e 's/\b[0-9]{8,10}:[A-Za-z0-9_-]{35}\b/<REDACTED>/g' \
+    -e 's/\b[A-Za-z0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b/<REDACTED>/g' \
     -e 's/(Bearer )[^ ]+/\1<REDACTED>/gi'
 }
 

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -207,16 +207,27 @@ function parseLockInfo(value: unknown): LockInfo | null {
 
 export function redactSensitiveText(value: unknown): string | null {
   if (typeof value !== "string") return null;
-  return value
-    .replace(
-      /(NVIDIA_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|COMPATIBLE_API_KEY|COMPATIBLE_ANTHROPIC_API_KEY|BRAVE_API_KEY)=\S+/gi,
-      "$1=<REDACTED>",
-    )
-    .replace(/Bearer\s+\S+/gi, "Bearer <REDACTED>")
-    .replace(/nvapi-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
-    .replace(/ghp_[A-Za-z0-9]{20,}/g, "<REDACTED>")
-    .replace(/sk-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
-    .slice(0, 240);
+  return (
+    value
+      .replace(
+        /(NVIDIA_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|COMPATIBLE_API_KEY|COMPATIBLE_ANTHROPIC_API_KEY|BRAVE_API_KEY|SLACK_BOT_TOKEN|SLACK_APP_TOKEN|DISCORD_BOT_TOKEN|TELEGRAM_BOT_TOKEN)=\S+/gi,
+        "$1=<REDACTED>",
+      )
+      .replace(/Bearer\s+\S+/gi, "Bearer <REDACTED>")
+      .replace(/nvapi-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
+      .replace(/nvcf-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
+      .replace(/ghp_[A-Za-z0-9]{20,}/g, "<REDACTED>")
+      .replace(/github_pat_[A-Za-z0-9_]{30,}/g, "<REDACTED>")
+      .replace(/sk-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
+      .replace(/(?:xox[bpas]|xapp)-[A-Za-z0-9-]{10,}/g, "<REDACTED>")
+      .replace(/\bbot\d{8,10}:[A-Za-z0-9_-]{35}\b/g, "bot<REDACTED>")
+      .replace(/\b\d{8,10}:[A-Za-z0-9_-]{35}\b/g, "<REDACTED>")
+      .replace(
+        /\b[A-Za-z0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b/g,
+        "<REDACTED>",
+      )
+      .slice(0, 240)
+  );
 }
 
 export function sanitizeFailure(

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -10,6 +10,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { TOKEN_PREFIX_PATTERNS } from "./secret-patterns";
 import type { WebSearchConfig } from "./web-search";
 
 export const SESSION_VERSION = 1;
@@ -207,27 +208,22 @@ function parseLockInfo(value: unknown): LockInfo | null {
 
 export function redactSensitiveText(value: unknown): string | null {
   if (typeof value !== "string") return null;
-  return (
-    value
-      .replace(
-        /(NVIDIA_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|COMPATIBLE_API_KEY|COMPATIBLE_ANTHROPIC_API_KEY|BRAVE_API_KEY|SLACK_BOT_TOKEN|SLACK_APP_TOKEN|DISCORD_BOT_TOKEN|TELEGRAM_BOT_TOKEN)=\S+/gi,
-        "$1=<REDACTED>",
-      )
-      .replace(/Bearer\s+\S+/gi, "Bearer <REDACTED>")
-      .replace(/nvapi-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
-      .replace(/nvcf-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
-      .replace(/ghp_[A-Za-z0-9]{20,}/g, "<REDACTED>")
-      .replace(/github_pat_[A-Za-z0-9_]{30,}/g, "<REDACTED>")
-      .replace(/sk-[A-Za-z0-9_-]{10,}/g, "<REDACTED>")
-      .replace(/(?:xox[bpas]|xapp)-[A-Za-z0-9-]{10,}/g, "<REDACTED>")
-      .replace(/\bbot\d{8,10}:[A-Za-z0-9_-]{35}\b/g, "bot<REDACTED>")
-      .replace(/\b\d{8,10}:[A-Za-z0-9_-]{35}\b/g, "<REDACTED>")
-      .replace(
-        /\b[A-Za-z0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b/g,
-        "<REDACTED>",
-      )
-      .slice(0, 240)
-  );
+
+  // Context-anchored patterns: preserve the key name for debuggability.
+  let result = value
+    .replace(
+      /(NVIDIA_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|COMPATIBLE_API_KEY|COMPATIBLE_ANTHROPIC_API_KEY|BRAVE_API_KEY|SLACK_BOT_TOKEN|SLACK_APP_TOKEN|DISCORD_BOT_TOKEN|TELEGRAM_BOT_TOKEN)=\S+/gi,
+      "$1=<REDACTED>",
+    )
+    .replace(/Bearer\s+\S+/gi, "Bearer <REDACTED>");
+
+  // Standalone token patterns — delegate to the canonical source of truth
+  // (secret-patterns.ts) instead of maintaining a duplicate regex list.
+  for (const pattern of TOKEN_PREFIX_PATTERNS) {
+    result = result.replace(pattern, "<REDACTED>");
+  }
+
+  return result.slice(0, 240);
 }
 
 export function sanitizeFailure(

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -18,6 +18,10 @@ export const TOKEN_PREFIX_PATTERNS: RegExp[] = [
   /nvcf-[A-Za-z0-9_-]{10,}/g,
   /ghp_[A-Za-z0-9_-]{10,}/g,
   /(?:github_pat_)[A-Za-z0-9_]{30,}/g,
+  /(?:xox[bpas]|xapp)-[A-Za-z0-9-]{10,}/g,
+  /\bbot\d{8,10}:[A-Za-z0-9_-]{35}\b/g,
+  /\b\d{8,10}:[A-Za-z0-9_-]{35}\b/g,
+  /\b[A-Za-z0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b/g,
 ];
 
 /** Context-anchored patterns (require a prefix like KEY=, Bearer, etc.). */
@@ -41,4 +45,6 @@ export const EXPECTED_SHELL_PREFIXES = [
   "nvcf-",
   "ghp_",
   "github_pat_",
+  "xox",
+  "xapp",
 ];

--- a/src/lib/secret-patterns.ts
+++ b/src/lib/secret-patterns.ts
@@ -18,6 +18,7 @@ export const TOKEN_PREFIX_PATTERNS: RegExp[] = [
   /nvcf-[A-Za-z0-9_-]{10,}/g,
   /ghp_[A-Za-z0-9_-]{10,}/g,
   /(?:github_pat_)[A-Za-z0-9_]{30,}/g,
+  /sk-[A-Za-z0-9_-]{10,}/g,
   /(?:xox[bpas]|xapp)-[A-Za-z0-9-]{10,}/g,
   /\bbot\d{8,10}:[A-Za-z0-9_-]{35}\b/g,
   /\b\d{8,10}:[A-Za-z0-9_-]{35}\b/g,
@@ -45,6 +46,7 @@ export const EXPECTED_SHELL_PREFIXES = [
   "nvcf-",
   "ghp_",
   "github_pat_",
+  "sk-",
   "xox",
   "xapp",
 ];

--- a/test/secret-redaction.test.ts
+++ b/test/secret-redaction.test.ts
@@ -41,6 +41,7 @@ describe("secret redaction consistency (#1736)", () => {
       name: "GitHub PAT (fine-grained)",
       token: "github_pat_" + "d".repeat(50),
     },
+    { name: "OpenAI API key", token: "sk-" + "e".repeat(40) },
   ];
 
   // Tokens added for messaging integrations (#2336). debug.sh uses
@@ -131,6 +132,18 @@ describe("secret redaction consistency (#1736)", () => {
       const text = redactSensitiveText(
         `Failed to reach https://api.telegram.org/bot${token}/getMe`,
       );
+      expect(text).not.toContain(token);
+    });
+
+    it("redacts Telegram token with 8-digit chat ID (boundary)", () => {
+      const token = "12345678:" + "B".repeat(35);
+      const text = redactSensitiveText(`bot returned ${token} in error`);
+      expect(text).not.toContain(token);
+    });
+
+    it("redacts Telegram token with 9-digit chat ID", () => {
+      const token = "123456789:" + "C".repeat(35);
+      const text = redactSensitiveText(`bot returned ${token} in error`);
       expect(text).not.toContain(token);
     });
 

--- a/test/secret-redaction.test.ts
+++ b/test/secret-redaction.test.ts
@@ -9,6 +9,7 @@ import {
   EXPECTED_SHELL_PREFIXES,
 } from "../src/lib/secret-patterns";
 import { redact as debugRedact } from "../src/lib/debug";
+import { redactSensitiveText } from "../src/lib/onboard-session";
 // runner.ts uses CJS exports — import via dist
 import { createRequire } from "node:module";
 
@@ -31,8 +32,8 @@ const DEBUG_TS = readFileSync(
 );
 
 describe("secret redaction consistency (#1736)", () => {
-  // Test tokens that MUST be redacted by all three modules
-  const TEST_TOKENS = [
+  // Tokens whose prefix is a literal string that must appear in debug.sh.
+  const LITERAL_PREFIX_TOKENS = [
     { name: "NVIDIA API key", token: "nvapi-" + "a".repeat(30) },
     { name: "NVIDIA Cloud Functions", token: "nvcf-" + "b".repeat(30) },
     { name: "GitHub PAT (classic)", token: "ghp_" + "c".repeat(36) },
@@ -41,6 +42,22 @@ describe("secret redaction consistency (#1736)", () => {
       token: "github_pat_" + "d".repeat(50),
     },
   ];
+
+  // Tokens added for messaging integrations (#2336). debug.sh uses
+  // character-class regexes for these, so the prefix-containment sub-test
+  // does not apply — they are covered by the runner/debug TS blocks and
+  // by the EXPECTED_SHELL_PREFIXES substring check (xox) where applicable.
+  const MESSAGING_TOKENS = [
+    { name: "Slack bot token", token: "xoxb-" + "1".repeat(12) + "-" + "e".repeat(24) },
+    { name: "Slack app token", token: "xapp-" + "1".repeat(12) + "-" + "f".repeat(24) },
+    { name: "Telegram bot token", token: "1234567890:" + "A".repeat(35) },
+    {
+      name: "Discord bot token",
+      token: "g".repeat(24) + "." + "h".repeat(6) + "." + "i".repeat(27),
+    },
+  ];
+
+  const TEST_TOKENS = [...LITERAL_PREFIX_TOKENS, ...MESSAGING_TOKENS];
 
   describe("runner.ts redacts all token types", () => {
     for (const { name, token } of TEST_TOKENS) {
@@ -85,7 +102,7 @@ describe("secret redaction consistency (#1736)", () => {
   });
 
   describe("debug.sh redact() function handles all token types", () => {
-    for (const { name, token } of TEST_TOKENS) {
+    for (const { name, token } of LITERAL_PREFIX_TOKENS) {
       it(`redacts ${name}`, () => {
         // Extract the redact function's sed patterns and verify they match
         const redactFn = DEBUG_SH.match(
@@ -97,5 +114,32 @@ describe("secret redaction consistency (#1736)", () => {
         expect(redactFn![0]).toContain(prefix);
       });
     }
+  });
+
+  describe("onboard-session redactSensitiveText (#2336)", () => {
+    for (const { name, token } of TEST_TOKENS) {
+      it(`redacts ${name} from persisted failure messages`, () => {
+        const text = redactSensitiveText(
+          `onboard step failed: provider returned ${token}`,
+        );
+        expect(text).not.toContain(token);
+      });
+    }
+
+    it("redacts Telegram token embedded in API URL path", () => {
+      const token = "1234567890:" + "A".repeat(35);
+      const text = redactSensitiveText(
+        `Failed to reach https://api.telegram.org/bot${token}/getMe`,
+      );
+      expect(text).not.toContain(token);
+    });
+
+    it("redacts Slack env-var assignments", () => {
+      const text = redactSensitiveText(
+        "SLACK_BOT_TOKEN=xoxb-notreal SLACK_APP_TOKEN=xapp-notreal",
+      );
+      expect(text).not.toContain("xoxb-notreal");
+      expect(text).not.toContain("xapp-notreal");
+    });
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The onboard session writer runs every error message through redactSensitiveText before persisting to ~/.nemoclaw/onboard-session.json, but the regex list only covered NVIDIA, OpenAI, and GitHub (classic) token prefixes. Slack, Discord, and Telegram tokens — the exact providers whose failure paths print raw tokens during messaging-channel onboarding — survived untouched, and the Telegram URL-path form (api.telegram.org/bot<token>/getMe) is not a shape redactUrl sanitises.

## Related Issue
Resolves #2336.

## Changes
Extend redactSensitiveText and the canonical secret-patterns list with xox[bpas]-/xapp-, Telegram standalone + URL-path forms, and Discord three-part bot tokens; also close pre-existing gaps for nvcf- and github_pat_. Mirror the same patterns in scripts/debug.sh so shell-side diagnostics stay in sync, and extend test/secret-redaction.test.ts with a dedicated #2336 block covering redactSensitiveText and the Telegram URL-path regression.

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [X] AI-assisted — tool: Claude Code<!-- e.g., Claude Code, Cursor, GitHub Copilot -->

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection and redaction of sensitive credentials in debug output and session initialization, now covering additional credential types and formats.

* **Tests**
  * Expanded test coverage for sensitive credential redaction to ensure comprehensive protection across various credential formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->