### PR TITLE
fix(e2e): increase double-onboard script-level timeout from 900s to 4800s

### DIFF
--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -15,7 +15,10 @@
 
 set -uo pipefail
 
-export NEMOCLAW_E2E_DEFAULT_TIMEOUT=900
+# Three sequential sandbox creations (~5-7 min each) plus cleanup phases need
+# well over the default 900s.  80 min leaves a 10 min buffer under the 90-min
+# CI job timeout.
+export NEMOCLAW_E2E_DEFAULT_TIMEOUT=4800
 SCRIPT_DIR_TIMEOUT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=test/e2e/e2e-timeout.sh
 source "${SCRIPT_DIR_TIMEOUT}/e2e-timeout.sh"


### PR DESCRIPTION
## Summary

Follow-up to #2658 — the script-level self-wrap timeout (`NEMOCLAW_E2E_DEFAULT_TIMEOUT`) of 900s (15 min) is far too tight for `test-double-onboard.sh`, which runs three sequential sandbox creations that each take 5-7 minutes on CI. Phase 4 was being killed by the script timeout (exit 124) before the per-phase timeout could fire. This commit was pushed to #2658 after it was already merged.

## Related Issue

Fixes #2654

## Changes

- **`test/e2e/test-double-onboard.sh`**: Increase `NEMOCLAW_E2E_DEFAULT_TIMEOUT` from 900s to 4800s (80 min), leaving a 10-min buffer under the 90-min CI job timeout

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Verified via nightly-e2e workflow_dispatch run 25090813418 — double-onboard-e2e passed 33/33 with this change
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude (pi agent)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended E2E test timeout to improve reliability for complex test scenarios requiring extended execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->