### PR TITLE
docs: add Hermes quickstart

### DIFF
--- a/docs/.docs-skip
+++ b/docs/.docs-skip
@@ -41,7 +41,6 @@ skip-features:
 
 skip-terms:
   - "permissive mode"                    # do not reference this concept in docs
-  - "Hermes"
   - "shields down"                       # experimental shields command, not advertised
   - "shields up"                         # experimental shields command, not advertised
   - "shields status"                     # experimental shields command, not advertised

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,7 +39,7 @@ The current generated skills and their source pages are:
 | Skill | Source docs |
 |---|---|
 | `nemoclaw-user-overview` | `docs/about/overview.md`, `docs/about/ecosystem.md`, `docs/about/how-it-works.md`, `docs/about/release-notes.md` |
-| `nemoclaw-user-get-started` | `docs/get-started/quickstart.md` |
+| `nemoclaw-user-get-started` | `docs/get-started/quickstart.md`, `docs/get-started/quickstart-hermes.md` |
 | `nemoclaw-user-configure-inference` | `docs/inference/inference-options.md`, `docs/inference/use-local-inference.md`, `docs/inference/switch-inference-providers.md` |
 | `nemoclaw-user-manage-policy` | `docs/network-policy/customize-network-policy.md`, `docs/network-policy/approve-network-requests.md` |
 | `nemoclaw-user-monitor-sandbox` | `docs/monitoring/monitor-sandbox-activity.md` |

--- a/docs/get-started/quickstart-hermes.md
+++ b/docs/get-started/quickstart-hermes.md
@@ -64,7 +64,7 @@ Sandbox name [my-assistant]: my-hermes
 
 Choose the inference provider that matches where you want Hermes model traffic to go.
 The provider options and credential environment variables are the same as the standard NemoClaw quickstart.
