### PR TITLE
fix(sandbox): keep sandbox root read-only (Fixes #2394)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -371,6 +371,9 @@ os.chmod(path, 0o600)"
 # hadolint ignore=DL3002
 USER root
 
+RUN chown root:root /sandbox \
+    && chmod 755 /sandbox
+
 # Ensure .openclaw-data subdirs and symlinks exist for logs, credentials,
 # sandbox, and plugin-runtime-deps. These are defined in Dockerfile.base but
 # the GHCR base image may not have been rebuilt yet. Idempotent — harmless

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -87,7 +87,9 @@ RUN arch="$(dpkg --print-architecture)" \
 RUN groupadd -r gateway && useradd -r -g gateway -d /sandbox -s /usr/sbin/nologin gateway \
     && groupadd -r sandbox && useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox \
     && mkdir -p /sandbox/.nemoclaw \
-    && chown -R sandbox:sandbox /sandbox
+    && chown root:root /sandbox \
+    && chmod 755 /sandbox \
+    && chown sandbox:sandbox /sandbox/.nemoclaw
 
 # Split .openclaw into immutable config dir + writable state dir.
 # The policy makes /sandbox/.openclaw read-only via Landlock, so the agent

--- a/test/sandbox-root-permissions.test.ts
+++ b/test/sandbox-root-permissions.test.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const sandboxRootChown = /(?:^RUN|\s&&)\s+chown root:root \/sandbox\s*(?:\\|$)/m;
+const sandboxRootChmod = /(?:^RUN|\s&&)\s+chmod 755 \/sandbox\s*(?:\\|$)/m;
+
+function readRepoFile(file: string): string {
+  return fs.readFileSync(path.join(repoRoot, file), "utf8");
+}
+
+describe("sandbox root permissions", () => {
+  it("keeps /sandbox root-owned in the base image", () => {
+    const dockerfile = readRepoFile("Dockerfile.base");
+
+    expect(dockerfile).not.toMatch(/chown -R sandbox:sandbox \/sandbox\s*(?:\\|$)/);
+    expect(dockerfile).toMatch(sandboxRootChown);
+    expect(dockerfile).toMatch(sandboxRootChmod);
+  });
+
+  it("relocks /sandbox in the production image for stale base images", () => {
+    const dockerfile = readRepoFile("Dockerfile");
+
+    expect(dockerfile).toMatch(sandboxRootChown);
+    expect(dockerfile).toMatch(sandboxRootChmod);
+  });
+});


### PR DESCRIPTION
## Summary

The sandbox image made `/sandbox` writable by the `sandbox` user, so `touch /sandbox/testfile` could succeed even though the sandbox root should stay read-only for normal agent use.

This keeps `/sandbox` owned by root with mode `0755`, while preserving writable state directories that the sandbox still needs.

## Changes

- `Dockerfile.base`: stop recursively handing `/sandbox` to the sandbox user; keep the root directory owned by root and writable only by root.
- `Dockerfile`: re-apply the root ownership/mode in the production image for compatibility with older base images.
- `test/sandbox-root-permissions.test.ts`: add static coverage so the image recipes do not regress back to a writable `/sandbox` root.

## Testing

- `npm run build:cli` passed
- `npm run typecheck:cli` passed
- `npm test -- test/sandbox-root-permissions.test.ts` passed
- `npm test` was also attempted. The full suite is not green on current main in this environment; failures are in existing installer/onboard/legacy-guard tests outside this Dockerfile permission change.

## Evidence it works

The new test checks that both image recipes set `/sandbox` to `root:root` and `0755`, and that the base image no longer recursively assigns `/sandbox` itself to the sandbox user.

Fixes #2394

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened top-level sandbox directory ownership and permissions in container images while preserving writable subpaths, improving filesystem access controls.

* **Tests**
  * Added automated tests to verify the sandbox directory ownership and permission hardening is present in image configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->