### PR TITLE
fix(jetson): apply br_netfilter on JetPack R39 when missing (Fixes #2418)

### DIFF
--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -16,26 +16,35 @@ error() {
   exit 1
 }
 
-# Returns 0 when `br_netfilter` is loaded AND the bridge-nf-call-iptables
-# sysctl is already set to 1. Used so we can skip host-state changes on
-# Jetson images that ship with this configured out of the box.
+# Returns 0 when `br_netfilter` is loaded AND both bridge-nf-call-iptables
+# and bridge-nf-call-ip6tables sysctls are already set to 1. Used so we
+# can skip host-state changes on Jetson images that ship with this
+# configured out of the box.
 bridge_netfilter_ready() {
   [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] \
-    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]]
+    && [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]] \
+    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]] \
+    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null)" == "1" ]]
 }
 
-# Load br_netfilter and flip the bridge-nf-call-iptables sysctl, then
-# persist both across reboots. Required for k3s (running inside the
-# OpenShell gateway container) to NAT pod → ClusterIP traffic; without
-# this the kube-proxy iptables rules are written but never matched for
-# bridged pod traffic, so sandbox pods cannot reach CoreDNS.
+# Load br_netfilter and flip the bridge-nf-call-{ip,ip6}tables sysctls,
+# then persist all three across reboots. Required for k3s (running inside
+# the OpenShell gateway container) to NAT pod → ClusterIP traffic;
+# without this the kube-proxy iptables rules are written but never
+# matched for bridged pod traffic, so sandbox pods cannot reach CoreDNS.
+# ip6tables is flipped alongside iptables to keep IPv4 and IPv6 cluster
+# services consistent and match the manual workaround validated on #2418.
 apply_br_netfilter_setup() {
   "${SUDO[@]}" modprobe br_netfilter
   "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
+  "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-ip6tables=1 >/dev/null
 
   # Persist across reboots
   echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
-  echo "net.bridge.bridge-nf-call-iptables=1" | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+  {
+    echo "net.bridge.bridge-nf-call-iptables=1"
+    echo "net.bridge.bridge-nf-call-ip6tables=1"
+  } | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
 }
 
 get_jetpack_version() {
@@ -56,9 +65,9 @@ get_jetpack_version() {
   if ((release >= 39)); then
     # JP7 R39 does not need iptables / daemon.json changes, but k3s inside
     # the OpenShell gateway container still needs br_netfilter +
-    # bridge-nf-call-iptables=1 for ClusterIP service routing. Some R39
-    # kernel images ship with it already in place, so check first and only
-    # apply when missing — avoids planting NemoClaw-owned drop-ins in
+    # bridge-nf-call-{ip,ip6}tables=1 for ClusterIP service routing. Some
+    # R39 kernel images ship with it already in place, so check first and
+    # only apply when missing — avoids planting NemoClaw-owned drop-ins in
     # /etc/modules-load.d and /etc/sysctl.d on systems that don't need
     # them. See #2418.
     if bridge_netfilter_ready; then

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -31,11 +31,6 @@ get_jetpack_version() {
     return 0
   fi
 
-  if ((release >= 39)); then
-    info "Jetson detected (L4T $l4t_version) — this version does not require any host setup" >&2
-    return 0
-  fi
-
   case "$l4t_version" in
     36.*)
       printf "%s" "jp6"
@@ -43,10 +38,27 @@ get_jetpack_version() {
     38.*)
       printf "%s" "jp7-r38"
       ;;
+    39.*)
+      # JP7 R39 does not need iptables or daemon.json changes (same as R38),
+      # but k3s inside the OpenShell gateway container requires br_netfilter
+      # + net.bridge.bridge-nf-call-iptables=1 for ClusterIP service routing.
+      # The earlier "R39 needs no host setup" assumption was wrong: some R39
+      # kernel builds ship without the module loaded, and sandbox agent pods
+      # then crash-loop on cluster.local lookups. See #2418.
+      printf "%s" "jp7-r39"
+      ;;
     *)
       info "Jetson detected (L4T $l4t_version) but version is not recognized — skipping host setup" >&2
       ;;
   esac
+}
+
+# Returns 0 when `br_netfilter` is loaded AND the bridge-nf-call-iptables
+# sysctl is already set to 1. Used so we can skip host-state changes on
+# Jetson images that ship with this configured out of the box.
+bridge_netfilter_ready() {
+  [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] \
+    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]]
 }
 
 configure_jetson_host() {
@@ -119,17 +131,34 @@ PYEOF
     jp7-r38)
       # JP7 R38 does not need iptables or Docker daemon.json changes.
       ;;
+    jp7-r39)
+      # Same as R38 — no iptables or daemon.json changes. Only the
+      # br_netfilter setup below is relevant, and that's applied
+      # conditionally further down (some R39 images already ship with
+      # it loaded).
+      ;;
     *)
       error "Unsupported Jetson version: $jetpack_version"
       ;;
   esac
 
