### PR TITLE
docs(cli): correct onboard banner and help to use --model/--provider long flags (#2370)

### DIFF
--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -101,7 +101,7 @@ Recover from a misconfigured sandbox without re-running the full onboard wizard 
 Change the active model or provider at runtime without rebuilding the sandbox:
 
 ```console
-$ openshell inference set -g nemoclaw -m <model> -p <provider>
+$ openshell inference set -g nemoclaw --model <model> --provider <provider>
 ```
 
 See Switch inference providers (use the `nemoclaw-user-configure-inference` skill) for provider-specific model IDs and API compatibility notes.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -162,7 +162,7 @@ Recover from a misconfigured sandbox without re-running the full onboard wizard 
 Change the active model or provider at runtime without rebuilding the sandbox:
 
 ```console
-$ openshell inference set -g nemoclaw -m <model> -p <provider>
+$ openshell inference set -g nemoclaw --model <model> --provider <provider>
 ```
 
 See [Switch inference providers](../inference/switch-inference-providers.md) for provider-specific model IDs and API compatibility notes.

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6293,7 +6293,7 @@ function printDashboard(sandboxName, model, provider, nimContainer = null, agent
   console.log(`  ${"─".repeat(50)}`);
   console.log("");
   console.log("  To change settings later:");
-  console.log(`    Model:       openshell inference set -g nemoclaw -m <model> -p <provider>`);
+  console.log(`    Model:       openshell inference set -g nemoclaw --model <model> --provider <provider>`);
   console.log(`    Policies:    nemoclaw ${sandboxName} policy-add`);
   console.log("    Credentials: nemoclaw credentials reset <KEY>  then  nemoclaw onboard");
   console.log("");

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -3000,7 +3000,7 @@ function help() {
 
   ${G}Reconfiguration (after onboard):${R}
     ${D}Change inference model at runtime (no re-onboard needed):${R}
-      openshell inference set -g nemoclaw -m <model> -p <provider>
+      openshell inference set -g nemoclaw --model <model> --provider <provider>
 
     ${D}Add network presets (e.g. Telegram, GitHub) to a running sandbox:${R}
       nemoclaw <name> policy-add


### PR DESCRIPTION
## Summary

The onboard completion banner and `nemoclaw --help` "Reconfiguration (after onboard)" section advertised `openshell inference set -g nemoclaw -m <model> -p <provider>`, but the openshell Rust CLI does not accept `-m` / `-p` short flags — users copying the snippet verbatim got `error: unexpected argument '-m' found`. Switch to the long form (`--model` / `--provider`) everywhere the snippet appears so copy-paste works.

## Changes

- `src/lib/onboard.ts` — onboard completion banner "To change settings later:" line
- `src/nemoclaw.ts` — `nemoclaw --help` "Reconfiguration (after onboard)" section
- `docs/get-started/quickstart.md` — "Change inference model or API" snippet
- `.agents/skills/nemoclaw-user-get-started/SKILL.md` — matching skill doc snippet

All four sites now advertise the long form: `openshell inference set -g nemoclaw --model <model> --provider <provider>`.

## Testing

- `npx prek run --files` on the four changed files — all hooks pass for the edited files (markdownlint, YAML tests, gitleaks, etc.)
- No tests snapshot the banner wording, so no snapshot updates are needed.
- Pre-existing CLI vitest environment failures (exit 127, connection-refused gateway probes) are unrelated to this text-only change and reproduce on untouched `origin/main`.

Fixes #2370

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples across quickstart guides and help text to use long-form flags (`--model`, `--provider`) instead of short flags (`-m`, `-p`) for runtime inference model switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->