### PR TITLE
fix: make Dockerfile replaceConfigFile patch robust for 2026.4.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,6 +151,7 @@ RUN set -eu; \
 # the next maintainer reviewing an OPENCLAW_VERSION bump knows to revisit.
 COPY scripts/rcf_patch.py /usr/local/lib/nemoclaw/rcf_patch.py
 # hadolint ignore=SC2016,DL3059,DL4006
+COPY scripts/rcf_patch.py /usr/local/lib/nemoclaw/rcf_patch.py
 RUN set -eu; \
     OC_DIST=/usr/local/lib/node_modules/openclaw/dist; \
     # --- Patch 1: rewrite fetch-guard export --- \


### PR DESCRIPTION
## Summary
- update the Dockerfile patch for `replaceConfigFile` to use a whitespace-tolerant regex around the `tryWriteSingleTopLevelIncludeMutation` + `writeConfigFile(params.nextConfig)` block
- keep the same EACCES sandbox handling behavior, but avoid brittle exact-string matching

## Why
The bundled OpenClaw 2026.4.24 code path is correct, but minor formatting differences in compiled dist files can make strict literal matching fail with:

`writeConfigFile(params.nextConfig) pattern not found`

This change keeps the patch aligned with the 2026.4.24 API while making rebuilds resilient to formatting drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent-branded CLI names; new list (JSON) and share (mount/unmount/status) commands; structured sandbox inventory shows agent and optional live inference.

* **Bug Fixes**
  * Stronger onboarding validations (agent binary/health, Dockerfile --from), better local/provider probing with retries/diagnostics, improved GPU reporting and TLS mismatch detection.

* **Chores**
  * Build/runtime adjustments: safer image patching, preload fix, startup gateway token, unified sandbox config layout, added timeouts and Hugging Face credential passthrough.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->