### PR TITLE
fix(sandbox): keep runtime shell state out of rc files

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -127,7 +127,8 @@ RUN printf '%s\n' \
         '# Source runtime proxy config' \
         '[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh' \
         > /sandbox/.profile \
-    && chown sandbox:sandbox /sandbox/.bashrc /sandbox/.profile
+    && chown root:root /sandbox/.bashrc /sandbox/.profile \
+    && chmod 444 /sandbox/.bashrc /sandbox/.profile
 
 # Install OpenClaw CLI + PyYAML for inline Python scripts in e2e tests.
 # OpenClaw version: change the OPENCLAW_VERSION ARG default so CI rebuilds

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -240,12 +240,12 @@ Operators can opt into immutability by running `nemoclaw <name> shields up`, whi
 
 - **DAC permissions (default).** The sandbox user owns `/sandbox/.openclaw` with mode `700` and `openclaw.json` with mode `600`, so the agent can read and write config directly.
 - **Config integrity hash.** The image includes a SHA256 hash of `openclaw.json`. In the default mutable state, `.config-hash` is sandbox-owned and is not a tamper-proof trust anchor, so startup does not fail closed on that hash. After `nemoclaw <name> shields up` locks the hash root-owned and read-only, startup enforces it and refuses to start if the hash does not match.
-- **Gateway token environment.** The gateway auth token is exported as `OPENCLAW_GATEWAY_TOKEN` and written to `/tmp/nemoclaw-proxy-env.sh` for interactive sandbox sessions. Keep this in mind when deciding whether a workload should run with mutable config or with Shields UP.
+- **Gateway token environment.** The gateway exports `OPENCLAW_GATEWAY_TOKEN` and writes it to `/tmp/nemoclaw-proxy-env.sh` for interactive sandbox sessions. Keep this in mind when deciding whether a workload should run with mutable config or with Shields UP.
 - **Shields UP (opt-in).** `nemoclaw <name> shields up` applies root-owned read-only permissions and best-effort immutable bits to sensitive config files, and locks writable state directories such as workspace, memory, skills, hooks, cron, agents, and extensions.
 
 | Aspect | Detail |
 |---|---|
-| Default | `/sandbox/.openclaw` is writable (`700 sandbox:sandbox`; `openclaw.json` is `600 sandbox:sandbox`). The agent can read and write config, install skills, and manage state directly. The gateway auth token is exported as `OPENCLAW_GATEWAY_TOKEN` and made available to interactive sandbox shells through `/tmp/nemoclaw-proxy-env.sh`, which is sourced by static shell startup files. |
+| Default | The sandbox keeps `/sandbox/.openclaw` writable (`700 sandbox:sandbox`), sets `openclaw.json` to `600 sandbox:sandbox`, lets the agent manage state directly, and has the gateway place `OPENCLAW_GATEWAY_TOKEN` in `/tmp/nemoclaw-proxy-env.sh` for interactive shells. |
 | What you can change | Run `nemoclaw <name> shields up` to lock config and state directories with DAC permissions and the immutable flag where available. Run `shields down` to return to the writable default. |
 | Risk of default | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS or redirecting inference to an attacker-controlled endpoint. |
 | Recommendation | For always-on assistants handling sensitive workloads, use `shields up` to lock config after initial setup. For development workflows, the writable default is appropriate. |

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -230,7 +230,7 @@ The container mounts system directories read-only to prevent the agent from modi
 ### Agent Config Directory
 
 The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
-The current entrypoint reads the gateway auth token from OpenClaw config when present, exports it as `OPENCLAW_GATEWAY_TOKEN`, and maintains marked blocks in `/sandbox/.bashrc` and `/sandbox/.profile` so interactive sandbox sessions can reach the gateway.
+The current entrypoint reads the gateway auth token from OpenClaw config when present, exports it as `OPENCLAW_GATEWAY_TOKEN`, and writes it to `/tmp/nemoclaw-proxy-env.sh` so interactive sandbox sessions can reach the gateway through the static `/sandbox/.bashrc` and `/sandbox/.profile` source shims.
 In root mode, the gateway process still runs as the separate `gateway` user, but the token is intentionally available to sandbox shells for local gateway access.
 
 Writable agent state such as plugins, skills, hooks, and workspace metadata lives directly under `/sandbox/.openclaw`.
@@ -240,12 +240,12 @@ Operators can opt into immutability by running `nemoclaw <name> shields up`, whi
 
 - **DAC permissions (default).** The sandbox user owns `/sandbox/.openclaw` with mode `700` and `openclaw.json` with mode `600`, so the agent can read and write config directly.
 - **Config integrity hash.** The image includes a SHA256 hash of `openclaw.json`. In the default mutable state, `.config-hash` is sandbox-owned and is not a tamper-proof trust anchor, so startup does not fail closed on that hash. After `nemoclaw <name> shields up` locks the hash root-owned and read-only, startup enforces it and refuses to start if the hash does not match.
-- **Gateway token environment.** The gateway auth token is exported as `OPENCLAW_GATEWAY_TOKEN` and written to marked shell rc blocks for interactive sandbox sessions. Keep this in mind when deciding whether a workload should run with mutable config or with Shields UP.
+- **Gateway token environment.** The gateway auth token is exported as `OPENCLAW_GATEWAY_TOKEN` and written to `/tmp/nemoclaw-proxy-env.sh` for interactive sandbox sessions. Keep this in mind when deciding whether a workload should run with mutable config or with Shields UP.
 - **Shields UP (opt-in).** `nemoclaw <name> shields up` applies root-owned read-only permissions and best-effort immutable bits to sensitive config files, and locks writable state directories such as workspace, memory, skills, hooks, cron, agents, and extensions.
 
 | Aspect | Detail |
 |---|---|
-| Default | `/sandbox/.openclaw` is writable (`700 sandbox:sandbox`; `openclaw.json` is `600 sandbox:sandbox`). The agent can read and write config, install skills, and manage state directly. The gateway auth token is exported as `OPENCLAW_GATEWAY_TOKEN` and made available to interactive sandbox shells through marked rc-file blocks. |
+| Default | `/sandbox/.openclaw` is writable (`700 sandbox:sandbox`; `openclaw.json` is `600 sandbox:sandbox`). The agent can read and write config, install skills, and manage state directly. The gateway auth token is exported as `OPENCLAW_GATEWAY_TOKEN` and made available to interactive sandbox shells through `/tmp/nemoclaw-proxy-env.sh`, which is sourced by static shell startup files. |
 | What you can change | Run `nemoclaw <name> shields up` to lock config and state directories with DAC permissions and the immutable flag where available. Run `shields down` to return to the writable default. |
 | Risk of default | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS or redirecting inference to an attacker-controlled endpoint. |
 | Recommendation | For always-on assistants handling sensitive workloads, use `shields up` to lock config after initial setup. For development workflows, the writable default is appropriate. |

