### PR TITLE
fix(policy): allow inference.local in base sandbox policy

### DIFF
--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -140,6 +140,30 @@ network_policies:
       - { path: /usr/local/bin/claude }
       - { path: /usr/local/bin/openclaw }
 
+  # ── Managed inference route ──────────────────────────────────────────
+  # inference.local is the OpenShell gateway's internal virtual hostname;
+  # the gateway proxies it to the configured provider (OpenAI, NVIDIA, etc.).
+  # Every sandbox uses this route regardless of provider, so it belongs in
+  # the base policy rather than an optional preset.
+  # Ref: https://github.com/NVIDIA/NemoClaw/issues/2663
+  managed_inference:
+    name: managed_inference
+    endpoints:
+      - host: inference.local
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/claude }
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+      - { path: /usr/bin/curl }
+      - { path: /usr/bin/python3 }
+
   # NOTE: github.com / api.github.com and the git/gh binaries used to
   # live in this base policy and were therefore granted to every
   # sandbox regardless of user opt-in. They have been moved into a

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -319,13 +319,15 @@ describe("base sandbox policy", () => {
 
   it("regression #2663: managed_inference allows openclaw, claude, and tool binaries", () => {
     const np = policy.network_policies ?? {};
-    const binaries = (np.managed_inference?.binaries ?? []).map((b) => b.path);
-    expect(binaries).toContain("/usr/local/bin/openclaw");
-    expect(binaries).toContain("/usr/local/bin/claude");
-    expect(binaries).toContain("/usr/local/bin/node");
-    expect(binaries).toContain("/usr/bin/node");
-    expect(binaries).toContain("/usr/bin/curl");
-    expect(binaries).toContain("/usr/bin/python3");
+    const binaries = (np.managed_inference?.binaries ?? []).map((b) => b.path).sort();
+    expect(binaries).toEqual([
+      "/usr/bin/curl",
+      "/usr/bin/node",
+      "/usr/bin/python3",
+      "/usr/local/bin/claude",
+      "/usr/local/bin/node",
+      "/usr/local/bin/openclaw",
+    ]);
   });
 
   it("regression #1458: baseline npm_registry must not include npm or node binaries", () => {

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -293,6 +293,41 @@ describe("base sandbox policy", () => {
     expect(githubHosts).toEqual([]);
   });
 
+  it("regression #2663: managed_inference policy allows inference.local:443 GET and POST", () => {
+    // inference.local is the OpenShell gateway's managed inference virtual
+    // hostname — the gateway proxies it to the configured provider (OpenAI,
+    // NVIDIA, etc.). Every sandbox uses this route regardless of provider.
+    // Without this entry the OpenShell proxy blocks url-fetch calls to
+    // https://inference.local/v1/... with "Blocked hostname or
+    // private/internal/special-use IP address", breaking all inference.
+    const np = policy.network_policies ?? {};
+    expect(np.managed_inference).toBeDefined();
+    const endpoints = np.managed_inference?.endpoints ?? [];
+    const inferenceEp = endpoints.find((ep) => ep.host === "inference.local");
+    expect(inferenceEp).toBeDefined();
+    expect(inferenceEp?.port).toBe(443);
+    const rules = inferenceEp?.rules ?? [];
+    const hasGet = rules.some(
+      (r) => r.allow?.method?.toUpperCase() === "GET" && r.allow?.path === "/**",
+    );
+    const hasPost = rules.some(
+      (r) => r.allow?.method?.toUpperCase() === "POST" && r.allow?.path === "/**",
+    );
+    expect(hasGet).toBe(true);
+    expect(hasPost).toBe(true);
+  });
+
+  it("regression #2663: managed_inference allows openclaw, claude, and tool binaries", () => {
+    const np = policy.network_policies ?? {};
+    const binaries = (np.managed_inference?.binaries ?? []).map((b) => b.path);
+    expect(binaries).toContain("/usr/local/bin/openclaw");
+    expect(binaries).toContain("/usr/local/bin/claude");
+    expect(binaries).toContain("/usr/local/bin/node");
+    expect(binaries).toContain("/usr/bin/node");
+    expect(binaries).toContain("/usr/bin/curl");
+    expect(binaries).toContain("/usr/bin/python3");
+  });
+
   it("regression #1458: baseline npm_registry must not include npm or node binaries", () => {
     const np = policy.network_policies ?? {};
     const npmRegistry = np.npm_registry;


### PR DESCRIPTION
## Summary

Fixes #2663 — users get "Connection error" when chatting with any provider (OpenAI, NVIDIA, Anthropic, etc.) because the sandbox blocks every inference call.

- `inference.local` is the OpenShell gateway's managed inference virtual hostname; the gateway proxies it to the configured provider
- The `.local` TLD is in the SSRF blocked-names list (RFC 6762 mDNS), so the OpenShell proxy rejects all outbound connections to `https://inference.local/v1/...`, logging `[security] blocked URL fetch (url-fetch) ... reason=Blocked hostname or private/internal/special-use IP address`
- The `local-inference` preset already allows `host.openshell.internal` for Ollama/vLLM, but the managed inference route was never added to any policy
- Since every sandbox uses `inference.local` regardless of provider, the fix belongs in the base `openclaw-sandbox.yaml` policy (not an optional preset)

## Security considerations

`inference.local` is not a real public hostname — it only resolves inside the sandbox's isolated network namespace where OpenShell controls DNS. The gateway owns what it points to (the configured inference provider) and is already a trust boundary: it authenticates the API key, rate-limits, and only routes to the one provider configured at onboard time. The risk profile is identical to the existing `integrate.api.nvidia.com` entries already in the base policy.

## Changes

- `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`: add `managed_inference` network policy block allowing `inference.local:443` GET+POST for openclaw, claude, node, curl, and python3
- `test/validate-blueprint.test.ts`: two regression tests (exact binary allowlist) that fail on the unfixed YAML and pass with the fix

## Test plan

- [ ] Run `nemoclaw onboard` selecting OpenAI — confirm chat works without "Connection error"
- [ ] Run `nemoclaw onboard` selecting NVIDIA Endpoints — confirm inference calls succeed
- [ ] Run `nemoclaw onboard` selecting Anthropic — confirm inference calls succeed
- [ ] `npx vitest run test/validate-blueprint.test.ts` passes (36 tests, including 2 new regressions)
- [ ] Confirm existing `local-inference` preset (Ollama/vLLM) still works independently

---

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)