### PR TITLE
fix(policy): ignore dotfile presets from directories

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2116,9 +2116,9 @@ function buildSandboxLogsArgs(sandboxName: string, follow: boolean): string[] {
  * for a single custom preset YAML, and `--from-dir <path>` for every
  * `.yaml`/`.yml` file in a directory. `--dry-run` previews without applying,
  * `--yes`/`-y`/`--force` (or `NEMOCLAW_NON_INTERACTIVE=1`) skips the
- * confirmation prompt. `--from-dir` applies files in lexicographic order
- * and aborts at the first failure (already-applied presets are not rolled
- * back).
+ * confirmation prompt. `--from-dir` applies non-hidden files in lexicographic
+ * order and aborts at the first failure (already-applied presets are not
+ * rolled back).
  */
 async function sandboxPolicyAdd(sandboxName: string, args: string[] = []): Promise<void> {
   const dryRun = args.includes("--dry-run");
@@ -2161,7 +2161,8 @@ async function sandboxPolicyAdd(sandboxName: string, args: string[] = []): Promi
     const files = fs
       .readdirSync(absDir, { withFileTypes: true })
       .filter(
-        (ent: { name: string; isFile(): boolean }) => ent.isFile() && /\.ya?ml$/i.test(ent.name),
+        (ent: { name: string; isFile(): boolean }) =>
+          ent.isFile() && !ent.name.startsWith(".") && /\.ya?ml$/i.test(ent.name),
       )
       .map((ent: { name: string }) => path.join(absDir, ent.name))
       .sort();

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1475,6 +1475,21 @@ setImmediate(() => {
       expect(result.stderr).toMatch(/Aborting --from-dir/);
     });
 
+    it("--from-dir skips hidden dotfile yaml presets", () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-from-dir-hidden-"));
+      fs.writeFileSync(
+        path.join(dir, ".bad.yaml"),
+        "preset:\n  name: bad\nnetwork_policies: {}\n",
+      );
+      fs.writeFileSync(path.join(dir, "real.yaml"), "preset:\n  name: real\nnetwork_policies: {}\n");
+      const result = runPolicyAddExternal(["--from-dir", dir, "--yes"]);
+      expect(result.status).toBe(0);
+      const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim()) as PolicyCall[];
+      const loads = calls.filter((c) => c.type === "load").map((c) => c.path);
+      expect(loads.length).toBe(1);
+      expect(loads[0]).toMatch(/real\.yaml$/);
+    });
+
     it("errors when --from-dir points at a non-directory", () => {
       const result = runPolicyAddExternal(["--from-dir", "/does/not/exist"]);
       expect(result.status).not.toBe(0);


### PR DESCRIPTION
Replays the approved functional change from @WuKongAI-CMU in #2525 onto current main.

Original PR:
- #2525 by @WuKongAI-CMU

Behavior:
- `policy-add --from-dir` ignores hidden dotfile YAML entries while still applying non-hidden `.yaml`/`.yml` files in lexicographic order.
- Explicit `policy-add --from-file .hidden.yaml` behavior is unchanged because the `--from-file` path is not filtered.

Replacement rationale:
- #2525 was already approved but is currently blocked by branch/process state.
- This PR carries the same functional change forward on a clean replay branch so it can be validated and merged without waiting on the original branch update.

Validation:
- `git diff --check` passed.
- `npm test -- test/policies.test.ts -t="--from-dir skips hidden dotfile yaml presets"` passed after installing dependencies and rebuilding the CLI.
- GitHub checks are being monitored before merge.