### PR TITLE
test(cli): cover global action facade

### DIFF
--- a/src/lib/credentials-cli-command-source.test.ts
+++ b/src/lib/credentials-cli-command-source.test.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prompt: vi.fn().mockResolvedValue("yes"),
+  recoverNamedGatewayRuntime: vi.fn().mockResolvedValue({ recovered: true }),
+  runOpenshellProviderCommand: vi.fn(),
+}));
+
+vi.mock("./credentials", () => ({ prompt: mocks.prompt }));
+vi.mock("./global-cli-actions", () => ({
+  recoverNamedGatewayRuntime: mocks.recoverNamedGatewayRuntime,
+  runOpenshellProviderCommand: mocks.runOpenshellProviderCommand,
+}));
+
+import {
+  CredentialsCommand,
+  CredentialsListCommand,
+  CredentialsResetCommand,
+} from "./credentials-cli-command";
+
+const rootDir = process.cwd();
+
+describe("credentials oclif adapter source coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.recoverNamedGatewayRuntime.mockResolvedValue({ recovered: true });
+    mocks.runOpenshellProviderCommand.mockReturnValue({ status: 0, stdout: "nvidia-prod\n" });
+  });
+
+  it("prints top-level credentials usage", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await CredentialsCommand.run([], rootDir);
+
+    const output = log.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    log.mockRestore();
+    expect(output).toContain("Usage: nemoclaw credentials <subcommand>");
+    expect(output).toContain("reset <PROVIDER> [--yes]");
+  });
+
+  it("lists credential providers while hiding messaging bridge providers", async () => {
+    mocks.runOpenshellProviderCommand.mockReturnValue({
+      status: 0,
+      stdout: "alpha-telegram-bridge\nnvidia-prod\nopenai-prod\n",
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await CredentialsListCommand.run([], rootDir);
+
+    expect(mocks.recoverNamedGatewayRuntime).toHaveBeenCalledWith();
+    expect(mocks.runOpenshellProviderCommand).toHaveBeenCalledWith(["provider", "list", "--names"], {
+      ignoreError: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+    const output = log.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    log.mockRestore();
+    expect(output).toContain("nvidia-prod");
+    expect(output).toContain("openai-prod");
+    expect(output).toContain("1 per-sandbox messaging bridge");
+    expect(output).not.toContain("alpha-telegram-bridge\n");
+  });
+
+  it("deletes provider credentials with --yes", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await CredentialsResetCommand.run(["nvidia-prod", "--yes"], rootDir);
+
+    expect(mocks.prompt).not.toHaveBeenCalled();
+    expect(mocks.runOpenshellProviderCommand).toHaveBeenCalledWith(["provider", "delete", "nvidia-prod"], {
+      ignoreError: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+    const output = log.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    log.mockRestore();
+    expect(output).toContain("Removed provider 'nvidia-prod'");
+  });
+});

--- a/src/lib/credentials-cli-command.ts
+++ b/src/lib/credentials-cli-command.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/* v8 ignore start -- thin oclif adapter covered through CLI integration tests. */
-
 import { Args, Command, Flags } from "@oclif/core";
 
 import { CLI_DISPLAY_NAME, CLI_NAME } from "./branding";


### PR DESCRIPTION
## Summary
Remove another broad coverage ignore by covering the global CLI action facade directly with mocked action/runtime dependencies.

## Stack Navigation
- Position: 44 of 60
- Previous PR: [#2942 — test(cli): cover remaining global and credentials adapters](https://github.com/NVIDIA/NemoClaw/pull/2942)
- Next PR: [#2944 — test(cli): cover runtime utility helpers](https://github.com/NVIDIA/NemoClaw/pull/2944)

## Changes
- Removed the file-level V8 ignore from `global-cli-actions.ts`.
- Added source-level tests for onboarding, deploy, maintenance, help/version, runtime recovery, OpenShell provider commands, and upgrade hook forwarding.
- Added an upgrade runtime hook so tests and future callers can avoid loading the subprocess-heavy upgrade action path.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
