### PR TITLE
fix(installer): surface current-shell PATH readiness

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -408,10 +408,37 @@ print_banner() {
   printf "\n"
 }
 
+print_cli_path_refresh_actions() {
+  local shell_name
+  shell_name="$(basename "${SHELL:-bash}")"
+
+  if [[ -z "$NEMOCLAW_RECOVERY_PROFILE" ]]; then
+    NEMOCLAW_RECOVERY_PROFILE="$(detect_shell_profile)"
+  fi
+
+  if [[ -n "$NEMOCLAW_RECOVERY_PROFILE" ]]; then
+    printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$NEMOCLAW_RECOVERY_PROFILE"
+  fi
+  if [[ -n "$NEMOCLAW_RECOVERY_EXPORT_DIR" ]]; then
+    case "$shell_name" in
+      fish)
+        printf "  %s$%s set -gx PATH \"%s\" \$PATH\n" "$C_GREEN" "$C_RESET" "$NEMOCLAW_RECOVERY_EXPORT_DIR"
+        ;;
+      tcsh | csh)
+        printf "  %s$%s setenv PATH \"%s:\${PATH}\"\n" "$C_GREEN" "$C_RESET" "$NEMOCLAW_RECOVERY_EXPORT_DIR"
+        ;;
+      *)
+        printf "  %s$%s export PATH=\"%s:\$PATH\"\n" "$C_GREEN" "$C_RESET" "$NEMOCLAW_RECOVERY_EXPORT_DIR"
+        ;;
+    esac
+  fi
+  printf "  ${C_DIM}Or open a new terminal after updating your shell profile.${C_RESET}\n"
+}
+
 print_done() {
   local elapsed=$((SECONDS - _INSTALL_START))
-  local _needs_reload=false
-  needs_shell_reload && _needs_reload=true
+  local _needs_cli_refresh=false
+  needs_shell_reload && _needs_cli_refresh=true
 
   info "=== Installation complete ==="
   printf "\n"
@@ -421,15 +448,22 @@ print_done() {
     local sandbox_name agent_name
     sandbox_name="$(resolve_default_sandbox_name)"
     agent_name="$(resolve_onboarded_agent)"
-    if [[ "$agent_name" == "openclaw" || -z "$agent_name" ]]; then
-      printf "  ${C_GREEN}Your OpenClaw Sandbox is live.${C_RESET}\n"
+    if [[ "$_needs_cli_refresh" == true ]]; then
+      printf "  ${C_YELLOW}%s installed, but this shell needs PATH refresh before '%s' will run.${C_RESET}\n" "$_CLI_DISPLAY" "$_CLI_BIN"
+      printf "  ${C_DIM}Onboarding completed; refresh PATH before using the CLI from this terminal.${C_RESET}\n"
     else
-      printf "  ${C_GREEN}Your %s Sandbox is live.${C_RESET}\n" "$(agent_display_name "$agent_name")"
+      if [[ "$agent_name" == "openclaw" || -z "$agent_name" ]]; then
+        printf "  ${C_GREEN}Your OpenClaw Sandbox is live.${C_RESET}\n"
+      else
+        printf "  ${C_GREEN}Your %s Sandbox is live.${C_RESET}\n" "$(agent_display_name "$agent_name")"
+      fi
+      printf "  ${C_DIM}Sandbox in, break things, and tell us what you find.${C_RESET}\n"
     fi
-    printf "  ${C_DIM}Sandbox in, break things, and tell us what you find.${C_RESET}\n"
     printf "\n"
     printf "  ${C_GREEN}Next:${C_RESET}\n"
-    if [[ "$_needs_reload" == true ]]; then
+    if [[ "$_needs_cli_refresh" == true ]]; then
+      print_cli_path_refresh_actions
+    else
       printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$(detect_shell_profile)"
     fi
     printf "  %s$%s %s %s connect\n" "$C_GREEN" "$C_RESET" "$_CLI_BIN" "$sandbox_name"
@@ -447,25 +481,26 @@ print_done() {
     esac
     printf "  %ssandbox@%s$%s %s\n" "$C_GREEN" "$sandbox_name" "$C_RESET" "$agent_cmd"
   elif [[ "$NEMOCLAW_READY_NOW" == true ]]; then
-    printf "  ${C_GREEN}%s CLI is installed.${C_RESET}\n" "$_CLI_DISPLAY"
+    if [[ "$_needs_cli_refresh" == true ]]; then
+      printf "  ${C_YELLOW}%s CLI is installed, but this shell needs PATH refresh before '%s' will run.${C_RESET}\n" "$_CLI_DISPLAY" "$_CLI_BIN"
+    else
+      printf "  ${C_GREEN}%s CLI is installed.${C_RESET}\n" "$_CLI_DISPLAY"
+    fi
     printf "  ${C_DIM}Onboarding has not run yet.${C_RESET}\n"
     printf "\n"
     printf "  ${C_GREEN}Next:${C_RESET}\n"
-    if [[ "$_needs_reload" == true ]]; then
+    if [[ "$_needs_cli_refresh" == true ]]; then
+      print_cli_path_refresh_actions
+    else
       printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$(detect_shell_profile)"
     fi
     printf "  %s$%s %s onboard\n" "$C_GREEN" "$C_RESET" "$_CLI_BIN"
   else
-    printf "  ${C_GREEN}%s CLI is installed.${C_RESET}\n" "$_CLI_DISPLAY"
-    printf "  ${C_DIM}Onboarding did not run because this shell cannot resolve '%s' yet.${C_RESET}\n" "$_CLI_BIN"
+    printf "  ${C_YELLOW}%s CLI is installed, but this shell cannot resolve '%s' yet.${C_RESET}\n" "$_CLI_DISPLAY" "$_CLI_BIN"
+    printf "  ${C_DIM}Onboarding did not run.${C_RESET}\n"
     printf "\n"
     printf "  ${C_GREEN}Next:${C_RESET}\n"
-    if [[ -n "$NEMOCLAW_RECOVERY_EXPORT_DIR" ]]; then
-      printf "  %s$%s export PATH=\"%s:\$PATH\"\n" "$C_GREEN" "$C_RESET" "$NEMOCLAW_RECOVERY_EXPORT_DIR"
-    fi
-    if [[ -n "$NEMOCLAW_RECOVERY_PROFILE" ]]; then
-      printf "  %s$%s source %s\n" "$C_GREEN" "$C_RESET" "$NEMOCLAW_RECOVERY_PROFILE"
-    fi
+    print_cli_path_refresh_actions
     printf "  %s$%s %s onboard\n" "$C_GREEN" "$C_RESET" "$_CLI_BIN"
   fi
   printf "\n"
@@ -626,6 +661,8 @@ NEMOCLAW_SHIM_DIR="${HOME}/.local/bin"
 NEMOCLAW_READY_NOW=false
 NEMOCLAW_RECOVERY_PROFILE=""
 NEMOCLAW_RECOVERY_EXPORT_DIR=""
+NEMOCLAW_CURRENT_SHELL_NEEDS_PATH_REFRESH=false
+NEMOCLAW_INSTALLER_INITIAL_PATH="${PATH:-}"
 NEMOCLAW_SOURCE_ROOT="$(resolve_repo_root)"
 ONBOARD_RAN=false
 
@@ -699,6 +736,48 @@ detect_shell_profile() {
       ;;
   esac
   printf "%s" "$profile"
+}
+
+path_contains_dir() {
+  local path_list="${1:-}" dir="${2:-}"
+  [[ -n "$path_list" && -n "$dir" ]] || return 1
+  [[ ":$path_list:" == *":$dir:"* ]]
+}
+
+record_cli_resolution_state() {
+  local resolved_cli="${1:-}" npm_bin="${2:-}" candidate_dir preferred_dir=""
+  local -a candidate_dirs=()
+
+  if [[ "$resolved_cli" == */* ]]; then
+    candidate_dirs+=("$(dirname "$resolved_cli")")
+  fi
+  if [[ -x "$NEMOCLAW_SHIM_DIR/$_CLI_BIN" ]]; then
+    candidate_dirs+=("$NEMOCLAW_SHIM_DIR")
+  fi
+  if [[ -n "$npm_bin" && -x "$npm_bin/$_CLI_BIN" ]]; then
+    candidate_dirs+=("$npm_bin")
+  fi
+
+  for candidate_dir in "${candidate_dirs[@]}"; do
+    if path_contains_dir "$NEMOCLAW_INSTALLER_INITIAL_PATH" "$candidate_dir"; then
+      NEMOCLAW_CURRENT_SHELL_NEEDS_PATH_REFRESH=false
+      return 0
+    fi
+  done
+
+  if [[ -x "$NEMOCLAW_SHIM_DIR/$_CLI_BIN" ]]; then
+    preferred_dir="$NEMOCLAW_SHIM_DIR"
+  elif [[ "$resolved_cli" == */* ]]; then
+    preferred_dir="$(dirname "$resolved_cli")"
+  elif [[ -n "$npm_bin" && -x "$npm_bin/$_CLI_BIN" ]]; then
+    preferred_dir="$npm_bin"
+  fi
+
+  if [[ -n "$preferred_dir" ]]; then
+    NEMOCLAW_CURRENT_SHELL_NEEDS_PATH_REFRESH=true
+    NEMOCLAW_RECOVERY_EXPORT_DIR="${NEMOCLAW_RECOVERY_EXPORT_DIR:-$preferred_dir}"
+    NEMOCLAW_RECOVERY_PROFILE="${NEMOCLAW_RECOVERY_PROFILE:-$(detect_shell_profile)}"
+  fi
 }
 
 # Check whether npm link can write to the active prefix targets.
@@ -805,16 +884,12 @@ ensure_nemoclaw_shim() {
   return "$status"
 }
 
-# Detect whether the parent shell likely needs a reload after install.
-# When running via `curl | bash`, the installer executes in a subprocess.
-# Even when the bin directory is already in PATH, the parent shell may have
-# stale bash hash-table entries pointing to a previously deleted binary
-# (e.g. upgrade/reinstall after `rm $(which nemoclaw)`).  Sourcing the
-# shell profile reassigns PATH which clears the hash table, so we always
-# recommend it when the installer verified nemoclaw in the subprocess.
+# Detect whether the caller's shell needs a PATH refresh after install.
+# install.sh can export PATH for its own subprocess, but that cannot mutate the
+# terminal that launched it. If the resolved CLI directory was not present at
+# installer start, make the final output say so explicitly.
 needs_shell_reload() {
-  [[ "$NEMOCLAW_READY_NOW" != true ]] && return 1
-  return 0
+  [[ "$NEMOCLAW_CURRENT_SHELL_NEEDS_PATH_REFRESH" == true ]]
 }
 
 # Add ~/.local/bin (and for fish, the nvm node bin) to the user's shell
@@ -1367,10 +1442,14 @@ is_real_nemoclaw_cli() {
 
 verify_nemoclaw() {
   if command_exists "$_CLI_BIN"; then
-    if is_real_nemoclaw_cli "$(command -v "$_CLI_BIN")" "$_CLI_BIN"; then
+    local resolved_cli npm_bin
+    resolved_cli="$(command -v "$_CLI_BIN")"
+    if is_real_nemoclaw_cli "$resolved_cli" "$_CLI_BIN"; then
       NEMOCLAW_READY_NOW=true
+      npm_bin="$(resolve_npm_bin)" || true
       ensure_nemoclaw_shim || true
-      info "Verified: ${_CLI_BIN} is available at $(command -v "$_CLI_BIN")"
+      record_cli_resolution_state "$resolved_cli" "$npm_bin"
+      info "Verified: ${_CLI_BIN} is available at $resolved_cli"
       return 0
     else
       warn "Found ${_CLI_BIN} at $(command -v "$_CLI_BIN") but it is not the real ${_CLI_DISPLAY} CLI."
@@ -1386,8 +1465,11 @@ verify_nemoclaw() {
     if is_real_nemoclaw_cli "$npm_bin/$_CLI_BIN" "$_CLI_BIN"; then
       ensure_nemoclaw_shim || true
       if command_exists "$_CLI_BIN"; then
+        local resolved_cli
+        resolved_cli="$(command -v "$_CLI_BIN")"
         NEMOCLAW_READY_NOW=true
-        info "Verified: ${_CLI_BIN} is available at $(command -v "$_CLI_BIN")"
+        record_cli_resolution_state "$resolved_cli" "$npm_bin"
+        info "Verified: ${_CLI_BIN} is available at $resolved_cli"
         return 0
       fi
 
@@ -1592,40 +1674,6 @@ run_onboard() {
   fi
 }
 
-# 6. Post-install message (printed last — after onboarding — so PATH hints stay visible)
-# ---------------------------------------------------------------------------
-post_install_message() {
-  if [[ "$NEMOCLAW_READY_NOW" == true ]]; then
-    return 0
-  fi
-
-  if [[ -z "$NEMOCLAW_RECOVERY_EXPORT_DIR" ]]; then
-    return 0
-  fi
-
-  if [[ -z "$NEMOCLAW_RECOVERY_PROFILE" ]]; then
-    NEMOCLAW_RECOVERY_PROFILE="$(detect_shell_profile)"
-  fi
-
-  echo ""
-  echo "  ──────────────────────────────────────────────────"
-  warn "Your current shell cannot resolve '${_CLI_BIN}' yet."
-  echo ""
-  echo "  To use ${_CLI_BIN} now, run:"
-  echo ""
-  echo "    export PATH=\"${NEMOCLAW_RECOVERY_EXPORT_DIR}:\$PATH\""
-  echo "    source ${NEMOCLAW_RECOVERY_PROFILE}"
-  echo ""
-  echo "  Then run:"
-  echo ""
-  echo "    ${_CLI_BIN} onboard"
-  echo ""
-  echo "  Or open a new terminal window after updating your shell profile."
-  echo "  ──────────────────────────────────────────────────"
-  echo ""
-}
-
-# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 main() {
@@ -1748,7 +1796,6 @@ except Exception:
   fi
 
   print_done
-  post_install_message
 }
 
 if [[ "${BASH_SOURCE[0]:-}" == "$0" ]] || { [[ -z "${BASH_SOURCE[0]:-}" ]] && { [[ "$0" == "bash" ]] || [[ "$0" == "-bash" ]]; }; }; then

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -1320,7 +1320,7 @@ exit 0
     expect(`${result.stdout}${result.stderr}`).toMatch(/Created user-local shim/);
   });
 
-  it("shows source hint even when bin dir is already in PATH (stale hash protection)", () => {
+  it("preserves ready output when nemoclaw is already resolvable after install", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-ready-shell-"));
     const fakeBin = path.join(tmp, "bin");
     const prefix = path.join(tmp, "prefix");
@@ -1442,12 +1442,12 @@ exit 0
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status).toBe(0);
     expect(output).not.toMatch(/current shell cannot resolve 'nemoclaw'/);
-    // Always show source hint — the parent shell may have stale hash-table
-    // entries after an upgrade/reinstall even when the dir is in PATH.
+    expect(output).not.toMatch(/this shell needs PATH refresh/);
     expect(output).toMatch(/\$ source /);
+    expect(output).toMatch(/\$ nemoclaw my-assistant connect/);
   });
 
-  it("shows shell reload hint when PATH was extended by the installer", () => {
+  it("makes current-shell PATH refresh obvious when the installer added the bin dir", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-reload-hint-"));
     const fakeBin = path.join(tmp, "bin");
     const prefix = path.join(tmp, "prefix");
@@ -1515,12 +1515,21 @@ fi`,
         NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
         NPM_PREFIX: prefix,
         NVM_DIR: nvmDir,
+        SHELL: "/bin/bash",
       },
     });
 
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status).toBe(0);
-    expect(output).toMatch(/\$ source /);
+    expect(output).toContain(
+      "NemoClaw installed, but this shell needs PATH refresh before 'nemoclaw' will run.",
+    );
+    expect(output).toContain(`$ source ${path.join(tmp, ".bashrc")}`);
+    expect(output).toContain(`$ export PATH="${path.join(tmp, ".local", "bin")}:$PATH"`);
+    expect(fs.readFileSync(path.join(tmp, ".bashrc"), "utf-8")).toContain(
+      "# NemoClaw PATH setup",
+    );
+    expect(output).not.toContain("Your OpenClaw Sandbox is live.");
     expect(output).not.toContain("Onboarding has not run yet.");
     expect(output).not.toContain(
       "Onboarding did not run because this shell cannot resolve 'nemoclaw' yet.",


### PR DESCRIPTION
## Summary
Fixes installer final messaging when `nemoclaw` is only resolvable inside the installer subprocess after PATH/shim updates. The final `Next` block now makes current-shell PATH refresh required before using the CLI, instead of presenting the CLI as ready in that terminal.

## Related Issue
Fixes #2868

## Changes
- Track the PATH present at installer start and compare it with the verified CLI bin/shim locations after install.
- Print concise shell-specific refresh actions when the current shell still needs PATH refresh (`source`, `export PATH`, fish `set -gx`, or csh `setenv`).
- Preserve the normal successful install behavior when `nemoclaw` was already resolvable after install.
- Update installer integration coverage for already-resolvable and PATH-refresh install output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Commands run:
- `bash -n scripts/install.sh`
- `bash -n install.sh`
- `npx vitest run test/install-preflight.test.ts --testNamePattern "ready output|PATH refresh"`
- `npx vitest run test/install-preflight.test.ts`
- `npx vitest run test/install-npm-resolution.test.ts`
- `npm run typecheck`
- `npm run typecheck:cli`
- `npm run build:cli`
- `git diff --check`

Note: `npx biome format --write test/install-preflight.test.ts` did not process the file because this test path is ignored by the repo Biome config.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved PATH refresh detection to accurately identify when your shell needs updating after installation
* Enhanced post-installation messaging with environment-specific guidance and clearer next steps for different setup scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->