### PR TITLE
docs: refresh daily docs for 0.0.29

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -119,7 +119,7 @@ This variable is only needed when switching between provider families.
 
 ## Step 3: Tune Model Metadata
 
-The sandbox image bakes model metadata (context window, max output tokens, and reasoning mode) into `openclaw.json` at build time.
+The sandbox image bakes model metadata (context window, max output tokens, reasoning mode, and accepted input modalities) into `openclaw.json` at build time.
 To change these values, set the corresponding environment variables before running `nemoclaw onboard` so they patch into the Dockerfile before the image builds.
 
 | Variable | Values | Default |
@@ -127,14 +127,17 @@ To change these values, set the corresponding environment variables before runni
 | `NEMOCLAW_CONTEXT_WINDOW` | Positive integer (tokens) | `131072` |
 | `NEMOCLAW_MAX_TOKENS` | Positive integer (tokens) | `4096` |
 | `NEMOCLAW_REASONING` | `true` or `false` | `false` |
+| `NEMOCLAW_INFERENCE_INPUTS` | `text` or `text,image` | `text` |
 | `NEMOCLAW_AGENT_TIMEOUT` | Positive integer (seconds) | `600` |
 
 Invalid values are ignored, and the default bakes into the image.
+Use `NEMOCLAW_INFERENCE_INPUTS=text,image` only for a model that accepts image input through the selected provider.
 
 ```console
 $ export NEMOCLAW_CONTEXT_WINDOW=65536
 $ export NEMOCLAW_MAX_TOKENS=8192
 $ export NEMOCLAW_REASONING=true
+$ export NEMOCLAW_INFERENCE_INPUTS=text,image
 $ export NEMOCLAW_AGENT_TIMEOUT=1800
 $ nemoclaw onboard
 ```

