### PR TITLE
fix(onboard): recover stale onboarding locks after PID reuse

### DIFF
--- a/src/lib/onboard-session.test.ts
+++ b/src/lib/onboard-session.test.ts
@@ -300,6 +300,50 @@ describe("onboard session", () => {
     expect(written.pid).toBe(process.pid);
   });
 
+  it("replaces a stale onboard lock when the recorded PID was reused by another process", () => {
+    fs.mkdirSync(path.dirname(session.LOCK_FILE), { recursive: true });
+    const reusedPid = 424242;
+    fs.writeFileSync(
+      session.LOCK_FILE,
+      JSON.stringify({
+        pid: reusedPid,
+        startedAt: "1970-01-01T00:20:00.000Z",
+        command: "nemoclaw onboard",
+      }),
+      { mode: 0o600 },
+    );
+
+    const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+    const originalReadFileSync = fs.readFileSync;
+    const readSpy = vi.spyOn(fs, "readFileSync").mockImplementation(((file, options) => {
+      const fileName = String(file);
+      if (fileName === `/proc/${reusedPid}/stat`) {
+        const fieldsAfterComm = Array.from({ length: 50 }, (_, index) => {
+          if (index === 0) return "S";
+          if (index === 19) return "23000";
+          return "0";
+        }).join(" ");
+        return `${reusedPid} (node) ${fieldsAfterComm}`;
+      }
+      if (fileName === "/proc/stat") {
+        return "cpu  1 2 3 4\nbtime 1000\n";
+      }
+      return originalReadFileSync(file, options);
+    }) as typeof fs.readFileSync);
+
+    try {
+      const acquired = session.acquireOnboardLock("nemoclaw onboard --resume");
+      expect(acquired.acquired).toBe(true);
+
+      const written = JSON.parse(fs.readFileSync(session.LOCK_FILE, "utf8"));
+      expect(written.pid).toBe(process.pid);
+    } finally {
+      readSpy.mockRestore();
+      killSpy.mockRestore();
+      session.releaseOnboardLock();
+    }
+  });
+
   it("regression #1281: stale-cleanup race does not unlink a fresh lock claimed by another process", () => {
     // Reproduces the race: the lock file we read as 'stale' gets replaced
     // with a fresh claim from a faster concurrent process between our
@@ -380,14 +424,69 @@ describe("onboard session", () => {
     }
   });
 
-  it("treats unreadable or transient lock contents as a retry, not a stale lock", () => {
+  it("treats recent malformed lock as transient and does not remove it", () => {
     fs.mkdirSync(path.dirname(session.LOCK_FILE), { recursive: true });
+    // Write a malformed lock with the current timestamp (< 30 s old).
     fs.writeFileSync(session.LOCK_FILE, "{not-json", { mode: 0o600 });
 
     const acquired = session.acquireOnboardLock("nemoclaw onboard --resume");
     expect(acquired.acquired).toBe(false);
     expect(acquired.stale).toBe(true);
+    // Recent malformed lock is preserved because another process may be mid-write.
     expect(fs.existsSync(session.LOCK_FILE)).toBe(true);
+  });
+
+  it("removes a stale malformed lock file older than 30 seconds (#2765)", () => {
+    fs.mkdirSync(path.dirname(session.LOCK_FILE), { recursive: true });
+    fs.writeFileSync(session.LOCK_FILE, "{not-json", { mode: 0o600 });
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(session.LOCK_FILE, past, past);
+
+    const acquired = session.acquireOnboardLock("nemoclaw onboard --resume");
+    expect(acquired.acquired).toBe(true);
+    expect(fs.existsSync(session.LOCK_FILE)).toBe(true);
+    const written = JSON.parse(fs.readFileSync(session.LOCK_FILE, "utf8"));
+    expect(written.pid).toBe(process.pid);
+    session.releaseOnboardLock();
+  });
+
+  it("does not remove a fresh lock that replaces stale malformed lock debris during cleanup", () => {
+    fs.mkdirSync(path.dirname(session.LOCK_FILE), { recursive: true });
+    fs.writeFileSync(session.LOCK_FILE, "{not-json", { mode: 0o600 });
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(session.LOCK_FILE, past, past);
+
+    let statCallCount = 0;
+    const originalStatSync = fs.statSync;
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementation((...args) => {
+      if (args[0] === session.LOCK_FILE) {
+        statCallCount += 1;
+        if (statCallCount === 3) {
+          const tmpClaim = session.LOCK_FILE + ".race-tmp";
+          fs.writeFileSync(
+            tmpClaim,
+            JSON.stringify({
+              pid: process.pid,
+              startedAt: new Date().toISOString(),
+              command: "nemoclaw onboard (fresh malformed-cleanup race claimant)",
+            }),
+            { mode: 0o600 },
+          );
+          fs.renameSync(tmpClaim, session.LOCK_FILE);
+        }
+      }
+      return originalStatSync(...args);
+    });
+
+    try {
+      const acquired = session.acquireOnboardLock("nemoclaw onboard --resume");
+      expect(acquired.acquired).toBe(false);
+      expect(acquired.holderPid).toBe(process.pid);
+      const onDisk = JSON.parse(fs.readFileSync(session.LOCK_FILE, "utf8"));
+      expect(onDisk.command).toContain("fresh malformed-cleanup race claimant");
+    } finally {
+      statSpy.mockRestore();
+    }
   });
 
   it("ignores malformed lock files when releasing the onboard lock", () => {

--- a/src/lib/onboard-session.ts
+++ b/src/lib/onboard-session.ts
@@ -399,6 +399,8 @@ function parseLockFile(contents: string): LockInfo | null {
   }
 }
 
+const MALFORMED_STALE_SECONDS = 30;
+
 function isProcessAlive(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
@@ -407,6 +409,49 @@ function isProcessAlive(pid: number): boolean {
   } catch (error) {
     return isErrnoException(error) && error.code === "EPERM";
   }
+}
+
+function readProcProcessStartMs(pid: number): number | null {
+  try {
+    const statText = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    const btimeLine = fs
+      .readFileSync("/proc/stat", "utf8")
+      .split("\n")
+      .find((line) => line.startsWith("btime "));
+    const bootSeconds = btimeLine ? Number(btimeLine.trim().split(/\s+/)[1]) : NaN;
+    const closeParen = statText.lastIndexOf(")");
+    if (!Number.isFinite(bootSeconds) || closeParen < 0) return null;
+
+    const fieldsAfterComm = statText
+      .slice(closeParen + 2)
+      .trim()
+      .split(/\s+/);
+    const startTicks = Number(fieldsAfterComm[19]);
+    if (!Number.isFinite(startTicks)) return null;
+
+    // Linux exposes /proc/<pid>/stat starttime in USER_HZ ticks. 100 is the
+    // stable value on supported NemoClaw Linux hosts.
+    const clockTicksPerSecond = 100;
+    return (bootSeconds + startTicks / clockTicksPerSecond) * 1000;
+  } catch {
+    return null;
+  }
+}
+
+function lockHolderStillMatches(lock: LockInfo): boolean {
+  if (!isProcessAlive(lock.pid)) return false;
+  if (lock.pid === process.pid) return true;
+
+  const lockStartedMs = lock.startedAt ? Date.parse(lock.startedAt) : NaN;
+  if (!Number.isFinite(lockStartedMs)) return true;
+
+  const processStartMs = readProcProcessStartMs(lock.pid);
+  if (processStartMs === null) return true;
+
+  // The original lock holder must have started before it wrote the lock. If
+  // the currently-live PID started after the lock timestamp, the PID was reused
+  // and the lock is stale even though kill(pid, 0) succeeds.
+  return processStartMs <= lockStartedMs + 1000;
 }
 
 // File descriptor we hold across the lifetime of an acquired lock. On
@@ -468,12 +513,25 @@ export function acquireOnboardLock(command: string | null = null): LockResult {
         throw readError;
       }
       if (!existing) {
-        // Malformed lock file — leave it on disk (a human or another
-        // process may be mid-write) and retry. Pre-#1281 behavior
-        // preserved: never unlink a malformed lock automatically.
+        // Malformed lock file. If the file is very recent (<30 s), a
+        // concurrent process may be mid-write — leave it and retry.
+        // Otherwise the file is stale debris from a crash between
+        // openSync("wx") and writeSync() — remove it so subsequent
+        // onboard runs are not permanently blocked (#2765).
+        try {
+          const lockStat = fs.statSync(LOCK_FILE);
+          const ageMs = Date.now() - lockStat.mtimeMs;
+          if (ageMs > MALFORMED_STALE_SECONDS * 1000) {
+            unlinkIfInodeMatches(LOCK_FILE, staleInode);
+          }
+        } catch (statErr) {
+          if (!(isErrnoException(statErr) && statErr.code === "ENOENT")) {
+            throw statErr;
+          }
+        }
         continue;
       }
-      if (isProcessAlive(existing.pid)) {
+      if (lockHolderStillMatches(existing)) {
         return {
           acquired: false,
           lockFile: LOCK_FILE,

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -49,6 +49,10 @@ function dockerRunCommandBetween(
       break;
     }
   }
+  const lastLine = runLines[runLines.length - 1]?.trimEnd() ?? "";
+  if (lastLine.endsWith("\\")) {
+    throw new Error(`Expected complete RUN instruction before ${endMarker}`);
+  }
   return runLines
     .join("\n")
     .trim()

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -42,8 +42,15 @@ function dockerRunCommandBetween(
   if (runIndex === -1 || runIndex > end) {
     throw new Error(`Expected RUN instruction after ${startMarker}`);
   }
-  return dockerfile
-    .slice(runIndex, end)
+  const runLines: string[] = [];
+  for (const line of dockerfile.slice(runIndex, end).split("\n")) {
+    runLines.push(line);
+    if (!line.trimEnd().endsWith("\\")) {
+      break;
+    }
+  }
+  return runLines
+    .join("\n")
     .trim()
     .replace(/^RUN\s+/, "")
     .replace(/\\\n/g, " ");
@@ -131,6 +138,38 @@ describe("sandbox provisioning: unified .openclaw layout (#2227)", () => {
         `chown root:root ${path.join(sandboxRoot, ".bashrc")} ${path.join(sandboxRoot, ".profile")}`,
       );
       expect(rc.calls).not.toContain("sandbox:sandbox");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("provisions system-wide runtime proxy hooks", () => {
+    const dockerfile = fs.readFileSync(DOCKERFILE_BASE, "utf-8");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-system-proxy-"));
+    const profileHook = path.join(tmp, "profile.d", "nemoclaw-proxy.sh");
+    const bashrc = path.join(tmp, "bash.bashrc");
+    const runtimeEnvShim = "[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh";
+
+    try {
+      fs.mkdirSync(path.dirname(profileHook), { recursive: true });
+      fs.writeFileSync(bashrc, "# existing bashrc\n");
+      const command = dockerRunCommandBetween(
+        dockerfile,
+        "# System-wide proxy hooks",
+        "# Install OpenClaw CLI + PyYAML",
+      )
+        .replaceAll("/etc/profile.d/nemoclaw-proxy.sh", profileHook)
+        .replaceAll("/etc/bash.bashrc", bashrc);
+
+      const { result } = runLoggedDockerShell(command, tmp);
+      expect(result.status).toBe(0);
+      expect(fs.readFileSync(profileHook, "utf-8").split(runtimeEnvShim).length - 1).toBe(1);
+      expect((fs.statSync(profileHook).mode & 0o777).toString(8)).toBe("444");
+
+      const bashrcContent = fs.readFileSync(bashrc, "utf-8");
+      expect(bashrcContent.split(runtimeEnvShim).length - 1).toBe(1);
+      expect(bashrcContent).toContain("# existing bashrc");
+      expect((fs.statSync(bashrc).mode & 0o777).toString(8)).toBe("444");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Replays the useful stale malformed `onboard.lock` cleanup from #2833, then adds the missing #2765 coverage for well-formed stale locks whose recorded PID has been reused by another process.

The lock acquisition path now:
- keeps recent malformed locks transient, so a concurrent writer is not raced
- removes stale malformed crash debris with the existing inode-verified unlink helper
- treats a live Linux PID as stale when `/proc/<pid>/stat` shows that process started after the lock timestamp, which covers PID reuse after an abnormal onboarding exit

## Attribution

This is based on the malformed-lock cleanup proposed in #2833 by @kagura-agent. The replay commit keeps that contribution credited with a `Co-authored-by` trailer.

## Testing

```bash
npm ci --ignore-scripts
git diff --check
npm run build:cli
npm run typecheck:cli
npx vitest run src/lib/onboard-session.test.ts --testTimeout 60000
```

Closes #2765
Supersedes #2833

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted lock files by validating modification time before removal
  * Enhanced detection of stale process locks using process start-time checks to avoid PID-reuse errors

* **Tests**
  * Added focused tests for malformed lock-file scenarios, stale-PID reuse, and concurrent cleanup races (replacing older regression cases)
  * Added test verifying runtime proxy shim provisioning and file write/mode behavior during sandbox provisioning
<!-- end of auto-generated comment: release notes by coderabbit.ai -->