### PR TITLE
chore(deps): bump OpenShell version pin from 0.0.32 to 0.0.36

### DIFF
--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version: "0.1.0"
-min_openshell_version: "0.0.36"
+min_openshell_version: "0.0.32"
 max_openshell_version: "0.0.36"
 min_openclaw_version: "2026.4.2"
 # Mirrors the components.sandbox.image manifest digest below. Lets a

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version: "0.1.0"
-min_openshell_version: "0.0.32"
-max_openshell_version: "0.0.32"
+min_openshell_version: "0.0.36"
+max_openshell_version: "0.0.36"
 min_openclaw_version: "2026.4.2"
 # Mirrors the components.sandbox.image manifest digest below. Lets a
 # downstream consumer (or release tooling) verify the blueprint declares

--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -28,7 +28,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/<ref>/scripts/brev-launchable-ci-cpu.sh | bash
 #
 # Environment overrides:
-#   OPENSHELL_VERSION     — OpenShell CLI release tag (default: v0.0.32)
+#   OPENSHELL_VERSION     — OpenShell CLI release tag (default: v0.0.36)
 #   NEMOCLAW_REF          — NemoClaw git ref to clone (default: main)
 #   NEMOCLAW_CLONE_DIR    — Where to clone NemoClaw (default: ~/NemoClaw)
 #   SKIP_DOCKER_PULL      — Set to 1 to skip Docker image pre-pulls
@@ -40,7 +40,7 @@
 set -euo pipefail
 
 # ── Configuration ────────────────────────────────────────────────────
-OPENSHELL_VERSION="${OPENSHELL_VERSION:-v0.0.32}"
+OPENSHELL_VERSION="${OPENSHELL_VERSION:-v0.0.36}"
 NEMOCLAW_REF="${NEMOCLAW_REF:-main}"
 TARGET_USER="${SUDO_USER:-$(id -un)}"
 TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -36,7 +36,7 @@ info "Detected $OS_LABEL ($ARCH_LABEL)"
 # Minimum version required for Landlock filesystem policy enforcement
 # (NVIDIA/OpenShell#810 fixes the drop_privileges/Landlock ordering bug
 # that caused /sandbox to remain writable on 0.0.26).
-MIN_VERSION="0.0.36"
+MIN_VERSION="0.0.32"
 # Maximum version validated for this NemoClaw release. Newer OpenShell builds
 # may change sandbox semantics; upgrade NemoClaw before upgrading past this.
 MAX_VERSION="0.0.36"

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -36,10 +36,10 @@ info "Detected $OS_LABEL ($ARCH_LABEL)"
 # Minimum version required for Landlock filesystem policy enforcement
 # (NVIDIA/OpenShell#810 fixes the drop_privileges/Landlock ordering bug
 # that caused /sandbox to remain writable on 0.0.26).
-MIN_VERSION="0.0.32"
+MIN_VERSION="0.0.36"
 # Maximum version validated for this NemoClaw release. Newer OpenShell builds
 # may change sandbox semantics; upgrade NemoClaw before upgrading past this.
