### PR TITLE
fix(cli): keep list flags out of canonical usage

### DIFF
--- a/src/lib/command-registry.test.ts
+++ b/src/lib/command-registry.test.ts
@@ -128,6 +128,12 @@ describe("command-registry", () => {
       }
     });
 
+    it("keeps optional flags out of canonical usage strings", () => {
+      for (const entry of canonicalUsageList()) {
+        expect(entry).not.toContain("[");
+      }
+    });
+
     it("excludes hidden commands", () => {
       const list = canonicalUsageList();
       expect(list).not.toContain("nemoclaw <name> shields down");

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -89,8 +89,9 @@ export const COMMANDS: readonly CommandDef[] = [
 
   // ── Sandbox Management ──
   {
-    usage: "nemoclaw list [--json]",
+    usage: "nemoclaw list",
     description: "List all sandboxes",
+    flags: "[--json]",
     group: "Sandbox Management",
     scope: "global",
   },


### PR DESCRIPTION
## Summary
Fixes CLI/docs parity for `nemoclaw list --json` by keeping the optional JSON flag in help metadata instead of canonical command signatures. This keeps `--dump-commands` aligned with docs headings while preserving `--json` in displayed help.

## Changes
- Updated `src/lib/command-registry.ts` so `nemoclaw list` remains canonical usage and `[--json]` is rendered through the `flags` field.
- Added a regression test in `src/lib/command-registry.test.ts` to keep optional flag syntax out of canonical usage output.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: OpenAI ChatGPT

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify canonical usage strings exclude optional-flag bracket notation.

* **Refactor**
  * Adjusted command signature representation in the registry for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->