### PR TITLE
fix(sandbox): ensure procps survives hardening and stale base images (#2343)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,21 @@ RUN npm ci && npm run build
 FROM ${BASE_IMAGE}
 
 # Harden: remove unnecessary build tools and network probes from base image (#830)
-RUN (apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
+# Protect procps before autoremove — the GHCR base may predate the procps
+# addition, leaving it absent or auto-marked. apt-mark + conditional install
+# guarantees ps/top/kill are present regardless of base image staleness.
+# Ref: #2343
+RUN apt-mark manual procps 2>/dev/null || true \
+    && (apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
         netcat-openbsd netcat-traditional ncat 2>/dev/null || true) \
     && apt-get autoremove --purge -y \
-    && rm -rf /var/lib/apt/lists/*
+    && if ! command -v ps >/dev/null 2>&1; then \
+        apt-get update && apt-get install -y --no-install-recommends procps=2:4.0.2-3 \
+        && rm -rf /var/lib/apt/lists/*; \
+    else \
+        rm -rf /var/lib/apt/lists/*; \
+    fi \
+    && ps --version
 
 
 # Copy built plugin and blueprint into the sandbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ FROM ${BASE_IMAGE}
 # addition, leaving it absent or auto-marked. apt-mark + conditional install
 # guarantees ps/top/kill are present regardless of base image staleness.
 # Ref: #2343
+# hadolint ignore=DL3001
 RUN apt-mark manual procps 2>/dev/null || true \
     && (apt-get remove --purge -y gcc gcc-12 g++ g++-12 cpp cpp-12 make \
         netcat-openbsd netcat-traditional ncat 2>/dev/null || true) \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         iproute2=6.1.0-3 \
         iptables=1.8.9-2 \
         libcap2-bin=1:2.66-4+deb12u2+b2 \
+        procps=2:4.0.2-3 \
     && rm -rf /var/lib/apt/lists/*
 
 # gosu for privilege separation (gateway vs sandbox user).

--- a/test/e2e-test.sh
+++ b/test/e2e-test.sh
@@ -413,6 +413,23 @@ else
   fail "State management broken"
 fi
 
+# -------------------------------------------------------
+info "11. Verify procps debug tools are present (#2343)"
+# -------------------------------------------------------
+for cmd in ps top free uptime vmstat; do
+  if command -v "$cmd" >/dev/null 2>&1; then
+    pass "$cmd is available at $(command -v "$cmd")"
+  else
+    fail "$cmd not found — procps package missing from sandbox image"
+  fi
+done
+# Smoke-test: ps must actually execute, not just resolve
+if ps --version >/dev/null 2>&1; then
+  pass "ps executes successfully"
+else
+  fail "ps found but failed to execute"
+fi
+
 echo ""
 echo -e "${GREEN}========================================${NC}"
 echo -e "${GREEN}  ALL E2E TESTS PASSED${NC}"

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -56,6 +56,22 @@ describe("sandbox provisioning: exec-approvals / update-check symlinks (#1027, #
   });
 });
 
+describe("sandbox provisioning: procps debug tools (#2343)", () => {
+  const baseSrc = fs.readFileSync(DOCKERFILE_BASE, "utf-8");
+  const mainSrc = fs.readFileSync(DOCKERFILE, "utf-8");
+
+  it("Dockerfile.base installs procps in the apt-get layer", () => {
+    expect(baseSrc).toMatch(/apt-get.*install.*procps/s);
+  });
+
+  it("Dockerfile has a procps fallback for stale GHCR base images", () => {
+    // The hardening step must protect procps from autoremove and install it
+    // if the base image predates the procps addition.
+    expect(mainSrc).toMatch(/command -v ps/);
+    expect(mainSrc).toMatch(/install.*procps/);
+  });
+});
+
 describe("sandbox provisioning: root-owned read-only config (#514)", () => {
   const src = fs.readFileSync(DOCKERFILE, "utf-8");
 


### PR DESCRIPTION
## Summary

Follow-up to #2356. The adversarial PR review found that `procps` tools (`ps`, `top`, `free`, `uptime`, `vmstat`) were still missing inside a real sandbox runtime even after #2356 added `procps` to `Dockerfile.base`. Root cause: the GHCR base image may not have been rebuilt yet, and the `Dockerfile` hardening step (`apt-get autoremove --purge`) could strip it.

This PR adds a three-layer defense in the production `Dockerfile`:
- **`apt-mark manual procps`** before the autoremove step, so apt never considers it auto-removable
- **Conditional `apt-get install procps`** if `ps` is still missing after hardening (handles stale GHCR base images that predate #2356)
- **Build-time `ps --version`** smoke test that fails the Docker build if procps didn't make it through

Plus regression tests:
- Static guards in `sandbox-provisioning.test.ts` verifying both Dockerfiles contain procps provisions
- Runtime E2E test in `e2e-test.sh` verifying all five procps tools are executable inside the sandbox container

## Test plan

- [ ] `hadolint Dockerfile` passes
- [ ] `hadolint Dockerfile.base` passes
- [ ] `vitest run test/sandbox-provisioning.test.ts` passes
- [ ] CI `test-e2e-sandbox` job passes (runs `e2e-test.sh` inside container, including new test 11)
- [ ] Docker build succeeds with both fresh base image and stale GHCR base

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end checks that verify common system debug tools (ps, top, free, uptime, vmstat) run in the sandbox.
  * Added regression tests ensuring Docker provisioning includes the debug tooling.

* **Chores**
  * Improved Docker provisioning to ensure procps/debug tools are present at runtime, with a fallback install path for older base images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->