--- a/scripts/lib/sandbox-init.sh
+++ b/scripts/lib/sandbox-init.sh
@@ -315,9 +315,9 @@ verify_config_integrity_if_locked() {
 }
 
 # ── RC file locking ──────────────────────────────────────────────
-# Lock .bashrc and .profile to 444 after all mutations (proxy snippets,
-# configure guard, gateway token export) are complete. This prevents the
-# sandbox user from injecting code that runs on every `nemoclaw connect`.
+# Lock .bashrc and .profile to 444 after startup has written dynamic shell
+# state to /tmp/nemoclaw-proxy-env.sh. This prevents the sandbox user from
+# injecting code that runs on every `nemoclaw connect`.
 #
 # SECURITY: This fixes the Hermes vulnerability where .bashrc/.profile
 # were never locked (unlike OpenClaw which had this via #2125).

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1652,6 +1652,9 @@ fi
 # Both uppercase and lowercase variants are required: Node.js undici prefers
 # lowercase (no_proxy) over uppercase (NO_PROXY) when both are set.
 # curl/wget use uppercase.  gRPC C-core uses lowercase.
+_RUNTIME_SHELL_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
+_RUNTIME_SHELL_ENV_SHIM="[ -f ${_RUNTIME_SHELL_ENV_FILE} ] && . ${_RUNTIME_SHELL_ENV_FILE}"
+
 write_runtime_shell_env() {
   _PROXY_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
   {
@@ -1771,6 +1774,65 @@ GUARDENVEOF
 # SANDBOX_CHILD_PIDS (array of all PIDs) and SANDBOX_WAIT_PID (the
 # primary process whose exit status is returned).
 # Each code path below sets these before registering the trap.
+
+# Stale base images may have rc files from before the runtime env source shim
+# was baked into Dockerfile.base. Backfill the static shim before lock_rc_files
+# makes those files read-only so connect sessions still receive proxy config,
+# gateway auth, and command guards through /tmp/nemoclaw-proxy-env.sh.
+ensure_runtime_shell_env_shim() {
+  local failed=0
+  local rc_file
+
+  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
+    if [ -L "$rc_file" ]; then
+      echo "[SECURITY] refusing symlinked rc file: $rc_file" >&2
+      failed=1
+      continue
+    fi
+    if [ -e "$rc_file" ] && [ ! -f "$rc_file" ]; then
+      echo "[SECURITY] refusing non-regular rc file: $rc_file" >&2
+      failed=1
+      continue
+    fi
+    if [ -f "$rc_file" ] && grep -qxF "$_RUNTIME_SHELL_ENV_SHIM" "$rc_file" 2>/dev/null; then
+      continue
+    fi
+
+    if [ "$(id -u)" -eq 0 ] && [ -f "$rc_file" ]; then
+      if ! chown root:root "$rc_file" 2>/dev/null; then
+        echo "[SECURITY] could not take ownership of $rc_file before shim backfill" >&2
+        failed=1
+        continue
+      fi
+      if ! chmod 644 "$rc_file" 2>/dev/null; then
+        echo "[SECURITY] could not make $rc_file writable before shim backfill" >&2
+        failed=1
+        continue
+      fi
+    elif [ -f "$rc_file" ]; then
+      chmod u+w "$rc_file" 2>/dev/null || true
+    fi
+
+    if [ -e "$rc_file" ]; then
+      if ! printf '\n%s\n%s\n' '# Source runtime proxy config' "$_RUNTIME_SHELL_ENV_SHIM" >>"$rc_file"; then
+        echo "[SECURITY] could not backfill runtime env shim into $rc_file" >&2
+        failed=1
+        continue
+      fi
+    elif ! printf '%s\n%s\n' '# Source runtime proxy config' "$_RUNTIME_SHELL_ENV_SHIM" >"$rc_file"; then
+      echo "[SECURITY] could not create $rc_file with runtime env shim" >&2
+      failed=1
+      continue
+    fi
+
+    if ! grep -qxF "$_RUNTIME_SHELL_ENV_SHIM" "$rc_file" 2>/dev/null; then
+      echo "[SECURITY] runtime env shim missing after backfill: $rc_file" >&2
+      failed=1
+    fi
+  done
+
+  return "$failed"
+}
 
 # ── Legacy layout migration ──────────────────────────────────────
 # Sandboxes created with the OLD base image have:
@@ -2029,6 +2091,7 @@ if [ "$(id -u)" -ne 0 ]; then
   apply_cors_override
   export_gateway_token
   write_runtime_shell_env
+  ensure_runtime_shell_env_shim
   lock_rc_files "$_SANDBOX_HOME"
   configure_messaging_channels
   install_slack_token_rewriter
@@ -2115,6 +2178,7 @@ apply_model_override
 apply_cors_override
 export_gateway_token
 write_runtime_shell_env
+ensure_runtime_shell_env_shim
 lock_rc_files "$_SANDBOX_HOME"
 
 # Inject messaging channel config if provider tokens are present.

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -816,185 +816,15 @@ except Exception:
 PYTOKEN
 }
 
-rewrite_rc_marker_block() {
-  local rc_file="$1"
-  local marker_begin="$2"
-  local marker_end="$3"
-  local snippet="${4:-}"
-  local dir base tmp
-
-  [ -e "$rc_file" ] || return 0
-  if [ -L "$rc_file" ] || [ ! -f "$rc_file" ]; then
-    echo "[SECURITY] refusing unsafe rc file: $rc_file" >&2
-    return 1
-  fi
-
-  dir="$(dirname "$rc_file")"
-  base="$(basename "$rc_file")"
-  tmp="$(mktemp "${dir}/.${base}.tmp.XXXXXX")" || return 1
-
-  awk -v b="$marker_begin" -v e="$marker_end" \
-    '$0==b{s=1;next} $0==e{s=0;next} !s' "$rc_file" >"$tmp" 2>/dev/null || {
-    rm -f "$tmp"
-    return 1
-  }
-
-  if [ -n "$snippet" ]; then
-    printf '%s\n' "$snippet" >>"$tmp" || {
-      rm -f "$tmp"
-      return 1
-    }
-  fi
-
-  if [ "$(id -u)" -eq 0 ] && ! chown root:root "$tmp"; then
-    rm -f "$tmp"
-    return 1
-  fi
-  chmod 644 "$tmp" 2>/dev/null || true
-
-  if [ -L "$rc_file" ]; then
-    echo "[SECURITY] refusing symlinked rc file during replace: $rc_file" >&2
-    rm -f "$tmp"
-    return 1
-  fi
-  mv -f "$tmp" "$rc_file" 2>/dev/null || {
-    rm -f "$tmp"
-    return 1
-  }
-}
-
-rewrite_rc_marker_block_or_fail_in_root() {
-  local rc_file="$1"
-  if rewrite_rc_marker_block "$@"; then
-    return 0
-  fi
-  if [ "$(id -u)" -eq 0 ]; then
-    return 1
-  fi
-  echo "[setup] could not update rc file ${rc_file}; continuing in non-root mode" >&2
-  return 0
-}
-
 export_gateway_token() {
   local token
   token="$(_read_gateway_token)"
-  local marker_begin="# nemoclaw-gateway-token begin"
-  local marker_end="# nemoclaw-gateway-token end"
 
   if [ -z "$token" ]; then
-    # Remove any stale marker blocks from rc files so revoked/old tokens
-    # are not re-exported in later interactive sessions.
     unset OPENCLAW_GATEWAY_TOKEN
-    for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
-      if [ -f "$rc_file" ] && ! [ -L "$rc_file" ] && grep -qF "$marker_begin" "$rc_file" 2>/dev/null; then
-        rewrite_rc_marker_block_or_fail_in_root "$rc_file" "$marker_begin" "$marker_end" ""
-      fi
-    done
     return
   fi
   export OPENCLAW_GATEWAY_TOKEN="$token"
-
-  # Persist to .bashrc/.profile so interactive sessions (openshell sandbox
-  # connect) also see the token — same pattern as the proxy config above.
-  # Shell-escape the token so quotes/dollars/backticks cannot break the
-  # sourced snippet or allow code injection.
-  local escaped_token
-  escaped_token="$(printf '%s' "$token" | sed "s/'/'\\\\''/g")"
-  local snippet
-  snippet="${marker_begin}
-export OPENCLAW_GATEWAY_TOKEN='${escaped_token}'
-${marker_end}"
-
-  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
-    [ -f "$rc_file" ] || continue
-    # Landlock may still block writes in non-root mode; root mode fails closed
-    # so detected rc-file trust-boundary violations cannot be booted through.
-    rewrite_rc_marker_block_or_fail_in_root "$rc_file" "$marker_begin" "$marker_end" "$snippet"
-  done
-}
-
-install_configure_guard() {
-  # Installs a shell function that intercepts `openclaw configure` inside the
-  # sandbox. Config changes made inside the sandbox do not persist across
-  # rebuilds. Instead of letting the user make ephemeral changes, guide
-  # them to the correct host-side workflow.
-  local marker_begin="# nemoclaw-configure-guard begin"
-  local marker_end="# nemoclaw-configure-guard end"
-  local snippet
-  read -r -d '' snippet <<'GUARD' || true
-# nemoclaw-configure-guard begin
-openclaw() {
-  case "$1" in
-    configure)
-      echo "Error: 'openclaw configure' cannot modify config inside the sandbox." >&2
-      echo "Changes inside the sandbox do not persist across rebuilds." >&2
-      echo "" >&2
-      echo "To change your configuration, exit the sandbox and run:" >&2
-      echo "  nemoclaw onboard --resume" >&2
-      echo "" >&2
-      echo "This rebuilds the sandbox with your updated settings." >&2
-      return 1
-      ;;
-    config)
-      case "$2" in
-        set | unset)
-          echo "Error: 'openclaw config $2' cannot modify config inside the sandbox." >&2
-          echo "Changes inside the sandbox do not persist across rebuilds." >&2
-          echo "" >&2
-          echo "To change your configuration, exit the sandbox and run:" >&2
-          echo "  nemoclaw onboard --resume" >&2
-          echo "" >&2
-          echo "This rebuilds the sandbox with your updated settings." >&2
-          return 1
-          ;;
-      esac
-      ;;
-    channels)
-      case "$2" in
-        list | "" | -h | --help) ;;
-        *)
-          echo "Error: 'openclaw channels $2' cannot modify channels inside the sandbox." >&2
-          echo "Changes inside the sandbox do not persist across rebuilds." >&2
-          echo "" >&2
-          echo "To add or remove messaging channels, exit the sandbox and run:" >&2
-          echo "  nemoclaw <sandbox> channels add <telegram|discord|slack>" >&2
-          echo "  nemoclaw <sandbox> channels remove <telegram|discord|slack>" >&2
-          echo "" >&2
-          echo "These stage the change and rebuild the sandbox to apply it." >&2
-          return 1
-          ;;
-      esac
-      ;;
-    agent)
-      # Block --local inside sandbox — it bypasses gateway protections and can
-      # crash the container's main process, bricking the sandbox. Ref: #1632, #2016
-      local _arg
-      for _arg in "$@"; do
-        if [ "$_arg" = "--local" ]; then
-          echo "Error: 'openclaw agent --local' is not supported inside NemoClaw sandboxes." >&2
-          echo "The --local flag bypasses the gateway's security protections (secret scanning," >&2
-          echo "network policy, inference auth) and can crash the sandbox." >&2
-          echo "" >&2
-          echo "Instead, run without --local to use the gateway's managed inference route:" >&2
-          echo "  openclaw agent --agent main -m \"hello\"" >&2
-          return 1
-        fi
-      done
-      ;;
-  esac
-  command openclaw "$@"
-}
-# nemoclaw-configure-guard end
-GUARD
-
-  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
-    [ -f "$rc_file" ] || continue
-    # Try to write the guard snippet. Landlock may block writes in non-root
-    # mode, but root mode fails closed on unsafe rc files.
-    rewrite_rc_marker_block_or_fail_in_root "$rc_file" "$marker_begin" "$marker_end" "$snippet"
-  done
-  # Best-effort lock — Landlock may already enforce read-only.
-  lock_rc_files "$_SANDBOX_HOME"
 }
 
 # Write an auth profile JSON for the NVIDIA API key so the gateway can authenticate.