-  "${SUDO[@]}" modprobe br_netfilter
-  "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
+  # Apply br_netfilter setup. For JP6/JP7-R38 keep the pre-existing
+  # unconditional behavior — writing the persistent drop-ins is
+  # idempotent on re-runs, and we don't want to change what works for
+  # those already-shipped versions. For JP7-R39, only touch host state
+  # when the module isn't already configured, so images that ship with
+  # it in place don't end up with NemoClaw-owned files they didn't
+  # need.
+  if [[ "$jetpack_version" == "jp7-r39" ]] && bridge_netfilter_ready; then
+    info "br_netfilter already loaded and net.bridge.bridge-nf-call-iptables=1 — skipping"
+  else
+    "${SUDO[@]}" modprobe br_netfilter
+    "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
 
-  # Persist across reboots
-  echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
-  echo "net.bridge.bridge-nf-call-iptables=1" | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+    # Persist across reboots
+    echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
+    echo "net.bridge.bridge-nf-call-iptables=1" | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+  fi
 
   if [[ "$jetpack_version" == "jp6" ]]; then
     "${SUDO[@]}" systemctl restart docker

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -18,51 +18,31 @@ error() {
 
 # Returns 0 only when both the live kernel state AND our persistent
 # drop-ins are in place:
-#   - runtime: bridge-nf-call-iptables sysctl reads back as 1 (and the
-#     same for bridge-nf-call-ip6tables IFF this kernel exposes it)
+#   - runtime: bridge-nf-call-iptables sysctl reads back as 1
 #   - persistence: /etc/modules-load.d/nemoclaw.conf contains `br_netfilter`
-#     and /etc/sysctl.d/99-nemoclaw.conf contains the sysctl=1 line(s)
-#     matching what the kernel actually supports
-# The IPv6 checks are gated on /proc/sys/net/bridge/bridge-nf-call-ip6tables
-# existing because kernels built without CONFIG_IPV6 do not expose that
-# sysctl; asserting it unconditionally would make this function (and the
-# apply step) fail on such hosts.
+#     and /etc/sysctl.d/99-nemoclaw.conf contains the sysctl=1 line
 # Skipping on runtime-only state is wrong: if someone transiently ran
 # `modprobe br_netfilter` + `sysctl -w ...=1` without persisting, the
 # fix would evaporate after the next reboot. Requiring persistence too
-# makes the skip branch safe and lets `apply_br_netfilter_setup_r39`
-# (which is idempotent) re-write the drop-ins whenever they're missing
-# or stale (e.g. an older v4-only version of this script left behind).
+# makes the skip branch safe and lets `apply_br_netfilter_setup` (which
+# is idempotent) re-write the drop-ins whenever they're missing.
 bridge_netfilter_ready() {
-  # Runtime — v4 is mandatory (br_netfilter loaded + sysctl on)
-  [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] || return 1
-  [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]] || return 1
-
-  # Persistence — modules-load drop-in
-  [[ -f /etc/modules-load.d/nemoclaw.conf ]] || return 1
-  grep -qx 'br_netfilter' /etc/modules-load.d/nemoclaw.conf 2>/dev/null || return 1
-
-  # Persistence — sysctl drop-in, v4 line mandatory
-  [[ -f /etc/sysctl.d/99-nemoclaw.conf ]] || return 1
-  grep -qx 'net.bridge.bridge-nf-call-iptables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null || return 1
-
-  # If this kernel exposes bridge-nf-call-ip6tables, require both runtime
-  # and persistence for it too. On kernels without IPv6 bridge netfilter
-  # the /proc node does not exist — we treat v4-only as fully-ready
-  # there, matching what apply_br_netfilter_setup_r39 actually wrote.
-  if [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]]; then
-    [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null)" == "1" ]] || return 1
-    grep -qx 'net.bridge.bridge-nf-call-ip6tables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null || return 1
-  fi
-
-  return 0
+  [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] \
+    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]] \
+    && [[ -f /etc/modules-load.d/nemoclaw.conf ]] \
+    && grep -qx 'br_netfilter' /etc/modules-load.d/nemoclaw.conf 2>/dev/null \
+    && [[ -f /etc/sysctl.d/99-nemoclaw.conf ]] \
+    && grep -qx 'net.bridge.bridge-nf-call-iptables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null
 }
 
 # Load br_netfilter and flip bridge-nf-call-iptables, then persist both
