### PR TITLE
fix(inference): inject force_nonempty_content for Nemotron models

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -908,6 +908,134 @@ HTTP_PROXY_FIX_EOF
   export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_PROXY_FIX_SCRIPT"
 fi
 
+# Nemotron inference parameter injection (NemoClaw#1193, NemoClaw#2051).
+# Nemotron models may return empty content (tool call instead of text) or
+# thinking-only blocks (stalls the conversation) when the model's chat
+# template produces an empty assistant turn. The vLLM / NIM chat template
+# kwarg `force_nonempty_content` prevents this by ensuring the template
+# always emits a non-empty content field.
+#
+# The preload wraps http.request() — the lowest common denominator every
+# HTTP client bottoms out at — buffers the JSON body for POST requests
+# to /v1/chat/completions, and injects the kwarg when the model ID
+# contains "nemotron". Backends that do not recognise the extra field
+# silently ignore it (OpenAI-compatible contract).
+#
+# Scoped strictly to Nemotron models: non-Nemotron requests pass through
+# completely untouched.
+_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"
+emit_sandbox_sourced_file "$_NEMOTRON_FIX_SCRIPT" <<'NEMOTRON_FIX_EOF'
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// nemotron-inference-fix.js — inject chat_template_kwargs for Nemotron models.
+//
+// Problem (NemoClaw#1193, NemoClaw#2051):
+//   Nemotron models sometimes generate tool calls instead of text for simple
+//   queries, or return thinking-only blocks with stopReason "stop" that
+//   OpenClaw treats as end-of-turn, causing the conversation to stall.
+//   The root cause is the model's chat template producing empty assistant
+//   content when tool definitions are present.
+//
+// Fix:
+//   Inject `chat_template_kwargs: { force_nonempty_content: true }` into
+//   /v1/chat/completions request bodies when the model ID contains
+//   "nemotron". This tells the vLLM/NIM serving layer to force the chat
+//   template to always produce non-empty content alongside any tool calls
+//   or thinking blocks.
+//
+//   Scoped strictly to Nemotron models — all other requests pass through
+//   untouched. Backends that do not support chat_template_kwargs silently
+//   ignore the extra field per the OpenAI-compatible API contract.
+
+(function () {
+  'use strict';
+
+  var http = require('http');
+  var https = require('https');
+
+  var NEMOTRON_RE = /nemotron/i;
+  var COMPLETIONS_RE = /\/v1\/chat\/completions/;
+
+  function wrapModule(mod) {
+    var origRequest = mod.request;
+
+    mod.request = function (options, callback) {
+      // Only intercept object-form calls with a recognisable path.
+      if (typeof options === 'string' || !options) {
+        return origRequest.apply(mod, arguments);
+      }
+
+      var path = options.path || '';
+      if (options.method !== 'POST' || !COMPLETIONS_RE.test(path)) {
+        return origRequest.apply(mod, arguments);
+      }
+
+      // Create the real request, then intercept write/end to buffer the body.
+      var req = origRequest.apply(mod, arguments);
+      var origWrite = req.write;
+      var origEnd = req.end;
+      var chunks = [];
+      var intercepted = false;
+
+      req.write = function (chunk, encoding, cb) {
+        if (chunk != null) {
+          chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk);
+        }
+        // Buffer instead of sending — we flush in end().
+        if (typeof encoding === 'function') { encoding(); }
+        else if (typeof cb === 'function') { cb(); }
+        return true;
+      };
+
+      req.end = function (chunk, encoding, cb) {
+        if (chunk != null && typeof chunk !== 'function') {
+          chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk);
+        }
+        // Resolve the callback argument (end has multiple overload signatures).
+        var endCb = typeof chunk === 'function' ? chunk
+          : typeof encoding === 'function' ? encoding
+          : typeof cb === 'function' ? cb
+          : null;
+
+        var raw = Buffer.concat(chunks);
+        try {
+          var body = JSON.parse(raw.toString('utf-8'));
+          if (body && body.model && NEMOTRON_RE.test(body.model)) {
+            if (!body.chat_template_kwargs) {
+              body.chat_template_kwargs = {};
+            }
+            body.chat_template_kwargs.force_nonempty_content = true;
+            intercepted = true;
+            var modified = Buffer.from(JSON.stringify(body), 'utf-8');
+            // Update Content-Length so the proxy/server reads the full body.
+            if (req.getHeader && req.setHeader) {
+              req.removeHeader('content-length');
+              req.setHeader('Content-Length', modified.length);
+            }
+            origWrite.call(req, modified);
+          } else {
+            // Not a Nemotron model — send original bytes unmodified.
+            origWrite.call(req, raw);
+          }
+        } catch (_e) {
+          // JSON parse failed — forward original bytes.
+          origWrite.call(req, raw);
+        }
+
+        return endCb ? origEnd.call(req, endCb) : origEnd.call(req);
+      };
+
+      return req;
+    };
+  }
+
+  wrapModule(http);
+  wrapModule(https);
+})();
+NEMOTRON_FIX_EOF
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCRIPT"
+
 # WebSocket CONNECT tunnel fix (NemoClaw#1570).
 # The `ws` library calls https.request() for wss:// WebSocket upgrades.
 # EnvHttpProxyAgent (NODE_USE_ENV_PROXY=1) sends a forward proxy request
