### PR TITLE
fix(sandbox): guard unsupported openclaw config writes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,9 +113,10 @@ RUN set -eu; \
 RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \
     && cp -r /opt/nemoclaw-blueprint/* /sandbox/.nemoclaw/blueprints/0.1.0/
 
-# Copy startup script
+# Copy startup scripts
 COPY scripts/nemoclaw-start.sh /usr/local/bin/nemoclaw-start
-RUN chmod 755 /usr/local/bin/nemoclaw-start
+COPY scripts/openclaw-wrapper.sh /usr/local/lib/nemoclaw/openclaw-wrapper.sh
+RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/openclaw-wrapper.sh
 
 # Build args for config that varies per deployment.
 # nemoclaw onboard passes these at image build time.
@@ -250,6 +251,19 @@ os.chmod(path, 0o600)"
 RUN openclaw doctor --fix > /dev/null 2>&1 || true \
     && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 
+# Install a stable OpenClaw wrapper inside the image. This avoids relying on
+# shell rc sourcing for `nemoclaw ... connect` sessions, while surfacing a
+# clear UX error for commands that cannot work inside the immutable sandbox.
+USER root
+RUN OPENCLAW_BIN="$(command -v openclaw)" \
+    && if [ "$OPENCLAW_BIN" != "/usr/local/bin/openclaw" ]; then \
+        echo "Error: expected openclaw at /usr/local/bin/openclaw, got $OPENCLAW_BIN"; \
+        exit 1; \
+    fi \
+    && mv "$OPENCLAW_BIN" /usr/local/bin/openclaw-real \
+    && install -m 755 /usr/local/lib/nemoclaw/openclaw-wrapper.sh /usr/local/bin/openclaw \
+    && chmod 755 /usr/local/bin/openclaw-real
+
 # Lock openclaw.json via DAC: chown to root so the sandbox user cannot modify
 # it at runtime.  This works regardless of Landlock enforcement status.
 # The Landlock policy (/sandbox/.openclaw in read_only) provides defense-in-depth
@@ -261,7 +275,6 @@ RUN openclaw doctor --fix > /dev/null 2>&1 || true \
 # (e.g., pointing /sandbox/.openclaw/hooks to an attacker-controlled path).
 # The writable state lives in .openclaw-data, reached via the symlinks.
 # hadolint ignore=DL3002
-USER root
 
 # Ensure .openclaw-data subdirs and symlinks exist for logs, credentials, and
 # sandbox. These are defined in Dockerfile.base but the GHCR base image may

--- a/scripts/openclaw-wrapper.sh
+++ b/scripts/openclaw-wrapper.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+REAL_OPENCLAW="${REAL_OPENCLAW:-/usr/local/bin/openclaw-real}"
+
+case "${1:-}" in
+  configure)
+    echo "Error: 'openclaw configure' cannot modify config inside the sandbox." >&2
+    echo "The sandbox config is read-only (Landlock enforced) for security." >&2
+    echo "" >&2
+    echo "To change your configuration, exit the sandbox and run:" >&2
+    echo "  nemoclaw onboard --resume" >&2
+    echo "" >&2
+    echo "This rebuilds the sandbox with your updated settings." >&2
+    exit 1
+    ;;
+  agents)
+    case "${2:-}" in
+      add)
+        echo "Error: 'openclaw agents add' cannot modify agent config inside a NemoClaw-managed sandbox." >&2
+        echo "The sandbox config is read-only (Landlock enforced) for security." >&2
+        echo "" >&2
+        echo "Creating additional OpenClaw agents inside the sandbox is not currently supported." >&2
+        echo "Exit the sandbox and use a host-side NemoClaw workflow instead." >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  agent)
+    # Warn when --local is used — it bypasses gateway protections including
+    # secret scanning, network policy, and inference auth. Ref: #1632
+    for _arg in "$@"; do
+      if [ "$_arg" = "--local" ]; then
+        echo "[SECURITY] Warning: 'openclaw agent --local' bypasses the NemoClaw gateway." >&2
+        echo "[SECURITY] Secret scanning, network policy, and inference auth are NOT enforced in local mode." >&2
+        break
+      fi
+    done
+    ;;
+esac
+
+exec "$REAL_OPENCLAW" "$@"

--- a/src/lib/sandbox-build-context.ts
+++ b/src/lib/sandbox-build-context.ts
@@ -59,10 +59,9 @@ function stageOptimizedSandboxBuildContext(rootDir, tmpDir = os.tmpdir()) {
   });
 
   fs.mkdirSync(stagedScriptsDir, { recursive: true });
-  fs.copyFileSync(
-    path.join(rootDir, "scripts", "nemoclaw-start.sh"),
-    path.join(stagedScriptsDir, "nemoclaw-start.sh"),
-  );
+  for (const scriptName of ["nemoclaw-start.sh", "openclaw-wrapper.sh"]) {
+    fs.copyFileSync(path.join(rootDir, "scripts", scriptName), path.join(stagedScriptsDir, scriptName));
+  }
 
   return { buildCtx, stagedDockerfile };
 }

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1336,6 +1336,7 @@ startGateway(null).catch(() => {});
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw", "src"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw-blueprint", ".venv"))).toBe(false);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "nemoclaw-start.sh"))).toBe(true);
+      expect(fs.existsSync(path.join(buildCtx, "scripts", "openclaw-wrapper.sh"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw", "node_modules"))).toBe(false);
     } finally {

--- a/test/openclaw-wrapper.test.ts
+++ b/test/openclaw-wrapper.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WRAPPER = path.join(import.meta.dirname, "..", "scripts", "openclaw-wrapper.sh");
+const DOCKERFILE = path.join(import.meta.dirname, "..", "Dockerfile");
+
+describe("openclaw sandbox wrapper", () => {
+  it("blocks config-mutating commands with actionable guidance", () => {
+    const src = fs.readFileSync(WRAPPER, "utf-8");
+
+    expect(src).toContain("openclaw configure");
+    expect(src).toContain("nemoclaw onboard --resume");
+    expect(src).toContain("openclaw agents add");
+    expect(src).toContain("not currently supported");
+    expect(src).toContain('exec "$REAL_OPENCLAW" "$@"');
+  });
+
+  it("is installed as the runtime openclaw binary in the sandbox image", () => {
+    const src = fs.readFileSync(DOCKERFILE, "utf-8");
+
+    expect(src).toContain("COPY scripts/openclaw-wrapper.sh /usr/local/lib/nemoclaw/openclaw-wrapper.sh");
+    expect(src).toContain('OPENCLAW_BIN="$(command -v openclaw)"');
+    expect(src).toContain('mv "$OPENCLAW_BIN" /usr/local/bin/openclaw-real');
+    expect(src).toContain("install -m 755 /usr/local/lib/nemoclaw/openclaw-wrapper.sh /usr/local/bin/openclaw");
+  });
+});

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -28,6 +28,7 @@ describe("sandbox build context staging", () => {
         ),
       ).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "nemoclaw-start.sh"))).toBe(true);
+      expect(fs.existsSync(path.join(buildCtx, "scripts", "openclaw-wrapper.sh"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- install a stable `openclaw` wrapper in the sandbox image so `openclaw configure` and `openclaw agents add` fail with actionable guidance instead of low-level permission errors
- stage the wrapper into the optimized sandbox build context so `nemoclaw onboard` can copy it into rebuilt sandbox images
- add regression coverage for wrapper installation and build-context staging

## Test plan
- [x] Reproduced the original `openclaw agents add ...` sandbox failure on Brev before the fix
- [x] Rebuilt and reinstalled `nemoclaw`, then recreated the sandbox on Brev
- [x] Verified `/usr/local/bin/openclaw` resolves to the wrapper and `/usr/local/bin/openclaw-real` resolves to the real binary inside the sandbox
- [x] Verified `openclaw agents add my_agent --workspace ~/.openclaw/workspace-my-agent` now returns the new UX guard message
- [x] Verified `openclaw configure` now returns the new UX guard message
- [x] Verified `openclaw --version` still passes through to the real binary
- [ ] Local `vitest` run in this workspace is currently blocked by the existing Node/vitest `ERR_REQUIRE_ESM` environment issue

Fixes #2145

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenClaw sandbox wrapper that intercepts and blocks configuration changes and agent additions within managed environments, providing clear guidance on proper workflows.
  * Added security warning when local mode is invoked, indicating it bypasses gateway protections including secret scanning and network policy enforcement.

* **Tests**
  * Added comprehensive test coverage for wrapper behavior and Docker integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->