### PR TITLE
fix(sandbox): export proxy env in bash -ic / bash -lc (#2704)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -442,6 +442,34 @@ RUN chown root:root /sandbox/.openclaw \
     && chmod 755 /sandbox/.openclaw \
     && chmod 444 /sandbox/.openclaw/openclaw.json
 
+# System-wide proxy hooks for shells where ~/.bashrc / ~/.profile aren't
+# sourced (e.g. `bash -ic` / `bash -lc` invoked under a different user or
+# without HOME=/sandbox). Defined in Dockerfile.base; replayed here so the
+# fix applies before the GHCR base image catches up. Idempotent — `mv` of
+# a freshly-rebuilt /etc/bash.bashrc is harmless once the base layer
+# already includes the prepended hook (the cat | mv block just rewrites
+# with the same first line).
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/2704
+# hadolint ignore=SC2028,DL4006
+RUN if ! grep -q "/tmp/nemoclaw-proxy-env.sh" /etc/profile.d/nemoclaw-proxy.sh 2>/dev/null; then \
+        printf '%s\n' \
+            '# NemoClaw runtime proxy config — see /tmp/nemoclaw-proxy-env.sh (#2704)' \
+            '[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh' \
+            > /etc/profile.d/nemoclaw-proxy.sh \
+        && chmod 444 /etc/profile.d/nemoclaw-proxy.sh; \
+    fi \
+    && if ! head -2 /etc/bash.bashrc | grep -q "/tmp/nemoclaw-proxy-env.sh"; then \
+        chmod 644 /etc/bash.bashrc 2>/dev/null || true; \
+        { printf '%s\n' \
+              '# NemoClaw runtime proxy config — see /tmp/nemoclaw-proxy-env.sh (#2704)' \
+              '[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh' \
+              ''; \
+          cat /etc/bash.bashrc; \
+        } > /etc/bash.bashrc.new \
+        && mv /etc/bash.bashrc.new /etc/bash.bashrc \
+        && chmod 444 /etc/bash.bashrc; \
+    fi
+
 # Pin config hash at build time so the entrypoint can verify integrity.
 # Prevents the agent from creating a copy with a tampered config and
 # restarting the gateway pointing at it.

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -150,6 +150,36 @@ RUN printf '%s\n' \
         > /sandbox/.profile \
     && chown sandbox:sandbox /sandbox/.bashrc /sandbox/.profile
 
+# System-wide proxy hooks. The per-home rc files above only fire for shells
+# that find `~/.bashrc` / `~/.profile` (sandbox user, HOME=/sandbox). SSH
+# sessions and tools that spawn `bash -ic` / `bash -lc` from a different user
+# or HOME silently miss the proxy env. These two hooks make the same
+# /tmp/nemoclaw-proxy-env.sh source for every bash mode regardless of user:
+#
+#   /etc/profile.d/nemoclaw-proxy.sh — sourced by /etc/profile for any login
+#     shell (bash -l, bash -lc).
+#   /etc/bash.bashrc — sourced by every interactive bash (bash -i, bash -ic).
+#     Prepend before the stock `[ -z "$PS1" ] && return` guard so the source
+#     line still runs in non-TTY contexts where PS1 may be unset when the
+#     file is first read.
+#
+# Both files are root-owned and not writable by the sandbox user.
+# Ref: https://github.com/NVIDIA/NemoClaw/issues/2704
+# hadolint ignore=SC2028
+RUN printf '%s\n' \
+        '# NemoClaw runtime proxy config — see /tmp/nemoclaw-proxy-env.sh (#2704)' \
+        '[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh' \
+        > /etc/profile.d/nemoclaw-proxy.sh \
+    && chmod 444 /etc/profile.d/nemoclaw-proxy.sh \
+    && { printf '%s\n' \
+            '# NemoClaw runtime proxy config — see /tmp/nemoclaw-proxy-env.sh (#2704)' \
+            '[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh' \
+            ''; \
+         cat /etc/bash.bashrc; \
+       } > /etc/bash.bashrc.new \
+    && mv /etc/bash.bashrc.new /etc/bash.bashrc \
+    && chmod 444 /etc/bash.bashrc
+
 # Install OpenClaw CLI + PyYAML for inline Python scripts in e2e tests.
 # OpenClaw version: change the OPENCLAW_VERSION ARG default so CI rebuilds
 # the base image on push to main, or use workflow_dispatch on base-image.yaml

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -404,6 +404,61 @@ else
   fail "proxy-env.sh has unexpected permissions: $OUT"
 fi
 
+# ── Test 26a: /etc/profile.d/nemoclaw-proxy.sh sources proxy-env (#2704) ──
+# Login shells (bash -lc) run /etc/profile, which dot-sources every
+# /etc/profile.d/*.sh.  Without this hook, login shells started as a user
+# whose HOME ≠ /sandbox (root, container exec without --user) silently miss
+# the proxy env even when /tmp/nemoclaw-proxy-env.sh is populated.
+
+info "26a. /etc/profile.d/nemoclaw-proxy.sh sources proxy config"
+OUT=$(run_as_root "cat /etc/profile.d/nemoclaw-proxy.sh 2>/dev/null || echo MISSING")
+if echo "$OUT" | grep -q "/tmp/nemoclaw-proxy-env.sh"; then
+  pass "/etc/profile.d/nemoclaw-proxy.sh sources /tmp/nemoclaw-proxy-env.sh"
+elif echo "$OUT" | grep -q "MISSING"; then
+  fail "/etc/profile.d/nemoclaw-proxy.sh is missing (#2704)"
+else
+  fail "/etc/profile.d/nemoclaw-proxy.sh does not source from expected path: $OUT"
+fi
+
+# ── Test 26b: /etc/bash.bashrc prepends the proxy hook (#2704) ────
+# Interactive non-login bash (bash -ic) sources /etc/bash.bashrc.  The
+# stock Debian/Ubuntu file has `[ -z "$PS1" ] && return` near the top, so
+# the hook must precede that guard to fire reliably in non-TTY contexts.
+
+info "26b. /etc/bash.bashrc prepends proxy source line ahead of PS1 guard"
+OUT=$(run_as_root "head -3 /etc/bash.bashrc")
+if echo "$OUT" | head -2 | grep -q "/tmp/nemoclaw-proxy-env.sh"; then
+  pass "/etc/bash.bashrc sources /tmp/nemoclaw-proxy-env.sh before the PS1 guard"
+else
+  fail "/etc/bash.bashrc does not source the proxy hook in the first 3 lines: $OUT"
+fi
+
+# ── Test 26c: bash -ic and bash -lc both pick up /tmp/nemoclaw-proxy-env.sh (#2704) ──
+# End-to-end check: write a sentinel export into the runtime proxy-env
+# file, then verify both interactive (bash -ic) and login (bash -lc)
+# bash modes export it, regardless of which user is running. Mirrors the
+# QA test T5893674.
+
+info "26c. bash -ic and bash -lc export proxy env from /tmp/nemoclaw-proxy-env.sh"
+OUT=$(docker run --rm --entrypoint "" "$IMAGE" bash -c '
+  printf "export NEMOCLAW_PROXY_PROBE=https://probe.invalid:9999\n" \
+    > /tmp/nemoclaw-proxy-env.sh
+  chmod 444 /tmp/nemoclaw-proxy-env.sh
+  echo "ROOT_BASH_IC=$(bash -ic "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
+  echo "ROOT_BASH_LC=$(bash -lc "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
+  echo "SANDBOX_BASH_IC=$(gosu sandbox bash -ic "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
+  echo "SANDBOX_BASH_LC=$(gosu sandbox bash -lc "echo \$NEMOCLAW_PROXY_PROBE" 2>/dev/null)"
+' 2>&1)
+EXPECTED="https://probe.invalid:9999"
+if echo "$OUT" | grep -qE "ROOT_BASH_IC=$EXPECTED" \
+  && echo "$OUT" | grep -qE "ROOT_BASH_LC=$EXPECTED" \
+  && echo "$OUT" | grep -qE "SANDBOX_BASH_IC=$EXPECTED" \
+  && echo "$OUT" | grep -qE "SANDBOX_BASH_LC=$EXPECTED"; then
+  pass "bash -ic / bash -lc export proxy env for both root and sandbox"
+else
+  fail "proxy env not set in all bash modes (#2704): $OUT"
+fi
+
 # ── Test 27: Non-root mode executes without gosu ──────────────────
 # The entrypoint detects uid != 0, skips gosu, and execs the command directly.
 # Use the image's actual sandbox uid/gid here: the system-assigned sandbox uid


### PR DESCRIPTION
## Summary

Fixes #2704 — `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` were missing in interactive (`bash -ic`) and login (`bash -lc`) shells inside the sandbox even though plain non-interactive SSH commands saw them.

The existing `/sandbox/.bashrc` and `/sandbox/.profile` only fire when bash finds them through `$HOME` (sandbox user, `HOME=/sandbox`). Tools or sessions that spawn `bash -ic` / `bash -lc` from a different user or with a different `$HOME` silently skip the runtime `/tmp/nemoclaw-proxy-env.sh`, so any tool invoking an interactive/login bash inside the sandbox fails to reach external services through the gateway proxy.

This PR adds two system-wide hooks at the base-image layer so the same `/tmp/nemoclaw-proxy-env.sh` is sourced for every bash mode regardless of HOME/user:

- `/etc/profile.d/nemoclaw-proxy.sh` — sourced by `/etc/profile` for any login shell (`bash -l`, `bash -lc`)
- `/etc/bash.bashrc` (prepend) — sourced by every interactive bash (`bash -i`, `bash -ic`). The hook is placed **above** the stock `[ -z "$PS1" ] && return` guard so it still fires in non-TTY contexts where `PS1` is unset when the file is first read.

The per-home rc files remain in place as defense in depth. Both new system files are root-owned and immutable to the sandbox user.

Reproduced and verified on `aits-log-worker-6` (Ubuntu 24.04, OpenShell 0.0.36) with a sandbox built from the patched base image.

## Test plan

- [x] Manual repro: `ssh openshell-<sandbox> "bash -ic 'printf HTTP=%s\n \$HTTP_PROXY'"` returns the proxy URL
- [x] Manual repro: `ssh openshell-<sandbox> "bash -lc 'printf HTTP=%s\n \$HTTP_PROXY'"` returns the proxy URL
- [x] `vitest run test/sandbox-init.test.ts test/service-env.test.ts test/http-proxy-fix-sync.test.ts` — all pass
- [x] `npm run typecheck:cli` — passes
- [x] `bash -n test/e2e-gateway-isolation.sh` — shell syntax OK
- [ ] CI: e2e-gateway-isolation runs (requires base image rebuild — Tests 26a/26b/26c added)

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker image updated to ensure proxy environment settings are consistently loaded in both login and interactive shells and protected against runtime modification.

* **Tests**
  * Added end-to-end tests verifying proxy environment propagation across shell initialization paths and for different users and shell invocation modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->