### PR TITLE
feat(cli): add local usage metrics

### DIFF
--- a/src/commands/sandbox/stats.ts
+++ b/src/commands/sandbox/stats.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { runStatsAction } from "../../lib/actions/stats";
+import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
+import { sandboxNameArg } from "../../lib/sandbox/command-support";
+
+export default class SandboxStatsCommand extends NemoClawCommand {
+  static id = "sandbox:stats";
+  static strict = true;
+  static summary = "Show usage metrics for one sandbox";
+  static description = "Filter locally recorded NemoClaw metrics for one sandbox.";
+  static usage = ["<name>"];
+  static examples = ["<%= config.bin %> sandbox stats alpha"];
+  static args = {
+    sandboxName: sandboxNameArg,
+  };
+  static flags = {};
+
+  public async run(): Promise<void> {
+    const { args } = await this.parse(SandboxStatsCommand);
+    runStatsAction({ sandboxName: args.sandboxName });
+  }
+}

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flags } from "@oclif/core";
+
+import { runStatsAction } from "../lib/actions/stats";
+import { NemoClawCommand } from "../lib/cli/nemoclaw-oclif-command";
+
+export default class StatsCommand extends NemoClawCommand {
+  static id = "stats";
+  static strict = true;
+  static summary = "Show local usage metrics";
+  static description = "Show locally recorded NemoClaw lifecycle and sandbox activity metrics.";
+  static usage = ["stats [--reset]"];
+  static examples = ["<%= config.bin %> stats", "<%= config.bin %> stats --reset"];
+  static flags = {
+    reset: Flags.boolean({
+      description: "Clear locally recorded metrics",
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(StatsCommand);
+    runStatsAction({ reset: flags.reset === true });
+  }
+}

--- a/src/lib/actions/global.ts
+++ b/src/lib/actions/global.ts
@@ -18,6 +18,7 @@ import {
   runSetupSparkAction as executeSetupSparkAction,
 } from "./onboard";
 import { help, version } from "./root-help";
+import { recordMetricEvent } from "../metrics";
 
 type GatewayRecovery = { recovered: boolean };
 
@@ -33,16 +34,60 @@ export function setGlobalCliActionRuntimeHooksForTest(hooks: GlobalCliActionRunt
   runtimeHooks = hooks;
 }
 
+function shouldRecordOnboardLifecycle(args: readonly string[]): boolean {
+  return !args.includes("--help") && !args.includes("-h");
+}
+
+async function runWithOnboardMetrics(
+  args: string[],
+  command: string,
+  runCommand: () => Promise<void>,
+): Promise<void> {
+  const shouldRecord = shouldRecordOnboardLifecycle(args);
+  let completeRecorded = false;
+  const recordComplete = (status: "success" | "failed"): void => {
+    completeRecorded = true;
+    recordMetricEvent("onboard_complete", { command, status });
+  };
+  const recordCompleteOnExit = (code: number): void => {
+    if (shouldRecord && !completeRecorded) {
+      recordComplete(code === 0 ? "success" : "failed");
+    }
+  };
+
+  if (shouldRecord) {
+    recordMetricEvent("onboard_start", {
+      command,
+      data: { nonInteractive: args.includes("--non-interactive") },
+    });
+    process.once("exit", recordCompleteOnExit);
+  }
+
+  try {
+    await runCommand();
+    if (shouldRecord) {
+      process.removeListener("exit", recordCompleteOnExit);
+      recordComplete("success");
+    }
+  } catch (error) {
+    if (shouldRecord) {
+      process.removeListener("exit", recordCompleteOnExit);
+      recordComplete("failed");
+    }
+    throw error;
+  }
+}
+
 export async function runOnboardAction(args: string[] = []): Promise<void> {
-  await executeOnboardAction(args);
+  await runWithOnboardMetrics(args, "onboard", () => executeOnboardAction(args));
 }
 
 export async function runSetupAction(args: string[] = []): Promise<void> {
-  await executeSetupAction(args);
+  await runWithOnboardMetrics(args, "setup", () => executeSetupAction(args));
 }
 
 export async function runSetupSparkAction(args: string[] = []): Promise<void> {
-  await executeSetupSparkAction(args);
+  await runWithOnboardMetrics(args, "setup-spark", () => executeSetupSparkAction(args));
 }
 
 export async function runDeployAction(instanceName?: string): Promise<void> {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -25,6 +25,7 @@ import {
 } from "../../inference/config";
 import { findReachableOllamaHost, probeLocalProviderHealth } from "../../inference/local";
 import { ensureOllamaAuthProxy, probeOllamaAuthProxyHealth } from "../../inference/ollama/proxy";
+import { recordMetricEvent } from "../../metrics";
 import { LOCAL_INFERENCE_TIMEOUT_SECS } from "../../onboard/env";
 import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import { isWsl } from "../../platform";
@@ -1073,6 +1074,11 @@ export async function connectSandbox(
     stdio: "inherit",
     cwd: ROOT,
     env: process.env,
+  });
+  recordMetricEvent("sandbox_connect", {
+    sandbox: sandboxName,
+    command: "connect",
+    status: result.status === 0 ? "success" : "failed",
   });
   exitWithSpawnResult(result);
 }

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -9,6 +9,7 @@ import { OPENSHELL_PROBE_TIMEOUT_MS } from "../../adapters/openshell/timeouts";
 import { CLI_NAME } from "../../cli/branding";
 import { G, R, YW } from "../../cli/terminal-style";
 import { prompt as askPrompt } from "../../credentials/store";
+import { recordMetricEvent } from "../../metrics";
 import {
   type DestroySandboxOptions,
   normalizeDestroySandboxOptions,
@@ -436,5 +437,11 @@ export async function destroySandbox(
   emitProviderDetachResidualHint(sandboxName, detachOutcome.failures, (m) =>
     console.warn(`  ${YW}⚠${R}${m}`),
   );
+  recordMetricEvent("sandbox_destroy", {
+    sandbox: sandboxName,
+    command: "destroy",
+    status: "success",
+    data: { alreadyGone },
+  });
   console.log(`  ${G}✓${R} Sandbox '${sandboxName}' destroyed`);
 }

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -27,6 +27,7 @@ import {
 } from "../../messaging";
 import { hydrateMessagingChannelConfig } from "../../messaging-channel-config";
 import { hashCredential } from "../../security/credential-hash";
+import { recordMetricEvent } from "../../metrics";
 
 const { isNonInteractive } = require("../../onboard") as { isNonInteractive: () => boolean };
 const onboardProviders = require("../../onboard/providers");
@@ -187,7 +188,14 @@ export async function addSandboxPolicy(
     if (confirm.trim().toLowerCase().startsWith("n")) return;
   }
 
-  if (!policies.applyPreset(sandboxName, answer)) {
+  const presetApplied = policies.applyPreset(sandboxName, answer);
+  recordMetricEvent("policy_apply", {
+    sandbox: sandboxName,
+    command: "policy-add",
+    status: presetApplied ? "success" : "failed",
+    data: { preset: answer },
+  });
+  if (!presetApplied) {
     process.exit(1);
   }
   syncSessionPolicyPresetsWithRegistry(sandboxName, answer, "add");

--- a/src/lib/actions/stats.ts
+++ b/src/lib/actions/stats.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  formatMetricSummary,
+  getMetricsFile,
+  readMetricEvents,
+  resetMetricEvents,
+  summarizeMetricEvents,
+} from "../metrics";
+
+export type StatsActionOptions = {
+  reset?: boolean;
+  sandboxName?: string;
+};
+
+export function runStatsAction({ reset = false, sandboxName }: StatsActionOptions = {}): void {
+  if (sandboxName && reset) {
+    console.error("  --reset is only supported on global stats.");
+    console.error("  Usage: nemoclaw stats --reset");
+    process.exitCode = 1;
+    return;
+  }
+
+  const metricsFile = getMetricsFile();
+  if (reset) {
+    try {
+      resetMetricEvents(metricsFile);
+      console.log(`  Metrics reset: ${metricsFile}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`  Failed to reset metrics: ${message}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  const summary = summarizeMetricEvents(readMetricEvents(metricsFile), sandboxName);
+  console.log(formatMetricSummary(summary, metricsFile));
+}

--- a/src/lib/cli/command-registry.test.ts
+++ b/src/lib/cli/command-registry.test.ts
@@ -45,6 +45,7 @@ describe("command-registry", () => {
       expect(usages).toContain("nemoclaw tunnel stop");
       expect(usages).toContain("nemoclaw tunnel status");
       expect(usages).toContain("nemoclaw status");
+      expect(usages).toContain("nemoclaw stats");
     });
 
     it("every entry has scope global", () => {
@@ -55,13 +56,13 @@ describe("command-registry", () => {
   });
 
   describe("sandboxCommands()", () => {
-    it("should return exactly 49 entries", () => {
-      // 43 visible + 6 hidden (shields×3 + config get/set/rotate-token).
-      // 43 visible includes the sessions group (root + list + reset + delete +
+    it("should return exactly 50 entries", () => {
+      // 44 visible + 6 hidden (shields×3 + config get/set/rotate-token).
+      // 44 visible includes stats, the sessions group (root + list + reset + delete +
       // export), the agents quartet (add + apply + delete + list), the
       // singular `agent` passthrough that forwards to `openclaw agent`, and
       // the download + upload host-side openshell wrappers.
-      expect(sandboxCommands()).toHaveLength(49);
+      expect(sandboxCommands()).toHaveLength(50);
     });
 
     it("every entry has scope sandbox", () => {
@@ -182,7 +183,7 @@ describe("command-registry", () => {
   });
 
   describe("globalCommandTokens()", () => {
-    it("returns the exact set of 24 tokens matching the global dispatch commands", () => {
+    it("returns the exact set of 25 tokens matching the global dispatch commands", () => {
       const tokens = globalCommandTokens();
       const expected = new Set([
         "onboard",
@@ -203,6 +204,7 @@ describe("command-registry", () => {
         "gc",
         "inference",
         "resources",
+        "stats",
         "help",
         "version",
         "--help",
@@ -215,9 +217,9 @@ describe("command-registry", () => {
   });
 
   describe("sandboxActionTokens()", () => {
-    it("returns exactly 29 unique action tokens including empty string", () => {
+    it("returns exactly 30 unique action tokens including empty string", () => {
       const tokens = sandboxActionTokens();
-      expect(tokens).toHaveLength(29);
+      expect(tokens).toHaveLength(30);
       // Must contain every first-level sandbox action plus the empty default action.
       const expected = new Set([
         "agent",
@@ -227,6 +229,7 @@ describe("command-registry", () => {
         "download",
         "exec",
         "status",
+        "stats",
         "doctor",
         "logs",
         "policy-add",

--- a/src/lib/cli/public-display-defaults.ts
+++ b/src/lib/cli/public-display-defaults.ts
@@ -113,6 +113,13 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
       flags: "[--json]",
     },
   ],
+  stats: [
+    {
+      group: "Troubleshooting",
+      order: 37.5,
+      flags: "[--reset]",
+    },
+  ],
   "root:version": [
     {
       group: "Getting Started",
@@ -427,6 +434,12 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
       group: "Sandbox Management",
       order: 4,
       description: "Sandbox health + NIM status",
+    },
+  ],
+  "sandbox:stats": [
+    {
+      group: "Sandbox Management",
+      order: 4.1,
     },
   ],
   setup: [

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  formatMetricSummary,
+  getMetricsFile,
+  readMetricEvents,
+  recordMetricEvent,
+  resetMetricEvents,
+  summarizeMetricEvents,
+} from "../../dist/lib/metrics";
+
+const originalHome = process.env.HOME;
+const restoreOriginalHome =
+  originalHome === undefined
+    ? () => {
+        delete process.env.HOME;
+      }
+    : () => {
+        process.env.HOME = originalHome;
+      };
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-metrics-"));
+  process.env.HOME = tmpDir;
+});
+
+afterEach(() => {
+  restoreOriginalHome();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("metrics", () => {
+  it("records local JSONL metric events", () => {
+    const ok = recordMetricEvent("sandbox_connect", {
+      sandbox: "alpha",
+      command: "connect",
+      status: "success",
+    });
+
+    expect(ok).toBe(true);
+    const read = readMetricEvents();
+    expect(read.invalidLines).toBe(0);
+    expect(read.events).toHaveLength(1);
+    expect(read.events[0]).toMatchObject({
+      event: "sandbox_connect",
+      sandbox: "alpha",
+      command: "connect",
+      status: "success",
+    });
+  });
+
+  it("tightens existing metrics file permissions after recording", () => {
+    const filePath = getMetricsFile();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "", { mode: 0o666 });
+    fs.chmodSync(filePath, 0o666);
+
+    recordMetricEvent("sandbox_connect", {
+      sandbox: "alpha",
+      command: "connect",
+    });
+
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+  });
+
+  it("summarizes events globally and by sandbox", () => {
+    recordMetricEvent("onboard_start", { command: "onboard" });
+    recordMetricEvent("sandbox_connect", {
+      sandbox: "alpha",
+      command: "connect",
+      status: "success",
+    });
+    recordMetricEvent("sandbox_destroy", {
+      sandbox: "beta",
+      command: "destroy",
+      status: "success",
+    });
+
+    const read = readMetricEvents();
+    const global = summarizeMetricEvents(read);
+    const alpha = summarizeMetricEvents(read, "alpha");
+
+    expect(global.totalEvents).toBe(3);
+    expect(global.eventCounts).toMatchObject({
+      onboard_start: 1,
+      sandbox_connect: 1,
+      sandbox_destroy: 1,
+    });
+    expect(global.sandboxCounts).toMatchObject({ alpha: 1, beta: 1 });
+    expect(alpha.totalEvents).toBe(1);
+    expect(alpha.eventCounts).toMatchObject({ sandbox_connect: 1 });
+    expect(alpha.sandboxCounts).toMatchObject({ alpha: 1 });
+  });
+
+  it("skips malformed JSONL lines without failing the summary", () => {
+    const filePath = getMetricsFile();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      [
+        JSON.stringify({ time: "2026-04-26T00:00:00.000Z", event: "policy_apply" }),
+        "{not-json",
+        JSON.stringify({ event: "missing-time" }),
+        JSON.stringify({ time: "2026-04-26T00:00:01.000Z", event: "unknown_event" }),
+        JSON.stringify({
+          time: "2026-04-26T00:00:02.000Z",
+          event: "sandbox_connect",
+          status: "unknown",
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const read = readMetricEvents(filePath);
+    const summary = summarizeMetricEvents(read);
+
+    expect(read.events).toHaveLength(1);
+    expect(read.invalidLines).toBe(4);
+    expect(summary.invalidLines).toBe(4);
+    expect(formatMetricSummary(summary, filePath)).toContain("Ignored malformed lines: 4");
+  });
+
+  it("resets the metrics file", () => {
+    recordMetricEvent("policy_apply", {
+      sandbox: "alpha",
+      command: "policy-add",
+      status: "success",
+      data: { preset: "github" },
+    });
+
+    resetMetricEvents();
+
+    expect(fs.readFileSync(getMetricsFile(), "utf8")).toBe("");
+    expect(readMetricEvents().events).toHaveLength(0);
+  });
+
+  it("tightens existing metrics file permissions after reset", () => {
+    const filePath = getMetricsFile();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "old\n", { mode: 0o666 });
+    fs.chmodSync(filePath, 0o666);
+
+    resetMetricEvents(filePath);
+
+    expect(fs.readFileSync(filePath, "utf8")).toBe("");
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { ensureConfigDir } from "./state/config-io";
+
+export type MetricEventName =
+  | "onboard_start"
+  | "onboard_complete"
+  | "sandbox_connect"
+  | "sandbox_destroy"
+  | "policy_apply";
+
+export type MetricStatus = "success" | "failed";
+
+const METRIC_EVENT_NAMES = new Set<string>([
+  "onboard_start",
+  "onboard_complete",
+  "sandbox_connect",
+  "sandbox_destroy",
+  "policy_apply",
+]);
+
+const METRIC_STATUSES = new Set<string>(["success", "failed"]);
+
+export interface MetricEvent {
+  time: string;
+  event: MetricEventName;
+  sandbox?: string;
+  command?: string;
+  status?: MetricStatus;
+  data?: Record<string, string | number | boolean | null>;
+}
+
+export interface MetricReadResult {
+  events: MetricEvent[];
+  invalidLines: number;
+}
+
+export interface MetricSummary {
+  events: MetricEvent[];
+  totalEvents: number;
+  invalidLines: number;
+  firstEventTime: string | null;
+  lastEventTime: string | null;
+  eventCounts: Record<string, number>;
+  sandboxCounts: Record<string, number>;
+  statusCounts: Record<string, number>;
+  sandbox?: string;
+}
+
+/**
+ * Resolve the local JSONL metrics file for the current user.
+ *
+ * Metrics are intentionally local-only and live beside other NemoClaw user
+ * state so operators can inspect or delete them without contacting a service.
+ */
+export function getMetricsFile(home = process.env.HOME || os.homedir()): string {
+  return path.join(home || "/tmp", ".nemoclaw", "metrics.jsonl");
+}
+
+function isMetricEvent(value: unknown): value is MetricEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<MetricEvent>;
+  if (typeof candidate.time !== "string" || typeof candidate.event !== "string") {
+    return false;
+  }
+  if (!METRIC_EVENT_NAMES.has(candidate.event)) {
+    return false;
+  }
+  if (
+    candidate.status !== undefined &&
+    (typeof candidate.status !== "string" || !METRIC_STATUSES.has(candidate.status))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function increment(counts: Record<string, number>, key: string): void {
+  counts[key] = (counts[key] ?? 0) + 1;
+}
+
+function ensureOwnerOnlyMetricsFile(filePath: string): void {
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Metrics are best-effort; command execution should not fail on chmod.
+  }
+}
+
+/**
+ * Append one timestamped metric event to the local metrics stream.
+ *
+ * Returns false when metrics cannot be written so callers can keep their
+ * primary CLI behavior best-effort and non-blocking.
+ */
+export function recordMetricEvent(
+  event: MetricEventName,
+  options: Omit<Partial<MetricEvent>, "event" | "time"> = {},
+): boolean {
+  const entry: MetricEvent = {
+    time: new Date().toISOString(),
+    event,
+    ...options,
+  };
+
+  try {
+    const filePath = getMetricsFile();
+    ensureConfigDir(path.dirname(filePath));
+    fs.appendFileSync(filePath, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+    ensureOwnerOnlyMetricsFile(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read metric events from JSONL, preserving malformed-line counts.
+ *
+ * A corrupt metrics file should not break `nemoclaw stats`; invalid lines are
+ * counted and skipped so operators can still inspect valid history.
+ */
+export function readMetricEvents(filePath = getMetricsFile()): MetricReadResult {
+  let text = "";
+  try {
+    text = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return { events: [], invalidLines: 0 };
+  }
+
+  const events: MetricEvent[] = [];
+  let invalidLines = 0;
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (isMetricEvent(parsed)) {
+        events.push(parsed);
+      } else {
+        invalidLines++;
+      }
+    } catch {
+      invalidLines++;
+    }
+  }
+  return { events, invalidLines };
+}
+
+/**
+ * Clear the local metrics stream while preserving the metrics file location.
+ */
+export function resetMetricEvents(filePath = getMetricsFile()): void {
+  ensureConfigDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, "", { mode: 0o600 });
+  ensureOwnerOnlyMetricsFile(filePath);
+}
+
+/**
+ * Aggregate raw metric events into counts used by the CLI stats view.
+ *
+ * When a sandbox name is supplied, only matching sandbox-scoped events are
+ * included while the malformed-line count remains global to the source file.
+ */
+export function summarizeMetricEvents(
+  readResult: MetricReadResult,
+  sandbox?: string,
+): MetricSummary {
+  const events = sandbox
+    ? readResult.events.filter((event) => event.sandbox === sandbox)
+    : [...readResult.events];
+  const eventCounts: Record<string, number> = {};
+  const sandboxCounts: Record<string, number> = {};
+  const statusCounts: Record<string, number> = {};
+
+  for (const event of events) {
+    increment(eventCounts, event.event);
+    if (event.sandbox) increment(sandboxCounts, event.sandbox);
+    if (event.status) increment(statusCounts, event.status);
+  }
+
+  return {
+    events,
+    totalEvents: events.length,
+    invalidLines: readResult.invalidLines,
+    firstEventTime: events[0]?.time ?? null,
+    lastEventTime: events.at(-1)?.time ?? null,
+    eventCounts,
+    sandboxCounts,
+    statusCounts,
+    sandbox,
+  };
+}
+
+function formatCounts(counts: Record<string, number>, emptyLabel: string): string[] {
+  const entries = Object.entries(counts).sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return [`    ${emptyLabel}`];
+  return entries.map(([key, count]) => `    ${key.padEnd(24)} ${count}`);
+}
+
+function displayPath(filePath: string): string {
+  const home = process.env.HOME || os.homedir();
+  const relative = path.relative(home, filePath);
+  if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+    return path.join("~", relative);
+  }
+  return filePath;
+}
+
+/**
+ * Render a human-readable CLI report for aggregated metric events.
+ */
+export function formatMetricSummary(summary: MetricSummary, filePath = getMetricsFile()): string {
+  const lines: string[] = [];
+  const title = summary.sandbox
+    ? `NemoClaw stats for sandbox '${summary.sandbox}'`
+    : "NemoClaw stats";
+
+  lines.push("");
+  lines.push(`  ${title}`);
+  lines.push(`    Source: ${displayPath(filePath)}`);
+
+  if (summary.totalEvents === 0) {
+    lines.push(
+      summary.sandbox
+        ? `    No metrics recorded for sandbox '${summary.sandbox}'.`
+        : "    No metrics recorded yet.",
+    );
+    if (summary.invalidLines > 0) {
+      lines.push(`    Ignored malformed lines: ${summary.invalidLines}`);
+    }
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push(`    Events: ${summary.totalEvents}`);
+  lines.push(`    First:  ${summary.firstEventTime ?? "unknown"}`);
+  lines.push(`    Last:   ${summary.lastEventTime ?? "unknown"}`);
+  if (summary.invalidLines > 0) {
+    lines.push(`    Ignored malformed lines: ${summary.invalidLines}`);
+  }
+
+  lines.push("");
+  lines.push("  Events by type:");
+  lines.push(...formatCounts(summary.eventCounts, "none"));
+
+  lines.push("");
+  lines.push("  Events by status:");
+  lines.push(...formatCounts(summary.statusCounts, "none"));
+
+  if (!summary.sandbox) {
+    lines.push("");
+    lines.push("  Sandbox activity:");
+    lines.push(...formatCounts(summary.sandboxCounts, "none"));
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/test/cli/stats-command.test.ts
+++ b/test/cli/stats-command.test.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runWithEnv } from "./helpers";
+
+type MetricFixture = Record<string, unknown>;
+
+function writeMetrics(home: string, events: readonly MetricFixture[]): string {
+  const metricsDir = path.join(home, ".nemoclaw");
+  const metricsFile = path.join(metricsDir, "metrics.jsonl");
+  fs.mkdirSync(metricsDir, { recursive: true });
+  fs.writeFileSync(metricsFile, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+  return metricsFile;
+}
+
+function writeSandboxRegistry(home: string, sandboxName: string): void {
+  const registryDir = path.join(home, ".nemoclaw");
+  fs.mkdirSync(registryDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(registryDir, "sandboxes.json"),
+    JSON.stringify({
+      sandboxes: {
+        [sandboxName]: {
+          name: sandboxName,
+          model: "test-model",
+          provider: "nvidia-prod",
+          gpuEnabled: false,
+          policies: [],
+        },
+      },
+      defaultSandbox: sandboxName,
+    }),
+    { mode: 0o600 },
+  );
+}
+
+describe("stats CLI", () => {
+  it("stats prints aggregate local metrics", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-stats-"));
+    writeMetrics(home, [
+      {
+        time: "2026-04-26T00:00:00.000Z",
+        event: "onboard_start",
+        command: "onboard",
+      },
+      {
+        time: "2026-04-26T00:01:00.000Z",
+        event: "sandbox_connect",
+        sandbox: "alpha",
+        command: "connect",
+        status: "success",
+      },
+    ]);
+
+    const result = runWithEnv("stats", { HOME: home });
+
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("NemoClaw stats");
+    expect(result.out).toContain("Events: 2");
+    expect(result.out).toContain("onboard_start");
+    expect(result.out).toContain("sandbox_connect");
+    expect(result.out).toContain("alpha");
+  });
+
+  it("stats --reset clears local metrics", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-stats-reset-"));
+    const metricsFile = writeMetrics(home, [
+      {
+        time: "2026-04-26T00:00:00.000Z",
+        event: "onboard_start",
+        command: "onboard",
+      },
+    ]);
+
+    const result = runWithEnv("stats --reset", { HOME: home });
+
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("Metrics reset:");
+    expect(fs.readFileSync(metricsFile, "utf8")).toBe("");
+  });
+
+  it("sandbox stats filters metrics by sandbox", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-stats-"));
+    writeSandboxRegistry(home, "alpha");
+    writeMetrics(home, [
+      {
+        time: "2026-04-26T00:01:00.000Z",
+        event: "sandbox_connect",
+        sandbox: "alpha",
+        command: "connect",
+        status: "success",
+      },
+      {
+        time: "2026-04-26T00:02:00.000Z",
+        event: "sandbox_connect",
+        sandbox: "beta",
+        command: "connect",
+        status: "success",
+      },
+    ]);
+
+    const result = runWithEnv("alpha stats", { HOME: home });
+
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("NemoClaw stats for sandbox 'alpha'");
+    expect(result.out).toContain("Events: 1");
+    expect(result.out).toContain("sandbox_connect");
+    expect(result.out).not.toContain("beta");
+  });
+});


### PR DESCRIPTION
## Summary

Adds lightweight local-only usage metrics for the NemoClaw CLI.
The CLI now records key lifecycle events to `~/.nemoclaw/metrics.jsonl` and exposes aggregate and per-sandbox summaries through `nemoclaw stats`.

## Related Issue

Closes #30.

## Changes

- Add `src/lib/metrics.ts` for best-effort JSONL event recording, parsing, resetting, and summary formatting.
- Record `onboard_start`, `onboard_complete`, `sandbox_connect`, `sandbox_destroy`, and `policy_apply` events from the CLI.
- Add `nemoclaw stats`, `nemoclaw stats --reset`, and `nemoclaw <name> stats` dispatch paths.
- Register the new global and sandbox-scoped stats commands in `src/lib/command-registry.ts`.
- Update CLI reference docs and regenerate the generated user reference skill.
- Add focused metrics and CLI dispatch tests for aggregate stats, reset behavior, sandbox filtering, malformed JSONL handling, permission hardening, and failed onboard lifecycle recording.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation run locally:

- [x] `npm run build:cli` passes
- [x] `npm test -- test/policies.test.ts src/lib/metrics.test.ts src/lib/command-registry.test.ts test/cli.test.ts` passes
- [x] `npm test -- test/credentials.test.ts` passes
- [x] `npm test -- test/runtime-shell.test.ts` passes
- [x] `npm run typecheck:cli` passes
- [x] `git diff --check` passes

Notes:

- `make check` passes formatting, license, generated docs/skills, shell, lint, schema, secret scan, and markdown hooks locally.
- Full `make check` does not complete in this local Codex session because the full CLI test hook hits unrelated local timeout/IPC issues in tests outside this PR's diff. The focused metrics/CLI tests and the affected timeout tests pass when run directly.

## AI Disclosure

- [x] AI-assisted - tool: OpenAI Codex

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-sandbox `nemoclaw <name> stats` and global `nemoclaw stats` (supports `--reset`) to view local CLI metrics; CLI now records onboarding, sandbox connect/destroy, and policy apply events.

* **Improvements**
  * Metrics persisted locally with tightened owner-only permissions; malformed lines are skipped and reported.

* **Documentation**
  * Command reference and user docs updated for the new metrics commands.

* **Tests**
  * End-to-end tests for recording, summarizing, formatting, filtering, and resetting metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
