### PR TITLE
fix(install): honor --yes-i-accept-third-party-software in non-TTY mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ bootstrap_usage() {
   printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
   printf "  Options:\n"
   printf "    --non-interactive    Skip prompts (uses env vars / defaults)\n"
-  printf "    --yes-i-accept-third-party-software Accept the third-party software notice in non-interactive mode\n"
+  printf "    --yes-i-accept-third-party-software Accept the third-party software notice without prompting (works in any mode)\n"
   printf "    --fresh              Discard any failed/interrupted onboarding session and start over\n"
   printf "    --version, -v        Print installer version and exit\n"
   printf "    --help, -h           Show this help message and exit\n\n"

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ bootstrap_usage() {
   printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
   printf "  Options:\n"
   printf "    --non-interactive    Skip prompts (uses env vars / defaults)\n"
-  printf "    --yes-i-accept-third-party-software Accept the third-party software notice without prompting (works in any mode)\n"
+  printf "    --yes-i-accept-third-party-software Accept the third-party software notice without prompting\n"
   printf "    --fresh              Discard any failed/interrupted onboarding session and start over\n"
   printf "    --version, -v        Print installer version and exit\n"
   printf "    --help, -h           Show this help message and exit\n\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -533,7 +533,7 @@ show_usage_notice() {
     "${notice_cmd[@]}"
   elif [ -t 0 ]; then
     "${notice_cmd[@]}"
-  elif exec 3</dev/tty; then
+  elif { exec 3</dev/tty; } 2>/dev/null; then
     info "Installer stdin is piped; attaching the usage notice to /dev/tty…"
     local status=0
     "${notice_cmd[@]}" <&3 || status=$?
@@ -1581,7 +1581,7 @@ run_onboard() {
     "${_CLI_BIN}" "${onboard_cmd[@]}"
   elif [ -t 0 ]; then
     "${_CLI_BIN}" "${onboard_cmd[@]}"
-  elif exec 3</dev/tty; then
+  elif { exec 3</dev/tty; } 2>/dev/null; then
     info "Installer stdin is piped; attaching onboarding to /dev/tty…"
     local status=0
     "${_CLI_BIN}" "${onboard_cmd[@]}" <&3 || status=$?

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -484,7 +484,7 @@ usage() {
   printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
   printf "  ${C_DIM}Options:${C_RESET}\n"
   printf "    --non-interactive    Skip prompts (uses env vars / defaults)\n"
-  printf "    --yes-i-accept-third-party-software Accept the third-party software notice without prompting (works in any mode)\n"
+  printf "    --yes-i-accept-third-party-software Accept the third-party software notice without prompting\n"
   printf "    --fresh              Discard any failed/interrupted onboarding session and start over\n"
   printf "    --version, -v        Print installer version and exit\n"
   printf "    --help, -h           Show this help message and exit\n\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -484,7 +484,7 @@ usage() {
   printf "    curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- [options]\n\n"
   printf "  ${C_DIM}Options:${C_RESET}\n"
   printf "    --non-interactive    Skip prompts (uses env vars / defaults)\n"
-  printf "    --yes-i-accept-third-party-software Accept the third-party software notice in non-interactive mode\n"
+  printf "    --yes-i-accept-third-party-software Accept the third-party software notice without prompting (works in any mode)\n"
   printf "    --fresh              Discard any failed/interrupted onboarding session and start over\n"
   printf "    --version, -v        Print installer version and exit\n"
   printf "    --help, -h           Show this help message and exit\n\n"
@@ -521,7 +521,11 @@ show_usage_notice() {
     notice_script="${repo_root}/bin/lib/usage-notice.js"
   fi
   local -a notice_cmd=(node "$notice_script")
-  if [ "${NON_INTERACTIVE:-}" = "1" ]; then
+  # When --yes-i-accept-third-party-software (or NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1)
+  # is set, treat the licence step as accepted regardless of --non-interactive — a
+  # flag whose name is "yes-i-accept" must be sufficient on its own to clear the
+  # notice, even in curl|bash mode where there is no TTY to fall back to. See #2670.
+  if [ "${NON_INTERACTIVE:-}" = "1" ] || [ "${ACCEPT_THIRD_PARTY_SOFTWARE:-}" = "1" ]; then
     notice_cmd+=(--non-interactive)
     if [ "${ACCEPT_THIRD_PARTY_SOFTWARE:-}" = "1" ]; then
       notice_cmd+=(--yes-i-accept-third-party-software)
@@ -536,7 +540,7 @@ show_usage_notice() {
     exec 3<&-
     return "$status"
   else
-    error "Interactive third-party software acceptance requires a TTY. Re-run in a terminal or set NEMOCLAW_NON_INTERACTIVE=1 with --yes-i-accept-third-party-software."
+    error "Interactive third-party software acceptance requires a TTY. Re-run in a terminal or pass --yes-i-accept-third-party-software (or set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1)."
   fi
 }
 

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -2513,12 +2513,19 @@ exit 0`,
 
     fs.writeFileSync(path.join(sourceRoot, "bin", "lib", "usage-notice.js"), "// stub\n");
 
-    // Source scripts/install.sh and invoke show_usage_notice with stdin closed
-    // so [ -t 0 ] is false (curl|bash mode). 2>/dev/null suppresses any
-    // top-level top-of-file noise that the source may emit before main() guard.
+    // Source scripts/install.sh and invoke show_usage_notice in a fresh
+    // session with no controlling TTY (setsid). Without setsid, WSL CI
+    // runners keep /dev/tty openable from the child process even when
+    // stdin is /dev/null — `(: </dev/tty)` succeeds and show_usage_notice
+    // takes its TTY-fallback branch instead of the `else error` we mean to
+    // exercise. setsid creates a new session with no controlling terminal,
+    // making /dev/tty deterministically unopenable across Linux/WSL/macOS.
+    // 2>/dev/null suppresses any top-level noise the source may emit
+    // before main()'s guard.
     const result = spawnSync(
-      "bash",
+      "setsid",
       [
+        "bash",
         "-c",
         `source ${JSON.stringify(INSTALLER_PAYLOAD)} 2>/dev/null; show_usage_notice </dev/null`,
       ],

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -2488,6 +2488,88 @@ exit 0`,
   });
 });
 
+describe("installer license acceptance (sourced)", () => {
+  /**
+   * Source scripts/install.sh and invoke show_usage_notice() in isolation. The
+   * helper stubs the usage-notice.js script to record the argv it received so
+   * tests can assert which flags flowed through, without actually downloading
+   * or evaluating the real notice.
+   */
+  function callShowUsageNotice(env: Record<string, string | undefined>) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-show-usage-"));
+    const fakeBin = path.join(tmp, "bin");
+    const sourceRoot = path.join(tmp, "src");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(path.join(sourceRoot, "bin", "lib"), { recursive: true });
+    const argLog = path.join(tmp, "notice-args.log");
+
+    writeExecutable(
+      path.join(fakeBin, "node"),
+      `#!/usr/bin/env bash
+# Stub node: write argv (excluding the script path) to argLog and exit 0.
+{ shift; printf '%s\\n' "$*"; } > ${JSON.stringify(argLog)}
+exit 0`,
+    );
+
+    fs.writeFileSync(path.join(sourceRoot, "bin", "lib", "usage-notice.js"), "// stub\n");
+
+    // Source scripts/install.sh and invoke show_usage_notice with stdin closed
+    // so [ -t 0 ] is false (curl|bash mode). 2>/dev/null suppresses any
+    // top-level top-of-file noise that the source may emit before main() guard.
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `source ${JSON.stringify(INSTALLER_PAYLOAD)} 2>/dev/null; show_usage_notice </dev/null`,
+      ],
+      {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: {
+          HOME: tmp,
+          PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+          NEMOCLAW_SOURCE_ROOT: sourceRoot,
+          ...env,
+        },
+      },
+    );
+    const args = fs.existsSync(argLog) ? fs.readFileSync(argLog, "utf-8").trim() : "";
+    return { result, args };
+  }
+
+  it("#2670: ACCEPT_THIRD_PARTY_SOFTWARE=1 alone clears the notice in non-TTY mode", () => {
+    const { result, args } = callShowUsageNotice({
+      // Simulates curl|bash mode: stdin is not a TTY, NON_INTERACTIVE is unset,
+      // and only --yes-i-accept-third-party-software was passed.
+      ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+    });
+    expect(result.status).toBe(0);
+    // Notice script must receive both flags so it actually accepts and exits.
+    expect(args).toMatch(/--non-interactive/);
+    expect(args).toMatch(/--yes-i-accept-third-party-software/);
+    expect(`${result.stdout}${result.stderr}`).not.toMatch(
+      /Interactive third-party software acceptance requires a TTY/,
+    );
+  });
+
+  it("NON_INTERACTIVE=1 alone keeps the notice prompt-driven (regression)", () => {
+    // Existing behavior preserved: --non-interactive without --yes-i-accept-... still
+    // launches the notice helper non-interactively (which itself prompts/declines).
+    const { result, args } = callShowUsageNotice({ NON_INTERACTIVE: "1" });
+    expect(result.status).toBe(0);
+    expect(args).toMatch(/--non-interactive/);
+    expect(args).not.toMatch(/--yes-i-accept-third-party-software/);
+  });
+
+  it("errors with the friendly hint when neither flag is set in non-TTY mode", () => {
+    const { result } = callShowUsageNotice({});
+    expect(result.status).not.toBe(0);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toMatch(/Interactive third-party software acceptance requires a TTY/);
+    expect(output).toMatch(/--yes-i-accept-third-party-software/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // scripts/install.sh (curl-pipe installer) release-tag resolution
 // ---------------------------------------------------------------------------

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -2514,32 +2514,47 @@ exit 0`,
     fs.writeFileSync(path.join(sourceRoot, "bin", "lib", "usage-notice.js"), "// stub\n");
 
     // Source scripts/install.sh and invoke show_usage_notice in a fresh
-    // session with no controlling TTY (setsid). Without setsid, WSL CI
-    // runners keep /dev/tty openable from the child process even when
-    // stdin is /dev/null — `(: </dev/tty)` succeeds and show_usage_notice
-    // takes its TTY-fallback branch instead of the `else error` we mean to
-    // exercise. setsid creates a new session with no controlling terminal,
-    // making /dev/tty deterministically unopenable across Linux/WSL/macOS.
+    // session with no controlling TTY. On Linux/WSL we wrap the child in
+    // setsid because WSL runners keep /dev/tty openable from the child
+    // process even when stdin is /dev/null — `(: </dev/tty)` succeeds and
+    // show_usage_notice takes its TTY-fallback branch instead of the
+    // `else error` we mean to exercise. setsid creates a new session with
+    // no controlling terminal so /dev/tty becomes unopenable.
+    //
+    // macOS does not ship setsid (it's a util-linux binary). Headless
+    // GitHub-hosted macOS runners have no controlling TTY in the first
+    // place, so plain bash is sufficient there.
+    //
     // 2>/dev/null suppresses any top-level noise the source may emit
     // before main()'s guard.
-    const result = spawnSync(
-      "setsid",
-      [
-        "bash",
-        "-c",
-        `source ${JSON.stringify(INSTALLER_PAYLOAD)} 2>/dev/null; show_usage_notice </dev/null`,
-      ],
-      {
-        cwd: tmp,
-        encoding: "utf-8",
-        env: {
-          HOME: tmp,
-          PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
-          NEMOCLAW_SOURCE_ROOT: sourceRoot,
-          ...env,
-        },
-      },
-    );
+    //
+    // The env object below is constructed as a fresh literal — process.env
+    // is intentionally NOT merged so ambient runner vars
+    // (NON_INTERACTIVE, ACCEPT_THIRD_PARTY_SOFTWARE) cannot leak into the
+    // child. Callers control the env entirely via the `env` parameter.
+    const useSetsid = process.platform !== "darwin";
+    const bashScript = `source ${JSON.stringify(INSTALLER_PAYLOAD)} 2>/dev/null; show_usage_notice </dev/null`;
+    const result = useSetsid
+      ? spawnSync("setsid", ["bash", "-c", bashScript], {
+          cwd: tmp,
+          encoding: "utf-8",
+          env: {
+            HOME: tmp,
+            PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+            NEMOCLAW_SOURCE_ROOT: sourceRoot,
+            ...env,
+          },
+        })
+      : spawnSync("bash", ["-c", bashScript], {
+          cwd: tmp,
+          encoding: "utf-8",
+          env: {
+            HOME: tmp,
+            PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+            NEMOCLAW_SOURCE_ROOT: sourceRoot,
+            ...env,
+          },
+        });
     const args = fs.existsSync(argLog) ? fs.readFileSync(argLog, "utf-8").trim() : "";
     return { result, args };
   }
@@ -2574,6 +2589,9 @@ exit 0`,
     const output = `${result.stdout}${result.stderr}`;
     expect(output).toMatch(/Interactive third-party software acceptance requires a TTY/);
     expect(output).toMatch(/--yes-i-accept-third-party-software/);
+    // No raw /dev/tty shell noise should leak (e.g. "exec 3</dev/tty")
+    // — the friendly hint is the only TTY-related output we expect.
+    expect(output).not.toMatch(/\/dev\/tty/);
   });
 });
 


