### PR TITLE
refactor(cli): model onboard flags with oclif

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -65,7 +65,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard [--non-interactive] [--resume] [--recreate-sandbox] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [--yes-i-accept-third-party-software]
+$ nemoclaw onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [--yes-i-accept-third-party-software]
 ```
 
 :::{warning}
@@ -315,12 +315,12 @@ $ nemoclaw my-assistant doctor [--json]
 ### `nemoclaw <name> logs`
 
 View sandbox logs.
-Use `--follow` to stream output in real time.
+Use `--follow` to stream output in real time, `--tail <lines>` (or `-n <lines>`) to choose how many lines to show, and `--since <duration>` for recent OpenShell logs such as `5m`, `1h`, or `30s`.
 The command reads both OpenClaw gateway output and OpenShell audit events, so policy denials appear alongside the gateway log stream.
 If one log source is unavailable, NemoClaw prints a warning and keeps reading the remaining source.
 
 ```console
-$ nemoclaw my-assistant logs [--follow]
+$ nemoclaw my-assistant logs [--follow] [--tail <lines>|-n <lines>] [--since <duration>]
 ```
 
 ### `nemoclaw <name> gateway-token`
@@ -357,7 +357,7 @@ If you want to upgrade the sandbox while preserving state, use `nemoclaw <name> 
 :::
 
 If another terminal has an active SSH session to the sandbox, `destroy` prints an active-session warning and requires a second confirmation before it proceeds.
-Pass `--yes` or `--force` to skip the prompt in scripted workflows.
+Pass `--yes`, `-y`, or `--force` to skip the prompt in scripted workflows.
 
 ```console
 $ nemoclaw my-assistant destroy
@@ -546,16 +546,16 @@ Credentials are stripped from backups before storage.
 Policy presets applied to the old sandbox are reapplied to the new one so your egress rules survive the rebuild.
 
 ```console
-$ nemoclaw my-assistant rebuild [--yes] [--verbose]
+$ nemoclaw my-assistant rebuild [--yes|-y|--force] [--verbose|-v]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--yes`, `--force` | Skip the confirmation prompt |
-| `--verbose` | Log SSH commands, exit codes, and session state (also enabled by `NEMOCLAW_REBUILD_VERBOSE=1`) |
+| `--yes`, `-y`, `--force` | Skip the confirmation prompt |
+| `--verbose`, `-v` | Log SSH commands, exit codes, and session state (also enabled by `NEMOCLAW_REBUILD_VERBOSE=1`) |
 
 If another terminal has an active SSH session to the sandbox, `rebuild` prints an active-session warning and requires confirmation before destroying the sandbox.
-Pass `--yes` or `--force` to skip the prompt in scripted workflows.
+Pass `--yes`, `-y`, or `--force` to skip the prompt in scripted workflows.
 
 The sandbox must be running for the backup step to succeed.
 After restore, the command runs `openclaw doctor --fix` for cross-version structure repair.
@@ -567,14 +567,14 @@ NemoClaw resolves the digest of `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` fr
 Sandboxes that match the current digest are left alone.
 
 ```console
-$ nemoclaw upgrade-sandboxes [--check] [--auto] [--yes]
+$ nemoclaw upgrade-sandboxes [--check] [--auto] [--yes|-y]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--check` | List stale sandboxes without rebuilding any of them. Exits non-zero if any are stale. |
 | `--auto` | Rebuild every stale sandbox without prompting. Used by the installer to upgrade in place. |
-| `--yes` | Skip the confirmation prompt for the rebuild plan. |
+| `--yes`, `-y` | Skip the confirmation prompt for the rebuild plan. |
 
 Each rebuild reuses the same workspace backup-and-restore flow as `nemoclaw <name> rebuild`, so workspace files survive the upgrade.
 If the registry is unreachable (offline or firewalled hosts), NemoClaw falls back to the unpinned `:latest` tag and reports that the digest could not be resolved instead of failing.
@@ -791,14 +791,14 @@ Gathers system info, Docker state, gateway logs, and sandbox status into a summa
 Use `--sandbox <name>` to target a specific sandbox, `--quick` for a smaller snapshot, or `--output <path>` to save a tarball that you can attach to an issue.
 
 ```console
-$ nemoclaw debug [--quick] [--sandbox NAME] [--output PATH]
+$ nemoclaw debug [--quick|-q] [--sandbox NAME] [--output PATH|-o PATH]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--quick` | Collect minimal diagnostics only |
+| `--quick`, `-q` | Collect minimal diagnostics only |
 | `--sandbox NAME` | Target a specific sandbox (default: auto-detect) |
-| `--output PATH` | Write diagnostics tarball to the given path |
+| `--output PATH`, `-o PATH` | Write diagnostics tarball to the given path |
 
 If `--output` is set and the tarball cannot be written (for example, the destination directory is missing or read-only), the command exits non-zero so scripts can detect the failure.
 
@@ -833,13 +833,13 @@ The `destroy` and `rebuild` commands clean up the image automatically, but image
 This command lists all `openshell/sandbox-from:*` images, cross-references the sandbox registry, and removes any that are no longer associated with a registered sandbox.
 
 ```console
