### PR TITLE
fix(sandbox): survive Landlock and seccomp restrictions on OpenShell 0.0.36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,12 @@ RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \
 # Copy startup script and shared sandbox initialisation library
 COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh
 COPY scripts/nemoclaw-start.sh /usr/local/bin/nemoclaw-start
-RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/sandbox-init.sh
+# Copy ws-proxy-fix.js to a Landlock-accessible path. OpenShell ≥0.0.36
+# blocks /opt/nemoclaw-blueprint/ from non-root users, but the entrypoint
+# needs to read this file to install the NODE_OPTIONS --require preload.
+COPY nemoclaw-blueprint/scripts/ws-proxy-fix.js /usr/local/lib/nemoclaw/ws-proxy-fix.js
+RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/sandbox-init.sh \
+    && chmod 644 /usr/local/lib/nemoclaw/ws-proxy-fix.js
 
 # Build args for config that varies per deployment.
 # nemoclaw onboard passes these at image build time.

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -37,7 +37,18 @@ set -euo pipefail
 # read failure), the output is still available for diagnostics.
 # The log is written in append mode and also forwarded to the original
 # stderr/stdout via tee so openshell sandbox create can still stream it.
-exec > >(tee -a /tmp/nemoclaw-start.log) 2> >(tee -a /tmp/nemoclaw-start.log >&2)
+# SECURITY: restrict permissions before writing — the script later prints
+# tokenized dashboard URLs to stderr (#token=...).
+_START_LOG="/tmp/nemoclaw-start.log"
+if [ "$(id -u)" -eq 0 ]; then
+  : >"$_START_LOG"
+  chown root:root "$_START_LOG"
+  chmod 600 "$_START_LOG"
+else
+  : >"$_START_LOG"
+  chmod 600 "$_START_LOG" 2>/dev/null || true
+fi
+exec > >(tee -a "$_START_LOG") 2> >(tee -a "$_START_LOG" >&2)
 
 # ── Source shared sandbox initialisation library ─────────────────
 # Single source of truth for security-sensitive primitives shared with

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -31,6 +31,14 @@
 
 set -euo pipefail
 
+# ── Early stderr/stdout capture ──────────────────────────────────
+# Capture all entrypoint output to /tmp/nemoclaw-start.log so that if
+# the script crashes before touch /tmp/gateway.log (e.g., a Landlock
+# read failure), the output is still available for diagnostics.
+# The log is written in append mode and also forwarded to the original
+# stderr/stdout via tee so openshell sandbox create can still stream it.
+exec > >(tee -a /tmp/nemoclaw-start.log) 2> >(tee -a /tmp/nemoclaw-start.log >&2)
+
 # ── Source shared sandbox initialisation library ─────────────────
 # Single source of truth for security-sensitive primitives shared with
 # agents/hermes/start.sh. Ref: https://github.com/NVIDIA/NemoClaw/issues/2277
@@ -1161,10 +1169,61 @@ export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCR
 # The preload patches https.request() to inject a CONNECT tunnel agent for
 # WebSocket upgrade requests. Activates whenever HTTPS_PROXY is set (the
 # script itself guards on the env var).
-_WS_FIX_SCRIPT="/opt/nemoclaw-blueprint/scripts/ws-proxy-fix.js"
-if [ -f "$_WS_FIX_SCRIPT" ]; then
+_WS_FIX_SOURCE="/usr/local/lib/nemoclaw/ws-proxy-fix.js"
+_WS_FIX_SCRIPT="/tmp/nemoclaw-ws-proxy-fix.js"
+if [ -f "$_WS_FIX_SOURCE" ]; then
+  # Copy to /tmp so the sandbox user can read it — /usr/local/lib/ may be
+  # Landlock-restricted in some runtimes. Same pattern as the other preloads.
+  emit_sandbox_sourced_file "$_WS_FIX_SCRIPT" <"$_WS_FIX_SOURCE"
   export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_WS_FIX_SCRIPT"
 fi
