### PR TITLE
feat(security): externalize gateway auth token from openclaw.json

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -211,8 +211,14 @@ The container mounts system directories read-only to prevent the agent from modi
 
 The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
 The gateway auth token is **not** stored in this directory — it is generated at container startup and passed via the `OPENCLAW_GATEWAY_TOKEN` environment variable only to the gateway process (which runs as the `gateway` user).
-The token is also persisted to `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`) for host-side reads.
-The sandbox user (agent) cannot access the token: the file is owned by a different uid, the env var is only in the gateway process (`/proc/pid/environ` is uid-gated), and `no-new-privileges` prevents escalation.
+
+The token file location depends on the startup mode:
+
+- **Root mode** (production): `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`).
+  The sandbox user cannot read this file (different uid), cannot read the gateway process env (`/proc/pid/environ` is uid-gated), and `no-new-privileges` prevents escalation.
+- **Non-root mode** (dev/fallback): `/tmp/.runtime/nemoclaw/gateway-token` (`sandbox:sandbox 0400`).
+  Without uid separation the sandbox user owns the file, matching the pre-externalization security posture.
+  The token is not exported to the shell env or written to rc files.
 
 The container mounts `.openclaw` read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
 
@@ -222,11 +228,11 @@ Multiple defense layers protect this directory:
 - **Immutable flag.** The entrypoint applies `chattr +i` to the directory and all symlinks, preventing modification even if other controls fail.
 - **Symlink validation.** At startup, the entrypoint verifies every symlink in `.openclaw` points to the expected `.openclaw-data` target. If any symlink points elsewhere, the container refuses to start.
 - **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match.
-- **Externalized gateway token.** The gateway auth token never appears in `openclaw.json`. It is generated at container startup, written to a gateway-user-only file, and passed to the gateway process via an environment variable that only the gateway process can see.
+- **Externalized gateway token.** The gateway auth token never appears in `openclaw.json`. It is generated at container startup, written to a mode-dependent token file, and passed to the gateway process via an environment variable. In root mode, the token file is owned by the `gateway` user and unreadable by the sandbox agent.
 
 | Aspect | Detail |
 |---|---|
-| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is stored separately at `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`). |
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is stored separately: `/run/nemoclaw/gateway-token` in root mode (`gateway:gateway 0400`) or `/tmp/.runtime/nemoclaw/gateway-token` in non-root mode (`sandbox:sandbox 0400`). |
 | What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
 | Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
 | Recommendation | Never make `/sandbox/.openclaw` writable. |

--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -209,8 +209,12 @@ The container mounts system directories read-only to prevent the agent from modi
 
 ### Read-Only `.openclaw` Config
 
-The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration, including auth tokens and CORS settings.
-The container mounts it read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
+The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
+The gateway auth token is **not** stored in this directory — it is generated at container startup and passed via the `OPENCLAW_GATEWAY_TOKEN` environment variable only to the gateway process (which runs as the `gateway` user).
+The token is also persisted to `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`) for host-side reads.
+The sandbox user (agent) cannot access the token: the file is owned by a different uid, the env var is only in the gateway process (`/proc/pid/environ` is uid-gated), and `no-new-privileges` prevents escalation.
+
+The container mounts `.openclaw` read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
 
 Multiple defense layers protect this directory:
 
@@ -218,12 +222,13 @@ Multiple defense layers protect this directory:
 - **Immutable flag.** The entrypoint applies `chattr +i` to the directory and all symlinks, preventing modification even if other controls fail.
 - **Symlink validation.** At startup, the entrypoint verifies every symlink in `.openclaw` points to the expected `.openclaw-data` target. If any symlink points elsewhere, the container refuses to start.
 - **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match.
+- **Externalized gateway token.** The gateway auth token never appears in `openclaw.json`. It is generated at container startup, written to a gateway-user-only file, and passed to the gateway process via an environment variable that only the gateway process can see.
 
 | Aspect | Detail |
 |---|---|
-| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. |
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is stored separately at `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`). |
 | What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
-| Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS, changing auth tokens, or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
+| Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
 | Recommendation | Never make `/sandbox/.openclaw` writable. |
 
 ### Writable Paths

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,11 +221,17 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
 WORKDIR /sandbox
 USER sandbox
 
-# Write the COMPLETE openclaw.json including gateway config and auth token.
+# Write openclaw.json with gateway config but WITHOUT the real auth token.
+# The gateway auth token is generated at container startup by the entrypoint
+# and passed via OPENCLAW_GATEWAY_TOKEN env var only to the gateway process
+# (running as 'gateway' user). The token is also persisted to
+# /run/nemoclaw/gateway-token (gateway:gateway 0400) for host-side reads.
+# The sandbox user (agent) cannot read the env var (/proc/pid/environ is
+# uid-gated) or the file (wrong uid, no-new-privileges blocks escalation).
+# See: scripts/nemoclaw-start.sh generate_gateway_token()
+#
 # This file is immutable at runtime (Landlock read-only on /sandbox/.openclaw).
-# No runtime writes to openclaw.json are needed or possible.
 # Build args (NEMOCLAW_MODEL, CHAT_UI_URL) customize per deployment.
-# Auth token is generated per build so each image has a unique token.
 #
 # Temporary workaround for NemoClaw#1738: the OpenClaw Discord extension's
 # gateway uses `ws` (via @buape/carbon), which ignores HTTPS_PROXY/HTTP_PROXY
@@ -238,7 +244,7 @@ USER sandbox
 # Remove once OpenClaw lands an env-var-honouring fix for the Discord
 # gateway equivalent to openclaw/openclaw#62878 (Slack Socket Mode).
 RUN python3 -c "\
-import base64, json, os, secrets; \
+import base64, json, os; \
 from urllib.parse import urlparse; \
 proxy_url = f\"http://{os.environ['NEMOCLAW_PROXY_HOST']}:{os.environ['NEMOCLAW_PROXY_PORT']}\"; \
 model = os.environ['NEMOCLAW_MODEL']; \
@@ -285,7 +291,7 @@ config = { \
             'allowedOrigins': origins, \
         }, \
         'trustedProxies': ['127.0.0.1', '::1'], \
-        'auth': {'token': secrets.token_hex(32)} \
+        'auth': {'token': ''} \
     } \
 }; \
 config.update({ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,8 +182,9 @@ ARG NEMOCLAW_DISCORD_GUILDS_B64=e30=
 # Set to "1" to disable device-pairing auth (development/headless only).
 # Default: "0" (device auth enabled — secure by default).
 ARG NEMOCLAW_DISABLE_DEVICE_AUTH=0
-# Unique per build to ensure each image gets a fresh auth token.
+# Unique per build to bust Docker cache for config materialization layers.
 # Pass --build-arg NEMOCLAW_BUILD_ID=$(date +%s) to bust the cache.
+# Gateway auth token is generated at container startup by the entrypoint.
 ARG NEMOCLAW_BUILD_ID=default
 # Sandbox egress proxy host/port. Defaults match the OpenShell-injected
 # gateway (10.200.0.1:3128). Operators on non-default networks can override

--- a/Dockerfile
+++ b/Dockerfile
@@ -315,6 +315,17 @@ os.chmod(path, 0o600)"
 RUN openclaw doctor --fix > /dev/null 2>&1 || true \
     && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