-For provider-specific prompts, refer to the [](quickstart.md#respond-to-the-onboard-wizard) section and the [Inference Options](../inference/inference-options.md) page.
+For provider-specific prompts, refer to the [Respond to the Onboard Wizard](quickstart.md#respond-to-the-onboard-wizard) section and the [Inference Options](../inference/inference-options.md) page.
 
 After provider and policy selection, review the summary and confirm the build.
 NemoClaw writes Hermes configuration into `/sandbox/.hermes`, routes model traffic through `inference.local`, and starts the Hermes gateway inside the sandbox.

--- a/docs/get-started/quickstart-hermes.md
+++ b/docs/get-started/quickstart-hermes.md
@@ -1,0 +1,170 @@
+---
+title:
+  page: "NemoClaw Quickstart with Hermes"
+  nav: "NemoClaw Quickstart with Hermes"
+description:
+  main: "Install NemoClaw, select the Hermes agent, and launch a sandboxed Hermes API endpoint."
+  agent: "Installs NemoClaw, selects the Hermes agent, and launches a sandboxed Hermes API endpoint. Use when users ask for Hermes setup, NemoHermes onboarding, or running Hermes inside OpenShell."
+keywords: ["nemohermes quickstart", "hermes agent nemoclaw", "run hermes openshell sandbox"]
+topics: ["generative_ai", "ai_agents"]
+tags: ["hermes", "openshell", "sandboxing", "inference_routing", "nemoclaw"]
+content:
+  type: get_started
+  difficulty: technical_beginner
+  audience: ["developer", "engineer"]
+status: published
+---
+
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# NemoClaw Quickstart with Hermes
+
+Use NemoHermes when you want NemoClaw to create an OpenShell sandbox that runs Hermes instead of the default OpenClaw agent.
+The `nemohermes` command is an alias for `nemoclaw` with the Hermes agent pre-selected.
+
+:::{warning}
+The Hermes agent option is experimental.
+Interfaces, defaults, and supported features may change without notice, and it is not recommended for production use.
+:::
+
+:::{note}
+Review the [Prerequisites](prerequisites.md) before starting.
+The first Hermes build can take several minutes because NemoClaw builds the Hermes sandbox base image if it is not already cached.
+:::
+
+## Install and Onboard
+
+Start the installer with `NEMOCLAW_AGENT=hermes` set in your shell.
+The installer installs the CLI, selects the `nemohermes` alias, and runs the guided onboarding flow.
+
+```console
+$ export NEMOCLAW_AGENT=hermes
+$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
+If NemoClaw is already installed, start Hermes onboarding directly.
+
+```console
+$ nemohermes onboard
+```
+
+## Respond to the Wizard
+
+The onboard wizard asks for a sandbox name, inference provider, model, credentials, and network policy preset.
+At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
+
+Use a distinct sandbox name, such as `my-hermes`, so you can run Hermes and OpenClaw sandboxes side by side.
+
+```text
+Sandbox name [my-assistant]: my-hermes
+```
+
+Choose the inference provider that matches where you want Hermes model traffic to go.
+The provider options and credential environment variables are the same as the standard NemoClaw quickstart.
+For provider-specific prompts, refer to the [](quickstart.md#respond-to-the-onboard-wizard) section and the [Inference Options](../inference/inference-options.md) page.
+
+After provider and policy selection, review the summary and confirm the build.
+NemoClaw writes Hermes configuration into `/sandbox/.hermes`, routes model traffic through `inference.local`, and starts the Hermes gateway inside the sandbox.
+
+## Use Non-Interactive Setup
+
+For CI or scripted installs, set the required environment variables before running the installer.
+The example below uses NVIDIA Endpoints and creates a sandbox named `my-hermes`.
+
+```console
+$ export NEMOCLAW_AGENT=hermes
+$ export NEMOCLAW_NON_INTERACTIVE=1
+$ export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1
+$ export NEMOCLAW_SANDBOX_NAME=my-hermes
+$ export NVIDIA_API_KEY=<your-key>
+$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
+Use the provider variables from [Inference Options](../inference/inference-options.md) when you choose a different provider.
+
+## Connect to Hermes
+
+When onboarding completes, NemoClaw prints the sandbox name, model, lifecycle commands, and Hermes API endpoint.
+Hermes exposes an OpenAI-compatible API on port `8642`, not a browser dashboard.
+
+```text
+──────────────────────────────────────────────────
+Sandbox      my-hermes (Landlock + seccomp + netns)
+Model        nvidia/nemotron-3-super-120b-a12b (NVIDIA Endpoints)
+──────────────────────────────────────────────────
+Run:         nemohermes my-hermes connect
+Status:      nemohermes my-hermes status
+Logs:        nemohermes my-hermes logs --follow
+
+Hermes Agent OpenAI-compatible API
+Port 8642 must be forwarded before connecting.
+http://127.0.0.1:8642/v1
+──────────────────────────────────────────────────
+```
+
+To chat with the agent from a terminal, follow these steps:
+
+1. Connect to the sandbox and start the Hermes CLI.
+
+   ```console
+   $ nemohermes my-hermes connect
+   ```
+
+2. Inside the sandbox, run the Hermes CLI.
+
+   ```console
+   $ hermes
+   ```
+
+## Check the API Endpoint
+
+The onboard flow starts the port forward automatically.
+Check the health endpoint from the host to confirm that the Hermes API is reachable.
+
+```console
+$ curl -sf http://127.0.0.1:8642/health
+```
+
+If the command cannot connect after a reboot or terminal restart, start the forward again.
+
+```console
+$ openshell forward start --background 8642 my-hermes
+```
+
+Configure an OpenAI-compatible client with the base URL `http://127.0.0.1:8642/v1`.
+Hermes uses API header authentication for client requests.
+Do not append an OpenClaw `#token=` URL fragment to the Hermes endpoint.
+
+## Manage the Sandbox
+
+Use the same lifecycle commands as a standard NemoClaw sandbox.
+The `nemohermes` alias keeps help text and recovery messages aligned with Hermes, while targeting the same registered sandbox.
+
+```console
+$ nemohermes my-hermes status
+$ nemohermes my-hermes logs --follow
+$ nemohermes my-hermes snapshot create --name before-change
+$ nemohermes my-hermes rebuild
+```
+
+To change the active model or provider without rebuilding the sandbox, use the OpenShell inference route.
+
+```console
+$ openshell inference set -g nemoclaw --model <model> --provider <provider>
+```
+
+To remove the sandbox when you are done, destroy it explicitly.
+
+```console
+$ nemohermes my-hermes destroy
+```
+
+## Next Steps
+
+- [Inference Options](../inference/inference-options.md) to choose a provider and model.
+- [Commands](../reference/commands.md) to see the full `nemohermes` alias behavior.
+- [Backup and Restore](../workspace/backup-restore.md) to preserve sandbox state before destructive operations.
+- [Monitor Sandbox Activity](../monitoring/monitor-sandbox-activity.md) to inspect OpenShell events and sandbox logs.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title:
-  page: "NemoClaw Quickstart: Install, Launch, and Run Your First Agent"
-  nav: "Quickstart"
+  page: "NemoClaw Quickstart with OpenClaw"
+  nav: "Quickstart with OpenClaw"
 description:
   main: "Install NemoClaw, launch a sandbox, and run your first agent prompt."
   agent: "Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when onboarding, installing, or launching a NemoClaw sandbox for the first time."
@@ -20,7 +20,7 @@ status: published
   SPDX-License-Identifier: Apache-2.0
 -->
 
-# Quickstart
+# NemoClaw Quickstart with OpenClaw
 
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
@@ -52,8 +52,9 @@ If you export `NEMOCLAW_DISABLE_DEVICE_AUTH` after onboarding finishes, it has n
 
 ### Respond to the Onboard Wizard
 
-After the installer launches `nemoclaw onboard`, the wizard walks you through a sandbox name, an inference provider, and a network policy preset.
+After the installer launches `nemoclaw onboard`, the wizard runs preflight checks, starts or reuses the OpenShell gateway, and asks for an inference provider, sandbox name, optional web search, optional messaging channels, and network policy presets.
 At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
+If existing sandbox sessions are running, the installer warns before onboarding because the setup can rebuild or upgrade sandboxes after the new sandbox launches.
 
 The inference provider prompt presents a numbered list.
 
@@ -64,12 +65,13 @@ The inference provider prompt presents a numbered list.
   4) Anthropic
   5) Other Anthropic-compatible endpoint
   6) Google Gemini
