### PR TITLE
fix(snapshot): replace openshell sandbox list gateway probe with dock…

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -189,6 +189,19 @@ function hasNoLiveSandboxes() {
   return parseLiveSandboxNames(liveList.output).size === 0;
 }
 
+// Returns true only when the openshell-cluster gateway Docker container is
+// actually running. `openshell sandbox list` reads local state and exits 0
+// even when the container is stopped, so it cannot be used as a gateway-alive
+// probe. docker inspect is the authoritative source. See #2673.
+function isGatewayContainerRunning(): boolean {
+  const container = `openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`;
+  const result = dockerCapture(
+    ["inspect", "--type", "container", "--format", "{{.State.Running}}", container],
+    { ignoreError: true },
+  );
+  return result.status === 0 && String(result.output || "").trim() === "true";
+}
+
 function isMissingSandboxDeleteResult(output = ""): boolean {
   return /\bNotFound\b|\bNot Found\b|sandbox not found|sandbox .* not found|sandbox .* not present|sandbox does not exist|no such sandbox/i.test(
     stripAnsi(output),
@@ -1399,8 +1412,7 @@ function makeConflictProbe() {
   let gatewayAlive: boolean | null = null;
   const isGatewayAlive = (): boolean => {
     if (gatewayAlive === null) {
-      const result = captureOpenshell(["sandbox", "list"], { ignoreError: true });
-      gatewayAlive = result.status === 0;
+      gatewayAlive = isGatewayContainerRunning();
     }
     return gatewayAlive;
   };
@@ -3774,11 +3786,13 @@ async function sandboxSnapshot(sandboxName: string, subArgs: string[]) {
   switch (subcommand) {
     case "create": {
       const opts = parseSnapshotCreateFlags(subArgs.slice(1));
-      const isLive = captureOpenshell(["sandbox", "list"], { ignoreError: true });
-      if (isLive.status !== 0) {
+      if (!isGatewayContainerRunning()) {
         console.error("  Failed to query live sandbox state from OpenShell.");
+        console.error(`  Gateway container 'openshell-cluster-${NEMOCLAW_GATEWAY_NAME}' is not running.`);
+        console.error("  Start it with: openshell gateway start --name nemoclaw");
         process.exit(1);
       }
+      const isLive = captureOpenshell(["sandbox", "list"], { ignoreError: true });
       const liveNames = parseLiveSandboxNames(isLive.output || "");
       if (!liveNames.has(sandboxName)) {
         console.error(`  Sandbox '${sandboxName}' is not running. Cannot create snapshot.`);
@@ -3839,11 +3853,13 @@ async function sandboxSnapshot(sandboxName: string, subArgs: string[]) {
         parsed.targetSandbox === sandboxName
           ? sandboxName
           : validateName(parsed.targetSandbox, "target sandbox name");
-      const isLive = captureOpenshell(["sandbox", "list"], { ignoreError: true });
-      if (isLive.status !== 0) {
+      if (!isGatewayContainerRunning()) {
         console.error("  Failed to query live sandbox state from OpenShell.");
+        console.error(`  Gateway container 'openshell-cluster-${NEMOCLAW_GATEWAY_NAME}' is not running.`);
+        console.error("  Start it with: openshell gateway start --name nemoclaw");
         process.exit(1);
       }
+      const isLive = captureOpenshell(["sandbox", "list"], { ignoreError: true });
       const liveNames = parseLiveSandboxNames(isLive.output || "");
       if (!liveNames.has(targetSandbox)) {
         // Self-restore: cannot auto-create, there is no source to clone from.


### PR DESCRIPTION
Issue
nemoclaw snapshot restore (and snapshot create) are supposed to block when the openshell-cluster-nemoclaw gateway container is stopped. The guard at [nemoclaw.ts:3841](vscode-webview://1lj83ht1d62b2m5pm2ev602d2vac4n7vidskqrqm50hsun6de7m9/src/nemoclaw.ts#L3841) checked openshell sandbox list exit code to detect this — but openshell sandbox list reads from a local state file on disk and always exits 0 regardless of whether the gateway Docker container is running or stopped.

This meant both guards always passed silently:

Exit-code check (isLive.status !== 0) — never triggered, always 0
Sandbox-name check (liveNames.has(targetSandbox)) — also passed, because local state still listed the sandbox name
Result: restore proceeded and reported ✓ Restored 12 directories with exit 0, violating the spec 5.3.4-sandbox-lifecycle.md scenario A safety contract.

The same flawed probe was also used in makeConflictProbe() to gate provider existence checks.

Fix
Added isGatewayContainerRunning() helper ([nemoclaw.ts:196](vscode-webview://1lj83ht1d62b2m5pm2ev602d2vac4n7vidskqrqm50hsun6de7m9/src/nemoclaw.ts#L196)) that uses:


docker inspect --type container --format {{.State.Running}} openshell-cluster-nemoclaw
This is the authoritative source — exits non-zero if the container doesn't exist, returns "false" if stopped. Matches the existing verifyGatewayContainerRunning() pattern already used in onboard.ts for the same reason.

Replaced the broken openshell sandbox list exit-code probe at all three sites:

snapshot create — [nemoclaw.ts:3788](vscode-webview://1lj83ht1d62b2m5pm2ev602d2vac4n7vidskqrqm50hsun6de7m9/src/nemoclaw.ts#L3788)
snapshot restore — [nemoclaw.ts:3855](vscode-webview://1lj83ht1d62b2m5pm2ev602d2vac4n7vidskqrqm50hsun6de7m9/src/nemoclaw.ts#L3855)
makeConflictProbe() — [nemoclaw.ts:1415](vscode-webview://1lj83ht1d62b2m5pm2ev602d2vac4n7vidskqrqm50hsun6de7m9/src/nemoclaw.ts#L1415)
The openshell sandbox list call is retained after the gateway check in both snapshot branches — it is still needed to enumerate live sandbox names once the gateway is confirmed running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of gateway container status detection using more authoritative Docker-based checks.
  * Added early validation for create and restore operations that provides explicit guidance to start the gateway container when it's not running, preventing confusing error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->