### PR TITLE
fix(snapshot): preserve Hermes durable state

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -228,6 +228,7 @@ RUN set -eu; \
         /sandbox/.hermes/cache \
         /sandbox/.hermes/pairing \
         /sandbox/.hermes/runtime \
+    && chmod 2770 /sandbox/.hermes/runtime \
     && chmod 640 /sandbox/.hermes/config.yaml \
     && chmod 640 /sandbox/.hermes/.env \
     && for name in state.db state.db-wal state.db-shm gateway.pid gateway.lock gateway_state.json channel_directory.json; do \

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -100,6 +100,7 @@ RUN mkdir -p /sandbox/.hermes/memories \
         /sandbox/.hermes/cache \
         /sandbox/.hermes/pairing \
         /sandbox/.hermes/runtime \
+    && chmod 2770 /sandbox/.hermes/runtime \
     && for name in state.db state.db-wal state.db-shm gateway.pid gateway.lock gateway_state.json channel_directory.json; do \
         rm -f "/sandbox/.hermes/${name}"; \
         ln -s "runtime/${name}" "/sandbox/.hermes/${name}"; \

--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -68,6 +68,16 @@ state_dirs:
   - cache
   - pairing
 
+# ── Top-level durable state files ───────────────────────────────
+# NemoClaw stores Hermes gateway-created top-level state under runtime/ and
+# exposes compatibility symlinks such as .hermes/state.db -> runtime/state.db.
+# The SQLite database is captured with SQLite's online backup API; WAL/SHM
+# files are intentionally omitted because the backup produces a consistent DB.
+state_files:
+  - path: SOUL.md
+  - path: runtime/state.db
+    strategy: sqlite_backup
+
 # ── Authentication ──────────────────────────────────────────────
 # Hermes does NOT have OpenClaw-style browser device pairing.
 # Web UI auth is Bearer token via API_SERVER_KEY env var.

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -505,6 +505,7 @@ if [ "$(id -u)" -ne 0 ]; then
 
   # Start decode proxy and Hermes gateway
   start_decode_proxy
+  umask 0007
   HERMES_HOME="${HERMES_DIR}" \
     HTTPS_PROXY="http://127.0.0.1:${DECODE_PROXY_PORT}" \
     HTTP_PROXY="http://127.0.0.1:${DECODE_PROXY_PORT}" \
@@ -555,7 +556,7 @@ HERMES_HOME="${HERMES_DIR}" \
   HTTP_PROXY="http://127.0.0.1:${DECODE_PROXY_PORT}" \
   https_proxy="http://127.0.0.1:${DECODE_PROXY_PORT}" \
   http_proxy="http://127.0.0.1:${DECODE_PROXY_PORT}" \
-  nohup gosu gateway sh -c 'exec "$@" >/tmp/gateway.log 2>&1' sh "$HERMES" gateway run &
+  nohup gosu gateway sh -c 'umask 0007; exec "$@" >/tmp/gateway.log 2>&1' sh "$HERMES" gateway run &
 GATEWAY_PID=$!
 echo "[gateway] hermes gateway launched as 'gateway' user (pid $GATEWAY_PID)" >&2
 start_gateway_log_stream

--- a/docs/manage-sandboxes/backup-restore.md
+++ b/docs/manage-sandboxes/backup-restore.md
@@ -39,6 +39,12 @@ This guide covers snapshot commands, manual backup with CLI commands, and an aut
 
 The fastest way to back up and restore sandbox state is with the built-in snapshot commands.
 Snapshots capture all workspace state directories defined in the agent manifest and store them in `~/.nemoclaw/rebuild-backups/<name>/`.
