### PR TITLE
test(e2e): add #2174 port auto-alloc assertions to double-onboard

### DIFF
--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -407,6 +407,27 @@ else
   fail "First sandbox '$SANDBOX_A' disappeared after creating '$SANDBOX_B' (regression: #849)"
 fi
 
+# #2174 regression: B must auto-allocate to a different dashboard port,
+# surface it in nemoclaw list, and not collide with A's 18789.
+if grep -q "is taken. Using port" <<<"$output3"; then
+  pass "Second-sandbox onboard logged port auto-allocation (#2174)"
+else
+  fail "Second-sandbox onboard did not log port auto-allocation — auto-alloc may not have fired (#2174)"
+fi
+
+LIST_LOG="$(mktemp)"
+run_nemoclaw list >"$LIST_LOG" 2>&1 || true
+list_output="$(cat "$LIST_LOG")"
+rm -f "$LIST_LOG"
+
+dashboard_ports_in_list="$(grep -oE 'dashboard: http://127\.0\.0\.1:[0-9]+' <<<"$list_output" | awk -F: '{print $NF}' | sort -u)"
+distinct_count="$(wc -l <<<"$dashboard_ports_in_list" | tr -d ' ')"
+if [ "$distinct_count" = "2" ]; then
+  pass "nemoclaw list shows two distinct dashboard ports (#2174)"
+else
+  fail "nemoclaw list did not show two distinct dashboard ports (got $distinct_count: $(tr '\n' ' ' <<<"$dashboard_ports_in_list"))"
+fi
+
 # ══════════════════════════════════════════════════════════════════
 # Phase 5: Stale registry reconciliation
 # ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Adds two regression assertions to Phase 4 of `test-double-onboard.sh` that verify the #2174 auto-allocation fix works end-to-end:

1. **Log check** — Second-sandbox onboard output contains `"is taken. Using port"` (confirms `ensureDashboardForward` auto-allocated)
2. **List check** — `nemoclaw list` shows two distinct `dashboard: http://127.0.0.1:<port>` entries for both sandboxes

## Related

- Guards against regression of #2174 (fix landed via #2411 + #2627)
- Supersedes #2455 (which had a stale assertion string `"allocated port"` that doesn't match any runtime output, and conflicting workflow changes already on main)

## Changes

- `test/e2e/test-double-onboard.sh` — 21 lines added between the existing #849 regression check and Phase 5

## Why this supersedes #2455

| Issue | #2455 | This PR |
|-------|-------|---------|
| Assertion string | `"allocated port"` (doesn't exist in codebase) | `"is taken. Using port"` (matches `ensureDashboardForward` line ~6600) |
| Workflow changes | Adds a `double-onboard-e2e` job that already exists on main → merge conflict | None needed — job already runs this script |
| Branch freshness | 95 commits behind main | Based on current main |

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `bash -n test/e2e/test-double-onboard.sh` — syntax check passes
- [x] shellcheck clean
- [x] No workflow changes needed — `double-onboard-e2e` nightly job already runs this script
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Claude (pi agent)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test assertions for multi-sandbox onboarding scenarios
  * Validates dashboard port auto-allocation prevents conflicts and maintains isolation across concurrent sandbox environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->