### PR TITLE
fix(policy): drop missing claude binary allowlist (Fixes #2748)

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -141,7 +141,7 @@ Endpoint rules restrict allowed HTTP methods and URL paths.
 
 | Aspect | Detail |
 |---|---|
-| Default | Some endpoints allow GET and POST on `/**` (for example, `clawhub.ai`). Others restrict methods and paths to specific API routes (for example, `api.anthropic.com` allows POST only to inference paths). Read-only endpoints such as `docs.openclaw.ai` and `sentry.io` allow GET only. The `npm_registry` baseline entry and the `npm`/`pypi` presets are GET-only (plus HEAD for PyPI). |
+| Default | Some endpoints allow GET and POST on `/**` (for example, `clawhub.ai`). Others restrict methods and paths to specific API routes (for example, `integrate.api.nvidia.com` allows POST only to inference and embedding paths and GET to model listings). Read-only endpoints such as `docs.openclaw.ai` allow GET only. The `npm_registry` baseline entry and the `npm`/`pypi` presets are GET-only (plus HEAD for PyPI). |
 | What you can change | Add methods (PUT, DELETE, PATCH) or restrict paths to specific prefixes. |
 | Risk if relaxed | Allowing all methods on an API endpoint gives the agent write and delete access. For example, allowing DELETE on `api.github.com` lets the agent delete repositories. |
 | Recommendation | Use GET-only rules for endpoints that the agent only reads. Add write methods only for endpoints where the agent must create or modify resources. Restrict paths to specific API routes when possible. |

--- a/.agents/skills/nemoclaw-user-reference/references/network-policies.md
+++ b/.agents/skills/nemoclaw-user-reference/references/network-policies.md
@@ -33,14 +33,9 @@ The following endpoint groups are allowed by default:
   - Binaries
   - Rules
 
-* - `claude_code`
-  - `api.anthropic.com:443`, `statsig.anthropic.com:443`, `sentry.io:443`
-  - `/usr/local/bin/claude`
-  - POST to inference paths on `api.anthropic.com`, POST on `statsig.anthropic.com`, GET only on `sentry.io`
-
 * - `nvidia`
   - `integrate.api.nvidia.com:443`, `inference-api.nvidia.com:443`
-  - `/usr/local/bin/claude`, `/usr/local/bin/openclaw`
+  - `/usr/local/bin/openclaw`
   - POST to inference and embedding paths, GET to model listings
 
 * - `clawhub`

--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -36,37 +36,6 @@ process:
   run_as_group: sandbox
 
 network_policies:
-  claude_code:
-    name: claude_code
-    endpoints:
-      - host: api.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: POST, path: "/v1/messages" }
-          - allow: { method: POST, path: "/v1/messages/batches" }
-          - allow: { method: GET, path: "/v1/messages/batches/**" }
-          - allow: { method: POST, path: "/v1/complete" }
-      - host: statsig.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: POST, path: "/**" }
-      - host: sentry.io
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: POST, path: "/api/*/envelope/**" }
-          - allow: { method: POST, path: "/api/*/store/**" }
-    binaries:
-      - { path: /usr/local/bin/claude }
-
   nvidia:
     name: nvidia
     endpoints:
@@ -93,7 +62,6 @@ network_policies:
           - allow: { method: GET, path: "/v1/models" }
           - allow: { method: GET, path: "/v1/models/**" }
     binaries:
-      - { path: /usr/local/bin/claude }
       - { path: /usr/local/bin/hermes }
       - { path: /usr/bin/python3.11 }
 

--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -53,14 +53,9 @@ The following endpoint groups are allowed by default:
   - Binaries
   - Rules
 
-* - `claude_code`
-  - `api.anthropic.com:443`, `statsig.anthropic.com:443`, `sentry.io:443`
-  - `/usr/local/bin/claude`
-  - POST to inference paths on `api.anthropic.com`, POST on `statsig.anthropic.com`, GET only on `sentry.io`
-
 * - `nvidia`
   - `integrate.api.nvidia.com:443`, `inference-api.nvidia.com:443`
-  - `/usr/local/bin/claude`, `/usr/local/bin/openclaw`
+  - `/usr/local/bin/openclaw`
   - POST to inference and embedding paths, GET to model listings
 
 * - `clawhub`

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -161,7 +161,7 @@ Endpoint rules restrict allowed HTTP methods and URL paths.
 
 | Aspect | Detail |
 |---|---|
