### PR TITLE
test(e2e): add cloudflared tunnel URL probe (HTTP + content)

### DIFF
--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -8,7 +8,9 @@
 #
 # Covers:
 #   TC-STATE-02: backup-workspace.sh backup → destroy → recreate → restore
-#   TC-DEPLOY-01: nemoclaw start/stop (cloudflared tunnel)
+#   TC-DEPLOY-01a: nemoclaw tunnel start (cloudflared tunnel)
+#   TC-DEPLOY-01b: tunnel URL serves the OpenClaw dashboard
+#   TC-DEPLOY-01c: nemoclaw tunnel stop removes URL from status
 #   TC-DEPLOY-03: nemoclaw uninstall --keep-openshell --yes
 #
 # Prerequisites:
@@ -285,64 +287,95 @@ test_state_02_backup_restore() {
 }
 
 # =============================================================================
-# TC-DEPLOY-01: nemoclaw start/stop (cloudflared tunnel)
+# TC-DEPLOY-01a: nemoclaw tunnel start (cloudflared tunnel)
+# TC-DEPLOY-01b: tunnel URL serves the OpenClaw dashboard
+# TC-DEPLOY-01c: nemoclaw tunnel stop removes tunnel URL from status
 # =============================================================================
 test_deploy_01_start_stop() {
-  log "=== TC-DEPLOY-01: Start/Stop Services ==="
+  log "=== TC-DEPLOY-01a/b/c: Start / Probe / Stop ==="
 
   if ! command -v cloudflared >/dev/null 2>&1; then
-    skip "TC-DEPLOY-01" "cloudflared not installed"
+    skip "TC-DEPLOY-01a / TC-DEPLOY-01b / TC-DEPLOY-01c" "cloudflared not installed"
     return
   fi
 
-  log "  Step 1: Running nemoclaw start..."
+  # ── TC-DEPLOY-01a: Start tunnel + verify URL surfaces ───────────────────────────────────
+  log "  Step 1: Running nemoclaw tunnel start..."
   local start_output
-  start_output=$(nemoclaw start 2>&1) || true
-  log "  Start output: ${start_output:0:400}"
+  start_output=$(nemoclaw tunnel start 2>&1) || true
+  log "  Start output: ${start_output}"
 
-  log "  Step 2: Polling nemoclaw status for tunnel URL (up to 30s)..."
-  local tunnel_url="" status_output=""
-  for i in $(seq 1 6); do
-    sleep 5
-    status_output=$(nemoclaw "$SANDBOX_NAME" status 2>&1) || true
-    tunnel_url=$(echo "$status_output" | grep -oE "https://[a-z0-9-]+\.trycloudflare\.com" | head -1) || true
-    if [[ -n "$tunnel_url" ]]; then
-      break
-    fi
-    log "  [$i] No tunnel URL yet, retrying..."
-  done
+  log "  Step 2: Reading nemoclaw status..."
+  sleep 5
+  local status_output tunnel_url
+  status_output=$(nemoclaw status 2>&1) || true
+  log "  Status output: $(echo "$status_output" | sed 's/^/    /')"
+  tunnel_url=$(echo "$status_output" | grep -oE "https://[a-z0-9-]+\.trycloudflare\.com" | head -1) || true
 
   if [[ -n "$tunnel_url" ]]; then
-    pass "TC-DEPLOY-01: Tunnel URL found in status ($tunnel_url)"
+    pass "TC-DEPLOY-01a: Tunnel URL found in status ($tunnel_url)"
   else
     local has_service
     has_service=$(echo "$start_output$status_output" | grep -i "cloudflared\|tunnel\|public\|services" || true)
     if [[ -n "$has_service" ]]; then
-      pass "TC-DEPLOY-01: Start command executed (tunnel URL not available — CI limitation)"
+      pass "TC-DEPLOY-01a: Start command executed (tunnel URL not available)"
     else
-      fail "TC-DEPLOY-01: Start" "No tunnel URL or service info in output"
+      fail "TC-DEPLOY-01a: Start" "No tunnel URL or service info in output"
       nemoclaw stop 2>/dev/null || true
       return
     fi
   fi
 
-  log "  Step 3: Running nemoclaw stop..."
+  # ── TC-DEPLOY-01b: Tunnel serves the OpenClaw dashboard ────────────────────────
+  if [[ -n "$tunnel_url" ]]; then
+    log "  Step 3: Probing tunnel URL (HTTP + content)..."
+    local http_code="000" body_file
+    body_file=$(mktemp)
+    for i in $(seq 1 6); do
+      http_code=$(curl -sS -o "$body_file" -w '%{http_code}' \
+        --max-time 10 "$tunnel_url" 2>/dev/null || echo "000")
+      if [[ "$http_code" == "200" ]]; then
+        break
+      fi
+      log "  [$i] Tunnel URL returned '$http_code', retrying in 5s..."
+      sleep 5
+    done
+
+    if [[ "$http_code" == "200" ]]; then
+      if grep -qE '<title>OpenClaw Control</title>|<openclaw-app' "$body_file"; then
+        pass "TC-DEPLOY-01b: Tunnel serves OpenClaw dashboard (HTTP 200, marker matched)"
+      else
+        fail "TC-DEPLOY-01b" "HTTP 200 but body lacks dashboard markers (first 200B: $(head -c 200 "$body_file" | tr -d '\n'))"
+      fi
+    else
+      fail "TC-DEPLOY-01b" "Tunnel URL returned unexpected status: $http_code"
+    fi
+    rm -f "$body_file"
+  else
+    skip "TC-DEPLOY-01b" "Tunnel URL not available"
+  fi
+
+  log "  Step 4: Running nemoclaw stop..."
   local stop_output
-  stop_output=$(nemoclaw stop 2>&1) || true
-  log "  Stop output: ${stop_output:0:200}"
+  stop_output=$(nemoclaw tunnel stop 2>&1) || true
+  log "  Tunnel stop output: $(echo "$stop_output" | sed 's/^/    /')"
 
   sleep 3
 
-  log "  Step 4: Verifying tunnel stopped..."
-  local post_status
-  post_status=$(nemoclaw "$SANDBOX_NAME" status 2>&1) || true
-  local post_url
-  post_url=$(echo "$post_status" | grep -oE "https://[a-z0-9-]+\.trycloudflare\.com" | head -1) || true
-
-  if [[ -z "$post_url" ]]; then
-    pass "TC-DEPLOY-01: Tunnel URL absent after stop"
+  # ── TC-DEPLOY-01c: Tunnel URL absent after stop ─────────────────────────────
+  log "  Step 5: Verifying tunnel stopped..."
+  if [[ -z "$tunnel_url" ]]; then
+    skip "TC-DEPLOY-01c" "Tunnel URL was never confirmed in status"
   else
-    fail "TC-DEPLOY-01: Stop" "Tunnel URL still present after stop ($post_url)"
+    local post_status post_url
+    post_status=$(nemoclaw status 2>&1) || true
+    post_url=$(echo "$post_status" | grep -oE "https://[a-z0-9-]+\.trycloudflare\.com" | head -1) || true
+
+    if [[ -z "$post_url" ]]; then
+      pass "TC-DEPLOY-01c: Tunnel URL absent after stop"
+    else
+      fail "TC-DEPLOY-01c: Stop" "Tunnel URL still present after stop ($post_url)"
+    fi
   fi
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds TC-DEPLOY-01b to `test-deployment-services.sh`: an HTTP + content probe of the cloudflared tunnel URL to catch the case where a tunnel publishes a public URL but the data plane never actually serves the OpenClaw dashboard. Also splits the existing TC-DEPLOY-01 into 01a/01b/01c.

## Related Issue
Closes #2636 

## Changes
- Split `test_deploy_01_start_stop()` into three sub-TCs:
  - **TC-DEPLOY-01a** — `nemoclaw tunnel start` surfaces a public URL in `status` (existing behavior, relabeled)
  - **TC-DEPLOY-01b** — *(new)* tunnel URL serves the OpenClaw dashboard
  - **TC-DEPLOY-01c** — `nemoclaw tunnel stop` removes URL from `status` (existing behavior, relabeled)
- New TC-DEPLOY-01b probe:
  - Strict HTTP 200 only
  - Body fingerprint: `<title>OpenClaw Control</title>` (verified-stable markers from a live probe)
- Replaced 6×5 s polling of `nemoclaw status` with a single 5 s wait + single status read (single source of truth, more readable)
- Gated TC-DEPLOY-01c on `tunnel_url` being confirmed in `status` so `post_url == ""` no longer false-PASSes when the URL was never present to begin with
- Updated file-header `Covers:` block and function-level comments to reflect the 01a/01b/01c split

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Hung Le <hple@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored deployment services end-to-end test with enhanced validation: tunnel start/stop operations, HTTP connectivity verification, and dashboard content accessibility checks now replace the previous verification approach for more reliable testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->