### PR TITLE
fix(onboard): surface NEMOCLAW_DASHBOARD_PORT/GATEWAY_PORT override in preflight error

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3239,18 +3239,22 @@ async function preflight(): Promise<ReturnType<typeof nim.detectGpu>> {
     }
   }
 
-  // Required ports — gateway and the dashboard port.
-  // When --control-ui-port is set, check that port instead of the default.
-  // When auto-allocation is possible (no explicit port), skip the dashboard
-  // port check entirely — ensureDashboardForward will find a free port.
+  // Required ports — gateway, plus the dashboard port when an explicit one
+  // is requested. envVar is the override env var documented in
+  // src/lib/ports.ts; surfacing it in the preflight error gives users a clear
+  // escape hatch when an unrelated process is holding the default port
+  // (closes #2497). When --control-ui-port is set, check that port instead
+  // of the default. When auto-allocation is possible (no explicit port),
+  // skip the dashboard port check entirely — ensureDashboardForward will
+  // find a free port.
   const dashboardPortToCheck = _preflightDashboardPort ?? null;
   const requiredPorts = [
-    { port: GATEWAY_PORT, label: "OpenShell gateway" },
+    { port: GATEWAY_PORT, label: "OpenShell gateway", envVar: "NEMOCLAW_GATEWAY_PORT" },
     ...(dashboardPortToCheck !== null
-      ? [{ port: dashboardPortToCheck, label: `${cliDisplayName()} dashboard` }]
+      ? [{ port: dashboardPortToCheck, label: `${cliDisplayName()} dashboard`, envVar: "NEMOCLAW_DASHBOARD_PORT" }]
       : []),
   ];
-  for (const { port, label } of requiredPorts) {
+  for (const { port, label, envVar } of requiredPorts) {
     let portCheck = await checkPortAvailable(port);
     if (!portCheck.ok) {
       if ((port === GATEWAY_PORT || port === DASHBOARD_PORT) && gatewayReuseState === "healthy") {
@@ -3302,6 +3306,9 @@ async function preflight(): Promise<ReturnType<typeof nim.detectGpu>> {
         console.error(`     Could not identify the process using port ${port}.`);
         console.error(`     Run: sudo lsof -i :${port} -sTCP:LISTEN`);
       }
+      console.error("");
+      console.error(`     Or rerun with a different port:`);
+      console.error(`       ${envVar}=<port> nemoclaw onboard`);
       console.error("");
       console.error(`     Detail: ${portCheck.reason}`);
       process.exit(1);

--- a/test/e2e/e2e-cloud-experimental/test-port8080-conflict.sh
+++ b/test/e2e/e2e-cloud-experimental/test-port8080-conflict.sh
@@ -97,6 +97,15 @@ else
   exit 1
 fi
 
+# #2497: the preflight error must surface the env-var override so users
+# can rerun with a different port instead of being blocked indefinitely.
+if echo "$p4_out" | grep -Fq "NEMOCLAW_GATEWAY_PORT=<port> nemoclaw onboard"; then
+  PASS "Onboard error surfaces NEMOCLAW_GATEWAY_PORT override hint (#2497)"
+else
+  FAIL "Expected NEMOCLAW_GATEWAY_PORT override hint in onboard output (#2497)"
+  exit 1
+fi
+
 INFO "Restoring nemoclaw gateway for subsequent phases..."
 if ! openshell gateway start --name nemoclaw 2>&1; then
   FAIL "openshell gateway start --name nemoclaw failed after port test"


### PR DESCRIPTION
## Summary

Closes #2497.

When `nemoclaw onboard` aborts at preflight because port 8080 or 18789 is held by an unrelated process, the error currently lists the conflicting process and tells the user to stop it (`sudo kill <PID>`) — but offers no way to keep the conflicting process and onboard on a different port. The override env vars `NEMOCLAW_GATEWAY_PORT` and `NEMOCLAW_DASHBOARD_PORT` have always been honored by `parsePort()` in [src/lib/ports.ts](src/lib/ports.ts); they were just undocumented and undiscoverable from the error message.

## Problem

@BryanTegomoh hit this on a clean install where an unrelated dev server was already on 18789. Their report (#2497) lists three acceptable fixes; this PR implements option 2 (*"Honor a `NEMOCLAW_DASHBOARD_PORT` env var and document it in the preflight error"*) — the smallest possible change that unblocks the user, since the env var already works and just needs surfacing.

The original error path (after my change):

```
  !! Port 18789 is not available.
     NemoClaw dashboard needs this port.

     Blocked by: node (PID 12345)

     To fix, stop the conflicting process:

       sudo kill 12345

     Or rerun with a different port:
       NEMOCLAW_DASHBOARD_PORT=<port> nemoclaw onboard

     Detail: ...
```

The new "Or rerun with a different port" hint is generated from a per-port `envVar` field threaded through the existing `requiredPorts` list, so the error message picks the correct override variable for each port (`NEMOCLAW_GATEWAY_PORT` for 8080 / `NEMOCLAW_DASHBOARD_PORT` for 18789) without any string matching.

## Test plan

- [x] Unit: 209 onboard + preflight tests pass (`npx vitest run --project cli --testTimeout=180000 test/onboard.test.ts src/lib/preflight.test.ts`).
- [x] E2E: extended `test/e2e/e2e-cloud-experimental/test-port8080-conflict.sh` to assert the new `NEMOCLAW_GATEWAY_PORT=<port> nemoclaw onboard` hint appears in onboard output, locking the behavior in for future refactors.
- [x] Manual: confirmed `NEMOCLAW_DASHBOARD_PORT=29999 node` resolves `DASHBOARD_PORT` to 29999 via `parsePort()` (env var was already wired — only the error-message discoverability was missing).
- [x] Build clean, signed commit, DCO ✅.

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved onboarding port-conflict messaging: when a required port is in use, the tool now includes a copy-paste ready environment-variable override hint to retry with a different port.

* **Tests**
  * End-to-end test updated to verify the new override-hint appears in port-conflict failure output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->