### PR TITLE
test(cli): cover maintenance action helpers

### DIFF
--- a/src/lib/maintenance-action-helpers.test.ts
+++ b/src/lib/maintenance-action-helpers.test.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./credentials", () => ({ prompt: vi.fn() }));
+vi.mock("./docker", () => ({
+  dockerListImagesFormat: vi.fn(),
+  dockerRmi: vi.fn(),
+}));
+vi.mock("./openshell-runtime", () => ({
+  captureOpenshell: vi.fn(() => ({ status: 0, output: "" })),
+}));
+vi.mock("./registry", () => ({ listSandboxes: vi.fn(() => ({ sandboxes: [] })) }));
+vi.mock("./runner", () => ({ ROOT: process.cwd() }));
+vi.mock("./sandbox-state", () => ({ backupSandboxState: vi.fn() }));
+vi.mock("./sandbox-rebuild-action", () => ({ rebuildSandbox: vi.fn() }));
+
+import { findOrphanedSandboxImages, parseSandboxImageRows } from "./maintenance-actions";
+import { shouldSkipUpgradeConfirmation } from "./upgrade-sandboxes-action";
+
+describe("maintenance action helpers", () => {
+  it("parses Docker image rows and fills missing sizes", () => {
+    expect(
+      parseSandboxImageRows("openshell/sandbox-from:one\t1GB\nopenshell/sandbox-from:two\n\n"),
+    ).toEqual([
+      { tag: "openshell/sandbox-from:one", size: "1GB" },
+      { tag: "openshell/sandbox-from:two", size: "unknown" },
+    ]);
+  });
+
+  it("finds orphaned sandbox images by registry image tags", () => {
+    expect(
+      findOrphanedSandboxImages(
+        [
+          { tag: "openshell/sandbox-from:one", size: "1GB" },
+          { tag: "openshell/sandbox-from:two", size: "2GB" },
+        ],
+        [{ imageTag: "openshell/sandbox-from:one" }, { imageTag: null }],
+      ),
+    ).toEqual([{ tag: "openshell/sandbox-from:two", size: "2GB" }]);
+  });
+
+  it("detects upgrade confirmation bypass modes", () => {
+    expect(shouldSkipUpgradeConfirmation({ auto: true })).toBe(true);
+    expect(shouldSkipUpgradeConfirmation({ yes: true })).toBe(true);
+    expect(shouldSkipUpgradeConfirmation({ check: true })).toBe(false);
+  });
+});

