### PR TITLE
fix(recovery): re-emit guard chain when /tmp is wiped after pod recreate (#2701)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,10 +223,12 @@ RUN mkdir -p /sandbox/.nemoclaw/blueprints/0.1.0 \
 
 # Copy startup script and shared sandbox initialisation library
 COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh
+COPY scripts/lib/emit-guards.sh /usr/local/lib/nemoclaw/emit-guards.sh
+COPY scripts/lib/guards/ /usr/local/lib/nemoclaw/guards/
 COPY scripts/nemoclaw-start.sh /usr/local/bin/nemoclaw-start
 COPY scripts/codex-acp-wrapper.sh /usr/local/bin/nemoclaw-codex-acp
 COPY scripts/generate-openclaw-config.py /usr/local/lib/nemoclaw/generate-openclaw-config.py
-RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-codex-acp /usr/local/lib/nemoclaw/sandbox-init.sh
+RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-codex-acp /usr/local/lib/nemoclaw/sandbox-init.sh /usr/local/lib/nemoclaw/emit-guards.sh
 
 # Build args for config that varies per deployment.
 # nemoclaw onboard passes these at image build time.

--- a/scripts/lib/emit-guards.sh
+++ b/scripts/lib/emit-guards.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# emit-guards.sh — (re-)emits the NODE_OPTIONS preload guard chain to /tmp.
+#
+# Called by:
+#   1. nemoclaw-start.sh (entrypoint) — initial guard installation
+#   2. Guard recovery path (TypeScript via kubectl exec) — re-emission after
+#      pod recreate wipes /tmp (#2701)
+#
+# Must run as root in root-mode sandboxes (files are root:root 444).
+# In non-root mode, files are sandbox:sandbox 444 (best-effort).
+#
+# Environment variables read:
+#   NEMOCLAW_PROXY_HOST   — proxy host (default: 10.200.0.1)
+#   NEMOCLAW_PROXY_PORT   — proxy port (default: 3128)
+#   NODE_USE_ENV_PROXY    — set to "1" to include http-proxy-fix preload
+#   GIT_SSL_CAINFO        — if set, included in proxy-env.sh
+#
+# Guard source files expected at:
+#   /usr/local/lib/nemoclaw/guards/*.js
+#
+# Output:
+#   /tmp/nemoclaw-sandbox-safety-net.js
+#   /tmp/nemoclaw-ciao-network-guard.js
+#   /tmp/nemoclaw-http-proxy-fix.js       (always installed; conditional in proxy-env)
+#   /tmp/nemoclaw-nemotron-inference-fix.js
+#   /tmp/nemoclaw-slack-channel-guard.js
+#   /tmp/nemoclaw-slack-token-rewriter.js
+#   /tmp/nemoclaw-proxy-env.sh            (aggregator — sources all via NODE_OPTIONS)
+
+set -euo pipefail
+
+# ── Source shared sandbox initialisation library ─────────────────
+_SANDBOX_INIT="/usr/local/lib/nemoclaw/sandbox-init.sh"
+if [ ! -f "$_SANDBOX_INIT" ]; then
+  _SANDBOX_INIT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sandbox-init.sh"
+fi
+# shellcheck source=scripts/lib/sandbox-init.sh
+source "$_SANDBOX_INIT"
+
+# ── Guard source directory ───────────────────────────────────────
+_GUARD_SRC="/usr/local/lib/nemoclaw/guards"
+if [ ! -d "$_GUARD_SRC" ]; then
+  # Dev fallback: relative to this script
+  _GUARD_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/guards"
+fi
+
+if [ ! -d "$_GUARD_SRC" ]; then
+  echo "[emit-guards] ERROR: guard source directory not found" >&2
+  exit 1
+fi
+
+# ── Install static JS guards ────────────────────────────────────
+_SANDBOX_SAFETY_NET="/tmp/nemoclaw-sandbox-safety-net.js"
+_CIAO_GUARD_SCRIPT="/tmp/nemoclaw-ciao-network-guard.js"
+_PROXY_FIX_SCRIPT="/tmp/nemoclaw-http-proxy-fix.js"
+_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"
+_SLACK_GUARD_SCRIPT="/tmp/nemoclaw-slack-channel-guard.js"
+_SLACK_REWRITER_SCRIPT="/tmp/nemoclaw-slack-token-rewriter.js"
+
+emit_sandbox_sourced_file "$_SANDBOX_SAFETY_NET" < "$_GUARD_SRC/nemoclaw-sandbox-safety-net.js"
+emit_sandbox_sourced_file "$_CIAO_GUARD_SCRIPT" < "$_GUARD_SRC/nemoclaw-ciao-network-guard.js"
+emit_sandbox_sourced_file "$_PROXY_FIX_SCRIPT" < "$_GUARD_SRC/nemoclaw-http-proxy-fix.js"
+emit_sandbox_sourced_file "$_NEMOTRON_FIX_SCRIPT" < "$_GUARD_SRC/nemoclaw-nemotron-inference-fix.js"
+emit_sandbox_sourced_file "$_SLACK_GUARD_SCRIPT" < "$_GUARD_SRC/nemoclaw-slack-channel-guard.js"
+emit_sandbox_sourced_file "$_SLACK_REWRITER_SCRIPT" < "$_GUARD_SRC/nemoclaw-slack-token-rewriter.js"
+
+# ── Generate proxy-env.sh (dynamic — depends on runtime config) ──
+_PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
+_PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
+_PROXY_URL="http://${_PROXY_HOST}:${_PROXY_PORT}"
+_NO_PROXY_VAL="localhost,127.0.0.1,::1,${_PROXY_HOST}"
+
+_WS_FIX_SCRIPT="/opt/nemoclaw-blueprint/scripts/ws-proxy-fix.js"
+
+_PROXY_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
+{
+  cat <<PROXYEOF
+# Proxy configuration (overrides narrow OpenShell defaults on connect)
+export HTTP_PROXY="$_PROXY_URL"
+export HTTPS_PROXY="$_PROXY_URL"
+export NO_PROXY="$_NO_PROXY_VAL"
+export http_proxy="$_PROXY_URL"
+export https_proxy="$_PROXY_URL"
+export no_proxy="$_NO_PROXY_VAL"
+PROXYEOF
+  # Global sandbox safety net for connect sessions — must be first.
+  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SANDBOX_SAFETY_NET\""
+  # HTTP library double-proxy fix: also expose NODE_OPTIONS in connect
+  # sessions so interactive shells and user commands started via
+  # `openshell sandbox connect` benefit from the preload. (NemoClaw#2109)
+  if [ "${NODE_USE_ENV_PROXY:-}" = "1" ]; then
+    echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_PROXY_FIX_SCRIPT\""
+  fi
+  # WebSocket CONNECT tunnel fix for connect sessions. (NemoClaw#1570)
+  if [ -f "$_WS_FIX_SCRIPT" ]; then
+    echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_WS_FIX_SCRIPT\""
+  fi
+  # Git TLS CA bundle for connect sessions (NemoClaw#2270)
+  if [ -n "${GIT_SSL_CAINFO:-}" ]; then
+    printf 'export GIT_SSL_CAINFO=%q\n' "$GIT_SSL_CAINFO"
+  fi
+  # Nemotron inference fix for connect sessions. (NemoClaw#1193, #2051)
+  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCRIPT\""
+  # ciao network guard for connect sessions.
+  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_CIAO_GUARD_SCRIPT\""
+  # Slack channel guard for connect sessions. Conditional on the file existing.
+  echo "[ -f \"$_SLACK_GUARD_SCRIPT\" ] && export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SLACK_GUARD_SCRIPT\""
+  # Slack token rewriter for connect sessions. Conditional on the file existing.
+  echo "[ -f \"$_SLACK_REWRITER_SCRIPT\" ] && export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SLACK_REWRITER_SCRIPT\""
+  # Tool cache redirects — /sandbox is Landlock read-only (#804)
+  echo '# Tool cache redirects — /sandbox is Landlock read-only (#804)'
+  echo 'export npm_config_cache=/tmp/.npm-cache'
+  echo 'export XDG_CACHE_HOME=/tmp/.cache'
+  echo 'export XDG_CONFIG_HOME=/tmp/.config'
+  echo 'export XDG_DATA_HOME=/tmp/.local/share'
+  echo 'export XDG_STATE_HOME=/tmp/.local/state'
+  echo 'export XDG_RUNTIME_DIR=/tmp/.runtime'
+  echo 'export NODE_REPL_HISTORY=/tmp/.node_repl_history'
+  echo 'export HISTFILE=/tmp/.bash_history'
+  echo 'export GIT_CONFIG_GLOBAL=/tmp/.gitconfig'
+  echo 'export GNUPGHOME=/tmp/.gnupg'
+  echo 'export PYTHONUSERBASE=/tmp/.local'
+  echo 'export PYTHON_HISTORY=/tmp/.python_history'
+  echo 'export CLAUDE_CONFIG_DIR=/tmp/.claude'
+  echo 'export npm_config_prefix=/tmp/npm-global'
+} | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"
+
+# ── Validate permissions ─────────────────────────────────────────
+validate_tmp_permissions \
+  "$_SANDBOX_SAFETY_NET" \
+  "$_PROXY_FIX_SCRIPT" \
+  "$_NEMOTRON_FIX_SCRIPT" \
+  "$_CIAO_GUARD_SCRIPT" \
+  "$_SLACK_GUARD_SCRIPT" \
+  "$_SLACK_REWRITER_SCRIPT"
+
+echo "[emit-guards] Guard chain installed successfully" >&2

--- a/scripts/lib/guards/nemoclaw-ciao-network-guard.js
+++ b/scripts/lib/guards/nemoclaw-ciao-network-guard.js
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ciao-network-guard.js — prevents @homebridge/ciao mDNS library from
+// crashing the gateway when os.networkInterfaces() fails in restricted
+// sandbox network namespaces.
+
+(function () {
+  'use strict';
+
+  // Monkey-patch os.networkInterfaces to return empty on failure.
+  var os = require('os');
+  var _origNetworkInterfaces = os.networkInterfaces;
+  // Rate-limit the failure log. The bonjour watchdog inside ciao retries
+  // advertising every few seconds, so a naive "log on every failure" fills
+  // sandbox logs with hundreds of identical lines per hour. Log the first
+  // failure (operator gets the actionable message) and at most one summary
+  // every 5 minutes thereafter, with a suppression count so volume is
+  // still observable. See GitHub issue #2611.
+  var _failureCount = 0;
+  var _lastLogMs = 0;
+  var _suppressedSinceLog = 0;
+  var _LOG_INTERVAL_MS = 5 * 60 * 1000;
+  os.networkInterfaces = function () {
+    try {
+      return _origNetworkInterfaces.call(os);
+    } catch (err) {
+      _failureCount++;
+      var nowMs = Date.now();
+      var shouldLog = _failureCount === 1 || (nowMs - _lastLogMs) >= _LOG_INTERVAL_MS;
+      if (shouldLog) {
+        var suffix = _suppressedSinceLog > 0
+          ? ' [' + _suppressedSinceLog + ' suppressed in last ~5min, ' + _failureCount + ' total]'
+          : '';
+        process.stderr.write(
+          '[guard] os.networkInterfaces() failed: ' + (err.message || err) +
+          ' — returning empty (mDNS disabled)' + suffix + '\n'
+        );
+        _lastLogMs = nowMs;
+        _suppressedSinceLog = 0;
+      } else {
+        _suppressedSinceLog++;
+      }
+      return {};
+    }
+  };
+
+  // Fallback: catch uncaughtException from ciao if the monkey-patch
+  // doesn't cover all call sites. Gateway-only — registering ANY
+  // uncaughtException listener tells Node "don't crash by default", and
+  // we want CLI processes (agent, doctor, plugins, tui) to keep default
+  // Node crash behavior so errors surface promptly.
+  //
+  // For gateway processes, non-ciao errors fall through (return) to the
+  // sandbox safety net registered later in the preload chain. The safety
+  // net is the single point of "keep gateway alive on unknown errors".
+  if (process.argv[2] === 'gateway') {
+    process.on('uncaughtException', function (err, origin) {
+      if (
+        err && err.code === 'ERR_SYSTEM_ERROR' &&
+        String(err.message || '').indexOf('uv_interface_addresses') !== -1
+      ) {
+        process.stderr.write(
+          '[guard] ciao/networkInterfaces crash caught: ' + (err.message || err) +
+          ' \u2014 gateway continues\n'
+        );
+        return;
+      }
+      if (err && err.stack && err.stack.indexOf('ciao') !== -1 &&
+          String(err.message || '').indexOf('networkInterfaces') !== -1) {
+        process.stderr.write(
+          '[guard] ciao network error caught: ' + (err.message || err) +
+          ' \u2014 gateway continues\n'
+        );
+        return;
+      }
+      // Not ciao — let the sandbox safety net handle it.
+    });
+  }
+})();

--- a/scripts/lib/guards/nemoclaw-http-proxy-fix.js
+++ b/scripts/lib/guards/nemoclaw-http-proxy-fix.js
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// http-proxy-fix.js — http.request() wrapper resolving the double-proxy
+// conflict between NODE_USE_ENV_PROXY=1 (Node.js 22+) and HTTP libraries
+// that independently read HTTPS_PROXY (axios, follow-redirects,
+// proxy-from-env). See NemoClaw#2109.
+//
+// Problem:
+//   Node.js 22 with NODE_USE_ENV_PROXY=1 (baked into the OpenShell base
+//   image) intercepts https.request() calls and handles proxying via a
+//   CONNECT tunnel. HTTP libraries also read HTTPS_PROXY and configure
+//   HTTP FORWARD mode, so the request is processed twice and the L7 proxy
+//   rejects it with "FORWARD rejected: HTTPS requires CONNECT".
+//
+// Fix:
+//   Wrap http.request() — the lowest common denominator every HTTP client
+//   bottoms out at. Detect FORWARD-mode requests (hostname = proxy IP,
+//   path = full https:// URL) and rewrite them as https.request() against
+//   the real target host, letting NODE_USE_ENV_PROXY handle the CONNECT
+//   tunnel correctly.
+//
+// Earlier PR #2110 tried a Module._load hook intercepting require('axios').
+// That could not catch follow-redirects + proxy-from-env bundled as ESM in
+// OpenClaw's dist/ — there are no require() calls to intercept. The
+// http.request wrapper sits below all libraries and catches every path.
+//
+// This file is the canonical source for review and tests. At sandbox boot
+// nemoclaw-start.sh writes an identical copy to /tmp/nemoclaw-http-proxy-fix.js
+// and loads it via NODE_OPTIONS=--require. A sync test enforces byte-for-byte
+// equality. The content cannot be baked into /opt/nemoclaw-blueprint/scripts/
+// because adding files to the optimized sandbox build context cache-busts the
+// `COPY nemoclaw-blueprint/` Dockerfile layer and hangs npm ci in k3s
+// Docker-in-Docker — see src/lib/sandbox-build-context.ts.
+
+(function () {
+  'use strict';
+  if (process.env.NODE_USE_ENV_PROXY !== '1') return;
+
+  var http = require('http');
+  var origRequest = http.request;
+
+  var proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy ||
+    '';
+  var proxyHost = '';
+  try {
+    proxyHost = new URL(proxyUrl).hostname;
+  } catch (_e) {
+    /* no usable proxy configured */
+  }
+  if (!proxyHost) return;
+
+  // Strip headers that were meaningful for the proxy hop only. Once we
+  // re-issue against the target via https.request, the original Host
+  // points at the proxy and the hop-by-hop headers (RFC 7230 §6.1) leak
+  // upstream — they describe the connection between the caller and the
+  // proxy, not the rewritten connection to the target.
+  //
+  // RFC 7230 §6.1 hop-by-hop set (request direction):
+  //   Connection, Keep-Alive, Proxy-Authorization, TE, Trailer,
+  //   Transfer-Encoding, Upgrade.
+  // Also stripped: Host (points at the proxy); Proxy-Connection (de
+  // facto deprecated header still emitted by some clients); and
+  // Proxy-Authenticate (response-only per RFC 7235 §4.3, included
+  // belt-and-suspenders for clients that echo response headers into
+  // retry-request options). Plus: per RFC 7230 §6.1, any token named in
+  // the Connection header is itself hop-by-hop and must be stripped.
+  var STATIC_HOP_BY_HOP = [
+    'host',
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'proxy-connection',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+  ];
+
+  function sanitizeHeaders(headers) {
+    if (!headers || typeof headers !== 'object') return undefined;
+    // Collect tokens named in the Connection header — those become
+    // hop-by-hop transitively per RFC 7230 §6.1.
+    var dynamic = new Set();
+    for (var k in headers) {
+      if (
+        !Object.prototype.hasOwnProperty.call(headers, k) ||
+        String(k).toLowerCase() !== 'connection'
+      ) {
+        continue;
+      }
+      var raw = headers[k];
+      var listed = Array.isArray(raw) ? raw.join(',') : raw;
+      if (typeof listed === 'string') {
+        listed.split(',').forEach(function (token) {
+          var t = token.trim().toLowerCase();
+          if (t) dynamic.add(t);
+        });
+      }
+    }
+    var staticSet = new Set(STATIC_HOP_BY_HOP);
+    var out = {};
+    for (var key in headers) {
+      if (!Object.prototype.hasOwnProperty.call(headers, key)) continue;
+      var lower = String(key).toLowerCase();
+      if (staticSet.has(lower) || dynamic.has(lower)) continue;
+      out[key] = headers[key];
+    }
+    return out;
+  }
+
+  http.request = function (options, callback) {
+    if (typeof options === 'string' || !options) {
+      return origRequest.apply(http, arguments);
+    }
+    if (
+      options.hostname === proxyHost &&
+      options.path &&
+      options.path.startsWith('https://')
+    ) {
+      var target;
+      try {
+        target = new URL(options.path);
+      } catch (_e) {
+        return origRequest.apply(http, arguments);
+      }
+      var https = require('https');
+      // Clone caller's options and overwrite proxy-specific routing
+      // fields. Strip fields that were set up for the proxy hop and
+      // would misbehave on the rewritten https.request to the target:
+      //   - agent: a forward-proxy http.Agent cannot speak TLS. Leaving
+      //     it attached caused upstreams like deepinfra to surface as
+      //     "LLM request failed: network connection error" while other
+      //     upstreams that don't end up on this code path still worked.
+      //     On Node 22 https.request throws a synchronous TypeError; on
+      //     Node 18/20 it falls through and the TLS handshake fails.
+      //   - auth: basic-auth meant for the proxy hop. Leaving it on
+      //     would Basic-auth the target server with proxy credentials.
+      //   - servername / checkServerIdentity: TLS SNI + cert validation
+      //     pre-computed for the proxy hop. Wrong cert chain and wrong
+      //     SNI must not survive into the rewrite — drop them so Node
+      //     re-derives from the new `hostname`.
+      //   - socketPath: Unix-socket proxies exist (e.g. cntlm-style
+      //     local proxies). Routing TLS bytes into the proxy's Unix
+      //     socket would defeat the entire rewrite.
+      //   - localAddress / lookup / family / hints: source-binding and
+      //     DNS hints picked for reachability to the proxy. The
+      //     rewritten target may not be reachable from the same NIC or
+      //     DNS family.
+      //   - Host / hop-by-hop headers (RFC 7230 §6.1): stripped via
+      //     sanitizeHeaders so Node regenerates Host from `host`/`port`
+      //     to point at the real target.
+      // Signal (AbortController) and TLS material (ca/cert/key/
+      // rejectUnauthorized), timeout, body, and target-intent headers
+      // (Authorization, Content-Type, …) are preserved.
+      var rewritten = Object.assign({}, options, {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        host: target.hostname,
+        port: target.port || 443,
+        path: target.pathname + target.search,
+        protocol: 'https:',
+        headers: sanitizeHeaders(options.headers),
+      });
+      delete rewritten.agent;
+      delete rewritten.auth;
+      delete rewritten.servername;
+      delete rewritten.checkServerIdentity;
+      delete rewritten.socketPath;
+      delete rewritten.localAddress;
+      delete rewritten.lookup;
+      delete rewritten.family;
+      delete rewritten.hints;
+      return https.request(rewritten, callback);
+    }
+    return origRequest.apply(http, arguments);
+  };
+})();

--- a/scripts/lib/guards/nemoclaw-nemotron-inference-fix.js
+++ b/scripts/lib/guards/nemoclaw-nemotron-inference-fix.js
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// nemotron-inference-fix.js — inject chat_template_kwargs for Nemotron models.
+//
+// Problem (NemoClaw#1193, NemoClaw#2051):
+//   Nemotron models sometimes generate tool calls instead of text for simple
+//   queries, or return thinking-only blocks with stopReason "stop" that
+//   OpenClaw treats as end-of-turn, causing the conversation to stall.
+//   The root cause is the model's chat template producing empty assistant
+//   content when tool definitions are present.
+//
+// Fix:
+//   Inject `chat_template_kwargs: { force_nonempty_content: true }` into
+//   /v1/chat/completions request bodies when the model ID contains
+//   "nemotron". This tells the vLLM/NIM serving layer to force the chat
+//   template to always produce non-empty content alongside any tool calls
+//   or thinking blocks.
+//
+//   Scoped strictly to Nemotron models — all other requests pass through
+//   untouched. Backends that do not support chat_template_kwargs silently
+//   ignore the extra field per the OpenAI-compatible API contract.
+
+(function () {
+  'use strict';
+
+  var http = require('http');
+  var https = require('https');
+
+  var NEMOTRON_RE = /nemotron/i;
+  var COMPLETIONS_RE = /\/v1\/chat\/completions/;
+
+  function wrapModule(mod) {
+    var origRequest = mod.request;
+
+    mod.request = function (options, callback) {
+      // Only intercept object-form calls with a recognisable path.
+      if (typeof options === 'string' || !options) {
+        return origRequest.apply(mod, arguments);
+      }
+
+      var path = options.path || '';
+      if (options.method !== 'POST' || !COMPLETIONS_RE.test(path)) {
+        return origRequest.apply(mod, arguments);
+      }
+
+      // Create the real request, then intercept write/end to buffer the body.
+      var req = origRequest.apply(mod, arguments);
+      var origWrite = req.write;
+      var origEnd = req.end;
+      var chunks = [];
+      var intercepted = false;
+
+      req.write = function (chunk, encoding, cb) {
+        if (chunk != null) {
+          chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk);
+        }
+        // Buffer instead of sending — we flush in end().
+        if (typeof encoding === 'function') { encoding(); }
+        else if (typeof cb === 'function') { cb(); }
+        return true;
+      };
+
+      req.end = function (chunk, encoding, cb) {
+        if (chunk != null && typeof chunk !== 'function') {
+          chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk);
+        }
+        // Resolve the callback argument (end has multiple overload signatures).
+        var endCb = typeof chunk === 'function' ? chunk
+          : typeof encoding === 'function' ? encoding
+          : typeof cb === 'function' ? cb
+          : null;
+
+        var raw = Buffer.concat(chunks);
+        try {
+          var body = JSON.parse(raw.toString('utf-8'));
+          if (body && body.model && NEMOTRON_RE.test(body.model)) {
+            if (!body.chat_template_kwargs) {
+              body.chat_template_kwargs = {};
+            }
+            body.chat_template_kwargs.force_nonempty_content = true;
+            intercepted = true;
+            var modified = Buffer.from(JSON.stringify(body), 'utf-8');
+            // Update Content-Length so the proxy/server reads the full body.
+            if (req.getHeader && req.setHeader) {
+              req.removeHeader('content-length');
+              req.setHeader('Content-Length', modified.length);
+            }
+            origWrite.call(req, modified);
+          } else {
+            // Not a Nemotron model — send original bytes unmodified.
+            origWrite.call(req, raw);
+          }
+        } catch (_e) {
+          // JSON parse failed — forward original bytes.
+          origWrite.call(req, raw);
+        }
+
+        return endCb ? origEnd.call(req, endCb) : origEnd.call(req);
+      };
+
+      return req;
+    };
+  }
+
+  wrapModule(http);
+  wrapModule(https);
+})();

