### PR TITLE
fix(cli): pass link.label to formatTerminalHyperlink instead of link.url

### DIFF
--- a/src/lib/usage-notice.ts
+++ b/src/lib/usage-notice.ts
@@ -165,7 +165,7 @@ export function printUsageNotice(
     writeLine("");
     const label =
       supportsTerminalHyperlinks() && link?.url && link?.label
-        ? formatTerminalHyperlink(link.url, link.url)
+        ? formatTerminalHyperlink(link.label, link.url)
         : link?.label || "";
     if (label) {
       writeLine(`  ${label}`);


### PR DESCRIPTION
\`formatTerminalHyperlink(label, url)\` takes the display text as its
first argument. The structured-link branch in \`printUsageNotice\` was
calling \`formatTerminalHyperlink(link.url, link.url)\`, passing the
URL as both arguments — so terminal hyperlinks displayed the raw URL
string as the clickable label instead of the configured \`link.label\`
text.

The plain-URL body branch at line 160 correctly passes the text as the
label. This brings the structured-link branch into line with it.

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal hyperlink display corrected to show the configured label text instead of the full URL as the visible text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->