@@ -1810,8 +1640,8 @@ fi
 # `/bin/bash -i` (interactive, non-login), which sources ~/.bashrc — NOT
 # ~/.profile or /etc/profile.d/*.
 #
-# We write the proxy config to /tmp/nemoclaw-proxy-env.sh. The pre-built
-# .bashrc and .profile source this file automatically.
+# We write dynamic connect-session config to /tmp/nemoclaw-proxy-env.sh. The
+# pre-built .bashrc and .profile source this file automatically.
 #
 # SECURITY: The proxy-env file is written via emit_sandbox_sourced_file()
 # which ensures root:root 444 in root mode (sandbox cannot modify) and
@@ -1822,9 +1652,10 @@ fi
 # Both uppercase and lowercase variants are required: Node.js undici prefers
 # lowercase (no_proxy) over uppercase (NO_PROXY) when both are set.
 # curl/wget use uppercase.  gRPC C-core uses lowercase.
-_PROXY_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
-{
-  cat <<PROXYEOF
+write_runtime_shell_env() {
+  _PROXY_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
+  {
+    cat <<PROXYEOF
 # Proxy configuration (overrides narrow OpenShell defaults on connect)
 export HTTP_PROXY="$_PROXY_URL"
 export HTTPS_PROXY="$_PROXY_URL"
@@ -1833,38 +1664,108 @@ export http_proxy="$_PROXY_URL"
 export https_proxy="$_PROXY_URL"
 export no_proxy="$_NO_PROXY_VAL"
 PROXYEOF
-  # Global sandbox safety net for connect sessions — must be first.
-  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SANDBOX_SAFETY_NET\""
-  # HTTP library double-proxy fix: also expose NODE_OPTIONS in connect
-  # sessions so interactive shells and user commands started via
-  # `openshell sandbox connect` benefit from the preload. (NemoClaw#2109)
-  if [ "${NODE_USE_ENV_PROXY:-}" = "1" ]; then
-    echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_PROXY_FIX_SCRIPT\""
-  fi
-  # WebSocket CONNECT tunnel fix for connect sessions. (NemoClaw#1570)
-  if [ -f "$_WS_FIX_SCRIPT" ]; then
-    echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_WS_FIX_SCRIPT\""
-  fi
-  # Git TLS CA bundle for connect sessions (NemoClaw#2270)
-  if [ -n "${GIT_SSL_CAINFO:-}" ]; then
-    printf 'export GIT_SSL_CAINFO=%q\n' "$GIT_SSL_CAINFO"
-  fi
-  # Nemotron inference fix for connect sessions. (NemoClaw#1193, #2051)
-  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCRIPT\""
-  # ciao network guard for connect sessions.
-  echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_CIAO_GUARD_SCRIPT\""
-  # Slack channel guard for connect sessions. The guard file is installed later
-  # by install_slack_channel_guard() — conditional on the file existing at
-  # source-time so connect sessions started before Slack is configured are safe.
-  echo "[ -f \"$_SLACK_GUARD_SCRIPT\" ] && export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SLACK_GUARD_SCRIPT\""
-  # Slack token rewriter for connect sessions — same conditional pattern.
-  echo "[ -f \"$_SLACK_REWRITER_SCRIPT\" ] && export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SLACK_REWRITER_SCRIPT\""
-  # Tool cache redirects — generated from _TOOL_REDIRECTS (single source of truth)
-  echo '# Tool cache redirects — /sandbox is Landlock read-only (#804)'
-  for _redir in "${_TOOL_REDIRECTS[@]}"; do
-    echo "export ${_redir?}"
-  done
-} | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"
+    if [ -n "${OPENCLAW_GATEWAY_TOKEN:-}" ]; then
+      _escaped_gateway_token="$(printf '%s' "$OPENCLAW_GATEWAY_TOKEN" | sed "s/'/'\\\\''/g")"
+      printf "export OPENCLAW_GATEWAY_TOKEN='%s'\n" "$_escaped_gateway_token"
+    fi
+    cat <<'GUARDENVEOF'
+# nemoclaw-configure-guard begin
+openclaw() {
+  case "$1" in
+    configure)
+      echo "Error: 'openclaw configure' cannot modify config inside the sandbox." >&2
+      echo "Changes inside the sandbox do not persist across rebuilds." >&2
+      echo "" >&2
+      echo "To change your configuration, exit the sandbox and run:" >&2
+      echo "  nemoclaw onboard --resume" >&2
+      echo "" >&2
+      echo "This rebuilds the sandbox with your updated settings." >&2
+      return 1
+      ;;
+    config)
+      case "$2" in
+        set | unset)
+          echo "Error: 'openclaw config $2' cannot modify config inside the sandbox." >&2
+          echo "Changes inside the sandbox do not persist across rebuilds." >&2
+          echo "" >&2
+          echo "To change your configuration, exit the sandbox and run:" >&2
+          echo "  nemoclaw onboard --resume" >&2
+          echo "" >&2
+          echo "This rebuilds the sandbox with your updated settings." >&2
+          return 1
+          ;;
+      esac
+      ;;
+    channels)
+      case "$2" in
+        list | "" | -h | --help) ;;
+        *)
+          echo "Error: 'openclaw channels $2' cannot modify channels inside the sandbox." >&2
+          echo "Changes inside the sandbox do not persist across rebuilds." >&2
+          echo "" >&2
+          echo "To add or remove messaging channels, exit the sandbox and run:" >&2
+          echo "  nemoclaw <sandbox> channels add <telegram|discord|slack>" >&2
+          echo "  nemoclaw <sandbox> channels remove <telegram|discord|slack>" >&2
+          echo "" >&2
+          echo "These stage the change and rebuild the sandbox to apply it." >&2
+          return 1
+          ;;
+      esac
+      ;;
+    agent)
+      # Block --local inside sandbox: it bypasses gateway protections and can
+      # crash the container's main process, bricking the sandbox. Ref: #1632, #2016
+      local _arg
+      for _arg in "$@"; do
+        if [ "$_arg" = "--local" ]; then
+          echo "Error: 'openclaw agent --local' is not supported inside NemoClaw sandboxes." >&2
+          echo "The --local flag bypasses the gateway's security protections (secret scanning," >&2
+          echo "network policy, inference auth) and can crash the sandbox." >&2
+          echo "" >&2
+          echo "Instead, run without --local to use the gateway's managed inference route:" >&2
+          echo "  openclaw agent --agent main -m \"hello\"" >&2
+          return 1
+        fi
+      done
+      ;;
+  esac
+  command openclaw "$@"
+}
+# nemoclaw-configure-guard end
+GUARDENVEOF
+    # Global sandbox safety net for connect sessions — must be first.
+    echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SANDBOX_SAFETY_NET\""
+    # HTTP library double-proxy fix: also expose NODE_OPTIONS in connect
+    # sessions so interactive shells and user commands started via
+    # `openshell sandbox connect` benefit from the preload. (NemoClaw#2109)
+    if [ "${NODE_USE_ENV_PROXY:-}" = "1" ]; then
+      echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_PROXY_FIX_SCRIPT\""
+    fi
+    # WebSocket CONNECT tunnel fix for connect sessions. (NemoClaw#1570)
+    if [ -f "$_WS_FIX_SCRIPT" ]; then
+      echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_WS_FIX_SCRIPT\""
+    fi
+    # Git TLS CA bundle for connect sessions (NemoClaw#2270)
+    if [ -n "${GIT_SSL_CAINFO:-}" ]; then
+      printf 'export GIT_SSL_CAINFO=%q\n' "$GIT_SSL_CAINFO"
+    fi
+    # Nemotron inference fix for connect sessions. (NemoClaw#1193, #2051)
+    echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_NEMOTRON_FIX_SCRIPT\""
+    # ciao network guard for connect sessions.
+    echo "export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_CIAO_GUARD_SCRIPT\""
+    # Slack channel guard for connect sessions. The guard file is installed later
+    # by install_slack_channel_guard() — conditional on the file existing at
+    # source-time so connect sessions started before Slack is configured are safe.
+    echo "[ -f \"$_SLACK_GUARD_SCRIPT\" ] && export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SLACK_GUARD_SCRIPT\""
+    # Slack token rewriter for connect sessions — same conditional pattern.
+    echo "[ -f \"$_SLACK_REWRITER_SCRIPT\" ] && export NODE_OPTIONS=\"\${NODE_OPTIONS:+\$NODE_OPTIONS }--require $_SLACK_REWRITER_SCRIPT\""
+    # Tool cache redirects — generated from _TOOL_REDIRECTS (single source of truth)
+    echo '# Tool cache redirects — /sandbox is Landlock read-only (#804)'
+    for _redir in "${_TOOL_REDIRECTS[@]}"; do
+      echo "export ${_redir?}"
+    done
+  } | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"
+}
 
 # cleanup_on_signal is provided by sandbox-init.sh. It reads
 # SANDBOX_CHILD_PIDS (array of all PIDs) and SANDBOX_WAIT_PID (the
