### PR TITLE
chore: upgrade Hermes from 2026.4.8 to 2026.4.23

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -22,8 +22,8 @@ FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Hermes version pinned for reproducibility.
-# Calver tag v2026.4.13 = semver 0.9.0.
-ARG HERMES_VERSION=v2026.4.13
+# Calver tag v2026.4.23 = semver 0.11.0.
+ARG HERMES_VERSION=v2026.4.23
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3=3.11.2-1+b1 \

--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -16,7 +16,7 @@ homepage: "https://github.com/NousResearch/hermes-agent"
 install_method: curl  # curl install.sh | bash
 binary_path: /usr/local/bin/hermes
 version_command: "hermes --version"
-expected_version: "2026.4.8"
+expected_version: "2026.4.23"
 gateway_command: "hermes gateway run"
 
 # ── Health probe ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This updates to the latest tagged release of Hermes Agent

## Changes
Hermes Agent v2026.4.8 -> v2026.4.23

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes - this throws a system permissions error on my linux machine
- [ ] `npm test` passes - there's a single failing test, which is also failing on main
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ben Barclay <ben@nousresearch.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hermes agent to version v2026.4.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->