### PR TITLE
refactor(types): consolidate duplicated errno and JSON type helpers

### DIFF
--- a/nemoclaw-blueprint/scripts/ws-proxy-fix.js
+++ b/nemoclaw-blueprint/scripts/ws-proxy-fix.js
@@ -174,6 +174,9 @@ const _PATCHED = Symbol.for("nemoclaw.wsProxyFix");
             host = opts.host.replace(/:\d+$/, "");
         }
         if (isDiscordWsUpgrade(host, opts.headers)) {
+            // Guard: if isDiscordWsUpgrade matched but host resolved to
+            // undefined, we cannot construct a CONNECT tunnel (no target).
+            // Fall through to the original https.request unchanged.
             if (!host) {
                 return callOriginalRequest(input, options, callback);
             }

--- a/nemoclaw-blueprint/scripts/ws-proxy-fix.ts
+++ b/nemoclaw-blueprint/scripts/ws-proxy-fix.ts
@@ -224,6 +224,11 @@ interface ReqOpts extends https.RequestOptions {
       host = opts.host.replace(/:\d+$/, "");
     }
     if (isDiscordWsUpgrade(host, opts.headers)) {
+      // Guard: if isDiscordWsUpgrade matched but host resolved to
+      // undefined, we cannot construct a CONNECT tunnel (no target).
+      // Fall through to the original https.request unchanged.  Before
+      // PR #2422 this path would have attempted the tunnel with an
+      // undefined host, which would fail in createTunnelAgent anyway.
       if (!host) {
         return callOriginalRequest(input, options, callback);
       }

--- a/src/lib/agent-onboard.ts
+++ b/src/lib/agent-onboard.ts
@@ -14,10 +14,7 @@ import { loadAgent, resolveAgentName, type AgentDefinition } from "./agent-defs"
 import { getProviderSelectionConfig } from "./inference-config";
 import * as onboardSession from "./onboard-session";
 import { sleepSeconds } from "./wait";
-
-type LooseScalar = string | number | boolean | null | undefined;
-type LooseValue = LooseScalar | LooseObject | LooseValue[];
-type LooseObject = { [key: string]: LooseValue };
+import type { JsonValue as LooseValue, JsonObject as LooseObject } from "./json-types";
 
 export interface OnboardContext {
   step: (current: number, total: number, message: string) => void;

--- a/src/lib/config-io.ts
+++ b/src/lib/config-io.ts
@@ -10,6 +10,8 @@ import path from "node:path";
 import { shellQuote } from "./shell-quote";
 import { isErrnoException, isPermissionError } from "./errno";
 
+// Strict JSON types for file serialization — unlike json-types.ts,
+// these exclude undefined since actual JSON cannot contain it.
 type JsonScalar = string | number | boolean | null;
 type JsonValue = JsonScalar | JsonObject | JsonValue[];
 type JsonObject = { [key: string]: JsonValue };

--- a/src/lib/config-io.ts
+++ b/src/lib/config-io.ts
@@ -8,8 +8,8 @@ import os from "node:os";
 import path from "node:path";
 
 import { shellQuote } from "./shell-quote";
+import { isErrnoException, isPermissionError } from "./errno";
 
-type ErrnoLike = Error | { code?: string | number } | null;
 type JsonScalar = string | number | boolean | null;
 type JsonValue = JsonScalar | JsonObject | JsonValue[];
 type JsonObject = { [key: string]: JsonValue };
@@ -17,14 +17,6 @@ type SerializableConfig = JsonScalar | JsonValue[] | object;
 
 function toError(error: Error | string | number | boolean | null | undefined): Error {
   return error instanceof Error ? error : new Error(String(error));
-}
-
-function isErrnoException(error: ErrnoLike): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
-}
-
-function isPermissionError(error: ErrnoLike): error is NodeJS.ErrnoException {
-  return isErrnoException(error) && (error.code === "EACCES" || error.code === "EPERM");
 }
 
 function parseJson<T>(text: string): T {

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -8,14 +8,9 @@ import path from "node:path";
 import readline from "node:readline";
 
 import { readConfigFile, writeConfigFile } from "./config-io";
+import { isErrnoException } from "./errno";
 
 const UNSAFE_HOME_PATHS = new Set(["/tmp", "/var/tmp", "/dev/shm", "/"]);
-
-type ErrnoLike = Error | { code?: string | number } | null;
-
-function isErrnoException(error: ErrnoLike): error is NodeJS.ErrnoException {
-  return error !== null && typeof error === "object" && "code" in error;
-}
 
 type CredentialInput = string | null | undefined;
 
@@ -40,7 +35,7 @@ export function resolveHomeDir(): string {
     }
   } catch (error) {
     if (
-      !(typeof error === "object" && error !== null && isErrnoException(error)) ||
+      !isErrnoException(error) ||
       error.code !== "ENOENT"
     ) {
       throw error;

--- a/src/lib/errno.ts
+++ b/src/lib/errno.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared errno helpers for safely narrowing caught errors to
+ * `NodeJS.ErrnoException`.
+ *
+ * Multiple modules (config-io, credentials, http-probe, onboard,
+ * onboard-session, registry) previously defined their own
+ * `isErrnoException` + `ErrnoLike` type.  This module unifies them
+ * into a single source of truth.
+ *
+ * Usage in catch blocks:
+ *
+ *   ```ts
+ *   try { … } catch (error) {
+ *     if (isErrnoException(error) && error.code === "ENOENT") { … }
+ *   }
+ *   ```
+ */
+
+/**
+ * Narrow an unknown caught value to `NodeJS.ErrnoException`.
+ *
+ * Accepts `unknown` so callers never need a pre-cast.  Returns `true`
+ * when the value is a non-null object carrying a `code` or `errno`
+ * property — the two fields Node.js sets on filesystem / child-process
+ * errors.
+ */
+export function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    ("code" in error || "errno" in error)
+  );
+}
+
+/**
+ * Convenience: true when the error is an `EACCES` or `EPERM` errno,
+ * commonly used for permission-denied guards.
+ */
+export function isPermissionError(error: unknown): error is NodeJS.ErrnoException {
+  return isErrnoException(error) && (error.code === "EACCES" || error.code === "EPERM");
+}

--- a/src/lib/http-probe.ts
+++ b/src/lib/http-probe.ts
@@ -14,13 +14,9 @@ import type { ProbeResult } from "./onboard-types";
 import { ROOT } from "./paths";
 import { compactText } from "./url-utils";
 
+import { isErrnoException } from "./errno";
+
 export type CurlProbeResult = ProbeResult;
-
-type ErrnoLike = Error | { code?: string | number; errno?: string | number } | null;
-
-function isErrnoException(error: ErrnoLike): error is NodeJS.ErrnoException {
-  return error !== null && typeof error === "object" && ("code" in error || "errno" in error);
-}
 
 export interface CurlProbeOptions {
   cwd?: string;

--- a/src/lib/json-types.ts
+++ b/src/lib/json-types.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared recursive JSON-like types for loosely-typed data boundaries.
+ *
+ * Several modules (onboard, agent-onboard, policies, onboard-session)
+ * defined their own Scalar / Value / Object triples for the same
+ * purpose: representing data parsed from JSON, YAML, or environment
+ * variables before it is validated into a narrower domain type.
+ *
+ * This module provides a single canonical set so the pattern is
+ * consistent across the CLI codebase.
+ *
+ * Note: The plugin (`nemoclaw/src/`) has its own parallel types
+ * (`PluginScalar`, `PluginValue`, `PluginRecord`) because the plugin
+ * and CLI are compiled separately and cannot share imports.
+ */
+
+/** A single JSON-compatible scalar (includes `undefined` for optional fields). */
+export type JsonScalar = string | number | boolean | null | undefined;
+
+/** A recursive JSON-compatible value: scalar, object, or array. */
+export type JsonValue = JsonScalar | JsonObject | JsonValue[];
+
+/** A JSON-compatible object with string keys and recursive values. */
+export type JsonObject = { [key: string]: JsonValue };

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -11,6 +11,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { redactSensitiveText, redactUrl } from "./redact";
+import { isErrnoException } from "./errno";
 import type { WebSearchConfig } from "./web-search";
 
 export const SESSION_VERSION = 1;
@@ -18,9 +19,11 @@ export const SESSION_DIR = path.join(process.env.HOME || "/tmp", ".nemoclaw");
 export const SESSION_FILE = path.join(SESSION_DIR, "onboard-session.json");
 export const LOCK_FILE = path.join(SESSION_DIR, "onboard.lock");
 
-type SessionJsonPrimitive = string | number | boolean | null;
-type SessionJsonValue = SessionJsonPrimitive | UnknownRecord | SessionJsonValue[];
-type UnknownRecord = { [key: string]: SessionJsonValue };
+import type { JsonValue, JsonObject } from "./json-types";
+
+// Session-specific aliases for the shared JSON types.
+type SessionJsonValue = JsonValue;
+type UnknownRecord = JsonObject;
 type StepStatus = "pending" | "in_progress" | "complete" | "failed" | "skipped";
 
 const STEP_STATES: readonly StepStatus[] = [
@@ -158,12 +161,6 @@ function defaultSteps(): Record<string, StepState> {
 
 export function isObject(value: unknown): value is UnknownRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-type ErrnoLike = Error | { code?: string | number } | null;
-
-function isErrnoException(error: ErrnoLike): error is NodeJS.ErrnoException {
-  return error !== null && error instanceof Error && "code" in error;
 }
 
 function readString(value: SessionJsonValue | undefined): string | null {
@@ -366,7 +363,7 @@ function isProcessAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    return error instanceof Error && isErrnoException(error) && error.code === "EPERM";
+    return isErrnoException(error) && error.code === "EPERM";
   }
 }
 
@@ -406,7 +403,7 @@ export function acquireOnboardLock(command: string | null = null): LockResult {
       // resolves to the same file we created (fstat ino vs stat ino).
       fd = fs.openSync(LOCK_FILE, "wx", 0o600);
     } catch (error) {
-      if (!(error instanceof Error && isErrnoException(error)) || error.code !== "EEXIST") {
+      if (!isErrnoException(error) || error.code !== "EEXIST") {
         throw error;
       }
 
@@ -423,11 +420,7 @@ export function acquireOnboardLock(command: string | null = null): LockResult {
         staleInode = stat.ino;
         existing = parseLockFile(fs.readFileSync(LOCK_FILE, "utf8"));
       } catch (readError) {
-        if (
-          readError instanceof Error &&
-          isErrnoException(readError) &&
-          readError.code === "ENOENT"
-        ) {
+        if (isErrnoException(readError) && readError.code === "ENOENT") {
           continue;
         }
         throw readError;
@@ -505,7 +498,7 @@ function unlinkIfInodeMatches(filePath: string, expectedInode: bigint | null): v
       return;
     }
   } catch (statError) {
-    if (statError instanceof Error && isErrnoException(statError) && statError.code === "ENOENT") {
+    if (isErrnoException(statError) && statError.code === "ENOENT") {
       return;
     }
     throw statError;
@@ -513,13 +506,7 @@ function unlinkIfInodeMatches(filePath: string, expectedInode: bigint | null): v
   try {
     fs.unlinkSync(filePath);
   } catch (unlinkError) {
-    if (
-      !(
-        unlinkError instanceof Error &&
-        isErrnoException(unlinkError) &&
-        unlinkError.code === "ENOENT"
-      )
-    ) {
+    if (!isErrnoException(unlinkError) || unlinkError.code !== "ENOENT") {
       throw unlinkError;
     }
   }
@@ -540,7 +527,7 @@ export function releaseOnboardLock(): void {
         const pathStat = fs.statSync(LOCK_FILE, { bigint: true });
         pathInode = pathStat.ino;
       } catch (error) {
-        if (!(error instanceof Error && isErrnoException(error) && error.code === "ENOENT")) {
+        if (!(isErrnoException(error) && error.code === "ENOENT")) {
           // Unexpected — fall through to closing the fd.
         }
       }
@@ -548,13 +535,7 @@ export function releaseOnboardLock(): void {
         try {
           fs.unlinkSync(LOCK_FILE);
         } catch (unlinkError) {
-          if (
-            !(
-              unlinkError instanceof Error &&
-              isErrnoException(unlinkError) &&
-              unlinkError.code === "ENOENT"
-            )
-          ) {
+          if (!(isErrnoException(unlinkError) && unlinkError.code === "ENOENT")) {
             // Best effort — surfacing this would mask the real error.
           }
         }
@@ -582,7 +563,7 @@ export function releaseOnboardLock(): void {
     try {
       existing = parseLockFile(fs.readFileSync(LOCK_FILE, "utf8"));
     } catch (error) {
-      if (error instanceof Error && isErrnoException(error) && error.code === "ENOENT") return;
+      if (isErrnoException(error) && error.code === "ENOENT") return;
       throw error;
     }
     if (!existing) return;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -27,6 +27,8 @@ const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 
 const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/g;
 const runner: typeof import("./runner") = require("./runner");
 const { ROOT, SCRIPTS, redact, run, runCapture, runFile, shellQuote, validateName } = runner;
+const errnoUtils: typeof import("./errno") = require("./errno");
+const { isErrnoException } = errnoUtils;
 
 type RunnerOptions = {
   env?: NodeJS.ProcessEnv;
@@ -36,10 +38,6 @@ type RunnerOptions = {
   timeout?: number;
   openshellBinary?: string;
 };
-
-function isErrnoException(error: object | null): error is NodeJS.ErrnoException {
-  return error !== null && "code" in error;
-}
 
 function parseJson<T>(text: string): T {
   return JSON.parse(text);
@@ -237,9 +235,9 @@ type RemoteProviderConfigEntry = {
   skipVerify?: boolean;
 };
 
-type LooseScalar = string | number | boolean | null | undefined;
-type LooseValue = LooseScalar | LooseObject | LooseValue[];
-type LooseObject = { [key: string]: LooseValue };
+// Re-export shared JSON types under the names used throughout this module.
+// See src/lib/json-types.ts for the canonical definitions.
+import type { JsonScalar as LooseScalar, JsonValue as LooseValue, JsonObject as LooseObject } from "./json-types";
 
 type OnboardOptions = {
   nonInteractive?: boolean;

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -3,6 +3,8 @@
 //
 // Policy preset management — list, load, merge, and apply presets.
 
+import type { JsonValue, JsonObject } from "./json-types";
+
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -13,8 +15,6 @@ const registry = require("./registry");
 const { loadAgent } = require("./agent-defs");
 
 const PRESETS_DIR = path.join(ROOT, "nemoclaw-blueprint", "policies", "presets");
-
-import type { JsonValue, JsonObject } from "./json-types";
 
 type PresetInfo = {
   file: string;

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -14,15 +14,17 @@ const { loadAgent } = require("./agent-defs");
 
 const PRESETS_DIR = path.join(ROOT, "nemoclaw-blueprint", "policies", "presets");
 
+import type { JsonValue, JsonObject } from "./json-types";
+
 type PresetInfo = {
   file: string;
   name: string;
   description: string;
 };
 
-type PolicyScalar = string | number | boolean | null | undefined;
-type PolicyValue = PolicyScalar | PolicyObject | PolicyValue[];
-type PolicyObject = { [key: string]: PolicyValue };
+// Re-use shared JSON types under policy-domain names.
+type PolicyValue = JsonValue;
+type PolicyObject = JsonObject;
 
 type PolicyDocument = PolicyObject & {
   version?: number;

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -5,12 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { ensureConfigDir, readConfigFile, writeConfigFile } from "./config-io";
-
-type ErrnoLike = Error | { code?: string | number } | null;
-
-function isErrnoException(error: ErrnoLike): error is NodeJS.ErrnoException {
-  return error !== null && typeof error === "object" && "code" in error;
-}
+import { isErrnoException } from "./errno";
 
 export interface SandboxEntry {
   name: string;
@@ -74,7 +69,7 @@ export function acquireLock(): void {
       return;
     } catch (error) {
       if (
-        !(typeof error === "object" && error !== null && isErrnoException(error)) ||
+        !isErrnoException(error) ||
         error.code !== "EEXIST"
       ) {
         throw error;
@@ -90,7 +85,7 @@ export function acquireLock(): void {
             alive = true;
           } catch (killErr) {
             alive =
-              typeof killErr === "object" && killErr !== null && isErrnoException(killErr)
+              isErrnoException(killErr)
                 ? killErr.code === "EPERM"
                 : false;
           }
@@ -127,7 +122,7 @@ export function releaseLock(): void {
     fs.unlinkSync(LOCK_OWNER);
   } catch (error) {
     if (
-      !(typeof error === "object" && error !== null && isErrnoException(error)) ||
+      !isErrnoException(error) ||
       error.code !== "ENOENT"
     ) {
       throw error;
@@ -137,7 +132,7 @@ export function releaseLock(): void {
     fs.rmSync(LOCK_DIR, { recursive: true, force: true });
   } catch (error) {
     if (
-      !(typeof error === "object" && error !== null && isErrnoException(error)) ||
+      !isErrnoException(error) ||
       error.code !== "ENOENT"
     ) {
       throw error;

--- a/src/lib/usage-notice.ts
+++ b/src/lib/usage-notice.ts
@@ -59,6 +59,10 @@ function parseJson<T>(text: string): T {
   return JSON.parse(text);
 }
 
+// Reflect.get is used throughout the codebase as a type-safe alternative to
+// direct property access on loosely-typed objects.  Unlike an `as Record<…>`
+// cast it never widens the target type and avoids eslint no-unsafe-member-access
+// warnings.  See also: deploy.ts, onboard.ts, ws-proxy-fix.ts.
 function readStringProperty(value: object | null, key: string): string | undefined {
   if (!value) {
     return undefined;

--- a/test/errno.test.ts
+++ b/test/errno.test.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { isErrnoException, isPermissionError } from "../src/lib/errno";
+
+describe("isErrnoException", () => {
+  it("returns true for Error with code property", () => {
+    const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    expect(isErrnoException(err)).toBe(true);
+  });
+
+  it("returns true for plain object with code property", () => {
+    expect(isErrnoException({ code: "EACCES" })).toBe(true);
+  });
+
+  it("returns true for object with errno property", () => {
+    expect(isErrnoException({ errno: -2 })).toBe(true);
+  });
+
+  it("returns true for Error with both code and errno", () => {
+    const err = Object.assign(new Error("fail"), { code: "ENOENT", errno: -2 });
+    expect(isErrnoException(err)).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isErrnoException(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isErrnoException(undefined)).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isErrnoException("ENOENT")).toBe(false);
+  });
+
+  it("returns false for a number", () => {
+    expect(isErrnoException(42)).toBe(false);
+  });
+
+  it("returns false for a plain Error without code/errno", () => {
+    expect(isErrnoException(new Error("oops"))).toBe(false);
+  });
+
+  it("returns false for an empty object", () => {
+    expect(isErrnoException({})).toBe(false);
+  });
+
+  it("narrows the type so .code is accessible", () => {
+    const err: unknown = Object.assign(new Error("fail"), { code: "EPERM" });
+    if (isErrnoException(err)) {
+      // TypeScript should allow this without a cast.
+      expect(err.code).toBe("EPERM");
+    } else {
+      throw new Error("Expected isErrnoException to return true");
+    }
+  });
+});
+
+describe("isPermissionError", () => {
+  it("returns true for EACCES", () => {
+    const err = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    expect(isPermissionError(err)).toBe(true);
+  });
+
+  it("returns true for EPERM", () => {
+    const err = Object.assign(new Error("not permitted"), { code: "EPERM" });
+    expect(isPermissionError(err)).toBe(true);
+  });
+
+  it("returns false for ENOENT", () => {
+    const err = Object.assign(new Error("not found"), { code: "ENOENT" });
+    expect(isPermissionError(err)).toBe(false);
+  });
+
+  it("returns false for non-errno values", () => {
+    expect(isPermissionError(null)).toBe(false);
+    expect(isPermissionError("EACCES")).toBe(false);
+    expect(isPermissionError(new Error("oops"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #2422 (`refactor(types): tighten repo-wide type boundaries`). Addresses the review warnings and suggestions from triage.

## Changes

### 1. Shared `isErrnoException` / `isPermissionError` — `src/lib/errno.ts`

PR #2422 removed all `@ts-nocheck` markers, which required each module to define its own `isErrnoException` + `ErrnoLike` type locally. This resulted in 6 slightly different copies across `config-io`, `credentials`, `http-probe`, `onboard`, `onboard-session`, and `registry`.

This PR extracts a single canonical version into `src/lib/errno.ts` that:
- Accepts `unknown` so callers never need an `instanceof Error` pre-cast
- Checks for both `code` and `errno` properties (covering all Node.js error shapes)
- Includes a convenience `isPermissionError` for the common EACCES/EPERM guard

This also simplifies many catch blocks that previously did `error instanceof Error && isErrnoException(error)` — the redundant `instanceof Error` check is now handled inside the shared function.

### 2. Shared JSON recursive types — `src/lib/json-types.ts`

PR #2422 introduced identical Scalar/Value/Object type triples in multiple modules:
- `LooseScalar` / `LooseValue` / `LooseObject` in `onboard.ts` and `agent-onboard.ts`
- `PolicyScalar` / `PolicyValue` / `PolicyObject` in `policies.ts`
- `SessionJsonPrimitive` / `SessionJsonValue` / `UnknownRecord` in `onboard-session.ts`

This PR extracts canonical `JsonScalar` / `JsonValue` / `JsonObject` types into `src/lib/json-types.ts`. Each module re-aliases them under its domain names for readability.

> **Note:** The plugin types (`PluginScalar`/`PluginValue`/`PluginRecord` in `nemoclaw/src/index.ts`) are intentionally kept in-place because the plugin compiles separately from the CLI and cannot share imports.

### 3. `Reflect.get` / `Reflect.set` convention comment

Adds a clarifying comment at the first usage site (`usage-notice.ts`) explaining why `Reflect.get` is preferred over `as Record<…>` casts throughout the codebase — it avoids widening the target type and satisfies `no-unsafe-member-access` lint rules.

### 4. `ws-proxy-fix.ts` behavioral guard documentation

Documents the `!host` null guard in the Discord WebSocket tunnel path, explaining that the previous code would have attempted a tunnel with an undefined host (which would fail downstream anyway). The guard now explicitly falls through to the original `https.request` unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `tsc -p tsconfig.cli.json --noEmit` passes
- [x] `npm test` passes (only pre-existing failures in install-preflight and ssrf-parity)
- [x] Tests added for new `errno.ts` module (15 test cases)
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)

## AI Disclosure
- [x] AI-assisted — tool: pi coding agent

---
Signed-off-by: Jess Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket proxy handling to avoid creating tunnels when the request target host is undefined.

* **Tests**
  * Added tests validating errno/permission detection utilities.

* **Documentation**
  * Added explanatory comment clarifying property-access rationale.

* **Chores**
  * Centralized JSON-type aliases and errno helpers for consistent error handling across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->