### PR TITLE
ci(nightly-e2e): scope concurrency group by event and branch

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -44,7 +44,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: nightly-e2e
+  group: nightly-e2e-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.ref || 'schedule' }}
   cancel-in-progress: true
 
 jobs:
@@ -664,7 +664,7 @@ jobs:
   notify-on-failure:
     runs-on: ubuntu-latest
     needs: [cloud-e2e, cloud-experimental-e2e, messaging-providers-e2e, token-rotation-e2e, sandbox-survival-e2e, hermes-e2e, skip-permissions-e2e, sandbox-operations-e2e, inference-routing-e2e, network-policy-e2e, deployment-services-e2e, diagnostics-e2e, snapshot-commands-e2e, shields-config-e2e, rebuild-openclaw-e2e, upgrade-stale-sandbox-e2e, rebuild-hermes-e2e, gpu-e2e]
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
     permissions:
       issues: write
     steps:
@@ -674,6 +674,14 @@ jobs:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const title = 'Nightly E2E failed';
+
+            const needs = ${{ toJSON(needs) }};
+            const failed = Object.entries(needs).filter(([, v]) => v.result === 'failure').map(([k]) => k);
+            const cancelled = Object.entries(needs).filter(([, v]) => v.result === 'cancelled').map(([k]) => k);
+            const summary = [
+              failed.length ? `**Failed:** ${failed.join(', ')}` : '',
+              cancelled.length ? `**Cancelled:** ${cancelled.join(', ')}` : '',
+            ].filter(Boolean).join('\n');
 
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -689,14 +697,14 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: match.number,
-                body: `Failed again on ${new Date().toISOString().split('T')[0]}.\n\n**Run:** ${runUrl}\n**Artifacts:** Check the run artifacts for install/test logs (artifact names vary by job).`,
+                body: `Failed again on ${new Date().toISOString().split('T')[0]}.\n\n**Run:** ${runUrl}\n${summary}\n**Artifacts:** Check the run artifacts for install/test logs (artifact names vary by job).`,
               });
             } else {
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: `${title} — ${new Date().toISOString().split('T')[0]}`,
-                body: `The nightly E2E pipeline failed.\n\n**Run:** ${runUrl}\n**Artifacts:** Check the run artifacts for install/test logs (artifact names vary by job).`,
+                body: `The nightly E2E pipeline failed.\n\n**Run:** ${runUrl}\n${summary}\n**Artifacts:** Check the run artifacts for install/test logs (artifact names vary by job).`,
                 labels: ['bug', 'CI/CD'],
               });
             }


### PR DESCRIPTION
## Summary

The nightly-e2e workflow used a flat concurrency group (`nightly-e2e`) that let `workflow_dispatch` runs cancel the scheduled nightly cron and vice versa. The last two consecutive nightly cron runs (Apr 22–23) were both cancelled by dispatch runs on `fix/slack-auth-crash-2340`, leaving no nightly data since Apr 21.

## Related Issue

Fixes #2375

## Changes

- **Scope concurrency group by event and branch** — scheduled cron runs get their own group (`nightly-e2e-schedule-schedule`) while dispatch runs are scoped per-branch (`nightly-e2e-workflow_dispatch-refs/heads/<branch>`). Dispatch runs on different branches no longer interfere with each other or the cron.
- **Extend `notify-on-failure` to fire on cancelled jobs** — the `if` condition now includes `contains(needs.*.result, 'cancelled')` as defense-in-depth. If a run is ever cancelled unexpectedly, the team gets notified.
- **Richer notification body** — the GitHub issue/comment now lists which jobs failed vs cancelled for faster triage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

> **Testing note:** This is a CI workflow YAML change — no unit/E2E tests apply. Verification requires a manual `workflow_dispatch` run on this branch to confirm the expression parses and the concurrency group resolves correctly. Full validation happens after merge when the next nightly cron runs uninterrupted.

## AI Disclosure

- [x] AI-assisted — tool: pi (Claude)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded nightly test failure notifications to include cancelled job reporting with detailed categorization.
  * Adjusted workflow concurrency configuration for improved job isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->