-| Default | Some endpoints allow GET and POST on `/**` (for example, `clawhub.ai`). Others restrict methods and paths to specific API routes (for example, `api.anthropic.com` allows POST only to inference paths). Read-only endpoints such as `docs.openclaw.ai` and `sentry.io` allow GET only. The `npm_registry` baseline entry and the `npm`/`pypi` presets are GET-only (plus HEAD for PyPI). |
+| Default | Some endpoints allow GET and POST on `/**` (for example, `clawhub.ai`). Others restrict methods and paths to specific API routes (for example, `integrate.api.nvidia.com` allows POST only to inference and embedding paths and GET to model listings). Read-only endpoints such as `docs.openclaw.ai` allow GET only. The `npm_registry` baseline entry and the `npm`/`pypi` presets are GET-only (plus HEAD for PyPI). |
 | What you can change | Add methods (PUT, DELETE, PATCH) or restrict paths to specific prefixes. |
 | Risk if relaxed | Allowing all methods on an API endpoint gives the agent write and delete access. For example, allowing DELETE on `api.github.com` lets the agent delete repositories. |
 | Recommendation | Use GET-only rules for endpoints that the agent only reads. Add write methods only for endpoints where the agent must create or modify resources. Restrict paths to specific API routes when possible. |

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -54,50 +54,6 @@ process:
   run_as_group: sandbox
 
 network_policies:
-  claude_code:
-    name: claude_code
-    endpoints:
-      - host: api.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: POST, path: "/v1/messages" }
-          - allow: { method: POST, path: "/v1/messages/batches" }
-          - allow: { method: GET, path: "/v1/messages/batches/**" }
-          - allow: { method: POST, path: "/v1/complete" }
-      - host: statsig.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: POST, path: "/**" }
-      # sentry.io is a multi-tenant SaaS — any authenticated client can POST
-      # to ANY Sentry project, not just NemoClaw's. Allowing POST /** turned
-      # the host into a generic exfiltration channel: a compromised agent
-      # could ship stack traces, env vars, file contents, etc. to a Sentry
-      # project controlled by an attacker via the public envelope endpoint
-      # (https://sentry.io/api/<any-project>/envelope/). Path-pattern
-      # restrictions cannot fix this because the project ID is part of the
-      # URL and there is no server-side allowlist of legitimate projects.
-      #
-      # Block POST entirely. GET stays allowed because it has no request
-      # body and is harmless for exfil. Side effect: Claude Code's crash
-      # telemetry to Sentry is silently dropped — that is the right
-      # tradeoff for a sandbox whose stated goal is preventing data egress.
-      # See #1437.
-      - host: sentry.io
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        tls: terminate
-        rules:
-          - allow: { method: GET, path: "/**" }
-    binaries:
-      - { path: /usr/local/bin/claude }
-
   nvidia:
     name: nvidia
     endpoints:
@@ -124,7 +80,6 @@ network_policies:
           - allow: { method: GET, path: "/v1/models" }
           - allow: { method: GET, path: "/v1/models/**" }
     binaries:
-      - { path: /usr/local/bin/claude }
       - { path: /usr/local/bin/openclaw }
 
   # ── Managed inference route ──────────────────────────────────────────
@@ -145,7 +100,6 @@ network_policies:
           - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
-      - { path: /usr/local/bin/claude }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
       - { path: /usr/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/local-inference.yaml
+++ b/nemoclaw-blueprint/policies/presets/local-inference.yaml
@@ -32,7 +32,6 @@ network_policies:
           - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/openclaw }
-      - { path: /usr/local/bin/claude }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }        # alternative Node install path (apt-installed)
       - { path: /usr/bin/curl }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -187,10 +187,10 @@ describe("policies", () => {
       expect(content).toContain("port: 8000");
     });
 
