### PR TITLE
fix: normalize OpenClaw config generator permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -230,7 +230,9 @@ COPY scripts/nemoclaw-start.sh /usr/local/bin/nemoclaw-start
 COPY nemoclaw-blueprint/scripts/ws-proxy-fix.js /usr/local/lib/nemoclaw/ws-proxy-fix.js
 COPY scripts/codex-acp-wrapper.sh /usr/local/bin/nemoclaw-codex-acp
 COPY scripts/generate-openclaw-config.py /usr/local/lib/nemoclaw/generate-openclaw-config.py
-RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-codex-acp /usr/local/lib/nemoclaw/sandbox-init.sh \
+RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-codex-acp \
+        /usr/local/lib/nemoclaw/sandbox-init.sh \
+        /usr/local/lib/nemoclaw/generate-openclaw-config.py \
     && chmod 644 /usr/local/lib/nemoclaw/ws-proxy-fix.js
 
 # Build args for config that varies per deployment.

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -202,6 +202,52 @@ describe("sandbox provisioning: procps debug tools (#2343)", () => {
   });
 });
 
+describe("sandbox provisioning: copied OpenClaw helper permissions (#2861)", () => {
+  it("normalizes the config generator mode after Docker COPY preserves a restrictive source mode", () => {
+    const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-helper-mode-"));
+    const localBin = path.join(tmp, "usr", "local", "bin");
+    const localLib = path.join(tmp, "usr", "local", "lib", "nemoclaw");
+    const files = [
+      path.join(localBin, "nemoclaw-start"),
+      path.join(localBin, "nemoclaw-codex-acp"),
+      path.join(localLib, "sandbox-init.sh"),
+      path.join(localLib, "generate-openclaw-config.py"),
+      path.join(localLib, "ws-proxy-fix.js"),
+    ];
+
+    try {
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.mkdirSync(localLib, { recursive: true });
+      for (const file of files) {
+        fs.writeFileSync(file, "# fixture\n", { mode: 0o600 });
+        fs.chmodSync(file, 0o600);
+      }
+
+      const command = dockerRunCommandBetween(
+        dockerfile,
+        "# Copy startup script and shared sandbox initialisation library",
+        "# Build args for config that varies per deployment.",
+      )
+        .replaceAll("/usr/local/bin", localBin)
+        .replaceAll("/usr/local/lib/nemoclaw", localLib);
+      const { result } = runLoggedDockerShell(command, tmp);
+
+      expect(result.status, result.stderr).toBe(0);
+      const generatorMode = (
+        fs.statSync(path.join(localLib, "generate-openclaw-config.py")).mode & 0o777
+      ).toString(8);
+      const wsProxyMode = (fs.statSync(path.join(localLib, "ws-proxy-fix.js")).mode & 0o777).toString(
+        8,
+      );
+      expect(generatorMode).toBe("755");
+      expect(wsProxyMode).toBe("644");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("Hermes sandbox provisioning", () => {
   function runHermesPathValidation(pathEntriesBeforeManifest: string[] = []) {
     const dockerfile = fs.readFileSync(HERMES_DOCKERFILE, "utf-8");


### PR DESCRIPTION
## Summary
- normalize `/usr/local/lib/nemoclaw/generate-openclaw-config.py` permissions in the Dockerfile after COPY
- add a regression guard for restrictive source modes preserved by Docker COPY

Fixes #2861.

## Evidence
- Live `main`, `v0.0.33`, and `v0.0.32` all have `scripts/generate-openclaw-config.py` at git mode `100755`.
- A focused Docker reproduction with the source file forced to `0600` preserves that mode as `root:root 600` in the image and reproduces `python3: can't open file ... [Errno 13] Permission denied` after switching to `USER sandbox`.
- With this patch, the copied file is normalized to `755` before `USER sandbox`, so the Python generator remains readable/executable regardless of host/build-context source mode.

## Validation
- `npx vitest run test/sandbox-provisioning.test.ts test/sandbox-build-context.test.ts test/security-c2-dockerfile-injection.test.ts`
- Focused Docker reproduction with source `generate-openclaw-config.py` set to `0600`: pre-fix reproduces permission denied, post-fix reports `root:root 755` and sandbox user can read it.
- Full `nightly-e2e.yaml` workflow dispatched on `codex/fix-2861-openclaw-config-mode`: https://github.com/NVIDIA/NemoClaw/actions/runs/25263936100

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>