### PR TITLE
fix(security): route dashboard URL output through redact() to prevent token leakage

### DIFF
--- a/src/lib/agent-onboard.ts
+++ b/src/lib/agent-onboard.ts
@@ -9,7 +9,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
-import { ROOT, run, shellQuote } from "./runner";
+import { ROOT, run, shellQuote, redact } from "./runner";
 import { dockerBuild, dockerImageInspect } from "./docker";
 import { loadAgent, resolveAgentName, type AgentDefinition } from "./agent-defs";
 import { getAgentBranding } from "./branding";
@@ -356,7 +356,7 @@ export function printDashboardUi(
       const url = path && path !== "/" ? `${withoutHash}${path}` : `${withoutHash}/`;
       if (seen.has(url)) continue;
       seen.add(url);
-      console.log(`  ${url}`);
+      console.log(`  ${redact(url)}`);
     }
     return;
   }
@@ -367,14 +367,14 @@ export function printDashboardUi(
     );
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(token, info.port)) {
-      console.log(`  ${url}`);
+      console.log(`  ${redact(url)}`);
     }
   } else {
     deps.note("  Could not read gateway token from the sandbox (download failed).");
     console.log(`  ${info.displayName} ${label}`);
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(null, info.port)) {
-      console.log(`  ${url}`);
+      console.log(`  ${redact(url)}`);
     }
   }
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -7564,7 +7564,7 @@ function printDashboard(
       console.log(`  ${line}`);
     }
     for (const entry of dashboardAccess) {
-      console.log(`  ${entry.label}: ${entry.url}`);
+      console.log(`  ${entry.label}: ${redact(entry.url)}`);
     }
   } else {
     note("  Could not read gateway token from the sandbox (download failed).");
@@ -7573,7 +7573,7 @@ function printDashboard(
       console.log(`  ${line}`);
     }
     for (const entry of dashboardAccess) {
-      console.log(`  ${entry.label}: ${entry.url}`);
+      console.log(`  ${entry.label}: ${redact(entry.url)}`);
     }
     console.log(
       `  Token:       ${cliName()} ${sandboxName} connect  →  jq -r '.gateway.auth.token' /sandbox/.openclaw/openclaw.json`,

--- a/test/redact-dashboard-urls.test.ts
+++ b/test/redact-dashboard-urls.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { redact } from "../dist/lib/redact";
+
+describe("redact dashboard URLs", () => {
+  it("redacts URLs with #token=<hex> fragment", () => {
+    const url = "http://127.0.0.1:8080/#token=abc123def456";
+    const redacted = redact(url);
+    expect(redacted).not.toContain("abc123def456");
+    expect(redacted).toContain("abc1");
+  });
+
+  it("leaves URLs without token unchanged", () => {
+    const url = "http://127.0.0.1:8080/";
+    const redacted = redact(url);
+    expect(redacted).toBe(url);
+  });
+
+  it("redacts URLs with long hex tokens", () => {
+    const longToken = "a".repeat(64);
+    const url = `http://127.0.0.1:8080/#token=${longToken}`;
+    const redacted = redact(url);
+    expect(redacted).not.toContain(longToken);
+    expect(redacted).toContain("aaaa****");
+  });
+});


### PR DESCRIPTION
## Summary

Route dashboard URL output through `redact()` to prevent gateway auth token leakage in terminal scrollback and CI/CD logs (CWE-532).

Closes #2467

## Changes

Dashboard URLs containing gateway auth tokens (`#token=<64-char-hex>`) were printed via raw `console.log()` in two files, bypassing the centralized `redact()` layer from `src/lib/redact.ts` (#2381).

### Files changed

- **`src/lib/agent-onboard.ts`**: Import `redact` from `./runner`, wrap all 3 URL console.log calls in `printDashboardUi()` with `redact()`
- **`src/lib/onboard.ts`**: Wrap both URL console.log calls in `printDashboard()` with `redact()` (import already present)
- **`test/redact-dashboard-urls.test.ts`**: 3 new vitest tests verifying token redaction

### How it works

The existing `redact()` function already handles `#token=<hex>` via `SECRET_PATTERNS` — this PR simply wires the two dashboard print paths through it.

### Testing

- `npx tsc -p tsconfig.src.json --noEmit` — ✅ passes
- `npx vitest run test/redact-dashboard-urls.test.ts` — ✅ 3/3 pass

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding and dashboard outputs now redact sensitive authentication tokens embedded in displayed URLs, preventing tokens from being exposed in console or stdout and improving security and privacy.

* **Tests**
  * Added automated tests to confirm token fragments in URLs are reliably redacted and that URLs without tokens remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->