### PR TITLE
test(validation): replace stale provider ID in shouldSkipResponsesProbe test

### DIFF
--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -286,7 +286,7 @@ describe("shouldSkipResponsesProbe", () => {
 
   it("does not skip the Responses probe for other providers", () => {
     expect(shouldSkipResponsesProbe("openai-api")).toBe(false);
-    expect(shouldSkipResponsesProbe("anthropic-api")).toBe(false);
+    expect(shouldSkipResponsesProbe("anthropic-prod")).toBe(false);
     expect(shouldSkipResponsesProbe("compatible-endpoint")).toBe(false);
     expect(shouldSkipResponsesProbe("")).toBe(false);
   });


### PR DESCRIPTION
The fixture on line 289 used \`"anthropic-api"\` which does not exist
anywhere in the codebase as a provider ID. The real Anthropic provider
ID used throughout \`inference-config.ts\`, \`onboard.ts\`, and
\`inference-health.ts\` is \`"anthropic-prod"\`.

The test still passed because \`shouldSkipResponsesProbe\` returns
\`false\` for any unrecognised string, so the assertion was never
actually exercising the Anthropic provider path — it was passing
vacuously.

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage for provider validation to ensure proper validation across different provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->