### PR TITLE
fix(ci): add --ignore-scripts to plugin npm install in brev launchable

### DIFF
--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -283,7 +283,7 @@ info "CLI built"
 
 info "Building TypeScript plugin..."
 cd "$NEMOCLAW_CLONE_DIR/nemoclaw"
-npm install 2>&1 | tail -3
+npm install --ignore-scripts 2>&1 | tail -3
 npm run build 2>&1 | tail -3
 cd "$NEMOCLAW_CLONE_DIR"
 info "Plugin built"


### PR DESCRIPTION
Every other \`npm install\` in \`brev-launchable-ci-cpu.sh\` passes
\`--ignore-scripts\` (line 274), and the same flag is used throughout
\`install.sh\` (lines 857, 859, 888, 890). The plugin build step at
line 286 was missing it.

Without the flag, postinstall scripts from NemoClaw's transitive
dependencies can execute as the Brev VM user during launchable boot.
This brings the script into line with the project's established
practice.

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration build configuration to optimize TypeScript plugin dependency installation during the automated build process. This modification enhances build efficiency and stability by streamlining the dependency resolution process, resulting in faster and more reliable builds across all development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->