### PR TITLE
docs: add task-specific sub-agent model guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,9 +79,8 @@ Other useful flags:
 ### How the Script Works
 
 The script reads YAML frontmatter from each doc page to determine its content type (`how_to`, `concept`, `reference`, `get_started`), then groups pages into skills using the `smart` strategy by default.
-Procedure pages (`how_to`, `get_started`) become the main body of the skill.
-Concept pages become a `## Context` section.
-Reference pages go into a `references/` subdirectory for progressive disclosure, keeping the `SKILL.md` concise (under 500 lines).
+Within each group, the first procedure page (`how_to`, `get_started`, or `tutorial`) becomes the main body of the skill.
+Sibling procedure pages, concept pages, and reference pages go into a `references/` subdirectory for progressive disclosure, keeping `SKILL.md` concise while preserving access to the full docs.
 
 Cross-references between doc pages are rewritten as skill-to-skill pointers so agents can navigate between skills.
 MyST/Sphinx directives are converted to standard markdown.

--- a/docs/index.md
+++ b/docs/index.md
@@ -307,7 +307,7 @@ Quickstart <get-started/quickstart>
 Inference Options <inference/inference-options>
 Use Local Inference <inference/use-local-inference>
 Switch Inference Providers <inference/switch-inference-providers>
-Use a Task-Specific Sub-Agent Model <inference/use-sub-agent-model>
+Set Up Task-Specific Sub-Agents <inference/set-up-sub-agent>
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -307,6 +307,7 @@ Quickstart <get-started/quickstart>
 Inference Options <inference/inference-options>
 Use Local Inference <inference/use-local-inference>
 Switch Inference Providers <inference/switch-inference-providers>
+Use a Task-Specific Sub-Agent Model <inference/use-sub-agent-model>
 ```
 
 ```{toctree}

--- a/docs/inference/set-up-sub-agent.md
+++ b/docs/inference/set-up-sub-agent.md
@@ -1,7 +1,7 @@
 ---
 title:
-  page: "Use a Task-Specific Sub-Agent Model"
-  nav: "Sub-Agent Model"
+  page: "Set up a Task-Specific Sub-Agent"
+  nav: "Task-Specific Sub-Agent"
 description:
   main: "Where NemoClaw stores OpenClaw sub-agent model configuration, credentials, and workspace files inside the sandbox."
   agent: "Shows the NemoClaw-specific file paths and update flow for adding an auxiliary OpenClaw sub-agent model. Use when users ask how to add a second model, configure a sub-agent model, use Omni for vision tasks, configure agents.list, or use sessions_spawn in NemoClaw."
@@ -20,7 +20,7 @@ status: published
   SPDX-License-Identifier: Apache-2.0
 -->
 
