### PR TITLE
fix: harden Dockerfile replaceConfigFile patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,7 @@ RUN set -eu; \
 #
 # Both patches fail-close: if grep finds no targets, the build aborts so
 # the next maintainer reviewing an OPENCLAW_VERSION bump knows to revisit.
+COPY scripts/rcf_patch.py /usr/local/lib/nemoclaw/rcf_patch.py
 # hadolint ignore=SC2016,DL3059,DL4006
 RUN set -eu; \
     OC_DIST=/usr/local/lib/node_modules/openclaw/dist; \
@@ -192,7 +193,7 @@ RUN set -eu; \
     # auto-discovery from the extensions directory. \
     rcf_file="$(grep -RIlE --include='*.js' 'async function replaceConfigFile\(params\)' "$OC_DIST" | head -n 1)"; \
     test -n "$rcf_file" || { echo "ERROR: replaceConfigFile function not found in OpenClaw dist" >&2; exit 1; }; \
-    python3 -c "import sys; p=sys.argv[1]; f=open(p); src=f.read(); f.close(); old='\tif (!await tryWriteSingleTopLevelIncludeMutation({\n\t\tsnapshot,\n\t\tnextConfig: params.nextConfig\n\t})) await writeConfigFile(params.nextConfig, {\n\t\tbaseSnapshot: snapshot,\n\t\t...writeOptions,\n\t\t...params.writeOptions\n\t});'; new='\ttry { if (!await tryWriteSingleTopLevelIncludeMutation({\n\t\tsnapshot,\n\t\tnextConfig: params.nextConfig\n\t})) await writeConfigFile(params.nextConfig, {\n\t\tbaseSnapshot: snapshot,\n\t\t...writeOptions,\n\t\t...params.writeOptions\n\t}); } catch(_rcfErr) { if (process.env.OPENSHELL_SANDBOX === \"1\" && _rcfErr.code === \"EACCES\") { console.error(\"[nemoclaw] Config is read-only in sandbox \\u2014 plugin metadata not persisted (plugins auto-load from extensions/)\"); } else { throw _rcfErr; } }'; assert old in src, 'tryWriteSingleTopLevelIncludeMutation/writeConfigFile pattern not found in replaceConfigFile'; f=open(p,'w'); f.write(src.replace(old,new,1)); f.close()" "$rcf_file"; \
+    python3 /usr/local/lib/nemoclaw/rcf_patch.py "$rcf_file"; \
     grep -REq --include='*.js' 'OPENSHELL_SANDBOX.*EACCES' "$rcf_file" || { echo "ERROR: Patch 4 (replaceConfigFile EACCES) not applied" >&2; exit 1; }; \
     # --- Patch 5: bump default WS handshake timeout 10s -> 60s (#2484) --- \
     # OpenClaw's WS connect handshake has a hard-coded 10s timeout on both \

--- a/scripts/rcf_patch.py
+++ b/scripts/rcf_patch.py
@@ -14,22 +14,57 @@ import sys
 p = sys.argv[1]
 src = open(p).read()
 
+
+def skip_quoted(text, i, quote):
+    i += 1
+    while i < len(text):
+        if text[i] == "\\":
+            i += 2
+            continue
+        if text[i] == quote:
+            return i + 1
+        i += 1
+    raise AssertionError("unterminated string while scanning replaceConfigFile")
+
+
+def find_matching_brace(text, open_idx):
+    depth = 0
+    i = open_idx
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+
+        if ch in ("'", '"', "`"):
+            i = skip_quoted(text, i, ch)
+            continue
+        if ch == "/" and nxt == "/":
+            newline = text.find("\n", i + 2)
+            i = len(text) if newline == -1 else newline + 1
+            continue
+        if ch == "/" and nxt == "*":
+            end = text.find("*/", i + 2)
+            assert end != -1, "unterminated block comment while scanning replaceConfigFile"
+            i = end + 2
+            continue
+
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+            assert depth > 0, "replaceConfigFile function body closed before it opened"
+        i += 1
+
+    raise AssertionError("replaceConfigFile function body not terminated")
+
+
 # Scope the search to the replaceConfigFile function body.
 fn_start = src.find("async function replaceConfigFile(")
 assert fn_start != -1, "replaceConfigFile function not found in file"
-# Find the matching closing brace by walking the source.
-depth = 0
 fn_body_start = src.index("{", fn_start)
-i = fn_body_start
-while i < len(src):
-    if src[i] == "{":
-        depth += 1
-    elif src[i] == "}":
-        depth -= 1
-        if depth == 0:
-            break
-    i += 1
-fn_src = src[fn_body_start : i + 1]
+fn_body_end = find_matching_brace(src, fn_body_start)
+fn_src = src[fn_body_start : fn_body_end + 1]
 
 # Match the tryWriteSingleTopLevelIncludeMutation / writeConfigFile block.
 # - Tolerates any whitespace around !, await, (, {, }, commas, ;
