### PR TITLE
fix(e2e): exercise public installer release path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,12 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-LOCAL_PAYLOAD="${SCRIPT_DIR}/scripts/install.sh"
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+  SCRIPT_DIR=""
+fi
+LOCAL_PAYLOAD="${SCRIPT_DIR:+${SCRIPT_DIR}/scripts/install.sh}"
 BOOTSTRAP_TMPDIR=""
 PAYLOAD_MARKER="NEMOCLAW_VERSIONED_INSTALLER_PAYLOAD=1"
 

--- a/test/e2e/test-cloud-onboard-e2e.sh
+++ b/test/e2e/test-cloud-onboard-e2e.sh
@@ -25,6 +25,7 @@
 #   NEMOCLAW_POLICY_PRESETS=npm,pypi                   — policy presets
 #   RUN_E2E_CLOUD_ONBOARD_INTERACTIVE_INSTALL=0        — set 0 for non-interactive (default), 1 for expect
 #   NEMOCLAW_INSTALL_SCRIPT_URL                        — override public installer URL
+#   NEMOCLAW_PUBLIC_INSTALL_CWD                        — override temp cwd for public install
 #   E2E_CLOUD_ONBOARD_INSTALL_LOG                      — install log path
 #
 # Usage:
@@ -78,6 +79,7 @@ SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-cloud-onboard}"
 CLOUD_MODEL="${NEMOCLAW_CLOUD_EXPERIMENTAL_MODEL:-moonshotai/kimi-k2.5}"
 INSTALL_LOG="${E2E_CLOUD_ONBOARD_INSTALL_LOG:-/tmp/nemoclaw-e2e-cloud-onboard-install.log}"
 INTERACTIVE_INSTALL="${RUN_E2E_CLOUD_ONBOARD_INTERACTIVE_INSTALL:-0}"
+PUBLIC_INSTALL_CWD="${NEMOCLAW_PUBLIC_INSTALL_CWD:-}"
 
 # Source shared teardown helper
 # shellcheck source=test/e2e/lib/sandbox-teardown.sh
@@ -144,11 +146,6 @@ fi
 # ══════════════════════════════════════════════════════════════════════
 section "Phase 3: Install via public URL"
 
-cd "$REPO" || {
-  fail "Could not cd to repo root: $REPO"
-  exit 1
-}
-
 export NEMOCLAW_SANDBOX_NAME="$SANDBOX_NAME"
 export NEMOCLAW_EXPERIMENTAL=1
 export NEMOCLAW_PROVIDER=cloud
@@ -169,8 +166,17 @@ if [ "$INTERACTIVE_INSTALL" = "1" ]; then
   fail "Interactive install (RUN_E2E_CLOUD_ONBOARD_INTERACTIVE_INSTALL=1) is not yet supported — use non-interactive mode"
   exit 1
 else
+  if [ -z "$PUBLIC_INSTALL_CWD" ]; then
+    PUBLIC_INSTALL_CWD="$(mktemp -d "${TMPDIR:-/tmp}/nemoclaw-public-install.XXXXXX")"
+  else
+    mkdir -p "$PUBLIC_INSTALL_CWD"
+  fi
   info "Installing (non-interactive): curl -fsSL ${NEMOCLAW_INSTALL_SCRIPT_URL} | bash"
-  curl -fsSL "$NEMOCLAW_INSTALL_SCRIPT_URL" | bash >"$INSTALL_LOG" 2>&1 &
+  info "Public install cwd: ${PUBLIC_INSTALL_CWD}"
+  (
+    cd "$PUBLIC_INSTALL_CWD" || exit 1
+    curl -fsSL "$NEMOCLAW_INSTALL_SCRIPT_URL" | bash
+  ) >"$INSTALL_LOG" 2>&1 &
   install_pid=$!
   tail -f "$INSTALL_LOG" --pid=$install_pid 2>/dev/null &
   tail_pid=$!
@@ -198,6 +204,24 @@ else
   fail "Public install failed (exit $install_exit)"
   info "Last 30 lines of install log:"
   tail -30 "$INSTALL_LOG"
