### PR TITLE
chore: upgrade OpenClaw from 2026.4.9 to 2026.4.24

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -152,7 +152,7 @@ RUN printf '%s\n' \
 # OpenClaw version: change the OPENCLAW_VERSION ARG default so CI rebuilds
 # the base image on push to main, or use workflow_dispatch on base-image.yaml
 # with the openclaw_version input for a one-off build without editing this file.
-ARG OPENCLAW_VERSION=2026.4.9
+ARG OPENCLAW_VERSION=2026.4.24
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/agents/openclaw/manifest.yaml
+++ b/agents/openclaw/manifest.yaml
@@ -19,7 +19,7 @@ homepage: "https://openclaw.ai"
 install_method: npm  # npm install -g openclaw@<version>
 binary_path: /usr/local/bin/openclaw
 version_command: "openclaw --version"
-expected_version: "2026.4.9"
+expected_version: "2026.4.24"
 gateway_command: "openclaw gateway run"
 
 # ── Health probe ────────────────────────────────────────────────

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -4,7 +4,7 @@
 version: "0.1.0"
 min_openshell_version: "0.0.32"
 max_openshell_version: "0.0.36"
-min_openclaw_version: "2026.4.9"
+min_openclaw_version: "2026.4.24"
 # Mirrors the components.sandbox.image manifest digest below. Lets a
 # downstream consumer (or release tooling) verify the blueprint declares
 # a specific sandbox image without parsing the components tree, and

--- a/src/lib/sandbox-version.test.ts
+++ b/src/lib/sandbox-version.test.ts
@@ -36,7 +36,7 @@ vi.mock("./agent-defs.js", () => ({
     name,
     displayName: name === "openclaw" ? "OpenClaw" : "Hermes Agent",
     versionCommand: name === "openclaw" ? "openclaw --version" : "hermes --version",
-    expectedVersion: name === "openclaw" ? "2026.4.9" : "2026.4.9",
+    expectedVersion: name === "openclaw" ? "2026.4.24" : "2026.4.24",
     stateDirs: [],
     configPaths: { writableDir: "/sandbox/.openclaw-data" },
   })),
@@ -76,12 +76,12 @@ describe("checkAgentVersion", () => {
     registry.registerSandbox({
       name: "test-sb",
       agent: null,
-      agentVersion: "2026.4.9",
+      agentVersion: "2026.4.24",
     });
 
     const result = checkAgentVersion("test-sb");
     expect(result.detectionMethod).toBe("registry");
-    expect(result.sandboxVersion).toBe("2026.4.9");
+    expect(result.sandboxVersion).toBe("2026.4.24");
     expect(result.isStale).toBe(false);
   });
 