-# across reboots. Used by the R36/R38 paths — byte-identical to the
-# original inline block that lived in configure_jetson_host before the
-# #2418 refactor. Do NOT add IPv6 here: the R36/R38 paths predate the
-# #2418 work and changing their behavior would be out of scope.
+# across reboots. Required for k3s (running inside the OpenShell gateway
+# container) to NAT pod → ClusterIP traffic; without this the kube-proxy
+# iptables rules are written but never matched for bridged pod traffic,
+# so sandbox pods cannot reach CoreDNS. Idempotent — safe to re-run
+# whenever bridge_netfilter_ready returns false, including the "runtime
+# is live but drop-ins missing" case (e.g. someone ran modprobe + sysctl
+# manually without persisting).
 apply_br_netfilter_setup() {
   "${SUDO[@]}" modprobe br_netfilter
   "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
@@ -70,44 +50,6 @@ apply_br_netfilter_setup() {
   # Persist across reboots
   echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
   echo "net.bridge.bridge-nf-call-iptables=1" | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
-}
-
-# R39-specific variant: flips bridge-nf-call-iptables and, when the
-# kernel exposes it, bridge-nf-call-ip6tables, then persists whatever
-# was actually applied. Kept separate from apply_br_netfilter_setup so
-# the R36/R38 behavior stays byte-identical to pre-#2418; the dual-stack
-# sysctl write is the configuration the reporter validated end-to-end
-# on their Jetson Orin R39 (#2418).
-# The IPv6 sysctl write is gated on /proc/sys/net/bridge/bridge-nf-call-ip6tables
-# existing because kernels built without CONFIG_IPV6 do not expose that
-# sysctl; `sysctl -w` on a missing key would fail under `set -e`. On
-# such hosts the persistence drop-in only carries the IPv4 line, and
-# bridge_netfilter_ready() mirrors this (only requires the IPv6 line
-# when the /proc node is present).
-# Idempotent: safe to call whenever bridge_netfilter_ready returns false,
-# including the "runtime is live but drop-ins missing" case (e.g. someone
-# ran modprobe + sysctl manually without persisting).
-apply_br_netfilter_setup_r39() {
-  "${SUDO[@]}" modprobe br_netfilter
-  "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
-
-  local has_ipv6=0
-  if [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]]; then
-    "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-ip6tables=1 >/dev/null
-    has_ipv6=1
-  fi
-
-  # Persist across reboots
-  echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
-  if ((has_ipv6)); then
-    {
-      echo "net.bridge.bridge-nf-call-iptables=1"
-      echo "net.bridge.bridge-nf-call-ip6tables=1"
-    } | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
-  else
-    echo "net.bridge.bridge-nf-call-iptables=1" \
-      | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
-  fi
 }
 
 get_jetpack_version() {
@@ -128,9 +70,9 @@ get_jetpack_version() {
   if ((release >= 39)); then
     # JP7 R39 does not need iptables / daemon.json changes, but k3s inside
     # the OpenShell gateway container still needs br_netfilter +
-    # bridge-nf-call-{ip,ip6}tables=1 for ClusterIP service routing. Some
-    # R39 kernel images ship with it already in place, so check first and
-    # only apply when missing — avoids planting NemoClaw-owned drop-ins in
+    # bridge-nf-call-iptables=1 for ClusterIP service routing. Some R39
+    # kernel images ship with it already in place, so check first and only
+    # apply when missing — avoids planting NemoClaw-owned drop-ins in
     # /etc/modules-load.d and /etc/sysctl.d on systems that don't need
     # them. See #2418.
     if bridge_netfilter_ready; then
@@ -141,21 +83,14 @@ get_jetpack_version() {
         "${SUDO[@]}" true >/dev/null \
           || error "Sudo is required to load br_netfilter and write /etc/modules-load.d and /etc/sysctl.d drop-ins."
       fi
-      apply_br_netfilter_setup_r39
-      # Read the values back from /proc (not just "we set it to 1") so the
+      apply_br_netfilter_setup
+      # Read the value back from /proc (not just "we set it to 1") so the
       # log is actual evidence that the apply path landed — useful when a
       # user is validating the fix on their own Jetson and needs to confirm
-      # from log output alone that the runtime state is correct. The IPv6
-      # leg is only included when the kernel exposes the sysctl, matching
-      # what apply_br_netfilter_setup_r39 actually wrote.
-      local v4 v6_summary
+      # from log output alone that the runtime state is correct.
+      local v4
       v4="$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo '?')"
-      if [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]]; then
-        v6_summary=", bridge-nf-call-ip6tables=$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null || echo '?')"
-      else
-        v6_summary=" (ip6tables not exposed by this kernel; IPv4-only persistence)"
-      fi
-      info "br_netfilter runtime: bridge-nf-call-iptables=$v4$v6_summary — sandbox → ClusterIP routing (CoreDNS, services) is unblocked; no docker or k3s restart needed" >&2
+      info "br_netfilter runtime: bridge-nf-call-iptables=$v4 — sandbox → ClusterIP routing (CoreDNS, services) is unblocked; no docker or k3s restart needed" >&2
       info "Reboot persistence: /etc/modules-load.d/nemoclaw.conf, /etc/sysctl.d/99-nemoclaw.conf" >&2
     fi
     return 0

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -16,25 +16,52 @@ error() {
   exit 1
 }
 
-# Returns 0 when `br_netfilter` is loaded AND both bridge-nf-call-iptables
-# and bridge-nf-call-ip6tables sysctls are already set to 1. Used so we
-# can skip host-state changes on Jetson images that ship with this
-# configured out of the box.
+# Returns 0 only when both the live kernel state AND our persistent
+# drop-ins are in place:
+#   - runtime: bridge-nf-call-{iptables,ip6tables} sysctls read back as 1
+#   - persistence: /etc/modules-load.d/nemoclaw.conf contains `br_netfilter`
+#     and /etc/sysctl.d/99-nemoclaw.conf contains both sysctl=1 lines
+# Skipping on runtime-only state is wrong: if someone transiently ran
+# `modprobe br_netfilter` + `sysctl -w ...=1` without persisting, the
+# fix would evaporate after the next reboot. Requiring persistence too
+# makes the skip branch safe and lets `apply_br_netfilter_setup_r39`
+# (which is idempotent) re-write the drop-ins whenever they're missing
+# or stale (e.g. an older v4-only version of this script left behind).
 bridge_netfilter_ready() {
   [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] \
     && [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]] \
     && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]] \