-    it("local-inference preset includes openclaw, claude, and common tool binaries", () => {
+    it("local-inference preset includes openclaw and common tool binaries", () => {
       const content = requirePresetContent(policies.loadPreset("local-inference"));
       expect(content).toContain("/usr/local/bin/openclaw");
-      expect(content).toContain("/usr/local/bin/claude");
+      expect(content).not.toContain("/usr/local/bin/claude");
       // node, curl, and python3 are needed for direct inference access (#2199)
       expect(content).toContain("/usr/local/bin/node");
       expect(content).toContain("/usr/bin/node");

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -244,34 +244,9 @@ describe("base sandbox policy", () => {
     return out;
   }
 
-  it("regression #1437: sentry.io has no POST allow rule (multi-tenant exfiltration vector)", () => {
+  it("regression #1437: base policy does not expose sentry.io by default", () => {
     const sentryEndpoints = findEndpoints((h) => h === "sentry.io");
-    for (const ep of sentryEndpoints) {
-      const rules = Array.isArray(ep.rules) ? ep.rules : [];
-      const hasPost = rules.some(
-        (r) =>
-          r &&
-          r.allow &&
-          typeof r.allow.method === "string" &&
-          r.allow.method.toUpperCase() === "POST",
-      );
-      expect(hasPost).toBe(false);
-    }
-  });
-
-  it("regression #1437: sentry.io retains GET (harmless, no body for exfil)", () => {
-    const sentryEndpoints = findEndpoints((h) => h === "sentry.io");
-    for (const ep of sentryEndpoints) {
-      const rules = Array.isArray(ep.rules) ? ep.rules : [];
-      const hasGet = rules.some(
-        (r) =>
-          r &&
-          r.allow &&
-          typeof r.allow.method === "string" &&
-          r.allow.method.toUpperCase() === "GET",
-      );
-      expect(hasGet).toBe(true);
-    }
+    expect(sentryEndpoints).toEqual([]);
   });
 
   it("regression #1583: base policy does not silently grant GitHub access", () => {

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -246,7 +246,6 @@ describe("base sandbox policy", () => {
 
   it("regression #1437: sentry.io has no POST allow rule (multi-tenant exfiltration vector)", () => {
     const sentryEndpoints = findEndpoints((h) => h === "sentry.io");
-    expect(sentryEndpoints.length).toBeGreaterThan(0); // should still appear
     for (const ep of sentryEndpoints) {
       const rules = Array.isArray(ep.rules) ? ep.rules : [];
       const hasPost = rules.some(
@@ -317,17 +316,21 @@ describe("base sandbox policy", () => {
     expect(hasPost).toBe(true);
   });
 
-  it("regression #2663: managed_inference allows openclaw, claude, and tool binaries", () => {
+  it("regression #2663: managed_inference allows openclaw and tool binaries", () => {
     const np = policy.network_policies ?? {};
     const binaries = (np.managed_inference?.binaries ?? []).map((b) => b.path).sort();
     expect(binaries).toEqual([
       "/usr/bin/curl",
       "/usr/bin/node",
       "/usr/bin/python3",
-      "/usr/local/bin/claude",
       "/usr/local/bin/node",
       "/usr/local/bin/openclaw",
     ]);
+  });
+
+  it("does not reference the absent Claude CLI binary", () => {
+    const serialized = JSON.stringify(policy.network_policies ?? {});
+    expect(serialized).not.toContain("/usr/local/bin/claude");
   });
 
   it("regression #1458: baseline npm_registry must not include npm or node binaries", () => {


### PR DESCRIPTION
## Summary

Fixes #2748.

The sandbox image does not ship `/usr/local/bin/claude`, but the default policy still referenced it in several binary allowlists. OpenShell tries to resolve those paths on each policy reload and logs repeated warnings. This removes the dead Claude binary references from the default OpenClaw and Hermes policy surfaces.

## Changes

- Removed the unused `claude_code` policy block from default OpenClaw and Hermes policy additions.
- Removed `/usr/local/bin/claude` from NVIDIA, managed inference, and local inference binary allowlists.
- Updated policy docs and regression tests to reflect the binaries that actually exist in the sandbox.

## Testing

- `npm run build:cli`
- `npm run typecheck:cli`
- `npm test -- test/policies.test.ts test/validate-blueprint.test.ts`
- `npm install --ignore-scripts && npm run build` in `nemoclaw/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated network policy and best-practices docs to reflect tightened default access (removed prior Anthropic/Claude examples; now cite NVIDIA endpoints and adjusted GET/POST path rules).

* **Chores**
  * Removed default outbound access for the Claude CLI and narrowed which host tools may use managed inference endpoints.

* **Tests**
  * Adjusted test expectations to validate the revised default network and sandbox policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