-  7) Local Ollama        (only shown when Ollama is detected on the host)
+  7) Local Ollama (localhost:11434)
   Choose [1]:
 ```
 
 Pick the option that matches where you want inference traffic to go, then expand the matching helper below for the follow-up prompts and the API key environment variable to set.
 For the full list of providers and validation behavior, refer to [Inference Options](../inference/inference-options.md).
+Local Ollama appears only when NemoClaw detects Ollama on the host.
 
 :::{tip}
 Export the API key before launching the installer so the wizard does not have to ask for it.
@@ -123,9 +125,12 @@ Respond to the wizard as follows.
 1. At the `Choose [1]:` prompt, type `3` to select **Other OpenAI-compatible endpoint**.
 2. At the `OpenAI-compatible base URL` prompt, enter the provider's base URL. Find the exact value in your provider's API documentation. NemoClaw appends `/v1` automatically, so leave that suffix off.
 3. At the `COMPATIBLE_API_KEY:` prompt, paste your key if it is not already exported.
-4. At the `Other OpenAI-compatible endpoint model []:` prompt, enter the model ID exactly as it appears in your provider's model catalog (for example, `openai/gpt-5.4` on OpenRouter).
+4. At the `Other OpenAI-compatible endpoint model []:` prompt, enter the model ID exactly as it appears in your provider's model catalog.
 
-NemoClaw sends a real inference request to validate the endpoint and model. NemoClaw forces the chat completions API for compatible endpoints because many backends advertise `/v1/responses` but mishandle the `developer` role used by the Responses API.
+For example, when you use NVIDIA's OpenAI-compatible inference endpoint, enter `https://inference-api.nvidia.com` as the base URL and the model ID your endpoint exposes, such as `openai/openai/gpt-5.5`.
+
+NemoClaw sends a real inference request to validate the endpoint and model.
+If the endpoint does not return the streaming events OpenClaw needs from the Responses API, NemoClaw falls back to the chat completions API and configures OpenClaw to use `openai-completions`.
 
 :::{tip}
 NVIDIA Nemotron models expose OpenAI-compatible APIs, so this option is the right choice for any Nemotron deployment that does not live on `build.nvidia.com`. Common examples include a self-hosted NIM container, an enterprise NVIDIA AI Enterprise gateway, or a vLLM/SGLang server running Nemotron weights. Point the base URL at your endpoint and enter the Nemotron model ID exactly as your server reports it.
