### PR TITLE
Fix(gateway): gracefully handle uv_interface_addresses system error i…

### DIFF
--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -20,6 +20,41 @@ import {
 } from "./onboard/config.js";
 import { scanForSecrets, isMemoryPath } from "./security/secret-scanner.js";
 
+import os from 'os';
+
+// Cache the original function
+const originalNetworkInterfaces = os.networkInterfaces;
+
+// Use (os as any) to bypass TypeScript's read-only protection
+(os as any).networkInterfaces = function () {
+  try {
+    // Just call the function directly! No args needed.
+    return originalNetworkInterfaces();
+  } catch (error: any) {
+    if (error?.message?.includes('uv_interface_addresses') || error?.code === 'EACCES') {
+      console.warn(
+        '\n[Sandbox Compatibility] Restricted network access detected. ' +
+        'Falling back to loopback (127.0.0.1) to prevent crash.\n'
+      );
+      
+      return {
+        lo: [
+          {
+            address: '127.0.0.1',
+            netmask: '255.0.0.0',
+            family: 'IPv4',
+            mac: '00:00:00:00:00:00',
+            internal: true,
+            cidr: '127.0.0.1/8'
+          }
+        ]
+      };
+    }
+    
+    throw error;
+  }
+};
+
 type PluginScalar = string | number | boolean | null | undefined;
 type PluginValue = PluginScalar | PluginRecord | PluginValue[];
 type PluginRecord = { [key: string]: PluginValue };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR resolves a fatal Gateway crash occurring in sandboxed environments (like OpenShell or Docker with default `seccomp` profiles). It intercepts a blocked `uv_interface_addresses` syscall triggered by `os.networkInterfaces()` and implements a graceful loopback fallback.

## Related Issue
Fixes #2427

## Changes
- Monkey-patched `os.networkInterfaces()` at the gateway entry point to catch restricted system calls.
- Added a `[Sandbox Compatibility]` warning log to provide clear context for discovery failures.
- Provided a mocked loopback fallback (`127.0.0.1`) to ensure process stability, allowing manual TUI connections via `--url`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Relying on CI pipeline for automated testing -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Google AI (Gemini)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved crashes in sandbox and restricted runtime environments. When network interface enumeration is restricted or unavailable, the app now implements graceful fallback mechanisms and diagnostic logging. This allows the application to maintain stability and function properly in constrained environments while providing helpful troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->