### PR TITLE
fix(security): redact dashboard token output

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -285,13 +285,13 @@ You can chat with the agent from the terminal or the browser.
 The onboard wizard starts a background port forward to the sandbox dashboard, then prints the dashboard URL in the install summary.
 The default host port is `18789`.
 If that port is already taken, NemoClaw uses the next free dashboard port, such as `18790`, and prints that port in the final URL.
-The gateway token is redacted from logs; retrieve it explicitly when the browser asks for authentication.
+The gateway token is redacted from displayed output; retrieve it explicitly when the browser asks for authentication.
 
 ```text
 ──────────────────────────────────────────────────
 OpenClaw UI (auth token redacted from displayed URLs)
 Port 18790 must be forwarded before opening these URLs.
-Dashboard: http://127.0.0.1:18790/#token=<redacted>
+Dashboard: http://127.0.0.1:18790/
 Token:       nemoclaw my-gpt-claw gateway-token --quiet
              append  #token=<token> locally if the browser asks for auth.
 ──────────────────────────────────────────────────

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -282,21 +282,24 @@ You can chat with the agent from the terminal or the browser.
 
 ### Open the OpenClaw UI in a Browser to Chat with the Agent
 
-The onboard wizard starts a background port forward to the sandbox dashboard, then prints a tokenized URL in the install summary.
+The onboard wizard starts a background port forward to the sandbox dashboard, then prints the dashboard URL in the install summary.
 The default host port is `18789`.
 If that port is already taken, NemoClaw uses the next free dashboard port, such as `18790`, and prints that port in the final URL.
+The gateway token is redacted from logs; retrieve it explicitly when the browser asks for authentication.
 
 ```text
 ──────────────────────────────────────────────────
-OpenClaw UI (tokenized URL; treat it like a password; save it now - it will not be printed again)
+OpenClaw UI (auth token redacted from displayed URLs)
 Port 18790 must be forwarded before opening these URLs.
