### PR TITLE
fix(config): gracefully skip invalid numeric env vars at build time

### DIFF
--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -44,8 +44,12 @@ from urllib.parse import urlparse
 
 def _coerce_positive_int(env: dict, name: str, default: int) -> int:
     raw = env.get(name) or str(default)
-    if raw.isdigit() and int(raw) > 0:
-        return int(raw)
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 0
+    if value > 0:
+        return value
     print(
         f'[SECURITY] {name} must be a positive integer, got "{raw}" '
         f"— skipping override, falling back to default ({default})",

--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -38,7 +38,20 @@ import base64
 import json
 import os
 import re
+import sys
 from urllib.parse import urlparse
+
+
+def _coerce_positive_int(env: dict, name: str, default: int) -> int:
+    raw = env.get(name) or str(default)
+    if raw.isdigit() and int(raw) > 0:
+        return int(raw)
+    print(
+        f'[SECURITY] {name} must be a positive integer, got "{raw}" '
+        f"— skipping override, falling back to default ({default})",
+        file=sys.stderr,
+    )
+    return default
 
 
 def is_loopback(hostname: str) -> bool:
@@ -77,8 +90,9 @@ def build_config(env: dict | None = None) -> dict:
     primary_model_ref = env["NEMOCLAW_PRIMARY_MODEL_REF"]
     inference_base_url = env["NEMOCLAW_INFERENCE_BASE_URL"]
     inference_api = env["NEMOCLAW_INFERENCE_API"]
-    context_window = int(env.get("NEMOCLAW_CONTEXT_WINDOW", "131072"))
-    max_tokens = int(env.get("NEMOCLAW_MAX_TOKENS", "4096"))
+    context_window = _coerce_positive_int(env, "NEMOCLAW_CONTEXT_WINDOW", 131072)
+    max_tokens = _coerce_positive_int(env, "NEMOCLAW_MAX_TOKENS", 4096)
+
     reasoning = env.get("NEMOCLAW_REASONING", "false") == "true"
     inference_inputs = [
         v.strip()

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -307,7 +307,11 @@ describe("generate-openclaw-config.py: numeric env var validation", () => {
       env,
       timeout: 10_000,
     });
-    expect(result.status).toBe(0);
+    if (result.status !== 0) {
+      throw new Error(
+        `Script failed (exit ${result.status}):\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      );
+    }
     const configPath = path.join(tmpDir, ".openclaw", "openclaw.json");
     return {
       config: JSON.parse(fs.readFileSync(configPath, "utf-8")),

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -344,12 +344,26 @@ describe("generate-openclaw-config.py: numeric env var validation", () => {
   });
 
   it("skips negative NEMOCLAW_CONTEXT_WINDOW and falls back to the default", () => {
-    const { config } = runCapturingStderr({ NEMOCLAW_CONTEXT_WINDOW: "-1" });
+    const { config, stderr } = runCapturingStderr({ NEMOCLAW_CONTEXT_WINDOW: "-1" });
     expect(config.models.providers["test-provider"].models[0].contextWindow).toBe(131072);
+    expect(stderr).toMatch(/NEMOCLAW_CONTEXT_WINDOW must be a positive integer/);
   });
 
   it("skips negative NEMOCLAW_MAX_TOKENS and falls back to the default", () => {
-    const { config } = runCapturingStderr({ NEMOCLAW_MAX_TOKENS: "-1" });
+    const { config, stderr } = runCapturingStderr({ NEMOCLAW_MAX_TOKENS: "-1" });
     expect(config.models.providers["test-provider"].models[0].maxTokens).toBe(4096);
+    expect(stderr).toMatch(/NEMOCLAW_MAX_TOKENS must be a positive integer/);
+  });
+
+  it("skips NEMOCLAW_CONTEXT_WINDOW that exceeds Python's int-string digit limit", () => {
+    const { config, stderr } = runCapturingStderr({ NEMOCLAW_CONTEXT_WINDOW: "9".repeat(10000) });
+    expect(config.models.providers["test-provider"].models[0].contextWindow).toBe(131072);
+    expect(stderr).toMatch(/NEMOCLAW_CONTEXT_WINDOW must be a positive integer/);
+  });
+
+  it("skips NEMOCLAW_MAX_TOKENS that exceeds Python's int-string digit limit", () => {
+    const { config, stderr } = runCapturingStderr({ NEMOCLAW_MAX_TOKENS: "9".repeat(10000) });
+    expect(config.models.providers["test-provider"].models[0].maxTokens).toBe(4096);
+    expect(stderr).toMatch(/NEMOCLAW_MAX_TOKENS must be a positive integer/);
   });
 });

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -278,4 +278,78 @@ describe("generate-openclaw-config.py: empty-string env vars fall back to defaul
     });
     expect(cfg.channels.telegram.accounts.default.proxy).toBe("http://10.200.0.1:3128");
   });
+
+  it("treats empty NEMOCLAW_CONTEXT_WINDOW as unset and uses the documented default", () => {
+    const cfg = runConfigScript({ NEMOCLAW_CONTEXT_WINDOW: "" });
+    expect(cfg.models.providers["test-provider"].models[0].contextWindow).toBe(131072);
+  });
+
+  it("treats empty NEMOCLAW_MAX_TOKENS as unset and uses the documented default", () => {
+    const cfg = runConfigScript({ NEMOCLAW_MAX_TOKENS: "" });
+    expect(cfg.models.providers["test-provider"].models[0].maxTokens).toBe(4096);
+  });
+});
+
+describe("generate-openclaw-config.py: numeric env var validation", () => {
+  function runCapturingStderr(envOverrides: Record<string, string>): {
+    config: any;
+    stderr: string;
+  } {
+    const env: Record<string, string> = {
+      PATH: process.env.PATH || "/usr/bin:/bin",
+      ...BASE_ENV,
+      ...envOverrides,
+      HOME: tmpDir,
+    };
+    const result = spawnSync("python3", [SCRIPT_PATH], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      env,
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(0);
+    const configPath = path.join(tmpDir, ".openclaw", "openclaw.json");
+    return {
+      config: JSON.parse(fs.readFileSync(configPath, "utf-8")),
+      stderr: result.stderr,
+    };
+  }
+
+  it("skips non-numeric NEMOCLAW_CONTEXT_WINDOW and falls back to the default", () => {
+    const { config, stderr } = runCapturingStderr({ NEMOCLAW_CONTEXT_WINDOW: "notanumber" });
+    expect(config.models.providers["test-provider"].models[0].contextWindow).toBe(131072);
+    expect(stderr).toMatch(
+      /\[SECURITY\] NEMOCLAW_CONTEXT_WINDOW must be a positive integer, got "notanumber"/,
+    );
+  });
+
+  it("skips non-numeric NEMOCLAW_MAX_TOKENS and falls back to the default", () => {
+    const { config, stderr } = runCapturingStderr({ NEMOCLAW_MAX_TOKENS: "notanumber" });
+    expect(config.models.providers["test-provider"].models[0].maxTokens).toBe(4096);
+    expect(stderr).toMatch(
+      /\[SECURITY\] NEMOCLAW_MAX_TOKENS must be a positive integer, got "notanumber"/,
+    );
+  });
+
+  it("skips zero NEMOCLAW_CONTEXT_WINDOW and falls back to the default", () => {
+    const { config, stderr } = runCapturingStderr({ NEMOCLAW_CONTEXT_WINDOW: "0" });
+    expect(config.models.providers["test-provider"].models[0].contextWindow).toBe(131072);
+    expect(stderr).toMatch(/NEMOCLAW_CONTEXT_WINDOW must be a positive integer/);
+  });
+
+  it("skips zero NEMOCLAW_MAX_TOKENS and falls back to the default", () => {
+    const { config, stderr } = runCapturingStderr({ NEMOCLAW_MAX_TOKENS: "0" });
+    expect(config.models.providers["test-provider"].models[0].maxTokens).toBe(4096);
+    expect(stderr).toMatch(/NEMOCLAW_MAX_TOKENS must be a positive integer/);
+  });
+
+  it("skips negative NEMOCLAW_CONTEXT_WINDOW and falls back to the default", () => {
+    const { config } = runCapturingStderr({ NEMOCLAW_CONTEXT_WINDOW: "-1" });
+    expect(config.models.providers["test-provider"].models[0].contextWindow).toBe(131072);
+  });
+
+  it("skips negative NEMOCLAW_MAX_TOKENS and falls back to the default", () => {
+    const { config } = runCapturingStderr({ NEMOCLAW_MAX_TOKENS: "-1" });
+    expect(config.models.providers["test-provider"].models[0].maxTokens).toBe(4096);
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #2762. The Dockerfile build invokes `scripts/generate-openclaw-config.py` once at image build time to bake `openclaw.json`. Two of the build args it consumes (`NEMOCLAW_CONTEXT_WINDOW`, `NEMOCLAW_MAX_TOKENS`) were coerced via an unguarded `int(env.get(...))`, so a non-numeric, zero, or negative `--build-arg` would surface a Python traceback and abort the build instead of skipping the override the way PR #2700 made the runtime entrypoint behave.

This change mirrors the runtime-entrypoint pattern: log a `[SECURITY] ... — skipping override, falling back to default` warning to stderr and use the documented default. Empty-string overrides also fall back to the default now, consistent with `NEMOCLAW_PROXY_HOST` / `NEMOCLAW_PROXY_PORT`.

## Related Issue

Resolves #2762

## Changes

- `scripts/generate-openclaw-config.py`: new private helper `_coerce_positive_int(env, name, default)` that returns the parsed value when it is a positive integer string, otherwise emits the `[SECURITY]` warning and returns the default. Both `NEMOCLAW_CONTEXT_WINDOW` (default 131072) and `NEMOCLAW_MAX_TOKENS` (default 4096) now route through it.
- `test/generate-openclaw-config.test.ts`: 8 new tests — 2 empty-string fallback cases (matching the existing `NEMOCLAW_PROXY_*` empty-string suite) plus 6 invalid-value cases (`notanumber`, `0`, `-1` for each var) that assert both the fallback value lands in the generated config AND the `[SECURITY]` warning text appears on stderr.

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [X] `npx prek run --all-files` passes
- [X] `npm test` passes (38/38 in `generate-openclaw-config.test.ts`, 112/112 in `nemoclaw-start.test.ts`)
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure

- [X] AI-assisted — tools: Claude Code, OpenAI Codex

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation tightened for context window and max token settings: only strictly positive integers are accepted. Empty, non-numeric, zero, negative, or excessively large values now trigger a security warning to stderr and revert to safe defaults.

* **Tests**
  * Added tests covering empty, non-numeric, zero/negative, and oversized environment inputs to verify warnings and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->