### PR TITLE
docs(version): bump docs to 0.0.24

### DIFF
--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.23"}
+{"name": "nemoclaw", "version": "0.0.24"}

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
   {
     "preferred": true,
+    "version": "0.0.24",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.24/"
+  },
+  {
     "version": "0.0.23",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.23/"
   },


### PR DESCRIPTION
## Summary

Promotes 0.0.24 to the preferred entry in the docs version switcher and updates `docs/project.json` to match, in preparation for the 0.0.24 release.

## Changes

- `docs/versions1.json`: add `0.0.24` as the preferred entry; demote `0.0.23`.
- `docs/project.json`: set `version` to `0.0.24`.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes on the changed files (full-tree run has pre-existing main-branch failures unrelated to the JSON bump)
- [ ] `npm test` passes (pre-existing test failures on `main` for `test/cli.test.ts > bare unknown name surfaces sandbox-not-found (#2164)` and several install-preflight / gateway-reconcile suites; not introduced by this PR, which only edits two JSON version strings)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Version incremented to 0.0.24
  * New documentation version now available and marked as preferred

<!-- end of auto-generated comment: release notes by coderabbit.ai -->