+  exit 1
+fi
+
+if grep -q "NemoClaw package.json found in the selected source checkout" "$INSTALL_LOG"; then
+  fail "Public install unexpectedly used the local source checkout"
+  info "Last 30 lines of install log:"
+  tail -30 "$INSTALL_LOG"
+  exit 1
+fi
+
+if grep -q "Installing NemoClaw from GitHub" "$INSTALL_LOG" \
+  && grep -q "Resolved install ref:" "$INSTALL_LOG" \
+  && grep -q "Cloning NemoClaw source" "$INSTALL_LOG"; then
+  pass "Public install used the GitHub clone path"
+else
+  fail "Public install did not show the GitHub clone path"
+  info "Last 40 lines of install log:"
+  tail -40 "$INSTALL_LOG"
   exit 1
 fi
 

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -732,9 +732,7 @@ fi`,
     });
 
     expect(result.status).not.toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toMatch(
-      /Previous onboarding session failed/,
-    );
+    expect(`${result.stdout}${result.stderr}`).toMatch(/Previous onboarding session failed/);
     expect(`${result.stdout}${result.stderr}`).toMatch(/--fresh/);
     // The installer must have bailed out before invoking nemoclaw onboard.
     expect(fs.existsSync(onboardLog)).toBe(false);
@@ -826,18 +824,14 @@ fi`,
     });
 
     expect(result.status).toBe(0);
-    expect(`${result.stdout}${result.stderr}`).toMatch(
-      /Starting a fresh onboarding session/,
-    );
+    expect(`${result.stdout}${result.stderr}`).toMatch(/Starting a fresh onboarding session/);
     expect(`${result.stdout}${result.stderr}`).not.toMatch(
       /Found an interrupted onboarding session/,
     );
     // onboard was called with --fresh (forwarded so the CLI clears the
     // existing session file) and without --resume.
     const log = fs.readFileSync(onboardLog, "utf-8");
-    expect(log).toMatch(
-      /^onboard --fresh --non-interactive --yes-i-accept-third-party-software$/m,
-    );
+    expect(log).toMatch(/^onboard --fresh --non-interactive --yes-i-accept-third-party-software$/m);
     expect(log).not.toMatch(/--resume/);
   });
 
@@ -2340,6 +2334,36 @@ exit 0`,
     expect(gitCalls).not.toMatch(/clone/);
     expect(gitCalls).not.toMatch(/fetch/);
     expect(`${result.stdout}${result.stderr}`).not.toMatch(/curl should not hit the releases API/);
+  });
+
+  it("piped root installer does not source a local payload from the caller cwd", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-piped-root-cwd-"));
+    const repoLike = path.join(tmp, "repo");
+    fs.mkdirSync(path.join(repoLike, "scripts"), { recursive: true });
+    const rootInstaller = path.join(repoLike, "install.sh");
+    fs.copyFileSync(CURL_PIPE_INSTALLER, rootInstaller);
+    writeExecutable(
+      path.join(repoLike, "scripts", "install.sh"),
+      `#!/usr/bin/env bash
+# NEMOCLAW_VERSIONED_INSTALLER_PAYLOAD=1
+main() {
+  printf 'LOCAL_PAYLOAD_USED\\n'
+}`,
+    );
+
+    const result = spawnSync("bash", ["-s", "--", "--version"], {
+      cwd: repoLike,
+      input: fs.readFileSync(rootInstaller, "utf-8"),
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NEMOCLAW_INSTALL_TAG: "v0.0.29",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/^nemoclaw-installer\s*$/m);
+    expect(`${result.stdout}${result.stderr}`).not.toMatch(/LOCAL_PAYLOAD_USED/);
   });
 
   it("falls back to the legacy root installer when the selected ref only has the old scripts/install.sh wrapper", () => {


### PR DESCRIPTION
## Summary
- make piped root install bootstrap independent of the caller cwd, so `curl | bash` cannot accidentally source a local checkout payload
- run cloud-onboard public install from a temp cwd instead of the repo checkout
- assert the install log used the GitHub clone/release path and did not use the local source checkout
- add a regression test for stdin execution from a repo-like cwd

## Validation
- `./node_modules/.bin/vitest run test/install-preflight.test.ts`
- `./node_modules/.bin/vitest run test/install-preflight.test.ts --testNamePattern "curl-pipe installer release-tag resolution"`
- `git diff --check`
- `bash -n install.sh test/e2e/test-cloud-onboard-e2e.sh`
- `shellcheck install.sh test/e2e/test-cloud-onboard-e2e.sh`
- `./node_modules/.bin/prettier --check test/install-preflight.test.ts`
- `cat install.sh | bash -s -- --version`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Public install flow now supports custom working directory specification via environment variable override.

* **Bug Fixes**
  * Enhanced installer path resolution to gracefully handle edge cases and prevent unintended use of local payloads during public installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->