### PR TITLE
fix(sandbox): stage generate-openclaw-config.py in optimised build context

### DIFF
--- a/src/lib/sandbox-build-context.ts
+++ b/src/lib/sandbox-build-context.ts
@@ -79,6 +79,10 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "scripts", "nemoclaw-start.sh"),
     path.join(stagedScriptsDir, "nemoclaw-start.sh"),
   );
+  fs.copyFileSync(
+    path.join(rootDir, "scripts", "generate-openclaw-config.py"),
+    path.join(stagedScriptsDir, "generate-openclaw-config.py"),
+  );
   // Shared sandbox initialisation library sourced by the entrypoint (#2277)
   fs.mkdirSync(path.join(stagedScriptsDir, "lib"), { recursive: true });
   fs.copyFileSync(

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -27,6 +27,10 @@ describe("sandbox build context staging", () => {
         ),
       ).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "nemoclaw-start.sh"))).toBe(true);
+      expect(
+        fs.existsSync(path.join(buildCtx, "scripts", "generate-openclaw-config.py")),
+      ).toBe(true);
+      expect(fs.existsSync(path.join(buildCtx, "scripts", "lib", "sandbox-init.sh"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
The optimised sandbox build context staging in
`stageOptimizedSandboxBuildContext` only copied `nemoclaw-start.sh` and `lib/sandbox-init.sh` into the staged scripts directory, but the Dockerfile (line 195) also COPYs `scripts/generate-openclaw-config.py`. The script was added in ca46f470 ("feat: extract inline Python config to scripts/generate-openclaw-config.py") which updated the Dockerfile but not the staging function, so `nemoclaw onboard` fails at the COPY step.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Fixes #2503

## Changes
<!-- Bullet list of key changes. -->
The legacy staging path (`stageLegacySandboxBuildContext`) recursively copies the entire `scripts/` directory and is therefore unaffected.

Also extend the optimised-staging test to assert both `generate-openclaw-config.py` and `lib/sandbox-init.sh` are present in the staged context, so future Dockerfile additions that miss the staging function will be caught immediately.

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [X] AI-assisted — tool: Claude Code<!-- e.g., Claude Code, Cursor, GitHub Copilot -->

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified sandbox build context staging to include an additional required script file in the build output.

* **Tests**
  * Updated test suite with new assertions to validate script file staging behavior, confirming proper inclusion of required files and exclusion of unnecessary files in the sandbox build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->