+Agent manifests may also declare durable top-level state files. For Hermes,
+snapshots include `SOUL.md` and the SQLite database behind `.hermes/state.db`
+using SQLite's online backup API, then restore that database through SQLite
+instead of copying a live raw database file.
+Treat snapshot directories as private local data: the Hermes database can
+contain session metadata and message history needed for a faithful restore.
 
 ```console
 $ nemoclaw my-assistant snapshot create
@@ -65,6 +71,10 @@ $ nemoclaw my-assistant snapshot restore 2026-04-14T
 The `nemoclaw <name> rebuild` command uses the same snapshot mechanism automatically.
 Snapshot restore performs a targeted repair for legacy `.openclaw-data` symlinks that were created by older images.
 Unsafe symlinks and hard links inside sandbox state are rejected during backup creation before they can enter a snapshot.
+Credential-bearing Hermes files such as `auth.json` are intentionally excluded
+from snapshots. NemoClaw-regenerated Hermes config files (`config.yaml` and
+`.env`) are also excluded; model/provider and messaging credentials are
+recreated from host-side onboarding and OpenShell provider state during rebuild.
 For full details, see the [Commands reference](../reference/commands.md).
 
 ## Manual Backup

--- a/docs/manage-sandboxes/lifecycle.md
+++ b/docs/manage-sandboxes/lifecycle.md
@@ -215,7 +215,7 @@ $ nemoclaw <sandbox-name> snapshot restore pre-upgrade
 Each rebuild destroys the existing container and creates a new one.
 NemoClaw protects your data through the same backup-and-restore flow as [`nemoclaw <name> rebuild`](../reference/commands.md#nemoclaw-name-rebuild):
 
-- NemoClaw preserves manifest-defined workspace state. Before deleting the old container, NemoClaw snapshots the state directories defined in the agent manifest, typically `/sandbox/.openclaw/workspace/`, and restores them into the new container. Stored credentials (`~/.nemoclaw/credentials.json`) and registered policy presets live on the host and are re-applied to the new sandbox automatically.
+- NemoClaw preserves manifest-defined workspace state. Before deleting the old container, NemoClaw snapshots the state directories and durable state files defined in the agent manifest, typically `/sandbox/.openclaw/workspace/`; for Hermes this also includes `SOUL.md` and the SQLite database behind `.hermes/state.db`. Stored credentials (`~/.nemoclaw/credentials.json`) and registered policy presets live on the host and are re-applied to the new sandbox automatically.
 - NemoClaw does not preserve runtime changes outside the workspace state directories. This includes packages installed inside the running container with `apt` or `pip`, files in non-workspace paths, and in-memory or process state. If you have customized the running container at runtime, capture that as `Dockerfile` changes for `nemoclaw onboard --from` or a manual `openshell sandbox download` before the rebuild starts.
 
 Aborts before the destroy step are non-destructive.

--- a/src/lib/agent-defs.ts
+++ b/src/lib/agent-defs.ts
@@ -32,6 +32,13 @@ export interface AgentConfigPaths {
   format: string;
 }
 
+export type AgentStateFileStrategy = "copy" | "sqlite_backup";
+
+export interface AgentStateFile {
+  path: string;
+  strategy: AgentStateFileStrategy;
+}
+
 export type AgentDashboardKind = "ui" | "api";
 
 export interface AgentDashboard {
@@ -62,6 +69,7 @@ export interface AgentDefinition {
   health_probe?: AgentHealthProbe;
   config?: ManifestRecord;
   state_dirs?: string[];
+  state_files?: AgentStateFile[];
   messaging_platforms?: { supported?: string[] };
   _legacy_paths?: StringMap;
   agentDir: string;
@@ -72,6 +80,7 @@ export interface AgentDefinition {
   readonly dashboard: AgentDashboard;
   readonly configPaths: AgentConfigPaths;
   readonly stateDirs: string[];
+  readonly stateFiles: AgentStateFile[];
   readonly versionCommand: string;
   readonly expectedVersion: string | null;
   readonly hasDevicePairing: boolean;
@@ -137,6 +146,36 @@ function readStringArray(record: ManifestRecord, key: string): string[] | undefi
   const value = record[key];
   if (!Array.isArray(value)) return undefined;
   return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function readStateFiles(record: ManifestRecord): AgentStateFile[] | undefined {
+  const value = record.state_files;
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error("Agent manifest field 'state_files' must be an array");
+  }
+
+  return value.map((entry, index) => {
+    if (typeof entry === "string") {
+      return { path: entry, strategy: "copy" };
+    }
+    if (!isManifestRecord(entry)) {
+      throw new Error(
+        `Agent manifest field 'state_files[${String(index)}]' must be a string or object`,
+      );
+    }
+    const statePath = readString(entry, "path");
+    if (!statePath) {
+      throw new Error(`Agent manifest field 'state_files[${String(index)}].path' is required`);
+    }
+    const rawStrategy = readString(entry, "strategy") ?? "copy";
+    if (rawStrategy !== "copy" && rawStrategy !== "sqlite_backup") {
+      throw new Error(
+        `Agent manifest field 'state_files[${String(index)}].strategy' must be copy or sqlite_backup`,
+      );
+    }
+    return { path: statePath, strategy: rawStrategy };
+  });
 }
 
 function isValidPort(value: unknown): value is number {
@@ -260,6 +299,7 @@ export function loadAgent(name: string): AgentDefinition {
   const healthProbe = readHealthProbe(raw);
   const config = readObject(raw, "config");
   const stateDirs = readStringArray(raw, "state_dirs");
+  const stateFiles = readStateFiles(raw);
   const phoneHomeHosts = readStringArray(raw, "phone_home_hosts");
   const messagingPlatforms = readMessagingPlatforms(raw);
   const legacyPathConfig = readStringMap(raw, "_legacy_paths");
@@ -279,6 +319,7 @@ export function loadAgent(name: string): AgentDefinition {
     health_probe: healthProbe,
     config,
     state_dirs: stateDirs,
+    state_files: stateFiles,
     messaging_platforms: messagingPlatforms,
     _legacy_paths: legacyPathConfig,
     agentDir,
@@ -327,6 +368,10 @@ export function loadAgent(name: string): AgentDefinition {
 
     get stateDirs(): string[] {
       return stateDirs ?? [];
+    },
+
+    get stateFiles(): AgentStateFile[] {
+      return stateFiles ?? [];
     },
 
     get versionCommand(): string {

--- a/src/lib/agent-onboard.test.ts
+++ b/src/lib/agent-onboard.test.ts
@@ -22,6 +22,7 @@ function makeAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
       format: "yaml",
     },
     stateDirs: [],
+    stateFiles: [],
     versionCommand: "agent --version",
     expectedVersion: null,
     hasDevicePairing: false,

--- a/src/lib/agent-runtime.test.ts
+++ b/src/lib/agent-runtime.test.ts
@@ -22,6 +22,7 @@ function makeAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
       format: "yaml",
     },
     stateDirs: [],
+    stateFiles: [],
     versionCommand: "test-agent --version",
     expectedVersion: null,
     hasDevicePairing: false,

--- a/src/lib/credential-filter.test.ts
+++ b/src/lib/credential-filter.test.ts
@@ -136,6 +136,8 @@ describe("isSensitiveFile", () => {
   it("detects auth-profiles.json", () => {
     expect(isSensitiveFile("auth-profiles.json")).toBe(true);
     expect(isSensitiveFile("Auth-Profiles.json")).toBe(true);
+    expect(isSensitiveFile("auth.json")).toBe(true);
+    expect(isSensitiveFile("AUTH.JSON")).toBe(true);
   });
 
   it("does not flag normal files", () => {

--- a/src/lib/credential-filter.ts
+++ b/src/lib/credential-filter.ts
@@ -39,7 +39,7 @@ const CREDENTIAL_PLACEHOLDER = "[STRIPPED_BY_MIGRATION]";
  * File basenames that contain sensitive auth material and should be
  * excluded from backups entirely.
  */
-export const CREDENTIAL_SENSITIVE_BASENAMES = new Set(["auth-profiles.json"]);
+export const CREDENTIAL_SENSITIVE_BASENAMES = new Set(["auth-profiles.json", "auth.json"]);
 
 /**
  * Credential field names that MUST be stripped from config files.

--- a/src/lib/maintenance-actions.ts
+++ b/src/lib/maintenance-actions.ts
@@ -42,11 +42,12 @@ export function backupAll(): void {
     const result = sandboxState.backupSandboxState(sb.name);
     if (result.success) {
       console.log(
-        `  ${G}✓${R} ${sb.name}: ${result.backedUpDirs.length} dirs → ${result.manifest?.backupPath || "unknown"}`,
+        `  ${G}✓${R} ${sb.name}: ${result.backedUpDirs.length} dirs, ${result.backedUpFiles.length} files → ${result.manifest?.backupPath || "unknown"}`,
       );
       backed++;
     } else {
-      console.error(`  ${RD}✗${R} ${sb.name}: backup failed (${result.failedDirs.join(", ")})`);
+      const failedItems = [...result.failedDirs, ...result.failedFiles];
+      console.error(`  ${RD}✗${R} ${sb.name}: backup failed (${failedItems.join(", ")})`);
       failed++;
     }
   }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4272,7 +4272,9 @@ async function createSandbox(
       try {
         const backup = sandboxState.backupSandboxState(sandboxName);
         if (backup.success) {
-          note(`  ✓ State backed up (${backup.backedUpDirs.length} directories)`);
+          note(
+            `  ✓ State backed up (${backup.backedUpDirs.length} directories, ${backup.backedUpFiles.length} files)`,
+          );
           pendingStateRestore = backup;
         } else {
           console.error("  State backup failed — aborting rebuild to prevent data loss.");
@@ -4895,7 +4897,9 @@ async function createSandbox(
       pendingStateRestore.manifest.backupPath,
     );
     if (restore.success) {
-      note(`  ✓ State restored (${restore.restoredDirs.length} directories)`);
+      note(
+        `  ✓ State restored (${restore.restoredDirs.length} directories, ${restore.restoredFiles.length} files)`,
+      );
     } else {
       console.error(
         `  Warning: partial restore. Manual recovery: ${pendingStateRestore.manifest.backupPath}`,

--- a/src/lib/sandbox-state.ts
+++ b/src/lib/sandbox-state.ts
@@ -27,6 +27,7 @@ import path from "node:path";
 
 import * as registry from "./registry.js";
 import { loadAgent } from "./agent-defs.js";
+import type { AgentStateFile } from "./agent-defs.js";
 import { resolveOpenshell } from "./resolve-openshell.js";
 import { captureOpenshellCommand } from "./openshell.js";
 import { sanitizeConfigFile, isSensitiveFile } from "./credential-filter.js";
@@ -51,6 +52,7 @@ export interface RebuildManifest {
   agentVersion: string | null;
   expectedVersion: string | null;
   stateDirs: string[];
+  stateFiles?: StateFileSpec[];
   /** Single config/state directory */
   dir: string;
   /** @deprecated Old field name for `dir` — retained for backward compat with pre-consolidation backups. */
@@ -80,6 +82,13 @@ export interface InstanceBackup {
   backedUpDirs: string[];
 }
 
+export type StateFileStrategy = "copy" | "sqlite_backup";
+
+export interface StateFileSpec {
+  path: string;
+  strategy: StateFileStrategy;
+}
+
 export interface BackupResult {
   success: boolean;
   // Only set once the backup has been written to disk — absent on
@@ -90,12 +99,16 @@ export interface BackupResult {
   // Set when the failure is a precondition (e.g. duplicate --name) rather
   // than a mid-backup error. CLI surfaces this to the user verbatim.
   error?: string;
+  backedUpFiles: string[];
+  failedFiles: string[];
 }
 
 export interface RestoreResult {
   success: boolean;
   restoredDirs: string[];
   failedDirs: string[];
+  restoredFiles: string[];
+  failedFiles: string[];
 }
 
 export interface TarValidationResult {
@@ -117,6 +130,15 @@ function isRecord(value: unknown): value is UnknownRecord {
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isStateFileSpec(value: unknown): value is StateFileSpec {
+  return (
+    isRecord(value) &&
+    typeof value.path === "string" &&
+    (value.strategy === "copy" || value.strategy === "sqlite_backup") &&
+    normalizeStateFileSpec({ path: value.path, strategy: value.strategy }) !== null
+  );
 }
 
 function isInstanceBackup(value: unknown): value is InstanceBackup {
@@ -142,6 +164,8 @@ function isRebuildManifest(value: unknown): value is RebuildManifest {
     isStringArray(value.stateDirs) &&
     (typeof value.dir === "string" || typeof value.writableDir === "string") &&
     typeof value.backupPath === "string" &&
+    (value.stateFiles === undefined ||
+      (Array.isArray(value.stateFiles) && value.stateFiles.every(isStateFileSpec))) &&
     (value.blueprintDigest === undefined ||
       value.blueprintDigest === null ||
       typeof value.blueprintDigest === "string") &&
@@ -550,6 +574,194 @@ export function validateSnapshotName(name: string): string | null {
   return null;
 }
 
+function normalizeStateFilePath(filePath: string): string | null {
+  if (!filePath || filePath.includes("\0") || path.isAbsolute(filePath)) return null;
+  const normalized = path.posix.normalize(filePath.replace(/\\/g, "/"));
+  if (normalized === "." || normalized.startsWith("../") || normalized === "..") return null;
+  return normalized;
+}
+
+function normalizeStateFileSpec(spec: AgentStateFile | StateFileSpec): StateFileSpec | null {
+  const normalized = normalizeStateFilePath(spec.path);
+  if (!normalized) return null;
+  if (spec.strategy !== "copy" && spec.strategy !== "sqlite_backup") return null;
+  return { path: normalized, strategy: spec.strategy };
+}
+
+function normalizeStateFileSpecs(specs: readonly (AgentStateFile | StateFileSpec)[]): StateFileSpec[] {
+  const normalized: StateFileSpec[] = [];
+  const seen = new Set<string>();
+  for (const spec of specs) {
+    const next = normalizeStateFileSpec(spec);
+    if (!next) continue;
+    const key = `${next.strategy}:${next.path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(next);
+  }
+  return normalized;
+}
+
+function stateFileRemotePath(dir: string, filePath: string): string {
+  return `${dir.replace(/\/+$/, "")}/${filePath}`;
+}
+
+const SQLITE_BACKUP_PY = [
+  "import sqlite3, sys",
+  "src, dst = sys.argv[1], sys.argv[2]",
+  "src_conn = sqlite3.connect('file:' + src + '?mode=ro', uri=True, timeout=30)",
+  "dst_conn = sqlite3.connect(dst, timeout=30)",
+  "try:",
+  "    dst_conn.execute('PRAGMA busy_timeout=30000')",
+  "    src_conn.backup(dst_conn)",
+  "    ok = dst_conn.execute('PRAGMA quick_check').fetchone()[0]",
+  "    if ok != 'ok':",
+  "        raise SystemExit('sqlite quick_check failed: ' + str(ok))",
+  "finally:",
+  "    dst_conn.close()",
+  "    src_conn.close()",
+].join("\n");
+
+const SQLITE_RESTORE_PY = [
+  "import os, sqlite3, sys",
+  "src, dst = sys.argv[1], sys.argv[2]",
+  "os.makedirs(os.path.dirname(dst), exist_ok=True)",
+  "src_conn = sqlite3.connect('file:' + src + '?mode=ro', uri=True, timeout=30)",
+  "dst_conn = sqlite3.connect(dst, timeout=30)",
+  "try:",
+  "    dst_conn.execute('PRAGMA busy_timeout=30000')",
+  "    src_conn.backup(dst_conn)",
+  "    ok = dst_conn.execute('PRAGMA quick_check').fetchone()[0]",
+  "    if ok != 'ok':",
+  "        raise SystemExit('sqlite quick_check failed: ' + str(ok))",
+  "finally:",
+  "    dst_conn.close()",
+  "    src_conn.close()",
+  "os.chmod(dst, 0o660)",
+].join("\n");
+
+function buildStateFileBackupCommand(dir: string, spec: StateFileSpec): string {
+  const remotePath = stateFileRemotePath(dir, spec.path);
+  const quotedRemotePath = shellQuote(remotePath);
+  if (spec.strategy === "sqlite_backup") {
+    return [
+      `src=${quotedRemotePath}`,
+      "[ ! -e \"$src\" ] && exit 2",
+      '[ -f "$src" ] && [ ! -L "$src" ] || { echo "unsafe sqlite state file: $src" >&2; exit 10; }',
+      'hardlink_count="$(find "$src" -maxdepth 0 -type f -links +1 -print 2>/dev/null | wc -l | tr -d " ")"',
+      '[ "${hardlink_count:-0}" = "0" ] || { echo "hard-linked sqlite state file rejected: $src" >&2; exit 11; }',
+      'tmp="$(mktemp /tmp/nemoclaw-sqlite-backup.XXXXXX)"',
+      'trap \'rm -f "$tmp"\' EXIT',
+      `python3 -c ${shellQuote(SQLITE_BACKUP_PY)} "$src" "$tmp"`,
+      'cat -- "$tmp"',
+    ].join("; ");
+  }
+
+  return [
+    `src=${quotedRemotePath}`,
+    "[ ! -e \"$src\" ] && exit 2",
+    '[ -f "$src" ] && [ ! -L "$src" ] || { echo "unsafe state file: $src" >&2; exit 10; }',
+    'hardlink_count="$(find "$src" -maxdepth 0 -type f -links +1 -print 2>/dev/null | wc -l | tr -d " ")"',
+    '[ "${hardlink_count:-0}" = "0" ] || { echo "hard-linked state file rejected: $src" >&2; exit 11; }',
+    'cat -- "$src"',
+  ].join("; ");
+}
+
+function backupStateFile(
+  configFile: string,
+  sandboxName: string,
+  dir: string,
+  spec: StateFileSpec,
+  backupPath: string,
+): "backed_up" | "missing" | "failed" {
+  const command = buildStateFileBackupCommand(dir, spec);
+  _log(`Backing up state file ${spec.path} (${spec.strategy})`);
+  const result = spawnSync("ssh", [...sshArgs(configFile, sandboxName), command], {
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 120000,
+    maxBuffer: 256 * 1024 * 1024,
+  });
+
+  if (result.status === 2) return "missing";
+  if (result.status !== 0 || result.error || result.signal || !result.stdout) {
+    const detail =
+      (result.stderr?.toString() || "").trim() ||
+      result.error?.message ||
+      (result.signal ? `signal ${result.signal}` : `exit ${String(result.status)}`);
+    _log(`FAILED: state file backup ${spec.path}: ${detail.substring(0, 200)}`);
+    return "failed";
+  }
+
+  const localPath = path.join(backupPath, spec.path);
+  const parent = path.dirname(localPath);
+  rejectSymlinksOnPath(parent);
+  mkdirSync(parent, { recursive: true, mode: 0o700 });
+  rejectSymlinksOnPath(localPath);
+  writeFileSync(localPath, result.stdout);
+  chmodSync(localPath, 0o600);
+  return "backed_up";
+}
+
+function buildStateFileRestoreCommand(dir: string, spec: StateFileSpec): string {
+  const remotePath = stateFileRemotePath(dir, spec.path);
+  const quotedRemotePath = shellQuote(remotePath);
+  if (spec.strategy === "sqlite_backup") {
+    return [
+      `dst=${quotedRemotePath}`,
+      'parent="$(dirname "$dst")"',
+      '[ ! -L "$parent" ] || { echo "refusing symlinked state parent: $parent" >&2; exit 10; }',
+      '[ ! -L "$dst" ] || { echo "refusing symlinked sqlite target: $dst" >&2; exit 11; }',
+      'mkdir -p "$parent"',
+      'tmp="$(mktemp /tmp/nemoclaw-sqlite-restore.XXXXXX)"',
+      'trap \'rm -f "$tmp"\' EXIT',
+      'cat > "$tmp"',
+      'chmod 600 "$tmp"',
+      `umask 0007; python3 -c ${shellQuote(SQLITE_RESTORE_PY)} "$tmp" "$dst"`,
+    ].join("; ");
+  }
+
+  return [
+    `dst=${quotedRemotePath}`,
+    'parent="$(dirname "$dst")"',
+    '[ ! -L "$parent" ] || { echo "refusing symlinked state parent: $parent" >&2; exit 10; }',
+    '[ ! -L "$dst" ] || { echo "refusing symlinked state target: $dst" >&2; exit 11; }',
+    'mkdir -p "$parent"',
+    'tmp="$(mktemp "${parent}/.nemoclaw-restore.XXXXXX")"',
+    'trap \'rm -f "$tmp"\' EXIT',
+    'cat > "$tmp"',
+    'chmod 640 "$tmp"',
+    'mv -f "$tmp" "$dst"',
+  ].join("; ");
+}
+
+function restoreStateFile(
+  configFile: string,
+  sandboxName: string,
+  dir: string,
+  spec: StateFileSpec,
+  backupPath: string,
+): boolean {
+  const localPath = path.join(backupPath, spec.path);
+  if (!existsSync(localPath)) return true;
+
+  const command = buildStateFileRestoreCommand(dir, spec);
+  _log(`Restoring state file ${spec.path} (${spec.strategy})`);
+  const result = spawnSync("ssh", [...sshArgs(configFile, sandboxName), command], {
+    input: readFileSync(localPath),
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 120000,
+  });
+
+  if (result.status === 0 && !result.error && !result.signal) return true;
+
+  const detail =
+    (result.stderr?.toString() || "").trim() ||
+    result.error?.message ||
+    (result.signal ? `signal ${result.signal}` : `exit ${String(result.status)}`);
+  _log(`FAILED: state file restore ${spec.path}: ${detail.substring(0, 200)}`);
+  return false;
+}
+
 // ── Backup ─────────────────────────────────────────────────────────
 
 /**
@@ -562,7 +774,10 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
   const agent = loadAgent(agentName);
   const dir = agent.configPaths.dir;
   const stateDirs = agent.stateDirs;
-  _log(`backupSandboxState: agent=${agentName}, dir=${dir}, stateDirs=[${stateDirs.join(",")}]`);
+  const stateFiles = normalizeStateFileSpecs(agent.stateFiles);
+  _log(
+    `backupSandboxState: agent=${agentName}, dir=${dir}, stateDirs=[${stateDirs.join(",")}], stateFiles=[${stateFiles.map((f) => f.path).join(",")}]`,
+  );
 
   // Validate user-supplied name and check for conflicts BEFORE creating any
   // files on disk.
@@ -577,6 +792,8 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         success: false,
         backedUpDirs: [],
         failedDirs: [],
+        backedUpFiles: [],
+        failedFiles: [],
         error: validationError,
       };
     }
@@ -586,6 +803,8 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         success: false,
         backedUpDirs: [],
         failedDirs: [],
+        backedUpFiles: [],
+        failedFiles: [],
         error:
           `Snapshot name '${providedName}' already exists for '${sandboxName}' ` +
           `(at ${conflict.timestamp}). Pick a different name or delete the existing snapshot.`,
@@ -619,6 +838,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
     agentVersion: sb?.agentVersion || null,
     expectedVersion: agent.expectedVersion,
     stateDirs,
+    stateFiles,
     dir,
     backupPath,
     blueprintDigest: computeBlueprintDigest(),
@@ -628,11 +848,13 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
 
   const backedUpDirs: string[] = [];
   const failedDirs: string[] = [];
+  const backedUpFiles: string[] = [];
+  const failedFiles: string[] = [];
 
-  if (stateDirs.length === 0) {
-    _log("WARNING: Agent manifest declares no state_dirs — nothing to back up");
+  if (stateDirs.length === 0 && stateFiles.length === 0) {
+    _log("WARNING: Agent manifest declares no state_dirs or state_files — nothing to back up");
     writeManifest(backupPath, manifest);
-    return { success: true, manifest, backedUpDirs, failedDirs };
+    return { success: true, manifest, backedUpDirs, failedDirs, backedUpFiles, failedFiles };
   }
 
   // SSH+tar single-roundtrip download
@@ -640,123 +862,151 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
   const sshConfig = getSshConfig(sandboxName);
   if (!sshConfig) {
     _log("FAILED: Could not get SSH config");
-    return { success: false, manifest, backedUpDirs, failedDirs: [...stateDirs] };
+    return {
+      success: false,
+      manifest,
+      backedUpDirs,
+      failedDirs: [...stateDirs],
+      backedUpFiles,
+      failedFiles: stateFiles.map((f) => f.path),
+    };
   }
   _log(`SSH config obtained (${sshConfig.length} bytes)`);
 
   const configFile = writeTempSshConfig(sshConfig);
   try {
-    // Build tar command that only includes existing directories.
-    // First, check which declared state dirs actually exist in the sandbox,
-    // then additionally discover per-agent `workspace-*` directories produced
-    // by multi-agent OpenClaw deployments (see issue #1260) so they get
-    // snapshotted alongside the manifest-declared dirs. `awk '!seen[$0]++'`
-    // dedupes while preserving order.
-    const existCheckCmd = stateDirs
-      .map((d) => `[ -d ${shellQuote(`${dir}/${d}`)} ] && printf '%s\\n' ${shellQuote(d)}`)
-      .join("; ");
-    const workspaceGlobCmd = `for d in ${shellQuote(dir)}/workspace-*/; do [ -d "$d" ] && basename "$d"; done 2>/dev/null`;
-    const fullCheckCmd = `{ ${existCheckCmd}; ${workspaceGlobCmd}; } 2>/dev/null | awk '!seen[$0]++'`;
-    _log(`Checking existing dirs via SSH: ${fullCheckCmd.substring(0, 100)}...`);
-    const existResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), fullCheckCmd], {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 30000,
-    });
-    _log(
-      `Dir check: exit=${existResult.status}, stdout=${(existResult.stdout || "").trim().substring(0, 200)}, stderr=${(existResult.stderr || "").trim().substring(0, 200)}`,
-    );
-    const existingDirs = (existResult.stdout || "")
-      .trim()
-      .split("\n")
-      .filter((d) => d.length > 0);
-    _log(
-      `Existing dirs in sandbox: [${existingDirs.join(",")}] (${existingDirs.length}/${stateDirs.length})`,
-    );
-
-    if (existResult.status !== 0) {
+    if (stateDirs.length > 0) {
+      // Build tar command that only includes existing directories.
+      // First, check which declared state dirs actually exist in the sandbox,
+      // then additionally discover per-agent `workspace-*` directories produced
+      // by multi-agent OpenClaw deployments (see issue #1260) so they get
+      // snapshotted alongside the manifest-declared dirs. `awk '!seen[$0]++'`
+      // dedupes while preserving order.
+      const existCheckCmd = stateDirs
+        .map((d) => `[ -d ${shellQuote(`${dir}/${d}`)} ] && printf '%s\\n' ${shellQuote(d)}`)
+        .join("; ");
+      const workspaceGlobCmd = `for d in ${shellQuote(dir)}/workspace-*/; do [ -d "$d" ] && basename "$d"; done 2>/dev/null`;
+      const fullCheckCmd = `{ ${existCheckCmd}; ${workspaceGlobCmd}; } 2>/dev/null | awk '!seen[$0]++'`;
+      _log(`Checking existing dirs via SSH: ${fullCheckCmd.substring(0, 100)}...`);
+      const existResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), fullCheckCmd], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 30000,
+      });
       _log(
-        `FAILED: SSH dir check exited ${existResult.status} — cannot determine which dirs exist`,
+        `Dir check: exit=${existResult.status}, stdout=${(existResult.stdout || "").trim().substring(0, 200)}, stderr=${(existResult.stderr || "").trim().substring(0, 200)}`,
       );
-      return { success: false, manifest, backedUpDirs, failedDirs: [...stateDirs] };
-    }
-
-    if (existingDirs.length === 0) {
-      _log("No state dirs found in sandbox (all empty)");
-      writeManifest(backupPath, manifest);
-      return { success: true, manifest, backedUpDirs, failedDirs };
-    }
-
-    // NC-2227-04: Pre-backup audit — reject symlinks, hardlinks, and special
-    // files inside state dirs. A compromised agent could plant a symlink like
-    // workspace/copy -> ../openclaw.json to exfiltrate config via backup.
-    const auditCmd = existingDirs
-      .map(
-        (d) =>
-          `find ${shellQuote(`${dir}/${d}`)} \\( -type l -o \\( -type f -a -links +1 \\) -o \\( ! -type f -a ! -type d \\) \\) -printf "%y %p\\n" 2>/dev/null`,
-      )
-      .join(" && ");
-    _log(`Pre-backup audit: checking for symlinks, hard links, and special files`);
-    const auditResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), auditCmd], {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 30000,
-    });
-    if (auditResult.status !== 0) {
-      const stderr = (auditResult.stderr || "").trim();
-      const detail = stderr || auditResult.error?.message || `exit ${String(auditResult.status)}`;
-      _log(`FAILED: Pre-backup audit command failed — ${detail}`);
-      return {
-        success: false,
-        manifest,
-        backedUpDirs,
-        failedDirs: [...existingDirs],
-        error: `Pre-backup audit failed: ${detail}`,
-      };
-    }
-    const auditOutput = (auditResult.stdout || "").trim();
-    if (auditOutput.length > 0) {
-      // Found symlinks or special files — log them and reject the backup
-      const violations = auditOutput.split("\n").filter((l) => l.length > 0);
+      const existingDirs = (existResult.stdout || "")
+        .trim()
+        .split("\n")
+        .filter((d) => d.length > 0);
       _log(
-        `SECURITY: Pre-backup audit found ${violations.length} unsafe entries: ${violations.slice(0, 5).join("; ")}`,
+        `Existing dirs in sandbox: [${existingDirs.join(",")}] (${existingDirs.length}/${stateDirs.length})`,
       );
-      return {
-        success: false,
-        manifest,
-        backedUpDirs,
-        failedDirs: [...existingDirs],
-        error: `Pre-backup audit rejected: symlinks, hard links, or special files found in state dirs: ${violations.slice(0, 3).join("; ")}`,
-      };
-    }
-    _log("Pre-backup audit passed — no symlinks, hard links, or special files found");
 
-    // Download via SSH+tar
-    // NC-2227-04: Removed -h flag (was following symlinks). State dirs are
-    // now agent-writable and co-located with config — a compromised agent
-    // could create symlinks to exfiltrate config contents via backup.
-    const tarCmd = `tar -cf - -C ${shellQuote(dir)} -- ${existingDirs.map(shellQuote).join(" ")}`;
-    _log(`Downloading via SSH+tar: ${tarCmd}`);
-    const result = spawnSync("ssh", [...sshArgs(configFile, sandboxName), tarCmd], {
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 120000,
-      maxBuffer: 256 * 1024 * 1024,
-    });
-    _log(
-      `SSH+tar download: exit=${result.status}, stdout=${result.stdout ? result.stdout.length + " bytes" : "null"}, stderr=${(result.stderr?.toString() || "").substring(0, 200)}`,
-    );
-
-    if (result.status === 0 && result.stdout && result.stdout.length > 0) {
-      // SECURITY: Validate tar entries, extract safely, audit symlinks
-      const extractResult = safeTarExtract(result.stdout, backupPath);
-      if (extractResult.success) {
-        backedUpDirs.push(...existingDirs);
-      } else {
-        _log(`SECURITY: tar extraction blocked: ${extractResult.error}`);
-        failedDirs.push(...existingDirs);
+      if (existResult.status !== 0) {
+        _log(
+          `FAILED: SSH dir check exited ${existResult.status} — cannot determine which dirs exist`,
+        );
+        return {
+          success: false,
+          manifest,
+          backedUpDirs,
+          failedDirs: [...stateDirs],
+          backedUpFiles,
+          failedFiles: stateFiles.map((f) => f.path),
+        };
       }
-    } else {
-      failedDirs.push(...existingDirs);
+
+      if (existingDirs.length === 0) {
+        _log("No state dirs found in sandbox (all empty)");
+      } else {
+        // NC-2227-04: Pre-backup audit — reject symlinks, hardlinks, and special
+        // files inside state dirs. A compromised agent could plant a symlink like
+        // workspace/copy -> ../openclaw.json to exfiltrate config via backup.
+        const auditCmd = existingDirs
+          .map(
+            (d) =>
+              `find ${shellQuote(`${dir}/${d}`)} \\( -type l -o \\( -type f -a -links +1 \\) -o \\( ! -type f -a ! -type d \\) \\) -printf "%y %p\\n" 2>/dev/null`,
+          )
+          .join(" && ");
+        _log(`Pre-backup audit: checking for symlinks, hard links, and special files`);
+        const auditResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), auditCmd], {
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 30000,
+        });
+        if (auditResult.status !== 0) {
+          const stderr = (auditResult.stderr || "").trim();
+          const detail =
+            stderr || auditResult.error?.message || `exit ${String(auditResult.status)}`;
+          _log(`FAILED: Pre-backup audit command failed — ${detail}`);
+          return {
+            success: false,
+            manifest,
+            backedUpDirs,
+            failedDirs: [...existingDirs],
+            backedUpFiles,
+            failedFiles: stateFiles.map((f) => f.path),
+            error: `Pre-backup audit failed: ${detail}`,
+          };
+        }
+        const auditOutput = (auditResult.stdout || "").trim();
+        if (auditOutput.length > 0) {
+          // Found symlinks or special files — log them and reject the backup
+          const violations = auditOutput.split("\n").filter((l) => l.length > 0);
+          _log(
+            `SECURITY: Pre-backup audit found ${violations.length} unsafe entries: ${violations.slice(0, 5).join("; ")}`,
+          );
+          return {
+            success: false,
+            manifest,
+            backedUpDirs,
+            failedDirs: [...existingDirs],
+            backedUpFiles,
+            failedFiles: stateFiles.map((f) => f.path),
+            error: `Pre-backup audit rejected: symlinks, hard links, or special files found in state dirs: ${violations.slice(0, 3).join("; ")}`,
+          };
+        }
+        _log("Pre-backup audit passed — no symlinks, hard links, or special files found");
+
+        // Download via SSH+tar
+        // NC-2227-04: Removed -h flag (was following symlinks). State dirs are
+        // now agent-writable and co-located with config — a compromised agent
+        // could create symlinks to exfiltrate config contents via backup.
+        const tarCmd = `tar -cf - -C ${shellQuote(dir)} -- ${existingDirs.map(shellQuote).join(" ")}`;
+        _log(`Downloading via SSH+tar: ${tarCmd}`);
+        const result = spawnSync("ssh", [...sshArgs(configFile, sandboxName), tarCmd], {
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 120000,
+          maxBuffer: 256 * 1024 * 1024,
+        });
+        _log(
+          `SSH+tar download: exit=${result.status}, stdout=${result.stdout ? result.stdout.length + " bytes" : "null"}, stderr=${(result.stderr?.toString() || "").substring(0, 200)}`,
+        );
+
+        if (result.status === 0 && result.stdout && result.stdout.length > 0) {
+          // SECURITY: Validate tar entries, extract safely, audit symlinks
+          const extractResult = safeTarExtract(result.stdout, backupPath);
+          if (extractResult.success) {
+            backedUpDirs.push(...existingDirs);
+          } else {
+            _log(`SECURITY: tar extraction blocked: ${extractResult.error}`);
+            failedDirs.push(...existingDirs);
+          }
+        } else {
+          failedDirs.push(...existingDirs);
+        }
+      }
+    }
+
+    for (const spec of stateFiles) {
+      const result = backupStateFile(configFile, sandboxName, dir, spec, backupPath);
+      if (result === "backed_up") {
+        backedUpFiles.push(spec.path);
+      } else if (result === "failed") {
+        failedFiles.push(spec.path);
+      }
     }
   } finally {
     try {
@@ -788,10 +1038,12 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
   manifest.backupPath = backupPath;
 
   return {
-    success: failedDirs.length === 0,
+    success: failedDirs.length === 0 && failedFiles.length === 0,
     manifest,
     backedUpDirs,
     failedDirs,
+    backedUpFiles,
+    failedFiles,
   };
 }
 
@@ -805,126 +1057,173 @@ export function restoreSandboxState(sandboxName: string, backupPath: string): Re
   const manifest = readManifest(backupPath);
   if (!manifest) {
     _log("FAILED: Could not read rebuild-manifest.json");
-    return { success: false, restoredDirs: [], failedDirs: ["manifest"] };
+    return {
+      success: false,
+      restoredDirs: [],
+      failedDirs: ["manifest"],
+      restoredFiles: [],
+      failedFiles: [],
+    };
   }
 
   const dir = manifest.dir || manifest.writableDir;
   if (!dir) {
     _log("FAILED: manifest has no dir or writableDir");
-    return { success: false, restoredDirs: [], failedDirs: ["manifest"] };
+    return {
+      success: false,
+      restoredDirs: [],
+      failedDirs: ["manifest"],
+      restoredFiles: [],
+      failedFiles: [],
+    };
   }
   const restoredDirs: string[] = [];
   const failedDirs: string[] = [];
+  const restoredFiles: string[] = [];
+  const failedFiles: string[] = [];
 
   // Find which backed-up directories actually exist locally
   const localDirs = manifest.stateDirs.filter((d) => existsSync(path.join(backupPath, d)));
+  const stateFiles = normalizeStateFileSpecs(manifest.stateFiles ?? []);
+  const localFiles = stateFiles.filter((f) => existsSync(path.join(backupPath, f.path)));
   _log(
     `Local backup dirs: [${localDirs.join(",")}] (${localDirs.length}/${manifest.stateDirs.length})`,
   );
+  _log(
+    `Local backup files: [${localFiles.map((f) => f.path).join(",")}] (${localFiles.length}/${stateFiles.length})`,
+  );
 
-  if (localDirs.length === 0) {
-    _log("No dirs to restore");
-    return { success: true, restoredDirs, failedDirs };
+  if (localDirs.length === 0 && localFiles.length === 0) {
+    _log("No dirs or files to restore");
+    return { success: true, restoredDirs, failedDirs, restoredFiles, failedFiles };
   }
 
   _log("Getting SSH config for restore");
   const sshConfig = getSshConfig(sandboxName);
   if (!sshConfig) {
     _log("FAILED: Could not get SSH config for restore");
-    return { success: false, restoredDirs, failedDirs: [...localDirs] };
+    return {
+      success: false,
+      restoredDirs,
+      failedDirs: [...localDirs],
+      restoredFiles,
+      failedFiles: localFiles.map((f) => f.path),
+    };
   }
 
   const configFile = writeTempSshConfig(sshConfig);
   try {
-    // Upload via tar pipe
-    // NC-2227-04: Removed -h flag from restore as well — no symlink following.
-    const tarResult = spawnSync("tar", ["-cf", "-", "-C", backupPath, ...localDirs], {
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 60000,
-      maxBuffer: 256 * 1024 * 1024,
-    });
+    if (localDirs.length > 0) {
+      // Upload via tar pipe
+      // NC-2227-04: Removed -h flag from restore as well — no symlink following.
+      const tarResult = spawnSync("tar", ["-cf", "-", "-C", backupPath, ...localDirs], {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 60000,
+        maxBuffer: 256 * 1024 * 1024,
+      });
 
-    if (tarResult.status !== 0 || !tarResult.stdout) {
-      return { success: false, restoredDirs, failedDirs: [...localDirs] };
-    }
+      if (tarResult.status !== 0 || !tarResult.stdout) {
+        return {
+          success: false,
+          restoredDirs,
+          failedDirs: [...localDirs],
+          restoredFiles,
+          failedFiles: localFiles.map((f) => f.path),
+        };
+      }
 
-    // Remove existing state dirs before extracting so stale files from
-    // later snapshots don't persist after restoring an earlier one.
-    const rmCmd = localDirs.map((d) => `rm -rf -- ${shellQuote(`${dir}/${d}`)}`).join(" && ");
-    _log(`Cleaning target dirs before restore: ${rmCmd}`);
-    const rmResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), rmCmd], {
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 30000,
-    });
-    if (rmResult.status !== 0 || rmResult.error || rmResult.signal) {
-      const stderr = (rmResult.stderr?.toString() || "").trim();
-      const detail =
-        stderr ||
-        rmResult.error?.message ||
-        (rmResult.signal ? `signal ${rmResult.signal}` : `exit ${String(rmResult.status)}`);
-      _log(`FAILED: pre-restore cleanup failed: ${detail.substring(0, 200)}`);
-      return { success: false, restoredDirs, failedDirs: [...localDirs] };
-    }
-
-    const extractCmd = `tar --no-same-owner -xf - -C ${shellQuote(dir)}`;
-    const sshResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), extractCmd], {
-      input: tarResult.stdout,
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 120000,
-    });
-
-    if (sshResult.status === 0) {
-      const restoredPaths = localDirs.map((d) => `${dir}/${d}`);
-
-      // Best-effort only: OpenShell exec/SSH normally runs as the sandbox user,
-      // which cannot chown even files it owns. The tar restore above runs as the
-      // same user, so the real restore gate is whether the restored state dirs
-      // are usable by that user.
-      const chownCmd = `chown -R sandbox:sandbox -- ${restoredPaths.map(shellQuote).join(" ")} 2>/dev/null || true`;
-      _log(`Best-effort ownership repair: ${chownCmd}`);
-      const chownResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), chownCmd], {
+      // Remove existing state dirs before extracting so stale files from
+      // later snapshots don't persist after restoring an earlier one.
+      const rmCmd = localDirs.map((d) => `rm -rf -- ${shellQuote(`${dir}/${d}`)}`).join(" && ");
+      _log(`Cleaning target dirs before restore: ${rmCmd}`);
+      const rmResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), rmCmd], {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 30000,
       });
-      if (chownResult.error || chownResult.signal) {
-        const detail =
-          chownResult.error?.message ||
-          (chownResult.signal ? `signal ${chownResult.signal}` : "unknown error");
-        _log(
-          `WARNING: post-restore ownership repair did not complete: ${detail.substring(0, 200)}`,
-        );
-      }
-
-      const usabilityCmd = restoredPaths
-        .map(
-          (p) =>
-            `[ -d ${shellQuote(p)} ] && [ ! -L ${shellQuote(p)} ] && [ -r ${shellQuote(p)} ] && [ -w ${shellQuote(p)} ]`,
-        )
-        .join(" && ");
-      _log(`Verifying restored state usability: ${usabilityCmd}`);
-      const usabilityResult = spawnSync(
-        "ssh",
-        [...sshArgs(configFile, sandboxName), usabilityCmd],
-        {
-          stdio: ["ignore", "pipe", "pipe"],
-          timeout: 30000,
-        },
-      );
-      if (usabilityResult.status === 0 && !usabilityResult.error && !usabilityResult.signal) {
-        restoredDirs.push(...localDirs);
-      } else {
-        const stderr = (usabilityResult.stderr?.toString() || "").trim();
+      if (rmResult.status !== 0 || rmResult.error || rmResult.signal) {
+        const stderr = (rmResult.stderr?.toString() || "").trim();
         const detail =
           stderr ||
-          usabilityResult.error?.message ||
-          (usabilityResult.signal
-            ? `signal ${usabilityResult.signal}`
-            : `exit ${String(usabilityResult.status)}`);
-        _log(`FAILED: restored state usability check failed: ${detail.substring(0, 200)}`);
+          rmResult.error?.message ||
+          (rmResult.signal ? `signal ${rmResult.signal}` : `exit ${String(rmResult.status)}`);
+        _log(`FAILED: pre-restore cleanup failed: ${detail.substring(0, 200)}`);
+        return {
+          success: false,
+          restoredDirs,
+          failedDirs: [...localDirs],
+          restoredFiles,
+          failedFiles: localFiles.map((f) => f.path),
+        };
+      }
+
+      const extractCmd = `tar --no-same-owner -xf - -C ${shellQuote(dir)}`;
+      const sshResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), extractCmd], {
+        input: tarResult.stdout,
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 120000,
+      });
+
+      if (sshResult.status === 0) {
+        const restoredPaths = localDirs.map((d) => `${dir}/${d}`);
+
+        // Best-effort only: OpenShell exec/SSH normally runs as the sandbox user,
+        // which cannot chown even files it owns. The tar restore above runs as the
+        // same user, so the real restore gate is whether the restored state dirs
+        // are usable by that user.
+        const chownCmd = `chown -R sandbox:sandbox -- ${restoredPaths.map(shellQuote).join(" ")} 2>/dev/null || true`;
+        _log(`Best-effort ownership repair: ${chownCmd}`);
+        const chownResult = spawnSync("ssh", [...sshArgs(configFile, sandboxName), chownCmd], {
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 30000,
+        });
+        if (chownResult.error || chownResult.signal) {
+          const detail =
+            chownResult.error?.message ||
+            (chownResult.signal ? `signal ${chownResult.signal}` : "unknown error");
+          _log(
+            `WARNING: post-restore ownership repair did not complete: ${detail.substring(0, 200)}`,
+          );
+        }
+
+        const usabilityCmd = restoredPaths
+          .map(
+            (p) =>
+              `[ -d ${shellQuote(p)} ] && [ ! -L ${shellQuote(p)} ] && [ -r ${shellQuote(p)} ] && [ -w ${shellQuote(p)} ]`,
+          )
+          .join(" && ");
+        _log(`Verifying restored state usability: ${usabilityCmd}`);
+        const usabilityResult = spawnSync(
+          "ssh",
+          [...sshArgs(configFile, sandboxName), usabilityCmd],
+          {
+            stdio: ["ignore", "pipe", "pipe"],
+            timeout: 30000,
+          },
+        );
+        if (usabilityResult.status === 0 && !usabilityResult.error && !usabilityResult.signal) {
+          restoredDirs.push(...localDirs);
+        } else {
+          const stderr = (usabilityResult.stderr?.toString() || "").trim();
+          const detail =
+            stderr ||
+            usabilityResult.error?.message ||
+            (usabilityResult.signal
+              ? `signal ${usabilityResult.signal}`
+              : `exit ${String(usabilityResult.status)}`);
+          _log(`FAILED: restored state usability check failed: ${detail.substring(0, 200)}`);
+          failedDirs.push(...localDirs);
+        }
+      } else {
         failedDirs.push(...localDirs);
       }
-    } else {
-      failedDirs.push(...localDirs);
+    }
+
+    for (const spec of localFiles) {
+      if (restoreStateFile(configFile, sandboxName, dir, spec, backupPath)) {
+        restoredFiles.push(spec.path);
+      } else {
+        failedFiles.push(spec.path);
+      }
     }
   } finally {
     try {
@@ -935,9 +1234,11 @@ export function restoreSandboxState(sandboxName: string, backupPath: string): Re
   }
 
   return {
-    success: failedDirs.length === 0,
+    success: failedDirs.length === 0 && failedFiles.length === 0,
     restoredDirs,
     failedDirs,
+    restoredFiles,
+    failedFiles,
   };
 }
 
@@ -961,6 +1262,7 @@ function readManifest(backupPath: string): RebuildManifest | null {
     return {
       ...manifest,
       dir,
+      stateFiles: normalizeStateFileSpecs(manifest.stateFiles ?? []),
       blueprintDigest: manifest.blueprintDigest ?? null,
     };
   } catch {

--- a/src/lib/snapshot-action.ts
+++ b/src/lib/snapshot-action.ts
@@ -232,8 +232,9 @@ export async function runSandboxSnapshot(sandboxName: string, subArgs: string[])
         const entry = sandboxState.findBackup(sandboxName, manifest.timestamp).match ?? manifest;
         const v = formatSnapshotVersion(entry);
         const nameSuffix = entry.name ? ` name=${entry.name}` : "";
+        const itemSummary = `${result.backedUpDirs.length} directories, ${result.backedUpFiles.length} files`;
         console.log(
-          `  ${G}\u2713${R} Snapshot ${v}${nameSuffix} created (${result.backedUpDirs.length} directories)`,
+          `  ${G}\u2713${R} Snapshot ${v}${nameSuffix} created (${itemSummary})`,
         );
         console.log(`    ${manifest.backupPath}`);
       } else {
@@ -243,6 +244,9 @@ export async function runSandboxSnapshot(sandboxName: string, subArgs: string[])
           console.error("  Snapshot failed.");
           if (result.failedDirs.length > 0) {
             console.error(`  Failed directories: ${result.failedDirs.join(", ")}`);
+          }
+          if (result.failedFiles.length > 0) {
+            console.error(`  Failed files: ${result.failedFiles.join(", ")}`);
           }
         }
         process.exit(1);
@@ -338,7 +342,9 @@ export async function runSandboxSnapshot(sandboxName: string, subArgs: string[])
       }
       const result = sandboxState.restoreSandboxState(targetSandbox, backupPath);
       if (result.success) {
-        console.log(`  ${G}\u2713${R} Restored ${result.restoredDirs.length} directories`);
+        console.log(
+          `  ${G}\u2713${R} Restored ${result.restoredDirs.length} directories, ${result.restoredFiles.length} files`,
+        );
       } else {
         console.error(`  Restore failed.`);
         if (result.restoredDirs.length > 0) {
@@ -346,6 +352,9 @@ export async function runSandboxSnapshot(sandboxName: string, subArgs: string[])
         }
         if (result.failedDirs.length > 0) {
           console.error(`  Failed: ${result.failedDirs.join(", ")}`);
+        }
+        if (result.failedFiles.length > 0) {
+          console.error(`  Failed files: ${result.failedFiles.join(", ")}`);
         }
         process.exit(1);
       }

--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -2532,7 +2532,7 @@ async function sandboxRebuild(
   log(`Agent type: ${sb.agent || "openclaw"}, stateDirs from manifest`);
   const backup = sandboxState.backupSandboxState(sandboxName);
   log(
-    `Backup result: success=${backup.success}, backed=${backup.backedUpDirs.join(",")}, failed=${backup.failedDirs.join(",")}`,
+    `Backup result: success=${backup.success}, backed=${backup.backedUpDirs.join(",")}; files=${backup.backedUpFiles.join(",")}, failed=${backup.failedDirs.join(",")}; failedFiles=${backup.failedFiles.join(",")}`,
   );
   if (!backup.success) {
     console.error("  Failed to back up sandbox state.");
@@ -2542,11 +2542,16 @@ async function sandboxRebuild(
     if (backup.failedDirs.length > 0) {
       console.error(`  Failed: ${backup.failedDirs.join(", ")}`);
     }
+    if (backup.failedFiles.length > 0) {
+      console.error(`  Failed files: ${backup.failedFiles.join(", ")}`);
+    }
     console.error("  Aborting rebuild to prevent data loss.");
     bail("Failed to back up sandbox state.");
     return;
   }
-  console.log(`  ${G}\u2713${R} State backed up (${backup.backedUpDirs.length} directories)`);
+  console.log(
+    `  ${G}\u2713${R} State backed up (${backup.backedUpDirs.length} directories, ${backup.backedUpFiles.length} files)`,
+  );
   console.log(`    Backup: ${backup.manifest.backupPath}`);
 
   // Step 3: Delete sandbox without tearing down gateway or session.
@@ -2736,14 +2741,19 @@ async function sandboxRebuild(
   log(`Restoring from: ${backup.manifest.backupPath} into sandbox: ${sandboxName}`);
   const restore = sandboxState.restoreSandboxState(sandboxName, backup.manifest.backupPath);
   log(
-    `Restore result: success=${restore.success}, restored=${restore.restoredDirs.join(",")}, failed=${restore.failedDirs.join(",")}`,
+    `Restore result: success=${restore.success}, restored=${restore.restoredDirs.join(",")}; files=${restore.restoredFiles.join(",")}, failed=${restore.failedDirs.join(",")}; failedFiles=${restore.failedFiles.join(",")}`,
   );
   if (!restore.success) {
     console.error(`  Partial restore: ${restore.restoredDirs.join(", ") || "none"}`);
     console.error(`  Failed: ${restore.failedDirs.join(", ")}`);
+    if (restore.failedFiles.length > 0) {
+      console.error(`  Failed files: ${restore.failedFiles.join(", ")}`);
+    }
     console.error(`  Manual restore available from: ${backup.manifest.backupPath}`);
   } else {
-    console.log(`  ${G}\u2713${R} State restored (${restore.restoredDirs.length} directories)`);
+    console.log(
+      `  ${G}\u2713${R} State restored (${restore.restoredDirs.length} directories, ${restore.restoredFiles.length} files)`,
+    );
   }
 
   // Step 5.5: Restore policy presets (#1952)

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -384,9 +384,12 @@ describe("Hermes sandbox provisioning", () => {
         expect(run.result.status).toBe(0);
         const hermesDir = path.join(run.sandboxRoot, ".hermes");
         expect((fs.statSync(hermesDir).mode & 0o777).toString(8)).toBe("750");
-        for (const dir of ["runtime", "logs", "cache"]) {
+        for (const dir of ["logs", "cache"]) {
           expect((fs.statSync(path.join(hermesDir, dir)).mode & 0o777).toString(8)).toBe("770");
         }
+        expect((fs.statSync(path.join(hermesDir, "runtime")).mode & 0o7777).toString(8)).toBe(
+          "2770",
+        );
         expect(fs.readlinkSync(path.join(hermesDir, "gateway_state.json"))).toBe(
           "runtime/gateway_state.json",
         );

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -88,6 +88,10 @@ beforeEach(() => {
   fs.rmSync(BACKUPS_ROOT, { recursive: true, force: true });
 });
 
+function writeExecutable(filePath: string, source: string): void {
+  fs.writeFileSync(filePath, source, { mode: 0o755 });
+}
+
 describe("validateSnapshotName", () => {
   it("accepts normal names", () => {
     expect(sandboxState.validateSnapshotName("before-upgrade")).toBeNull();
@@ -340,5 +344,146 @@ describe("parseRestoreArgs", () => {
       targetSandbox: "src",
       selector: "v1",
     });
+  });
+});
+
+describe("Hermes durable state files", () => {
+  it("backs up and restores SOUL.md plus the SQLite state database without credential files", () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-snapshot-"));
+    const oldPath = process.env.PATH;
+    const oldOpenshell = process.env.NEMOCLAW_OPENSHELL_BIN;
+    try {
+      const binDir = path.join(fixture, "bin");
+      const fakeRoot = path.join(fixture, "sandbox-root");
+      const hermesDir = path.join(fakeRoot, ".hermes");
+      const runtimeDir = path.join(hermesDir, "runtime");
+      const sshLog = path.join(fixture, "ssh-log.jsonl");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(runtimeDir, { recursive: true });
+      fs.writeFileSync(path.join(hermesDir, "SOUL.md"), "original soul\n");
+      fs.writeFileSync(path.join(runtimeDir, "state.db"), "original sqlite backup\n");
+      fs.writeFileSync(path.join(hermesDir, "config.yaml"), "token: should-not-copy\n");
+      fs.writeFileSync(path.join(hermesDir, ".env"), "API_TOKEN=should-not-copy\n");
+      fs.writeFileSync(path.join(hermesDir, "auth.json"), '{"token":"should-not-copy"}\n');
+
+      const openshell = path.join(binDir, "openshell");
+      writeExecutable(
+        openshell,
+        `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "sandbox" && args[1] === "ssh-config") {
+  process.stdout.write("Host openshell-hermes\\n  HostName 127.0.0.1\\n  User sandbox\\n");
+  process.exit(0);
+}
+process.exit(0);
+`,
+      );
+
+      writeExecutable(
+        path.join(binDir, "ssh"),
+        `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const root = ${JSON.stringify(fakeRoot)};
+const log = ${JSON.stringify(sshLog)};
+const cmd = process.argv[process.argv.length - 1] || "";
+fs.appendFileSync(log, JSON.stringify({ cmd }) + "\\n");
+const hermesDir = path.join(root, ".hermes");
+function readStdin() {
+  const chunks = [];
+  for (;;) {
+    const buf = Buffer.alloc(65536);
+    const n = fs.readSync(0, buf, 0, buf.length, null);
+    if (n === 0) break;
+    chunks.push(buf.subarray(0, n));
+  }
+  return Buffer.concat(chunks);
+}
+if (cmd.includes("[ -d ")) {
+  process.exit(0);
+}
+if (cmd.includes("nemoclaw-sqlite-backup")) {
+  process.stdout.write(fs.readFileSync(path.join(hermesDir, "runtime", "state.db")));
+  process.exit(0);
+}
+if (cmd.includes("SOUL.md") && cmd.includes("cat --")) {
+  process.stdout.write(fs.readFileSync(path.join(hermesDir, "SOUL.md")));
+  process.exit(0);
+}
+if (cmd.includes("nemoclaw-sqlite-restore")) {
+  fs.mkdirSync(path.join(hermesDir, "runtime"), { recursive: true });
+  fs.writeFileSync(path.join(hermesDir, "runtime", "state.db"), readStdin());
+  process.exit(0);
+}
+if (cmd.includes(".nemoclaw-restore") && cmd.includes("SOUL.md")) {
+  fs.writeFileSync(path.join(hermesDir, "SOUL.md"), readStdin());
+  process.exit(0);
+}
+process.exit(0);
+`,
+      );
+
+      fs.mkdirSync(path.join(TMP_HOME, ".nemoclaw"), { recursive: true });
+      fs.writeFileSync(
+        path.join(TMP_HOME, ".nemoclaw", "sandboxes.json"),
+        JSON.stringify({
+          defaultSandbox: "hermes",
+          sandboxes: {
+            hermes: {
+              name: "hermes",
+              model: "m",
+              provider: "p",
+              gpuEnabled: false,
+              policies: [],
+              agent: "hermes",
+            },
+          },
+        }),
+      );
+
+      process.env.NEMOCLAW_OPENSHELL_BIN = openshell;
+      process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
+
+      const backup = sandboxState.backupSandboxState("hermes", { name: "hermes-state" });
+      expect(backup.success).toBe(true);
+      expect(backup.backedUpFiles).toEqual(["SOUL.md", "runtime/state.db"]);
+      expect(backup.failedFiles).toEqual([]);
+      expect(backup.manifest?.stateFiles).toEqual([
+        { path: "SOUL.md", strategy: "copy" },
+        { path: "runtime/state.db", strategy: "sqlite_backup" },
+      ]);
+      expect(fs.readFileSync(path.join(backup.manifest!.backupPath, "SOUL.md"), "utf-8")).toBe(
+        "original soul\n",
+      );
+      expect(
+        fs.readFileSync(path.join(backup.manifest!.backupPath, "runtime", "state.db"), "utf-8"),
+      ).toBe("original sqlite backup\n");
+      expect(fs.existsSync(path.join(backup.manifest!.backupPath, "config.yaml"))).toBe(false);
+      expect(fs.existsSync(path.join(backup.manifest!.backupPath, ".env"))).toBe(false);
+      expect(fs.existsSync(path.join(backup.manifest!.backupPath, "auth.json"))).toBe(false);
+
+      fs.writeFileSync(path.join(hermesDir, "SOUL.md"), "changed soul\n");
+      fs.writeFileSync(path.join(runtimeDir, "state.db"), "changed db\n");
+      const restore = sandboxState.restoreSandboxState("hermes", backup.manifest!.backupPath);
+      expect(restore.success).toBe(true);
+      expect(restore.restoredFiles).toEqual(["SOUL.md", "runtime/state.db"]);
+      expect(fs.readFileSync(path.join(hermesDir, "SOUL.md"), "utf-8")).toBe("original soul\n");
+      expect(fs.readFileSync(path.join(runtimeDir, "state.db"), "utf-8")).toBe(
+        "original sqlite backup\n",
+      );
+
+      const loggedCommands = fs.readFileSync(sshLog, "utf-8");
+      expect(loggedCommands).toContain("sqlite3.connect");
+      expect(loggedCommands).toContain("src_conn.backup(dst_conn)");
+      expect(loggedCommands).toContain("PRAGMA quick_check");
+    } finally {
+      if (oldOpenshell === undefined) {
+        delete process.env.NEMOCLAW_OPENSHELL_BIN;
+      } else {
+        process.env.NEMOCLAW_OPENSHELL_BIN = oldOpenshell;
+      }
+      process.env.PATH = oldPath;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes #2882

## Summary
- Adds manifest-declared `state_files` support for snapshot backup/restore so agents can opt into durable files separately from state directories.
- Declares Hermes `SOUL.md` and `runtime/state.db` as durable snapshot state. `runtime/state.db` backs the compatibility symlink `.hermes/state.db`.
- Backs up and restores the Hermes SQLite database through Python's SQLite online backup API with `PRAGMA quick_check`, instead of archiving a live raw DB/WAL/SHM set.
- Keeps the existing directory tar safety model intact, including validated extraction and `--no-same-owner` restore behavior.
- Makes Hermes runtime DB files group-cooperative (`runtime` setgid plus gateway `umask 0007`) so restored DB state remains usable by both the sandbox and gateway users.

## Credential and state handling
- Includes `state.db` because Hermes uses it for durable session metadata, message history, and model/session state; snapshot directories should be treated as private local state.
- Includes `SOUL.md` because it is durable Hermes persona state and is currently omitted by directory-only snapshots.
- Intentionally excludes `auth.json`; it is credential-bearing OAuth/auth state and is now classified as a sensitive backup basename.
- Intentionally excludes Hermes `config.yaml` and `.env`; NemoClaw regenerates those from host-side onboarding/session and OpenShell provider state, and restoring them without the root-owned hash anchor would be misleading.

## Validation
- `npm run build:cli`
- `npx vitest run test/snapshot.test.ts`
- `zsh -o nonomatch -c 'npx vitest run src/lib/sandbox-state*.test.ts test/*snapshot*.test.ts'`
- `npx vitest run test/snapshot.test.ts test/snapshot-gateway-guard.test.ts src/lib/agent-defs.test.ts src/lib/credential-filter.test.ts test/sandbox-provisioning.test.ts`
- `git diff --check`

Did not run `test/e2e/test-snapshot-commands.sh`; it provisions a live OpenShell sandbox rather than a cheap hermetic snapshot path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for backing up/restoring durable agent state files (including DBs) with selectable strategies; richer backup/restore file reporting.

* **Bug Fixes**
  * Treat additional auth files as sensitive (excluded from snapshots).
  * Ensure runtime directory group-write behavior and consistent startup umask for agent runtime.

* **Documentation**
  * Clarified snapshot/restore behavior for durable state and excluded credentials.

* **Tests**
  * Added tests for durable state backup/restore and runtime permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->