### PR TITLE
docs: refresh daily docs for 0.0.29

### DIFF
--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -132,6 +132,7 @@ $ nemoclaw onboard
 ```
 
 These values are baked into the sandbox image at build time.
+They are also forwarded into the runtime container during sandbox creation, so `/tmp/nemoclaw-proxy-env.sh` uses the same host and port that the image build used.
 Only alphanumeric characters, dots, hyphens, and colons are accepted for the host.
 The port must be numeric (0-65535).
 Changing the proxy after onboarding requires re-running `nemoclaw onboard`.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -276,16 +276,24 @@ openshell forward list
 
 ### Run Multiple Sandboxes
 
-Each sandbox needs its own dashboard port, since `openshell forward` refuses to bind a port that another sandbox is already using. Override the port with `CHAT_UI_URL` at onboard time — the dashboard port is derived automatically.
+Each sandbox needs its own dashboard port, since `openshell forward` refuses to bind a port that another sandbox is already using.
+When the default port is already held by another sandbox, `nemoclaw onboard` scans ports `18789` through `18799` and uses the next free port.
 
 ```console
 $ nemoclaw onboard                                            # first sandbox uses 18789
-$ CHAT_UI_URL=http://127.0.0.1:19000 nemoclaw onboard         # second sandbox uses 19000
+$ nemoclaw onboard                                            # second sandbox uses the next free port
 ```
 
-You can also use `NEMOCLAW_DASHBOARD_PORT` directly if you prefer:
+To choose a specific port, pass `--control-ui-port`:
 
 ```console
+$ nemoclaw onboard --control-ui-port 19000
+```
+
+You can also set `CHAT_UI_URL` or `NEMOCLAW_DASHBOARD_PORT` before onboarding:
+
+```console
+$ CHAT_UI_URL=http://127.0.0.1:19000 nemoclaw onboard
 $ NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard
 ```
 

--- a/docs/inference/inference-options.md
+++ b/docs/inference/inference-options.md
@@ -34,6 +34,8 @@ OpenShell intercepts inference traffic on the host and forwards it to the provid
 
 Provider credentials stay on the host.
 The sandbox does not receive your API key.
+Local Ollama and local vLLM do not require your host `OPENAI_API_KEY`.
+NemoClaw uses provider-specific local tokens for those routes, and rebuilds of legacy local-inference sandboxes migrate away from stale OpenAI credential requirements.
 
 ## Provider Status
 
@@ -108,6 +110,7 @@ Other provider credentials, such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMI
 | Anthropic-compatible | Tries `/v1/messages`. |
 | NVIDIA Endpoints (manual model entry) | Validates the model name against the catalog API. |
 | Compatible endpoints | Sends a real inference request because many proxies do not expose a `/models` endpoint. For OpenAI-compatible endpoints, the probe includes tool calling before NemoClaw favors `/responses`. |
+| Local NVIDIA NIM | Uses the same validation behavior as NVIDIA Endpoints and skips the `/v1/responses` probe for endpoints that do not expose it. |
 
 ## Next Steps
 

--- a/docs/inference/switch-inference-providers.md
+++ b/docs/inference/switch-inference-providers.md
@@ -192,6 +192,7 @@ The output includes the active provider, model, and endpoint.
 - Same-provider model switches take effect immediately via the gateway route alone.
 - Cross-provider switches also require `NEMOCLAW_MODEL_OVERRIDE` (and `NEMOCLAW_INFERENCE_API_OVERRIDE`) plus a sandbox recreate so the entrypoint patches the config at startup.
 - Overrides are applied at container startup. Changing or removing env vars requires a sandbox recreate to take effect.
+- Local Ollama and local vLLM routes use local provider tokens rather than `OPENAI_API_KEY`. Rebuilds of older local-inference sandboxes clear the stale OpenAI credential requirement automatically.
 
 ## Related Topics
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -134,6 +134,10 @@ Uppercase letters are automatically lowercased.
 Names that match global CLI commands (`status`, `list`, `debug`, etc.) are rejected to avoid routing conflicts.
 Use `--agent <name>` to target a specific installed agent profile during onboarding.
 
+Use `--control-ui-port <N>` to choose the host dashboard port for a sandbox.
+The value must be an integer from `1024` through `65535`.
+This flag takes precedence over `CHAT_UI_URL`, `NEMOCLAW_DASHBOARD_PORT`, the previous registry value, and the default port.
+
 If you enable Slack during onboarding, the wizard collects both the Bot Token (`SLACK_BOT_TOKEN`) and the App-Level Token (`SLACK_APP_TOKEN`).
 Socket Mode requires both tokens.
 The app-level token is stored in a dedicated `slack-app` OpenShell provider and forwarded to the sandbox alongside the bot token.
@@ -211,6 +215,7 @@ $ nemoclaw onboard --from ./Dockerfile.custom
 
 List all registered sandboxes with their model, provider, and policy presets.
 Sandboxes with an active SSH session are marked with a `●` indicator so you can tell at a glance which sandbox you are already connected to in another terminal.
+When a sandbox has a recorded dashboard port, the output includes its local dashboard URL.
 
 ```console
 $ nemoclaw list