+
+# ── Seccomp syscall guard ─────────────────────────────────────
+# OpenShell ≥0.0.36 seccomp policy blocks syscalls like getifaddrs
+# (used by Node's os.networkInterfaces()). Third-party libraries (e.g.,
+# @homebridge/ciao mDNS) call these without error handling, producing
+# unhandled promise rejections that crash the gateway under Node v22's
+# default --unhandled-rejections=throw.
+#
+# This preload catches those specific sandbox-infrastructure errors
+# and logs them as warnings instead of letting them kill the process.
+# Unlike the Slack channel guard, this is always installed because the
+# seccomp-blocked syscalls affect all sandboxes, not just Slack ones.
+_SECCOMP_GUARD_SCRIPT="/tmp/nemoclaw-seccomp-guard.js"
+emit_sandbox_sourced_file "$_SECCOMP_GUARD_SCRIPT" <<'SECCOMP_GUARD_EOF'
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// seccomp-guard.js — patch syscalls that are blocked by OpenShell ≥0.0.36
+// seccomp policy. Third-party libraries (e.g., @homebridge/ciao mDNS) call
+// os.networkInterfaces() without error handling, producing unhandled promise
+// rejections. OpenClaw's rejection handler (unhandled-rejections-*.js) calls
+// process.exit(1) for unrecognised errors, crashing the gateway.
+//
+// Rather than trying to catch the rejection (which races with OpenClaw's own
+// handler), this preload patches the syscall wrappers to return safe defaults
+// when the underlying call is blocked by seccomp.
+
+(function () {
+  'use strict';
+  var os = require('os');
+  var _origNetworkInterfaces = os.networkInterfaces;
+
+  os.networkInterfaces = function () {
+    try {
+      return _origNetworkInterfaces.call(os);
+    } catch (err) {
+      if (err && String(err.message || '').indexOf('uv_interface_addresses') !== -1) {
+        // seccomp blocks getifaddrs — return empty result.
+        // mDNS discovery is not needed inside a sandbox.
+        return {};
+      }
+      throw err;
+    }
+  };
+})();
+SECCOMP_GUARD_EOF
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_SECCOMP_GUARD_SCRIPT"
 
 # OpenShell re-injects narrow NO_PROXY/no_proxy=127.0.0.1,localhost,::1 every
 # time a user connects via `openshell sandbox connect`.  The connect path spawns
@@ -1207,6 +1266,8 @@ PROXYEOF
   fi
   # Nemotron inference fix for connect sessions. (NemoClaw#1193, #2051)
   echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCRIPT\""
+  # Seccomp guard for connect sessions.
+  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SECCOMP_GUARD_SCRIPT\""
   # Tool cache redirects — generated from _TOOL_REDIRECTS (single source of truth)
   echo '# Tool cache redirects — /sandbox is Landlock read-only (#804)'
   for _redir in "${_TOOL_REDIRECTS[@]}"; do
@@ -1343,7 +1404,7 @@ if [ "$(id -u)" -ne 0 ]; then
   # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
   # (both are trust-boundary files; tampering would let the sandbox user
   # inject code into any Node process via NODE_OPTIONS).
-  validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT"
+  validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_WS_FIX_SCRIPT" "$_SECCOMP_GUARD_SCRIPT"
 
   # Start gateway in background, auto-pair, then wait.
   # Pass OPENCLAW_GATEWAY_TOKEN only on this launch line so it lives solely
@@ -1483,7 +1544,7 @@ harden_openclaw_symlinks
 # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
 # (both are trust-boundary files; tampering would let the sandbox user
 # inject code into any Node process via NODE_OPTIONS).
-validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT"
+validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_WS_FIX_SCRIPT" "$_SECCOMP_GUARD_SCRIPT"
 
 # Start the gateway as the 'gateway' user.
 # SECURITY: The sandbox user cannot kill this process because it runs

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -1181,6 +1181,15 @@ if echo "$gw_port" | grep -q "OPEN"; then
   pass "S1: Gateway is serving on port 18789 — Slack auth failure did not crash it"
 else
   fail "S1: Gateway is not serving on port 18789 (${gw_port:0:200})"
+  # Dump early entrypoint log — captures crashes that happen before
+  # touch /tmp/gateway.log (e.g., Landlock read failures, seccomp blocks).
+  start_log=$(openshell sandbox exec --name "$SANDBOX_NAME" -- cat /tmp/nemoclaw-start.log 2>/dev/null || true)
+  if [ -n "$start_log" ]; then
+    info "Entrypoint log (last 40 lines of /tmp/nemoclaw-start.log):"
+    echo "$start_log" | tail -40 | while IFS= read -r line; do
+      info "  $line"
+    done
+  fi
 fi
 
 # S2: Dump gateway.log for diagnostics (must use openshell exec — SSH user

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -5066,7 +5066,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
         input: "\n",
       });
       assert.equal(introspect.status, 0, introspect.stderr);
-      const introspectOut = JSON.parse(introspect.stdout.trim().split("\n").pop());
+      const introspectOut = JSON.parse(introspect.stdout.trim().split("\n").pop()!);
       const slackIdx = introspectOut.slackIndex1Based;
       assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
