### PR TITLE
fix(dockerfile): drop invalid channels.defaults.configWrites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -275,7 +275,7 @@ providers = { \
 config = { \
     'agents': {'defaults': {'model': {'primary': primary_model_ref}}}, \
     'models': {'mode': 'merge', 'providers': providers}, \
-    'channels': dict({'defaults': {'configWrites': False}}, **_ch_cfg), \
+    'channels': {'defaults': {}, **_ch_cfg}, \
     'update': {'checkOnStart': False}, \
     'gateway': { \
         'mode': 'local', \


### PR DESCRIPTION
## Summary

Re-applies #2337 (by @rluo8) which was reverted after a botched admin merge.

The baked `openclaw.json` contained `channels.defaults.configWrites: false`, but OpenClaw's `ChannelsSchema.defaults` is `.strict()` and only accepts `groupPolicy` and `heartbeat`. Every sandbox first-boot produced two ERROR-level log lines from the schema validator, then stripped the key.

Fixes #2316

## Changes

One line in Dockerfile:
```diff
-    'channels': dict({'defaults': {'configWrites': False}}, **_ch_cfg), \
+    'channels': {'defaults': {}, **_ch_cfg}, \
```

## Credit

Original fix by @rluo8 in #2337.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel configuration initialization during build process to properly set default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->