### PR TITLE
test(install-preflight): bump nvm upgrade test timeout to 15s

### DIFF
--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -104,6 +104,16 @@ echo "unexpected npm invocation: $*" >&2; exit 98`,
 // ---------------------------------------------------------------------------
 
 describe("installer runtime preflight", () => {
+  // install.sh sources scripts/install.sh (1374-line payload), which runs
+  // resolve_installer_version() → resolve_repo_root() → git describe at source
+  // time. In isolation this takes ~0.9s. Under vitest's default parallelism on
+  // macOS (up to 14 workers), fork()/execve() serializes and each subprocess
+  // spawn balloons 50-200× (200-500ms instead of 1-10ms). With 5-6 subprocess
+  // spawns per installer run, total can reach 5-7s, blowing past the default
+  // 5000ms testTimeout. The default is correct for every other test here; this
+  // one has a legitimately different workload (real bash + real subprocesses).
+  const INSTALLER_TEST_TIMEOUT = 15_000;
+
   it("attempts nvm upgrade when system Node.js is below minimum version", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-preflight-"));
     const fakeBin = path.join(tmp, "bin");
@@ -156,7 +166,7 @@ exit 1
     expect(output).toMatch(/v18\.19\.1.*found but NemoClaw requires/);
     expect(output).toMatch(/upgrading via nvm/);
     expect(output).toMatch(/Failed to download nvm installer/);
-  });
+  }, INSTALLER_TEST_TIMEOUT);
 
   it("treats the installer script's checkout as the source root even when cwd is elsewhere", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-fallback-"));


### PR DESCRIPTION
## Summary

Unblocks local pre-commit hook on mac: `install-preflight > attempts nvm upgrade when system Node.js is below minimum version` times out at 5s under parallel vitest load. Bumps per-test timeout to 15s with a comment explaining the root cause.

## Root cause

`install.sh` sources `scripts/install.sh` (1374-line payload), which runs `resolve_installer_version()` → `resolve_repo_root()` → `git describe` at source time. In isolation the test takes ~0.9s. Under vitest's default parallelism on mac (up to 14 workers), `fork()`/`execve()` serializes and each subprocess spawn balloons 50–200×, pushing total runtime to 5–7s.

Reproduced 14/14 locally; CI (ubuntu) doesn't hit it because Linux fork is fast.

## Changes

- `test/install-preflight.test.ts`: add per-test `INSTALLER_TEST_TIMEOUT = 15_000` on the one failing test, with a comment pointing at the root cause for future readers.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

## Follow-up (tracked, not in this PR)

Cache `resolve_installer_version` / `resolve_repo_root` in `scripts/install.sh` so sourcing doesn't re-subshell every invocation. Would let us drop the special-case timeout and also help real installs on busy CI runners.

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved installer preflight test reliability by increasing timeout duration for full installation flow testing, preventing timeout failures during complex version-resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->