### PR TITLE
docs(reference): document onboard recreate-sandbox and agent flags

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -158,6 +158,25 @@ In interactive mode, the wizard asks for confirmation before delete and recreate
 In non-interactive mode, NemoClaw recreates automatically when the stored selection is readable and differs; if NemoClaw cannot read the stored selection, NemoClaw reuses by default.
 Set `NEMOCLAW_RECREATE_SANDBOX=1` to force recreation even when no drift is detected.
 
+#### `--recreate-sandbox`
+
+Delete and recreate the existing sandbox instead of reusing it.
+Use this when you need onboarding to rebuild the sandbox after configuration changes, to recover from a broken sandbox state, or to force recreation when no provider or model drift is detected.
+
+```console
+$ nemoclaw onboard --resume --recreate-sandbox
+```
+
+In non-interactive mode, `NEMOCLAW_RECREATE_SANDBOX=1` provides the same behavior.
+
+#### `--agent <name>`
+
+Select a specific installed agent profile during onboarding instead of using the default agent.
+
+```console
+$ nemoclaw onboard --agent hermes
+```
+
 Before creating the gateway, the wizard runs preflight checks.
 It verifies that Docker is reachable, warns on untested runtimes such as Podman, and prints host remediation guidance when prerequisites are missing.
 The preflight also enforces the OpenShell version range declared in the blueprint (`min_openshell_version` and `max_openshell_version`).

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -180,6 +180,25 @@ In interactive mode, the wizard asks for confirmation before delete and recreate
 In non-interactive mode, NemoClaw recreates automatically when the stored selection is readable and differs; if NemoClaw cannot read the stored selection, NemoClaw reuses by default.
 Set `NEMOCLAW_RECREATE_SANDBOX=1` to force recreation even when no drift is detected.
 
+#### `--recreate-sandbox`
+
+Delete and recreate the existing sandbox instead of reusing it.
+Use this when you need onboarding to rebuild the sandbox after configuration changes, to recover from a broken sandbox state, or to force recreation when no provider or model drift is detected.
+
+```console
+$ nemoclaw onboard --resume --recreate-sandbox
+```
+
+In non-interactive mode, `NEMOCLAW_RECREATE_SANDBOX=1` provides the same behavior.
+
+#### `--agent <name>`
+
+Select a specific installed agent profile during onboarding instead of using the default agent.
+
+```console
+$ nemoclaw onboard --agent hermes
+```
+
 Before creating the gateway, the wizard runs preflight checks.
 It verifies that Docker is reachable, warns on untested runtimes such as Podman, and prints host remediation guidance when prerequisites are missing.
 The preflight also enforces the OpenShell version range declared in the blueprint (`min_openshell_version` and `max_openshell_version`).


### PR DESCRIPTION
## Summary
- add dedicated `nemoclaw onboard` reference entries for the remaining undocumented flags `--recreate-sandbox` and `--agent <name>`
- keep the scope to the docs gap that remains after nearby onboard/reference changes merged into `main`
- regenerate the derived user-reference skill content from `docs/`

## Testing
- not run (docs-only change)

## Related
- follow-up to #1795
- relates to #1730

Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new `--recreate-sandbox` option in the `nemoclaw onboard` command, enabling users to delete and recreate sandboxes, with support for non-interactive mode via environment variable.
  * Added documentation for the new `--agent <name>` option, allowing users to select and onboard a specific installed agent profile during setup, with example invocations provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->