### PR TITLE
fix(cli): keep sandbox status on direct runtime path

### DIFF
--- a/src/lib/legacy-oclif-dispatch.test.ts
+++ b/src/lib/legacy-oclif-dispatch.test.ts
@@ -6,10 +6,11 @@ import { describe, expect, it } from "vitest";
 import { resolveSandboxOclifDispatch } from "./legacy-oclif-dispatch";
 
 describe("resolveSandboxOclifDispatch", () => {
-  it("keeps sandbox status on the direct runtime path", () => {
+  it("routes sandbox status through oclif", () => {
     expect(resolveSandboxOclifDispatch("alpha", "status", [])).toEqual({
-      kind: "legacy",
-      target: "status",
+      kind: "oclif",
+      commandId: "sandbox:status",
+      args: ["alpha"],
     });
   });
 

--- a/src/lib/legacy-oclif-dispatch.test.ts
+++ b/src/lib/legacy-oclif-dispatch.test.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { resolveSandboxOclifDispatch } from "./legacy-oclif-dispatch";
+
+describe("resolveSandboxOclifDispatch", () => {
+  it("keeps sandbox status on the direct runtime path", () => {
+    expect(resolveSandboxOclifDispatch("alpha", "status", [])).toEqual({
+      kind: "legacy",
+      target: "status",
+    });
+  });
+
+  it("keeps sandbox status help public", () => {
+    expect(resolveSandboxOclifDispatch("alpha", "status", ["--help"])).toEqual({
+      kind: "help",
+      usage: "status",
+    });
+  });
+});

--- a/src/lib/legacy-oclif-dispatch.ts
+++ b/src/lib/legacy-oclif-dispatch.ts
@@ -21,7 +21,7 @@ export type UsageErrorDispatch = {
 
 export type LegacyDispatch = {
   kind: "legacy";
-  target: "doctor" | "policy-add" | "skill" | "snapshot" | "status";
+  target: "doctor" | "policy-add" | "skill" | "snapshot";
 };
 
 export type UnknownSubcommandDispatch = {
@@ -107,7 +107,7 @@ export function resolveSandboxOclifDispatch(
       return { kind: "oclif", commandId: "sandbox:connect", args: [sandboxName, ...actionArgs] };
     case "status":
       if (hasHelpFlag(actionArgs)) return { kind: "help", usage: "status" };
-      return { kind: "legacy", target: "status" };
+      return { kind: "oclif", commandId: "sandbox:status", args: [sandboxName, ...actionArgs] };
     case "logs":
       if (hasHelpFlag(actionArgs)) return { kind: "help", usage: "logs [--follow]" };
       return { kind: "oclif", commandId: "sandbox:logs", args: [sandboxName, ...actionArgs] };

--- a/src/lib/legacy-oclif-dispatch.ts
+++ b/src/lib/legacy-oclif-dispatch.ts
@@ -21,7 +21,7 @@ export type UsageErrorDispatch = {
 
 export type LegacyDispatch = {
   kind: "legacy";
-  target: "doctor" | "policy-add" | "skill" | "snapshot";
+  target: "doctor" | "policy-add" | "skill" | "snapshot" | "status";
 };
 
 export type UnknownSubcommandDispatch = {
@@ -107,7 +107,7 @@ export function resolveSandboxOclifDispatch(
       return { kind: "oclif", commandId: "sandbox:connect", args: [sandboxName, ...actionArgs] };
     case "status":
       if (hasHelpFlag(actionArgs)) return { kind: "help", usage: "status" };
-      return { kind: "oclif", commandId: "sandbox:status", args: [sandboxName, ...actionArgs] };
+      return { kind: "legacy", target: "status" };
     case "logs":
       if (hasHelpFlag(actionArgs)) return { kind: "help", usage: "logs [--follow]" };
       return { kind: "oclif", commandId: "sandbox:logs", args: [sandboxName, ...actionArgs] };

--- a/src/lib/openshell.test.ts
+++ b/src/lib/openshell.test.ts
@@ -6,6 +6,7 @@ import type { SpawnSyncReturns } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 import {
+  captureOpenshellCommandAsync,
   captureOpenshellCommand,
   getInstalledOpenshellVersion,
   type OpenshellSpawnSync,
@@ -150,6 +151,26 @@ describe("openshell helpers", () => {
       error: expect.objectContaining({ message: expect.stringContaining("ETIMEDOUT") }),
       signal: "SIGTERM",
     });
+  });
+
+  it("bounds async captures and reports timeout metadata", async () => {
+    const script = [
+      "const { spawn } = require('node:child_process');",
+      "spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'inherit' });",
+      "setInterval(() => {}, 1000);",
+    ].join("");
+
+    const started = Date.now();
+    const result = await captureOpenshellCommandAsync(process.execPath, ["-e", script], {
+      ignoreError: true,
+      timeout: 50,
+      killGraceMs: 10,
+    });
+
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(result.status).toBeNull();
+    expect(result.error).toEqual(expect.objectContaining({ code: "ETIMEDOUT" }));
+    expect(result.signal).toBeTruthy();
   });
 
   it("uses the injected exit handler on failure", () => {

--- a/src/lib/openshell.ts
+++ b/src/lib/openshell.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  spawn,
   spawnSync,
+  type ChildProcess,
   type SpawnSyncOptions,
   type SpawnSyncOptionsWithStringEncoding,
   type SpawnSyncReturns,
@@ -13,6 +15,8 @@ export type OpenshellSpawnSync = (
   args: readonly string[],
   options: SpawnSyncOptionsWithStringEncoding,
 ) => SpawnSyncReturns<string>;
+
+export type OpenshellSpawn = typeof spawn;
 
 interface OpenshellSpawnOptions {
   cwd?: string;
@@ -29,6 +33,11 @@ export interface RunOpenshellOptions extends OpenshellSpawnOptions {
 }
 
 export interface CaptureOpenshellOptions extends OpenshellSpawnOptions {}
+
+export interface CaptureOpenshellAsyncOptions extends CaptureOpenshellOptions {
+  killGraceMs?: number;
+  spawnImpl?: OpenshellSpawn;
+}
 
 export interface CaptureOpenshellResult {
   status: number | null;
@@ -78,6 +87,31 @@ function handleSpawnError(
 
 function isIgnoredTimeout(error: Error, opts: OpenshellSpawnOptions): boolean {
   return opts.ignoreError === true && (error as NodeJS.ErrnoException).code === "ETIMEDOUT";
+}
+
+function timeoutError(binary: string, args: string[], timeout: number): NodeJS.ErrnoException {
+  const error = new Error(
+    `spawn ${binary} ${args.join(" ")} timed out after ${timeout} ms`,
+  ) as NodeJS.ErrnoException;
+  error.code = "ETIMEDOUT";
+  return error;
+}
+
+function signalProcessTree(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (!child.pid) return;
+  try {
+    if (process.platform !== "win32") {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 export function runOpenshellCommand(
@@ -136,6 +170,88 @@ export function captureOpenshellCommand(
     status: result.status ?? 1,
     output: `${result.stdout || ""}${opts.ignoreError ? "" : result.stderr || ""}`.trim(),
   };
+}
+
+export function captureOpenshellCommandAsync(
+  binary: string,
+  args: string[],
+  opts: CaptureOpenshellAsyncOptions = {},
+): Promise<CaptureOpenshellResult> {
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  return new Promise((resolve) => {
+    const child = spawnImpl(binary, args, {
+      cwd: opts.cwd,
+      env: { ...process.env, ...opts.env },
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    }) as ChildProcess;
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let timeout: NodeJS.Timeout | undefined;
+    let killTimer: NodeJS.Timeout | undefined;
+    let forceTimer: NodeJS.Timeout | undefined;
+    let capturedError: Error | undefined;
+
+    const clearTimers = () => {
+      if (timeout) clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      if (forceTimer) clearTimeout(forceTimer);
+    };
+
+    const buildOutput = () => `${stdout}${opts.ignoreError ? "" : stderr}`.trim();
+
+    const settle = (
+      status: number | null,
+      signal: NodeJS.Signals | null,
+      error?: Error,
+    ) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      resolve({
+        status: status ?? (timedOut ? null : 1),
+        output: buildOutput(),
+        ...(error ? { error } : {}),
+        signal,
+      });
+    };
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      capturedError = error;
+      settle(1, null, error);
+    });
+    child.on("close", (status, signal) => {
+      settle(status, signal, capturedError);
+    });
+
+    if (opts.timeout && opts.timeout > 0) {
+      timeout = setTimeout(() => {
+        timedOut = true;
+        capturedError = timeoutError(binary, args, opts.timeout as number);
+        child.unref();
+        signalProcessTree(child, "SIGTERM");
+        killTimer = setTimeout(() => {
+          signalProcessTree(child, "SIGKILL");
+          forceTimer = setTimeout(() => {
+            child.stdout?.destroy();
+            child.stderr?.destroy();
+            settle(null, "SIGKILL", capturedError);
+          }, opts.killGraceMs ?? 1000);
+        }, opts.killGraceMs ?? 1000);
+      }, opts.timeout);
+    }
+  });
 }
 
 export function getInstalledOpenshellVersion(

--- a/src/lib/sandbox-version.test.ts
+++ b/src/lib/sandbox-version.test.ts
@@ -155,6 +155,20 @@ describe("checkAgentVersion", () => {
     expect(result.isStale).toBe(false);
   });
 
+  it("can skip live probing when no cached version is available", () => {
+    registry.registerSandbox({ name: "test-sb", agent: null });
+    vi.mocked(captureOpenshellCommand).mockClear();
+    vi.mocked(spawnSync).mockClear();
+
+    const result = checkAgentVersion("test-sb", { skipProbe: true });
+
+    expect(result.detectionMethod).toBe("unavailable");
+    expect(result.sandboxVersion).toBeNull();
+    expect(result.isStale).toBe(false);
+    expect(captureOpenshellCommand).not.toHaveBeenCalled();
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
   it("force probe bypasses cached version", () => {
     registry.registerSandbox({
       name: "test-sb",

--- a/src/lib/sandbox-version.ts
+++ b/src/lib/sandbox-version.ts
@@ -87,7 +87,7 @@ export function probeAgentVersion(sandboxName: string): string | null {
  */
 export function checkAgentVersion(
   sandboxName: string,
-  opts?: { forceProbe?: boolean },
+  opts?: { forceProbe?: boolean; skipProbe?: boolean },
 ): VersionCheckResult {
   const agent = resolveAgentForSandbox(sandboxName);
   const expectedVersion = agent.expectedVersion;
@@ -107,6 +107,10 @@ export function checkAgentVersion(
       isStale,
       detectionMethod: "registry",
     };
+  }
+
+  if (opts?.skipProbe && !opts.forceProbe) {
+    return { sandboxVersion: null, expectedVersion, isStale: false, detectionMethod: "unavailable" };
   }
 
   // Slow path: SSH exec into sandbox

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -4864,9 +4864,6 @@ async function runDispatchResult(
         throw new Error(`Missing sandbox name for legacy dispatch target ${result.target}`);
       }
       switch (result.target) {
-        case "status":
-          await sandboxStatus(sandboxName);
-          return;
         case "doctor":
           await sandboxDoctor(sandboxName, actionArgs);
           return;

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -60,6 +60,7 @@ const { parseLiveSandboxNames } = require("./lib/runtime-recovery");
 const { NOTICE_ACCEPT_ENV, NOTICE_ACCEPT_FLAG } = require("./lib/usage-notice");
 const { runDeprecatedOnboardAliasCommand, runOnboardCommand } = require("./lib/onboard-command");
 const {
+  captureOpenshellCommandAsync,
   captureOpenshellCommand,
   getInstalledOpenshellVersion,
   runOpenshellCommand,
@@ -198,6 +199,26 @@ function captureOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   });
 }
 
+function getStatusProbeTimeoutMs(): number {
+  const raw = process.env.NEMOCLAW_STATUS_PROBE_TIMEOUT_MS;
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : OPENSHELL_PROBE_TIMEOUT_MS;
+}
+
+function captureOpenshellForStatus(args: CommandArgs, opts: RunnerOptions = {}) {
+  return captureOpenshellCommandAsync(getOpenshellBinary(), args, {
+    cwd: ROOT,
+    env: opts.env,
+    ignoreError: opts.ignoreError,
+    timeout: opts.timeout ?? getStatusProbeTimeoutMs(),
+    killGraceMs: 1000,
+  });
+}
+
+function isCommandTimeout(result: { error?: Error }) {
+  return (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
+}
+
 function cleanupGatewayAfterLastSandbox() {
   runOpenshell(["forward", "stop", DASHBOARD_FORWARD_PORT], {
     ignoreError: true,
@@ -328,6 +349,28 @@ function executeSandboxExecCommand(
   }
 }
 
+async function executeSandboxExecCommandForStatus(
+  sandboxName: string,
+  command: string,
+): Promise<SandboxCommandResult | null> {
+  const markedCommand = `printf '%s\\n' '${SANDBOX_EXEC_STARTED_MARKER}'; ${command}`;
+  const result = await captureOpenshellForStatus(
+    ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", markedCommand],
+    { ignoreError: true },
+  );
+  if (isCommandTimeout(result) || result.error) return null;
+  const stdout = (result.output || "").trim();
+  const stdoutLines = stdout.split(/\r?\n/);
+  const markerIndex = stdoutLines.indexOf(SANDBOX_EXEC_STARTED_MARKER);
+  if (markerIndex === -1) return null;
+  const commandStdoutLines = stdoutLines.slice(markerIndex + 1);
+  return {
+    status: result.status ?? 1,
+    stdout: commandStdoutLines.join("\n").trim(),
+    stderr: "",
+  };
+}
+
 function parseSandboxGatewayProbe(result: SandboxCommandResult | null): boolean | null {
   if (!result) return null;
   if (result.stdout === "RUNNING") return true;
@@ -348,6 +391,13 @@ function isSandboxGatewayRunning(sandboxName: string): boolean | null {
   const execProbe = parseSandboxGatewayProbe(executeSandboxExecCommand(sandboxName, command));
   if (execProbe !== null) return execProbe;
   return parseSandboxGatewayProbe(executeSandboxCommand(sandboxName, command));
+}
+
+async function isSandboxGatewayRunningForStatus(sandboxName: string): Promise<boolean | null> {
+  const agent = agentRuntime.getSessionAgent(sandboxName);
+  const probeUrl = agentRuntime.getHealthProbeUrl(agent);
+  const command = `curl -sf --max-time 3 ${shellQuote(probeUrl)} > /dev/null 2>&1 && echo RUNNING || echo STOPPED`;
+  return parseSandboxGatewayProbe(await executeSandboxExecCommandForStatus(sandboxName, command));
 }
 
 /**
@@ -784,6 +834,39 @@ async function recoverNamedGatewayRuntime() {
   return { recovered: false, before, after, attempted: true };
 }
 
+function mergeLivePolicyIntoSandboxOutput(output: string, livePolicyOutput: string): string {
+  const rawLines = String(output).split("\n");
+  const cleanLines = stripAnsi(String(output)).split("\n");
+  const policyLineIdx = cleanLines.findIndex((l: string) => l.trim() === "Policy:");
+  if (policyLineIdx === -1) return output;
+
+  // Keep everything before Policy (Sandbox info with colors),
+  // plus the original colored "Policy:" header line.
+  const before = rawLines.slice(0, policyLineIdx + 1).join("\n");
+  // Extract YAML content from policy get --full (skip metadata header before "---").
+  // Use a regex to handle varying line endings (\n, \r\n) and optional trailing whitespace.
+  const delimIdx = livePolicyOutput.search(/^---\s*$/m);
+  const yamlPart =
+    delimIdx !== -1
+      ? livePolicyOutput.slice(delimIdx).replace(/^---\s*[\r\n]+/, "")
+      : livePolicyOutput;
+  // Guard: only replace if the extracted content looks like policy YAML
+  // (starts with a YAML key like "version:" or "network_policies:").
+  // Avoids replacing with warnings or status text from unexpected output.
+  const trimmedYaml = yamlPart.trim();
+  const looksLikeError = /^(error|failed|invalid|warning|status)\b/i.test(trimmedYaml);
+  if (!trimmedYaml || looksLikeError || !/^[a-z_][a-z0-9_]*\s*:/m.test(trimmedYaml)) {
+    return output;
+  }
+
+  // Add 2-space indent to match the original sandbox get output format.
+  const indented = trimmedYaml
+    .split("\n")
+    .map((l: string) => (l ? "  " + l : l))
+    .join("\n");
+  return before + "\n\n" + indented + "\n";
+}
+
 /** Query sandbox presence and return its output with the live enforced policy. */
 function getSandboxGatewayState(sandboxName: string) {
   const result = captureOpenshell(["sandbox", "get", sandboxName], {
@@ -801,34 +884,7 @@ function getSandboxGatewayState(sandboxName: string) {
       timeout: OPENSHELL_PROBE_TIMEOUT_MS,
     });
     if (livePolicy.status === 0 && livePolicy.output.trim()) {
-      const rawLines = String(output).split("\n");
-      const cleanLines = stripAnsi(String(output)).split("\n");
-      const policyLineIdx = cleanLines.findIndex((l: string) => l.trim() === "Policy:");
-      if (policyLineIdx !== -1) {
-        // Keep everything before Policy (Sandbox info with colors),
-        // plus the original colored "Policy:" header line.
-        const before = rawLines.slice(0, policyLineIdx + 1).join("\n");
-        // Extract YAML content from policy get --full (skip metadata header before "---").
-        // Use a regex to handle varying line endings (\n, \r\n) and optional trailing whitespace.
-        const delimIdx = livePolicy.output.search(/^---\s*$/m);
-        const yamlPart =
-          delimIdx !== -1
-            ? livePolicy.output.slice(delimIdx).replace(/^---\s*[\r\n]+/, "")
-            : livePolicy.output;
-        // Guard: only replace if the extracted content looks like policy YAML
-        // (starts with a YAML key like "version:" or "network_policies:").
-        // Avoids replacing with warnings or status text from unexpected output.
-        const trimmedYaml = yamlPart.trim();
-        const looksLikeError = /^(error|failed|invalid|warning|status)\b/i.test(trimmedYaml);
-        if (trimmedYaml && !looksLikeError && /^[a-z_][a-z0-9_]*\s*:/m.test(trimmedYaml)) {
-          // Add 2-space indent to match the original sandbox get output format.
-          const indented = trimmedYaml
-            .split("\n")
-            .map((l: string) => (l ? "  " + l : l))
-            .join("\n");
-          output = before + "\n\n" + indented + "\n";
-        }
-      }
+      output = mergeLivePolicyIntoSandboxOutput(output, livePolicy.output);
     }
     return { state: "present", output };
   }
@@ -844,6 +900,47 @@ function getSandboxGatewayState(sandboxName: string) {
   }
   return { state: "unknown_error", output };
 }
+
+async function getSandboxGatewayStateForStatus(sandboxName: string) {
+  const timeoutMs = getStatusProbeTimeoutMs();
+  const result = await captureOpenshellForStatus(["sandbox", "get", sandboxName], {
+    timeout: timeoutMs,
+  });
+  let output = result.output;
+  if (isCommandTimeout(result)) {
+    return {
+      state: "status_probe_timeout",
+      output: `  Live sandbox status probe timed out after ${Math.ceil(timeoutMs / 1000)}s. Local registry data is shown above.`,
+    };
+  }
+  if (result.status === 0) {
+    const livePolicy = await captureOpenshellForStatus(["policy", "get", "--full", sandboxName], {
+      ignoreError: true,
+      timeout: timeoutMs,
+    });
+    if (!isCommandTimeout(livePolicy) && livePolicy.status === 0 && livePolicy.output.trim()) {
+      output = mergeLivePolicyIntoSandboxOutput(output, livePolicy.output);
+    }
+    return { state: "present", output };
+  }
+  if (/\bNotFound\b|\bNot Found\b|sandbox not found/i.test(output)) {
+    return { state: "missing", output };
+  }
+  if (
+    /transport error|Connection refused|handshake verification failed|Missing gateway auth token|device identity required/i.test(
+      output,
+    )
+  ) {
+    return { state: "gateway_error", output };
+  }
+  return { state: "unknown_error", output };
+}
+
+type SandboxGatewayStateLookup = (
+  sandboxName: string,
+) =>
+  | ReturnType<typeof getSandboxGatewayState>
+  | ReturnType<typeof getSandboxGatewayStateForStatus>;
 
 /**
  * Reconcile a NotFound sandbox lookup against the named NemoClaw gateway state.
@@ -961,8 +1058,12 @@ function printGatewayLifecycleHint(output = "", sandboxName = "", writer = conso
   }
 }
 
-async function getReconciledSandboxGatewayState(sandboxName: string) {
-  let lookup = getSandboxGatewayState(sandboxName);
+async function getReconciledSandboxGatewayState(
+  sandboxName: string,
+  opts: { getState?: SandboxGatewayStateLookup } = {},
+) {
+  const getState = opts.getState ?? getSandboxGatewayState;
+  let lookup = await getState(sandboxName);
   if (lookup.state === "present") {
     return lookup;
   }
@@ -973,7 +1074,7 @@ async function getReconciledSandboxGatewayState(sandboxName: string) {
   if (lookup.state === "gateway_error") {
     const recovery = await recoverNamedGatewayRuntime();
     if (recovery.recovered) {
-      const retried = getSandboxGatewayState(sandboxName);
+      const retried = await getState(sandboxName);
       if (retried.state === "present" || retried.state === "missing") {
         return { ...retried, recoveredGateway: true, recoveryVia: recovery.via || null };
       }
@@ -2101,11 +2202,11 @@ async function sandboxDoctor(sandboxName: string, args: string[] = []): Promise<
 // eslint-disable-next-line complexity
 async function sandboxStatus(sandboxName: string) {
   const sb = registry.getSandbox(sandboxName);
+  const liveResult = await captureOpenshellForStatus(["inference", "get"], {
+    ignoreError: true,
+  });
   const live = parseGatewayInference(
-    captureOpenshell(["inference", "get"], {
-      ignoreError: true,
-      timeout: OPENSHELL_PROBE_TIMEOUT_MS,
-    }).output,
+    isCommandTimeout(liveResult) ? "" : liveResult.output,
   );
   const currentModel = (live && live.model) || (sb && sb.model) || "unknown";
   const currentProvider = (live && live.provider) || (sb && sb.provider) || "unknown";
@@ -2154,7 +2255,7 @@ async function sandboxStatus(sandboxName: string) {
 
     // Agent version check
     try {
-      const versionCheck = sandboxVersion.checkAgentVersion(sandboxName);
+      const versionCheck = sandboxVersion.checkAgentVersion(sandboxName, { skipProbe: true });
       const agent = agentRuntime.getSessionAgent(sandboxName);
       const agentName = agentRuntime.getAgentDisplayName(agent);
       if (versionCheck.sandboxVersion) {
@@ -2169,7 +2270,9 @@ async function sandboxStatus(sandboxName: string) {
     }
   }
 
-  const lookup = await getReconciledSandboxGatewayState(sandboxName);
+  const lookup = await getReconciledSandboxGatewayState(sandboxName, {
+    getState: getSandboxGatewayStateForStatus,
+  });
   if (lookup.state === "present") {
     console.log("");
     if ("recoveredGateway" in lookup && lookup.recoveredGateway) {
@@ -2276,14 +2379,12 @@ async function sandboxStatus(sandboxName: string) {
 
   // OpenClaw process health inside the sandbox
   if (lookup.state === "present") {
-    const processCheck = checkAndRecoverSandboxProcesses(sandboxName, { quiet: true });
-    if (processCheck.checked) {
+    const running = await isSandboxGatewayRunningForStatus(sandboxName);
+    if (running !== null) {
       const _sa = agentRuntime.getSessionAgent(sandboxName);
       const _saName = agentRuntime.getAgentDisplayName(_sa);
-      if (processCheck.wasRunning) {
+      if (running) {
         console.log(`    ${_saName}: ${G}running${R}`);
-      } else if (processCheck.recovered) {
-        console.log(`    ${_saName}: ${G}recovered${R} (gateway restarted after sandbox restart)`);
       } else {
         console.log(`    ${_saName}: ${_RD}not running${R}`);
         console.log("");

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -4763,6 +4763,9 @@ async function runDispatchResult(
         throw new Error(`Missing sandbox name for legacy dispatch target ${result.target}`);
       }
       switch (result.target) {
+        case "status":
+          await sandboxStatus(sandboxName);
+          return;
         case "doctor":
           await sandboxDoctor(sandboxName, actionArgs);
           return;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3450,6 +3450,62 @@ describe("CLI dispatch", () => {
     testTimeout(10_000),
   );
 
+  it(
+    "keeps status bounded when a live sandbox probe leaves child pipes open",
+    () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-status-timeout-"));
+      const localBin = path.join(home, "bin");
+      const registryDir = path.join(home, ".nemoclaw");
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.mkdirSync(registryDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(registryDir, "sandboxes.json"),
+        JSON.stringify({
+          sandboxes: {
+            alpha: {
+              name: "alpha",
+              model: "test-model",
+              provider: "nvidia-prod",
+              gpuEnabled: false,
+              policies: [],
+            },
+          },
+          defaultSandbox: "alpha",
+        }),
+        { mode: 0o600 },
+      );
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/usr/bin/env bash",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "alpha" ]; then',
+          `  ${JSON.stringify(process.execPath)} -e "setInterval(() => {}, 1000)" &`,
+          "  wait",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const started = Date.now();
+      const r = runWithEnv(
+        "alpha status",
+        {
+          HOME: home,
+          PATH: `${localBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_STATUS_PROBE_TIMEOUT_MS: "100",
+        },
+        10000,
+      );
+
+      expect(Date.now() - started).toBeLessThan(7000);
+      expect(r.code).toBe(0);
+      expect(r.out).toContain("Model:    test-model");
+      expect(r.out).toContain("Live sandbox status probe timed out");
+    },
+    testTimeout(10_000),
+  );
+
   it("recovers status after gateway runtime is reattached", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-recover-status-"));
     const localBin = path.join(home, "bin");


### PR DESCRIPTION
## Summary
- route `nemoclaw <sandbox> status` through the Oclif `sandbox:status` command path
- remove sandbox status from the legacy dispatch target set
- harden `nemoclaw <sandbox> status` so live OpenShell probes cannot hang the command when descendant `openshell`/`ssh` processes keep captured pipes open
- keep status useful from local registry data when a live sandbox status probe times out, and avoid live SSH agent-version probing from the informational status path
- keep `status --help` on the public sandbox-scoped usage path
- add regression coverage for the child-pipe hang shape that reproduced in `diagnostics-e2e`

## Evidence
- `diagnostics-e2e` timed out on main run 25244372371 at `a8dfa272` after `TC-DIAG-05: openclaw.json readable inside sandbox`, hanging at `Checking nemoclaw status from host...` until the 45-minute job timeout
- the same timeout repeated on main run 25245181101 at `32d3ab3e`, again hanging at `Checking nemoclaw status from host...` with orphan `openshell`/`ssh` children killed by job cleanup
- focused diagnostics-only rerun 25252679721 at `d73371da` reproduced the same failure: `TC-DIAG-05` passed the in-sandbox config read at 13:27:44, then hung at `Checking nemoclaw status from host...` until GitHub cancelled at 13:56:55; cleanup killed the outer `timeout`/`bash` plus two `openshell`/`ssh` pairs
- first PR rerun 25253547462 on `84b4955c` confirmed that routing alone was insufficient: it hit the same `Checking nemoclaw status from host...` hang and the same orphan `openshell`/`ssh` cleanup
- fixed PR rerun 25254068156 on `2956cd0e` passed `diagnostics-e2e`; TC-DIAG-05 moved from `Checking nemoclaw status from host...` at 14:41:31Z to `PASS TC-DIAG-05: nemoclaw status shows Model field` at 14:41:32Z, and the job ended `PASS: 8` / `FAIL: 0`
- Oclif-routing PR rerun 25254765479 on `3224a5c5` passed `diagnostics-e2e`; TC-DIAG-05 moved from `Checking nemoclaw status from host...` at 15:16:11Z to `PASS TC-DIAG-05: nemoclaw status shows Model field` at 15:16:11Z, and the job ended `PASS: 8` / `FAIL: 0`
- last observed passing diagnostics job before the regression was run 25204743855 at `b83ffe20`, where the same status check completed in about 6 seconds
- the failure is a NemoClaw status-path regression: our status command allowed synchronous child-process probes to leave descendant processes holding captured pipes open past the nominal timeout

## Oclif conformance
- `resolveSandboxOclifDispatch("<name>", "status", [])` now returns `{ kind: "oclif", commandId: "sandbox:status", args: ["<name>"] }`
- `LegacyDispatch` no longer includes `status`
- `runDispatchResult()` no longer has a legacy `status` branch
- `SandboxStatusCommand` remains the Oclif command surface and invokes the current status runtime implementation through the existing runtime bridge pattern used by migrated commands in this repo
- public help stays stable: `nemoclaw <name> status --help` still renders `<name> status` rather than exposing the internal `sandbox:status` id

## Validation
- `npm test -- src/lib/openshell.test.ts src/lib/sandbox-version.test.ts src/lib/legacy-oclif-dispatch.test.ts`
- `npm run build:cli`
- `npm test -- test/cli.test.ts -t "keeps status bounded|keeps registry entries when status hits|recovers status after gateway runtime|status --help|status shows|sandbox inspection help"`
- `npm run typecheck:cli`
- `npm run lint -- src/lib/legacy-oclif-dispatch.ts src/lib/legacy-oclif-dispatch.test.ts src/nemoclaw.ts`
- `npm run format:check -- src/lib/legacy-oclif-dispatch.ts src/lib/legacy-oclif-dispatch.test.ts src/nemoclaw.ts`
- `git diff --check`
- focused `diagnostics-e2e` run 25254068156 on `2956cd0e`: pass
- focused `diagnostics-e2e` run 25254765479 on Oclif-routing SHA `3224a5c5`: pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added async command execution with timeout support for sandboxes.

* **Improvements**
  * Sandbox status checks now use a dedicated probe path with configurable timeouts to prevent hanging.
  * Status operations gracefully handle long-running background processes.

* **Tests**
  * Added test coverage for async operations and status probe timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->