### PR TITLE
fix(cli): include OpenShell audit events in logs

### DIFF
--- a/src/lib/openshell.test.ts
+++ b/src/lib/openshell.test.ts
@@ -39,6 +39,10 @@ function stubSpawnSync(spec: SpawnResultSpec): OpenshellSpawnSync {
   return () => makeSpawnResult(spec);
 }
 
+function timeoutError(): Error {
+  return Object.assign(new Error("spawnSync openshell ETIMEDOUT"), { code: "ETIMEDOUT" });
+}
+
 function exitWithCode(code: number): never {
   throw new Error(`exit:${code}`);
 }
@@ -92,6 +96,60 @@ describe("openshell helpers", () => {
       }),
     });
     expect(result.status).toBe(0);
+  });
+
+  it("passes timeout options through to OpenShell spawn calls", () => {
+    const timeouts: Array<number | undefined> = [];
+    const spawnSyncImpl: OpenshellSpawnSync = (_command, _args, options) => {
+      timeouts.push(options.timeout);
+      return makeSpawnResult({ status: 0, stdout: "ok\n", stderr: "" });
+    };
+
+    runOpenshellCommand("openshell", ["status"], { timeout: 4321, spawnSyncImpl });
+    captureOpenshellCommand("openshell", ["status"], { timeout: 9876, spawnSyncImpl });
+
+    expect(timeouts).toEqual([4321, 9876]);
+  });
+
+  it("returns ignored run timeouts so callers can fall back", () => {
+    const result = runOpenshellCommand("openshell", ["status"], {
+      ignoreError: true,
+      timeout: 1,
+      spawnSyncImpl: stubSpawnSync({
+        status: null,
+        stdout: "",
+        stderr: "",
+        error: timeoutError(),
+        signal: "SIGTERM",
+      }),
+      exit: exitWithCode,
+    });
+
+    expect(result.status).toBeNull();
+    expect(result.signal).toBe("SIGTERM");
+    expect(result.error?.message).toContain("ETIMEDOUT");
+  });
+
+  it("returns ignored capture timeouts with timeout metadata", () => {
+    const result = captureOpenshellCommand("openshell", ["sandbox", "list"], {
+      ignoreError: true,
+      timeout: 1,
+      spawnSyncImpl: stubSpawnSync({
+        status: null,
+        stdout: "partial\n",
+        stderr: "timeout detail\n",
+        error: timeoutError(),
+        signal: "SIGTERM",
+      }),
+      exit: exitWithCode,
+    });
+
+    expect(result).toEqual({
+      status: null,
+      output: "partial",
+      error: expect.objectContaining({ message: expect.stringContaining("ETIMEDOUT") }),
+      signal: "SIGTERM",
+    });
   });
 
   it("uses the injected exit handler on failure", () => {

--- a/src/lib/openshell.ts
+++ b/src/lib/openshell.ts
@@ -17,6 +17,8 @@ export type OpenshellSpawnSync = (
 interface OpenshellSpawnOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  timeout?: number;
+  ignoreError?: boolean;
   spawnSyncImpl?: OpenshellSpawnSync;
   errorLine?: (message: string) => void;
   exit?: (code: number) => never;
@@ -24,16 +26,15 @@ interface OpenshellSpawnOptions {
 
 export interface RunOpenshellOptions extends OpenshellSpawnOptions {
   stdio?: SpawnSyncOptions["stdio"];
-  ignoreError?: boolean;
 }
 
-export interface CaptureOpenshellOptions extends OpenshellSpawnOptions {
-  ignoreError?: boolean;
-}
+export interface CaptureOpenshellOptions extends OpenshellSpawnOptions {}
 
 export interface CaptureOpenshellResult {
-  status: number;
+  status: number | null;
   output: string;
+  error?: Error;
+  signal?: NodeJS.Signals | null;
 }
 
 // eslint-disable-next-line no-control-regex
@@ -76,6 +77,10 @@ function handleSpawnError(
   return (opts.exit ?? ((code) => process.exit(code)))(1);
 }
 
+function isIgnoredTimeout(error: Error, opts: OpenshellSpawnOptions): boolean {
+  return opts.ignoreError === true && (error as NodeJS.ErrnoException).code === "ETIMEDOUT";
+}
+
 export function runOpenshellCommand(
   binary: string,
   args: string[],
@@ -87,8 +92,12 @@ export function runOpenshellCommand(
     env: { ...process.env, ...opts.env },
     encoding: "utf-8",
     stdio: opts.stdio ?? "inherit",
+    timeout: opts.timeout,
   });
   if (result.error) {
+    if (isIgnoredTimeout(result.error, opts)) {
+      return result;
+    }
     return handleSpawnError(binary, args, result.error, opts);
   }
   if (result.status !== 0 && !opts.ignoreError) {
@@ -111,8 +120,17 @@ export function captureOpenshellCommand(
     env: { ...process.env, ...opts.env },
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: opts.timeout,
   });
   if (result.error) {
+    if (isIgnoredTimeout(result.error, opts)) {
+      return {
+        status: result.status,
+        output: `${result.stdout || ""}${opts.ignoreError ? "" : result.stderr || ""}`.trim(),
+        error: result.error,
+        signal: result.signal,
+      };
+    }
     return handleSpawnError(binary, args, result.error, opts);
   }
   return {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const { execFileSync, spawnSync } = require("child_process");
+const { execFileSync, spawn, spawnSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
@@ -113,6 +113,8 @@ type SpawnLikeResult = {
   stdout?: string;
   stderr?: string;
   output?: string;
+  error?: Error;
+  signal?: NodeJS.Signals | null;
 };
 
 type SandboxCommandResult = {
@@ -131,6 +133,8 @@ const REMOTE_UNINSTALL_URL = buildVersionedUninstallUrl(getVersion());
 let OPENSHELL_BIN: string | null = null;
 const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
 const DASHBOARD_FORWARD_PORT = String(DASHBOARD_PORT);
+const DEFAULT_LOGS_PROBE_TIMEOUT_MS = 5000;
+const LOGS_PROBE_TIMEOUT_ENV = "NEMOCLAW_LOGS_PROBE_TIMEOUT_MS";
 
 function getOpenshellBinary(): string {
   if (!OPENSHELL_BIN) {
@@ -1904,8 +1908,14 @@ async function sandboxStatus(sandboxName: string) {
 }
 
 function sandboxLogs(sandboxName: string, follow: boolean) {
-  const args = buildSandboxLogsArgs(sandboxName, follow);
+  if (follow) {
+    streamSandboxFollowLogs(sandboxName);
+    return;
+  }
 
+  enableSandboxAuditLogs(sandboxName);
+  runOpenclawGatewayLogs(sandboxName, false);
+  const args = buildSandboxLogsArgs(sandboxName, false);
   const result = runOpenshell(args, {
     stdio: "inherit",
     ignoreError: true,
@@ -1916,12 +1926,188 @@ function sandboxLogs(sandboxName: string, follow: boolean) {
   exitWithSpawnResult(result);
 }
 
-function buildSandboxLogsArgs(sandboxName: string, follow: boolean): string[] {
+function getLogsProbeTimeoutMs(): number {
+  const rawValue = process.env[LOGS_PROBE_TIMEOUT_ENV];
+  if (!rawValue) {
+    return DEFAULT_LOGS_PROBE_TIMEOUT_MS;
+  }
+  const parsed = Number(rawValue);
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.floor(parsed)
+    : DEFAULT_LOGS_PROBE_TIMEOUT_MS;
+}
+
+function describeLogProbeResult(result: SpawnLikeResult): string {
+  if (result.error) {
+    return result.error.message;
+  }
+  if (result.signal) {
+    return `signal ${result.signal}`;
+  }
+  return `exit ${result.status ?? "unknown"}`;
+}
+
+function runOpenclawGatewayLogs(sandboxName: string, follow: boolean): SpawnLikeResult {
+  const args = buildSandboxOpenclawGatewayLogsArgs(sandboxName, follow);
+  const result = runOpenshell(args, {
+    stdio: "inherit",
+    ignoreError: true,
+    timeout: getLogsProbeTimeoutMs(),
+  });
+  if (result.status !== 0) {
+    console.error(
+      `  OpenClaw log source unavailable (${describeLogProbeResult(result)}): ` +
+        `openshell ${args.join(" ")}`,
+    );
+  }
+  return result;
+}
+
+function streamSandboxFollowLogs(sandboxName: string): void {
+  const openclawArgs = buildSandboxOpenclawGatewayLogsArgs(sandboxName, true);
+  const openshellArgs = buildSandboxLogsArgs(sandboxName, true);
+  const spawnOptions = {
+    cwd: ROOT,
+    env: process.env,
+    stdio: "inherit" as const,
+  };
+  const sources: Array<{
+    label: string;
+    args: string[];
+    child: import("node:child_process").ChildProcess;
+    done: boolean;
+  }> = [];
+  let exiting = false;
+  let completedSources = 0;
+  let finalStatus = 0;
+  let requestedExitCode: number | null = null;
+  let forcedExitTimer: NodeJS.Timeout | null = null;
+  // Guard against early exit: a source spawned before enableSandboxAuditLogs
+  // can fire its exit event during the blocking spawnSync call, before the
+  // second source is registered. Without this flag, maybeExit would see
+  // completedSources === sources.length === 1 and exit prematurely.
+  let setupComplete = false;
+
+  const stopChildren = (signal: NodeJS.Signals) => {
+    for (const { child } of sources) {
+      if (!child.killed && child.exitCode === null && child.signalCode === null) {
+        child.kill(signal);
+      }
+    }
+  };
+  const maybeExit = () => {
+    if (!setupComplete || completedSources !== sources.length) {
+      return;
+    }
+    if (forcedExitTimer) {
+      clearTimeout(forcedExitTimer);
+      forcedExitTimer = null;
+    }
+    process.exit(requestedExitCode ?? finalStatus);
+  };
+  const exitFromSignal = (signal: NodeJS.Signals | null): number => {
+    if (!signal) return 1;
+    const signalNumber = os.constants.signals[signal];
+    return signalNumber ? 128 + signalNumber : 1;
+  };
+  const markSourceDone = (
+    source: (typeof sources)[number],
+    status: number,
+    detail: string | null = null,
+  ) => {
+    if (source.done) return;
+    source.done = true;
+    completedSources += 1;
+    if (status !== 0 && finalStatus === 0) {
+      finalStatus = status;
+    }
+    if (completedSources < sources.length && !exiting) {
+      const suffix = detail || `exit ${status}`;
+      console.error(`  ${source.label} stopped (${suffix}); continuing with remaining log source.`);
+    }
+    maybeExit();
+  };
+  const requestExitAfterSignal = (signal: NodeJS.Signals, exitCode: number) => {
+    if (requestedExitCode !== null) return;
+    exiting = true;
+    requestedExitCode = exitCode;
+    stopChildren(signal);
+    forcedExitTimer = setTimeout(() => process.exit(exitCode), 2000);
+    forcedExitTimer.unref?.();
+    maybeExit();
+  };
+
+  process.once("SIGINT", () => {
+    requestExitAfterSignal("SIGINT", 130);
+  });
+  process.once("SIGTERM", () => {
+    requestExitAfterSignal("SIGTERM", 143);
+  });
+
+  const addSource = (label: string, args: string[]) => {
+    const source = { label, args, child: spawn(getOpenshellBinary(), args, spawnOptions), done: false };
+    sources.push(source);
+    source.child.on("error", (error: Error) => {
+      markSourceDone(source, 1, error.message);
+    });
+    source.child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+      markSourceDone(source, code ?? exitFromSignal(signal), signal ? `signal ${signal}` : null);
+    });
+  };
+
+  addSource("OpenClaw log source", openclawArgs);
+  enableSandboxAuditLogs(sandboxName);
+  addSource("OpenShell log source", openshellArgs);
+  setupComplete = true;
+  maybeExit();
+}
+
+function enableSandboxAuditLogs(sandboxName: string) {
+  const args = buildEnableSandboxAuditLogsArgs(sandboxName);
+  const result = runOpenshell(args, {
+    stdio: ["ignore", "ignore", "pipe"],
+    ignoreError: true,
+    timeout: getLogsProbeTimeoutMs(),
+  });
+  if (result.status !== 0) {
+    warnSandboxAuditLogsUnavailable(sandboxName, args, result);
+  }
+}
+
+function warnSandboxAuditLogsUnavailable(
+  sandboxName: string,
+  args: string[],
+  result: SpawnLikeResult,
+): void {
+  const stderr = String(result.stderr || "").trim();
+  console.error(
+    `  Warning: failed to enable OpenShell audit logs for sandbox '${sandboxName}' ` +
+      `(${describeLogProbeResult(result)}): openshell ${args.join(" ")}`,
+  );
+  if (stderr) {
+    console.error(`  ${stderr}`);
+  }
+  console.error("  Policy denial events may be missing from OpenShell logs.");
+}
+
+function buildEnableSandboxAuditLogsArgs(sandboxName: string): string[] {
+  return ["settings", "set", sandboxName, "--key", "ocsf_json_enabled", "--value", "true"];
+}
+
+function buildSandboxOpenclawGatewayLogsArgs(sandboxName: string, follow: boolean): string[] {
   const args = ["sandbox", "exec", "-n", sandboxName, "--", "tail", "-n", "200"];
   if (follow) {
     args.push("-f");
   }
   args.push("/tmp/gateway.log");
+  return args;
+}
+
+function buildSandboxLogsArgs(sandboxName: string, follow: boolean): string[] {
+  const args = ["logs", sandboxName, "-n", "200", "--source", "all"];
+  if (follow) {
+    args.push("--tail");
+  }
   return args;
 }
 

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1932,9 +1932,8 @@ function getLogsProbeTimeoutMs(): number {
     return DEFAULT_LOGS_PROBE_TIMEOUT_MS;
   }
   const parsed = Number(rawValue);
-  return Number.isFinite(parsed) && parsed > 0
-    ? Math.floor(parsed)
-    : DEFAULT_LOGS_PROBE_TIMEOUT_MS;
+  const timeoutMs = Number.isFinite(parsed) ? Math.floor(parsed) : Number.NaN;
+  return timeoutMs > 0 ? timeoutMs : DEFAULT_LOGS_PROBE_TIMEOUT_MS;
 }
 
 function describeLogProbeResult(result: SpawnLikeResult): string {

--- a/test/check-docs-links.test.ts
+++ b/test/check-docs-links.test.ts
@@ -140,18 +140,22 @@ describe("check-docs link validation", () => {
     );
   });
 
-  it("fails on malformed HTML comments", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-check-docs-badcomment-"));
-    const mdPath = path.join(tempDir, "guide.md");
-    fs.writeFileSync(
-      mdPath,
-      ["# Guide", "<!-- missing close", "[ignored](./inside-comment.md)", ""].join("\n"),
-    );
+  it(
+    "fails on malformed HTML comments",
+    { timeout: 15000 },
+    () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-check-docs-badcomment-"));
+      const mdPath = path.join(tempDir, "guide.md");
+      fs.writeFileSync(
+        mdPath,
+        ["# Guide", "<!-- missing close", "[ignored](./inside-comment.md)", ""].join("\n"),
+      );
 
-    const result = runCheckDocs(mdPath);
+      const result = runCheckDocs(mdPath);
 
-    expect(result.status).toBe(1);
-    expect(`${result.stdout}${result.stderr}`).toContain(`malformed HTML comment in ${mdPath}`);
-    expect(`${result.stdout}${result.stderr}`).not.toContain("inside-comment.md");
-  });
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}${result.stderr}`).toContain(`malformed HTML comment in ${mdPath}`);
+      expect(`${result.stdout}${result.stderr}`).not.toContain("inside-comment.md");
+    },
+  );
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { execSync, spawnSync } from "node:child_process";
+import { execSync, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -109,6 +109,53 @@ function writeSandboxRegistry(home: string): void {
     }),
     { mode: 0o600 },
   );
+}
+
+const FAKE_OPENCLAW_LOG_LINE = "openclaw gateway log: policy checker ready";
+const FAKE_OPENSHELL_LOG_LINE = "openshell audit log: DENIED example.com:443";
+
+function createLogsTestSetup(prefix: string, openshellLines: string[] = []) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const localBin = path.join(home, "bin");
+  const markerFile = path.join(home, "logs-calls");
+  fs.mkdirSync(localBin, { recursive: true });
+  writeSandboxRegistry(home);
+  fs.writeFileSync(
+    path.join(localBin, "openshell"),
+    [
+      "#!/usr/bin/env bash",
+      `marker_file=${JSON.stringify(markerFile)}`,
+      'printf \'%s\\n\' "$*" >> "$marker_file"',
+      ...openshellLines,
+      'if [ "$1" = "settings" ]; then',
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "sandbox" ]; then',
+      `  echo ${JSON.stringify(FAKE_OPENCLAW_LOG_LINE)}`,
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "logs" ]; then',
+      `  echo ${JSON.stringify(FAKE_OPENSHELL_LOG_LINE)}`,
+      "  exit 0",
+      "fi",
+      "exit 0",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  return {
+    home,
+    localBin,
+    markerFile,
+    readCalls: () =>
+      fs.existsSync(markerFile) ? fs.readFileSync(markerFile, "utf8").trim().split(/\n/) : [],
+    runLogs: (args = "alpha logs", env: Record<string, string | undefined> = {}) =>
+      runWithEnv(args, {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+        ...env,
+      }),
+  };
 }
 
 describe("CLI dispatch", () => {
@@ -402,65 +449,128 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("Collecting diagnostics for sandbox 'mybox'");
   });
 
-  it("routes logs to sandbox exec tailing the gateway log", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-"));
-    const localBin = path.join(home, "bin");
-    const registryDir = path.join(home, ".nemoclaw");
-    const markerFile = path.join(home, "logs-args");
-    fs.mkdirSync(localBin, { recursive: true });
-    fs.mkdirSync(registryDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(registryDir, "sandboxes.json"),
-      JSON.stringify({
-        sandboxes: {
-          alpha: {
-            name: "alpha",
-            model: "test-model",
-            provider: "nvidia-prod",
-            gpuEnabled: false,
-            policies: [],
-          },
-        },
-        defaultSandbox: "alpha",
-      }),
-      { mode: 0o600 },
-    );
-    fs.writeFileSync(
-      path.join(localBin, "openshell"),
-      [
-        "#!/usr/bin/env bash",
-        `marker_file=${JSON.stringify(markerFile)}`,
-        'printf \'%s \' "$@" > "$marker_file"',
-        "exit 0",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
+  it("routes logs to OpenClaw and OpenShell log sources", () => {
+    const setup = createLogsTestSetup("nemoclaw-cli-logs-routing-");
+    const r = setup.runLogs();
 
-    const r = runWithEnv("alpha logs", {
-      HOME: home,
-      PATH: `${localBin}:${process.env.PATH || ""}`,
-    });
-
+    const calls = setup.readCalls();
     expect(r.code).toBe(0);
-    expect(readRecordedArgs(markerFile)).toEqual([
-      "sandbox",
-      "exec",
-      "-n",
-      "alpha",
-      "--",
-      "tail",
-      "-n",
-      "200",
-      "/tmp/gateway.log",
+    expect(calls).toEqual([
+      "settings set alpha --key ocsf_json_enabled --value true",
+      "sandbox exec -n alpha -- tail -n 200 /tmp/gateway.log",
+      "logs alpha -n 200 --source all",
     ]);
-    expect(readRecordedArgs(markerFile)).not.toContain("-f");
+    expect(r.out).toContain(FAKE_OPENCLAW_LOG_LINE);
+    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
   });
 
-  it("passes --follow through to tail inside sandbox exec", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-"));
+  it("enables OpenShell audit events before reading logs", () => {
+    const setup = createLogsTestSetup("nemoclaw-cli-logs-audit-");
+    const r = setup.runLogs();
+
+    const calls = setup.readCalls();
+    expect(r.code).toBe(0);
+    expect(calls[0]).toBe("settings set alpha --key ocsf_json_enabled --value true");
+    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
+  });
+
+  it("warns when OpenShell audit events cannot be enabled", () => {
+    const setup = createLogsTestSetup("nemoclaw-cli-logs-audit-failed-", [
+      'if [ "$1" = "settings" ]; then',
+      "  echo 'settings unavailable' >&2",
+      "  exit 7",
+      "fi",
+    ]);
+
+    const r = setup.runLogs("alpha logs 2>&1");
+
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("failed to enable OpenShell audit logs for sandbox 'alpha'");
+    expect(r.out).toContain("openshell settings set alpha --key ocsf_json_enabled --value true");
+    expect(r.out).toContain("settings unavailable");
+    expect(r.out).toContain(FAKE_OPENCLAW_LOG_LINE);
+    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
+  });
+
+  it("continues log collection when audit enable times out", () => {
+    const setup = createLogsTestSetup("nemoclaw-cli-logs-audit-timeout-", [
+      'if [ "$1" = "settings" ]; then',
+      "  sleep 5",
+      "  exit 0",
+      "fi",
+    ]);
+
+    const r = setup.runLogs("alpha logs 2>&1", { NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "1500" });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("failed to enable OpenShell audit logs for sandbox 'alpha'");
+    expect(r.out).toContain("ETIMEDOUT");
+    expect(r.out).toContain(FAKE_OPENCLAW_LOG_LINE);
+    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
+  });
+
+  it("continues to OpenShell logs when the OpenClaw gateway log probe times out", () => {
+    const setup = createLogsTestSetup("nemoclaw-cli-logs-openclaw-timeout-", [
+      'if [ "$1" = "sandbox" ]; then',
+      "  sleep 2",
+      "  exit 0",
+      "fi",
+    ]);
+
+    const r = setup.runLogs("alpha logs 2>&1", { NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "500" });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("OpenClaw log source unavailable");
+    expect(r.out).toContain("ETIMEDOUT");
+    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
+  });
+
+  it("maps --follow to OpenShell live log streaming", () => {
+    const setup = createLogsTestSetup("nemoclaw-cli-logs-follow-");
+    const r = setup.runLogs("alpha logs --follow");
+
+    const calls = setup.readCalls();
+    expect(r.code).toBe(0);
+    expect(calls).toContain("settings set alpha --key ocsf_json_enabled --value true");
+    expect(calls).toContain("sandbox exec -n alpha -- tail -n 200 -f /tmp/gateway.log");
+    expect(calls).toContain("logs alpha -n 200 --source all --tail");
+    expect(r.out).toContain(FAKE_OPENCLAW_LOG_LINE);
+    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
+  });
+
+  it("starts OpenClaw logs before enabling audit logs for logs --follow", () => {
+    const setup = createLogsTestSetup("nemoclaw-cli-logs-follow-audit-slow-", [
+      'if [ "$1" = "settings" ]; then',
+      "  sleep 1",
+      "  exit 0",
+      "fi",
+    ]);
+
+    const start = Date.now();
+    const r = setup.runLogs("alpha logs --follow", { NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "2000" });
+    const calls = setup.readCalls();
+
+    expect(Date.now() - start).toBeGreaterThanOrEqual(900);
+    expect(r.code).toBe(0);
+    // All three calls must happen: OpenClaw log stream, audit enable, OpenShell log stream.
+    expect(calls).toContain("sandbox exec -n alpha -- tail -n 200 -f /tmp/gateway.log");
+    expect(calls).toContain("settings set alpha --key ocsf_json_enabled --value true");
+    expect(calls).toContain("logs alpha -n 200 --source all --tail");
+    // Audit enable must complete before OpenShell logs start (both are synchronous
+    // relative to each other). We can't assert ordering vs the OpenClaw spawn
+    // because spawn() is async and marker-file write order is racy.
+    const auditIdx = calls.indexOf("settings set alpha --key ocsf_json_enabled --value true");
+    const openshellIdx = calls.indexOf("logs alpha -n 200 --source all --tail");
+    expect(auditIdx).toBeLessThan(openshellIdx);
+    expect(r.out).toContain(FAKE_OPENCLAW_LOG_LINE);
+    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
+  });
+
+  it("keeps logs --follow running when one log source exits", { timeout: 15000 }, async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-source-exit-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
-    const markerFile = path.join(home, "logs-follow-args");
+    const markerFile = path.join(home, "logs-follow-source-exit-args");
     fs.mkdirSync(localBin, { recursive: true });
     fs.mkdirSync(registryDir, { recursive: true });
     fs.writeFileSync(
@@ -484,34 +594,122 @@ describe("CLI dispatch", () => {
       [
         "#!/usr/bin/env bash",
         `marker_file=${JSON.stringify(markerFile)}`,
-        'if [ "$1" = "--version" ]; then',
-        "  echo 'openshell 0.0.16'",
+        'printf \'%s\\n\' "$*" >> "$marker_file"',
+        'if [ "$1" = "settings" ]; then',
         "  exit 0",
         "fi",
-        'printf \'%s \' "$@" > "$marker_file"',
+        'if [ "$1" = "logs" ]; then',
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "sandbox" ]; then',
+        "  trap 'exit 0' TERM INT",
+        "  while true; do sleep 1; done",
+        "fi",
         "exit 0",
       ].join("\n"),
       { mode: 0o755 },
     );
 
-    const r = runWithEnv("alpha logs --follow", {
-      HOME: home,
-      PATH: `${localBin}:${process.env.PATH || ""}`,
+    const child = spawn(process.execPath, [CLI, "alpha", "logs", "--follow"], {
+      cwd: path.join(import.meta.dirname, ".."),
+      env: { ...process.env, HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` },
+      stdio: "ignore",
     });
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("exit", (code) => resolve(code));
+    });
+    const readCalls = () =>
+      fs.existsSync(markerFile) ? fs.readFileSync(markerFile, "utf8").trim().split(/\n/) : [];
 
-    expect(r.code).toBe(0);
-    expect(readRecordedArgs(markerFile)).toEqual([
-      "sandbox",
-      "exec",
-      "-n",
-      "alpha",
-      "--",
-      "tail",
-      "-n",
-      "200",
-      "-f",
-      "/tmp/gateway.log",
-    ]);
+    try {
+      let calls: string[] = [];
+      const configuredTimeout = Number(process.env.NEMOCLAW_TEST_TIMEOUT || 10000);
+      const pollTimeoutMs = Math.min(
+        Number.isFinite(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : 10000,
+        10000,
+      );
+      const deadline = Date.now() + pollTimeoutMs;
+      while (Date.now() < deadline) {
+        calls = readCalls();
+        if (
+          calls.includes("logs alpha -n 200 --source all --tail") &&
+          calls.includes("sandbox exec -n alpha -- tail -n 200 -f /tmp/gateway.log")
+        ) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      expect(child.exitCode).toBeNull();
+      expect(calls).toContain("logs alpha -n 200 --source all --tail");
+      expect(calls).toContain("sandbox exec -n alpha -- tail -n 200 -f /tmp/gateway.log");
+    } finally {
+      if (child.exitCode === null) {
+        child.kill("SIGTERM");
+      }
+      expect(await exitPromise).toBe(143);
+    }
+  });
+
+  it("waits for logs --follow children to stop after SIGTERM", { timeout: 15000 }, async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-sigterm-wait-"));
+    const localBin = path.join(home, "bin");
+    const markerFile = path.join(home, "logs-follow-sigterm-wait-args");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home);
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        `marker_file=${JSON.stringify(markerFile)}`,
+        'printf \'%s\\n\' "$*" >> "$marker_file"',
+        'if [ "$1" = "settings" ]; then',
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "logs" ] || [ "$1" = "sandbox" ]; then',
+        "  trap 'sleep 0.3; exit 0' TERM INT",
+        "  while true; do sleep 1; done",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const child = spawn(process.execPath, [CLI, "alpha", "logs", "--follow"], {
+      cwd: path.join(import.meta.dirname, ".."),
+      env: { ...process.env, HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` },
+      stdio: "ignore",
+    });
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("exit", (code) => resolve(code));
+    });
+    const readCalls = () =>
+      fs.existsSync(markerFile) ? fs.readFileSync(markerFile, "utf8").trim().split(/\n/) : [];
+
+    try {
+      let calls: string[] = [];
+      const deadline = Date.now() + 10000;
+      while (Date.now() < deadline) {
+        calls = readCalls();
+        if (
+          calls.includes("logs alpha -n 200 --source all --tail") &&
+          calls.includes("sandbox exec -n alpha -- tail -n 200 -f /tmp/gateway.log")
+        ) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      child.kill("SIGTERM");
+      const exitedEarly = await Promise.race([
+        exitPromise.then(() => true),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 100)),
+      ]);
+      expect(exitedEarly).toBe(false);
+      expect(await exitPromise).toBe(143);
+    } finally {
+      if (child.exitCode === null) {
+        child.kill("SIGKILL");
+      }
+    }
   });
 
   it("uses named sandbox exec for bridge status helpers", () => {
@@ -1003,18 +1201,9 @@ describe("CLI dispatch", () => {
     });
 
     expect(r.code).toBe(0);
-    expect(readRecordedArgs(markerFile)).toEqual([
-      "sandbox",
-      "exec",
-      "-n",
-      "alpha",
-      "--",
-      "tail",
-      "-n",
-      "200",
-      "/tmp/gateway.log",
-    ]);
-    expect(readRecordedArgs(markerFile)).not.toContain("-f");
+    const recordedArgs = readRecordedArgs(markerFile);
+    expect(recordedArgs).toEqual(["logs", "alpha", "-n", "200", "--source", "all"]);
+    expect(recordedArgs).not.toContain("--tail");
   });
 
   it("connect does not pre-start a duplicate port forward", () => {
@@ -1864,6 +2053,9 @@ describe("CLI dispatch", () => {
         "#!/usr/bin/env bash",
         'if [ "$1" = "--version" ]; then',
         "  echo 'openshell 0.0.16'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "settings" ]; then',
         "  exit 0",
         "fi",
         "kill -INT $$",

--- a/test/e2e/test-skill-agent-e2e.sh
+++ b/test/e2e/test-skill-agent-e2e.sh
@@ -71,7 +71,7 @@ unset _script_dir _candidate
 E2E_DIR="$(cd "$(dirname "$0")" && pwd)"
 SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-skill-agent}"
 SKILL_ID="skill-smoke-fixture"
-VERIFY_TOKEN="SKILL_SMOKE_VERIFY_K9X2"
+VERIFY_PHRASE="SKILL_SMOKE_VERIFY_K9X2"
 MAX_ATTEMPTS="${E2E_SKILL_AGENT_MAX_ATTEMPTS:-3}"
 RETRY_SLEEP="${E2E_SKILL_AGENT_RETRY_SLEEP_SEC:-15}"
 [[ "$MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || MAX_ATTEMPTS=3
@@ -176,14 +176,14 @@ while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
     NVIDIA_API_KEY="$NVIDIA_API_KEY" \
       SANDBOX_NAME="$SANDBOX_NAME" \
       SKILL_ID="$SKILL_ID" \
-      VERIFY_TOKEN="$VERIFY_TOKEN" \
+      VERIFY_TOKEN="$VERIFY_PHRASE" \
       bash "$E2E_DIR/e2e-cloud-experimental/features/skill/verify-sandbox-skill-via-agent.sh" 2>&1
   )
   agent_rc=$?
   set -uo pipefail
 
   if [ "$agent_rc" -eq 0 ]; then
-    pass "Agent returned ${VERIFY_TOKEN} (attempt ${attempt}/${MAX_ATTEMPTS})"
+    pass "Agent returned ${VERIFY_PHRASE} (attempt ${attempt}/${MAX_ATTEMPTS})"
     agent_ok=1
     break
   fi
@@ -196,10 +196,10 @@ while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
   agent_section=$(printf '%s' "$agent_out" | sed -n '/--- agent stdout\/stderr/,/--- end ---/p')
   if [ -n "$agent_section" ]; then
     collapsed=$(printf '%s' "$agent_section" | tr -d '\n\r' | tr -d '`"'\''' | tr '[:upper:]' '[:lower:]')
-    token_lower=$(printf '%s' "$VERIFY_TOKEN" | tr '[:upper:]' '[:lower:]')
+    token_lower=$(printf '%s' "$VERIFY_PHRASE" | tr '[:upper:]' '[:lower:]')
     if printf '%s' "$collapsed" | grep -Fq "$token_lower"; then
       info "Token found in agent output section (fuzzy match — script exited ${agent_rc} but token present in delimited output)"
-      pass "Agent returned ${VERIFY_TOKEN} via fuzzy match (attempt ${attempt}/${MAX_ATTEMPTS})"
+      pass "Agent returned ${VERIFY_PHRASE} via fuzzy match (attempt ${attempt}/${MAX_ATTEMPTS})"
       agent_ok=1
       break
     fi

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -4544,24 +4544,27 @@ console.log(JSON.stringify({ exists: providerExistsInGateway("nonexistent") }));
     assert.equal(payload.exists, false);
   });
 
-  it("continues once the sandbox is Ready even if the create stream never closes", async () => {
-    const repoRoot = path.join(import.meta.dirname, "..");
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-create-ready-"));
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "create-sandbox-ready-check.js");
-    const payloadPath = path.join(tmpDir, "payload.json");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
-    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
-    const preflightPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "preflight.js"));
-    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
+  it(
+    "continues once the sandbox is Ready even if the create stream never closes",
+    { timeout: 20000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-create-ready-"));
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "create-sandbox-ready-check.js");
+      const payloadPath = path.join(tmpDir, "payload.json");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+      const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+      const preflightPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "preflight.js"));
+      const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
-      mode: 0o755,
-    });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -4643,29 +4646,30 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-      },
-      timeout: 15000,
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+        timeout: 15000,
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(fs.readFileSync(payloadPath, "utf8"));
-    assert.equal(payload.sandboxName, "my-assistant");
-    assert.ok(payload.sandboxListCalls >= 2);
-    assert.deepEqual(payload.killCalls, ["SIGTERM"]);
-    assert.equal(payload.unrefCalls, 1);
-    assert.equal(payload.stdoutDestroyCalls, 1);
-    assert.equal(payload.stderrDestroyCalls, 1);
-  });
+      assert.equal(result.status, 0, result.stderr);
+      const payload = JSON.parse(fs.readFileSync(payloadPath, "utf8"));
+      assert.equal(payload.sandboxName, "my-assistant");
+      assert.ok(payload.sandboxListCalls >= 2);
+      assert.deepEqual(payload.killCalls, ["SIGTERM"]);
+      assert.equal(payload.unrefCalls, 1);
+      assert.equal(payload.stdoutDestroyCalls, 1);
+      assert.equal(payload.stderrDestroyCalls, 1);
+    },
+  );
 
   it("restores the dashboard forward when onboarding reuses an existing ready sandbox", async () => {
     const repoRoot = path.join(import.meta.dirname, "..");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       {
         test: {
           name: "cli",
+          testTimeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 15000),
           include: ["test/**/*.test.{js,ts}", "src/**/*.test.ts"],
           exclude: [
             "**/node_modules/**",


### PR DESCRIPTION
## Summary
Make `nemoclaw <sandbox> logs` include OpenShell audit events so policy denials show up alongside the existing OpenClaw gateway log output.

## Related Issue
Fixes #2512

## Changes
- Enable sandbox audit logs before reading logs.
- Read both the in-sandbox `/tmp/gateway.log` source and `openshell logs <sandbox> --source all`.
- In `--follow` mode, keep the remaining log source running if one source exits.
- Add CLI regression coverage for both log sources and follow-mode source shutdown.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:
- `npm run build:cli`
- `npx vitest run test/cli.test.ts -t logs`
- `npm run typecheck:cli`
- Pre-push hooks passed during `git push --force-with-lease`
- E2E repro confirmed denied `curl https://example.com` appears in `nemoclaw repro-2512-e2e logs --follow`

## AI Disclosure
- [x] AI-assisted — tool: OpenAI Codex

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `logs --follow` now streams gateway and sandbox logs concurrently and derives CLI exit status from child streams.

* **Improvements**
  * Non-follow log collection probes gateway availability before gathering logs, with a configurable timeout and clearer “unavailable” messaging.
  * Per-command timeouts honored and follow lifecycle handles signals with a timed forced-exit fallback.

* **Bug Fixes**
  * Still collects logs and emits warnings when enabling sandbox audit logging fails or times out.

* **Tests / Chores**
  * Expanded tests for multi-source streaming, probes/timeouts, signal handling, and minor test/e2e updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->