--- a/src/lib/maintenance-actions.ts
+++ b/src/lib/maintenance-actions.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/* v8 ignore start -- exercised through CLI subprocess maintenance tests. */
-
 import { prompt as askPrompt } from "./credentials";
 import {
   type GarbageCollectImagesOptions,
@@ -23,6 +21,31 @@ const R = useColor ? "\x1b[0m" : "";
 const RD = useColor ? "\x1b[1;31m" : "";
 const YW = useColor ? "\x1b[1;33m" : "";
 
+export type SandboxImageRow = { tag: string; size: string };
+
+export function parseSandboxImageRows(imagesOutput: string): SandboxImageRow[] {
+  return imagesOutput
+    .split("\n")
+    .map((line: string) => line.trim())
+    .filter(Boolean)
+    .map((line: string) => {
+      const [tag, size] = line.split("\t");
+      return { tag, size: size || "unknown" };
+    });
+}
+
+export function findOrphanedSandboxImages(
+  images: SandboxImageRow[],
+  sandboxes: Array<{ imageTag?: string | null }>,
+): SandboxImageRow[] {
+  const registeredTags = new Set<string>();
+  for (const sb of sandboxes) {
+    if (sb.imageTag) registeredTags.add(sb.imageTag);
+  }
+  return images.filter((img) => !registeredTags.has(img.tag));
+}
+
+/* v8 ignore next -- OpenShell backup orchestration is covered through CLI subprocess tests. */
 export function backupAll(): void {
   const { sandboxes } = registry.listSandboxes();
   if (sandboxes.length === 0) {
@@ -64,6 +87,7 @@ export function backupAll(): void {
   }
 }
 
+/* v8 ignore next -- Docker image deletion orchestration is covered through CLI subprocess tests. */
 export async function garbageCollectImages(
   options: string[] | GarbageCollectImagesOptions = {},
 ): Promise<void> {
@@ -82,29 +106,15 @@ export async function garbageCollectImages(
     process.exit(1);
   }
 
-  const allImages = imagesOutput
-    .split("\n")
-    .map((line: string) => line.trim())
-    .filter(Boolean)
-    .map((line: string) => {
-      const [tag, size] = line.split("\t");
-      return { tag, size: size || "unknown" };
-    });
+  const allImages = parseSandboxImageRows(imagesOutput);
 
   if (allImages.length === 0) {
     console.log("  No sandbox images found on the host.");
     return;
   }
 
-  const registeredTags = new Set();
   const { sandboxes } = registry.listSandboxes();
-  for (const sb of sandboxes) {
-    if (sb.imageTag) registeredTags.add(sb.imageTag);
-  }
-
-  const orphans = allImages.filter(
-    (img: { tag: string; size: string }) => !registeredTags.has(img.tag),
-  );
+  const orphans = findOrphanedSandboxImages(allImages, sandboxes);
 
   if (orphans.length === 0) {
     console.log(`  All ${allImages.length} sandbox image(s) are in use. Nothing to clean up.`);

--- a/src/lib/maintenance-actions.ts
+++ b/src/lib/maintenance-actions.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/* v8 ignore start -- exercised through CLI subprocess maintenance tests. */
+
 import { prompt as askPrompt } from "./credentials";
 import {
   type GarbageCollectImagesOptions,

--- a/src/lib/upgrade-sandboxes-action.ts
+++ b/src/lib/upgrade-sandboxes-action.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/* v8 ignore start -- exercised through CLI subprocess upgrade tests. */
-
 import { CLI_NAME } from "./branding";
 import { prompt as askPrompt } from "./credentials";
 import {
@@ -19,13 +17,18 @@ import { B, D, G, R, YW } from "./terminal-style";
 // ── Upgrade sandboxes (#1904) ────────────────────────────────────
 // Detect sandboxes running stale agent versions and offer to rebuild them.
 
+export function shouldSkipUpgradeConfirmation(options: UpgradeSandboxesOptions): boolean {
+  return options.auto === true || options.yes === true;
+}
+
+/* v8 ignore next -- OpenShell rebuild orchestration is covered through CLI subprocess tests. */
 export async function upgradeSandboxes(
   options: string[] | UpgradeSandboxesOptions = {},
 ): Promise<void> {
   const normalized = normalizeUpgradeSandboxesOptions(options);
   const checkOnly = normalized.check === true;
   const auto = normalized.auto === true;
-  const skipConfirm = auto || normalized.yes === true;
+  const skipConfirm = shouldSkipUpgradeConfirmation(normalized);
 
   const sandboxes = registry.listSandboxes().sandboxes;
   if (sandboxes.length === 0) {

--- a/src/lib/upgrade-sandboxes-action.ts
+++ b/src/lib/upgrade-sandboxes-action.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/* v8 ignore start -- exercised through CLI subprocess upgrade tests. */
+
 import { CLI_NAME } from "./branding";
 import { prompt as askPrompt } from "./credentials";
 import {


### PR DESCRIPTION
## Summary
Add direct helper coverage for maintenance and upgrade action logic while keeping broad coverage boundaries around subprocess-heavy orchestration.

## Changes
- Extracted Docker image row parsing and orphan image selection helpers for direct testing.
- Added a small upgrade confirmation helper for direct testing.
- Kept file-level coverage boundaries for Docker/OpenShell/prompt orchestration because full CI coverage is still driven by subprocess tests for those paths.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>