### PR TITLE
fix(onboard): include GPU model name in preflight detection line

### DIFF
--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -165,6 +165,36 @@ describe("nim", () => {
       }
     });
 
+    it("preserves commas inside the GPU model name (last-comma split)", () => {
+      // The CSV split must use the LAST comma, not the first, so that GPU
+      // models whose names contain a comma round-trip intact. The split was
+      // designed for this; the test guards against future "split on first
+      // comma" regressions.
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
+        if (
+          cmd[0] === "nvidia-smi" &&
+          cmd.some((a: string) => a.includes("name,memory.total"))
+        ) {
+          return "NVIDIA RTX A,B, 81920\n";
+        }
+        return "";
+      });
+      const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
+
+      try {
+        expect(nimModule.detectGpu()).toMatchObject({
+          type: "nvidia",
+          name: "NVIDIA RTX A,B",
+          count: 1,
+          totalMemoryMB: 81920,
+          perGpuMB: 81920,
+        });
+      } finally {
+        restore();
+      }
+    });
+
     it("drops name on mixed-model multi-GPU hosts so we don't attribute one model to the others", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
         if (!Array.isArray(cmd)) throw new Error("expected argv array");

--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -110,6 +110,90 @@ describe("nim", () => {
       }
     });
 
+    it("populates name and memory from primary nvidia-smi path", () => {
+      // Primary path returns name+memory.total in a single CSV line per GPU.
+      // Regression guard for #2669: the GB300 preflight line was missing the
+      // GPU model because only memory.total was being queried.
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
+        if (
+          cmd[0] === "nvidia-smi" &&
+          cmd.some((a: string) => a.includes("name,memory.total"))
+        ) {
+          return "NVIDIA GB300, 284208\n";
+        }
+        return "";
+      });
+      const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
+
+      try {
+        expect(nimModule.detectGpu()).toMatchObject({
+          type: "nvidia",
+          name: "NVIDIA GB300",
+          count: 1,
+          totalMemoryMB: 284208,
+          perGpuMB: 284208,
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it("aggregates totalMemoryMB across multiple GPUs from primary path", () => {
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
+        if (
+          cmd[0] === "nvidia-smi" &&
+          cmd.some((a: string) => a.includes("name,memory.total"))
+        ) {
+          return "NVIDIA H100 80GB HBM3, 81920\nNVIDIA H100 80GB HBM3, 81920\n";
+        }
+        return "";
+      });
+      const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
+
+      try {
+        expect(nimModule.detectGpu()).toMatchObject({
+          type: "nvidia",
+          name: "NVIDIA H100 80GB HBM3",
+          count: 2,
+          totalMemoryMB: 163840,
+          perGpuMB: 81920,
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it("drops name on mixed-model multi-GPU hosts so we don't attribute one model to the others", () => {
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
+        if (
+          cmd[0] === "nvidia-smi" &&
+          cmd.some((a: string) => a.includes("name,memory.total"))
+        ) {
+          return "NVIDIA H100 80GB HBM3, 81920\nNVIDIA A100-SXM4-80GB, 81920\n";
+        }
+        return "";
+      });
+      const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
+
+      try {
+        const result = nimModule.detectGpu();
+        expect(result).toMatchObject({
+          type: "nvidia",
+          count: 2,
+          totalMemoryMB: 163840,
+        });
+        // Mixed-model hosts must not pin a single name; the preflight line
+        // would otherwise read "2x NVIDIA H100" on a host that's actually
+        // half H100 and half A100.
+        expect(result?.name).toBeUndefined();
+      } finally {
+        restore();
+      }
+    });
+
     it("detects GB10 unified-memory GPUs as Spark-capable NVIDIA devices", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
         if (!Array.isArray(cmd)) throw new Error("expected argv array");

--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -72,24 +72,43 @@ export function canRunNimWithMemory(totalMemoryMB: number): boolean {
 }
 
 export function detectGpu(): GpuDetection | null {
-  // Try NVIDIA first — query VRAM
+  // Try NVIDIA first — query name and VRAM in a single call so the preflight
+  // line can show the GPU model alongside the memory size.
   try {
     const output = runCapture(
-      ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
+      ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
       { ignoreError: true },
     );
     if (output) {
-      const lines = output.split("\n").filter((l: string) => l.trim());
-      const perGpuMB = lines
-        .map((l: string) => parseInt(l.trim(), 10))
-        .filter((n: number) => !isNaN(n));
-      if (perGpuMB.length > 0) {
-        const totalMemoryMB = perGpuMB.reduce((a: number, b: number) => a + b, 0);
+      type ParsedGpu = { name: string; memoryMB: number };
+      const parsed: ParsedGpu[] = [];
+      for (const raw of output.split("\n")) {
+        const line = raw.trim();
+        if (!line) continue;
+        // Split on the LAST comma — GPU names can contain commas in rare cases.
+        const idx = line.lastIndexOf(",");
+        if (idx === -1) continue;
+        const name = line.slice(0, idx).trim();
+        const memoryMB = parseInt(line.slice(idx + 1).trim(), 10);
+        if (isNaN(memoryMB)) continue;
+        parsed.push({ name, memoryMB });
+      }
+      if (parsed.length > 0) {
+        const totalMemoryMB = parsed.reduce(
+          (sum: number, p: ParsedGpu) => sum + p.memoryMB,
+          0,
+        );
+        const firstName = parsed[0].name;
+        // Only surface a single name when every GPU reports the same model;
+        // a mixed-GPU host would otherwise be misreported as `Nx <firstName>`.
+        const allSameName =
+          !!firstName && parsed.every((p: ParsedGpu) => p.name === firstName);
         return {
           type: "nvidia",
-          count: perGpuMB.length,
+          ...(allSameName ? { name: firstName } : {}),
+          count: parsed.length,
           totalMemoryMB,
-          perGpuMB: perGpuMB[0],
+          perGpuMB: parsed[0].memoryMB,
           nimCapable: canRunNimWithMemory(totalMemoryMB),
         };
       }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2873,7 +2873,17 @@ async function preflight(): Promise<ReturnType<typeof nim.detectGpu>> {
   // GPU
   const gpu = nim.detectGpu();
   if (gpu && gpu.type === "nvidia") {
-    console.log(`  ✓ NVIDIA GPU detected: ${gpu.count} GPU(s), ${gpu.totalMemoryMB} MB VRAM`);
+    if (gpu.name) {
+      // Match DevTest case 517913 cross-check format when the GPU model is
+      // known: `NVIDIA GPU detected (<model>, <vram> MB)`. Multi-GPU hosts
+      // with the same model render as `Nx <model>` inside the parens.
+      const detail = gpu.count > 1 ? `${gpu.count}x ${gpu.name}` : gpu.name;
+      console.log(`  ✓ NVIDIA GPU detected (${detail}, ${gpu.totalMemoryMB} MB)`);
+    } else {
+      // Mixed-model or unnamed devices fall back to the count-only form so
+      // we never falsely attribute one GPU's name to the others.
+      console.log(`  ✓ NVIDIA GPU detected: ${gpu.count} GPU(s), ${gpu.totalMemoryMB} MB VRAM`);
+    }
     if (!gpu.nimCapable) {
       console.log("  ⓘ Local NIM unavailable — GPU VRAM too small");
     }


### PR DESCRIPTION
## Summary
The Phase [1/8] preflight line reported only `1 GPU(s), 284208 MB VRAM` with no GPU model name, even though `nvidia-smi` could identify the device (e.g. `NVIDIA GB300`). The data wasn't being queried. This change asks for the name in the same `nvidia-smi` call already being made and surfaces it in the preflight output.

## Related Issue
Fixes #2669

## Changes
- `src/lib/nim.ts`: `detectGpu()` primary path now queries `--query-gpu=name,memory.total` (single CSV call). Parses on the last comma so GPU names with embedded commas don't trip the split. Only sets the result's `name` field when **every** GPU reports the same model — a mixed-model host can't be misreported as `Nx <firstModel>`.
- `src/lib/onboard.ts`: when a name is known, render the parenthesised form `NVIDIA GPU detected (<model>, <vram> MB)` to match DevTest case 517913 cross-check; multi-GPU same-model uses `(2x <model>, <total> MB)`. Mixed/unnamed devices keep the existing `count GPU(s), vram MB VRAM` form.
- `src/lib/nim.test.ts`: 3 new unit tests against the existing `loadNimWithMockedRunner(runCapture)` pattern — single-GPU primary path, multi-GPU same-model, mixed-model (verifies `name` is `undefined`).

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Claude Code, Codex

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU detection now reports GPU model names alongside total VRAM.
  * Preflight console output shows model info as either a single name or "<count>x <name>" when available.

* **Bug Fixes**
  * Multi-GPU systems correctly aggregate total VRAM across all GPUs.
  * GPU name handling improved for mixed-model systems and for model names containing commas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->