-    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null)" == "1" ]]
+    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null)" == "1" ]] \
+    && [[ -f /etc/modules-load.d/nemoclaw.conf ]] \
+    && grep -qx 'br_netfilter' /etc/modules-load.d/nemoclaw.conf 2>/dev/null \
+    && [[ -f /etc/sysctl.d/99-nemoclaw.conf ]] \
+    && grep -qx 'net.bridge.bridge-nf-call-iptables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null \
+    && grep -qx 'net.bridge.bridge-nf-call-ip6tables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null
 }
 
-# Load br_netfilter and flip the bridge-nf-call-{ip,ip6}tables sysctls,
-# then persist all three across reboots. Required for k3s (running inside
-# the OpenShell gateway container) to NAT pod → ClusterIP traffic;
-# without this the kube-proxy iptables rules are written but never
-# matched for bridged pod traffic, so sandbox pods cannot reach CoreDNS.
-# ip6tables is flipped alongside iptables to keep IPv4 and IPv6 cluster
-# services consistent and match the manual workaround validated on #2418.
+# Load br_netfilter and flip bridge-nf-call-iptables, then persist both
+# across reboots. Used by the R36/R38 paths — byte-identical to the
+# original inline block that lived in configure_jetson_host before the
+# #2418 refactor. Do NOT add IPv6 here: the R36/R38 paths predate the
+# #2418 work and changing their behavior would be out of scope.
 apply_br_netfilter_setup() {
+  "${SUDO[@]}" modprobe br_netfilter
+  "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
+
+  # Persist across reboots
+  echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
+  echo "net.bridge.bridge-nf-call-iptables=1" | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+}
+
+# R39-specific variant: flips both bridge-nf-call-iptables and
+# bridge-nf-call-ip6tables and persists both. Kept separate from
+# apply_br_netfilter_setup so the R36/R38 behavior stays byte-identical
+# to pre-#2418; the dual-stack sysctl write is the configuration the
+# reporter validated end-to-end on their Jetson Orin R39 (#2418).
+# Idempotent: safe to call whenever bridge_netfilter_ready returns false,
+# including the "runtime is live but drop-ins missing" case (e.g. someone
+# ran modprobe + sysctl manually without persisting).
+apply_br_netfilter_setup_r39() {
   "${SUDO[@]}" modprobe br_netfilter
   "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
   "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-ip6tables=1 >/dev/null
@@ -78,7 +105,7 @@ get_jetpack_version() {
         "${SUDO[@]}" true >/dev/null \
           || error "Sudo is required to load br_netfilter and write /etc/modules-load.d and /etc/sysctl.d drop-ins."
       fi
-      apply_br_netfilter_setup
+      apply_br_netfilter_setup_r39
       # Read the values back from /proc (not just "we set it to 1") so the
       # log is actual evidence that the apply path landed — useful when a
       # user is validating the fix on their own Jetson and needs to confirm

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -18,9 +18,15 @@ error() {
 
 # Returns 0 only when both the live kernel state AND our persistent
 # drop-ins are in place:
-#   - runtime: bridge-nf-call-{iptables,ip6tables} sysctls read back as 1
+#   - runtime: bridge-nf-call-iptables sysctl reads back as 1 (and the
+#     same for bridge-nf-call-ip6tables IFF this kernel exposes it)
 #   - persistence: /etc/modules-load.d/nemoclaw.conf contains `br_netfilter`
-#     and /etc/sysctl.d/99-nemoclaw.conf contains both sysctl=1 lines
+#     and /etc/sysctl.d/99-nemoclaw.conf contains the sysctl=1 line(s)
+#     matching what the kernel actually supports
+# The IPv6 checks are gated on /proc/sys/net/bridge/bridge-nf-call-ip6tables
+# existing because kernels built without CONFIG_IPV6 do not expose that
+# sysctl; asserting it unconditionally would make this function (and the
+# apply step) fail on such hosts.
 # Skipping on runtime-only state is wrong: if someone transiently ran
 # `modprobe br_netfilter` + `sysctl -w ...=1` without persisting, the
 # fix would evaporate after the next reboot. Requiring persistence too
@@ -28,15 +34,28 @@ error() {
 # (which is idempotent) re-write the drop-ins whenever they're missing
 # or stale (e.g. an older v4-only version of this script left behind).
 bridge_netfilter_ready() {
-  [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] \
-    && [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]] \
-    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]] \
-    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null)" == "1" ]] \
-    && [[ -f /etc/modules-load.d/nemoclaw.conf ]] \
-    && grep -qx 'br_netfilter' /etc/modules-load.d/nemoclaw.conf 2>/dev/null \
-    && [[ -f /etc/sysctl.d/99-nemoclaw.conf ]] \
-    && grep -qx 'net.bridge.bridge-nf-call-iptables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null \
-    && grep -qx 'net.bridge.bridge-nf-call-ip6tables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null
+  # Runtime — v4 is mandatory (br_netfilter loaded + sysctl on)
+  [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] || return 1
+  [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]] || return 1
+
+  # Persistence — modules-load drop-in
+  [[ -f /etc/modules-load.d/nemoclaw.conf ]] || return 1
+  grep -qx 'br_netfilter' /etc/modules-load.d/nemoclaw.conf 2>/dev/null || return 1
+
+  # Persistence — sysctl drop-in, v4 line mandatory
+  [[ -f /etc/sysctl.d/99-nemoclaw.conf ]] || return 1
+  grep -qx 'net.bridge.bridge-nf-call-iptables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null || return 1
+
+  # If this kernel exposes bridge-nf-call-ip6tables, require both runtime
+  # and persistence for it too. On kernels without IPv6 bridge netfilter
+  # the /proc node does not exist — we treat v4-only as fully-ready
+  # there, matching what apply_br_netfilter_setup_r39 actually wrote.
+  if [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]]; then
+    [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null)" == "1" ]] || return 1
+    grep -qx 'net.bridge.bridge-nf-call-ip6tables=1' /etc/sysctl.d/99-nemoclaw.conf 2>/dev/null || return 1
+  fi
+
+  return 0
 }
 
 # Load br_netfilter and flip bridge-nf-call-iptables, then persist both
