### PR TITLE
ci: quiet CI failure logs

### DIFF
--- a/.github/workflows/e2e-branch-validation.yaml
+++ b/.github/workflows/e2e-branch-validation.yaml
@@ -201,7 +201,7 @@ jobs:
           LAUNCHABLE_SETUP_SCRIPT: ${{ inputs.setup_script_url || '' }}
           BREV_PROVIDER: gcp
           KEEP_ALIVE: ${{ inputs.keep_alive }}
-        run: npx vitest run --project e2e-branch-validation --reporter=verbose
+        run: npx vitest run --project e2e-branch-validation
 
       - name: Update check run (completed)
         if: always() && inputs.pr_number != '' && env.CHECK_RUN_ID != ''

--- a/.github/workflows/wsl-e2e.yaml
+++ b/.github/workflows/wsl-e2e.yaml
@@ -60,15 +60,44 @@ jobs:
           # Native commands do not throw in PowerShell; check LASTEXITCODE.
           $null = wsl -d $env:WSL_DISTRO -- echo ok 2>&1
           if ($LASTEXITCODE -ne 0) {
-            Write-Host 'Ubuntu not found - installing via wsl --install'
-            wsl --install -d $env:WSL_DISTRO --no-launch --web-download
-            if ($LASTEXITCODE -ne 0) {
-              throw ('wsl --install failed with exit code ' + $LASTEXITCODE)
+            $maxAttempts = 3
+            $installed = $false
+            for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+              Write-Host "Ubuntu not found - installing via wsl --install (attempt $attempt/$maxAttempts)"
+              wsl --install -d $env:WSL_DISTRO --no-launch --web-download
+              $installExitCode = $LASTEXITCODE
+              if ($installExitCode -eq 0) {
+                # The first launch initialises the distro with the default root user.
+                wsl -d $env:WSL_DISTRO -- bash -c 'echo distro initialised'
+                $launchExitCode = $LASTEXITCODE
+                if ($launchExitCode -eq 0) {
+                  $installed = $true
+                  break
+                }
+                Write-Warning "distro first-launch failed with exit code $launchExitCode"
+              } else {
+                Write-Warning "wsl --install failed with exit code $installExitCode"
+              }
+
+              # Some WSL installs return a non-zero code after registering a usable distro.
+              $null = wsl -d $env:WSL_DISTRO -- echo ok 2>&1
+              if ($LASTEXITCODE -eq 0) {
+                Write-Host 'Ubuntu became available after the install command returned non-zero'
+                $installed = $true
+                break
+              }
+
+              if ($attempt -lt $maxAttempts) {
+                Write-Host 'Cleaning up any partial WSL registration before retrying'
+                $null = wsl --unregister $env:WSL_DISTRO 2>&1
+                $delaySeconds = [Math]::Min(60, 20 * $attempt)
+                Write-Host "Retrying WSL install in $delaySeconds seconds..."
+                Start-Sleep -Seconds $delaySeconds
+              }
             }
-            # The first launch initialises the distro with the default root user.
-            wsl -d $env:WSL_DISTRO -- bash -c 'echo distro initialised'
-            if ($LASTEXITCODE -ne 0) {
-              throw ('distro first-launch failed with exit code ' + $LASTEXITCODE)
+
+            if (-not $installed) {
+              throw ("failed to install and initialize $env:WSL_DISTRO after $maxAttempts attempts")
             }
           } else {
             Write-Host 'Ubuntu already available'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -276,7 +276,7 @@ repos:
     hooks:
       - id: test-cli
         name: Test (CLI)
-        entry: bash -c 'npm run build:cli && npx vitest run --project cli --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.include="dist/lib/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
+        entry: bash -c 'npm run build:cli && npx vitest run --project cli --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.include="dist/lib/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
         language: system
         pass_filenames: false
         files: ^(bin/|src/|test/)
@@ -284,7 +284,7 @@ repos:
 
       - id: test-plugin
         name: Test (plugin)
-        entry: bash -c 'npx vitest run --project plugin --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/plugin --coverage.include="nemoclaw/src/**/*.ts" --coverage.exclude="**/*.test.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"'
+        entry: bash -c 'npx vitest run --project plugin --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/plugin --coverage.include="nemoclaw/src/**/*.ts" --coverage.exclude="**/*.test.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"'
         language: system
         pass_filenames: false
         files: ^nemoclaw/

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -67,6 +67,7 @@ function runWithEnv(
   try {
     const out = execSync(`node "${CLI}" ${args}`, {
       encoding: "utf-8",
+      stdio: "pipe",
       timeout,
       env: {
         ...process.env,
@@ -322,6 +323,7 @@ describe("CLI dispatch", () => {
   it("nemohermes list --help uses alias branding", () => {
     const out = execSync(`node "${HERMES_CLI}" list --help`, {
       encoding: "utf-8",
+      stdio: "pipe",
       timeout: execTimeout(),
       env: {
         ...process.env,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,8 +5,16 @@ import { defineConfig } from "vitest/config";
 
 import { testTimeout } from "./test/helpers/timeouts";
 
+const isGithubActions = process.env.GITHUB_ACTIONS === "true";
+const isCi = isGithubActions || process.env.CI === "true" || process.env.CI === "1";
+
 export default defineConfig({
   test: {
+    // CI logs are easiest to scan when test chatter stays quiet and failures
+    // surface as GitHub annotations at the relevant file and line.
+    reporters: isGithubActions ? ["github-actions"] : ["default"],
+    silent: isCi,
+    hideSkippedTests: isCi,
     projects: [
       {
         test: {
@@ -58,7 +66,7 @@ export default defineConfig({
       provider: "v8",
       include: ["nemoclaw/src/**/*.ts"],
       exclude: ["**/*.test.ts"],
-      reporter: ["text", "json-summary"],
+      reporter: ["text-summary", "json-summary"],
     },
   },
 });


### PR DESCRIPTION
## Summary
Quiet CI test output so failures are easier to find in GitHub Actions logs. This switches CI Vitest runs to GitHub annotations, suppresses passing-test chatter, and trims coverage output to summaries.

## Changes
- Configure Vitest to use GitHub Actions annotations with silent output in CI.
- Replace verbose coverage tables with compact coverage summaries in shared prek test hooks.
- Stop forcing the Brev E2E workflow to use the verbose Vitest reporter.
- Retry transient WSL Ubuntu install failures and clean up partial registrations before retrying.
- Pipe expected CLI subprocess stderr in tests so intentional error output does not leak into passing CI logs.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure
- [x] AI-assisted — tool: Pi coding agent

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized test reporting and coverage output formats across CI, local hooks, and test runs for clearer, more consistent test feedback.
  * Adjusted test execution behavior to produce more reliable and appropriately-verbose output in CI and developer environments.

* **Bug Fixes**
  * Improved CI WSL installation step with retry and validation logic to reduce intermittent setup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
