### PR TITLE
fix(onboard): skip Brave prompt for Hermes

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1531,6 +1531,13 @@ function agentSupportsWebSearch(
   agent: AgentDefinition | null | undefined,
   dockerfilePathOverride: string | null = null,
 ): boolean {
+  // Hermes has native web tools, but the NemoClaw onboarding wizard wires the
+  // OpenClaw Brave provider path. Do not offer a Brave prompt for Hermes until
+  // that provider is supported end to end.
+  if (agent?.name === "hermes") {
+    return false;
+  }
+
   const candidates = [
     dockerfilePathOverride,
     agent?.dockerfilePath,

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1073,7 +1073,7 @@ describe("onboard helpers", () => {
     expect(agentSupportsWebSearch(loadAgent("hermes"))).toBe(false);
   });
 
-  it("#2433: agentSupportsWebSearch honors the effective custom Dockerfile", () => {
+  it("#2433: agentSupportsWebSearch honors the effective custom Dockerfile for Brave-capable agents", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-web-search-custom-"));
     const withoutArg = path.join(tmpDir, "Dockerfile.no-web");
     const withArg = path.join(tmpDir, "Dockerfile.web");
@@ -1082,7 +1082,7 @@ describe("onboard helpers", () => {
     fs.writeFileSync(withArg, "FROM scratch\n  ARG NEMOCLAW_WEB_SEARCH_ENABLED=0\n");
     try {
       expect(agentSupportsWebSearch(loadAgent("openclaw"), withoutArg)).toBe(false);
-      expect(agentSupportsWebSearch(loadAgent("hermes"), withArg)).toBe(true);
+      expect(agentSupportsWebSearch(loadAgent("hermes"), withArg)).toBe(false);
       expect(agentSupportsWebSearch(loadAgent("openclaw"), missing)).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- explicitly disables the NemoClaw Brave Web Search prompt when the selected agent is Hermes
- keeps Dockerfile-based web-search detection for Brave-capable agents such as OpenClaw
- updates onboard helper coverage so a Hermes custom Dockerfile does not accidentally re-enable the Brave prompt

## Testing
- npm run build:cli
- npm run typecheck:cli
- npm test -- test/onboard.test.ts
- git diff --check
- Targeted onboarding E2E requested by CodeRabbit: queued in https://github.com/NVIDIA/NemoClaw/actions/runs/25234837342 (`cloud-e2e,sandbox-operations-e2e,rebuild-openclaw-e2e`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hermes agent no longer reports or offers web-search capability in the onboarding flow, so Brave web-search configuration will not be presented for Hermes. Related tests have been updated to reflect this behavior. No public APIs or exported interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->