### PR TITLE
fix(entrypoint): gracefully skip invalid overrides instead of hard-exit

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -237,8 +237,8 @@ apply_model_override() {
     case "$api_override" in
       openai-completions | anthropic-messages) ;;
       *)
-        printf '[SECURITY] NEMOCLAW_INFERENCE_API_OVERRIDE must be "openai-completions" or "anthropic-messages", got "%s"\n' "$api_override" >&2
-        return 1
+        printf '[SECURITY] NEMOCLAW_INFERENCE_API_OVERRIDE must be "openai-completions" or "anthropic-messages", got "%s" — skipping override\n' "$api_override" >&2
+        return 0
         ;;
     esac
   fi
@@ -249,20 +249,20 @@ apply_model_override() {
 
   # Validate numeric values
   if [ -n "$context_window" ] && ! printf '%s' "$context_window" | grep -qE '^[0-9]+$'; then
-    printf '[SECURITY] NEMOCLAW_CONTEXT_WINDOW must be a positive integer, got "%s"\n' "$context_window" >&2
-    return 1
+    printf '[SECURITY] NEMOCLAW_CONTEXT_WINDOW must be a positive integer, got "%s" — skipping override\n' "$context_window" >&2
+    return 0
   fi
   if [ -n "$max_tokens" ] && ! printf '%s' "$max_tokens" | grep -qE '^[0-9]+$'; then
-    printf '[SECURITY] NEMOCLAW_MAX_TOKENS must be a positive integer, got "%s"\n' "$max_tokens" >&2
-    return 1
+    printf '[SECURITY] NEMOCLAW_MAX_TOKENS must be a positive integer, got "%s" — skipping override\n' "$max_tokens" >&2
+    return 0
   fi
   # Validate reasoning is true/false
   if [ -n "$reasoning" ]; then
     case "$reasoning" in
       true | false) ;;
       *)
-        printf '[SECURITY] NEMOCLAW_REASONING must be "true" or "false", got "%s"\n' "$reasoning" >&2
-        return 1
+        printf '[SECURITY] NEMOCLAW_REASONING must be "true" or "false", got "%s" — skipping override\n' "$reasoning" >&2
+        return 0
         ;;
     esac
   fi
@@ -365,8 +365,8 @@ apply_cors_override() {
     return 1
   fi
   if ! printf '%s' "$cors_origin" | grep -qE '^https?://'; then
-    printf '[SECURITY] NEMOCLAW_CORS_ORIGIN must start with http:// or https://, got "%s"\n' "$cors_origin" >&2
-    return 1
+    printf '[SECURITY] NEMOCLAW_CORS_ORIGIN must start with http:// or https://, got "%s" — skipping override\n' "$cors_origin" >&2
+    return 0
   fi
 
   printf '[config] Adding CORS origin: %s\n' "$cors_origin" >&2


### PR DESCRIPTION
## Summary

Fixes #2698 — `runtime-overrides-e2e` test 14 crashes because invalid override validation uses `return 1`, which under `set -euo pipefail` kills the container before CMD runs.

## Root Cause

PR #2659 tightened the trigger guard for `apply_model_override()` but kept `return 1` for validation failures. When `NEMOCLAW_CONTEXT_WINDOW=notanumber` is rejected, `return 1` propagates through `set -e` and exits the entrypoint. The container dies before the test can read the config.

## Fix

Change non-security-critical validation failures from `return 1` to `return 0`:
- Invalid API type → skip, don't crash
- Non-integer context window → skip, don't crash
- Non-integer max tokens → skip, don't crash
- Invalid reasoning boolean → skip, don't crash
- Non-http CORS origin → skip, don't crash

Security-critical rejections remain `return 1`:
- Symlink on config/hash path (indicates tampering)
- Control characters in model override (indicates injection)
- Oversized model override (indicates injection)

The security warning is still logged to stderr, but the container starts normally with config unchanged.

## Verification
- [x] Unit tests pass (`test/nemoclaw-start.test.ts` — assertions use `toContain` on message strings which are preserved)
- [ ] `runtime-overrides-e2e` passes (to be validated on sparky)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (pi agent)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup resilience by gracefully handling invalid configuration parameters. The system now logs warnings and continues instead of aborting when misconfigured environment variables are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->