### PR TITLE
fix(policy): ignore dotfile presets from directories

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1817,9 +1817,9 @@ function buildSandboxLogsArgs(sandboxName: string, follow: boolean): string[] {
  * for a single custom preset YAML, and `--from-dir <path>` for every
  * `.yaml`/`.yml` file in a directory. `--dry-run` previews without applying,
  * `--yes`/`-y`/`--force` (or `NEMOCLAW_NON_INTERACTIVE=1`) skips the
- * confirmation prompt. `--from-dir` applies files in lexicographic order
- * and aborts at the first failure (already-applied presets are not rolled
- * back).
+ * confirmation prompt. `--from-dir` applies non-hidden files in lexicographic
+ * order and aborts at the first failure (already-applied presets are not
+ * rolled back).
  */
 async function sandboxPolicyAdd(sandboxName: string, args: string[] = []): Promise<void> {
   const dryRun = args.includes("--dry-run");
@@ -1861,7 +1861,10 @@ async function sandboxPolicyAdd(sandboxName: string, args: string[] = []): Promi
     }
     const files = fs
       .readdirSync(absDir, { withFileTypes: true })
-      .filter((ent: { name: string; isFile(): boolean }) => ent.isFile() && /\.ya?ml$/i.test(ent.name))
+      .filter(
+        (ent: { name: string; isFile(): boolean }) =>
+          ent.isFile() && !ent.name.startsWith(".") && /\.ya?ml$/i.test(ent.name),
+      )
       .map((ent: { name: string }) => path.join(absDir, ent.name))
       .sort();
     if (files.length === 0) {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1496,5 +1496,23 @@ setImmediate(() => {
       expect(loads.length).toBe(1);
       expect(loads[0]).toMatch(/real\.yaml$/);
     });
+
+    it("--from-dir skips hidden dotfile yaml presets", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-from-dir-dotfile-"));
+      fs.writeFileSync(
+        path.join(dir, ".bad.yaml"),
+        "preset:\n  name: bad\nnetwork_policies: {}\n",
+      );
+      fs.writeFileSync(
+        path.join(dir, "real.yaml"),
+        "preset:\n  name: real\nnetwork_policies: {}\n",
+      );
+      const result = runPolicyAddExternal(["--from-dir", dir, "--yes"]);
+      expect(result.status).toBe(0);
+      const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim()) as PolicyCall[];
+      const loads = calls.filter((c) => c.type === "load").map((c) => c.path);
+      expect(loads.length).toBe(1);
+      expect(loads[0]).toMatch(/real\.yaml$/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Ignore hidden dotfile YAML entries when applying custom presets from a directory.
- Keep explicit --from-file behavior unchanged for users who pass a hidden file directly.

Addresses one hardening item from #2521.

## Test plan

- npm run build:cli
- npm run typecheck:cli
- npm test -- test/policies.test.ts -t="--from-dir skips hidden dotfile yaml presets"
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `policy-add --from-dir` command now ignores hidden dotfiles (those beginning with a dot) when loading YAML policies, ensuring only visible configuration files are applied.

* **Tests**
  * Added an integration test verifying hidden YAML presets are skipped and only visible presets are loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->