@@ -207,19 +212,22 @@ For setup, refer to [Use a Local Inference Server](../inference/use-local-infere
 
 ### Review the Configuration Before the Sandbox Build
 
-After you enter the sandbox name, the wizard prints a review summary and asks for final confirmation before starting the destructive sandbox image build. For example, if you picked NVIDIA Endpoints, the summary looks like the following:
+After you enter the sandbox name, the wizard prints a review summary and asks for final confirmation before registering the provider, prompting for optional integrations, and building the sandbox image.
+For example, if you picked an OpenAI-compatible endpoint, the summary looks like the following:
 
 ```text
   ──────────────────────────────────────────────────
   Review configuration
   ──────────────────────────────────────────────────
-  Provider:      nvidia-api
-  Model:         nvidia/nemotron-3-super-120b-a12b
-  API key:       NVIDIA_API_KEY (registered with the OpenShell gateway)
+  Provider:      compatible-endpoint
+  Model:         openai/openai/gpt-5.5
+  API key:       COMPATIBLE_API_KEY (staged for OpenShell gateway registration)
   Web search:    disabled
   Messaging:     none
-  Sandbox name:  my-assistant
+  Sandbox name:  my-gpt-claw
+  Note:          Sandbox build takes ~6 minutes on this host.
   ──────────────────────────────────────────────────
+  Web search and messaging channels will be prompted next.
   Apply this configuration? [Y/n]:
 ```
 
@@ -227,18 +235,38 @@ The default is `Y`, so you can press Enter once to continue. Answer `n` to abort
 
 Non-interactive runs (`NEMOCLAW_NON_INTERACTIVE=1`) print the summary for log clarity but skip the prompt.
 
+### Configure Web Search and Messaging
+
+After you confirm the summary, NemoClaw registers the selected provider with the OpenShell gateway and sets the `inference.local` route.
+The wizard then asks whether to enable Brave Web Search.
+If you enable it, enter a Brave Search API key when prompted.
+
+The wizard also offers messaging channels such as Telegram, Discord, and Slack.
+Press a channel number to toggle it, then press Enter to continue.
+If you select a channel, NemoClaw validates the token format before it bakes the channel configuration into the sandbox.
+For example, Slack bot tokens must start with `xoxb-`.
+
+### Choose Network Policy Presets
+
+After the sandbox image builds and OpenClaw starts inside the sandbox, NemoClaw asks which network policy tier to apply.
+The default **Balanced** tier includes common development presets such as npm, PyPI, Hugging Face, Homebrew, and Brave Search.
+Use the arrow keys or `j` and `k` to move, Space to select, and Enter to confirm.
+
+The preset selector lets you include more destinations, such as GitHub, Jira, Slack, Telegram, or local inference.
+Press `r` to toggle a selected preset between read-only and read-write when the preset supports both modes.
+
 When the install completes, a summary confirms the running environment.
 The `Model` and provider line reflects the inference option you picked during onboarding.
-The example below shows the result if you picked NVIDIA Endpoints during onboarding.
+The example below shows the result if you picked an OpenAI-compatible endpoint during onboarding.
 
 ```text
 ──────────────────────────────────────────────────
-Sandbox      my-assistant (Landlock + seccomp + netns)
-Model        nvidia/nemotron-3-super-120b-a12b (NVIDIA Endpoints)
+Sandbox      my-gpt-claw (Landlock + seccomp + netns)
+Model        openai/openai/gpt-5.5 (Other OpenAI-compatible endpoint)
 ──────────────────────────────────────────────────
-Run:         nemoclaw my-assistant connect
-Status:      nemoclaw my-assistant status
-Logs:        nemoclaw my-assistant logs --follow
+Run:         nemoclaw my-gpt-claw connect
+Status:      nemoclaw my-gpt-claw status
+Logs:        nemoclaw my-gpt-claw logs --follow
 ──────────────────────────────────────────────────
 
 [INFO]  === Installation complete ===
@@ -248,30 +276,34 @@ If you picked a different option, the `Model` line shows that provider's model a
 
 ## Open the OpenClaw UI in a Browser
 
-The onboard wizard automatically starts an SSH port forward from your host's `127.0.0.1:18789` to the sandbox dashboard, then prints a tokenized URL in the install summary.
+The onboard wizard starts a background port forward to the sandbox dashboard, then prints a tokenized URL in the install summary.
+The default host port is `18789`.
+If that port is already taken, NemoClaw uses the next free dashboard port, such as `18790`, and prints that port in the final URL.
 
 ```text
 ──────────────────────────────────────────────────
 OpenClaw UI (tokenized URL; treat it like a password; save it now - it will not be printed again)
-Port 18789 must be forwarded before opening these URLs.
-Dashboard: http://127.0.0.1:18789/#token=<auth-token>
+Port 18790 must be forwarded before opening these URLs.
+Dashboard: http://127.0.0.1:18790/#token=<auth-token>
 ──────────────────────────────────────────────────
 ```
 
-Open that URL in your browser. The `#token=<auth-token>` fragment authenticates the browser to the sandbox gateway, so save the URL securely and treat it like a password. NemoClaw prints the token only once.
+Open the printed URL in your browser.
+The `#token=<auth-token>` fragment authenticates the browser to the sandbox gateway, so save the URL securely and treat it like a password.
+NemoClaw prints the token only once.
 
 ### Restart the Port Forward
 
-If the forward stopped (for example, after a reboot) or you opened a new terminal and the URL no longer responds, restart it manually.
+If the forward stopped, or the installer reported that no active forward was found and the URL does not load, restart it manually with the port from the install summary.
 
-```bash
-openshell forward start --background 18789 my-assistant
+```console
+$ openshell forward start --background <dashboard-port> my-gpt-claw
 ```
 
 To list active forwards across all sandboxes, run the following command.
 
-```bash
-openshell forward list
+```console
+$ openshell forward list
 ```
 
 ### Run Multiple Sandboxes
@@ -280,8 +312,8 @@ Each sandbox needs its own dashboard port, since `openshell forward` refuses to 
 When the default port is already held by another sandbox, `nemoclaw onboard` scans ports `18789` through `18799` and uses the next free port.
 
 ```console
-$ nemoclaw onboard                                            # first sandbox uses 18789
-$ nemoclaw onboard                                            # second sandbox uses the next free port
+$ nemoclaw onboard                                      # first sandbox uses 18789
+$ nemoclaw onboard                                      # second sandbox uses the next free port, such as 18790
 ```
 
 To choose a specific port, pass `--control-ui-port`:
@@ -446,6 +478,7 @@ For a full comparison of the two forms — what they fetch, what they trust, and
 
 ## Next Steps
 
+- [NemoHermes Quickstart](quickstart-hermes.md) to launch Hermes instead of the default OpenClaw agent.
 - [Switch inference providers](../inference/switch-inference-providers.md) to use a different model or endpoint.
 - [Approve or deny network requests](../network-policy/approve-network-requests.md) when the agent tries to reach external hosts.
 - [Customize the network policy](../network-policy/customize-network-policy.md) to pre-approve trusted domains.

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,6 +182,16 @@ Install the CLI, configure inference, and launch your first sandboxed agent.
 {bdg-secondary}`Tutorial`
 :::
 
+:::{grid-item-card} NemoClaw Quickstart for Hermes
+:link: get-started/quickstart-hermes
+:link-type: doc
+
+Launch Hermes in an OpenShell sandbox with the `nemohermes` alias.
+
++++
+{bdg-secondary}`Tutorial`
+:::
+
 :::{grid-item-card} Commands
 :link: reference/commands
 :link-type: doc
@@ -287,7 +297,7 @@ This software automatically retrieves, accesses or interacts with external mater
 :hidden:
 
 Overview <about/overview>
-How It Works <about/how-it-works>
+Architecture Overview <about/how-it-works>
 Ecosystem <about/ecosystem>
 Release Notes <about/release-notes>
 ```
@@ -297,7 +307,8 @@ Release Notes <about/release-notes>
 :hidden:
 
 Prerequisites <get-started/prerequisites>
-Quickstart <get-started/quickstart>
+Quickstart with OpenClaw <get-started/quickstart>
+Quickstart with Hermes <get-started/quickstart-hermes>
 ```
 
 ```{toctree}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -840,6 +840,8 @@ Every `nemohermes` command is equivalent to running `nemoclaw` with `--agent her
 ```console
 $ nemohermes onboard              # equivalent to: nemoclaw onboard --agent hermes
 $ nemohermes my-sandbox connect   # same as: nemoclaw my-sandbox connect
+$ nemohermes --help               # show NemoHermes-branded help
+$ nemohermes --version            # show the installed NemoHermes CLI version
 ```
 
 The alias is installed alongside `nemoclaw` via `npm link` or `npm install -g`.


### PR DESCRIPTION
## Summary
Adds a Hermes-focused quickstart that explains how to install NemoClaw with the `nemohermes` alias, onboard a Hermes sandbox, connect to the API endpoint, and manage the sandbox lifecycle. Also updates the getting-started navigation and command reference so users can discover the Hermes path and alias behavior.

Preview: https://nvidia.github.io/NemoClaw/pr-preview/pr-2778/get-started/quickstart-hermes.html

## Changes
- Add `docs/get-started/quickstart-hermes.md` with install, non-interactive setup, API health check, and lifecycle examples for Hermes.
- Update the main OpenClaw quickstart and docs index to point users to the Hermes quickstart.
- Document `nemohermes --help` and `nemohermes --version` in the command reference alias section.
- Update docs metadata so the generated get-started skill includes the Hermes quickstart.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [x] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Cursor

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Added a new Hermes quickstart covering installation, onboarding, connecting to the Hermes API, port forwarding, sandbox management, and troubleshooting.
* Updated the OpenClaw quickstart with improved onboarding flow, provider selection, network policy presets, and port-forwarding behavior.
* Homepage navigation now highlights both Hermes and OpenClaw quickstarts.
* CLI docs expanded with NemoHermes help/version examples.
* Documentation checks/filters adjusted to include the Hermes term.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->