@@ -265,8 +270,10 @@ The command probes every inference provider and reports one of three states on t
 Local providers (Ollama, vLLM) probe the host-side health endpoint.
 Remote providers (NVIDIA Endpoints, OpenAI, Anthropic, Gemini) use a lightweight reachability check; any HTTP response, including `401` or `403`, counts as reachable.
 No API keys are sent.
+For cloud-only providers, the output omits the NIM status line unless a NIM container is registered or an unexpected NIM container is running.
 
 A `Connected` line reports whether the sandbox has any active SSH sessions and, if so, how many.
+The sandbox list in the status output includes the dashboard port suffix for sandboxes with a recorded dashboard port.
 
 The Policy section displays the live enforced policy (fetched via `openshell policy get --full`), which reflects presets added or removed after sandbox creation.
 If the sandbox is running an outdated agent version, the output includes an `Update` line with the available version and a `nemoclaw <name> rebuild` hint.
@@ -490,6 +497,8 @@ $ nemoclaw my-assistant skill install ./my-skill/
 The skill directory must contain a `SKILL.md` file with YAML frontmatter that includes a `name` field.
 Skill names must contain only alphanumeric characters, dots, hyphens, and underscores.
 OpenClaw plugins are a different kind of extension. To install an OpenClaw plugin, see [Install OpenClaw Plugins](../deployment/install-openclaw-plugins.md).
+Run `nemoclaw <name> skill install --help` to print usage for this subcommand.
+If you pass a plugin-shaped directory to `skill install`, the CLI prints a plugin-specific hint instead of treating it as a missing skill file.
 
 Files with names starting with `.` (dotfiles) are skipped and listed in the output.
 Files with unsafe path characters are rejected to prevent shell injection.
@@ -806,6 +815,8 @@ $ nemoclaw onboard
 
 These overrides apply to onboarding, status checks, health probes, and the uninstaller.
 Defaults are unchanged when no variable is set.
+If `NEMOCLAW_DASHBOARD_PORT` or the port from `CHAT_UI_URL` is already occupied by another sandbox, onboarding scans `18789` through `18799` and uses the next free dashboard port.
+Pass `--control-ui-port <N>` to require a specific port.
 
 ### Legacy `nemoclaw setup`
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -160,8 +160,10 @@ When the lookup returns an answer, retry onboarding.
 ### Port already in use
 
 The NemoClaw dashboard uses port `18789` by default and the gateway uses port `8080`.
-If another process is already bound to one of these ports, onboarding fails.
-Identify the conflicting process, verify it is safe to stop, and terminate it:
+If another sandbox already owns the dashboard port, onboarding scans ports `18789` through `18799` and uses the next free port.
+If all ports in that range are occupied, the error lists the owner for each port and suggests using `--control-ui-port` with a port outside the range.
+
+If a non-NemoClaw process is already bound to the dashboard port or the gateway port, identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```console
 $ sudo lsof -i :18789
@@ -172,7 +174,13 @@ If the process does not exit, use `kill -9 <PID>` to force-terminate it.
 Then retry onboarding.
 
 Alternatively, override the conflicting port instead of stopping the other process.
-Set `CHAT_UI_URL` with the desired port — the dashboard port is derived automatically:
+Pass `--control-ui-port` with the desired dashboard port:
+
+```console
+$ nemoclaw onboard --control-ui-port 19000
+```
+
+You can also set `CHAT_UI_URL` with the desired port:
 
 ```console
 $ CHAT_UI_URL=http://127.0.0.1:19000 nemoclaw onboard
