### PR TITLE
fix(security): address NC-2227-01 through NC-2227-05 from security review

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -934,9 +934,50 @@ cleanup() {
 #   .openclaw-data/ containing real state data
 # Migrate to the new layout: real data lives directly in .openclaw/.
 # Idempotent: no-op if .openclaw-data doesn't exist.
+#
+# SECURITY (NC-2227-01): Guard against agent-planted data dirs.
+# Only migrate if (a) we are running as root (the agent cannot call
+# this path), (b) the data directory is NOT agent-writable (root-owned),
+# and (c) a migration-complete sentinel does not already exist.
+# After migration, reapply shields-up ownership if shields were active.
 migrate_legacy_layout() {
   local config_dir="$1" data_dir="$2" label="$3"
   [ -d "$data_dir" ] || return 0
+
+  local sentinel="${config_dir}/.migration-complete"
+
+  # Guard 1: Already migrated — the sentinel proves a prior trusted run.
+  if [ -f "$sentinel" ]; then
+    echo "[migration] ${label}: already migrated (sentinel exists), skipping" >&2
+    return 0
+  fi
+
+  # Guard 2: Only root may run migration. The sandbox user cannot reach
+  # this code path (entrypoint runs as root or the non-root branch never
+  # calls migrate), but be explicit.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "[SECURITY] ${label}: migration skipped — requires root" >&2
+    return 0
+  fi
+
+  # Guard 3: Reject agent-planted data directories. A legitimate legacy
+  # data dir was created by the image build (root-owned). If the data dir
+  # is owned by sandbox, the agent may have planted it to trigger migration.
+  local data_owner
+  data_owner="$(stat -c '%U' "$data_dir" 2>/dev/null || stat -f '%Su' "$data_dir" 2>/dev/null || echo "unknown")"
+  if [ "$data_owner" = "sandbox" ]; then
+    echo "[SECURITY] ${label}: data dir ${data_dir} is sandbox-owned — refusing migration (possible agent-planted trigger)" >&2
+    return 1
+  fi
+
+  # Check if shields were previously active (config dir is root-owned).
+  local shields_were_active=false
+  local config_dir_owner
+  config_dir_owner="$(stat -c '%U' "$config_dir" 2>/dev/null || stat -f '%Su' "$config_dir" 2>/dev/null || echo "unknown")"
+  if [ "$config_dir_owner" = "root" ]; then
+    shields_were_active=true
+  fi
+
   echo "[migration] Detected legacy ${label} layout (${data_dir} exists), migrating..." >&2
   for entry in "$data_dir"/*; do
     [ -e "$entry" ] || [ -L "$entry" ] || continue
@@ -950,8 +991,37 @@ migrate_legacy_layout() {
       cp -a "$entry" "$target"
     fi
   done
-  chown -R sandbox:sandbox "$config_dir" 2>/dev/null || true
+
+  # Only chown state subdirectories, NOT the config dir itself or
+  # protected files (openclaw.json, .config-hash, .env).
+  # This prevents undoing shields-up root ownership on the config dir.
+  for entry in "$config_dir"/*; do
+    [ -d "$entry" ] || continue
+    chown -R sandbox:sandbox "$entry" 2>/dev/null || true
+  done
+
   rm -rf "$data_dir"
+
+  # Write the migration sentinel (root-owned, read-only) so we never
+  # re-run migration on this sandbox.
+  echo "migrated=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$sentinel"
+  chown root:root "$sentinel" 2>/dev/null || true
+  chmod 444 "$sentinel" 2>/dev/null || true
+
+  # Reapply shields-up ownership if config dir was previously root-locked.
+  if [ "$shields_were_active" = "true" ]; then
+    echo "[migration] Reapplying shields-up ownership on ${config_dir}" >&2
+    chown root:root "$config_dir" 2>/dev/null || true
+    chmod 755 "$config_dir" 2>/dev/null || true
+    # Re-lock known sensitive files if they exist
+    for f in "$config_dir"/openclaw.json "$config_dir"/.config-hash "$config_dir"/.env; do
+      if [ -f "$f" ]; then
+        chown root:root "$f" 2>/dev/null || true
+        chmod 444 "$f" 2>/dev/null || true
+      fi
+    done
+  fi
+
   echo "[migration] Completed ${label} layout migration (${data_dir} removed)" >&2
 }
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -171,14 +171,14 @@ if [ "${1:-}" = "env" ]; then
   _self_wrapper_index=""
   for ((i = 1; i < ${#_raw_args[@]}; i += 1)); do
     case "${_raw_args[$i]}" in
-    *=*) ;;
-    nemoclaw-start | /usr/local/bin/nemoclaw-start)
-      _self_wrapper_index="$i"
-      break
-      ;;
-    *)
-      break
-      ;;
+      *=*) ;;
+      nemoclaw-start | /usr/local/bin/nemoclaw-start)
+        _self_wrapper_index="$i"
+        break
+        ;;
+      *)
+        break
+        ;;
     esac
   done
   if [ -n "$_self_wrapper_index" ]; then
@@ -193,7 +193,7 @@ fi
 # receiving our own name as $1 would otherwise recurse via the NEMOCLAW_CMD
 # exec path. Only strip from $1 — later args with this name are legitimate.
 case "${1:-}" in
-nemoclaw-start | /usr/local/bin/nemoclaw-start) shift ;;
+  nemoclaw-start | /usr/local/bin/nemoclaw-start) shift ;;
 esac
 NEMOCLAW_CMD=("$@")
 # Validate NEMOCLAW_DASHBOARD_PORT if set (same behavior as ports.js: fail fast).
@@ -203,10 +203,10 @@ if [ -z "$_DASHBOARD_PORT_RAW" ]; then
 else
   _DASHBOARD_PORT="$(printf '%s' "$_DASHBOARD_PORT_RAW" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   case "$_DASHBOARD_PORT" in
-  *[!0-9]* | '')
-    echo "[SECURITY] Invalid NEMOCLAW_DASHBOARD_PORT='${NEMOCLAW_DASHBOARD_PORT}' — must be an integer between 1024 and 65535" >&2
-    exit 1
-    ;;
+    *[!0-9]* | '')
+      echo "[SECURITY] Invalid NEMOCLAW_DASHBOARD_PORT='${NEMOCLAW_DASHBOARD_PORT}' — must be an integer between 1024 and 65535" >&2
+      exit 1
+      ;;
   esac
   if [ "$_DASHBOARD_PORT" -lt 1024 ] || [ "$_DASHBOARD_PORT" -gt 65535 ]; then
     echo "[SECURITY] Invalid NEMOCLAW_DASHBOARD_PORT='${NEMOCLAW_DASHBOARD_PORT}' — must be an integer between 1024 and 65535" >&2
@@ -257,12 +257,12 @@ verify_config_integrity() {
 
 apply_model_override() {
   # Any of these env vars trigger a config patch
-  [ -n "${NEMOCLAW_MODEL_OVERRIDE:-}" ] ||
-    [ -n "${NEMOCLAW_INFERENCE_API_OVERRIDE:-}" ] ||
-    [ -n "${NEMOCLAW_CONTEXT_WINDOW:-}" ] ||
-    [ -n "${NEMOCLAW_MAX_TOKENS:-}" ] ||
-    [ -n "${NEMOCLAW_REASONING:-}" ] ||
-    return 0
+  [ -n "${NEMOCLAW_MODEL_OVERRIDE:-}" ] \
+    || [ -n "${NEMOCLAW_INFERENCE_API_OVERRIDE:-}" ] \
+    || [ -n "${NEMOCLAW_CONTEXT_WINDOW:-}" ] \
+    || [ -n "${NEMOCLAW_MAX_TOKENS:-}" ] \
+    || [ -n "${NEMOCLAW_REASONING:-}" ] \
+    || return 0
 
   # SECURITY: Only root can write to /sandbox/.openclaw (root:root 444).
   # In non-root mode the sandbox user cannot modify the config.
@@ -297,11 +297,11 @@ apply_model_override() {
   # SECURITY: Allowlist inference API types to prevent unexpected routing.
   if [ -n "$api_override" ]; then
     case "$api_override" in
-    openai-completions | anthropic-messages) ;;
-    *)
-      printf '[SECURITY] NEMOCLAW_INFERENCE_API_OVERRIDE must be "openai-completions" or "anthropic-messages", got "%s"\n' "$api_override" >&2
-      return 1
-      ;;
+      openai-completions | anthropic-messages) ;;
+      *)
+        printf '[SECURITY] NEMOCLAW_INFERENCE_API_OVERRIDE must be "openai-completions" or "anthropic-messages", got "%s"\n' "$api_override" >&2
+        return 1
+        ;;
     esac
   fi
 
@@ -321,11 +321,11 @@ apply_model_override() {
   # Validate reasoning is true/false
   if [ -n "$reasoning" ]; then
     case "$reasoning" in
-    true | false) ;;
-    *)
-      printf '[SECURITY] NEMOCLAW_REASONING must be "true" or "false", got "%s"\n' "$reasoning" >&2
-      return 1
-      ;;
+      true | false) ;;
+      *)
+        printf '[SECURITY] NEMOCLAW_REASONING must be "true" or "false", got "%s"\n' "$reasoning" >&2
+        return 1
+        ;;
     esac
   fi
 
@@ -472,20 +472,20 @@ apply_slack_token_override() {
 
   # SECURITY: Validate token prefixes — reject anything that doesn't look like a real Slack token.
   case "${SLACK_BOT_TOKEN}" in
-  xoxb-*) ;;
-  *)
-    printf '[channels] SLACK_BOT_TOKEN does not start with xoxb- — skipping Slack placeholder resolution\n' >&2
-    return 0
-    ;;
+    xoxb-*) ;;
+    *)
+      printf '[channels] SLACK_BOT_TOKEN does not start with xoxb- — skipping Slack placeholder resolution\n' >&2
+      return 0
+      ;;
   esac
 
   if [ -n "${SLACK_APP_TOKEN:-}" ]; then
     case "$SLACK_APP_TOKEN" in
-    xapp-*) ;;
-    *)
-      printf '[channels] SLACK_APP_TOKEN does not start with xapp- — skipping Slack placeholder resolution\n' >&2
-      return 0
-      ;;
+      xapp-*) ;;
+      *)
+        printf '[channels] SLACK_APP_TOKEN does not start with xapp- — skipping Slack placeholder resolution\n' >&2
+        return 0
+        ;;
     esac
   else
     printf '[channels] Warning: SLACK_BOT_TOKEN is set but SLACK_APP_TOKEN is missing — Socket Mode requires both tokens\n' >&2
@@ -1069,9 +1069,9 @@ if [ "$(id -u)" -ne 0 ]; then
       mkdir -p "${openclaw_dir}/${sub}" 2>/dev/null || true
     done
     if find "$openclaw_dir" ! -uid "$(id -u)" -print -quit 2>/dev/null | grep -q .; then
-      chown -R "$(id -u):$(id -g)" "$openclaw_dir" 2>/dev/null &&
-        echo "[setup] fixed ownership on ${openclaw_dir}" >&2 ||
-        echo "[setup] could not fix ownership on ${openclaw_dir}; writes may fail" >&2
+      chown -R "$(id -u):$(id -g)" "$openclaw_dir" 2>/dev/null \
+        && echo "[setup] fixed ownership on ${openclaw_dir}" >&2 \
+        || echo "[setup] could not fix ownership on ${openclaw_dir}; writes may fail" >&2
     fi
   }
   fix_openclaw_ownership

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1004,7 +1004,7 @@ migrate_legacy_layout() {
 
   # Write the migration sentinel (root-owned, read-only) so we never
   # re-run migration on this sandbox.
-  echo "migrated=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$sentinel"
+  printf 'migrated=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$sentinel"
   chown root:root "$sentinel" 2>/dev/null || true
   chmod 444 "$sentinel" 2>/dev/null || true
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -171,14 +171,14 @@ if [ "${1:-}" = "env" ]; then
   _self_wrapper_index=""
   for ((i = 1; i < ${#_raw_args[@]}; i += 1)); do
     case "${_raw_args[$i]}" in
-      *=*) ;;
-      nemoclaw-start | /usr/local/bin/nemoclaw-start)
-        _self_wrapper_index="$i"
-        break
-        ;;
-      *)
-        break
-        ;;
+    *=*) ;;
+    nemoclaw-start | /usr/local/bin/nemoclaw-start)
+      _self_wrapper_index="$i"
+      break
+      ;;
+    *)
+      break
+      ;;
     esac
   done
   if [ -n "$_self_wrapper_index" ]; then
@@ -193,7 +193,7 @@ fi
 # receiving our own name as $1 would otherwise recurse via the NEMOCLAW_CMD
 # exec path. Only strip from $1 — later args with this name are legitimate.
 case "${1:-}" in
-  nemoclaw-start | /usr/local/bin/nemoclaw-start) shift ;;
+nemoclaw-start | /usr/local/bin/nemoclaw-start) shift ;;
 esac
 NEMOCLAW_CMD=("$@")
 # Validate NEMOCLAW_DASHBOARD_PORT if set (same behavior as ports.js: fail fast).
@@ -203,10 +203,10 @@ if [ -z "$_DASHBOARD_PORT_RAW" ]; then
 else
   _DASHBOARD_PORT="$(printf '%s' "$_DASHBOARD_PORT_RAW" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
   case "$_DASHBOARD_PORT" in
-    *[!0-9]* | '')
-      echo "[SECURITY] Invalid NEMOCLAW_DASHBOARD_PORT='${NEMOCLAW_DASHBOARD_PORT}' — must be an integer between 1024 and 65535" >&2
-      exit 1
-      ;;
+  *[!0-9]* | '')
+    echo "[SECURITY] Invalid NEMOCLAW_DASHBOARD_PORT='${NEMOCLAW_DASHBOARD_PORT}' — must be an integer between 1024 and 65535" >&2
+    exit 1
+    ;;
   esac
   if [ "$_DASHBOARD_PORT" -lt 1024 ] || [ "$_DASHBOARD_PORT" -gt 65535 ]; then
     echo "[SECURITY] Invalid NEMOCLAW_DASHBOARD_PORT='${NEMOCLAW_DASHBOARD_PORT}' — must be an integer between 1024 and 65535" >&2
@@ -257,12 +257,12 @@ verify_config_integrity() {
 
 apply_model_override() {
   # Any of these env vars trigger a config patch
-  [ -n "${NEMOCLAW_MODEL_OVERRIDE:-}" ] \
-    || [ -n "${NEMOCLAW_INFERENCE_API_OVERRIDE:-}" ] \
-    || [ -n "${NEMOCLAW_CONTEXT_WINDOW:-}" ] \
-    || [ -n "${NEMOCLAW_MAX_TOKENS:-}" ] \
-    || [ -n "${NEMOCLAW_REASONING:-}" ] \
-    || return 0
+  [ -n "${NEMOCLAW_MODEL_OVERRIDE:-}" ] ||
+    [ -n "${NEMOCLAW_INFERENCE_API_OVERRIDE:-}" ] ||
+    [ -n "${NEMOCLAW_CONTEXT_WINDOW:-}" ] ||
+    [ -n "${NEMOCLAW_MAX_TOKENS:-}" ] ||
+    [ -n "${NEMOCLAW_REASONING:-}" ] ||
+    return 0
 
   # SECURITY: Only root can write to /sandbox/.openclaw (root:root 444).
   # In non-root mode the sandbox user cannot modify the config.
@@ -297,11 +297,11 @@ apply_model_override() {
   # SECURITY: Allowlist inference API types to prevent unexpected routing.
   if [ -n "$api_override" ]; then
     case "$api_override" in
-      openai-completions | anthropic-messages) ;;
-      *)
-        printf '[SECURITY] NEMOCLAW_INFERENCE_API_OVERRIDE must be "openai-completions" or "anthropic-messages", got "%s"\n' "$api_override" >&2
-        return 1
-        ;;
+    openai-completions | anthropic-messages) ;;
+    *)
+      printf '[SECURITY] NEMOCLAW_INFERENCE_API_OVERRIDE must be "openai-completions" or "anthropic-messages", got "%s"\n' "$api_override" >&2
+      return 1
+      ;;
     esac
   fi
 
@@ -321,11 +321,11 @@ apply_model_override() {
   # Validate reasoning is true/false
   if [ -n "$reasoning" ]; then
     case "$reasoning" in
-      true | false) ;;
-      *)
-        printf '[SECURITY] NEMOCLAW_REASONING must be "true" or "false", got "%s"\n' "$reasoning" >&2
-        return 1
-        ;;
+    true | false) ;;
+    *)
+      printf '[SECURITY] NEMOCLAW_REASONING must be "true" or "false", got "%s"\n' "$reasoning" >&2
+      return 1
+      ;;
     esac
   fi
 
@@ -472,20 +472,20 @@ apply_slack_token_override() {
 
   # SECURITY: Validate token prefixes — reject anything that doesn't look like a real Slack token.
   case "${SLACK_BOT_TOKEN}" in
-    xoxb-*) ;;
-    *)
-      printf '[channels] SLACK_BOT_TOKEN does not start with xoxb- — skipping Slack placeholder resolution\n' >&2
-      return 0
-      ;;
+  xoxb-*) ;;
+  *)
+    printf '[channels] SLACK_BOT_TOKEN does not start with xoxb- — skipping Slack placeholder resolution\n' >&2
+    return 0
+    ;;
   esac
 
   if [ -n "${SLACK_APP_TOKEN:-}" ]; then
     case "$SLACK_APP_TOKEN" in
-      xapp-*) ;;
-      *)
-        printf '[channels] SLACK_APP_TOKEN does not start with xapp- — skipping Slack placeholder resolution\n' >&2
-        return 0
-        ;;
+    xapp-*) ;;
+    *)
+      printf '[channels] SLACK_APP_TOKEN does not start with xapp- — skipping Slack placeholder resolution\n' >&2
+      return 0
+      ;;
     esac
   else
     printf '[channels] Warning: SLACK_BOT_TOKEN is set but SLACK_APP_TOKEN is missing — Socket Mode requires both tokens\n' >&2
@@ -1004,7 +1004,7 @@ migrate_legacy_layout() {
 
   # Write the migration sentinel (root-owned, read-only) so we never
   # re-run migration on this sandbox.
-  printf 'migrated=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$sentinel"
+  printf 'migrated=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$sentinel"
   chown root:root "$sentinel" 2>/dev/null || true
   chmod 444 "$sentinel" 2>/dev/null || true
 
@@ -1069,9 +1069,9 @@ if [ "$(id -u)" -ne 0 ]; then
       mkdir -p "${openclaw_dir}/${sub}" 2>/dev/null || true
     done
     if find "$openclaw_dir" ! -uid "$(id -u)" -print -quit 2>/dev/null | grep -q .; then
-      chown -R "$(id -u):$(id -g)" "$openclaw_dir" 2>/dev/null \
-        && echo "[setup] fixed ownership on ${openclaw_dir}" >&2 \
-        || echo "[setup] could not fix ownership on ${openclaw_dir}; writes may fail" >&2
+      chown -R "$(id -u):$(id -g)" "$openclaw_dir" 2>/dev/null &&
+        echo "[setup] fixed ownership on ${openclaw_dir}" >&2 ||
+        echo "[setup] could not fix ownership on ${openclaw_dir}; writes may fail" >&2
     fi
   }
   fix_openclaw_ownership

--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -546,8 +546,43 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
       return { success: true, manifest, backedUpDirs, failedDirs };
     }
 
+    // NC-2227-04: Pre-backup audit — reject symlinks, hardlinks, and special
+    // files inside state dirs. A compromised agent could plant a symlink like
+    // workspace/copy -> ../openclaw.json to exfiltrate config via backup.
+    const auditCmd = existingDirs
+      .map(
+        (d) =>
+          `find "${dir}/${d}" \\( -type l -o ! -type f -a ! -type d \\) -printf "%y %p\\n" 2>/dev/null`,
+      )
+      .join("; ");
+    _log(`Pre-backup audit: checking for symlinks/special files`);
+    const auditResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), auditCmd], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30000,
+    });
+    const auditOutput = (auditResult.stdout || "").trim();
+    if (auditOutput.length > 0) {
+      // Found symlinks or special files — log them and reject the backup
+      const violations = auditOutput.split("\n").filter((l) => l.length > 0);
+      _log(
+        `SECURITY: Pre-backup audit found ${violations.length} unsafe entries: ${violations.slice(0, 5).join("; ")}`,
+      );
+      return {
+        success: false,
+        manifest,
+        backedUpDirs,
+        failedDirs: [...existingDirs],
+        error: `Pre-backup audit rejected: symlinks or special files found in state dirs: ${violations.slice(0, 3).join("; ")}`,
+      };
+    }
+    _log("Pre-backup audit passed — no symlinks or special files found");
+
     // Download via SSH+tar
-    const tarCmd = `tar -chf - -C ${dir} ${existingDirs.join(" ")}`;
+    // NC-2227-04: Removed -h flag (was following symlinks). State dirs are
+    // now agent-writable and co-located with config — a compromised agent
+    // could create symlinks to exfiltrate config contents via backup.
+    const tarCmd = `tar -cf - -C ${dir} ${existingDirs.join(" ")}`;
     _log(`Downloading via SSH+tar: ${tarCmd}`);
     const result = spawnSync("ssh", [...sshArgs(configFile, sandboxName), tarCmd], {
       stdio: ["ignore", "pipe", "pipe"],
@@ -634,7 +669,8 @@ export function restoreSandboxState(sandboxName: string, backupPath: string): Re
   const configFile = writeTempSshConfig(sshConfig);
   try {
     // Upload via tar pipe
-    const tarResult = spawnSync("tar", ["-chf", "-", "-C", backupPath, ...localDirs], {
+    // NC-2227-04: Removed -h flag from restore as well — no symlink following.
+    const tarResult = spawnSync("tar", ["-cf", "-", "-C", backupPath, ...localDirs], {
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 60000,
       maxBuffer: 256 * 1024 * 1024,

--- a/src/lib/shields-timer.ts
+++ b/src/lib/shields-timer.ts
@@ -14,6 +14,7 @@ const path = require("path");
 const { run } = require("./runner");
 const { buildPolicySetCommand } = require("./policies");
 const { lockAgentConfig } = require("./shields");
+const { resolveAgentConfig } = require("./sandbox-config");
 
 const STATE_DIR = path.join(process.env.HOME ?? "/tmp", ".nemoclaw", "state");
 const AUDIT_FILE = path.join(STATE_DIR, "shields-audit.jsonl");
@@ -94,10 +95,23 @@ setTimeout(() => {
     // Re-lock config file using the shared lockAgentConfig from shields.ts.
     // lockAgentConfig runs each operation independently and verifies the
     // on-disk state — it throws if verification fails.
+    //
+    // NC-2227-03: Resolve the full agent config target (including sensitive
+    // files like .config-hash, .env) so the timer re-locks the same scope
+    // that interactive `shields up` uses. Fall back to the bare configPath/
+    // configDir from argv if resolution fails (e.g., registry unavailable).
     let lockVerified = true;
     if (configPath) {
+      let lockTarget: { configPath: string; configDir: string; sensitiveFiles?: string[] };
       try {
-        lockAgentConfig(sandboxName, { configPath, configDir });
+        lockTarget = resolveAgentConfig(sandboxName);
+      } catch {
+        // Fall back to argv-supplied paths without sensitive files —
+        // better to lock the main config than nothing at all.
+        lockTarget = { configPath, configDir };
+      }
+      try {
+        lockAgentConfig(sandboxName, lockTarget);
       } catch (lockErr) {
         lockVerified = false;
         appendAudit({

--- a/src/lib/shields.ts
+++ b/src/lib/shields.ts
@@ -203,7 +203,7 @@ const HIGH_RISK_STATE_DIRS = [
   "cron",
   "agents",
   "extensions",
-  "plugins",    // Hermes equivalent of extensions
+  "plugins", // Hermes equivalent of extensions
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/lib/shields.ts
+++ b/src/lib/shields.ts
@@ -91,6 +91,12 @@ function stateFilePath(sandboxName: string): string {
   return path.join(STATE_DIR, `shields-${sandboxName}.json`);
 }
 
+// Three-state shields model:
+//   "mutable_default" — fresh sandbox, shields never configured (the default)
+//   "locked"          — shields up has been run and verified
+//   "temporarily_unlocked" — shields down after a prior shields up
+type ShieldsMode = "mutable_default" | "locked" | "temporarily_unlocked";
+
 interface ShieldsState {
   shieldsDown?: boolean;
   shieldsDownAt?: string | null;
@@ -101,19 +107,39 @@ interface ShieldsState {
   updatedAt?: string;
 }
 
-function loadShieldsState(sandboxName: string): ShieldsState {
+/**
+ * Derive the effective shields mode from persisted state.
+ *
+ * NC-2227-02: A fresh sandbox with no state file must report as
+ * "mutable_default", NOT as "locked". Only report locked after
+ * shields up has actually been run (shieldsDown === false AND
+ * the state file exists with an updatedAt timestamp).
+ */
+function deriveShieldsMode(state: ShieldsState, hasStateFile: boolean): ShieldsMode {
+  if (!hasStateFile) return "mutable_default";
+  if (state.shieldsDown === true) return "temporarily_unlocked";
+  if (state.shieldsDown === false) return "locked";
+  // State file exists but shieldsDown is undefined — treat as mutable default
+  return "mutable_default";
+}
+
+function loadShieldsState(sandboxName: string): ShieldsState & { _hasStateFile: boolean } {
   const filePath = stateFilePath(sandboxName);
-  if (!fs.existsSync(filePath)) return {};
+  if (!fs.existsSync(filePath)) return { _hasStateFile: false };
   try {
-    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as ShieldsState;
+    const state = JSON.parse(fs.readFileSync(filePath, "utf-8")) as ShieldsState;
+    return { ...state, _hasStateFile: true };
   } catch {
-    return {};
+    return { _hasStateFile: false };
   }
 }
 
 function saveShieldsState(sandboxName: string, patch: ShieldsState): ShieldsState {
   const current = loadShieldsState(sandboxName);
-  const updated: ShieldsState = { ...current, ...patch, updatedAt: new Date().toISOString() };
+  // Strip the internal _hasStateFile flag before persisting — it is a
+  // runtime-only marker and must not leak into the JSON state file.
+  const { _hasStateFile: _, ...currentClean } = current;
+  const updated: ShieldsState = { ...currentClean, ...patch, updatedAt: new Date().toISOString() };
   fs.mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
   fs.writeFileSync(stateFilePath(sandboxName), JSON.stringify(updated, null, 2), { mode: 0o600 });
   return updated;
@@ -160,6 +186,27 @@ function killTimer(sandboxName: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// NC-2227-05: High-risk state directories that can contain executable code.
+//
+// During shields-up, these must be locked (root:root 755) so the sandbox
+// user cannot create new entries or modify existing ones. This covers both
+// OpenClaw and Hermes agent state dirs that contain executable artifacts
+// (skills, hooks, cron jobs, extensions, plugins, agent definitions).
+//
+// The list is a superset: directories that don't exist in a given agent's
+// config dir are silently skipped.
+// ---------------------------------------------------------------------------
+
+const HIGH_RISK_STATE_DIRS = [
+  "skills",
+  "hooks",
+  "cron",
+  "agents",
+  "extensions",
+  "plugins",    // Hermes equivalent of extensions
+];
+
+// ---------------------------------------------------------------------------
 // Config unlock — returns config to the default (mutable) state
 //
 // Sets permissions to sandbox:sandbox 0600/0700, matching what OpenClaw
@@ -204,6 +251,24 @@ function unlockAgentConfig(
   } catch {
     errors.push("chmod 700 config dir");
   }
+
+  // NC-2227-05: Restore sandbox ownership on high-risk state directories.
+  // Use chown -R to restore the full tree (files within may have been
+  // locked to root:root by a prior shields-up).
+  for (const dirName of HIGH_RISK_STATE_DIRS) {
+    const dirPath = `${target.configDir}/${dirName}`;
+    try {
+      kubectlExec(sandboxName, ["chown", "-R", "sandbox:sandbox", dirPath]);
+    } catch {
+      // Directory may not exist for this agent — silently skip
+    }
+    try {
+      kubectlExec(sandboxName, ["chmod", "755", dirPath]);
+    } catch {
+      // Silently skip
+    }
+  }
+
   if (errors.length > 0) {
     console.error(
       `  Warning: Some unlock operations failed: ${errors.join(", ")}. Config may remain read-only.`,
@@ -269,6 +334,24 @@ function lockAgentConfig(
       kubectlExec(sandboxName, ["chattr", "+i", f]);
     } catch {
       chattrSucceeded = false;
+    }
+  }
+
+  // NC-2227-05: Lock high-risk state directories that can contain executable
+  // code (skills, hooks, cron, agents, extensions, plugins). Root-own the
+  // directory and set 755 so the sandbox user can read/execute but cannot
+  // create new entries or modify existing ones.
+  for (const dirName of HIGH_RISK_STATE_DIRS) {
+    const dirPath = `${target.configDir}/${dirName}`;
+    try {
+      kubectlExec(sandboxName, ["chown", "-R", "root:root", dirPath]);
+    } catch {
+      // Directory may not exist for this agent — silently skip
+    }
+    try {
+      kubectlExec(sandboxName, ["chmod", "755", dirPath]);
+    } catch {
+      // Silently skip
     }
   }
 
@@ -586,40 +669,59 @@ function shieldsStatus(sandboxName: string): void {
   validateName(sandboxName, "sandbox name");
 
   const state = loadShieldsState(sandboxName);
+  const mode = deriveShieldsMode(state, state._hasStateFile);
 
-  if (!state.shieldsDown) {
-    console.log("  Shields: UP (lockdown active)");
-    console.log(
-      `  Policy:  restrictive${state.shieldsPolicySnapshotPath ? " (snapshot preserved)" : ""}`,
-    );
-    if (state.shieldsDownAt) {
-      console.log(`  Last unlocked: ${state.shieldsDownAt}`);
+  switch (mode) {
+    case "mutable_default":
+      // NC-2227-02: Fresh sandbox with no shields history — do NOT claim locked
+      console.log("  Shields: NOT CONFIGURED (default mutable state)");
+      console.log("  Config is mutable. Run `nemoclaw <sandbox> shields up` to opt into lockdown.");
+      return;
+
+    case "locked":
+      console.log("  Shields: UP (lockdown active)");
+      console.log(
+        `  Policy:  restrictive${state.shieldsPolicySnapshotPath ? " (snapshot preserved)" : ""}`,
+      );
+      if (state.shieldsDownAt) {
+        console.log(`  Last unlocked: ${state.shieldsDownAt}`);
+      }
+      return;
+
+    case "temporarily_unlocked": {
+      const downSince = state.shieldsDownAt ? new Date(state.shieldsDownAt) : null;
+      const elapsed = downSince ? Math.floor((Date.now() - downSince.getTime()) / 1000) : 0;
+      const remaining =
+        state.shieldsDownTimeout != null ? Math.max(0, state.shieldsDownTimeout - elapsed) : null;
+
+      console.log("  Shields: DOWN (temporarily unlocked)");
+      console.log(`  Since:   ${state.shieldsDownAt ?? "unknown"}`);
+      if (remaining !== null) {
+        const mins = Math.floor(remaining / 60);
+        const secs = remaining % 60;
+        console.log(`  Auto-lockdown in: ${mins}m ${secs}s`);
+      }
+      console.log(`  Reason:  ${state.shieldsDownReason ?? "not specified"}`);
+      console.log(`  Policy:  ${state.shieldsDownPolicy ?? "permissive"}`);
+      return;
     }
-    return;
   }
-
-  const downSince = state.shieldsDownAt ? new Date(state.shieldsDownAt) : null;
-  const elapsed = downSince ? Math.floor((Date.now() - downSince.getTime()) / 1000) : 0;
-  const remaining =
-    state.shieldsDownTimeout != null ? Math.max(0, state.shieldsDownTimeout - elapsed) : null;
-
-  console.log("  Shields: DOWN (default mutable state)");
-  console.log(`  Since:   ${state.shieldsDownAt ?? "unknown"}`);
-  if (remaining !== null) {
-    const mins = Math.floor(remaining / 60);
-    const secs = remaining % 60;
-    console.log(`  Auto-lockdown in: ${mins}m ${secs}s`);
-  }
-  console.log(`  Reason:  ${state.shieldsDownReason ?? "not specified"}`);
-  console.log(`  Policy:  ${state.shieldsDownPolicy ?? "permissive"}`);
 }
 
 // ---------------------------------------------------------------------------
 // Query — check whether shields are currently down
 // ---------------------------------------------------------------------------
 
+/**
+ * Returns true if shields are currently down (temporarily unlocked).
+ * NC-2227-02: Fresh sandboxes (no state file, mutable_default) return
+ * true since the config IS mutable. Only returns false when shields
+ * have been explicitly locked via `shields up`.
+ */
 function isShieldsDown(sandboxName: string): boolean {
-  return loadShieldsState(sandboxName).shieldsDown === true;
+  const state = loadShieldsState(sandboxName);
+  const mode = deriveShieldsMode(state, state._hasStateFile);
+  return mode !== "locked";
 }
 
 // ---------------------------------------------------------------------------
@@ -631,8 +733,10 @@ export {
   shieldsUp,
   shieldsStatus,
   isShieldsDown,
+  deriveShieldsMode,
   parseDuration,
   lockAgentConfig,
+  unlockAgentConfig,
   MAX_TIMEOUT_SECONDS,
   DEFAULT_TIMEOUT_SECONDS,
 };

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -735,3 +735,57 @@ describe("nemoclaw-start CHAT_UI_URL override for configurable dashboard port (#
     );
   });
 });
+
+// -------------------------------------------------------------------
+// NC-2227-01: Legacy migration guards
+// -------------------------------------------------------------------
+describe("NC-2227-01: legacy migration guards", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("uses a migration-complete sentinel to prevent re-running migration", () => {
+    const fn = src.match(/migrate_legacy_layout\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain(".migration-complete");
+    expect(fn[1]).toContain("sentinel");
+  });
+
+  it("requires root to run migration", () => {
+    const fn = src.match(/migrate_legacy_layout\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("id -u");
+    expect(fn[1]).toContain("migration skipped");
+    expect(fn[1]).toContain("requires root");
+  });
+
+  it("rejects sandbox-owned data directories as potentially agent-planted", () => {
+    const fn = src.match(/migrate_legacy_layout\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("data_owner");
+    expect(fn[1]).toContain("sandbox-owned");
+    expect(fn[1]).toContain("possible agent-planted trigger");
+  });
+
+  it("does not chown -R the config directory itself", () => {
+    const fn = src.match(/migrate_legacy_layout\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    // The old pattern chown -R sandbox:sandbox "$config_dir" must NOT exist
+    expect(fn[1]).not.toMatch(/chown -R sandbox:sandbox "\$config_dir"\s/);
+    // Only subdirectories should be chowned
+    expect(fn[1]).toContain('[ -d "$entry" ] || continue');
+  });
+
+  it("reapplies shields-up ownership if shields were previously active", () => {
+    const fn = src.match(/migrate_legacy_layout\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("shields_were_active");
+    expect(fn[1]).toContain("Reapplying shields-up ownership");
+  });
+
+  it("writes a root-owned read-only sentinel after successful migration", () => {
+    const fn = src.match(/migrate_legacy_layout\(\) \{([\s\S]*?)^}/m);
+    expect(fn).toBeTruthy();
+    // Sentinel must be root-owned and 444
+    expect(fn[1]).toMatch(/chown root:root "\$sentinel"/);
+    expect(fn[1]).toMatch(/chmod 444 "\$sentinel"/);
+  });
+});

--- a/test/shields.test.ts
+++ b/test/shields.test.ts
@@ -21,9 +21,15 @@ vi.mock("../../src/lib/runner", () => ({
 
 vi.mock("../../src/lib/policies", () => ({
   buildPolicyGetCommand: vi.fn((name) => ["openshell", "policy", "get", "--full", name]),
-  buildPolicySetCommand: vi.fn(
-    (file, name) => ["openshell", "policy", "set", "--policy", file, "--wait", name],
-  ),
+  buildPolicySetCommand: vi.fn((file, name) => [
+    "openshell",
+    "policy",
+    "set",
+    "--policy",
+    file,
+    "--wait",
+    name,
+  ]),
   parseCurrentPolicy: vi.fn((raw) => raw || ""),
   PERMISSIVE_POLICY_PATH: "/mock/permissive.yaml",
 }));
@@ -106,8 +112,14 @@ describe("shields — unit logic", () => {
       // Write state for two different sandboxes
       const alphaState = { shieldsDown: true, updatedAt: new Date().toISOString() };
       const betaState = { shieldsDown: false, updatedAt: new Date().toISOString() };
-      fs.writeFileSync(path.join(stateDir, "shields-alpha.json"), JSON.stringify(alphaState, null, 2));
-      fs.writeFileSync(path.join(stateDir, "shields-beta.json"), JSON.stringify(betaState, null, 2));
+      fs.writeFileSync(
+        path.join(stateDir, "shields-alpha.json"),
+        JSON.stringify(alphaState, null, 2),
+      );
+      fs.writeFileSync(
+        path.join(stateDir, "shields-beta.json"),
+        JSON.stringify(betaState, null, 2),
+      );
 
       const alpha = JSON.parse(fs.readFileSync(path.join(stateDir, "shields-alpha.json"), "utf-8"));
       const beta = JSON.parse(fs.readFileSync(path.join(stateDir, "shields-beta.json"), "utf-8"));
@@ -134,9 +146,14 @@ describe("shields — unit logic", () => {
         shieldsPolicySnapshotPath: snapshotPath,
         updatedAt: new Date().toISOString(),
       };
-      fs.writeFileSync(path.join(stateDir, "shields-openclaw.json"), JSON.stringify(state, null, 2));
+      fs.writeFileSync(
+        path.join(stateDir, "shields-openclaw.json"),
+        JSON.stringify(state, null, 2),
+      );
 
-      const loaded = JSON.parse(fs.readFileSync(path.join(stateDir, "shields-openclaw.json"), "utf-8"));
+      const loaded = JSON.parse(
+        fs.readFileSync(path.join(stateDir, "shields-openclaw.json"), "utf-8"),
+      );
       expect(loaded.shieldsDown).toBe(true);
       expect(loaded.shieldsDownTimeout).toBe(300);
       expect(loaded.shieldsDownPolicy).toBe("permissive");
@@ -159,7 +176,10 @@ describe("shields — unit logic", () => {
         shieldsPolicySnapshotPath: snapshotPath,
         updatedAt: new Date().toISOString(),
       };
-      fs.writeFileSync(path.join(stateDir, "shields-openclaw.json"), JSON.stringify(downState, null, 2));
+      fs.writeFileSync(
+        path.join(stateDir, "shields-openclaw.json"),
+        JSON.stringify(downState, null, 2),
+      );
 
       const cleared = {
         ...downState,
@@ -170,9 +190,14 @@ describe("shields — unit logic", () => {
         shieldsDownPolicy: null,
         updatedAt: new Date().toISOString(),
       };
-      fs.writeFileSync(path.join(stateDir, "shields-openclaw.json"), JSON.stringify(cleared, null, 2));
+      fs.writeFileSync(
+        path.join(stateDir, "shields-openclaw.json"),
+        JSON.stringify(cleared, null, 2),
+      );
 
-      const loaded = JSON.parse(fs.readFileSync(path.join(stateDir, "shields-openclaw.json"), "utf-8"));
+      const loaded = JSON.parse(
+        fs.readFileSync(path.join(stateDir, "shields-openclaw.json"), "utf-8"),
+      );
       expect(loaded.shieldsDown).toBe(false);
       expect(loaded.shieldsDownAt).toBeNull();
       expect(loaded.shieldsPolicySnapshotPath).toBe(snapshotPath);
@@ -281,7 +306,11 @@ describe("shields — unit logic", () => {
     it("temporarily unlocked sandbox (shieldsDown: true) reports temporarily_unlocked", () => {
       const stateDir = path.join(tmpDir, ".nemoclaw", "state");
       fs.mkdirSync(stateDir, { recursive: true });
-      const state = { shieldsDown: true, shieldsDownAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+      const state = {
+        shieldsDown: true,
+        shieldsDownAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
       fs.writeFileSync(path.join(stateDir, "shields-temp.json"), JSON.stringify(state, null, 2));
 
       const hasStateFile = true;

--- a/test/shields.test.ts
+++ b/test/shields.test.ts
@@ -236,4 +236,170 @@ describe("shields — unit logic", () => {
   // feasible here because shields.ts uses CJS require() which doesn't resolve
   // through vitest's ESM mock system. The full call chain is exercised by the
   // E2E test (test/e2e/test-shields-config.sh) against a live sandbox.
+
+  // -------------------------------------------------------------------
+  // NC-2227-02: Three-state shields model
+  // -------------------------------------------------------------------
+  describe("NC-2227-02: three-state shields model", () => {
+    it("fresh sandbox (no state file) reports mutable_default, not locked", () => {
+      const stateDir = path.join(tmpDir, ".nemoclaw", "state");
+      fs.mkdirSync(stateDir, { recursive: true });
+      // Do NOT create shields-fresh.json — simulates fresh sandbox
+      const stateFile = path.join(stateDir, "shields-fresh.json");
+      expect(fs.existsSync(stateFile)).toBe(false);
+
+      // Manually replicate the deriveShieldsMode logic to test the invariant
+      // (we can't import the CJS module directly)
+      const hasStateFile = false;
+      const state = {};
+      // deriveShieldsMode: no state file => mutable_default
+      let mode: string;
+      if (!hasStateFile) mode = "mutable_default";
+      else if (state["shieldsDown"] === true) mode = "temporarily_unlocked";
+      else if (state["shieldsDown"] === false) mode = "locked";
+      else mode = "mutable_default";
+
+      expect(mode).toBe("mutable_default");
+    });
+
+    it("explicitly locked sandbox (shieldsDown: false, file exists) reports locked", () => {
+      const stateDir = path.join(tmpDir, ".nemoclaw", "state");
+      fs.mkdirSync(stateDir, { recursive: true });
+      const state = { shieldsDown: false, updatedAt: new Date().toISOString() };
+      fs.writeFileSync(path.join(stateDir, "shields-locked.json"), JSON.stringify(state, null, 2));
+
+      const hasStateFile = true;
+      let mode: string;
+      if (!hasStateFile) mode = "mutable_default";
+      else if (state.shieldsDown === true) mode = "temporarily_unlocked";
+      else if (state.shieldsDown === false) mode = "locked";
+      else mode = "mutable_default";
+
+      expect(mode).toBe("locked");
+    });
+
+    it("temporarily unlocked sandbox (shieldsDown: true) reports temporarily_unlocked", () => {
+      const stateDir = path.join(tmpDir, ".nemoclaw", "state");
+      fs.mkdirSync(stateDir, { recursive: true });
+      const state = { shieldsDown: true, shieldsDownAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+      fs.writeFileSync(path.join(stateDir, "shields-temp.json"), JSON.stringify(state, null, 2));
+
+      const hasStateFile = true;
+      let mode: string;
+      if (!hasStateFile) mode = "mutable_default";
+      else if (state.shieldsDown === true) mode = "temporarily_unlocked";
+      else if (state.shieldsDown === false) mode = "locked";
+      else mode = "mutable_default";
+
+      expect(mode).toBe("temporarily_unlocked");
+    });
+
+    it("state file with undefined shieldsDown reports mutable_default", () => {
+      const stateDir = path.join(tmpDir, ".nemoclaw", "state");
+      fs.mkdirSync(stateDir, { recursive: true });
+      const state = { updatedAt: new Date().toISOString() };
+      fs.writeFileSync(path.join(stateDir, "shields-undef.json"), JSON.stringify(state, null, 2));
+
+      const hasStateFile = true;
+      let mode: string;
+      if (!hasStateFile) mode = "mutable_default";
+      else if (state["shieldsDown"] === true) mode = "temporarily_unlocked";
+      else if (state["shieldsDown"] === false) mode = "locked";
+      else mode = "mutable_default";
+
+      expect(mode).toBe("mutable_default");
+    });
+  });
+});
+
+// -------------------------------------------------------------------
+// NC-2227-04: Regression test — tar commands must not follow symlinks
+// -------------------------------------------------------------------
+describe("NC-2227-04: sandbox-state.ts tar commands do not follow symlinks", () => {
+  function getSourceCode(): string {
+    return fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "sandbox-state.ts"),
+      "utf-8",
+    );
+  }
+
+  it("backup tar command does not use -h flag (no symlink following)", () => {
+    const src = getSourceCode();
+    // Find the backup tar command in backupSandboxState
+    const fnStart = src.indexOf("function backupSandboxState");
+    expect(fnStart).not.toBe(-1);
+    const fnBody = src.slice(fnStart);
+
+    // The tar command should be `tar -cf` not `tar -chf`
+    const tarCmdMatch = fnBody.match(/tar -c([a-z]*)f/g);
+    expect(tarCmdMatch).not.toBeNull();
+    for (const match of tarCmdMatch!) {
+      expect(match).not.toContain("h");
+    }
+  });
+
+  it("restore tar command does not use -h flag (no symlink following)", () => {
+    const src = getSourceCode();
+    // Find the restore function
+    const fnStart = src.indexOf("function restoreSandboxState");
+    expect(fnStart).not.toBe(-1);
+    const fnBody = src.slice(fnStart);
+
+    // Check tar commands in the restore path
+    const tarCmdMatches = fnBody.match(/"-c([a-z]*)f"/g);
+    if (tarCmdMatches) {
+      for (const match of tarCmdMatches) {
+        expect(match).not.toContain("h");
+      }
+    }
+  });
+
+  it("backup includes pre-backup symlink audit before tar", () => {
+    const src = getSourceCode();
+    const fnStart = src.indexOf("function backupSandboxState");
+    const fnBody = src.slice(fnStart);
+
+    // Must have the pre-backup audit command checking for symlinks
+    expect(fnBody).toContain("Pre-backup audit");
+    expect(fnBody).toContain("-type l");
+  });
+});
+
+// -------------------------------------------------------------------
+// NC-2227-05: Regression test — shields.ts locks high-risk state dirs
+// -------------------------------------------------------------------
+describe("NC-2227-05: shields.ts locks high-risk state directories", () => {
+  function getSourceCode(): string {
+    return fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "shields.ts"),
+      "utf-8",
+    );
+  }
+
+  it("HIGH_RISK_STATE_DIRS constant includes skills, hooks, cron, agents, extensions, plugins", () => {
+    const src = getSourceCode();
+    expect(src).toContain("HIGH_RISK_STATE_DIRS");
+    for (const dir of ["skills", "hooks", "cron", "agents", "extensions", "plugins"]) {
+      expect(src).toContain(`"${dir}"`);
+    }
+  });
+
+  it("lockAgentConfig iterates over HIGH_RISK_STATE_DIRS", () => {
+    const src = getSourceCode();
+    const fnStart = src.indexOf("function lockAgentConfig");
+    expect(fnStart).not.toBe(-1);
+    const fnBody = src.slice(fnStart);
+    expect(fnBody).toContain("HIGH_RISK_STATE_DIRS");
+    expect(fnBody).toContain("chown");
+    expect(fnBody).toContain("root:root");
+  });
+
+  it("unlockAgentConfig restores sandbox ownership on HIGH_RISK_STATE_DIRS", () => {
+    const src = getSourceCode();
+    const fnStart = src.indexOf("function unlockAgentConfig");
+    expect(fnStart).not.toBe(-1);
+    const fnBody = src.slice(fnStart, src.indexOf("function lockAgentConfig"));
+    expect(fnBody).toContain("HIGH_RISK_STATE_DIRS");
+    expect(fnBody).toContain("sandbox:sandbox");
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #2227 (`refactor(sandbox): default to mutable config, make shields opt-in`). Addresses all five findings from the 2026-04-24 security and vulnerability review so #2227 can proceed to merge without blocking on these concerns.

Fixes #2300 (partial — shared concern about mutable config attack surface)

## Changes

### NC-2227-01 (Critical): Legacy migration can undo `shields up`

`migrate_legacy_layout()` in `scripts/nemoclaw-start.sh` now has three guards:

1. **Sentinel** — `.migration-complete` marker prevents re-running on already-migrated sandboxes
2. **Root-only** — refuses to run if not root (blocks agent from triggering it)
3. **Ownership** — rejects data directories owned by `sandbox` user (detects agent-planted triggers; legitimate legacy dirs are root-owned from the image build)

Additionally: replaced blanket `chown -R sandbox:sandbox "$config_dir"` with targeted subdirectory-only chown, preserving root ownership on `openclaw.json`, `.config-hash`, `.env`. Reapplies shields-up ownership after migration if shields were previously active.

### NC-2227-02 (High): Fresh mutable sandboxes report `Shields: UP`

Introduced a three-state model in `src/lib/shields.ts`: `mutable_default`, `locked`, `temporarily_unlocked`. Fresh sandboxes (no state file) now report `NOT CONFIGURED (default mutable state)` instead of falsely claiming lockdown is active. `isShieldsDown()` returns true for both `mutable_default` and `temporarily_unlocked` — only `locked` (after explicit `shields up`) returns false.

### NC-2227-03 (High): Auto-restore does not re-lock sensitive sidecar files

`src/lib/shields-timer.ts` now calls `resolveAgentConfig(sandboxName)` to get the full lock target (including `.config-hash`, `.env`) before calling `lockAgentConfig`. Falls back to bare `configPath`/`configDir` from argv if resolution fails.

### NC-2227-04 (High): Backup dereferences untrusted symlinks

Removed `tar -h` flag from both backup and restore in `src/lib/sandbox-state.ts`. Added a pre-backup `find`-based audit that rejects symlinks (`-type l`) and special files before creating the tar, preventing exfiltration of config contents via agent-planted symlinks.

### NC-2227-05 (High): `shields up` leaves co-located state directories writable

Added `HIGH_RISK_STATE_DIRS` constant (`skills`, `hooks`, `cron`, `agents`, `extensions`, `plugins`). `lockAgentConfig()` now recursively `chown -R root:root` and `chmod 755` these directories during shields-up. `unlockAgentConfig()` restores `sandbox:sandbox` ownership during shields-down.

## Type of Change

- [X] Code change (feature, bug fix, or refactor)

## Verification

- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed

Tests added:
- `test/nemoclaw-start.test.ts` — 6 tests for migration guards (sentinel, root-only, ownership, no blanket chown, shields reapplication, sentinel permissions)
- `test/shields.test.ts` — 10 tests covering three-state model derivation, tar flag regression, and state directory locking

Note: NC-2227-02 unit tests replicate `deriveShieldsMode` logic inline (CJS module not directly importable in vitest). Full code path is exercised by E2E tests in `test/e2e/test-shields-config.sh`.

---
Signed-off-by: Andrew Erickson <aerickson@nvidia.com>