### PR TITLE
fix(onboard): defer sandboxName to post-create to prevent phantom list

### DIFF
--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -12,7 +12,10 @@ describe("inventory commands", () => {
     const inventory = await getSandboxInventory({
       recoverRegistryEntries: async () => ({ sandboxes: [], defaultSandbox: null }),
       getLiveInference,
-      loadLastSession: () => ({ sandboxName: "alpha" }),
+      loadLastSession: () => ({
+        sandboxName: "alpha",
+        steps: { sandbox: { status: "complete" } },
+      }),
     });
 
     expect(inventory).toEqual({
@@ -51,7 +54,10 @@ describe("inventory commands", () => {
         recoveredFromGateway: 2,
       }),
       getLiveInference,
-      loadLastSession: () => ({ sandboxName: "alpha" }),
+      loadLastSession: () => ({
+        sandboxName: "alpha",
+        steps: { sandbox: { status: "complete" } },
+      }),
       getActiveSessionCount: (sandboxName) => (sandboxName === "alpha" ? 1 : 0),
     });
 
@@ -85,13 +91,36 @@ describe("inventory commands", () => {
     await listSandboxesCommand({
       recoverRegistryEntries: async () => ({ sandboxes: [], defaultSandbox: null }),
       getLiveInference: () => null,
-      loadLastSession: () => ({ sandboxName: "alpha" }),
+      loadLastSession: () => ({
+        sandboxName: "alpha",
+        steps: { sandbox: { status: "complete" } },
+      }),
       log: (message = "") => lines.push(message),
     });
 
     expect(lines).toContain(
       "  No sandboxes registered locally, but the last onboarded sandbox was 'alpha'.",
     );
+  });
+
+  it("#2753: suppresses last-onboarded hint when sandbox step never completed", async () => {
+    // The session retains a sandbox name from an interrupted onboard
+    // (pre-fix sessions on disk, or any in-progress write between steps).
+    // Surfacing it as the "last onboarded sandbox" would resurrect the
+    // phantom users were complaining about.
+    const lines: string[] = [];
+    await listSandboxesCommand({
+      recoverRegistryEntries: async () => ({ sandboxes: [], defaultSandbox: null }),
+      getLiveInference: () => null,
+      loadLastSession: () => ({
+        sandboxName: "interrupt-test",
+        steps: { sandbox: { status: "in_progress" } },
+      }),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines.some((l) => l.includes("interrupt-test"))).toBe(false);
+    expect(lines).toContain("  No sandboxes registered. Run `nemoclaw onboard` to get started.");
   });
 
   it("prints recovered sandbox inventory details", async () => {

--- a/src/lib/inventory-commands.ts
+++ b/src/lib/inventory-commands.ts
@@ -31,7 +31,15 @@ export interface RecoveryResult {
 export interface ListSandboxesCommandDeps {
   recoverRegistryEntries: () => Promise<RecoveryResult>;
   getLiveInference: () => GatewayInference | null;
-  loadLastSession: () => { sandboxName?: string | null } | null;
+  /**
+   * Returns the last onboard session's sandbox name and step state. The
+   * step state is needed to filter out phantom names from interrupted
+   * onboards — see #2753.
+   */
+  loadLastSession: () => {
+    sandboxName?: string | null;
+    steps?: { sandbox?: { status?: string } | null } | null;
+  } | null;
   /** Detect active SSH sessions for a sandbox. Returns session count or null if unavailable. */
   getActiveSessionCount?: (sandboxName: string) => number | null;
   log?: (message?: string) => void;
@@ -140,6 +148,13 @@ export async function getSandboxInventory(
   const recovery = await deps.recoverRegistryEntries();
   const defaultSandbox = recovery.defaultSandbox || null;
   const lastSession = deps.loadLastSession();
+  // #2753: only surface the last-onboarded name when its sandbox step
+  // actually completed. Otherwise an interrupted onboard would leave the
+  // name in the session and the empty-state hint would resurrect it.
+  const lastOnboardedSandbox =
+    lastSession?.sandboxName && lastSession.steps?.sandbox?.status === "complete"
+      ? lastSession.sandboxName
+      : null;
 
   return {
     schemaVersion: 1,
@@ -148,7 +163,7 @@ export async function getSandboxInventory(
       recoveredFromSession: recovery.recoveredFromSession === true,
       recoveredFromGateway: recovery.recoveredFromGateway || 0,
     },
-    lastOnboardedSandbox: lastSession?.sandboxName || null,
+    lastOnboardedSandbox,
     sandboxes: recovery.sandboxes.map((sandbox) =>
       buildSandboxInventoryRow(sandbox, defaultSandbox, deps.getActiveSessionCount),
     ),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2376,13 +2376,19 @@ function getResumeSandboxConflict(
   // is impossible). Falling back to the env var here would fire spurious
   // conflicts for interactive resume runs whose shell happens to export
   // NEMOCLAW_SANDBOX_NAME but which never actually consult it.
+  // #2753: only treat session.sandboxName as a conflict source if the
+  // sandbox step actually completed. A pre-fix incomplete session would
+  // otherwise reject a legitimate `--resume --name <new>` that the user
+  // is supplying precisely to recover from the phantom.
   const raw = typeof opts.sandboxName === "string" ? opts.sandboxName.trim().toLowerCase() : "";
   const requestedSandboxName = raw || null;
-  if (!requestedSandboxName || !session?.sandboxName) {
+  const recordedSandboxName =
+    session?.steps?.sandbox?.status === "complete" ? session?.sandboxName ?? null : null;
+  if (!requestedSandboxName || !recordedSandboxName) {
     return null;
   }
-  return requestedSandboxName !== session.sandboxName
-    ? { requestedSandboxName, recordedSandboxName: session.sandboxName }
+  return requestedSandboxName !== recordedSandboxName
+    ? { requestedSandboxName, recordedSandboxName }
     : null;
 }
 
@@ -8644,7 +8650,14 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       onboardSession.markStepComplete("gateway");
     }
 
-    let sandboxName = session?.sandboxName || requestedSandboxName || null;
+    // #2753: prefer requestedSandboxName over an unconfirmed session name.
+    // A pre-fix session may carry sandboxName even though sandbox creation
+    // never completed; users supplying `--name` / NEMOCLAW_SANDBOX_NAME on
+    // the resume run must win, otherwise the stale name silently overrides
+    // their explicit recovery input.
+    const recordedSandboxName =
+      session?.steps?.sandbox?.status === "complete" ? session?.sandboxName || null : null;
+    let sandboxName = recordedSandboxName || requestedSandboxName || null;
     if (sandboxName && RESERVED_SANDBOX_NAMES.has(sandboxName)) {
       console.error(
         `  Reserved name in resumed session: '${sandboxName}' is a ${cliDisplayName()} CLI command.`,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -8486,6 +8486,28 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         return current;
       });
       session = onboardSession.loadSession();
+      // #2753: a resumed non-interactive onboard whose sandbox step did not
+      // complete has no recorded sandboxName (the onboard fix only persists
+      // it after createSandbox succeeds). Falling through would silently
+      // default to the agent's `my-assistant` instead of the user's original
+      // --name. Require an explicit name so the resume targets the right
+      // sandbox. Fires before preflight/gateway side effects.
+      const sandboxStepCompleted = session?.steps?.sandbox?.status === "complete";
+      if (
+        isNonInteractive() &&
+        !session?.sandboxName &&
+        !requestedSandboxName &&
+        !process.env.NEMOCLAW_SANDBOX_NAME &&
+        !sandboxStepCompleted
+      ) {
+        console.error(
+          "  Cannot resume non-interactive onboard: the previous run was interrupted before sandbox creation completed,",
+        );
+        console.error(
+          "  so no sandbox name was recorded. Re-run with --name <sandbox> (or set NEMOCLAW_SANDBOX_NAME).",
+        );
+        process.exit(1);
+      }
     } else {
       // --fresh asks for an explicit fresh start. createSession + saveSession
       // already overwrites any existing file, but clearing first removes the
@@ -8651,7 +8673,12 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         skippedStepMessage("provider_selection", `${provider} / ${model}`);
         hydrateCredentialEnv(credentialEnv);
       } else {
-        startRecordedStep("provider_selection", { sandboxName });
+        // #2753: do not persist sandboxName to onboard-session.json before
+        // the sandbox actually exists in the gateway (Step 6 markStepComplete
+        // below). A SIGINT between any earlier step and createSandbox would
+        // otherwise leave a phantom that `nemoclaw list` resurrects until
+        // manually destroyed.
+        startRecordedStep("provider_selection");
         const selection = await setupNim(gpu, sandboxName);
         model = selection.model;
         provider = selection.provider;
@@ -8662,7 +8689,6 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         onboardSession.markStepComplete(
           "provider_selection",
           toSessionUpdates({
-            sandboxName,
             provider,
             model,
             endpointUrl,
@@ -8687,7 +8713,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         }
         onboardSession.markStepComplete(
           "inference",
-          toSessionUpdates({ sandboxName, provider, model, nimContainer }),
+          toSessionUpdates({ provider, model, nimContainer }),
         );
         break;
       }
@@ -8723,7 +8749,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         }
       }
 
-      startRecordedStep("inference", { sandboxName, provider, model });
+      startRecordedStep("inference", { provider, model });
       const inferenceResult = await setupInference(
         sandboxName,
         model,
@@ -8741,7 +8767,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       }
       onboardSession.markStepComplete(
         "inference",
-        toSessionUpdates({ sandboxName, provider, model, nimContainer }),
+        toSessionUpdates({ provider, model, nimContainer }),
       );
       break;
     }
@@ -8827,7 +8853,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       } else {
         nextWebSearchConfig = await configureWebSearch(null, agent, webSearchSupportProbePath);
       }
-      startRecordedStep("sandbox", { sandboxName, provider, model });
+      startRecordedStep("sandbox", { provider, model });
       selectedMessagingChannels = await setupMessagingChannels();
       onboardSession.updateSession((current: Session) => {
         current.messagingChannels = selectedMessagingChannels;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -8486,20 +8486,18 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         return current;
       });
       session = onboardSession.loadSession();
-      // #2753: a resumed non-interactive onboard whose sandbox step did not
-      // complete has no recorded sandboxName (the onboard fix only persists
-      // it after createSandbox succeeds). Falling through would silently
-      // default to the agent's `my-assistant` instead of the user's original
-      // --name. Require an explicit name so the resume targets the right
-      // sandbox. Fires before preflight/gateway side effects.
+      // #2753: a resumed onboard whose sandbox step did not complete has no
+      // recorded sandboxName (the onboard fix only persists it after
+      // createSandbox succeeds). Falling through would silently default to
+      // the agent's `my-assistant` instead of the user's original --name.
+      // Use `cannotPrompt` so non-TTY runs without explicit --non-interactive
+      // are also caught, and `requestedSandboxName` (already env-var-resolved
+      // and trimmed above, lines 8302-8308) so whitespace-only env values
+      // can't satisfy the guard.
       const sandboxStepCompleted = session?.steps?.sandbox?.status === "complete";
-      if (
-        isNonInteractive() &&
-        !session?.sandboxName &&
-        !requestedSandboxName &&
-        !process.env.NEMOCLAW_SANDBOX_NAME &&
-        !sandboxStepCompleted
-      ) {
+      const recoveredSandboxName =
+        requestedSandboxName || (sandboxStepCompleted ? session?.sandboxName || null : null);
+      if (cannotPrompt && !recoveredSandboxName) {
         console.error(
           "  Cannot resume non-interactive onboard: the previous run was interrupted before sandbox creation completed,",
         );

--- a/src/lib/registry-recovery-action.test.ts
+++ b/src/lib/registry-recovery-action.test.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SandboxEntry } from "./registry.js";
+
+interface MockRegistryState {
+  sandboxes: Record<string, SandboxEntry>;
+  defaultSandbox: string | null;
+}
+
+const mockRegistryState: MockRegistryState = { sandboxes: {}, defaultSandbox: null };
+
+vi.mock("./registry.js", () => ({
+  listSandboxes: () => ({
+    sandboxes: Object.values(mockRegistryState.sandboxes),
+    defaultSandbox: mockRegistryState.defaultSandbox,
+  }),
+  getSandbox: (name: string) => mockRegistryState.sandboxes[name] ?? null,
+  registerSandbox: (entry: SandboxEntry) => {
+    mockRegistryState.sandboxes[entry.name] = entry;
+  },
+  updateSandbox: (name: string, partial: Partial<SandboxEntry>) => {
+    if (mockRegistryState.sandboxes[name]) {
+      mockRegistryState.sandboxes[name] = { ...mockRegistryState.sandboxes[name], ...partial };
+    }
+  },
+  setDefault: (name: string) => {
+    if (mockRegistryState.sandboxes[name]) {
+      mockRegistryState.defaultSandbox = name;
+    }
+  },
+}));
+
+vi.mock("./resolve-openshell.js", () => ({
+  resolveOpenshell: vi.fn(() => null),
+}));
+
+vi.mock("./gateway-runtime-action.js", () => ({
+  recoverNamedGatewayRuntime: vi.fn(),
+}));
+
+vi.mock("./openshell-runtime.js", () => ({
+  captureOpenshell: vi.fn(),
+}));
+
+vi.mock("./onboard-session.js", () => ({
+  loadSession: vi.fn(),
+}));
+
+vi.mock("./runtime-recovery.js", () => ({
+  parseLiveSandboxNames: () => new Set<string>(),
+}));
+
+vi.mock("./runner.js", () => ({
+  validateName: (name: string) => {
+    if (!/^[a-z]([a-z0-9-]*[a-z0-9])?$/.test(name)) {
+      throw new Error(`Invalid sandbox name: '${name}'`);
+    }
+    return name;
+  },
+}));
+
+import { recoverRegistryEntries } from "./registry-recovery-action.js";
+import { loadSession } from "./onboard-session.js";
+
+describe("recoverRegistryEntries (#2753 seed-time guard)", () => {
+  beforeEach(() => {
+    mockRegistryState.sandboxes = {};
+    mockRegistryState.defaultSandbox = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not seed the session sandbox when the sandbox step never completed", async () => {
+    vi.mocked(loadSession).mockReturnValue({
+      sandboxName: "interrupt-test",
+      provider: "nvidia",
+      model: "nemotron",
+      policyPresets: [],
+      nimContainer: null,
+      steps: {
+        sandbox: { status: "pending", startedAt: null, completedAt: null, error: null },
+      },
+    } as never);
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromSession).toBe(false);
+    expect(result.sandboxes.find((s) => s.name === "interrupt-test")).toBeUndefined();
+    expect(mockRegistryState.sandboxes["interrupt-test"]).toBeUndefined();
+  });
+
+  it("seeds the session sandbox when the sandbox step completed", async () => {
+    vi.mocked(loadSession).mockReturnValue({
+      sandboxName: "alpha",
+      provider: "nvidia",
+      model: "nemotron",
+      policyPresets: ["npm"],
+      nimContainer: null,
+      steps: {
+        sandbox: { status: "complete", startedAt: null, completedAt: null, error: null },
+      },
+    } as never);
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromSession).toBe(true);
+    const recovered = result.sandboxes.find((s) => s.name === "alpha");
+    expect(recovered).toBeDefined();
+    expect(recovered?.policies).toEqual(["npm"]);
+  });
+
+  it("returns empty recovery when there is no session and no registry entries", async () => {
+    vi.mocked(loadSession).mockReturnValue(null);
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromSession).toBe(false);
+    expect(result.sandboxes).toEqual([]);
+  });
+
+  it("does not evict a registered sandbox even when its session step is incomplete (avoids false positives)", async () => {
+    // A user with a real registered sandbox alpha and a stale session that
+    // happens to record alpha with an incomplete sandbox step (e.g. a
+    // pre-fix interrupted re-onboard) must NOT lose their real registry
+    // entry. Persisted phantoms in sandboxes.json from before this fix are
+    // a documented one-time `nemoclaw destroy <name>` migration instead.
+    mockRegistryState.sandboxes["alpha"] = {
+      name: "alpha",
+      provider: "nvidia",
+      model: "nemotron",
+      gpuEnabled: false,
+      policies: [],
+      nimContainer: null,
+      agent: null,
+    };
+    vi.mocked(loadSession).mockReturnValue({
+      sandboxName: "alpha",
+      provider: "nvidia",
+      model: "nemotron",
+      policyPresets: [],
+      nimContainer: null,
+      steps: {
+        sandbox: { status: "pending", startedAt: null, completedAt: null, error: null },
+      },
+    } as never);
+
+    const result = await recoverRegistryEntries();
+
+    expect(mockRegistryState.sandboxes["alpha"]).toBeDefined();
+    expect(result.sandboxes.find((s) => s.name === "alpha")).toBeDefined();
+  });
+});

--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -78,6 +78,17 @@ function shouldRecoverRegistryEntries(
   };
 }
 
+/**
+ * #2753: a session that records sandboxName but never completed the sandbox
+ * step is a phantom from an interrupted onboard. Going forward, the onboard
+ * fix prevents such writes; this guard catches stale on-disk sessions that
+ * pre-date the fix so `nemoclaw list` does not resurrect them.
+ */
+function isSessionSandboxConfirmed(session: Session | null): boolean {
+  if (!session?.sandboxName) return false;
+  return session.steps?.sandbox?.status === "complete";
+}
+
 function seedRecoveryMetadata(
   current: { sandboxes: SandboxEntry[] },
   session: Session | null,
@@ -88,7 +99,7 @@ function seedRecoveryMetadata(
   );
   let recoveredFromSession = false;
 
-  if (!session?.sandboxName) {
+  if (!isSessionSandboxConfirmed(session) || !session?.sandboxName) {
     return { metadataByName, recoveredFromSession };
   }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1018,6 +1018,79 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("--name <sandbox>")).toBeTruthy();
   });
 
+  it("#2753: whitespace-only NEMOCLAW_SANDBOX_NAME does not satisfy the resume guard", () => {
+    // The env-var ingest pipeline trims and rejects whitespace-only values
+    // before populating requestedSandboxName, so the guard sees no recovered
+    // name and fires correctly.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-resume-ws-name-"));
+    const localBin = path.join(home, "bin");
+    const nemoclawDir = path.join(home, ".nemoclaw");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(nemoclawDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "--version" ]; then echo "openshell 0.0.36"; exit 0; fi',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(nemoclawDir, "onboard-session.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          sessionId: "session-1",
+          resumable: true,
+          status: "in_progress",
+          mode: "interactive",
+          startedAt: "2026-05-03T00:00:00.000Z",
+          updatedAt: "2026-05-03T00:00:00.000Z",
+          lastStepStarted: "inference",
+          lastCompletedStep: "inference",
+          failure: null,
+          sandboxName: null,
+          provider: "nvidia-prod",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          endpointUrl: null,
+          credentialEnv: null,
+          preferredInferenceApi: null,
+          nimContainer: null,
+          policyPresets: null,
+          metadata: { gatewayName: "nemoclaw" },
+          steps: {
+            preflight: { status: "complete", startedAt: null, completedAt: null, error: null },
+            gateway: { status: "complete", startedAt: null, completedAt: null, error: null },
+            provider_selection: {
+              status: "complete",
+              startedAt: null,
+              completedAt: null,
+              error: null,
+            },
+            inference: { status: "complete", startedAt: null, completedAt: null, error: null },
+            sandbox: { status: "pending", startedAt: null, completedAt: null, error: null },
+          },
+        },
+        null,
+        2,
+      ),
+      { mode: 0o600 },
+    );
+
+    const r = runWithEnv(
+      "onboard --resume --non-interactive --yes-i-accept-third-party-software",
+      {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_SANDBOX_NAME: "   ",
+      },
+    );
+
+    expect(r.code).toBe(1);
+    expect(r.out.includes("Cannot resume non-interactive onboard")).toBeTruthy();
+  });
+
   it("setup-spark --help exits 0 and shows onboard usage", () => {
     const r = run("setup-spark --help");
     expect(r.code).toBe(0);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -943,6 +943,81 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("nemoclaw onboard")).toBeTruthy();
   });
 
