### PR TITLE
fix(cli): recognize BuildKit sandbox build progress (Fixes #2311)

### DIFF
--- a/src/lib/sandbox-create-stream.test.ts
+++ b/src/lib/sandbox-create-stream.test.ts
@@ -68,6 +68,32 @@ describe("sandbox-create-stream", () => {
     expect(logLine).toHaveBeenCalledWith("Created sandbox: demo");
   });
 
+  it("streams BuildKit progress lines as build output", async () => {
+    const child = new FakeChild();
+    const logLine = vi.fn();
+    const promise = streamSandboxCreate("echo create", process.env, {
+      logLine,
+      spawnImpl: () => child as never,
+      heartbeatIntervalMs: 1_000,
+      silentPhaseMs: 10_000,
+    });
+
+    child.stdout.emit(
+      "data",
+      Buffer.from("#1 [internal] load build definition from Dockerfile\n#2 CACHED\n#3 DONE 0.1s\n"),
+    );
+    child.emit("close", 0);
+
+    await expect(promise).resolves.toMatchObject({
+      status: 0,
+      sawProgress: true,
+      output: expect.stringContaining("#1 [internal] load build definition from Dockerfile"),
+    });
+    expect(logLine).toHaveBeenCalledWith("#1 [internal] load build definition from Dockerfile");
+    expect(logLine).toHaveBeenCalledWith("#2 CACHED");
+    expect(logLine).toHaveBeenCalledWith("#3 DONE 0.1s");
+  });
+
   it("forces success when the sandbox becomes ready before the stream exits", async () => {
     vi.useFakeTimers();
 

--- a/src/lib/sandbox-create-stream.ts
+++ b/src/lib/sandbox-create-stream.ts
@@ -48,6 +48,35 @@ export interface StreamableChildProcess {
   on(event: "close", listener: (code: number | null) => void): this;
 }
 
+export const BUILD_PROGRESS_PATTERNS: readonly RegExp[] = [
+  /^ {2}Building image /,
+  /^ {2}Step \d+\/\d+ : /,
+  /^#\d+ \[/,
+  /^#\d+ (DONE|CACHED)\b/,
+];
+
+const UPLOAD_PROGRESS_PATTERNS: readonly RegExp[] = [
+  /^ {2}Pushing image /,
+  /^\s*\[progress\]/,
+  /^ {2}Image .*available in the gateway/,
+];
+
+const VISIBLE_PROGRESS_PATTERNS: readonly RegExp[] = [
+  ...BUILD_PROGRESS_PATTERNS,
+  /^ {2}Context: /,
+  /^ {2}Gateway: /,
+  /^Successfully built /,
+  /^Successfully tagged /,
+  /^ {2}Built image /,
+  ...UPLOAD_PROGRESS_PATTERNS,
+  /^Created sandbox: /,
+  /^✓ /,
+];
+
+function matchesAny(line: string, patterns: readonly RegExp[]) {
+  return patterns.some((pattern) => pattern.test(line));
+}
+
 export function streamSandboxCreate(
   command: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -124,13 +153,9 @@ export function streamSandboxCreate(
     if (!line) return;
     lines.push(line);
     lastOutputAt = Date.now();
-    if (/^ {2}Building image /.test(line) || /^ {2}Step \d+\/\d+ : /.test(line)) {
+    if (matchesAny(line, BUILD_PROGRESS_PATTERNS)) {
       setPhase("build");
-    } else if (
-      /^ {2}Pushing image /.test(line) ||
-      /^\s*\[progress\]/.test(line) ||
-      /^ {2}Image .*available in the gateway/.test(line)
-    ) {
+    } else if (matchesAny(line, UPLOAD_PROGRESS_PATTERNS)) {
       setPhase("upload");
     } else if (/^Created sandbox: /.test(line)) {
       setPhase("create");
@@ -142,20 +167,7 @@ export function streamSandboxCreate(
   }
 
   function shouldShowLine(line: string) {
-    return (
-      /^ {2}Building image /.test(line) ||
-      /^ {2}Step \d+\/\d+ : /.test(line) ||
-      /^ {2}Context: /.test(line) ||
-      /^ {2}Gateway: /.test(line) ||
-      /^Successfully built /.test(line) ||
-      /^Successfully tagged /.test(line) ||
-      /^ {2}Built image /.test(line) ||
-      /^ {2}Pushing image /.test(line) ||
-      /^\s*\[progress\]/.test(line) ||
-      /^ {2}Image .*available in the gateway/.test(line) ||
-      /^Created sandbox: /.test(line) ||
-      /^✓ /.test(line)
-    );
+    return matchesAny(line, VISIBLE_PROGRESS_PATTERNS);
   }
 
   function onChunk(chunk: Buffer | string) {


### PR DESCRIPTION
## Summary

NemoClaw's sandbox create stream only recognized the legacy Docker builder format, so BuildKit output would not be treated as active build progress once OpenShell emits it.

This adds BuildKit progress markers to the same parser path as the existing legacy builder output. It keeps the current legacy behavior and makes `#1 [internal] ...`, `#2 CACHED`, and `#3 DONE ...` visible as build progress.

## Changes

- `src/lib/sandbox-create-stream.ts`: recognize BuildKit step and completion lines while tracking the build phase.
- `src/lib/sandbox-create-stream.test.ts`: cover BuildKit progress output and verify it is streamed to the user.

## Testing

- `npm run build:cli` passed
- `npm run typecheck:cli` passed
- `npm test -- src/lib/sandbox-create-stream.test.ts` passed
- `npm test` was also attempted. The full suite is not green on current main in this environment; failures are in existing installer/onboard/legacy-guard tests outside this change.

## Evidence it works

The new focused test feeds BuildKit-style output into `streamSandboxCreate` and verifies that the lines are logged, collected in output, and mark sandbox creation as having seen progress.

Fixes #2311

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and display of BuildKit and upload progress so progress markers and completion states are recognized reliably.

* **Refactor**
  * Centralized progress-detection logic for more consistent handling of build and upload output.

* **Tests**
  * Added a test ensuring BuildKit-formatted progress lines are captured, included in output, and reported to the log callback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->