### PR TITLE
fix(onboard): bound local Ollama and vLLM detection probes with timeouts

### DIFF
--- a/src/lib/local-inference.ts
+++ b/src/lib/local-inference.ts
@@ -285,8 +285,12 @@ export function parseOllamaTags(output: string | null | undefined): string[] {
 
 export function getOllamaModelOptions(runCaptureImpl?: RunCaptureFn): string[] {
   const capture = runCaptureImpl ?? runCapture;
+  // Bound the loopback probe at the spawnSync layer so a stalled listener
+  // can't hang the model-selection step (#2674, same hazard as the
+  // detection probes in onboard.ts). 5s is plenty for /api/tags.
   const tagsOutput = capture(["curl", "-sf", `http://127.0.0.1:${OLLAMA_PORT}/api/tags`], {
     ignoreError: true,
+    timeout: 5_000,
   });
   const tagsParsed = parseOllamaTags(tagsOutput);
   if (tagsParsed.length > 0) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4245,14 +4245,21 @@ async function setupNim(gpu: ReturnType<typeof nim.detectGpu>): Promise<{
   let credentialEnv: string | null = REMOTE_PROVIDER_CONFIG.build.credentialEnv;
   let preferredInferenceApi: string | null = null;
 
-  // Detect local inference options
+  // Detect local inference options. The runCapture timeout caps each probe
+  // at the spawnSync layer so a half-open port or stalled listener cannot
+  // hang the wizard at [3/8] (#2674; reproduced on macOS / M3 Pro with
+  // Ollama running but unreachable). 5s is plenty for a loopback HTTP
+  // round-trip; matches the existing { ignoreError, timeout } pattern at
+  // onboard.ts:1514, 1537, 2078.
   const hasOllama = hostCommandExists("ollama");
-  const ollamaRunning = !!runCapture(["curl", "-sf", `http://127.0.0.1:${OLLAMA_PORT}/api/tags`], {
-    ignoreError: true,
-  });
-  const vllmRunning = !!runCapture(["curl", "-sf", `http://127.0.0.1:${VLLM_PORT}/v1/models`], {
-    ignoreError: true,
-  });
+  const ollamaRunning = !!runCapture(
+    ["curl", "-sf", `http://127.0.0.1:${OLLAMA_PORT}/api/tags`],
+    { ignoreError: true, timeout: 5_000 },
+  );
+  const vllmRunning = !!runCapture(
+    ["curl", "-sf", `http://127.0.0.1:${VLLM_PORT}/v1/models`],
+    { ignoreError: true, timeout: 5_000 },
+  );
   const requestedProvider = isNonInteractive() ? getNonInteractiveProvider() : null;
   const requestedModel = isNonInteractive()
     ? getNonInteractiveModel(requestedProvider || "build")

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -200,6 +200,129 @@ const { setupNim } = require(${onboardPath});
     );
   });
 
