### PR TITLE
ci: gate every PR on tsc-cli regardless of touched paths

### DIFF
--- a/.github/actions/basic-checks/action.yaml
+++ b/.github/actions/basic-checks/action.yaml
@@ -38,6 +38,14 @@ runs:
       shell: bash
       run: npm run build:cli
 
+    - name: Typecheck CLI + tests (strict)
+      # Explicit gate independent of the prek tsc-cli hook's file-pattern filter.
+      # The hook's `files:` scope excludes test/ and src/, which let #2130 +
+      # #2422 interact to ship a strict-mode regression onto main silently.
+      # Running this unconditionally here catches that class of drift.
+      shell: bash
+      run: npm run typecheck:cli
+
     - name: Validate config schemas
       shell: bash
       run: npm run validate:configs


### PR DESCRIPTION
## Summary

Prevents the class of regression that required #2458. Adds an unconditional `typecheck:cli` step to the shared CI action so future hook-filter drift can't hide a tsc error.

## Related

Follow-up to #2458 (which fixed the symptom — this addresses the root cause).

## Root cause recap

- `.pre-commit-config.yaml` had `files: ^(bin|scripts)/` on the `tsc-cli` hook.
- PRs that touched only `test/` or `src/` never triggered the check.
- #2130 (test-only Slack validation) slipped through that gap.
- #2422 later turned on `strict: true`, and the latent errors surfaced — but for every downstream PR, not the PR that introduced them.
- Six open PRs ended up blocked on the same error cluster before anyone noticed.

## Changes

`.github/actions/basic-checks/action.yaml` — new **Typecheck CLI + tests (strict)** step running `npm run typecheck:cli` unconditionally. Independent of prek hook configuration, so future filter drift can't hide a tsc error from CI.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] YAML parses
- [x] `npm run typecheck:cli` exits 0 on this branch (requires #2458 merged to main first)
- [x] Tests added or updated for new or changed behavior (N/A — infra change, existing suite covers)
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with additional TypeScript typechecking to improve code quality assurance and detect type-related issues earlier in the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->