### PR TITLE
docs: catch up release prep for 0.0.25

### DIFF
--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -183,15 +183,15 @@ For setup, refer to Use a Local Inference Server (use the `nemoclaw-user-configu
 
 ### Review the Configuration Before the Sandbox Build
 
-After you enter the sandbox name, the wizard prints a review summary and asks for final confirmation before starting the destructive sandbox image build.
+After you enter the sandbox name, the wizard prints a review summary and asks for final confirmation before starting the destructive sandbox image build. For example, if you picked NVIDIA Endpoints, the summary looks like the following:
 
 ```text
   ──────────────────────────────────────────────────
   Review configuration
   ──────────────────────────────────────────────────
-  Provider:      gemini-api
-  Model:         gemini-2.5-flash
-  API key:       GEMINI_API_KEY (stored in ~/.nemoclaw/credentials.json)
+  Provider:      nvidia-api
+  Model:         nvidia/nemotron-3-super-120b-a12b
+  API key:       NVIDIA_API_KEY (stored in ~/.nemoclaw/credentials.json)
   Web search:    disabled
   Messaging:     none
   Sandbox name:  my-assistant
@@ -204,8 +204,8 @@ The default is `Y`, so you can press Enter once to continue. Answer `n` to abort
 Non-interactive runs (`NEMOCLAW_NON_INTERACTIVE=1`) print the summary for log clarity but skip the prompt.
 
 When the install completes, a summary confirms the running environment.
-The `Model` and provider line reflects whichever inference option you picked in the wizard.
-The example below shows the result if you accept the NVIDIA Endpoints default.
+The `Model` and provider line reflects the inference option you picked during onboarding.
+The example below shows the result if you picked NVIDIA Endpoints during onboarding.
 
 ```text
 ──────────────────────────────────────────────────

--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -181,6 +181,28 @@ These options appear when `NEMOCLAW_EXPERIMENTAL=1` is set and the prerequisites
 For setup, refer to Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill).
 :::
 
+### Review the Configuration Before the Sandbox Build
+
+After you enter the sandbox name, the wizard prints a review summary and asks for final confirmation before starting the destructive sandbox image build.
+
+```text
+  ──────────────────────────────────────────────────
+  Review configuration
+  ──────────────────────────────────────────────────
+  Provider:      gemini-api
+  Model:         gemini-2.5-flash
+  API key:       GEMINI_API_KEY (stored in ~/.nemoclaw/credentials.json)
+  Web search:    disabled
+  Messaging:     none
+  Sandbox name:  my-assistant
+  ──────────────────────────────────────────────────
+  Apply this configuration? [Y/n]:
+```
+
+The default is `Y`, so you can press Enter once to continue. Answer `n` to abort cleanly, fix the entries, and re-run `nemoclaw onboard`.
+
+Non-interactive runs (`NEMOCLAW_NON_INTERACTIVE=1`) print the summary for log clarity but skip the prompt.
+
 When the install completes, a summary confirms the running environment.
 The `Model` and provider line reflects whichever inference option you picked in the wizard.
 The example below shows the result if you accept the NVIDIA Endpoints default.

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -106,9 +106,30 @@ If the Jetson setup step fails, verify that you have `sudo` access and that Dock
 
 For JetPack 6 (L4T 36.x), the setup switches iptables to legacy mode and adjusts the Docker daemon configuration.
 For JetPack 7 (L4T 38.x / Thor), only bridge netfilter and sysctl settings are applied.
-BSP R39 and later do not require host customization and are handled automatically.
+For JetPack 7 (L4T 39.x), bridge netfilter is loaded only when the host is missing it. Some R39 images already ship with `br_netfilter` configured and are left untouched. On affected R39 hosts, the installer prints `loading br_netfilter (required by k3s inside the OpenShell gateway)`. Without this fix, sandbox pods fail DNS resolution against the in-cluster service and the onboard `Setting up OpenClaw inside sandbox` step times out.
 
 If the L4T version is not recognized, the setup step is skipped and the installer continues normally.
+
+### DNS resolution from inside docker fails (corporate firewall)
+
+Some corporate networks block outbound UDP port 53 to public DNS servers and force all host name resolution through DNS over TLS on TCP port 853. Containers do not inherit the host's DNS-over-TLS configuration, so the sandbox build's `npm ci` step times out trying to resolve `registry.npmjs.org` against `1.1.1.1` or `8.8.8.8`.
+
+NemoClaw's preflight runs a short `docker run --rm busybox nslookup registry.npmjs.org` probe before starting the sandbox build. When the probe confirms a DNS failure, onboarding stops with platform-specific remediation instead of hanging for ~15 minutes and printing a cryptic `Exit handler never called`.
+
+The fix depends on your platform and runtime. Pick the matching path from the preflight output, apply it, then re-run `nemoclaw onboard`.
+
+- **Linux with systemd-resolved.** Add a `DNSStubListenerExtra` drop-in pointing at the docker bridge gateway IP (the preflight prints the detected IP), then add the same IP to `/etc/docker/daemon.json` under `dns`. Restart `systemd-resolved` and `docker`.
+- **macOS with Colima.** Restart Colima with the corporate DNS address, for example `colima stop && colima start --dns <corp-dns-ip>`.
+- **macOS with Docker Desktop.** Add the corporate DNS address to `~/.docker/daemon.json` under `dns`, then restart Docker Desktop.
+- **Windows or WSL.** Configure DNS in the Docker Desktop settings GUI, or apply the Linux fix above when running native docker inside WSL.
+
+Verify the fix worked:
+
+```console
+$ docker run --rm busybox nslookup registry.npmjs.org
+```
+
+When the lookup returns an answer, retry onboarding.
 
 ### Port already in use
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -207,15 +207,15 @@ For setup, refer to [Use a Local Inference Server](../inference/use-local-infere
 
 ### Review the Configuration Before the Sandbox Build
 
-After you enter the sandbox name, the wizard prints a review summary and asks for final confirmation before starting the destructive sandbox image build.
+After you enter the sandbox name, the wizard prints a review summary and asks for final confirmation before starting the destructive sandbox image build. For example, if you picked NVIDIA Endpoints, the summary looks like the following:
 
 ```text
   ──────────────────────────────────────────────────
   Review configuration
   ──────────────────────────────────────────────────
-  Provider:      gemini-api
-  Model:         gemini-2.5-flash
-  API key:       GEMINI_API_KEY (stored in ~/.nemoclaw/credentials.json)
+  Provider:      nvidia-api
+  Model:         nvidia/nemotron-3-super-120b-a12b
+  API key:       NVIDIA_API_KEY (stored in ~/.nemoclaw/credentials.json)
   Web search:    disabled
   Messaging:     none
   Sandbox name:  my-assistant
@@ -228,8 +228,8 @@ The default is `Y`, so you can press Enter once to continue. Answer `n` to abort
 Non-interactive runs (`NEMOCLAW_NON_INTERACTIVE=1`) print the summary for log clarity but skip the prompt.
 
 When the install completes, a summary confirms the running environment.
-The `Model` and provider line reflects whichever inference option you picked in the wizard.
-The example below shows the result if you accept the NVIDIA Endpoints default.
+The `Model` and provider line reflects the inference option you picked during onboarding.
+The example below shows the result if you picked NVIDIA Endpoints during onboarding.
 
 ```text
 ──────────────────────────────────────────────────

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -205,6 +205,28 @@ These options appear when `NEMOCLAW_EXPERIMENTAL=1` is set and the prerequisites
 For setup, refer to [Use a Local Inference Server](../inference/use-local-inference.md).
 :::
 
+### Review the Configuration Before the Sandbox Build
+
+After you enter the sandbox name, the wizard prints a review summary and asks for final confirmation before starting the destructive sandbox image build.
+
+```text
+  ──────────────────────────────────────────────────
+  Review configuration
+  ──────────────────────────────────────────────────
+  Provider:      gemini-api
+  Model:         gemini-2.5-flash
+  API key:       GEMINI_API_KEY (stored in ~/.nemoclaw/credentials.json)
+  Web search:    disabled
+  Messaging:     none
+  Sandbox name:  my-assistant
+  ──────────────────────────────────────────────────
+  Apply this configuration? [Y/n]:
+```
+
+The default is `Y`, so you can press Enter once to continue. Answer `n` to abort cleanly, fix the entries, and re-run `nemoclaw onboard`.
+
+Non-interactive runs (`NEMOCLAW_NON_INTERACTIVE=1`) print the summary for log clarity but skip the prompt.
+
 When the install completes, a summary confirms the running environment.
 The `Model` and provider line reflects whichever inference option you picked in the wizard.
 The example below shows the result if you accept the NVIDIA Endpoints default.

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.24"}
+{"name": "nemoclaw", "version": "0.0.25"}

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -132,9 +132,30 @@ If the Jetson setup step fails, verify that you have `sudo` access and that Dock
 
 For JetPack 6 (L4T 36.x), the setup switches iptables to legacy mode and adjusts the Docker daemon configuration.
 For JetPack 7 (L4T 38.x / Thor), only bridge netfilter and sysctl settings are applied.
-BSP R39 and later do not require host customization and are handled automatically.
+For JetPack 7 (L4T 39.x), bridge netfilter is loaded only when the host is missing it. Some R39 images already ship with `br_netfilter` configured and are left untouched. On affected R39 hosts, the installer prints `loading br_netfilter (required by k3s inside the OpenShell gateway)`. Without this fix, sandbox pods fail DNS resolution against the in-cluster service and the onboard `Setting up OpenClaw inside sandbox` step times out.
 
 If the L4T version is not recognized, the setup step is skipped and the installer continues normally.
+
+### DNS resolution from inside docker fails (corporate firewall)
+
+Some corporate networks block outbound UDP port 53 to public DNS servers and force all host name resolution through DNS over TLS on TCP port 853. Containers do not inherit the host's DNS-over-TLS configuration, so the sandbox build's `npm ci` step times out trying to resolve `registry.npmjs.org` against `1.1.1.1` or `8.8.8.8`.
+
+NemoClaw's preflight runs a short `docker run --rm busybox nslookup registry.npmjs.org` probe before starting the sandbox build. When the probe confirms a DNS failure, onboarding stops with platform-specific remediation instead of hanging for ~15 minutes and printing a cryptic `Exit handler never called`.
+
+The fix depends on your platform and runtime. Pick the matching path from the preflight output, apply it, then re-run `nemoclaw onboard`.
+
+- **Linux with systemd-resolved.** Add a `DNSStubListenerExtra` drop-in pointing at the docker bridge gateway IP (the preflight prints the detected IP), then add the same IP to `/etc/docker/daemon.json` under `dns`. Restart `systemd-resolved` and `docker`.
+- **macOS with Colima.** Restart Colima with the corporate DNS address, for example `colima stop && colima start --dns <corp-dns-ip>`.
+- **macOS with Docker Desktop.** Add the corporate DNS address to `~/.docker/daemon.json` under `dns`, then restart Docker Desktop.
+- **Windows or WSL.** Configure DNS in the Docker Desktop settings GUI, or apply the Linux fix above when running native docker inside WSL.
+
+Verify the fix worked:
+
+```console
+$ docker run --rm busybox nslookup registry.npmjs.org
+```
+
+When the lookup returns an answer, retry onboarding.
 
 ### Port already in use
 

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
   {
     "preferred": true,
+    "version": "0.0.25",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.25/"
+  },
+  {
     "version": "0.0.24",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.24/"
   },
@@ -35,33 +39,5 @@
   {
     "version": "0.0.16",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.16/"
-  },
-  {
-    "version": "0.0.15",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.15/"
-  },
-  {
-    "version": "0.0.14",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.14/"
-  },
-  {
-    "version": "0.0.13",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.13/"
-  },
-  {
-    "version": "0.0.12",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.12/"
-  },
-  {
-    "version": "0.0.11",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.11/"
-  },
-  {
-    "version": "0.0.10",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.10/"
-  },
-  {
-    "version": "0.0.9",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.9/"
   }
 ]


### PR DESCRIPTION
## Summary
Catches up the user-facing docs for changes merged since v0.0.24 and bumps `docs/versions1.json` so the next docs build publishes as 0.0.25.

## Changes
- `docs/reference/troubleshooting.md`: corrected the JetPack 7 (L4T 39.x) entry to reflect the new conditional `br_netfilter` auto-load on R39 hosts that lack it (from #2419), and added a new "DNS resolution from inside docker fails (corporate firewall)" section covering the new container-DNS preflight probe and platform-specific remediation paths (from #2349).
- `docs/get-started/quickstart.md`: added a "Review the Configuration Before the Sandbox Build" subsection documenting the new `[Y/n]` review gate that fires after the sandbox-name prompt (from #2221).
- `docs/versions1.json`: promoted 0.0.25 to `preferred: true`, demoted 0.0.24, and trimmed to ten entries to match what `scripts/bump-version.ts` writes. `docs/project.json` regenerates from `versions1.json` at build time and now reports `0.0.25`.
- `.agents/skills/nemoclaw-user-get-started/` and `.agents/skills/nemoclaw-user-reference/`: regenerated via `scripts/docs-to-skills.py`.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now shows a configuration review and requires explicit confirmation before building a sandbox; non-interactive mode prints the summary without prompting.

* **Documentation**
  * Expanded Jetson troubleshooting for JetPack 7 / L4T 39.x and conditional br_netfilter guidance.
  * Added corporate-firewall DNS troubleshooting with platform-specific remediation and a verification nslookup step.
  * Quickstart updated to document the new confirmation flow.

* **Chores**
  * Documentation version index updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->