### PR TITLE
fix(validation): add nvidia-nim to shouldSkipResponsesProbe

### DIFF
--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -280,6 +280,10 @@ describe("shouldSkipResponsesProbe", () => {
     expect(shouldSkipResponsesProbe("nvidia-prod")).toBe(true);
   });
 
+  it("skips the Responses probe for nvidia-nim (same endpoint as nvidia-prod, no /v1/responses)", () => {
+    expect(shouldSkipResponsesProbe("nvidia-nim")).toBe(true);
+  });
+
   it("skips the Responses probe for gemini-api (Gemini does not support /v1/responses)", () => {
     expect(shouldSkipResponsesProbe("gemini-api")).toBe(true);
   });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -143,7 +143,7 @@ export function nvcfFunctionNotFoundMessage(model: string): string {
  * See issue #1601 (Bug 1) and issue #1960.
  */
 export function shouldSkipResponsesProbe(provider: string): boolean {
-  return provider === "nvidia-prod" || provider === "gemini-api";
+  return provider === "nvidia-prod" || provider === "nvidia-nim" || provider === "gemini-api";
 }
 
 /**


### PR DESCRIPTION
\`nvidia-prod\` and \`nvidia-nim\` map to the same NVIDIA endpoint config
in \`inference-config.ts\` — same base URL, same credential env, same
\`providerLabel: "NVIDIA Endpoints"\`. Neither supports \`/v1/responses\`.

\`nvidia-prod\` was already listed in \`shouldSkipResponsesProbe\` but
\`nvidia-nim\` was missing, so sandboxes onboarded with the \`nvidia-nim\`
provider incorrectly ran the Responses probe against an endpoint that
does not expose it.

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The nvidia-nim inference provider is now properly supported in the setup wizard's response validation logic, with consistent handling across all supported providers.

* **Tests**
  * Added unit test coverage to verify nvidia-nim provider response validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->