### PR TITLE
fix(validation): pass normalizedEndpointUrl to fetch functions in provider-models

### DIFF
--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -195,7 +195,7 @@ export function validateAnthropicModel(
   options: ProviderModelOptions = {},
 ): ModelValidationResult {
   const normalizedEndpointUrl = String(endpointUrl).replace(/\/+$/, "");
-  const available = fetchAnthropicModels(endpointUrl, apiKey, options);
+  const available = fetchAnthropicModels(normalizedEndpointUrl, apiKey, options);
   if (!available.ok) {
     if (available.httpStatus === 404 || available.httpStatus === 405) {
       return { ok: true, validated: false };
@@ -226,7 +226,7 @@ export function validateOpenAiLikeModel(
   options: ProviderModelOptions = {},
 ): ModelValidationResult {
   const normalizedEndpointUrl = String(endpointUrl).replace(/\/+$/, "");
-  const available = fetchOpenAiLikeModels(endpointUrl, apiKey, options);
+  const available = fetchOpenAiLikeModels(normalizedEndpointUrl, apiKey, options);
   if (!available.ok) {
     if (available.httpStatus === 404 || available.httpStatus === 405) {
       return { ok: true, validated: false };


### PR DESCRIPTION
Both \`validateAnthropicModel\` and \`validateOpenAiLikeModel\` compute a
trailing-slash-stripped URL into \`normalizedEndpointUrl\` but then pass
the original \`endpointUrl\` to \`fetchAnthropicModels\` /
\`fetchOpenAiLikeModels\`. The normalized variable was only used in error
message strings — so a caller with a trailing slash in their endpoint
URL would see the slash stripped in the error message but not in the
actual HTTP request.

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent handling of AI model endpoint URLs by normalizing URL formatting during validation to prevent errors related to trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->