### PR TITLE
test(wsl): centralize timeout budgets

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -7,6 +7,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { execTimeout, testTimeout, testTimeoutOptions } from "./helpers/timeouts";
+
 const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
 const HERMES_CLI = path.join(import.meta.dirname, "..", "bin", "nemohermes.js");
 
@@ -60,7 +62,7 @@ function run(args: string): CliRunResult {
 function runWithEnv(
   args: string,
   env: Record<string, string | undefined> = {},
-  timeout: number = Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+  timeout: number = execTimeout(),
 ): CliRunResult {
   try {
     const out = execSync(`node "${CLI}" ${args}`, {
@@ -187,8 +189,13 @@ function createDebugCommandTestEnv(prefix: string): Record<string, string> {
 
 describe("CLI dispatch", () => {
   it("config get validates flags and values before dispatch", () => {
-    const src = fs.readFileSync(path.join(import.meta.dirname, "..", "src", "nemoclaw.ts"), "utf-8");
-    const configGet = src.match(/case "get": \{([\s\S]*?)sandboxConfig\.configGet\(cmd, configOpts\);/);
+    const src = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "nemoclaw.ts"),
+      "utf-8",
+    );
+    const configGet = src.match(
+      /case "get": \{([\s\S]*?)sandboxConfig\.configGet\(cmd, configOpts\);/,
+    );
     expect(configGet).toBeTruthy();
     expect(configGet![1]).toContain("--key requires a value");
     expect(configGet![1]).toContain("--format requires a value");
@@ -220,7 +227,7 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("nemoclaw")).toBeTruthy();
   });
 
-  it("bare unknown name surfaces sandbox-not-found (#2164)", { timeout: 35000 }, () => {
+  it("bare unknown name surfaces sandbox-not-found (#2164)", testTimeoutOptions(35_000), () => {
     // Longer timeout: when openshell is installed but the gateway is down,
     // the CLI probes the gateway before reporting "not found" and the
     // default 10s is not enough for the connection to time out.
@@ -252,7 +259,7 @@ describe("CLI dispatch", () => {
   it("nemohermes list --help uses alias branding", () => {
     const out = execSync(`node "${HERMES_CLI}" list --help`, {
       encoding: "utf-8",
-      timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+      timeout: execTimeout(),
       env: {
         ...process.env,
         HOME: `/tmp/nemoclaw-cli-test-${Date.now()}`,
@@ -405,7 +412,7 @@ describe("CLI dispatch", () => {
 
   it(
     "start does not prompt for NVIDIA_API_KEY before launching local services",
-    { timeout: 35000 },
+    testTimeoutOptions(35_000),
     () => {
       const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-start-no-key-"));
       const localBin = path.join(home, "bin");
@@ -541,7 +548,7 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("--output")).toBeTruthy();
   });
 
-  it("debug --quick exits 0 and produces diagnostic output", { timeout: 30000 }, () => {
+  it("debug --quick exits 0 and produces diagnostic output", testTimeoutOptions(30_000), () => {
     const r = runWithEnv(
       "debug --quick",
       createDebugCommandTestEnv("nemoclaw-cli-debug-quick-"),
@@ -567,7 +574,7 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("nemoclaw debug")).toBeTruthy();
   });
 
-  it("debug --sandbox NAME targets the specified sandbox", { timeout: 30000 }, () => {
+  it("debug --sandbox NAME targets the specified sandbox", testTimeoutOptions(30_000), () => {
     const r = runWithEnv(
       "debug --quick --sandbox mybox",
       createDebugCommandTestEnv("nemoclaw-cli-debug-sandbox-"),
@@ -582,7 +589,7 @@ describe("CLI dispatch", () => {
     expect(r.code).not.toBe(0);
   });
 
-  it("debug warns when default sandbox is stale", { timeout: 15000 }, () => {
+  it("debug warns when default sandbox is stale", testTimeoutOptions(), () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-stale-"));
     fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
     fs.writeFileSync(
@@ -597,7 +604,7 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("--sandbox NAME");
   });
 
-  it("debug --sandbox skips stale default warning", { timeout: 15000 }, () => {
+  it("debug --sandbox skips stale default warning", testTimeoutOptions(), () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-stale-"));
     fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
     fs.writeFileSync(
@@ -728,7 +735,7 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
   });
 
-  it("keeps logs --follow running when one log source exits", { timeout: 15000 }, async () => {
+  it("keeps logs --follow running when one log source exits", testTimeoutOptions(), async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-source-exit-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -785,11 +792,7 @@ describe("CLI dispatch", () => {
 
     try {
       let calls: string[] = [];
-      const configuredTimeout = Number(process.env.NEMOCLAW_TEST_TIMEOUT || 10000);
-      const pollTimeoutMs = Math.min(
-        Number.isFinite(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : 10000,
-        10000,
-      );
+      const pollTimeoutMs = Math.min(testTimeout(10_000), Math.max(1_000, testTimeout() - 5_000));
       const deadline = Date.now() + pollTimeoutMs;
       while (Date.now() < deadline) {
         calls = readCalls();
@@ -812,7 +815,7 @@ describe("CLI dispatch", () => {
     }
   });
 
-  it("waits for logs --follow children to stop after SIGTERM", { timeout: 15000 }, async () => {
+  it("waits for logs --follow children to stop after SIGTERM", testTimeoutOptions(), async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-sigterm-wait-"));
     const localBin = path.join(home, "bin");
     const markerFile = path.join(home, "logs-follow-sigterm-wait-args");
@@ -2281,7 +2284,7 @@ describe("CLI dispatch", () => {
           HOME: home,
           PATH: `${localBin}:${process.env.PATH || ""}`,
         },
-        Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+        execTimeout(),
       );
 
       expect(r.code).toBe(0);
@@ -2290,7 +2293,7 @@ describe("CLI dispatch", () => {
       const saved = JSON.parse(fs.readFileSync(path.join(registryDir, "sandboxes.json"), "utf8"));
       expect(saved.sandboxes.alpha).toBeTruthy();
     },
-    Number(process.env.NEMOCLAW_TEST_TIMEOUT || 10000),
+    testTimeout(10_000),
   );
 
   it("recovers status after gateway runtime is reattached", () => {
@@ -2507,7 +2510,7 @@ describe("CLI dispatch", () => {
           HOME: home,
           PATH: `${localBin}:${process.env.PATH || ""}`,
         },
-        Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+        execTimeout(),
       );
 
       expect(r.code).toBe(0);
@@ -2515,7 +2518,7 @@ describe("CLI dispatch", () => {
       expect(r.out.includes("Could not verify sandbox 'alpha'")).toBeTruthy();
       expect(r.out.includes("verify the active gateway")).toBeTruthy();
     },
-    Number(process.env.NEMOCLAW_TEST_TIMEOUT || 10000),
+    testTimeout(10_000),
   );
 
   it(
@@ -2575,13 +2578,13 @@ describe("CLI dispatch", () => {
           HOME: home,
           PATH: `${localBin}:${process.env.PATH || ""}`,
         },
-        Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+        execTimeout(),
       );
 
       expect(r.code).toBe(0);
       expect(r.out.includes("current gateway/runtime is not reachable")).toBeTruthy();
     },
-    Number(process.env.NEMOCLAW_TEST_TIMEOUT || 10000),
+    testTimeout(10_000),
   );
 
   it(
@@ -2641,7 +2644,7 @@ describe("CLI dispatch", () => {
           HOME: home,
           PATH: `${localBin}:${process.env.PATH || ""}`,
         },
-        Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+        execTimeout(),
       );
 
       expect(r.code).toBe(0);
@@ -2649,7 +2652,7 @@ describe("CLI dispatch", () => {
         r.out.includes("Verify the active gateway and retry after re-establishing the runtime."),
       ).toBeTruthy();
     },
-    Number(process.env.NEMOCLAW_TEST_TIMEOUT || 10000),
+    testTimeout(10_000),
   );
 
   it("explains unrecoverable gateway trust rotation after restart", () => {
@@ -2706,7 +2709,7 @@ describe("CLI dispatch", () => {
         HOME: home,
         PATH: `${localBin}:${process.env.PATH || ""}`,
       },
-      Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+      execTimeout(),
     );
     expect(statusResult.code).toBe(0);
     expect(statusResult.out.includes("gateway trust material rotated after restart")).toBeTruthy();
@@ -2787,7 +2790,7 @@ describe("CLI dispatch", () => {
           HOME: home,
           PATH: `${localBin}:${process.env.PATH || ""}`,
         },
-        Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+        execTimeout(),
       );
       expect(statusResult.code).toBe(0);
       expect(
@@ -2807,7 +2810,7 @@ describe("CLI dispatch", () => {
       ).toBeTruthy();
       expect(connectResult.out.includes("If the gateway never becomes healthy")).toBeTruthy();
     },
-    Number(process.env.NEMOCLAW_TEST_TIMEOUT || 10000),
+    testTimeout(10_000),
   );
 
   it(
@@ -2868,7 +2871,7 @@ describe("CLI dispatch", () => {
           HOME: home,
           PATH: `${localBin}:${process.env.PATH || ""}`,
         },
-        Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 10000),
+        execTimeout(),
       );
       expect(statusResult.code).toBe(0);
       expect(
@@ -2876,7 +2879,7 @@ describe("CLI dispatch", () => {
       ).toBeTruthy();
       expect(statusResult.out.includes("Start the gateway again")).toBeTruthy();
     },
-    Number(process.env.NEMOCLAW_TEST_TIMEOUT || 10000),
+    testTimeout(10_000),
   );
 });
 
@@ -2991,7 +2994,7 @@ describe("list shows live gateway inference", () => {
 
   it(
     "upgrade-sandboxes --check detects a stale sandbox after NemoClaw upgrade (#1904)",
-    { timeout: 15000 },
+    testTimeoutOptions(),
     () => {
       const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-upgrade-sandboxes-"));
       const localBin = path.join(home, "bin");
@@ -3051,7 +3054,7 @@ describe("list shows live gateway inference", () => {
 
   it(
     "upgrade-sandboxes --check reports all-current when no sandboxes are stale (#1904)",
-    { timeout: 15000 },
+    testTimeoutOptions(),
     () => {
       const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-upgrade-current-"));
       const localBin = path.join(home, "bin");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -231,7 +231,7 @@ describe("CLI dispatch", () => {
     // Longer timeout: when openshell is installed but the gateway is down,
     // the CLI probes the gateway before reporting "not found" and the
     // default 10s is not enough for the connection to time out.
-    const r = runWithEnv("boguscmd", {}, 30000);
+    const r = runWithEnv("boguscmd", {}, execTimeout(30_000));
     expect(r.code).toBe(1);
     expect(r.out.includes("Sandbox 'boguscmd' does not exist")).toBeTruthy();
   });
@@ -852,7 +852,8 @@ describe("CLI dispatch", () => {
 
     try {
       let calls: string[] = [];
-      const deadline = Date.now() + 10000;
+      const pollTimeoutMs = Math.min(testTimeout(10_000), Math.max(1_000, testTimeout() - 5_000));
+      const deadline = Date.now() + pollTimeoutMs;
       while (Date.now() < deadline) {
         calls = readCalls();
         if (
@@ -863,6 +864,8 @@ describe("CLI dispatch", () => {
         }
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
+      expect(calls).toContain("logs alpha -n 200 --source all --tail");
+      expect(calls).toContain("sandbox exec -n alpha -- tail -n 200 -f /tmp/gateway.log");
       child.kill("SIGTERM");
       const exitedEarly = await Promise.race([
         exitPromise.then(() => true),
@@ -1504,7 +1507,7 @@ describe("CLI dispatch", () => {
         HOME: home,
         PATH: `${localBin}:${process.env.PATH || ""}`,
       },
-      30000,
+      execTimeout(30_000),
     );
 
     expect(r.code).toBe(0);

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -24,8 +24,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, beforeEach, afterEach } from "vitest";
+import { testTimeout } from "./helpers/timeouts";
 
-const TIMEOUT_MS = Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000);
+const TIMEOUT_MS = testTimeout(20_000);
 const SANDBOX_NAME = "my-assistant";
 
 // Output fixtures that mirror real OpenShell CLI output.

--- a/test/helpers/timeouts.ts
+++ b/test/helpers/timeouts.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const DEFAULT_EXEC_TIMEOUT_MS = 10_000;
+const DEFAULT_TEST_TIMEOUT_MS = 15_000;
+
+function parsePositiveInt(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : null;
+}
+
+function envAwareTimeout(envName: string, defaultMs: number): number {
+  const override = parsePositiveInt(process.env[envName]);
+  // Treat env values as a minimum budget. That lets slower environments such as
+  // WSL raise timeout ceilings without accidentally shortening genuinely slow
+  // tests that need a larger explicit budget.
+  return override === null ? defaultMs : Math.max(defaultMs, override);
+}
+
+export function execTimeout(defaultMs = DEFAULT_EXEC_TIMEOUT_MS): number {
+  return envAwareTimeout("NEMOCLAW_EXEC_TIMEOUT", defaultMs);
+}
+
+export function testTimeout(defaultMs = DEFAULT_TEST_TIMEOUT_MS): number {
+  return envAwareTimeout("NEMOCLAW_TEST_TIMEOUT", defaultMs);
+}
+
+export function testTimeoutOptions(defaultMs = DEFAULT_TEST_TIMEOUT_MS): { timeout: number } {
+  return { timeout: testTimeout(defaultMs) };
+}

--- a/test/nemoclaw-cli-recovery.test.ts
+++ b/test/nemoclaw-cli-recovery.test.ts
@@ -7,11 +7,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, it } from "vitest";
+import { testTimeoutOptions } from "./helpers/timeouts";
 
 describe("nemoclaw CLI runtime recovery", () => {
   it(
     "recovers sandbox status when openshell is only available via the resolved fallback path",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 15_000) },
+    testTimeoutOptions(),
     () => {
       const repoRoot = path.join(import.meta.dirname, "..");
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-recovery-"));

--- a/test/nemohermes-alias.test.ts
+++ b/test/nemohermes-alias.test.ts
@@ -6,6 +6,8 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+import { execTimeout } from "./helpers/timeouts";
+
 const HERMES_CLI = path.join(import.meta.dirname, "..", "bin", "nemohermes.js");
 const NEMOCLAW_CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
 
@@ -16,7 +18,7 @@ function runHermes(
   try {
     const out = execSync(`node "${HERMES_CLI}" ${args}`, {
       encoding: "utf-8",
-      timeout: 10000,
+      timeout: execTimeout(),
       env: {
         ...process.env,
         HOME: "/tmp/nemohermes-test-" + Date.now(),
@@ -41,7 +43,7 @@ function runNemoClaw(
   try {
     const out = execSync(`node "${NEMOCLAW_CLI}" ${args}`, {
       encoding: "utf-8",
-      timeout: 10000,
+      timeout: execTimeout(),
       env: {
         ...process.env,
         HOME: "/tmp/nemohermes-test-" + Date.now(),

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { describe, it, expect, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import policies from "../dist/lib/policies";
+import { execTimeout } from "./helpers/timeouts";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const CLI_PATH = JSON.stringify(path.join(REPO_ROOT, "bin", "nemoclaw.js"));
@@ -108,7 +109,7 @@ selectFromList(items, options)
   return spawnSync(process.execPath, ["-e", script], {
     cwd: REPO_ROOT,
     encoding: "utf-8",
-    timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 5000),
+    timeout: execTimeout(5_000),
     input,
     env: {
       ...process.env,
@@ -865,7 +866,7 @@ selectForRemoval(items, options)
       return spawnSync(process.execPath, ["-e", script], {
         cwd: REPO_ROOT,
         encoding: "utf-8",
-        timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 5000),
+        timeout: execTimeout(5_000),
         input,
         env: {
           ...process.env,
@@ -1477,11 +1478,11 @@ setImmediate(() => {
 
     it("--from-dir skips hidden dotfile yaml presets", () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-from-dir-hidden-"));
+      fs.writeFileSync(path.join(dir, ".bad.yaml"), "preset:\n  name: bad\nnetwork_policies: {}\n");
       fs.writeFileSync(
-        path.join(dir, ".bad.yaml"),
-        "preset:\n  name: bad\nnetwork_policies: {}\n",
+        path.join(dir, "real.yaml"),
+        "preset:\n  name: real\nnetwork_policies: {}\n",
       );
-      fs.writeFileSync(path.join(dir, "real.yaml"), "preset:\n  name: real\nnetwork_policies: {}\n");
       const result = runPolicyAddExternal(["--from-dir", dir, "--yes"]);
       expect(result.status).toBe(0);
       const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim()) as PolicyCall[];
@@ -1516,10 +1517,7 @@ setImmediate(() => {
 
   describe("interactive prompt cleanup", () => {
     it("releases stdin after preset prompts so the event loop drains on a TTY", () => {
-      const source = fs.readFileSync(
-        path.join(REPO_ROOT, "src", "lib", "policies.ts"),
-        "utf-8",
-      );
+      const source = fs.readFileSync(path.join(REPO_ROOT, "src", "lib", "policies.ts"), "utf-8");
       // A TTY-only guard around pause/unref pins the event loop on
       // interactive runs and stops the wizard from exiting after its last
       // prompt resolves.
@@ -1532,10 +1530,7 @@ setImmediate(() => {
     });
 
     it("re-refs stdin before each preset prompt so a follow-up prompt is not stranded by a sticky unref()", () => {
-      const source = fs.readFileSync(
-        path.join(REPO_ROOT, "src", "lib", "policies.ts"),
-        "utf-8",
-      );
+      const source = fs.readFileSync(path.join(REPO_ROOT, "src", "lib", "policies.ts"), "utf-8");
       // unref() above is sticky — a subsequent createInterface will not
       // re-ref by itself; an explicit ref() before each one keeps follow-up
       // prompts able to wait for input.

--- a/test/presets-checkbox.test.ts
+++ b/test/presets-checkbox.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { execTimeout } from "./helpers/timeouts";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const ONBOARD_PATH = JSON.stringify(path.join(REPO_ROOT, "dist", "lib", "onboard.js"));
@@ -72,7 +73,7 @@ presetsCheckboxSelector(presets, initialSelected)
   return spawnSync(process.execPath, ["-e", script], {
     cwd: REPO_ROOT,
     encoding: "utf-8",
-    timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 5000),
+    timeout: execTimeout(5_000),
     env: {
       ...process.env,
       NEMOCLAW_TEST_PRESETS: JSON.stringify(presets),

--- a/test/reboot-identity-drift.test.ts
+++ b/test/reboot-identity-drift.test.ts
@@ -16,6 +16,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { execTimeout, testTimeoutOptions } from "./helpers/timeouts";
 
 const tmpFixtures: string[] = [];
 
@@ -245,14 +246,14 @@ function runCli(tmpDir: string, args: string[]) {
       PATH: "/usr/bin:/bin",
       NEMOCLAW_NO_CONNECT_HINT: "1",
     },
-    timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 15_000),
+    timeout: execTimeout(15_000),
   });
 }
 
 describe("post-reboot SSH identity drift (#2056)", () => {
   it(
     "bare `nemoclaw <name>` (no action) resolves to connect and finds registry entry",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupFixture("reboot-test", "healthy");
       const result = runCli(tmpDir, [sandboxName]);
@@ -262,7 +263,7 @@ describe("post-reboot SSH identity drift (#2056)", () => {
 
   it(
     "explicit `nemoclaw <name> connect` works for healthy sandbox",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupFixture("reboot-explicit", "healthy");
       const result = runCli(tmpDir, [sandboxName, "connect"]);
@@ -272,7 +273,7 @@ describe("post-reboot SSH identity drift (#2056)", () => {
 
   it(
     "identity drift is detected when gateway SSH keys have changed",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupFixture("drift-sandbox", "identity_drift");
       const result = runCli(tmpDir, [sandboxName, "connect"]);
@@ -284,7 +285,7 @@ describe("post-reboot SSH identity drift (#2056)", () => {
 
   it(
     "bare `nemoclaw <name>` also detects identity drift (not silent failure)",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupFixture("drift-bare", "identity_drift");
       const result = runCli(tmpDir, [sandboxName]);
@@ -298,7 +299,7 @@ describe("post-reboot SSH identity drift (#2056)", () => {
 describe("post-reboot registry recovery gate (#2056)", () => {
   it(
     "explicit `nemoclaw <name> connect` recovers registry from live gateway",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupEmptyRegistry("orphan-explicit");
       const result = runCli(tmpDir, [sandboxName, "connect"]);
@@ -308,7 +309,7 @@ describe("post-reboot registry recovery gate (#2056)", () => {
 
   it(
     "bare `nemoclaw <name>` recovers registry from live gateway",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupEmptyRegistry("orphan-bare");
       const result = runCli(tmpDir, [sandboxName]);

--- a/test/rebuild-credential-hydration.test.ts
+++ b/test/rebuild-credential-hydration.test.ts
@@ -25,22 +25,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { execTimeout, testTimeout } from "./helpers/timeouts";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const tmpFixtures: string[] = [];
 
-function parsePositiveInt(value: string | undefined): number | null {
-  if (!value) return null;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-const CHILD_PROCESS_TIMEOUT_MS = Math.max(
-  10_000,
-  parsePositiveInt(process.env.NEMOCLAW_EXEC_TIMEOUT) ?? 0,
-  parsePositiveInt(process.env.NEMOCLAW_TEST_TIMEOUT) ?? 0,
-);
-const TEST_TIMEOUT_MS = Math.max(30_000, CHILD_PROCESS_TIMEOUT_MS + 10_000);
+const CHILD_PROCESS_TIMEOUT_MS = Math.max(execTimeout(10_000), testTimeout(10_000));
+const TEST_TIMEOUT_MS = testTimeout(Math.max(30_000, CHILD_PROCESS_TIMEOUT_MS + 10_000));
 
 afterEach(() => {
   for (const dir of tmpFixtures.splice(0)) {
@@ -121,8 +112,16 @@ describe("Issue #2273 Layer 1: credential hydration from legacy storage", () => 
     { name: "OpenAI", credentialEnv: "OPENAI_API_KEY", value: "sk-test-hydrate" },
     { name: "Anthropic", credentialEnv: "ANTHROPIC_API_KEY", value: "sk-ant-test-hydrate" },
     { name: "Google Gemini", credentialEnv: "GEMINI_API_KEY", value: "gemini-test-hydrate" },
-    { name: "Custom OpenAI-compatible", credentialEnv: "COMPATIBLE_API_KEY", value: "compat-test-hydrate" },
-    { name: "Custom Anthropic-compatible", credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY", value: "compat-ant-test-hydrate" },
+    {
+      name: "Custom OpenAI-compatible",
+      credentialEnv: "COMPATIBLE_API_KEY",
+      value: "compat-test-hydrate",
+    },
+    {
+      name: "Custom Anthropic-compatible",
+      credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY",
+      value: "compat-ant-test-hydrate",
+    },
   ];
 
   for (const { name, credentialEnv, value } of providers) {

--- a/test/sandbox-connect-inference.test.ts
+++ b/test/sandbox-connect-inference.test.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { execTimeout, testTimeoutOptions } from "./helpers/timeouts";
 
 /**
  * Tests for #1248 — inference route swap on sandbox connect.
@@ -133,7 +134,7 @@ function runConnect(tmpDir: string, sandboxName: string) {
         PATH: "/usr/bin:/bin",
         NEMOCLAW_NO_CONNECT_HINT: "1",
       },
-      timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 15_000),
+      timeout: execTimeout(15_000),
     },
   );
 }
@@ -141,7 +142,7 @@ function runConnect(tmpDir: string, sandboxName: string) {
 describe("sandbox connect inference route swap (#1248)", () => {
   it(
     "swaps inference route when live route does not match sandbox provider",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, stateFile, sandboxName } = setupFixture(
         {
@@ -178,7 +179,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
 
   it(
     "does not swap inference route for legacy sandbox without provider",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, stateFile, sandboxName } = setupFixture(
         {
@@ -201,7 +202,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
 
   it(
     "does not swap when live route already matches sandbox provider",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, stateFile, sandboxName } = setupFixture(
         {

--- a/test/sandbox-stuck-recovery.test.ts
+++ b/test/sandbox-stuck-recovery.test.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { execTimeout, testTimeoutOptions } from "./helpers/timeouts";
 
 const tmpFixtures: string[] = [];
 
@@ -117,7 +118,7 @@ function runCli(
         NEMOCLAW_NO_CONNECT_HINT: "1",
         ...extraEnv,
       },
-      timeout: Number(process.env.NEMOCLAW_EXEC_TIMEOUT || 15_000),
+      timeout: execTimeout(15_000),
     },
   );
 }
@@ -125,7 +126,7 @@ function runCli(
 describe("sandbox stuck in non-Ready phase (#2016)", () => {
   it(
     "connect times out with guidance when sandbox is stuck in Provisioning",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupFixture("stuck-sandbox", "Provisioning");
 
@@ -146,7 +147,7 @@ describe("sandbox stuck in non-Ready phase (#2016)", () => {
 
   it(
     "connect exits immediately with recovery hint when sandbox is in a terminal failure state",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupFixture("failed-sandbox", "Failed");
 
@@ -162,7 +163,7 @@ describe("sandbox stuck in non-Ready phase (#2016)", () => {
 
   it(
     "status shows recovery hint when sandbox is stuck in Provisioning",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
+    testTimeoutOptions(20_000),
     () => {
       const { tmpDir, sandboxName } = setupFixture("stuck-status", "Provisioning");
 
@@ -173,17 +174,13 @@ describe("sandbox stuck in non-Ready phase (#2016)", () => {
     },
   );
 
-  it(
-    "connect succeeds when sandbox phase is Ready",
-    { timeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 20_000) },
-    () => {
-      const { tmpDir, sandboxName } = setupFixture("ready-sandbox", "Ready");
+  it("connect succeeds when sandbox phase is Ready", testTimeoutOptions(20_000), () => {
+    const { tmpDir, sandboxName } = setupFixture("ready-sandbox", "Ready");
 
-      const result = runCli(tmpDir, sandboxName, "connect");
-      expect(result.status).toBe(0);
+    const result = runCli(tmpDir, sandboxName, "connect");
+    expect(result.status).toBe(0);
 
-      const combined = (result.stdout || "") + (result.stderr || "");
-      expect(combined).not.toContain("stuck in");
-    },
-  );
+    const combined = (result.stdout || "") + (result.stderr || "");
+    expect(combined).not.toContain("stuck in");
+  });
 });

--- a/test/snapshot-gateway-guard.test.ts
+++ b/test/snapshot-gateway-guard.test.ts
@@ -11,18 +11,17 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { execTimeout } from "./helpers/timeouts";
+
 const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
 
 type CliRunResult = { code: number; out: string };
 
-function runCli(
-  args: string,
-  env: Record<string, string | undefined> = {},
-): CliRunResult {
+function runCli(args: string, env: Record<string, string | undefined> = {}): CliRunResult {
   try {
     const out = execSync(`node "${CLI}" ${args}`, {
       encoding: "utf-8",
-      timeout: 10000,
+      timeout: execTimeout(),
       env: {
         ...process.env,
         NEMOCLAW_HEALTH_POLL_COUNT: "1",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,13 +3,15 @@
 
 import { defineConfig } from "vitest/config";
 
+import { testTimeout } from "./test/helpers/timeouts";
+
 export default defineConfig({
   test: {
     projects: [
       {
         test: {
           name: "cli",
-          testTimeout: Number(process.env.NEMOCLAW_TEST_TIMEOUT || 15000),
+          testTimeout: testTimeout(),
           include: ["test/**/*.test.{js,ts}", "src/**/*.test.ts"],
           exclude: [
             "**/node_modules/**",
@@ -30,7 +32,9 @@ export default defineConfig({
           // Slow tests that spawn real bash install.sh processes.
           // Run in CI or explicitly: npx vitest run --project installer-integration
           // Excluded from pre-commit/pre-push to avoid flaky timeouts.
-          enabled: process.env.CI === "true" || process.env.CI === "1" ||
+          enabled:
+            process.env.CI === "true" ||
+            process.env.CI === "1" ||
             process.env.NEMOCLAW_RUN_INSTALLER_TESTS === "1",
         },
       },


### PR DESCRIPTION
## Summary
Centralizes CLI test timeout handling so WSL-specific timeout budgets are honored consistently. This restores the WSL compatibility suite by replacing scattered hardcoded child-process and Vitest limits with shared helpers.

## Changes
- Add `test/helpers/timeouts.ts` with shared `execTimeout`, `testTimeout`, and `testTimeoutOptions` helpers.
- Update `vitest.config.ts` and WSL-sensitive CLI tests to use the shared timeout budget helpers.
- Convert remaining CLI readiness and log-follow probes to honor the same WSL timeout budget.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: OpenAI Codex

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test timeout configurations across multiple test suites to use centralized timeout helpers for consistent behavior.
  * Updated test assertions to explicitly verify expected behavior in timeout scenarios.

* **Chores**
  * Introduced a shared timeout helper module to standardize execution and test timeout management.
  * Consolidated environment-variable-based timeout logic into reusable utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->