### PR TITLE
fix(cli): require argv arrays for runCapture

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6276,7 +6276,7 @@ function printDashboard(
 
   const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
   const chatUiUrl = process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`;
-  const wslAddr = isWsl() ? (String(runCapture(["hostname", "-I"], { ignoreError: true }) || "").trim().split(/\s+/)[0] || null) : null;
+  const wslAddr = getWslHostAddress();
   const chain = buildChain({ chatUiUrl, isWsl: isWsl(), wslHostAddress: wslAddr });
 
   // Build access info inline — uses chain instead of re-deriving from env

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1838,6 +1838,22 @@ function getGatewayClusterContainerName(): string {
   return `openshell-cluster-${GATEWAY_NAME}`;
 }
 
+function buildGatewayClusterExecArgv(script: string): string[] {
+  return ["docker", "exec", getGatewayClusterContainerName(), "sh", "-lc", script];
+}
+
+function hostCommandExists(commandName: string): boolean {
+  return !!runCapture(["sh", "-c", 'command -v "$1"', "--", commandName], {
+    ignoreError: true,
+  });
+}
+
+function captureProcessArgs(pid: number): string {
+  return runCapture(["ps", "-p", String(pid), "-o", "args="], {
+    ignoreError: true,
+  }).trim();
+}
+
 function getGatewayLocalEndpoint(): string {
   return `https://127.0.0.1:${GATEWAY_PORT}`;
 }
