### PR TITLE
feat(cli): add sandbox doctor command

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -294,6 +294,19 @@ The command also tails `/tmp/gateway.log` inside the default sandbox and flags T
 $ nemoclaw my-assistant status
 ```
 
+### `nemoclaw <name> doctor`
+
+Run a focused health check for one sandbox and the host services it depends on.
+The command checks the local CLI build, Docker daemon, OpenShell CLI, NemoClaw gateway container, gateway port mapping, live sandbox state, inference route, provider reachability, messaging channel conflicts, Ollama reachability, and the cloudflared tunnel state.
+
+Warnings do not make the command fail.
+Failed checks exit non-zero so scripts can use `doctor` as a readiness gate.
+Use `--json` for machine-readable output.
+
+```console
+$ nemoclaw my-assistant doctor [--json]
+```
+
 ### `nemoclaw <name> logs`
 
 View sandbox logs.

--- a/src/lib/command-registry.test.ts
+++ b/src/lib/command-registry.test.ts
@@ -17,10 +17,10 @@ import type { CommandDef } from "./command-registry";
 
 describe("command-registry", () => {
   describe("COMMANDS array", () => {
-    it("should contain exactly 48 commands", () => {
+    it("should contain exactly 49 commands", () => {
       // 23 global (18 visible + 5 hidden help/version aliases)
-      // 25 sandbox (21 visible + 4 hidden shields/config)
-      expect(COMMANDS).toHaveLength(48);
+      // 26 sandbox (22 visible + 4 hidden shields/config)
+      expect(COMMANDS).toHaveLength(49);
     });
 
     it("should have no duplicate usage strings", () => {
@@ -52,9 +52,9 @@ describe("command-registry", () => {
   });
 
   describe("sandboxCommands()", () => {
-    it("should return exactly 25 entries", () => {
-      // 21 visible + 4 hidden (shields×3 + config get)
-      expect(sandboxCommands()).toHaveLength(25);
+    it("should return exactly 26 entries", () => {
+      // 22 visible + 4 hidden (shields×3 + config get)
+      expect(sandboxCommands()).toHaveLength(26);
     });
 
     it("every entry has scope sandbox", () => {
@@ -65,10 +65,10 @@ describe("command-registry", () => {
   });
 
   describe("visibleCommands()", () => {
-    it("should exclude 9 hidden commands (39 visible)", () => {
+    it("should exclude 9 hidden commands (40 visible)", () => {
       // 5 hidden global (help, --help, -h, --version, -v) +
       // 4 hidden sandbox (shields×3, config get)
-      expect(visibleCommands()).toHaveLength(39);
+      expect(visibleCommands()).toHaveLength(40);
     });
 
     it("no visible command has hidden=true", () => {
@@ -165,13 +165,14 @@ describe("command-registry", () => {
   });
 
   describe("sandboxActionTokens()", () => {
-    it("returns exactly 16 unique action tokens including empty string", () => {
+    it("returns exactly 17 unique action tokens including empty string", () => {
       const tokens = sandboxActionTokens();
-      expect(tokens).toHaveLength(16);
-      // Must contain the same set as the old sandboxActions array
+      expect(tokens).toHaveLength(17);
+      // Must contain every first-level sandbox action plus the empty default action.
       const expected = new Set([
         "connect",
         "status",
+        "doctor",
         "logs",
         "policy-add",
         "policy-remove",

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -89,8 +89,9 @@ export const COMMANDS: readonly CommandDef[] = [
 
   // ── Sandbox Management ──
   {
-    usage: "nemoclaw list [--json]",
+    usage: "nemoclaw list",
     description: "List all sandboxes",
+    flags: "[--json]",
     group: "Sandbox Management",
     scope: "global",
   },
@@ -103,6 +104,12 @@ export const COMMANDS: readonly CommandDef[] = [
   {
     usage: "nemoclaw <name> status",
     description: "Sandbox health + NIM status",
+    group: "Sandbox Management",
+    scope: "sandbox",
+  },
+  {
+    usage: "nemoclaw <name> doctor",
+    description: "Run host, gateway, sandbox, and inference health checks",
     group: "Sandbox Management",
     scope: "sandbox",
   },

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -5,7 +5,7 @@ const { execFileSync, spawn, spawnSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { DASHBOARD_PORT } = require("./lib/ports");
+const { DASHBOARD_PORT, GATEWAY_PORT, OLLAMA_PORT } = require("./lib/ports");
 
 // ---------------------------------------------------------------------------
 // Color / style — respects NO_COLOR and non-TTY environments.
@@ -145,6 +145,23 @@ const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
 const DASHBOARD_FORWARD_PORT = String(DASHBOARD_PORT);
 const DEFAULT_LOGS_PROBE_TIMEOUT_MS = 5000;
 const LOGS_PROBE_TIMEOUT_ENV = "NEMOCLAW_LOGS_PROBE_TIMEOUT_MS";
+
+type DoctorStatus = "ok" | "warn" | "fail" | "info";
+
+type DoctorCheck = {
+  group: string;
+  label: string;
+  status: DoctorStatus;
+  detail: string;
+  hint?: string;
+};
+
+type CommandCapture = {
+  status: number;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+};
 
 function getOpenshellBinary(): string {
   if (!OPENSHELL_BIN) {
@@ -1720,6 +1737,493 @@ async function sandboxConnect(sandboxName: string) {
     env: process.env,
   });
   exitWithSpawnResult(result);
+}
+
+function captureHostCommand(
+  command: string,
+  args: string[],
+  timeout = 5000,
+): CommandCapture {
+  const result = spawnSync(command, args, {
+    cwd: ROOT,
+    env: process.env,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout,
+  });
+  return {
+    status: result.status ?? (result.error ? 1 : 0),
+    stdout: String(result.stdout || ""),
+    stderr: String(result.stderr || ""),
+    error: result.error,
+  };
+}
+
+function oneLine(value = ""): string {
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function doctorSummary(checks: DoctorCheck[]): { status: DoctorStatus; failed: number; warned: number } {
+  const failed = checks.filter((check) => check.status === "fail").length;
+  const warned = checks.filter((check) => check.status === "warn").length;
+  if (failed > 0) return { status: "fail", failed, warned };
+  if (warned > 0) return { status: "warn", failed, warned };
+  return { status: "ok", failed, warned };
+}
+
+function doctorStatusLabel(status: DoctorStatus): string {
+  switch (status) {
+    case "ok":
+      return `${G}[ok]${R}`;
+    case "warn":
+      return `${YW}[warn]${R}`;
+    case "fail":
+      return `${_RD}[fail]${R}`;
+    case "info":
+      return `${D}[info]${R}`;
+    default:
+      return `[${status}]`;
+  }
+}
+
+function renderDoctorReport(sandboxName: string, checks: DoctorCheck[], asJson: boolean): number {
+  const summary = doctorSummary(checks);
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          sandbox: sandboxName,
+          status: summary.status,
+          failed: summary.failed,
+          warnings: summary.warned,
+          checks,
+        },
+        null,
+        2,
+      ),
+    );
+    return summary.failed > 0 ? 1 : 0;
+  }
+
+  console.log("");
+  console.log(`  ${B}${CLI_DISPLAY_NAME} doctor:${R} ${sandboxName}`);
+  const groupOrder = ["Host", "Gateway", "Sandbox", "Inference", "Messaging", "Local services"];
+  const orderedGroups = [
+    ...groupOrder,
+    ...checks
+      .map((check) => check.group)
+      .filter((group, index, all) => !groupOrder.includes(group) && all.indexOf(group) === index),
+  ];
+  for (const group of orderedGroups) {
+    const groupChecks = checks.filter((check) => check.group === group);
+    if (groupChecks.length === 0) continue;
+    console.log("");
+    console.log(`  ${G}${group}:${R}`);
+    for (const check of groupChecks) {
+      console.log(`    ${doctorStatusLabel(check.status)} ${check.label}: ${check.detail}`);
+      if (check.hint) {
+        console.log(`         ${D}hint: ${check.hint}${R}`);
+      }
+    }
+  }
+
+  console.log("");
+  if (summary.status === "ok") {
+    console.log(`  Summary: ${G}healthy${R}`);
+  } else if (summary.status === "warn") {
+    console.log(`  Summary: ${YW}healthy with ${summary.warned} warning(s)${R}`);
+  } else {
+    console.log(
+      `  Summary: ${_RD}attention needed${R} (${summary.failed} failed, ${summary.warned} warning(s))`,
+    );
+  }
+  console.log("");
+  return summary.failed > 0 ? 1 : 0;
+}
+
+function dockerInspectGateway(containerName: string): DoctorCheck[] {
+  const checks: DoctorCheck[] = [];
+  const inspect = captureHostCommand(
+    "docker",
+    [
+      "inspect",
+      "--format",
+      "{{.State.Running}}\t{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}\t{{.Config.Image}}",
+      containerName,
+    ],
+    5000,
+  );
+  if (inspect.status !== 0) {
+    checks.push({
+      group: "Gateway",
+      label: "Docker container",
+      status: "fail",
+      detail: `${containerName} not found or not inspectable`,
+      hint: "run `docker ps --filter name=openshell-cluster-nemoclaw`",
+    });
+    return checks;
+  }
+
+  const [runningRaw, healthRaw, imageRaw] = inspect.stdout.trim().split("\t");
+  const running = runningRaw === "true";
+  const health = healthRaw || "none";
+  const image = imageRaw || "unknown";
+  const healthOk = health === "healthy" || health === "none";
+  checks.push({
+    group: "Gateway",
+    label: "Docker container",
+    status: running && healthOk ? "ok" : "fail",
+    detail: `${containerName} ${running ? "running" : "stopped"} (${health}; ${image})`,
+    hint: running ? undefined : "restart the gateway with `openshell gateway start --name nemoclaw`",
+  });
+
+  const port = captureHostCommand("docker", ["port", containerName, "30051/tcp"], 5000);
+  if (port.status === 0 && port.stdout.trim()) {
+    const mapping = oneLine(port.stdout);
+    checks.push({
+      group: "Gateway",
+      label: "Port mapping",
+      status: mapping.includes(`:${GATEWAY_PORT}`) ? "ok" : "warn",
+      detail: mapping,
+      hint: mapping.includes(`:${GATEWAY_PORT}`)
+        ? undefined
+        : `expected host port ${GATEWAY_PORT} from NEMOCLAW_GATEWAY_PORT`,
+    });
+  } else {
+    checks.push({
+      group: "Gateway",
+      label: "Port mapping",
+      status: "fail",
+      detail: "30051/tcp is not published on the host",
+      hint: "gateway traffic will not reach OpenShell until the container is recreated with a host port",
+    });
+  }
+  return checks;
+}
+
+function findSandboxListLine(output: string, sandboxName: string): string | null {
+  const lines = stripAnsi(output).split(/\r?\n/);
+  return (
+    lines.find((line: string) => {
+      const columns = line.trim().split(/\s+/);
+      return columns.includes(sandboxName);
+    }) || null
+  );
+}
+
+function inferSandboxReadyFromLine(line: string | null): boolean | null {
+  if (!line) return null;
+  if (/\bReady\b/i.test(line)) return true;
+  if (/\b(Failed|Error|CrashLoopBackOff|ImagePullBackOff|Unknown|Evicted)\b/i.test(line)) {
+    return false;
+  }
+  return null;
+}
+
+function cloudflaredDoctorCheck(sandboxName: string): DoctorCheck {
+  const pidFile = path.join(`/tmp/nemoclaw-services-${sandboxName}`, "cloudflared.pid");
+  if (!fs.existsSync(pidFile)) {
+    return {
+      group: "Local services",
+      label: "cloudflared",
+      status: "info",
+      detail: "stopped",
+      hint: `start when needed with \`${CLI_NAME} tunnel start\``,
+    };
+  }
+  const pid = Number(fs.readFileSync(pidFile, "utf-8").trim());
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return {
+      group: "Local services",
+      label: "cloudflared",
+      status: "warn",
+      detail: "stale PID file",
+      hint: `run \`${CLI_NAME} tunnel stop\` and start it again if you need a public tunnel`,
+    };
+  }
+  try {
+    process.kill(pid, 0);
+    return {
+      group: "Local services",
+      label: "cloudflared",
+      status: "ok",
+      detail: `running (PID ${pid})`,
+    };
+  } catch {
+    return {
+      group: "Local services",
+      label: "cloudflared",
+      status: "warn",
+      detail: `stale PID ${pid}`,
+      hint: `run \`${CLI_NAME} tunnel stop\` to clean up the service state`,
+    };
+  }
+}
+
+function ollamaDoctorCheck(currentProvider: string): DoctorCheck {
+  const endpoint = `http://127.0.0.1:${OLLAMA_PORT}/api/tags`;
+  const result = captureHostCommand(
+    "curl",
+    ["-sS", "--connect-timeout", "2", "--max-time", "4", endpoint],
+    6000,
+  );
+  const required = currentProvider === "ollama-local";
+  if (result.status !== 0) {
+    return {
+      group: "Local services",
+      label: "Ollama",
+      status: required ? "fail" : "info",
+      detail: `not reachable at ${endpoint}`,
+      hint: required ? "start Ollama or change the sandbox inference provider" : undefined,
+    };
+  }
+
+  let modelCount = "unknown model count";
+  try {
+    const parsed = JSON.parse(result.stdout);
+    if (Array.isArray(parsed.models)) {
+      modelCount = `${parsed.models.length} model(s)`;
+    }
+  } catch {
+    /* keep generic detail */
+  }
+  return {
+    group: "Local services",
+    label: "Ollama",
+    status: "ok",
+    detail: `reachable at ${endpoint} (${modelCount})`,
+  };
+}
+
+function messagingDoctorCheck(sandboxName: string, sb: SandboxEntry): DoctorCheck {
+  const channels = Array.isArray(sb.messagingChannels) ? sb.messagingChannels : [];
+  if (channels.length === 0) {
+    return {
+      group: "Messaging",
+      label: "Channels",
+      status: "info",
+      detail: "no messaging channels registered",
+    };
+  }
+
+  const degraded = checkMessagingBridgeHealth(sandboxName, channels);
+  if (degraded.length === 0) {
+    return {
+      group: "Messaging",
+      label: "Channels",
+      status: "ok",
+      detail: `${channels.join(", ")} enabled; no recent conflict signatures`,
+    };
+  }
+
+  return {
+    group: "Messaging",
+    label: "Channels",
+    status: "warn",
+    detail: degraded
+      .map((item: { channel: string; conflicts: number }) => `${item.channel}: ${item.conflicts} conflict(s)`)
+      .join("; "),
+    hint: `run \`${CLI_NAME} ${sandboxName} logs --follow\` for bridge details`,
+  };
+}
+
+// eslint-disable-next-line complexity
+async function sandboxDoctor(sandboxName: string, args: string[] = []): Promise<void> {
+  const asJson = args.includes("--json");
+  const helpRequested = args.includes("--help") || args.includes("-h");
+  const unknown = args.filter((arg) => !["--json", "--help", "-h"].includes(arg));
+  if (helpRequested) {
+    console.log(`  Usage: ${CLI_NAME} <name> doctor [--json]`);
+    return;
+  }
+  if (unknown.length > 0) {
+    console.error(`  Unknown doctor argument${unknown.length === 1 ? "" : "s"}: ${unknown.join(" ")}`);
+    console.error(`  Usage: ${CLI_NAME} <name> doctor [--json]`);
+    process.exit(1);
+  }
+
+  const sb = registry.getSandbox(sandboxName);
+  const checks: DoctorCheck[] = [];
+
+  checks.push({
+    group: "Host",
+    label: "CLI build",
+    status: fs.existsSync(path.join(ROOT, "dist", "nemoclaw.js")) ? "ok" : "fail",
+    detail: fs.existsSync(path.join(ROOT, "dist", "nemoclaw.js"))
+      ? "dist/nemoclaw.js present"
+      : "dist/nemoclaw.js missing",
+    hint: fs.existsSync(path.join(ROOT, "dist", "nemoclaw.js")) ? undefined : "run `npm run build:cli`",
+  });
+
+  const dockerInfo = captureHostCommand("docker", ["info", "--format", "{{.ServerVersion}}"], 8000);
+  checks.push({
+    group: "Host",
+    label: "Docker daemon",
+    status: dockerInfo.status === 0 ? "ok" : "fail",
+    detail:
+      dockerInfo.status === 0
+        ? `server ${dockerInfo.stdout.trim() || "unknown"}`
+        : oneLine(dockerInfo.stderr || dockerInfo.error?.message || "docker info failed"),
+    hint: dockerInfo.status === 0 ? undefined : "start Docker and verify your user can access the daemon",
+  });
+
+  const openshellBin = resolveOpenshell();
+  checks.push({
+    group: "Host",
+    label: "OpenShell CLI",
+    status: openshellBin ? "ok" : "fail",
+    detail: openshellBin || "not found on PATH",
+    hint: openshellBin ? undefined : "install OpenShell before using sandbox commands",
+  });
+
+  checks.push(...dockerInspectGateway(`openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`));
+
+  let openshellConnected = false;
+  if (openshellBin) {
+    const status = captureOpenshell(["status"], {
+      ignoreError: true,
+      timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+    });
+    const cleanStatus = stripAnsi(status.output || "");
+    openshellConnected = status.status === 0 && /^\s*Status:\s*Connected\b/im.test(cleanStatus);
+    checks.push({
+      group: "Gateway",
+      label: "OpenShell status",
+      status: openshellConnected ? "ok" : "fail",
+      detail: openshellConnected ? "connected" : oneLine(cleanStatus || "not connected"),
+      hint: openshellConnected
+        ? undefined
+        : "run `openshell status`; if needed start the nemoclaw gateway",
+    });
+  }
+
+  if (openshellBin) {
+    const list = captureOpenshell(["sandbox", "list"], {
+      ignoreError: true,
+      timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+    });
+    const liveNames = parseLiveSandboxNames(list.output || "");
+    const present = list.status === 0 && liveNames.has(sandboxName);
+    const line = findSandboxListLine(list.output || "", sandboxName);
+    const ready = inferSandboxReadyFromLine(line);
+    checks.push({
+      group: "Sandbox",
+      label: "Live sandbox",
+      status: present && ready !== false ? "ok" : "fail",
+      detail: present
+        ? ready === true
+          ? `${sandboxName} present (Ready)`
+          : `${sandboxName} present${line ? ` (${oneLine(line)})` : ""}`
+        : `${sandboxName} not present in live OpenShell sandbox list`,
+      hint: present ? undefined : `run \`${CLI_NAME} ${sandboxName} status\` or recreate with \`${CLI_NAME} onboard\``,
+    });
+  }
+
+  const live = openshellBin
+    ? parseGatewayInference(
+        captureOpenshell(["inference", "get"], {
+          ignoreError: true,
+          timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+        }).output,
+      )
+    : null;
+  const currentModel = (live && live.model) || (sb && sb.model) || "unknown";
+  const currentProvider = (live && live.provider) || (sb && sb.provider) || "unknown";
+  checks.push({
+    group: "Inference",
+    label: "Route",
+    status: currentProvider !== "unknown" || currentModel !== "unknown" ? "ok" : "warn",
+    detail: `${currentProvider} / ${currentModel}`,
+    hint:
+      currentProvider !== "unknown" || currentModel !== "unknown"
+        ? undefined
+        : `run \`${CLI_NAME} ${sandboxName} status\` after the gateway is healthy`,
+  });
+
+  if (typeof currentProvider === "string" && currentProvider !== "unknown") {
+    const inferenceHealth = probeProviderHealth(currentProvider);
+    if (!inferenceHealth) {
+      checks.push({
+        group: "Inference",
+        label: "Provider health",
+        status: "info",
+        detail: `no health probe registered for ${currentProvider}`,
+      });
+    } else if (!inferenceHealth.probed) {
+      checks.push({
+        group: "Inference",
+        label: "Provider health",
+        status: "info",
+        detail: inferenceHealth.detail,
+      });
+    } else {
+      checks.push({
+        group: "Inference",
+        label: "Provider health",
+        status: inferenceHealth.ok ? "ok" : "fail",
+        detail: inferenceHealth.ok
+          ? `${inferenceHealth.endpoint} reachable`
+          : inferenceHealth.detail,
+        hint: inferenceHealth.ok ? undefined : "check network access or provider credentials",
+      });
+    }
+  }
+
+  if (sb) {
+    try {
+      const versionCheck = sandboxVersion.checkAgentVersion(sandboxName);
+      const agent = agentRuntime.getSessionAgent(sandboxName);
+      const agentName = agentRuntime.getAgentDisplayName(agent);
+      if (versionCheck.isStale) {
+        checks.push({
+          group: "Sandbox",
+          label: "Agent version",
+          status: "warn",
+          detail: `${agentName} v${versionCheck.sandboxVersion || "unknown"}; v${versionCheck.expectedVersion} available`,
+          hint: `run \`${CLI_NAME} ${sandboxName} rebuild\``,
+        });
+      } else if (versionCheck.sandboxVersion) {
+        checks.push({
+          group: "Sandbox",
+          label: "Agent version",
+          status: "ok",
+          detail: `${agentName} v${versionCheck.sandboxVersion}`,
+        });
+      } else {
+        checks.push({
+          group: "Sandbox",
+          label: "Agent version",
+          status: "info",
+          detail: "could not detect version",
+        });
+      }
+    } catch {
+      checks.push({
+        group: "Sandbox",
+        label: "Agent version",
+        status: "info",
+        detail: "version check unavailable",
+      });
+    }
+
+    checks.push({
+      group: "Sandbox",
+      label: "Shields",
+      status: shields.isShieldsDown(sandboxName) ? "warn" : "ok",
+      detail: shields.isShieldsDown(sandboxName) ? "down" : "up",
+      hint: shields.isShieldsDown(sandboxName)
+        ? `run \`${CLI_NAME} ${sandboxName} shields status\` for details`
+        : undefined,
+    });
+    checks.push(messagingDoctorCheck(sandboxName, sb));
+  }
+
+  checks.push(ollamaDoctorCheck(currentProvider));
+  checks.push(cloudflaredDoctorCheck(sandboxName));
+
+  const exitCode = renderDoctorReport(sandboxName, checks, asJson);
+  if (exitCode !== 0) process.exit(exitCode);
 }
 
 // eslint-disable-next-line complexity
