### PR TITLE
fix(inference): reject colliding ollama proxy port (#2318)

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -671,8 +671,11 @@ All ports must be non-privileged integers between 1024 and 65535.
 | `NEMOCLAW_DASHBOARD_PORT` | 18789 | Dashboard UI |
 | `NEMOCLAW_VLLM_PORT` | 8000 | vLLM / NIM inference |
 | `NEMOCLAW_OLLAMA_PORT` | 11434 | Ollama inference |
+| `NEMOCLAW_OLLAMA_PROXY_PORT` | 11435 | Ollama auth proxy |
 
 If a port value is not a valid integer or falls outside the allowed range, the CLI exits with an error.
+On non-WSL hosts, `NEMOCLAW_OLLAMA_PORT` and `NEMOCLAW_OLLAMA_PROXY_PORT` must be different.
+If you run Ollama on port 11435, set `NEMOCLAW_OLLAMA_PROXY_PORT` to another free port before onboarding.
 
 ```console
 $ export NEMOCLAW_DASHBOARD_PORT=19000

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -701,8 +701,11 @@ All ports must be non-privileged integers between 1024 and 65535.
 | `NEMOCLAW_DASHBOARD_PORT` | 18789 | Dashboard UI |
 | `NEMOCLAW_VLLM_PORT` | 8000 | vLLM / NIM inference |
 | `NEMOCLAW_OLLAMA_PORT` | 11434 | Ollama inference |
+| `NEMOCLAW_OLLAMA_PROXY_PORT` | 11435 | Ollama auth proxy |
 
 If a port value is not a valid integer or falls outside the allowed range, the CLI exits with an error.
+On non-WSL hosts, `NEMOCLAW_OLLAMA_PORT` and `NEMOCLAW_OLLAMA_PROXY_PORT` must be different.
+If you run Ollama on port 11435, set `NEMOCLAW_OLLAMA_PROXY_PORT` to another free port before onboarding.
 
 ```console
 $ export NEMOCLAW_DASHBOARD_PORT=19000

--- a/src/lib/local-inference.test.ts
+++ b/src/lib/local-inference.test.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
 
 // Import from compiled dist/ for correct coverage attribution.
 import {
@@ -52,36 +54,46 @@ describe("local inference helpers", () => {
   });
 
   it("returns the expected health check command for ollama-local", () => {
-    expect(getLocalProviderHealthEndpoint("ollama-local")).toBe(
-      "http://127.0.0.1:11434/api/tags",
-    );
+    expect(getLocalProviderHealthEndpoint("ollama-local")).toBe("http://127.0.0.1:11434/api/tags");
     expect(getLocalProviderLabel("ollama-local")).toBe("Local Ollama");
-    expect(getLocalProviderHealthCheck("ollama-local")).toEqual(
-      ["curl", "-sf", "http://127.0.0.1:11434/api/tags"],
-    );
+    expect(getLocalProviderHealthCheck("ollama-local")).toEqual([
+      "curl",
+      "-sf",
+      "http://127.0.0.1:11434/api/tags",
+    ]);
   });
 
   it("returns the expected validation and health check commands for vllm-local", () => {
     expect(getLocalProviderValidationBaseUrl("ollama-local")).toBe("http://127.0.0.1:11434/v1");
     expect(getLocalProviderHealthEndpoint("vllm-local")).toBe("http://127.0.0.1:8000/v1/models");
     expect(getLocalProviderLabel("vllm-local")).toBe("Local vLLM");
-    expect(getLocalProviderHealthCheck("vllm-local")).toEqual(
-      ["curl", "-sf", "http://127.0.0.1:8000/v1/models"],
-    );
+    expect(getLocalProviderHealthCheck("vllm-local")).toEqual([
+      "curl",
+      "-sf",
+      "http://127.0.0.1:8000/v1/models",
+    ]);
     expect(getLocalProviderContainerReachabilityCheck("vllm-local")).toEqual([
-      "docker", "run", "--rm",
-      "--add-host", "host.openshell.internal:host-gateway",
+      "docker",
+      "run",
+      "--rm",
+      "--add-host",
+      "host.openshell.internal:host-gateway",
       CONTAINER_REACHABILITY_IMAGE,
-      "-sf", "http://host.openshell.internal:8000/v1/models",
+      "-sf",
+      "http://host.openshell.internal:8000/v1/models",
     ]);
   });
 
   it("returns the expected container reachability command for ollama-local (via auth proxy or direct)", () => {
     expect(getLocalProviderContainerReachabilityCheck("ollama-local")).toEqual([
-      "docker", "run", "--rm",
-      "--add-host", "host.openshell.internal:host-gateway",
+      "docker",
+      "run",
+      "--rm",
+      "--add-host",
+      "host.openshell.internal:host-gateway",
       CONTAINER_REACHABILITY_IMAGE,
-      "-sf", `http://host.openshell.internal:${OLLAMA_CONTAINER_PORT}/api/tags`,
+      "-sf",
+      `http://host.openshell.internal:${OLLAMA_CONTAINER_PORT}/api/tags`,
     ]);
   });
 
@@ -94,6 +106,37 @@ describe("local inference helpers", () => {
     const result = validateLocalProvider("ollama-local", mockCapture);
     expect(result).toEqual({ ok: true });
     expect(callCount).toBe(2);
+  });
+
+  it("rejects non-WSL Ollama when the backend and proxy ports collide", () => {
+    const output = execFileSync(
+      process.execPath,
+      [
+        "-e",
+        [
+          "const platform = require('./dist/lib/platform.js');",
+          "platform.isWsl = () => false;",
+          "const localInference = require('./dist/lib/local-inference.js');",
+          "const result = localInference.validateLocalProvider('ollama-local', () => '{\"models\":[]}');",
+          "process.stdout.write(JSON.stringify(result));",
+        ].join(""),
+      ],
+      {
+        cwd: path.resolve(__dirname, "../.."),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NEMOCLAW_OLLAMA_PORT: "11435",
+          NEMOCLAW_OLLAMA_PROXY_PORT: "11435",
+        },
+      },
+    );
+
+    const result = JSON.parse(output);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("NEMOCLAW_OLLAMA_PORT");
+    expect(result.message).toContain("NEMOCLAW_OLLAMA_PROXY_PORT");
+    expect(result.message).toContain("11435");
   });
 
   it("returns a clear error when ollama-local is unavailable", () => {
@@ -110,7 +153,9 @@ describe("local inference helpers", () => {
     };
     const result = validateLocalProvider("ollama-local", mockCapture);
     expect(result.ok).toBe(false);
-    expect(result.message).toMatch(new RegExp(`host\\.openshell\\.internal:${OLLAMA_CONTAINER_PORT}`));
+    expect(result.message).toMatch(
+      new RegExp(`host\\.openshell\\.internal:${OLLAMA_CONTAINER_PORT}`),
+    );
     expect(result.message).toMatch(/auth proxy/);
   });
 
@@ -258,9 +303,10 @@ describe("local inference helpers", () => {
     expect(
       getBootstrapOllamaModelOptions({ totalMemoryMB: LARGE_OLLAMA_MIN_MEMORY_MB - 1 }),
     ).toEqual(["qwen2.5:7b"]);
-    expect(
-      getBootstrapOllamaModelOptions({ totalMemoryMB: LARGE_OLLAMA_MIN_MEMORY_MB }),
-    ).toEqual(["qwen2.5:7b", DEFAULT_OLLAMA_MODEL]);
+    expect(getBootstrapOllamaModelOptions({ totalMemoryMB: LARGE_OLLAMA_MIN_MEMORY_MB })).toEqual([
+      "qwen2.5:7b",
+      DEFAULT_OLLAMA_MODEL,
+    ]);
     expect(getDefaultOllamaModel({ totalMemoryMB: 16384 }, () => "")).toBe("qwen2.5:7b");
   });
 
@@ -300,18 +346,16 @@ describe("local inference helpers", () => {
   });
 
   it("fails ollama model validation when Ollama returns an error payload", () => {
-    const result = validateOllamaModel(
-      "gabegoodhart/minimax-m2.1:latest",
-      () => JSON.stringify({ error: "model requires more system memory" }),
+    const result = validateOllamaModel("gabegoodhart/minimax-m2.1:latest", () =>
+      JSON.stringify({ error: "model requires more system memory" }),
     );
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/requires more system memory/);
   });
 
   it("passes ollama model validation when the probe returns a normal payload", () => {
-    const result = validateOllamaModel(
-      "nemotron-3-nano:30b",
-      () => JSON.stringify({ model: "nemotron-3-nano:30b", response: "hello", done: true }),
+    const result = validateOllamaModel("nemotron-3-nano:30b", () =>
+      JSON.stringify({ model: "nemotron-3-nano:30b", response: "hello", done: true }),
     );
     expect(result).toEqual({ ok: true });
   });

--- a/src/lib/local-inference.ts
+++ b/src/lib/local-inference.ts
@@ -48,6 +48,20 @@ export interface LocalProviderHealthProbeOptions {
   runCurlProbeImpl?: (argv: string[]) => CurlProbeResult;
 }
 
+export function validateOllamaPortConfiguration(): ValidationResult {
+  if (!isWsl() && OLLAMA_PORT === OLLAMA_PROXY_PORT) {
+    return {
+      ok: false,
+      message:
+        `NEMOCLAW_OLLAMA_PORT and NEMOCLAW_OLLAMA_PROXY_PORT both resolve to ${OLLAMA_PORT}. ` +
+        "Run Ollama on a different port or set NEMOCLAW_OLLAMA_PROXY_PORT to a free port so " +
+        "the auth proxy does not route back to itself.",
+    };
+  }
+
+  return { ok: true };
+}
+
 export function getLocalProviderBaseUrl(provider: string): string | null {
   switch (provider) {
     case "vllm-local":
@@ -157,19 +171,27 @@ export function getLocalProviderContainerReachabilityCheck(provider: string): st
   switch (provider) {
     case "vllm-local":
       return [
-        "docker", "run", "--rm",
-        "--add-host", "host.openshell.internal:host-gateway",
+        "docker",
+        "run",
+        "--rm",
+        "--add-host",
+        "host.openshell.internal:host-gateway",
         CONTAINER_REACHABILITY_IMAGE,
-        "-sf", `http://host.openshell.internal:${VLLM_PORT}/v1/models`,
+        "-sf",
+        `http://host.openshell.internal:${VLLM_PORT}/v1/models`,
       ];
     case "ollama-local":
       // Check the auth proxy port, not Ollama directly. The proxy listens
       // on 0.0.0.0 and is reachable from containers; Ollama is on 127.0.0.1.
       return [
-        "docker", "run", "--rm",
-        "--add-host", "host.openshell.internal:host-gateway",
+        "docker",
+        "run",
+        "--rm",
+        "--add-host",
+        "host.openshell.internal:host-gateway",
         CONTAINER_REACHABILITY_IMAGE,
-        "-sf", `http://host.openshell.internal:${OLLAMA_CONTAINER_PORT}/api/tags`,
+        "-sf",
+        `http://host.openshell.internal:${OLLAMA_CONTAINER_PORT}/api/tags`,
       ];
     default:
       return null;
@@ -180,6 +202,13 @@ export function validateLocalProvider(
   provider: string,
   runCaptureImpl?: RunCaptureFn,
 ): ValidationResult {
+  if (provider === "ollama-local") {
+    const portValidation = validateOllamaPortConfiguration();
+    if (!portValidation.ok) {
+      return portValidation;
+    }
+  }
+
   const capture = runCaptureImpl ?? runCapture;
   const command = getLocalProviderHealthCheck(provider);
   if (!command) {
@@ -197,8 +226,7 @@ export function validateLocalProvider(
       case "ollama-local":
         return {
           ok: false,
-          message:
-            `Local Ollama was selected, but nothing is responding on http://127.0.0.1:${OLLAMA_PORT}.`,
+          message: `Local Ollama was selected, but nothing is responding on http://127.0.0.1:${OLLAMA_PORT}.`,
         };
       default:
         return { ok: false, message: "The selected local inference provider is unavailable." };
@@ -219,14 +247,12 @@ export function validateLocalProvider(
     case "vllm-local":
       return {
         ok: false,
-        message:
-          `Local vLLM is responding on 127.0.0.1, but containers cannot reach http://host.openshell.internal:${VLLM_PORT}. Ensure the server is reachable from containers, not only from the host shell.`,
+        message: `Local vLLM is responding on 127.0.0.1, but containers cannot reach http://host.openshell.internal:${VLLM_PORT}. Ensure the server is reachable from containers, not only from the host shell.`,
       };
     case "ollama-local":
       return {
         ok: false,
-        message:
-          `Local Ollama is responding on 127.0.0.1, but containers cannot reach the auth proxy at http://host.openshell.internal:${OLLAMA_CONTAINER_PORT}. Ensure the Ollama auth proxy is running.`,
+        message: `Local Ollama is responding on 127.0.0.1, but containers cannot reach the auth proxy at http://host.openshell.internal:${OLLAMA_CONTAINER_PORT}. Ensure the Ollama auth proxy is running.`,
       };
     default:
       return {
@@ -303,7 +329,8 @@ export function getOllamaWarmupCommand(model: string, keepAlive = "15m"): string
   // chars) then shellQuote'd (single-quoted), so injection through model
   // names is not feasible. This is the one intentional bash -c exception.
   return [
-    "bash", "-c",
+    "bash",
+    "-c",
     `nohup curl -s http://127.0.0.1:${OLLAMA_PORT}/api/generate -H 'Content-Type: application/json' -d ${shellQuote(payload)} >/dev/null 2>&1 &`,
   ];
 }
@@ -320,11 +347,15 @@ export function getOllamaProbeCommand(
     keep_alive: keepAlive,
   });
   return [
-    "curl", "-sS",
-    "--max-time", String(timeoutSeconds),
+    "curl",
+    "-sS",
+    "--max-time",
+    String(timeoutSeconds),
     `http://127.0.0.1:${OLLAMA_PORT}/api/generate`,
-    "-H", "Content-Type: application/json",
-    "-d", payload,
+    "-H",
+    "Content-Type: application/json",
+    "-d",
+    payload,
   ];
 }
 

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -52,6 +52,7 @@ const {
   getLocalProviderValidationBaseUrl,
   getOllamaModelOptions,
   getOllamaWarmupCommand,
+  validateOllamaPortConfiguration,
   validateOllamaModel,
   validateLocalProvider,
 } = require("./local-inference");
@@ -4166,6 +4167,20 @@ async function setupNim(gpu) {
     }
   }
 
+  function checkOllamaPortsOrWarn(): boolean {
+    const portValidation = validateOllamaPortConfiguration();
+    if (!portValidation.ok) {
+      console.error(`  ${portValidation.message}`);
+      if (isNonInteractive()) {
+        process.exit(1);
+      }
+      console.log("  Choose a different local inference provider or fix the port settings.");
+      console.log("");
+      return false;
+    }
+    return true;
+  }
+
   if (options.length > 1) {
     selectionLoop: while (true) {
       let selected;
@@ -4635,6 +4650,7 @@ async function setupNim(gpu) {
         }
         break;
       } else if (selected.key === "ollama") {
+        if (!checkOllamaPortsOrWarn()) continue selectionLoop;
         if (!ollamaRunning) {
           console.log("  Starting Ollama...");
           // On WSL2, binding to 0.0.0.0 creates a dual-stack socket that Docker
@@ -4707,6 +4723,7 @@ async function setupNim(gpu) {
         }
         break;
       } else if (selected.key === "install-ollama") {
+        if (!checkOllamaPortsOrWarn()) continue selectionLoop;
         if (process.platform === "darwin") {
           console.log("  Installing Ollama via Homebrew...");
           run(["brew", "install", "ollama"], { ignoreError: true });


### PR DESCRIPTION
## Summary

Signed replay of #2322 by @futhgar — the original PR's commits were unsigned and could not pass DCO.

Fail fast when non-WSL Ollama local inference resolves the Ollama backend and auth proxy to the same port. This prevents the proxy from routing requests back into itself and surfacing as `HTTP 401: Unauthorized` during agent calls.

## Related Issue

Fixes #2318
Supersedes #2322

## Changes

- Add `validateOllamaPortConfiguration()` with non-WSL collision check in `src/lib/local-inference.ts`
- Extract `checkOllamaPortsOrWarn()` helper in `setupNim` for both `ollama` and `install-ollama` onboard paths
- Document `NEMOCLAW_OLLAMA_PROXY_PORT` env var and the non-WSL port-collision rule
- Add regression test for the `11435`/`11435` collision case

## Credit

All code authored by @futhgar in #2322. Replayed here with a signed commit to satisfy DCO.

## Verification
- [x] Tests added for new behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `NEMOCLAW_OLLAMA_PROXY_PORT` environment variable documentation with default value `11435`.

* **Bug Fixes**
  * Added validation to prevent Ollama port configuration conflicts on non-WSL systems.
  * Integrated preflight checks during setup to detect and handle port collision errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->