### PR TITLE
fix(onboard): validate custom Dockerfile path before onboarding

### DIFF
--- a/src/lib/onboard-command.test.ts
+++ b/src/lib/onboard-command.test.ts
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -113,9 +117,13 @@ describe("onboard command", () => {
   });
 
   it("parses --from <Dockerfile>", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-from-parse-"));
+    const dockerfilePath = path.join(tmpDir, "Custom.Dockerfile");
+    fs.writeFileSync(dockerfilePath, "FROM scratch\n");
+
     expect(
       parseOnboardArgs(
-        ["--resume", "--from", "/tmp/Custom.Dockerfile"],
+        ["--resume", "--from", dockerfilePath],
         "--yes-i-accept-third-party-software",
         "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE",
         {
@@ -129,7 +137,7 @@ describe("onboard command", () => {
       resume: true,
       fresh: false,
       recreateSandbox: false,
-      fromDockerfile: "/tmp/Custom.Dockerfile",
+      fromDockerfile: dockerfilePath,
       acceptThirdPartySoftware: false,
       agent: null,
       dangerouslySkipPermissions: false,
@@ -192,6 +200,27 @@ describe("onboard command", () => {
         },
       ),
     ).toThrow("exit:1");
+  });
+
+  it("exits before onboarding when --from points to a missing Dockerfile", async () => {
+    const runOnboard = vi.fn(async () => {});
+    const errors: string[] = [];
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-from-missing-"));
+
+    await expect(
+      runOnboardCommand({
+        args: ["--from", path.join(tmpDir, "no-such-dockerfile-2589")],
+        noticeAcceptFlag: "--yes-i-accept-third-party-software",
+        noticeAcceptEnv: "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE",
+        env: {},
+        runOnboard,
+        error: (message = "") => errors.push(message),
+        exit: exitWithPrefixedCode,
+      }),
+    ).rejects.toThrow("exit:1");
+
+    expect(runOnboard).not.toHaveBeenCalled();
+    expect(errors.join("\n")).toContain("--from path not found:");
   });
 
   it("exits with usage on unknown args", () => {

--- a/src/lib/onboard-command.ts
+++ b/src/lib/onboard-command.ts
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import path from "node:path";
+
 export interface OnboardCommandOptions {
   nonInteractive: boolean;
   resume: boolean;
@@ -63,12 +66,18 @@ export function parseOnboardArgs(
   let fromDockerfile: string | null = null;
   const fromIdx = parsedArgs.indexOf("--from");
   if (fromIdx !== -1) {
-    fromDockerfile = parsedArgs[fromIdx + 1] || null;
-    if (!fromDockerfile || fromDockerfile.startsWith("--")) {
+    const requestedFromDockerfile = parsedArgs[fromIdx + 1];
+    if (!requestedFromDockerfile || requestedFromDockerfile.startsWith("--")) {
       error("  --from requires a path to a Dockerfile");
       printOnboardUsage(error, noticeAcceptFlag);
       exit(1);
     }
+    const resolvedFromDockerfile = path.resolve(requestedFromDockerfile);
+    if (!fs.existsSync(resolvedFromDockerfile)) {
+      error(`  --from path not found: ${resolvedFromDockerfile}`);
+      exit(1);
+    }
+    fromDockerfile = requestedFromDockerfile;
     parsedArgs.splice(fromIdx, 2);
   }
 


### PR DESCRIPTION
## Summary
- Validate `nemoclaw onboard --from <Dockerfile>` during command parsing when the path is missing.
- Exit before calling the onboarding flow so bad paths do not start preflight, gateway, inference, or sandbox setup side effects.
- Add regression coverage that asserts `runOnboard` is not called for a missing `--from` path.

## Test plan
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm test -- src/lib/onboard-command.test.ts`
- Manual Brev check: `node ./bin/nemoclaw.js onboard --from /tmp/no-such-dockerfile-2589 --non-interactive --yes-i-accept-third-party-software` exits immediately with `--from path not found:` before `[1/8] Preflight checks`

Fixes #2589

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the `--from <Dockerfile>` argument: provided paths are resolved to absolute locations, missing targets produce a clear error message and the command exits with a failure status.

* **Tests**
  * Added tests exercising real, temporary Dockerfile paths and the failure path when a referenced Dockerfile does not exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>