### PR TITLE
test(sandbox): assert sandbox init is staged

### DIFF
--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -31,6 +31,7 @@ describe("sandbox build context staging", () => {
       expect(fs.existsSync(path.join(buildCtx, "scripts", "generate-openclaw-config.py"))).toBe(
         true,
       );
+      expect(fs.existsSync(path.join(buildCtx, "scripts", "lib", "sandbox-init.sh"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Adds a regression assertion that the optimized sandbox build context stages `scripts/lib/sandbox-init.sh`. This protects the shared sandbox entrypoint library required by the sandbox startup path.

## Related Issue
Fixes #2277

Supersedes #2645 (rebased onto current main to resolve merge conflict).

## Changes
- Adds test coverage for `scripts/lib/sandbox-init.sh` in optimized sandbox build context staging.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

## AI Disclosure
- [x] AI-assisted — tool: Codex (original), pi (rebase + conflict resolution)

---
Co-authored-by: Sameh Mohamed <samehm@nvidia.com>
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for sandbox build context validation to verify additional required files are present in staged output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->