@@ -53,25 +72,42 @@ apply_br_netfilter_setup() {
   echo "net.bridge.bridge-nf-call-iptables=1" | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
 }
 
-# R39-specific variant: flips both bridge-nf-call-iptables and
-# bridge-nf-call-ip6tables and persists both. Kept separate from
-# apply_br_netfilter_setup so the R36/R38 behavior stays byte-identical
-# to pre-#2418; the dual-stack sysctl write is the configuration the
-# reporter validated end-to-end on their Jetson Orin R39 (#2418).
+# R39-specific variant: flips bridge-nf-call-iptables and, when the
+# kernel exposes it, bridge-nf-call-ip6tables, then persists whatever
+# was actually applied. Kept separate from apply_br_netfilter_setup so
+# the R36/R38 behavior stays byte-identical to pre-#2418; the dual-stack
+# sysctl write is the configuration the reporter validated end-to-end
+# on their Jetson Orin R39 (#2418).
+# The IPv6 sysctl write is gated on /proc/sys/net/bridge/bridge-nf-call-ip6tables
+# existing because kernels built without CONFIG_IPV6 do not expose that
+# sysctl; `sysctl -w` on a missing key would fail under `set -e`. On
+# such hosts the persistence drop-in only carries the IPv4 line, and
+# bridge_netfilter_ready() mirrors this (only requires the IPv6 line
+# when the /proc node is present).
 # Idempotent: safe to call whenever bridge_netfilter_ready returns false,
 # including the "runtime is live but drop-ins missing" case (e.g. someone
 # ran modprobe + sysctl manually without persisting).
 apply_br_netfilter_setup_r39() {
   "${SUDO[@]}" modprobe br_netfilter
   "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
-  "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-ip6tables=1 >/dev/null
+
+  local has_ipv6=0
+  if [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]]; then
+    "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-ip6tables=1 >/dev/null
+    has_ipv6=1
+  fi
 
   # Persist across reboots
   echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