@@ -102,7 +102,7 @@ describe("checkAgentVersion", () => {
     registry.registerSandbox({
       name: "test-sb",
       agent: null,
-      agentVersion: "2026.4.9",
+      agentVersion: "2026.4.24",
     });
 
     const result = checkAgentVersion("test-sb");
@@ -119,7 +119,7 @@ describe("checkAgentVersion", () => {
 
     vi.mocked(spawnSync).mockReturnValue({
       status: 0,
-      stdout: "OpenClaw 2026.4.9 (abc123)\n",
+      stdout: "OpenClaw 2026.4.24 (abc123)\n",
       stderr: "",
       pid: 1234,
       output: [],
@@ -128,12 +128,12 @@ describe("checkAgentVersion", () => {
 
     const result = checkAgentVersion("test-sb");
     expect(result.detectionMethod).toBe("ssh-exec");
-    expect(result.sandboxVersion).toBe("2026.4.9");
+    expect(result.sandboxVersion).toBe("2026.4.24");
     expect(result.isStale).toBe(false);
 
     // Should have cached the version in registry
     const updated = registry.getSandbox("test-sb");
-    expect(updated?.agentVersion).toBe("2026.4.9");
+    expect(updated?.agentVersion).toBe("2026.4.24");
   });
 
   it("returns unavailable when SSH config fails", () => {
@@ -163,7 +163,7 @@ describe("checkAgentVersion", () => {
 
     vi.mocked(spawnSync).mockReturnValue({
       status: 0,
-      stdout: "OpenClaw 2026.4.9 (abc123)\n",
+      stdout: "OpenClaw 2026.4.24 (abc123)\n",
       stderr: "",
       pid: 1234,
       output: [],
@@ -172,7 +172,7 @@ describe("checkAgentVersion", () => {
 
     const result = checkAgentVersion("test-sb", { forceProbe: true });
     expect(result.detectionMethod).toBe("ssh-exec");
-    expect(result.sandboxVersion).toBe("2026.4.9");
+    expect(result.sandboxVersion).toBe("2026.4.24");
   });
 });
 
@@ -199,14 +199,14 @@ describe("formatStalenessWarning", () => {
   it("includes sandbox name, versions, and rebuild hint", () => {
     const lines = formatStalenessWarning("my-sb", {
       sandboxVersion: "2026.3.11",
-      expectedVersion: "2026.4.9",
+      expectedVersion: "2026.4.24",
       isStale: true,
       detectionMethod: "registry",
     });
     const joined = lines.join("\n");
     expect(joined).toContain("my-sb");
     expect(joined).toContain("2026.3.11");
-    expect(joined).toContain("2026.4.9");
+    expect(joined).toContain("2026.4.24");
     expect(joined).toContain("rebuild");
   });
 });


### PR DESCRIPTION
## Summary

- Bumps the pinned OpenClaw version from **2026.4.9** to **2026.4.24** (latest stable release, CalVer 2026.4.24)
- Updates version references in `Dockerfile.base`, `nemoclaw-blueprint/blueprint.yaml`, `agents/openclaw/manifest.yaml`, and `src/lib/sandbox-version.test.ts`
- NemoClaw does **not** use the deprecated `registerEmbeddedExtensionFactory` Plugin SDK API, so the 2026.4.24 breaking change does not directly affect plugin registration

### Notable upstream changes (2026.4.9 → 2026.4.24)

- Google Meet integration as a bundled plugin
- DeepSeek V4 Flash/Pro models added to the bundled catalog
- Realtime voice loops (Talk, Voice Call, Google Meet)
- WebRTC sessions backed by OpenAI Realtime
- Gemini Live realtime voice provider
- Browser automation improvements (coordinate clicks, 60s action budgets, tab recovery)
- Lighter startup (static model catalogs, manifest-backed model rows, lazy provider deps)
- **Breaking:** Plugin SDK tool-result transforms migrated from `registerEmbeddedExtensionFactory()` to `registerAgentToolResultMiddleware()` — verified NemoClaw does not use either API
- Heartbeat prompt injection fix
- MCP session idle eviction for resource leaks
- Gateway crash recovery improvements
- Stale Chromium lock recovery
- Slack message ordering fix

### Risk areas to verify

1. **Dockerfile patches** — Patches 1–4 in the `Dockerfile` grep for specific function names in OpenClaw's compiled dist (`withStrictGuardedFetchMode`, `assertExplicitProxyAllowed`, `replaceConfigFile`, `install-safe-path`). These patches fail-close: if the symbols were renamed or removed in 2026.4.24, the Docker build will abort. **CI must pass the Docker build to confirm patch compatibility.**
2. **Exec approvals path** — Both `Dockerfile.base` and `Dockerfile` patch the exec approvals path. Verify the dist bundle still uses the expected path pattern.
3. **Blueprint digest** — The `blueprint.yaml` `digest` and `components.sandbox.image` digest are unchanged; they will need updating once the base image is rebuilt with the new OpenClaw version.

## Test plan

- [ ] CI passes lint, typecheck, and unit tests
- [ ] Docker base image build (`Dockerfile.base`) succeeds with `OPENCLAW_VERSION=2026.4.24`
- [ ] Docker sandbox image build (`Dockerfile`) succeeds — all four dist patches apply cleanly
- [ ] E2E tests pass on a Brev instance with the new image
- [ ] Manual smoke test: `nemoclaw onboard` + sandbox start + basic agent interaction