### PR TITLE
fix(deploy): correct vLLM HF model id and pass HF_TOKEN to VM

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -174,6 +174,15 @@ $ NEMOCLAW_DANGEROUSLY_SKIP_PERMISSIONS=1 nemoclaw onboard --non-interactive --y
 
 The flag is persisted on the sandbox registry entry, so `nemoclaw <sandbox> status` surfaces `Permissions: dangerously-skip-permissions (shields permanently down)` for sandboxes created this way. To tighten a sandbox after the fact, re-run `nemoclaw onboard` without the flag.
 
+### `nemoclaw onboard --from`
+
+Use a custom Dockerfile for the sandbox image.
+This variant of `nemoclaw onboard` accepts a `--from <Dockerfile>` argument to build the sandbox from a user-supplied Dockerfile instead of the default NemoClaw image.
+
+```console
+$ nemoclaw onboard --from ./Dockerfile.custom
+```
+
 ### `nemoclaw list`
 
 List all registered sandboxes with their model, provider, and policy presets.
@@ -566,12 +575,35 @@ $ nemoclaw tunnel stop
 
 `nemoclaw stop` remains as a deprecated alias that prints a warning and delegates to `tunnel stop`.
 
+### `nemoclaw start`
+
+> **Warning:** Deprecated. Use `nemoclaw tunnel start` instead.
+
+This command remains as a compatibility alias to `nemoclaw tunnel start`.
+
+### `nemoclaw stop`
+
+> **Warning:** Deprecated. Use `nemoclaw tunnel stop` instead.
+
+This command remains as a compatibility alias to `nemoclaw tunnel stop`.
+
 ### `nemoclaw status`
 
 Show the sandbox list and the status of host auxiliary services (for example cloudflared).
 
 ```console
 $ nemoclaw status
+```
+
+### `nemoclaw setup`
+
+> **Warning:** The `nemoclaw setup` command is deprecated.
+> Use `nemoclaw onboard` instead.
+
+This command remains as a compatibility alias to `nemoclaw onboard`.
+
+```console
+$ nemoclaw setup
 ```
 
 ### `nemoclaw setup-spark`

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /opt/nemoclaw
 RUN npm ci && npm run build
 
 # Stage 2: Runtime image — pull cached base from GHCR
+# hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
 # Harden: remove unnecessary build tools and network probes from base image (#830)
@@ -366,6 +367,7 @@ json.dump(config, open(path, 'w'), indent=2); \
 os.chmod(path, 0o600)"
 
 # Install NemoClaw plugin into OpenClaw
+# hadolint ignore=SC2015
 RUN openclaw doctor --fix > /dev/null 2>&1 || true \
     && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,12 @@ RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \
 # Copy startup script and shared sandbox initialisation library
 COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh
 COPY scripts/nemoclaw-start.sh /usr/local/bin/nemoclaw-start
-RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/sandbox-init.sh
+# Copy ws-proxy-fix.js to a Landlock-accessible path. OpenShell ≥0.0.36
+# blocks /opt/nemoclaw-blueprint/ from non-root users, but the entrypoint
+# needs to read this file to install the NODE_OPTIONS --require preload.
+COPY nemoclaw-blueprint/scripts/ws-proxy-fix.js /usr/local/lib/nemoclaw/ws-proxy-fix.js
+RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/sandbox-init.sh \
+    && chmod 644 /usr/local/lib/nemoclaw/ws-proxy-fix.js
 
 # Build args for config that varies per deployment.
 # nemoclaw onboard passes these at image build time.

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -63,7 +63,9 @@ components:
         provider_type: "openai"
         provider_name: "vllm-local"
         endpoint: "http://localhost:8000/v1"
-        model: "nvidia/nemotron-3-nano-30b-a3b"
+        # HF repo id (not the NIM catalog name); vLLM must be started with
+        # --trust-remote-code for models that ship custom code.
+        model: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8"
         credential_env: "OPENAI_API_KEY"
         credential_default: "dummy"
         timeout_secs: 180