--- a/scripts/lib/guards/nemoclaw-sandbox-safety-net.js
+++ b/scripts/lib/guards/nemoclaw-sandbox-safety-net.js
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// sandbox-safety-net.js — last-resort handler that keeps the gateway alive
+// when any library throws an uncaught exception or unhandled rejection.
+//
+// Contract:
+//
+//   1. Inside the OpenShell sandbox the gateway is shared infrastructure.
+//      User-initiated actions (loading a plugin, starting a sidecar,
+//      running an agent against the gateway) must not be able to take it
+//      down. Node.js 22+ defaults --unhandled-rejections=throw which
+//      crashes on the first stray rejection from any library — including
+//      libraries we don't control.
+//
+//   2. Specific known-benign patterns are documented inline below. They
+//      get a single-line summary and are absorbed silently. Each pattern
+//      MUST document which library produces it, why it's safe to absorb
+//      in the sandbox context, and what the upstream fix is. Prefer
+//      disabling/configuring the upstream component so the rejection
+//      never fires; this list is the safety net, not the policy.
+//
+//   3. Unknown errors do NOT crash the gateway either, but they are
+//      logged with full stack so they can be diagnosed and either fixed
+//      upstream or added to the allow-list with explicit justification.
+//      "Unknown means crash" is the wrong default for shared
+//      infrastructure; "unknown means log loudly" is the right default.
+//
+//   4. No process.exit interception. An earlier iteration intercepted
+//      process.exit during swallow windows, which masked legitimate
+//      shutdown signals and was itself the kind of catch-all hack we
+//      want to avoid.
+//
+//   5. Only active when OPENSHELL_SANDBOX=1 (set by OpenShell at runtime),
+//      and only for `openclaw gateway run …` invocations
+//      (process.argv[2] === "gateway"). CLI commands (agent, doctor,
+//      plugins, tui, etc.) get default Node behavior so errors surface
+//      promptly to users running short-lived tools.
+
+(function () {
+  'use strict';
+  if (process.env.OPENSHELL_SANDBOX !== '1') return;
+  if (process.argv[2] !== 'gateway') return;
+
+  // KNOWN-BENIGN ERROR PATTERNS
+  //
+  // ciao / @homebridge/ciao — mDNS service-discovery library used by the
+  // OpenClaw bonjour plugin (introduced in 2026.4.15). Sandboxes have
+  // restricted network namespaces with no multicast. Two failure modes:
+  //   - sync: os.networkInterfaces() throws ERR_SYSTEM_ERROR
+  //     uv_interface_addresses. Pre-empted by ciao-network-guard.js,
+  //     which monkey-patches os.networkInterfaces() to return {}.
+  //   - async: the probe state machine cancels itself during gateway
+  //     startup/reload and emits "CIAO PROBING CANCELLED" as an unhandled
+  //     rejection. This is the path we catch here.
+  // Upstream fix: bonjour is disabled via plugins.entries.bonjour.enabled
+  // = false in the sandbox openclaw.json. This pattern is a backstop in
+  // case the disable is bypassed or a future release introduces another
+  // mDNS code path.
+  function classifyBenignRejection(reason) {
+    if (!reason) return null;
+    var msg = String((reason && reason.message) || reason);
+    var stack = (reason && reason.stack) || '';
+
+    if (msg.indexOf('CIAO') !== -1 ||
+        stack.indexOf('@homebridge/ciao') !== -1 ||
+        stack.indexOf('/ciao/') !== -1) {
+      return 'ciao/mDNS (sandbox lacks multicast; bonjour should be disabled in openclaw.json)';
+    }
+    if (reason && reason.code === 'ERR_SYSTEM_ERROR' &&
+        msg.indexOf('uv_interface_addresses') !== -1) {
+      return 'uv_interface_addresses (restricted netns)';
+    }
+    return null;
+  }
+
+  process.on('uncaughtException', function (err, origin) {
+    // Sync error paths are pre-empted by the targeted guards
+    // (ciao-network-guard.js, slack-channel-guard.js when Slack is
+    // configured). If we get here it's an error those guards didn't
+    // recognize. Log full stack and stay alive — registering this
+    // listener is what tells Node "don't crash on uncaughtException".
+    try {
+      process.stderr.write(
+        '[sandbox-safety-net] uncaughtException [unhandled by upstream guards \u2014 please diagnose]: ' +
+        ((err && err.stack) ? err.stack : String(err)) +
+        ' (origin: ' + origin + ') \u2014 gateway continues\n'
+      );
+    } catch (_) {}
+  });
+
+  process.on('unhandledRejection', function (reason, promise) {
+    var benign = classifyBenignRejection(reason);
+    if (benign) {
+      try {
+        process.stderr.write(
+          '[sandbox-safety-net] unhandledRejection [known-benign: ' + benign + ']: ' +
+          ((reason && reason.message) ? reason.message : String(reason)) + '\n'
+        );
+      } catch (_) {}
+      return;
+    }
+    try {
+      process.stderr.write(
+        '[sandbox-safety-net] unhandledRejection [UNKNOWN PATTERN \u2014 please diagnose]: ' +
+        ((reason && reason.stack) ? reason.stack : String(reason)) +
+        ' \u2014 gateway continues\n'
+      );
+    } catch (_) {}
+  });
+})();

