### PR TITLE
fix(preflight): detect stopped Docker daemon via exit code on macOS

### DIFF
--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -283,9 +283,14 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   let dockerReachable = false;
   let dockerRunning = false;
   if (dockerInstalled && dockerInfoOutput === undefined) {
-    dockerInfoOutput = runCaptureImpl("docker info --format '{{json .}}' 2>/dev/null", {
-      ignoreError: true,
-    });
+      try {
+        runCaptureImpl("docker info", { ignoreError: false });
+        dockerInfoOutput = runCaptureImpl("docker info --format '{{json .}}'", {
+          ignoreError: true,
+        });
+      } catch {
+        dockerInfoOutput = "";
+      }
   }
   if (dockerInstalled && String(dockerInfoOutput || "").trim()) {
     dockerReachable = true;


### PR DESCRIPTION
## Summary

Fixes #2348

## Problem

assessHost() ran 'docker info --format {{json .}}' with ignoreError:true and treated non-empty stdout as proof the daemon was running. On macOS with Colima stopped, the Docker CLI still emits a client-side JSON struct without contacting the daemon, causing dockerRunning=true incorrectly. Onboarding then passed preflight [1/8] with a false positive and hung indefinitely at [2/8] waiting for gateway health.

## Fix

Attempt 'docker info' with ignoreError:false first. If the daemon is unreachable it throws — caught and dockerInfoOutput set to empty string so dockerReachable and dockerRunning remain false. Only on success follow up with the --format call for structured JSON output.

## Testing

- 2044 tests pass, 0 new failures introduced
- 1 pre-existing failure (ssrf-parity.test.ts) requires npm run build inside nemoclaw/ — unrelated to this change
- Verified on macOS Apple Silicon M3 Pro with Docker Desktop stopped and running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker detection during startup validation to avoid false positives when Docker is unreachable, resulting in more reliable readiness checks and clearer handling of Docker detection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->