### PR TITLE
fix(gateway): gracefully handle uv_interface_addresses system error i…

### DIFF
--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -20,6 +20,37 @@ import {
 } from "./onboard/config.js";
 import { scanForSecrets, isMemoryPath } from "./security/secret-scanner.js";
 
+import os from 'os';
+
+// [PATCH] OpenShell/Sandbox Compatibility
+// Sandbox environments block uv_interface_addresses. We catch this and mock a loopback.
+const originalNetworkInterfaces = os.networkInterfaces;
+
+os.networkInterfaces = function () {
+  try {
+    return originalNetworkInterfaces.apply(this, arguments);
+  } catch (error: any) {
+    console.warn(
+      '\n[Sandbox Compatibility] Restricted network access detected (Likely Docker/OpenShell).' +
+      '\nos.networkInterfaces() failed. Falling back to loopback interface (127.0.0.1) to prevent crash.\n'
+    );
+    
+    // Return a mocked loopback interface so dependencies like `ciao` don't crash
+    return {
+      lo:[
+        {
+          address: '127.0.0.1',
+          netmask: '255.0.0.0',
+          family: 'IPv4',
+          mac: '00:00:00:00:00:00',
+          internal: true,
+          cidr: '127.0.0.1/8'
+        }
+      ]
+    };
+  }
+};
+
 // Resolve live inference config from OpenShell as a fallback when the
 // onboard config file is not available (e.g. when running inside the
 // sandbox). Returns empty strings if the probe fails.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR resolves a fatal Gateway crash occurring in sandboxed environments (like OpenShell or Docker with default `seccomp` profiles). It intercepts a blocked `uv_interface_addresses` syscall triggered by `os.networkInterfaces()` and implements a graceful loopback fallback.

## Related Issue
Fixes #2427

## Changes
- Monkey-patched `os.networkInterfaces()` at the gateway entry point to catch restricted system calls.
- Added a `[Sandbox Compatibility]` warning log to provide clear context for discovery failures.
- Provided a mocked loopback fallback (`127.0.0.1`) to ensure process stability, allowing manual TUI connections via `--url`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Relying on CI pipeline for automated testing -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Google AI (Gemini)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility with sandboxed and restricted environments. Applications will now gracefully handle scenarios where network interface information is unavailable, allowing dependent libraries to proceed and preventing unexpected runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->