-$ nemoclaw gc [--dry-run] [--yes|--force]
+$ nemoclaw gc [--dry-run] [--yes|-y|--force]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--dry-run` | List orphaned images without removing them |
-| `--yes`, `--force` | Skip the confirmation prompt |
+| `--yes`, `-y`, `--force` | Skip the confirmation prompt |
 
 ### `nemoclaw uninstall`
 

--- a/src/lib/onboard-cli-commands.ts
+++ b/src/lib/onboard-cli-commands.ts
@@ -3,45 +3,122 @@
 
 /* v8 ignore start -- thin oclif adapters covered through CLI integration tests. */
 
-import { Command } from "@oclif/core";
+import { Command, Flags } from "@oclif/core";
 
 import { runOnboardAction, runSetupAction, runSetupSparkAction } from "./global-cli-actions";
+import { NOTICE_ACCEPT_FLAG } from "./usage-notice";
+
+const acceptFlagName = NOTICE_ACCEPT_FLAG.replace(/^--/, "");
+
+const onboardUsage = [
+  `onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [${NOTICE_ACCEPT_FLAG}]`,
+];
+
+const onboardExamples = [
+  "<%= config.bin %> onboard",
+  "<%= config.bin %> onboard --name alpha",
+  "<%= config.bin %> onboard --resume",
+  "<%= config.bin %> onboard --fresh",
+  "<%= config.bin %> onboard --from ./Dockerfile --name alpha",
+  `<%= config.bin %> onboard --non-interactive --name alpha ${NOTICE_ACCEPT_FLAG}`,
+];
+
+type OnboardFlags = {
+  "non-interactive"?: boolean;
+  resume?: boolean;
+  fresh?: boolean;
+  "recreate-sandbox"?: boolean;
+  from?: string;
+  name?: string;
+  agent?: string;
+  "control-ui-port"?: number;
+  [acceptFlagName]?: boolean;
+};
+
+function buildOnboardFlags(): Record<string, any> {
+  return {
+    help: Flags.help({ char: "h" }),
+    "non-interactive": Flags.boolean({ description: "Run without interactive prompts" }),
+    resume: Flags.boolean({ description: "Resume an interrupted onboarding session" }),
+    fresh: Flags.boolean({ description: "Ignore any saved onboarding session" }),
+    "recreate-sandbox": Flags.boolean({ description: "Delete and recreate an existing sandbox" }),
+    from: Flags.string({ description: "Path to a Dockerfile to use as the sandbox image source" }),
+    name: Flags.string({ description: "Sandbox name" }),
+    agent: Flags.string({ description: "Agent runtime to onboard" }),
+    "control-ui-port": Flags.integer({
+      description: "Host port for the local control UI",
+      max: 65535,
+      min: 1024,
+    }),
+    [acceptFlagName]: Flags.boolean({ description: "Accept the third-party software notice" }),
+  } as Record<string, any>;
+}
+
+function toLegacyOnboardArgs(flags: OnboardFlags): string[] {
+  const args: string[] = [];
+  if (flags["non-interactive"]) args.push("--non-interactive");
+  if (flags.resume) args.push("--resume");
+  if (flags.fresh) args.push("--fresh");
+  if (flags["recreate-sandbox"]) args.push("--recreate-sandbox");
+  if (flags.from) args.push("--from", flags.from);
+  if (flags.name) args.push("--name", flags.name);
+  if (flags.agent) args.push("--agent", flags.agent);
+  if (flags["control-ui-port"] !== undefined) {
+    args.push("--control-ui-port", String(flags["control-ui-port"]));
+  }
+  if (flags[acceptFlagName]) args.push(NOTICE_ACCEPT_FLAG);
+  return args;
+}
 
 export class OnboardCliCommand extends Command {
   static id = "onboard";
-  static strict = false;
+  static strict = true;
   static summary = "Configure inference endpoint and credentials";
   static description = "Configure inference, credentials, and sandbox settings.";
-  static usage = ["onboard [flags]"];
+  static usage = onboardUsage;
+  static examples = onboardExamples;
+  static flags = buildOnboardFlags();
 
   public async run(): Promise<void> {
-    this.parsed = true;
-    await runOnboardAction(this.argv);
+    const { flags } = await this.parse(OnboardCliCommand);
+    await runOnboardAction(toLegacyOnboardArgs(flags as OnboardFlags));
   }
 }
 
 export class SetupCliCommand extends Command {
   static id = "setup";
-  static strict = false;
+  static strict = true;
   static summary = "Deprecated alias for nemoclaw onboard";
   static description = "Deprecated alias for onboard.";
   static usage = ["setup [flags]"];
+  static examples = ["<%= config.bin %> setup --name alpha"];
+  static flags = buildOnboardFlags();
 
   public async run(): Promise<void> {
-    this.parsed = true;
-    await runSetupAction(this.argv);
+    if (this.argv.includes("--help") || this.argv.includes("-h")) {
+      await runSetupAction(["--help"]);
+      return;
+    }
+    const { flags } = await this.parse(SetupCliCommand);
+    await runSetupAction(toLegacyOnboardArgs(flags as OnboardFlags));
   }
 }
 
 export class SetupSparkCliCommand extends Command {
   static id = "setup-spark";
-  static strict = false;
+  static strict = true;
   static summary = "Deprecated alias for nemoclaw onboard";
   static description = "Deprecated alias for onboard.";
   static usage = ["setup-spark [flags]"];
+  static examples = ["<%= config.bin %> setup-spark --name alpha"];
+  static flags = buildOnboardFlags();
 
   public async run(): Promise<void> {
-    this.parsed = true;
-    await runSetupSparkAction(this.argv);
+    if (this.argv.includes("--help") || this.argv.includes("-h")) {
+      await runSetupSparkAction(["--help"]);
+      return;
+    }
+    const { flags } = await this.parse(SetupSparkCliCommand);
+    await runSetupSparkAction(toLegacyOnboardArgs(flags as OnboardFlags));
   }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -898,26 +898,27 @@ describe("CLI dispatch", () => {
   it("onboard --help exits 0 and shows usage", () => {
     const r = run("onboard --help");
     expect(r.code).toBe(0);
-    expect(r.out.includes("Usage: nemoclaw onboard")).toBeTruthy();
-    expect(r.out.includes("--from <Dockerfile>")).toBeTruthy();
+    expect(r.out).toContain("USAGE");
+    expect(r.out).toContain("nemoclaw onboard");
+    expect(r.out).toContain("--from <Dockerfile>");
   });
 
   it("unknown onboard option exits 1", () => {
     const r = run("onboard --non-interactiv");
-    expect(r.code).toBe(1);
-    expect(r.out.includes("Unknown onboard option")).toBeTruthy();
+    expect(r.code).not.toBe(0);
+    expect(r.out).toContain("Nonexistent flag: --non-interactiv");
   });
 
   it("accepts onboard --resume in CLI parsing", () => {
     const r = run("onboard --resume --non-interactiv");
-    expect(r.code).toBe(1);
-    expect(r.out.includes("Unknown onboard option(s): --non-interactiv")).toBeTruthy();
+    expect(r.code).not.toBe(0);
+    expect(r.out).toContain("Nonexistent flag: --non-interactiv");
   });
 
   it("accepts the third-party software flag in onboard CLI parsing", () => {
     const r = run("onboard --yes-i-accept-third-party-software --non-interactiv");
-    expect(r.code).toBe(1);
-    expect(r.out.includes("Unknown onboard option(s): --non-interactiv")).toBeTruthy();
+    expect(r.code).not.toBe(0);
+    expect(r.out).toContain("Nonexistent flag: --non-interactiv");
   });
 
   it("setup --help exits 0 and shows onboard usage", () => {
@@ -930,9 +931,8 @@ describe("CLI dispatch", () => {
 
   it("setup forwards unknown options into onboard parsing", () => {
     const r = run("setup --non-interactiv");
-    expect(r.code).toBe(1);
-    expect(r.out.includes("deprecated")).toBeTruthy();
-    expect(r.out.includes("Unknown onboard option(s): --non-interactiv")).toBeTruthy();
+    expect(r.code).not.toBe(0);
+    expect(r.out).toContain("Nonexistent flag: --non-interactiv");
   });
 
   it("setup forwards --resume into onboard parsing", () => {


### PR DESCRIPTION
## Summary
Model the onboard, setup, and setup-spark flag surfaces in oclif while preserving the existing onboarding action validation for Dockerfile paths, agents, saved sessions, and notice acceptance. This lets oclif own unknown flags and missing flag values before onboarding starts.

## Changes
- Added oclif flags for onboard/setup/setup-spark options.
- Added examples for common onboard flows.
- Reconstructed legacy argv for the existing onboarding action so domain validation stays centralized.
- Preserved deprecated setup/setup-spark help paths through existing deprecation messaging.
- Updated CLI expectations for parser-owned unknown flag errors.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>