--- a/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
@@ -75,7 +75,9 @@ For setup instructions, refer to Use a Local Inference Server (use the `nemoclaw
 ## Validation
 
 NemoClaw validates the selected provider and model before creating the sandbox.
-If validation fails, the wizard returns to provider selection.
+If credential validation fails, the wizard asks whether to re-enter the API key, choose a different provider, retry, or exit.
+The `nvapi-` prefix check applies only to `NVIDIA_API_KEY`.
+Other provider credentials, such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and compatible endpoint keys, use provider-aware validation during retry.
 
 | Provider type | Validation method |
 |---|---|

--- a/.agents/skills/nemoclaw-user-deploy-remote/SKILL.md
+++ b/.agents/skills/nemoclaw-user-deploy-remote/SKILL.md
@@ -106,8 +106,8 @@ default), so no extra configuration is needed.
 > set on a headless host, the compatibility wrapper prints a warning.
 >
 > `NEMOCLAW_DISABLE_DEVICE_AUTH` is also evaluated at image build time.
-> If you disable device auth for a remote deployment, any device that can reach the dashboard origin can connect without pairing.
-> Avoid this on internet-reachable or shared-network deployments.
+> When `CHAT_UI_URL` points at a non-loopback origin, NemoClaw disables OpenClaw device pairing in the generated sandbox configuration because browser-only remote users cannot complete terminal-based pairing.
+> Any device that can reach the configured dashboard origin can connect without pairing, so avoid exposing that origin on internet-reachable or shared-network deployments.
 
 ## Step 7: Proxy Configuration
 

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -318,7 +318,9 @@ If the preset name is unknown or already applied, the command exits non-zero wit
 
 | Flag | Description |
 |------|-------------|
-| `--yes`, `--force` | Skip the confirmation prompt (requires a preset name) |
+| `--from-file <path>` | Apply a custom preset YAML file instead of a built-in preset |
+| `--from-dir <path>` | Apply every custom preset YAML file in a directory in lexicographic order |
+| `--yes`, `--force` | Skip the confirmation prompt (requires a preset name, `--from-file`, or `--from-dir`) |
 | `--dry-run` | Preview the endpoints a preset would open without applying changes |
 
 Use `--dry-run` to audit a preset before applying it:
@@ -326,6 +328,21 @@ Use `--dry-run` to audit a preset before applying it:
 ```console
 $ nemoclaw my-assistant policy-add --dry-run
 ```
+
+Apply a custom preset file when you need to grant access to an endpoint that is not covered by a built-in preset:
+
+```console
+$ nemoclaw my-assistant policy-add --from-file ./presets/my-internal-api.yaml
+```
+
+For batch workflows, apply all preset files from a directory:
+
+```console
+$ nemoclaw my-assistant policy-add --from-dir ./presets/ --yes
+```
+
+Review every host in custom preset files before applying them.
+Custom presets bypass the built-in preset review process and can widen sandbox egress.
 
 ### `nemoclaw <name> policy-list`
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -466,6 +466,24 @@ The status command detects the sandbox context and reports "active (inside sandb
 
 Run `openshell sandbox list` on the host to check the underlying sandbox state.
 
+### Git clone fails with a certificate verification error
+
+In networks that inspect TLS, OpenShell injects a proxy CA bundle into the sandbox.
+Current NemoClaw exports that bundle as `GIT_SSL_CAINFO` during sandbox startup and persists it for `nemoclaw <name> connect` sessions, so Git can trust the proxy CA.
+It also forwards standard CA bundle variables for subprocesses, including `GIT_SSL_CAPATH`, `CURL_CA_BUNDLE`, and `REQUESTS_CA_BUNDLE`.
+
+If Git still reports `server certificate verification failed`, reconnect to the sandbox and check that the CA variables are present:
+
+```console
+$ env | grep -E 'SSL_CERT_FILE|GIT_SSL_CAINFO|CURL_CA_BUNDLE|REQUESTS_CA_BUNDLE'
+```
+
+If they are missing on an older sandbox, upgrade NemoClaw and run:
+
+```console
+$ nemoclaw <name> rebuild
+```
+
 ### `openclaw update` hangs or times out inside the sandbox
 
 This is expected for the current NemoClaw deployment model.

--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -116,8 +116,8 @@ available when the installer builds the sandbox image. If `CHAT_UI_URL` is not
 set on a headless host, the compatibility wrapper prints a warning.
 
 `NEMOCLAW_DISABLE_DEVICE_AUTH` is also evaluated at image build time.
-If you disable device auth for a remote deployment, any device that can reach the dashboard origin can connect without pairing.
-Avoid this on internet-reachable or shared-network deployments.
+When `CHAT_UI_URL` points at a non-loopback origin, NemoClaw disables OpenClaw device pairing in the generated sandbox configuration because browser-only remote users cannot complete terminal-based pairing.
+Any device that can reach the configured dashboard origin can connect without pairing, so avoid exposing that origin on internet-reachable or shared-network deployments.
 :::
 
 ## Proxy Configuration

--- a/docs/inference/inference-options.md
+++ b/docs/inference/inference-options.md
@@ -95,7 +95,9 @@ For setup instructions, refer to [Use a Local Inference Server](use-local-infere
 ## Validation
 
 NemoClaw validates the selected provider and model before creating the sandbox.
-If validation fails, the wizard returns to provider selection.
+If credential validation fails, the wizard asks whether to re-enter the API key, choose a different provider, retry, or exit.
+The `nvapi-` prefix check applies only to `NVIDIA_API_KEY`.
+Other provider credentials, such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and compatible endpoint keys, use provider-aware validation during retry.
 
 | Provider type | Validation method |
 |---|---|

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -133,7 +133,7 @@ This variable is only needed when switching between provider families.
 
 ## Tune Model Metadata
 
-The sandbox image bakes model metadata (context window, max output tokens, and reasoning mode) into `openclaw.json` at build time.
+The sandbox image bakes model metadata (context window, max output tokens, reasoning mode, and accepted input modalities) into `openclaw.json` at build time.
 To change these values, set the corresponding environment variables before running `nemoclaw onboard` so they patch into the Dockerfile before the image builds.
 
 | Variable | Values | Default |
@@ -141,14 +141,17 @@ To change these values, set the corresponding environment variables before runni
 | `NEMOCLAW_CONTEXT_WINDOW` | Positive integer (tokens) | `131072` |
 | `NEMOCLAW_MAX_TOKENS` | Positive integer (tokens) | `4096` |
 | `NEMOCLAW_REASONING` | `true` or `false` | `false` |
+| `NEMOCLAW_INFERENCE_INPUTS` | `text` or `text,image` | `text` |
 | `NEMOCLAW_AGENT_TIMEOUT` | Positive integer (seconds) | `600` |
 
 Invalid values are ignored, and the default bakes into the image.
+Use `NEMOCLAW_INFERENCE_INPUTS=text,image` only for a model that accepts image input through the selected provider.
 
 ```console
 $ export NEMOCLAW_CONTEXT_WINDOW=65536
 $ export NEMOCLAW_MAX_TOKENS=8192
 $ export NEMOCLAW_REASONING=true
+$ export NEMOCLAW_INFERENCE_INPUTS=text,image
 $ export NEMOCLAW_AGENT_TIMEOUT=1800
 $ nemoclaw onboard
 ```

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.25"}
+{"name": "nemoclaw", "version": "0.0.29"}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -348,7 +348,9 @@ If the preset name is unknown or already applied, the command exits non-zero wit
 
 | Flag | Description |
 |------|-------------|
-| `--yes`, `--force` | Skip the confirmation prompt (requires a preset name) |
+| `--from-file <path>` | Apply a custom preset YAML file instead of a built-in preset |
+| `--from-dir <path>` | Apply every custom preset YAML file in a directory in lexicographic order |
+| `--yes`, `--force` | Skip the confirmation prompt (requires a preset name, `--from-file`, or `--from-dir`) |
 | `--dry-run` | Preview the endpoints a preset would open without applying changes |
 
 Use `--dry-run` to audit a preset before applying it:
@@ -356,6 +358,21 @@ Use `--dry-run` to audit a preset before applying it:
 ```console
 $ nemoclaw my-assistant policy-add --dry-run
 ```
+
+Apply a custom preset file when you need to grant access to an endpoint that is not covered by a built-in preset:
+
+```console
+$ nemoclaw my-assistant policy-add --from-file ./presets/my-internal-api.yaml
+```
+
+For batch workflows, apply all preset files from a directory:
+
+```console
+$ nemoclaw my-assistant policy-add --from-dir ./presets/ --yes
+```
+
+Review every host in custom preset files before applying them.
+Custom presets bypass the built-in preset review process and can widen sandbox egress.
 
 ### `nemoclaw <name> policy-list`
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -496,6 +496,24 @@ The status command detects the sandbox context and reports "active (inside sandb
 
 Run `openshell sandbox list` on the host to check the underlying sandbox state.
 
+### Git clone fails with a certificate verification error
+
+In networks that inspect TLS, OpenShell injects a proxy CA bundle into the sandbox.
+Current NemoClaw exports that bundle as `GIT_SSL_CAINFO` during sandbox startup and persists it for `nemoclaw <name> connect` sessions, so Git can trust the proxy CA.
+It also forwards standard CA bundle variables for subprocesses, including `GIT_SSL_CAPATH`, `CURL_CA_BUNDLE`, and `REQUESTS_CA_BUNDLE`.
+
+If Git still reports `server certificate verification failed`, reconnect to the sandbox and check that the CA variables are present:
+
+```console
+$ env | grep -E 'SSL_CERT_FILE|GIT_SSL_CAINFO|CURL_CA_BUNDLE|REQUESTS_CA_BUNDLE'
+```
+
+If they are missing on an older sandbox, upgrade NemoClaw and run:
+
+```console
+$ nemoclaw <name> rebuild
+```
+
 ### `openclaw update` hangs or times out inside the sandbox
 
 This is expected for the current NemoClaw deployment model.

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,18 +5,6 @@
     "url": "https://docs.nvidia.com/nemoclaw/0.0.29/"
   },
   {
-    "version": "0.0.28",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.28/"
-  },
-  {
-    "version": "0.0.27",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.27/"
-  },
-  {
-    "version": "0.0.26",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.26/"
-  },
-  {
     "version": "0.0.25",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.25/"
   },

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,22 @@
 [
   {
     "preferred": true,
+    "version": "0.0.29",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.29/"
+  },
+  {
+    "version": "0.0.28",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.28/"
+  },
+  {
+    "version": "0.0.27",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.27/"
+  },
+  {
+    "version": "0.0.26",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.26/"
+  },
+  {
     "version": "0.0.25",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.25/"
   },
@@ -23,21 +39,5 @@
   {
     "version": "0.0.20",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.20/"
-  },
-  {
-    "version": "0.0.19",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.19/"
-  },
-  {
-    "version": "0.0.18",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.18/"
-  },
-  {
-    "version": "0.0.17",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.17/"
-  },
-  {
-    "version": "0.0.16",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.16/"
   }
 ]


### PR DESCRIPTION
## Summary
Refreshes user-facing docs for the last 24 hours of merged NemoClaw history and bumps the docs metadata to 0.0.29, the next version after v0.0.28. The updates are limited to behavior supported by merged PR descriptions and diffs.

## Changes
- `docs/reference/commands.md`: documented `nemoclaw <name> policy-add --from-file` and `--from-dir`, including custom preset review guidance, from #2077 / commit `7720b175`.
- `docs/deployment/deploy-to-remote-gpu.md`: clarified that non-loopback `CHAT_UI_URL` disables OpenClaw device pairing for remote browser-only deployments, from #2449 / commit `f5ee8a4d`.
- `docs/inference/inference-options.md`: documented provider-aware credential retry validation and the NVIDIA-only `nvapi-` prefix check, from #2389 / commit `6f7f0c6d`.
- `docs/inference/switch-inference-providers.md`: documented `NEMOCLAW_INFERENCE_INPUTS` for text/image-capable model metadata baked into `openclaw.json`, from #2441 / commit `f4391892`.
- `docs/reference/troubleshooting.md`: added the Git certificate verification entry for proxy CA propagation through `GIT_SSL_CAINFO`, `GIT_SSL_CAPATH`, `CURL_CA_BUNDLE`, and `REQUESTS_CA_BUNDLE`, from #2345 / commit `fa0dc1ab`.
- `docs/versions1.json` and `docs/project.json`: promoted docs version `0.0.29`; `docs/versions1.json` omits unpublished `0.0.26`, `0.0.27`, and `0.0.28` entries.
- `.agents/skills/nemoclaw-user-*`: regenerated derived user skill references from the updated docs.
- Reviewed with no extra doc changes: #2575 / `d392ec07`, #2565 / `a3231049`, #1965 / `db1ef3ca`, #1990 / `db665834`, #2495 / `7da86fa3`, #2496 / `3192f4f4`, #2490 / `8c209058`, #2487 / `1f615e2f`, #2483 / `5653d33a`, #2482 / `31c782c0`, #2464 / `23bb5703`, #2472 / `a54f9a34`, and #2437 / `6bc860d7`.
- Skipped per docs policy: #2420 / `7b76df6b` touched the experimental sandbox config path listed in `docs/.docs-skip`; #2466 / `cc15689c` touched a skipped term and CI-only sandbox image files.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes — failed locally in installer-integration tests and one onboard helper timeout; the doc-scoped hook test projects passed under `prek`.
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only) — build succeeded, but local Sphinx emitted the existing version-switcher file read message.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
<!-- If an AI agent authored or co-authored this PR, check the box and name the tool. Remove this section for fully human-authored PRs. -->
- [x] AI-assisted — tool: Codex

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom YAML presets in policy configuration via --from-file and --from-dir.
  * New build-time inference input option to declare accepted modalities (text or text,image).

* **Improvements**
  * Credential validation now offers interactive recovery: re-enter key, retry, choose another provider, or exit.
  * Clarified provider-specific API key prefix handling (nvapi- only applies to NVIDIA keys).

* **Documentation**
  * TLS certificate troubleshooting for inspected networks.
  * Clarified remote dashboard security/device-pairing behavior; command docs updated; docs version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
