### PR TITLE
fix(services): dynamic banner box width prevents URL corruption (Closes #2716)

### DIFF
--- a/nemoclaw/src/banner.test.ts
+++ b/nemoclaw/src/banner.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { renderBox } from "./banner.js";
+
+describe("renderBox (nemoclaw plugin)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders registration banner with dynamic width", () => {
+    const lines = renderBox([
+      "  NemoClaw registered",
+      null,
+      "  Endpoint:  https://integrate.api.nvidia.com/v1",
+      "  Provider:  NVIDIA Endpoints",
+      "  Model:     nvidia/nemotron-3-super-120b-a12b",
+      "  Slash:     /nemoclaw",
+    ]);
+    // All lines same length
+    const lengths = lines.map((l) => l.length);
+    expect(new Set(lengths).size).toBe(1);
+    // Endpoint line has trailing space before │
+    const endpointLine = lines[3];
+    expect(endpointLine).toMatch(/\s{2,}│$/);
+  });
+
+  it("expands for very long endpoint URLs", () => {
+    const longEndpoint =
+      "  Endpoint:  https://very-long-custom-endpoint.internal.nvidia.com/v1/completions";
+    const lines = renderBox([longEndpoint]);
+    // Should contain the full URL without truncation
+    expect(lines[1]).toContain("very-long-custom-endpoint.internal.nvidia.com");
+    // Should have trailing space
+    expect(lines[1]).toMatch(/\s{2,}│$/);
+  });
+
+  it("produces equal-length lines (box integrity)", () => {
+    const lines = renderBox(["  Short", null, "  A much longer line of text here"]);
+    const lengths = lines.map((l) => l.length);
+    expect(new Set(lengths).size).toBe(1);
+  });
+});

--- a/nemoclaw/src/banner.ts
+++ b/nemoclaw/src/banner.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Render content lines inside a dynamically-sized Unicode box.
+ *
+ * Computes the inner width as:
+ *   min(terminalColumns - 4, max(minInner, longestLine + 2))
+ *
+ * The `- 4` accounts for the two-space indent plus `│` borders on each side.
+ * This ensures:
+ *   1. Long content (e.g. cloudflare URLs) never causes the closing `│` to be
+ *      adjacent to URL text (which terminals Punycode-encode, breaking links).
+ *   2. The box never overflows the terminal width.
+ *
+ * @param lines - Content strings to render, or `null` for blank separator rows.
+ * @param options - Configuration options.
+ * @param options.minInner - Minimum inner box width (default: 53).
+ * @returns Array of formatted box lines ready for console output.
+ */
+export function renderBox(
+  lines: (string | null)[],
+  { minInner = 53 }: { minInner?: number } = {},
+): string[] {
+  const termCols = Math.max(60, Number(process.stdout.columns || 100));
+  const maxInner = termCols - 4;
+  const contentMax = lines.reduce<number>(
+    (max, line) => (line === null ? max : Math.max(max, line.length + 2)),
+    minInner,
+  );
+  const inner = Math.min(maxInner, contentMax);
+
+  const pad = (s: string): string => s + " ".repeat(Math.max(0, inner - s.length));
+  const hBar = "─".repeat(inner);
+  const blank = " ".repeat(inner);
+
+  return [
+    `  ┌${hBar}┐`,
+    ...lines.map((line) => (line === null ? `  │${blank}│` : `  │${pad(line)}│`)),
+    `  └${hBar}┘`,
+  ];
+}

