### PR TITLE
feat(cli): add gateway-token command to retrieve sandbox auth token

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -261,6 +261,24 @@ Use `--follow` to stream output in real time.
 $ nemoclaw my-assistant logs [--follow]
 ```
 
+### `nemoclaw <name> gateway-token`
+
+Print the OpenClaw gateway auth token for a running sandbox to stdout.
+The token is required by `openclaw tui` and the OpenClaw dashboard URL, but onboarding only prints it once.
+Pipe it into automation or capture it into an environment variable:
+
+```console
+$ TOKEN=$(nemoclaw my-assistant gateway-token --quiet)
+$ export OPENCLAW_GATEWAY_TOKEN="$TOKEN"
+```
+
+The token is written to stdout with no surrounding text.
+A one-line security warning is written to stderr; pass `--quiet` (or `-q`) to suppress it.
+The command exits non-zero with a diagnostic on stderr when the sandbox is not registered or when the token cannot be retrieved (for example, if the sandbox is not running).
+
+> **Warning:** Treat the gateway token like a password.
+> Do not log it, share it, or commit it to version control.
+
 ### `nemoclaw <name> destroy`
 
 Stop the NIM container, remove the host-side Docker image built during onboard, and delete the sandbox.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -287,6 +287,26 @@ Use `--follow` to stream output in real time.
 $ nemoclaw my-assistant logs [--follow]
 ```
 
+### `nemoclaw <name> gateway-token`
+
+Print the OpenClaw gateway auth token for a running sandbox to stdout.
+The token is required by `openclaw tui` and the OpenClaw dashboard URL, but onboarding only prints it once.
+Pipe it into automation or capture it into an environment variable:
+
+```console
+$ TOKEN=$(nemoclaw my-assistant gateway-token --quiet)
+$ export OPENCLAW_GATEWAY_TOKEN="$TOKEN"
+```
+
+The token is written to stdout with no surrounding text.
+A one-line security warning is written to stderr; pass `--quiet` (or `-q`) to suppress it.
+The command exits non-zero with a diagnostic on stderr when the sandbox is not registered or when the token cannot be retrieved (for example, if the sandbox is not running).
+
+:::{warning}
+Treat the gateway token like a password.
+Do not log it, share it, or commit it to version control.
+:::
+
 ### `nemoclaw <name> destroy`
 
 Stop the NIM container, remove the host-side Docker image built during onboard, and delete the sandbox.