@@ -1900,13 +1916,11 @@ fi
 }
 
 function runGatewayClusterCapture(script: string, opts: RunnerOptions = {}) {
-  const containerName = getGatewayClusterContainerName();
-  return runCapture(["docker", "exec", containerName, "sh", "-lc", script], opts);
+  return runCapture(buildGatewayClusterExecArgv(script), opts);
 }
 
 function runGatewayCluster(script: string, opts: RunnerOptions = {}) {
-  const containerName = getGatewayClusterContainerName();
-  return run(["docker", "exec", containerName, "sh", "-lc", script], opts);
+  return run(buildGatewayClusterExecArgv(script), opts);
 }
 
 function listMissingGatewayBootstrapSecrets() {
@@ -2448,9 +2462,7 @@ async function preflight(): Promise<ReturnType<typeof nim.detectGpu>> {
       // tunnels the user may have set up on the same port. (#1950)
       if (port === DASHBOARD_PORT && portCheck.process === "ssh" && portCheck.pid) {
         // Use `ps` to get the command line — works on Linux, macOS, and WSL.
-        const cmdline = runCapture(["ps", "-p", String(portCheck.pid), "-o", "args="], {
-          ignoreError: true,
-        }).trim();
+        const cmdline = captureProcessArgs(portCheck.pid);
         if (cmdline.includes("openshell")) {
           console.log(
             `  Cleaning up orphaned SSH port-forward on port ${port} (PID ${portCheck.pid})...`,
@@ -3849,9 +3861,7 @@ async function setupNim(gpu: ReturnType<typeof nim.detectGpu>): Promise<{
   let preferredInferenceApi: string | null = null;
 
   // Detect local inference options
-  const hasOllama = !!runCapture(["sh", "-c", 'command -v "$1"', "--", "ollama"], {
-    ignoreError: true,
-  });
+  const hasOllama = hostCommandExists("ollama");
   const ollamaRunning = !!runCapture(["curl", "-sf", `http://127.0.0.1:${OLLAMA_PORT}/api/tags`], {
     ignoreError: true,
   });
@@ -6182,11 +6192,10 @@ function getWslHostAddress(
   }
   const runCaptureFn = options.runCapture || runCapture;
   const output = runCaptureFn(["hostname", "-I"], { ignoreError: true });
-  const candidates = String(output || "")
+  return String(output || "")
     .trim()
     .split(/\s+/)
-    .filter(Boolean);
-  return candidates[0] || null;
+    .filter(Boolean)[0] || null;
 }
 
 function getDashboardAccessInfo(

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1798,7 +1798,15 @@ function destroyGateway() {
 function getGatewayClusterContainerState(): string {
   const containerName = getGatewayClusterContainerName();
   const state = runCapture(
-    `docker inspect --type container --format '{{.State.Status}}{{if .State.Health}} {{.State.Health.Status}}{{end}}' ${shellQuote(containerName)} 2>/dev/null`,
+    [
+      "docker",
+      "inspect",
+      "--type",
+      "container",
+      "--format",
+      "{{.State.Status}}{{if .State.Health}} {{.State.Health.Status}}{{end}}",
+      containerName,
+    ],
     { ignoreError: true },
   )
     .trim()
@@ -1893,12 +1901,12 @@ fi
 
 function runGatewayClusterCapture(script: string, opts: RunnerOptions = {}) {
   const containerName = getGatewayClusterContainerName();
-  return runCapture(`docker exec ${shellQuote(containerName)} sh -lc ${shellQuote(script)}`, opts);
+  return runCapture(["docker", "exec", containerName, "sh", "-lc", script], opts);
 }
 
 function runGatewayCluster(script: string, opts: RunnerOptions = {}) {
   const containerName = getGatewayClusterContainerName();
-  return run(`docker exec ${shellQuote(containerName)} sh -lc ${shellQuote(script)}`, opts);
+  return run(["docker", "exec", containerName, "sh", "-lc", script], opts);
 }
 
 function listMissingGatewayBootstrapSecrets() {
@@ -2440,7 +2448,7 @@ async function preflight(): Promise<ReturnType<typeof nim.detectGpu>> {
       // tunnels the user may have set up on the same port. (#1950)
       if (port === DASHBOARD_PORT && portCheck.process === "ssh" && portCheck.pid) {
         // Use `ps` to get the command line — works on Linux, macOS, and WSL.
-        const cmdline = runCapture(`ps -p ${portCheck.pid} -o args= 2>/dev/null`, {
+        const cmdline = runCapture(["ps", "-p", String(portCheck.pid), "-o", "args="], {
           ignoreError: true,
         }).trim();
         if (cmdline.includes("openshell")) {
@@ -3841,8 +3849,9 @@ async function setupNim(gpu: ReturnType<typeof nim.detectGpu>): Promise<{
   let preferredInferenceApi: string | null = null;
 
   // Detect local inference options
-  // "command -v" is a shell builtin — must go through bash.
-  const hasOllama = !!runCapture("command -v ollama", { ignoreError: true });
+  const hasOllama = !!runCapture(["sh", "-c", 'command -v "$1"', "--", "ollama"], {
+    ignoreError: true,
+  });
   const ollamaRunning = !!runCapture(["curl", "-sf", `http://127.0.0.1:${OLLAMA_PORT}/api/tags`], {
     ignoreError: true,
   });
@@ -6172,7 +6181,7 @@ function getWslHostAddress(
     return null;
   }
   const runCaptureFn = options.runCapture || runCapture;
-  const output = runCaptureFn("hostname -I 2>/dev/null", { ignoreError: true });
+  const output = runCaptureFn(["hostname", "-I"], { ignoreError: true });
   const candidates = String(output || "")
     .trim()
     .split(/\s+/)
@@ -6258,7 +6267,7 @@ function printDashboard(
 
   const token = fetchGatewayAuthTokenFromSandbox(sandboxName);
   const chatUiUrl = process.env.CHAT_UI_URL || `http://127.0.0.1:${CONTROL_UI_PORT}`;
-  const wslAddr = isWsl() ? (String(runCapture("hostname -I 2>/dev/null", { ignoreError: true }) || "").trim().split(/\s+/)[0] || null) : null;
+  const wslAddr = isWsl() ? (String(runCapture(["hostname", "-I"], { ignoreError: true }) || "").trim().split(/\s+/)[0] || null) : null;
   const chain = buildChain({ chatUiUrl, isWsl: isWsl(), wslHostAddress: wslAddr });
 
   // Build access info inline — uses chain instead of re-deriving from env

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -314,11 +314,11 @@ describe("assessHost", () => {
       readFileImpl: () => '{"default-cgroupns-mode":"private"}',
       commandExistsImpl: (name: string) =>
         name === "docker" || name === "apt-get" || name === "systemctl",
-      runCaptureImpl: (command: string) => {
-        if (command === "command -v apt-get") return "/usr/bin/apt-get";
-        if (command === "command -v systemctl") return "/usr/bin/systemctl";
-        if (command === "systemctl is-active docker") return "active";
-        if (command === "systemctl is-enabled docker") return "enabled";
+      runCaptureImpl: (command: readonly string[]) => {
+        if (command.join(" ") === 'sh -c command -v "$1" -- apt-get') return "/usr/bin/apt-get";
+        if (command.join(" ") === 'sh -c command -v "$1" -- systemctl') return "/usr/bin/systemctl";
+        if (command.join(" ") === "systemctl is-active docker") return "active";
+        if (command.join(" ") === "systemctl is-enabled docker") return "enabled";
         return "";
       },
     });
@@ -731,8 +731,7 @@ describe("probeContainerDns", () => {
     "Address: 104.16.26.35\n" +
     "Address: 104.16.27.35\n";
 
-  const BUSYBOX_FAILURE =
-    ";; connection timed out; no servers could be reached\n";
+  const BUSYBOX_FAILURE = ";; connection timed out; no servers could be reached\n";
 
   it("returns ok when busybox nslookup succeeds", () => {
     const result = probeContainerDns({ outputOverride: BUSYBOX_SUCCESS });
@@ -760,7 +759,7 @@ describe("probeContainerDns", () => {
     const pullError =
       "Unable to find image 'busybox:latest' locally\n" +
       "latest: Pulling from library/busybox\n" +
-      "docker: Error response from daemon: Head \"https://registry-1.docker.io/v2/library/busybox/manifests/latest\": dial tcp: lookup registry-1.docker.io: no such host.\n";
+      'docker: Error response from daemon: Head "https://registry-1.docker.io/v2/library/busybox/manifests/latest": dial tcp: lookup registry-1.docker.io: no such host.\n';
     const result = probeContainerDns({ outputOverride: pullError });
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("image_pull_failed");
@@ -807,30 +806,30 @@ describe("probeContainerDns", () => {
   });
 
   it("captures the spawned command for runCapture override", () => {
-    const captured: string[] = [];
+    const captured: string[][] = [];
     const result = probeContainerDns({
       runCaptureImpl: (command) => {
-        captured.push(command);
+        captured.push([...command]);
         return BUSYBOX_SUCCESS;
       },
     });
     expect(result.ok).toBe(true);
     expect(captured).toHaveLength(1);
-    expect(captured[0]).toContain("docker run");
-    expect(captured[0]).toContain("busybox");
+    expect(captured[0].slice(0, 3)).toEqual(["docker", "run", "--rm"]);
+    expect(captured[0]).toContain("busybox:latest");
     expect(captured[0]).toContain("registry.npmjs.org");
   });
 
   it("allows the command to be overridden", () => {
-    let seen = "";
+    let seen: readonly string[] = [];
     probeContainerDns({
-      command: "echo OVERRIDDEN",
+      command: ["echo", "OVERRIDDEN"],
       runCaptureImpl: (command) => {
         seen = command;
         return "Name:\tregistry.npmjs.org\nAddress: 1.2.3.4\n";
       },
     });
-    expect(seen).toBe("echo OVERRIDDEN");
+    expect(seen).toEqual(["echo", "OVERRIDDEN"]);
   });
 
   it("treats thrown runCapture errors as error reason", () => {
@@ -868,17 +867,17 @@ describe("probeContainerDns", () => {
     expect(seenOpts?.timeout).toBe(20_000);
   });
 
-  it("emits a plain `docker run ...` command (no shell-specific wrappers)", () => {
-    let captured = "";
+  it("emits a plain argv docker run command (no shell-specific wrappers)", () => {
+    let captured: readonly string[] = [];
     probeContainerDns({
       runCaptureImpl: (command) => {
         captured = command;
         return BUSYBOX_SUCCESS;
       },
     });
-    expect(captured.startsWith("docker run")).toBe(true);
-    expect(captured.startsWith("timeout ")).toBe(false);
-    expect(captured.startsWith("gtimeout ")).toBe(false);
+    expect(captured.slice(0, 2)).toEqual(["docker", "run"]);
+    expect(captured).not.toContain("timeout");
+    expect(captured).not.toContain("gtimeout");
   });
 });
 
@@ -930,12 +929,12 @@ describe("getDockerBridgeGatewayIp", () => {
   });
 
   it("uses the expected docker network inspect command shape", () => {
-    let captured = "";
+    let captured: readonly string[] = [];
     getDockerBridgeGatewayIp((cmd) => {
       captured = cmd;
       return "172.17.0.1";
     });
-    expect(captured).toContain("docker network inspect bridge");
-    expect(captured).toContain("Gateway");
+    expect(captured.slice(0, 4)).toEqual(["docker", "network", "inspect", "bridge"]);
+    expect(captured).toContain("{{range .IPAM.Config}}{{.Gateway}}{{end}}");
   });
 });

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -815,9 +815,14 @@ describe("probeContainerDns", () => {
     });
     expect(result.ok).toBe(true);
     expect(captured).toHaveLength(1);
-    expect(captured[0].slice(0, 3)).toEqual(["docker", "run", "--rm"]);
-    expect(captured[0]).toContain("busybox:latest");
-    expect(captured[0]).toContain("registry.npmjs.org");
+    // Probe shells out via `sh -c "<script> 2>&1"` so docker/busybox
+    // stderr lands in stdout where the parser can see it.
+    expect(captured[0].slice(0, 2)).toEqual(["sh", "-c"]);
+    const script = captured[0][2];
+    expect(script).toContain("docker run --rm");
+    expect(script).toContain("busybox:latest");
+    expect(script).toContain("registry.npmjs.org");
+    expect(script).toContain("2>&1");
   });
 
   it("allows the command to be overridden", () => {
@@ -867,7 +872,10 @@ describe("probeContainerDns", () => {
     expect(seenOpts?.timeout).toBe(20_000);
   });
 
-  it("emits a plain argv docker run command (no shell-specific wrappers)", () => {
+  it("does not depend on a host-side timeout/gtimeout binary", () => {
+    // The probe bounds itself via Node's spawn-level timeout, not a
+    // host `timeout`/`gtimeout` wrapper (the latter is missing on
+    // macOS by default).
     let captured: readonly string[] = [];
     probeContainerDns({
       runCaptureImpl: (command) => {
@@ -875,9 +883,9 @@ describe("probeContainerDns", () => {
         return BUSYBOX_SUCCESS;
       },
     });
-    expect(captured.slice(0, 2)).toEqual(["docker", "run"]);
-    expect(captured).not.toContain("timeout");
-    expect(captured).not.toContain("gtimeout");
+    const script = captured[2] ?? "";
+    expect(script).not.toMatch(/^\s*timeout\b/);
+    expect(script).not.toMatch(/^\s*gtimeout\b/);
   });
 });
 

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -20,6 +20,13 @@ import { DASHBOARD_PORT } from "./ports";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { runCapture } = require("./runner");
 
+type RunCaptureFn = typeof import("./runner").runCapture;
+type RunCaptureOpts = Parameters<RunCaptureFn>[1];
+type NullableRunCaptureFn = (
+  command: Parameters<RunCaptureFn>[0],
+  options?: RunCaptureOpts,
+) => string | null;
+
 // ── Types ────────────────────────────────────────────────────────
 
 export interface PortProbeResult {
@@ -123,19 +130,18 @@ export interface AssessHostOpts {
   dockerInfoOutput?: string;
   dockerInfoError?: string;
   readFileImpl?: (filePath: string, encoding: BufferEncoding) => string;
-  runCaptureImpl?: (command: readonly string[], options?: { ignoreError?: boolean }) => string;
+  runCaptureImpl?: RunCaptureFn;
   commandExistsImpl?: (commandName: string) => boolean;
   gpuProbeImpl?: () => boolean;
 }
 
-function commandExists(
-  commandName: string,
-  runCaptureImpl: (command: readonly string[], options?: { ignoreError?: boolean }) => string,
-): boolean {
+function buildCommandVArgv(commandName: string): readonly string[] {
+  return ["sh", "-c", 'command -v "$1"', "--", commandName];
+}
+
+function commandExists(commandName: string, runCaptureImpl: RunCaptureFn): boolean {
   try {
-    const output = runCaptureImpl(["sh", "-c", 'command -v "$1"', "--", commandName], {
-      ignoreError: true,
-    });
+    const output = runCaptureImpl(buildCommandVArgv(commandName), { ignoreError: true });
     return Boolean(String(output || "").trim());
   } catch {
     return false;
@@ -227,18 +233,14 @@ function isHeadlessLikely(env: NodeJS.ProcessEnv): boolean {
   return !env.DISPLAY && !env.WAYLAND_DISPLAY && !env.TERM_PROGRAM;
 }
 
-function detectNvidiaGpu(
-  runCaptureImpl: (command: readonly string[], options?: { ignoreError?: boolean }) => string,
-): boolean {
+function detectNvidiaGpu(runCaptureImpl: RunCaptureFn): boolean {
   if (!commandExists("nvidia-smi", runCaptureImpl)) {
     return false;
   }
   return Boolean(String(runCaptureImpl(["nvidia-smi", "-L"], { ignoreError: true }) || "").trim());
 }
 
-function detectPackageManager(
-  runCaptureImpl: (command: readonly string[], options?: { ignoreError?: boolean }) => string,
-): PackageManager {
+function detectPackageManager(runCaptureImpl: RunCaptureFn): PackageManager {
   if (commandExists("apt-get", runCaptureImpl)) return "apt";
   if (commandExists("dnf", runCaptureImpl)) return "dnf";
   if (commandExists("yum", runCaptureImpl)) return "yum";
@@ -886,10 +888,7 @@ export interface ProbeContainerDnsOpts {
   /** Inject captured output (bypasses execution). */
   outputOverride?: string | null;
   /** Override runCapture. */
-  runCaptureImpl?: (
-    command: readonly string[],
-    opts?: { ignoreError?: boolean; timeout?: number },
-  ) => string | null;
+  runCaptureImpl?: NullableRunCaptureFn;
 }
 
 /**
@@ -908,10 +907,8 @@ const PROBE_TIMEOUT_MS = 20_000;
  * `172.17.0.1`.
  */
 export function getDockerBridgeGatewayIp(
-  runCaptureImpl: (
-    command: readonly string[],
-    opts?: { ignoreError?: boolean },
-  ) => string | null = (cmd, o) => runCapture(cmd, { ignoreError: o?.ignoreError ?? false }),
+  runCaptureImpl: NullableRunCaptureFn = (cmd, o) =>
+    runCapture(cmd, { ignoreError: o?.ignoreError ?? false }),
 ): string | null {
   let raw: string | null;
   try {
@@ -980,7 +977,7 @@ export function probeContainerDns(opts: ProbeContainerDnsOpts = {}): DnsProbeRes
     try {
       const runCaptureImpl =
         opts.runCaptureImpl ??
-        ((cmd: readonly string[], o?: { ignoreError?: boolean; timeout?: number }) =>
+        ((cmd: readonly string[], o?: RunCaptureOpts) =>
           runCapture(cmd, {
             ignoreError: o?.ignoreError ?? false,
             timeout: o?.timeout,

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -962,14 +962,16 @@ export function probeContainerDns(opts: ProbeContainerDnsOpts = {}): DnsProbeRes
   // platform Node supports — no dependency on a host-side `timeout`
   // binary). Child process is killed, runCapture returns "" under
   // ignoreError, and we fall through to the `no_output` branch.
+  //
+  // We funnel through `sh -c` so we can `2>&1` the docker pull progress
+  // and busybox nslookup diagnostics into stdout — both write the
+  // signatures the parser below depends on (`Error response from daemon`,
+  // `no servers could be reached`) to stderr. Every token in the script
+  // is a fixed constant, so no shell injection surface.
   const command = opts.command ?? [
-    "docker",
-    "run",
-    "--rm",
-    "--pull=missing",
-    "busybox:latest",
-    "nslookup",
-    "registry.npmjs.org",
+    "sh",
+    "-c",
+    "docker run --rm --pull=missing busybox:latest nslookup registry.npmjs.org 2>&1",
   ];
 
   let output: string | null | undefined = opts.outputOverride;

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -123,17 +123,19 @@ export interface AssessHostOpts {
   dockerInfoOutput?: string;
   dockerInfoError?: string;
   readFileImpl?: (filePath: string, encoding: BufferEncoding) => string;
-  runCaptureImpl?: (command: string, options?: { ignoreError?: boolean }) => string;
+  runCaptureImpl?: (command: readonly string[], options?: { ignoreError?: boolean }) => string;
   commandExistsImpl?: (commandName: string) => boolean;
   gpuProbeImpl?: () => boolean;
 }
 
 function commandExists(
   commandName: string,
-  runCaptureImpl: (command: string, options?: { ignoreError?: boolean }) => string,
+  runCaptureImpl: (command: readonly string[], options?: { ignoreError?: boolean }) => string,
 ): boolean {
   try {
-    const output = runCaptureImpl(`command -v ${commandName}`, { ignoreError: true });
+    const output = runCaptureImpl(["sh", "-c", 'command -v "$1"', "--", commandName], {
+      ignoreError: true,
+    });
     return Boolean(String(output || "").trim());
   } catch {
     return false;
@@ -226,16 +228,16 @@ function isHeadlessLikely(env: NodeJS.ProcessEnv): boolean {
 }
 
 function detectNvidiaGpu(
-  runCaptureImpl: (command: string, options?: { ignoreError?: boolean }) => string,
+  runCaptureImpl: (command: readonly string[], options?: { ignoreError?: boolean }) => string,
 ): boolean {
   if (!commandExists("nvidia-smi", runCaptureImpl)) {
     return false;
   }
-  return Boolean(String(runCaptureImpl("nvidia-smi -L", { ignoreError: true }) || "").trim());
+  return Boolean(String(runCaptureImpl(["nvidia-smi", "-L"], { ignoreError: true }) || "").trim());
 }
 
 function detectPackageManager(
-  runCaptureImpl: (command: string, options?: { ignoreError?: boolean }) => string,
+  runCaptureImpl: (command: readonly string[], options?: { ignoreError?: boolean }) => string,
 ): PackageManager {
   if (commandExists("apt-get", runCaptureImpl)) return "apt";
   if (commandExists("dnf", runCaptureImpl)) return "dnf";
@@ -267,7 +269,7 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   const env = opts.env ?? process.env;
   const runCaptureImpl =
     opts.runCaptureImpl ??
-    ((command: string, options?: { ignoreError?: boolean }) =>
+    ((command: readonly string[], options?: { ignoreError?: boolean }) =>
       runCapture(command, { ignoreError: options?.ignoreError ?? false }));
   const readFileImpl = opts.readFileImpl ?? fs.readFileSync;
   const dockerInstalled =
@@ -283,7 +285,7 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   let dockerReachable = false;
   let dockerRunning = false;
   if (dockerInstalled && dockerInfoOutput === undefined) {
-    dockerInfoOutput = runCaptureImpl("docker info --format '{{json .}}' 2>/dev/null", {
+    dockerInfoOutput = runCaptureImpl(["docker", "info", "--format", "{{json .}}"], {
       ignoreError: true,
     });
   }
@@ -339,11 +341,15 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   const dockerDefaultCgroupnsMode = readDockerDefaultCgroupnsMode(readFileImpl);
   const dockerServiceActive =
     platform === "linux" && systemctlAvailable && dockerInstalled
-      ? parseSystemctlState(runCaptureImpl("systemctl is-active docker", { ignoreError: true }))
+      ? parseSystemctlState(
+          runCaptureImpl(["systemctl", "is-active", "docker"], { ignoreError: true }),
+        )
       : null;
   const dockerServiceEnabled =
     platform === "linux" && systemctlAvailable && dockerInstalled
-      ? parseSystemctlState(runCaptureImpl("systemctl is-enabled docker", { ignoreError: true }))
+      ? parseSystemctlState(
+          runCaptureImpl(["systemctl", "is-enabled", "docker"], { ignoreError: true }),
+        )
       : null;
   const assessment: HostAssessment = {
     platform,
@@ -573,8 +579,9 @@ export async function checkPortAvailable(
     if (typeof o.lsofOutput === "string") {
       lsofOut = o.lsofOutput;
     } else {
-      // "command -v" is a shell builtin — must go through bash.
-      const hasLsof = runCapture("command -v lsof", { ignoreError: true });
+      const hasLsof = commandExists("lsof", (command, options) =>
+        runCapture(command, { ignoreError: options?.ignoreError ?? false }),
+      );
       if (hasLsof) {
         lsofOut = runCapture(["lsof", "-i", `:${p}`, "-sTCP:LISTEN", "-P", "-n"], {
           ignoreError: true,
@@ -713,11 +720,10 @@ function getExistingSwapResult(mem: MemoryInfo): SwapResult | null {
 
 function checkSwapDiskSpace(): SwapResult | null {
   try {
-    // Pipe requires a shell: df ... | tail -1
-    const dfOut = runCapture("df / --output=avail -k 2>/dev/null | tail -1", {
+    const dfOut = runCapture(["df", "/", "--output=avail", "-k"], {
       ignoreError: true,
     });
-    const freeKB = parseInt((dfOut || "").trim(), 10);
+    const freeKB = parseInt((dfOut || "").split(/\r?\n/).at(-1)?.trim() || "", 10);
     if (!isNaN(freeKB) && freeKB < 5000000) {
       return {
         ok: false,
@@ -764,11 +770,17 @@ function createSwapfile(mem: MemoryInfo): SwapResult {
     runCapture(["sudo", "chmod", "600", "/swapfile"], { ignoreError: false });
     runCapture(["sudo", "mkswap", "/swapfile"], { ignoreError: false });
     runCapture(["sudo", "swapon", "/swapfile"], { ignoreError: false });
-    // Shell required: grep || echo | tee pipeline
-    runCapture(
-      "grep -q '/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab",
-      { ignoreError: false },
-    );
+    const fstab = runCapture(["sudo", "cat", "/etc/fstab"], { ignoreError: true });
+    if (
+      !String(fstab || "")
+        .split(/\r?\n/)
+        .some((line) => /^\/swapfile\s/.test(line.trim()))
+    ) {
+      runCapture(["sudo", "tee", "-a", "/etc/fstab"], {
+        ignoreError: false,
+        input: "/swapfile none swap sw 0 0\n",
+      });
+    }
     writeManagedSwapMarker();
 
     return { ok: true, totalMB: mem.totalMB + 4096, swapCreated: true };
@@ -870,12 +882,12 @@ export interface DnsProbeResult {
 
 export interface ProbeContainerDnsOpts {
   /** Override the docker run command. */
-  command?: string;
-  /** Inject captured output (bypasses shell). */
+  command?: readonly string[];
+  /** Inject captured output (bypasses execution). */
   outputOverride?: string | null;
   /** Override runCapture. */
   runCaptureImpl?: (
-    command: string,
+    command: readonly string[],
     opts?: { ignoreError?: boolean; timeout?: number },
   ) => string | null;
 }
@@ -896,15 +908,22 @@ const PROBE_TIMEOUT_MS = 20_000;
  * `172.17.0.1`.
  */
 export function getDockerBridgeGatewayIp(
-  runCaptureImpl: (command: string, opts?: { ignoreError?: boolean }) => string | null = (
-    cmd,
-    o,
-  ) => runCapture(cmd, { ignoreError: o?.ignoreError ?? false }),
+  runCaptureImpl: (
+    command: readonly string[],
+    opts?: { ignoreError?: boolean },
+  ) => string | null = (cmd, o) => runCapture(cmd, { ignoreError: o?.ignoreError ?? false }),
 ): string | null {
   let raw: string | null;
   try {
     raw = runCaptureImpl(
-      "docker network inspect bridge --format '{{range .IPAM.Config}}{{.Gateway}}{{end}}' 2>/dev/null",
+      [
+        "docker",
+        "network",
+        "inspect",
+        "bridge",
+        "--format",
+        "{{range .IPAM.Config}}{{.Gateway}}{{end}}",
+      ],
       { ignoreError: true },
     );
   } catch {
@@ -946,17 +965,22 @@ export function probeContainerDns(opts: ProbeContainerDnsOpts = {}): DnsProbeRes
   // platform Node supports — no dependency on a host-side `timeout`
   // binary). Child process is killed, runCapture returns "" under
   // ignoreError, and we fall through to the `no_output` branch.
-  const command =
-    opts.command ??
-    "docker run --rm --pull=missing busybox:latest " +
-      "nslookup registry.npmjs.org 2>&1";
+  const command = opts.command ?? [
+    "docker",
+    "run",
+    "--rm",
+    "--pull=missing",
+    "busybox:latest",
+    "nslookup",
+    "registry.npmjs.org",
+  ];
 
   let output: string | null | undefined = opts.outputOverride;
   if (output === undefined) {
     try {
       const runCaptureImpl =
         opts.runCaptureImpl ??
-        ((cmd: string, o?: { ignoreError?: boolean; timeout?: number }) =>
+        ((cmd: readonly string[], o?: { ignoreError?: boolean; timeout?: number }) =>
           runCapture(cmd, {
             ignoreError: o?.ignoreError ?? false,
             timeout: o?.timeout,

--- a/src/lib/runner-argv.test.ts
+++ b/src/lib/runner-argv.test.ts
@@ -73,6 +73,15 @@ describe("runCapture with argv array", () => {
     expect(output).toBe("trimmed");
   });
 
+  it("trims trailing blank lines so callers can safely parse the last line", () => {
+    const output = runner.runCapture([
+      process.execPath,
+      "-e",
+      'process.stdout.write("2048\\n\\n")',
+    ]);
+    expect(output).toBe("2048");
+  });
+
   it("throws when argv array is empty", () => {
     expect(() => runner.runCapture([])).toThrow(/must not be empty/);
   });

--- a/src/lib/runner-argv.test.ts
+++ b/src/lib/runner-argv.test.ts
@@ -23,26 +23,23 @@ describe("run with argv array", () => {
   });
 
   it("passes extra env vars to the child process", () => {
-    const result = runner.run(
-      ["env"],
-      { env: { NEMOCLAW_TEST_VAR: "injection-safe" }, suppressOutput: true },
-    );
+    const result = runner.run(["env"], {
+      env: { NEMOCLAW_TEST_VAR: "injection-safe" },
+      suppressOutput: true,
+    });
     expect(result.status).toBe(0);
     expect(result.stdout.toString()).toContain("NEMOCLAW_TEST_VAR=injection-safe");
   });
 
   it("rejects shell: true to prevent security bypass", () => {
-    expect(() => runner.run(["echo", "hi"], { shell: true })).toThrow(
-      /shell option is forbidden/,
-    );
+    expect(() => runner.run(["echo", "hi"], { shell: true })).toThrow(/shell option is forbidden/);
   });
 
   it("does not interpret shell metacharacters in arguments", () => {
     // If shell interpretation occurred, $(whoami) would be expanded
-    const result = runner.runCapture(
-      ["echo", "$(whoami)", "&&", "rm", "-rf", "/"],
-      { ignoreError: true },
-    );
+    const result = runner.runCapture(["echo", "$(whoami)", "&&", "rm", "-rf", "/"], {
+      ignoreError: true,
+    });
     // echo receives literal argv — no shell expansion
     expect(result).toContain("$(whoami)");
     expect(result).toContain("&&");
@@ -55,10 +52,10 @@ describe("run with argv array", () => {
   });
 
   it("surfaces ENOENT error for missing executables", () => {
-    const result = runner.run(
-      ["nonexistent-binary-xyz-12345"],
-      { ignoreError: true, suppressOutput: true },
-    );
+    const result = runner.run(["nonexistent-binary-xyz-12345"], {
+      ignoreError: true,
+      suppressOutput: true,
+    });
     // spawnSync sets result.error for missing executables
     expect(result.error).toBeDefined();
     expect(result.error.code).toBe("ENOENT");
@@ -121,16 +118,12 @@ describe("runCapture with argv array", () => {
   });
 
   it("passes extra env to the child process", () => {
-    const output = runner.runCapture(
-      ["env"],
-      { env: { TEST_ARGV_ENV: "captured" } },
-    );
+    const output = runner.runCapture(["env"], { env: { TEST_ARGV_ENV: "captured" } });
     expect(output).toContain("TEST_ARGV_ENV=captured");
   });
 
-  it("still works with string commands (legacy path)", () => {
-    const output = runner.runCapture("echo hello");
-    expect(output).toBe("hello");
+  it("rejects string commands", () => {
+    expect(() => runner.runCapture("echo hello")).toThrow(/argv array instead/);
   });
 
   it("throws ENOENT for missing executables", () => {
@@ -147,12 +140,12 @@ describe("shell injection regression tests", () => {
   it("sandbox names with shell metacharacters are safe with argv arrays", () => {
     // These names would cause injection if passed through bash -c
     const dangerousNames = [
-      'my-sandbox; rm -rf /',
-      'test$(whoami)',
-      'sandbox`id`',
+      "my-sandbox; rm -rf /",
+      "test$(whoami)",
+      "sandbox`id`",
       "sandbox' || echo pwned",
       'sandbox" && echo pwned',
-      'sandbox\necho pwned',
+      "sandbox\necho pwned",
     ];
 
     for (const name of dangerousNames) {
@@ -163,9 +156,7 @@ describe("shell injection regression tests", () => {
   });
 
   it("model names with shell metacharacters are safe with argv arrays", () => {
-    const output = runner.runCapture(
-      ["echo", 'nvidia/model;curl http://evil.com'],
-    );
-    expect(output).toBe('nvidia/model;curl http://evil.com');
+    const output = runner.runCapture(["echo", "nvidia/model;curl http://evil.com"]);
+    expect(output).toBe("nvidia/model;curl http://evil.com");
   });
 });

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
-  ExecSyncOptionsWithStringEncoding,
   SpawnSyncOptions,
   SpawnSyncOptionsWithStringEncoding,
   SpawnSyncReturns,
 } from "node:child_process";
 
-const { execSync, spawnSync } = require("child_process");
+const { spawnSync } = require("child_process");
 const path = require("path");
 const { detectDockerHost } = require("./platform");
 
@@ -22,11 +21,7 @@ type RunnerOptions = SpawnSyncOptions & {
   suppressOutput?: boolean;
 };
 
-type CaptureOptions = Omit<ExecSyncOptionsWithStringEncoding, "encoding"> & {
-  ignoreError?: boolean;
-};
-
-type ArrayCaptureOptions = Omit<SpawnSyncOptionsWithStringEncoding, "encoding"> & {
+type CaptureOptions = Omit<SpawnSyncOptionsWithStringEncoding, "encoding"> & {
   ignoreError?: boolean;
 };
 
@@ -177,40 +172,17 @@ function runFile(
 }
 
 /**
- * Run a command and return its stdout as a trimmed string.
+ * Run a program directly with argv-style arguments and capture trimmed stdout.
  * Throws a redacted error on failure, or returns '' when opts.ignoreError is true.
  *
- * Accepts two forms:
- *   runCapture("some shell command")  — legacy: passes the string to execSync (shell)
- *   runCapture(["curl", "-sf", url])  — safe: calls spawnSync(exe, args) with no shell
- *
- * When an argv array is passed, the shell option is forbidden to prevent
- * callers from accidentally re-enabling shell interpretation.
+ * Shell-string capture is intentionally unsupported. If you truly need shell
+ * parsing, spell it out explicitly at the call site (for example
+ * ["sh", "-c", script]) so reviews and static checks can see the boundary.
  */
-function runCapture(cmd: string | readonly string[], opts: CaptureOptions = {}): string {
-  if (Array.isArray(cmd)) {
-    return runArrayCapture(cmd, opts);
+function runCapture(cmd: readonly string[], opts: CaptureOptions = {}): string {
+  if (!Array.isArray(cmd)) {
+    throw new Error("runCapture no longer accepts shell strings; pass an argv array instead");
   }
-  const shellCmd = String(cmd);
-  try {
-    return execSync(shellCmd, {
-      ...opts,
-      encoding: "utf-8",
-      cwd: ROOT,
-      env: { ...process.env, ...opts.env },
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
-  } catch (err) {
-    if (opts.ignoreError) return "";
-    throw redactError(err);
-  }
-}
-
-/**
- * Internal: capture stdout from an argv array via spawnSync with no shell.
- * Shared by runCapture() and kept separate for clarity.
- */
-function runArrayCapture(cmd: readonly string[], opts: ArrayCaptureOptions = {}): string {
   if (cmd.length === 0) {
     throw new Error("runCapture: argv array must not be empty");
   }

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -150,9 +150,12 @@ describe("runner env merging", () => {
     const originalGateway = process.env.OPENSHELL_GATEWAY;
     process.env.OPENSHELL_GATEWAY = "nemoclaw";
     try {
-      const output = runCapture('printf \'%s %s\' "$OPENSHELL_GATEWAY" "$OPENAI_API_KEY"', {
-        env: { OPENAI_API_KEY: "sk-test-secret" },
-      });
+      const output = runCapture(
+        ["sh", "-c", 'printf "%s %s" "$OPENSHELL_GATEWAY" "$OPENAI_API_KEY"'],
+        {
+          env: { OPENAI_API_KEY: "sk-test-secret" },
+        },
+      );
       expect(output).toBe("nemoclaw sk-test-secret");
     } finally {
       if (originalGateway === undefined) {
@@ -388,13 +391,17 @@ describe("redact", () => {
 });
 
 describe("regression guards", () => {
-  it("runCapture redacts secrets before rethrowing errors", () => {
-    const originalExecSync = childProcess.execSync;
-    childProcess.execSync = () => {
-      throw new Error(
+  it("runCapture redacts secrets before rethrowing spawn errors", () => {
+    const originalSpawnSync = childProcess.spawnSync;
+    // @ts-expect-error — intentional partial mock for testing
+    childProcess.spawnSync = () => ({
+      error: new Error(
         'command failed: export SERVICE_KEY="supersecretvalue12345" ghp_abcdefghijklmnopqrstuvwxyz1234567890',
-      );
-    };
+      ),
+      status: null,
+      stdout: "",
+      stderr: "",
+    });
 
     try {
       delete require.cache[require.resolve(runnerPath)];
@@ -402,7 +409,7 @@ describe("regression guards", () => {
 
       let error: Error | undefined;
       try {
-        runCapture("echo nope");
+        runCapture(["echo", "nope"]);
       } catch (err) {
         if (err instanceof Error) {
           error = err;
@@ -419,18 +426,24 @@ describe("regression guards", () => {
       expect(error.message).not.toContain("supersecretvalue12345");
       expect(error.message).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
     } finally {
-      childProcess.execSync = originalExecSync;
+      childProcess.spawnSync = originalSpawnSync;
       delete require.cache[require.resolve(runnerPath)];
     }
   });
 
-  it("runCapture redacts execSync error cmd/output fields", () => {
-    const originalExecSync = childProcess.execSync;
-    childProcess.execSync = () => {
+  it("runCapture redacts spawn error cmd/output fields", () => {
+    const originalSpawnSync = childProcess.spawnSync;
+    // @ts-expect-error — intentional partial mock for testing
+    childProcess.spawnSync = () => {
       const err: RedactedRunnerError = new Error("command failed");
       err.cmd = "echo nvapi-aaaabbbbcccc1111 && echo ghp_abcdefghijklmnopqrstuvwxyz123456";
       err.output = ["stdout: nvapi-aaaabbbbcccc1111", "stderr: PASSWORD=secret123456"];
-      throw err;
+      return {
+        error: err,
+        status: null,
+        stdout: "",
+        stderr: "",
+      };
     };
 
     try {
@@ -439,7 +452,7 @@ describe("regression guards", () => {
 
       let error: RedactedRunnerError | undefined;
       try {
-        runCapture("echo nope");
+        runCapture(["echo", "nope"]);
       } catch (err) {
         if (err instanceof Error) {
           error = err;
@@ -466,7 +479,7 @@ describe("regression guards", () => {
       expect(error.output[0]).toContain("****");
       expect(error.output[1]).toContain("****");
     } finally {
-      childProcess.execSync = originalExecSync;
+      childProcess.spawnSync = originalSpawnSync;
       delete require.cache[require.resolve(runnerPath)];
     }
   });


### PR DESCRIPTION
## Summary
This PR removes the shell-string overload from `runCapture()` and makes argv arrays the only supported input. It updates the remaining call sites to use explicit argv execution so shell parsing is always opt-in and visible in review.

## Changes
- Remove the `execSync`-based shell-string path from `src/lib/runner.ts` and make `runCapture()` reject string inputs at runtime.
- Convert `src/lib/preflight.ts` and `src/lib/onboard.ts` call sites from shell strings to argv arrays for command discovery, Docker inspection, DNS probing, `ps`, and `hostname -I`.
- Update runner and preflight tests to cover argv-only behavior and spawn-based error redaction.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: pi coding agent

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized command execution for host and container probes, improving reliability of gateway, IP/gateway discovery, disk/swap detection, and process/network checks for more consistent inspection results.

* **Tests**
  * Updated tests to validate the new argument-array execution model, tighten error/regression guards, and ensure command output trimming and expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->