--- a/nemoclaw/src/banner.ts
+++ b/nemoclaw/src/banner.ts
@@ -22,15 +22,18 @@ export function renderBox(
   lines: (string | null)[],
   { minInner = 53 }: { minInner?: number } = {},
 ): string[] {
-  const termCols = Math.max(60, Number(process.stdout.columns || 100));
-  const maxInner = termCols - 4;
+  const termCols = process.stdout.columns > 0 ? process.stdout.columns : 100;
+  const maxInner = Math.max(0, termCols - 4);
   const contentMax = lines.reduce<number>(
     (max, line) => (line === null ? max : Math.max(max, line.length + 2)),
     minInner,
   );
   const inner = Math.min(maxInner, contentMax);
 
-  const pad = (s: string): string => s + " ".repeat(Math.max(0, inner - s.length));
+  const pad = (s: string): string => {
+    if (s.length > inner) return s.slice(0, inner);
+    return s + " ".repeat(inner - s.length);
+  };
   const hBar = "─".repeat(inner);
   const blank = " ".repeat(inner);
 

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { renderBox } from "./banner.js";
 import { handleSlashCommand } from "./commands/slash.js";
 import {
   describeOnboardEndpoint,
@@ -422,14 +423,18 @@ export default function register(api: OpenClawPluginApi): void {
     );
   }
 
+  const bannerLines: (string | null)[] = [
+    "  NemoClaw registered",
+    null,
+    `  Endpoint:  ${bannerEndpoint}`,
+    `  Provider:  ${bannerProvider}`,
+    `  Model:     ${bannerModel}`,
+    "  Slash:     /nemoclaw",
+  ];
+
   api.logger.info("");
-  api.logger.info("  ┌─────────────────────────────────────────────────────┐");
-  api.logger.info("  │  NemoClaw registered                                │");
-  api.logger.info("  │                                                     │");
-  api.logger.info(`  │  Endpoint:  ${bannerEndpoint.padEnd(40)}│`);
-  api.logger.info(`  │  Provider:  ${bannerProvider.padEnd(40)}│`);
-  api.logger.info(`  │  Model:     ${bannerModel.padEnd(40)}│`);
-  api.logger.info("  │  Slash:     /nemoclaw                               │");
-  api.logger.info("  └─────────────────────────────────────────────────────┘");
+  for (const line of renderBox(bannerLines)) {
+    api.logger.info(line);
+  }
   api.logger.info("");
 }

--- a/src/lib/banner.test.ts
+++ b/src/lib/banner.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { renderBox } from "./banner.js";
+
+describe("renderBox", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a basic box with default minInner of 53", () => {
+    const lines = renderBox(["  Hello"]);
+    // First line is top border
+    expect(lines[0]).toMatch(/^\s+┌─+┐$/);
+    // Inner width should be at least 53
+    const inner = lines[0].length - 4; // "  ┌" (3) + "┐" (1)
+    expect(inner).toBeGreaterThanOrEqual(53);
+    // Last line is bottom border
+    expect(lines[lines.length - 1]).toMatch(/^\s+└─+┘$/);
+  });
+
+  it("expands box for long content", () => {
+    const longUrl = "  Public URL:  https://very-long-subdomain-name.trycloudflare.com";
+    const lines = renderBox([longUrl]);
+    // The content line should have trailing space before │
+    const contentLine = lines[1];
+    expect(contentLine).toMatch(/\s\s│$/);
+    // Should NOT truncate the URL
+    expect(contentLine).toContain("very-long-subdomain-name.trycloudflare.com");
+  });
+
+  it("renders null entries as blank separator rows", () => {
+    const lines = renderBox(["  Title", null, "  Content"]);
+    // Line at index 2 should be a blank row
+    const blankLine = lines[2];
+    expect(blankLine).toMatch(/^\s+│\s+│$/);
+  });
+
+  it("produces lines of equal length (box integrity)", () => {
+    const lines = renderBox([
+      "  NemoClaw Services",
+      null,
+      "  Public URL:  https://abc-def-ghi.trycloudflare.com",
+      "  Messaging:   via OpenClaw native channels (if configured)",
+      null,
+      "  Run 'openshell term' to monitor egress approvals",
+    ]);
+    const lengths = lines.map((l) => l.length);
+    expect(new Set(lengths).size).toBe(1);
+  });
+
+  it("ensures at least 2 trailing spaces before closing border", () => {
+    const url = "  Public URL:  https://some-subdomain.trycloudflare.com";
+    const lines = renderBox([url]);
+    const contentLine = lines[1];
+    // Extract text between │ markers
+    const match = contentLine.match(/│(.+)│/);
+    expect(match).not.toBeNull();
+    const content = match![1];
+    // Should end with at least 2 spaces (the +2 in contentMax calculation)
+    expect(content).toMatch(/\s{2,}$/);
+  });
+
+  it("caps width at terminal columns", () => {
+    // Mock a narrow terminal
+    Object.defineProperty(process.stdout, "columns", {
+      value: 80,
+      writable: true,
+      configurable: true,
+    });
+    const veryLong = "x".repeat(200);
+    const lines = renderBox([veryLong]);
+    // Box should not exceed 80 chars
+    expect(lines[0].length).toBeLessThanOrEqual(80);
+  });
+
+  it("respects custom minInner option", () => {
+    const lines = renderBox(["  Hi"], { minInner: 30 });
+    const inner = lines[0].length - 4;
+    expect(inner).toBeGreaterThanOrEqual(30);
+  });
+
+  it("handles empty lines array", () => {
+    const lines = renderBox([]);
+    expect(lines).toHaveLength(2); // just top + bottom border
+    expect(lines[0]).toMatch(/^\s+┌─+┐$/);
+    expect(lines[1]).toMatch(/^\s+└─+┘$/);
+  });
+});