-  {
-    echo "net.bridge.bridge-nf-call-iptables=1"
-    echo "net.bridge.bridge-nf-call-ip6tables=1"
-  } | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+  if ((has_ipv6)); then
+    {
+      echo "net.bridge.bridge-nf-call-iptables=1"
+      echo "net.bridge.bridge-nf-call-ip6tables=1"
+    } | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+  else
+    echo "net.bridge.bridge-nf-call-iptables=1" \
+      | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+  fi
 }
 
 get_jetpack_version() {
@@ -109,11 +145,17 @@ get_jetpack_version() {
       # Read the values back from /proc (not just "we set it to 1") so the
       # log is actual evidence that the apply path landed — useful when a
       # user is validating the fix on their own Jetson and needs to confirm
-      # from log output alone that the runtime state is correct.
-      local v4 v6
+      # from log output alone that the runtime state is correct. The IPv6
+      # leg is only included when the kernel exposes the sysctl, matching
+      # what apply_br_netfilter_setup_r39 actually wrote.
+      local v4 v6_summary
       v4="$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo '?')"
-      v6="$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null || echo '?')"
-      info "br_netfilter runtime: bridge-nf-call-iptables=$v4, bridge-nf-call-ip6tables=$v6 — sandbox → ClusterIP routing (CoreDNS, services) is unblocked; no docker or k3s restart needed" >&2
+      if [[ -f /proc/sys/net/bridge/bridge-nf-call-ip6tables ]]; then
+        v6_summary=", bridge-nf-call-ip6tables=$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null || echo '?')"
+      else
+        v6_summary=" (ip6tables not exposed by this kernel; IPv4-only persistence)"
+      fi
+      info "br_netfilter runtime: bridge-nf-call-iptables=$v4$v6_summary — sandbox → ClusterIP routing (CoreDNS, services) is unblocked; no docker or k3s restart needed" >&2
       info "Reboot persistence: /etc/modules-load.d/nemoclaw.conf, /etc/sysctl.d/99-nemoclaw.conf" >&2
     fi
     return 0

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -16,6 +16,28 @@ error() {
   exit 1
 }
 
+# Returns 0 when `br_netfilter` is loaded AND the bridge-nf-call-iptables
+# sysctl is already set to 1. Used so we can skip host-state changes on
+# Jetson images that ship with this configured out of the box.
+bridge_netfilter_ready() {
+  [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] \
+    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]]
+}
+
+# Load br_netfilter and flip the bridge-nf-call-iptables sysctl, then
+# persist both across reboots. Required for k3s (running inside the
+# OpenShell gateway container) to NAT pod → ClusterIP traffic; without
+# this the kube-proxy iptables rules are written but never matched for
+# bridged pod traffic, so sandbox pods cannot reach CoreDNS.
+apply_br_netfilter_setup() {
+  "${SUDO[@]}" modprobe br_netfilter
+  "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
+
+  # Persist across reboots
+  echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
+  echo "net.bridge.bridge-nf-call-iptables=1" | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
+}
+
 get_jetpack_version() {
   local release_line release revision l4t_version
 
@@ -31,6 +53,27 @@ get_jetpack_version() {
     return 0
   fi
 
+  if ((release >= 39)); then
+    # JP7 R39 does not need iptables / daemon.json changes, but k3s inside
+    # the OpenShell gateway container still needs br_netfilter +
+    # bridge-nf-call-iptables=1 for ClusterIP service routing. Some R39
+    # kernel images ship with it already in place, so check first and only
+    # apply when missing — avoids planting NemoClaw-owned drop-ins in
+    # /etc/modules-load.d and /etc/sysctl.d on systems that don't need
+    # them. See #2418.
+    if bridge_netfilter_ready; then
+      info "Jetson detected (L4T $l4t_version) — br_netfilter already configured; no host setup needed" >&2
+    else
+      info "Jetson detected (L4T $l4t_version) — loading br_netfilter (required by k3s inside the OpenShell gateway; see #2418)" >&2
+      if ((EUID != 0)); then
+        "${SUDO[@]}" true >/dev/null \
+          || error "Sudo is required to load br_netfilter and write /etc/modules-load.d and /etc/sysctl.d drop-ins."
+      fi
+      apply_br_netfilter_setup
+    fi
+    return 0
+  fi
+
   case "$l4t_version" in
     36.*)
       printf "%s" "jp6"
@@ -38,27 +81,10 @@ get_jetpack_version() {
     38.*)
       printf "%s" "jp7-r38"
       ;;
-    39.*)
-      # JP7 R39 does not need iptables or daemon.json changes (same as R38),
-      # but k3s inside the OpenShell gateway container requires br_netfilter
-      # + net.bridge.bridge-nf-call-iptables=1 for ClusterIP service routing.
-      # The earlier "R39 needs no host setup" assumption was wrong: some R39
-      # kernel builds ship without the module loaded, and sandbox agent pods
-      # then crash-loop on cluster.local lookups. See #2418.
-      printf "%s" "jp7-r39"
-      ;;
     *)
       info "Jetson detected (L4T $l4t_version) but version is not recognized — skipping host setup" >&2
       ;;
   esac
-}
-
-# Returns 0 when `br_netfilter` is loaded AND the bridge-nf-call-iptables
-# sysctl is already set to 1. Used so we can skip host-state changes on
-# Jetson images that ship with this configured out of the box.
-bridge_netfilter_ready() {
-  [[ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]] \
-    && [[ "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null)" == "1" ]]
 }
 
 configure_jetson_host() {
@@ -131,34 +157,12 @@ PYEOF
     jp7-r38)
       # JP7 R38 does not need iptables or Docker daemon.json changes.
       ;;
-    jp7-r39)
-      # Same as R38 — no iptables or daemon.json changes. Only the
-      # br_netfilter setup below is relevant, and that's applied
-      # conditionally further down (some R39 images already ship with
-      # it loaded).
-      ;;
     *)
       error "Unsupported Jetson version: $jetpack_version"
       ;;
   esac
 