--- a/scripts/lib/guards/nemoclaw-slack-channel-guard.js
+++ b/scripts/lib/guards/nemoclaw-slack-channel-guard.js
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// slack-channel-guard.js — catches unhandled promise rejections from Slack
+// channel initialization so a single channel auth failure does not crash
+// the entire OpenClaw gateway. Node v22 treats unhandled rejections as
+// fatal (--unhandled-rejections=throw is the default), taking down
+// inference, chat, and TUI alongside the failed Slack channel.
+//
+// This preload wraps process.emit for Slack-specific process-level failures
+// and consumes those events before later OpenClaw handlers can treat the
+// provider startup failure as fatal. Non-Slack failures pass through to the
+// original event machinery unchanged.
+//
+// Ref: https://github.com/NVIDIA/NemoClaw/issues/2340
+
+(function () {
+  'use strict';
+
+  // Slack-specific error codes from @slack/web-api that indicate auth failure.
+  // These appear as error.code on the WebAPIRequestError or CodedError objects.
+  var SLACK_AUTH_ERRORS = [
+    'slack_webapi_platform_error',
+    'slack_webapi_request_error',
+    'slackbot_error',
+  ];
+
+  // Slack-specific error messages that indicate auth/token problems.
+  var SLACK_AUTH_MESSAGES = [
+    'invalid_auth',
+    'not_authed',
+    'token_revoked',
+    'token_expired',
+    'account_inactive',
+    'missing_scope',
+    'not_allowed_token_type',
+    'An API error occurred: invalid_auth',
+  ];
+
+  function isSlackRejection(reason) {
+    if (!reason) return false;
+
+    // Check error code (Slack SDK sets .code on its errors)
+    var code = reason.code || '';
+    for (var i = 0; i < SLACK_AUTH_ERRORS.length; i++) {
+      if (code === SLACK_AUTH_ERRORS[i]) return true;
+    }
+
+    // Check error message
+    var msg = String(reason.message || reason);
+    for (var j = 0; j < SLACK_AUTH_MESSAGES.length; j++) {
+      if (msg.indexOf(SLACK_AUTH_MESSAGES[j]) !== -1) return true;
+    }
+
+    // Check stack trace for @slack/ packages
+    var stack = reason.stack || '';
+    if (stack.indexOf('@slack/') !== -1 || stack.indexOf('slack-') !== -1) {
+      return true;
+    }
+
+    // Check for proxy/network errors targeting Slack domains.
+    // When the network policy blocks or rejects connections to Slack
+    // servers, the error comes from the HTTP client (CONNECT tunnel
+    // failure), not from @slack/ code. The stack won't contain @slack/
+    // but the error message or URL may reference the Slack hostname.
+    if (msg.indexOf('slack.com') !== -1) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function handleSlackError(reason, source) {
+    if (isSlackRejection(reason)) {
+      var msg = (reason && reason.message) ? reason.message : String(reason);
+      process.stderr.write(
+        '[channels] [slack] provider failed to start: ' + msg +
+        ' \u2014 ' + source + ' caught by safety net, gateway continues\n'
+      );
+      return true; // handled
+    }
+    return false;
+  }
+
+  if (process.__nemoclawSlackChannelGuardInstalled) return;
+  try {
+    Object.defineProperty(process, '__nemoclawSlackChannelGuardInstalled', { value: true });
+  } catch (_e) {
+    process.__nemoclawSlackChannelGuardInstalled = true;
+  }
+
+  var origEmit = process.emit;
+  process.emit = function (eventName) {
+    if (eventName === 'unhandledRejection') {
+      if (handleSlackError(arguments[1], 'unhandledRejection')) return true;
+    } else if (eventName === 'uncaughtException') {
+      if (handleSlackError(arguments[1], 'uncaughtException')) return true;
+    }
+    return origEmit.apply(this, arguments);
+  };
+})();

--- a/scripts/lib/guards/nemoclaw-slack-token-rewriter.js
+++ b/scripts/lib/guards/nemoclaw-slack-token-rewriter.js
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// slack-token-rewriter.js — translates the Bolt-compatible placeholder
+// (xoxb|xapp)-OPENSHELL-RESOLVE-ENV-VAR into the canonical
+// openshell:resolve:env:VAR form on outbound HTTP, so Slack tokens travel
+// the same OpenShell substitution path Discord / Telegram / Brave already
+// use without any real token touching openclaw.json.
+//
+// Why this preload exists:
+//   Slack's Bolt SDK validates token shape (^xoxb-[A-Za-z0-9_-]+$ /
+//   ^xapp-…$) at App construction, before any HTTP call leaves the
+//   process — so the canonical openshell:resolve:env:VAR placeholder is
+//   rejected synchronously and the gateway crashes. We emit a Bolt-shape
+//   placeholder into openclaw.json (which Bolt accepts), then translate
+//   it back to canonical form here, just before the bytes hit the wire,
+//   where OpenShell's L7 proxy substitutes the real token from env.
+//
+// Wraps http.request / https.request — every Node HTTP client bottoms
+// out here, including @slack/web-api (axios → follow-redirects → http)
+// and Bolt's Socket Mode HTTPS auth (apps.connections.open → http).
+// Also wraps http.get / https.get because they call the module-local
+// `request` function, not module.exports.request — wrapping `request`
+// alone would miss any `get` caller.
+// Request body chunks are wrapped too: Bolt's auth.test path can put the
+// token in both Authorization and the urlencoded body.
+//
+// Invariants:
+//   - No env reads. Translation is purely structural.
+//   - Mutates options/headers in place. axios reuses the headers object
+//     after request creation, so cloning would break the request lifecycle.
+//   - Idempotent. The output (openshell:resolve:env:VAR) does not match
+//     the Bolt-shape regex, so re-entering the wrapper on a retry is safe.
+//   - Fast path: indexOf short-circuits the regex on the 99.9% of
+//     requests that don't contain a placeholder.
+//
+// This file is the canonical source for review and tests. At sandbox boot,
+// nemoclaw-start.sh writes a byte-identical copy to /tmp and loads it via
+// NODE_OPTIONS=--require. A sync test enforces byte-for-byte equality.
+// Mirrors the http-proxy-fix.js / ws-proxy-fix.js convention; see those
+// files for the rationale on why the content cannot live under
+// /opt/nemoclaw-blueprint/scripts/ in the optimized sandbox build.
+//
+// Ref: https://github.com/NVIDIA/NemoClaw/issues/2085
+
+(function () {
+  'use strict';
+
+  // Bolt-shape placeholder → canonical form. Single source of truth used
+  // by every code path below. <VAR> = [A-Z_][A-Z0-9_]* — the charset
+  // OpenShell's substitution layer accepts.
+  var BOLT_PLACEHOLDER =
+    /\b(?:xoxb|xapp)-OPENSHELL-RESOLVE-ENV-([A-Z_][A-Z0-9_]*)\b/g;
+  var FAST_PATH = 'OPENSHELL-RESOLVE-ENV-';
+
+  function rewriteString(s) {
+    if (typeof s !== 'string') return s;
+    if (s.indexOf(FAST_PATH) === -1) return s;
+    return s.replace(BOLT_PLACEHOLDER, 'openshell:resolve:env:$1');
+  }
+
+  function rewriteHeaders(headers) {
+    if (!headers || typeof headers !== 'object') return headers;
+    var keys = Object.keys(headers);
+    for (var i = 0; i < keys.length; i++) {
+      var v = headers[keys[i]];
+      if (Array.isArray(v)) {
+        for (var j = 0; j < v.length; j++) v[j] = rewriteString(v[j]);
+      } else {
+        headers[keys[i]] = rewriteString(v);
+      }
+    }
+    return headers;
+  }
+
+  function rewriteOptions(options) {
+    if (!options || typeof options !== 'object') return options;
+    if (typeof options.path === 'string') {
+      options.path = rewriteString(options.path);
+    }
+    if (options.headers) rewriteHeaders(options.headers);
+    return options;
+  }
+
+  function adjustContentLength(req, beforeLength, afterLength) {
+    var delta = afterLength - beforeLength;
+    if (!delta || !req || typeof req.getHeader !== 'function' || typeof req.setHeader !== 'function') {
+      return;
+    }
+    // Once Node has built/sent the header block, changing Content-Length would
+    // be too late. Axios writes the urlencoded Slack body in one chunk before
+    // headers are flushed, which is the path this adjustment is for.
+    if (req.headersSent || req._header) return;
+    var current = req.getHeader('content-length');
+    if (Array.isArray(current)) current = current[0];
+    if (current === undefined || current === null || current === '') return;
+    var n = Number(current);
+    if (!isFinite(n)) return;
+    req.setHeader('Content-Length', String(n + delta));
+  }
+
+  function rewriteBodyChunk(req, chunk, encoding) {
+    if (typeof chunk === 'string') {
+      var rewritten = rewriteString(chunk);
+      if (rewritten !== chunk) {
+        adjustContentLength(
+          req,
+          Buffer.byteLength(chunk, encoding),
+          Buffer.byteLength(rewritten, encoding)
+        );
+      }
+      return rewritten;
+    }
+
+    if (!chunk || typeof chunk !== 'object') return chunk;
+    var isBuffer = Buffer.isBuffer(chunk);
+    if (!isBuffer && !(chunk instanceof Uint8Array)) return chunk;
+
+    var buf = isBuffer
+      ? chunk
+      : Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+    if (buf.indexOf(FAST_PATH) === -1) return chunk;
+    var s = buf.toString('utf8');
+    if (s.indexOf(FAST_PATH) === -1) return chunk;
+    // Do not rewrite arbitrary binary data. Slack's urlencoded bodies are
+    // valid UTF-8 and round-trip exactly.
+    if (!Buffer.from(s, 'utf8').equals(buf)) return chunk;
+    var rs = rewriteString(s);
+    if (rs === s) return chunk;
+    var out = Buffer.from(rs, 'utf8');
+    adjustContentLength(req, buf.length, out.length);
+    return out;
+  }
+
+  function wrapClientRequest(req) {
+    if (!req || typeof req !== 'object') return req;
+    if (req.__nemoclawSlackTokenRewriter) return req;
+    try {
+      Object.defineProperty(req, '__nemoclawSlackTokenRewriter', { value: true });
+    } catch (_e) {
+      req.__nemoclawSlackTokenRewriter = true;
+    }
+
+    var origWrite = req.write;
+    if (typeof origWrite === 'function') {
+      req.write = function (chunk, encoding, cb) {
+        if (typeof encoding === 'function') {
+          cb = encoding;
+          encoding = undefined;
+        }
+        chunk = rewriteBodyChunk(this, chunk, encoding);
+        if (cb) return origWrite.call(this, chunk, encoding, cb);
+        if (encoding !== undefined) return origWrite.call(this, chunk, encoding);
+        return origWrite.call(this, chunk);
+      };
+    }
+
+    var origEnd = req.end;
+    if (typeof origEnd === 'function') {
+      req.end = function (chunk, encoding, cb) {
+        if (arguments.length === 0) return origEnd.call(this);
+        if (typeof chunk === 'function') return origEnd.call(this, chunk);
+        if (typeof encoding === 'function') {
+          cb = encoding;
+          encoding = undefined;
+        }
+        if (chunk !== undefined && chunk !== null) {
+          chunk = rewriteBodyChunk(this, chunk, encoding);
+        }
+        if (cb) return origEnd.call(this, chunk, encoding, cb);
+        if (encoding !== undefined) return origEnd.call(this, chunk, encoding);
+        return origEnd.call(this, chunk);
+      };
+    }
+
+    return req;
+  }
+
+  function wrap(mod, methodName) {
+    var orig = mod[methodName];
+    if (typeof orig !== 'function') return;
+    mod[methodName] = function (arg1, arg2, arg3) {
+      // Signatures: m(options[, cb]); m(url[, options][, cb])
+      if (typeof arg1 === 'string') {
+        arg1 = rewriteString(arg1);
+        if (arg2 && typeof arg2 === 'object' && typeof arg2 !== 'function') {
+          rewriteOptions(arg2);
+        }
+      } else if (arg1 instanceof URL) {
+        // URL instances are immutable by component; rebuild only if needed.
+        var s = arg1.href;
+        var rs = rewriteString(s);
+        if (rs !== s) arg1 = new URL(rs);
+        if (arg2 && typeof arg2 === 'object' && typeof arg2 !== 'function') {
+          rewriteOptions(arg2);
+        }
+      } else {
+        rewriteOptions(arg1);
+      }
+      return wrapClientRequest(orig.call(this, arg1, arg2, arg3));
+    };
+  }
+
+  var http = require('http');
+  var https = require('https');
+  wrap(http, 'request');
+  wrap(http, 'get');
+  wrap(https, 'request');
+  wrap(https, 'get');
+})();

--- a/src/lib/guard-recovery.test.ts
+++ b/src/lib/guard-recovery.test.ts
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./docker/exec", () => ({
+  dockerExecFileSync: vi.fn(),
+}));
+
+vi.mock("./openshell-timeouts", () => ({
+  OPENSHELL_OPERATION_TIMEOUT_MS: 30_000,
+}));
+
+import { checkGuardsPresent, reEmitGuards } from "./guard-recovery";
+import { dockerExecFileSync } from "./docker/exec";
+
+const mockDockerExec = vi.mocked(dockerExecFileSync);
+
+describe("guard-recovery", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("checkGuardsPresent", () => {
+    it("returns true when guards are present", () => {
+      mockDockerExec.mockReturnValue("GUARDS_OK\n");
+      expect(checkGuardsPresent("my-sandbox")).toBe(true);
+    });
+
+    it("returns false when guards are missing", () => {
+      mockDockerExec.mockReturnValue("GUARDS_MISSING\n");
+      expect(checkGuardsPresent("my-sandbox")).toBe(false);
+    });
+
+    it("returns null when kubectl exec fails", () => {
+      mockDockerExec.mockImplementation(() => {
+        throw new Error("container not running");
+      });
+      expect(checkGuardsPresent("my-sandbox")).toBeNull();
+    });
+
+    it("returns null for unexpected output", () => {
+      mockDockerExec.mockReturnValue("some garbage output");
+      expect(checkGuardsPresent("my-sandbox")).toBeNull();
+    });
+
+    it("constructs the correct kubectl exec command", () => {
+      mockDockerExec.mockReturnValue("GUARDS_OK");
+      checkGuardsPresent("test-sandbox");
+
+      expect(mockDockerExec).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          "exec",
+          "openshell-cluster-nemoclaw",
+          "kubectl",
+          "exec",
+          "-n",
+          "openshell",
+          "test-sandbox",
+          "-c",
+          "agent",
+          "--",
+          "sh",
+          "-c",
+          expect.stringContaining("nemoclaw-proxy-env.sh"),
+        ]),
+        expect.objectContaining({ timeout: 30_000 }),
+      );
+    });
+
+    it("checks for both proxy-env.sh and ciao-network-guard.js", () => {
+      mockDockerExec.mockReturnValue("GUARDS_OK");
+      checkGuardsPresent("test-sandbox");
+
+      const args = mockDockerExec.mock.calls[0][0] as string[];
+      const shCommand = args[args.length - 1];
+      expect(shCommand).toContain("nemoclaw-proxy-env.sh");
+      expect(shCommand).toContain("nemoclaw-ciao-network-guard.js");
+    });
+  });
+
+  describe("reEmitGuards", () => {
+    it("returns true when emit-guards.sh succeeds", () => {
+      mockDockerExec.mockReturnValue("[emit-guards] Guard chain installed successfully\n");
+      expect(reEmitGuards("my-sandbox")).toBe(true);
+    });
+
+    it("returns false when emit-guards.sh fails", () => {
+      mockDockerExec.mockImplementation(() => {
+        throw new Error("exec failed");
+      });
+      expect(reEmitGuards("my-sandbox")).toBe(false);
+    });
+
+    it("returns false when output doesn't contain success marker", () => {
+      mockDockerExec.mockReturnValue("some error output\n");
+      expect(reEmitGuards("my-sandbox")).toBe(false);
+    });
+
+    it("calls emit-guards.sh at the expected path", () => {
+      mockDockerExec.mockReturnValue("[emit-guards] Guard chain installed successfully");
+      reEmitGuards("test-sandbox");
+
+      expect(mockDockerExec).toHaveBeenCalledWith(
+        [
+          "exec",
+          "openshell-cluster-nemoclaw",
+          "kubectl",
+          "exec",
+          "-n",
+          "openshell",
+          "test-sandbox",
+          "-c",
+          "agent",
+          "--",
+          "/usr/local/lib/nemoclaw/emit-guards.sh",
+        ],
+        expect.objectContaining({ timeout: 30_000 }),
+      );
+    });
+  });
+});