-MAX_VERSION="0.0.32"
+MAX_VERSION="0.0.36"
 # Pin fresh installs to this version instead of pulling "latest".
 PIN_VERSION="$MAX_VERSION"
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2678,7 +2678,7 @@ async function preflight() {
       // Source of truth: min_openshell_version in nemoclaw-blueprint/blueprint.yaml.
       // Fall back to the Landlock-enforcement floor (also MIN_VERSION in
       // scripts/install-openshell.sh) if the blueprint cannot be read.
-      const minOpenshellVersion = getBlueprintMinOpenshellVersion() ?? "0.0.36";
+      const minOpenshellVersion = getBlueprintMinOpenshellVersion() ?? "0.0.32";
       const needsUpgrade = !versionGte(currentVersion, minOpenshellVersion);
       if (needsUpgrade) {
         console.log(

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2678,7 +2678,7 @@ async function preflight() {
       // Source of truth: min_openshell_version in nemoclaw-blueprint/blueprint.yaml.
       // Fall back to the Landlock-enforcement floor (also MIN_VERSION in
       // scripts/install-openshell.sh) if the blueprint cannot be read.
-      const minOpenshellVersion = getBlueprintMinOpenshellVersion() ?? "0.0.32";
+      const minOpenshellVersion = getBlueprintMinOpenshellVersion() ?? "0.0.36";
       const needsUpgrade = !versionGte(currentVersion, minOpenshellVersion);
       if (needsUpgrade) {
         console.log(

--- a/test/e2e/test-sandbox-survival.sh
+++ b/test/e2e/test-sandbox-survival.sh
@@ -357,16 +357,19 @@ section "Phase 5: Plant state markers in sandbox"
 
 MARKER_VALUE="nemoclaw-survival-$(date +%s)"
 
-# 5a: Workspace file in /sandbox/
+# 5a: Workspace file in writable agent state directory.
+# /sandbox/ is read-only by policy (openclaw-sandbox.yaml); writable state
+# lives under /sandbox/.openclaw-data/. OpenShell ≥0.0.36 correctly enforces
+# this (NVIDIA/OpenShell#910), so markers must target the writable path.
 # shellcheck disable=SC2029
-if ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "echo ${MARKER_VALUE} > /sandbox/.survival-marker" 2>/dev/null; then
-  pass "Planted workspace marker: /sandbox/.survival-marker"
+if ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "echo ${MARKER_VALUE} > /sandbox/.openclaw-data/.survival-marker-workspace" 2>/dev/null; then
+  pass "Planted workspace marker: /sandbox/.openclaw-data/.survival-marker-workspace"
 else
   fail "Could not plant workspace marker"
 fi
 
 # Verify read-back before restart
-readback=$(ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "cat /sandbox/.survival-marker" 2>/dev/null)
+readback=$(ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "cat /sandbox/.openclaw-data/.survival-marker-workspace" 2>/dev/null)
 if [ "$readback" = "$MARKER_VALUE" ]; then
   pass "Workspace marker verified before restart"
 else
@@ -401,11 +404,12 @@ if [ -n "$agent_files_before" ]; then
 fi
 
 # 5d: Record a deeper workspace file to test nested persistence
+# Uses writable .openclaw-data path — /sandbox/ is read-only by policy.
 # shellcheck disable=SC2029
 if ssh "${SSH_OPTS[@]}" "$SSH_TARGET" \
-  "mkdir -p /sandbox/test-data && echo ${MARKER_VALUE} > /sandbox/test-data/nested-marker.txt" \
+  "mkdir -p /sandbox/.openclaw-data/test-data && echo ${MARKER_VALUE} > /sandbox/.openclaw-data/test-data/nested-marker.txt" \
   2>/dev/null; then
-  pass "Planted nested marker: /sandbox/test-data/nested-marker.txt"
+  pass "Planted nested marker: /sandbox/.openclaw-data/test-data/nested-marker.txt"
 else
   fail "Could not plant nested workspace marker"
 fi
@@ -595,7 +599,7 @@ fi
 section "Phase 9: Verify state persisted across restart"
 
 # 9a: Workspace marker
-post_restart_marker=$(ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "cat /sandbox/.survival-marker" 2>/dev/null)
+post_restart_marker=$(ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "cat /sandbox/.openclaw-data/.survival-marker-workspace" 2>/dev/null)
 if [ "$post_restart_marker" = "$MARKER_VALUE" ]; then
   pass "Workspace marker survived restart: $MARKER_VALUE"
 else
@@ -613,7 +617,7 @@ if [ "$agent_data_exists" = "yes" ]; then
 fi
 
 # 9c: Nested workspace file
-nested_marker=$(ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "cat /sandbox/test-data/nested-marker.txt" 2>/dev/null)
+nested_marker=$(ssh "${SSH_OPTS[@]}" "$SSH_TARGET" "cat /sandbox/.openclaw-data/test-data/nested-marker.txt" 2>/dev/null)
 if [ "$nested_marker" = "$MARKER_VALUE" ]; then
   pass "Nested workspace marker survived restart"
 else

--- a/test/install-openshell-version-check.test.ts
+++ b/test/install-openshell-version-check.test.ts
@@ -59,10 +59,10 @@ exit 1`,
 }
 
 describe("install-openshell.sh version check", () => {
-  it("exits cleanly when openshell 0.0.36 is already installed", () => {
-    const result = runWithInstalledVersion("0.0.36");
+  it("exits cleanly when openshell 0.0.32 is already installed", () => {
+    const result = runWithInstalledVersion("0.0.32");
     expect(result.status).toBe(0);
-    expect(result.stdout).toMatch(/already installed.*0\.0\.36/);
+    expect(result.stdout).toMatch(/already installed.*0\.0\.32/);
   });
 
   it("triggers upgrade when openshell 0.0.28 is installed (below MIN_VERSION)", () => {

--- a/test/install-openshell-version-check.test.ts
+++ b/test/install-openshell-version-check.test.ts
@@ -59,10 +59,10 @@ exit 1`,
 }
 
 describe("install-openshell.sh version check", () => {
-  it("exits cleanly when openshell 0.0.32 is already installed", () => {
-    const result = runWithInstalledVersion("0.0.32");
+  it("exits cleanly when openshell 0.0.36 is already installed", () => {
+    const result = runWithInstalledVersion("0.0.36");
     expect(result.status).toBe(0);
-    expect(result.stdout).toMatch(/already installed.*0\.0\.32/);
+    expect(result.stdout).toMatch(/already installed.*0\.0\.36/);
   });
 
   it("triggers upgrade when openshell 0.0.28 is installed (below MIN_VERSION)", () => {
@@ -85,7 +85,7 @@ describe("install-openshell.sh version check", () => {
   });
 
   it("fails with a clear error when openshell is above MAX_VERSION", () => {
-    const result = runWithInstalledVersion("0.0.33");
+    const result = runWithInstalledVersion("0.0.37");
     expect(result.status).toBe(1);
     expect(result.stdout).toMatch(/above the maximum/);
   });


### PR DESCRIPTION
## Summary
- Bumps min/max OpenShell version from `0.0.32` to `0.0.36` (latest stable release) across all four pin locations: `blueprint.yaml`, `install-openshell.sh`, `brev-launchable-ci-cpu.sh`, and the `onboard.ts` fallback
- Required to unblock the daily tag cut

## Files changed
| File | What changed |
|------|-------------|
| `nemoclaw-blueprint/blueprint.yaml` | `min_openshell_version` / `max_openshell_version` → `0.0.36` |
| `scripts/install-openshell.sh` | `MIN_VERSION` / `MAX_VERSION` → `0.0.36` |
| `scripts/brev-launchable-ci-cpu.sh` | Default `OPENSHELL_VERSION` → `v0.0.36` |
| `src/lib/onboard.ts` | Hardcoded fallback → `0.0.36` |

## Test plan
- [ ] `make check` passes
- [ ] `npm test` passes
- [ ] CI launchable boots with the new version
- [ ] `nemoclaw onboard` succeeds against OpenShell 0.0.36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended OpenShell compatibility to support installations up to 0.0.36.
  * Updated default OpenShell version to 0.0.36 for CI/setup flows.
  * Enhanced version validation to accept installs within the new supported range.

* **Tests**
  * Updated end-to-end survival test to verify workspace marker persistence across restarts.
  * Adjusted version-check test to reflect the new maximum supported version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->