### PR TITLE
fix(sandbox): derive staged scripts from Dockerfile to prevent drift

### DIFF
--- a/src/lib/sandbox-build-context.ts
+++ b/src/lib/sandbox-build-context.ts
@@ -58,17 +58,22 @@ function stageOptimizedSandboxBuildContext(rootDir, tmpDir = os.tmpdir()) {
     recursive: true,
   });
 
-  fs.mkdirSync(stagedScriptsDir, { recursive: true });
-  fs.copyFileSync(
-    path.join(rootDir, "scripts", "nemoclaw-start.sh"),
-    path.join(stagedScriptsDir, "nemoclaw-start.sh"),
-  );
-  // Shared sandbox initialisation library sourced by the entrypoint (#2277)
-  fs.mkdirSync(path.join(stagedScriptsDir, "lib"), { recursive: true });
-  fs.copyFileSync(
-    path.join(rootDir, "scripts", "lib", "sandbox-init.sh"),
-    path.join(stagedScriptsDir, "lib", "sandbox-init.sh"),
-  );
+  // Derive the scripts to stage directly from the Dockerfile so this function
+  // never drifts out of sync with it.  Every `COPY scripts/<src> <dest>` line
+  // (excluding multi-stage `--from=` copies) is extracted and the source path
+  // is copied into the build context at the same relative location.
+  const dockerfileContent = fs.readFileSync(stagedDockerfile, "utf8");
+  const copyPattern = /^COPY(?:\s+--\w+[^\s]*)*\s+(scripts\/\S+)\s+\S/gm;
+  let match;
+  while ((match = copyPattern.exec(dockerfileContent)) !== null) {
+    // Skip --from=<stage> copies — those are inter-stage, not host → context.
+    if (/--from=/i.test(match[0])) continue;
+    const relSrc = match[1]; // e.g. "scripts/nemoclaw-start.sh"
+    const srcPath = path.join(rootDir, relSrc);
+    const destPath = path.join(buildCtx, relSrc);
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.copyFileSync(srcPath, destPath);
+  }
 
   return { buildCtx, stagedDockerfile };
 }

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -20,11 +20,13 @@ describe("sandbox build context staging", () => {
     const dockerfileContent = fs.readFileSync(dockerfilePath, "utf8");
 
     // Extract source paths from every "COPY scripts/<path>" line in the Dockerfile.
-    // Skips multi-source COPY forms (multiple sources before dest) for simplicity.
-    const copyPattern = /^COPY\s+(scripts\/\S+)\s+\S/gm;
+    // Skips multi-source COPY forms and inter-stage --from= copies.
+    const copyPattern = /^COPY(?:\s+--\w+[^\s]*)*\s+(scripts\/\S+)\s+\S/gm;
     const scriptSources: string[] = [];
     let match: RegExpExecArray | null;
     while ((match = copyPattern.exec(dockerfileContent)) !== null) {
+      // Skip --from=<stage> copies — those are inter-stage, not host → context.
+      if (/--from=/i.test(match[0])) continue;
       scriptSources.push(match[1]);
     }
 

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -14,6 +14,36 @@ import {
 } from "../dist/lib/sandbox-build-context";
 
 describe("sandbox build context staging", () => {
+  it("staged build context includes every file referenced by COPY scripts/ in the Dockerfile", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const dockerfilePath = path.join(repoRoot, "Dockerfile");
+    const dockerfileContent = fs.readFileSync(dockerfilePath, "utf8");
+
+    // Extract source paths from every "COPY scripts/<path>" line in the Dockerfile.
+    // Skips multi-source COPY forms (multiple sources before dest) for simplicity.
+    const copyPattern = /^COPY\s+(scripts\/\S+)\s+\S/gm;
+    const scriptSources: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = copyPattern.exec(dockerfileContent)) !== null) {
+      scriptSources.push(match[1]);
+    }
+
+    expect(scriptSources.length, "expected at least one COPY scripts/ line in Dockerfile").toBeGreaterThan(0);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-scripts-"));
+    try {
+      const { buildCtx } = stageOptimizedSandboxBuildContext(repoRoot, tmpDir);
+      for (const src of scriptSources) {
+        expect(
+          fs.existsSync(path.join(buildCtx, src)),
+          `"${src}" is referenced by a COPY in the Dockerfile but is missing from the staged build context — update stageOptimizedSandboxBuildContext in src/lib/sandbox-build-context.ts`,
+        ).toBe(true);
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("optimized staging excludes blueprint .venv and extra scripts while preserving required files", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-opt-"));


### PR DESCRIPTION
## Summary

`stageOptimizedSandboxBuildContext` maintained a hardcoded list of `scripts/` files to copy into the Docker build context. Any `COPY scripts/<file>` added to the Dockerfile without a matching entry in that list caused a silent \"file not found in build context\" failure at sandbox creation time (see #2503). Replace the explicit allowlist with a Dockerfile parser so the two can never drift.

## Related Issue

Fixes #2503

## Changes

- `src/lib/sandbox-build-context.ts`: replace hardcoded `scripts/` file list with a loop that parses every `COPY scripts/<src> <dest>` line in the staged Dockerfile (skipping `--from=` inter-stage copies) and copies each source into the build context at the same relative path. The Dockerfile is now the single source of truth.
- `test/sandbox-build-context.test.ts`: add regression test that parses the same `COPY scripts/` lines from the Dockerfile and asserts each source path exists in the staged build context produced by `stageOptimizedSandboxBuildContext`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Cursor

---
Signed-off-by: jama <jama@nvidia.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Build script staging now dynamically aligns staged scripts with build configuration instead of using fixed references, ensuring staged contents match declared script entries.

* **Tests**
  * Added a validation test that checks all scripts referenced by the build configuration are present in the staged build context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->