### PR TITLE
fix(snapshot): allow /sandbox/.openclaw-data symlinks in safeTarExtract

### DIFF
--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -279,11 +279,34 @@ function auditExtractedSymlinks(dirPath: string, allowedRoots: string[]): string
         const stat = lstatSync(fullPath);
         if (stat.isSymbolicLink()) {
           const linkTarget = readlinkSync(fullPath);
-          const resolvedTarget = path.resolve(path.dirname(fullPath), linkTarget);
-          const inAnyAllowedRoot = allowedRoots.some((root) => isWithinRoot(resolvedTarget, root));
+
+          // Resolve relative to the symlink's containing directory (standard).
+          const resolvedRelative = path.resolve(path.dirname(fullPath), linkTarget);
+
+          // For absolute symlinks that point into the canonical sandbox data
+          // directory (/sandbox/.openclaw-data/** or /sandbox/.hermes-data/**),
+          // also check whether the target falls within the extraction root when
+          // the leading /sandbox/ prefix is mapped onto the archive root. This
+          // mirrors how the symlink resolves once the backup is restored inside
+          // the sandbox container (where /sandbox/.openclaw-data/* exists).
+          //
+          // Only /sandbox/ prefixed targets receive this treatment so that
+          // symlinks pointing to arbitrary absolute paths (e.g. /etc/passwd)
+          // are still rejected. Fixes #2317.
+          const SANDBOX_DATA_PREFIXES = ["/sandbox/.openclaw-data/", "/sandbox/.hermes-data/"];
+          const resolvedInArchive =
+            path.isAbsolute(linkTarget) &&
+            SANDBOX_DATA_PREFIXES.some((p) => linkTarget.startsWith(p))
+              ? path.resolve(dirPath, linkTarget.replace(/^\//, ""))
+              : null;
+
+          const inAnyAllowedRoot =
+            allowedRoots.some((root) => isWithinRoot(resolvedRelative, root)) ||
+            (resolvedInArchive !== null && isWithinRoot(resolvedInArchive, dirPath));
+
           if (!inAnyAllowedRoot) {
             violations.push(
-              `symlink escape: ${fullPath} -> ${linkTarget} (resolves to ${resolvedTarget})`,
+              `symlink escape: ${fullPath} -> ${linkTarget} (resolves to ${resolvedRelative})`,
             );
           }
         } else if (stat.isDirectory()) {

--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -294,10 +294,15 @@ function auditExtractedSymlinks(dirPath: string, allowedRoots: string[]): string
           // symlinks pointing to arbitrary absolute paths (e.g. /etc/passwd)
           // are still rejected. Fixes #2317.
           const SANDBOX_DATA_PREFIXES = ["/sandbox/.openclaw-data/", "/sandbox/.hermes-data/"];
+          // Normalize the target first to collapse any .. traversal segments
+          // (e.g. /sandbox/.openclaw-data/../../etc/passwd → /etc/passwd).
+          // Only then check the prefix — this prevents a traversal bypass
+          // where a crafted target starts with an allowed prefix but escapes it.
+          const normalizedTarget = path.posix.normalize(linkTarget);
           const resolvedInArchive =
-            path.isAbsolute(linkTarget) &&
-            SANDBOX_DATA_PREFIXES.some((p) => linkTarget.startsWith(p))
-              ? path.resolve(dirPath, linkTarget.replace(/^\//, ""))
+            path.isAbsolute(normalizedTarget) &&
+            SANDBOX_DATA_PREFIXES.some((p) => normalizedTarget.startsWith(p))
+              ? path.resolve(dirPath, normalizedTarget.replace(/^\//, ""))
               : null;
 
           const inAnyAllowedRoot =

--- a/test/security-sandbox-tar-traversal.test.ts
+++ b/test/security-sandbox-tar-traversal.test.ts
@@ -385,6 +385,58 @@ describe("Fix: safeTarExtract blocks malicious archives and extracts safe ones",
       fs.rmSync(workDir, { recursive: true, force: true });
     }
   });
+
+  // Regression #2317: /sandbox/.openclaw-data/* symlinks are created by
+  // Dockerfile.base for the .openclaw / .openclaw-data split. When a backup
+  // is extracted on the host, these absolute targets don't exist on the host
+  // and were falsely rejected as escapes. The fix maps /sandbox/ paths onto
+  // the extraction root before checking, matching the sandbox-internal view.
+  it("regression #2317: allows known-safe /sandbox/.openclaw-data symlinks in backup archives", async () => {
+    const { safeTarExtract } = await loadSandboxState();
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-2317-"));
+    try {
+      const targetDir = path.join(workDir, "backup");
+      fs.mkdirSync(targetDir, { recursive: true });
+
+      // Simulate the workspace/media symlink created by Dockerfile.base
+      const tar = buildTar([
+        {
+          path: "workspace/media",
+          type: "2",
+          linkTarget: "/sandbox/.openclaw-data/media",
+        },
+      ]);
+
+      const result = safeTarExtract(tar, targetDir);
+      expect(result.success).toBe(true);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("regression #2317: still blocks absolute symlinks outside /sandbox/.openclaw-data", async () => {
+    const { safeTarExtract } = await loadSandboxState();
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-2317-block-"));
+    try {
+      const targetDir = path.join(workDir, "backup");
+      fs.mkdirSync(targetDir, { recursive: true });
+
+      // /etc/passwd should still be rejected — not in /sandbox/.openclaw-data/
+      const tar = buildTar([
+        {
+          path: "evil-link",
+          type: "2",
+          linkTarget: "/etc/passwd",
+        },
+      ]);
+
+      const result = safeTarExtract(tar, targetDir);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("symlink");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("Fix: rejectHardLinks blocks hard-link entries at validation time", () => {

--- a/test/security-sandbox-tar-traversal.test.ts
+++ b/test/security-sandbox-tar-traversal.test.ts
@@ -437,6 +437,30 @@ describe("Fix: safeTarExtract blocks malicious archives and extracts safe ones",
       fs.rmSync(workDir, { recursive: true, force: true });
     }
   });
+
+  it("regression #2317: blocks path traversal within allowed prefix (/sandbox/.openclaw-data/../../etc/passwd)", async () => {
+    const { safeTarExtract } = await loadSandboxState();
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-2317-traversal-"));
+    try {
+      const targetDir = path.join(workDir, "backup");
+      fs.mkdirSync(targetDir, { recursive: true });
+
+      // Crafted target starts with allowed prefix but traverses out of it
+      const tar = buildTar([
+        {
+          path: "evil-traversal",
+          type: "2",
+          linkTarget: "/sandbox/.openclaw-data/../../etc/passwd",
+        },
+      ]);
+
+      const result = safeTarExtract(tar, targetDir);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("symlink");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("Fix: rejectHardLinks blocks hard-link entries at validation time", () => {


### PR DESCRIPTION
## Problem

`nemoclaw snapshot create`, `rebuild`, and `backup-all` all fail on 0.0.22 with:

```
SECURITY: tar extraction blocked: post-extraction symlink audit failed:
symlink escape: workspace/media -> /sandbox/.openclaw-data/media
```

PR #2163 hardened `safeTarExtract` against tar-slip path traversal by rejecting any symlink whose target resolves outside the extraction root. This correctly blocks `/etc/passwd` etc., but over-rejects legitimate intra-sandbox symlinks created by `Dockerfile.base` for the `.openclaw` / `.openclaw-data` split. When extracted on the host, `/sandbox/.openclaw-data/media` doesn't exist on the host and isn't within the extraction root — so the audit falsely rejects it.

## Fix

When the symlink target is an absolute path starting with `/sandbox/.openclaw-data/` or `/sandbox/.hermes-data/`, also resolve it relative to the extraction root (strip the leading `/sandbox/` prefix, resolve under `targetDir`). This mirrors how the symlink would resolve inside the sandbox container where these paths exist.

Absolute paths outside these known prefixes are still rejected as before. The security boundary is unchanged.

## Tests

Added two regression tests:
- `allows known-safe /sandbox/.openclaw-data symlinks in backup archives` — the direct #2317 repro
- `still blocks absolute symlinks outside /sandbox/.openclaw-data` — `/etc/passwd` must stay blocked

23/23 tests pass.

Fixes #2317

Signed-off-by: Benedikt Schackenberg <6381261+BenediktSchackenberg@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symlink validation during archive extraction to correctly allow symlinks that map into authorized sandbox data directories while still blocking attempts to escape containment; error messages now report the resolved path shown to users.

* **Tests**
  * Added regression tests verifying allowed symlinks to sandbox data and continued rejection of symlinks pointing outside or using traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->