### PR TITLE
fix(onboard): short-circuit gateway start when Docker daemon is unreachable (#2347)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -682,6 +682,7 @@ const {
   classifyValidationFailure,
   classifyApplyFailure,
   classifySandboxCreateFailure,
+  classifyGatewayStartFailure,
   validateNvidiaApiKeyValue,
   isSafeModelId,
   isNvcfFunctionNotFoundForAccount,
@@ -3011,6 +3012,7 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
   // the second attempt benefit from cached images and cleaner cgroup state.
   // See: https://github.com/NVIDIA/OpenShell/issues/433
   const retries = exitOnFailure ? 2 : 0;
+  let dockerUnreachable = false;
   try {
     await pRetry(
       async () => {
@@ -3029,6 +3031,18 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
             .map((l) => `    ${l}`);
           if (lines.length > 0) {
             console.log(`  Gateway start returned before healthy:\n${lines.join("\n")}`);
+          }
+          // Fast-fail when the underlying Docker daemon is unreachable
+          // (e.g. `colima stop` on macOS). Retrying the health poll against
+          // a dead socket wastes ~5–15 minutes and produces an unactionable
+          // error; short-circuit with a "start Docker" message instead.
+          // See NemoClaw #2347.
+          const failure = classifyGatewayStartFailure(startResult.output || "");
+          if (failure.kind === "docker_unreachable") {
+            dockerUnreachable = true;
+            throw new pRetry.AbortError(
+              "Docker daemon is not reachable (gateway cannot start).",
+            );
           }
         }
         console.log("  Waiting for gateway health...");
@@ -3084,6 +3098,21 @@ async function startGatewayWithOptions(_gpu, { exitOnFailure = true } = {}) {
     );
   } catch {
     if (exitOnFailure) {
+      if (dockerUnreachable) {
+        // Unrecoverable-by-retry: the Docker daemon is stopped. Give the
+        // user the exact command to run instead of dumping openshell logs.
+        console.error("  Docker daemon is not running — cannot start the gateway.");
+        console.error("");
+        console.error("  Start Docker, then rerun `nemoclaw onboard`:");
+        if (process.platform === "darwin") {
+          console.error("    colima start            # or start Docker Desktop");
+        } else if (process.platform === "linux") {
+          console.error("    sudo systemctl start docker");
+        } else {
+          console.error("    Start the Docker daemon.");
+        }
+        process.exit(1);
+      }
       console.error(`  Gateway failed to start after ${retries + 1} attempts.`);
       console.error("  Gateway state preserved for diagnostics.");
       console.error("");
@@ -6816,6 +6845,7 @@ module.exports = {
   buildSandboxConfigSyncScript,
   compactText,
   copyBuildContextDir,
+  classifyGatewayStartFailure,
   classifySandboxCreateFailure,
   configureWebSearch,
   createSandbox,

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -7,6 +7,7 @@ import {
   classifyValidationFailure,
   classifyApplyFailure,
   classifySandboxCreateFailure,
+  classifyGatewayStartFailure,
   validateNvidiaApiKeyValue,
   isSafeModelId,
   isNvcfFunctionNotFoundForAccount,
@@ -181,6 +182,55 @@ describe("classifySandboxCreateFailure", () => {
   it("returns unknown for unrecognized output", () => {
     const result = classifySandboxCreateFailure("something else happened");
     expect(result.kind).toBe("unknown");
+  });
+});
+
+describe("classifyGatewayStartFailure", () => {
+  // Regression: NemoClaw #2347. When Colima is stopped on macOS, the
+  // openshell gateway-start stream prints "Failed to create Docker client.
+  // Socket not found: /var/run/docker.sock" before exiting non-zero. Onboard
+  // must short-circuit the retry loop with an actionable message instead of
+  // burning ~15 minutes on health polls against a dead socket.
+  it("detects colima-stopped signature on macOS (Socket not found)", () => {
+    const output = [
+      "  Error: Failed to create Docker client.",
+      "  Socket not found: /var/run/docker.sock",
+    ].join("\n");
+    expect(classifyGatewayStartFailure(output)).toEqual({ kind: "docker_unreachable" });
+  });
+
+  it("detects dockerd-stopped signature on Linux (Cannot connect to the Docker daemon)", () => {
+    const output =
+      "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?";
+    expect(classifyGatewayStartFailure(output)).toEqual({ kind: "docker_unreachable" });
+  });
+
+  it("detects the standalone 'Failed to create Docker client' marker", () => {
+    expect(classifyGatewayStartFailure("Failed to create Docker client")).toEqual({
+      kind: "docker_unreachable",
+    });
+  });
+
+  it("detects free-form 'docker daemon is not running' wording", () => {
+    expect(classifyGatewayStartFailure("the docker daemon is not running on this host")).toEqual({
+      kind: "docker_unreachable",
+    });
+  });
+
+  it("returns unknown for healthy-but-slow output (should not short-circuit)", () => {
+    // Real output seen during a slow first-time k3s bootstrap — the retry
+    // loop must stay engaged for these, so we must not misclassify them.
+    const output = [
+      "Applying HelmChart openshell",
+      "openshell-0 still starting",
+      "Observed pod startup duration 90s",
+    ].join("\n");
+    expect(classifyGatewayStartFailure(output)).toEqual({ kind: "unknown" });
+  });
+
+  it("returns unknown for empty or missing output", () => {
+    expect(classifyGatewayStartFailure("")).toEqual({ kind: "unknown" });
+    expect(classifyGatewayStartFailure()).toEqual({ kind: "unknown" });
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -17,6 +17,17 @@ export interface SandboxCreateFailure {
   uploadedToGateway: boolean;
 }
 
+export interface GatewayStartFailure {
+  /**
+   * - `docker_unreachable`: the underlying Docker daemon (Colima on macOS,
+   *   dockerd on Linux) is not responding. Retrying the openshell health
+   *   poll cannot recover from this — the user must start Docker first.
+   * - `unknown`: any other failure; callers should fall through to the
+   *   normal retry/health-wait behavior.
+   */
+  kind: "docker_unreachable" | "unknown";
+}
+
 export function classifyValidationFailure({
   httpStatus = 0,
   curlStatus = 0,
@@ -76,6 +87,34 @@ export function classifySandboxCreateFailure(output = ""): SandboxCreateFailure 
     return { kind: "sandbox_create_incomplete", uploadedToGateway: true };
   }
   return { kind: "unknown", uploadedToGateway };
+}
+
+/**
+ * Classify a non-zero `openshell gateway start` result so the onboard retry
+ * loop can short-circuit on unrecoverable failures.
+ *
+ * The only case we special-case today is "Docker daemon not reachable" — on
+ * macOS this surfaces as `Socket not found: /var/run/docker.sock` (Colima
+ * stopped) and on Linux as `Cannot connect to the Docker daemon at
+ * unix:///var/run/docker.sock. Is the docker daemon running?`. Retrying the
+ * health poll against a stopped daemon wastes ~5–15 minutes and produces an
+ * unactionable error at the end; bailing out immediately with a clear
+ * "start Docker" message is strictly better UX. See NemoClaw #2347.
+ */
+export function classifyGatewayStartFailure(output = ""): GatewayStartFailure {
+  const text = String(output || "");
+  // Match both macOS (Colima / Docker Desktop) and Linux docker daemon-down
+  // signatures. The openshell CLI echoes these verbatim from the underlying
+  // Docker client error when the gateway controller starts.
+  if (
+    /Socket not found:\s*\/var\/run\/docker\.sock/i.test(text) ||
+    /Cannot connect to the Docker daemon/i.test(text) ||
+    /Failed to create Docker client/i.test(text) ||
+    /docker daemon.*(is not running|not responding|unreachable)/i.test(text)
+  ) {
+    return { kind: "docker_unreachable" };
+  }
+  return { kind: "unknown" };
 }
 
 export function validateNvidiaApiKeyValue(key: string): string | null {


### PR DESCRIPTION
## Summary

When Colima/Docker is stopped on macOS, `nemoclaw onboard` failed at `[2/8] Starting OpenShell gateway` with `Socket not found: /var/run/docker.sock` and then kept retrying the health poll for up to ~15 minutes (3 attempts × ~300s ARM64 health-wait) before surfacing a generic `openshell doctor logs` troubleshooting message. The issue author reported this as an indefinite hang (against `v0.0.23`, which predated the existing `NEMOCLAW_GATEWAY_START_TIMEOUT` bound added in #1830).

This PR makes that failure mode fast-fail with an actionable error instead of burning ~15 minutes:

- Adds a pure `classifyGatewayStartFailure(output)` helper in `src/lib/validation.ts` that recognizes the `Socket not found: /var/run/docker.sock` (macOS Colima stopped) and `Cannot connect to the Docker daemon` (Linux dockerd stopped) signatures emitted by `openshell gateway start`.
- In `startGatewayWithOptions`, when `openshell gateway start` exits non-zero AND the output classifies as `docker_unreachable`, aborts the retry loop via `pRetry.AbortError` — no further health polls, no further retries.
- In the onboard failure branch, prints a short platform-specific remediation (`colima start` on macOS, `sudo systemctl start docker` on Linux) in place of the openshell troubleshooting dump.

Picks option (b) from the issue — does not auto-invoke `colima start` or `systemctl start docker`.

## Relationship to #2348 / PR #2372

PR #2372 (for sibling issue #2348) adds the preflight detection so onboard fast-fails at step `[1/8]` when Docker is already stopped before onboard runs. That PR is the primary defense; this PR is the defense-in-depth for the case where the daemon dies mid-onboard or preflight is bypassed. Together they cover both halves of what the #2347 issue asks for.

The helper name (`classifyGatewayStartFailure`) parallels the existing `classifySandboxCreateFailure` and `classifyValidationFailure` conventions in `src/lib/validation.ts`.

## Behavior unchanged on the success path

The classifier is only consulted when `startResult.status !== 0`. When `openshell gateway start` succeeds, or when it exits non-zero for reasons other than the Docker socket (e.g. slow k3s bootstrap, image pull), the retry + health-poll behavior is identical to before.

## Testing

- Added 6 unit tests for `classifyGatewayStartFailure`:
  - macOS Colima-stopped signature (`Socket not found: /var/run/docker.sock`)
  - Linux dockerd-stopped signature (`Cannot connect to the Docker daemon at unix:///var/run/docker.sock`)
  - Bare `Failed to create Docker client` marker
  - Free-form `docker daemon is not running` wording
  - Slow-bootstrap output (Helm chart apply, pod startup duration) returns `unknown` so the retry loop stays engaged — regression guard
  - Empty / missing output → `unknown`
- `npx vitest run src/lib/validation.test.ts` → 48/48 passing
- `npx vitest run test/gateway-start-wait.test.ts test/onboard.test.ts test/onboard-readiness.test.ts` → 176/176 passing
- `npx tsc -p tsconfig.src.json` / `npx tsc -p tsconfig.cli.json` clean
- Live macOS repro (`colima stop` → `nemoclaw onboard`): not run. The change is exercised by the unit tests on the pure classifier + is a surgical edit to a well-tested code path.

## Diff size

3 files changed, 119 insertions(+), 0 deletions(-).

Fixes #2347

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced gateway startup error detection to identify Docker daemon connectivity issues and provide targeted OS-specific instructions for resolution, streamlining troubleshooting.

* **Tests**
  * Added test coverage for Docker daemon failure classification across multiple error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->