### PR TITLE
fix(hermes): skip unsupported Brave web search

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6882,6 +6882,13 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
     if (webSearchConfig && !agentSupportsWebSearch(agent, webSearchSupportProbePath)) {
       note(`  Web search is not yet supported by ${agent?.displayName ?? "this sandbox image"}. Clearing stale config.`);
       webSearchConfig = null;
+      if (session) {
+        session.webSearchConfig = null;
+      }
+      onboardSession.updateSession((current: Session) => {
+        current.webSearchConfig = null;
+        return current;
+      });
     }
 
     const sandboxReuseState = getSandboxReuseState(sandboxName);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1241,13 +1241,19 @@ function agentSupportsWebSearch(
   agent: AgentDefinition | null | undefined,
   dockerfilePathOverride: string | null = null,
 ): boolean {
-  const dockerfilePath = dockerfilePathOverride || agent?.dockerfilePath || path.join(ROOT, "Dockerfile");
-  try {
-    const content = fs.readFileSync(dockerfilePath, "utf-8");
-    return /^ARG NEMOCLAW_WEB_SEARCH_ENABLED=/m.test(content);
-  } catch {
-    return false;
+  const candidates = [dockerfilePathOverride, agent?.dockerfilePath, path.join(ROOT, "Dockerfile")].filter(
+    (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+  );
+
+  for (const dockerfilePath of candidates) {
+    try {
+      const content = fs.readFileSync(dockerfilePath, "utf-8");
+      return /^\s*ARG\s+NEMOCLAW_WEB_SEARCH_ENABLED=/m.test(content);
+    } catch {
+      // Try the next candidate; custom Dockerfile paths can disappear between resume runs.
+    }
   }
+  return false;
 }
 
 async function configureWebSearch(

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1330,9 +1330,12 @@ function verifyWebSearchInsideSandbox(
         console.warn("  ⚠ Could not verify web search config inside sandbox (hermes dump failed).");
         return;
       }
-      // A working web backend shows as "web.backend: <name>" in config_overrides
-      // or as "web" in the active toolsets section.
-      const hasWebBackend = /web\.backend:\s*\S+/.test(dump) || /\bweb\b.*\bsearch\b/i.test(dump);
+      // A working web backend shows as an explicit config override or active-toolset entry.
+      // Avoid broad /web.*search/ matching so warning text never looks like success.
+      const hasWebBackend =
+        /^\s*web\.backend:\s*\S+/m.test(dump) ||
+        /^\s*active toolsets:\s*.*\bweb\b/im.test(dump) ||
+        /^\s*toolsets:\s*.*\bweb\b/im.test(dump);
       if (!hasWebBackend) {
         console.warn("  ⚠ Web search was configured but Hermes does not report an active web backend.");
         console.warn("    The agent may not have accepted the web search configuration.");
@@ -1340,7 +1343,7 @@ function verifyWebSearchInsideSandbox(
       } else {
         console.log("  ✓ Web search is active inside sandbox");
       }
-    } else {
+    } else if (agentName === "openclaw") {
       // OpenClaw: verify tools.web.search block exists in the baked config.
       const configCheck = runCaptureOpenshell(
         ["sandbox", "exec", sandboxName, "cat", "/sandbox/.openclaw/openclaw.json"],
@@ -1360,6 +1363,8 @@ function verifyWebSearchInsideSandbox(
       } catch {
         console.warn("  ⚠ Could not parse openclaw.json to verify web search config.");
       }
+    } else {
+      console.warn(`  ⚠ Web search verification is not implemented for agent '${agentName}'.`);
     }
   } catch {
     // Best-effort — don't let probe failures derail onboarding.

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1384,8 +1384,11 @@ async function ensureValidatedBraveSearchCredential(
  * OpenClaw uses the root Dockerfile (not agents/openclaw/Dockerfile), so we
  * fall back to the root Dockerfile when the agent-specific one doesn't exist.
  */
-function agentSupportsWebSearch(agent: AgentDefinition | null | undefined): boolean {
-  const dockerfilePath = agent?.dockerfilePath || path.join(ROOT, "Dockerfile");
+function agentSupportsWebSearch(
+  agent: AgentDefinition | null | undefined,
+  dockerfilePathOverride: string | null = null,
+): boolean {
+  const dockerfilePath = dockerfilePathOverride || agent?.dockerfilePath || path.join(ROOT, "Dockerfile");
   try {
     const content = fs.readFileSync(dockerfilePath, "utf-8");
     return /^ARG NEMOCLAW_WEB_SEARCH_ENABLED=/m.test(content);
@@ -1397,8 +1400,9 @@ function agentSupportsWebSearch(agent: AgentDefinition | null | undefined): bool
 async function configureWebSearch(
   existingConfig: WebSearchConfig | null = null,
   agent: AgentDefinition | null = null,
+  dockerfilePathOverride: string | null = null,
 ): Promise<WebSearchConfig | null> {
-  if (!agentSupportsWebSearch(agent)) {
+  if (!agentSupportsWebSearch(agent, dockerfilePathOverride)) {
     note(`  Web search is not yet supported by ${agent?.displayName ?? "this agent"}. Skipping.`);
     return null;
   }
@@ -7742,6 +7746,12 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       break;
     }
 
+    const webSearchSupportProbePath = fromDockerfile ? path.resolve(fromDockerfile) : null;
+    if (webSearchConfig && !agentSupportsWebSearch(agent, webSearchSupportProbePath)) {
+      note(`  Web search is not yet supported by ${agent?.displayName ?? "this sandbox image"}. Clearing stale config.`);
+      webSearchConfig = null;
+    }
+
     const sandboxReuseState = getSandboxReuseState(sandboxName);
     const webSearchConfigChanged = Boolean(session?.webSearchConfig) !== Boolean(webSearchConfig);
     const resumeSandbox =
@@ -7775,10 +7785,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         }
       }
       let nextWebSearchConfig = webSearchConfig;
-      if (nextWebSearchConfig && !agentSupportsWebSearch(agent)) {
-        note(`  Web search is not yet supported by ${agent?.displayName ?? "this agent"}. Clearing stale config.`);
-        nextWebSearchConfig = null;
-      } else if (nextWebSearchConfig) {
+      if (nextWebSearchConfig) {
         note("  [resume] Revalidating Brave Search configuration for sandbox recreation.");
         const braveApiKey = await ensureValidatedBraveSearchCredential();
         nextWebSearchConfig = braveApiKey ? { fetchEnabled: true } : null;
@@ -7786,7 +7793,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
           note("  [resume] Reusing Brave Search configuration.");
         }
       } else {
-        nextWebSearchConfig = await configureWebSearch(null, agent);
+        nextWebSearchConfig = await configureWebSearch(null, agent, webSearchSupportProbePath);
       }
       startRecordedStep("sandbox", { sandboxName, provider, model });
       selectedMessagingChannels = await setupMessagingChannels();

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1375,9 +1375,34 @@ async function ensureValidatedBraveSearchCredential(
   }
 }
 
+/**
+ * Check whether the agent's Dockerfile declares ARG NEMOCLAW_WEB_SEARCH_ENABLED.
+ * If the ARG is absent, the patchStagedDockerfile replace is a silent no-op and
+ * the config generator has no code path to emit a web search block — so offering
+ * the Brave prompt would mislead the user.
+ *
+ * OpenClaw uses the root Dockerfile (not agents/openclaw/Dockerfile), so we
+ * fall back to the root Dockerfile when the agent-specific one doesn't exist.
+ */
+function agentSupportsWebSearch(agent: AgentDefinition | null | undefined): boolean {
+  const dockerfilePath = agent?.dockerfilePath || path.join(ROOT, "Dockerfile");
+  try {
+    const content = fs.readFileSync(dockerfilePath, "utf-8");
+    return /^ARG NEMOCLAW_WEB_SEARCH_ENABLED=/m.test(content);
+  } catch {
+    return false;
+  }
+}
+
 async function configureWebSearch(
   existingConfig: WebSearchConfig | null = null,
+  agent: AgentDefinition | null = null,
 ): Promise<WebSearchConfig | null> {
+  if (!agentSupportsWebSearch(agent)) {
+    note(`  Web search is not yet supported by ${agent?.displayName ?? "this agent"}. Skipping.`);
+    return null;
+  }
+
   if (existingConfig) {
     return { fetchEnabled: true };
   }
@@ -1413,6 +1438,70 @@ async function configureWebSearch(
   console.log("  ✓ Enabled Brave Web Search");
   console.log("");
   return { fetchEnabled: true };
+}
+
+/**
+ * Post-creation probe: verify web search is actually functional inside the
+ * sandbox. Hermes silently ignores unknown web.backend values, so checking
+ * the config file alone is insufficient — we need to ask the runtime.
+ *
+ * For Hermes: runs `hermes dump` and checks for an active web backend.
+ * For OpenClaw: checks that the tools.web.search block is present in the config.
+ *
+ * This is a best-effort warning — it does not abort onboarding.
+ */
+function verifyWebSearchInsideSandbox(
+  sandboxName: string,
+  agent: AgentDefinition | null | undefined,
+): void {
+  const agentName = agent?.name || "openclaw";
+  try {
+    if (agentName === "hermes") {
+      // `hermes dump` outputs config_overrides and active toolsets.
+      // Look for the web backend in its output.
+      const dump = runCaptureOpenshell(
+        ["sandbox", "exec", sandboxName, "hermes", "dump"],
+        { ignoreError: true, timeout: 10_000 },
+      );
+      if (!dump) {
+        console.warn("  ⚠ Could not verify web search config inside sandbox (hermes dump failed).");
+        return;
+      }
+      // A working web backend shows as "web.backend: <name>" in config_overrides
+      // or as "web" in the active toolsets section.
+      const hasWebBackend = /web\.backend:\s*\S+/.test(dump) || /\bweb\b.*\bsearch\b/i.test(dump);
+      if (!hasWebBackend) {
+        console.warn("  ⚠ Web search was configured but Hermes does not report an active web backend.");
+        console.warn("    The agent may not have accepted the web search configuration.");
+        console.warn("    Check: nemoclaw " + sandboxName + " exec hermes dump");
+      } else {
+        console.log("  ✓ Web search is active inside sandbox");
+      }
+    } else {
+      // OpenClaw: verify tools.web.search block exists in the baked config.
+      const configCheck = runCaptureOpenshell(
+        ["sandbox", "exec", sandboxName, "cat", "/sandbox/.openclaw/openclaw.json"],
+        { ignoreError: true, timeout: 10_000 },
+      );
+      if (!configCheck) {
+        console.warn("  ⚠ Could not verify web search config inside sandbox.");
+        return;
+      }
+      try {
+        const parsed = JSON.parse(configCheck);
+        if (parsed?.tools?.web?.search?.enabled) {
+          console.log("  ✓ Web search is active inside sandbox");
+        } else {
+          console.warn("  ⚠ Web search was configured but tools.web.search is not enabled in openclaw.json.");
+        }
+      } catch {
+        console.warn("  ⚠ Could not parse openclaw.json to verify web search config.");
+      }
+    }
+  } catch {
+    // Best-effort — don't let probe failures derail onboarding.
+    console.warn("  ⚠ Web search verification probe failed (non-fatal).");
+  }
 }
 
 function getSandboxInferenceConfig(
@@ -4580,6 +4669,15 @@ async function createSandbox(
     }
   }
 
+  // Verify web search config was actually accepted by the agent runtime.
+  // Hermes silently ignores unknown web.backend values (e.g. "brave" before
+  // upstream support lands), so we exec into the sandbox and check for a
+  // recognizable signal. OpenClaw validates at config-generation time, but
+  // this probe catches drift for all agents.
+  if (webSearchConfig?.fetchEnabled) {
+    verifyWebSearchInsideSandbox(sandboxName, agent);
+  }
+
   // Release any stale forward on the dashboard port before claiming it for the new sandbox.
   // A previous onboard run may have left the port forwarded to a different sandbox,
   // which would silently prevent the new sandbox's dashboard from being reachable.
@@ -7677,7 +7775,10 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         }
       }
       let nextWebSearchConfig = webSearchConfig;
-      if (nextWebSearchConfig) {
+      if (nextWebSearchConfig && !agentSupportsWebSearch(agent)) {
+        note(`  Web search is not yet supported by ${agent?.displayName ?? "this agent"}. Clearing stale config.`);
+        nextWebSearchConfig = null;
+      } else if (nextWebSearchConfig) {
         note("  [resume] Revalidating Brave Search configuration for sandbox recreation.");
         const braveApiKey = await ensureValidatedBraveSearchCredential();
         nextWebSearchConfig = braveApiKey ? { fetchEnabled: true } : null;
@@ -7685,7 +7786,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
           note("  [resume] Reusing Brave Search configuration.");
         }
       } else {
-        nextWebSearchConfig = await configureWebSearch(null);
+        nextWebSearchConfig = await configureWebSearch(null, agent);
       }
       startRecordedStep("sandbox", { sandboxName, provider, model });
       selectedMessagingChannels = await setupMessagingChannels();
@@ -7891,6 +7992,7 @@ module.exports = {
   findDashboardForwardOwner,
   startGatewayForRecovery,
   runCaptureOpenshell,
+  agentSupportsWebSearch,
   setupInference,
   setupMessagingChannels,
   MESSAGING_CHANNELS,

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -9,6 +9,8 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
+import type { AgentDefinition } from "../dist/lib/agent-defs.js";
+import { loadAgent } from "../dist/lib/agent-defs.js";
 import { buildChain, buildControlUiUrls } from "../dist/lib/dashboard-contract.js";
 import { stageOptimizedSandboxBuildContext } from "../dist/lib/sandbox-build-context.js";
 
@@ -74,8 +76,15 @@ type OnboardTestInternals = {
   isGatewayHealthy: ShimFn<boolean>;
   classifyValidationFailure: ShimFn<ValidationClassification>;
   hasResponsesToolCall: (body?: string | null) => boolean;
-  agentSupportsWebSearch: ShimFn<boolean>;
-  configureWebSearch: ShimFn<Promise<ShimValue>>;
+  agentSupportsWebSearch: (
+    agent?: AgentDefinition | null,
+    dockerfilePathOverride?: string | null,
+  ) => boolean;
+  configureWebSearch: (
+    existingConfig?: ShimValue,
+    agent?: AgentDefinition | null,
+    dockerfilePathOverride?: string | null,
+  ) => Promise<ShimValue>;
   isLoopbackHostname: (hostname?: string) => boolean;
   normalizeProviderBaseUrl: (
     value: string | null | undefined,
@@ -108,6 +117,8 @@ function isOnboardTestInternals(
     value !== null &&
     typeof value.buildProviderArgs === "function" &&
     typeof value.classifySandboxCreateFailure === "function" &&
+    typeof value.agentSupportsWebSearch === "function" &&
+    typeof value.configureWebSearch === "function" &&
     typeof value.writeSandboxConfigSyncFile === "function"
   );
 }
@@ -597,7 +608,9 @@ describe("onboard helpers", () => {
     // Forward target via buildChain replaces resolveDashboardForwardTarget
     expect(buildChain({ chatUiUrl: "http://127.0.0.1:18789" }).forwardTarget).toBe("18789");
     expect(buildChain({ chatUiUrl: "http://[::1]:18789" }).forwardTarget).toBe("18789");
-    expect(buildChain({ chatUiUrl: "https://chat.example.com:18789" }).forwardTarget).toBe("0.0.0.0:18789");
+    expect(buildChain({ chatUiUrl: "https://chat.example.com:18789" }).forwardTarget).toBe(
+      "0.0.0.0:18789",
+    );
     expect(buildChain({ chatUiUrl: "http://10.0.0.25:18789" }).forwardTarget).toBe("0.0.0.0:18789");
   });
 
@@ -1021,14 +1034,26 @@ describe("onboard helpers", () => {
     // OpenClaw Dockerfile has ARG NEMOCLAW_WEB_SEARCH_ENABLED → supported.
     // Hermes Dockerfile does not → not supported.
     // null agent (default) → supported (assumes OpenClaw).
-    const { loadAgent } = require("../dist/lib/agent-defs.js");
     expect(agentSupportsWebSearch(null)).toBe(true);
     expect(agentSupportsWebSearch(loadAgent("openclaw"))).toBe(true);
     expect(agentSupportsWebSearch(loadAgent("hermes"))).toBe(false);
   });
 
+  it("#2433: agentSupportsWebSearch honors the effective custom Dockerfile", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-web-search-custom-"));
+    const withoutArg = path.join(tmpDir, "Dockerfile.no-web");
+    const withArg = path.join(tmpDir, "Dockerfile.web");
+    fs.writeFileSync(withoutArg, "FROM scratch\n");
+    fs.writeFileSync(withArg, "FROM scratch\nARG NEMOCLAW_WEB_SEARCH_ENABLED=0\n");
+    try {
+      expect(agentSupportsWebSearch(loadAgent("openclaw"), withoutArg)).toBe(false);
+      expect(agentSupportsWebSearch(loadAgent("hermes"), withArg)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("#2433: configureWebSearch skips unsupported Hermes instead of prompting for Brave", async () => {
-    const { loadAgent } = require("../dist/lib/agent-defs.js");
     const priorBraveKey = process.env.BRAVE_API_KEY;
     process.env.BRAVE_API_KEY = "brv-test-key";
     try {
@@ -5130,9 +5155,7 @@ const { setupMessagingChannels } = require(${onboardPath});
       const scriptPath = path.join(tmpDir, "slack-format-reject.js");
       const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
       const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
-      const credentialsPath = JSON.stringify(
-        path.join(repoRoot, "dist", "lib", "credentials.js"),
-      );
+      const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
 
       fs.mkdirSync(fakeBin, { recursive: true });
       fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
@@ -5243,9 +5266,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
       const scriptPath = path.join(tmpDir, "slack-app-format-reject.js");
       const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
       const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
-      const credentialsPath = JSON.stringify(
-        path.join(repoRoot, "dist", "lib", "credentials.js"),
-      );
+      const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
 
       fs.mkdirSync(fakeBin, { recursive: true });
       fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
@@ -5305,9 +5326,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
         input: "\n",
       });
       assert.equal(introspect.status, 0, introspect.stderr);
-      const slackIdx = JSON.parse(
-        introspect.stdout.trim().split("\n").pop()!,
-      ).slackIndex1Based;
+      const slackIdx = JSON.parse(introspect.stdout.trim().split("\n").pop()!).slackIndex1Based;
       assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
       // Real run: toggle Slack on, exit UI, bot prompt returns valid, app

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1078,11 +1078,20 @@ describe("onboard helpers", () => {
     const agentDefsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "agent-defs.js"));
 
     const script = `
-const credentials = require(${credentialsPath});
 let promptCalls = 0;
-credentials.prompt = async () => {
+const actualCredentials = require(${credentialsPath});
+const mockedCredentials = {
+  ...actualCredentials,
+  prompt: async () => {
   promptCalls += 1;
   throw new Error("prompt should not be called");
+  },
+};
+require.cache[require.resolve(${credentialsPath})] = {
+  id: require.resolve(${credentialsPath}),
+  filename: require.resolve(${credentialsPath}),
+  loaded: true,
+  exports: mockedCredentials,
 };
 process.env.BRAVE_API_KEY = "brv-test-key";
 const { configureWebSearch } = require(${onboardPath});

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1069,6 +1069,52 @@ describe("onboard helpers", () => {
     }
   });
 
+  it("#2433: configureWebSearch does not call the prompt helper for unsupported Hermes", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-web-search-prompt-"));
+    const scriptPath = path.join(tmpDir, "web-search-prompt-check.cjs");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
+    const agentDefsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "agent-defs.js"));
+
+    const script = `
+const credentials = require(${credentialsPath});
+let promptCalls = 0;
+credentials.prompt = async () => {
+  promptCalls += 1;
+  throw new Error("prompt should not be called");
+};
+process.env.BRAVE_API_KEY = "brv-test-key";
+const { configureWebSearch } = require(${onboardPath});
+const { loadAgent } = require(${agentDefsPath});
+
+(async () => {
+  const result = await configureWebSearch(null, loadAgent("hermes"));
+  console.log(JSON.stringify({ result, promptCalls }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+    try {
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+        },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseStdoutJson<{ result: null; promptCalls: number }>(result.stdout);
+      assert.equal(payload.result, null);
+      assert.equal(payload.promptCalls, 0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("maps Gemini to the routed inference provider with supportsStore disabled", () => {
     assert.deepEqual(getSandboxInferenceConfig("gemini-2.5-flash", "gemini-api"), {
       providerKey: "inference",

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -74,6 +74,8 @@ type OnboardTestInternals = {
   isGatewayHealthy: ShimFn<boolean>;
   classifyValidationFailure: ShimFn<ValidationClassification>;
   hasResponsesToolCall: (body?: string | null) => boolean;
+  agentSupportsWebSearch: ShimFn<boolean>;
+  configureWebSearch: ShimFn<Promise<ShimValue>>;
   isLoopbackHostname: (hostname?: string) => boolean;
   normalizeProviderBaseUrl: (
     value: string | null | undefined,
@@ -146,6 +148,8 @@ const {
   isGatewayHealthy,
   classifyValidationFailure,
   hasResponsesToolCall,
+  agentSupportsWebSearch,
+  configureWebSearch,
   isLoopbackHostname,
   normalizeProviderBaseUrl,
   parsePolicyPresetEnv,
@@ -1010,6 +1014,31 @@ describe("onboard helpers", () => {
         process.env.BRAVE_API_KEY = priorBraveKey;
       }
       fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("#2433: agentSupportsWebSearch detects whether agent Dockerfile declares the web search ARG", () => {
+    // OpenClaw Dockerfile has ARG NEMOCLAW_WEB_SEARCH_ENABLED → supported.
+    // Hermes Dockerfile does not → not supported.
+    // null agent (default) → supported (assumes OpenClaw).
+    const { loadAgent } = require("../dist/lib/agent-defs.js");
+    expect(agentSupportsWebSearch(null)).toBe(true);
+    expect(agentSupportsWebSearch(loadAgent("openclaw"))).toBe(true);
+    expect(agentSupportsWebSearch(loadAgent("hermes"))).toBe(false);
+  });
+
+  it("#2433: configureWebSearch skips unsupported Hermes instead of prompting for Brave", async () => {
+    const { loadAgent } = require("../dist/lib/agent-defs.js");
+    const priorBraveKey = process.env.BRAVE_API_KEY;
+    process.env.BRAVE_API_KEY = "brv-test-key";
+    try {
+      await expect(configureWebSearch(null, loadAgent("hermes"))).resolves.toBeNull();
+    } finally {
+      if (priorBraveKey === undefined) {
+        delete process.env.BRAVE_API_KEY;
+      } else {
+        process.env.BRAVE_API_KEY = priorBraveKey;
+      }
     }
   });
 

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1043,11 +1043,13 @@ describe("onboard helpers", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-web-search-custom-"));
     const withoutArg = path.join(tmpDir, "Dockerfile.no-web");
     const withArg = path.join(tmpDir, "Dockerfile.web");
+    const missing = path.join(tmpDir, "Dockerfile.missing");
     fs.writeFileSync(withoutArg, "FROM scratch\n");
-    fs.writeFileSync(withArg, "FROM scratch\nARG NEMOCLAW_WEB_SEARCH_ENABLED=0\n");
+    fs.writeFileSync(withArg, "FROM scratch\n  ARG NEMOCLAW_WEB_SEARCH_ENABLED=0\n");
     try {
       expect(agentSupportsWebSearch(loadAgent("openclaw"), withoutArg)).toBe(false);
       expect(agentSupportsWebSearch(loadAgent("hermes"), withArg)).toBe(true);
+      expect(agentSupportsWebSearch(loadAgent("openclaw"), missing)).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
Avoid claiming Brave Web Search works for Hermes when its sandbox image has no web-search wiring. The onboard flow now skips unsupported web search for Hermes and adds a best-effort runtime verification probe for configured web search.

## Related Issue
Fixes #2433

## Changes
- Detect web-search support from the agent Dockerfile before prompting for Brave.
- Skip/clear stale web-search config for unsupported agents like current Hermes.
- Add a post-creation probe to verify configured web search is actually active in the sandbox.
- Add regression coverage for the Hermes unsupported path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:
- `npm run build:cli`
- `npx vitest run test/onboard.test.ts`
- `npm run typecheck:cli`
- E2E repro through `nemoclaw onboard --agent hermes` with a live OpenShell gateway:
  - Old code requested Brave Web Search when `BRAVE_API_KEY` was present.
  - New code prints `Web search is not yet supported by Hermes Agent. Skipping.`

## AI Disclosure
- [x] AI-assisted — tool: OpenCode

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web search is now gated by the agent image declaration; setup is skipped for agents that don't declare support.
  * Brave web-search setup is no longer offered for unsupported agents; resuming clears any stale web-search configuration.
  * A non-fatal runtime check verifies web search inside the sandbox and warns if configured but inactive.

* **Tests**
  * Added tests for agent web-search detection, image-path overrides, and configuration short-circuiting for unsupported agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->