### PR TITLE
fix(rebuild): tolerate root-owned files in sandbox state backup

### DIFF
--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -759,12 +759,19 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
       `SSH+tar download: exit=${result.status}, stdout=${result.stdout ? result.stdout.length + " bytes" : "null"}, stderr=${tarStderr.substring(0, 200)}`,
     );
 
-    // Parse any per-file permission errors from tar stderr so callers can
-    // surface which files were skipped (partial backup).
-    skippedFiles = tarStderr
-      .split("\n")
-      .filter((l) => l.includes("Cannot open") || l.includes("Permission denied"))
-      .map((l) => l.replace(/^tar:\s*/, "").replace(/: Cannot open.*$/, "").replace(/: Permission denied.*$/, ""));
+    // Parse per-file permission errors from tar stderr so callers can surface
+    // which files were skipped (partial backup). Only match lines whose reason
+    // is actually "Permission denied" — "Cannot open: No such file or directory"
+    // and other non-permission errors should not be misclassified as skips.
+    const permissionDeniedRe = /^tar:\s+(.*?):\s+(?:Cannot open:\s+)?Permission denied$/;
+    skippedFiles = Array.from(
+      new Set(
+        tarStderr
+          .split("\n")
+          .map((line) => permissionDeniedRe.exec(line)?.[1] ?? "")
+          .filter((file) => file.length > 0),
+      ),
+    );
 
     // With --ignore-failed-read, GNU tar exits 0 even when individual files
     // are unreadable. Reject truly fatal exits: null (signal-killed), 2

--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -87,6 +87,12 @@ export interface BackupResult {
   manifest?: RebuildManifest;
   backedUpDirs: string[];
   failedDirs: string[];
+  // Files skipped during tar due to permission errors (e.g. root-owned
+  // files from kubectl-exec diagnostics). Callers should only display
+  // these when `success` is true (partial but usable backup). May also
+  // be populated on failure if stderr contained permission errors before
+  // a fatal exit. See issue #2727.
+  skippedFiles: string[];
   // Set when the failure is a precondition (e.g. duplicate --name) rather
   // than a mid-backup error. CLI surfaces this to the user verbatim.
   error?: string;
@@ -577,6 +583,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         success: false,
         backedUpDirs: [],
         failedDirs: [],
+        skippedFiles: [],
         error: validationError,
       };
     }
@@ -586,6 +593,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         success: false,
         backedUpDirs: [],
         failedDirs: [],
+        skippedFiles: [],
         error:
           `Snapshot name '${providedName}' already exists for '${sandboxName}' ` +
           `(at ${conflict.timestamp}). Pick a different name or delete the existing snapshot.`,
@@ -628,11 +636,12 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
 
   const backedUpDirs: string[] = [];
   const failedDirs: string[] = [];
+  let skippedFiles: string[] = [];
 
   if (stateDirs.length === 0) {
     _log("WARNING: Agent manifest declares no state_dirs — nothing to back up");
     writeManifest(backupPath, manifest);
-    return { success: true, manifest, backedUpDirs, failedDirs };
+    return { success: true, manifest, backedUpDirs, failedDirs, skippedFiles };
   }
 
   // SSH+tar single-roundtrip download
@@ -640,7 +649,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
   const sshConfig = getSshConfig(sandboxName);
   if (!sshConfig) {
     _log("FAILED: Could not get SSH config");
-    return { success: false, manifest, backedUpDirs, failedDirs: [...stateDirs] };
+    return { success: false, manifest, backedUpDirs, failedDirs: [...stateDirs], skippedFiles };
   }
   _log(`SSH config obtained (${sshConfig.length} bytes)`);
 
@@ -678,13 +687,13 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
       _log(
         `FAILED: SSH dir check exited ${existResult.status} — cannot determine which dirs exist`,
       );
-      return { success: false, manifest, backedUpDirs, failedDirs: [...stateDirs] };
+      return { success: false, manifest, backedUpDirs, failedDirs: [...stateDirs], skippedFiles };
     }
 
     if (existingDirs.length === 0) {
       _log("No state dirs found in sandbox (all empty)");
       writeManifest(backupPath, manifest);
-      return { success: true, manifest, backedUpDirs, failedDirs };
+      return { success: true, manifest, backedUpDirs, failedDirs, skippedFiles };
     }
 
     // NC-2227-04: Pre-backup audit — reject symlinks, hardlinks, and special
@@ -711,6 +720,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         manifest,
         backedUpDirs,
         failedDirs: [...existingDirs],
