### PR TITLE
docs: prepare documentation for v0.0.32

### DIFF
--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -43,6 +43,7 @@ If you are connecting from your local machine and still need to provision the re
 
 - The [Brev CLI](https://brev.nvidia.com) installed and authenticated.
 - A provider credential for the inference backend you want to use during onboarding.
+- `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` exported when your remote vLLM or Hugging Face workflow needs access to gated models.
 - NemoClaw installed locally if you plan to use the deprecated `nemoclaw deploy` wrapper. Otherwise, install NemoClaw directly on the remote host after provisioning it.
 
 ## Deploy the Instance
@@ -68,6 +69,7 @@ The legacy compatibility flow performs the following steps on the VM:
 4. Starts optional host auxiliary services (for example the cloudflared tunnel) when `cloudflared` is available. Channel messaging is configured during onboarding and runs through OpenShell-managed processes, not through `nemoclaw tunnel start`.
 
 By default, the compatibility wrapper asks Brev to provision on `gcp`. Override this with `NEMOCLAW_BREV_PROVIDER` if you need a different Brev cloud provider.
+If you export `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN`, the wrapper forwards those values to the VM so remote setup can pull gated Hugging Face model repositories.
 
 ## Connect to the Remote Sandbox
 

--- a/docs/get-started/windows-preparation.md
+++ b/docs/get-started/windows-preparation.md
@@ -96,17 +96,20 @@ If you see "Cannot connect to the Docker daemon", confirm that Docker Desktop is
 
 ## Set Up Local Inference with Ollama (Optional)
 
-If you plan to select Ollama as your inference provider during onboarding, install it inside WSL before running the NemoClaw installer:
+If you plan to select Ollama as your inference provider during onboarding, run one Ollama instance that WSL can reach.
+You can install Ollama inside WSL:
 
 ```console
 $ curl -fsSL https://ollama.com/install.sh | sh
 ```
 
-If Ollama is also running on the Windows side, quit it before running `nemoclaw onboard` (system tray > right-click > Quit).
-The Windows and WSL instances bind to the same port and conflict.
-
-The onboarding process starts Ollama in WSL if it is not already running.
+If Ollama is not already running in WSL, the onboarding process starts it for you.
 You can also start it yourself beforehand with `ollama serve`.
+
+You can also use Ollama for Windows.
+When Ollama runs on the Windows host, NemoClaw detects it from WSL through `host.docker.internal` and pulls missing models through the Ollama HTTP API.
+Do not run both the Windows and WSL Ollama instances on port `11434` at the same time.
+Use one instance, or move one of them to a different port before running `nemoclaw onboard`.
 
 ## Next Step
 

--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -52,6 +52,7 @@ $ nemoclaw onboard
 Select **Local Ollama** from the provider list.
 NemoClaw lists installed models or offers starter models if none are installed.
 It pulls the selected model, loads it into memory, and validates it before continuing.
+On WSL, if Ollama is running on the Windows host, NemoClaw pulls missing models through the Ollama HTTP API instead of requiring the `ollama` CLI inside WSL.
 
 ### Authenticated Reverse Proxy
 
@@ -83,6 +84,12 @@ All other endpoints (including `POST /api/tags`) require the Bearer token.
 If Ollama is already running on a non-loopback address when you start onboard,
 the wizard restarts it on `127.0.0.1:11434` so the proxy is the only network
 path to the model server.
+
+### GPU Memory Cleanup
+
+When you switch away from Ollama, stop host services, or destroy an Ollama-backed sandbox, NemoClaw asks Ollama to unload currently loaded models from GPU memory.
+The cleanup sends `keep_alive: 0` for each model reported by Ollama and runs on a best-effort basis, so shutdown continues if Ollama is already stopped.
+This does not delete downloaded model files.
 
 ### Non-Interactive Setup
 

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.31"}
+{"name": "nemoclaw", "version": "0.0.32"}

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -160,12 +160,16 @@ For the DGX Spark-specific variant of this topology (cgroup v2, aarch64, unified
 
 The plugin is a thin TypeScript package that registers an inference provider and the `/nemoclaw` slash command.
 It runs in-process with the OpenClaw gateway inside the sandbox.
+It also registers runtime hooks that keep the agent aware of its environment.
+Before an agent turn starts, the plugin prepends a short context block with the active sandbox name, sandbox phase, network policy summary, and filesystem policy summary.
+When the policy or phase changes during a session, the plugin sends a smaller update block instead of repeating the full context.
 
 ```text
 nemoclaw/
 ├── src/
 │   ├── index.ts                    Plugin entry: registers all commands
 │   ├── cli.ts                      Commander.js subcommand wiring
+│   ├── runtime-context.ts          Sandbox and policy context injection
 │   ├── commands/
 │   │   ├── launch.ts               Fresh install into OpenShell
 │   │   ├── connect.ts              Interactive shell into sandbox
@@ -231,6 +235,7 @@ container image. Inside the sandbox:
 - Inference calls are routed through OpenShell to the configured provider.
 - Network egress is restricted by the baseline policy in `openclaw-sandbox.yaml`.
 - Filesystem access is confined to `/sandbox` and `/tmp` for read-write access, with system paths read-only.
+- The NemoClaw plugin injects sandbox and policy context into agent turns so the agent can report policy blocks accurately.
 
 ## Inference Routing
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -329,6 +329,7 @@ Do not log it, share it, or commit it to version control.
 
 Stop the NIM container, remove the host-side Docker image built during onboard, and delete the sandbox.
 This removes the sandbox from the registry.
+For Ollama-backed sandboxes, `destroy` also asks Ollama to unload currently loaded models and clears stale auth proxy state on a best-effort basis.
 
 :::{warning}
 This command permanently deletes the sandbox **and its persistent volume**.

--- a/docs/security/credential-storage.md
+++ b/docs/security/credential-storage.md
@@ -66,10 +66,12 @@ A typical deploy invocation looks like:
 
 ```console
 $ NVIDIA_API_KEY=nvapi-... \
+    HF_TOKEN=hf_... \
     TELEGRAM_BOT_TOKEN=... \
     nemoclaw deploy my-instance
 ```
 
+For remote vLLM or Hugging Face workflows that need gated model access, `nemoclaw deploy` also forwards `HF_TOKEN` and `HUGGING_FACE_HUB_TOKEN` to the VM when either variable is present.
 If a required credential is missing the deploy aborts before any remote work begins.
 
 ## GitHub Tokens

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
   {
     "preferred": true,
+    "version": "0.0.32",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.32/"
+  },
+  {
     "version": "0.0.31",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.31/"
   },


### PR DESCRIPTION
## Summary
Updates NemoClaw documentation for the v0.0.32 release candidate, covering user-facing changes that landed since v0.0.31 and promoting the docs version switcher to 0.0.32.

## Changes
- Document Windows-host Ollama support from WSL, including HTTP model pulls and avoiding duplicate Ollama instances on port 11434. Matches dev PR #2768.
- Add Ollama GPU memory cleanup behavior for provider switches, service stops, and sandbox destroy. Matches dev PR #2651.
- Document Hugging Face token forwarding for remote deploy workflows that pull gated model repositories. Matches dev PR #2729.
- Add runtime sandbox and policy context injection to the architecture reference. Matches dev PR #2751.
- Bump `docs/versions1.json` and regenerated `docs/project.json` to 0.0.32 for release prep. No separate dev PR.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Cursor

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for deploying with Hugging Face gated models
  * Improved Windows/WSL Ollama configuration instructions
  * Documented GPU memory cleanup behavior during model transitions
  * Enhanced architecture and command reference documentation
  * Version bumped to 0.0.32

<!-- end of auto-generated comment: release notes by coderabbit.ai -->