+# SECURITY: Clear any gateway auth token that openclaw doctor/plugins may have
+# auto-generated. The real token is created at container startup by the
+# entrypoint (generate_gateway_token) and never stored in openclaw.json.
+RUN python3 -c "\
+import json, os; \
+path = os.path.expanduser('~/.openclaw/openclaw.json'); \
+cfg = json.load(open(path)); \
+cfg.setdefault('gateway', {}).setdefault('auth', {})['token'] = ''; \
+json.dump(cfg, open(path, 'w'), indent=2); \
+os.chmod(path, 0o600)"
+
 # Lock openclaw.json via DAC: chown to root so the sandbox user cannot modify
 # it at runtime.  This works regardless of Landlock enforcement status.
 # The Landlock policy (/sandbox/.openclaw in read_only) provides defense-in-depth

--- a/Dockerfile
+++ b/Dockerfile
@@ -225,9 +225,10 @@ USER sandbox
 # Write openclaw.json with gateway config but WITHOUT the real auth token.
 # The gateway auth token is generated at container startup by the entrypoint
 # and passed via OPENCLAW_GATEWAY_TOKEN env var only to the gateway process
-# (running as 'gateway' user). The token is also persisted to
-# /run/nemoclaw/gateway-token (gateway:gateway 0400) for host-side reads.
-# The sandbox user (agent) cannot read the env var (/proc/pid/environ is
+# (running as 'gateway' user). The token file location depends on startup mode:
+#   Root mode:     /run/nemoclaw/gateway-token (gateway:gateway 0400)
+#   Non-root mode: $XDG_RUNTIME_DIR/nemoclaw/gateway-token (sandbox:sandbox 0400)
+# In root mode the sandbox user cannot read the env var (/proc/pid/environ is
 # uid-gated) or the file (wrong uid, no-new-privileges blocks escalation).
 # See: scripts/nemoclaw-start.sh generate_gateway_token()
 #

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -231,8 +231,14 @@ The container mounts system directories read-only to prevent the agent from modi
 
 The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
 The gateway auth token is **not** stored in this directory — it is generated at container startup and passed via the `OPENCLAW_GATEWAY_TOKEN` environment variable only to the gateway process (which runs as the `gateway` user).
-The token is also persisted to `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`) for host-side reads.
-The sandbox user (agent) cannot access the token: the file is owned by a different uid, the env var is only in the gateway process (`/proc/pid/environ` is uid-gated), and `no-new-privileges` prevents escalation.
+
+The token file location depends on the startup mode:
+
+- **Root mode** (production): `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`).
+  The sandbox user cannot read this file (different uid), cannot read the gateway process env (`/proc/pid/environ` is uid-gated), and `no-new-privileges` prevents escalation.
+- **Non-root mode** (dev/fallback): `/tmp/.runtime/nemoclaw/gateway-token` (`sandbox:sandbox 0400`).
+  Without uid separation the sandbox user owns the file, matching the pre-externalization security posture.
+  The token is not exported to the shell env or written to rc files.
 
 The container mounts `.openclaw` read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
 
@@ -242,11 +248,11 @@ Multiple defense layers protect this directory:
 - **Immutable flag.** The entrypoint applies `chattr +i` to the directory and all symlinks, preventing modification even if other controls fail.
 - **Symlink validation.** At startup, the entrypoint verifies every symlink in `.openclaw` points to the expected `.openclaw-data` target. If any symlink points elsewhere, the container refuses to start.
 - **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match.
-- **Externalized gateway token.** The gateway auth token never appears in `openclaw.json`. It is generated at container startup, written to a gateway-user-only file, and passed to the gateway process via an environment variable that only the gateway process can see.
+- **Externalized gateway token.** The gateway auth token never appears in `openclaw.json`. It is generated at container startup, written to a mode-dependent token file, and passed to the gateway process via an environment variable. In root mode, the token file is owned by the `gateway` user and unreadable by the sandbox agent.
 
 | Aspect | Detail |
 |---|---|
-| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is stored separately at `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`). |
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is stored separately: `/run/nemoclaw/gateway-token` in root mode (`gateway:gateway 0400`) or `/tmp/.runtime/nemoclaw/gateway-token` in non-root mode (`sandbox:sandbox 0400`). |
 | What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
 | Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
 | Recommendation | Never make `/sandbox/.openclaw` writable. |

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -229,8 +229,12 @@ The container mounts system directories read-only to prevent the agent from modi
 
 ### Read-Only `.openclaw` Config
 
-The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration, including auth tokens and CORS settings.
-The container mounts it read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
+The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
+The gateway auth token is **not** stored in this directory — it is generated at container startup and passed via the `OPENCLAW_GATEWAY_TOKEN` environment variable only to the gateway process (which runs as the `gateway` user).
+The token is also persisted to `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`) for host-side reads.
+The sandbox user (agent) cannot access the token: the file is owned by a different uid, the env var is only in the gateway process (`/proc/pid/environ` is uid-gated), and `no-new-privileges` prevents escalation.
+
+The container mounts `.openclaw` read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
 
 Multiple defense layers protect this directory:
 
@@ -238,12 +242,13 @@ Multiple defense layers protect this directory:
 - **Immutable flag.** The entrypoint applies `chattr +i` to the directory and all symlinks, preventing modification even if other controls fail.
 - **Symlink validation.** At startup, the entrypoint verifies every symlink in `.openclaw` points to the expected `.openclaw-data` target. If any symlink points elsewhere, the container refuses to start.
 - **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match.
+- **Externalized gateway token.** The gateway auth token never appears in `openclaw.json`. It is generated at container startup, written to a gateway-user-only file, and passed to the gateway process via an environment variable that only the gateway process can see.
 
 | Aspect | Detail |
 |---|---|
-| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. |
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is stored separately at `/run/nemoclaw/gateway-token` (`gateway:gateway 0400`). |
 | What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
-| Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS, changing auth tokens, or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
+| Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
 | Recommendation | Never make `/sandbox/.openclaw` writable. |
 
 ### Writable Paths

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -983,8 +983,13 @@ if [ "$(id -u)" -ne 0 ]; then
   _NONROOT_GATEWAY_TOKEN="$(python3 -c "import secrets; print(secrets.token_hex(32), end='')")"
   export OPENCLAW_GATEWAY_TOKEN="$_NONROOT_GATEWAY_TOKEN"
   # Write token file so host-side retrieval (openshell sandbox download) works.
-  mkdir -p "$GATEWAY_TOKEN_DIR" 2>/dev/null || true
-  printf '%s' "$_NONROOT_GATEWAY_TOKEN" >"$GATEWAY_TOKEN_FILE" 2>/dev/null || true
+  # Try default location first; if not writable, fall back to user-writable location.
+  if ! mkdir -p "$GATEWAY_TOKEN_DIR" 2>/dev/null; then
+    GATEWAY_TOKEN_DIR="${XDG_RUNTIME_DIR:-/tmp}/nemoclaw"
+    GATEWAY_TOKEN_FILE="${GATEWAY_TOKEN_DIR}/gateway-token"
+    mkdir -p "$GATEWAY_TOKEN_DIR"
+  fi
+  printf '%s' "$_NONROOT_GATEWAY_TOKEN" >"$GATEWAY_TOKEN_FILE"
   printf '[SECURITY] Non-root mode — gateway token generated but not isolated (no privilege separation)\n' >&2
   install_configure_guard
   configure_messaging_channels

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -465,66 +465,47 @@ PYSLACK
   printf '[channels] Config hash recomputed after Slack token override\n' >&2
 }
 
