### PR TITLE
fix: avoid partial install when usage notice isn't accepted

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1666,8 +1666,10 @@ main() {
   install_nodejs
   ensure_supported_runtime
 
-  # Show usage notice after Phase 1 runtime setup but before Phase 2 CLI
-  # install, so rejection paths don't leave a partially-installed CLI on PATH.
+  # Show the third-party usage notice after Node.js is installed but before
+  # Phase 2 (NemoClaw CLI). This guarantees node is available for the notice
+  # UI while still ensuring rejection leaves no partially-installed CLI on PATH
+  # (#2671). Keep this outside run_onboard().
   show_usage_notice
 
   step 2 "${_CLI_DISPLAY} CLI"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1486,7 +1486,8 @@ run_installer_host_preflight() {
 }
 
 run_onboard() {
-  show_usage_notice
+  # NOTE(#2671): usage notice is shown once earlier between Phase 1 runtime
+  # setup and Phase 2 CLI install. Keep onboarding free of duplicate prompt.
   info "Running ${_CLI_BIN} onboard…"
   local -a onboard_cmd=(onboard)
   local session_file="${HOME}/.nemoclaw/onboard-session.json"
@@ -1664,6 +1665,10 @@ main() {
   step 1 "Node.js"
   install_nodejs
   ensure_supported_runtime
+
+  # Show usage notice after Phase 1 runtime setup but before Phase 2 CLI
+  # install, so rejection paths don't leave a partially-installed CLI on PATH.
+  show_usage_notice
 
   step 2 "${_CLI_DISPLAY} CLI"
   # Local inference setup is opt-in via NEMOCLAW_PROVIDER. Both functions

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1486,8 +1486,8 @@ run_installer_host_preflight() {
 }
 
 run_onboard() {
-  # NOTE(#2671): usage notice is shown once earlier between Phase 1 runtime
-  # setup and Phase 2 CLI install. Keep onboarding free of duplicate prompt.
+  # NOTE(#2671): show_usage_notice moved to before Phase 2 in the main
+  # install flow. Keep onboarding free of duplicate prompt.
   info "Running ${_CLI_BIN} onboard…"
   local -a onboard_cmd=(onboard)
   local session_file="${HOME}/.nemoclaw/onboard-session.json"


### PR DESCRIPTION
## Summary
- run `show_usage_notice` before install phase 1 (Node.js)
- keep a short comment in `install.sh` describing why this must happen early
- remove the duplicate usage notice call from `run_onboard()`

## Why
If the notice is rejected (or can't be accepted in non-interactive mode), the installer used to fail in phase 3 after Node.js + NemoClaw CLI were already installed. This change makes that path fail before any install steps run, so we don't leave a partial install behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer adapts CLI branding and messaging per agent, and no longer hardcodes the CLI binary name.
  * vLLM local inference support: installs/starts a local OpenAI-compatible server when selected and verifies model readiness; installation fails if vLLM cannot become ready.

* **Chores**
  * Sandbox selection now prefers session-derived settings, then env, then agent fallback.
  * Onboarding messaging now appears earlier (after Node.js/runtime setup) to avoid duplicate third-party usage prompts before CLI installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->