### PR TITLE
feat(security): runtime gateway token injection

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -209,19 +209,22 @@ The container mounts system directories read-only to prevent the agent from modi
 
 ### Read-Only `.openclaw` Config
 
-The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration, including auth tokens and CORS settings.
-The container mounts it read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
+The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
+The gateway auth token is **not** baked into the Docker image — it is generated uniquely at each container startup. In root mode, the token is injected into `openclaw.json` before the config is locked with `chattr +i`. In non-root mode, the token is delivered via the `OPENCLAW_GATEWAY_TOKEN` environment variable. Both modes also persist the token to rc files and `/tmp/nemoclaw-gateway-token.env` so interactive sessions (`openclaw tui` via `openshell sandbox connect`) can authenticate.
+
+The container mounts `.openclaw` read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
 
 Multiple defense layers protect this directory:
 
 - **DAC permissions.** Root owns the directory and `openclaw.json` with `chmod 444`, so the sandbox user cannot write to them.
 - **Immutable flag.** The entrypoint applies `chattr +i` to the directory and all symlinks, preventing modification even if other controls fail.
 - **Symlink validation.** At startup, the entrypoint verifies every symlink in `.openclaw` points to the expected `.openclaw-data` target. If any symlink points elsewhere, the container refuses to start.
-- **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match.
+- **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match. Runtime token injection recomputes the hash.
+- **Runtime token generation.** The gateway auth token is not stored in Docker image layers. Each container generates a unique token at startup, preventing token reuse across instances built from the same image.
 
 | Aspect | Detail |
 |---|---|
-| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. |
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is generated per container start and injected into `openclaw.json` (root mode) before locking. In non-root mode the token is delivered via env var only. |
 | What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
 | Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS, changing auth tokens, or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
 | Recommendation | Never make `/sandbox/.openclaw` writable. |

--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -210,7 +210,10 @@ The container mounts system directories read-only to prevent the agent from modi
 ### Read-Only `.openclaw` Config
 
 The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
-The gateway auth token is **not** baked into the Docker image — it is generated uniquely at each container startup. In root mode, the token is injected into `openclaw.json` before the config is locked with `chattr +i`. In non-root mode, the token is delivered via the `OPENCLAW_GATEWAY_TOKEN` environment variable. Both modes also persist the token to rc files and `/tmp/nemoclaw-gateway-token.env` so interactive sessions (`openclaw tui` via `openshell sandbox connect`) can authenticate.
+The gateway auth token is generated uniquely at each container startup, not baked into the Docker image.
+In root mode, the entrypoint injects the token into `openclaw.json` before the config is locked with `chattr +i`.
+In non-root mode, the entrypoint delivers the token via the `OPENCLAW_GATEWAY_TOKEN` environment variable.
+Both modes also persist the token to rc files and `/tmp/nemoclaw-gateway-token.env` so interactive sessions (`openclaw tui` via `openshell sandbox connect`) can authenticate.
 
 The container mounts `.openclaw` read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
 
@@ -224,7 +227,7 @@ Multiple defense layers protect this directory:
 
 | Aspect | Detail |
 |---|---|
-| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is generated per container start and injected into `openclaw.json` (root mode) before locking. In non-root mode the token is delivered via env var only. |
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is generated per container start and injected into `openclaw.json` (root mode) before locking; in non-root mode the token is delivered via env var only. |
 | What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
 | Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS, changing auth tokens, or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
 | Recommendation | Never make `/sandbox/.openclaw` writable. |

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -15,6 +15,10 @@
 #                            probe → live inference. Validates the multi-agent architecture.
 #   skip-permissions-e2e     Validates --dangerously-skip-permissions activates the permissive
 #                            policy (not stuck in Pending) and sandbox egress works (not 403).
+#   gateway-token-upgrade-e2e Gateway auth token upgrade — `openclaw tui` works on the
+#                            pre-PR build-baked design AND after rebuilding to the
+#                            runtime-injected design (issue #2480). Token must rotate
+#                            on container restart.
 #   gpu-e2e                  Local Ollama inference on a GPU self-hosted runner.
 #                            Controlled by the GPU_E2E_ENABLED repository variable.
 #                            Set vars.GPU_E2E_ENABLED to "true" in repo settings to enable.
@@ -483,6 +487,40 @@ jobs:
             /tmp/nemoclaw-e2e-upgrade-install.log
           if-no-files-found: ignore
 
+  # ── Gateway-token upgrade E2E (#2480) ────────────────────────
+  # Proves `openclaw tui` keeps working across the build-baked-token
+  # → runtime-injected-token transition. Builds a sandbox at the
+  # pre-PR commit (token baked via secrets.token_hex), runs TUI as a
+  # canary, rebuilds with current source, runs TUI again, and checks
+  # the token rotates on restart (runtime mechanism). Needs deeper
+  # git history than the default shallow checkout to reach the pre-ref.
+  gateway-token-upgrade-e2e:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gateway-token upgrade E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-gateway-token-upgrade"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-gateway-token-upgrade.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gateway-token-upgrade-install-log
+          path: /tmp/nemoclaw-e2e-install.log
+          if-no-files-found: ignore
+
   # ── Hermes rebuild upgrade E2E ──────────────────────────────
   # Same upgrade scenario as OpenClaw but for Hermes Agent.
   rebuild-hermes-e2e:
@@ -613,6 +651,7 @@ jobs:
         shields-config-e2e,
         rebuild-openclaw-e2e,
         upgrade-stale-sandbox-e2e,
+        gateway-token-upgrade-e2e,
         rebuild-hermes-e2e,
         overlayfs-autofix-e2e,
         gpu-e2e,

--- a/Dockerfile
+++ b/Dockerfile
@@ -227,8 +227,9 @@ ARG NEMOCLAW_DISCORD_GUILDS_B64=e30=
 # Set to "1" to disable device-pairing auth (development/headless only).
 # Default: "0" (device auth enabled — secure by default).
 ARG NEMOCLAW_DISABLE_DEVICE_AUTH=0
-# Unique per build to ensure each image gets a fresh auth token.
+# Unique per build to bust Docker cache for config materialization layers.
 # Pass --build-arg NEMOCLAW_BUILD_ID=$(date +%s) to bust the cache.
+# Gateway auth token is generated at container startup by the entrypoint.
 ARG NEMOCLAW_BUILD_ID=default
 # Sandbox egress proxy host/port. Defaults match the OpenShell-injected
 # gateway (10.200.0.1:3128). Operators on non-default networks can override
@@ -267,11 +268,11 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
 WORKDIR /sandbox
 USER sandbox
 
-# Write the COMPLETE openclaw.json including gateway config and auth token.
-# This file is immutable at runtime (Landlock read-only on /sandbox/.openclaw).
-# No runtime writes to openclaw.json are needed or possible.
+# Write openclaw.json with gateway config but WITHOUT the real auth token.
+# The gateway auth token is generated at container startup by the entrypoint
+# and injected into openclaw.json (root mode) or delivered via env var (non-root).
 # Build args (NEMOCLAW_MODEL, CHAT_UI_URL) customize per deployment.
-# Auth token is generated per build so each image has a unique token.
+# See: scripts/nemoclaw-start.sh inject_gateway_token() / export_gateway_token()
 #
 # Temporary workaround for NemoClaw#1738: the OpenClaw Discord extension's
 # gateway uses `ws` (via @buape/carbon), which ignores HTTPS_PROXY/HTTP_PROXY
@@ -284,7 +285,7 @@ USER sandbox
 # Remove once OpenClaw lands an env-var-honouring fix for the Discord
 # gateway equivalent to openclaw/openclaw#62878 (Slack Socket Mode).
 RUN NEMOCLAW_BUILD_ID="${NEMOCLAW_BUILD_ID}" python3 -c "\
-import base64, json, os, secrets; \
+import base64, json, os; \
 from urllib.parse import urlparse; \
 proxy_url = f\"http://{os.environ['NEMOCLAW_PROXY_HOST']}:{os.environ['NEMOCLAW_PROXY_PORT']}\"; \
 model = os.environ['NEMOCLAW_MODEL']; \
@@ -333,7 +334,7 @@ config = { \
             'allowedOrigins': origins, \
         }, \
         'trustedProxies': ['127.0.0.1', '::1'], \
-        'auth': {'token': secrets.token_hex(32)} \
+        'auth': {'token': ''} \
     } \
 }; \
 config.update({ \
@@ -355,6 +356,17 @@ os.chmod(path, 0o600)"
 # Install NemoClaw plugin into OpenClaw
 RUN openclaw doctor --fix > /dev/null 2>&1 || true \
     && openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true
+
+# SECURITY: Clear any gateway auth token that openclaw doctor/plugins may have
+# auto-generated. The real token is injected at container startup by the
+# entrypoint (inject_gateway_token / export_gateway_token).
+RUN python3 -c "\
+import json, os; \
+path = os.path.expanduser('~/.openclaw/openclaw.json'); \
+cfg = json.load(open(path)); \
+cfg.setdefault('gateway', {}).setdefault('auth', {})['token'] = ''; \
+json.dump(cfg, open(path, 'w'), indent=2); \
+os.chmod(path, 0o600)"
 
 # Lock openclaw.json via DAC: chown to root so the sandbox user cannot modify
 # it at runtime.  This works regardless of Landlock enforcement status.

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -230,7 +230,10 @@ The container mounts system directories read-only to prevent the agent from modi
 ### Read-Only `.openclaw` Config
 
 The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
-The gateway auth token is **not** baked into the Docker image — it is generated uniquely at each container startup. In root mode, the token is injected into `openclaw.json` before the config is locked with `chattr +i`. In non-root mode, the token is delivered via the `OPENCLAW_GATEWAY_TOKEN` environment variable. Both modes also persist the token to rc files and `/tmp/nemoclaw-gateway-token.env` so interactive sessions (`openclaw tui` via `openshell sandbox connect`) can authenticate.
+The gateway auth token is generated uniquely at each container startup, not baked into the Docker image.
+In root mode, the entrypoint injects the token into `openclaw.json` before the config is locked with `chattr +i`.
+In non-root mode, the entrypoint delivers the token via the `OPENCLAW_GATEWAY_TOKEN` environment variable.
+Both modes also persist the token to rc files and `/tmp/nemoclaw-gateway-token.env` so interactive sessions (`openclaw tui` via `openshell sandbox connect`) can authenticate.
 
 The container mounts `.openclaw` read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
 
