### PR TITLE
fix: restart ollama proxy when token diverges from persisted token

### DIFF
--- a/src/lib/onboard-ollama-proxy.ts
+++ b/src/lib/onboard-ollama-proxy.ts
@@ -94,6 +94,20 @@ function clearPersistedProxyPid(): void {
 
 // ── Process management ───────────────────────────────────────────
 
+/**
+ * Verify that the running proxy accepts the given token.
+ * /v1/models is an authenticated endpoint (unlike /api/tags which is exempt),
+ * so a 200 response confirms the token matches what the proxy was started with.
+ */
+function isProxyTokenValid(token: string): boolean {
+  const result = spawnSync(
+    "curl",
+    ["-sf", "--max-time", "3", "-H", `Authorization: Bearer ${token}`, `http://localhost:${OLLAMA_PROXY_PORT}/v1/models`],
+    { encoding: "utf8" },
+  );
+  return result.status === 0;
+}
+
 function isOllamaProxyProcess(pid: number | null | undefined): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   const cmdline = runCapture(["ps", "-p", String(pid), "-o", "args="], { ignoreError: true });
@@ -168,6 +182,12 @@ function startOllamaAuthProxy(): boolean {
 /**
  * Ensure the auth proxy is running — called on sandbox connect to recover
  * from host reboots where the background proxy process was lost.
+ *
+ * Also handles token divergence: if the proxy is running but was started with
+ * a different token than what is persisted on disk (which can happen when
+ * multiple onboard runs occur without the proxy being restarted in between),
+ * the proxy is killed and restarted with the persisted token so the sandbox
+ * credential and the proxy stay in sync.
  */
 function ensureOllamaAuthProxy(): void {
   // Try to load persisted token first — if none, this isn't an Ollama setup.
@@ -175,12 +195,12 @@ function ensureOllamaAuthProxy(): void {
   if (!token) return;
 
   const pid = loadPersistedProxyPid();
-  if (isOllamaProxyProcess(pid)) {
+  if (isOllamaProxyProcess(pid) && isProxyTokenValid(token)) {
     ollamaProxyToken = token;
     return;
   }
 
-  // Proxy not running — restart it with the persisted token.
+  // Proxy not running, or running with a stale token — restart with the persisted token.
   killStaleProxy();
   ollamaProxyToken = token;
   spawnOllamaAuthProxy(token);


### PR DESCRIPTION
## Problem

Closes #2553.

`ensureOllamaAuthProxy()` checks whether the PID from `ollama-auth-proxy.pid` belongs to a running proxy process, and if so, loads the persisted token and returns — **without verifying the running process was actually started with that token**.

The two diverge when multiple `nemoclaw onboard` runs occur in sequence: each full onboard calls `startOllamaAuthProxy()`, which generates a new token and writes it to `~/.nemoclaw/ollama-proxy-token`. If `killStaleProxy()` fails to kill the original proxy (e.g. stale PID file, `lsof` race on Linux), the proxy keeps running with its original token while the file and provider credential are updated. The next `nemoclaw rebuild` wires the new token into the sandbox, but the proxy rejects it — every inference call returns `HTTP 401 Unauthorized`.

This is silent: `nemoclaw status` shows the sandbox as healthy, the Telegram bridge receives messages, but every bot response is an auth error.

## Fix

Add `isProxyTokenValid()` which probes `/v1/models` with the stored token (an authenticated endpoint — unlike `/api/tags` which is explicitly exempt from auth in `ollama-auth-proxy.js`). In `ensureOllamaAuthProxy()`, if the probe fails, fall through to `killStaleProxy()` and restart with the persisted token.

```diff
-  if (isOllamaProxyProcess(pid)) {
+  if (isOllamaProxyProcess(pid) && isProxyTokenValid(token)) {
     ollamaProxyToken = token;
     return;
   }
-  // Proxy not running — restart it with the persisted token.
+  // Proxy not running, or running with a stale token — restart with the persisted token.
```

## Behavior

- **Happy path (first run, reboot recovery):** One extra `curl` call to `/v1/models` that returns immediately. No other behavior change.
- **Diverged token (the bug):** Proxy is killed and restarted with the correct persisted token. Subsequent rebuild picks up the right token automatically.

## Test

Manually verified on NVIDIA DGX Spark (GB10, ARM64, Ubuntu) with NemoClaw v0.0.25 / OpenClaw v2026.4.9 / nemotron-3-super:120b via Ollama. Before this fix, running `nemoclaw onboard` twice reliably reproduced the 401. After, `ensureOllamaAuthProxy()` detects the mismatch and self-heals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication proxy validation to ensure consistent token handling. The system now validates that the running proxy instance properly accepts the persisted authentication token before reuse. If validation fails or a token mismatch is detected, the proxy automatically restarts with the correct configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->