-_read_gateway_token() {
-  python3 - <<'PYTOKEN'
-import json
-try:
-    with open('/sandbox/.openclaw/openclaw.json') as f:
-        cfg = json.load(f)
-    print(cfg.get('gateway', {}).get('auth', {}).get('token', ''))
-except Exception:
-    print('')
-PYTOKEN
+# ── Gateway auth token (externalized) ──────────────────────────
+# The gateway auth token is NOT stored in openclaw.json. It is generated
+# at container startup by generate_gateway_token() and:
+#   1. Written to /run/nemoclaw/gateway-token (gateway:gateway 0400)
+#      for host-side reads via openshell sandbox download.
+#   2. Passed as OPENCLAW_GATEWAY_TOKEN env var only to the gateway
+#      process launch line (gosu gateway ...). OpenClaw reads this
+#      natively via its resolveGatewayCredentialsFromValues() path.
+#
+# The sandbox user (agent) cannot access the token:
+#   - The file is owned by gateway:gateway 0400 (wrong uid).
+#   - The env var is only in the gateway process (/proc/pid/environ
+#     is uid-gated, no-new-privileges blocks escalation).
+#
+# /run is tmpfs — the token file is regenerated on every container start.
+GATEWAY_TOKEN_DIR="/run/nemoclaw"
+GATEWAY_TOKEN_FILE="${GATEWAY_TOKEN_DIR}/gateway-token"
+
+generate_gateway_token() {
+  [ "$(id -u)" -eq 0 ] || {
+    printf '[SECURITY] generate_gateway_token requires root — skipping\n' >&2
+    return 1
+  }
+
+  mkdir -p "$GATEWAY_TOKEN_DIR"
+  chmod 755 "$GATEWAY_TOKEN_DIR"
+
+  python3 -c "import secrets; print(secrets.token_hex(32), end='')" \
+    >"$GATEWAY_TOKEN_FILE"
+
+  chown gateway:gateway "$GATEWAY_TOKEN_FILE"
+  chmod 400 "$GATEWAY_TOKEN_FILE"
+  printf '[token] Gateway auth token generated at %s (gateway:gateway 0400)\n' \
+    "$GATEWAY_TOKEN_FILE" >&2
 }
 
-export_gateway_token() {
-  local token
-  token="$(_read_gateway_token)"
-  local marker_begin="# nemoclaw-gateway-token begin"
-  local marker_end="# nemoclaw-gateway-token end"
-
-  if [ -z "$token" ]; then
-    # Remove any stale marker blocks from rc files so revoked/old tokens
-    # are not re-exported in later interactive sessions.
-    unset OPENCLAW_GATEWAY_TOKEN
-    for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
-      if [ -f "$rc_file" ] && grep -qF "$marker_begin" "$rc_file" 2>/dev/null; then
-        local tmp
-        tmp="$(mktemp)"
-        awk -v b="$marker_begin" -v e="$marker_end" \
-          '$0==b{s=1;next} $0==e{s=0;next} !s' "$rc_file" >"$tmp"
-        cat "$tmp" >"$rc_file"
-        rm -f "$tmp"
-      fi
-    done
-    return
-  fi
-  export OPENCLAW_GATEWAY_TOKEN="$token"
-
-  # Persist to .bashrc/.profile so interactive sessions (openshell sandbox
-  # connect) also see the token — same pattern as the proxy config above.
-  # Shell-escape the token so quotes/dollars/backticks cannot break the
-  # sourced snippet or allow code injection.
-  local escaped_token
-  escaped_token="$(printf '%s' "$token" | sed "s/'/'\\\\''/g")"
-  local snippet
-  snippet="${marker_begin}
-export OPENCLAW_GATEWAY_TOKEN='${escaped_token}'
-${marker_end}"
-
-  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
-    if [ -f "$rc_file" ] && grep -qF "$marker_begin" "$rc_file" 2>/dev/null; then
-      local tmp
-      tmp="$(mktemp)"
-      awk -v b="$marker_begin" -v e="$marker_end" \
-        '$0==b{s=1;next} $0==e{s=0;next} !s' "$rc_file" >"$tmp"
-      printf '%s\n' "$snippet" >>"$tmp"
-      cat "$tmp" >"$rc_file"
-      rm -f "$tmp"
-    elif [ -w "$rc_file" ] || [ -w "$(dirname "$rc_file")" ]; then
-      printf '\n%s\n' "$snippet" >>"$rc_file"
-    fi
-  done
+_read_gateway_token() {
+  # Read the gateway token from the externalized file.
+  # Callable by root (entrypoint) and gateway user only.
+  # Returns the token on stdout; empty output means no token.
+  cat "$GATEWAY_TOKEN_FILE" 2>/dev/null || true
 }
 
 install_configure_guard() {
@@ -614,8 +595,8 @@ GUARD
       printf '\n%s\n' "$snippet" >>"$rc_file"
     fi
   done
-  # Final lock after all rc-file mutations (export_gateway_token + this
-  # function) are complete so Landlock read_only enforcement holds.
+  # Final lock after all rc-file mutations are complete so Landlock
+  # read_only enforcement holds.
   lock_rc_files "$_SANDBOX_HOME"
 }
 
@@ -996,7 +977,9 @@ if [ "$(id -u)" -ne 0 ]; then
   apply_model_override
   apply_cors_override
   apply_slack_token_override
-  export_gateway_token
+  # Non-root: no privilege separation, so we cannot isolate the token from
+  # the sandbox user. OpenClaw will auto-generate a token at gateway startup.
+  printf '[SECURITY] Non-root mode — gateway token not externalized (no privilege separation)\n' >&2
   install_configure_guard
   configure_messaging_channels
   validate_openclaw_symlinks
@@ -1111,7 +1094,7 @@ verify_config_integrity /sandbox/.openclaw
 apply_model_override
 apply_cors_override
 apply_slack_token_override
-export_gateway_token
+generate_gateway_token
 install_configure_guard
 
 # Inject messaging channel config if provider tokens are present.
@@ -1161,7 +1144,10 @@ validate_tmp_permissions "$_PROXY_FIX_SCRIPT"
 # SECURITY: The sandbox user cannot kill this process because it runs
 # under a different UID. The fake-HOME attack no longer works because
 # the agent cannot restart the gateway with a tampered config.
-nohup gosu gateway "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
+# SECURITY: OPENCLAW_GATEWAY_TOKEN is passed only to the gateway process
+# env — the sandbox user cannot read /proc/<pid>/environ (different uid).
+OPENCLAW_GATEWAY_TOKEN="$(_read_gateway_token)" \
+  nohup gosu gateway "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
 GATEWAY_PID=$!
 echo "[gateway] openclaw gateway launched as 'gateway' user (pid $GATEWAY_PID)" >&2
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -977,9 +977,15 @@ if [ "$(id -u)" -ne 0 ]; then
   apply_model_override
   apply_cors_override
   apply_slack_token_override
-  # Non-root: no privilege separation, so we cannot isolate the token from
-  # the sandbox user. OpenClaw will auto-generate a token at gateway startup.
-  printf '[SECURITY] Non-root mode — gateway token not externalized (no privilege separation)\n' >&2
+  # Non-root: no privilege separation — the sandbox user can read the token.
+  # Generate a token anyway so the gateway has valid auth credentials.
+  # Without this, openclaw.json has an empty token and the gateway will fail.
+  _NONROOT_GATEWAY_TOKEN="$(python3 -c "import secrets; print(secrets.token_hex(32), end='')")"
+  export OPENCLAW_GATEWAY_TOKEN="$_NONROOT_GATEWAY_TOKEN"
+  # Write token file so host-side retrieval (openshell sandbox download) works.
+  mkdir -p "$GATEWAY_TOKEN_DIR" 2>/dev/null || true
+  printf '%s' "$_NONROOT_GATEWAY_TOKEN" >"$GATEWAY_TOKEN_FILE" 2>/dev/null || true
+  printf '[SECURITY] Non-root mode — gateway token generated but not isolated (no privilege separation)\n' >&2
   install_configure_guard
   configure_messaging_channels
   validate_openclaw_symlinks

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -467,19 +467,20 @@ PYSLACK
 
 # ── Gateway auth token (externalized) ──────────────────────────
 # The gateway auth token is NOT stored in openclaw.json. It is generated
-# at container startup by generate_gateway_token() and:
-#   1. Written to /run/nemoclaw/gateway-token (gateway:gateway 0400)
-#      for host-side reads via openshell sandbox download.
-#   2. Passed as OPENCLAW_GATEWAY_TOKEN env var only to the gateway
-#      process launch line (gosu gateway ...). OpenClaw reads this
-#      natively via its resolveGatewayCredentialsFromValues() path.
+# at container startup and passed as OPENCLAW_GATEWAY_TOKEN env var only
+# to the gateway process launch line. OpenClaw reads this natively via
+# its resolveGatewayCredentialsFromValues() path.
 #
-# The sandbox user (agent) cannot access the token:
-#   - The file is owned by gateway:gateway 0400 (wrong uid).
-#   - The env var is only in the gateway process (/proc/pid/environ
-#     is uid-gated, no-new-privileges blocks escalation).
+# Token file location depends on startup mode:
+#   Root mode:     /run/nemoclaw/gateway-token (gateway:gateway 0400)
+#                  Host reads via kubectl exec (runs as root in pod).
+#                  Sandbox user cannot access: wrong uid, /proc/pid/environ
+#                  is uid-gated, no-new-privileges blocks escalation.
+#   Non-root mode: $XDG_RUNTIME_DIR/nemoclaw/gateway-token (sandbox:sandbox 0400)
+#                  Host reads via openshell sandbox download (sandbox user).
+#                  No uid isolation — matches pre-externalization posture.
 #
-# /run is tmpfs — the token file is regenerated on every container start.
+# Both paths regenerate the token on every container start.
 GATEWAY_TOKEN_DIR="/run/nemoclaw"
 GATEWAY_TOKEN_FILE="${GATEWAY_TOKEN_DIR}/gateway-token"
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -977,13 +977,19 @@ if [ "$(id -u)" -ne 0 ]; then
   apply_model_override
   apply_cors_override
   apply_slack_token_override
-  # Non-root: no privilege separation, but we still avoid unnecessary exposure.
-  # Generate a token and store it in a script-local variable — do NOT export
-  # it or write it to a file. Pass it only on the gateway launch line so it
-  # lives solely in the gateway process env, not in the sandbox shell env or
-  # the filesystem.
+  # Non-root: no privilege separation — uid separation is unavailable, so the
+  # sandbox user can read the token file. This is no worse than the pre-PR
+  # state where the token lived in openclaw.json (also sandbox-readable).
+  # Write the token to a restrictive file (0400) so it is not world-readable,
+  # and pass it on the gateway launch line (not exported to the shell env).
   _NONROOT_GATEWAY_TOKEN="$(python3 -c "import secrets; print(secrets.token_hex(32), end='')")"
-  printf '[SECURITY] Non-root mode — gateway token generated (process-env only, no file written)\n' >&2
+  _NONROOT_TOKEN_DIR="${XDG_RUNTIME_DIR:-/tmp}/nemoclaw"
+  _NONROOT_TOKEN_FILE="${_NONROOT_TOKEN_DIR}/gateway-token"
+  mkdir -p "$_NONROOT_TOKEN_DIR"
+  rm -f "$_NONROOT_TOKEN_FILE"
+  printf '%s' "$_NONROOT_GATEWAY_TOKEN" >"$_NONROOT_TOKEN_FILE"
+  chmod 0400 "$_NONROOT_TOKEN_FILE"
+  printf '[SECURITY] Non-root mode — gateway token at %s (no uid isolation)\n' "$_NONROOT_TOKEN_FILE" >&2
   install_configure_guard
   configure_messaging_channels
   validate_openclaw_symlinks

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -977,20 +977,13 @@ if [ "$(id -u)" -ne 0 ]; then
   apply_model_override
   apply_cors_override
   apply_slack_token_override
-  # Non-root: no privilege separation — the sandbox user can read the token.
-  # Generate a token anyway so the gateway has valid auth credentials.
-  # Without this, openclaw.json has an empty token and the gateway will fail.
+  # Non-root: no privilege separation, but we still avoid unnecessary exposure.
+  # Generate a token and store it in a script-local variable — do NOT export
+  # it or write it to a file. Pass it only on the gateway launch line so it
+  # lives solely in the gateway process env, not in the sandbox shell env or
+  # the filesystem.
   _NONROOT_GATEWAY_TOKEN="$(python3 -c "import secrets; print(secrets.token_hex(32), end='')")"
-  export OPENCLAW_GATEWAY_TOKEN="$_NONROOT_GATEWAY_TOKEN"
-  # Write token file so host-side retrieval (openshell sandbox download) works.
-  # Try default location first; if not writable, fall back to user-writable location.
-  if ! mkdir -p "$GATEWAY_TOKEN_DIR" 2>/dev/null; then
-    GATEWAY_TOKEN_DIR="${XDG_RUNTIME_DIR:-/tmp}/nemoclaw"
-    GATEWAY_TOKEN_FILE="${GATEWAY_TOKEN_DIR}/gateway-token"
-    mkdir -p "$GATEWAY_TOKEN_DIR"
-  fi
-  printf '%s' "$_NONROOT_GATEWAY_TOKEN" >"$GATEWAY_TOKEN_FILE"
-  printf '[SECURITY] Non-root mode — gateway token generated but not isolated (no privilege separation)\n' >&2
+  printf '[SECURITY] Non-root mode — gateway token generated (process-env only, no file written)\n' >&2
   install_configure_guard
   configure_messaging_channels
   validate_openclaw_symlinks
@@ -1079,8 +1072,11 @@ if [ "$(id -u)" -ne 0 ]; then
   # inject code into any Node process via NODE_OPTIONS).
   validate_tmp_permissions "$_PROXY_FIX_SCRIPT"
 
-  # Start gateway in background, auto-pair, then wait
-  nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
+  # Start gateway in background, auto-pair, then wait.
+  # Pass OPENCLAW_GATEWAY_TOKEN only on this launch line so it lives solely
+  # in the gateway process env — not exported to the sandbox shell.
+  OPENCLAW_GATEWAY_TOKEN="$_NONROOT_GATEWAY_TOKEN" \
+    nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
   GATEWAY_PID=$!
   echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)" >&2
   start_auto_pair

--- a/spark-install.md
+++ b/spark-install.md
@@ -174,7 +174,7 @@ The OpenClaw gateway includes a built-in web UI. Access it at:
 http://127.0.0.1:18789/#token=<your-gateway-token>
 ```
 
-Find your gateway token in `~/.openclaw/openclaw.json` under `gateway.auth.token` inside the sandbox.
+The gateway token is printed by `nemoclaw onboard` at startup. It is stored at `/run/nemoclaw/gateway-token` inside the sandbox (readable only by root and the gateway user).
 
 > **Important**: Use `127.0.0.1` (not `localhost`) — the gateway's origin check requires an exact match. External dashboards like Mission Control cannot currently connect due to the gateway resetting `controlUi.allowedOrigins` on every config reload (see [openclaw#49950](https://github.com/openclaw/openclaw/issues/49950)).
 

--- a/spark-install.md
+++ b/spark-install.md
@@ -174,7 +174,7 @@ The OpenClaw gateway includes a built-in web UI. Access it at:
 http://127.0.0.1:18789/#token=<your-gateway-token>
 ```
 
-The gateway token is printed by `nemoclaw onboard` at startup. It is stored at `/run/nemoclaw/gateway-token` inside the sandbox (readable only by root and the gateway user).
+The gateway token is printed by `nemoclaw onboard` at startup. It is stored at `/run/nemoclaw/gateway-token` (root mode, readable only by root and the gateway user) or `/tmp/.runtime/nemoclaw/gateway-token` (non-root mode).
 
 > **Important**: Use `127.0.0.1` (not `localhost`) — the gateway's origin check requires an exact match. External dashboards like Mission Control cannot currently connect due to the gateway resetting `controlUi.allowedOrigins` on every config reload (see [openclaw#49950](https://github.com/openclaw/openclaw/issues/49950)).
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -10,7 +10,7 @@ const crypto = require("node:crypto");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { spawn, spawnSync } = require("child_process");
+const { execFileSync, spawn, spawnSync } = require("child_process");
 const pRetry = require("p-retry");
 
 /** Parse a numeric env var, returning `fallback` when unset or non-finite. */
@@ -6111,32 +6111,34 @@ function findOpenclawJsonPath(dir) {
 
 /**
  * Pull gateway auth token from the sandbox. The token lives at
- * /run/nemoclaw/gateway-token (not in openclaw.json). Host-side
- * openshell sandbox download runs as root and can read it.
+ * /run/nemoclaw/gateway-token (gateway:gateway 0400). Since
+ * `openshell sandbox download` runs as the sandbox user (uid 998)
+ * and cannot read gateway-owned files, we use kubectl exec (via
+ * the K3s container) which runs as root and can read the file.
  *
- * Falls back to openclaw.json for images that predate this change.
+ * Falls back to sandbox download of openclaw.json for images that
+ * predate this change.
  */
 function fetchGatewayAuthTokenFromSandbox(sandboxName) {
+  // Primary: read the externalized token via kubectl exec (runs as root,
+  // bypasses DAC on gateway:gateway 0400 file). Same pattern as shields.ts.
+  try {
+    const K3S_CONTAINER = "openshell-cluster-nemoclaw";
+    const result = execFileSync("docker", [
+      "exec", K3S_CONTAINER,
+      "kubectl", "exec", "-n", "openshell", sandboxName, "-c", "agent", "--",
+      "cat", "/run/nemoclaw/gateway-token",
+    ], { stdio: ["ignore", "pipe", "pipe"], timeout: 15000 });
+    const token = result.toString().trim();
+    if (token.length > 0) return token;
+  } catch {
+    // kubectl exec not available (e.g., non-K3s environment) — fall through
+  }
+
+  // Fallback: read from openclaw.json via sandbox download (pre-externalization images)
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
   try {
     const destDir = `${tmpDir}${path.sep}`;
-
-    // Primary: externalized token file (gateway:gateway 0400, root can read)
-    const tokenFileResult = runOpenshell(
-      ["sandbox", "download", sandboxName, "/run/nemoclaw/gateway-token", destDir],
-      { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },
-    );
-    if (tokenFileResult.status === 0) {
-      // sandbox download may flatten the file or preserve the directory
-      // structure (run/nemoclaw/gateway-token), so search recursively.
-      const tokenPath = findFileRecursive(tmpDir, "gateway-token");
-      if (tokenPath) {
-        const token = fs.readFileSync(tokenPath, "utf-8").trim();
-        if (token.length > 0) return token;
-      }
-    }
-
-    // Fallback: read from openclaw.json (pre-externalization images)
     const result = runOpenshell(
       ["sandbox", "download", sandboxName, "/sandbox/.openclaw/openclaw.json", destDir],
       { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6095,13 +6095,31 @@ function findOpenclawJsonPath(dir) {
 }
 
 /**
- * Pull gateway.auth.token from the sandbox image via openshell sandbox download
- * so onboard can print copy-paste Control UI URLs with #token= (same idea as nemoclaw-start.sh).
+ * Pull gateway auth token from the sandbox. The token lives at
+ * /run/nemoclaw/gateway-token (not in openclaw.json). Host-side
+ * openshell sandbox download runs as root and can read it.
+ *
+ * Falls back to openclaw.json for images that predate this change.
  */
 function fetchGatewayAuthTokenFromSandbox(sandboxName) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
   try {
     const destDir = `${tmpDir}${path.sep}`;
+
+    // Primary: externalized token file (gateway:gateway 0400, root can read)
+    const tokenFileResult = runOpenshell(
+      ["sandbox", "download", sandboxName, "/run/nemoclaw/gateway-token", destDir],
+      { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },
+    );
+    if (tokenFileResult.status === 0) {
+      const tokenPath = path.join(tmpDir, "gateway-token");
+      if (fs.existsSync(tokenPath)) {
+        const token = fs.readFileSync(tokenPath, "utf-8").trim();
+        if (token.length > 0) return token;
+      }
+    }
+
+    // Fallback: read from openclaw.json (pre-externalization images)
     const result = runOpenshell(
       ["sandbox", "download", sandboxName, "/sandbox/.openclaw/openclaw.json", destDir],
       { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },
@@ -6284,7 +6302,7 @@ function printDashboard(sandboxName, model, provider, nimContainer = null, agent
       console.log(`  ${entry.label}: ${entry.url}`);
     }
     console.log(
-      `  Token:       nemoclaw ${sandboxName} connect  →  jq -r '.gateway.auth.token' /sandbox/.openclaw/openclaw.json`,
+      `  Token:       see /tmp/gateway.log inside the sandbox, or re-run onboard.`,
     );
     console.log(
       `               append  #token=<token>  to the URL, or see /tmp/gateway.log inside the sandbox.`,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6110,18 +6110,20 @@ function findOpenclawJsonPath(dir) {
 }
 
 /**
- * Pull gateway auth token from the sandbox. The token lives at
- * /run/nemoclaw/gateway-token (gateway:gateway 0400). Since
- * `openshell sandbox download` runs as the sandbox user (uid 998)
- * and cannot read gateway-owned files, we use kubectl exec (via
- * the K3s container) which runs as root and can read the file.
+ * Pull gateway auth token from the sandbox.
  *
- * Falls back to sandbox download of openclaw.json for images that
- * predate this change.
+ * Tries three retrieval paths in order:
+ *  1. kubectl exec cat /run/nemoclaw/gateway-token  (root mode — gateway:gateway 0400)
+ *  2. sandbox download /tmp/.runtime/nemoclaw/gateway-token  (non-root mode — sandbox:sandbox 0400)
+ *  3. sandbox download openclaw.json → gateway.auth.token  (pre-externalization images)
+ *
+ * Path 1 uses the same kubectl-via-K3s pattern as shields.ts — it runs as
+ * root inside the pod so it can read gateway-owned files.
+ * Path 2 works because sandbox download runs as the sandbox user, which owns
+ * the non-root token file.
  */
 function fetchGatewayAuthTokenFromSandbox(sandboxName) {
-  // Primary: read the externalized token via kubectl exec (runs as root,
-  // bypasses DAC on gateway:gateway 0400 file). Same pattern as shields.ts.
+  // 1. Root mode: kubectl exec reads gateway:gateway 0400 file (same as shields.ts)
   try {
     const K3S_CONTAINER = "openshell-cluster-nemoclaw";
     const result = execFileSync("docker", [
@@ -6132,13 +6134,27 @@ function fetchGatewayAuthTokenFromSandbox(sandboxName) {
     const token = result.toString().trim();
     if (token.length > 0) return token;
   } catch {
-    // kubectl exec not available (e.g., non-K3s environment) — fall through
+    // kubectl exec not available or file absent — fall through
   }
 
-  // Fallback: read from openclaw.json via sandbox download (pre-externalization images)
+  // 2. Non-root mode: token at $XDG_RUNTIME_DIR/nemoclaw/gateway-token
+  // (sandbox-owned, downloadable via openshell sandbox download)
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
   try {
     const destDir = `${tmpDir}${path.sep}`;
+    const nonRootResult = runOpenshell(
+      ["sandbox", "download", sandboxName, "/tmp/.runtime/nemoclaw/gateway-token", destDir],
+      { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },
+    );
+    if (nonRootResult.status === 0) {
+      const tokenPath = findFileRecursive(tmpDir, "gateway-token");
+      if (tokenPath) {
+        const token = fs.readFileSync(tokenPath, "utf-8").trim();
+        if (token.length > 0) return token;
+      }
+    }
+
+    // 3. Legacy: openclaw.json (pre-externalization images)
     const result = runOpenshell(
       ["sandbox", "download", sandboxName, "/sandbox/.openclaw/openclaw.json", destDir],
       { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6079,6 +6079,21 @@ function ensureDashboardForward(sandboxName, chatUiUrl = `http://127.0.0.1:${CON
   }
 }
 
+function findFileRecursive(dir, filename) {
+  if (!fs.existsSync(dir)) return null;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      const found = findFileRecursive(p, filename);
+      if (found) return found;
+    } else if (e.name === filename) {
+      return p;
+    }
+  }
+  return null;
+}
+
 function findOpenclawJsonPath(dir) {
   if (!fs.existsSync(dir)) return null;
   const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -6112,8 +6127,10 @@ function fetchGatewayAuthTokenFromSandbox(sandboxName) {
       { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },
     );
     if (tokenFileResult.status === 0) {
-      const tokenPath = path.join(tmpDir, "gateway-token");
-      if (fs.existsSync(tokenPath)) {
+      // sandbox download may flatten the file or preserve the directory
+      // structure (run/nemoclaw/gateway-token), so search recursively.
+      const tokenPath = findFileRecursive(tmpDir, "gateway-token");
+      if (tokenPath) {
         const token = fs.readFileSync(tokenPath, "utf-8").trim();
         if (token.length > 0) return token;
       }

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -205,6 +205,81 @@ describe("Dockerfile gateway token externalization", () => {
   });
 });
 
+describe("gateway token security regression tests", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+  const dockerfile = fs.readFileSync(
+    path.join(import.meta.dirname, "..", "Dockerfile"),
+    "utf-8",
+  );
+
+  it("openclaw.json never contains a non-empty gateway auth token at build time", () => {
+    // The Dockerfile must write an empty token, clear after doctor, then pin hash.
+    // At no point should a real token survive into the final image layer.
+    expect(dockerfile).toContain("'auth': {'token': ''}");
+    // Post-doctor clearing step exists
+    expect(dockerfile).toContain("cfg.setdefault('gateway', {}).setdefault('auth', {})['token'] = ''");
+  });
+
+  it("gateway process runs under a distinct uid via gosu in root mode", () => {
+    // The gateway must run as the 'gateway' user, not as sandbox or root.
+    // This ensures /proc/<pid>/environ is uid-gated from the sandbox user.
+    expect(src).toMatch(/gosu gateway.*gateway run/);
+  });
+
+  it("sandbox shell env and rc files never receive the gateway token", () => {
+    // No global export of OPENCLAW_GATEWAY_TOKEN
+    expect(src).not.toMatch(/export OPENCLAW_GATEWAY_TOKEN/);
+    // Old export_gateway_token function must not exist (wrote to .bashrc/.profile)
+    expect(src).not.toMatch(/^export_gateway_token\(\)/m);
+    // No marker blocks for token in rc files
+    expect(src).not.toContain("nemoclaw-gateway-token begin");
+  });
+
+  it("non-root token file uses restrictive permissions (0400)", () => {
+    expect(src).toContain('chmod 0400 "$_NONROOT_TOKEN_FILE"');
+  });
+
+  it("non-root token file is removed before rewrite to prevent stale reads", () => {
+    // rm -f before write prevents reading a stale token from a previous start
+    const rmIdx = src.indexOf('rm -f "$_NONROOT_TOKEN_FILE"');
+    const writeIdx = src.indexOf('printf \'%s\' "$_NONROOT_GATEWAY_TOKEN" >"$_NONROOT_TOKEN_FILE"');
+    expect(rmIdx).toBeGreaterThan(-1);
+    expect(writeIdx).toBeGreaterThan(-1);
+    expect(writeIdx).toBeGreaterThan(rmIdx);
+  });
+
+  it("host-side token retrieval tries three paths in the correct order", () => {
+    const onboardSrc = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+    const fn = onboardSrc.match(
+      /function fetchGatewayAuthTokenFromSandbox[\s\S]*?^}/m,
+    );
+    expect(fn).toBeTruthy();
+    const body = fn[0];
+    // Path 1: kubectl exec for root-mode token
+    const kubectlIdx = body.indexOf("/run/nemoclaw/gateway-token");
+    // Path 2: sandbox download for non-root token
+    const nonRootIdx = body.indexOf("/tmp/.runtime/nemoclaw/gateway-token");
+    // Path 3: legacy openclaw.json fallback
+    const legacyIdx = body.indexOf("openclaw.json");
+    expect(kubectlIdx).toBeGreaterThan(-1);
+    expect(nonRootIdx).toBeGreaterThan(-1);
+    expect(legacyIdx).toBeGreaterThan(-1);
+    // Correct order: kubectl → non-root download → legacy
+    expect(nonRootIdx).toBeGreaterThan(kubectlIdx);
+    expect(legacyIdx).toBeGreaterThan(nonRootIdx);
+  });
+
+  it("entrypoint documents both root and non-root token paths", () => {
+    // Root mode path documented
+    expect(src).toContain("Root mode:     /run/nemoclaw/gateway-token");
+    // Non-root mode path documented
+    expect(src).toContain("Non-root mode: $XDG_RUNTIME_DIR/nemoclaw/gateway-token");
+  });
+});
+
 describe("nemoclaw-start configure guard (#1114)", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -162,17 +162,15 @@ describe("nemoclaw-start externalized gateway token", () => {
     expect(src).toContain('OPENCLAW_GATEWAY_TOKEN="$_NONROOT_GATEWAY_TOKEN"');
   });
 
-  it("does not export token or write token file in non-root mode", () => {
-    // Token must NOT be globally exported to sandbox shell env
+  it("writes non-root token file with restrictive permissions", () => {
+    // Non-root token file uses XDG_RUNTIME_DIR, not /run
+    expect(src).toContain('_NONROOT_TOKEN_DIR="${XDG_RUNTIME_DIR:-/tmp}/nemoclaw"');
+    // File must be locked down to 0400
+    expect(src).toContain('chmod 0400 "$_NONROOT_TOKEN_FILE"');
+  });
+
+  it("does not export token to sandbox shell env", () => {
     expect(src).not.toMatch(/export OPENCLAW_GATEWAY_TOKEN/);
-    // The non-root path must not write to GATEWAY_TOKEN_FILE (prevents
-    // filesystem leak via XDG_RUNTIME_DIR fallback)
-    const nonRootTokenGen = src.indexOf("_NONROOT_GATEWAY_TOKEN");
-    const rootGenerateCall = src.indexOf("generate_gateway_token\n");
-    // Between the non-root token gen and the root path, there should be
-    // no reference to GATEWAY_TOKEN_FILE
-    const nonRootSection = src.slice(nonRootTokenGen, rootGenerateCall);
-    expect(nonRootSection).not.toContain("GATEWAY_TOKEN_FILE");
   });
 });
 

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -157,6 +157,37 @@ describe("nemoclaw-start externalized gateway token", () => {
   });
 });
 
+describe("Dockerfile gateway token externalization", () => {
+  const dockerfile = fs.readFileSync(
+    path.join(import.meta.dirname, "..", "Dockerfile"),
+    "utf-8",
+  );
+
+  it("writes empty token in initial openclaw.json config", () => {
+    expect(dockerfile).toContain("'auth': {'token': ''}");
+  });
+
+  it("clears any auto-generated token after openclaw doctor/plugins", () => {
+    // openclaw doctor --fix may auto-generate a gateway token when it finds
+    // an empty one. A post-doctor step must re-clear it so the token is never
+    // baked into the image. Verify the clearing step comes AFTER doctor.
+    const doctorIdx = dockerfile.indexOf("openclaw doctor --fix");
+    const clearIdx = dockerfile.indexOf("cfg.setdefault('gateway', {}).setdefault('auth', {})['token'] = ''");
+    expect(doctorIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeGreaterThan(doctorIdx);
+  });
+
+  it("pins config hash after token is cleared", () => {
+    const clearIdx = dockerfile.indexOf("['token'] = ''");
+    const hashIdx = dockerfile.indexOf("sha256sum /sandbox/.openclaw/openclaw.json");
+    // Both must exist and hash must come after the clear step
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(hashIdx).toBeGreaterThan(-1);
+    expect(hashIdx).toBeGreaterThan(clearIdx);
+  });
+});
+
 describe("nemoclaw-start configure guard (#1114)", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -155,6 +155,19 @@ describe("nemoclaw-start externalized gateway token", () => {
     );
     expect(rootBlock).toBeTruthy();
   });
+
+  it("generates a token in non-root mode for gateway auth", () => {
+    const nonRootBlock = src.match(
+      /if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)^fi$/m,
+    );
+    expect(nonRootBlock).toBeTruthy();
+    const body = nonRootBlock[1];
+    // Non-root path must generate a token so the gateway has valid auth
+    expect(body).toContain("secrets.token_hex(32)");
+    expect(body).toContain("OPENCLAW_GATEWAY_TOKEN");
+    // Must also write token file for host-side retrieval
+    expect(body).toContain("GATEWAY_TOKEN_FILE");
+  });
 });
 
 describe("Dockerfile gateway token externalization", () => {

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -157,16 +157,22 @@ describe("nemoclaw-start externalized gateway token", () => {
   });
 
   it("generates a token in non-root mode for gateway auth", () => {
-    const nonRootBlock = src.match(
-      /if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)^fi$/m,
-    );
-    expect(nonRootBlock).toBeTruthy();
-    const body = nonRootBlock[1];
-    // Non-root path must generate a token so the gateway has valid auth
-    expect(body).toContain("secrets.token_hex(32)");
-    expect(body).toContain("OPENCLAW_GATEWAY_TOKEN");
-    // Must also write token file for host-side retrieval
-    expect(body).toContain("GATEWAY_TOKEN_FILE");
+    // The non-root path generates a token for the gateway
+    expect(src).toContain("_NONROOT_GATEWAY_TOKEN");
+    expect(src).toContain('OPENCLAW_GATEWAY_TOKEN="$_NONROOT_GATEWAY_TOKEN"');
+  });
+
+  it("does not export token or write token file in non-root mode", () => {
+    // Token must NOT be globally exported to sandbox shell env
+    expect(src).not.toMatch(/export OPENCLAW_GATEWAY_TOKEN/);
+    // The non-root path must not write to GATEWAY_TOKEN_FILE (prevents
+    // filesystem leak via XDG_RUNTIME_DIR fallback)
+    const nonRootTokenGen = src.indexOf("_NONROOT_GATEWAY_TOKEN");
+    const rootGenerateCall = src.indexOf("generate_gateway_token\n");
+    // Between the non-root token gen and the root path, there should be
+    // no reference to GATEWAY_TOKEN_FILE
+    const nonRootSection = src.slice(nonRootTokenGen, rootGenerateCall);
+    expect(nonRootSection).not.toContain("GATEWAY_TOKEN_FILE");
   });
 });
 

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -99,13 +99,6 @@ describe("nemoclaw-start _SANDBOX_HOME variable (#1609)", () => {
     }
   });
 
-  it("uses _SANDBOX_HOME for rc file paths in export_gateway_token", () => {
-    const exportFn = src.match(/export_gateway_token\(\) \{([\s\S]*?)^\}/m);
-    expect(exportFn).toBeTruthy();
-    expect(exportFn[1]).toContain("${_SANDBOX_HOME}/.bashrc");
-    expect(exportFn[1]).toContain("${_SANDBOX_HOME}/.profile");
-  });
-
   it("uses _SANDBOX_HOME for rc file paths in install_configure_guard", () => {
     const guardFn = src.match(
       /install_configure_guard\(\) \{([\s\S]*?)^validate_openclaw_symlinks/m,
@@ -116,50 +109,51 @@ describe("nemoclaw-start _SANDBOX_HOME variable (#1609)", () => {
   });
 });
 
-describe("nemoclaw-start gateway token export (#1114)", () => {
+describe("nemoclaw-start externalized gateway token", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 
-  it("defines _read_gateway_token helper used by both export and dashboard", () => {
-    expect(src).toMatch(/_read_gateway_token\(\) \{/);
-    // export_gateway_token calls the helper
-    expect(src).toMatch(/token="\$\(_read_gateway_token\)"/);
-    // print_dashboard_urls also calls the helper
+  it("defines generate_gateway_token that writes to GATEWAY_TOKEN_FILE", () => {
+    const fn = src.match(/generate_gateway_token\(\) \{([\s\S]*?)^\}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("GATEWAY_TOKEN_FILE");
+    expect(fn[1]).toContain("secrets.token_hex(32)");
+    expect(fn[1]).toContain("chown gateway:gateway");
+    expect(fn[1]).toContain("chmod 400");
+  });
+
+  it("defines GATEWAY_TOKEN_FILE at /run/nemoclaw/gateway-token", () => {
+    expect(src).toContain('GATEWAY_TOKEN_FILE="${GATEWAY_TOKEN_DIR}/gateway-token"');
+    expect(src).toContain('GATEWAY_TOKEN_DIR="/run/nemoclaw"');
+  });
+
+  it("defines _read_gateway_token that reads from the token file", () => {
+    const fn = src.match(/_read_gateway_token\(\) \{([\s\S]*?)^\}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("GATEWAY_TOKEN_FILE");
+  });
+
+  it("passes OPENCLAW_GATEWAY_TOKEN env var only on gateway launch line", () => {
+    expect(src).toMatch(
+      /OPENCLAW_GATEWAY_TOKEN="\$\(_read_gateway_token\)"[\s\\]*\n\s*nohup gosu gateway/,
+    );
+  });
+
+  it("does not export token to sandbox user shell env", () => {
+    // export_gateway_token must not exist — token must never reach .bashrc
+    expect(src).not.toMatch(/^export_gateway_token\(\)/m);
+  });
+
+  it("print_dashboard_urls uses _read_gateway_token", () => {
     const dashboardFn = src.match(/print_dashboard_urls\(\) \{([\s\S]*?)^\}/m);
     expect(dashboardFn).toBeTruthy();
     expect(dashboardFn[1]).toContain("_read_gateway_token");
   });
 
-  it("uses with-open context manager in the Python snippet", () => {
-    const helperFn = src.match(/_read_gateway_token\(\) \{([\s\S]*?)^\}/m);
-    expect(helperFn).toBeTruthy();
-    expect(helperFn[1]).toContain("with open(");
-  });
-
-  it("unsets stale OPENCLAW_GATEWAY_TOKEN when token is empty", () => {
-    const exportFn = src.match(/export_gateway_token\(\) \{([\s\S]*?)^\}/m);
-    expect(exportFn).toBeTruthy();
-    const body = exportFn[1];
-    // Must unset before returning on empty token
-    const unsetPos = body.indexOf("unset OPENCLAW_GATEWAY_TOKEN");
-    const returnPos = body.indexOf("return");
-    expect(unsetPos).toBeGreaterThan(-1);
-    expect(returnPos).toBeGreaterThan(-1);
-    expect(unsetPos).toBeLessThan(returnPos);
-  });
-
-  it("shell-escapes the token before embedding in rc snippet", () => {
-    const exportFn = src.match(/export_gateway_token\(\) \{([\s\S]*?)^\}/m);
-    expect(exportFn).toBeTruthy();
-    const body = exportFn[1];
-    // Must use single quotes around the escaped token value
-    expect(body).toContain("escaped_token");
-    expect(body).toMatch(/export OPENCLAW_GATEWAY_TOKEN='\$\{escaped_token\}'/);
-  });
-
-  it("calls export_gateway_token in both root and non-root paths", () => {
-    const calls = src.match(/export_gateway_token/g) || [];
-    // definition + 2 call sites
-    expect(calls.length).toBeGreaterThanOrEqual(3);
+  it("calls generate_gateway_token in root path", () => {
+    const rootBlock = src.match(
+      /# ── Root path[\s\S]*?generate_gateway_token/,
+    );
+    expect(rootBlock).toBeTruthy();
   });
 });
 
@@ -304,12 +298,12 @@ describe("runtime model override (#759)", () => {
     const nonRootBlock = src.match(/if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)# ── Root path/);
     expect(nonRootBlock).toBeTruthy();
     expect(nonRootBlock[1]).toMatch(
-      /verify_config_integrity[\s\S]*?apply_model_override[\s\S]*?export_gateway_token/,
+      /verify_config_integrity[\s\S]*?apply_model_override/,
     );
 
-    // Root path: verify_config_integrity → apply_model_override → apply_cors_override
+    // Root path: verify_config_integrity → apply_model_override → apply_cors_override → generate_gateway_token
     const rootBlock = src.match(
-      /# ── Root path[\s\S]*?verify_config_integrity[\s\S]*?apply_model_override[\s\S]*?apply_cors_override[\s\S]*?export_gateway_token/,
+      /# ── Root path[\s\S]*?verify_config_integrity[\s\S]*?apply_model_override[\s\S]*?apply_cors_override[\s\S]*?generate_gateway_token/,
     );
     expect(rootBlock).toBeTruthy();
   });
@@ -426,11 +420,11 @@ describe("runtime CORS origin override (#719)", () => {
     const nonRootBlock = src.match(/if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)# ── Root path/);
     expect(nonRootBlock).toBeTruthy();
     expect(nonRootBlock[1]).toMatch(
-      /apply_model_override[\s\S]*?apply_cors_override[\s\S]*?apply_slack_token_override[\s\S]*?export_gateway_token/,
+      /apply_model_override[\s\S]*?apply_cors_override[\s\S]*?apply_slack_token_override/,
     );
 
     const rootBlock = src.match(
-      /# ── Root path[\s\S]*?apply_model_override\n\s*apply_cors_override\n\s*apply_slack_token_override\n\s*export_gateway_token/,
+      /# ── Root path[\s\S]*?apply_model_override\n\s*apply_cors_override\n\s*apply_slack_token_override\n\s*generate_gateway_token/,
     );
     expect(rootBlock).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

Move the gateway auth token out of `openclaw.json` (readable by the sandbox agent) and generate it at container startup instead. The token is now written to a runtime file and passed via `OPENCLAW_GATEWAY_TOKEN` env var only to the gateway process.

**Root mode (full privilege separation):** The token is written to `/run/nemoclaw/gateway-token` owned by `gateway:gateway 0400`. The sandbox user cannot access it: the file is owned by a different uid, the env var is only in the gateway process (`/proc/pid/environ` is uid-gated), and `no-new-privileges` prevents escalation.

**Non-root mode (privilege separation disabled):** The token is written to `/tmp/.runtime/nemoclaw/gateway-token` owned by `sandbox:sandbox`. Because privilege separation is not available in this mode, the sandbox user can read the token file directly. This is a known limitation consistent with the existing non-root security posture — other trust-boundary files in `/tmp` have the same caveat (see `sandbox-init.sh` trust boundary map). The improvement in non-root mode is that the token no longer appears in `openclaw.json`, shell rc files, or the process environment.

## Changes

- **Dockerfile**: Build `openclaw.json` with an empty auth token placeholder; remove `secrets` import
- **scripts/nemoclaw-start.sh**: Replace `export_gateway_token()` (which wrote tokens into `.bashrc`/`.profile`) with `generate_gateway_token()` that writes to `/run/nemoclaw/gateway-token` and pass token via env var only to the gateway process launch line
- **src/lib/onboard.ts**: `fetchGatewayAuthTokenFromSandbox()` now reads from `/run/nemoclaw/gateway-token` first, falls back to `openclaw.json` for pre-externalization images; update dashboard token guidance
- **src/nemoclaw.ts**: Remove `MIN_LOGS_OPENSHELL_VERSION` gating and `printOldLogsCompatibilityGuidance()`; simplify `sandboxLogs()`
- **docs/security/best-practices.md**: Document the externalized token architecture and update risk descriptions
- **spark-install.md**: Update token location guidance
- **test/cli.test.ts**, **test/nemoclaw-start.test.ts**: Update tests for new token flow

Also includes unrelated changes already merged to main:
- ci(nightly-e2e): replace per-job failure check with wildcard `contains()`
- refactor(e2e): centralize timeout/gtimeout handling into `e2e-timeout.sh`
- fix: stream sandbox logs via tail
- chore(deps): bump setup-uv, setup-qemu-action
- fix(e2e): make nightly teardown reliable
- fix(dockerfile): drop invalid `channels.defaults.configWrites`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes (branch-modified tests: 127/127 pass)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>