@@ -62,6 +97,6 @@ replacement = (
 # Reconstruct: everything before the fn body match, patched fn body, rest.
 fn_offset = fn_body_start
 patched_fn = fn_src[: m.start()] + replacement + fn_src[m.end() :]
-out = src[:fn_offset] + patched_fn + src[fn_offset + len(fn_src):]
+out = src[:fn_offset] + patched_fn + src[fn_body_end + 1:]
 open(p, "w").write(out)
 print(f"[nemoclaw] rcf_patch applied to {p}")

--- a/scripts/rcf_patch.py
+++ b/scripts/rcf_patch.py
@@ -1,0 +1,67 @@
+"""
+Patch replaceConfigFile in OpenClaw dist to wrap the
+tryWriteSingleTopLevelIncludeMutation/writeConfigFile block in a try/catch
+that suppresses EACCES when running inside an OpenShell sandbox.
+
+Uses a broad regex anchored on function-call names, not whitespace or object
+property ordering, so minor formatting changes across OpenClaw versions don't
+cause false misses (#2689). The match is scoped to the replaceConfigFile
+function body to avoid patching unrelated blocks.
+"""
+import re
+import sys
+
+p = sys.argv[1]
+src = open(p).read()
+
+# Scope the search to the replaceConfigFile function body.
+fn_start = src.find("async function replaceConfigFile(")
+assert fn_start != -1, "replaceConfigFile function not found in file"
+# Find the matching closing brace by walking the source.
+depth = 0
+fn_body_start = src.index("{", fn_start)
+i = fn_body_start
+while i < len(src):
+    if src[i] == "{":
+        depth += 1
+    elif src[i] == "}":
+        depth -= 1
+        if depth == 0:
+            break
+    i += 1
+fn_src = src[fn_body_start : i + 1]
+
+# Match the tryWriteSingleTopLevelIncludeMutation / writeConfigFile block.
+# - Tolerates any whitespace around !, await, (, {, }, commas, ;
+# - Allows snapshot / nextConfig properties in either order
+# - Allows optional semicolon at end
+# - Uses DOTALL so \s matches newlines
+pat = re.compile(
+    r"(?P<pre>[ \t]*)if\s*\(\s*!\s*await\s+tryWriteSingleTopLevelIncludeMutation\s*\("
+    r"\s*\{(?=[^}]*\bsnapshot\b)(?=[^}]*\bnextConfig\s*:\s*params\.nextConfig\b)[^}]*?\}\s*\)\s*\)"
+    r"\s*await\s+writeConfigFile\s*\(\s*params\.nextConfig\s*,\s*\{[^}]*?\}\s*\)\s*;?",
+    re.DOTALL,
+)
+m = pat.search(fn_src)
+assert m, "tryWriteSingleTopLevelIncludeMutation/writeConfigFile pattern not found in replaceConfigFile"
+
+indent = m.group("pre")
+replacement = (
+    indent + "try { if (!await tryWriteSingleTopLevelIncludeMutation({\n"
+    + indent + "\tsnapshot,\n"
+    + indent + "\tnextConfig: params.nextConfig\n"
+    + indent + "})) await writeConfigFile(params.nextConfig, {\n"
+    + indent + "\tbaseSnapshot: snapshot,\n"
+    + indent + "\t...writeOptions,\n"
+    + indent + "\t...params.writeOptions\n"
+    + indent + '}); } catch(_rcfErr) { if (process.env.OPENSHELL_SANDBOX === "1" && _rcfErr.code === "EACCES") {'
+    + ' console.error("[nemoclaw] Config is read-only in sandbox \\u2014 plugin metadata not persisted (plugins auto-load from extensions/)"); }'
+    + " else { throw _rcfErr; } }"
+)
+
+# Reconstruct: everything before the fn body match, patched fn body, rest.
+fn_offset = fn_body_start
+patched_fn = fn_src[: m.start()] + replacement + fn_src[m.end() :]
+out = src[:fn_offset] + patched_fn + src[fn_offset + len(fn_src):]
+open(p, "w").write(out)
+print(f"[nemoclaw] rcf_patch applied to {p}")

--- a/src/lib/sandbox-build-context.ts
+++ b/src/lib/sandbox-build-context.ts
@@ -99,6 +99,12 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "scripts", "generate-openclaw-config.py"),
     path.join(stagedScriptsDir, "generate-openclaw-config.py"),
   );
+  // Dockerfile Patch 4 helper — must be present in the build context because
+  // the Dockerfile COPYs it before the patching RUN step (#2689).
+  fs.copyFileSync(
+    path.join(rootDir, "scripts", "rcf_patch.py"),
+    path.join(stagedScriptsDir, "rcf_patch.py"),
+  );
 
   return { buildCtx, stagedDockerfile };
 }