@@ -244,7 +247,7 @@ Multiple defense layers protect this directory:
 
 | Aspect | Detail |
 |---|---|
-| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is generated per container start and injected into `openclaw.json` (root mode) before locking. In non-root mode the token is delivered via env var only. |
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is generated per container start and injected into `openclaw.json` (root mode) before locking; in non-root mode the token is delivered via env var only. |
 | What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
 | Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS, changing auth tokens, or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
 | Recommendation | Never make `/sandbox/.openclaw` writable. |

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -229,19 +229,22 @@ The container mounts system directories read-only to prevent the agent from modi
 
 ### Read-Only `.openclaw` Config
 
-The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration, including auth tokens and CORS settings.
-The container mounts it read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
+The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
+The gateway auth token is **not** baked into the Docker image — it is generated uniquely at each container startup. In root mode, the token is injected into `openclaw.json` before the config is locked with `chattr +i`. In non-root mode, the token is delivered via the `OPENCLAW_GATEWAY_TOKEN` environment variable. Both modes also persist the token to rc files and `/tmp/nemoclaw-gateway-token.env` so interactive sessions (`openclaw tui` via `openshell sandbox connect`) can authenticate.
+
+The container mounts `.openclaw` read-only while writable agent state (plugins, agent data) lives in `/sandbox/.openclaw-data` through symlinks.
 
 Multiple defense layers protect this directory:
 
 - **DAC permissions.** Root owns the directory and `openclaw.json` with `chmod 444`, so the sandbox user cannot write to them.
 - **Immutable flag.** The entrypoint applies `chattr +i` to the directory and all symlinks, preventing modification even if other controls fail.
 - **Symlink validation.** At startup, the entrypoint verifies every symlink in `.openclaw` points to the expected `.openclaw-data` target. If any symlink points elsewhere, the container refuses to start.
-- **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match.
+- **Config integrity hash.** The build process pins a SHA256 hash of `openclaw.json`. The entrypoint verifies it at startup and refuses to start if the hash does not match. Runtime token injection recomputes the hash.
+- **Runtime token generation.** The gateway auth token is not stored in Docker image layers. Each container generates a unique token at startup, preventing token reuse across instances built from the same image.
 
 | Aspect | Detail |
 |---|---|
-| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. |
+| Default | The container mounts `/sandbox/.openclaw` as read-only, root-owned, immutable, and integrity-verified at startup. `/sandbox/.openclaw-data` remains writable. The gateway auth token is generated per container start and injected into `openclaw.json` (root mode) before locking. In non-root mode the token is delivered via env var only. |
 | What you can change | Move `/sandbox/.openclaw` from `read_only` to `read_write` in the policy file. |
 | Risk if relaxed | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS, changing auth tokens, or redirecting inference to an attacker-controlled endpoint. This is the single most dangerous filesystem change. |
 | Recommendation | Never make `/sandbox/.openclaw` writable. |

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -674,8 +674,11 @@ inject_gateway_token() {
     return 1
   fi
 
+  # Atomic write: temp file in same dir → fsync → os.replace, so an
+  # interrupt mid-write can't leave the integrity-pinned config truncated
+  # (which would brick the next boot via verify_config_integrity).
   python3 - "$config_file" "$token" <<'PYINJECT'
-import json, sys
+import json, os, sys, tempfile
 
 config_file, token = sys.argv[1], sys.argv[2]
 
@@ -684,11 +687,24 @@ with open(config_file) as f:
 
 cfg.setdefault("gateway", {}).setdefault("auth", {})["token"] = token
 
-with open(config_file, "w") as f:
-    json.dump(cfg, f, indent=2)
+dir_name = os.path.dirname(config_file) or "."
+fd, tmp_path = tempfile.mkstemp(dir=dir_name, prefix=".openclaw.json.")
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.chmod(tmp_path, 0o444)
+    os.replace(tmp_path, config_file)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except FileNotFoundError:
+        pass
+    raise
 PYINJECT
 
-  # Recompute config hash after injection.
+  # Recompute config hash after the atomic replace lands.
   (cd /sandbox/.openclaw && sha256sum openclaw.json >"$hash_file")
   printf '[token] Gateway auth token injected into openclaw.json (hash recomputed)\n' >&2
 }
@@ -716,6 +732,10 @@ export_gateway_token() {
 
   if [ -z "$token" ]; then
     unset OPENCLAW_GATEWAY_TOKEN
+    # Drop the /tmp token file too — proxy-env.sh sources it on every
+    # connect session, so a leftover would resurrect the previous
+    # credential and break TUI auth with a stale value.
+    rm -f "$_GATEWAY_TOKEN_ENV_FILE" 2>/dev/null || true
     for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
       if [ -f "$rc_file" ] && grep -qF "$marker_begin" "$rc_file" 2>/dev/null; then
         local tmp

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -674,9 +674,11 @@ inject_gateway_token() {
     return 1
   fi
 
-  # Atomic write: temp file in same dir → fsync → os.replace, so an
-  # interrupt mid-write can't leave the integrity-pinned config truncated
-  # (which would brick the next boot via verify_config_integrity).
+  # Atomic write: temp file in same dir → fsync file → os.replace →
+  # fsync parent dir, so an interrupt mid-write can't leave the
+  # integrity-pinned config truncated, AND a crash between the rename
+  # and the next sha256sum can't leave a stale directory entry
+  # alongside a fresh hash file (which would brick verify_config_integrity).
   python3 - "$config_file" "$token" <<'PYINJECT'
 import json, os, sys, tempfile
 
@@ -688,20 +690,27 @@ with open(config_file) as f:
 cfg.setdefault("gateway", {}).setdefault("auth", {})["token"] = token
 
 dir_name = os.path.dirname(config_file) or "."
-fd, tmp_path = tempfile.mkstemp(dir=dir_name, prefix=".openclaw.json.")
+dir_fd = os.open(dir_name, os.O_RDONLY)
 try:
-    with os.fdopen(fd, "w") as f:
-        json.dump(cfg, f, indent=2)
-        f.flush()
-        os.fsync(f.fileno())
-    os.chmod(tmp_path, 0o444)
-    os.replace(tmp_path, config_file)
-except Exception:
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, prefix=".openclaw.json.")
     try:
-        os.unlink(tmp_path)
-    except FileNotFoundError:
-        pass
-    raise
+        with os.fdopen(fd, "w") as f:
+            json.dump(cfg, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o444)
+        os.replace(tmp_path, config_file)
+        # Persist the directory entry so the rename survives a crash
+        # before the subsequent .config-hash write.
+        os.fsync(dir_fd)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
+finally:
+    os.close(dir_fd)
 PYINJECT
 
   # Recompute config hash after the atomic replace lands.

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -600,8 +600,37 @@ SLACK_GUARD_EOF
   printf '[channels] Slack channel guard installed (NODE_OPTIONS updated)\n' >&2
 }
 
+# ── Gateway auth token (runtime injection) ───────────────────────
+# The gateway auth token is NOT baked into the Docker image. It is
+# generated at container startup so each container instance gets a
+# unique token (not shared across images, not in Docker layer history).
+#
+# Token delivery depends on startup mode:
+#
+#   Root mode:
+#     1. inject_gateway_token: generate token, write into openclaw.json
+#        before chattr +i — openclaw tui reads this via config natively.
+#     2. export_gateway_token: export OPENCLAW_GATEWAY_TOKEN env var +
+#        persist to rc files + /tmp token file (belt-and-suspenders).
+#
+#   Non-root mode:
+#     1. export_gateway_token: generate token, export env var, persist
+#        to rc files + /tmp token file. Cannot write openclaw.json
+#        (root:root 444). Gateway and TUI both read from env var.
+#
+# OpenClaw 2026.4.9 resolution order:
+#   OPENCLAW_GATEWAY_TOKEN env var → --token flag → gateway.auth.token
+#   in config → secret provider.
+#
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/2480
+_GATEWAY_TOKEN_ENV_FILE="/tmp/nemoclaw-gateway-token.env"
+
 _read_gateway_token() {
-  python3 - <<'PYTOKEN'
+  # Read the gateway token from openclaw.json, falling back to env var.
+  # Returns the token on stdout; empty output means no token.
+  local token
+  token="$(
+    python3 - <<'PYTOKEN'
 import json
 try:
     with open('/sandbox/.openclaw/openclaw.json') as f:
@@ -610,17 +639,81 @@ try:
 except Exception:
     print('')
 PYTOKEN
+  )"
+  if [ -n "$token" ]; then
+    printf '%s' "$token"
+  else
+    printf '%s' "${OPENCLAW_GATEWAY_TOKEN:-}"
+  fi
 }
 
