### PR TITLE
Correctly install Hermes Agent dependencies

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -93,8 +93,12 @@ RUN mkdir -p /sandbox/.hermes-data/memories \
 # Hermes is not on PyPI — official install is via their install script or
 # direct pip install from the release tarball.
 # hadolint ignore=DL3013
-RUN pip3 install --no-cache-dir --break-system-packages \
-        "hermes-agent @ https://github.com/NousResearch/hermes-agent/archive/refs/tags/${HERMES_VERSION}.tar.gz" \
-        "pyyaml==6.0.3" \
-        "python-telegram-bot>=21.0" \
-    && hermes --version
+RUN pip3 install --no-cache-dir --break-system-packages uv
+RUN mkdir /opt/hermes && curl -L https://github.com/NousResearch/hermes-agent/archive/refs/tags/${HERMES_VERSION}.tar.gz | tar -xz -C /opt/hermes --strip-components=1
+WORKDIR /opt/hermes
+RUN uv venv && \
+    uv pip install --no-cache-dir -e ".[all]" && \
+    npm install --prefer-offline --no-audit
+
+ENV PATH="/opt/hermes/.venv/bin:${PATH}"
+RUN hermes --version


### PR DESCRIPTION
## Summary
This change introduces UV to sync the .[all] target for all python dependencies. This was introduced due to missing dependencies such as `discord.py` in the logs.

Additionally runs npm install to get the JS dependencies for the TUI and web dashboards.

Technically the UV part of this change is optional, though it's easier than handling the virtualenv, etc manually in the container. I can remove that part if desired.

## Changes
- Adds UV for python dependencies
- Uses UV to install Hermes Agent python dependencies in a virtualenv
- Does an npm install

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ben Barclay <ben@nousresearch.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Hermes Agent build and deployment process with enhanced dependency management and isolation for better build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->