### PR TITLE
fix(onboard): auto-remove stale malformed lock files (Fixes #2765)

### DIFF
--- a/src/lib/onboard-session.test.ts
+++ b/src/lib/onboard-session.test.ts
@@ -342,14 +342,31 @@ describe("onboard session", () => {
     }
   });
 
-  it("treats unreadable or transient lock contents as a retry, not a stale lock", () => {
+  it("treats recent malformed lock as transient and does not remove it", () => {
     fs.mkdirSync(path.dirname(session.LOCK_FILE), { recursive: true });
+    // Write a malformed lock with the current timestamp (< 30 s old)
     fs.writeFileSync(session.LOCK_FILE, "{not-json", { mode: 0o600 });
 
     const acquired = session.acquireOnboardLock("nemoclaw onboard --resume");
     expect(acquired.acquired).toBe(false);
     expect(acquired.stale).toBe(true);
+    // Recent malformed lock is preserved (may be mid-write)
     expect(fs.existsSync(session.LOCK_FILE)).toBe(true);
+  });
+
+  it("removes a stale malformed lock file older than 30 seconds (#2765)", () => {
+    fs.mkdirSync(path.dirname(session.LOCK_FILE), { recursive: true });
+    fs.writeFileSync(session.LOCK_FILE, "{not-json", { mode: 0o600 });
+    // Back-date the lock file mtime to 60 seconds ago so it looks stale
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(session.LOCK_FILE, past, past);
+
+    const acquired = session.acquireOnboardLock("nemoclaw onboard --resume");
+    expect(acquired.acquired).toBe(true);
+    expect(fs.existsSync(session.LOCK_FILE)).toBe(true); // re-created by acquirer
+    const written = JSON.parse(fs.readFileSync(session.LOCK_FILE, "utf8"));
+    expect(written.pid).toBe(process.pid);
+    session.releaseOnboardLock();
   });
 
   it("ignores malformed lock files when releasing the onboard lock", () => {

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -454,9 +454,23 @@ export function acquireOnboardLock(command: string | null = null): LockResult {
         throw readError;
       }
       if (!existing) {
-        // Malformed lock file — leave it on disk (a human or another
-        // process may be mid-write) and retry. Pre-#1281 behavior
-        // preserved: never unlink a malformed lock automatically.
+        // Malformed lock file. If the file is very recent (<30 s), a
+        // concurrent process may be mid-write — leave it and retry.
+        // Otherwise the file is stale debris from a crash between
+        // openSync("wx") and writeSync() — remove it so subsequent
+        // onboard runs are not permanently blocked (#2765).
+        const MALFORMED_STALE_SECONDS = 30;
+        try {
+          const lockStat = fs.statSync(LOCK_FILE);
+          const ageMs = Date.now() - lockStat.mtimeMs;
+          if (ageMs > MALFORMED_STALE_SECONDS * 1000) {
+            unlinkIfInodeMatches(LOCK_FILE, staleInode);
+          }
+        } catch (statErr) {
+          if (!(isErrnoException(statErr) && statErr.code === "ENOENT")) {
+            throw statErr;
+          }
+        }
         continue;
       }
       if (isProcessAlive(existing.pid)) {


### PR DESCRIPTION
## Summary

Fix stale `onboard.lock` files permanently blocking subsequent `nemoclaw onboard` runs after an abnormal exit.

## Related Issue

Closes #2765

## Root Cause

When `nemoclaw onboard` crashes between `fs.openSync(LOCK_FILE, "wx")` (which atomically creates the file) and `fs.writeSync(fd, payload)` (which writes the JSON content), the lock file is left on disk as an empty/malformed file.

In `acquireOnboardLock()`, malformed lock files were unconditionally preserved under the assumption that a concurrent process might be mid-write. This meant all `MAX_ATTEMPTS` retry iterations would hit the same un-removable file, permanently blocking future onboard runs with:

```
Another NemoClaw onboarding run is already in progress.
```

## Changes

**`src/lib/onboard-session.ts`**: When `parseLockFile()` returns `null` (malformed content), check the file's `mtime`:
- If older than 30 seconds → treat as stale crash debris and remove via the existing `unlinkIfInodeMatches()` helper (preserves the inode-verified safety from #1281)
- If recent (<30 s) → preserve and retry (existing behavior, protects against racing a concurrent writer)

**`src/lib/onboard-session.test.ts`**: Updated existing test + added new test:
- `treats recent malformed lock as transient and does not remove it` — verifies fresh malformed locks are preserved (existing behavior)
- `removes a stale malformed lock file older than 30 seconds (#2765)` — verifies stale malformed locks are cleaned up and the lock can be re-acquired

## Testing

```bash
npx vitest run src/lib/onboard-session.test.ts
# 27 tests passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding session recovery by better handling of stale or corrupted session data, reducing potential interruptions during onboarding and minimizing cases requiring manual recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->