### PR TITLE
fix(sandbox): include generate-openclaw-config.py in optimized build context

### DIFF
--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -8,6 +8,10 @@ description: "Reviews and approves blocked agent network requests in the TUI. Us
 
 # Approve or Deny NemoClaw Agent Network Requests
 
+## Gotchas
+
+- Custom preset hosts bypass NemoClaw's review process and can widen sandbox egress to arbitrary destinations.
+
 ## Prerequisites
 
 - A running NemoClaw sandbox.
@@ -307,9 +311,18 @@ Files are processed in lexicographic order.
 Processing stops at the first failure; presets already applied are not rolled back.
 Fix the failing file and re-run the command to continue.
 
-> [!WARNING]
-> Custom preset hosts bypass NemoClaw's review process and can widen sandbox egress to arbitrary destinations.
+> **Warning:** Custom preset hosts bypass NemoClaw's review process and can widen sandbox egress to arbitrary destinations.
 > Review every host in a custom preset before applying it, especially when the file originates outside your team.
+
+### Remove a Custom Preset
+
+Custom presets applied with `--from-file` or `--from-dir` are recorded in the NemoClaw sandbox registry alongside their full YAML content, so they can be removed by name — the original file does not need to be kept on disk:
+
+```console
+$ nemoclaw my-assistant policy-remove my-internal-api --yes
+```
+
+`policy-remove` accepts both built-in and custom preset names. Run `nemoclaw <name> policy-list` to see every preset currently applied to the sandbox.
 
 ## Related Skills
 

--- a/src/lib/sandbox-build-context.ts
+++ b/src/lib/sandbox-build-context.ts
@@ -85,6 +85,11 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "scripts", "lib", "sandbox-init.sh"),
     path.join(stagedScriptsDir, "lib", "sandbox-init.sh"),
   );
+  // OpenClaw config generator extracted in #2449
+  fs.copyFileSync(
+    path.join(rootDir, "scripts", "generate-openclaw-config.py"),
+    path.join(stagedScriptsDir, "generate-openclaw-config.py"),
+  );
 
   return { buildCtx, stagedDockerfile };
 }

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -27,6 +27,7 @@ describe("sandbox build context staging", () => {
         ),
       ).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "nemoclaw-start.sh"))).toBe(true);
+      expect(fs.existsSync(path.join(buildCtx, "scripts", "generate-openclaw-config.py"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

PR #2449 extracted inline Python config generation from the Dockerfile into `scripts/generate-openclaw-config.py` and added a `COPY` instruction (Dockerfile line 195), but did not update `stageOptimizedSandboxBuildContext()` to include the new file. This causes every `nemoclaw onboard` to fail with a Docker `COPY failed: file not found in build context` error. This PR adds the missing `copyFileSync` and a regression test assertion.

## Related Issue

Fixes #2503
Closes #2509 

## Changes

- **`src/lib/sandbox-build-context.ts`** — Added `fs.copyFileSync` for `scripts/generate-openclaw-config.py` in `stageOptimizedSandboxBuildContext()`, alongside the existing `nemoclaw-start.sh` and `lib/sandbox-init.sh` copies.
- **`test/sandbox-build-context.test.ts`** — Added assertion that `scripts/generate-openclaw-config.py` is present in the staged optimized build context, preventing future regressions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (pi)

---
Signed-off-by: Brandon Pelfrey <bpelfrey@nvidia.com>