### PR TITLE
fix(onboard): roll back orphaned sandbox when dashboard alloc fails (#2174 followup)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6183,18 +6183,6 @@ function findAvailableDashboardPort(sandboxName: string, preferredPort: number, 
 }
 
 /**
- * Set up the dashboard forward for a sandbox. Auto-allocates the next free
- * port if the preferred port is taken by a different sandbox (Fixes #2174).
- * Returns the actual port number used.
- *
- * When `rollbackSandboxOnFailure` is true, deletes the just-created openshell
- * sandbox before exiting on unrecoverable port-allocation failure. This keeps
- * `openshell sandbox list` and the NemoClaw registry from drifting when the
- * range is exhausted between sandbox-create and forward-setup ("leaks ghost
- * sandbox" half of #2174). Mirrors the not-ready rollback pattern in
- * createSandbox.
- */
-/**
  * Build the actionable error lines printed when the just-created openshell
  * sandbox is rolled back after a dashboard port-allocation failure. Pure
  * function over (sandboxName, alloc-error, delete-result) so the rollback path
@@ -6219,6 +6207,18 @@ function buildOrphanedSandboxRollbackMessage(
   return lines;
 }
 
+/**
+ * Set up the dashboard forward for a sandbox. Auto-allocates the next free
+ * port if the preferred port is taken by a different sandbox (Fixes #2174).
+ * Returns the actual port number used.
+ *
+ * When `rollbackSandboxOnFailure` is true, deletes the just-created openshell
+ * sandbox before exiting on unrecoverable port-allocation failure. This keeps
+ * `openshell sandbox list` and the NemoClaw registry from drifting when the
+ * range is exhausted between sandbox-create and forward-setup ("leaks ghost
+ * sandbox" half of #2174). Mirrors the not-ready rollback pattern in
+ * createSandbox.
+ */
 function ensureDashboardForward(
   sandboxName: string,
   chatUiUrl = `http://127.0.0.1:${CONTROL_UI_PORT}`,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6194,6 +6194,31 @@ function findAvailableDashboardPort(sandboxName: string, preferredPort: number, 
  * sandbox" half of #2174). Mirrors the not-ready rollback pattern in
  * createSandbox.
  */
+/**
+ * Build the actionable error lines printed when the just-created openshell
+ * sandbox is rolled back after a dashboard port-allocation failure. Pure
+ * function over (sandboxName, alloc-error, delete-result) so the rollback path
+ * is testable without spawning subprocesses or exiting the process (#2174).
+ */
+function buildOrphanedSandboxRollbackMessage(
+  sandboxName: string,
+  err: unknown,
+  deleteSucceeded: boolean,
+): string[] {
+  const lines = [
+    "",
+    `  Could not allocate a dashboard port for '${sandboxName}'.`,
+    `  ${err instanceof Error ? err.message : String(err)}`,
+  ];
+  if (deleteSucceeded) {
+    lines.push("  The orphaned sandbox has been removed — you can safely retry.");
+  } else {
+    lines.push("  Could not remove the orphaned sandbox. Manual cleanup:");
+    lines.push(`    openshell sandbox delete "${sandboxName}"`);
+  }
+  return lines;
+}
+
 function ensureDashboardForward(
   sandboxName: string,
   chatUiUrl = `http://127.0.0.1:${CONTROL_UI_PORT}`,
@@ -6208,14 +6233,8 @@ function ensureDashboardForward(
   } catch (err) {
     if (!rollbackSandboxOnFailure) throw err;
     const delResult = runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
-    console.error("");
-    console.error(`  Could not allocate a dashboard port for '${sandboxName}'.`);
-    console.error(`  ${err instanceof Error ? err.message : String(err)}`);
-    if (delResult.status === 0) {
-      console.error("  The orphaned sandbox has been removed — you can safely retry.");
-    } else {
-      console.error("  Could not remove the orphaned sandbox. Manual cleanup:");
-      console.error(`    openshell sandbox delete "${sandboxName}"`);
+    for (const line of buildOrphanedSandboxRollbackMessage(sandboxName, err, delResult.status === 0)) {
+      console.error(line);
     }
     process.exit(1);
   }
@@ -7185,6 +7204,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
 }
 
 module.exports = {
+  buildOrphanedSandboxRollbackMessage,
   buildProviderArgs,
   buildGatewayBootstrapSecretsScript,
   buildSandboxConfigSyncScript,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3827,7 +3827,11 @@ async function createSandbox(
   // A previous onboard run may have left the port forwarded to a different sandbox,
   // which would silently prevent the new sandbox's dashboard from being reachable.
   // Auto-allocates the next free port if the preferred one is taken (Fixes #2174).
-  const actualDashboardPort = ensureDashboardForward(sandboxName, chatUiUrl);
+  // Roll back the just-created openshell sandbox on unrecoverable allocation
+  // failure so the registry and `openshell sandbox list` don't drift (#2174).
+  const actualDashboardPort = ensureDashboardForward(sandboxName, chatUiUrl, {
+    rollbackSandboxOnFailure: true,
+  });
   // Update chatUiUrl and CHAT_UI_URL env so printDashboard / getDashboardAccessInfo
   // see the final port (they re-read process.env.CHAT_UI_URL independently).
   if (actualDashboardPort !== Number(getDashboardForwardPort(chatUiUrl))) {
@@ -6182,11 +6186,39 @@ function findAvailableDashboardPort(sandboxName: string, preferredPort: number, 
  * Set up the dashboard forward for a sandbox. Auto-allocates the next free
  * port if the preferred port is taken by a different sandbox (Fixes #2174).
  * Returns the actual port number used.
+ *
+ * When `rollbackSandboxOnFailure` is true, deletes the just-created openshell
+ * sandbox before exiting on unrecoverable port-allocation failure. This keeps
+ * `openshell sandbox list` and the NemoClaw registry from drifting when the
+ * range is exhausted between sandbox-create and forward-setup ("leaks ghost
+ * sandbox" half of #2174). Mirrors the not-ready rollback pattern in
+ * createSandbox.
  */
-function ensureDashboardForward(sandboxName: string, chatUiUrl = `http://127.0.0.1:${CONTROL_UI_PORT}`): number {
+function ensureDashboardForward(
+  sandboxName: string,
+  chatUiUrl = `http://127.0.0.1:${CONTROL_UI_PORT}`,
+  options: { rollbackSandboxOnFailure?: boolean } = {},
+): number {
+  const { rollbackSandboxOnFailure = false } = options;
   const preferredPort = Number(getDashboardForwardPort(chatUiUrl));
   const existingForwards = runCaptureOpenshell(["forward", "list"], { ignoreError: true });
-  const actualPort = findAvailableDashboardPort(sandboxName, preferredPort, existingForwards);
+  let actualPort: number;
+  try {
+    actualPort = findAvailableDashboardPort(sandboxName, preferredPort, existingForwards);
+  } catch (err) {
+    if (!rollbackSandboxOnFailure) throw err;
+    const delResult = runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
+    console.error("");
+    console.error(`  Could not allocate a dashboard port for '${sandboxName}'.`);
+    console.error(`  ${err instanceof Error ? err.message : String(err)}`);
+    if (delResult.status === 0) {
+      console.error("  The orphaned sandbox has been removed — you can safely retry.");
+    } else {
+      console.error("  Could not remove the orphaned sandbox. Manual cleanup:");
+      console.error(`    openshell sandbox delete "${sandboxName}"`);
+    }
+    process.exit(1);
+  }
 
   if (actualPort !== preferredPort) {
     console.warn(`  ! Port ${preferredPort} is taken. Using port ${actualPort} instead.`);

--- a/test/onboard-rollback.test.ts
+++ b/test/onboard-rollback.test.ts
@@ -3,6 +3,12 @@
 
 import { describe, it, expect } from "vitest";
 
+// Internals are reached via require() (matching credential-rotation.test.ts,
+// gemini-probe-auth.test.ts, ssh-known-hosts.test.ts, wsl2-probe-timeout.test.ts):
+// dist/lib/onboard uses bottom-of-file `module.exports = {...}` instead of
+// per-function `export` keywords, and several tests rely on the d.ts staying
+// `unknown`-shaped so their runtime guards type-narrow correctly. Switching to
+// a named ESM import would break those neighbouring tests' narrowing.
 type OnboardRollbackInternals = {
   buildOrphanedSandboxRollbackMessage: (
     sandboxName: string,

--- a/test/onboard-rollback.test.ts
+++ b/test/onboard-rollback.test.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+
+type OnboardRollbackInternals = {
+  buildOrphanedSandboxRollbackMessage: (
+    sandboxName: string,
+    err: unknown,
+    deleteSucceeded: boolean,
+  ) => string[];
+};
+
+function isOnboardRollbackInternals(value: object | null): value is OnboardRollbackInternals {
+  return (
+    value !== null &&
+    typeof Reflect.get(value, "buildOrphanedSandboxRollbackMessage") === "function"
+  );
+}
+
+const loadedOnboardInternals = require("../dist/lib/onboard");
+const onboardInternals =
+  typeof loadedOnboardInternals === "object" && loadedOnboardInternals !== null
+    ? loadedOnboardInternals
+    : null;
+if (!isOnboardRollbackInternals(onboardInternals)) {
+  throw new Error("Expected onboard rollback internals to be available");
+}
+const { buildOrphanedSandboxRollbackMessage } = onboardInternals;
+
+describe("ghost-sandbox rollback message (#2174)", () => {
+  it("reports successful cleanup when delete returns 0", () => {
+    const lines = buildOrphanedSandboxRollbackMessage(
+      "alpha",
+      new Error("All dashboard ports in range 18789-18798 are occupied"),
+      true,
+    );
+    expect(lines[0]).toBe("");
+    expect(lines).toContain("  Could not allocate a dashboard port for 'alpha'.");
+    expect(lines).toContain(
+      "  All dashboard ports in range 18789-18798 are occupied",
+    );
+    expect(lines).toContain(
+      "  The orphaned sandbox has been removed — you can safely retry.",
+    );
+    expect(lines.some((l: string) => l.includes("Manual cleanup"))).toBeFalsy();
+  });
+
+  it("falls back to manual-cleanup guidance when delete fails", () => {
+    const lines = buildOrphanedSandboxRollbackMessage(
+      "beta",
+      new Error("range exhausted"),
+      false,
+    );
+    expect(lines).toContain("  Could not remove the orphaned sandbox. Manual cleanup:");
+    expect(lines).toContain('    openshell sandbox delete "beta"');
+    expect(
+      lines.some((l: string) => l.includes("orphaned sandbox has been removed")),
+    ).toBeFalsy();
+  });
+
+  it("renders non-Error throwables via String coercion", () => {
+    const lines = buildOrphanedSandboxRollbackMessage("gamma", "raw string failure", true);
+    expect(lines).toContain("  raw string failure");
+  });
+
+  it("escapes the sandbox name into the manual-cleanup command exactly", () => {
+    const lines = buildOrphanedSandboxRollbackMessage(
+      "weird-name_42",
+      new Error("oops"),
+      false,
+    );
+    expect(lines).toContain('    openshell sandbox delete "weird-name_42"');
+  });
+});


### PR DESCRIPTION
## Summary

Followup to #2411 (merged). Closes the second half of #2174's title — "leaks ghost sandbox" — that the merged fix didn't address.

When `findAvailableDashboardPort` exhausts the port range it `throw`s. By the time `ensureDashboardForward` runs (`src/lib/onboard.ts:3830`), the openshell sandbox has already been streamed into existence (`streamSandboxCreate` at line 3734, ready-wait at lines 3789–3803). The throw escapes unhandled, leaving the sandbox in `openshell sandbox list` with no NemoClaw registry entry — exactly the drift reported in #2174.

Issue comment with the analysis: https://github.com/NVIDIA/NemoClaw/issues/2174#issuecomment-4336937684

## Related Issue

Followup to #2174 (closed by #2411). #2411 fixed the crash; this PR fixes the leak.

## Changes

- `src/lib/onboard.ts` — `ensureDashboardForward` takes a new `{ rollbackSandboxOnFailure?: boolean }` option. On unrecoverable port-allocation failure (range exhaustion), the just-created openshell sandbox is deleted, an actionable error is printed, and the process exits with code 1 — mirroring the not-ready rollback pattern already in place at lines 3789–3803.
- The post-create call site (line 3830) opts in (`rollbackSandboxOnFailure: true`).
- The four reuse-path call sites (lines 3295, 3326, 3372, 3390) keep the default (`false`) — they operate on already-existing sandboxes where deleting on alloc failure would destroy user state.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npm run build:cli` + `npm run typecheck:cli` green
- [x] `npx vitest run --project cli` — 2250/2250 passed
- [x] `npx vitest run --project plugin` — 410/410 passed
- [x] `npx prek run --files src/lib/onboard.ts` — green
- [x] No new tests added: the rollback path mirrors the existing not-ready rollback (3789–3803), which also has no dedicated unit test. Adding test infrastructure here would exceed the minimum scope of this followup.
- [x] No secrets, API keys, or credentials committed

## Notes for reviewer

- Diff is ~35 lines on a single file. Surgical fix matching an existing pattern in the same function.
- Doc comment on `ensureDashboardForward` updated to describe the new option and reference the pattern it mirrors.

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox initialization now attempts automatic rollback if dashboard port allocation fails, and exits safely when rollback succeeds.
  * When automatic cleanup fails, users are shown clear manual-cleanup instructions and the exact command to remove the orphaned sandbox.

* **Tests**
  * Added runtime tests verifying rollback messaging covers both successful and failed cleanup scenarios and accurate sandbox naming in instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->