### PR TITLE
fix(test): satisfy strict typecheck on Slack token validation tests

### DIFF
--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -5066,7 +5066,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
         input: "\n",
       });
       assert.equal(introspect.status, 0, introspect.stderr);
-      const introspectOut = JSON.parse(introspect.stdout.trim().split("\n").pop());
+      const introspectOut = JSON.parse(introspect.stdout.trim().split("\n").pop()!);
       const slackIdx = introspectOut.slackIndex1Based;
       assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
@@ -5085,14 +5085,14 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
 
       assert.equal(result.status, 0, result.stderr);
-      const out = JSON.parse(result.stdout.trim().split("\n").pop());
+      const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
 
       assert.ok(
         !out.result.includes("slack"),
         `slack should have been dropped after invalid token; got ${JSON.stringify(out.result)}`,
       );
       assert.ok(
-        !out.saveCalls.some((c) => c.key === "SLACK_BOT_TOKEN"),
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
         `SLACK_BOT_TOKEN should NOT have been persisted; saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
@@ -5177,7 +5177,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
       assert.equal(introspect.status, 0, introspect.stderr);
       const slackIdx = JSON.parse(
-        introspect.stdout.trim().split("\n").pop(),
+        introspect.stdout.trim().split("\n").pop()!,
       ).slackIndex1Based;
       assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
@@ -5195,7 +5195,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
 
       assert.equal(result.status, 0, result.stderr);
-      const out = JSON.parse(result.stdout.trim().split("\n").pop());
+      const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
 
       assert.ok(
         !out.result.includes("slack"),
@@ -5205,11 +5205,11 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       // user can retry later and the pre-saved bot token will light up as
       // "already configured" on the next onboard.
       assert.ok(
-        out.saveCalls.some((c) => c.key === "SLACK_BOT_TOKEN"),
+        out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
         `SLACK_BOT_TOKEN should have been persisted (valid format); saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
-        !out.saveCalls.some((c) => c.key === "SLACK_APP_TOKEN"),
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_APP_TOKEN"),
         `SLACK_APP_TOKEN should NOT have been persisted (invalid format); saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
@@ -5225,7 +5225,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
     // Cache-bust the dynamic import so repeated test runs pick up rebuilds.
     const onboardUrl = `${pathToFileURL(onboardPath).href}?update=${Date.now()}`;
     const { MESSAGING_CHANNELS } = await import(onboardUrl);
-    const slack = MESSAGING_CHANNELS.find((c) => c.name === "slack");
+    const slack = MESSAGING_CHANNELS.find((c: { name: string }) => c.name === "slack");
 
     assert.ok(slack, "slack messaging channel definition present");
     assert.ok(slack.tokenFormat instanceof RegExp, "slack.tokenFormat is a regex");


### PR DESCRIPTION
## Summary

Tip of `main` currently fails `npm run typecheck:cli` with 8 errors in `test/onboard.test.ts` — patterns introduced by #2130 (Slack token validation tests) don't satisfy the `strict: true` setting introduced by #2422. Every PR opened against main inherits these errors, which makes the `checks` CI job red on unrelated PRs (e.g. #2454).

## Related

Follows from #2130 + #2422 interaction. No linked issue — local-only breakage caught by CI on downstream PRs.

## Changes

`test/onboard.test.ts` — 8 annotations, zero behavior change:

- **4× `.pop()!`** — `Array.pop()` returns `string | undefined`. Each site is immediately preceded by an `assert.equal(result.status, 0)` that guarantees non-empty stdout, so the non-null assertion is safe.
- **3× `(c: { key: string }) => c.key === …`** — `saveCalls` entries only read `.key`.
- **1× `(c: { name: string }) => c.name === …`** — `MESSAGING_CHANNELS` entry lookup only reads `.name`.

The tests themselves still exercise the same cases; these changes are purely to make the TypeScript compiler happy.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npx tsc -p tsconfig.cli.json` — exits 0 (was 2 with 8 errors)
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
  * Improved reliability of JSON payload extraction in onboarding tests with defensive null-checks before parsing.
  * Enhanced type safety in test callbacks and iterators with explicit TypeScript type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->