### PR TITLE
fix(ci): run scorecard on workflow_dispatch in addition to schedule

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1657,7 +1657,7 @@ jobs:
         gpu-e2e,
         gpu-double-onboard-e2e,
       ]
-    if: ${{ always() && github.event_name == 'schedule' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     permissions:
       actions: read
     steps:


### PR DESCRIPTION
## Summary

One-line change: allow the `scorecard` job in `nightly-e2e.yaml` to also run on `workflow_dispatch` so we can trigger it ad-hoc to verify output without waiting for the nightly cron.

### Change

```yaml
# Before
if: ${{ always() && github.event_name == 'schedule' }}

# After
if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
```

The `report-to-pr` job continues to run independently for PR-targeted results.

### Checklist

- [x] YAML validates
- [x] No functional change to scheduled behavior
- [x] Enables manual verification of scorecard output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the automated scoring process to support manual triggering in addition to its regular scheduled runs, improving operational flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->