+        skippedFiles,
         error: `Pre-backup audit failed: ${detail}`,
       };
     }
@@ -726,36 +736,69 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         manifest,
         backedUpDirs,
         failedDirs: [...existingDirs],
+        skippedFiles,
         error: `Pre-backup audit rejected: symlinks, hard links, or special files found in state dirs: ${violations.slice(0, 3).join("; ")}`,
       };
     }
     _log("Pre-backup audit passed — no symlinks, hard links, or special files found");
 
     // Download via SSH+tar
-    // NC-2227-04: Removed -h flag (was following symlinks). State dirs are
-    // now agent-writable and co-located with config — a compromised agent
-    // could create symlinks to exfiltrate config contents via backup.
-    const tarCmd = `tar -cf - -C ${shellQuote(dir)} -- ${existingDirs.map(shellQuote).join(" ")}`;
+    // --ignore-failed-read: tolerate per-file permission errors (e.g. root-owned
+    // files created by kubectl-exec diagnostics). GNU tar will still write all
+    // readable files to stdout and log warnings to stderr, but exits 0 instead
+    // of 2. LC_ALL=C ensures English stderr for the parsing below. See #2727.
+    const tarCmd = `LC_ALL=C tar --ignore-failed-read -cf - -C ${shellQuote(dir)} -- ${existingDirs.map(shellQuote).join(" ")}`;
     _log(`Downloading via SSH+tar: ${tarCmd}`);
     const result = spawnSync("ssh", [...sshArgs(configFile, sandboxName), tarCmd], {
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 120000,
       maxBuffer: 256 * 1024 * 1024,
     });
+    const tarStderr = result.stderr?.toString() || "";
     _log(
-      `SSH+tar download: exit=${result.status}, stdout=${result.stdout ? result.stdout.length + " bytes" : "null"}, stderr=${(result.stderr?.toString() || "").substring(0, 200)}`,
+      `SSH+tar download: exit=${result.status}, stdout=${result.stdout ? result.stdout.length + " bytes" : "null"}, stderr=${tarStderr.substring(0, 200)}`,
     );
 
-    if (result.status === 0 && result.stdout && result.stdout.length > 0) {
+    // Parse any per-file permission errors from tar stderr so callers can
+    // surface which files were skipped (partial backup).
+    skippedFiles = tarStderr
+      .split("\n")
+      .filter((l) => l.includes("Cannot open") || l.includes("Permission denied"))
+      .map((l) => l.replace(/^tar:\s*/, "").replace(/: Cannot open.*$/, "").replace(/: Permission denied.*$/, ""));
+
+    // With --ignore-failed-read, GNU tar exits 0 even when individual files
+    // are unreadable. Reject truly fatal exits: null (signal-killed), 2
+    // (fatal tar error without --ignore-failed-read fallback), or ≥128
+    // (signal/SSH failures like 255). Exit 1 is "some files differ" which
+    // is benign for backup purposes.
+    const isFatalExit =
+      result.status === null || result.status === 2 || result.status >= 128;
+
+    if (!isFatalExit && result.stdout && result.stdout.length > 0) {
       // SECURITY: Validate tar entries, extract safely, audit symlinks
       const extractResult = safeTarExtract(result.stdout, backupPath);
       if (extractResult.success) {
         backedUpDirs.push(...existingDirs);
+        if (result.status !== 0) {
+          _log(
+            `WARN: tar exited ${result.status} but produced valid output (partial backup); stderr: ${tarStderr.substring(0, 500)}`,
+          );
+        }
+        if (skippedFiles.length > 0) {
+          _log(
+            `WARN: ${skippedFiles.length} file(s) skipped due to permission errors: ${skippedFiles.slice(0, 10).join(", ")}`,
+          );
+        }
       } else {
         _log(`SECURITY: tar extraction blocked: ${extractResult.error}`);
         failedDirs.push(...existingDirs);
       }
     } else {
+      if (isFatalExit) {
+        _log(
+          `FAILED: tar exited with fatal status ${result.status} — rejecting backup; stderr: ${tarStderr.substring(0, 500)}`,
+        );
+      }
       failedDirs.push(...existingDirs);
     }
   } finally {
@@ -792,6 +835,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
     manifest,
     backedUpDirs,
     failedDirs,
+    skippedFiles,
   };
 }
 

