### PR TITLE
fix(recovery): show backgrounded command when gateway restart fails (#2426)

### DIFF
--- a/src/lib/agent-runtime.test.ts
+++ b/src/lib/agent-runtime.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, it, expect } from "vitest";
 // Import from compiled dist/ so coverage is attributed correctly.
-import { buildOpenClawRecoveryScript, buildRecoveryScript } from "../../dist/lib/agent-runtime";
+import {
+  buildManualRecoveryCommand,
+  buildOpenClawRecoveryScript,
+  buildRecoveryScript,
+} from "../../dist/lib/agent-runtime";
 import type { AgentDefinition } from "./agent-defs";
 
 function makeAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
@@ -255,5 +259,45 @@ describe("buildRecoveryScript", () => {
       expect(script).not.toContain("gosu gateway");
       expect(script).not.toContain("gosu 'gateway'");
     });
+  });
+});
+
+describe("buildManualRecoveryCommand (#2426)", () => {
+  const hermesAgent = {
+    name: "hermes",
+    displayName: "Hermes Agent",
+    gateway_command: "hermes gateway run",
+  } as unknown as AgentDefinition;
+
+  it("backgrounds the process with nohup and '&'", () => {
+    const cmd = buildManualRecoveryCommand(minimalAgent, 19000);
+    expect(cmd.startsWith("nohup ")).toBe(true);
+    expect(cmd.endsWith(" &")).toBe(true);
+  });
+
+  it("embeds the port, matching buildRecoveryScript", () => {
+    const cmd = buildManualRecoveryCommand(minimalAgent, 19000);
+    expect(cmd).toContain("--port 19000");
+  });
+
+  it("redirects stdout and stderr to /tmp/gateway.log", () => {
+    const cmd = buildManualRecoveryCommand(minimalAgent, 19000);
+    expect(cmd).toContain(">/tmp/gateway.log 2>&1");
+  });
+
+  it("prefixes HERMES_HOME for the hermes agent so the gateway can find its config", () => {
+    const cmd = buildManualRecoveryCommand(hermesAgent, 8642);
+    expect(cmd).toContain("HERMES_HOME=/sandbox/.hermes-data");
+    expect(cmd).toContain("nohup hermes gateway run --port 8642");
+  });
+
+  it("does not prefix HERMES_HOME for non-hermes agents", () => {
+    const cmd = buildManualRecoveryCommand(minimalAgent, 19000);
+    expect(cmd).not.toContain("HERMES_HOME");
+  });
+
+  it("falls back to openclaw gateway run for null agent (OpenClaw path)", () => {
+    const cmd = buildManualRecoveryCommand(null, 18789);
+    expect(cmd).toBe("nohup openclaw gateway run --port 18789 >/tmp/gateway.log 2>&1 &");
   });
 });

