### PR TITLE
ci(wsl): run e2e from ext4 workspace

### DIFF
--- a/.github/workflows/wsl-e2e.yaml
+++ b/.github/workflows/wsl-e2e.yaml
@@ -43,15 +43,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Resolve workspace path for WSL
+      - name: Resolve workspace paths for WSL
         shell: powershell
         run: |
           $winPath = "${{ github.workspace }}"
           $drive = $winPath.Substring(0,1).ToLower()
           $rest = $winPath.Substring(2).Replace('\','/')
-          $wslPath = "/mnt/$drive$rest"
-          "WSL_WORKDIR=$wslPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Host "WSL_WORKDIR=$wslPath"
+          $wslCheckoutPath = "/mnt/$drive$rest"
+          $wslWorkdir = "/tmp/nemoclaw-wsl-workdir/${env:GITHUB_RUN_ID}-${env:GITHUB_RUN_ATTEMPT}"
+          "WSL_CHECKOUT_DIR=$wslCheckoutPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "WSL_WORKDIR=$wslWorkdir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "WSL_CHECKOUT_DIR=$wslCheckoutPath"
+          Write-Host "WSL_WORKDIR=$wslWorkdir"
 
       - name: Ensure Ubuntu WSL exists
         shell: powershell
@@ -137,6 +140,40 @@ jobs:
           node --version
           npm --version
           '@
+          $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
+          [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
+          $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
+          wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
+
+      - name: Copy checkout into WSL ext4 workspace
+        shell: powershell
+        run: |
+          $checkout = $env:WSL_CHECKOUT_DIR
+          $workdir = $env:WSL_WORKDIR
+          $workdirParent = $workdir.Substring(0, $workdir.LastIndexOf('/'))
+          $script = @"
+          set -euo pipefail
+          echo 'Syncing checkout from $checkout to $workdir'
+          if [ ! -d '$checkout/.git' ]; then
+            echo 'Expected a Git checkout at $checkout' >&2
+            exit 1
+          fi
+          # Keep npm and test I/O on WSL's ext4 VHD. Running directly from
+          # /mnt/<drive> (DrvFS) is slower and has Windows-style permission
+          # semantics that hide Linux permission regressions.
+          rm -rf '$workdir'
+          mkdir -p '$workdirParent'
+          rsync -a --no-owner --no-group --delete \
+            --exclude '/node_modules/' \
+            --exclude '/nemoclaw/node_modules/' \
+            --exclude '/nemoclaw-blueprint/.venv/' \
+            '$checkout'/ '$workdir'/
+          git config --global --add safe.directory '$workdir'
+          git -C '$workdir' reset --hard HEAD
+          git -C '$workdir' clean -ffdx
+          git -C '$workdir' status --short
+          echo 'WSL ext4 workspace ready at $workdir'
+          "@
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -566,6 +566,7 @@ describe("nemoclaw-start persistent gateway log hardening", () => {
   it("creates a regular read-only persistent log mirror and refuses unsafe paths", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-persistent-log-"));
     const gatewayLog = path.join(tmpDir, "gateway.log");
+    const persistentLog = path.join(tmpDir, "logs", "gateway-persistent.log");
     const scriptPath = path.join(tmpDir, "run.sh");
     fs.writeFileSync(gatewayLog, "initial gateway line\n");
     fs.writeFileSync(
@@ -577,7 +578,7 @@ describe("nemoclaw-start persistent gateway log hardening", () => {
         "start_persistent_gateway_log_mirror",
         "sleep 0.2",
         `printf '%s\\n' later-line >> ${JSON.stringify(gatewayLog)}`,
-        "sleep 0.4",
+        `for _ in {1..30}; do grep -Fq later-line ${JSON.stringify(persistentLog)} 2>/dev/null && break; sleep 0.1; done`,
         'kill "$GATEWAY_LOG_PERSIST_PID" 2>/dev/null || true',
         'wait "$GATEWAY_LOG_PERSIST_PID" 2>/dev/null || true',
         "printf 'PID=%s\\n' \"$GATEWAY_LOG_PERSIST_PID\"",
@@ -589,7 +590,6 @@ describe("nemoclaw-start persistent gateway log hardening", () => {
       const result = spawnSync("bash", [scriptPath], { encoding: "utf-8", timeout: 5000 });
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("PID=");
-      const persistentLog = path.join(tmpDir, "logs", "gateway-persistent.log");
       const stat = fs.statSync(persistentLog);
       expect(stat.isFile()).toBe(true);
       expect((stat.mode & 0o777).toString(8)).toBe("644");

--- a/test/repro-2681-group-writable.test.ts
+++ b/test/repro-2681-group-writable.test.ts
@@ -74,6 +74,7 @@ describe("Issue #2681 — mutable OpenClaw config permissions", () => {
           [
             "set -euo pipefail",
             'id() { if [ "${1:-}" = "-u" ]; then printf "0"; else command id "$@"; fi; }',
+            'stat() { if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%U" ]; then printf "sandbox\\n"; else command stat "$@"; fi; }',
             normalizeMutableConfigPermsFor(configDir),
             "normalize_mutable_config_perms",
           ].join("\n"),


### PR DESCRIPTION
## Summary
Run the WSL E2E workflow from a copied workspace on WSL's ext4 filesystem instead of directly from the Windows-mounted checkout. This should reduce DrvFS I/O overhead and expose Linux permission behavior more realistically during WSL tests.

## Changes
- Resolve both the Windows-mounted checkout path and a WSL-native `/tmp/nemoclaw-wsl-workdir/...` workdir.
- Add a WSL copy step that syncs the checkout with `rsync`, avoids preserving Windows ownership, and marks the copied repo as a safe Git directory.
- Keep the existing install, build, compatibility test, and full E2E steps pointed at `WSL_WORKDIR`, now backed by ext4.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * WSL CI now uses a dedicated Linux-backed workspace copy to improve build consistency and avoid issues with Windows-mounted paths.
* **Tests**
  * Replaced time-based waits with content-based polling for log readiness to reduce flakiness.
  * Adjusted a regression test to better simulate file ownership for more reliable permission verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->