-# Use a Task-Specific Sub-Agent Model
+# Set Up Task-Specific Sub-Agents
 
 OpenClaw documents the sub-agent behavior, `sessions_spawn` tool, `agents.list` configuration, tool policy, nesting, and auth model in [Sub-Agents](https://docs.openclaw.ai/tools/subagents).
 Use that page as the source of truth for how OpenClaw sub-agents work.

--- a/docs/inference/use-sub-agent-model.md
+++ b/docs/inference/use-sub-agent-model.md
@@ -1,0 +1,139 @@
+---
+title:
+  page: "Use a Task-Specific Sub-Agent Model"
+  nav: "Sub-Agent Model"
+description:
+  main: "Where NemoClaw stores OpenClaw sub-agent model configuration, credentials, and workspace files inside the sandbox."
+  agent: "Shows the NemoClaw-specific file paths and update flow for adding an auxiliary OpenClaw sub-agent model. Use when users ask how to add a second model, configure a sub-agent model, use Omni for vision tasks, configure agents.list, or use sessions_spawn in NemoClaw."
+keywords: ["nemoclaw additional model", "nemoclaw sub-agent model", "openclaw sub-agent", "agents.list", "sessions_spawn", "vlm-demo"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["nemoclaw", "openclaw", "inference", "sub-agent", "models"]
+content:
+  type: how_to
+  difficulty: technical_intermediate
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Use a Task-Specific Sub-Agent Model
+
+OpenClaw documents the sub-agent behavior, `sessions_spawn` tool, `agents.list` configuration, tool policy, nesting, and auth model in [Sub-Agents](https://docs.openclaw.ai/tools/subagents).
+Use that page as the source of truth for how OpenClaw sub-agents work.
+
+This NemoClaw page covers the sandbox-specific pieces: where the OpenClaw config lives, where to put per-agent credentials, which writable workspace path agents should use, and how the Omni VLM demo maps onto those paths.
+
+## NemoClaw Sandbox Paths
+
+NemoClaw runs OpenClaw inside an OpenShell sandbox.
+When adapting an OpenClaw sub-agent setup, use these paths inside the sandbox:
+
+| Path | Purpose |
+|---|---|
+| `/sandbox/.openclaw/openclaw.json` | OpenClaw config, including `models.providers`, `agents.defaults`, and `agents.list`. |
+| `/sandbox/.openclaw/.config-hash` | Integrity hash for `openclaw.json`. Refresh it after editing the config. |
+| `/sandbox/.openclaw-data/agents/<agent-id>/agent/auth-profiles.json` | Per-agent provider credentials. Use this when a sub-agent calls an auxiliary provider directly. |
+| `/sandbox/.openclaw-data/workspace/` | Writable shared workspace path for files the primary agent passes to the sub-agent. |
+| `/tmp/gateway.log` | OpenClaw gateway log. Use it to confirm config reloads and diagnose sub-agent failures. |
+
+For file-based tasks, instruct agents to use `/sandbox/.openclaw-data/workspace/`.
+Avoid relying on symlinked or read-only OpenClaw paths in delegation instructions.
+
+## Omni Vision Sub-Agent Example
+
+The [`vlm-demo`](https://github.com/brevdev/nemoclaw-demos/tree/main/vlm-demo) applies the OpenClaw sub-agent pattern to a vision task.
+It keeps the primary `main` agent on the normal NemoClaw inference route and adds a `vision-operator` sub-agent backed by an Omni vision model.
+
+| OpenClaw field | Omni example value |
+|---|---|
+| Primary agent | `main` |
+| Primary model | `inference/nvidia/nemotron-3-super-120b-a12b` |
+| Auxiliary provider | `nvidia-omni` |
+| Sub-agent | `vision-operator` |
+| Sub-agent model | `nvidia-omni/private/nvidia/nemotron-3-nano-omni-reasoning-30b-a3b` |
+| Delegation tool | `sessions_spawn` |
+
+Omni is used as the specialist model for image tasks.
+The primary orchestration model remains responsible for conversation, planning, and deciding when to delegate.
+
+## Update the Sandbox Config
+
+Fetch the current OpenClaw config from the sandbox, patch it with your auxiliary provider and `agents.list` changes, then upload it back.
+
+```console
+$ export SANDBOX=my-assistant
+$ export DOCKER_CTR=openshell-cluster-nemoclaw
+$ docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- cat /sandbox/.openclaw/openclaw.json > /tmp/openclaw.json
+```
+
+Create `/tmp/openclaw.updated.json` with the OpenClaw sub-agent config.
+For the Omni example, the demo provides `vlm-demo/vlm-subagent/openclaw-patch.py`.
+
+Upload the patched config and refresh the hash:
+
+```console
+$ docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chmod 644 /sandbox/.openclaw/openclaw.json
+$ docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chmod 644 /sandbox/.openclaw/.config-hash
+$ cat /tmp/openclaw.updated.json | docker exec -i "$DOCKER_CTR" kubectl exec -i -n openshell "$SANDBOX" -c agent -- sh -c 'cat > /sandbox/.openclaw/openclaw.json'
+$ docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- /bin/bash -c "cd /sandbox/.openclaw && sha256sum openclaw.json > .config-hash"
+$ docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chmod 444 /sandbox/.openclaw/openclaw.json
+$ docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chmod 444 /sandbox/.openclaw/.config-hash
+```
+
+Check `/tmp/gateway.log` after upload and confirm the gateway hot-reloaded the provider or `agents.list` change.
+
+## Add Sub-Agent Credentials
+
+If the auxiliary model uses a provider key outside the normal NemoClaw inference route, put that key in the sub-agent auth profile.
+For the Omni example:
+
+```text
+/sandbox/.openclaw-data/agents/vision-operator/agent/auth-profiles.json
+```
+
+Use the same provider ID that appears in `models.providers`, such as `nvidia-omni`.
+After uploading the auth profile, make sure the sub-agent directory is owned by the sandbox user:
+
+```console
+$ docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chown -R sandbox:sandbox /sandbox/.openclaw-data/agents/vision-operator
+```
+
+## Allow Auxiliary Provider Egress
+
+If the sub-agent calls a provider directly, update the OpenShell network policy for the binary that makes the request.
+In the Omni demo, the OpenClaw gateway runs as `/usr/local/bin/node`, so the NVIDIA endpoint policy must allow that binary.
+
+Refer to [Customize the Network Policy](../network-policy/customize-network-policy.md) for policy update workflows.
+
+## Add Delegation Instructions
+
+OpenClaw handles `sessions_spawn`, but the primary agent still needs task instructions.
+Place those instructions in the writable workspace, for example:
+
+```text
+/sandbox/.openclaw-data/workspace/TOOLS.md
+```
+
+The Omni demo includes `vlm-demo/vlm-subagent/TOOLS.md`, which tells `main` to delegate image tasks to `vision-operator` and tells the sub-agent to read the image path it receives.
+Adapt that file for other task-specific models.
+
+## Demo Assets
+
+Use the [`vlm-demo`](https://github.com/brevdev/nemoclaw-demos/tree/main/vlm-demo) repository for runnable Omni example assets:
+
+- `vlm-subagent-guide.md` for a command-by-command walkthrough.
+- `vlm-subagent/openclaw-patch.py` for patching `openclaw.json`.
+- `vlm-subagent/auth-profiles.template.json` for the sub-agent auth profile.
+- `vlm-subagent/TOOLS.md` for delegation instructions.
+
+## Next Steps
+
+Use the following resources for more information:
+
+- Refer to [OpenClaw Sub-Agents](https://docs.openclaw.ai/tools/subagents) for `sessions_spawn`, `agents.list`, nesting, tool policy, and auth behavior.
+- Refer to [Switch Inference Providers](switch-inference-providers.md) to change the primary orchestration model instead of adding a sub-agent model.
+- Refer to [Workspace Files](../workspace/workspace-files.md) to understand per-agent workspace directories.

--- a/docs/workspace/workspace-files.md
+++ b/docs/workspace/workspace-files.md
@@ -115,6 +115,6 @@ You can edit them in two ways:
 
 ## Next Steps
 
-- [Use a Task-Specific Sub-Agent Model](../inference/use-sub-agent-model.md)
+- [Set Up Task-Specific Sub-Agents](../inference/set-up-sub-agent.md)
 - [Backup and Restore workspace files](backup-restore.md)
 - [Commands reference](../reference/commands.md)

--- a/docs/workspace/workspace-files.md
+++ b/docs/workspace/workspace-files.md
@@ -115,5 +115,6 @@ You can edit them in two ways:
 
 ## Next Steps
 
+- [Use a Task-Specific Sub-Agent Model](../inference/use-sub-agent-model.md)
 - [Backup and Restore workspace files](backup-restore.md)
 - [Commands reference](../reference/commands.md)

--- a/scripts/docs-to-skills.py
+++ b/scripts/docs-to-skills.py
@@ -19,19 +19,20 @@ What it does:
   2. Classifies each page by content type (how_to, concept, reference,
      get_started) using the frontmatter `content.type` field.
   3. Groups pages into skills using one of three strategies:
-       - smart (default): groups by directory; concept and reference pages
-         in the same directory ride along as reference files next to any
-         procedure pages.
+       - smart (default): groups by directory; one primary procedure page
+         becomes the main SKILL.md body, while sibling procedure, concept,
+         and reference pages ride along as reference files.
        - grouped: groups all pages in the same parent directory.
        - individual: each doc page becomes its own skill.
   4. Generates a skill directory per group containing:
        - SKILL.md with frontmatter (name, description), prerequisites,
-         procedural steps, a References section that links to the full
-         concept/reference files, and a Related Skills section. Concept
-         and reference bodies are not inlined, so SKILL.md stays small
-         and nothing is truncated mid-table or mid-code-fence.
-       - references/ with the full concept and reference content for
-         progressive disclosure (loaded by the agent on demand).
+         procedural steps for the primary procedure page, a References
+         section that links to sibling pages, and a Related Skills section.
+         Sibling procedure, concept, and reference bodies are not inlined,
+         so SKILL.md stays small and nothing is truncated mid-table or
+         mid-code-fence.
+       - references/ with the full sibling procedure, concept, and reference
+         content for progressive disclosure (loaded by the agent on demand).
   5. Resolves all relative doc paths to repo-root-relative paths, and
      converts cross-references between docs into skill-to-skill pointers
      so agents can navigate between skills.
@@ -1080,6 +1081,37 @@ def markdown_spdx_header() -> str:
     )
 
 
+def partition_skill_pages(
+    pages: list[DocPage],
+) -> tuple[list[DocPage], list[DocPage], list[DocPage], list[DocPage]]:
+    """Split a doc group into inline procedures and deferred references.
+
+    The converter preserves the existing one-skill-per-docs-area grouping, but
+    keeps SKILL.md focused by inlining only one primary procedure. Additional
+    how-to/tutorial pages still contribute triggers through the skill
+    description and are written to references/ for progressive disclosure.
+    """
+    procedures = [
+        p for p in pages if CONTENT_TYPE_ROLE.get(p.content_type) == "procedure"
+    ]
+    # Pages without a recognized content_type default to procedure.
+    procedures.extend([p for p in pages if p.content_type not in CONTENT_TYPE_ROLE])
+
+    context_pages = [
+        p for p in pages if CONTENT_TYPE_ROLE.get(p.content_type) == "context"
+    ]
+    reference_pages = [
+        p for p in pages if CONTENT_TYPE_ROLE.get(p.content_type) == "reference"
+    ]
+
+    if not procedures:
+        return [], [], context_pages, reference_pages
+
+    primary = [procedures[0]]
+    deferred = procedures[1:]
+    return primary, deferred, context_pages, reference_pages
+
+
 def generate_skill(
     name: str,
     pages: list[DocPage],
@@ -1100,8 +1132,6 @@ def generate_skill(
 
     Returns a summary dict for reporting.
     """
-    description = build_skill_description(name, pages)
-
     def _clean(text: str, source: DocPage) -> str:
         """Apply directive cleanup and path rewriting for a source page."""
         result = clean_myst_directives(text)
@@ -1115,19 +1145,15 @@ def generate_skill(
             )
         return result
 
-    procedures = [
-        p for p in pages if CONTENT_TYPE_ROLE.get(p.content_type) == "procedure"
-    ]
-    context_pages = [
-        p for p in pages if CONTENT_TYPE_ROLE.get(p.content_type) == "context"
-    ]
-    reference_pages = [
-        p for p in pages if CONTENT_TYPE_ROLE.get(p.content_type) == "reference"
-    ]
-
-    # Pages without a recognized content_type default to procedure
-    untyped = [p for p in pages if p.content_type not in CONTENT_TYPE_ROLE]
-    procedures.extend(untyped)
+    procedures, deferred_procedures, context_pages, reference_pages = (
+        partition_skill_pages(pages)
+    )
+    description_pages = (
+        procedures + deferred_procedures + context_pages + reference_pages
+        if procedures
+        else pages
+    )
+    description = build_skill_description(name, description_pages)
 
     # Build SKILL.md content
     lines: list[str] = []
@@ -1144,8 +1170,9 @@ def generate_skill(
     # Title — prefer the lead page's frontmatter `title.page` (or H1)
     # verbatim so the SKILL.md heading matches the source doc instead of
     # echoing the auto-generated, prefix-laden skill name.
-    if pages and pages[0].title:
-        skill_title = pages[0].title
+    lead_page = procedures[0] if procedures else pages[0] if pages else None
+    if lead_page and lead_page.title:
+        skill_title = lead_page.title
     else:
         skill_title = _brand_case(name.replace("-", " ").title())
     lines.append(f"# {skill_title}")
@@ -1249,7 +1276,7 @@ def generate_skill(
     # trigger from description.agent (the "Use when ..." clause) so the
     # agent can decide on-sight whether to load the file, which is how
     # progressive disclosure is supposed to work.
-    ref_section_pages = context_pages + reference_pages
+    ref_section_pages = deferred_procedures + context_pages + reference_pages
     if ref_section_pages:
         lines.append("")
         lines.append("## References")
@@ -1280,7 +1307,7 @@ def generate_skill(
 
     # --- Build reference files ---
     ref_files: dict[str, str] = {}
-    for rp in reference_pages + context_pages:
+    for rp in deferred_procedures + reference_pages + context_pages:
         ref_name = rp.path.stem + ".md"
         body = normalize_heading_levels(_clean(rp.body, rp))
         ref_files[ref_name] = body
@@ -1339,12 +1366,12 @@ def group_individual(pages: list[DocPage]) -> dict[str, list[DocPage]]:
 
 
 def group_by_content_type(pages: list[DocPage]) -> dict[str, list[DocPage]]:
-    """Group pages by content type, merging concept+how_to for same topic."""
+    """Group pages by directory when an area has procedural content."""
     # First pass: group by directory
     dir_groups = group_by_directory(pages)
 
-    # Second pass: within each directory, merge concept pages as context
-    # for procedure pages in the same directory
+    # Second pass: keep each procedural docs area together. generate_skill()
+    # decides which page to inline and which sibling pages to defer.
     result: dict[str, list[DocPage]] = {}
     for cat, group_pages in dir_groups.items():
         has_procedures = any(
@@ -1426,9 +1453,9 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent("""\
             Strategies:
-              grouped     Group docs by parent directory (default)
+              grouped     Group docs by parent directory
               individual  Each doc page becomes its own skill
-              smart       Group by directory, merge concept pages as context
+              smart       Group by directory, inline one procedure, defer siblings
 
             Examples:
               %(prog)s docs/ .agents/skills/ --prefix nemoclaw-user


### PR DESCRIPTION
## Summary
Adds a NemoClaw how-to for configuring a task-specific OpenClaw sub-agent model inside the sandbox, using Omni as the vision example while keeping OpenClaw's sub-agent docs as the source of truth. Updates docs-to-skills conversion so sibling how-to pages become progressive-disclosure references instead of bloating the primary SKILL.md.

New doc page preview: https://nvidia.github.io/NemoClaw/pr-preview/pr-2648/inference/set-up-sub-agent.html

## Changes
- Added `docs/inference/use-sub-agent-model.md` with NemoClaw sandbox paths, config update flow, Omni sub-agent example, and demo links.
- Added the new guide to the inference navigation and workspace next steps.
- Updated `scripts/docs-to-skills.py` to inline one primary procedure page per skill and defer sibling procedures into `references/`.
- Updated `docs/CONTRIBUTING.md` to describe the revised docs-to-skills behavior.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [x] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Codex

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new page describing how to set up task-specific sub-agents.
  * Updated docs navigation with a “Set Up Task-Specific Sub-Agents” link and added a “Next Steps” pointer from related pages.
  * Revised doc-to-skill guidance so one primary procedure is inlined in generated skill pages while related procedure, concept, and reference content is consolidated into a deferred references area for progressive disclosure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->