### PR TITLE
fix(security): restrict permissions on service tmp dir and log file

### DIFF
--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -61,7 +61,7 @@ function warn(msg: string): void {
 
 function ensurePidDir(pidDir: string): void {
   if (!existsSync(pidDir)) {
-    mkdirSync(pidDir, { recursive: true });
+    mkdirSync(pidDir, { recursive: true, mode: 0o700 });
   }
 }
 
@@ -123,7 +123,7 @@ function startService(
   // Uses child_process.spawn directly because execa's typed API
   // does not accept raw file descriptors for stdio.
   const logFile = join(pidDir, `${name}.log`);
-  const logFd = openSync(logFile, "w");
+  const logFd = openSync(logFile, "w", 0o600);
   const subprocess = spawn(command, args, {
     detached: true,
     stdio: ["ignore", logFd, logFd],

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -3,8 +3,10 @@
 
 import { execSync, spawn } from "node:child_process";
 import {
+  chmodSync,
   closeSync,
   existsSync,
+  fchmodSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -63,6 +65,7 @@ function ensurePidDir(pidDir: string): void {
   if (!existsSync(pidDir)) {
     mkdirSync(pidDir, { recursive: true, mode: 0o700 });
   }
+  chmodSync(pidDir, 0o700);
 }
 
 function readPid(pidDir: string, name: string): number | null {
@@ -124,6 +127,7 @@ function startService(
   // does not accept raw file descriptors for stdio.
   const logFile = join(pidDir, `${name}.log`);
   const logFd = openSync(logFile, "w", 0o600);
+  fchmodSync(logFd, 0o600);
   const subprocess = spawn(command, args, {
     detached: true,
     stdio: ["ignore", logFd, logFd],


### PR DESCRIPTION
\`/tmp/nemoclaw-services-{name}/\` was created with the default 0o755
mode, making \`cloudflared.log\` world-readable. The log contains the
public \`*.trycloudflare.com\` tunnel URL — any local user on a
multi-user system could read it and use the URL to probe the dashboard
from anywhere on the internet.

Set the directory to 0o700 and the log file to 0o600 so only the
owning user can access them.

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PID directories and per-service log files are now created with explicit restrictive filesystem permissions to prevent unauthorized access.
  * Permission settings are applied deterministically (not relying on system defaults) to ensure the intended access restrictions are always enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->