+  it("#2674: bounds local Ollama and vLLM detection probes with a runCapture timeout", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-probe-timeout-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "probe-timeout-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+body='{"id":"ok"}'
+status="200"
+outfile=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) outfile="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s' "$body" > "$outfile"
+printf '%s' "$status"
+`,
+      { mode: 0o755 },
+    );
+
+    const script = String.raw`
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+
+// Pick the cloud path so setupNim returns quickly without further probing.
+const answers = ["1", "1"];
+const messages = [];
+const probes = [];
+
+credentials.prompt = async (message) => {
+  messages.push(message);
+  return answers.shift() || "";
+};
+credentials.ensureApiKey = async () => { process.env.NVIDIA_API_KEY = "nvapi-test"; };
+runner.runCapture = (command, opts) => {
+  // Record every captured argv together with the runCapture options so the
+  // test can assert that the loopback detection probes carry a spawnSync-level
+  // timeout (Option C — protects against a curl that ignores its own flags).
+  probes.push({
+    cmd: Array.isArray(command) ? command.slice() : String(command),
+    opts: opts ?? {},
+  });
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (cmd.includes("127.0.0.1:11434/api/tags")) return JSON.stringify({ models: [] });
+  if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
+  return "";
+};
+registry.updateSandbox = () => {};
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  const originalLog = console.log;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim("probe-timeout-test", null);
+    originalLog(JSON.stringify({ result, probes, messages, lines }));
+  } finally {
+    console.log = originalLog;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const payload = JSON.parse(result.stdout.trim());
+    const probes: Array<{ cmd: string | string[]; opts: Record<string, unknown> }> =
+      payload.probes;
+
+    // Locate each detection probe by URL substring, then assert the runCapture
+    // opts include a finite spawnSync-level timeout so a stalled listener
+    // can't hang the wizard at [3/8] (#2674 was reproducible on M3 Pro under
+    // Colima with Ollama running but unreachable).
+    function findProbe(urlMatch: string) {
+      return probes.find((p) => {
+        const argv = Array.isArray(p.cmd) ? p.cmd : [p.cmd];
+        return argv.some((arg) => typeof arg === "string" && arg.includes(urlMatch));
+      });
+    }
+
+    const ollamaProbe = findProbe("127.0.0.1:11434/api/tags");
+    const vllmProbe = findProbe("127.0.0.1:8000/v1/models");
+    assert.ok(ollamaProbe, "expected an Ollama detection probe to fire");
+    assert.ok(vllmProbe, "expected a vLLM detection probe to fire");
+
+    for (const [label, probe] of [["ollama", ollamaProbe!], ["vllm", vllmProbe!]] as const) {
+      const timeout = probe.opts.timeout;
+      assert.ok(
+        typeof timeout === "number" && timeout > 0 && timeout <= 30_000,
+        `${label} probe missing finite timeout (opts: ${JSON.stringify(probe.opts)})`,
+      );
+      assert.equal(
+        probe.opts.ignoreError,
+        true,
+        `${label} probe must keep ignoreError=true so a timeout returns "" (opts: ${JSON.stringify(probe.opts)})`,
+      );
+    }
+  });
+
   it("does not label NVIDIA Endpoints as recommended in the provider list", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-no-recommended-label-"));


### PR DESCRIPTION
## Summary

`nemoclaw onboard` hangs at `[3/8] Configuring inference (NIM)` with no further output, on macOS / Apple M3 Pro under Colima with Ollama running locally. The two curl probes that detect a local Ollama or vLLM listener at the top of step [3/8] had no timeout — when a port is half-open or a listener stalls, curl waits forever and the wizard is stuck. Reported by @Devin-Yue with a clean repro. Fixes #2674.

## Fix

The reporter's diagnosis is correct (curl probes need a timeout); this PR applies the fix one level higher than `--connect-timeout` / `--max-time` flags. Both detection probes now pass `{ ignoreError: true, timeout: 5_000 }` to `runCapture`, which forwards `timeout` to `spawnSync`. The OS kills the curl process at the deadline regardless of whether curl itself honors its flags — covers the rare-but-real case where libcurl is buggy or mis-built. Matches the existing pattern at `onboard.ts:1514, 1537, 2078` and the spawnSync timeout work in [#1069](https://github.com/NVIDIA/NemoClaw/pull/1069).

Same fix applied to a third loopback probe of the same shape: `getOllamaModelOptions` in `src/lib/local-inference.ts:288`, which runs during model selection if the user picks Ollama. Without the timeout, the same hazard applies one step later in the wizard.

Out of scope: the post-selection vLLM model query at `onboard.ts:4989` has the same shape but only runs after the user actively chose vLLM — by then the `[3/8]` hang is already past. A follow-up can adopt the same timeout there if a similar stall is observed.

## Test plan

- [x] `npx vitest run test/onboard-selection.test.ts -t '#2674'` — new regression test mocks `runner.runCapture` to record both `cmd` and `opts` for every captured call, then asserts the loopback detection probes (`127.0.0.1:11434/api/tags` and `127.0.0.1:8000/v1/models`) carry a finite numeric `timeout` and keep `ignoreError: true`.
- [x] Full `onboard` + `onboard-selection` + `local-inference` + `inference-health` suites: 242/242 pass.
- [x] `npm run typecheck` clean.

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced local inference setup detection with timeout constraints for Ollama and vLLM availability checks, improving reliability and responsiveness during the onboarding process.

* **Tests**
  * Added comprehensive test coverage for local inference detection probes, validating timeout behavior, fallback mechanisms, and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->