@@ -960,6 +1088,8 @@ PROXYEOF
   if [ -f "$_WS_FIX_SCRIPT" ]; then
     echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_WS_FIX_SCRIPT\""
   fi
+  # Nemotron inference fix for connect sessions. (NemoClaw#1193, #2051)
+  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCRIPT\""
   # Tool cache redirects — generated from _TOOL_REDIRECTS (single source of truth)
   echo '# Tool cache redirects — /sandbox is Landlock read-only (#804)'
   for _redir in "${_TOOL_REDIRECTS[@]}"; do
@@ -1083,7 +1213,7 @@ if [ "$(id -u)" -ne 0 ]; then
   # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
   # (both are trust-boundary files; tampering would let the sandbox user
   # inject code into any Node process via NODE_OPTIONS).
-  validate_tmp_permissions "$_PROXY_FIX_SCRIPT"
+  validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT"
 
   # Start gateway in background, auto-pair, then wait
   nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
@@ -1155,7 +1285,7 @@ harden_openclaw_symlinks
 # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
 # (both are trust-boundary files; tampering would let the sandbox user
 # inject code into any Node process via NODE_OPTIONS).
-validate_tmp_permissions "$_PROXY_FIX_SCRIPT"
+validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT"
 
 # Start the gateway as the 'gateway' user.
 # SECURITY: The sandbox user cannot kill this process because it runs