@@ -5085,14 +5085,14 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
 
       assert.equal(result.status, 0, result.stderr);
-      const out = JSON.parse(result.stdout.trim().split("\n").pop());
+      const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
 
       assert.ok(
         !out.result.includes("slack"),
         `slack should have been dropped after invalid token; got ${JSON.stringify(out.result)}`,
       );
       assert.ok(
-        !out.saveCalls.some((c) => c.key === "SLACK_BOT_TOKEN"),
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
         `SLACK_BOT_TOKEN should NOT have been persisted; saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
@@ -5177,7 +5177,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
       assert.equal(introspect.status, 0, introspect.stderr);
       const slackIdx = JSON.parse(
-        introspect.stdout.trim().split("\n").pop(),
+        introspect.stdout.trim().split("\n").pop()!,
       ).slackIndex1Based;
       assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
@@ -5195,7 +5195,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
 
       assert.equal(result.status, 0, result.stderr);
-      const out = JSON.parse(result.stdout.trim().split("\n").pop());
+      const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
 
       assert.ok(
         !out.result.includes("slack"),
@@ -5205,11 +5205,11 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       // user can retry later and the pre-saved bot token will light up as
       // "already configured" on the next onboard.
       assert.ok(
-        out.saveCalls.some((c) => c.key === "SLACK_BOT_TOKEN"),
+        out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
         `SLACK_BOT_TOKEN should have been persisted (valid format); saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
-        !out.saveCalls.some((c) => c.key === "SLACK_APP_TOKEN"),
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_APP_TOKEN"),
         `SLACK_APP_TOKEN should NOT have been persisted (invalid format); saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
@@ -5225,7 +5225,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
     // Cache-bust the dynamic import so repeated test runs pick up rebuilds.
     const onboardUrl = `${pathToFileURL(onboardPath).href}?update=${Date.now()}`;
     const { MESSAGING_CHANNELS } = await import(onboardUrl);
-    const slack = MESSAGING_CHANNELS.find((c) => c.name === "slack");
+    const slack = MESSAGING_CHANNELS.find((c: { name: string }) => c.name === "slack");
 
     assert.ok(slack, "slack messaging channel definition present");
     assert.ok(slack.tokenFormat instanceof RegExp, "slack.tokenFormat is a regex");

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -134,7 +134,7 @@ describe("policies", () => {
     it("returns expected preset names", () => {
       const names = policies
         .listPresets()
-        .map((p) => p.name)
+        .map((p: { name: string }) => p.name)
         .sort();
       const expected = [
         "brave",

--- a/test/seccomp-guard.test.ts
+++ b/test/seccomp-guard.test.ts
@@ -1,0 +1,175 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, it, expect } from "vitest";
+
+const START_SCRIPT = path.join(import.meta.dirname, "..", "scripts", "nemoclaw-start.sh");
+
+describe("Seccomp guard preload", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("defines _SECCOMP_GUARD_SCRIPT path variable", () => {
+    expect(src).toContain('_SECCOMP_GUARD_SCRIPT="/tmp/nemoclaw-seccomp-guard.js"');
+  });
+
+  it("embeds the guard via a SECCOMP_GUARD_EOF heredoc", () => {
+    expect(src).toMatch(
+      /emit_sandbox_sourced_file\s+"\$_SECCOMP_GUARD_SCRIPT"\s+<<'SECCOMP_GUARD_EOF'/,
+    );
+    expect(src).toMatch(/^SECCOMP_GUARD_EOF$/m);
+  });
+
+  it("registers the preload in NODE_OPTIONS", () => {
+    expect(src).toContain(
+      'export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_SECCOMP_GUARD_SCRIPT"',
+    );
+  });
+
+  it("includes the preload in the proxy-env sourced file for connect sessions", () => {
+    expect(src).toMatch(/# Seccomp guard for connect sessions/);
+    expect(src).toContain("--require $_SECCOMP_GUARD_SCRIPT");
+  });
+
+  it("passes the preload path to validate_tmp_permissions in both root and non-root branches", () => {
+    const calls =
+      src.match(/validate_tmp_permissions\s+[^;\n]*\$_SECCOMP_GUARD_SCRIPT/g) || [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("preload patches os.networkInterfaces to catch uv_interface_addresses errors", () => {
+    const heredoc = src.match(/<<'SECCOMP_GUARD_EOF'\n([\s\S]*?)\nSECCOMP_GUARD_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    expect(script).toContain("os.networkInterfaces");
+    expect(script).toContain("uv_interface_addresses");
+    expect(script).toContain("_origNetworkInterfaces");
+  });
+
+  it("preload returns empty object when uv_interface_addresses is blocked", () => {
+    // Extract the guard script from the heredoc and run it in a subprocess
+    // that simulates a seccomp-blocked os.networkInterfaces().
+    const heredoc = src.match(/<<'SECCOMP_GUARD_EOF'\n([\s\S]*?)\nSECCOMP_GUARD_EOF/);
+    expect(heredoc).not.toBeNull();
+    const guardScript = heredoc[1];
+
+    const testScript = `
+      // Simulate seccomp-blocked os.networkInterfaces
+      const os = require('os');
+      const origNI = os.networkInterfaces;
+      os.networkInterfaces = function() {
+        throw new SystemError('uv_interface_addresses');
+      };
+      class SystemError extends Error {
+        constructor(msg) { super('A system error occurred: ' + msg + ' returned Unknown system error 1 (Unknown system error 1)'); }
+      }
+
+      // Load the guard (it patches os.networkInterfaces)
+      ${guardScript}
+
+      // Verify the patch works
+      const result = os.networkInterfaces();
+      console.log(JSON.stringify({ result, type: typeof result }));
+    `;
+
+    const r = spawnSync(process.execPath, ["-e", testScript], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).toBe(0);
+    const output = JSON.parse(r.stdout.trim());
+    expect(output.result).toEqual({});
+    expect(output.type).toBe("object");
+  });
+
+  it("preload re-throws non-seccomp errors from os.networkInterfaces", () => {
+    const heredoc = src.match(/<<'SECCOMP_GUARD_EOF'\n([\s\S]*?)\nSECCOMP_GUARD_EOF/);
+    expect(heredoc).not.toBeNull();
+    const guardScript = heredoc[1];
+
+    const testScript = `
+      const os = require('os');
+      os.networkInterfaces = function() {
+        throw new Error('some other error');
+      };
+
+      ${guardScript}
+
+      try {
+        os.networkInterfaces();
+        console.log('NO_THROW');
+      } catch (e) {
+        console.log('THREW:' + e.message);
+      }
+    `;
+
+    const r = spawnSync(process.execPath, ["-e", testScript], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("THREW:some other error");
+  });
+
+  it("preload passes through when os.networkInterfaces works normally", () => {
+    const heredoc = src.match(/<<'SECCOMP_GUARD_EOF'\n([\s\S]*?)\nSECCOMP_GUARD_EOF/);
+    expect(heredoc).not.toBeNull();
+    const guardScript = heredoc[1];
+
+    const testScript = `
+      const os = require('os');
+      const fakeResult = { lo: [{ address: '127.0.0.1', family: 'IPv4' }] };
+      os.networkInterfaces = function() { return fakeResult; };
+
+      ${guardScript}
+
+      const result = os.networkInterfaces();
+      console.log(JSON.stringify(result));
+    `;
+
+    const r = spawnSync(process.execPath, ["-e", testScript], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).toBe(0);
+    const output = JSON.parse(r.stdout.trim());
+    expect(output.lo).toBeDefined();
+    expect(output.lo[0].address).toBe("127.0.0.1");
+  });
+});
+
+describe("ws-proxy-fix Landlock mitigation", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("reads ws-proxy-fix.js from /usr/local/lib/nemoclaw/ not /opt/nemoclaw-blueprint/", () => {
+    expect(src).toContain('_WS_FIX_SOURCE="/usr/local/lib/nemoclaw/ws-proxy-fix.js"');
+    expect(src).not.toContain('_WS_FIX_SCRIPT="/opt/nemoclaw-blueprint/scripts/ws-proxy-fix.js"');
+  });
+
+  it("copies ws-proxy-fix.js to /tmp via emit_sandbox_sourced_file", () => {
+    expect(src).toContain('_WS_FIX_SCRIPT="/tmp/nemoclaw-ws-proxy-fix.js"');
+    expect(src).toMatch(/emit_sandbox_sourced_file\s+"\$_WS_FIX_SCRIPT"\s+<\s*"\$_WS_FIX_SOURCE"/);
+  });
+
+  it("Dockerfile copies ws-proxy-fix.js to /usr/local/lib/nemoclaw/", () => {
+    const dockerfile = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "Dockerfile"),
+      "utf-8",
+    );
+    expect(dockerfile).toContain(
+      "COPY nemoclaw-blueprint/scripts/ws-proxy-fix.js /usr/local/lib/nemoclaw/ws-proxy-fix.js",
+    );
+  });
+});
+
+describe("Early entrypoint stderr capture", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("redirects stdout and stderr to /tmp/nemoclaw-start.log via tee", () => {
+    expect(src).toMatch(/exec\s+>\s+>\(tee\s+-a\s+\/tmp\/nemoclaw-start\.log\)/);
+    expect(src).toMatch(/2>\s+>\(tee\s+-a\s+\/tmp\/nemoclaw-start\.log\s+>&2\)/);
+  });
+});

--- a/test/seccomp-guard.test.ts
+++ b/test/seccomp-guard.test.ts
@@ -59,7 +59,7 @@ describe("Seccomp guard preload", () => {
     const testScript = `
       // Simulate seccomp-blocked os.networkInterfaces
       const os = require('os');
-      const origNI = os.networkInterfaces;
+      const _origNI = os.networkInterfaces;
       os.networkInterfaces = function() {
         throw new SystemError('uv_interface_addresses');
       };
@@ -169,7 +169,12 @@ describe("Early entrypoint stderr capture", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 
   it("redirects stdout and stderr to /tmp/nemoclaw-start.log via tee", () => {
-    expect(src).toMatch(/exec\s+>\s+>\(tee\s+-a\s+\/tmp\/nemoclaw-start\.log\)/);
-    expect(src).toMatch(/2>\s+>\(tee\s+-a\s+\/tmp\/nemoclaw-start\.log\s+>&2\)/);
+    expect(src).toContain('_START_LOG="/tmp/nemoclaw-start.log"');
+    expect(src).toMatch(/exec\s+>\s+>\(tee\s+-a\s+"\$_START_LOG"\)/);
+    expect(src).toMatch(/2>\s+>\(tee\s+-a\s+"\$_START_LOG"\s+>&2\)/);
+  });
+
+  it("restricts log permissions before writing to prevent token leakage", () => {
+    expect(src).toMatch(/chmod 600 "\$_START_LOG"/);
   });
 });


