### PR TITLE
fix(cli): hide NIM status line for cloud-only providers

### DIFF
--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -303,6 +303,24 @@ describe("nim", () => {
     });
   });
 
+  describe("shouldShowNimLine", () => {
+    it("hides the line for cloud-only sandboxes (no container, nothing running)", () => {
+      expect(nim.shouldShowNimLine(null, false)).toBe(false);
+      expect(nim.shouldShowNimLine(undefined, false)).toBe(false);
+      expect(nim.shouldShowNimLine("", false)).toBe(false);
+    });
+
+    it("shows the line when the sandbox is bound to a NIM container", () => {
+      expect(nim.shouldShowNimLine("nim-foo", false)).toBe(true);
+      expect(nim.shouldShowNimLine("nim-foo", true)).toBe(true);
+    });
+
+    it("still surfaces an orphan NIM container even when none is registered", () => {
+      expect(nim.shouldShowNimLine(null, true)).toBe(true);
+      expect(nim.shouldShowNimLine(undefined, true)).toBe(true);
+    });
+  });
+
   describe("isNgcLoggedIn", () => {
     const fs = require("fs");
     const os = require("os");

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -348,3 +348,14 @@ export function nimStatusByName(name: string, port?: number): NimStatus {
     return { running: false, container: name };
   }
 }
+
+// Cloud-only providers leave nimContainer unset; printing "NIM: not running"
+// for those sandboxes implies a fault when NIM is simply not part of the
+// deployment. Still surface the line if a container is unexpectedly alive,
+// so an orphan NIM is not silently hidden.
+export function shouldShowNimLine(
+  nimContainer: string | null | undefined,
+  nimRunning: boolean,
+): boolean {
+  return Boolean(nimContainer) || nimRunning;
+}

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6306,6 +6306,7 @@ function printDashboard(
   agent: AgentDefinition | null = null,
 ): void {
   const nimStat = nimContainer ? nim.nimStatusByName(nimContainer) : nim.nimStatus(sandboxName);
+  const showNim = nim.shouldShowNimLine(nimContainer, nimStat.running);
   const nimLabel = nimStat.running ? "running" : "not running";
 
   const providerLabel = getProviderLabel(provider);
@@ -6334,7 +6335,9 @@ function printDashboard(
   // console.log(`  Dashboard    http://localhost:${DASHBOARD_PORT}/`);
   console.log(`  Sandbox      ${sandboxName} (Landlock + seccomp + netns)`);
   console.log(`  Model        ${model} (${providerLabel})`);
-  console.log(`  NIM          ${nimLabel}`);
+  if (showNim) {
+    console.log(`  NIM          ${nimLabel}`);
+  }
   console.log(`  ${"─".repeat(50)}`);
   console.log(`  Run:         nemoclaw ${sandboxName} connect`);
   console.log(`  Status:      nemoclaw ${sandboxName} status`);

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1777,14 +1777,15 @@ async function sandboxStatus(sandboxName: string) {
     }
   }
 
-  // NIM health
   const nimStat =
     sb && sb.nimContainer ? nim.nimStatusByName(sb.nimContainer) : nim.nimStatus(sandboxName);
-  console.log(
-    `    NIM:      ${nimStat.running ? `running (${nimStat.container})` : "not running"}`,
-  );
-  if (nimStat.running) {
-    console.log(`    Healthy:  ${nimStat.healthy ? "yes" : "no"}`);
+  if (nim.shouldShowNimLine(sb && sb.nimContainer, nimStat.running)) {
+    console.log(
+      `    NIM:      ${nimStat.running ? `running (${nimStat.container})` : "not running"}`,
+    );
+    if (nimStat.running) {
+      console.log(`    Healthy:  ${nimStat.healthy ? "yes" : "no"}`);
+    }
   }
   console.log("");
 }


### PR DESCRIPTION
## Summary

`nemoclaw <name> status` and the post-onboard dashboard printed `NIM: not running` even when the sandbox was provisioned against a Cloud API provider (e.g. `nvidia-prod`), where no local NIM container is ever expected. The line implied a fault when none existed and confused users on otherwise healthy cloud-API setups.

The output now suppresses the NIM line when the sandbox has no `nimContainer` registered and no orphan NIM container is running. A still-running container with no registered binding is surfaced intentionally so an unexpectedly alive NIM is not silently hidden.

## Related Issue

Closes #2605

## Changes

- `src/lib/nim.ts`: add `shouldShowNimLine(nimContainer, nimRunning)` predicate alongside the other NIM helpers; returns true iff the sandbox is bound to a NIM container or one is unexpectedly alive.
- `src/nemoclaw.ts`: gate the status-block NIM print on the new helper. The `nimStatus` lookup itself is preserved so orphan detection still fires.
- `src/lib/onboard.ts`: gate the post-onboard dashboard NIM print on the same helper, so the same UX problem doesn't reappear right after `nemoclaw onboard`.
- `src/lib/nim.test.ts`: truth-table coverage for the helper — cloud-only (`null` / `undefined` / `""`), bound, and orphan-running cases.

Verification before/after on a Cloud API sandbox:
- Before: `Provider: nvidia-prod ... NIM: not running` (misleading)
- After: NIM line absent; OpenClaw / Sandbox status unchanged

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes (3 new tests in `nim.test.ts`)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure

- [x] AI-assisted — tools: Claude Code, Codex

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NIM status information now displays conditionally in dashboard output. The status line appears only when a NIM container is present or when an unexpected running container is detected, reducing unnecessary clutter.

* **Tests**
  * Added comprehensive test coverage for the new conditional display behavior across multiple deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->