--- a/src/lib/banner.test.ts
+++ b/src/lib/banner.test.ts
@@ -63,16 +63,25 @@ describe("renderBox", () => {
   });
 
   it("caps width at terminal columns", () => {
-    // Mock a narrow terminal
+    // Mock a narrow terminal by overriding the columns getter
+    const original = Object.getOwnPropertyDescriptor(process.stdout, "columns");
     Object.defineProperty(process.stdout, "columns", {
-      value: 80,
-      writable: true,
+      get: () => 80,
       configurable: true,
     });
-    const veryLong = "x".repeat(200);
-    const lines = renderBox([veryLong]);
-    // Box should not exceed 80 chars
-    expect(lines[0].length).toBeLessThanOrEqual(80);
+    try {
+      const veryLong = "x".repeat(200);
+      const lines = renderBox([veryLong]);
+      // Every rendered row should stay within the terminal width
+      expect(lines.every((line) => line.length <= 80)).toBe(true);
+    } finally {
+      if (original) {
+        Object.defineProperty(process.stdout, "columns", original);
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete (process.stdout as unknown as Record<string, unknown>)["columns"];
+      }
+    }
   });
 
   it("respects custom minInner option", () => {

--- a/src/lib/banner.ts
+++ b/src/lib/banner.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Render content lines inside a dynamically-sized Unicode box.
+ *
+ * Computes the inner width as:
+ *   min(terminalColumns - 4, max(minInner, longestLine + 2))
+ *
+ * The `- 4` accounts for the two-space indent plus `│` borders on each side.
+ * This ensures:
+ *   1. Long content (e.g. cloudflare URLs) never causes the closing `│` to be
+ *      adjacent to URL text (which terminals Punycode-encode, breaking links).
+ *   2. The box never overflows the terminal width.
+ *
+ * @param lines - Content strings to render, or `null` for blank separator rows.
+ * @param options - Configuration options.
+ * @param options.minInner - Minimum inner box width (default: 53).
+ * @returns Array of formatted box lines ready for console output.
+ */
+export function renderBox(
+  lines: (string | null)[],
+  { minInner = 53 }: { minInner?: number } = {},
+): string[] {
+  const termCols = Math.max(60, Number(process.stdout.columns || 100));
+  const maxInner = termCols - 4;
+  const contentMax = lines.reduce<number>(
+    (max, line) => (line === null ? max : Math.max(max, line.length + 2)),
+    minInner,
+  );
+  const inner = Math.min(maxInner, contentMax);
+
+  const pad = (s: string): string => s + " ".repeat(Math.max(0, inner - s.length));
+  const hBar = "─".repeat(inner);
+  const blank = " ".repeat(inner);
+
+  return [
+    `  ┌${hBar}┐`,
+    ...lines.map((line) => (line === null ? `  │${blank}│` : `  │${pad(line)}│`)),
+    `  └${hBar}┘`,
+  ];
+}

--- a/src/lib/banner.ts
+++ b/src/lib/banner.ts
@@ -22,15 +22,19 @@ export function renderBox(
   lines: (string | null)[],
   { minInner = 53 }: { minInner?: number } = {},
 ): string[] {
-  const termCols = Math.max(60, Number(process.stdout.columns || 100));
-  const maxInner = termCols - 4;
+  const detectedCols = process.stdout.columns;
+  const termCols = detectedCols !== undefined && detectedCols > 0 ? detectedCols : 100;
+  const maxInner = Math.max(0, termCols - 4);
   const contentMax = lines.reduce<number>(
     (max, line) => (line === null ? max : Math.max(max, line.length + 2)),
     minInner,
   );
   const inner = Math.min(maxInner, contentMax);
 
-  const pad = (s: string): string => s + " ".repeat(Math.max(0, inner - s.length));
+  const pad = (s: string): string => {
+    if (s.length > inner) return s.slice(0, inner);
+    return s + " ".repeat(inner - s.length);
+  };
   const hBar = "─".repeat(inner);
   const blank = " ".repeat(inner);
 

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -16,6 +16,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { renderBox } from "./banner.js";
 import { DASHBOARD_PORT } from "./ports";
 import { buildSubprocessEnv } from "./subprocess-env";
 
@@ -302,11 +303,6 @@ export async function startAll(opts: ServiceOptions = {}): Promise<void> {
   }
 
   // Banner
-  console.log("");
-  console.log("  ┌─────────────────────────────────────────────────────┐");
-  console.log(`  │  ${(CLI_DISPLAY_NAME + " Services").padEnd(52)}│`);
-  console.log("  │                                                     │");
-
   let tunnelUrl = "";
   const cfLogFile = join(pidDir, "cloudflared.log");
   if (isRunning(pidDir, "cloudflared") && existsSync(cfLogFile)) {
@@ -317,15 +313,19 @@ export async function startAll(opts: ServiceOptions = {}): Promise<void> {
     }
   }
 
-  if (tunnelUrl) {
-    console.log(`  │  Public URL:  ${tunnelUrl.padEnd(40)}│`);
+  const bannerLines: (string | null)[] = [
+    `  ${CLI_DISPLAY_NAME} Services`,
+    null,
+    ...(tunnelUrl ? [`  Public URL:  ${tunnelUrl}`] : []),
+    `  Messaging:   via ${AGENT_PRODUCT_NAME} native channels (if configured)`,
+    null,
+    "  Run 'openshell term' to monitor egress approvals",
+  ];
+
+  console.log("");
+  for (const line of renderBox(bannerLines)) {
+    console.log(line);
   }
-
-  console.log(`  │  ${("Messaging:   via " + AGENT_PRODUCT_NAME + " native channels (if configured)").padEnd(52)}│`);
-
-  console.log("  │                                                     │");
-  console.log("  │  Run 'openshell term' to monitor egress approvals   │");
-  console.log("  └─────────────────────────────────────────────────────┘");
   console.log("");
 }
 


### PR DESCRIPTION
## Summary

Rework of #1419 (now closed) from latest main. When the cloudflared tunnel URL (~50 chars) is printed inside a fixed-width ASCII box using `padEnd(40)`, the closing `│` (U+2502) character lands immediately after the URL. Terminals auto-detect the `│` as part of the URL and Punycode-encode `.com│` → `.xn--com-hs4a`, producing a broken, non-clickable link.

Closes #2716

## Changes

- **`src/lib/banner.ts`** (new): Shared `renderBox()` utility that dynamically computes box width based on content length (min 53 inner, capped at terminal width), ensuring at least 2 trailing spaces before the closing border.
- **`src/lib/banner.test.ts`** (new): 8 unit tests covering dynamic expansion, terminal capping, null separators, box integrity, and trailing-space invariant.
- **`src/lib/services.ts`**: Replace hardcoded banner with `renderBox()` call.
- **`nemoclaw/src/banner.ts`** (new): Same utility co-located for the plugin package.
- **`nemoclaw/src/banner.test.ts`** (new): 3 plugin-specific tests.
- **`nemoclaw/src/index.ts`**: Replace hardcoded registration banner with `renderBox()` call.

## Credit

Core approach (dynamic `renderBox` with terminal-width capping) originated in PR #1419 by @MauroDruwel.

`Co-authored-by: Mauro Druwel <mauro.druwel@gmail.com>`

## Type of Change

- [x] Code change for a new feature, bug fix, or refactor.

## Testing

- [x] `npx vitest run src/lib/banner.test.ts nemoclaw/src/banner.test.ts` — 11/11 passing
- [x] Full suite: 154 test files pass (3 pre-existing failures in installer-integration/ssrf-parity unrelated to this change)
- [x] Prettier formatting clean
- [x] CLI typecheck clean (`tsc --noEmit -p jsconfig.json`)

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).

### Code Changes

- [x] Formatters applied.
- [x] Tests added for new behavior.
- [x] No secrets, API keys, or credentials committed.
- [x] Docstrings on exported functions (80%+ coverage).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup banner now renders as a responsive Unicode boxed layout that adapts to terminal width, preserves long URLs, and conditionally shows the Public URL when present
  * Added instruction: "Run 'openshell term' to monitor egress approvals"

* **Refactor**
  * Banner rendering moved to a reusable, data-driven renderer to ensure consistent box formatting and spacing

* **Tests**
  * Added tests validating banner layout, terminal-width constraints, blank spacer rows, consistent line lengths, and long-line preservation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->