### PR DESCRIPTION
## Summary

Two bugs caused the gateway to crash on OpenShell ≥0.0.36, both reproduced and verified on a live 0.0.36 cluster:

- **Landlock blocks ws-proxy-fix.js**: The only `NODE_OPTIONS --require` script read from `/opt/nemoclaw-blueprint/` (all others use `/tmp/`). Landlock blocks that path from non-root users, crashing the entrypoint before `touch /tmp/gateway.log` — leaving no log to diagnose.
- **Seccomp blocks `os.networkInterfaces()`**: The mDNS library (`@homebridge/ciao`) calls `getifaddrs` without error handling. OpenClaw's rejection handler calls `process.exit(1)` for unrecognised errors, killing the gateway ~200ms after it logs "listening".

### Fixes

1. Copy `ws-proxy-fix.js` to `/usr/local/lib/nemoclaw/` at build time, then to `/tmp/` at runtime via `emit_sandbox_sourced_file` (same pattern as every other preload)
2. New always-installed preload (`seccomp-guard.js`) monkey-patches `os.networkInterfaces()` to return `{}` when seccomp blocks `getifaddrs`
3. Early `exec > >(tee)` capture to `/tmp/nemoclaw-start.log` for diagnosing pre-gateway crashes
4. E2e test dumps `/tmp/nemoclaw-start.log` on Phase 7 S1 failure
5. 13 unit tests covering seccomp guard, ws-proxy-fix Landlock mitigation, and early stderr capture

## Test plan

- [x] Reproduced both bugs on OpenShell 0.0.36 — gateway crashed
- [x] Applied fixes, rebuilt sandbox — gateway stays alive, `gateway.log` shows normal operation
- [x] 13 new unit tests pass (structural + functional: seccomp guard returns `{}`, re-throws non-seccomp errors, passes through normal calls)
- [x] Full test suite passes (2150+ tests, minus pre-existing flaky gateway timeout)
- [ ] Nightly e2e run on 0.0.36 validates end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented gateway crashes by adding a seccomp guard that safely handles blocked network-interface errors.
  * Added a WebSocket proxy mitigation to avoid sandbox/entrypoint access issues and adjusted runtime file permissions.

* **New Features**
  * Entrypoint now captures combined stdout/stderr to a reserved startup log for improved diagnostics.

* **Tests**
  * Added end-to-end and unit tests validating startup logging, seccomp guard behavior, and the WebSocket mitigation.

* **Chores**
  * Improved test diagnostics to include recent startup logs on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->