--- a/test/rcf-patch.test.ts
+++ b/test/rcf-patch.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const PATCH_SCRIPT = path.join(REPO_ROOT, "scripts", "rcf_patch.py");
+
+function runPatch(source: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-rcf-patch-"));
+  const file = path.join(dir, "mutate.js");
+  fs.writeFileSync(file, source);
+  try {
+    const result = spawnSync("python3", [PATCH_SCRIPT, file], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    return {
+      result,
+      patched: fs.readFileSync(file, "utf-8"),
+    };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function replaceConfigFileBody(properties: string) {
+  return `
+async function replaceConfigFile(params) {
+  const snapshot = params.snapshot;
+  const writeOptions = params.writeOptions ?? {};
+  if (! await tryWriteSingleTopLevelIncludeMutation({
+${properties}
+  })) await writeConfigFile(params.nextConfig, {
+    baseSnapshot: snapshot,
+    ...writeOptions,
+    ...params.writeOptions
+  });
+}
+`;
+}
+
+describe("rcf_patch.py", () => {
+  it("patches replaceConfigFile with either snapshot/nextConfig property order", () => {
+    for (const properties of [
+      "    snapshot,\n    nextConfig: params.nextConfig",
+      "    nextConfig: params.nextConfig,\n    snapshot",
+    ]) {
+      const { result, patched } = runPatch(replaceConfigFileBody(properties));
+      expect(result.status).toBe(0);
+      expect(patched).toContain("OPENSHELL_SANDBOX");
+      expect(patched).toContain("try { if (!await tryWriteSingleTopLevelIncludeMutation");
+    }
+  });
+
+  it("ignores braces inside strings and comments when locating replaceConfigFile", () => {
+    const { result, patched } = runPatch(`
+async function replaceConfigFile(params) {
+  const stringBrace = "}";
+  // comment brace: }
+  /* block comment brace: } */
+  const snapshot = params.snapshot;
+  const writeOptions = params.writeOptions ?? {};
+  if (!await tryWriteSingleTopLevelIncludeMutation({
+    nextConfig: params.nextConfig,
+    snapshot
+  })) await writeConfigFile(params.nextConfig, {
+    baseSnapshot: snapshot,
+    ...writeOptions,
+    ...params.writeOptions
+  });
+}
+`);
+
+    expect(result.status).toBe(0);
+    expect(patched).toContain('const stringBrace = "}";');
+    expect(patched).toContain("comment brace: }");
+    expect(patched).toContain("OPENSHELL_SANDBOX");
+  });
+
+  it("fails closed when replaceConfigFile lacks the expected write block", () => {
+    const { result, patched } = runPatch(`
+async function replaceConfigFile(params) {
+  await writeConfigFile(params.nextConfig, {});
+}
+`);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "tryWriteSingleTopLevelIncludeMutation/writeConfigFile pattern not found",
+    );
+    expect(patched).not.toContain("OPENSHELL_SANDBOX");
+  });
+});


### PR DESCRIPTION
## Summary
- replay #2696 by @BenediktSchackenberg: extract the OpenClaw `replaceConfigFile` patch into `scripts/rcf_patch.py` and stage that helper into the sandbox image/build context
- keep the helper scoped to `replaceConfigFile`, tolerant of whitespace drift, and tolerant of `snapshot` / `nextConfig` property-order drift
- keep the hadolint ignore attached to the long Dockerfile patching `RUN` block so the basic checks gate can pass

Fixes #2689.
Closes #2875.

## Credit
This is based on #2696 by @BenediktSchackenberg. The commit includes Benedikt as co-author:

`Co-authored-by: Benedikt Schackenberg <6381261+BenediktSchackenberg@users.noreply.github.com>`

## Validation
- `python3` fixture harness for `scripts/rcf_patch.py`: current order, reversed property order, unrelated-block scoping, and missing-target fail-close behavior
- `hadolint Dockerfile`
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run validate:configs`
- `cd nemoclaw && npm install && npm run build`
- `npx prek run hadolint --files Dockerfile --stage pre-push`
- `npx vitest run test/local-inference-setup.test.ts --testNamePattern "vLLM startup uses trusted loopback serving and waits for exact model readiness"`

Note: `npx prek run --all-files --stage pre-push` passed through lint/build/config and then hit one local temp-file failure in `test/local-inference-setup.test.ts`; the exact failing test passed when rerun by itself.

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved Docker build patching into a dedicated helper script for clearer build steps and maintainability.

* **Bug Fix**
  * Prevents build failures inside the read-only sandbox by catching and logging EACCES when the sandbox marker is present, allowing builds to proceed.

* **Chores**
  * Ensured the helper script is included in the staged build context for Docker.

* **Tests**
  * Added tests to validate the patching behavior and sandbox safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->