### PR DESCRIPTION
## Summary

`bash install.sh --help` lists `--yes-i-accept-third-party-software` as a top-level flag for skipping the third-party-software notice, but in `curl | bash` mode (no TTY) the flag is silently ignored unless `--non-interactive` (or `NEMOCLAW_NON_INTERACTIVE=1`) is also passed — the install still tries to read `/dev/tty` and fails with `[ERROR] Interactive third-party software acceptance requires a TTY.` The error message points at the workaround, but a flag whose name is "yes-i-accept" should clear the notice on its own. The current behavior is the worst-of-both: the parser accepts the flag, the installer rejects the install. Fixes #2670.

## Problem

`scripts/install.sh::show_usage_notice` only honored `ACCEPT_THIRD_PARTY_SOFTWARE=1` inside the `[ "${NON_INTERACTIVE:-}" = "1" ]` branch. In curl|bash mode (`-t 0` false, `/dev/tty` not openable, `NON_INTERACTIVE` unset), control fell through past every interactive branch to the friendly `error` message — even though the user had explicitly accepted the licence on the command line. Help text in `install.sh` and `scripts/install.sh` further misled users by claiming the flag worked "in non-interactive mode".

The `run_onboard` step has the same flag-name on a separate gate, but onboard genuinely needs a TTY or `--non-interactive` to drive the wizard, and its error message already names both flags. That gate is unchanged here — this PR scopes itself to the licence-acceptance step the flag is named for.