--- a/src/lib/agent-runtime.test.ts
+++ b/src/lib/agent-runtime.test.ts
@@ -288,7 +288,13 @@ describe("buildManualRecoveryCommand (#2426)", () => {
   it("prefixes HERMES_HOME for the hermes agent so the gateway can find its config", () => {
     const cmd = buildManualRecoveryCommand(hermesAgent, 8642);
     expect(cmd).toContain("HERMES_HOME=/sandbox/.hermes-data");
-    expect(cmd).toContain("nohup hermes gateway run --port 8642");
+    expect(cmd).toContain("nohup hermes gateway run >/tmp/gateway.log");
+  });
+
+  it("omits --port for hermes so it reads the listen port from HERMES_HOME/config.yaml (NemoClaw provisions 18642, socat bridges 0.0.0.0:8642)", () => {
+    const cmd = buildManualRecoveryCommand(hermesAgent, 8642);
+    expect(cmd).not.toContain("--port");
+    expect(cmd).toBe("HERMES_HOME=/sandbox/.hermes-data nohup hermes gateway run >/tmp/gateway.log 2>&1 &");
   });
 
   it("does not prefix HERMES_HOME for non-hermes agents", () => {

--- a/src/lib/agent-runtime.test.ts
+++ b/src/lib/agent-runtime.test.ts
@@ -306,4 +306,10 @@ describe("buildManualRecoveryCommand (#2426)", () => {
     const cmd = buildManualRecoveryCommand(null, 18789);
     expect(cmd).toBe("nohup openclaw gateway run --port 18789 >/tmp/gateway.log 2>&1 &");
   });
+
+  it("falls back to openclaw gateway run when gateway_command is whitespace-only (mirrors buildRecoveryScript)", () => {
+    const agent = makeAgent({ gateway_command: "   " });
+    const cmd = buildManualRecoveryCommand(agent, 19000);
+    expect(cmd).toBe("nohup openclaw gateway run --port 19000 >/tmp/gateway.log 2>&1 &");
+  });
 });

--- a/src/lib/agent-runtime.test.ts
+++ b/src/lib/agent-runtime.test.ts
@@ -307,8 +307,20 @@ describe("buildManualRecoveryCommand (#2426)", () => {
     expect(cmd).toBe("nohup openclaw gateway run --port 18789 >/tmp/gateway.log 2>&1 &");
   });
 
-  it("falls back to openclaw gateway run when gateway_command is whitespace-only (mirrors buildRecoveryScript)", () => {
+  it("derives the default gateway command from binary_path when gateway_command is whitespace-only (mirrors buildRecoveryScript)", () => {
     const agent = makeAgent({ gateway_command: "   " });
+    const cmd = buildManualRecoveryCommand(agent, 19000);
+    expect(cmd).toBe("nohup test-agent gateway run --port 19000 >/tmp/gateway.log 2>&1 &");
+  });
+
+  it("derives the default gateway command from binary_path when gateway_command is undefined (mirrors buildRecoveryScript)", () => {
+    const agent = makeAgent({ gateway_command: undefined });
+    const cmd = buildManualRecoveryCommand(agent, 19000);
+    expect(cmd).toBe("nohup test-agent gateway run --port 19000 >/tmp/gateway.log 2>&1 &");
+  });
+
+  it("falls back to openclaw gateway run when both binary_path and gateway_command are absent", () => {
+    const agent = makeAgent({ binary_path: undefined, gateway_command: undefined });
     const cmd = buildManualRecoveryCommand(agent, 19000);
     expect(cmd).toBe("nohup openclaw gateway run --port 19000 >/tmp/gateway.log 2>&1 &");
   });

--- a/src/lib/agent-runtime.ts
+++ b/src/lib/agent-runtime.ts
@@ -262,7 +262,7 @@ export function getGatewayCommand(agent: AgentDefinition | null): string {
  * log redirect → backgrounded`.
  */
 export function buildManualRecoveryCommand(agent: AgentDefinition | null, port: number): string {
-  const gatewayCmd = getGatewayCommand(agent);
+  const gatewayCmd = getGatewayCommand(agent).trim() || "openclaw gateway run";
   const isHermes = agent?.name === "hermes";
   const envPrefix = isHermes ? "HERMES_HOME=/sandbox/.hermes-data " : "";
   const portFlag = isHermes ? "" : ` --port ${port}`;

--- a/src/lib/agent-runtime.ts
+++ b/src/lib/agent-runtime.ts
@@ -262,7 +262,10 @@ export function getGatewayCommand(agent: AgentDefinition | null): string {
  * log redirect → backgrounded`.
  */
 export function buildManualRecoveryCommand(agent: AgentDefinition | null, port: number): string {
-  const gatewayCmd = getGatewayCommand(agent).trim() || "openclaw gateway run";
+  const binaryPath = agent?.binary_path || "/usr/local/bin/openclaw";
+  const binaryName = binaryPath.split("/").pop() ?? "openclaw";
+  const defaultGatewayCommand = `${binaryName} gateway run`;
+  const gatewayCmd = agent?.gateway_command?.trim() || defaultGatewayCommand;
   const isHermes = agent?.name === "hermes";
   const envPrefix = isHermes ? "HERMES_HOME=/sandbox/.hermes-data " : "";
   const portFlag = isHermes ? "" : ` --port ${port}`;

--- a/src/lib/agent-runtime.ts
+++ b/src/lib/agent-runtime.ts
@@ -241,19 +241,30 @@ export function getGatewayCommand(agent: AgentDefinition | null): string {
 
 /**
  * Build a single copy-pasteable command that starts the agent gateway as a
- * backgrounded, persistent process — the manual equivalent of
+ * backgrounded, persistent process, the manual equivalent of
  * {@link buildRecoveryScript}. Shown to the user when automatic recovery
  * fails.
  *
  * The raw `gateway_command` (e.g. `hermes gateway run`) is a foreground
- * debugging command; it does not survive a disconnect and lacks the port
- * flag and agent-specific env vars that the sandbox boot sequence sets.
- * This helper mirrors what nemoclaw-start.sh and buildRecoveryScript do:
- * agent-specific env vars → nohup → gateway_command → --port → log redirect
- * → backgrounded.
+ * debugging command; it does not survive a disconnect and lacks the
+ * agent-specific env vars that the sandbox boot sequence sets.
+ *
+ * Port source varies by agent. OpenClaw reads the port from the `--port`
+ * flag; Hermes reads it from HERMES_HOME/config.yaml (NemoClaw provisions
+ * `platforms.api_server.extra.port: 18642` with socat forwarding
+ * 0.0.0.0:8642 → 127.0.0.1:18642 from agents/hermes/start.sh). Passing
+ * `--port 8642` to `hermes gateway run` would override the config and
+ * break the forwarder, so we omit the flag for hermes and mirror what
+ * start.sh does: set HERMES_HOME and let config.yaml drive the port.
+ *
+ * This helper mirrors nemoclaw-start.sh / buildRecoveryScript for
+ * non-hermes agents: `env vars → nohup → gateway_command → --port →
+ * log redirect → backgrounded`.
  */
 export function buildManualRecoveryCommand(agent: AgentDefinition | null, port: number): string {
   const gatewayCmd = getGatewayCommand(agent);
-  const envPrefix = agent?.name === "hermes" ? "HERMES_HOME=/sandbox/.hermes-data " : "";
-  return `${envPrefix}nohup ${gatewayCmd} --port ${port} >/tmp/gateway.log 2>&1 &`;
+  const isHermes = agent?.name === "hermes";
+  const envPrefix = isHermes ? "HERMES_HOME=/sandbox/.hermes-data " : "";
+  const portFlag = isHermes ? "" : ` --port ${port}`;
+  return `${envPrefix}nohup ${gatewayCmd}${portFlag} >/tmp/gateway.log 2>&1 &`;
 }

--- a/src/lib/agent-runtime.ts
+++ b/src/lib/agent-runtime.ts
@@ -238,3 +238,22 @@ export function getAgentDisplayName(agent: AgentDefinition | null): string {
 export function getGatewayCommand(agent: AgentDefinition | null): string {
   return agent?.gateway_command || "openclaw gateway run";
 }
+
+/**
+ * Build a single copy-pasteable command that starts the agent gateway as a
+ * backgrounded, persistent process — the manual equivalent of
+ * {@link buildRecoveryScript}. Shown to the user when automatic recovery
+ * fails.
+ *
+ * The raw `gateway_command` (e.g. `hermes gateway run`) is a foreground
+ * debugging command; it does not survive a disconnect and lacks the port
+ * flag and agent-specific env vars that the sandbox boot sequence sets.
+ * This helper mirrors what nemoclaw-start.sh and buildRecoveryScript do:
+ * agent-specific env vars → nohup → gateway_command → --port → log redirect
+ * → backgrounded.
+ */
+export function buildManualRecoveryCommand(agent: AgentDefinition | null, port: number): string {
+  const gatewayCmd = getGatewayCommand(agent);
+  const envPrefix = agent?.name === "hermes" ? "HERMES_HOME=/sandbox/.hermes-data " : "";
+  return `${envPrefix}nohup ${gatewayCmd} --port ${port} >/tmp/gateway.log 2>&1 &`;
+}

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -458,8 +458,13 @@ function checkAndRecoverSandboxProcesses(
     // recovered process can be alive before the OpenAI-compatible API is ready.
     if (!waitForRecoveredSandboxGateway(sandboxName)) {
       if (!quiet) {
+        const _recoveryPort = _recoveryAgent?.forwardPort ?? DASHBOARD_PORT;
         console.error("  Gateway process started but is not responding.");
         console.error("  Check /tmp/gateway.log inside the sandbox for details.");
+        console.error("  Connect to the sandbox and run manually:");
+        console.error(
+          `    ${agentRuntime.buildManualRecoveryCommand(_recoveryAgent, _recoveryPort)}`,
+        );
       }
       return { checked: true, wasRunning: false, recovered: false };
     }
@@ -471,11 +476,14 @@ function checkAndRecoverSandboxProcesses(
       console.log(`  ${G}✓${R} Dashboard port forward re-established.`);
     }
   } else if (!quiet) {
+    const _recoveryPort = _recoveryAgent?.forwardPort ?? DASHBOARD_PORT;
     console.error(
       `  Could not restart ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway automatically.`,
     );
     console.error("  Connect to the sandbox and run manually:");
-    console.error(`    ${agentRuntime.getGatewayCommand(_recoveryAgent)}`);
+    console.error(
+      `    ${agentRuntime.buildManualRecoveryCommand(_recoveryAgent, _recoveryPort)}`,
+    );
   }
 
   return { checked: true, wasRunning: false, recovered };


### PR DESCRIPTION
## Summary

When automatic gateway recovery fails, the fallback "run manually" message tells the user to run the raw `gateway_command` from the agent manifest (`hermes gateway run`). That is the foreground debugging command: it dies on disconnect and lacks the `--port` flag plus the agent-specific env vars that `nemoclaw-start.sh` sets at boot. The user pastes it, the gateway comes up, then dies as soon as they exit the sandbox, which matches the "impossible to restart" symptom @oparoz reports in #2426.

This PR keeps the auto-recovery path unchanged and fixes the manual fallback: print a single copy-pasteable command that actually persists.

## Related Issue

Fixes #2426

## Changes

- `src/lib/agent-runtime.ts`: add `buildManualRecoveryCommand(agent, port)`. Returns the single-line equivalent of `buildRecoveryScript`'s launch line: `<env-prefix> nohup <gateway_command> --port <port> >/tmp/gateway.log 2>&1 &`. Hermes gets `HERMES_HOME=/sandbox/.hermes-data`, same as the existing recovery script. Null agent falls back to `nohup openclaw gateway run --port 18789 …`.
- `src/nemoclaw.ts`: `checkAndRecoverSandboxProcesses` now prints the new helper's output instead of the bare `gateway_command`. Port resolves to `_recoveryAgent?.forwardPort ?? DASHBOARD_PORT`, matching the expression `recoverSandboxProcesses` already uses on the auto-recovery path.
- `src/lib/agent-runtime.test.ts`: 6 regression tests covering `nohup`, `&`, `--port`, `/tmp/gateway.log` redirect, `HERMES_HOME` on hermes, absence of `HERMES_HOME` on other agents, and the null-agent openclaw fallback.

## Before / after

Before (from #2426 log):

```
  Hermes Agent gateway is not running inside the sandbox (sandbox likely restarted).
  Recovering...
  Could not restart Hermes Agent gateway automatically.
  Connect to the sandbox and run manually:
    hermes gateway run
```

After:

```
  Hermes Agent gateway is not running inside the sandbox (sandbox likely restarted).
  Recovering...
  Could not restart Hermes Agent gateway automatically.
  Connect to the sandbox and run manually:
    HERMES_HOME=/sandbox/.hermes-data nohup hermes gateway run --port 8642 >/tmp/gateway.log 2>&1 &
```

For the default OpenClaw path the message becomes:

```
    nohup openclaw gateway run --port 18789 >/tmp/gateway.log 2>&1 &
```

## Scope

Intentionally narrow. The auto-recovery path in `recoverSandboxProcesses` / `buildRecoveryScript` is untouched; this PR only fixes the text the user sees when auto-recovery fails. A separate, broader investigation of *why* auto-recovery fails in @oparoz's repro (the sandbox-side script returned non-zero) is a reasonable follow-up; this PR makes the manual fallback actually work in the meantime, which is the half of #2426 I can verify.

Not related to #2050 (which adds a standalone `nemoclaw <name> recover` CLI command for a different gap).

## Verification

Stash-bisect against this branch:

- Src changes stashed, dist rebuilt, targeted tests run: **6 new tests fail** with `TypeError: buildManualRecoveryCommand is not a function`.
- Stash restored, dist rebuilt, same tests run: **11/11 pass**.

```
 ✓ src/lib/agent-runtime.test.ts > buildManualRecoveryCommand (#2426) > backgrounds the process with nohup and '&'
 ✓ src/lib/agent-runtime.test.ts > buildManualRecoveryCommand (#2426) > embeds the port, matching buildRecoveryScript
 ✓ src/lib/agent-runtime.test.ts > buildManualRecoveryCommand (#2426) > redirects stdout and stderr to /tmp/gateway.log
 ✓ src/lib/agent-runtime.test.ts > buildManualRecoveryCommand (#2426) > prefixes HERMES_HOME for the hermes agent so the gateway can find its config
 ✓ src/lib/agent-runtime.test.ts > buildManualRecoveryCommand (#2426) > does not prefix HERMES_HOME for non-hermes agents
 ✓ src/lib/agent-runtime.test.ts > buildManualRecoveryCommand (#2426) > falls back to openclaw gateway run for null agent (OpenClaw path)

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm run build:cli` passes
- [x] `npx vitest run src/lib/agent-runtime.test.ts`: 11/11 pass (5 existing + 6 new)
- [x] Stash-bisect confirms the 6 new tests fail without the `src/lib/agent-runtime.ts` change
- [x] Prettier applied
- [x] Tests added for new behavior
- [x] No secrets, API keys, or credentials committed

## AI Disclosure

- [x] AI-assisted (tool: Claude Code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual recovery now provides a single, copy-pasteable background command (nohup ... &) that redirects logs and adds an agent-specific environment prefix when required.

* **Tests**
  * Added unit tests covering manual recovery command formatting, environment prefixing, port handling, and log redirection.

* **Bug Fixes**
  * Recovery output now consistently uses the resolved port when generating the runnable gateway command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->