### PR TITLE
feat(compat): bump OpenClaw from 2026.4.2 to 2026.4.22

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -151,7 +151,7 @@ RUN printf '%s\n' \
 # OpenClaw version: change the OPENCLAW_VERSION ARG default so CI rebuilds
 # the base image on push to main, or use workflow_dispatch on base-image.yaml
 # with the openclaw_version input for a one-off build without editing this file.
-ARG OPENCLAW_VERSION=2026.4.2
+ARG OPENCLAW_VERSION=2026.4.22
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/agents/openclaw/manifest.yaml
+++ b/agents/openclaw/manifest.yaml
@@ -19,7 +19,7 @@ homepage: "https://openclaw.ai"
 install_method: npm  # npm install -g openclaw@<version>
 binary_path: /usr/local/bin/openclaw
 version_command: "openclaw --version"
-expected_version: "2026.4.2"
+expected_version: "2026.4.22"
 gateway_command: "openclaw gateway run"
 
 # ── Health probe ────────────────────────────────────────────────

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -4,7 +4,7 @@
 version: "0.1.0"
 min_openshell_version: "0.0.32"
 max_openshell_version: "0.0.32"
-min_openclaw_version: "2026.4.2"
+min_openclaw_version: "2026.4.22"
 # Mirrors the components.sandbox.image manifest digest below. Lets a
 # downstream consumer (or release tooling) verify the blueprint declares
 # a specific sandbox image without parsing the components tree, and


### PR DESCRIPTION
## Summary

Bumps OpenClaw from `2026.4.2` (Apr 2) to `2026.4.22` (Apr 23) to pick up the upstream incomplete-turn guard that fixes the Nemotron-3-Super-120b TUI hang reported in #2099, #2051, and #1193.

All three issues share the same root cause: the model returns an assistant turn with `stopReason: "stop"` + empty content + an unsigned thinking block, and OpenClaw's pre-2026.4.20 loop treated this as end-of-turn, leaving the TUI in a "flibbertigibbeting…" spinner forever. OpenClaw's new `src/agents/pi-embedded-runner/run/incomplete-turn.ts` guard converts this shape into a user-visible `⚠️ Agent couldn't generate a response` payload.

Verified empirically:
- The guard file exists at `v2026.4.22` (HTTP 200, 20086 bytes)
- Same file returns HTTP 404 at `v2026.4.2`
- Primary fix commit: openclaw/openclaw@9337e1bd ("fix(agents): accept silent no-reply turns", 2026-04-22)

## Changes

| File | Change |
|---|---|
| `nemoclaw-blueprint/blueprint.yaml` | `min_openclaw_version: "2026.4.2"` → `"2026.4.22"` |
| `agents/openclaw/manifest.yaml` | `expected_version: "2026.4.2"` → `"2026.4.22"` |
| `Dockerfile.base` | `ARG OPENCLAW_VERSION=2026.4.2` → `2026.4.22` |

No image digest bump: the `ghcr.io/nvidia/openshell-community/sandboxes/openclaw` registry only publishes a `latest` tag (same digest as currently pinned), and the runtime `Dockerfile` (L56-69) already auto-upgrades OpenClaw at build time by reading `min_openclaw_version` from `blueprint.yaml` and running `npm install -g openclaw@${MIN_VER}`.

## Compatibility note for @ericksoa

Aaron — the Dockerfile.base / Dockerfile contain several build-time patches that target OpenClaw dist files by string (`withStrictGuardedFetchMode` → `withTrustedEnvProxyGuardedFetchMode` `sed`, exec-approvals path rewrites, `assertExplicitProxyAllowed` bypass injection). CI image-build will surface any symbol drift between 2026.4.2 and 2026.4.22. Flagging you on review in case any of those need updating.

## Release-note review (2026.4.3 → 2026.4.22)

- `2026.4.22` release notes are additive (xAI image/TTS, STT streaming, local embedded TUI, WhatsApp reply quoting, `/models add` command) — no breaking changes visible.
- Breaking changes in `2026.4.2`'s release notes (xAI and Firecrawl config-path migrations) are already absorbed by NemoClaw's current baseline.

## Test plan

- [ ] CI: image build step (verifies Aaron's patches still apply)
- [ ] CI: E2E suite
- [ ] Manual: `nemoclaw onboard` → openclaw-tui → ask for any multi-file coding task → confirm either a real response or the new "Agent couldn't generate a response" error, **not** an indefinite spinner

Closes #2099
Closes #2051
Closes #1193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenClaw CLI version requirement to 2026.4.22 across all platform configurations and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->