### PR TITLE
fix: block snapshot restore when nemoclaw gateway is down

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ RUN set -eu; \
     # auto-discovery from the extensions directory. \
     rcf_file="$(grep -RIlE --include='*.js' 'async function replaceConfigFile\(params\)' "$OC_DIST" | head -n 1)"; \
     test -n "$rcf_file" || { echo "ERROR: replaceConfigFile function not found in OpenClaw dist" >&2; exit 1; }; \
-    python3 -c "import sys; p=sys.argv[1]; f=open(p); src=f.read(); f.close(); old='\tif (!await tryWriteSingleTopLevelIncludeMutation({\n\t\tsnapshot,\n\t\tnextConfig: params.nextConfig\n\t})) await writeConfigFile(params.nextConfig, {\n\t\tbaseSnapshot: snapshot,\n\t\t...writeOptions,\n\t\t...params.writeOptions\n\t});'; new='\ttry { if (!await tryWriteSingleTopLevelIncludeMutation({\n\t\tsnapshot,\n\t\tnextConfig: params.nextConfig\n\t})) await writeConfigFile(params.nextConfig, {\n\t\tbaseSnapshot: snapshot,\n\t\t...writeOptions,\n\t\t...params.writeOptions\n\t}); } catch(_rcfErr) { if (process.env.OPENSHELL_SANDBOX === \"1\" && _rcfErr.code === \"EACCES\") { console.error(\"[nemoclaw] Config is read-only in sandbox \\u2014 plugin metadata not persisted (plugins auto-load from extensions/)\"); } else { throw _rcfErr; } }'; assert old in src, 'tryWriteSingleTopLevelIncludeMutation/writeConfigFile pattern not found in replaceConfigFile'; f=open(p,'w'); f.write(src.replace(old,new,1)); f.close()" "$rcf_file"; \
+    python3 "${SCRIPT_DIR}/scripts/rcf_patch.py" "$rcf_file"; \
     grep -REq --include='*.js' 'OPENSHELL_SANDBOX.*EACCES' "$rcf_file" || { echo "ERROR: Patch 4 (replaceConfigFile EACCES) not applied" >&2; exit 1; }; \
     # --- Patch 5: bump default WS handshake timeout 10s -> 60s (#2484) --- \
     # OpenClaw's WS connect handshake has a hard-coded 10s timeout on both \

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -3839,6 +3839,17 @@ async function sandboxSnapshot(sandboxName: string, subArgs: string[]) {
         parsed.targetSandbox === sandboxName
           ? sandboxName
           : validateName(parsed.targetSandbox, "target sandbox name");
+
+      // `openshell sandbox list` can return cached metadata even when the
+      // gateway container is stopped. Probe the named gateway lifecycle first
+      // so restore never proceeds on a dead/unreachable gateway. (#2673)
+      const gatewayLifecycle = getNamedGatewayLifecycleState();
+      if (gatewayLifecycle.state !== "healthy_named") {
+        console.error("  NemoClaw gateway is not reachable. Cannot restore snapshot.");
+        console.error("  Start it with 'openshell gateway start --name nemoclaw' or run 'nemoclaw onboard'.");
+        process.exit(1);
+      }
+
       const isLive = captureOpenshell(["sandbox", "list"], { ignoreError: true });
       if (isLive.status !== 0) {
         console.error("  Failed to query live sandbox state from OpenShell.");

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -3845,8 +3845,19 @@ async function sandboxSnapshot(sandboxName: string, subArgs: string[]) {
       // so restore never proceeds on a dead/unreachable gateway. (#2673)
       const gatewayLifecycle = getNamedGatewayLifecycleState();
       if (gatewayLifecycle.state !== "healthy_named") {
-        console.error("  NemoClaw gateway is not reachable. Cannot restore snapshot.");
-        console.error("  Start it with 'openshell gateway start --name nemoclaw' or run 'nemoclaw onboard'.");
+        if (gatewayLifecycle.state === "connected_other") {
+          printWrongGatewayActiveGuidance(
+            sandboxName,
+            gatewayLifecycle.activeGateway,
+            console.error,
+          );
+        } else {
+          console.error(
+            `  Cannot restore snapshot: the nemoclaw gateway is not running (state: ${gatewayLifecycle.state}).`,
+          );
+          console.error(`  Start it with: openshell gateway start nemoclaw`);
+          printGatewayLifecycleHint(gatewayLifecycle.status || "", sandboxName, console.error);
+        }
         process.exit(1);
       }
 


### PR DESCRIPTION
## Summary
- add a real named-gateway liveness guard before snapshot restore
- keep the existing sandbox live-name check after the gateway probe
- fail early with a clear remediation message when the nemoclaw gateway is unreachable

## Why
`openshell sandbox list` can succeed from cached metadata even if the `openshell-cluster-nemoclaw` container is stopped. With this change, restore only proceeds when the named NemoClaw gateway is actually healthy and reachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added health verification before snapshot restoration to prevent failures when the gateway is unavailable.
  * Improved restore error messaging to give clearer guidance when the wrong gateway is active or when the gateway is not running.

* **Chores**
  * Simplified config patching by moving the one-off rewrite into a dedicated maintenance script and kept verification of the patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->