@@ -4405,6 +4909,9 @@ const [cmd, ...args] = process.argv.slice(2);
       case "status":
         await sandboxStatus(cmd);
         break;
+      case "doctor":
+        await sandboxDoctor(cmd, actionArgs);
+        break;
       case "logs":
         sandboxLogs(cmd, actionArgs.includes("--follow"));
         break;
@@ -4599,7 +5106,7 @@ const [cmd, ...args] = process.argv.slice(2);
       default:
         console.error(`  Unknown action: ${action}`);
         console.error(
-          `  Valid actions: connect, status, logs, policy-add, policy-remove, policy-list, skill, snapshot, share, rebuild, shields, config, channels, gateway-token, destroy`,
+          `  Valid actions: connect, status, doctor, logs, policy-add, policy-remove, policy-list, skill, snapshot, share, rebuild, shields, config, channels, gateway-token, destroy`,
         );
         process.exit(1);
     }


### PR DESCRIPTION
## Summary

Adds a sandbox-scoped `nemoclaw <name> doctor` command that runs a focused host and runtime health check from the main CLI.

The command reports grouped checks for:

- local CLI build availability
- Docker daemon access
- OpenShell CLI availability and gateway status
- NemoClaw gateway container health and port mapping
- live sandbox presence/readiness
- inference route and provider reachability
- agent version and shields state
- messaging channel conflicts
- local Ollama reachability
- cloudflared tunnel state

It also supports `--json` for automation and exits non-zero only when a check fails. Warnings remain visible but do not fail the command.

## Motivation

`nemoclaw status` is useful for inspecting sandbox state, but users troubleshooting always-on assistants often need a single readiness-style command that answers: "is the host, gateway, sandbox, and inference path healthy enough to use?"

This PR adds that CLI-native health check without requiring a separate script or dashboard. It is complementary to broader monitoring proposals such as #1530, but keeps the core diagnostic path available directly from the `nemoclaw` binary.

## Documentation

Updates the CLI command registry and reference docs with:

```bash
nemoclaw <name> doctor
nemoclaw <name> doctor --json
```

Examples use generic sandbox names only.

## Validation

Ran locally:

```bash
npm test -- src/lib/command-registry.test.ts src/lib/inventory-commands.test.ts
npm run typecheck:cli
npm run build:cli
bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli
nemoclaw <name> doctor
nemoclaw <name> doctor --json
```
