### PR TITLE
docs: refresh daily docs for 0.0.31

### DIFF
--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -67,6 +67,7 @@ The onboard wizard manages the proxy automatically:
   `~/.nemoclaw/ollama-proxy-token` with `0600` permissions.
 - Starts the proxy after Ollama and verifies it before continuing.
 - Cleans up stale proxy processes from previous runs.
+- Retries the sandbox container reachability check and can continue when the host-side proxy is healthy even if the container probe fails.
 - Reuses the persisted token after a host reboot so you do not need to re-run
   onboard.
 
@@ -257,7 +258,7 @@ To select a specific model, set `NEMOCLAW_MODEL`.
 ## Timeout Configuration
 
 Local inference requests use a default timeout of 180 seconds.
-Large prompts on hardware such as DGX Spark can exceed shorter timeouts, so NemoClaw sets a higher default for local providers (Ollama, vLLM, NIM).
+Large prompts on hardware such as DGX Spark can exceed shorter timeouts, so NemoClaw sets a higher default for Ollama, vLLM, NIM, and compatible-endpoint setup.
 
 To override the timeout, set the `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` environment variable before onboarding:
 

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.29"}
+{"name": "nemoclaw", "version": "0.0.31"}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -127,6 +127,8 @@ $ BRAVE_API_KEY=... \
 ```
 
 `BRAVE_API_KEY` enables Brave Search in non-interactive mode and also enables `web_fetch`.
+If Brave Search key validation fails in non-interactive mode, onboarding prints a warning, skips web search setup, and continues with the rest of the sandbox setup.
+After fixing the key, re-enable web search with `nemoclaw config web-search`.
 
 The wizard prompts for a sandbox name.
 Names must follow RFC 1123 subdomain rules: lowercase alphanumeric characters and hyphens only, and must start and end with an alphanumeric character.
@@ -170,6 +172,9 @@ If the directory contains unreadable files (for example, Windows system files vi
 ```console
 $ nemoclaw onboard --from path/to/Dockerfile
 ```
+
+The Dockerfile path must exist.
+Missing paths fail during command parsing before preflight, gateway setup, inference setup, or sandbox creation starts.
 
 The file can have any name; if it is not already named `Dockerfile`, onboard copies it to `Dockerfile` inside the staged build context automatically.
 To create an isolated build context, create a dedicated directory that contains only the Dockerfile and the files it needs:
@@ -315,6 +320,8 @@ $ nemoclaw my-assistant status
 
 View sandbox logs.
 Use `--follow` to stream output in real time.
+The command reads both OpenClaw gateway output and OpenShell audit events, so policy denials appear alongside the gateway log stream.
+If one log source is unavailable, NemoClaw prints a warning and keeps reading the remaining source.
 
 ```console
 $ nemoclaw my-assistant logs [--follow]

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -41,6 +41,10 @@ The `nemoclaw` binary is installed but the shell session does not know where to 
 
 Run `source ~/.bashrc` (or `source ~/.zshrc` for zsh), or open a new terminal window.
 
+When installing from a source checkout with `npm install`, NemoClaw first tries `npm link`.
+If the global npm prefix is not writable, it writes a managed shim to `~/.local/bin/nemoclaw` instead.
+Add `~/.local/bin` to your `PATH` if the command is still not found.
+
 ### Installer fails on unsupported platform
 
 The installer checks for a supported OS and architecture before proceeding.