--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -763,7 +763,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
     // which files were skipped (partial backup). Only match lines whose reason
     // is actually "Permission denied" — "Cannot open: No such file or directory"
     // and other non-permission errors should not be misclassified as skips.
-    const permissionDeniedRe = /^tar:\s+(.*?):\s+(?:Cannot open:\s+)?Permission denied$/;
+    const permissionDeniedRe = /^tar:\s+(.*):\s+(?:Cannot open:\s+)?Permission denied$/;
     skippedFiles = Array.from(
       new Set(
         tarStderr
@@ -773,27 +773,30 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
       ),
     );
 
-    // With --ignore-failed-read, GNU tar exits 0 even when individual files
-    // are unreadable. Reject truly fatal exits: null (signal-killed), 2
-    // (fatal tar error without --ignore-failed-read fallback), or ≥128
-    // (signal/SSH failures like 255). Exit 1 is "some files differ" which
-    // is benign for backup purposes.
-    const isFatalExit =
-      result.status === null || result.status === 2 || result.status >= 128;
-
-    if (!isFatalExit && result.stdout && result.stdout.length > 0) {
+    // With --ignore-failed-read, GNU tar exits 0 when files are unreadable
+    // (permission denied, vanished mid-read, etc.) — it archives what it can
+    // and logs warnings to stderr. Any non-zero exit (1 = files changed during
+    // read, 2 = fatal error, null = signal-killed, ≥128 = SSH failures)
+    // indicates a problem that --ignore-failed-read did not absorb.
+    if (result.status === 0 && result.stdout && result.stdout.length > 0) {
       // SECURITY: Validate tar entries, extract safely, audit symlinks
       const extractResult = safeTarExtract(result.stdout, backupPath);
       if (extractResult.success) {
         backedUpDirs.push(...existingDirs);
-        if (result.status !== 0) {
-          _log(
-            `WARN: tar exited ${result.status} but produced valid output (partial backup); stderr: ${tarStderr.substring(0, 500)}`,
-          );
-        }
         if (skippedFiles.length > 0) {
           _log(
             `WARN: ${skippedFiles.length} file(s) skipped due to permission errors: ${skippedFiles.slice(0, 10).join(", ")}`,
+          );
+        }
+        // Log any tar stderr warnings that weren't permission-denied skips
+        // (e.g. "file changed as we read it", "file removed before we read it").
+        // These don't fail the backup but should be visible in verbose mode.
+        const unrecognizedWarnings = tarStderr
+          .split("\n")
+          .filter((l) => l.startsWith("tar:") && !permissionDeniedRe.test(l) && l.trim().length > 0);
+        if (unrecognizedWarnings.length > 0) {
+          _log(
+            `WARN: tar stderr contained ${unrecognizedWarnings.length} non-permission warning(s): ${unrecognizedWarnings.slice(0, 5).join("; ")}`,
           );
         }
       } else {
@@ -801,11 +804,9 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         failedDirs.push(...existingDirs);
       }
     } else {
-      if (isFatalExit) {
-        _log(
-          `FAILED: tar exited with fatal status ${result.status} — rejecting backup; stderr: ${tarStderr.substring(0, 500)}`,
-        );
-      }
+      _log(
+        `FAILED: tar exited ${result.status} — rejecting backup; stderr: ${tarStderr.substring(0, 500)}`,
+      );
       failedDirs.push(...existingDirs);
     }
   } finally {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -3250,6 +3250,17 @@ async function sandboxRebuild(
   }
   console.log(`  ${G}\u2713${R} State backed up (${backup.backedUpDirs.length} directories)`);
   console.log(`    Backup: ${backup.manifest.backupPath}`);
+  if (backup.skippedFiles.length > 0) {
+    console.log(
+      `  ${YW}⚠${R} ${backup.skippedFiles.length} file(s) skipped (permission denied — likely root-owned):`,
+    );
+    for (const f of backup.skippedFiles.slice(0, 10)) {
+      console.log(`    ${D}${f}${R}`);
+    }
+    if (backup.skippedFiles.length > 10) {
+      console.log(`    ${D}... and ${backup.skippedFiles.length - 10} more${R}`);
+    }
+  }
 
   // Step 3: Delete sandbox without tearing down gateway or session.
   // sandboxDestroy() cleans up the gateway when it's the last sandbox and
@@ -3824,6 +3835,17 @@ async function sandboxSnapshot(sandboxName: string, subArgs: string[]) {
           `  ${G}\u2713${R} Snapshot ${v}${nameSuffix} created (${result.backedUpDirs.length} directories)`,
         );
         console.log(`    ${result.manifest.backupPath}`);
+        if (result.skippedFiles.length > 0) {
+          console.log(
+            `  ${YW}⚠${R} ${result.skippedFiles.length} file(s) skipped (permission denied — likely root-owned):`,
+          );
+          for (const f of result.skippedFiles.slice(0, 10)) {
+            console.log(`    ${D}${f}${R}`);
+          }
+          if (result.skippedFiles.length > 10) {
+            console.log(`    ${D}... and ${result.skippedFiles.length - 10} more${R}`);
+          }
+        }
       } else {
         if (result.error) {
           console.error(`  ${result.error}`);
@@ -4037,6 +4059,11 @@ function backupAll() {
       console.log(
         `  ${G}\u2713${R} ${sb.name}: ${result.backedUpDirs.length} dirs → ${result.manifest.backupPath}`,
       );
+      if (result.skippedFiles.length > 0) {
+        console.log(
+          `    ${YW}⚠${R} ${result.skippedFiles.length} file(s) skipped (permission denied)`,
+        );
+      }
       backed++;
     } else {
       console.error(`  ${_RD}✗${R} ${sb.name}: backup failed (${result.failedDirs.join(", ")})`);

--- a/test/shields.test.ts
+++ b/test/shields.test.ts
@@ -294,10 +294,13 @@ describe("NC-2227-04: sandbox-state.ts tar commands do not follow symlinks", () 
 
   it("backup tar command does not use -h flag (no symlink following)", () => {
     const src = getSourceCode();
-    // Find the backup tar command in backupSandboxState
+    // Find the backup tar command in backupSandboxState (bounded to that
+    // function only — stop at restoreSandboxState so restore-path tar
+    // commands don't satisfy this assertion if the backup command regresses).
     const fnStart = src.indexOf("function backupSandboxState");
     expect(fnStart).not.toBe(-1);
-    const fnBody = src.slice(fnStart);
+    const fnEnd = src.indexOf("function restoreSandboxState", fnStart);
+    const fnBody = src.slice(fnStart, fnEnd === -1 ? undefined : fnEnd);
 
     // The tar command should be `tar ... -cf` not `tar ... -chf`
     // Account for flags like --ignore-failed-read between tar and -cf.

--- a/test/shields.test.ts
+++ b/test/shields.test.ts
@@ -299,11 +299,14 @@ describe("NC-2227-04: sandbox-state.ts tar commands do not follow symlinks", () 
     expect(fnStart).not.toBe(-1);
     const fnBody = src.slice(fnStart);
 
-    // The tar command should be `tar -cf` not `tar -chf`
-    const tarCmdMatch = fnBody.match(/tar -c([a-z]*)f/g);
-    expect(tarCmdMatch).not.toBeNull();
-    for (const match of tarCmdMatch!) {
-      expect(match).not.toContain("h");
+    // The tar command should be `tar ... -cf` not `tar ... -chf`
+    // Account for flags like --ignore-failed-read between tar and -cf.
+    // Use matchAll to extract only the flags between -c and f (capture
+    // group 1), not the entire match which may contain unrelated 'h's.
+    const tarCmdMatches = [...fnBody.matchAll(/tar\b[^\n]*?-c([a-z]*)f/g)];
+    expect(tarCmdMatches.length).toBeGreaterThan(0);
+    for (const m of tarCmdMatches) {
+      expect(m[1]).not.toContain("h");
     }
   });
 


### PR DESCRIPTION
## Summary
Tolerates root-owned files during sandbox state backups so rebuilds and snapshots can continue with a usable partial backup. Permission-denied files are recorded and surfaced to users instead of aborting the whole operation.

## Related Issue
Fixes #2727

## Changes
- Adds `--ignore-failed-read` and `LC_ALL=C` to the SSH tar backup path.
- Tracks permission-denied tar entries as `skippedFiles` on `BackupResult`.
- Reports skipped-file warnings in rebuild, snapshot create, and backup-all output.
- Updates the symlink shield test to allow long tar flags while still rejecting `-h`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Codex

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backup and snapshot operations now tolerate per-file permission errors: partial backups proceed when possible and report skipped files instead of failing outright.

* **New Features**
  * Users now see warnings showing the number of skipped files and a sample list (up to 10) when backups are partial.
  * Backup results now include a machine-readable list of skipped files so tooling can detect partial backups.

* **Tests**
  * Improved test to reduce false positives around backup command invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->