### PR TITLE
fix(onboard): match default yes/no echo casing

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -337,6 +337,23 @@ function note(message: string): void {
   console.log(`${DIM}${message}${RESET}`);
 }
 
+function formatDefaultPromptEcho(question: string, value: string): string {
+  const match = question.trim().match(/\[([Yy])\/([Nn])\]:?$/);
+  if (!match) {
+    return value;
+  }
+
+  const [, yesToken, noToken] = match;
+  const normalizedValue = value.toLowerCase();
+  if (normalizedValue === "y" && yesToken === "Y") {
+    return "Y";
+  }
+  if (normalizedValue === "n" && noToken === "N") {
+    return "N";
+  }
+  return value;
+}
+
 // Prompt wrapper: returns env var value or default in non-interactive mode,
 // otherwise prompts the user interactively.
 async function promptOrDefault(
@@ -347,7 +364,8 @@ async function promptOrDefault(
   if (isNonInteractive()) {
     const val = envVar ? process.env[envVar] : null;
     const result = val || defaultValue;
-    note(`  [non-interactive] ${question.trim()} → ${result}`);
+    const displayResult = val ? result : formatDefaultPromptEcho(question, result);
+    note(`  [non-interactive] ${question.trim()} → ${displayResult}`);
     return result;
   }
   return prompt(question);
@@ -7843,6 +7861,7 @@ module.exports = {
   configureWebSearch,
   createSandbox,
   ensureValidatedBraveSearchCredential,
+  formatDefaultPromptEcho,
   formatEnvAssignment,
   getFutureShellPathHint,
   getGatewayBootstrapRepairPlan,

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -43,6 +43,7 @@ type OnboardTestInternals = {
   classifySandboxCreateFailure: (output?: string) => { kind: string; uploadedToGateway: boolean };
   compactText: (value?: string) => string;
   computeSetupPresetSuggestions: ShimFn<string[]>;
+  formatDefaultPromptEcho: (question: string, value: string) => string;
   formatEnvAssignment: (name: string, value: string) => string;
   findDashboardForwardOwner: (
     forwardListOutput: string | null | undefined,
@@ -125,6 +126,7 @@ const {
   classifySandboxCreateFailure,
   compactText,
   computeSetupPresetSuggestions,
+  formatDefaultPromptEcho,
   formatEnvAssignment,
   getNavigationChoice,
   getGatewayReuseState,
@@ -162,6 +164,13 @@ const {
 } = onboardTestInternals;
 
 describe("onboard helpers", () => {
+  it("formats non-interactive default yes/no echoes using the prompt default casing", () => {
+    expect(formatDefaultPromptEcho("  Apply this configuration? [Y/n]: ", "y")).toBe("Y");
+    expect(formatDefaultPromptEcho("  Continue anyway? [y/N]: ", "n")).toBe("N");
+    expect(formatDefaultPromptEcho("  Continue anyway? [y/N]: ", "yes")).toBe("yes");
+    expect(formatDefaultPromptEcho("  Enter sandbox name: ", "nemoclaw")).toBe("nemoclaw");
+  });
+
   it("classifies sandbox create timeout failures and tracks upload progress", () => {
     expect(
       classifySandboxCreateFailure("Error: failed to read image export stream\nTimeout error").kind,


### PR DESCRIPTION
## Summary

- Format non-interactive onboard yes/no default echoes using the uppercase marker shown in the prompt.
- Preserve the original lowercase return values so existing answer parsing keeps working.

Closes #2517.

## Test plan

- npm run build:cli
- npm run typecheck:cli
- npm test -- test/onboard.test.ts -t "formats non-interactive default yes/no echoes"
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-interactive prompt handling so default answers are echoed with the correct Y/N casing shown in prompts, making displayed responses match user expectations.

* **Tests**
  * Added unit tests to verify correct casing behavior for default prompt responses and ensure non-yes/no defaults remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->