### PR TITLE
ci: deduplicate PR E2E — move sandbox tests exclusively to NVIDIA runners

### DIFF
--- a/.github/workflows/pr-self-hosted.yaml
+++ b/.github/workflows/pr-self-hosted.yaml
@@ -78,6 +78,29 @@ jobs:
           path: /tmp/isolation-image.tar.gz
           retention-days: 1
 
+  build-sandbox-images-arm64:
+    runs-on: linux-arm64-cpu4
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Pull base image from GHCR (fall back to local build)
+        run: |
+          if docker pull ghcr.io/nvidia/nemoclaw/sandbox-base:latest 2>/dev/null; then
+            echo "BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest" >> "$GITHUB_ENV"
+          else
+            echo "::warning::GHCR base image not available, building locally"
+            docker build -f Dockerfile.base -t nemoclaw-sandbox-base-local .
+            echo "BASE_IMAGE=nemoclaw-sandbox-base-local" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build production image on arm64
+        run: docker build --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }} -t nemoclaw-production-arm64 .
+
+      - name: Build sandbox test image on arm64
+        run: docker build -f test/Dockerfile.sandbox --build-arg BASE_IMAGE=nemoclaw-production-arm64 -t nemoclaw-sandbox-test-arm64 .
+
   test-e2e-sandbox:
     runs-on: linux-amd64-cpu4
     timeout-minutes: 15
@@ -117,3 +140,23 @@ jobs:
 
       - name: Run gateway isolation E2E tests
         run: NEMOCLAW_TEST_IMAGE=nemoclaw-production bash test/e2e-gateway-isolation.sh
+
+  test-e2e-port-overrides:
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 10
+    needs: build-sandbox-images
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download image artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: isolation-image
+          path: /tmp
+
+      - name: Load image
+        run: gunzip -c /tmp/isolation-image.tar.gz | docker load
+
+      - name: Run port override E2E tests
+        run: NEMOCLAW_TEST_IMAGE=nemoclaw-production bash test/e2e-port-overrides.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,9 +66,6 @@ jobs:
       - name: Run Ollama auth proxy E2E tests
         run: bash test/e2e-ollama-proxy.sh
 
-  sandbox-images-and-e2e:
-    needs: [checks, changes]
-    if: needs.changes.outputs.code == 'true'
-    uses: ./.github/workflows/sandbox-images-and-e2e.yaml
-    with:
-      run_arm64: true
+  # Sandbox image builds and E2E tests have moved to pr-self-hosted.yaml,
+  # which runs on NVIDIA self-hosted runners via copy-pr-bot.
+  # See: .github/workflows/pr-self-hosted.yaml


### PR DESCRIPTION
## Summary

Remove duplicate sandbox image builds and E2E tests from `pr.yaml`. These jobs now run exclusively on NVIDIA self-hosted runners via `pr-self-hosted.yaml`, which was enabled in #2374.

## Before (duplicate work on every PR)

| Job | `pr.yaml` (GitHub-hosted) | `pr-self-hosted.yaml` (NVIDIA) |
|-----|--------------------------|-------------------------------|
| build-sandbox-images | ✅ `ubuntu-latest` ~6m | ✅ `linux-amd64-cpu4` ~3m |
| build-sandbox-images-arm64 | ✅ `ubuntu-24.04-arm` ~2m | ❌ missing |
| test-e2e-sandbox | ✅ `ubuntu-latest` ~1m | ✅ `linux-amd64-cpu4` ~1m |
| test-e2e-gateway-isolation | ✅ `ubuntu-latest` ~1m | ✅ `linux-amd64-cpu4` ~1m |
| test-e2e-port-overrides | ✅ `ubuntu-latest` ~1m | ❌ missing |

**Total: ~12m GitHub-hosted + ~5m NVIDIA = ~17m of compute per PR**

## After (single run on NVIDIA runners)

| Job | `pr.yaml` (GitHub-hosted) | `pr-self-hosted.yaml` (NVIDIA) |
|-----|--------------------------|-------------------------------|
| build-sandbox-images | ❌ removed | ✅ `linux-amd64-cpu4` ~3m |
| build-sandbox-images-arm64 | ❌ removed | ✅ `linux-arm64-cpu4` (new) |
| test-e2e-sandbox | ❌ removed | ✅ `linux-amd64-cpu4` ~1m |
| test-e2e-gateway-isolation | ❌ removed | ✅ `linux-amd64-cpu4` ~1m |
| test-e2e-port-overrides | ❌ removed | ✅ `linux-amd64-cpu4` (new) |

**Total: ~6m on NVIDIA runners only — 65% less total compute**

## Performance: build-sandbox-images

Measured across recent PRs:

| Runner | Avg duration | Samples |
|--------|-------------|---------|
| GitHub `ubuntu-latest` | **362s** (~6m) | PR 2147: 371s, PR 2328: 373s, PR 2366: 353s |
| NVIDIA `linux-amd64-cpu4` | **187s** (~3m) | PR 2147: 190s, PR 2393: 176s, PR 2328: 187s, PR 2366: 198s, PR 2113: 180s |
| **Improvement** | **48% faster** | |

## Changes

### `.github/workflows/pr.yaml`
- Remove `sandbox-images-and-e2e` reusable workflow call (was running on GitHub-hosted runners)
- Keep: `changes`, `checks`, `test-e2e-ollama-proxy` (lightweight, GitHub-hosted)

### `.github/workflows/pr-self-hosted.yaml`
- Add `build-sandbox-images-arm64` on `linux-arm64-cpu4`
- Add `test-e2e-port-overrides` on `linux-amd64-cpu4`

### Not deleted
- `sandbox-images-and-e2e.yaml` reusable workflow — still used by `main.yaml` (post-merge CI)

## Type of Change
- [x] Code change (feature, bug fix, or refactor)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (pi agent)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized CI/CD pipeline to improve build and test management.
  * Added support for arm64 Docker image builds.
  * Enhanced E2E testing coverage with port override test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->