### PR TITLE
fix(cli): suppress provider-not-found and forward-not-active noise on destroy

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -171,7 +171,10 @@ function captureOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
 }
 
 function cleanupGatewayAfterLastSandbox() {
-  runOpenshell(["forward", "stop", DASHBOARD_FORWARD_PORT], { ignoreError: true });
+  runOpenshell(["forward", "stop", DASHBOARD_FORWARD_PORT], {
+    ignoreError: true,
+    stdio: ["ignore", "ignore", "ignore"],
+  });
   runOpenshell(["gateway", "destroy", "-g", NEMOCLAW_GATEWAY_NAME], { ignoreError: true });
   run(
     `docker volume ls -q --filter "name=openshell-cluster-${NEMOCLAW_GATEWAY_NAME}" | grep . && docker volume ls -q --filter "name=openshell-cluster-${NEMOCLAW_GATEWAY_NAME}" | xargs docker volume rm || true`,
@@ -2298,9 +2301,13 @@ function cleanupSandboxServices(
     // PID directory may not exist — ignore.
   }
 
-  // Delete messaging providers created during onboard.
+  // Delete messaging providers created during onboard. Suppress stderr so
+  // "! Provider not found" noise doesn't appear when messaging was never configured.
   for (const suffix of ["telegram-bridge", "discord-bridge", "slack-bridge"]) {
-    runOpenshell(["provider", "delete", `${sandboxName}-${suffix}`], { ignoreError: true });
+    runOpenshell(["provider", "delete", `${sandboxName}-${suffix}`], {
+      ignoreError: true,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
   }
 }
 


### PR DESCRIPTION
Fixes #2170.

\`nemoclaw destroy\` printed three "! Provider not found" lines (one
per messaging bridge) and "! No active forward found for port 18789"
even when messaging and NIM were never configured for the sandbox.

Both are best-effort cleanup calls that already use \`ignoreError: true\`,
but \`runOpenshell\` defaults to \`stdio: "inherit"\`, so openshell's own
stderr reached the terminal regardless of the error-ignore flag.

Adding \`stdio: ["ignore", "ignore", "ignore"]\` on both callsites keeps
the cleanup attempts intact while suppressing the expected "not found"
output that has no actionable meaning for the user.

Signed-off-by: ColinM-sys <cmcdonough@50words.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed noisy output during sandbox cleanup so dashboard shutdown and messaging-provider removals no longer emit unnecessary stdout/stderr messages.
  * Kept existing tolerant behavior for provider deletion attempts while eliminating “provider not found” noise in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->