-Dashboard: http://127.0.0.1:18790/#token=<auth-token>
+Dashboard: http://127.0.0.1:18790/#token=<redacted>
+Token:       nemoclaw my-gpt-claw gateway-token --quiet
+             append  #token=<token> locally if the browser asks for auth.
 ──────────────────────────────────────────────────
 ```
 
-Open the printed URL in your browser.
-The `#token=<auth-token>` fragment authenticates the browser to the sandbox gateway, so save the URL securely and treat it like a password.
-NemoClaw prints the token only once.
+Open the dashboard URL in your browser.
+If the browser asks for authentication, run the printed `gateway-token --quiet` command and append `#token=<token>` locally.
+Treat the token like a password.
 
 ### Chat with the Agent from the Terminal
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1153,7 +1153,7 @@ harden_auth_profiles() {
 
 # configure_messaging_channels is provided by sandbox-init.sh (shared).
 
-# Print the local and remote dashboard URLs with any auth token redacted.
+# Print the local and remote dashboard URLs without the auth token fragment.
 print_dashboard_urls() {
   local token chat_ui_base local_url remote_url
 
@@ -1162,10 +1162,6 @@ print_dashboard_urls() {
   chat_ui_base="${CHAT_UI_URL%/}"
   local_url="http://127.0.0.1:${PUBLIC_PORT}/"
   remote_url="${chat_ui_base}/"
-  if [ -n "$token" ]; then
-    local_url="${local_url}#token=<redacted>"
-    remote_url="${remote_url}#token=<redacted>"
-  fi
 
   echo "[gateway] Local UI: ${local_url}" >&2
   echo "[gateway] Remote UI: ${remote_url}" >&2

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1159,7 +1159,8 @@ print_dashboard_urls() {
 
   token="$(_read_gateway_token)"
 
-  chat_ui_base="${CHAT_UI_URL%/}"
+  chat_ui_base="${CHAT_UI_URL%%#*}"
+  chat_ui_base="${chat_ui_base%/}"
   local_url="http://127.0.0.1:${PUBLIC_PORT}/"
   remote_url="${chat_ui_base}/"
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -42,8 +42,8 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 # read failure), the output is still available for diagnostics.
 # The log is written in append mode and also forwarded to the original
 # stderr/stdout via tee so openshell sandbox create can still stream it.
-# SECURITY: restrict permissions before writing — the script later prints
-# tokenized dashboard URLs to stderr (#token=...).
+# SECURITY: restrict permissions before writing — startup diagnostics may
+# include dashboard URLs, but auth tokens must stay redacted in logs.
 _START_LOG="/tmp/nemoclaw-start.log"
 if [ "$(id -u)" -eq 0 ]; then
   : >"$_START_LOG"
@@ -1153,7 +1153,7 @@ harden_auth_profiles() {
 
 # configure_messaging_channels is provided by sandbox-init.sh (shared).
 
-# Print the local and remote dashboard URLs, appending the auth token if available.
+# Print the local and remote dashboard URLs with any auth token redacted.
 print_dashboard_urls() {
   local token chat_ui_base local_url remote_url
 
@@ -1163,12 +1163,15 @@ print_dashboard_urls() {
   local_url="http://127.0.0.1:${PUBLIC_PORT}/"
   remote_url="${chat_ui_base}/"
   if [ -n "$token" ]; then
-    local_url="${local_url}#token=${token}"
-    remote_url="${remote_url}#token=${token}"
+    local_url="${local_url}#token=<redacted>"
+    remote_url="${remote_url}#token=<redacted>"
   fi
 
   echo "[gateway] Local UI: ${local_url}" >&2
   echo "[gateway] Remote UI: ${remote_url}" >&2
+  if [ -n "$token" ]; then
+    echo "[gateway] Dashboard auth token redacted from startup logs." >&2
+  fi
 }
 
 start_persistent_gateway_log_mirror() {

--- a/src/lib/agent-onboard.test.ts
+++ b/src/lib/agent-onboard.test.ts
@@ -118,8 +118,9 @@ describe("printDashboardUi — regression for #2078 (port 8642 is not a chat UI)
     const output = logSpy.mock.calls.map((args) => String(args[0])).join("\n");
     expect(output).toContain("Ficticious UI (auth token redacted from displayed URLs)");
     expect(output).toContain("Port 19000 must be forwarded before opening this URL.");
-    expect(output).toContain("http://127.0.0.1:19000/#token=aaaa********************");
+    expect(output).toContain("http://127.0.0.1:19000/");
     expect(output).toContain("Token: nemoclaw sandbox-y gateway-token --quiet");
+    expect(output).not.toContain("http://127.0.0.1:19000/#token=");
     expect(output).not.toContain(token);
   });
 });

--- a/src/lib/agent-onboard.test.ts
+++ b/src/lib/agent-onboard.test.ts
@@ -108,18 +108,19 @@ describe("printDashboardUi — regression for #2078 (port 8642 is not a chat UI)
     expect(noteSpy).not.toHaveBeenCalled();
   });
 
-  it("prints tokenized URL with save-now warning for UI-kind agents", () => {
-    printDashboardUi("sandbox-y", "tok", uiAgent, {
+  it("redacts tokenized URLs for UI-kind agents and shows the token retrieval command", () => {
+    const token = "a".repeat(64);
+    printDashboardUi("sandbox-y", token, uiAgent, {
       note: noteSpy,
       buildControlUiUrls: buildUrlsLoopback,
     });
 
     const output = logSpy.mock.calls.map((args) => String(args[0])).join("\n");
-    expect(output).toContain(
-      "Ficticious UI (tokenized URL; treat it like a password; save it now - it will not be printed again)",
-    );
+    expect(output).toContain("Ficticious UI (auth token redacted from displayed URLs)");
     expect(output).toContain("Port 19000 must be forwarded before opening this URL.");
-    expect(output).toContain("http://127.0.0.1:19000/#token=tok");
+    expect(output).toContain("http://127.0.0.1:19000/#token=aaaa********************");
+    expect(output).toContain("Token: nemoclaw sandbox-y gateway-token --quiet");
+    expect(output).not.toContain(token);
   });
 });
 

--- a/src/lib/agent-onboard.ts
+++ b/src/lib/agent-onboard.ts
@@ -338,6 +338,10 @@ export function getAgentDashboardInfo(agent: AgentDefinition): {
   };
 }
 
+function dashboardUrlForDisplay(url: string): string {
+  return redact(url.replace(/#token=[^\s'"]*$/i, ""));
+}
+
 /**
  * Print the dashboard UI section for a non-OpenClaw agent.
  *
@@ -368,7 +372,7 @@ export function printDashboardUi(
       const url = path && path !== "/" ? `${withoutHash}${path}` : `${withoutHash}/`;
       if (seen.has(url)) continue;
       seen.add(url);
-      console.log(`  ${redact(url)}`);
+      console.log(`  ${dashboardUrlForDisplay(url)}`);
     }
     return;
   }
@@ -379,7 +383,7 @@ export function printDashboardUi(
     );
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(token, info.port)) {
-      console.log(`  ${redact(url)}`);
+      console.log(`  ${dashboardUrlForDisplay(url)}`);
     }
     console.log(`  Token: ${cliName} ${sandboxName} gateway-token --quiet`);
     console.log(`         append  #token=<token> locally if the browser asks for auth.`);
@@ -388,7 +392,7 @@ export function printDashboardUi(
     console.log(`  ${info.displayName} ${label}`);
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(null, info.port)) {
-      console.log(`  ${redact(url)}`);
+      console.log(`  ${dashboardUrlForDisplay(url)}`);
     }
   }
 }

--- a/src/lib/agent-onboard.ts
+++ b/src/lib/agent-onboard.ts
@@ -9,7 +9,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
-import { ROOT, run, shellQuote } from "./runner";
+import { ROOT, run, shellQuote, redact } from "./runner";
 import { dockerBuild, dockerImageInspect } from "./docker";
 import { loadAgent, resolveAgentName, type AgentDefinition } from "./agent-defs";
 import { getAgentBranding } from "./branding";
@@ -347,7 +347,7 @@ export function getAgentDashboardInfo(agent: AgentDefinition): {
  * back to the original UI-style output used by browser dashboards.
  */
 export function printDashboardUi(
-  _sandboxName: string,
+  sandboxName: string,
   token: string | null,
   agent: AgentDefinition,
   deps: {
@@ -357,6 +357,7 @@ export function printDashboardUi(
 ): void {
   const info = getAgentDashboardInfo(agent);
   const { kind, label, path } = agent.dashboard;
+  const cliName = getAgentBranding(agent.name).cli;
 
   if (kind === "api") {
     console.log(`  ${info.displayName} ${label}`);
@@ -367,25 +368,27 @@ export function printDashboardUi(
       const url = path && path !== "/" ? `${withoutHash}${path}` : `${withoutHash}/`;
       if (seen.has(url)) continue;
       seen.add(url);
-      console.log(`  ${url}`);
+      console.log(`  ${redact(url)}`);
     }
     return;
   }
 
   if (token) {
     console.log(
-      `  ${info.displayName} ${label} (tokenized URL; treat it like a password; save it now - it will not be printed again)`,
+      `  ${info.displayName} ${label} (auth token redacted from displayed URLs)`,
     );
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(token, info.port)) {
-      console.log(`  ${url}`);
+      console.log(`  ${redact(url)}`);
     }
+    console.log(`  Token: ${cliName} ${sandboxName} gateway-token --quiet`);
+    console.log(`         append  #token=<token> locally if the browser asks for auth.`);
   } else {
     deps.note("  Could not read gateway token from the sandbox (download failed).");
     console.log(`  ${info.displayName} ${label}`);
     console.log(`  Port ${info.port} must be forwarded before opening this URL.`);
     for (const url of deps.buildControlUiUrls(null, info.port)) {
-      console.log(`  ${url}`);
+      console.log(`  ${redact(url)}`);
     }
   }
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -7991,6 +7991,10 @@ function buildAuthenticatedDashboardUrl(baseUrl: string, token: string | null = 
   return `${baseUrl}#token=${encodeURIComponent(token)}`;
 }
 
+function dashboardUrlForDisplay(url: string): string {
+  return redact(url.replace(/#token=[^\s'"]*$/i, ""));
+}
+
 function getWslHostAddress(
   options: {
     wslHostAddress?: string | null;
@@ -8145,7 +8149,7 @@ function printDashboard(
       console.log(`  ${line}`);
     }
     for (const entry of dashboardAccess) {
-      console.log(`  ${entry.label}: ${redact(entry.url)}`);
+      console.log(`  ${entry.label}: ${dashboardUrlForDisplay(entry.url)}`);
     }
     console.log(`  Token:       ${cliName()} ${sandboxName} gateway-token --quiet`);
     console.log(`               append  #token=<token> locally if the browser asks for auth.`);
@@ -8156,7 +8160,7 @@ function printDashboard(
       console.log(`  ${line}`);
     }
     for (const entry of dashboardAccess) {
-      console.log(`  ${entry.label}: ${redact(entry.url)}`);
+      console.log(`  ${entry.label}: ${dashboardUrlForDisplay(entry.url)}`);
     }
     console.log(
       `  Token:       ${cliName()} ${sandboxName} connect  →  jq -r '.gateway.auth.token' /sandbox/.openclaw/openclaw.json`,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -7885,7 +7885,8 @@ function findOpenclawJsonPath(dir: string): string | null {
 
 /**
  * Pull gateway.auth.token from the sandbox image via openshell sandbox download
- * so onboard can print copy-paste Control UI URLs with #token= (same idea as nemoclaw-start.sh).
+ * so onboard can build dashboard access URLs. User-visible output must redact
+ * the token fragment.
  */
 function fetchGatewayAuthTokenFromSandbox(sandboxName: string): string | null {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-token-"));
@@ -8138,14 +8139,16 @@ function printDashboard(
     });
   } else if (token) {
     console.log(
-      `  ${agentProductName()} UI (tokenized URL; treat it like a password; save it now - it will not be printed again)`,
+      `  ${agentProductName()} UI (auth token redacted from displayed URLs)`,
     );
     for (const line of guidanceLines) {
       console.log(`  ${line}`);
     }
     for (const entry of dashboardAccess) {
-      console.log(`  ${entry.label}: ${entry.url}`);
+      console.log(`  ${entry.label}: ${redact(entry.url)}`);
     }
+    console.log(`  Token:       ${cliName()} ${sandboxName} gateway-token --quiet`);
+    console.log(`               append  #token=<token> locally if the browser asks for auth.`);
   } else {
     note("  Could not read gateway token from the sandbox (download failed).");
     console.log(`  ${agentProductName()} UI`);
@@ -8153,14 +8156,12 @@ function printDashboard(
       console.log(`  ${line}`);
     }
     for (const entry of dashboardAccess) {
-      console.log(`  ${entry.label}: ${entry.url}`);
+      console.log(`  ${entry.label}: ${redact(entry.url)}`);
     }
     console.log(
       `  Token:       ${cliName()} ${sandboxName} connect  →  jq -r '.gateway.auth.token' /sandbox/.openclaw/openclaw.json`,
     );
-    console.log(
-      `               append  #token=<token>  to the URL, or see /tmp/gateway.log inside the sandbox.`,
-    );
+    console.log(`               append  #token=<token>  to the URL locally if needed.`);
   }
   console.log(`  ${"─".repeat(50)}`);
   console.log("");

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -179,13 +179,10 @@ describe("nemoclaw-start non-root fallback", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("Setting up NemoClaw");
-    expect(result.stderr).toContain(
-      "[gateway] Local UI: http://127.0.0.1:19000/#token=<redacted>",
-    );
-    expect(result.stderr).toContain(
-      "[gateway] Remote UI: https://remote.example.test/ui/#token=<redacted>",
-    );
+    expect(result.stderr).toContain("[gateway] Local UI: http://127.0.0.1:19000/");
+    expect(result.stderr).toContain("[gateway] Remote UI: https://remote.example.test/ui/");
     expect(result.stderr).toContain("Dashboard auth token redacted from startup logs.");
+    expect(result.stderr).not.toContain("#token=");
     expect(result.stderr).not.toContain(token);
   });
 
@@ -441,9 +438,10 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("TOKEN=tok'en");
-    expect(result.stderr).toContain("http://127.0.0.1:18789/#token=<redacted>");
-    expect(result.stderr).toContain("https://remote.example.test/ui/#token=<redacted>");
+    expect(result.stderr).toContain("http://127.0.0.1:18789/");
+    expect(result.stderr).toContain("https://remote.example.test/ui/");
     expect(result.stderr).toContain("Dashboard auth token redacted from startup logs.");
+    expect(result.stderr).not.toContain("#token=");
     expect(result.stderr).not.toContain("tok'en");
     expect(envFile).toContain("export OPENCLAW_GATEWAY_TOKEN='tok'\\''en'");
     expect(envFile).toContain("nemoclaw-configure-guard begin");

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -168,7 +168,7 @@ describe("nemoclaw-start non-root fallback", () => {
       "set -euo pipefail",
       `_read_gateway_token() { printf "${token}\\n"; }`,
       'PUBLIC_PORT="19000"',
-      'CHAT_UI_URL="https://remote.example.test/ui"',
+      `CHAT_UI_URL="https://remote.example.test/ui/#token=${token}"`,
       startScriptLine(src, "echo 'Setting up NemoClaw...'"),
       extractShellFunctionFromSource(src, "print_dashboard_urls"),
       "print_dashboard_urls",

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -163,9 +163,10 @@ describe("nemoclaw-start non-root fallback", () => {
 
   it("sends startup diagnostics to stderr so they do not leak into bridge output (#1064)", () => {
     const src = fs.readFileSync(START_SCRIPT, "utf-8");
+    const token = "a".repeat(64);
     const script = [
       "set -euo pipefail",
-      '_read_gateway_token() { printf "tok\\n"; }',
+      `_read_gateway_token() { printf "${token}\\n"; }`,
       'PUBLIC_PORT="19000"',
       'CHAT_UI_URL="https://remote.example.test/ui"',
       startScriptLine(src, "echo 'Setting up NemoClaw...'"),
@@ -178,10 +179,14 @@ describe("nemoclaw-start non-root fallback", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("Setting up NemoClaw");
-    expect(result.stderr).toContain("[gateway] Local UI: http://127.0.0.1:19000/#token=tok");
     expect(result.stderr).toContain(
-      "[gateway] Remote UI: https://remote.example.test/ui/#token=tok",
+      "[gateway] Local UI: http://127.0.0.1:19000/#token=<redacted>",
     );
+    expect(result.stderr).toContain(
+      "[gateway] Remote UI: https://remote.example.test/ui/#token=<redacted>",
+    );
+    expect(result.stderr).toContain("Dashboard auth token redacted from startup logs.");
+    expect(result.stderr).not.toContain(token);
   });
 
   it("unwraps the sandbox-create env self-wrapper and applies dashboard port defaults", () => {
@@ -436,8 +441,10 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("TOKEN=tok'en");
-    expect(result.stderr).toContain("http://127.0.0.1:18789/#token=tok'en");
-    expect(result.stderr).toContain("https://remote.example.test/ui/#token=tok'en");
+    expect(result.stderr).toContain("http://127.0.0.1:18789/#token=<redacted>");
+    expect(result.stderr).toContain("https://remote.example.test/ui/#token=<redacted>");
+    expect(result.stderr).toContain("Dashboard auth token redacted from startup logs.");
+    expect(result.stderr).not.toContain("tok'en");
     expect(envFile).toContain("export OPENCLAW_GATEWAY_TOKEN='tok'\\''en'");
     expect(envFile).toContain("nemoclaw-configure-guard begin");
     expect(envFile).not.toContain(".bashrc");

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -10,7 +10,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
-import { runCapture } from "../dist/lib/runner";
+import { redact, runCapture } from "../dist/lib/runner";
 
 const runnerPath = path.join(import.meta.dirname, "..", "dist", "lib", "runner.js");
 
@@ -377,7 +377,6 @@ describe("redact", () => {
   });
 
   it("masks dashboard URL hash tokens", () => {
-    const { redact } = require(runnerPath);
     const token = "a".repeat(64);
     const output = redact(`http://127.0.0.1:18789/#token=${token}`);
     expect(output).toBe("http://127.0.0.1:18789/#token=aaaa********************");

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -376,6 +376,14 @@ describe("redact", () => {
     expect(output).toBe("https://example.com/?Signature=****&AUTH=****");
   });
 
+  it("masks dashboard URL hash tokens", () => {
+    const { redact } = require(runnerPath);
+    const token = "a".repeat(64);
+    const output = redact(`http://127.0.0.1:18789/#token=${token}`);
+    expect(output).toBe("http://127.0.0.1:18789/#token=aaaa********************");
+    expect(output).not.toContain(token);
+  });
+
   it("leaves non-secret strings untouched", () => {
     const { redact } = require(runnerPath);
     expect(redact("docker run --name my-sandbox")).toBe("docker run --name my-sandbox");


### PR DESCRIPTION
## Summary

- Redact dashboard URLs printed by the TypeScript onboard paths before they reach terminal output.
- Redact the sandbox entrypoint dashboard URLs before they are written to stderr/startup logs.
- Replace the misleading "save this tokenized URL" wording with explicit `gateway-token --quiet` retrieval guidance.
- Update focused tests and quickstart docs for the redacted-token display contract.

## Credit

This replays and extends the security fix proposed in #2468 by @kagura-agent. Thanks to @kagura-agent for identifying the dashboard URL leakage issue and wiring the initial TypeScript output paths through redaction.

Closes #2467.
Supersedes #2468.

## Validation

- `npm run build:cli`
- `npx biome lint src/lib/agent-onboard.ts src/lib/onboard.ts src/lib/agent-onboard.test.ts test/nemoclaw-start.test.ts test/runner.test.ts docs/get-started/quickstart.md`
- `npx vitest run src/lib/agent-onboard.test.ts test/nemoclaw-start.test.ts test/runner.test.ts src/lib/dashboard-contract.test.ts`
- `npx vitest run test/onboard.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard URLs and startup logs no longer expose auth tokens; displayed URLs omit any `#token=` fragment and a redaction notice is printed. When authentication is required, retrieve the gateway token via the CLI and append `#token=<token>` locally.

* **Documentation**
  * Clarified browser UI instructions: background dashboard forwarding, forwarded-port behavior when the default port is occupied, and the revised token retrieval/appending workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->