### PR TITLE
fix(onboard): display port override hint in dashboard port conflict error

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2910,6 +2910,11 @@ async function preflight(): Promise<ReturnType<typeof nim.detectGpu>> {
       }
       console.error("");
       console.error(`     Detail: ${portCheck.reason}`);
+      if (port === DASHBOARD_PORT) {
+        console.error("");
+        console.error("     Or use a different port instead:");
+        console.error("       NEMOCLAW_DASHBOARD_PORT=<N> nemoclaw onboard");
+      }
       process.exit(1);
     }
     console.log(`  ✓ Port ${port} available (${label})`);


### PR DESCRIPTION
## Summary

When preflight fails because port 18789 is already bound by an unrelated process, the error message now surfaces \`NEMOCLAW_DASHBOARD_PORT\` so users can pick an alternative port without having to stop the conflicting process. Previously the error only suggested killing the blocker, with no mention of the documented override mechanism.

## Related Issue

Fixes #2497

## Changes

- \`src/lib/onboard.ts\`: after the port conflict detail line, print a hint with \`NEMOCLAW_DASHBOARD_PORT=<N> nemoclaw onboard\` — guarded by \`port === DASHBOARD_PORT\` so it only appears for dashboard port conflicts, not gateway port conflicts.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] \`npx prek run --all-files\` passes
- [x] \`npm test\` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] \`make docs\` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

**Notes:**
- \`npx prek run --all-files\`: two pre-existing environment failures unrelated to this change — \`hadolint\` not installed on this machine, and \`nemoclaw/\` ESLint missing its subproject \`node_modules\`. The ESLint CLI hook covering the changed file (\`src/lib/onboard.ts\`) passed.
- \`npm test\`: 139/139 onboard tests pass. Two pre-existing failures in \`preflight.test.ts\` are environment-specific (an \`nc\` process is bound to port 18789 on the test machine, reproducing the exact scenario from #2497).
- The troubleshooting docs already document \`NEMOCLAW_DASHBOARD_PORT\` as an override; no doc update needed.
- The multi-sandbox port conflict path (\`ensureDashboardForward\`) was refactored upstream to auto-allocate a free port instead of erroring, so point 2 from the review is now moot.

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---
Signed-off-by: Abhishek Pareek <makeittotop@users.noreply.github.com>