@@ -189,15 +197,15 @@ See [Environment Variables](commands.md#environment-variables) for the full list
 ### Running multiple sandboxes simultaneously
 
 Each sandbox requires its own dashboard port.
-If you onboard a second sandbox without overriding the port, onboarding fails with a clear error because port `18789` is already forwarded to the first sandbox.
+If you onboard a second sandbox without overriding the port, onboarding uses the next free port in the `18789` to `18799` range.
 `onboard` checks `openshell forward list` before starting a new forward, so a second onboard cannot silently take over the first sandbox's port.
 
-Assign a distinct port to each sandbox at onboard time.
-Set `CHAT_UI_URL` with the desired port — the dashboard port is derived automatically:
+Assign a distinct port only when you want a specific value:
 
 ```console
-$ nemoclaw onboard                                                   # first sandbox — uses default 18789
-$ CHAT_UI_URL=http://127.0.0.1:19000 nemoclaw onboard               # second sandbox — uses 19000
+$ nemoclaw onboard                                                   # first sandbox uses default 18789
+$ nemoclaw onboard                                                   # second sandbox uses the next free port
+$ nemoclaw onboard --control-ui-port 19000                          # explicit port override
 ```
 
 Each sandbox then has its own SSH tunnel and its own dashboard URL:
@@ -211,7 +219,10 @@ You can verify which tunnel belongs to which sandbox with:
 
 ```console
 $ openshell forward list
+$ nemoclaw list
 ```
+
+`nemoclaw list` prints the recorded dashboard URL for each sandbox.
 
 ## Onboarding
 

--- a/docs/workspace/backup-restore.md
+++ b/docs/workspace/backup-restore.md
@@ -61,6 +61,8 @@ $ nemoclaw my-assistant snapshot restore 2026-04-14T
 ```
 
 The `nemoclaw <name> rebuild` command uses the same snapshot mechanism automatically.
+Snapshot restore accepts symlinks that resolve to NemoClaw-managed sandbox data paths such as `/sandbox/.openclaw-data/`.
+Symlinks that point outside the known sandbox data paths are still rejected during extraction.
 For full details, see the [Commands reference](../reference/commands.md).
 
 ## Manual Backup


### PR DESCRIPTION
## Summary
Refreshes the 0.0.29 documentation for user-facing changes merged in the past 24 hours. Version metadata stays on `0.0.29`.

## Changes
- `docs/get-started/quickstart.md`, `docs/reference/commands.md`, and `docs/reference/troubleshooting.md`: Document dashboard port auto-allocation, `--control-ui-port`, and `nemoclaw list` dashboard URL output from [#2411](https://github.com/NVIDIA/NemoClaw/pull/2411).
- `docs/inference/inference-options.md` and `docs/inference/switch-inference-providers.md`: Document local Ollama and local vLLM credential isolation from `OPENAI_API_KEY` from [#2580](https://github.com/NVIDIA/NemoClaw/pull/2580).
- `docs/inference/inference-options.md`: Document Local NVIDIA NIM validation behavior from [#2505](https://github.com/NVIDIA/NemoClaw/pull/2505).
- `docs/reference/commands.md`: Document the cloud-only NIM status display behavior from [#2622](https://github.com/NVIDIA/NemoClaw/pull/2622).
- `docs/deployment/deploy-to-remote-gpu.md`: Clarify runtime propagation for `NEMOCLAW_PROXY_HOST` and `NEMOCLAW_PROXY_PORT` from [#2581](https://github.com/NVIDIA/NemoClaw/pull/2581).
- `docs/workspace/backup-restore.md`: Document snapshot restore symlink handling for sandbox data paths from [#2488](https://github.com/NVIDIA/NemoClaw/pull/2488).
- `docs/reference/commands.md`: Document `skill install --help` and OpenClaw plugin-shaped directory guidance from [#2585](https://github.com/NVIDIA/NemoClaw/pull/2585).

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Codex

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `--control-ui-port` flag for explicit dashboard port control
  * Implemented automatic port selection (18789–18799) when the default port is occupied
  * Clarified that local inference routes (Ollama, local vLLM) don't require `OPENAI_API_KEY`
  * Improved dashboard URL display in list and status commands
  * Enhanced symlink handling in workspace backup restoration
  * Updated multi-sandbox quickstart and troubleshooting guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->