+# Inject a runtime-generated token into openclaw.json so openclaw tui
+# and other OpenClaw tools read it from the config natively.
+# Root-only: non-root cannot write to openclaw.json (root:root 444).
+# Must run AFTER verify_config_integrity and BEFORE chattr +i.
+inject_gateway_token() {
+  [ "$(id -u)" -eq 0 ] || {
+    printf '[token] inject_gateway_token requires root — non-root uses env var path\n' >&2
+    return 0
+  }
+
+  local config_file="/sandbox/.openclaw/openclaw.json"
+  local hash_file="/sandbox/.openclaw/.config-hash"
+
+  # SECURITY: Refuse to write through symlinks.
+  if [ -L "$config_file" ] || [ -L "$hash_file" ]; then
+    printf '[SECURITY] Refusing token injection — config or hash path is a symlink\n' >&2
+    return 1
+  fi
+
+  local token
+  token="$(python3 -c "import secrets; print(secrets.token_hex(32), end='')")"
+  if [ -z "$token" ]; then
+    printf '[SECURITY] Failed to generate gateway token\n' >&2
+    return 1
+  fi
+
+  python3 - "$config_file" "$token" <<'PYINJECT'
+import json, sys
+
+config_file, token = sys.argv[1], sys.argv[2]
+
+with open(config_file) as f:
+    cfg = json.load(f)
+
+cfg.setdefault("gateway", {}).setdefault("auth", {})["token"] = token
+
+with open(config_file, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYINJECT
+
+  # Recompute config hash after injection.
+  (cd /sandbox/.openclaw && sha256sum openclaw.json >"$hash_file")
+  printf '[token] Gateway auth token injected into openclaw.json (hash recomputed)\n' >&2
+}
+
+# Export the gateway token to the process env, rc files, and a /tmp
+# sourced file so interactive sessions (openclaw tui via openshell sandbox
+# connect) inherit it. In non-root mode when openclaw.json has no token,
+# generates a fresh one for env-var-only delivery.
 export_gateway_token() {
   local token
   token="$(_read_gateway_token)"
+
+  # Non-root fallback: openclaw.json has empty token (root-only injection
+  # could not write). Generate one for env-var delivery (OpenClaw reads
+  # OPENCLAW_GATEWAY_TOKEN env var first).
+  if [ -z "$token" ] && [ "$(id -u)" -ne 0 ]; then
+    token="$(python3 -c "import secrets; print(secrets.token_hex(32), end='')")"
+    if [ -n "$token" ]; then
+      printf '[token] Non-root: generated gateway token for env-var delivery\n' >&2
+    fi
+  fi
+
   local marker_begin="# nemoclaw-gateway-token begin"
   local marker_end="# nemoclaw-gateway-token end"
 
   if [ -z "$token" ]; then
-    # Remove any stale marker blocks from rc files so revoked/old tokens
-    # are not re-exported in later interactive sessions.
     unset OPENCLAW_GATEWAY_TOKEN
     for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
       if [ -f "$rc_file" ] && grep -qF "$marker_begin" "$rc_file" 2>/dev/null; then
@@ -639,10 +732,7 @@ export_gateway_token() {
   fi
   export OPENCLAW_GATEWAY_TOKEN="$token"
 
-  # Persist to .bashrc/.profile so interactive sessions (openshell sandbox
-  # connect) also see the token — same pattern as the proxy config above.
-  # Shell-escape the token so quotes/dollars/backticks cannot break the
-  # sourced snippet or allow code injection.
+  # Shell-escape the token to prevent code injection.
   local escaped_token
   escaped_token="$(printf '%s' "$token" | sed "s/'/'\\\\''/g")"
   local snippet
@@ -650,6 +740,7 @@ export_gateway_token() {
 export OPENCLAW_GATEWAY_TOKEN='${escaped_token}'
 ${marker_end}"
 
+  # Persist to rc files (best-effort — Landlock may block writes).
   for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
     [ -f "$rc_file" ] || continue
     # All writes use || true because Landlock may block writes even though
@@ -669,6 +760,15 @@ ${marker_end}"
       printf '\n%s\n' "$snippet" >>"$rc_file" 2>/dev/null || true
     fi
   done
+
+  # Belt-and-suspenders: write to /tmp file sourced by proxy-env.sh.
+  # This survives Landlock-blocked rc-file writes in non-root mode.
+  printf 'export OPENCLAW_GATEWAY_TOKEN='\''%s'\''\n' "$escaped_token" \
+    | emit_sandbox_sourced_file "$_GATEWAY_TOKEN_ENV_FILE"
+  printf '[token] Gateway token exported to env, rc files, and %s\n' "$_GATEWAY_TOKEN_ENV_FILE" >&2
+
+  # Best-effort lock — Landlock may already enforce read-only.
+  lock_rc_files "$_SANDBOX_HOME"
 }
 
 install_configure_guard() {
@@ -1389,6 +1489,11 @@ PROXYEOF
   for _redir in "${_TOOL_REDIRECTS[@]}"; do
     echo "export ${_redir?}"
   done
+  # Gateway auth token for connect sessions. The token file is written later
+  # by export_gateway_token() — conditional source ensures no failure if the
+  # file doesn't exist yet (e.g., first boot before export_gateway_token runs).
+  echo "# Gateway auth token for openclaw tui in connect sessions (#2480)"
+  echo "[ -f \"$_GATEWAY_TOKEN_ENV_FILE\" ] && . \"$_GATEWAY_TOKEN_ENV_FILE\""
 } | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"
 
 # cleanup_on_signal is provided by sandbox-init.sh. It reads
@@ -1508,7 +1613,7 @@ if [ "$(id -u)" -ne 0 ]; then
   # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
   # (both are trust-boundary files; tampering would let the sandbox user
   # inject code into any Node process via NODE_OPTIONS).
-  validate_tmp_permissions "$_SANDBOX_SAFETY_NET" "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_CIAO_GUARD_SCRIPT" "$_SLACK_GUARD_SCRIPT"
+  validate_tmp_permissions "$_SANDBOX_SAFETY_NET" "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_CIAO_GUARD_SCRIPT" "$_SLACK_GUARD_SCRIPT" "$_GATEWAY_TOKEN_ENV_FILE"
 
   # Start gateway in background, auto-pair, then wait
   nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
@@ -1536,6 +1641,7 @@ verify_config_integrity /sandbox/.openclaw
 apply_model_override
 apply_cors_override
 apply_slack_token_override
+inject_gateway_token
 export_gateway_token
 install_configure_guard
 
@@ -1646,7 +1752,7 @@ harden_openclaw_symlinks
 # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
 # (both are trust-boundary files; tampering would let the sandbox user
 # inject code into any Node process via NODE_OPTIONS).
-validate_tmp_permissions "$_SANDBOX_SAFETY_NET" "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_CIAO_GUARD_SCRIPT" "$_SLACK_GUARD_SCRIPT"
+validate_tmp_permissions "$_SANDBOX_SAFETY_NET" "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_CIAO_GUARD_SCRIPT" "$_SLACK_GUARD_SCRIPT" "$_GATEWAY_TOKEN_ENV_FILE"
 
 # Start the gateway as the 'gateway' user.
 # SECURITY: The sandbox user cannot kill this process because it runs

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6088,9 +6088,14 @@ function fetchGatewayAuthTokenFromSandbox(sandboxName: string): string | null {
     if (result.status === 0) {
       const jsonPath = findOpenclawJsonPath(tmpDir);
       if (jsonPath) {
-        const cfg = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
-        const token = cfg && cfg.gateway && cfg.gateway.auth && cfg.gateway.auth.token;
-        if (typeof token === "string" && token.length > 0) return token;
+        try {
+          const cfg = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+          const token = cfg && cfg.gateway && cfg.gateway.auth && cfg.gateway.auth.token;
+          if (typeof token === "string" && token.length > 0) return token;
+        } catch {
+          // openclaw.json unreadable or malformed — fall through to the
+          // env-file fallback rather than aborting both retrieval paths.
+        }
       }
     }
 
@@ -6356,10 +6361,10 @@ function printDashboard(
       console.log(`  ${entry.label}: ${entry.url}`);
     }
     console.log(
-      `  Token:       see /tmp/gateway.log inside the sandbox, or re-run onboard.`,
+      `  Token:       run \`cat /tmp/nemoclaw-gateway-token.env\` inside the sandbox, or re-run onboard.`,
     );
     console.log(
-      `               append  #token=<token>  to the URL, or see /tmp/gateway.log inside the sandbox.`,
+      `               append  #token=<token>  to the URL, or inspect /tmp/nemoclaw-gateway-token.env inside the sandbox.`,
     );
   }
   console.log(`  ${"─".repeat(50)}`);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6791,6 +6791,21 @@ function ensureDashboardForward(
   }
 }
 
+function findFileRecursive(dir: string, filename: string): string | null {
+  if (!fs.existsSync(dir)) return null;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      const found = findFileRecursive(p, filename);
+      if (found) return found;
+    } else if (e.name === filename) {
+      return p;
+    }
+  }
+  return null;
+}
+
 function findOpenclawJsonPath(dir: string): string | null {
   if (!fs.existsSync(dir)) return null;
   const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -6807,23 +6822,51 @@ function findOpenclawJsonPath(dir: string): string | null {
 }
 
 /**
- * Pull gateway.auth.token from the sandbox image via openshell sandbox download
- * so onboard can print copy-paste Control UI URLs with #token= (same idea as nemoclaw-start.sh).
+ * Pull gateway auth token from the sandbox.
+ *
+ * Tries two retrieval paths in order:
+ *  1. sandbox download openclaw.json → gateway.auth.token  (root mode — injected at startup)
+ *  2. sandbox download /tmp/nemoclaw-gateway-token.env  (non-root mode — env file)
+ *
+ * Path 1 works for root mode where inject_gateway_token writes the token
+ * into openclaw.json before chattr +i locks the config.
+ * Path 2 works for non-root mode where export_gateway_token writes the
+ * token to a /tmp file sourced by proxy-env.sh.
  */
 function fetchGatewayAuthTokenFromSandbox(sandboxName: string): string | null {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
   try {
     const destDir = `${tmpDir}${path.sep}`;
+
+    // 1. openclaw.json (root mode: token injected at startup)
     const result = runOpenshell(
       ["sandbox", "download", sandboxName, "/sandbox/.openclaw/openclaw.json", destDir],
       { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },
     );
-    if (result.status !== 0) return null;
-    const jsonPath = findOpenclawJsonPath(tmpDir);
-    if (!jsonPath) return null;
-    const cfg = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
-    const token = cfg && cfg.gateway && cfg.gateway.auth && cfg.gateway.auth.token;
-    return typeof token === "string" && token.length > 0 ? token : null;
+    if (result.status === 0) {
+      const jsonPath = findOpenclawJsonPath(tmpDir);
+      if (jsonPath) {
+        const cfg = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+        const token = cfg && cfg.gateway && cfg.gateway.auth && cfg.gateway.auth.token;
+        if (typeof token === "string" && token.length > 0) return token;
+      }
+    }
+
+    // 2. /tmp env file (non-root mode: env-var delivery)
+    const envResult = runOpenshell(
+      ["sandbox", "download", sandboxName, "/tmp/nemoclaw-gateway-token.env", destDir],
+      { ignoreError: true, stdio: ["ignore", "ignore", "ignore"] },
+    );
+    if (envResult.status === 0) {
+      const envPath = findFileRecursive(tmpDir, "nemoclaw-gateway-token.env");
+      if (envPath) {
+        const content = fs.readFileSync(envPath, "utf-8");
+        const match = content.match(/OPENCLAW_GATEWAY_TOKEN='([^']+)'/);
+        if (match && match[1].length > 0) return match[1];
+      }
+    }
+
+    return null;
   } catch {
     return null;
   } finally {
@@ -7080,7 +7123,7 @@ function printDashboard(
       console.log(`  ${entry.label}: ${entry.url}`);
     }
     console.log(
-      `  Token:       nemoclaw ${sandboxName} connect  →  jq -r '.gateway.auth.token' /sandbox/.openclaw/openclaw.json`,
+      `  Token:       see /tmp/gateway.log inside the sandbox, or re-run onboard.`,
     );
     console.log(
       `               append  #token=<token>  to the URL, or see /tmp/gateway.log inside the sandbox.`,

--- a/src/lib/sandbox-build-context.ts
+++ b/src/lib/sandbox-build-context.ts
@@ -79,6 +79,10 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "scripts", "nemoclaw-start.sh"),
     path.join(stagedScriptsDir, "nemoclaw-start.sh"),
   );
+  fs.copyFileSync(
+    path.join(rootDir, "scripts", "generate-openclaw-config.py"),
+    path.join(stagedScriptsDir, "generate-openclaw-config.py"),
+  );
   // Shared sandbox initialisation library sourced by the entrypoint (#2277)
   fs.mkdirSync(path.join(stagedScriptsDir, "lib"), { recursive: true });
   fs.copyFileSync(

--- a/test/e2e/test-gateway-token-upgrade.sh
+++ b/test/e2e/test-gateway-token-upgrade.sh
@@ -77,35 +77,26 @@ if ! git -C "${REPO_ROOT}" cat-file -e "${PRE_REF}^{commit}" 2>/dev/null; then
     || fail "Could not fetch pre-ref ${PRE_REF}"
 fi
 
-# ── tui_smoke: replicates `openclaw tui`'s token resolution and runs
-# the real binary as a canary. The #2480 failure mode was an early
-# "Missing gateway auth token" before any UI work, so we assert both:
-# the token resolves to a 64-hex string, AND `openclaw tui` doesn't
-# emit that error.
+# ── fetch_resolved_token: replicates `openclaw tui`'s token resolution
+# (env var → gateway.auth.token in config) without failing the test on
+# transient errors. Sets RESOLVED_TOKEN on success, leaves it empty on
+# failure. Used by both tui_smoke (assertive) and the rotation poll in
+# Phase 6 (best-effort).
 #
 # Important: `openshell sandbox exec` rejects arguments that contain
 # newlines or carriage returns (gRPC InvalidArgument), so every
 # in-sandbox command here must be a single line.
-tui_smoke() {
+fetch_resolved_token() {
   local sandbox_name="$1"
-  local label="$2"
+  RESOLVED_TOKEN=""
 
-  info "${label}: running TUI smoke test inside ${sandbox_name}..."
-
-  # Step 1a: read OPENCLAW_GATEWAY_TOKEN from a non-interactive shell
-  # the same way `openclaw tui` would (it inherits the env). Single-
-  # line printf so openshell exec's no-newline rule isn't tripped.
+  # 1a: env var the same way `openclaw tui` would inherit it.
   local env_token=""
-  local env_status=0
   # shellcheck disable=SC2016 # ${OPENCLAW_GATEWAY_TOKEN} must expand in-sandbox, not on host.
-  env_token="$(openshell sandbox exec --name "${sandbox_name}" -- bash -lc 'printf %s "${OPENCLAW_GATEWAY_TOKEN:-}"' 2>&1)" || env_status=$?
-  if [ "${env_status}" -ne 0 ]; then
-    echo "${env_token}" | head -20 >&2
-    fail "${label}: env-var probe failed (exit ${env_status})"
-  fi
+  env_token="$(openshell sandbox exec --name "${sandbox_name}" -- bash -lc 'printf %s "${OPENCLAW_GATEWAY_TOKEN:-}"' 2>/dev/null || true)"
 
-  # Step 1b: download openclaw.json and parse on the host. This avoids
-  # multi-line python -c arguments inside openshell exec entirely.
+  # 1b: download openclaw.json and parse on the host (avoids multi-line
+  # python -c arguments inside openshell exec).
   local cfg_token=""
   local fetch_dir
   fetch_dir="$(mktemp -d -t nemoclaw-tui-XXXXXX)"
@@ -118,8 +109,22 @@ tui_smoke() {
   fi
   rm -rf "${fetch_dir}"
 
-  # OpenClaw 2026.4.9 resolution: env var → gateway.auth.token in config.
-  local token="${env_token:-${cfg_token}}"
+  RESOLVED_TOKEN="${env_token:-${cfg_token}}"
+}
+
+# ── tui_smoke: asserts both that token resolution yields a 64-hex
+# string AND that `openclaw tui` doesn't emit "Missing gateway auth
+# token" (the #2480 failure mode).
+tui_smoke() {
+  local sandbox_name="$1"
+  local label="$2"
+
+  info "${label}: running TUI smoke test inside ${sandbox_name}..."
+
+  RESOLVED_TOKEN=""
+  fetch_resolved_token "${sandbox_name}"
+  local token="${RESOLVED_TOKEN}"
+
   if [ -z "${token}" ]; then
     fail "${label}: no token resolvable (env var empty, config token empty) — TUI would fail with 'Missing gateway auth token'"
   fi
@@ -127,9 +132,9 @@ tui_smoke() {
     fail "${label}: resolved token does not match secrets.token_hex(32) format: '${token}'"
   fi
 
-  # Step 2: run `openclaw tui` itself with a 6s timeout and a single-
-  # line bash command (no heredoc). The bug we guard against is a fast
-  # exit with the #2480 error string before any UI work happens.
+  # Run `openclaw tui` itself with a 6s timeout and a single-line bash
+  # command (no heredoc). The bug we guard against is a fast exit with
+  # the #2480 error string before any UI work happens.
   local tui_out
   tui_out="$(openshell sandbox exec --name "${sandbox_name}" -- bash -c 'timeout --preserve-status 6 openclaw tui </dev/null 2>&1 | head -c 8192' 2>&1 || true)"
 
@@ -140,6 +145,31 @@ tui_smoke() {
 
   pass "${label}: TUI startup resolved gateway token (${#token} chars)"
   TUI_RESULT_TOKEN="${token}"
+}
+
+# ── wait_for_token_change: polls fetch_resolved_token until the
+# resolved token differs from the supplied baseline. Returns 0 with
+# RESOLVED_TOKEN set on success, 1 (timed out) otherwise. Use this
+# instead of waiting on `openshell sandbox list` after a restart —
+# `sandbox restart` may return before the pod transitions, so the
+# Ready→Ready window is too narrow to detect reliably.
+wait_for_token_change() {
+  local sandbox_name="$1"
+  local baseline="$2"
+  local timeout_seconds="${3:-90}"
+  local deadline=$(($(date +%s) + timeout_seconds))
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    sleep 5
+    RESOLVED_TOKEN=""
+    fetch_resolved_token "${sandbox_name}"
+    if [ -n "${RESOLVED_TOKEN}" ] \
+      && [ "${RESOLVED_TOKEN}" != "${baseline}" ] \
+      && printf '%s' "${RESOLVED_TOKEN}" | grep -Eq '^[0-9a-fA-F]{64}$'; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 # ── Phase 1: Install current NemoClaw ──────────────────────────────
@@ -208,27 +238,16 @@ openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready" \
 pass "Phase 2: pre-upgrade sandbox running (build-baked token design)"
 
 # ── Phase 3: TUI smoke + capture pre-upgrade token ─────────────────
+# Establish the pre-upgrade baseline. We do *not* exercise a restart
+# here because `openshell sandbox restart` returns before the pod has
+# transitioned, so a "token unchanged across restart" check on a
+# build-baked token is satisfied even when the entrypoint never
+# actually re-runs — false sense of security. The meaningful upgrade
+# proof is the Phase 5/6 pair below: post-upgrade token differs from
+# pre-upgrade, and post-restart token differs from post-upgrade.
 TUI_RESULT_TOKEN=""
 tui_smoke "${SANDBOX_NAME}" "Phase 3 pre-upgrade"
 PRE_TOKEN="${TUI_RESULT_TOKEN}"
-
-# Sanity: in the OLD design the token comes from the Docker layer, so
-# it must be identical across container restarts. Restart and reread to
-# pin down the current behavior we're upgrading away from.
-openshell sandbox restart "${SANDBOX_NAME}" >/dev/null 2>&1 || true
-for _i in $(seq 1 30); do
-  if openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready"; then
-    break
-  fi
-  sleep 5
-done
-TUI_RESULT_TOKEN=""
-tui_smoke "${SANDBOX_NAME}" "Phase 3 pre-upgrade post-restart"
-PRE_TOKEN_AFTER_RESTART="${TUI_RESULT_TOKEN}"
-if [ "${PRE_TOKEN}" != "${PRE_TOKEN_AFTER_RESTART}" ]; then
-  fail "Phase 3: build-baked token unexpectedly changed across restart — PRE_REF may already include runtime injection"
-fi
-pass "Phase 3: pre-upgrade token is stable across restart (build-baked behavior confirmed)"
 
 # Register the sandbox in NemoClaw's registry so `nemoclaw rebuild`
 # treats it as a known sandbox (otherwise the rebuild command refuses).
@@ -321,22 +340,29 @@ pass "Phase 5: host-side gateway-token matches in-sandbox token"
 # ── Phase 6: Token rotates on restart (runtime mechanism) ──────────
 info "Phase 6: Restarting sandbox to confirm runtime token rotation..."
 
+# `openshell sandbox restart` returns before the pod has actually
+# transitioned, and the kubelet may roll quickly enough that a "wait
+# for non-Ready, then Ready" check misses the window entirely. Poll
+# the resolved token directly — the entrypoint regenerates it on
+# every start, so an observed rotation is unambiguous proof the
+# entrypoint re-ran. A 90s deadline tolerates slow node-image pulls
+# without hiding a real "entrypoint never ran" regression.
 openshell sandbox restart "${SANDBOX_NAME}" >/dev/null 2>&1 || true
-for _i in $(seq 1 30); do
-  if openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready"; then
-    break
-  fi
-  sleep 5
-done
 
-TUI_RESULT_TOKEN=""
-tui_smoke "${SANDBOX_NAME}" "Phase 6 post-restart"
-ROTATED_TOKEN="${TUI_RESULT_TOKEN}"
-
-if [ "${ROTATED_TOKEN}" = "${POST_TOKEN}" ]; then
-  fail "Phase 6: token did not rotate across restart — entrypoint inject_gateway_token() did not run"
+RESOLVED_TOKEN=""
+if ! wait_for_token_change "${SANDBOX_NAME}" "${POST_TOKEN}" 90; then
+  fail "Phase 6: token did not rotate within 90s — entrypoint inject_gateway_token() did not re-run, or sandbox restart did not propagate"
 fi
+ROTATED_TOKEN="${RESOLVED_TOKEN}"
 pass "Phase 6: token rotated on restart (runtime injection confirmed)"
+
+# Final TUI smoke against the rotated container — one more guard
+# against a "Missing gateway auth token" regression after restart.
+TUI_RESULT_TOKEN=""
+tui_smoke "${SANDBOX_NAME}" "Phase 6 post-rotation"
+if [ "${TUI_RESULT_TOKEN}" != "${ROTATED_TOKEN}" ]; then
+  fail "Phase 6: TUI-resolved token (${#TUI_RESULT_TOKEN} chars) does not match polled rotated token (${#ROTATED_TOKEN} chars)"
+fi
 
 echo ""
 echo -e "${GREEN}═══════════════════════════════════════════════════════════${NC}"

--- a/test/e2e/test-gateway-token-upgrade.sh
+++ b/test/e2e/test-gateway-token-upgrade.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Gateway-token upgrade E2E — proves `openclaw tui` keeps working
+# across the build-baked-token → runtime-injected-token transition that
+# landed in the runtime-gateway-token PR (issue #2480).
+#
+# `openclaw tui` is the user-visible canary: the original failure mode
+# was "Missing gateway auth token" inside the sandbox, so we run TUI as
+# the proof-of-life for the broader gateway-auth capability.
+#
+#   1. Install current NemoClaw via install.sh.
+#   2. Build a sandbox from the PRE-PR source revision (token baked
+#      into openclaw.json at build time via secrets.token_hex(32)).
+#   3. Drive `openclaw tui` inside that sandbox and capture the token.
+#   4. Rebuild the sandbox using the CURRENT source (runtime injection).
+#   5. Drive `openclaw tui` again — must still authenticate.
+#   6. Restart the sandbox — token must rotate (runtime-generated, not
+#      baked into the image layer).
+#
+# Prerequisites:
+#   - Docker running on the runner.
+#   - NVIDIA_API_KEY set (real key, starts with nvapi-).
+#   - GHCR access for ghcr.io/nvidia/nemoclaw/sandbox-base:latest.
+
+set -euo pipefail
+
+# Last commit before the runtime-gateway-token PR. This is the
+# externalization-revert (PR #2482) so the build still bakes a real
+# token via secrets.token_hex(32) into openclaw.json. If this commit
+# disappears from history (rebased out, etc.), pin a tag instead.
+PRE_REF="${NEMOCLAW_PRE_UPGRADE_REF:-31c782c02732819df86e6af6116e75135cd8b7e2}"
+
+SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-gateway-token-upgrade}"
+
+# shellcheck source=test/e2e/lib/sandbox-teardown.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox-teardown.sh"
+register_sandbox_for_teardown "$SANDBOX_NAME"
+
+REGISTRY_FILE="$HOME/.nemoclaw/sandboxes.json"
+SESSION_FILE="$HOME/.nemoclaw/onboard-session.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() {
+  echo -e "${RED}[FAIL]${NC} $1" >&2
+  echo -e "${YELLOW}[DIAG]${NC} --- Failure diagnostics ---" >&2
+  echo -e "${YELLOW}[DIAG]${NC} Registry: $(cat "${REGISTRY_FILE}" 2>/dev/null || echo 'not found')" >&2
+  echo -e "${YELLOW}[DIAG]${NC} Sandboxes: $(openshell sandbox list 2>&1 || echo 'openshell unavailable')" >&2
+  echo -e "${YELLOW}[DIAG]${NC} Docker: $(docker ps --format '{{.Names}} {{.Image}} {{.Status}}' 2>&1 | head -5)" >&2
+  echo -e "${YELLOW}[DIAG]${NC} --- End diagnostics ---" >&2
+  exit 1
+}
+info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+# ── Preflight ──────────────────────────────────────────────────────
+[ -n "${NVIDIA_API_KEY:-}" ] || fail "NVIDIA_API_KEY is required"
+[ "${NEMOCLAW_NON_INTERACTIVE:-}" = "1" ] || fail "NEMOCLAW_NON_INTERACTIVE=1 is required"
+command -v git >/dev/null 2>&1 || fail "git is required"
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+info "Gateway-token upgrade E2E (pre-ref: ${PRE_REF:0:12}, sandbox: ${SANDBOX_NAME})"
+
+# Ensure the pre-ref is fetchable (CI checkout is shallow by default).
+if ! git -C "${REPO_ROOT}" cat-file -e "${PRE_REF}^{commit}" 2>/dev/null; then
+  info "Pre-ref ${PRE_REF:0:12} not in local history — fetching..."
+  git -C "${REPO_ROOT}" fetch --depth 200 origin "${PRE_REF}" 2>/dev/null \
+    || git -C "${REPO_ROOT}" fetch --unshallow origin 2>/dev/null \
+    || fail "Could not fetch pre-ref ${PRE_REF}"
+fi
+
+# ── tui_smoke: drives `openclaw tui` inside the sandbox and asserts
+# the auth-resolution path works. The original #2480 bug surfaced as
+# "Missing gateway auth token" on stderr — we treat any output that
+# omits that string AND yields a non-empty resolved token as success.
+tui_smoke() {
+  local sandbox_name="$1"
+  local label="$2"
+
+  info "${label}: running TUI smoke test inside ${sandbox_name}..."
+
+  # Step 1: replicate openclaw tui's token resolution exactly so we can
+  # tell a "missing token" failure from a "TUI doesn't like our pty"
+  # failure. Resolution order matches OpenClaw 2026.4.9: env var first,
+  # then gateway.auth.token from config.
+  local resolved
+  resolved="$(openshell sandbox exec --name "${sandbox_name}" -- bash -lc '
+    python3 - <<"PY"
+import json, os, sys
+token = os.environ.get("OPENCLAW_GATEWAY_TOKEN", "")
+if not token:
+    try:
+        with open("/sandbox/.openclaw/openclaw.json") as f:
+            token = json.load(f).get("gateway", {}).get("auth", {}).get("token", "")
+    except Exception:
+        pass
+if not token:
+    print("MISSING_GATEWAY_AUTH_TOKEN", file=sys.stderr)
+    sys.exit(2)
+print(token)
+PY
+  ' 2>&1 || true)"
+
+  if echo "${resolved}" | grep -q "MISSING_GATEWAY_AUTH_TOKEN"; then
+    fail "${label}: token resolution path mirrors 'openclaw tui' and returned empty — TUI would fail with 'Missing gateway auth token'"
+  fi
+
+  # Pull the actual token off the last line (the python script may emit
+  # warnings before printing) and reject anything that doesn't look like
+  # a hex string of plausible length.
+  local token
+  token="$(echo "${resolved}" | tail -n 1)"
+  if [ -z "${token}" ] || [ "${#token}" -lt 16 ]; then
+    fail "${label}: resolved token is empty or implausibly short: '${token}'"
+  fi
+
+  # Step 2: actually start `openclaw tui`. We can't drive it
+  # interactively without a pty, but we can confirm it gets past the
+  # auth-resolution step — the bug we're guarding against was an early
+  # exit with "Missing gateway auth token" before any UI work.
+  local tui_out
+  tui_out="$(openshell sandbox exec --name "${sandbox_name}" -- bash -lc '
+    timeout --preserve-status 6 openclaw tui </dev/null 2>&1 | head -c 8192
+  ' 2>&1 || true)"
+
+  if echo "${tui_out}" | grep -qi "Missing gateway auth token"; then
+    echo "${tui_out}" | head -40 >&2
+    fail "${label}: 'openclaw tui' emitted 'Missing gateway auth token' (#2480 regression)"
+  fi
+
+  pass "${label}: TUI startup resolved gateway token (${#token} chars)"
+  printf '%s' "${token}"
+}
+
+# ── Phase 1: Install current NemoClaw ──────────────────────────────
+info "Phase 1: Installing NemoClaw via install.sh..."
+
+export NEMOCLAW_NON_INTERACTIVE=1
+export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1
+export NEMOCLAW_SANDBOX_NAME="${SANDBOX_NAME}"
+export NEMOCLAW_RECREATE_SANDBOX=1
+export NEMOCLAW_REBUILD_VERBOSE=1
+
+INSTALL_LOG="/tmp/nemoclaw-e2e-install.log"
+if ! bash "${REPO_ROOT}/install.sh" --non-interactive >"$INSTALL_LOG" 2>&1; then
+  info "install.sh exited non-zero (may be expected on re-install). Continuing..."
+fi
+
+if [ -f "$HOME/.bashrc" ]; then
+  # shellcheck source=/dev/null
+  source "$HOME/.bashrc" 2>/dev/null || true
+fi
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+fi
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+command -v nemoclaw >/dev/null 2>&1 || fail "nemoclaw not found on PATH after install"
+command -v openshell >/dev/null 2>&1 || fail "openshell not found on PATH after install"
+pass "NemoClaw installed; gateway running"
+
+# install.sh creates the default sandbox; we replace it with a build
+# from the PRE_REF source tree, but keep the gateway it set up.
+openshell sandbox delete "${SANDBOX_NAME}" 2>/dev/null || true
+
+# ── Phase 2: Build PRE-upgrade sandbox from the old source tree ────
+info "Phase 2: Materializing pre-upgrade source at ${PRE_REF:0:12}..."
+
+WORKTREE_DIR="$(mktemp -d -t nemoclaw-pre-XXXXXX)"
+trap 'git -C "${REPO_ROOT}" worktree remove -f "${WORKTREE_DIR}" 2>/dev/null || true; rm -rf "${WORKTREE_DIR}"' EXIT
+git -C "${REPO_ROOT}" worktree add -f --detach "${WORKTREE_DIR}" "${PRE_REF}" >/dev/null
+
+[ -f "${WORKTREE_DIR}/Dockerfile" ] || fail "Pre-ref worktree is missing Dockerfile — wrong commit?"
+grep -q "secrets.token_hex" "${WORKTREE_DIR}/Dockerfile" \
+  || fail "Pre-ref Dockerfile does not bake a token (expected secrets.token_hex). PRE_REF may be wrong."
+
+info "Phase 2: Creating sandbox from pre-upgrade source..."
+openshell sandbox create \
+  --name "${SANDBOX_NAME}" \
+  --from "${WORKTREE_DIR}/Dockerfile" \
+  --gateway nemoclaw \
+  --no-tty \
+  -- true
+
+for _i in $(seq 1 60); do
+  if openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready"; then
+    break
+  fi
+  sleep 5
+done
+openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready" \
+  || fail "Pre-upgrade sandbox did not reach Ready"
+
+pass "Phase 2: pre-upgrade sandbox running (build-baked token design)"
+
+# ── Phase 3: TUI smoke + capture pre-upgrade token ─────────────────
+PRE_TOKEN="$(tui_smoke "${SANDBOX_NAME}" "Phase 3 pre-upgrade")"
+
+# Sanity: in the OLD design the token comes from the Docker layer, so
+# it must be identical across container restarts. Restart and reread to
+# pin down the current behavior we're upgrading away from.
+openshell sandbox restart "${SANDBOX_NAME}" >/dev/null 2>&1 || true
+for _i in $(seq 1 30); do
+  if openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready"; then
+    break
+  fi
+  sleep 5
+done
+PRE_TOKEN_AFTER_RESTART="$(tui_smoke "${SANDBOX_NAME}" "Phase 3 pre-upgrade post-restart")"
+if [ "${PRE_TOKEN}" != "${PRE_TOKEN_AFTER_RESTART}" ]; then
+  fail "Phase 3: build-baked token unexpectedly changed across restart — PRE_REF may already include runtime injection"
+fi
+pass "Phase 3: pre-upgrade token is stable across restart (build-baked behavior confirmed)"
+
+# Register the sandbox in NemoClaw's registry so `nemoclaw rebuild`
+# treats it as a known sandbox (otherwise the rebuild command refuses).
+python3 - <<PY
+import json, os, datetime
+reg_path = os.path.expanduser("${REGISTRY_FILE}")
+sess_path = os.path.expanduser("${SESSION_FILE}")
+now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.000Z")
+reg = {
+    "sandboxes": {
+        "${SANDBOX_NAME}": {
+            "name": "${SANDBOX_NAME}",
+            "createdAt": now,
+            "model": "nvidia/nemotron-3-super-120b-a12b",
+            "provider": "nvidia-prod",
+            "gpuEnabled": False,
+            "policies": [],
+            "policyTier": None,
+            "agent": None,
+            "agentVersion": "pre-upgrade",
+        }
+    },
+    "defaultSandbox": "${SANDBOX_NAME}",
+}
+os.makedirs(os.path.dirname(reg_path), exist_ok=True)
+with open(reg_path, "w") as f:
+    json.dump(reg, f, indent=2)
+
+complete = {"status": "complete", "startedAt": now, "completedAt": now, "error": None}
+pending = {"status": "pending", "startedAt": None, "completedAt": None, "error": None}
+sess = {
+    "sandboxName": "${SANDBOX_NAME}",
+    "status": "complete",
+    "resumable": True,
+    "lastCompletedStep": "gateway",
+    "failure": None,
+    "steps": {
+        "preflight": complete,
+        "gateway": complete,
+        "sandbox": pending,
+        "provider_selection": pending,
+        "inference": pending,
+        "openclaw": pending,
+        "agent_setup": pending,
+        "policies": pending,
+    },
+}
+with open(sess_path, "w") as f:
+    json.dump(sess, f, indent=2)
+PY
+
+# ── Phase 4: Rebuild using current source (the upgrade) ────────────
+info "Phase 4: Rebuilding sandbox using current source (HEAD)..."
+
+nemoclaw "${SANDBOX_NAME}" rebuild --yes 2>&1 \
+  || fail "Phase 4: nemoclaw rebuild failed"
+
+for _i in $(seq 1 60); do
+  if openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready"; then
+    break
+  fi
+  sleep 5
+done
+openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready" \
+  || fail "Phase 4: post-upgrade sandbox did not reach Ready"
+
+pass "Phase 4: post-upgrade sandbox running (runtime-injection design)"
+
+# ── Phase 5: TUI smoke after upgrade ───────────────────────────────
+POST_TOKEN="$(tui_smoke "${SANDBOX_NAME}" "Phase 5 post-upgrade")"
+
+if [ "${POST_TOKEN}" = "${PRE_TOKEN}" ]; then
+  fail "Phase 5: post-upgrade token equals pre-upgrade token — rebuild reused the old image layer (NEMOCLAW_BUILD_ID cache miss?) or runtime injection didn't run"
+fi
+pass "Phase 5: post-upgrade token differs from pre-upgrade (upgrade installed runtime injection)"
+
+# Cross-check the host CLI's token-fetch path matches what's in the
+# sandbox. This guards against onboard.ts drifting from the entrypoint.
+HOST_TOKEN="$(nemoclaw "${SANDBOX_NAME}" gateway-token --quiet 2>/dev/null || true)"
+if [ -z "${HOST_TOKEN}" ]; then
+  fail "Phase 5: 'nemoclaw ${SANDBOX_NAME} gateway-token' returned nothing"
+fi
+if [ "${HOST_TOKEN}" != "${POST_TOKEN}" ]; then
+  fail "Phase 5: host gateway-token (${#HOST_TOKEN} chars) does not match in-sandbox token (${#POST_TOKEN} chars)"
+fi
+pass "Phase 5: host-side gateway-token matches in-sandbox token"
+
+# ── Phase 6: Token rotates on restart (runtime mechanism) ──────────
+info "Phase 6: Restarting sandbox to confirm runtime token rotation..."
+
+openshell sandbox restart "${SANDBOX_NAME}" >/dev/null 2>&1 || true
+for _i in $(seq 1 30); do
+  if openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready"; then
+    break
+  fi
+  sleep 5
+done
+
+ROTATED_TOKEN="$(tui_smoke "${SANDBOX_NAME}" "Phase 6 post-restart")"
+
+if [ "${ROTATED_TOKEN}" = "${POST_TOKEN}" ]; then
+  fail "Phase 6: token did not rotate across restart — entrypoint inject_gateway_token() did not run"
+fi
+pass "Phase 6: token rotated on restart (runtime injection confirmed)"
+
+echo ""
+echo -e "${GREEN}═══════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  Gateway-token upgrade E2E PASSED${NC}"
+echo -e "${GREEN}  pre-upgrade token: ${PRE_TOKEN:0:8}…${NC}"
+echo -e "${GREEN}  post-upgrade token: ${POST_TOKEN:0:8}…${NC}"
+echo -e "${GREEN}  rotated token: ${ROTATED_TOKEN:0:8}…${NC}"
+echo -e "${GREEN}═══════════════════════════════════════════════════════════${NC}"

--- a/test/e2e/test-gateway-token-upgrade.sh
+++ b/test/e2e/test-gateway-token-upgrade.sh
@@ -91,7 +91,12 @@ tui_smoke() {
   # tell a "missing token" failure from a "TUI doesn't like our pty"
   # failure. Resolution order matches OpenClaw 2026.4.9: env var first,
   # then gateway.auth.token from config.
+  #
+  # Capture the exec exit status separately — `|| true` would mask a
+  # broken sandbox-exec call, and stderr leaking into ${resolved} could
+  # then satisfy a length-only token check.
   local resolved
+  local resolved_status=0
   resolved="$(openshell sandbox exec --name "${sandbox_name}" -- bash -lc '
     python3 - <<"PY"
 import json, os, sys
@@ -107,19 +112,24 @@ if not token:
     sys.exit(2)
 print(token)
 PY
-  ' 2>&1 || true)"
+  ' 2>&1)" || resolved_status=$?
 
-  if echo "${resolved}" | grep -q "MISSING_GATEWAY_AUTH_TOKEN"; then
-    fail "${label}: token resolution path mirrors 'openclaw tui' and returned empty — TUI would fail with 'Missing gateway auth token'"
+  if [ "${resolved_status}" -ne 0 ]; then
+    if echo "${resolved}" | grep -q "MISSING_GATEWAY_AUTH_TOKEN"; then
+      fail "${label}: token resolution path mirrors 'openclaw tui' and returned empty — TUI would fail with 'Missing gateway auth token'"
+    fi
+    echo "${resolved}" | head -20 >&2
+    fail "${label}: token-resolution sandbox exec failed (exit ${resolved_status})"
   fi
 
-  # Pull the actual token off the last line (the python script may emit
-  # warnings before printing) and reject anything that doesn't look like
-  # a hex string of plausible length.
+  # Pull the actual token off the last line and require the exact
+  # secrets.token_hex(32) format the entrypoint generates: 64 hex chars,
+  # nothing else. This rejects any stderr fragment that happens to land
+  # on the last line.
   local token
-  token="$(echo "${resolved}" | tail -n 1)"
-  if [ -z "${token}" ] || [ "${#token}" -lt 16 ]; then
-    fail "${label}: resolved token is empty or implausibly short: '${token}'"
+  token="$(printf '%s\n' "${resolved}" | tail -n 1)"
+  if ! printf '%s' "${token}" | grep -Eq '^[0-9a-fA-F]{64}$'; then
+    fail "${label}: resolved token does not match 64-hex format: '${token}'"
   fi
 
   # Step 2: actually start `openclaw tui`. We can't drive it

--- a/test/e2e/test-gateway-token-upgrade.sh
+++ b/test/e2e/test-gateway-token-upgrade.sh
@@ -77,69 +77,61 @@ if ! git -C "${REPO_ROOT}" cat-file -e "${PRE_REF}^{commit}" 2>/dev/null; then
     || fail "Could not fetch pre-ref ${PRE_REF}"
 fi
 
-# ── tui_smoke: drives `openclaw tui` inside the sandbox and asserts
-# the auth-resolution path works. The original #2480 bug surfaced as
-# "Missing gateway auth token" on stderr — we treat any output that
-# omits that string AND yields a non-empty resolved token as success.
+# ── tui_smoke: replicates `openclaw tui`'s token resolution and runs
+# the real binary as a canary. The #2480 failure mode was an early
+# "Missing gateway auth token" before any UI work, so we assert both:
+# the token resolves to a 64-hex string, AND `openclaw tui` doesn't
+# emit that error.
+#
+# Important: `openshell sandbox exec` rejects arguments that contain
+# newlines or carriage returns (gRPC InvalidArgument), so every
+# in-sandbox command here must be a single line.
 tui_smoke() {
   local sandbox_name="$1"
   local label="$2"
 
   info "${label}: running TUI smoke test inside ${sandbox_name}..."
 
-  # Step 1: replicate openclaw tui's token resolution exactly so we can
-  # tell a "missing token" failure from a "TUI doesn't like our pty"
-  # failure. Resolution order matches OpenClaw 2026.4.9: env var first,
-  # then gateway.auth.token from config.
-  #
-  # Capture the exec exit status separately — `|| true` would mask a
-  # broken sandbox-exec call, and stderr leaking into ${resolved} could
-  # then satisfy a length-only token check.
-  local resolved
-  local resolved_status=0
-  resolved="$(openshell sandbox exec --name "${sandbox_name}" -- bash -lc '
-    python3 - <<"PY"
-import json, os, sys
-token = os.environ.get("OPENCLAW_GATEWAY_TOKEN", "")
-if not token:
-    try:
-        with open("/sandbox/.openclaw/openclaw.json") as f:
-            token = json.load(f).get("gateway", {}).get("auth", {}).get("token", "")
-    except Exception:
-        pass
-if not token:
-    print("MISSING_GATEWAY_AUTH_TOKEN", file=sys.stderr)
-    sys.exit(2)
-print(token)
-PY
-  ' 2>&1)" || resolved_status=$?
+  # Step 1a: read OPENCLAW_GATEWAY_TOKEN from a non-interactive shell
+  # the same way `openclaw tui` would (it inherits the env). Single-
+  # line printf so openshell exec's no-newline rule isn't tripped.
+  local env_token=""
+  local env_status=0
+  # shellcheck disable=SC2016 # ${OPENCLAW_GATEWAY_TOKEN} must expand in-sandbox, not on host.
+  env_token="$(openshell sandbox exec --name "${sandbox_name}" -- bash -lc 'printf %s "${OPENCLAW_GATEWAY_TOKEN:-}"' 2>&1)" || env_status=$?
+  if [ "${env_status}" -ne 0 ]; then
+    echo "${env_token}" | head -20 >&2
+    fail "${label}: env-var probe failed (exit ${env_status})"
+  fi
 
-  if [ "${resolved_status}" -ne 0 ]; then
-    if echo "${resolved}" | grep -q "MISSING_GATEWAY_AUTH_TOKEN"; then
-      fail "${label}: token resolution path mirrors 'openclaw tui' and returned empty — TUI would fail with 'Missing gateway auth token'"
+  # Step 1b: download openclaw.json and parse on the host. This avoids
+  # multi-line python -c arguments inside openshell exec entirely.
+  local cfg_token=""
+  local fetch_dir
+  fetch_dir="$(mktemp -d -t nemoclaw-tui-XXXXXX)"
+  if openshell sandbox download "${sandbox_name}" /sandbox/.openclaw/openclaw.json "${fetch_dir}/" >/dev/null 2>&1; then
+    local cfg_path
+    cfg_path="$(find "${fetch_dir}" -name openclaw.json -print -quit)"
+    if [ -n "${cfg_path}" ]; then
+      cfg_token="$(python3 -c "import json,sys; cfg=json.load(open(sys.argv[1])); print(cfg.get('gateway',{}).get('auth',{}).get('token',''))" "${cfg_path}" 2>/dev/null || true)"
     fi
-    echo "${resolved}" | head -20 >&2
-    fail "${label}: token-resolution sandbox exec failed (exit ${resolved_status})"
   fi
+  rm -rf "${fetch_dir}"
 
-  # Pull the actual token off the last line and require the exact
-  # secrets.token_hex(32) format the entrypoint generates: 64 hex chars,
-  # nothing else. This rejects any stderr fragment that happens to land
-  # on the last line.
-  local token
-  token="$(printf '%s\n' "${resolved}" | tail -n 1)"
+  # OpenClaw 2026.4.9 resolution: env var → gateway.auth.token in config.
+  local token="${env_token:-${cfg_token}}"
+  if [ -z "${token}" ]; then
+    fail "${label}: no token resolvable (env var empty, config token empty) — TUI would fail with 'Missing gateway auth token'"
+  fi
   if ! printf '%s' "${token}" | grep -Eq '^[0-9a-fA-F]{64}$'; then
-    fail "${label}: resolved token does not match 64-hex format: '${token}'"
+    fail "${label}: resolved token does not match secrets.token_hex(32) format: '${token}'"
   fi
 
-  # Step 2: actually start `openclaw tui`. We can't drive it
-  # interactively without a pty, but we can confirm it gets past the
-  # auth-resolution step — the bug we're guarding against was an early
-  # exit with "Missing gateway auth token" before any UI work.
+  # Step 2: run `openclaw tui` itself with a 6s timeout and a single-
+  # line bash command (no heredoc). The bug we guard against is a fast
+  # exit with the #2480 error string before any UI work happens.
   local tui_out
-  tui_out="$(openshell sandbox exec --name "${sandbox_name}" -- bash -lc '
-    timeout --preserve-status 6 openclaw tui </dev/null 2>&1 | head -c 8192
-  ' 2>&1 || true)"
+  tui_out="$(openshell sandbox exec --name "${sandbox_name}" -- bash -c 'timeout --preserve-status 6 openclaw tui </dev/null 2>&1 | head -c 8192' 2>&1 || true)"
 
   if echo "${tui_out}" | grep -qi "Missing gateway auth token"; then
     echo "${tui_out}" | head -40 >&2
@@ -147,7 +139,7 @@ PY
   fi
 
   pass "${label}: TUI startup resolved gateway token (${#token} chars)"
-  printf '%s' "${token}"
+  TUI_RESULT_TOKEN="${token}"
 }
 
 # ── Phase 1: Install current NemoClaw ──────────────────────────────
@@ -216,7 +208,9 @@ openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready" \
 pass "Phase 2: pre-upgrade sandbox running (build-baked token design)"
 
 # ── Phase 3: TUI smoke + capture pre-upgrade token ─────────────────
-PRE_TOKEN="$(tui_smoke "${SANDBOX_NAME}" "Phase 3 pre-upgrade")"
+TUI_RESULT_TOKEN=""
+tui_smoke "${SANDBOX_NAME}" "Phase 3 pre-upgrade"
+PRE_TOKEN="${TUI_RESULT_TOKEN}"
 
 # Sanity: in the OLD design the token comes from the Docker layer, so
 # it must be identical across container restarts. Restart and reread to
@@ -228,7 +222,9 @@ for _i in $(seq 1 30); do
   fi
   sleep 5
 done
-PRE_TOKEN_AFTER_RESTART="$(tui_smoke "${SANDBOX_NAME}" "Phase 3 pre-upgrade post-restart")"
+TUI_RESULT_TOKEN=""
+tui_smoke "${SANDBOX_NAME}" "Phase 3 pre-upgrade post-restart"
+PRE_TOKEN_AFTER_RESTART="${TUI_RESULT_TOKEN}"
 if [ "${PRE_TOKEN}" != "${PRE_TOKEN_AFTER_RESTART}" ]; then
   fail "Phase 3: build-baked token unexpectedly changed across restart — PRE_REF may already include runtime injection"
 fi
@@ -302,7 +298,9 @@ openshell sandbox list 2>/dev/null | grep -q "${SANDBOX_NAME}.*Ready" \
 pass "Phase 4: post-upgrade sandbox running (runtime-injection design)"
 
 # ── Phase 5: TUI smoke after upgrade ───────────────────────────────
-POST_TOKEN="$(tui_smoke "${SANDBOX_NAME}" "Phase 5 post-upgrade")"
+TUI_RESULT_TOKEN=""
+tui_smoke "${SANDBOX_NAME}" "Phase 5 post-upgrade"
+POST_TOKEN="${TUI_RESULT_TOKEN}"
 
 if [ "${POST_TOKEN}" = "${PRE_TOKEN}" ]; then
   fail "Phase 5: post-upgrade token equals pre-upgrade token — rebuild reused the old image layer (NEMOCLAW_BUILD_ID cache miss?) or runtime injection didn't run"
@@ -331,7 +329,9 @@ for _i in $(seq 1 30); do
   sleep 5
 done
 
-ROTATED_TOKEN="$(tui_smoke "${SANDBOX_NAME}" "Phase 6 post-restart")"
+TUI_RESULT_TOKEN=""
+tui_smoke "${SANDBOX_NAME}" "Phase 6 post-restart"
+ROTATED_TOKEN="${TUI_RESULT_TOKEN}"
 
 if [ "${ROTATED_TOKEN}" = "${POST_TOKEN}" ]; then
   fail "Phase 6: token did not rotate across restart — entrypoint inject_gateway_token() did not run"

--- a/test/e2e/test-gateway-token-upgrade.sh
+++ b/test/e2e/test-gateway-token-upgrade.sh
@@ -337,27 +337,28 @@ if [ "${HOST_TOKEN}" != "${POST_TOKEN}" ]; then
 fi
 pass "Phase 5: host-side gateway-token matches in-sandbox token"
 
-# ── Phase 6: Token rotates on restart (runtime mechanism) ──────────
-info "Phase 6: Restarting sandbox to confirm runtime token rotation..."
+# ── Phase 6: Token rotates on container recreation (runtime mech) ──
+info "Phase 6: Recreating container via 'nemoclaw rebuild' to confirm runtime token rotation..."
 
-# `openshell sandbox restart` returns before the pod has actually
-# transitioned, and the kubelet may roll quickly enough that a "wait
-# for non-Ready, then Ready" check misses the window entirely. Poll
-# the resolved token directly — the entrypoint regenerates it on
-# every start, so an observed rotation is unambiguous proof the
-# entrypoint re-ran. A 90s deadline tolerates slow node-image pulls
-# without hiding a real "entrypoint never ran" regression.
-openshell sandbox restart "${SANDBOX_NAME}" >/dev/null 2>&1 || true
+# `openshell sandbox` exposes create/delete/exec/etc. but NOT a
+# restart subcommand, so the rebuild path is the supported way to
+# force a fresh entrypoint run. The image layer is already cached
+# from Phase 4, so this re-runs container creation only — it's the
+# closest thing to "container restart" available, and a fresh
+# entrypoint run is exactly what we want to verify rotates the
+# token. 240s tolerates a stale-cache rebuild + Ready transition.
+nemoclaw "${SANDBOX_NAME}" rebuild --yes >/dev/null 2>&1 \
+  || fail "Phase 6: nemoclaw rebuild (rotation trigger) failed"
 
 RESOLVED_TOKEN=""
-if ! wait_for_token_change "${SANDBOX_NAME}" "${POST_TOKEN}" 90; then
-  fail "Phase 6: token did not rotate within 90s — entrypoint inject_gateway_token() did not re-run, or sandbox restart did not propagate"
+if ! wait_for_token_change "${SANDBOX_NAME}" "${POST_TOKEN}" 240; then
+  fail "Phase 6: token did not rotate within 240s — entrypoint inject_gateway_token() did not re-run on the recreated container"
 fi
 ROTATED_TOKEN="${RESOLVED_TOKEN}"
-pass "Phase 6: token rotated on restart (runtime injection confirmed)"
+pass "Phase 6: token rotated on container recreation (runtime injection confirmed)"
 
 # Final TUI smoke against the rotated container — one more guard
-# against a "Missing gateway auth token" regression after restart.
+# against a "Missing gateway auth token" regression on the new pod.
 TUI_RESULT_TOKEN=""
 tui_smoke "${SANDBOX_NAME}" "Phase 6 post-rotation"
 if [ "${TUI_RESULT_TOKEN}" != "${ROTATED_TOKEN}" ]; then

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -163,6 +163,80 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
   });
 });
 
+describe("nemoclaw-start runtime gateway token injection (#2480)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  it("defines inject_gateway_token function", () => {
+    expect(src).toMatch(/inject_gateway_token\(\) \{/);
+  });
+
+  it("inject_gateway_token only applies in root mode", () => {
+    const fn = src.match(/inject_gateway_token\(\) \{([\s\S]*?)^\}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toMatch(/id -u.*-eq 0/);
+    expect(fn[1]).toContain("requires root");
+  });
+
+  it("inject_gateway_token guards against symlink attacks", () => {
+    const fn = src.match(/inject_gateway_token\(\) \{([\s\S]*?)^\}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain('-L "$config_file"');
+    expect(fn[1]).toContain('-L "$hash_file"');
+  });
+
+  it("inject_gateway_token recomputes config hash", () => {
+    const fn = src.match(/inject_gateway_token\(\) \{([\s\S]*?)^\}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("sha256sum openclaw.json");
+  });
+
+  it("calls inject_gateway_token before export_gateway_token in root path", () => {
+    const rootBlock = src.match(
+      /# ── Root path[\s\S]*?inject_gateway_token[\s\S]*?export_gateway_token/,
+    );
+    expect(rootBlock).toBeTruthy();
+  });
+
+  it("export_gateway_token generates token in non-root when openclaw.json is empty", () => {
+    const fn = src.match(/export_gateway_token\(\) \{([\s\S]*?)^\}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("secrets.token_hex(32)");
+    expect(fn[1]).toContain("Non-root");
+  });
+
+  it("export_gateway_token writes /tmp token file via emit_sandbox_sourced_file", () => {
+    const fn = src.match(/export_gateway_token\(\) \{([\s\S]*?)^\}/m);
+    expect(fn).toBeTruthy();
+    expect(fn[1]).toContain("_GATEWAY_TOKEN_ENV_FILE");
+    expect(fn[1]).toContain("emit_sandbox_sourced_file");
+  });
+
+  it("proxy-env.sh sources the gateway token file for connect sessions", () => {
+    expect(src).toContain("nemoclaw-gateway-token.env");
+    // The proxy-env generation block should conditionally source the token file
+    expect(src).toMatch(
+      /\[ -f.*_GATEWAY_TOKEN_ENV_FILE.*\] && \. .*_GATEWAY_TOKEN_ENV_FILE/,
+    );
+  });
+
+  it("Dockerfile builds with empty token placeholder", () => {
+    const dockerfilePath = path.join(
+      path.dirname(START_SCRIPT),
+      "..",
+      "Dockerfile",
+    );
+    const dockerfile = fs.readFileSync(dockerfilePath, "utf-8");
+    expect(dockerfile).toContain("'auth': {'token': ''}");
+    // secrets.token_hex should not be used in the config generation RUN
+    // (it may still appear in comments or the token-clearing RUN)
+    const configRun = dockerfile.match(
+      /RUN.*python3 -c.*import base64.*json\.dump/s,
+    );
+    expect(configRun).toBeTruthy();
+    expect(configRun[0]).not.toContain("secrets.token_hex");
+  });
+});
+
 describe("nemoclaw-start configure guard (#1114)", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -27,6 +27,10 @@ describe("sandbox build context staging", () => {
         ),
       ).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "nemoclaw-start.sh"))).toBe(true);
+      expect(
+        fs.existsSync(path.join(buildCtx, "scripts", "generate-openclaw-config.py")),
+      ).toBe(true);
+      expect(fs.existsSync(path.join(buildCtx, "scripts", "lib", "sandbox-init.sh"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Generate the gateway auth token at **container startup** instead of Docker build time
- Each container gets a unique token (not shared across images, not in Docker layer history)
- `openclaw tui` works in both root and non-root sandbox modes (fixes the regression from the reverted #2378)

## What we learned from the first attempt (#2378 / 51aa6af3)

The original externalization (51aa6af3) removed the token from `openclaw.json` entirely, generated it at container startup, and passed it **only** to the gateway process via `OPENCLAW_GATEWAY_TOKEN` on the launch line. This broke `openclaw tui` in three ways:

1. **`openclaw tui` couldn't read the token from config.** The token was cleared from `openclaw.json` at build time, so OpenClaw's native config resolution (`gateway.auth.token`) returned empty.

2. **`openclaw tui` couldn't inherit the env var.** `OPENCLAW_GATEWAY_TOKEN` was scoped to the gateway process launch line (`OPENCLAW_GATEWAY_TOKEN="$token" nohup ... &`), not exported to the shell env. Interactive sessions started via `openshell sandbox connect` never saw it — they source `.bashrc`/`.profile` and `proxy-env.sh`, none of which contained the token.

3. **Non-root mode crashed the entrypoint.** The `install_configure_guard` function (added in a separate commit) wrote to `.bashrc`/`.profile` without `|| true` guards. Under Landlock, the DAC check (`[ -w file ]`) passed but the actual write was blocked, crashing the entrypoint under `set -e` before the gateway ever started. This caused a 5-day outage on non-root sandboxes (Brev Launchable, Spark).

Issue #2480 confirmed the symptom: `openclaw tui` inside the sandbox failed with "Missing gateway auth token" because none of the resolution paths had a token.

## How this PR handles things differently

### Root mode (full privilege separation)

1. **`inject_gateway_token()`** generates a fresh token at startup and **writes it into `openclaw.json`** before `chattr +i` locks the config. This means `openclaw tui` and all OpenClaw tools can read it natively from the config — no env var dependency required.
2. **`export_gateway_token()`** also exports `OPENCLAW_GATEWAY_TOKEN` to the process env, persists it to `.bashrc`/`.profile` marker blocks, and writes `/tmp/nemoclaw-gateway-token.env` (a sourced file). This is belt-and-suspenders — the config path is primary, the env var is backup.
3. The config hash is **recomputed** after token injection so the integrity check passes on subsequent startups.

### Non-root mode (no privilege separation)

1. **Cannot write to `openclaw.json`** (root:root 444, and we're running as sandbox user). `inject_gateway_token()` returns early with a log message.
2. **`export_gateway_token()`** detects the empty token in `openclaw.json`, generates a fresh one, and delivers it via:
   - `export OPENCLAW_GATEWAY_TOKEN="$token"` in the current process (gateway inherits it)
   - Marker block in `.bashrc`/`.profile` (best-effort, Landlock may block — all writes use `|| true`)
   - `/tmp/nemoclaw-gateway-token.env` via `emit_sandbox_sourced_file` (root:root 444, tamper-proof)
3. **`proxy-env.sh` conditionally sources the `/tmp` token file.** Even if rc-file writes are Landlock-blocked, connect sessions pick up the token because `.bashrc` sources `proxy-env.sh` which sources the token file. This is the key missing piece from the first attempt.

### OpenClaw 2026.4.9 compatibility

OpenClaw resolves the gateway token in this order: `OPENCLAW_GATEWAY_TOKEN` env var → `--token` CLI flag → `gateway.auth.token` in config → secret provider. Both modes now deliver the token via at least one of these paths:

| Mode | Config (`gateway.auth.token`) | Env var (`OPENCLAW_GATEWAY_TOKEN`) | `/tmp` file |
|------|------|---------|-------------|
| Root | Injected at startup | Exported + rc files | Written |
| Non-root | Empty (can't write) | Exported + rc files (best-effort) | Written |

### Security improvements over build-time token

- Token is **not in Docker image layers** — `docker history` cannot extract it
- Each container **generates a unique token** at startup — no sharing across instances
- Token can be **rotated** by restarting the container
- `/tmp/nemoclaw-gateway-token.env` is created via `emit_sandbox_sourced_file` (root:root 444 in root mode) and validated by `validate_tmp_permissions`

## Files changed

| File | What changed |
|------|-------------|
| `Dockerfile` | Empty token placeholder, removed `secrets` import, added post-plugin token clearing RUN |
| `scripts/nemoclaw-start.sh` | Added `inject_gateway_token()`, extended `export_gateway_token()` with non-root fallback + `/tmp` file + Landlock guards, added proxy-env.sh token source line |
| `src/lib/onboard.ts` | Added `/tmp/nemoclaw-gateway-token.env` fallback for host-side token retrieval (non-root) |
| `test/nemoclaw-start.test.ts` | 9 new tests for injection, root guard, symlink guard, hash recomputation, non-root fallback, `/tmp` delivery |
| `docs/security/best-practices.md` | Updated token description to reflect runtime generation |
| `.agents/skills/.../best-practices.md` | Mirror of docs update |

Supersedes reverted commit 51aa6af3. Fixes #2480.

## Test plan

- [x] `npm run typecheck:cli` passes
- [x] 2119 tests pass (9 new tests for token injection)
- [x] All pre-commit and pre-push hooks pass
- [ ] E2E: `openclaw tui` works inside sandbox after rebuild (root mode)
- [ ] E2E: `openclaw tui` works inside sandbox after rebuild (non-root mode)
- [ ] Verify `docker history` does not contain the token
- [ ] Verify two containers from the same image get different tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Gateway auth tokens are generated at container startup (not baked into images), persist for interactive sessions, and rotate on restart; root-mode injects into the locked config, non-root delivers via environment and tmp files.

* **Documentation**
  * Updated security and setup guides to explain per-container token generation, delivery paths, integrity-hash recomputation, and updated default posture description.

* **Tests**
  * Added unit, E2E tests and a nightly E2E job validating token injection, rotation, resolution order, and host-side reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->