--- a/src/lib/guard-recovery.ts
+++ b/src/lib/guard-recovery.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Guard chain recovery — re-emits NODE_OPTIONS preload guard files into /tmp
+ * when they are missing after a pod recreate.
+ *
+ * Uses kubectl exec (via docker exec) to run /usr/local/lib/nemoclaw/emit-guards.sh
+ * as root inside the sandbox container, bypassing Landlock. This is the same
+ * mechanism used by shields.ts and sandbox-config.ts for privileged operations.
+ *
+ * Ref: https://github.com/NVIDIA/NemoClaw/issues/2701
+ */
+
+import { dockerExecFileSync } from "./docker/exec";
+import { OPENSHELL_OPERATION_TIMEOUT_MS } from "./openshell-timeouts";
+
+const K3S_CONTAINER = "openshell-cluster-nemoclaw";
+const EMIT_GUARDS_PATH = "/usr/local/lib/nemoclaw/emit-guards.sh";
+
+/**
+ * Check whether the critical guard files exist inside the sandbox.
+ * Returns true if the minimum required guards are present, false if missing.
+ * Returns null if the check itself failed (sandbox unreachable).
+ */
+export function checkGuardsPresent(sandboxName: string): boolean | null {
+  try {
+    const result = dockerExecFileSync(
+      [
+        "exec",
+        K3S_CONTAINER,
+        "kubectl",
+        "exec",
+        "-n",
+        "openshell",
+        sandboxName,
+        "-c",
+        "agent",
+        "--",
+        "sh",
+        "-c",
+        // Check for the two most critical files:
+        // - proxy-env.sh (the aggregator that sources all guards via NODE_OPTIONS)
+        // - ciao-network-guard.js (prevents the specific crash in #2701)
+        "test -f /tmp/nemoclaw-proxy-env.sh && test -f /tmp/nemoclaw-ciao-network-guard.js && echo GUARDS_OK || echo GUARDS_MISSING",
+      ],
+      { stdio: ["ignore", "pipe", "pipe"], timeout: OPENSHELL_OPERATION_TIMEOUT_MS },
+    );
+    if (result.trim() === "GUARDS_OK") return true;
+    if (result.trim() === "GUARDS_MISSING") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-emit all guard files by running emit-guards.sh inside the sandbox as root.
+ * Uses kubectl exec (bypasses Landlock) to write root:root 444 files.
+ *
+ * Returns true if re-emission succeeded, false otherwise.
+ */
+export function reEmitGuards(sandboxName: string): boolean {
+  try {
+    const result = dockerExecFileSync(
+      [
+        "exec",
+        K3S_CONTAINER,
+        "kubectl",
+        "exec",
+        "-n",
+        "openshell",
+        sandboxName,
+        "-c",
+        "agent",
+        "--",
+        EMIT_GUARDS_PATH,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"], timeout: OPENSHELL_OPERATION_TIMEOUT_MS },
+    );
+    return result.includes("Guard chain installed successfully");
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/sandbox-build-context.ts
+++ b/src/lib/sandbox-build-context.ts
@@ -91,6 +91,17 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "scripts", "lib", "sandbox-init.sh"),
     path.join(stagedScriptsDir, "lib", "sandbox-init.sh"),
   );
+  // Guard re-emission script callable by recovery path (#2701)
+  fs.copyFileSync(
+    path.join(rootDir, "scripts", "lib", "emit-guards.sh"),
+    path.join(stagedScriptsDir, "lib", "emit-guards.sh"),
+  );
+  // Static JS guard files used by emit-guards.sh (#2701)
+  fs.cpSync(
+    path.join(rootDir, "scripts", "lib", "guards"),
+    path.join(stagedScriptsDir, "lib", "guards"),
+    { recursive: true },
+  );
   // OpenClaw config generator extracted in #2449 (fixed in #2565)
   fs.copyFileSync(
     path.join(rootDir, "scripts", "generate-openclaw-config.py"),

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -95,9 +95,13 @@ import {
   persistChannelTokens,
 } from "./lib/sandbox-channels";
 import {
+  OPENSHELL_DOWNLOAD_TIMEOUT_MS,
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "./lib/openshell-timeouts";
+import { buildChain } from "./lib/dashboard-contract";
+import type { DashboardRecoverDeps } from "./lib/dashboard-recover";
+import { recoverDashboardChain } from "./lib/dashboard-recover";
 const onboardProviders = require("./lib/onboard-providers");
 
 // ── Global commands (derived from command registry) ──────────────
@@ -346,10 +350,62 @@ function ensureSandboxPortForward(sandboxName: string): void {
   });
 }
 
+/** Build bounded DashboardRecoverDeps wired to real openshell calls. */
+function buildDashboardRecoverDeps(): DashboardRecoverDeps {
+  return {
+    executeSandboxCommand: (name: string, script: string) => {
+      const result = executeSandboxCommand(name, script);
+      if (!result) return null;
+      return { status: result.status, stdout: result.stdout };
+    },
+    captureForwardList: () => {
+      const result = captureOpenshell(["forward", "list"], {
+        ignoreError: true,
+        timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+      });
+      return result.status === 0 ? result.output : null;
+    },
+    downloadSandboxConfig: (name: string) => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cfg-"));
+      try {
+        const destDir = `${tmpDir}${path.sep}`;
+        const result = runOpenshell(
+          ["sandbox", "download", name, "/sandbox/.openclaw/openclaw.json", destDir],
+          { ignoreError: true, stdio: ["ignore", "ignore", "ignore"], timeout: OPENSHELL_DOWNLOAD_TIMEOUT_MS },
+        );
+        if (result.status !== 0) return null;
+        const files = fs.readdirSync(tmpDir, { recursive: true }) as string[];
+        const jsonFile = files.find((f: string) => f.endsWith("openclaw.json"));
+        if (!jsonFile) return null;
+        return JSON.parse(fs.readFileSync(path.join(tmpDir, jsonFile), "utf-8"));
+      } catch {
+        return null;
+      } finally {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+      }
+    },
+    restartGateway: (name: string, _port: number, _agent: unknown) => recoverSandboxProcesses(name),
+    stopForward: (port: number) => {
+      runOpenshell(["forward", "stop", String(port)], {
+        ignoreError: true,
+        timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
+      });
+    },
+    startForward: (target: string, name: string) => {
+      runOpenshell(["forward", "start", "--background", target, name], {
+        ignoreError: true,
+        timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
+      });
+    },
+    getSessionAgent: (name: string) => agentRuntime.getSessionAgent(name),
+  };
+}
+
 /**
  * Detect and recover from a sandbox that survived a gateway restart but
- * whose OpenClaw processes are not running. Returns an object describing
- * the outcome: { checked, wasRunning, recovered }.
+ * whose OpenClaw processes are not running. Uses the Dashboard Delivery
+ * Contract to verify and recover all links (gateway, forward, CORS).
+ * Returns an object describing the outcome: { checked, wasRunning, recovered }.
  */
 function checkAndRecoverSandboxProcesses(
   sandboxName: string,
@@ -363,7 +419,7 @@ function checkAndRecoverSandboxProcesses(
     return { checked: true, wasRunning: true, recovered: false };
   }
 
-  // Gateway not running — attempt recovery
+  // Gateway not running — attempt chain-level recovery
   const _recoveryAgent = agentRuntime.getSessionAgent(sandboxName);
   if (!quiet) {
     console.log("");
@@ -373,33 +429,39 @@ function checkAndRecoverSandboxProcesses(
     console.log("  Recovering...");
   }
 
-  const recovered = recoverSandboxProcesses(sandboxName);
-  if (recovered) {
-    // Wait for gateway to bind its HTTP port before declaring success
-    sleepSeconds(3);
-    if (isSandboxGatewayRunning(sandboxName) !== true) {
-      if (!quiet) {
-        console.error("  Gateway process started but is not responding.");
-        console.error("  Check /tmp/gateway.log inside the sandbox for details.");
-      }
-      return { checked: true, wasRunning: false, recovered: false };
-    }
-    ensureSandboxPortForward(sandboxName);
+  const agent = agentRuntime.getSessionAgent(sandboxName);
+  const port = agent?.forwardPort ?? DASHBOARD_PORT;
+  const chain = buildChain({ port, chatUiUrl: process.env.CHAT_UI_URL });
+  const deps = buildDashboardRecoverDeps();
+  const result = recoverDashboardChain(sandboxName, chain, deps);
+
+  if (result.after?.healthy) {
     if (!quiet) {
-      console.log(
-        `  ${G}✓${R} ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway restarted inside sandbox.`,
-      );
-      console.log(`  ${G}✓${R} Dashboard port forward re-established.`);
+      for (const action of result.actions) {
+        console.log(`  ${G}✓${R} ${action}`);
+      }
     }
-  } else if (!quiet) {
+    return { checked: true, wasRunning: false, recovered: true };
+  }
+
+  // Chain recovery didn't fully succeed — report diagnosis
+  if (!quiet) {
+    if (result.actions.length > 0) {
+      for (const action of result.actions) {
+        console.log(`  • ${action}`);
+      }
+    }
+    if (result.after && !result.after.healthy) {
+      console.error(`  Recovery incomplete: ${result.after.diagnosis || "unknown"}`);
+    }
     console.error(
-      `  Could not restart ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway automatically.`,
+      `  Could not fully recover ${agentRuntime.getAgentDisplayName(_recoveryAgent)} dashboard chain.`,
     );
     console.error("  Connect to the sandbox and run manually:");
     console.error(`    ${agentRuntime.getGatewayCommand(_recoveryAgent)}`);
   }
 
-  return { checked: true, wasRunning: false, recovered };
+  return { checked: true, wasRunning: false, recovered: false };
 }
 
 function buildRecoveredSandboxEntry(

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -294,9 +294,10 @@ function isSandboxGatewayRunning(sandboxName: string): boolean | null {
  * Cleans stale lock/temp files, sources proxy config, and launches the gateway
  * in the background. Returns true on success.
  */
-function recoverSandboxProcesses(sandboxName: string): boolean {
+function recoverSandboxProcesses(sandboxName: string, opts: { port?: number } = {}): boolean {
   const agent = agentRuntime.getSessionAgent(sandboxName);
-  const agentScript = agentRuntime.buildRecoveryScript(agent, agent?.forwardPort ?? DASHBOARD_PORT);
+  const port = opts.port ?? agent?.forwardPort ?? DASHBOARD_PORT;
+  const agentScript = agentRuntime.buildRecoveryScript(agent, port);
   const script =
     agentScript ||
     [
@@ -313,7 +314,7 @@ function recoverSandboxProcesses(sandboxName: string): boolean {
       "if [ -r /tmp/nemoclaw-proxy-env.sh ]; then . /tmp/nemoclaw-proxy-env.sh; _PE_MISSING=0; else _PE_MISSING=1; fi;",
       "[ -f ~/.bashrc ] && . ~/.bashrc;",
       'case "${NODE_OPTIONS:-}" in *nemoclaw-sandbox-safety-net*) _GUARDS_MISSING=0 ;; *) _GUARDS_MISSING=1 ;; esac;',
-      `if curl -sf --max-time 3 http://127.0.0.1:${DASHBOARD_PORT}/ > /dev/null 2>&1; then echo ALREADY_RUNNING; exit 0; fi;`,
+      `if curl -sf --max-time 3 http://127.0.0.1:${port}/ > /dev/null 2>&1; then echo ALREADY_RUNNING; exit 0; fi;`,
       "rm -rf /tmp/openclaw-*/gateway.*.lock 2>/dev/null;",
       "rm -f /tmp/gateway.log /tmp/auto-pair.log;",
       "touch /tmp/gateway.log; chmod 600 /tmp/gateway.log;",
@@ -324,7 +325,7 @@ function recoverSandboxProcesses(sandboxName: string): boolean {
       'if [ -z "$OPENCLAW" ]; then echo OPENCLAW_MISSING; exit 1; fi;',
       // Append rather than truncate so [gateway-recovery] WARNING lines
       // written above survive past the launch. (#2478)
-      `nohup "$OPENCLAW" gateway run --port ${DASHBOARD_PORT} >> /tmp/gateway.log 2>&1 &`,
+      `nohup "$OPENCLAW" gateway run --port ${port} >> /tmp/gateway.log 2>&1 &`,
       "GPID=$!; sleep 2;",
       'if kill -0 "$GPID" 2>/dev/null; then echo "GATEWAY_PID=$GPID"; else echo GATEWAY_FAILED; cat /tmp/gateway.log 2>/dev/null | tail -5; fi',
     ].join(" ");
@@ -384,7 +385,7 @@ function buildDashboardRecoverDeps(): DashboardRecoverDeps {
         try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
       }
     },
-    restartGateway: (name: string, _port: number, _agent: unknown) => recoverSandboxProcesses(name),
+    restartGateway: (name: string, port: number, _agent: unknown) => recoverSandboxProcesses(name, { port }),
     stopForward: (port: number) => {
       runOpenshell(["forward", "stop", String(port)], {
         ignoreError: true,
@@ -402,10 +403,12 @@ function buildDashboardRecoverDeps(): DashboardRecoverDeps {
 }
 
 /**
- * Detect and recover from a sandbox that survived a gateway restart but
- * whose OpenClaw processes are not running. Uses the Dashboard Delivery
- * Contract to verify and recover all links (gateway, forward, CORS).
- * Returns an object describing the outcome: { checked, wasRunning, recovered }.
+ * Detect and recover from a sandbox whose dashboard delivery chain is
+ * unhealthy. Checks all links (gateway process, port forward, CORS) and
+ * repairs whatever is broken — even when the in-sandbox gateway is alive
+ * but the forward or CORS link has drifted (e.g. after a pod restart that
+ * killed only the SSH tunnel). Returns an object describing the outcome:
+ * { checked, wasRunning, recovered }.
  */
 function checkAndRecoverSandboxProcesses(
   sandboxName: string,
@@ -415,19 +418,6 @@ function checkAndRecoverSandboxProcesses(
   if (running === null) {
     return { checked: false, wasRunning: null, recovered: false };
   }
-  if (running) {
-    return { checked: true, wasRunning: true, recovered: false };
-  }
-
-  // Gateway not running — attempt chain-level recovery
-  const _recoveryAgent = agentRuntime.getSessionAgent(sandboxName);
-  if (!quiet) {
-    console.log("");
-    console.log(
-      `  ${agentRuntime.getAgentDisplayName(_recoveryAgent)} gateway is not running inside the sandbox (sandbox likely restarted).`,
-    );
-    console.log("  Recovering...");
-  }
 
   const agent = agentRuntime.getSessionAgent(sandboxName);
   const port = agent?.forwardPort ?? DASHBOARD_PORT;
@@ -435,13 +425,27 @@ function checkAndRecoverSandboxProcesses(
   const deps = buildDashboardRecoverDeps();
   const result = recoverDashboardChain(sandboxName, chain, deps);
 
+  // Chain was already healthy — nothing to do
+  if (!result.attempted) {
+    return { checked: true, wasRunning: running, recovered: false };
+  }
+
+  // Recovery was attempted — report progress
+  if (!quiet && !running) {
+    console.log("");
+    console.log(
+      `  ${agentRuntime.getAgentDisplayName(agent)} gateway is not running inside the sandbox (sandbox likely restarted).`,
+    );
+    console.log("  Recovering...");
+  }
+
   if (result.after?.healthy) {
     if (!quiet) {
       for (const action of result.actions) {
         console.log(`  ${G}✓${R} ${action}`);
       }
     }
-    return { checked: true, wasRunning: false, recovered: true };
+    return { checked: true, wasRunning: running, recovered: true };
   }
 
   // Chain recovery didn't fully succeed — report diagnosis
@@ -455,13 +459,13 @@ function checkAndRecoverSandboxProcesses(
       console.error(`  Recovery incomplete: ${result.after.diagnosis || "unknown"}`);
     }
     console.error(
-      `  Could not fully recover ${agentRuntime.getAgentDisplayName(_recoveryAgent)} dashboard chain.`,
+      `  Could not fully recover ${agentRuntime.getAgentDisplayName(agent)} dashboard chain.`,
     );
     console.error("  Connect to the sandbox and run manually:");
-    console.error(`    ${agentRuntime.getGatewayCommand(_recoveryAgent)}`);
+    console.error(`    ${agentRuntime.getGatewayCommand(agent)}`);
   }
 
-  return { checked: true, wasRunning: false, recovered: false };
+  return { checked: true, wasRunning: running, recovered: false };
 }
 
 function buildRecoveredSandboxEntry(

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -376,7 +376,7 @@ function buildDashboardRecoverDeps(): DashboardRecoverDeps {
         );
         if (result.status !== 0) return null;
         const files = fs.readdirSync(tmpDir, { recursive: true }) as string[];
-        const jsonFile = files.find((f: string) => f.endsWith("openclaw.json"));
+        const jsonFile = files.find((f) => f.endsWith("openclaw.json"));
         if (!jsonFile) return null;
         return JSON.parse(fs.readFileSync(path.join(tmpDir, jsonFile), "utf-8"));
       } catch {
@@ -385,7 +385,11 @@ function buildDashboardRecoverDeps(): DashboardRecoverDeps {
         try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
       }
     },
-    restartGateway: (name: string, port: number, _agent: unknown) => recoverSandboxProcesses(name, { port }),
+    restartGateway: (name: string, port: number, _agent: unknown) => {
+      const ok = recoverSandboxProcesses(name, { port });
+      if (ok) sleepSeconds(3); // Wait for HTTP listener to bind before re-verify
+      return ok;
+    },
     stopForward: (port: number) => {
       runOpenshell(["forward", "stop", String(port)], {
         ignoreError: true,

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -424,7 +424,20 @@ function checkAndRecoverSandboxProcesses(
   }
 
   const agent = agentRuntime.getSessionAgent(sandboxName);
-  const port = agent?.forwardPort ?? DASHBOARD_PORT;
+
+  // Dashboard chain recovery only applies to OpenClaw sandboxes.
+  // Non-OpenClaw agents (Hermes, etc.) use different config paths and don't
+  // expose the OpenClaw control UI — fall back to gateway-only recovery.
+  if (agent !== null) {
+    return checkAndRecoverGatewayOnly(sandboxName, running, agent, { quiet });
+  }
+
+  // OpenClaw sandbox: use the registry's persisted dashboardPort (which
+  // reflects auto-allocated or user-overridden ports) before falling back
+  // to the default. This ensures multi-sandbox setups with custom ports
+  // (e.g. 18790) probe and recover the correct port.
+  const sb = registry.getSandbox(sandboxName);
+  const port = sb?.dashboardPort ?? DASHBOARD_PORT;
   const chain = buildChain({ port, chatUiUrl: process.env.CHAT_UI_URL });
   const deps = buildDashboardRecoverDeps();
   const result = recoverDashboardChain(sandboxName, chain, deps);
@@ -437,9 +450,7 @@ function checkAndRecoverSandboxProcesses(
   // Recovery was attempted — report progress
   if (!quiet && !running) {
     console.log("");
-    console.log(
-      `  ${agentRuntime.getAgentDisplayName(agent)} gateway is not running inside the sandbox (sandbox likely restarted).`,
-    );
+    console.log("  OpenClaw gateway is not running inside the sandbox (sandbox likely restarted).");
     console.log("  Recovering...");
   }
 
@@ -462,14 +473,65 @@ function checkAndRecoverSandboxProcesses(
     if (result.after && !result.after.healthy) {
       console.error(`  Recovery incomplete: ${result.after.diagnosis || "unknown"}`);
     }
-    console.error(
-      `  Could not fully recover ${agentRuntime.getAgentDisplayName(agent)} dashboard chain.`,
-    );
+    console.error("  Could not fully recover OpenClaw dashboard chain.");
     console.error("  Connect to the sandbox and run manually:");
     console.error(`    ${agentRuntime.getGatewayCommand(agent)}`);
   }
 
   return { checked: true, wasRunning: running, recovered: false };
+}
+
+/**
+ * Simplified gateway-only recovery for non-OpenClaw agents (Hermes, etc.).
+ * Only checks/restarts the gateway process and re-establishes the port forward.
+ * Does NOT attempt CORS verification (agents use different config paths).
+ */
+function checkAndRecoverGatewayOnly(
+  sandboxName: string,
+  running: boolean,
+  agent: unknown,
+  { quiet = false }: { quiet?: boolean } = {},
+) {
+  if (running) {
+    return { checked: true, wasRunning: true, recovered: false };
+  }
+
+  if (!quiet) {
+    console.log("");
+    console.log(
+      `  ${agentRuntime.getAgentDisplayName(agent)} gateway is not running inside the sandbox (sandbox likely restarted).`,
+    );
+    console.log("  Recovering...");
+  }
+
+  const sb = registry.getSandbox(sandboxName);
+  const port = sb?.dashboardPort ?? (agent as { forwardPort?: number })?.forwardPort ?? DASHBOARD_PORT;
+  const recovered = recoverSandboxProcesses(sandboxName, { port });
+  if (recovered) {
+    sleepSeconds(3);
+    if (isSandboxGatewayRunning(sandboxName) !== true) {
+      if (!quiet) {
+        console.error("  Gateway process started but is not responding.");
+        console.error("  Check /tmp/gateway.log inside the sandbox for details.");
+      }
+      return { checked: true, wasRunning: false, recovered: false };
+    }
+    ensureSandboxPortForward(sandboxName);
+    if (!quiet) {
+      console.log(
+        `  ${G}✓${R} ${agentRuntime.getAgentDisplayName(agent)} gateway restarted inside sandbox.`,
+      );
+      console.log(`  ${G}✓${R} Port forward re-established.`);
+    }
+  } else if (!quiet) {
+    console.error(
+      `  Could not restart ${agentRuntime.getAgentDisplayName(agent)} gateway automatically.`,
+    );
+    console.error("  Connect to the sandbox and run manually:");
+    console.error(`    ${agentRuntime.getGatewayCommand(agent)}`);
+  }
+
+  return { checked: true, wasRunning: false, recovered };
 }
 
 function buildRecoveredSandboxEntry(

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -54,6 +54,7 @@ const { getVersion } = require("./lib/version");
 const onboardSession = require("./lib/onboard-session");
 import type { Session } from "./lib/onboard-session";
 const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
+const { checkGuardsPresent, reEmitGuards } = require("./lib/guard-recovery");
 const { NOTICE_ACCEPT_ENV, NOTICE_ACCEPT_FLAG } = require("./lib/usage-notice");
 const { runDebugCommand } = require("./lib/debug-command");
 const { runDeprecatedOnboardAliasCommand, runOnboardCommand } = require("./lib/onboard-command");
@@ -297,6 +298,27 @@ function isSandboxGatewayRunning(sandboxName: string): boolean | null {
 function recoverSandboxProcesses(sandboxName: string, opts: { port?: number } = {}): boolean {
   const agent = agentRuntime.getSessionAgent(sandboxName);
   const port = opts.port ?? agent?.forwardPort ?? DASHBOARD_PORT;
+
+  // ── Guard re-emission (#2701) ─────────────────────────────────
+  // Before launching the gateway, check whether the NODE_OPTIONS preload
+  // guard chain exists in /tmp. After a pod recreate, /tmp is fresh and
+  // the guards are gone — launching without them crash-loops the gateway
+  // on the first @homebridge/ciao os.networkInterfaces() call.
+  // Re-emit via kubectl exec (as root, bypassing Landlock) so the
+  // subsequent recovery script can source proxy-env.sh successfully.
+  const guardsPresent = checkGuardsPresent(sandboxName);
+  if (guardsPresent === false) {
+    const reEmitted = reEmitGuards(sandboxName);
+    if (!reEmitted) {
+      // Best-effort: log the failure but proceed with recovery anyway.
+      // The recovery script will emit the WARNING and the gateway may
+      // crash-loop, matching pre-fix behavior — at least we tried.
+      console.error(
+        "  [guard-recovery] Could not re-emit guard chain — gateway may crash-loop (#2701)",
+      );
+    }
+  }
+
   const agentScript = agentRuntime.buildRecoveryScript(agent, port);
   const script =
     agentScript ||


### PR DESCRIPTION
## Summary

Fixes #2701 — After a pod recreate, the sandbox's `/tmp` is fresh and all NODE_OPTIONS preload guard files are gone. The recovery path previously detected this and warned but launched the gateway anyway — causing a crash-loop from `@homebridge/ciao`'s `os.networkInterfaces()` call.

This PR adds automatic guard re-emission: when recovery detects missing guards, it calls `/usr/local/lib/nemoclaw/emit-guards.sh` inside the sandbox via `kubectl exec` (as root, bypassing Landlock) before launching the gateway.

## Changes

- **`scripts/lib/guards/`** — 6 JS guard files extracted from `nemoclaw-start.sh` heredocs into standalone files, baked into the Docker image at `/usr/local/lib/nemoclaw/guards/`
- **`scripts/lib/emit-guards.sh`** — Standalone script that installs guards to `/tmp` with correct permissions (root:root 444) and generates `proxy-env.sh` dynamically. Callable by both the entrypoint and the recovery path.
- **`Dockerfile`** — COPY guards/ and emit-guards.sh into the image
- **`src/lib/guard-recovery.ts`** — New module: `checkGuardsPresent()` + `reEmitGuards()` using docker exec → kubectl exec
- **`src/nemoclaw.ts`** — Wired guard re-emission into `recoverSandboxProcesses()` before gateway launch
- **`src/lib/sandbox-build-context.ts`** — Stage new files in optimized build context

## Dependencies

- **Depends on PR #2710** (rebased on its branch) — needs to merge first or be combined
- `test/e2e/test-issue-2478-crash-loop-recovery.sh` Phase 4 assertion will need updating: the negative case (proxy-env.sh removed) will now see successful re-emission instead of the WARNING, since our fix restores the file before launching

## Verification

```bash
npm run typecheck:cli
npx vitest run src/lib/guard-recovery.test.ts src/lib/agent-runtime.test.ts test/sandbox-build-context.test.ts test/nemoclaw-start.test.ts
```

## E2E Validation

Target the **`issue-2478-crash-loop-recovery-e2e`** nightly job. The test's Phase 4 negative case will validate that:
1. Guards are removed → recovery detects missing guards → re-emits → gateway starts clean
2. Crash-recovery loops (Phase 3) continue to work with guards intact

Once #2710 merges, rebase onto main and update the #2478 E2E test assertions to expect re-emission instead of WARNING.

## Follow-up

- **Phase 2**: Refactor `nemoclaw-start.sh` to source guards from `/usr/local/lib/nemoclaw/guards/` (DRY the heredocs) — separate PR
- **Phase 4**: Dedicated `test-issue-2701-guard-reemission.sh` E2E test