-  # Apply br_netfilter setup. For JP6/JP7-R38 keep the pre-existing
-  # unconditional behavior — writing the persistent drop-ins is
-  # idempotent on re-runs, and we don't want to change what works for
-  # those already-shipped versions. For JP7-R39, only touch host state
-  # when the module isn't already configured, so images that ship with
-  # it in place don't end up with NemoClaw-owned files they didn't
-  # need.
-  if [[ "$jetpack_version" == "jp7-r39" ]] && bridge_netfilter_ready; then
-    info "br_netfilter already loaded and net.bridge.bridge-nf-call-iptables=1 — skipping"
-  else
-    "${SUDO[@]}" modprobe br_netfilter
-    "${SUDO[@]}" sysctl -w net.bridge.bridge-nf-call-iptables=1 >/dev/null
-
-    # Persist across reboots
-    echo "br_netfilter" | "${SUDO[@]}" tee /etc/modules-load.d/nemoclaw.conf >/dev/null
-    echo "net.bridge.bridge-nf-call-iptables=1" | "${SUDO[@]}" tee /etc/sysctl.d/99-nemoclaw.conf >/dev/null
-  fi
+  apply_br_netfilter_setup
 
   if [[ "$jetpack_version" == "jp6" ]]; then
     "${SUDO[@]}" systemctl restart docker

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -79,7 +79,15 @@ get_jetpack_version() {
           || error "Sudo is required to load br_netfilter and write /etc/modules-load.d and /etc/sysctl.d drop-ins."
       fi
       apply_br_netfilter_setup
-      info "br_netfilter applied: bridge-nf-call-{iptables,ip6tables}=1; persisted to /etc/sysctl.d/99-nemoclaw.conf + /etc/modules-load.d/nemoclaw.conf" >&2
+      # Read the values back from /proc (not just "we set it to 1") so the
+      # log is actual evidence that the apply path landed — useful when a
+      # user is validating the fix on their own Jetson and needs to confirm
+      # from log output alone that the runtime state is correct.
+      local v4 v6
+      v4="$(cat /proc/sys/net/bridge/bridge-nf-call-iptables 2>/dev/null || echo '?')"
+      v6="$(cat /proc/sys/net/bridge/bridge-nf-call-ip6tables 2>/dev/null || echo '?')"
+      info "br_netfilter runtime: bridge-nf-call-iptables=$v4, bridge-nf-call-ip6tables=$v6 — sandbox → ClusterIP routing (CoreDNS, services) is unblocked; no docker or k3s restart needed" >&2
+      info "Reboot persistence: /etc/modules-load.d/nemoclaw.conf, /etc/sysctl.d/99-nemoclaw.conf" >&2
     fi
     return 0
   fi

--- a/scripts/setup-jetson.sh
+++ b/scripts/setup-jetson.sh
@@ -79,6 +79,7 @@ get_jetpack_version() {
           || error "Sudo is required to load br_netfilter and write /etc/modules-load.d and /etc/sysctl.d drop-ins."
       fi
       apply_br_netfilter_setup
+      info "br_netfilter applied: bridge-nf-call-{iptables,ip6tables}=1; persisted to /etc/sysctl.d/99-nemoclaw.conf + /etc/modules-load.d/nemoclaw.conf" >&2
     fi
     return 0
   fi


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                                     
   
  Fixes #2418.                                                                                                                                                                                                                                                                                                                   
                                                         
  JetPack R39 was silently skipped by `setup-jetson.sh` — `get_jetpack_version()` returned empty for any release ≥ 39, so `main()` exited before ever setting up `br_netfilter`. Without `net.bridge.bridge-nf-call-iptables=1`, kube-proxy's iptables NAT rules are present but don't match pod-originated traffic, so sandbox  
  agent pods can't resolve `openshell.openshell.svc.cluster.local` and crash-loop during onboard's `[7/8] Setting up OpenClaw inside sandbox` step.
                                                                                                                                                                                                                                                                                                                                 
  See #2418 for full diagnostic chain: pod-IP DNS query works, service-IP times out, iptables `KUBE-SVC-*` rules exist, `lsmod | grep br_netfilter` is empty, and loading the module immediately fixes it.                                                                                                                       
   
  ## Changes                                                                                                                                                                                                                                                                                                                     
                                                         
  Scoped to `scripts/setup-jetson.sh` only. Approach keeps R36/R38 code paths untouched and **co-locates R39 handling inside the existing `if ((release >= 39))` branch** rather than threading a new `jp7-r39` token through `configure_jetson_host()`.                                                                         
   
  1. **New helper `bridge_netfilter_ready()`** — returns 0 when `/proc/sys/net/bridge/bridge-nf-call-iptables` exists and reads `1`. That file only appears after the module is loaded, so a single check covers both conditions.                                                                                                
                                                         
  2. **New helper `apply_br_netfilter_setup()`** — extracts the four-line `modprobe` + `sysctl` + `tee /etc/modules-load.d/` + `tee /etc/sysctl.d/` block that previously lived inline in `configure_jetson_host()`. Both the R39 branch and the R36/R38 path now call this helper, so behavior for R36/R38 is byte-identical to 
  main.                                                  
                                                                                                                                                                                                                                                                                                                                 
  3. **R39 branch in `get_jetpack_version()`** — the existing `if ((release >= 39))` early-return now carries the work instead of just logging and returning:
     - If `bridge_netfilter_ready` → log and return empty (main exits, no host state is modified).                                                                                                                                                                                                                               
     - Otherwise → check sudo, call `apply_br_netfilter_setup`, return empty.                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                 
     Returning empty preserves the existing invariant that R39 does not flow through `configure_jetson_host()` (which handles iptables-legacy / `daemon.json` / post-setup docker restart — none of which R39 needs).                                                                                                            
                                                                                                                                                                                                                                                                                                                                 
  Conditional on R39 only because not every R39 image hits the bug: some ship with `br_netfilter` already loaded and we don't want to plant `/etc/modules-load.d/nemoclaw.conf` + `/etc/sysctl.d/99-nemoclaw.conf` drop-ins on those systems. For JP6 / JP7-R38 the behavior is preserved exactly (unconditional 
  `apply_br_netfilter_setup` via `configure_jetson_host`).                                                                                                                                                                                                                                                                       
                                                         
  ### What the user sees on affected R39 hosts                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                 
  Before (bug):
  ```                                                                                                                                                                                                                                                                                                                            
  Jetson detected (L4T 39.1) — this version does not require any host setup
  ```                                                                                                                                                                                                                                                                                                                            
  (…then onboard[7/8] fails with `sandbox is not ready`.)
                                                                                                                                                                                                                                                                                                                                 
  After, first-affected R39 install:                     
  ```                                                                                                                                                                                                                                                                                                                            
  Jetson detected (L4T 39.1) — loading br_netfilter (required by k3s inside the OpenShell gateway; see #2418)
  ```                                                                                                                                                                                                                                                                                                                            
   
  After, R39 image that already has it:                                                                                                                                                                                                                                                                                          
  ```                                                                                                                                                                                                                                                                                                                            
  Jetson detected (L4T 39.1) — br_netfilter already configured; no host setup needed
  ```                                                                                                                                                                                                                                                                                                                            
                                                         
  ## Verification                                                                                                                                                                                                                                                                                                                
                                                         
  - `bash -n scripts/setup-jetson.sh` — clean (syntax check).
  - `npm run typecheck:cli` — clean.                                                                                                                                                                                                                                                                                             
  - `npm run ts-migration:guard -- --base origin/main --head HEAD` — `No edits to migrated legacy paths or removed compatibility shims detected.`                                                                                                                                                                                
  - Existing `test/setup-jetson.test.ts` (4 tests for the Python `daemon.json` patcher, which is unchanged) — all pass.                                                                                                                                                                                                          
  - **Manual end-to-end on a JetPack R39 Jetson Orin** (the #2418 reporter's affected machine):                                                                                                                                                                                                                                  
    - **Before**: `nemoclaw onboard` reaches `[7/8]` and fails with `sandbox is not ready`; `kubectl describe pod my-assistant -n openshell` shows the `agent` container in `CrashLoopBackOff` with 156+ restarts, logs show `Temporary failure in name resolution` for `openshell.openshell.svc.cluster.local`.                 
    - **After applying the equivalent of this fix manually** (`sudo modprobe br_netfilter && sudo sysctl -w net.bridge.bridge-nf-call-iptables=1 net.bridge.bridge-nf-call-ip6tables=1`) and rerunning `nemoclaw onboard` → `[1/8]`–`[8/8]` complete, sandbox reaches Ready, dashboard reachable.                                
                                                                                                                                                                                                                                                                                                                                 
  No bash-level unit tests added because the existing test coverage for this script only exercises the embedded Python `daemon.json` patcher (extracted via regex), and the new logic is top-level bash that would require either a source-guard refactor or mocking `/etc/nv_tegra_release` / `/proc/sys/...` via env-var       
  indirection — neither matches existing patterns. Happy to add them if a reviewer prefers.                                                                                                                                                                                                                                      
                                                         
  ## Type of Change                                                                                                                                                                                                                                                                                                              
                                                         
  - [x] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates                                                                                                                                                                                                                                                                                             
  - [ ] Doc only (prose changes, no code sample modifications)                                                                                                                                                                                                                                                                   
  - [ ] Doc only (includes code sample changes)                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                 
  ## AI Disclosure                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                 
  - [x] AI-assisted — tool: Claude Code                  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized bridge/netfilter setup with a readiness check so host changes are applied only when needed.
  * Newer releases get a conditional dual‑stack (IPv4+IPv6) setup; older paths use iptables‑only configuration.
  * Ensures elevated privileges when required, persists bridge/IPv4/IPv6 settings across reboots, and logs runtime values and persistence locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
                                                                                                                                                                                                                                                                                                                               

<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>