## Fix

Relax the gate in `show_usage_notice` so `ACCEPT_THIRD_PARTY_SOFTWARE=1` alone routes through the same notice-helper invocation that `NON_INTERACTIVE=1 + ACCEPT_THIRD_PARTY_SOFTWARE=1` already used. The notice helper itself was already designed to accept that combo; only the installer's gate was wrong. Help text updated from "in non-interactive mode" to "without prompting (works in any mode)" so the contract matches the runtime behavior.

## Test plan

- [x] `npx vitest run --project installer-integration -t "installer license acceptance"` — 3 new sourced tests (8.7s):
  - **`#2670`: ACCEPT_THIRD_PARTY_SOFTWARE=1 alone clears the notice in non-TTY mode** — stubs `usage-notice.js` to record argv, sources `scripts/install.sh`, runs `show_usage_notice </dev/null` with only `ACCEPT_THIRD_PARTY_SOFTWARE=1` set; asserts exit 0 and that both `--non-interactive` and `--yes-i-accept-third-party-software` flow through.
  - **`NON_INTERACTIVE=1` alone keeps the notice prompt-driven (regression)** — same harness with only `NON_INTERACTIVE=1`; asserts existing behavior (helper gets `--non-interactive` but not the licence flag) is preserved.
  - **errors with the friendly hint when neither flag is set in non-TTY mode** — neither flag set; asserts non-zero exit and the original "requires a TTY" + flag-name hint still surface.
- [x] Full `installer-integration` suite: **70/70 pass** (72.9s) — no regressions in the adjacent license/path-resolution tests.
- [x] `npm run typecheck` clean.

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now treats the third‑party acceptance flag/env as effective in any mode, clearing the usage notice without prompting; CLI help and failure guidance updated to reference the acceptance flag/env.

* **Tests**
  * Added preflight tests covering TTY vs non‑TTY installer flows and combinations of acceptance and non‑interactive flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->