--- a/nemoclaw-blueprint/scripts/ws-proxy-fix.js
+++ b/nemoclaw-blueprint/scripts/ws-proxy-fix.js
@@ -176,7 +176,9 @@ const _PATCHED = Symbol.for("nemoclaw.wsProxyFix");
         if (isDiscordWsUpgrade(host, opts.headers)) {
             // Guard: if isDiscordWsUpgrade matched but host resolved to
             // undefined, we cannot construct a CONNECT tunnel (no target).
-            // Fall through to the original https.request unchanged.
+            // Fall through to the original https.request unchanged.  Before
+            // PR #2422 this path would have attempted the tunnel with an
+            // undefined host, which would fail in createTunnelAgent anyway.
             if (!host) {
                 return callOriginalRequest(input, options, callback);
             }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -845,6 +845,78 @@ install_or_upgrade_ollama() {
 }
 
 # ---------------------------------------------------------------------------
+# 3. vLLM (Brev GPU deploys, restored from removed brev-setup.sh — #996)
+# ---------------------------------------------------------------------------
+# Default model id mirrors the vllm profile in nemoclaw-blueprint/blueprint.yaml.
+# Update both together; install.sh queries the blueprint at runtime when present.
+VLLM_DEFAULT_MODEL="nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8"
+VLLM_PORT=8000
+VLLM_READY_TIMEOUT_SECS=240
+
+resolve_vllm_model() {
+  local blueprint="${SCRIPT_DIR}/../nemoclaw-blueprint/blueprint.yaml"
+  if [ -r "$blueprint" ]; then
+    awk '/^      vllm:/{f=1; next} f && /model:/{ gsub(/.*model: *"|".*/, ""); print; exit }' \
+      "$blueprint" 2>/dev/null
+  fi
+}
+
+install_or_start_vllm() {
+  if [[ "${NEMOCLAW_PROVIDER:-}" != "vllm" ]]; then
+    return 0
+  fi
+  if ! detect_gpu; then
+    warn "NEMOCLAW_PROVIDER=vllm but no GPU detected — skipping vLLM setup."
+    return 0
+  fi
+
+  local model
+  model="$(resolve_vllm_model)"
+  [ -n "$model" ] || model="$VLLM_DEFAULT_MODEL"
+
+  if ! python3 -c "import vllm" 2>/dev/null; then
+    info "Installing vLLM…"
+    if ! command_exists pip3; then
+      sudo apt-get install -y -qq python3-pip >/dev/null 2>&1 || true
+    fi
+    pip3 install --break-system-packages vllm 2>/dev/null || pip3 install vllm
+  else
+    info "vLLM already installed"
+  fi
+
+  if curl -fsS "http://localhost:${VLLM_PORT}/v1/models" >/dev/null 2>&1; then
+    info "vLLM already running on :${VLLM_PORT}"
+    return 0
+  fi
+
+  info "Starting vLLM with model ${model} on :${VLLM_PORT}…"
+  nohup python3 -m vllm.entrypoints.openai.api_server \
+    --model "$model" \
+    --port "$VLLM_PORT" \
+    --host 0.0.0.0 \
+    --trust-remote-code \
+    >/tmp/vllm-server.log 2>&1 &
+  local vllm_pid=$!
+
+  info "Waiting for vLLM (model load can take several minutes)…"
+  local elapsed=0
+  while [ "$elapsed" -lt "$VLLM_READY_TIMEOUT_SECS" ]; do
+    if curl -fsS "http://localhost:${VLLM_PORT}/v1/models" >/dev/null 2>&1; then
+      info "vLLM ready (PID $vllm_pid)"
+      return 0
+    fi
+    if ! kill -0 "$vllm_pid" 2>/dev/null; then
+      warn "vLLM exited early. See /tmp/vllm-server.log"
+      return 1
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  warn "vLLM did not become ready within ${VLLM_READY_TIMEOUT_SECS}s. See /tmp/vllm-server.log"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
 # Fix npm permissions for global installs (Linux only).
 # If the npm global prefix points to a system directory (e.g. /usr or
 # /usr/local) the user likely lacks write permissions and npm link will fail
@@ -1303,7 +1375,13 @@ main() {
   ensure_supported_runtime
 
   step 2 "NemoClaw CLI"
-  # install_or_upgrade_ollama
+  # Local inference setup is opt-in via NEMOCLAW_PROVIDER. Both functions
+  # short-circuit when the env var doesn't match, so the regular cloud-only
+  # install path runs unchanged.
+  if [[ "${NEMOCLAW_PROVIDER:-}" == "ollama" ]]; then
+    install_or_upgrade_ollama
+  fi
+  install_or_start_vllm
   fix_npm_permissions
   install_nemoclaw
   verify_nemoclaw

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -37,7 +37,18 @@ set -euo pipefail
 # read failure), the output is still available for diagnostics.
 # The log is written in append mode and also forwarded to the original
 # stderr/stdout via tee so openshell sandbox create can still stream it.
-exec > >(tee -a /tmp/nemoclaw-start.log) 2> >(tee -a /tmp/nemoclaw-start.log >&2)
+# SECURITY: restrict permissions before writing — the script later prints
+# tokenized dashboard URLs to stderr (#token=...).
+_START_LOG="/tmp/nemoclaw-start.log"
+if [ "$(id -u)" -eq 0 ]; then
+  : >"$_START_LOG"
+  chown root:root "$_START_LOG"
+  chmod 600 "$_START_LOG"
+else
+  : >"$_START_LOG"
+  chmod 600 "$_START_LOG" 2>/dev/null || true
+fi
+exec > >(tee -a "$_START_LOG") 2> >(tee -a "$_START_LOG" >&2)
 
 # ── Source shared sandbox initialisation library ─────────────────
 # Single source of truth for security-sensitive primitives shared with

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -31,6 +31,14 @@
 
 set -euo pipefail
 
+# ── Early stderr/stdout capture ──────────────────────────────────
+# Capture all entrypoint output to /tmp/nemoclaw-start.log so that if
+# the script crashes before touch /tmp/gateway.log (e.g., a Landlock
+# read failure), the output is still available for diagnostics.
+# The log is written in append mode and also forwarded to the original
+# stderr/stdout via tee so openshell sandbox create can still stream it.
+exec > >(tee -a /tmp/nemoclaw-start.log) 2> >(tee -a /tmp/nemoclaw-start.log >&2)
+
 # ── Source shared sandbox initialisation library ─────────────────
 # Single source of truth for security-sensitive primitives shared with
 # agents/hermes/start.sh. Ref: https://github.com/NVIDIA/NemoClaw/issues/2277
@@ -1161,10 +1169,61 @@ export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCR
 # The preload patches https.request() to inject a CONNECT tunnel agent for
 # WebSocket upgrade requests. Activates whenever HTTPS_PROXY is set (the
 # script itself guards on the env var).
-_WS_FIX_SCRIPT="/opt/nemoclaw-blueprint/scripts/ws-proxy-fix.js"
-if [ -f "$_WS_FIX_SCRIPT" ]; then
+_WS_FIX_SOURCE="/usr/local/lib/nemoclaw/ws-proxy-fix.js"
+_WS_FIX_SCRIPT="/tmp/nemoclaw-ws-proxy-fix.js"
+if [ -f "$_WS_FIX_SOURCE" ]; then
+  # Copy to /tmp so the sandbox user can read it — /usr/local/lib/ may be
+  # Landlock-restricted in some runtimes. Same pattern as the other preloads.
+  emit_sandbox_sourced_file "$_WS_FIX_SCRIPT" <"$_WS_FIX_SOURCE"
   export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_WS_FIX_SCRIPT"
 fi
+
+# ── Seccomp syscall guard ─────────────────────────────────────
+# OpenShell ≥0.0.36 seccomp policy blocks syscalls like getifaddrs
+# (used by Node's os.networkInterfaces()). Third-party libraries (e.g.,
+# @homebridge/ciao mDNS) call these without error handling, producing
+# unhandled promise rejections that crash the gateway under Node v22's
+# default --unhandled-rejections=throw.
+#
+# This preload catches those specific sandbox-infrastructure errors
+# and logs them as warnings instead of letting them kill the process.
+# Unlike the Slack channel guard, this is always installed because the
+# seccomp-blocked syscalls affect all sandboxes, not just Slack ones.
+_SECCOMP_GUARD_SCRIPT="/tmp/nemoclaw-seccomp-guard.js"
+emit_sandbox_sourced_file "$_SECCOMP_GUARD_SCRIPT" <<'SECCOMP_GUARD_EOF'
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// seccomp-guard.js — patch syscalls that are blocked by OpenShell ≥0.0.36
+// seccomp policy. Third-party libraries (e.g., @homebridge/ciao mDNS) call
+// os.networkInterfaces() without error handling, producing unhandled promise
+// rejections. OpenClaw's rejection handler (unhandled-rejections-*.js) calls
+// process.exit(1) for unrecognised errors, crashing the gateway.
+//
+// Rather than trying to catch the rejection (which races with OpenClaw's own
+// handler), this preload patches the syscall wrappers to return safe defaults
+// when the underlying call is blocked by seccomp.
+
+(function () {
+  'use strict';
+  var os = require('os');
+  var _origNetworkInterfaces = os.networkInterfaces;
+
+  os.networkInterfaces = function () {
+    try {
+      return _origNetworkInterfaces.call(os);
+    } catch (err) {
+      if (err && String(err.message || '').indexOf('uv_interface_addresses') !== -1) {
+        // seccomp blocks getifaddrs — return empty result.
+        // mDNS discovery is not needed inside a sandbox.
+        return {};
+      }
+      throw err;
+    }
+  };
+})();
+SECCOMP_GUARD_EOF
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_SECCOMP_GUARD_SCRIPT"
 
 # OpenShell re-injects narrow NO_PROXY/no_proxy=127.0.0.1,localhost,::1 every
 # time a user connects via `openshell sandbox connect`.  The connect path spawns
@@ -1207,6 +1266,8 @@ PROXYEOF
   fi
   # Nemotron inference fix for connect sessions. (NemoClaw#1193, #2051)
   echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCRIPT\""
+  # Seccomp guard for connect sessions.
+  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SECCOMP_GUARD_SCRIPT\""
   # Tool cache redirects — generated from _TOOL_REDIRECTS (single source of truth)
   echo '# Tool cache redirects — /sandbox is Landlock read-only (#804)'
   for _redir in "${_TOOL_REDIRECTS[@]}"; do
@@ -1343,7 +1404,7 @@ if [ "$(id -u)" -ne 0 ]; then
   # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
   # (both are trust-boundary files; tampering would let the sandbox user
   # inject code into any Node process via NODE_OPTIONS).
-  validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT"
+  validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_WS_FIX_SCRIPT" "$_SECCOMP_GUARD_SCRIPT"
 
   # Start gateway in background, auto-pair, then wait.
   # Pass OPENCLAW_GATEWAY_TOKEN only on this launch line so it lives solely
@@ -1483,7 +1544,7 @@ harden_openclaw_symlinks
 # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
 # (both are trust-boundary files; tampering would let the sandbox user
 # inject code into any Node process via NODE_OPTIONS).
-validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT"
+validate_tmp_permissions "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_WS_FIX_SCRIPT" "$_SECCOMP_GUARD_SCRIPT"
 
 # Start the gateway as the 'gateway' user.
 # SECURITY: The sandbox user cannot kill this process because it runs

--- a/scripts/test-inference-local.sh
+++ b/scripts/test-inference-local.sh
@@ -5,5 +5,5 @@
 # Test inference.local routing through OpenShell provider (local vLLM)
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
-echo '{"model":"nvidia/nemotron-3-nano-30b-a3b","messages":[{"role":"user","content":"say hello"}]}' >"$TMPFILE"
+echo '{"model":"nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8","messages":[{"role":"user","content":"say hello"}]}' >"$TMPFILE"
 curl -s https://inference.local/v1/chat/completions -H "Content-Type: application/json" -d @"$TMPFILE"

--- a/src/lib/deploy.test.ts
+++ b/src/lib/deploy.test.ts
@@ -77,6 +77,23 @@ describe("buildDeployEnvLines", () => {
     expect(envLines).toContain("ALLOWED_CHAT_IDS='111,222'");
   });
 
+  it("passes HF_TOKEN and HUGGING_FACE_HUB_TOKEN to the VM when set", () => {
+    const envLines = buildDeployEnvLines({
+      env: {},
+      sandboxName: "my-assistant",
+      provider: "build",
+      credentials: {
+        NVIDIA_API_KEY: "nvapi-test",
+        HF_TOKEN: "hf_abc123",
+        HUGGING_FACE_HUB_TOKEN: "hf_def456",
+      },
+      shellQuote: (value: string) => `'${value}'`,
+    });
+
+    expect(envLines).toContain("HF_TOKEN='hf_abc123'");
+    expect(envLines).toContain("HUGGING_FACE_HUB_TOKEN='hf_def456'");
+  });
+
   it("omits ALLOWED_CHAT_IDS when Telegram is not configured", () => {
     const envLines = buildDeployEnvLines({
       env: {},

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -34,6 +34,8 @@ export interface DeployCredentials {
   COMPATIBLE_API_KEY?: string | null;
   COMPATIBLE_ANTHROPIC_API_KEY?: string | null;
   GITHUB_TOKEN?: string | null;
+  HF_TOKEN?: string | null;
+  HUGGING_FACE_HUB_TOKEN?: string | null;
   TELEGRAM_BOT_TOKEN?: string | null;
   ALLOWED_CHAT_IDS?: string | null;
   DISCORD_BOT_TOKEN?: string | null;
@@ -284,6 +286,8 @@ export async function executeDeploy(opts: DeployExecutionOptions): Promise<void>
     COMPATIBLE_API_KEY: getCredential("COMPATIBLE_API_KEY"),
     COMPATIBLE_ANTHROPIC_API_KEY: getCredential("COMPATIBLE_ANTHROPIC_API_KEY"),
     GITHUB_TOKEN: getCredential("GITHUB_TOKEN"),
+    HF_TOKEN: getCredential("HF_TOKEN"),
+    HUGGING_FACE_HUB_TOKEN: getCredential("HUGGING_FACE_HUB_TOKEN"),
     TELEGRAM_BOT_TOKEN: getCredential("TELEGRAM_BOT_TOKEN"),
     ALLOWED_CHAT_IDS: getCredential("ALLOWED_CHAT_IDS"),
     DISCORD_BOT_TOKEN: getCredential("DISCORD_BOT_TOKEN"),

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -1181,6 +1181,15 @@ if echo "$gw_port" | grep -q "OPEN"; then
   pass "S1: Gateway is serving on port 18789 — Slack auth failure did not crash it"
 else
   fail "S1: Gateway is not serving on port 18789 (${gw_port:0:200})"
+  # Dump early entrypoint log — captures crashes that happen before
+  # touch /tmp/gateway.log (e.g., Landlock read failures, seccomp blocks).
+  start_log=$(openshell sandbox exec --name "$SANDBOX_NAME" -- cat /tmp/nemoclaw-start.log 2>/dev/null || true)
+  if [ -n "$start_log" ]; then
+    info "Entrypoint log (last 40 lines of /tmp/nemoclaw-start.log):"
+    echo "$start_log" | tail -40 | while IFS= read -r line; do
+      info "  $line"
+    done
+  fi
 fi
 
 # S2: Dump gateway.log for diagnostics (must use openshell exec — SSH user

--- a/test/local-inference-setup.test.ts
+++ b/test/local-inference-setup.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const INSTALL_SH = path.join(REPO_ROOT, "scripts", "install.sh");
+const BLUEPRINT = path.join(REPO_ROOT, "nemoclaw-blueprint", "blueprint.yaml");
+
+function sourceAndRun(body: string) {
+  return spawnSync(
+    "bash",
+    [
+      "-c",
+      `set -euo pipefail; SCRIPT_DIR="$(dirname "${INSTALL_SH}")"; source "${INSTALL_SH}"; ${body}`,
+    ],
+    { encoding: "utf-8" },
+  );
+}
+
+describe("local inference setup (install.sh)", () => {
+  it("install_or_start_vllm is a no-op when NEMOCLAW_PROVIDER is not vllm", () => {
+    const result = sourceAndRun(
+      `NEMOCLAW_PROVIDER=openai install_or_start_vllm; echo "rc=$?"`,
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("rc=0");
+    expect(result.stdout).not.toContain("Installing vLLM");
+    expect(result.stdout).not.toContain("Starting vLLM");
+  });
+
+  it("install_or_upgrade_ollama is not invoked when NEMOCLAW_PROVIDER is not ollama", () => {
+    // Sanity-check the main() gating by grepping for the conditional wrapping the call.
+    const content = fs.readFileSync(INSTALL_SH, "utf-8");
+    expect(content).toMatch(/NEMOCLAW_PROVIDER:-.*==\s*"ollama"[\s\S]*install_or_upgrade_ollama/);
+  });
+
+  it("vLLM default model id matches the blueprint", () => {
+    const content = fs.readFileSync(INSTALL_SH, "utf-8");
+    const installMatch = content.match(/VLLM_DEFAULT_MODEL="([^"]+)"/);
+    expect(installMatch).not.toBeNull();
+    const installModel = installMatch![1];
+
+    const blueprintContent = fs.readFileSync(BLUEPRINT, "utf-8");
+    const blueprintMatch = blueprintContent.match(/vllm:[\s\S]*?model:\s*"([^"]+)"/);
+    expect(blueprintMatch).not.toBeNull();
+    const blueprintModel = blueprintMatch![1];
+
+    expect(installModel).toBe(blueprintModel);
+  });
+
+  it("vLLM startup uses --trust-remote-code", () => {
+    const content = fs.readFileSync(INSTALL_SH, "utf-8");
+    expect(content).toMatch(/vllm\.entrypoints\.openai\.api_server[\s\S]*--trust-remote-code/);
+  });
+});

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -5066,7 +5066,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
         input: "\n",
       });
       assert.equal(introspect.status, 0, introspect.stderr);
-      const introspectOut = JSON.parse(introspect.stdout.trim().split("\n").pop());
+      const introspectOut = JSON.parse(introspect.stdout.trim().split("\n").pop()!);
       const slackIdx = introspectOut.slackIndex1Based;
       assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
@@ -5085,14 +5085,14 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
 
       assert.equal(result.status, 0, result.stderr);
-      const out = JSON.parse(result.stdout.trim().split("\n").pop());
+      const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
 
       assert.ok(
         !out.result.includes("slack"),
         `slack should have been dropped after invalid token; got ${JSON.stringify(out.result)}`,
       );
       assert.ok(
-        !out.saveCalls.some((c) => c.key === "SLACK_BOT_TOKEN"),
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
         `SLACK_BOT_TOKEN should NOT have been persisted; saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
@@ -5177,7 +5177,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
       assert.equal(introspect.status, 0, introspect.stderr);
       const slackIdx = JSON.parse(
-        introspect.stdout.trim().split("\n").pop(),
+        introspect.stdout.trim().split("\n").pop()!,
       ).slackIndex1Based;
       assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
@@ -5195,7 +5195,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       });
 
       assert.equal(result.status, 0, result.stderr);
-      const out = JSON.parse(result.stdout.trim().split("\n").pop());
+      const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
 
       assert.ok(
         !out.result.includes("slack"),
@@ -5205,11 +5205,11 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       // user can retry later and the pre-saved bot token will light up as
       // "already configured" on the next onboard.
       assert.ok(
-        out.saveCalls.some((c) => c.key === "SLACK_BOT_TOKEN"),
+        out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
         `SLACK_BOT_TOKEN should have been persisted (valid format); saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
-        !out.saveCalls.some((c) => c.key === "SLACK_APP_TOKEN"),
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_APP_TOKEN"),
         `SLACK_APP_TOKEN should NOT have been persisted (invalid format); saveCalls=${JSON.stringify(out.saveCalls)}`,
       );
       assert.ok(
@@ -5225,7 +5225,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
     // Cache-bust the dynamic import so repeated test runs pick up rebuilds.
     const onboardUrl = `${pathToFileURL(onboardPath).href}?update=${Date.now()}`;
     const { MESSAGING_CHANNELS } = await import(onboardUrl);
-    const slack = MESSAGING_CHANNELS.find((c) => c.name === "slack");
+    const slack = MESSAGING_CHANNELS.find((c: { name: string }) => c.name === "slack");
 
     assert.ok(slack, "slack messaging channel definition present");
     assert.ok(slack.tokenFormat instanceof RegExp, "slack.tokenFormat is a regex");

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -134,7 +134,7 @@ describe("policies", () => {
     it("returns expected preset names", () => {
       const names = policies
         .listPresets()
-        .map((p) => p.name)
+        .map((p: { name: string }) => p.name)
         .sort();
       const expected = [
         "brave",

--- a/test/seccomp-guard.test.ts
+++ b/test/seccomp-guard.test.ts
@@ -1,0 +1,175 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, it, expect } from "vitest";
+
+const START_SCRIPT = path.join(import.meta.dirname, "..", "scripts", "nemoclaw-start.sh");
+
+describe("Seccomp guard preload", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("defines _SECCOMP_GUARD_SCRIPT path variable", () => {
+    expect(src).toContain('_SECCOMP_GUARD_SCRIPT="/tmp/nemoclaw-seccomp-guard.js"');
+  });
+
+  it("embeds the guard via a SECCOMP_GUARD_EOF heredoc", () => {
+    expect(src).toMatch(
+      /emit_sandbox_sourced_file\s+"\$_SECCOMP_GUARD_SCRIPT"\s+<<'SECCOMP_GUARD_EOF'/,
+    );
+    expect(src).toMatch(/^SECCOMP_GUARD_EOF$/m);
+  });
+
+  it("registers the preload in NODE_OPTIONS", () => {
+    expect(src).toContain(
+      'export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_SECCOMP_GUARD_SCRIPT"',
+    );
+  });
+
+  it("includes the preload in the proxy-env sourced file for connect sessions", () => {
+    expect(src).toMatch(/# Seccomp guard for connect sessions/);
+    expect(src).toContain("--require $_SECCOMP_GUARD_SCRIPT");
+  });
+
+  it("passes the preload path to validate_tmp_permissions in both root and non-root branches", () => {
+    const calls =
+      src.match(/validate_tmp_permissions\s+[^;\n]*\$_SECCOMP_GUARD_SCRIPT/g) || [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("preload patches os.networkInterfaces to catch uv_interface_addresses errors", () => {
+    const heredoc = src.match(/<<'SECCOMP_GUARD_EOF'\n([\s\S]*?)\nSECCOMP_GUARD_EOF/);
+    expect(heredoc).not.toBeNull();
+    const script = heredoc[1];
+    expect(script).toContain("os.networkInterfaces");
+    expect(script).toContain("uv_interface_addresses");
+    expect(script).toContain("_origNetworkInterfaces");
+  });
+
+  it("preload returns empty object when uv_interface_addresses is blocked", () => {
+    // Extract the guard script from the heredoc and run it in a subprocess
+    // that simulates a seccomp-blocked os.networkInterfaces().
+    const heredoc = src.match(/<<'SECCOMP_GUARD_EOF'\n([\s\S]*?)\nSECCOMP_GUARD_EOF/);
+    expect(heredoc).not.toBeNull();
+    const guardScript = heredoc[1];
+
+    const testScript = `
+      // Simulate seccomp-blocked os.networkInterfaces
+      const os = require('os');
+      const origNI = os.networkInterfaces;
+      os.networkInterfaces = function() {
+        throw new SystemError('uv_interface_addresses');
+      };
+      class SystemError extends Error {
+        constructor(msg) { super('A system error occurred: ' + msg + ' returned Unknown system error 1 (Unknown system error 1)'); }
+      }
+
+      // Load the guard (it patches os.networkInterfaces)
+      ${guardScript}
+
+      // Verify the patch works
+      const result = os.networkInterfaces();
+      console.log(JSON.stringify({ result, type: typeof result }));
+    `;
+
+    const r = spawnSync(process.execPath, ["-e", testScript], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).toBe(0);
+    const output = JSON.parse(r.stdout.trim());
+    expect(output.result).toEqual({});
+    expect(output.type).toBe("object");
+  });
+
+  it("preload re-throws non-seccomp errors from os.networkInterfaces", () => {
+    const heredoc = src.match(/<<'SECCOMP_GUARD_EOF'\n([\s\S]*?)\nSECCOMP_GUARD_EOF/);
+    expect(heredoc).not.toBeNull();
+    const guardScript = heredoc[1];
+
+    const testScript = `
+      const os = require('os');
+      os.networkInterfaces = function() {
+        throw new Error('some other error');
+      };
+
+      ${guardScript}
+
+      try {
+        os.networkInterfaces();
+        console.log('NO_THROW');
+      } catch (e) {
+        console.log('THREW:' + e.message);
+      }
+    `;
+
+    const r = spawnSync(process.execPath, ["-e", testScript], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("THREW:some other error");
+  });
+
+  it("preload passes through when os.networkInterfaces works normally", () => {
+    const heredoc = src.match(/<<'SECCOMP_GUARD_EOF'\n([\s\S]*?)\nSECCOMP_GUARD_EOF/);
+    expect(heredoc).not.toBeNull();
+    const guardScript = heredoc[1];
+
+    const testScript = `
+      const os = require('os');
+      const fakeResult = { lo: [{ address: '127.0.0.1', family: 'IPv4' }] };
+      os.networkInterfaces = function() { return fakeResult; };
+
+      ${guardScript}
+
+      const result = os.networkInterfaces();
+      console.log(JSON.stringify(result));
+    `;
+
+    const r = spawnSync(process.execPath, ["-e", testScript], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(r.status).toBe(0);
+    const output = JSON.parse(r.stdout.trim());
+    expect(output.lo).toBeDefined();
+    expect(output.lo[0].address).toBe("127.0.0.1");
+  });
+});
+
+describe("ws-proxy-fix Landlock mitigation", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("reads ws-proxy-fix.js from /usr/local/lib/nemoclaw/ not /opt/nemoclaw-blueprint/", () => {
+    expect(src).toContain('_WS_FIX_SOURCE="/usr/local/lib/nemoclaw/ws-proxy-fix.js"');
+    expect(src).not.toContain('_WS_FIX_SCRIPT="/opt/nemoclaw-blueprint/scripts/ws-proxy-fix.js"');
+  });
+
+  it("copies ws-proxy-fix.js to /tmp via emit_sandbox_sourced_file", () => {
+    expect(src).toContain('_WS_FIX_SCRIPT="/tmp/nemoclaw-ws-proxy-fix.js"');
+    expect(src).toMatch(/emit_sandbox_sourced_file\s+"\$_WS_FIX_SCRIPT"\s+<\s*"\$_WS_FIX_SOURCE"/);
+  });
+
+  it("Dockerfile copies ws-proxy-fix.js to /usr/local/lib/nemoclaw/", () => {
+    const dockerfile = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "Dockerfile"),
+      "utf-8",
+    );
+    expect(dockerfile).toContain(
+      "COPY nemoclaw-blueprint/scripts/ws-proxy-fix.js /usr/local/lib/nemoclaw/ws-proxy-fix.js",
+    );
+  });
+});
+
+describe("Early entrypoint stderr capture", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("redirects stdout and stderr to /tmp/nemoclaw-start.log via tee", () => {
+    expect(src).toMatch(/exec\s+>\s+>\(tee\s+-a\s+\/tmp\/nemoclaw-start\.log\)/);
+    expect(src).toMatch(/2>\s+>\(tee\s+-a\s+\/tmp\/nemoclaw-start\.log\s+>&2\)/);
+  });
+});

--- a/test/seccomp-guard.test.ts
+++ b/test/seccomp-guard.test.ts
@@ -59,7 +59,7 @@ describe("Seccomp guard preload", () => {
     const testScript = `
       // Simulate seccomp-blocked os.networkInterfaces
       const os = require('os');
-      const origNI = os.networkInterfaces;
+      const _origNI = os.networkInterfaces;
       os.networkInterfaces = function() {
         throw new SystemError('uv_interface_addresses');
       };
@@ -169,7 +169,12 @@ describe("Early entrypoint stderr capture", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 
   it("redirects stdout and stderr to /tmp/nemoclaw-start.log via tee", () => {
-    expect(src).toMatch(/exec\s+>\s+>\(tee\s+-a\s+\/tmp\/nemoclaw-start\.log\)/);
-    expect(src).toMatch(/2>\s+>\(tee\s+-a\s+\/tmp\/nemoclaw-start\.log\s+>&2\)/);
+    expect(src).toContain('_START_LOG="/tmp/nemoclaw-start.log"');
+    expect(src).toMatch(/exec\s+>\s+>\(tee\s+-a\s+"\$_START_LOG"\)/);
+    expect(src).toMatch(/2>\s+>\(tee\s+-a\s+"\$_START_LOG"\s+>&2\)/);
+  });
+
+  it("restricts log permissions before writing to prevent token leakage", () => {
+    expect(src).toMatch(/chmod 600 "\$_START_LOG"/);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
           name: "cli",
           include: ["test/**/*.test.{js,ts}", "src/**/*.test.ts"],
           exclude: ["**/node_modules/**", "**/.claude/**", "test/e2e/**"],
+          testTimeout: 15000,
         },
       },
       {


### PR DESCRIPTION
## Summary

Fixes three issues from #996 that prevented vLLM from starting on Brev deploy:

- **Wrong HF model id**: The vLLM blueprint profile used the NIM catalog name (`nvidia/nemotron-3-nano-30b-a3b`) which returns 404 on Hugging Face. Replaced with the correct HF repo id (`nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8`).
- **No HF_TOKEN on VM**: Added `HF_TOKEN` and `HUGGING_FACE_HUB_TOKEN` to `DeployCredentials` so Brev deploy passes them to the VM — without these, gated HF models return 401.
- **Missing --trust-remote-code**: Documented in the blueprint profile comment that vLLM must be started with `--trust-remote-code` for models with custom code. NemoClaw doesn't launch vLLM itself, so this is a documentation fix.

Also updated `scripts/test-inference-local.sh` to use the correct HF model id.

Note: `nim-images.json` and `index.ts` NIM model entries are **not** changed — those use the NIM catalog name which is correct for the NIM API provider.

Closes #996

## Test plan

- [x] New test: `HF_TOKEN` and `HUGGING_FACE_HUB_TOKEN` are passed through in `buildDeployEnvLines`
- [x] Existing deploy tests pass (10/10)
- [x] NIM tests unchanged and passing (27/27)
- [x] All pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * CLI reference updated: `onboard --from <Dockerfile>` documented and deprecated aliases for legacy commands clarified.

* **New Features**
  * Deployment now accepts Hugging Face auth tokens.
  * Optional local vLLM inference setup and updated default model target.

* **Bug Fixes**
  * Improved WebSocket proxy handling and added seccomp guard to prevent Node runtime crashes.
  * Entrypoint now captures startup logs for easier diagnostics.

* **Tests**
  * New and expanded tests covering deployment credentials, startup guards, vLLM setup, and related stability fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->