@@ -2127,7 +2028,8 @@ if [ "$(id -u)" -ne 0 ]; then
   apply_model_override
   apply_cors_override
   export_gateway_token
-  install_configure_guard
+  write_runtime_shell_env
+  lock_rc_files "$_SANDBOX_HOME"
   configure_messaging_channels
   install_slack_token_rewriter
   install_slack_channel_guard
@@ -2212,7 +2114,8 @@ verify_config_integrity_if_locked /sandbox/.openclaw
 apply_model_override
 apply_cors_override
 export_gateway_token
-install_configure_guard
+write_runtime_shell_env
+lock_rc_files "$_SANDBOX_HOME"
 
 # Inject messaging channel config if provider tokens are present.
 # Must run AFTER integrity check (to detect build-time tampering) and

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -10,6 +10,23 @@ import { describe, it, expect } from "vitest";
 
 const START_SCRIPT = path.join(import.meta.dirname, "..", "scripts", "nemoclaw-start.sh");
 
+function configureGuardBlock(src: string): string {
+  const start = src.indexOf("# nemoclaw-configure-guard begin");
+  const end = src.indexOf("# nemoclaw-configure-guard end", start);
+  const endMarker = "# nemoclaw-configure-guard end";
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end + endMarker.length);
+}
+
+function runtimeShellEnvBlock(src: string): string {
+  const start = src.indexOf("write_runtime_shell_env() {");
+  const end = src.indexOf("# cleanup_on_signal", start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
 describe("nemoclaw-start non-root fallback", () => {
   it("detaches gateway output from sandbox create in non-root mode", () => {
     const src = fs.readFileSync(START_SCRIPT, "utf-8");
@@ -102,7 +119,7 @@ describe("nemoclaw-start _SANDBOX_HOME variable (#1609)", () => {
 
     // All usages must come after the definition
     const usages = [...src.matchAll(/\$\{?_SANDBOX_HOME\}?/g)];
-    expect(usages.length).toBeGreaterThanOrEqual(3);
+    expect(usages.length).toBeGreaterThanOrEqual(2);
     for (const m of usages) {
       // Skip the definition line itself
       if (m.index === defPos) continue;
@@ -110,18 +127,21 @@ describe("nemoclaw-start _SANDBOX_HOME variable (#1609)", () => {
     }
   });
 
-  it("uses _SANDBOX_HOME for rc file paths in export_gateway_token", () => {
+  it("does not rewrite rc files while exporting the gateway token", () => {
     const exportFn = src.match(/export_gateway_token\(\) \{([\s\S]*?)^\}/m);
     expect(exportFn).toBeTruthy();
-    expect(exportFn[1]).toContain("${_SANDBOX_HOME}/.bashrc");
-    expect(exportFn[1]).toContain("${_SANDBOX_HOME}/.profile");
+    expect(exportFn[1]).not.toContain("${_SANDBOX_HOME}/.bashrc");
+    expect(exportFn[1]).not.toContain("${_SANDBOX_HOME}/.profile");
+    expect(exportFn[1]).not.toContain("rewrite_rc_marker_block");
   });
 
-  it("uses _SANDBOX_HOME for rc file paths in install_configure_guard", () => {
-    const guardFn = src.match(/install_configure_guard\(\) \{([\s\S]*?)^write_auth_profile/m);
-    expect(guardFn).toBeTruthy();
-    expect(guardFn[1]).toContain("${_SANDBOX_HOME}/.bashrc");
-    expect(guardFn[1]).toContain("${_SANDBOX_HOME}/.profile");
+  it("keeps dynamic shell state in the sourced runtime env file", () => {
+    const runtimeBlock = runtimeShellEnvBlock(src);
+    expect(runtimeBlock).toContain("/tmp/nemoclaw-proxy-env.sh");
+    expect(runtimeBlock).toContain("OPENCLAW_GATEWAY_TOKEN");
+    expect(runtimeBlock).toContain("nemoclaw-configure-guard begin");
+    expect(runtimeBlock).not.toContain("${_SANDBOX_HOME}/.bashrc");
+    expect(runtimeBlock).not.toContain("${_SANDBOX_HOME}/.profile");
   });
 });
 
@@ -156,41 +176,17 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
     expect(unsetPos).toBeLessThan(returnPos);
   });
 
-  it("shell-escapes the token before embedding in rc snippet", () => {
-    const exportFn = src.match(/export_gateway_token\(\) \{([\s\S]*?)^\}/m);
-    expect(exportFn).toBeTruthy();
-    const body = exportFn[1];
-    // Must use single quotes around the escaped token value
-    expect(body).toContain("escaped_token");
-    expect(body).toMatch(/export OPENCLAW_GATEWAY_TOKEN='\$\{escaped_token\}'/);
+  it("shell-escapes the token before embedding it in proxy-env.sh", () => {
+    const runtimeBlock = runtimeShellEnvBlock(src);
+    expect(runtimeBlock).toContain("_escaped_gateway_token");
+    expect(runtimeBlock).toContain("sed \"s/'/'\\\\\\\\''/g\"");
+    expect(runtimeBlock).toMatch(/export OPENCLAW_GATEWAY_TOKEN='%s'/);
   });
 
-  it("rewrites rc marker blocks through a symlink-safe temp rename helper", () => {
-    const helperFn = src.match(/rewrite_rc_marker_block\(\) \{([\s\S]*?)^}/m);
-    expect(helperFn).toBeTruthy();
-    expect(helperFn![1]).toContain('[ -L "$rc_file" ]');
-    expect(helperFn![1]).toContain('mktemp "${dir}/.${base}.tmp.XXXXXX"');
-    expect(helperFn![1]).toContain('chown root:root "$tmp"');
-    expect(helperFn![1]).toContain('mv -f "$tmp" "$rc_file"');
-
-    const exportFn = src.match(/export_gateway_token\(\) \{([\s\S]*?)^}/m);
-    expect(exportFn).toBeTruthy();
-    expect(exportFn![1]).toContain("rewrite_rc_marker_block");
-    expect(exportFn![1]).not.toContain('>"$rc_file"');
-    expect(exportFn![1]).not.toContain('>>"$rc_file"');
-  });
-
-  it("fails closed on rc marker rewrite failures in root mode", () => {
-    const helperFn = src.match(/rewrite_rc_marker_block_or_fail_in_root\(\) \{([\s\S]*?)^}/m);
-    expect(helperFn).toBeTruthy();
-    expect(helperFn![1]).toContain('[ "$(id -u)" -eq 0 ]');
-    expect(helperFn![1]).toContain("return 1");
-    expect(src).not.toContain(
-      'rewrite_rc_marker_block "$rc_file" "$marker_begin" "$marker_end" "$snippet" || true',
-    );
-    expect(src).not.toContain(
-      'rewrite_rc_marker_block "$rc_file" "$marker_begin" "$marker_end" "" || true',
-    );
+  it("does not mutate .bashrc or .profile for token propagation", () => {
+    expect(src).not.toContain("rewrite_rc_marker_block");
+    expect(src).not.toContain(".bashrc.tmp");
+    expect(src).not.toContain("nemoclaw-gateway-token begin");
   });
 
   it("calls export_gateway_token in both root and non-root paths", () => {
@@ -203,49 +199,41 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
 describe("nemoclaw-start configure guard (#1114)", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 
-  it("defines install_configure_guard function", () => {
-    expect(src).toMatch(/install_configure_guard\(\) \{/);
+  it("emits configure guard through proxy-env.sh", () => {
+    const runtimeBlock = runtimeShellEnvBlock(src);
+    expect(runtimeBlock).toContain("nemoclaw-configure-guard begin");
+    expect(runtimeBlock).toContain("emit_sandbox_sourced_file");
   });
 
   it("intercepts openclaw configure with an actionable error", () => {
-    // The guard installs a heredoc containing a shell function — extract the
-    // full block between the function definition and the next top-level function.
-    const guardBlock = src.match(/install_configure_guard\(\) \{([\s\S]*?)^write_auth_profile/m);
-    expect(guardBlock).toBeTruthy();
-    const body = guardBlock[1];
+    const body = configureGuardBlock(src);
     expect(body).toContain("configure)");
     expect(body).toContain("nemoclaw onboard --resume");
     expect(body).toContain("return 1");
   });
 
   it("passes non-configure subcommands through to the real binary", () => {
-    const guardBlock = src.match(/install_configure_guard\(\) \{([\s\S]*?)^write_auth_profile/m);
-    expect(guardBlock).toBeTruthy();
-    expect(guardBlock[1]).toContain('command openclaw "$@"');
+    expect(configureGuardBlock(src)).toContain('command openclaw "$@"');
   });
 
-  it("uses idempotent marker blocks", () => {
-    const guardBlock = src.match(/install_configure_guard\(\) \{([\s\S]*?)^write_auth_profile/m);
-    expect(guardBlock).toBeTruthy();
-    const body = guardBlock[1];
+  it("keeps marker comments while relying on proxy-env replacement for idempotence", () => {
+    const body = configureGuardBlock(src);
     expect(body).toContain("nemoclaw-configure-guard begin");
     expect(body).toContain("nemoclaw-configure-guard end");
-    // Delegates marker replacement to the shared symlink-safe helper.
-    expect(body).toContain("rewrite_rc_marker_block");
+    expect(runtimeShellEnvBlock(src)).toContain('emit_sandbox_sourced_file "$_PROXY_ENV_FILE"');
   });
 
-  it("calls install_configure_guard in both root and non-root paths", () => {
-    const calls = src.match(/install_configure_guard/g) || [];
+  it("writes runtime shell env in both root and non-root paths", () => {
+    const calls = src.match(/write_runtime_shell_env/g) || [];
     // definition + 2 call sites
     expect(calls.length).toBeGreaterThanOrEqual(3);
   });
 
-  it("uses the symlink-safe rc marker helper for configure guard writes", () => {
-    const guardBlock = src.match(/install_configure_guard\(\) \{([\s\S]*?)^write_auth_profile/m);
-    expect(guardBlock).toBeTruthy();
-    expect(guardBlock![1]).toContain("rewrite_rc_marker_block");
-    expect(guardBlock![1]).not.toContain('>"$rc_file"');
-    expect(guardBlock![1]).not.toContain('>>"$rc_file"');
+  it("does not write configure guard into rc files", () => {
+    const runtimeBlock = runtimeShellEnvBlock(src);
+    expect(runtimeBlock).not.toContain('>"$rc_file"');
+    expect(runtimeBlock).not.toContain('>>"$rc_file"');
+    expect(src).not.toContain("install_configure_guard");
   });
 });
 
@@ -253,9 +241,7 @@ describe("nemoclaw-start configure guard blocks --local (#2016)", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 
   it("blocks openclaw agent --local with a hard error and return 1", () => {
-    const guardBlock = src.match(/install_configure_guard\(\) \{([\s\S]*?)^write_auth_profile/m);
-    expect(guardBlock).toBeTruthy();
-    const body = guardBlock[1];
+    const body = configureGuardBlock(src);
     // Must contain the agent) case that checks for --local
     expect(body).toContain("agent)");
     expect(body).toContain('"--local"');
@@ -267,15 +253,11 @@ describe("nemoclaw-start configure guard blocks --local (#2016)", () => {
   });
 
   it("suggests the correct alternative command without --local", () => {
-    const guardBlock = src.match(/install_configure_guard\(\) \{([\s\S]*?)^write_auth_profile/m);
-    expect(guardBlock).toBeTruthy();
-    expect(guardBlock[1]).toContain("openclaw agent --agent main");
+    expect(configureGuardBlock(src)).toContain("openclaw agent --agent main");
   });
 
   it("allows openclaw agent without --local to pass through", () => {
-    const guardBlock = src.match(/install_configure_guard\(\) \{([\s\S]*?)^write_auth_profile/m);
-    expect(guardBlock).toBeTruthy();
-    const body = guardBlock[1];
+    const body = configureGuardBlock(src);
     // The agent) case only returns 1 inside the --local check.
     // After the for loop, execution falls through to `command openclaw "$@"`.
     expect(body).toContain('command openclaw "$@"');

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -27,6 +27,14 @@ function runtimeShellEnvBlock(src: string): string {
   return src.slice(start, end);
 }
 
+function runtimeShellEnvShimBlock(src: string): string {
+  const start = src.indexOf("ensure_runtime_shell_env_shim() {");
+  const end = src.indexOf("# ── Legacy layout migration", start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
 describe("nemoclaw-start non-root fallback", () => {
   it("detaches gateway output from sandbox create in non-root mode", () => {
     const src = fs.readFileSync(START_SCRIPT, "utf-8");
@@ -142,6 +150,30 @@ describe("nemoclaw-start _SANDBOX_HOME variable (#1609)", () => {
     expect(runtimeBlock).toContain("nemoclaw-configure-guard begin");
     expect(runtimeBlock).not.toContain("${_SANDBOX_HOME}/.bashrc");
     expect(runtimeBlock).not.toContain("${_SANDBOX_HOME}/.profile");
+  });
+
+  it("backfills the runtime env shim into stale rc files before locking them", () => {
+    const shimBlock = runtimeShellEnvShimBlock(src);
+    expect(src).toContain(
+      '_RUNTIME_SHELL_ENV_SHIM="[ -f ${_RUNTIME_SHELL_ENV_FILE} ] && . ${_RUNTIME_SHELL_ENV_FILE}"',
+    );
+    expect(shimBlock).toContain('"${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"');
+    expect(shimBlock).toContain('grep -qxF "$_RUNTIME_SHELL_ENV_SHIM" "$rc_file"');
+    expect(shimBlock).toContain('chown root:root "$rc_file"');
+    expect(shimBlock).toContain("printf '\\n%s\\n%s\\n'");
+
+    for (const block of [
+      src.match(/if \[ "\$\(id -u\)" -ne 0 \]; then([\s\S]*?)# ── Root path/)?.[1],
+      src.slice(src.indexOf("# ── Root path")),
+    ]) {
+      expect(block).toBeTruthy();
+      const writePos = block!.indexOf("write_runtime_shell_env");
+      const ensurePos = block!.indexOf("ensure_runtime_shell_env_shim");
+      const lockPos = block!.indexOf('lock_rc_files "$_SANDBOX_HOME"');
+      expect(writePos).toBeGreaterThan(-1);
+      expect(ensurePos).toBeGreaterThan(writePos);
+      expect(lockPos).toBeGreaterThan(ensurePos);
+    }
   });
 });
 

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -44,7 +44,8 @@ describe("sandbox provisioning: unified .openclaw layout (#2227)", () => {
   });
 
   it("Dockerfile.base keeps shell startup files static and trusted", () => {
-    expect(src).toContain("[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh");
+    const runtimeEnvShim = "[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh";
+    expect(src.split(runtimeEnvShim).length - 1).toBe(2);
     expect(src).toMatch(/chown root:root \/sandbox\/\.bashrc \/sandbox\/\.profile/);
     expect(src).toMatch(/chmod 444 \/sandbox\/\.bashrc \/sandbox\/\.profile/);
     expect(src).not.toMatch(/chown sandbox:sandbox \/sandbox\/\.bashrc \/sandbox\/\.profile/);

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -42,6 +42,13 @@ describe("sandbox provisioning: unified .openclaw layout (#2227)", () => {
   it("Dockerfile.base sets .openclaw to sandbox:sandbox ownership (mutable by default)", () => {
     expect(src).toMatch(/chown -R sandbox:sandbox \/sandbox\/\.openclaw/);
   });
+
+  it("Dockerfile.base keeps shell startup files static and trusted", () => {
+    expect(src).toContain("[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh");
+    expect(src).toMatch(/chown root:root \/sandbox\/\.bashrc \/sandbox\/\.profile/);
+    expect(src).toMatch(/chmod 444 \/sandbox\/\.bashrc \/sandbox\/\.profile/);
+    expect(src).not.toMatch(/chown sandbox:sandbox \/sandbox\/\.bashrc \/sandbox\/\.profile/);
+  });
 });
 
 describe("sandbox provisioning: procps debug tools (#2343)", () => {

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -13,6 +13,21 @@ import { join } from "node:path";
 import { resolveOpenshell } from "../dist/lib/resolve-openshell";
 import { parseAllowedChatIds, isChatAllowed } from "../dist/lib/chat-filter.js";
 
+const NEMOCLAW_START_SCRIPT = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
+
+function extractRuntimeShellEnvSnippet() {
+  const src = readFileSync(NEMOCLAW_START_SCRIPT, "utf-8");
+  const start = src.indexOf("write_runtime_shell_env() {");
+  const end = src.indexOf("# cleanup_on_signal", start);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(
+      "Failed to extract write_runtime_shell_env from scripts/nemoclaw-start.sh — " +
+        "the runtime shell env function may have been moved or renamed",
+    );
+  }
+  return `${src.slice(start, end).trimEnd()}\nwrite_runtime_shell_env`;
+}
+
 describe("service environment", () => {
   describe("start-services behavior", () => {
     const scriptPath = join(import.meta.dirname, "../scripts/start-services.sh");
@@ -182,17 +197,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-git-ssl-env-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\\$_PROXY_ENV_FILE/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error(
-            "sed anchors (_PROXY_ENV_FILE…emit_sandbox_sourced_file) not found in nemoclaw-start.sh — test cannot run",
-          );
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         // Create a fake CA bundle so the -f check passes
         writeFileSync(fakeCaBundle, "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n");
         const wrapper = [
@@ -234,15 +239,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-git-ssl-noop-env-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\\$_PROXY_ENV_FILE/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error("sed anchors not found in nemoclaw-start.sh — test cannot run");
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const wrapper = [
           "#!/usr/bin/env bash",
           "set -euo pipefail",
@@ -427,18 +424,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-proxyenv-write-test-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error(
-            "Failed to extract proxy persistence block from scripts/nemoclaw-start.sh — " +
-              "the _PROXY_ENV_FILE..emit_sandbox_sourced_file block may have been moved or renamed",
-          );
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const toolRedirects = extractToolRedirects();
         const wrapper = [
           "#!/usr/bin/env bash",
@@ -448,6 +434,7 @@ describe("service environment", () => {
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
           '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          'export OPENCLAW_GATEWAY_TOKEN="test-token-123"',
           // Override the hardcoded path to use our temp dir
           persistBlock
             .trimEnd()
@@ -462,6 +449,9 @@ describe("service environment", () => {
         expect(envFile).toContain("export NO_PROXY=");
         expect(envFile).not.toContain("inference.local");
         expect(envFile).toContain("10.200.0.1");
+        expect(envFile).toContain("export OPENCLAW_GATEWAY_TOKEN='test-token-123'");
+        expect(envFile).toContain("nemoclaw-configure-guard begin");
+        expect(envFile).toContain('command openclaw "$@"');
         // Tool cache redirects should be present (#804)
         expect(envFile).toContain("npm_config_cache");
         expect(envFile).toContain("HISTFILE");
@@ -506,18 +496,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-idempotent-write-test-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error(
-            "Failed to extract proxy persistence block from scripts/nemoclaw-start.sh — " +
-              "the _PROXY_ENV_FILE..emit_sandbox_sourced_file block may have been moved or renamed",
-          );
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const toolRedirects = extractToolRedirects();
         const wrapper = [
           "#!/usr/bin/env bash",
@@ -561,18 +540,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-replace-write-test-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error(
-            "Failed to extract proxy persistence block from scripts/nemoclaw-start.sh — " +
-              "the _PROXY_ENV_FILE..emit_sandbox_sourced_file block may have been moved or renamed",
-          );
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const toolRedirects = extractToolRedirects();
         const makeWrapper = (host: string) =>
           [
@@ -617,18 +585,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-symlink-write-test-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*\$_PROXY_ENV_FILE/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error(
-            "Failed to extract proxy persistence block from scripts/nemoclaw-start.sh — " +
-              "the _PROXY_ENV_FILE..emit_sandbox_sourced_file block may have been moved or renamed",
-          );
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const sensitiveFile = join(fakeDataDir, "sensitive");
         writeFileSync(sensitiveFile, "SECRET_DATA");
         const proxyEnvPath = join(fakeDataDir, "proxy-env.sh");
@@ -710,17 +667,7 @@ describe("service environment", () => {
       const tmpFile = join(tmpdir(), `nemoclaw-http-fix-env-${process.pid}.sh`);
       const fakeFixPath = "/tmp/nemoclaw-http-proxy-fix.js";
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*$_PROXY_ENV_FILE/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error(
-            "sed anchors (_PROXY_ENV_FILE=…emit_sandbox_sourced_file) not found in nemoclaw-start.sh — test cannot run",
-          );
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const wrapper = [
           "#!/usr/bin/env bash",
           "set -euo pipefail",
@@ -764,15 +711,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-http-noop-env-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file.*$_PROXY_ENV_FILE/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error("sed anchors not found in nemoclaw-start.sh — test cannot run");
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const wrapper = [
           "#!/usr/bin/env bash",
           "set -euo pipefail",
@@ -816,17 +755,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-ws-fix-env-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error(
-            "sed anchors (_PROXY_ENV_FILE…emit_sandbox_sourced_file) not found in nemoclaw-start.sh — test cannot run",
-          );
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const wrapper = [
           "#!/usr/bin/env bash",
           "set -euo pipefail",
@@ -866,15 +795,7 @@ describe("service environment", () => {
       execFileSync("mkdir", ["-p", fakeDataDir]);
       const tmpFile = join(tmpdir(), `nemoclaw-ws-noop-env-${process.pid}.sh`);
       try {
-        const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
-        const persistBlock = execFileSync(
-          "sed",
-          ["-n", "/^_PROXY_ENV_FILE=/,/emit_sandbox_sourced_file/p", scriptPath],
-          { encoding: "utf-8" },
-        );
-        if (!persistBlock.trim()) {
-          throw new Error("sed anchors not found in nemoclaw-start.sh — test cannot run");
-        }
+        const persistBlock = extractRuntimeShellEnvSnippet();
         const wrapper = [
           "#!/usr/bin/env bash",
           "set -euo pipefail",

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -28,6 +28,19 @@ function extractRuntimeShellEnvSnippet() {
   return `${src.slice(start, end).trimEnd()}\nwrite_runtime_shell_env`;
 }
 
+function extractRuntimeShellEnvShimSnippet() {
+  const src = readFileSync(NEMOCLAW_START_SCRIPT, "utf-8");
+  const start = src.indexOf("ensure_runtime_shell_env_shim() {");
+  const end = src.indexOf("# ── Legacy layout migration", start);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(
+      "Failed to extract ensure_runtime_shell_env_shim from scripts/nemoclaw-start.sh — " +
+        "the rc shim helper may have been moved or renamed",
+    );
+  }
+  return `${src.slice(start, end).trimEnd()}\nensure_runtime_shell_env_shim`;
+}
+
 describe("service environment", () => {
   describe("start-services behavior", () => {
     const scriptPath = join(import.meta.dirname, "../scripts/start-services.sh");
@@ -485,6 +498,45 @@ describe("service environment", () => {
         }
         try {
           execFileSync("rm", ["-rf", fakeDataDir]);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    it("backfills proxy-env.sh source shims into stale rc files", () => {
+      const fakeHome = join(tmpdir(), `nemoclaw-rc-shim-test-${process.pid}`);
+      const proxyEnvPath = join(fakeHome, "proxy-env.sh");
+      const tmpFile = join(tmpdir(), `nemoclaw-rc-shim-write-test-${process.pid}.sh`);
+      const runtimeEnvShim = `[ -f ${proxyEnvPath} ] && . ${proxyEnvPath}`;
+      try {
+        execFileSync("mkdir", ["-p", fakeHome]);
+        writeFileSync(join(fakeHome, ".bashrc"), "# old bashrc\n", { mode: 0o644 });
+        writeFileSync(join(fakeHome, ".profile"), "# old profile\n", { mode: 0o444 });
+
+        const wrapper = [
+          "#!/usr/bin/env bash",
+          `_SANDBOX_HOME=${JSON.stringify(fakeHome)}`,
+          `_RUNTIME_SHELL_ENV_FILE=${JSON.stringify(proxyEnvPath)}`,
+          '_RUNTIME_SHELL_ENV_SHIM="[ -f ${_RUNTIME_SHELL_ENV_FILE} ] && . ${_RUNTIME_SHELL_ENV_FILE}"',
+          extractRuntimeShellEnvShimSnippet(),
+          "ensure_runtime_shell_env_shim",
+        ].join("\n");
+        writeFileSync(tmpFile, wrapper, { mode: 0o700 });
+        execFileSync("bash", [tmpFile], { encoding: "utf-8" });
+
+        for (const rcName of [".bashrc", ".profile"]) {
+          const rcFile = readFileSync(join(fakeHome, rcName), "utf-8");
+          expect(rcFile.split(runtimeEnvShim).length - 1).toBe(1);
+        }
+      } finally {
+        try {
+          unlinkSync(tmpFile);
+        } catch {
+          /* ignore */
+        }
+        try {
+          execFileSync("rm", ["-rf", fakeHome]);
         } catch {
           /* ignore */
         }


### PR DESCRIPTION
## Summary
- Follow-up to #2227: keep `/sandbox/.bashrc` and `/sandbox/.profile` as static source shims instead of rewriting them at startup.
- Generate gateway token export and the NemoClaw configure guard into `/tmp/nemoclaw-proxy-env.sh` via the existing trusted `emit_sandbox_sourced_file` path.
- Make the base image create shell startup files as `root:root` mode `444`, and update docs/tests for the new default behavior.

## Validation
- `npm test -- test/nemoclaw-start.test.ts test/service-env.test.ts test/sandbox-provisioning.test.ts test/sandbox-init.test.ts`
- `NEMOCLAW_TEST_IMAGE=nemoclaw-override-test-d7ea5b15 bash test/e2e/test-runtime-overrides.sh`

## Notes
- This targets the raw `docker run` runtime-overrides failure where root had already dropped `CAP_DAC_OVERRIDE` and could no longer create `/sandbox/.bashrc` temp files.
- The OpenClaw default `$HOME/.openclaw` mutable state behavior from #2227 remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Hardened sandbox shell startup by making user RC files root-owned and read-only, and moving runtime token/export handling to a generated runtime env script that is sourced via a static shim.

* **Documentation**
  * Updated security best-practices to describe the new runtime env script flow and revised default locked-down posture wording.

* **Tests**
  * Adjusted and added tests to validate the runtime env emission, shim backfill, and immutable RC file expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->