### PR TITLE
refactor(cli): harden oclif bridge

### DIFF
--- a/src/lib/oclif-runner.ts
+++ b/src/lib/oclif-runner.ts
@@ -3,6 +3,8 @@
 
 import { Config as OclifConfig } from "@oclif/core";
 
+import { CLI_NAME } from "./branding";
+
 export interface OclifCommandRunOptions {
   rootDir: string;
   error?: (message?: string) => void;
@@ -40,11 +42,20 @@ export async function runRegisteredOclifCommand(
   opts: OclifCommandRunOptions,
 ): Promise<void> {
   const config = await OclifConfig.load(opts.rootDir);
+  config.bin = CLI_NAME;
   const errorLine = opts.error ?? console.error;
   const exit = opts.exit ?? ((code: number) => process.exit(code));
 
   try {
-    await config.runCommand(commandId, args);
+    const commandRef = config.findCommand(commandId, { must: true });
+    const Command = await commandRef.load();
+    await config.runHook("prerun", { argv: args, Command });
+    const CommandCtor = Command as unknown as new (
+      argv: string[],
+      config: OclifConfig,
+    ) => { _run: () => Promise<unknown> };
+    const result = await new CommandCtor(args, config)._run();
+    await config.runHook("postrun", { argv: args, Command, result });
   } catch (error) {
     const exitCode = getOclifExitCode(error);
     if (exitCode === 0) {

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -1521,12 +1521,16 @@ function showStatus() {
   });
 }
 
-async function listSandboxes(args: string[] = []): Promise<void> {
-  await runRegisteredOclifCommand("list", args, {
+async function runOclif(commandId: string, args: string[] = []): Promise<void> {
+  await runRegisteredOclifCommand(commandId, args, {
     rootDir: ROOT,
     error: console.error,
     exit: (code: number) => process.exit(code),
   });
+}
+
+async function listSandboxes(args: string[] = []): Promise<void> {
+  await runOclif("list", args);
 }
 
 // ── Sandbox-scoped actions ───────────────────────────────────────

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 
 const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
+const HERMES_CLI = path.join(import.meta.dirname, "..", "bin", "nemohermes.js");
 
 type CliRunResult = {
   code: number;
@@ -246,6 +247,19 @@ describe("CLI dispatch", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("list [--json]");
     expect(r.out).toContain("List all sandboxes");
+  });
+
+  it("nemohermes list --help uses alias branding", () => {
+    const out = execSync(`node "${HERMES_CLI}" list --help`, {
+      encoding: "utf-8",
+      timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+      env: {
+        ...process.env,
+        HOME: `/tmp/nemoclaw-cli-test-${Date.now()}`,
+      },
+    });
+    expect(out).toContain("$ nemohermes list [--json]");
+    expect(out).not.toContain("$ nemoclaw list [--json]");
   });
 
   it("list --json emits structured empty inventory", () => {

--- a/test/uninstall.test.ts
+++ b/test/uninstall.test.ts
@@ -103,7 +103,7 @@ describe("uninstall helpers", () => {
 
     expect(result.status).toBe(0);
     expect(fs.existsSync(shimPath)).toBe(false);
-  });
+  }, 60_000);
 
   it("preserves a user-managed nemoclaw file in the shim directory", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-preserve-"));
@@ -122,7 +122,7 @@ describe("uninstall helpers", () => {
     expect(result.status).toBe(0);
     expect(fs.existsSync(shimPath)).toBe(true);
     expect(`${result.stdout}${result.stderr}`).toMatch(/not an installer-managed shim/);
-  });
+  }, 60_000);
 
   it("removes an installer-managed nemoclaw wrapper file in the shim directory", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-wrapper-"));
@@ -177,7 +177,7 @@ describe("uninstall helpers", () => {
 
     expect(result.status).toBe(0);
     expect(fs.existsSync(shimPath)).toBe(false);
-  });
+  }, 60_000);
 
   it("preserves a wrapper-like shim when extra content is appended", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-wrapper-extra-"));
@@ -206,7 +206,7 @@ describe("uninstall helpers", () => {
     expect(result.status).toBe(0);
     expect(fs.existsSync(shimPath)).toBe(true);
     expect(`${result.stdout}${result.stderr}`).toMatch(/not an installer-managed shim/);
-  });
+  }, 60_000);
 
   it("removes the onboard session file as part of NemoClaw state cleanup", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-session-"));


### PR DESCRIPTION
## Summary
Hardens the oclif bridge introduced for `nemoclaw list` so command help uses the active launcher branding, including the `nemohermes` alias. It also centralizes legacy dispatch through a `runOclif()` helper and relaxes uninstall helper test timeouts that were flaky under full-suite load.

## Changes
- Set the oclif config bin to the active `CLI_NAME` and invoke command classes with that config so alias help renders correctly.
- Add a shared `runOclif()` delegation helper in `src/nemoclaw.ts` and route `list` through it.
- Add CLI coverage for `nemohermes list --help` branding.
- Increase timeouts for uninstall helper tests that can exceed Vitest's default when the full CLI suite runs concurrently.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: OpenAI Codex

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation for the nemohermes command alias to ensure correct branding in CLI output.
  * Adjusted execution timeouts for uninstall operation tests.

* **Refactor**
  * Optimized command execution flow for improved reliability.
  * Improved sandbox listing implementation through centralized configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->