### PR TITLE
ci: gate every PR on tsc-cli regardless of touched paths

### DIFF
--- a/.github/actions/basic-checks/action.yaml
+++ b/.github/actions/basic-checks/action.yaml
@@ -38,6 +38,14 @@ runs:
       shell: bash
       run: npm run build:cli
 
+    - name: Typecheck CLI + tests (strict)
+      # Explicit gate independent of the prek tsc-cli hook's file-pattern filter.
+      # The hook's `files:` scope excludes test/ and src/, which let #2130 +
+      # #2422 interact to ship a strict-mode regression onto main silently.
+      # Running this unconditionally here catches that class of drift.
+      shell: bash
+      run: npm run typecheck:cli
+
     - name: Validate config schemas
       shell: bash
       run: npm run validate:configs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -239,7 +239,10 @@ repos:
         entry: npx tsc -p tsconfig.cli.json
         language: system
         pass_filenames: false
-        files: ^(bin|scripts)/
+        # Match what tsconfig.cli.json actually typechecks — previously ^(bin|scripts)/
+        # missed test-only and src-only PRs, which allowed a strict-mode regression
+        # (#2130 × #2422) to land on main silently.
+        files: ^(bin/|scripts/|src/|test/|tsconfig.*\.json$)
         types_or: [ts, tsx]
         stages: [pre-push]
         priority: 10


### PR DESCRIPTION
## Summary

Prevents the class of regression that required #2458. Adds an unconditional `typecheck:cli` step to the shared CI action, and broadens the prek hook filter to match what `tsconfig.cli.json` actually typechecks.

## Related

Follow-up to #2458 (which fixed the symptom — this addresses the root cause).

## Root cause recap

- `.pre-commit-config.yaml` had `files: ^(bin|scripts)/` on the `tsc-cli` hook.
- PRs that touched only `test/` or `src/` never triggered the check.
- #2130 (test-only Slack validation) slipped through that gap.
- #2422 later turned on `strict: true`, and the latent errors surfaced — but for every downstream PR, not the PR that introduced them.
- Six open PRs ended up blocked on the same error cluster before anyone noticed.

## Changes

- `.github/actions/basic-checks/action.yaml` — new **Typecheck CLI + tests (strict)** step running `npm run typecheck:cli` unconditionally. Independent of prek hook configuration, so future filter drift can't hide a tsc error from CI.
- `.pre-commit-config.yaml` — widen `tsc-cli` hook's `files:` from `^(bin|scripts)/` to `^(bin/|scripts/|src/|test/|tsconfig.*\.json$)`. Local pre-push now gates the same surface CI does.

Belt-and-suspenders. Either one would have caught #2130's regression on its own; running both means local hook and CI are always in sync on this class of check.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] YAML parses for both files
- [x] `npm run typecheck:cli` exits 0 on this branch (rebased on main after #2458 lands will confirm)
- [x] `npx prek run --all-files` passes
- [x] Tests added or updated for new or changed behavior (N/A — infra change, existing suite covers)
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration with stricter type-checking validation to prevent regressions and improve code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->