### PR TITLE
fix(destroy): use actual image tag from build output instead of buildId

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4212,6 +4212,18 @@ async function createSandbox(
       providerCredentialHashes[envKey] = hash;
     }
   }
+  // Parse the actual image tag from openshell's build output.
+  // openshell assigns its own timestamp (seconds) as the tag, e.g.
+  // "Built image openshell/sandbox-from:1777534687", while the local
+  // buildId uses Date.now() (milliseconds). Using the parsed tag keeps
+  // the registry in sync with what Docker actually tagged. Fixes #2672.
+  const builtImageMatch = createResult.output.match(
+    /Built image (openshell\/sandbox-from:\S+)/,
+  );
+  const resolvedImageTag = builtImageMatch
+    ? builtImageMatch[1]
+    : `openshell/sandbox-from:${buildId}`;
+
   registry.registerSandbox({
     name: sandboxName,
     model: model || null,
@@ -4219,7 +4231,7 @@ async function createSandbox(
     gpuEnabled: !!gpu,
     agent: agent ? agent.name : null,
     agentVersion: fromDockerfile ? null : effectiveAgent.expectedVersion || null,
-    imageTag: `openshell/sandbox-from:${buildId}`,
+    imageTag: resolvedImageTag,
     providerCredentialHashes:
       Object.keys(providerCredentialHashes).length > 0 ? providerCredentialHashes : undefined,
     messagingChannels: activeMessagingChannels,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4212,14 +4212,15 @@ async function createSandbox(
       providerCredentialHashes[envKey] = hash;
     }
   }
-  // Parse the actual image tag from openshell's build output.
-  // openshell assigns its own timestamp (seconds) as the tag, e.g.
-  // "Built image openshell/sandbox-from:1777534687", while the local
-  // buildId uses Date.now() (milliseconds). Using the parsed tag keeps
-  // the registry in sync with what Docker actually tagged. Fixes #2672.
+  // openshell tags images with seconds; buildId is ms. Parse actual tag from output. Fixes #2672.
   const builtImageMatch = createResult.output.match(
-    /Built image (openshell\/sandbox-from:\S+)/,
+    /Built image (openshell\/sandbox-from:\d+)/,
   );
+  if (!builtImageMatch) {
+    console.warn(
+      "  Warning: could not parse image tag from build output; imageTag may be stale. Run 'nemoclaw gc' if destroy fails.",
+    );
+  }
   const resolvedImageTag = builtImageMatch
     ? builtImageMatch[1]
     : `openshell/sandbox-from:${buildId}`;

--- a/test/image-cleanup.test.ts
+++ b/test/image-cleanup.test.ts
@@ -75,8 +75,10 @@ describe("image cleanup: onboard records imageTag in registry (#2086)", () => {
 
   it("registerSandbox uses resolvedImageTag parsed from build output", () => {
     expect(onboardSrc).toContain("resolvedImageTag");
-    expect(onboardSrc).toMatch(/Built image \(openshell\\\/sandbox-from:\\d\+\)/);
+    expect(onboardSrc).toMatch(/sandbox-from:\\d\+/);
     expect(onboardSrc).toMatch(/imageTag:\s*resolvedImageTag/);
+    expect(onboardSrc).toMatch(/buildId/);
+    expect(onboardSrc).toMatch(/console\.warn/);
   });
 
   it("onboard recreate path cleans up old image", () => {

--- a/test/image-cleanup.test.ts
+++ b/test/image-cleanup.test.ts
@@ -74,9 +74,6 @@ describe("image cleanup: onboard records imageTag in registry (#2086)", () => {
   });
 
   it("registerSandbox uses resolvedImageTag parsed from build output", () => {
-    // After fix for #2672: imageTag uses resolvedImageTag (parsed from openshell
-    // build output) rather than the local buildId (ms). The fallback still uses
-    // buildId if the line is not found in output.
     expect(onboardSrc).toContain("resolvedImageTag");
     expect(onboardSrc).toMatch(/Built image \(openshell\\\/sandbox-from:\\d\+\)/);
     expect(onboardSrc).toMatch(/imageTag:\s*resolvedImageTag/);

--- a/test/image-cleanup.test.ts
+++ b/test/image-cleanup.test.ts
@@ -78,7 +78,7 @@ describe("image cleanup: onboard records imageTag in registry (#2086)", () => {
     // build output) rather than the local buildId (ms). The fallback still uses
     // buildId if the line is not found in output.
     expect(onboardSrc).toContain("resolvedImageTag");
-    expect(onboardSrc).toMatch(/Built image \(openshell\\\/sandbox-from:\\S\+\)/);
+    expect(onboardSrc).toMatch(/Built image \(openshell\\\/sandbox-from:\\d\+\)/);
     expect(onboardSrc).toMatch(/imageTag:\s*resolvedImageTag/);
   });
 

--- a/test/image-cleanup.test.ts
+++ b/test/image-cleanup.test.ts
@@ -73,8 +73,13 @@ describe("image cleanup: onboard records imageTag in registry (#2086)", () => {
     expect(onboardSrc).toContain("const buildId = String(Date.now())");
   });
 
-  it("registerSandbox includes imageTag with buildId", () => {
-    expect(onboardSrc).toMatch(/imageTag:\s*`openshell\/sandbox-from:\$\{buildId\}`/);
+  it("registerSandbox uses resolvedImageTag parsed from build output", () => {
+    // After fix for #2672: imageTag uses resolvedImageTag (parsed from openshell
+    // build output) rather than the local buildId (ms). The fallback still uses
+    // buildId if the line is not found in output.
+    expect(onboardSrc).toContain("resolvedImageTag");
+    expect(onboardSrc).toMatch(/Built image \(openshell\\\/sandbox-from:\\S\+\)/);
+    expect(onboardSrc).toMatch(/imageTag:\s*resolvedImageTag/);
   });
 
   it("onboard recreate path cleans up old image", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw destroy` was failing with "No such image: openshell/sandbox-from:<id>" because the registry stored a millisecond-precision `buildId` as the image tag, while openshell tags the built image using seconds. This PR parses the actual tag from the build output and stores that instead.

## Related Issue

Fixes #2672

## Changes

- Parse `Built image openshell/sandbox-from:<tag>` from `createResult.output` to get the real image tag
- Fall back to `openshell/sandbox-from:${buildId}` with a console warning if the line is not found
- Tighten regex from `\S+` to `\d+` since openshell tags are numeric timestamps
- Update test in `test/image-cleanup.test.ts` to assert the new `resolvedImageTag` behavior

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

Signed-off-by: Tian Zhang <tiazhang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sandbox image tagging to accurately extract tags from build output instead of relying on assumed format, with fallback handling for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->