### PR TITLE
ci(nightly): fix Prettier formatting in nightly-e2e.yaml

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -670,7 +670,27 @@ jobs:
 
   notify-on-failure:
     runs-on: ubuntu-latest
-    needs: [cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e, token-rotation-e2e, sandbox-survival-e2e, hermes-e2e, skip-permissions-e2e, sandbox-operations-e2e, inference-routing-e2e, network-policy-e2e, deployment-services-e2e, diagnostics-e2e, snapshot-commands-e2e, shields-config-e2e, rebuild-openclaw-e2e, upgrade-stale-sandbox-e2e, rebuild-hermes-e2e, gpu-e2e]
+    needs:
+      [
+        cloud-e2e,
+        cloud-experimental-e2e,
+        messaging-providers-e2e,
+        token-rotation-e2e,
+        sandbox-survival-e2e,
+        hermes-e2e,
+        skip-permissions-e2e,
+        sandbox-operations-e2e,
+        inference-routing-e2e,
+        network-policy-e2e,
+        deployment-services-e2e,
+        diagnostics-e2e,
+        snapshot-commands-e2e,
+        shields-config-e2e,
+        rebuild-openclaw-e2e,
+        upgrade-stale-sandbox-e2e,
+        rebuild-hermes-e2e,
+        gpu-e2e,
+      ]
     if: ${{ always() && (needs.cloud-e2e.result == 'failure' || needs.cloud-experimental-e2e.result == 'failure' || needs.messaging-providers-e2e.result == 'failure' || needs.token-rotation-e2e.result == 'failure' || needs.sandbox-survival-e2e.result == 'failure' || needs.hermes-e2e.result == 'failure' || needs.skip-permissions-e2e.result == 'failure' || needs.sandbox-operations-e2e.result == 'failure' || needs.inference-routing-e2e.result == 'failure' || needs.network-policy-e2e.result == 'failure' || needs.deployment-services-e2e.result == 'failure' || needs.diagnostics-e2e.result == 'failure' || needs.snapshot-commands-e2e.result == 'failure' || needs.shields-config-e2e.result == 'failure' || needs.rebuild-openclaw-e2e.result == 'failure' || needs.upgrade-stale-sandbox-e2e.result == 'failure' || needs.rebuild-hermes-e2e.result == 'failure' || needs.gpu-e2e.result == 'failure') }}
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

Fix Prettier formatting in `.github/workflows/nightly-e2e.yaml` that is breaking the `checks` CI job for all PRs on main.

## Related Issue

Caused by #2351 which was merged at 2026-04-23T14:11. Every main CI run since then fails with `Files were modified by following hooks...Failed`.

## Changes

- Run `npx prettier --write .github/workflows/nightly-e2e.yaml` to wrap the long single-line `needs:` array and `if:` expression that #2351 introduced.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: pi (Claude)

---
Signed-off-by: Test User <test@example.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration formatting for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->