@@ -525,6 +529,16 @@ If they are missing on an older sandbox, upgrade NemoClaw and run:
 $ nemoclaw <name> rebuild
 ```
 
+### Sandbox creation reports a TLS certificate mismatch
+
+If sandbox creation reports a TLS or certificate mismatch, the OpenShell gateway certificate may have changed since the CLI last trusted it.
+Refresh the gateway trust and then resume onboarding:
+
+```console
+$ openshell gateway trust -g nemoclaw
+$ nemoclaw onboard --resume
+```
+
 ### `openclaw update` hangs or times out inside the sandbox
 
 This is expected for the current NemoClaw deployment model.
@@ -552,13 +566,16 @@ If that line shows `unreachable`, start the local backend first and then retry t
 If the endpoint is correct but requests still fail, check for network policy rules that may block the connection.
 Then verify the credential and base URL for the provider you selected during onboarding.
 
-For local providers (Ollama, vLLM, NIM), the default timeout is 180 seconds.
+For Ollama, vLLM, NIM, and compatible-endpoint setup, the default timeout is 180 seconds.
 If large prompts still cause timeouts, increase it with `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` before re-running onboard:
 
 ```console
 $ export NEMOCLAW_LOCAL_INFERENCE_TIMEOUT=300
 $ nemoclaw onboard
 ```
+
+For local Ollama and vLLM, onboarding retries the container reachability check and can fall back to the host-side health check when the local backend is healthy.
+If all attempts fail, the error includes container reachability diagnostics such as HTTP status and host gateway resolution.
 
 ### Agent fails at runtime after onboarding succeeds with a compatible endpoint
 
@@ -731,6 +748,9 @@ $ nemoclaw onboard
 
 These are build-time settings baked into the sandbox image.
 Changing them after onboarding requires re-running `nemoclaw onboard` to rebuild the image.
+
+When `HTTP_PROXY` or `HTTPS_PROXY` is set on the host, NemoClaw adds `localhost` and `127.0.0.1` to `NO_PROXY` for managed subprocesses.
+This keeps local Ollama health checks and model pulls from being routed through a corporate or desktop proxy while preserving the proxy for external hosts.
 
 ### Agent cannot reach a host-side HTTP service
 

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,8 +1,8 @@
 [
   {
     "preferred": true,
-    "version": "0.0.29",
-    "url": "https://docs.nvidia.com/nemoclaw/0.0.29/"
+    "version": "0.0.31",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.31/"
   },
   {
     "version": "0.0.25",


### PR DESCRIPTION
## Summary
Refreshes the daily docs from NemoClaw commits merged in the past 24 hours and advances the docs metadata from 0.0.29 to 0.0.31, the next version after tag v0.0.30.
The updates cover documented behavior gaps found in the merged PRs listed below.

## Related Issue
None.

## Changes
- `docs/versions1.json` and `docs/project.json`: bump the preferred docs version to `0.0.31` for daily release preparation after latest tag `v0.0.30`.
- `docs/reference/commands.md`: document non-interactive Brave Search validation fallback from #2511 / 9bfe30b9, missing `--from <Dockerfile>` path validation from #2597 / 7186834e, and `logs` reading OpenShell audit events from #2590 / e225dfb3.
- `docs/inference/use-local-inference.md`: document local inference reachability retry and host-side fallback from #2453 / 9dbe855a, plus compatible-endpoint timeout coverage from #2583 / b4ef3db2.
- `docs/reference/troubleshooting.md`: document source-install shim fallback from #2520 / 01a177cf, TLS gateway trust recovery from #1936 / 24725d27, compatible-endpoint timeout coverage from #2583 / b4ef3db2, local reachability diagnostics from #2453 / 9dbe855a, and host proxy `NO_PROXY` injection from #2662 / b4df07ea.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:
- `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --dry-run` passed.
- `git diff --check` passed.
- Pre-push hooks passed through markdownlint, docs-to-skills, JSON checks, gitleaks, and version sync before `Test (skills YAML)` failed because this fresh worktree lacked `vitest/config`.
- `npx prek run --all-files` could not run from the fresh worktree because `npx prek` resolved to a missing `prek@*` package; downloading `@j178/prek` was not approved.
- `npm test` could not complete from the fresh worktree because dependencies and compiled `dist/lib/*` artifacts were absent.

## AI Disclosure
- [x] AI-assisted — tool: OpenAI Codex

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Version updated to 0.0.31
  * Local inference onboarding now includes retry logic for container reachability checks
  * Web search setup failure handling clarified with fallback guidance
  * Dockerfile path validation timing documented
  * Logging behavior clarified for concurrent stream reading
  * New TLS/certificate troubleshooting section added
  * Install path and proxy configuration troubleshooting updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->