### PR TITLE
docs: document policy path for host services (#1551)

### DIFF
--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -74,6 +74,10 @@ Add, remove, or modify the endpoints that the sandbox is allowed to reach.
 The sandbox policy is defined in a declarative YAML file in the NemoClaw repository and enforced at runtime by [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell).
 NemoClaw supports both static policy changes that persist across restarts and dynamic updates applied to a running sandbox through the OpenShell CLI.
 
+> **Note:** If the sandbox needs to reach an HTTP service running on the host, expose the service on a host IP that the OpenShell gateway can reach and apply a custom NemoClaw preset with `nemoclaw <sandbox> policy-add --from-file`.
+> Do not rely on `host.docker.internal` as a general host-service path because it bypasses the OpenShell policy path and may not be reachable in every sandbox runtime.
+> See Agent cannot reach a host-side HTTP service (use the `nemoclaw-user-reference` skill).
+
 ## Step 5: Static Changes
 
 Static changes modify the baseline policy file and take effect after the next sandbox creation.

--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -74,7 +74,8 @@ Add, remove, or modify the endpoints that the sandbox is allowed to reach.
 The sandbox policy is defined in a declarative YAML file in the NemoClaw repository and enforced at runtime by [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell).
 NemoClaw supports both static policy changes that persist across restarts and dynamic updates applied to a running sandbox through the OpenShell CLI.
 
-> **Note:** If the sandbox needs to reach an HTTP service running on the host, expose the service on a host IP that the OpenShell gateway can reach and apply a custom NemoClaw preset with `nemoclaw <sandbox> policy-add --from-file`.
+> **Note:** If the sandbox needs to reach an HTTP service running on the host, expose the service on a host IP that the OpenShell gateway can reach.
+> Apply a custom NemoClaw preset with `nemoclaw <sandbox> policy-add --from-file`.
 > Do not rely on `host.docker.internal` as a general host-service path because it bypasses the OpenShell policy path and may not be reachable in every sandbox runtime.
 > See Agent cannot reach a host-side HTTP service (use the `nemoclaw-user-reference` skill).
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -736,7 +736,7 @@ Apply the preset to the running sandbox with the NemoClaw CLI:
 $ nemoclaw my-assistant policy-add --from-file ./host-memory-api.yaml
 ```
 
-After the policy is applied, retry the request from inside the sandbox without disabling the proxy:
+After you apply the policy, retry the request from inside the sandbox without disabling the proxy:
 
 ```console
 $ curl -s http://10.0.0.5:50001/health

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -691,6 +691,62 @@ $ nemoclaw onboard
 These are build-time settings baked into the sandbox image.
 Changing them after onboarding requires re-running `nemoclaw onboard` to rebuild the image.
 
+### Agent cannot reach a host-side HTTP service
+
+When a sandbox needs to call an HTTP service running on the host, use the normal OpenShell network policy path.
+Expose the service on a host IP address that the OpenShell gateway can reach, create a custom NemoClaw policy preset for that IP and port, and apply it with `nemoclaw <sandbox> policy-add --from-file`.
+The sandbox request then flows through the OpenShell proxy while NemoClaw preserves the existing live policy entries.
+
+Do not rely on `host.docker.internal` or `host.openshell.internal` as a general-purpose host-service path.
+Those names may appear in the sandbox's `/etc/hosts`, but in OpenShell's sandbox network they are not guaranteed to point at a reachable host gateway.
+Bypassing the proxy with `--noproxy '*'` also bypasses network policy enforcement and audit.
+
+First, make sure the host-side service listens on a non-loopback address.
+For example, a health endpoint on port `50001` should be reachable from the host IP, not only from `127.0.0.1`:
+
+```console
+$ curl -s http://10.0.0.5:50001/health
+{"status":"ok"}
+```
+
+Then create a custom NemoClaw preset for the host-side service.
+Replace `10.0.0.5`, `50001`, paths, methods, and binaries with the service you want the sandbox to reach:
+
+```yaml
+preset:
+  name: host-memory-api
+  description: "Host memory API"
+network_policies:
+  host_memory_api:
+    name: host_memory_api
+    endpoints:
+      - host: 10.0.0.5
+        port: 50001
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/health" }
+    binaries:
+      - { path: /usr/bin/curl }
+```
+
+Apply the preset to the running sandbox with the NemoClaw CLI:
+
+```console
+$ nemoclaw my-assistant policy-add --from-file ./host-memory-api.yaml
+```
+
+After the policy is applied, retry the request from inside the sandbox without disabling the proxy:
+
+```console
+$ curl -s http://10.0.0.5:50001/health
+{"status":"ok"}
+```
+
+If the request is still denied, check the blocked request in `openshell term`.
+The policy `binaries` list must include the executable path that actually made the request.
+If the response changes from `policy_denied` to `upstream_unreachable`, the policy matched, but the OpenShell gateway could not reach the host IP and port.
+
 ### Agent cannot reach an external host
 
 OpenShell blocks outbound connections to hosts not listed in the network policy.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -27,6 +27,12 @@ Add, remove, or modify the endpoints that the sandbox is allowed to reach.
 The sandbox policy is defined in a declarative YAML file in the NemoClaw repository and enforced at runtime by [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell).
 NemoClaw supports both static policy changes that persist across restarts and dynamic updates applied to a running sandbox through the OpenShell CLI.
 
+:::{note}
+If the sandbox needs to reach an HTTP service running on the host, expose the service on a host IP that the OpenShell gateway can reach and apply a custom NemoClaw preset with `nemoclaw <sandbox> policy-add --from-file`.
+Do not rely on `host.docker.internal` as a general host-service path because it bypasses the OpenShell policy path and may not be reachable in every sandbox runtime.
+See [Agent cannot reach a host-side HTTP service](../reference/troubleshooting.md#agent-cannot-reach-a-host-side-http-service).
+:::
+
 ## Prerequisites
 
 - A running NemoClaw sandbox for dynamic changes, or the NemoClaw source repository for static changes.

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -28,7 +28,8 @@ The sandbox policy is defined in a declarative YAML file in the NemoClaw reposit
 NemoClaw supports both static policy changes that persist across restarts and dynamic updates applied to a running sandbox through the OpenShell CLI.
 
 :::{note}
-If the sandbox needs to reach an HTTP service running on the host, expose the service on a host IP that the OpenShell gateway can reach and apply a custom NemoClaw preset with `nemoclaw <sandbox> policy-add --from-file`.
+If the sandbox needs to reach an HTTP service running on the host, expose the service on a host IP that the OpenShell gateway can reach.
+Apply a custom NemoClaw preset with `nemoclaw <sandbox> policy-add --from-file`.
 Do not rely on `host.docker.internal` as a general host-service path because it bypasses the OpenShell policy path and may not be reachable in every sandbox runtime.
 See [Agent cannot reach a host-side HTTP service](../reference/troubleshooting.md#agent-cannot-reach-a-host-side-http-service).
 :::

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -721,6 +721,62 @@ $ nemoclaw onboard
 These are build-time settings baked into the sandbox image.
 Changing them after onboarding requires re-running `nemoclaw onboard` to rebuild the image.
 
+### Agent cannot reach a host-side HTTP service
+
+When a sandbox needs to call an HTTP service running on the host, use the normal OpenShell network policy path.
+Expose the service on a host IP address that the OpenShell gateway can reach, create a custom NemoClaw policy preset for that IP and port, and apply it with `nemoclaw <sandbox> policy-add --from-file`.
+The sandbox request then flows through the OpenShell proxy while NemoClaw preserves the existing live policy entries.
+
+Do not rely on `host.docker.internal` or `host.openshell.internal` as a general-purpose host-service path.
+Those names may appear in the sandbox's `/etc/hosts`, but in OpenShell's sandbox network they are not guaranteed to point at a reachable host gateway.
+Bypassing the proxy with `--noproxy '*'` also bypasses network policy enforcement and audit.
+
+First, make sure the host-side service listens on a non-loopback address.
+For example, a health endpoint on port `50001` should be reachable from the host IP, not only from `127.0.0.1`:
+
+```console
+$ curl -s http://10.0.0.5:50001/health
+{"status":"ok"}
+```
+
+Then create a custom NemoClaw preset for the host-side service.
+Replace `10.0.0.5`, `50001`, paths, methods, and binaries with the service you want the sandbox to reach:
+
+```yaml
+preset:
+  name: host-memory-api
+  description: "Host memory API"
+network_policies:
+  host_memory_api:
+    name: host_memory_api
+    endpoints:
+      - host: 10.0.0.5
+        port: 50001
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/health" }
+    binaries:
+      - { path: /usr/bin/curl }
+```
+
+Apply the preset to the running sandbox with the NemoClaw CLI:
+
+```console
+$ nemoclaw my-assistant policy-add --from-file ./host-memory-api.yaml
+```
+
+After the policy is applied, retry the request from inside the sandbox without disabling the proxy:
+
+```console
+$ curl -s http://10.0.0.5:50001/health
+{"status":"ok"}
+```
+
+If the request is still denied, check the blocked request in `openshell term`.
+The policy `binaries` list must include the executable path that actually made the request.
+If the response changes from `policy_denied` to `upstream_unreachable`, the policy matched, but the OpenShell gateway could not reach the host IP and port.
+
 ### Agent cannot reach an external host
 
 OpenShell blocks outbound connections to hosts not listed in the network policy.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -766,7 +766,7 @@ Apply the preset to the running sandbox with the NemoClaw CLI:
 $ nemoclaw my-assistant policy-add --from-file ./host-memory-api.yaml
 ```
 
-After the policy is applied, retry the request from inside the sandbox without disabling the proxy:
+After you apply the policy, retry the request from inside the sandbox without disabling the proxy:
 
 ```console
 $ curl -s http://10.0.0.5:50001/health


### PR DESCRIPTION
  <!-- markdownlint-disable MD041 -->
  ## Summary

  Document the recommended path for accessing host-side HTTP services from a NemoClaw sandbox through the normal OpenShell policy/proxy flow. This avoids recommending direct `host.docker.internal` access, which bypasses policy enforcement and may not be reachable in every sandbox runtime.

  ## Related Issue

  Fixes #1551

  ## Changes

  - Add troubleshooting guidance for host-side HTTP services.
  - Show how to create a custom NemoClaw policy preset for a host IP and port.
  - Document applying that preset with `nemoclaw <sandbox> policy-add --from-file`.
  - Add a network-policy note that `host.docker.internal` should not be treated as a general host-service path.
  - Regenerate the generated `nemoclaw-user-*` agent skills from the docs.

  ## Type of Change

  - [ ] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates
  - [ ] Doc only (prose changes, no code sample modifications)
  - [x] Doc only (includes code sample changes)

  ## Verification

  - [ ] `npx prek run --all-files` passes
  - [ ] `npm test` passes
  - [ ] Tests added or updated for new or changed behavior
  - [x] No secrets, API keys, or credentials committed
  - [x] Docs updated for user-facing behavior changes
  - [x] `make docs` builds without warnings (doc changes only)
  - [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
  - [ ] New doc pages include SPDX header and frontmatter (new pages only)

  ## AI Disclosure

  - [x] AI-assisted — tool: Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring sandbox agents to access HTTP services on the host via the platform's network/proxy path.
  * Included steps for creating and applying custom network policy presets to allow host-service access and verify policy application.
  * Added troubleshooting diagnostics to distinguish policy matches from gateway reachability failures, plus warnings against bypassing the proxy with special hostnames or global no-proxy workarounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---
Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>