### PR TITLE
fix(onboard): downgrade Brave validation failure from fatal to warning in non-interactive mode

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1390,11 +1390,11 @@ async function configureWebSearch(
     note("  [non-interactive] Brave Web Search requested.");
     const validation = validateBraveSearchApiKey(braveApiKey);
     if (!validation.ok) {
-      console.error("  Brave Search API key validation failed.");
+      console.warn("  ⚠ Brave Search API key validation failed — web search will be disabled.");
       if (validation.message) {
-        console.error(`  ${validation.message}`);
+        console.warn(`  ${validation.message}`);
       }
-      process.exit(1);
+      return null;
     }
     saveCredential(webSearch.BRAVE_API_KEY_ENV, braveApiKey);
     process.env[webSearch.BRAVE_API_KEY_ENV] = braveApiKey;

--- a/test/brave-validation-skip.test.ts
+++ b/test/brave-validation-skip.test.ts
@@ -5,8 +5,11 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, afterEach } from "vitest";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 
 describe("configureWebSearch non-interactive Brave validation failure", () => {

--- a/test/brave-validation-skip.test.ts
+++ b/test/brave-validation-skip.test.ts
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, afterEach } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..");
+
+describe("configureWebSearch non-interactive Brave validation failure", () => {
+  const tmpFiles: string[] = [];
+
+  afterEach(() => {
+    for (const f of tmpFiles) {
+      try {
+        fs.unlinkSync(f);
+      } catch {}
+    }
+    tmpFiles.length = 0;
+  });
+
+  it("returns null instead of exiting when Brave API key validation fails", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brave-skip-"));
+    const scriptPath = path.join(tmpDir, "test-brave-skip.mjs");
+    tmpFiles.push(scriptPath);
+
+    // Script that imports configureWebSearch with mocked runCurlProbe
+    const script = `
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const Module = require("module");
+
+// Intercept require to mock runCurlProbe
+const origResolve = Module._resolveFilename;
+Module._resolveFilename = function(request, parent, isMain, options) {
+  return origResolve.call(this, request, parent, isMain, options);
+};
+
+// We need to patch the onboard module after loading.
+// Load the compiled module and call configureWebSearch.
+const onboard = require("${repoRoot.replace(/\\/g, "/")}/dist/lib/onboard.js");
+
+// Mock the validation function by patching the module-level function.
+// configureWebSearch calls validateBraveSearchApiKey internally,
+// which calls runCurlProbe which calls spawnSync(curl, ...).
+// We mock spawnSync at the child_process level.
+const cp = require("node:child_process");
+const origSpawnSync = cp.spawnSync;
+cp.spawnSync = function(cmd, args, opts) {
+  // When curl is called for Brave validation, return a 429 error
+  if (cmd === "curl" && args && args.some(a => typeof a === "string" && a.includes("brave.com"))) {
+    return {
+      status: 0,
+      stdout: '{"type":"ErrorResponse","error":{"status":429,"detail":"Rate limit exceeded"}}',
+      stderr: "",
+    };
+  }
+  return origSpawnSync.call(this, cmd, args, opts);
+};
+
+async function main() {
+  const result = await onboard.configureWebSearch(null);
+  // If we reach here, process.exit was NOT called
+  console.log("RESULT:" + JSON.stringify(result));
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error("ERROR:" + err.message);
+  process.exit(2);
+});
+`;
+
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      timeout: 15_000,
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        BRAVE_API_KEY: "test-invalid-key-12345",
+        NEMOCLAW_NON_INTERACTIVE: "1",
+      },
+    });
+
+    // Should exit 0, not 1
+    expect(result.status).toBe(0);
+
+    // Should return null (skip web search)
+    expect(result.stdout).toContain("RESULT:null");
+
+    // Should print a warning about validation failure
+    expect(result.stderr).toContain("Brave Search API key validation failed");
+
+    // Cleanup tmpDir
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("skips Brave web search when no BRAVE_API_KEY is set", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brave-none-"));
+    const scriptPath = path.join(tmpDir, "test-brave-none.mjs");
+    tmpFiles.push(scriptPath);
+
+    const script = `
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const onboard = require("${repoRoot.replace(/\\/g, "/")}/dist/lib/onboard.js");
+
+async function main() {
+  const result = await onboard.configureWebSearch(null);
+  console.log("RESULT:" + JSON.stringify(result));
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error("ERROR:" + err.message);
+  process.exit(2);
+});
+`;
+
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      timeout: 15_000,
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        // No BRAVE_API_KEY set
+      },
+    });
+
+    // Should exit 0 and return null (no Brave key → skip)
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("RESULT:null");
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/test/brave-validation-skip.test.ts
+++ b/test/brave-validation-skip.test.ts
@@ -16,7 +16,9 @@ describe("configureWebSearch non-interactive Brave validation failure", () => {
     for (const f of tmpFiles) {
       try {
         fs.unlinkSync(f);
-      } catch {}
+      } catch {
+        // Best-effort cleanup: temp file may already be removed.
+      }
     }
     tmpFiles.length = 0;
   });


### PR DESCRIPTION
## Summary

Closes #2507

Brave Web Search is an optional integration. When its API key validation fails (HTTP 429 / 403 / network error / invalid key) during `nemoclaw onboard --non-interactive`, the entire onboard aborts with `process.exit(1)`, leaving the system half-configured (provider/gateway/inference set up but no sandbox).

## Changes

**`src/lib/onboard.ts`** — In `configureWebSearch()`, replace the non-interactive validation failure path:
- `console.error` → `console.warn` (downgrade severity)
- `process.exit(1)` → `return null` (skip web search, continue onboard)

This matches the existing behavior for missing `BRAVE_API_KEY` (already returns `null`) and the interactive mode's "skip" option.

## Testing

**`test/brave-validation-skip.test.ts`** — Two new tests:
1. **Validation failure returns null** — Mocks curl to return HTTP 429, verifies `configureWebSearch` returns `null` instead of exiting
2. **Missing API key returns null** — Verifies no-key path continues to work

All 2681 existing tests pass (5 pre-existing failures in preflight tests unrelated to this change).

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.

Signed-off-by: kagura-agent <kagura-agent@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Brave Search API key validation failures now emit warnings and gracefully disable web search in non-interactive flows instead of terminating the process.

* **Tests**
  * Added tests verifying non-interactive Brave web search behavior when API key validation fails or is absent, asserting graceful fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->