+  it("#2753: refuses non-interactive --resume when sandbox step never completed and no name is provided", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-resume-no-name-"));
+    const localBin = path.join(home, "bin");
+    const nemoclawDir = path.join(home, ".nemoclaw");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(nemoclawDir, { recursive: true });
+    // Fake openshell so preflight passes and we reach the resume sandbox-name
+    // init where the new guard lives.
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "--version" ]; then echo "openshell 0.0.36"; exit 0; fi',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    // Simulates a pre-fix on-disk session that recorded only provider/model
+    // (with #2753's onboard fix, sandboxName is no longer written here either).
+    fs.writeFileSync(
+      path.join(nemoclawDir, "onboard-session.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          sessionId: "session-1",
+          resumable: true,
+          status: "in_progress",
+          mode: "interactive",
+          startedAt: "2026-05-03T00:00:00.000Z",
+          updatedAt: "2026-05-03T00:00:00.000Z",
+          lastStepStarted: "inference",
+          lastCompletedStep: "inference",
+          failure: null,
+          sandboxName: null,
+          provider: "nvidia-prod",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          endpointUrl: null,
+          credentialEnv: null,
+          preferredInferenceApi: null,
+          nimContainer: null,
+          policyPresets: null,
+          metadata: { gatewayName: "nemoclaw" },
+          steps: {
+            preflight: { status: "complete", startedAt: null, completedAt: null, error: null },
+            gateway: { status: "complete", startedAt: null, completedAt: null, error: null },
+            provider_selection: {
+              status: "complete",
+              startedAt: null,
+              completedAt: null,
+              error: null,
+            },
+            inference: { status: "complete", startedAt: null, completedAt: null, error: null },
+            sandbox: { status: "pending", startedAt: null, completedAt: null, error: null },
+          },
+        },
+        null,
+        2,
+      ),
+      { mode: 0o600 },
+    );
+
+    const r = runWithEnv(
+      "onboard --resume --non-interactive --yes-i-accept-third-party-software",
+      {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_SANDBOX_NAME: "",
+      },
+    );
+
+    expect(r.code).toBe(1);
+    expect(r.out.includes("Cannot resume non-interactive onboard")).toBeTruthy();
+    expect(r.out.includes("--name <sandbox>")).toBeTruthy();
+  });
+
   it("setup-spark --help exits 0 and shows onboard usage", () => {
     const r = run("setup-spark --help");
     expect(r.code).toBe(0);

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1884,7 +1884,7 @@ startGateway(null).catch(() => {});
   it("detects resume conflicts when --name does not match the recorded sandbox", () => {
     expect(
       getResumeConfigConflicts(
-        { sandboxName: "my-assistant" },
+        { sandboxName: "my-assistant", steps: { sandbox: { status: "complete" } } },
         { sandboxName: "second-assistant" },
       ),
     ).toEqual([
@@ -1898,13 +1898,19 @@ startGateway(null).catch(() => {});
 
   it("detects resume conflicts when a different sandbox is requested", () => {
     expect(
-      getResumeSandboxConflict({ sandboxName: "my-assistant" }, { sandboxName: "other-sandbox" }),
+      getResumeSandboxConflict(
+        { sandboxName: "my-assistant", steps: { sandbox: { status: "complete" } } },
+        { sandboxName: "other-sandbox" },
+      ),
     ).toEqual({
       requestedSandboxName: "other-sandbox",
       recordedSandboxName: "my-assistant",
     });
     expect(
-      getResumeSandboxConflict({ sandboxName: "other-sandbox" }, { sandboxName: "other-sandbox" }),
+      getResumeSandboxConflict(
+        { sandboxName: "other-sandbox", steps: { sandbox: { status: "complete" } } },
+        { sandboxName: "other-sandbox" },
+      ),
     ).toBe(null);
   });
 
@@ -1916,7 +1922,12 @@ startGateway(null).catch(() => {});
     const previous = process.env.NEMOCLAW_SANDBOX_NAME;
     process.env.NEMOCLAW_SANDBOX_NAME = "other-sandbox";
     try {
-      expect(getResumeSandboxConflict({ sandboxName: "my-assistant" })).toBe(null);
+      expect(
+        getResumeSandboxConflict({
+          sandboxName: "my-assistant",
+          steps: { sandbox: { status: "complete" } },
+        }),
+      ).toBe(null);
     } finally {
       if (previous === undefined) {
         delete process.env.NEMOCLAW_SANDBOX_NAME;
@@ -1924,6 +1935,24 @@ startGateway(null).catch(() => {});
         process.env.NEMOCLAW_SANDBOX_NAME = previous;
       }
     }
+  });
+
+  it("#2753: ignores an incomplete session sandbox name when checking resume conflicts", () => {
+    // A pre-fix on-disk session may carry sandboxName even though the
+    // sandbox step never completed. Treating that as a conflict source
+    // would block users from running `--resume --name <new>` to recover.
+    expect(
+      getResumeSandboxConflict(
+        { sandboxName: "interrupt-test", steps: { sandbox: { status: "pending" } } },
+        { sandboxName: "fresh-name" },
+      ),
+    ).toBe(null);
+    expect(
+      getResumeConfigConflicts(
+        { sandboxName: "interrupt-test", steps: { sandbox: { status: "pending" } } },
+        { sandboxName: "fresh-name" },
+      ),
+    ).toEqual([]);
   });
 
   it("returns provider and model hints only for non-interactive runs", () => {
@@ -3038,7 +3067,10 @@ const { setupInference } = require(${onboardPath});
 
     assert.match(
       source,
-      /let sandboxName = session\?\.sandboxName \|\| requestedSandboxName \|\| null;\s*if \(sandboxName && RESERVED_SANDBOX_NAMES\.has\(sandboxName\)\) \{[\s\S]*?process\.exit\(1\);\s*\}/,
+      // #2753: a stale `session.sandboxName` from an interrupted onboard
+      // must not override a fresh `--name` / NEMOCLAW_SANDBOX_NAME, so the
+      // session value participates only when its sandbox step completed.
+      /const recordedSandboxName =\s*session\?\.steps\?\.sandbox\?\.status === "complete" \? session\?\.sandboxName \|\| null : null;\s*let sandboxName = recordedSandboxName \|\| requestedSandboxName \|\| null;\s*if \(sandboxName && RESERVED_SANDBOX_NAMES\.has\(sandboxName\)\) \{[\s\S]*?process\.exit\(1\);\s*\}/,
     );
   });
   it("delegates sandbox-create progress streaming to the extracted helper module", () => {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -2974,7 +2974,43 @@ const { setupInference } = require(${onboardPath});
 
     assert.match(
       source,
-      /startRecordedStep\("sandbox", \{ sandboxName, provider, model \}\);\s*selectedMessagingChannels = await setupMessagingChannels\(\);\s*onboardSession\.updateSession\(\(current[^)]*\) => \{\s*current\.messagingChannels = selectedMessagingChannels;\s*return current;\s*\}\);[\s\S]*?sandboxName = await createSandbox\(\s*gpu,\s*model,\s*provider,\s*preferredInferenceApi,\s*sandboxName,\s*nextWebSearchConfig,\s*selectedMessagingChannels,\s*fromDockerfile,\s*agent,\s*opts\.controlUiPort \|\| null,\s*\);/,
+      // #2753: sandboxName is intentionally absent from the options here so
+      // the session does not record a name before createSandbox completes.
+      /startRecordedStep\("sandbox", \{ provider, model \}\);\s*selectedMessagingChannels = await setupMessagingChannels\(\);\s*onboardSession\.updateSession\(\(current[^)]*\) => \{\s*current\.messagingChannels = selectedMessagingChannels;\s*return current;\s*\}\);[\s\S]*?sandboxName = await createSandbox\(\s*gpu,\s*model,\s*provider,\s*preferredInferenceApi,\s*sandboxName,\s*nextWebSearchConfig,\s*selectedMessagingChannels,\s*fromDockerfile,\s*agent,\s*opts\.controlUiPort \|\| null,\s*\);/,
+    );
+  });
+
+  it("does not persist sandboxName to onboard-session.json before createSandbox completes (#2753)", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+
+    // Steps that run before `openshell sandbox create` succeeds must not
+    // write sandboxName into the session — otherwise a SIGINT in between
+    // leaves a phantom name that `nemoclaw list` resurrects until the user
+    // manually destroys it. sandboxName is only persisted at the sandbox
+    // step's markStepComplete, which runs after createSandbox returns.
+    assert.match(source, /startRecordedStep\("provider_selection"\);/);
+    assert.match(source, /startRecordedStep\("inference", \{ provider, model \}\);/);
+    assert.match(source, /startRecordedStep\("sandbox", \{ provider, model \}\);/);
+    assert.doesNotMatch(
+      source,
+      /startRecordedStep\("(?:provider_selection|inference|sandbox)",\s*\{[^}]*\bsandboxName\b/,
+    );
+    // The first markStepComplete that records sandboxName is the sandbox
+    // step, after createSandbox(). Locked in by checking createSandbox
+    // appears before the first sandboxName-bearing markStepComplete. The
+    // toSessionUpdates({ ... }) options object is matched non-greedily so a
+    // later sandboxName reference from a different call site cannot leak
+    // into the match.
+    const createIdx = source.indexOf("sandboxName = await createSandbox(");
+    const firstSandboxNameMarkComplete = source.search(
+      /onboardSession\.markStepComplete\(\s*"[^"]+",\s*toSessionUpdates\(\{[^}]*\bsandboxName\b/,
+    );
+    assert.ok(
+      createIdx > 0 && firstSandboxNameMarkComplete > createIdx,
+      `createSandbox (${createIdx}) must precede the first sandboxName-bearing markStepComplete (${firstSandboxNameMarkComplete})`,
     );
   });
 


### PR DESCRIPTION
## Summary

`nemoclaw onboard` wrote `sandboxName` into `onboard-session.json` at Step 3 (provider_selection), well before sandbox creation in Step 6. A SIGINT in between left a session entry pointing at a sandbox that was never created — and `nemoclaw list` then surfaced the phantom name both as a "recovered" registry entry and as the empty-state "last onboarded sandbox" hint, persisting until the user manually destroyed it.

This PR addresses the bug at the root: the session only records `sandboxName` after `openshell sandbox create` has actually returned. Three layered guards make the surface symptom-free without taking any destructive action against existing registry state:

1. **Root-cause fix** — strip `sandboxName` from every `startRecordedStep` / `markStepComplete` call before the `sandbox` step's `markStepComplete` (which runs after `createSandbox()` returns). Pre-create writes can no longer create phantoms.
2. **Seed-time guard** — `seedRecoveryMetadata` and `getSandboxInventory` skip session-derived surfaces when `session.steps.sandbox.status !== "complete"`. Pre-fix on-disk session files no longer get re-seeded into the registry, and the empty-state hint suppresses them too.
3. **Resume guard** — non-interactive `--resume` exits early with a clear error when no name can be recovered from `--name` / `NEMOCLAW_SANDBOX_NAME` / a complete prior session. Prevents silently defaulting to the agent's `my-assistant`.

## Related Issue

Fixes #2753

## Changes

- `src/lib/onboard.ts`:
  - Strip `sandboxName` from `startRecordedStep("provider_selection")`, `markStepComplete("provider_selection", …)`, the resume-branch `markStepComplete`, `startRecordedStep("inference", …)`, both `markStepComplete("inference", …)` calls, and `startRecordedStep("sandbox", …)`. The first persistence of `sandboxName` is now `markStepComplete("sandbox", …)`, which runs after `createSandbox()` succeeds.
  - Add a non-interactive resume guard right after the resume init block (before preflight side effects). Errors with `Cannot resume non-interactive onboard: the previous run was interrupted before sandbox creation completed, so no sandbox name was recorded. Re-run with --name <sandbox> (or set NEMOCLAW_SANDBOX_NAME).` when the session shows the sandbox step did not complete and no name was provided through `--name` or `NEMOCLAW_SANDBOX_NAME`.

- `src/lib/registry-recovery-action.ts`: add `isSessionSandboxConfirmed(session)` predicate that requires `session.steps.sandbox.status === "complete"`. `seedRecoveryMetadata` early-returns when not confirmed, so `nemoclaw list` cannot resurrect a phantom by reading a stale session file.

- `src/lib/inventory-commands.ts`: extend the `loadLastSession` dep type to include `steps`, then filter `lastOnboardedSandbox` on `steps.sandbox.status === "complete"`. The empty-state hint stops resurrecting phantom names.

- `test/onboard.test.ts`: update the existing source-level regex to match the new `{ provider, model }` options shape on the sandbox step's `startRecordedStep`. New `does not persist sandboxName … (#2753)` test pins the contract: no `startRecordedStep` call before sandbox passes `sandboxName`, no `markStepComplete` records `sandboxName` until after `createSandbox()`.

- `test/cli.test.ts`: new `#2753: refuses non-interactive --resume when sandbox step never completed and no name is provided` test exercising the resume guard end-to-end with a stale session fixture.

- `src/lib/inventory-commands.test.ts`: existing fixtures updated to include `steps: { sandbox: { status: "complete" } }` (preserves the original "alpha was successfully onboarded previously" intent). New `#2753: suppresses last-onboarded hint when sandbox step never completed` test asserts the phantom name does not surface in the empty-state hint.

- `src/lib/registry-recovery-action.test.ts` (new): four tests for the seed-time guard — phantom skipped, completed session seeded, empty state, and a defensive "registered alpha + stale session ≠ eviction" case to lock in that this PR does not actively mutate the registry.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [X] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

(No user-facing docs needed for this fix — the user-visible behaviour is "phantom no longer appears", which is the absence of the bug.)

### Migration note for existing users

This PR does **not** actively evict already-persisted phantoms from `sandboxes.json` — the false-positive risk against real registry entries that share a name with a stale session is too high to justify destructive cleanup. Anyone who already hit the bug on a prior NemoClaw release and has the phantom registered locally can clean it up with one command:

```
nemoclaw destroy <phantom-name>
```

## Verification

- [X] `npx prek run --all-files` passes (modulo the pre-existing `test/secret-redaction.test.ts > debug.sh sed fallback includes essential prefixes > redacts essential token prefixes when node is unavailable` failure that exists on `main` unchanged)
- [X] `npm test` passes — 2576 CLI tests pass with the same single pre-existing failure
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure

- [X] AI-assisted — tools: Claude Code, OpenAI Codex

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery and resume logic now only trusts sandboxes from fully completed onboarding sessions; incomplete sessions are ignored.
  * Non-interactive onboarding resume now fails fast when the prior session didn’t finish sandbox onboarding instead of silently using a saved name.
  * Session persistence no longer records sandbox identifiers until sandbox creation completes.

* **Tests**
  * Added regression and unit tests covering resume guards, registry recovery, and session persistence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
