### PR TITLE
fix(hermes): install root Node dependencies in base image

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -128,6 +128,7 @@ RUN printf '%s\n' \
 # integrations: messaging (Telegram, Discord, Slack) and web (API health/UI
 # runtime). New Hermes integrations should be installed by the agent workflow
 # when they are enabled rather than shipped in the base image by default.
+# Root Node dependencies provide Hermes browser tooling such as agent-browser.
 RUN pip3 install --no-cache-dir --break-system-packages "uv==${UV_VERSION}"
 RUN mkdir -p /opt/hermes \
     && curl -fsSL "https://github.com/NousResearch/hermes-agent/archive/refs/tags/${HERMES_VERSION}.tar.gz" -o /tmp/hermes.tar.gz \
@@ -143,6 +144,8 @@ RUN set -eu; \
         set -- "$@" --extra "$extra"; \
     done; \
     uv sync --frozen --no-dev "$@" --no-cache \
+    && npm ci --prefer-offline --no-audit --no-fund \
+    && rm -rf /tmp/camoufox-* \
     && ln -sf /opt/hermes/.venv/bin/hermes /usr/local/bin/hermes \
     && ln -sf /opt/hermes/.venv/bin/hermes-agent /usr/local/bin/hermes-agent \
     && ln -sf /opt/hermes/.venv/bin/hermes-acp /usr/local/bin/hermes-acp


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Follows up on NousResearch's dependency-bootstrap proposal in #2834 and the maintainer-side #2846 by carrying the remaining root Node dependency install into the Hermes base image. The existing `uv sync` step covers the supported Python integration extras; this adds deterministic `npm ci` from the Hermes root lockfile so browser tooling such as `agent-browser` is available in the extracted Hermes tree.

## Credit
Thanks to Ben Barclay and the NousResearch team for the original PR #2834. They identified the Hermes dependency-bootstrap gap and proposed the direction this follow-up carries into the current NemoClaw base-image flow.

## Related Issue
Follow-up to #2834 and #2846.

## Changes
- Install Hermes root Node dependencies with `npm ci --prefer-offline --no-audit --no-fund` after the existing `uv sync` step.
- Remove transient `/tmp/camoufox-*` installer downloads in the same Docker layer so large temporary archives do not persist into the image.
- Document why the root Node install belongs in the Hermes base image.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation:
- `git diff --check`
- `docker build --progress=plain --output=type=cacheonly -f agents/hermes/Dockerfile.base .`
  - validated the `uv sync` step
  - validated the new `npm ci` step
  - validated `/usr/local/bin/hermes --version` reports `Hermes Agent v0.11.0 (2026.4.23)`

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized the container image build by removing temporary build artifacts to reduce clutter and image size.
  * Made tooling dependencies for browser-related features explicit so tooling is reliably present during build.
  * Ensured Node package installation runs deterministically during image creation to improve build stability and reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