--- a/src/lib/command-registry.test.ts
+++ b/src/lib/command-registry.test.ts
@@ -17,10 +17,10 @@ import type { CommandDef } from "./command-registry";
 
 describe("command-registry", () => {
   describe("COMMANDS array", () => {
-    it("should contain exactly 46 commands", () => {
+    it("should contain exactly 47 commands", () => {
       // 23 global (18 visible + 5 hidden help/version aliases)
-      // 23 sandbox (17 visible + 6 hidden shields/config)
-      expect(COMMANDS).toHaveLength(46);
+      // 24 sandbox (18 visible + 6 hidden shields/config)
+      expect(COMMANDS).toHaveLength(47);
     });
 
     it("should have no duplicate usage strings", () => {
@@ -52,9 +52,9 @@ describe("command-registry", () => {
   });
 
   describe("sandboxCommands()", () => {
-    it("should return exactly 23 entries", () => {
-      // 17 visible + 6 hidden (shields×3 + config×3)
-      expect(sandboxCommands()).toHaveLength(23);
+    it("should return exactly 24 entries", () => {
+      // 18 visible + 6 hidden (shields×3 + config×3)
+      expect(sandboxCommands()).toHaveLength(24);
     });
 
     it("every entry has scope sandbox", () => {
@@ -65,10 +65,10 @@ describe("command-registry", () => {
   });
 
   describe("visibleCommands()", () => {
-    it("should exclude 11 hidden commands (35 visible)", () => {
+    it("should exclude 11 hidden commands (36 visible)", () => {
       // 5 hidden global (help, --help, -h, --version, -v) +
       // 6 hidden sandbox (shields×3, config×3)
-      expect(visibleCommands()).toHaveLength(35);
+      expect(visibleCommands()).toHaveLength(36);
     });
 
     it("no visible command has hidden=true", () => {
@@ -167,9 +167,9 @@ describe("command-registry", () => {
   });
 
   describe("sandboxActionTokens()", () => {
-    it("returns exactly 14 unique action tokens including empty string", () => {
+    it("returns exactly 15 unique action tokens including empty string", () => {
       const tokens = sandboxActionTokens();
-      expect(tokens).toHaveLength(14);
+      expect(tokens).toHaveLength(15);
       // Must contain the same set as the old sandboxActions array
       const expected = new Set([
         "connect",
@@ -185,6 +185,7 @@ describe("command-registry", () => {
         "shields",
         "config",
         "channels",
+        "gateway-token",
         "",
       ]);
       expect(new Set(tokens)).toEqual(expected);

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -131,6 +131,13 @@ export const COMMANDS: readonly CommandDef[] = [
     scope: "sandbox",
   },
   {
+    usage: "nemoclaw <name> gateway-token",
+    description: "Print the OpenClaw gateway auth token to stdout",
+    flags: "[--quiet|-q]",
+    group: "Sandbox Management",
+    scope: "sandbox",
+  },
+  {
     usage: "nemoclaw <name> destroy",
     description: "Stop NIM + delete sandbox",
     flags: "(--yes to skip prompt)",

--- a/src/lib/gateway-token-command.test.ts
+++ b/src/lib/gateway-token-command.test.ts
@@ -52,7 +52,7 @@ describe("runGatewayTokenCommand", () => {
     const exitCode = runGatewayTokenCommand(
       "alpha",
       { quiet: false },
-      { getSandbox: () => ({ name: "alpha" }), fetchToken, log: sinks.log, error: sinks.error },
+      { fetchToken, log: sinks.log, error: sinks.error },
     );
     expect(exitCode).toBe(0);
     expect(fetchToken).toHaveBeenCalledWith("alpha");
@@ -67,7 +67,6 @@ describe("runGatewayTokenCommand", () => {
       "alpha",
       { quiet: true },
       {
-        getSandbox: () => ({ name: "alpha" }),
         fetchToken: () => "secret-token-abc",
         log: sinks.log,
         error: sinks.error,
@@ -78,27 +77,12 @@ describe("runGatewayTokenCommand", () => {
     expect(sinks.err).toEqual([]);
   });
 
-  it("exits 1 when the sandbox is not registered", () => {
-    const sinks = makeSinks();
-    const fetchToken = vi.fn();
-    const exitCode = runGatewayTokenCommand(
-      "ghost",
-      { quiet: false },
-      { getSandbox: () => null, fetchToken, log: sinks.log, error: sinks.error },
-    );
-    expect(exitCode).toBe(1);
-    expect(fetchToken).not.toHaveBeenCalled();
-    expect(sinks.out).toEqual([]);
-    expect(sinks.err.join("\n")).toMatch(/not registered/);
-  });
-
   it("exits 1 with diagnostics when the token cannot be fetched", () => {
     const sinks = makeSinks();
     const exitCode = runGatewayTokenCommand(
       "alpha",
       { quiet: false },
       {
-        getSandbox: () => ({ name: "alpha" }),
         fetchToken: () => null,
         log: sinks.log,
         error: sinks.error,
@@ -116,7 +100,6 @@ describe("runGatewayTokenCommand", () => {
       "alpha",
       { quiet: true },
       {
-        getSandbox: () => ({ name: "alpha" }),
         fetchToken: () => {
           throw new Error("openshell offline");
         },
@@ -135,7 +118,6 @@ describe("runGatewayTokenCommand", () => {
       "alpha",
       { quiet: false },
       {
-        getSandbox: () => ({ name: "alpha" }),
         fetchToken: () => "",
         log: sinks.log,
         error: sinks.error,

--- a/src/lib/gateway-token-command.test.ts
+++ b/src/lib/gateway-token-command.test.ts
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  parseGatewayTokenArgs,
+  runGatewayTokenCommand,
+} from "../../dist/lib/gateway-token-command";
+
+function makeSinks() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    log: (m: string) => out.push(m),
+    error: (m: string) => err.push(m),
+  };
+}
+
+describe("parseGatewayTokenArgs", () => {
+  it("defaults quiet to false when no flags are given", () => {
+    expect(parseGatewayTokenArgs([])).toEqual({ options: { quiet: false }, unknown: [] });
+  });
+
+  it("parses --quiet", () => {
+    expect(parseGatewayTokenArgs(["--quiet"])).toEqual({
+      options: { quiet: true },
+      unknown: [],
+    });
+  });
+
+  it("parses -q", () => {
+    expect(parseGatewayTokenArgs(["-q"])).toEqual({
+      options: { quiet: true },
+      unknown: [],
+    });
+  });
+
+  it("collects unknown flags without throwing", () => {
+    const { options, unknown } = parseGatewayTokenArgs(["--bogus", "-q", "extra"]);
+    expect(options).toEqual({ quiet: true });
+    expect(unknown).toEqual(["--bogus", "extra"]);
+  });
+});
+
+describe("runGatewayTokenCommand", () => {
+  it("prints the token to stdout and warns on stderr", () => {
+    const sinks = makeSinks();
+    const fetchToken = vi.fn(() => "secret-token-abc");
+    const exitCode = runGatewayTokenCommand(
+      "alpha",
+      { quiet: false },
+      { getSandbox: () => ({ name: "alpha" }), fetchToken, log: sinks.log, error: sinks.error },
+    );
+    expect(exitCode).toBe(0);
+    expect(fetchToken).toHaveBeenCalledWith("alpha");
+    expect(sinks.out).toEqual(["secret-token-abc"]);
+    expect(sinks.err).toHaveLength(1);
+    expect(sinks.err[0]).toMatch(/like a password/i);
+  });
+
+  it("suppresses the security warning when quiet is set", () => {
+    const sinks = makeSinks();
+    const exitCode = runGatewayTokenCommand(
+      "alpha",
+      { quiet: true },
+      {
+        getSandbox: () => ({ name: "alpha" }),
+        fetchToken: () => "secret-token-abc",
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+    expect(exitCode).toBe(0);
+    expect(sinks.out).toEqual(["secret-token-abc"]);
+    expect(sinks.err).toEqual([]);
+  });
+
+  it("exits 1 when the sandbox is not registered", () => {
+    const sinks = makeSinks();
+    const fetchToken = vi.fn();
+    const exitCode = runGatewayTokenCommand(
+      "ghost",
+      { quiet: false },
+      { getSandbox: () => null, fetchToken, log: sinks.log, error: sinks.error },
+    );
+    expect(exitCode).toBe(1);
+    expect(fetchToken).not.toHaveBeenCalled();
+    expect(sinks.out).toEqual([]);
+    expect(sinks.err.join("\n")).toMatch(/not registered/);
+  });
+
+  it("exits 1 with diagnostics when the token cannot be fetched", () => {
+    const sinks = makeSinks();
+    const exitCode = runGatewayTokenCommand(
+      "alpha",
+      { quiet: false },
+      {
+        getSandbox: () => ({ name: "alpha" }),
+        fetchToken: () => null,
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+    expect(exitCode).toBe(1);
+    expect(sinks.out).toEqual([]);
+    expect(sinks.err.join("\n")).toMatch(/Could not retrieve/);
+    expect(sinks.err.join("\n")).toMatch(/sandbox is running/);
+  });
+
+  it("exits 1 when fetchToken throws", () => {
+    const sinks = makeSinks();
+    const exitCode = runGatewayTokenCommand(
+      "alpha",
+      { quiet: true },
+      {
+        getSandbox: () => ({ name: "alpha" }),
+        fetchToken: () => {
+          throw new Error("openshell offline");
+        },
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+    expect(exitCode).toBe(1);
+    expect(sinks.out).toEqual([]);
+    expect(sinks.err.join("\n")).toMatch(/Could not retrieve/);
+  });
+
+  it("treats an empty-string token as missing", () => {
+    const sinks = makeSinks();
+    const exitCode = runGatewayTokenCommand(
+      "alpha",
+      { quiet: false },
+      {
+        getSandbox: () => ({ name: "alpha" }),
+        fetchToken: () => "",
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+    expect(exitCode).toBe(1);
+    expect(sinks.out).toEqual([]);
+  });
+});

--- a/src/lib/gateway-token-command.ts
+++ b/src/lib/gateway-token-command.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `nemoclaw <name> gateway-token` — print the OpenClaw gateway auth token
+ * for a running sandbox to stdout so automation can capture it.
+ *
+ * Output contract (intended to be pipe-friendly):
+ *   stdout: the token, followed by a single newline.
+ *   stderr: a one-line security warning, suppressed by --quiet / -q.
+ *   exit 0: token printed.
+ *   exit 1: token unavailable; diagnostics written to stderr.
+ */
+
+export interface GatewayTokenCommandDeps {
+  /** Look up a sandbox in the registry; returns null/undefined when unknown. */
+  getSandbox: (name: string) => unknown;
+  /** Pull gateway.auth.token from the sandbox config (host-side helper). */
+  fetchToken: (sandboxName: string) => string | null;
+  /** Optional stdout sink — defaults to console.log. */
+  log?: (message: string) => void;
+  /** Optional stderr sink — defaults to console.error. */
+  error?: (message: string) => void;
+}
+
+export interface GatewayTokenCommandOptions {
+  /** Suppress the stderr security warning when set (`--quiet` / `-q`). */
+  quiet?: boolean;
+}
+
+const SECURITY_WARNING =
+  "Treat this token like a password — do not log, share, or commit it.";
+
+/**
+ * Run the gateway-token command. Returns the process exit code (0 on success,
+ * 1 on failure). The caller is responsible for invoking `process.exit`.
+ */
+export function runGatewayTokenCommand(
+  sandboxName: string,
+  options: GatewayTokenCommandOptions,
+  deps: GatewayTokenCommandDeps,
+): number {
+  const log = deps.log ?? ((m: string) => console.log(m));
+  const error = deps.error ?? ((m: string) => console.error(m));
+
+  if (!deps.getSandbox(sandboxName)) {
+    error(`  Sandbox '${sandboxName}' is not registered.`);
+    error(`  Run 'nemoclaw list' to see registered sandboxes.`);
+    return 1;
+  }
+
+  let token: string | null;
+  try {
+    token = deps.fetchToken(sandboxName);
+  } catch {
+    token = null;
+  }
+
+  if (!token) {
+    error(`  Could not retrieve the gateway auth token for sandbox '${sandboxName}'.`);
+    error(`  Make sure the sandbox is running: nemoclaw ${sandboxName} status`);
+    return 1;
+  }
+
+  log(token);
+  if (!options.quiet) {
+    error(SECURITY_WARNING);
+  }
+  return 0;
+}
+
+/** Parse the raw `gateway-token` action arguments. */
+export function parseGatewayTokenArgs(actionArgs: readonly string[]): {
+  options: GatewayTokenCommandOptions;
+  unknown: string[];
+} {
+  const options: GatewayTokenCommandOptions = { quiet: false };
+  const unknown: string[] = [];
+  for (const arg of actionArgs) {
+    if (arg === "--quiet" || arg === "-q") {
+      options.quiet = true;
+    } else {
+      unknown.push(arg);
+    }
+  }
+  return { options, unknown };
+}

--- a/src/lib/gateway-token-command.ts
+++ b/src/lib/gateway-token-command.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * `nemoclaw <name> gateway-token` — print the OpenClaw gateway auth token
+ * `nemoclaw <name> gateway-token` -- print the OpenClaw gateway auth token
  * for a running sandbox to stdout so automation can capture it.
  *
  * Output contract (intended to be pipe-friendly):
@@ -13,13 +13,11 @@
  */
 
 export interface GatewayTokenCommandDeps {
-  /** Look up a sandbox in the registry; returns null/undefined when unknown. */
-  getSandbox: (name: string) => unknown;
   /** Pull gateway.auth.token from the sandbox config (host-side helper). */
   fetchToken: (sandboxName: string) => string | null;
-  /** Optional stdout sink — defaults to console.log. */
+  /** Optional stdout sink -- defaults to console.log. */
   log?: (message: string) => void;
-  /** Optional stderr sink — defaults to console.error. */
+  /** Optional stderr sink -- defaults to console.error. */
   error?: (message: string) => void;
 }
 
@@ -29,11 +27,12 @@ export interface GatewayTokenCommandOptions {
 }
 
 const SECURITY_WARNING =
-  "Treat this token like a password — do not log, share, or commit it.";
+  "Treat this token like a password -- do not log, share, or commit it.";
 
 /**
  * Run the gateway-token command. Returns the process exit code (0 on success,
- * 1 on failure). The caller is responsible for invoking `process.exit`.
+ * 1 on failure). The caller is responsible for invoking `process.exit` and for
+ * having validated that the sandbox exists in the registry.
  */
 export function runGatewayTokenCommand(
   sandboxName: string,
@@ -42,12 +41,6 @@ export function runGatewayTokenCommand(
 ): number {
   const log = deps.log ?? ((m: string) => console.log(m));
   const error = deps.error ?? ((m: string) => console.error(m));
-
-  if (!deps.getSandbox(sandboxName)) {
-    error(`  Sandbox '${sandboxName}' is not registered.`);
-    error(`  Run 'nemoclaw list' to see registered sandboxes.`);
-    return 1;
-  }
 
   let token: string | null;
   try {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -7916,6 +7916,7 @@ module.exports = {
   writeSandboxConfigSyncFile,
   patchStagedDockerfile,
   ensureOllamaAuthProxy,
+  fetchGatewayAuthTokenFromSandbox,
   getProbeAuthMode,
   getValidationProbeCurlArgs,
   checkTelegramReachability,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -31,11 +31,16 @@ const {
 } = require("./lib/runner");
 const { resolveOpenshell } = require("./lib/resolve-openshell");
 const {
+  fetchGatewayAuthTokenFromSandbox,
   startGatewayForRecovery,
   pruneKnownHostsEntries,
   ensureOllamaAuthProxy,
   isNonInteractive,
 } = require("./lib/onboard");
+const {
+  parseGatewayTokenArgs,
+  runGatewayTokenCommand,
+} = require("./lib/gateway-token-command");
 const {
   getCredential,
   deleteCredential,
@@ -3694,6 +3699,21 @@ const [cmd, ...args] = process.argv.slice(2);
       case "destroy":
         await sandboxDestroy(cmd, actionArgs);
         break;
+      case "gateway-token": {
+        const { options: gatewayTokenOpts, unknown: gatewayTokenUnknown } =
+          parseGatewayTokenArgs(actionArgs);
+        if (gatewayTokenUnknown.length > 0) {
+          console.error(`  Unknown flag: ${gatewayTokenUnknown[0]}`);
+          console.error("  Usage: nemoclaw <name> gateway-token [--quiet|-q]");
+          process.exit(1);
+        }
+        const exitCode = runGatewayTokenCommand(cmd, gatewayTokenOpts, {
+          getSandbox: registry.getSandbox,
+          fetchToken: fetchGatewayAuthTokenFromSandbox,
+        });
+        if (exitCode !== 0) process.exit(exitCode);
+        break;
+      }
       case "skill":
         await sandboxSkillInstall(cmd, actionArgs);
         break;
@@ -3852,7 +3872,7 @@ const [cmd, ...args] = process.argv.slice(2);
       default:
         console.error(`  Unknown action: ${action}`);
         console.error(
-          `  Valid actions: connect, status, logs, policy-add, policy-remove, policy-list, skill, snapshot, rebuild, shields, config, channels, destroy`,
+          `  Valid actions: connect, status, logs, policy-add, policy-remove, policy-list, skill, snapshot, rebuild, shields, config, channels, gateway-token, destroy`,
         );
         process.exit(1);
     }

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -3707,8 +3707,12 @@ const [cmd, ...args] = process.argv.slice(2);
           console.error("  Usage: nemoclaw <name> gateway-token [--quiet|-q]");
           process.exit(1);
         }
+        // Suppress EPIPE traces when the consumer closes the pipe early
+        // (e.g. `... | head -c 0`). The token has already been written.
+        process.stdout.on("error", (err: NodeJS.ErrnoException) => {
+          if (err.code === "EPIPE") process.exit(0);
+        });
         const exitCode = runGatewayTokenCommand(cmd, gatewayTokenOpts, {
-          getSandbox: registry.getSandbox,
           fetchToken: fetchGatewayAuthTokenFromSandbox,
         });
         if (exitCode !== 0) process.exit(exitCode);


### PR DESCRIPTION
## Summary
Add `nemoclaw <name> gateway-token` so automation can capture the OpenClaw gateway auth token after onboarding without scraping `/sandbox/.openclaw/openclaw.json` by hand.

## Related Issue
Closes #938

## Changes
- Add `src/lib/gateway-token-command.ts` with a host-side handler that takes a `fetchToken` dependency plus log/error sinks, keeping it unit-testable in isolation.
- Reuse the existing host-side helper `fetchGatewayAuthTokenFromSandbox` from `src/lib/onboard.ts` (now exported) instead of duplicating token retrieval.
- Wire the new sandbox action into `src/nemoclaw.ts` dispatch, parse `--quiet` / `-q`, reject unknown flags, and silence EPIPE on stdout so consumers like `... | head -c 0` don't see a Node stack trace after the token has been written.
- Register the command in `src/lib/command-registry.ts` so it appears in `nemoclaw --help` automatically.
- Document the command under `docs/reference/commands.md` (skill page regenerated by the doc-to-skills hook).
- Add unit tests in `src/lib/gateway-token-command.test.ts` covering the success path, `--quiet`, fetch returning null, fetch throwing, and empty-string token.

Output contract:
- stdout: token only, no surrounding text (pipe-friendly).
- stderr: one-line security warning, suppressed by `--quiet` / `-q`.
- exit 0 when the token prints; exit 1 when the sandbox is unknown or the token cannot be retrieved (with a diagnostic on stderr).

Example:

```bash
TOKEN=$(nemoclaw my-assistant gateway-token --quiet)
export OPENCLAW_GATEWAY_TOKEN="$TOKEN"
```

## Review Follow-ups

After the initial commit, an adversarial code review surfaced several issues. Addressed in commit `925673ec`:

- **Dead `getSandbox` check + latent unbound-`this` risk** — the upstream `recoverRegistryEntries` guard at `src/nemoclaw.ts:3651` already rejects unknown sandbox names before the action switch is reached, so the in-command "not registered" branch was unreachable from the CLI. Dropped the dependency entirely; the unknown-sandbox path now relies on the same guard every other sandbox subcommand uses.
- **EPIPE on stdout** — added a stdout error handler so `nemoclaw foo gateway-token | head -c 0` no longer emits a Node stack trace after the token has been written.
- **Em-dash → `--`** — the stderr security warning now uses ASCII so it renders cleanly on legacy Windows consoles.

Considered and explicitly skipped, with reasoning:

- **TTY refusal / `--print` flag** — issue #938 carves out two commands: `open` to minimize TTY exposure, and `gateway-token` for the scripting use case. Adding TTY refusal here would depart from the issue's design.
- **Audit logging on token read** — sibling sandbox subcommands (including the credential-related ones) don't audit reads, and the existing onboard wizard prints the same token without auditing. Adding it only here would be inconsistent and out of scope for #938.
- **`--help` flag for the subcommand** — no other sandbox subcommand accepts `--help`; matching convention.
- **Surface the underlying fetch error** — `fetchGatewayAuthTokenFromSandbox` swallows every failure to `null` today, so there is nothing to surface without a deeper refactor of the helper. Out of scope.

## Type of Change

- [x] Code change with doc updates

## Verification
- [x] `npm run typecheck:cli` passes
- [x] `npx vitest run --project cli` passes for all tests except the four pre-existing slow-timeout flakes in `test/onboard.test.ts` (5 s timeout vs 7–12 s actual on slow hardware) that also fail on clean main and are unrelated to this change
- [x] `npx prek run --all-files` passes apart from the same pre-existing `test/onboard.test.ts` flakes
- [x] Tests added for new behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for the new command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `nemoclaw <name> gateway-token` CLI command to output a sandbox's OpenClaw gateway auth token to stdout; emits a one-line security warning to stderr unless suppressed with `--quiet`/`-q`; exits non-zero with diagnostics on failure.

* **Documentation**
  * Added command reference entry documenting usage, warning behavior, and failure semantics.

* **Tests**
  * Added tests covering argument parsing, success/failure behavior, and expected stdout/stderr outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->