--- a/test/nemotron-inference-fix.test.ts
+++ b/test/nemotron-inference-fix.test.ts
@@ -1,0 +1,105 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+
+const START_SCRIPT = path.join(import.meta.dirname, "..", "scripts", "nemoclaw-start.sh");
+
+describe("Nemotron inference fix preload (#1193, #2051)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("defines _NEMOTRON_FIX_SCRIPT path variable", () => {
+    expect(src).toContain('_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"');
+  });
+
+  it("embeds the fix via a NEMOTRON_FIX_EOF heredoc", () => {
+    expect(src).toMatch(
+      /emit_sandbox_sourced_file\s+"\$_NEMOTRON_FIX_SCRIPT"\s+<<'NEMOTRON_FIX_EOF'/,
+    );
+    expect(src).toMatch(/^NEMOTRON_FIX_EOF$/m);
+  });
+
+  it("registers the preload in NODE_OPTIONS", () => {
+    expect(src).toContain(
+      'export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCRIPT"',
+    );
+  });
+
+  it("includes the preload in the proxy-env sourced file for connect sessions", () => {
+    expect(src).toMatch(/# Nemotron inference fix for connect sessions/);
+    expect(src).toContain("--require $_NEMOTRON_FIX_SCRIPT");
+  });
+
+  it("passes the preload path to validate_tmp_permissions in both root and non-root branches", () => {
+    const calls =
+      src.match(/validate_tmp_permissions\s+"[^"]*"\s+"\$_NEMOTRON_FIX_SCRIPT"/g) || [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("preload wraps both http and https modules", () => {
+    const heredoc = src.match(/<<'NEMOTRON_FIX_EOF'\n([\s\S]*?)\nNEMOTRON_FIX_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    expect(script).toContain("wrapModule(http)");
+    expect(script).toContain("wrapModule(https)");
+  });
+
+  it("preload only intercepts POST requests to /v1/chat/completions", () => {
+    const heredoc = src.match(/<<'NEMOTRON_FIX_EOF'\n([\s\S]*?)\nNEMOTRON_FIX_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    expect(script).toContain("options.method !== 'POST'");
+    expect(script).toContain("/v1/chat/completions");
+  });
+
+  it("preload matches Nemotron models case-insensitively", () => {
+    const heredoc = src.match(/<<'NEMOTRON_FIX_EOF'\n([\s\S]*?)\nNEMOTRON_FIX_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    expect(script).toMatch(/nemotron\/i/);
+  });
+
+  it("preload injects force_nonempty_content into chat_template_kwargs", () => {
+    const heredoc = src.match(/<<'NEMOTRON_FIX_EOF'\n([\s\S]*?)\nNEMOTRON_FIX_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    expect(script).toContain("chat_template_kwargs");
+    expect(script).toContain("force_nonempty_content");
+  });
+
+  it("preload passes through non-Nemotron models unmodified", () => {
+    const heredoc = src.match(/<<'NEMOTRON_FIX_EOF'\n([\s\S]*?)\nNEMOTRON_FIX_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    // The else branch sends original bytes
+    expect(script).toContain("origWrite.call(req, raw)");
+  });
+
+  it("preload falls back gracefully on JSON parse failure", () => {
+    const heredoc = src.match(/<<'NEMOTRON_FIX_EOF'\n([\s\S]*?)\nNEMOTRON_FIX_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    expect(script).toMatch(/catch\s*\(_e\)/);
+    // Must forward original bytes on error, not crash
+    expect(script).toMatch(/catch[\s\S]*?origWrite\.call\(req, raw\)/);
+  });
+
+  it("preload updates Content-Length header after body modification", () => {
+    const heredoc = src.match(/<<'NEMOTRON_FIX_EOF'\n([\s\S]*?)\nNEMOTRON_FIX_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    expect(script).toContain("removeHeader('content-length')");
+    expect(script).toContain("setHeader('Content-Length'");
+  });
+
+  it("preload is placed before the WebSocket fix in the script", () => {
+    const nemotronPos = src.indexOf("_NEMOTRON_FIX_SCRIPT=");
+    const wsPos = src.indexOf("_WS_FIX_SCRIPT=");
+    expect(nemotronPos).toBeGreaterThan(-1);
+    expect(wsPos).toBeGreaterThan(-1);
+    expect(nemotronPos).toBeLessThan(wsPos);
+  });
+});

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -620,6 +620,7 @@ describe("service environment", () => {
           "_TOOL_REDIRECTS=()",
           `_PROXY_FIX_SCRIPT="${fakeFixPath}"`,
           `_WS_FIX_SCRIPT="/nonexistent/ws-proxy-fix.js"`,
+          `_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"`,
           "set +u  # array expansion safe on macOS bash",
           persistBlock
             .trimEnd()
@@ -671,6 +672,7 @@ describe("service environment", () => {
           "_TOOL_REDIRECTS=()",
           `_PROXY_FIX_SCRIPT="/tmp/nemoclaw-http-proxy-fix.js"`,
           `_WS_FIX_SCRIPT="/nonexistent/ws-proxy-fix.js"`,
+          `_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"`,
           "set +u  # array expansion safe on macOS bash",
           persistBlock
             .trimEnd()
@@ -680,11 +682,12 @@ describe("service environment", () => {
         execFileSync("bash", [tmpFile], { encoding: "utf-8" });
 
         const envFile = readFileSync(join(fakeDataDir, "proxy-env.sh"), "utf-8");
-        // NODE_OPTIONS preload should NOT be injected when NODE_USE_ENV_PROXY is not 1
-        // and ws fix script does not exist
-        expect(envFile).not.toContain("--require");
+        // Proxy and ws fix preloads should NOT be injected when NODE_USE_ENV_PROXY
+        // is not 1 and ws fix script does not exist. The Nemotron inference fix is
+        // unconditional (always needed regardless of proxy config).
         expect(envFile).not.toContain("http-proxy-fix");
         expect(envFile).not.toContain("ws-proxy-fix");
+        expect(envFile).toContain("nemotron-inference-fix");
       } finally {
         try {
           execFileSync("rm", ["-rf", fakeDataDir, tmpFile]);
@@ -721,6 +724,7 @@ describe("service environment", () => {
           `_NO_PROXY_VAL="localhost,127.0.0.1,::1,\${PROXY_HOST}"`,
           `_PROXY_FIX_SCRIPT="/tmp/nemoclaw-http-proxy-fix.js"`,
           `_WS_FIX_SCRIPT="${fakeWsFixScript}"`,
+          `_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"`,
           `_TOOL_REDIRECTS=()`,
           "set +u  # array expansion safe on macOS bash",
           persistBlock
@@ -768,6 +772,7 @@ describe("service environment", () => {
           `_NO_PROXY_VAL="localhost,127.0.0.1,::1,\${PROXY_HOST}"`,
           `_PROXY_FIX_SCRIPT="/tmp/nemoclaw-http-proxy-fix.js"`,
           `_WS_FIX_SCRIPT="/nonexistent/ws-proxy-fix.js"`,
+          `_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"`,
           `_TOOL_REDIRECTS=()`,
           "set +u  # array expansion safe on macOS bash",
           persistBlock


### PR DESCRIPTION
## Summary

- Adds a Node.js `--require` preload that injects `chat_template_kwargs: { force_nonempty_content: true }` into `/v1/chat/completions` requests when the model ID contains "nemotron"
- Follows the established `http-proxy-fix.js` preload pattern (IIFE, `emit_sandbox_sourced_file`, `validate_tmp_permissions`, registered in `NODE_OPTIONS`)
- Non-Nemotron models pass through completely untouched; backends that don't support the extra field silently ignore it

## Context

Nemotron models sometimes return empty content (tool call instead of text, #1193) or thinking-only blocks that OpenClaw treats as end-of-turn, stalling the conversation (#2051). The root cause is the vLLM/NIM chat template producing empty assistant content when tool definitions are present.

The `force_nonempty_content` chat template kwarg ([HuggingFace model card](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4#api-client)) tells the serving layer to always produce non-empty content alongside any tool calls or thinking blocks. OpenClaw's model config schema doesn't support `extra_body` passthrough, so the preload injects the parameter at the HTTP layer — transparent to OpenClaw.

Fixes #1193
Fixes #2051

## Test plan

- [x] New test file `test/nemotron-inference-fix.test.ts` (13 tests) — verifies heredoc embedding, NODE_OPTIONS registration, proxy-env inclusion, validate_tmp_permissions in both paths, model matching, body injection, passthrough, error handling, Content-Length update
- [x] Updated `test/service-env.test.ts` — adds `_NEMOTRON_FIX_SCRIPT` to proxy-env test harnesses, updates assertion to allow the unconditional Nemotron preload
- [x] Existing `test/nemoclaw-start.test.ts` (61 tests) — all pass
- [x] Existing `test/http-proxy-fix-sync.test.ts` (5 tests) — all pass
- [ ] E2E: onboard with Nemotron model, send a simple "hello" message, verify text response (not empty/tool-call-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Nemotron model inference in chat completions by automatically injecting required content validation into API requests.

* **Tests**
  * Introduced comprehensive test coverage for the Nemotron inference fix, validating request interception behavior, model-specific modifications, and integration with system environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->