### PR TITLE
fix(cli): show live gateway inference in list/status (#2369)

### DIFF
--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -50,7 +50,7 @@ describe("inventory commands", () => {
     );
   });
 
-  it("uses live gateway inference for the default sandbox and annotates drift from onboarded config", async () => {
+  it("uses live gateway inference for the default sandbox in list output (#2369)", async () => {
     const lines: string[] = [];
     await listSandboxesCommand({
       recoverRegistryEntries: async () => ({
@@ -77,18 +77,15 @@ describe("inventory commands", () => {
       log: (message = "") => lines.push(message),
     });
 
-    // Default sandbox reflects live gateway state (#2369).
+    // Default sandbox reflects live gateway state, with an onboarded drift note.
     expect(lines).toContain(
       "      model: live-model  provider: live-provider  GPU  policies: none",
     );
     expect(lines).toContain(
       "      (onboarded: model=configured-alpha, provider=configured-provider)",
     );
-    expect(lines).not.toContain(
-      "      model: configured-alpha  provider: configured-provider  GPU  policies: none",
-    );
-    // Non-default sandboxes keep their stored config — the gateway inference
-    // only applies to whichever sandbox is currently connected/active.
+    // Non-default sandbox keeps its stored config — the gateway only applies
+    // to whichever sandbox is currently connected.
     expect(lines).toContain(
       "      model: configured-beta  provider: beta-provider  CPU  policies: none",
     );
@@ -175,9 +172,9 @@ describe("inventory commands", () => {
 
   it("flags messaging bridge as degraded when checkMessagingBridgeHealth reports conflicts", () => {
     const lines: string[] = [];
-    const checkMessagingBridgeHealth = vi
-      .fn()
-      .mockReturnValue([{ channel: "telegram", conflicts: 7 }]);
+    const checkMessagingBridgeHealth = vi.fn().mockReturnValue([
+      { channel: "telegram", conflicts: 7 },
+    ]);
     showStatusCommand({
       listSandboxes: () => ({
         sandboxes: [
@@ -221,9 +218,9 @@ describe("inventory commands", () => {
 
   it("prints a cross-sandbox overlap warning when backfillAndFindOverlaps reports overlaps", () => {
     const lines: string[] = [];
-    const backfillAndFindOverlaps = vi
-      .fn()
-      .mockReturnValue([{ channel: "telegram", sandboxes: ["alice", "bob"] }]);
+    const backfillAndFindOverlaps = vi.fn().mockReturnValue([
+      { channel: "telegram", sandboxes: ["alice", "bob"] },
+    ]);
     showStatusCommand({
       listSandboxes: () => ({
         sandboxes: [
@@ -239,22 +236,20 @@ describe("inventory commands", () => {
     });
 
     expect(backfillAndFindOverlaps).toHaveBeenCalled();
-    expect(lines.some((l) => l.includes("telegram is enabled on both 'alice' and 'bob'"))).toBe(
-      true,
-    );
+    expect(
+      lines.some((l) => l.includes("telegram is enabled on both 'alice' and 'bob'")),
+    ).toBe(true);
   });
 
   it("surfaces Hermes gateway log when messaging is degraded", () => {
     const lines: string[] = [];
-    const checkMessagingBridgeHealth = vi
-      .fn()
-      .mockReturnValue([{ channel: "telegram", conflicts: 3 }]);
-    const readGatewayLog = vi
-      .fn()
-      .mockReturnValue(
-        "2026-04-17 getUpdates conflict: terminated by other getUpdates\n" +
-          "2026-04-17 retrying in 5s",
-      );
+    const checkMessagingBridgeHealth = vi.fn().mockReturnValue([
+      { channel: "telegram", conflicts: 3 },
+    ]);
+    const readGatewayLog = vi.fn().mockReturnValue(
+      "2026-04-17 getUpdates conflict: terminated by other getUpdates\n" +
+      "2026-04-17 retrying in 5s",
+    );
     showStatusCommand({
       listSandboxes: () => ({
         sandboxes: [
@@ -281,9 +276,9 @@ describe("inventory commands", () => {
 
   it("does not show gateway log for non-Hermes sandboxes", () => {
     const lines: string[] = [];
-    const checkMessagingBridgeHealth = vi
-      .fn()
-      .mockReturnValue([{ channel: "telegram", conflicts: 3 }]);
+    const checkMessagingBridgeHealth = vi.fn().mockReturnValue([
+      { channel: "telegram", conflicts: 3 },
+    ]);
     const readGatewayLog = vi.fn();
     showStatusCommand({
       listSandboxes: () => ({
@@ -306,7 +301,7 @@ describe("inventory commands", () => {
     expect(readGatewayLog).not.toHaveBeenCalled();
   });
 
-  it("shows live gateway model for the default sandbox in status and delegates service status (#2369)", () => {
+  it("prints sandbox models in status and delegates service status", () => {
     const lines: string[] = [];
     const showServiceStatus = vi.fn();
     showStatusCommand({
@@ -329,16 +324,17 @@ describe("inventory commands", () => {
     });
 
     expect(lines).toContain("  Sandboxes:");
+    // Default sandbox shows the live gateway model (#2369), annotated with
+    // the onboarded model when they differ.
     expect(lines).toContain("    alpha * (moonshotai/kimi-k2.5)");
     expect(lines).toContain("      (onboarded: nvidia/nemotron-3-super-120b-a12b)");
-    expect(lines).not.toContain("    alpha * (nvidia/nemotron-3-super-120b-a12b)");
-    // Non-default sandbox keeps its stored model, because the gateway applies
+    // Non-default sandbox keeps its stored model — the gateway only applies
     // to whichever sandbox is currently connected.
     expect(lines).toContain("    beta (z-ai/glm5)");
     expect(showServiceStatus).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 
-  it("does not annotate status when the live gateway matches onboarded model", () => {
+  it("does not annotate status when the live gateway matches the onboarded model", () => {
     const lines: string[] = [];
     showStatusCommand({
       listSandboxes: () => ({

--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -50,7 +50,7 @@ describe("inventory commands", () => {
     );
   });
 
-  it("shows stored sandbox inference instead of live gateway inference in list output", async () => {
+  it("uses live gateway inference for the default sandbox and annotates drift from onboarded config", async () => {
     const lines: string[] = [];
     await listSandboxesCommand({
       recoverRegistryEntries: async () => ({
@@ -77,22 +77,107 @@ describe("inventory commands", () => {
       log: (message = "") => lines.push(message),
     });
 
+    // Default sandbox reflects live gateway state (#2369).
     expect(lines).toContain(
-      "      model: configured-alpha  provider: configured-provider  GPU  policies: none",
-    );
-    expect(lines).not.toContain(
       "      model: live-model  provider: live-provider  GPU  policies: none",
     );
+    expect(lines).toContain(
+      "      (onboarded: model=configured-alpha, provider=configured-provider)",
+    );
+    expect(lines).not.toContain(
+      "      model: configured-alpha  provider: configured-provider  GPU  policies: none",
+    );
+    // Non-default sandboxes keep their stored config — the gateway inference
+    // only applies to whichever sandbox is currently connected/active.
     expect(lines).toContain(
       "      model: configured-beta  provider: beta-provider  CPU  policies: none",
     );
   });
 
+  it("does not annotate the default sandbox when live gateway matches onboarded config", async () => {
+    const lines: string[] = [];
+    await listSandboxesCommand({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          {
+            name: "alpha",
+            model: "configured-alpha",
+            provider: "configured-provider",
+            gpuEnabled: true,
+            policies: [],
+          },
+        ],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => ({ provider: "configured-provider", model: "configured-alpha" }),
+      loadLastSession: () => null,
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain(
+      "      model: configured-alpha  provider: configured-provider  GPU  policies: none",
+    );
+    expect(lines.some((l) => l.includes("onboarded"))).toBe(false);
+  });
+
+  it("falls back to onboarded config when the gateway is unreachable", async () => {
+    const lines: string[] = [];
+    await listSandboxesCommand({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          {
+            name: "alpha",
+            model: "configured-alpha",
+            provider: "configured-provider",
+            gpuEnabled: true,
+            policies: [],
+          },
+        ],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain(
+      "      model: configured-alpha  provider: configured-provider  GPU  policies: none",
+    );
+    expect(lines.some((l) => l.includes("onboarded"))).toBe(false);
+  });
+
+  it("annotates only the drifting field when the live gateway reports partial overrides", async () => {
+    const lines: string[] = [];
+    await listSandboxesCommand({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          {
+            name: "alpha",
+            model: "configured-alpha",
+            provider: "configured-provider",
+            gpuEnabled: true,
+            policies: [],
+          },
+        ],
+        defaultSandbox: "alpha",
+      }),
+      // Only the model changed at the gateway; provider matches onboarded.
+      getLiveInference: () => ({ provider: "configured-provider", model: "live-model" }),
+      loadLastSession: () => null,
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain(
+      "      model: live-model  provider: configured-provider  GPU  policies: none",
+    );
+    expect(lines).toContain("      (onboarded: model=configured-alpha)");
+  });
+
   it("flags messaging bridge as degraded when checkMessagingBridgeHealth reports conflicts", () => {
     const lines: string[] = [];
-    const checkMessagingBridgeHealth = vi.fn().mockReturnValue([
-      { channel: "telegram", conflicts: 7 },
-    ]);
+    const checkMessagingBridgeHealth = vi
+      .fn()
+      .mockReturnValue([{ channel: "telegram", conflicts: 7 }]);
     showStatusCommand({
       listSandboxes: () => ({
         sandboxes: [
@@ -136,9 +221,9 @@ describe("inventory commands", () => {
 
   it("prints a cross-sandbox overlap warning when backfillAndFindOverlaps reports overlaps", () => {
     const lines: string[] = [];
-    const backfillAndFindOverlaps = vi.fn().mockReturnValue([
-      { channel: "telegram", sandboxes: ["alice", "bob"] },
-    ]);
+    const backfillAndFindOverlaps = vi
+      .fn()
+      .mockReturnValue([{ channel: "telegram", sandboxes: ["alice", "bob"] }]);
     showStatusCommand({
       listSandboxes: () => ({
         sandboxes: [
@@ -154,20 +239,22 @@ describe("inventory commands", () => {
     });
 
     expect(backfillAndFindOverlaps).toHaveBeenCalled();
-    expect(
-      lines.some((l) => l.includes("telegram is enabled on both 'alice' and 'bob'")),
-    ).toBe(true);
+    expect(lines.some((l) => l.includes("telegram is enabled on both 'alice' and 'bob'"))).toBe(
+      true,
+    );
   });
 
   it("surfaces Hermes gateway log when messaging is degraded", () => {
     const lines: string[] = [];
-    const checkMessagingBridgeHealth = vi.fn().mockReturnValue([
-      { channel: "telegram", conflicts: 3 },
-    ]);
-    const readGatewayLog = vi.fn().mockReturnValue(
-      "2026-04-17 getUpdates conflict: terminated by other getUpdates\n" +
-      "2026-04-17 retrying in 5s",
-    );
+    const checkMessagingBridgeHealth = vi
+      .fn()
+      .mockReturnValue([{ channel: "telegram", conflicts: 3 }]);
+    const readGatewayLog = vi
+      .fn()
+      .mockReturnValue(
+        "2026-04-17 getUpdates conflict: terminated by other getUpdates\n" +
+          "2026-04-17 retrying in 5s",
+      );
     showStatusCommand({
       listSandboxes: () => ({
         sandboxes: [
@@ -194,9 +281,9 @@ describe("inventory commands", () => {
 
   it("does not show gateway log for non-Hermes sandboxes", () => {
     const lines: string[] = [];
-    const checkMessagingBridgeHealth = vi.fn().mockReturnValue([
-      { channel: "telegram", conflicts: 3 },
-    ]);
+    const checkMessagingBridgeHealth = vi
+      .fn()
+      .mockReturnValue([{ channel: "telegram", conflicts: 3 }]);
     const readGatewayLog = vi.fn();
     showStatusCommand({
       listSandboxes: () => ({
@@ -219,7 +306,7 @@ describe("inventory commands", () => {
     expect(readGatewayLog).not.toHaveBeenCalled();
   });
 
-  it("prints stored sandbox models in status and delegates service status", () => {
+  it("shows live gateway model for the default sandbox in status and delegates service status (#2369)", () => {
     const lines: string[] = [];
     const showServiceStatus = vi.fn();
     showStatusCommand({
@@ -242,9 +329,47 @@ describe("inventory commands", () => {
     });
 
     expect(lines).toContain("  Sandboxes:");
-    expect(lines).toContain("    alpha * (nvidia/nemotron-3-super-120b-a12b)");
-    expect(lines).not.toContain("    alpha * (moonshotai/kimi-k2.5)");
+    expect(lines).toContain("    alpha * (moonshotai/kimi-k2.5)");
+    expect(lines).toContain("      (onboarded: nvidia/nemotron-3-super-120b-a12b)");
+    expect(lines).not.toContain("    alpha * (nvidia/nemotron-3-super-120b-a12b)");
+    // Non-default sandbox keeps its stored model, because the gateway applies
+    // to whichever sandbox is currently connected.
     expect(lines).toContain("    beta (z-ai/glm5)");
     expect(showServiceStatus).toHaveBeenCalledWith({ sandboxName: "alpha" });
+  });
+
+  it("does not annotate status when the live gateway matches onboarded model", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", model: "nvidia/nemotron-3-super-120b-a12b" }],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => ({
+        provider: "nvidia-prod",
+        model: "nvidia/nemotron-3-super-120b-a12b",
+      }),
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("    alpha * (nvidia/nemotron-3-super-120b-a12b)");
+    expect(lines.some((l) => l.includes("onboarded"))).toBe(false);
+  });
+
+  it("falls back to stored status model when the gateway is unreachable", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", model: "nvidia/nemotron-3-super-120b-a12b" }],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => null,
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("    alpha * (nvidia/nemotron-3-super-120b-a12b)");
+    expect(lines.some((l) => l.includes("onboarded"))).toBe(false);
   });
 });

--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -81,6 +81,10 @@ describe("inventory commands", () => {
     expect(lines).toContain(
       "      model: live-model  provider: live-provider  GPU  policies: none",
     );
+    // Stale stored row for the default sandbox must not leak through.
+    expect(lines).not.toContain(
+      "      model: configured-alpha  provider: configured-provider  GPU  policies: none",
+    );
     expect(lines).toContain(
       "      (onboarded: model=configured-alpha, provider=configured-provider)",
     );

--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -170,6 +170,33 @@ describe("inventory commands", () => {
     expect(lines).toContain("      (onboarded: model=configured-alpha)");
   });
 
+  it("annotates only the provider field when the live gateway provider drifts", async () => {
+    const lines: string[] = [];
+    await listSandboxesCommand({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          {
+            name: "alpha",
+            model: "configured-alpha",
+            provider: "configured-provider",
+            gpuEnabled: true,
+            policies: [],
+          },
+        ],
+        defaultSandbox: "alpha",
+      }),
+      // Only the provider changed at the gateway; model matches onboarded.
+      getLiveInference: () => ({ provider: "live-provider", model: "configured-alpha" }),
+      loadLastSession: () => null,
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain(
+      "      model: configured-alpha  provider: live-provider  GPU  policies: none",
+    );
+    expect(lines).toContain("      (onboarded: provider=configured-provider)");
+  });
+
   it("flags messaging bridge as degraded when checkMessagingBridgeHealth reports conflicts", () => {
     const lines: string[] = [];
     const checkMessagingBridgeHealth = vi.fn().mockReturnValue([
@@ -367,5 +394,22 @@ describe("inventory commands", () => {
 
     expect(lines).toContain("    alpha * (nvidia/nemotron-3-super-120b-a12b)");
     expect(lines.some((l) => l.includes("onboarded"))).toBe(false);
+  });
+
+  it("annotates status drift with 'unknown' when the onboarded model is missing", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        // sandbox registered without a model (possible per SandboxEntry type).
+        sandboxes: [{ name: "alpha" }],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => ({ provider: "nvidia-prod", model: "moonshotai/kimi-k2.5" }),
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("    alpha * (moonshotai/kimi-k2.5)");
+    expect(lines).toContain("      (onboarded: unknown)");
   });
 });

--- a/src/lib/inventory-commands.ts
+++ b/src/lib/inventory-commands.ts
@@ -133,8 +133,8 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
       const liveModel = isDefault && live ? live.model : null;
       const model = liveModel || sb.model;
       log(`    ${sb.name}${def}${model ? ` (${model})` : ""}`);
-      if (isDefault && liveModel && sb.model && liveModel !== sb.model) {
-        log(`      (onboarded: ${sb.model})`);
+      if (isDefault && liveModel && liveModel !== sb.model) {
+        log(`      (onboarded: ${sb.model || "unknown"})`);
       }
     }
     log("");

--- a/src/lib/inventory-commands.ts
+++ b/src/lib/inventory-commands.ts
@@ -43,13 +43,62 @@ export interface ShowStatusCommandDeps {
   listSandboxes: () => { sandboxes: SandboxEntry[]; defaultSandbox?: string | null };
   getLiveInference: () => GatewayInference | null;
   showServiceStatus: (options: { sandboxName?: string }) => void;
-  checkMessagingBridgeHealth?: (
-    sandboxName: string,
-    channels: string[],
-  ) => MessagingBridgeHealth[];
+  checkMessagingBridgeHealth?: (sandboxName: string, channels: string[]) => MessagingBridgeHealth[];
   backfillAndFindOverlaps?: () => MessagingOverlap[];
   readGatewayLog?: (sandboxName: string) => string | null;
   log?: (message?: string) => void;
+}
+
+/**
+ * Resolve the model/provider to display for a sandbox row, preferring the
+ * live gateway inference for the default sandbox so `nemoclaw list`/`status`
+ * reflect what `openshell inference set` most recently applied (#2369).
+ *
+ * The gateway holds a single active inference config; it can only apply to
+ * one sandbox at a time — the currently-connected one, which we treat as the
+ * default. Non-default sandboxes keep their onboarded config, because that is
+ * what they'll swap the gateway to on their next `connect`.
+ */
+function resolveDisplayInference(
+  sb: SandboxEntry,
+  isDefault: boolean,
+  live: GatewayInference | null,
+): {
+  model: string;
+  provider: string;
+  onboardedDrift: { model: string | null; provider: string | null } | null;
+} {
+  const storedModel = sb.model || "unknown";
+  const storedProvider = sb.provider || "unknown";
+
+  if (!isDefault || !live) {
+    return { model: storedModel, provider: storedProvider, onboardedDrift: null };
+  }
+
+  const modelDrifted = !!live.model && live.model !== sb.model;
+  const providerDrifted = !!live.provider && live.provider !== sb.provider;
+
+  return {
+    model: live.model || storedModel,
+    provider: live.provider || storedProvider,
+    onboardedDrift:
+      modelDrifted || providerDrifted
+        ? {
+            model: modelDrifted ? storedModel : null,
+            provider: providerDrifted ? storedProvider : null,
+          }
+        : null,
+  };
+}
+
+function formatOnboardedDriftLabel(drift: {
+  model: string | null;
+  provider: string | null;
+}): string {
+  const parts: string[] = [];
+  if (drift.model) parts.push(`model=${drift.model}`);
+  if (drift.provider) parts.push(`provider=${drift.provider}`);
+  return `(onboarded: ${parts.join(", ")})`;
 }
 
 export async function listSandboxesCommand(deps: ListSandboxesCommandDeps): Promise<void> {
@@ -74,7 +123,7 @@ export async function listSandboxesCommand(deps: ListSandboxesCommandDeps): Prom
     return;
   }
 
-  deps.getLiveInference();
+  const live = deps.getLiveInference();
 
   log("");
   if (recovery.recoveredFromSession) {
@@ -83,21 +132,25 @@ export async function listSandboxesCommand(deps: ListSandboxesCommandDeps): Prom
   }
   if ((recovery.recoveredFromGateway || 0) > 0) {
     const count = recovery.recoveredFromGateway || 0;
-    log(`  Recovered ${count} sandbox entr${count === 1 ? "y" : "ies"} from the live OpenShell gateway.`);
+    log(
+      `  Recovered ${count} sandbox entr${count === 1 ? "y" : "ies"} from the live OpenShell gateway.`,
+    );
     log("");
   }
   log("  Sandboxes:");
   for (const sb of sandboxes) {
     const isDefault = sb.name === defaultSandbox;
     const def = isDefault ? " *" : "";
-    const model = sb.model || "unknown";
-    const provider = sb.provider || "unknown";
+    const { model, provider, onboardedDrift } = resolveDisplayInference(sb, isDefault, live);
     const gpu = sb.gpuEnabled ? "GPU" : "CPU";
     const presets = sb.policies && sb.policies.length > 0 ? sb.policies.join(", ") : "none";
     const sessionCount = deps.getActiveSessionCount ? deps.getActiveSessionCount(sb.name) : null;
     const connected = sessionCount !== null && sessionCount > 0 ? " ●" : "";
     log(`    ${sb.name}${def}${connected}`);
     log(`      model: ${model}  provider: ${provider}  ${gpu}  policies: ${presets}`);
+    if (onboardedDrift) {
+      log(`      ${formatOnboardedDriftLabel(onboardedDrift)}`);
+    }
   }
   log("");
   log("  * = default sandbox");
@@ -108,14 +161,20 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
   const log = deps.log ?? console.log;
   const { sandboxes, defaultSandbox } = deps.listSandboxes();
   if (sandboxes.length > 0) {
-    deps.getLiveInference();
+    const live = deps.getLiveInference();
     log("");
     log("  Sandboxes:");
     for (const sb of sandboxes) {
       const isDefault = sb.name === defaultSandbox;
       const def = isDefault ? " *" : "";
-      const model = sb.model;
+      // Prefer live gateway model for the default sandbox so `status` agrees
+      // with what `openshell inference get` reports (#2369).
+      const liveModel = isDefault && live ? live.model : null;
+      const model = liveModel || sb.model;
       log(`    ${sb.name}${def}${model ? ` (${model})` : ""}`);
+      if (isDefault && liveModel && sb.model && liveModel !== sb.model) {
+        log(`      (onboarded: ${sb.model})`);
+      }
     }
     log("");
   }
@@ -149,9 +208,7 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
       if (degraded.length > 0) {
         log("");
         for (const { channel, conflicts } of degraded) {
-          log(
-            `  ⚠ ${channel} bridge: degraded (${conflicts} conflict errors in /tmp/gateway.log)`,
-          );
+          log(`  ⚠ ${channel} bridge: degraded (${conflicts} conflict errors in /tmp/gateway.log)`);
         }
         log(
           "    Another sandbox is likely polling with the same bot token. See docs/reference/troubleshooting.md.",

--- a/src/lib/inventory-commands.ts
+++ b/src/lib/inventory-commands.ts
@@ -43,62 +43,13 @@ export interface ShowStatusCommandDeps {
   listSandboxes: () => { sandboxes: SandboxEntry[]; defaultSandbox?: string | null };
   getLiveInference: () => GatewayInference | null;
   showServiceStatus: (options: { sandboxName?: string }) => void;
-  checkMessagingBridgeHealth?: (sandboxName: string, channels: string[]) => MessagingBridgeHealth[];
+  checkMessagingBridgeHealth?: (
+    sandboxName: string,
+    channels: string[],
+  ) => MessagingBridgeHealth[];
   backfillAndFindOverlaps?: () => MessagingOverlap[];
   readGatewayLog?: (sandboxName: string) => string | null;
   log?: (message?: string) => void;
-}
-
-/**
- * Resolve the model/provider to display for a sandbox row, preferring the
- * live gateway inference for the default sandbox so `nemoclaw list`/`status`
- * reflect what `openshell inference set` most recently applied (#2369).
- *
- * The gateway holds a single active inference config; it can only apply to
- * one sandbox at a time — the currently-connected one, which we treat as the
- * default. Non-default sandboxes keep their onboarded config, because that is
- * what they'll swap the gateway to on their next `connect`.
- */
-function resolveDisplayInference(
-  sb: SandboxEntry,
-  isDefault: boolean,
-  live: GatewayInference | null,
-): {
-  model: string;
-  provider: string;
-  onboardedDrift: { model: string | null; provider: string | null } | null;
-} {
-  const storedModel = sb.model || "unknown";
-  const storedProvider = sb.provider || "unknown";
-
-  if (!isDefault || !live) {
-    return { model: storedModel, provider: storedProvider, onboardedDrift: null };
-  }
-
-  const modelDrifted = !!live.model && live.model !== sb.model;
-  const providerDrifted = !!live.provider && live.provider !== sb.provider;
-
-  return {
-    model: live.model || storedModel,
-    provider: live.provider || storedProvider,
-    onboardedDrift:
-      modelDrifted || providerDrifted
-        ? {
-            model: modelDrifted ? storedModel : null,
-            provider: providerDrifted ? storedProvider : null,
-          }
-        : null,
-  };
-}
-
-function formatOnboardedDriftLabel(drift: {
-  model: string | null;
-  provider: string | null;
-}): string {
-  const parts: string[] = [];
-  if (drift.model) parts.push(`model=${drift.model}`);
-  if (drift.provider) parts.push(`provider=${drift.provider}`);
-  return `(onboarded: ${parts.join(", ")})`;
 }
 
 export async function listSandboxesCommand(deps: ListSandboxesCommandDeps): Promise<void> {
@@ -132,24 +83,34 @@ export async function listSandboxesCommand(deps: ListSandboxesCommandDeps): Prom
   }
   if ((recovery.recoveredFromGateway || 0) > 0) {
     const count = recovery.recoveredFromGateway || 0;
-    log(
-      `  Recovered ${count} sandbox entr${count === 1 ? "y" : "ies"} from the live OpenShell gateway.`,
-    );
+    log(`  Recovered ${count} sandbox entr${count === 1 ? "y" : "ies"} from the live OpenShell gateway.`);
     log("");
   }
   log("  Sandboxes:");
   for (const sb of sandboxes) {
     const isDefault = sb.name === defaultSandbox;
     const def = isDefault ? " *" : "";
-    const { model, provider, onboardedDrift } = resolveDisplayInference(sb, isDefault, live);
+    // For the default sandbox, prefer the live gateway values so the display
+    // agrees with `openshell inference get` (#2369). The gateway holds a
+    // single active config at a time and applies to whichever sandbox is
+    // currently connected; non-default sandboxes will swap it to their stored
+    // config on their next `connect`, so they keep showing stored values.
+    const useLive = isDefault && live;
+    const model = (useLive && live.model) || sb.model || "unknown";
+    const provider = (useLive && live.provider) || sb.provider || "unknown";
+    const modelDrifted = !!(useLive && live.model && live.model !== sb.model);
+    const providerDrifted = !!(useLive && live.provider && live.provider !== sb.provider);
     const gpu = sb.gpuEnabled ? "GPU" : "CPU";
     const presets = sb.policies && sb.policies.length > 0 ? sb.policies.join(", ") : "none";
     const sessionCount = deps.getActiveSessionCount ? deps.getActiveSessionCount(sb.name) : null;
     const connected = sessionCount !== null && sessionCount > 0 ? " ●" : "";
     log(`    ${sb.name}${def}${connected}`);
     log(`      model: ${model}  provider: ${provider}  ${gpu}  policies: ${presets}`);
-    if (onboardedDrift) {
-      log(`      ${formatOnboardedDriftLabel(onboardedDrift)}`);
+    if (modelDrifted || providerDrifted) {
+      const parts: string[] = [];
+      if (modelDrifted) parts.push(`model=${sb.model || "unknown"}`);
+      if (providerDrifted) parts.push(`provider=${sb.provider || "unknown"}`);
+      log(`      (onboarded: ${parts.join(", ")})`);
     }
   }
   log("");
@@ -167,8 +128,8 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
     for (const sb of sandboxes) {
       const isDefault = sb.name === defaultSandbox;
       const def = isDefault ? " *" : "";
-      // Prefer live gateway model for the default sandbox so `status` agrees
-      // with what `openshell inference get` reports (#2369).
+      // Prefer the live gateway model for the default sandbox so `status`
+      // agrees with `openshell inference get` (#2369).
       const liveModel = isDefault && live ? live.model : null;
       const model = liveModel || sb.model;
       log(`    ${sb.name}${def}${model ? ` (${model})` : ""}`);
@@ -208,7 +169,9 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
       if (degraded.length > 0) {
         log("");
         for (const { channel, conflicts } of degraded) {
-          log(`  ⚠ ${channel} bridge: degraded (${conflicts} conflict errors in /tmp/gateway.log)`);
+          log(
+            `  ⚠ ${channel} bridge: degraded (${conflicts} conflict errors in /tmp/gateway.log)`,
+          );
         }
         log(
           "    Another sandbox is likely polling with the same bot token. See docs/reference/troubleshooting.md.",

--- a/src/lib/inventory-commands.ts
+++ b/src/lib/inventory-commands.ts
@@ -52,6 +52,17 @@ export interface ShowStatusCommandDeps {
   log?: (message?: string) => void;
 }
 
+/**
+ * Render the `nemoclaw list` output. For the default sandbox (the one the
+ * cluster-wide gateway is currently serving) the live gateway `model`/
+ * `provider` take precedence over the onboarded snapshot so the CLI agrees
+ * with `openshell inference get` (#2369); when they drift from stored values
+ * a `(onboarded: …)` line is appended. Non-default sandboxes keep their
+ * stored config — the gateway only applies to one sandbox at a time, and
+ * each non-default sandbox swaps the gateway back to its stored config on
+ * its next `connect`. Falls back to stored values when `getLiveInference()`
+ * returns `null` (gateway unreachable).
+ */
 export async function listSandboxesCommand(deps: ListSandboxesCommandDeps): Promise<void> {
   const log = deps.log ?? console.log;
   const recovery = await deps.recoverRegistryEntries();
@@ -118,6 +129,14 @@ export async function listSandboxesCommand(deps: ListSandboxesCommandDeps): Prom
   log("");
 }
 
+/**
+ * Render the `nemoclaw status` output (no sandbox name): a compact per-row
+ * listing followed by gateway/service status and messaging-bridge warnings.
+ * For the default sandbox the per-row `(model)` prefers the live gateway
+ * model so it agrees with `openshell inference get` (#2369); when it drifts
+ * from the stored onboarded model a `(onboarded: …)` line is appended.
+ * Non-default rows and the unreachable-gateway case fall back to stored.
+ */
 export function showStatusCommand(deps: ShowStatusCommandDeps): void {
   const log = deps.log ?? console.log;
   const { sandboxes, defaultSandbox } = deps.listSandboxes();

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2319,7 +2319,7 @@ describe("CLI dispatch", () => {
 });
 
 describe("list shows live gateway inference", () => {
-  it("shows stored sandbox inference instead of live gateway inference", () => {
+  it("shows live gateway inference for the default sandbox (#2369)", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-list-live-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -2364,10 +2364,11 @@ describe("list shows live gateway inference", () => {
     });
 
     expect(r.code).toBe(0);
-    expect(r.out).toContain("configured-model");
-    expect(r.out).toContain("configured-provider");
-    expect(r.out).not.toContain("nvidia/nemotron-3-super-120b-a12b");
-    expect(r.out).not.toContain("nvidia-prod");
+    // Live gateway values are shown for the default sandbox's row.
+    expect(r.out).toContain("nvidia/nemotron-3-super-120b-a12b");
+    expect(r.out).toContain("nvidia-prod");
+    // Onboarded values appear in the drift annotation, not the main row.
+    expect(r.out).toContain("(onboarded: model=configured-model, provider=configured-provider)");
   });
 
   it("falls back to registry values when openshell inference get fails", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2364,10 +2364,15 @@ describe("list shows live gateway inference", () => {
     });
 
     expect(r.code).toBe(0);
-    // Live gateway values are shown for the default sandbox's row.
-    expect(r.out).toContain("nvidia/nemotron-3-super-120b-a12b");
-    expect(r.out).toContain("nvidia-prod");
-    // Onboarded values appear in the drift annotation, not the main row.
+    // Live gateway values render on the default sandbox's main row.
+    expect(r.out).toContain(
+      "model: nvidia/nemotron-3-super-120b-a12b  provider: nvidia-prod  GPU  policies: pypi, npm",
+    );
+    // The stale (stored) row must not appear.
+    expect(r.out).not.toContain(
+      "model: configured-model  provider: configured-provider  GPU  policies: pypi, npm",
+    );
+    // Onboarded values appear in the drift annotation.
     expect(r.out).toContain("(onboarded: model=configured-model, provider=configured-provider)");
   });
 


### PR DESCRIPTION
## Summary

`nemoclaw list` and bare `nemoclaw status` called `getLiveInference()` but discarded the return value, so the displayed `model`/`provider` always came from the onboard-time snapshot in `~/.nemoclaw/sandboxes.json`. After `openshell inference set` changed the gateway at runtime, those two commands appeared stale — disagreeing with what `openshell inference get` reported.

This PR makes the two commands use the live gateway inference for the **default sandbox** (the one the single cluster-wide gateway is currently serving) and annotates the row with `(onboarded: …)` when it drifts from the stored config, so users can still see what was configured at onboard time.

## Related Issue

Fixes #2369

## Changes

- `src/lib/inventory-commands.ts`
  - `listSandboxesCommand`: use `getLiveInference()` for the default sandbox's `model`/`provider`; emit a `(onboarded: model=…, provider=…)` line when the live gateway differs from the stored config. Non-default sandboxes keep their stored values because the gateway only serves one sandbox at a time — each non-default sandbox will swap the gateway to its stored config on its next `connect` (see `src/nemoclaw.ts:1275-1302`).
  - `showStatusCommand`: same treatment for the per-row `(model)` display, with an indented `(onboarded: <stored-model>)` annotation when the live gateway model drifts.
  - Both paths fall back cleanly to stored values when `getLiveInference()` returns `null` (gateway unreachable).
- `src/lib/inventory-commands.test.ts`
  - Rewrote the two existing tests that had codified the buggy behavior ("shows stored sandbox inference instead of live gateway inference").
  - Added 5 new cases: drift with both fields, drift with only one field, no-drift (no annotation), gateway-unreachable fallback, status no-drift.

`nemoclaw <name> status` (the per-sandbox status handler in `sandboxStatus`) already handled this correctly via `(live && live.model) || (sb && sb.model)` and is not touched.

## Reproduction + verification

Reproduced on Linux (x86_64 Ubuntu 22.04) with a minimal harness — fake `openshell` stub that only implements `inference get` + a handwritten `~/.nemoclaw/sandboxes.json` — so no real sandbox/gateway setup required. The bug-path isolates to Node-side JSON read plus `openshell inference get` shell-out, which the harness exercises exactly.

Before the patch, on `origin/main`:

```
STEP C: nemoclaw list — gateway changed to moonshotai/kimi-k2.5
  Sandboxes:
    tel *
      model: nvidia/nemotron-3-super-120b-a12b  provider: nvidia-prod  CPU  policies: pypi, github
```

After the patch:

```
STEP C: nemoclaw list — gateway changed to moonshotai/kimi-k2.5
  Sandboxes:
    tel *
      model: moonshotai/kimi-k2.5  provider: nvidia-prod  CPU  policies: pypi, github
      (onboarded: model=nvidia/nemotron-3-super-120b-a12b)
```

Same pattern for bare `nemoclaw status`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm test` — `src/lib/inventory-commands.test.ts` 14/14 pass (2 rewritten + 5 new + 7 untouched). Full vitest suite had pre-existing failures on my macOS host (e.g. `sha256sum` missing, installer shell-script tests) unrelated to this change; Linux CI should be clean.
- [x] `tsc -p tsconfig.src.json` / `tsconfig.cli.json` / `jsconfig.json` — clean.
- [x] `prettier --write` applied.
- [x] End-to-end reproduction + fix verification on Linux (see above).
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes — the `(onboarded: …)` annotation is a visible output tweak; happy to add a line to `docs/reference/commands.md` if reviewers want.

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

---

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inventory and status views now prefer and display live model/provider info reported by the gateway and show an "(onboarded: ...)" line when values differ.

* **Improvements**
  * Default sandboxes reflect current gateway state; non-default sandboxes keep stored configuration.
  * Handles gateway-unreachable fallback, partial drift (model-only/provider-only), and missing onboarded model shows "(onboarded: unknown)".

* **Tests**
  * Updated tests to cover live-vs-onboarded display, drift annotations, fallbacks, and wording changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->