### PR TITLE
fix(channels): allow distinct messaging credentials across sandboxes

### DIFF
--- a/docs/manage-sandboxes/messaging-channels.md
+++ b/docs/manage-sandboxes/messaging-channels.md
@@ -151,8 +151,11 @@ $ nemoclaw my-assistant channels stop telegram
 $ nemoclaw my-assistant channels start telegram
 ```
 
-Telegram, Discord, and Slack each allow only one active consumer per bot token.
+Telegram, Discord, and Slack each allow only one active consumer per channel credential.
+Multiple sandboxes can use the same channel type at the same time when each sandbox uses a distinct bot/app token.
+For example, two Telegram sandboxes can DM the same `TELEGRAM_ALLOWED_IDS` account as long as they use different `TELEGRAM_BOT_TOKEN` values.
 If you enable a messaging channel and another sandbox already uses the same token, onboarding prompts you to confirm before continuing in interactive mode and exits non-zero in non-interactive mode.
+If NemoClaw only has legacy channel metadata and cannot compare credential hashes, it keeps the conservative warning; re-run `channels add <channel>` with the intended token to refresh the stored non-secret hash.
 `nemoclaw status` reports cross-sandbox overlaps so you can resolve duplicates before messages start dropping.
 
 ## Stop Messaging Delivery

--- a/src/lib/credential-hash.ts
+++ b/src/lib/credential-hash.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from "node:crypto";
+
+export function hashCredential(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return crypto.createHash("sha256").update(String(value).trim()).digest("hex");
+}

--- a/src/lib/credential-hash.ts
+++ b/src/lib/credential-hash.ts
@@ -4,6 +4,7 @@
 import crypto from "node:crypto";
 
 export function hashCredential(value: string | null | undefined): string | null {
-  if (!value) return null;
-  return crypto.createHash("sha256").update(String(value).trim()).digest("hex");
+  const normalized = String(value ?? "").trim();
+  if (!normalized) return null;
+  return crypto.createHash("sha256").update(normalized).digest("hex");
 }

--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -380,7 +380,9 @@ describe("inventory commands", () => {
     const lines: string[] = [];
     const backfillAndFindOverlaps = vi
       .fn()
-      .mockReturnValue([{ channel: "telegram", sandboxes: ["alice", "bob"] }]);
+      .mockReturnValue([
+        { channel: "telegram", sandboxes: ["alice", "bob"], reason: "matching-token" },
+      ]);
     showStatusCommand({
       listSandboxes: () => ({
         sandboxes: [
@@ -396,9 +398,11 @@ describe("inventory commands", () => {
     });
 
     expect(backfillAndFindOverlaps).toHaveBeenCalled();
-    expect(lines.some((l) => l.includes("telegram is enabled on both 'alice' and 'bob'"))).toBe(
-      true,
-    );
+    expect(
+      lines.some((l) =>
+        l.includes("'alice' and 'bob' share the same telegram credential"),
+      ),
+    ).toBe(true);
   });
 
   it("surfaces Hermes gateway log when messaging is degraded", () => {

--- a/src/lib/inventory-commands.test.ts
+++ b/src/lib/inventory-commands.test.ts
@@ -405,6 +405,34 @@ describe("inventory commands", () => {
     ).toBe(true);
   });
 
+  it("defaults missing overlap reason to the conservative warning", () => {
+    const lines: string[] = [];
+    const backfillAndFindOverlaps = vi
+      .fn()
+      .mockReturnValue([{ channel: "telegram", sandboxes: ["alice", "bob"] }]);
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [
+          { name: "alice", model: "m", messagingChannels: ["telegram"] },
+          { name: "bob", model: "m", messagingChannels: ["telegram"] },
+        ],
+        defaultSandbox: "alice",
+      }),
+      getLiveInference: () => null,
+      showServiceStatus: vi.fn(),
+      backfillAndFindOverlaps,
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(
+      lines.some((l) =>
+        l.includes(
+          "'alice' and 'bob' may share a telegram credential; stored credential hashes are incomplete",
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("surfaces Hermes gateway log when messaging is degraded", () => {
     const lines: string[] = [];
     const checkMessagingBridgeHealth = vi

--- a/src/lib/inventory-commands.ts
+++ b/src/lib/inventory-commands.ts
@@ -11,6 +11,7 @@ export interface SandboxEntry {
   provider?: string | null;
   gpuEnabled?: boolean;
   policies?: string[] | null;
+  providerCredentialHashes?: Record<string, string> | null;
   messagingChannels?: string[] | null;
   agent?: string | null;
   dashboardPort?: number | null;
@@ -72,6 +73,7 @@ export interface SandboxInventoryResult {
 export interface MessagingOverlap {
   channel: string;
   sandboxes: [string, string];
+  reason?: "matching-token" | "unknown-token";
 }
 
 export interface ShowStatusCommandDeps {
@@ -351,13 +353,17 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
     const overlaps = deps.backfillAndFindOverlaps();
     if (overlaps.length > 0) {
       log("");
-      for (const { channel, sandboxes: pair } of overlaps) {
+      for (const { channel, sandboxes: pair, reason } of overlaps) {
+        const detail =
+          reason === "unknown-token"
+            ? `may share a ${channel} credential; stored credential hashes are incomplete`
+            : `share the same ${channel} credential`;
         log(
-          `  ⚠ ${channel} is enabled on both '${pair[0]}' and '${pair[1]}'. Bot tokens only allow one sandbox to poll — both bridges will fail.`,
+          `  ⚠ '${pair[0]}' and '${pair[1]}' ${detail}. Only one bridge can poll/connect per credential.`,
         );
       }
       log(
-        `    Run \`${CLI_NAME} <sandbox> destroy\` on whichever sandbox should stop polling, or rerun onboarding with the channel disabled.`,
+        `    Run \`${CLI_NAME} <sandbox> channels stop <channel>\` to pause one bridge, or \`${CLI_NAME} <sandbox> channels remove <channel>\` to remove stale bridge metadata.`,
       );
     }
   }

--- a/src/lib/inventory-commands.ts
+++ b/src/lib/inventory-commands.ts
@@ -355,9 +355,9 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
       log("");
       for (const { channel, sandboxes: pair, reason } of overlaps) {
         const detail =
-          reason === "unknown-token"
-            ? `may share a ${channel} credential; stored credential hashes are incomplete`
-            : `share the same ${channel} credential`;
+          reason === "matching-token"
+            ? `share the same ${channel} credential`
+            : `may share a ${channel} credential; stored credential hashes are incomplete`;
         log(
           `  ⚠ '${pair[0]}' and '${pair[1]}' ${detail}. Only one bridge can poll/connect per credential.`,
         );

--- a/src/lib/messaging-conflict.test.ts
+++ b/src/lib/messaging-conflict.test.ts
@@ -30,14 +30,53 @@ function makeRegistry(sandboxes: SandboxEntry[]) {
 }
 
 describe("findChannelConflicts", () => {
-  it("returns conflicts when another sandbox already has the channel", () => {
+  it("returns unknown conflicts when another sandbox has the channel without hashes", () => {
     const registry = makeRegistry([
       { name: "alice", messagingChannels: ["telegram"] },
       { name: "bob", messagingChannels: [] },
     ]);
     expect(findChannelConflicts("bob", ["telegram"], registry)).toEqual([
-      { channel: "telegram", sandbox: "alice" },
+      { channel: "telegram", sandbox: "alice", reason: "unknown-token" },
     ]);
+  });
+
+  it("returns conflicts only when the same channel credential hash matches", () => {
+    const registry = makeRegistry([
+      {
+        name: "alice",
+        messagingChannels: ["telegram"],
+        providerCredentialHashes: { TELEGRAM_BOT_TOKEN: "hash-a" },
+      },
+      {
+        name: "carol",
+        messagingChannels: ["telegram"],
+        providerCredentialHashes: { TELEGRAM_BOT_TOKEN: "hash-c" },
+      },
+    ]);
+    expect(
+      findChannelConflicts(
+        "bob",
+        [{ channel: "telegram", credentialHashes: { TELEGRAM_BOT_TOKEN: "hash-a" } }],
+        registry,
+      ),
+    ).toEqual([{ channel: "telegram", sandbox: "alice", reason: "matching-token" }]);
+  });
+
+  it("allows multiple telegram sandboxes with distinct token hashes", () => {
+    const registry = makeRegistry([
+      {
+        name: "alice",
+        messagingChannels: ["telegram"],
+        providerCredentialHashes: { TELEGRAM_BOT_TOKEN: "hash-a" },
+      },
+    ]);
+    expect(
+      findChannelConflicts(
+        "bob",
+        [{ channel: "telegram", credentialHashes: { TELEGRAM_BOT_TOKEN: "hash-b" } }],
+        registry,
+      ),
+    ).toEqual([]);
   });
 
   it("excludes the current sandbox from its own conflicts", () => {
@@ -64,20 +103,54 @@ describe("findAllOverlaps", () => {
       { name: "carol", messagingChannels: ["discord"] },
     ]);
     expect(findAllOverlaps(registry)).toEqual([
-      { channel: "telegram", sandboxes: ["alice", "bob"] },
+      { channel: "telegram", sandboxes: ["alice", "bob"], reason: "unknown-token" },
     ]);
   });
 
-  it("reports all pairs when three sandboxes share a channel", () => {
+  it("reports all unknown pairs when three sandboxes share a channel without hashes", () => {
     const registry = makeRegistry([
       { name: "a", messagingChannels: ["telegram"] },
       { name: "b", messagingChannels: ["telegram"] },
       { name: "c", messagingChannels: ["telegram"] },
     ]);
     expect(findAllOverlaps(registry)).toEqual([
-      { channel: "telegram", sandboxes: ["a", "b"] },
-      { channel: "telegram", sandboxes: ["a", "c"] },
-      { channel: "telegram", sandboxes: ["b", "c"] },
+      { channel: "telegram", sandboxes: ["a", "b"], reason: "unknown-token" },
+      { channel: "telegram", sandboxes: ["a", "c"], reason: "unknown-token" },
+      { channel: "telegram", sandboxes: ["b", "c"], reason: "unknown-token" },
+    ]);
+  });
+
+  it("does not report overlaps when same-channel credential hashes differ", () => {
+    const registry = makeRegistry([
+      {
+        name: "alice",
+        messagingChannels: ["telegram"],
+        providerCredentialHashes: { TELEGRAM_BOT_TOKEN: "hash-a" },
+      },
+      {
+        name: "bob",
+        messagingChannels: ["telegram"],
+        providerCredentialHashes: { TELEGRAM_BOT_TOKEN: "hash-b" },
+      },
+    ]);
+    expect(findAllOverlaps(registry)).toEqual([]);
+  });
+
+  it("reports matching-token overlaps when same-channel credential hashes match", () => {
+    const registry = makeRegistry([
+      {
+        name: "alice",
+        messagingChannels: ["telegram"],
+        providerCredentialHashes: { TELEGRAM_BOT_TOKEN: "hash-a" },
+      },
+      {
+        name: "bob",
+        messagingChannels: ["telegram"],
+        providerCredentialHashes: { TELEGRAM_BOT_TOKEN: "hash-a" },
+      },
+    ]);
+    expect(findAllOverlaps(registry)).toEqual([
+      { channel: "telegram", sandboxes: ["alice", "bob"], reason: "matching-token" },
     ]);
   });
 

--- a/src/lib/messaging-conflict.ts
+++ b/src/lib/messaging-conflict.ts
@@ -4,17 +4,20 @@
 // Cross-sandbox messaging-channel conflict detection.
 //
 // Telegram (getUpdates long-polling), Discord (gateway connection), and Slack
-// (Socket Mode) all enforce one active consumer per bot token. Two sandboxes
-// sharing the same token silently break both bridges; see issue #1953.
+// (Socket Mode) all enforce one active consumer per channel credential. Two
+// sandboxes sharing the same token silently break both bridges; see issue #1953.
 //
-// The registry persists which channels each sandbox uses. This module detects
+// The registry persists which channels each sandbox uses plus a non-secret hash
+// of the provider credential when available. This module detects true same-token
 // overlaps and — because pre-existing sandboxes created before the field was
-// added have no record — can optionally backfill the field by probing the live
-// OpenShell gateway for known provider names.
+// added have no record — can optionally backfill the channel field by probing
+// the live OpenShell gateway for known provider names.
 
 import type { SandboxEntry } from "./registry";
+import { getChannelDef, getChannelTokenKeys } from "./sandbox-channels";
 
 type ProbeResult = "present" | "absent" | "error";
+type ConflictReason = "matching-token" | "unknown-token";
 
 interface ConflictProbe {
   // Tri-state — "error" is distinct from "absent" so a transient gateway
@@ -28,9 +31,17 @@ interface ConflictRegistry {
   updateSandbox: (name: string, updates: Partial<SandboxEntry>) => boolean;
 }
 
+interface RequestedChannel {
+  channel: string;
+  credentialHashes?: Record<string, string | null | undefined>;
+}
+
+type ChannelRequest = string | RequestedChannel;
+
 interface Conflict {
   channel: string;
   sandbox: string;
+  reason: ConflictReason;
 }
 
 // NemoClaw attaches one OpenShell provider per messaging channel per sandbox.
@@ -44,6 +55,69 @@ const PROVIDER_SUFFIXES: Record<string, string> = {
 };
 
 const KNOWN_CHANNELS = Object.keys(PROVIDER_SUFFIXES);
+
+function normalizeRequest(request: ChannelRequest): RequestedChannel | null {
+  if (typeof request === "string") {
+    return request ? { channel: request, credentialHashes: {} } : null;
+  }
+  if (!request || typeof request.channel !== "string" || request.channel.length === 0) return null;
+  return request;
+}
+
+function getTokenKeys(channel: string): string[] {
+  const def = getChannelDef(channel);
+  return def ? getChannelTokenKeys(def) : [];
+}
+
+function hasStoredChannel(entry: SandboxEntry, channel: string): boolean {
+  return Array.isArray(entry.messagingChannels) && entry.messagingChannels.includes(channel);
+}
+
+function conflictReasonForRequest(
+  entry: SandboxEntry,
+  request: RequestedChannel,
+): ConflictReason | null {
+  if (!hasStoredChannel(entry, request.channel)) return null;
+  const requestedHashes = request.credentialHashes || {};
+  const storedHashes = entry.providerCredentialHashes || {};
+  const tokenKeys = getTokenKeys(request.channel);
+  const comparisonKeys = tokenKeys.length > 0 ? tokenKeys : Object.keys(requestedHashes);
+  if (comparisonKeys.length === 0) return "unknown-token";
+
+  let sawUnknown = false;
+  for (const key of comparisonKeys) {
+    const requestedHash = requestedHashes[key] || null;
+    const storedHash = storedHashes[key] || null;
+    if (requestedHash && storedHash) {
+      if (requestedHash === storedHash) return "matching-token";
+      continue;
+    }
+    sawUnknown = true;
+  }
+  return sawUnknown ? "unknown-token" : null;
+}
+
+function conflictReasonForPair(
+  channel: string,
+  left: SandboxEntry,
+  right: SandboxEntry,
+): ConflictReason | null {
+  if (!hasStoredChannel(left, channel) || !hasStoredChannel(right, channel)) return null;
+  const tokenKeys = getTokenKeys(channel);
+  if (tokenKeys.length === 0) return "unknown-token";
+
+  let sawUnknown = false;
+  for (const key of tokenKeys) {
+    const leftHash = left.providerCredentialHashes?.[key] || null;
+    const rightHash = right.providerCredentialHashes?.[key] || null;
+    if (leftHash && rightHash) {
+      if (leftHash === rightHash) return "matching-token";
+      continue;
+    }
+    sawUnknown = true;
+  }
+  return sawUnknown ? "unknown-token" : null;
+}
 
 /**
  * For registry entries missing `messagingChannels`, probe OpenShell to infer
@@ -87,50 +161,59 @@ export function backfillMessagingChannels(
 
 /**
  * Return every (channel, other-sandbox) pair where another sandbox in the
- * registry already has one of the `enabledChannels` in use.
+ * registry already has one of the requested channels in use with either a
+ * matching credential hash or insufficient hash metadata to prove it differs.
  */
 export function findChannelConflicts(
   currentSandbox: string | null,
-  enabledChannels: string[],
+  enabledChannels: ChannelRequest[],
   registry: ConflictRegistry,
 ): Conflict[] {
   if (!Array.isArray(enabledChannels) || enabledChannels.length === 0) return [];
+  const requests = enabledChannels.map(normalizeRequest).filter((r): r is RequestedChannel => !!r);
+  if (requests.length === 0) return [];
   const { sandboxes } = registry.listSandboxes();
   const others = sandboxes.filter(
     (s) => s.name !== currentSandbox && Array.isArray(s.messagingChannels),
   );
-  return enabledChannels.flatMap((channel) =>
-    others
-      .filter((s) => (s.messagingChannels || []).includes(channel))
-      .map((s) => ({ channel, sandbox: s.name })),
+  return requests.flatMap((request) =>
+    others.flatMap((sandbox) => {
+      const reason = conflictReasonForRequest(sandbox, request);
+      return reason ? [{ channel: request.channel, sandbox: sandbox.name, reason }] : [];
+    }),
   );
 }
 
 /**
  * Detect overlaps across every sandbox in the registry, returning each pair at
  * most once. Used by `nemoclaw status` to warn users whose sandboxes already
- * share a messaging token.
+ * share a messaging token or whose legacy metadata is too old to verify.
  */
 export function findAllOverlaps(registry: ConflictRegistry): Array<{
   channel: string;
   sandboxes: [string, string];
+  reason: ConflictReason;
 }> {
   const { sandboxes } = registry.listSandboxes();
-  const byChannel = new Map<string, string[]>();
+  const byChannel = new Map<string, SandboxEntry[]>();
   for (const entry of sandboxes) {
     if (!Array.isArray(entry.messagingChannels)) continue;
     for (const channel of entry.messagingChannels) {
       const list = byChannel.get(channel) || [];
-      list.push(entry.name);
+      list.push(entry);
       byChannel.set(channel, list);
     }
   }
-  const overlaps: Array<{ channel: string; sandboxes: [string, string] }> = [];
-  for (const [channel, names] of byChannel) {
-    if (names.length < 2) continue;
-    for (let i = 0; i < names.length; i += 1) {
-      for (let j = i + 1; j < names.length; j += 1) {
-        overlaps.push({ channel, sandboxes: [names[i], names[j]] });
+  const overlaps: Array<{ channel: string; sandboxes: [string, string]; reason: ConflictReason }> =
+    [];
+  for (const [channel, entries] of byChannel) {
+    if (entries.length < 2) continue;
+    for (let i = 0; i < entries.length; i += 1) {
+      for (let j = i + 1; j < entries.length; j += 1) {
+        const reason = conflictReasonForPair(channel, entries[i], entries[j]);
+        if (reason) {
+          overlaps.push({ channel, sandboxes: [entries[i].name, entries[j].name], reason });
+        }
       }
     }
   }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -268,6 +268,7 @@ const {
   resolveProviderCredential,
   saveCredential,
 } = credentials;
+const { hashCredential }: typeof import("./credential-hash") = require("./credential-hash");
 const registry: typeof import("./registry") = require("./registry");
 const nim: typeof import("./nim") = require("./nim");
 const onboardSession: typeof import("./onboard-session") = require("./onboard-session");
@@ -1237,18 +1238,6 @@ function upsertMessagingProviders(tokenDefs: MessagingTokenDef[]) {
 }
 function providerExistsInGateway(name: string) {
   return onboardProviders.providerExistsInGateway(name, runOpenshell);
-}
-
-/**
- * Compute a SHA-256 hash of a credential value for change detection.
- * Stored in the sandbox registry so we can detect rotation on reuse
- * without needing to read the credential back from OpenShell.
- * @param {string} value - Credential value to hash.
- * @returns {string|null} Hex-encoded SHA-256 hash, or null if value is falsy.
- */
-function hashCredential(value: string | null | undefined): string | null {
-  if (!value) return null;
-  return crypto.createHash("sha256").update(String(value).trim()).digest("hex");
 }
 
 /**
@@ -4025,29 +4014,42 @@ async function createSandbox(
   // skipped the token prompt for. Only channels with a real token will have a
   // provider attached, so the conflict check must filter out the skipped ones
   // (otherwise we warn about phantom channels that will never poll).
-  const conflictCheckChannels: string[] = Array.isArray(enabledChannels)
-    ? enabledChannels.filter((name) => {
+  const conflictCheckChannels = Array.isArray(enabledChannels)
+    ? enabledChannels.flatMap((name) => {
         const def = MESSAGING_CHANNELS.find((c) => c.name === name);
-        return def ? !!getMessagingToken(def.envKey) : false;
+        if (!def || !getMessagingToken(def.envKey)) return [];
+        const tokenEnvKeys = def.appTokenEnvKey ? [def.envKey, def.appTokenEnvKey] : [def.envKey];
+        const credentialHashes: Record<string, string> = {};
+        for (const envKey of tokenEnvKeys) {
+          const hash = hashCredential(getMessagingToken(envKey));
+          if (hash) credentialHashes[envKey] = hash;
+        }
+        if (Object.keys(credentialHashes).length === 0) return [];
+        return [{ channel: name, credentialHashes }];
       })
     : [];
 
   // Messaging channels like Telegram (getUpdates), Discord (gateway), and Slack
-  // (Socket Mode) enforce one consumer per bot token. Two sandboxes sharing
-  // a token silently break both bridges (see #1953). Warn before we commit.
+  // (Socket Mode) enforce one consumer per channel credential. Two sandboxes
+  // sharing a credential silently break both bridges (see #1953). Warn before
+  // we commit.
   if (conflictCheckChannels.length > 0) {
     const { backfillMessagingChannels, findChannelConflicts } = require("./messaging-conflict");
     backfillMessagingChannels(registry, makeConflictProbe());
     const conflicts = findChannelConflicts(sandboxName, conflictCheckChannels, registry);
     if (conflicts.length > 0) {
-      for (const { channel, sandbox } of conflicts) {
+      for (const { channel, sandbox, reason } of conflicts) {
+        const detail =
+          reason === "matching-token"
+            ? `uses the same ${channel} credential`
+            : `already has ${channel} enabled, but its credential hash is unavailable`;
         console.log(
-          `  ⚠ Sandbox '${sandbox}' already has ${channel} enabled. Bot tokens only allow one sandbox to poll — continuing will break both bridges.`,
+          `  ⚠ Sandbox '${sandbox}' ${detail}. Shared channel credentials only allow one sandbox to poll/connect — continuing may break both bridges.`,
         );
       }
       if (isNonInteractive()) {
         console.error(
-          `  Aborting: resolve the messaging channel conflict above or run \`${cliName()} <sandbox> destroy\` on the other sandbox.`,
+          `  Aborting: resolve the messaging channel conflict above or run \`${cliName()} <sandbox> channels stop <channel>\` / \`${cliName()} <sandbox> channels remove <channel>\` on the other sandbox.`,
         );
         process.exit(1);
       }

--- a/src/lib/policy-channel-actions.ts
+++ b/src/lib/policy-channel-actions.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { CLI_DISPLAY_NAME, CLI_NAME } from "./branding";
+import { hashCredential } from "./credential-hash";
 import { getCredential, prompt as askPrompt } from "./credentials";
 import { recoverNamedGatewayRuntime } from "./gateway-runtime-action";
 const { isNonInteractive } = require("./onboard") as { isNonInteractive: () => boolean };
@@ -310,9 +311,16 @@ async function applyChannelAddToGatewayAndRegistry(
     const enabled = new Set(entry.messagingChannels || []);
     enabled.add(channelName);
     const disabled = (entry.disabledChannels || []).filter((c: string) => c !== channelName);
+    const providerCredentialHashes = { ...(entry.providerCredentialHashes || {}) };
+    for (const [envKey, token] of Object.entries(acquired)) {
+      const hash = hashCredential(token);
+      if (hash) providerCredentialHashes[envKey] = hash;
+    }
     registry.updateSandbox(sandboxName, {
       messagingChannels: Array.from(enabled).sort(),
       disabledChannels: disabled,
+      providerCredentialHashes:
+        Object.keys(providerCredentialHashes).length > 0 ? providerCredentialHashes : undefined,
     });
   }
 }
@@ -366,7 +374,15 @@ async function applyChannelRemoveToGatewayAndRegistry(
   const entry = registry.getSandbox(sandboxName);
   if (entry) {
     const enabled = (entry.messagingChannels || []).filter((c: string) => c !== channelName);
-    registry.updateSandbox(sandboxName, { messagingChannels: enabled });
+    const providerCredentialHashes = { ...(entry.providerCredentialHashes || {}) };
+    for (const envKey of channelTokenKeys) {
+      delete providerCredentialHashes[envKey];
+    }
+    registry.updateSandbox(sandboxName, {
+      messagingChannels: enabled,
+      providerCredentialHashes:
+        Object.keys(providerCredentialHashes).length > 0 ? providerCredentialHashes : undefined,
+    });
   }
 }
 

--- a/test/credential-rotation.test.ts
+++ b/test/credential-rotation.test.ts
@@ -84,6 +84,11 @@ describe("credential rotation detection", () => {
       expect(hashCredential(undefined)).toBeNull();
     });
 
+    it("returns null for whitespace-only values", () => {
+      expect(hashCredential("   ")).toBeNull();
+      expect(hashCredential("\r\n\t")).toBeNull();
+    });
+
     it("returns a 64-char hex SHA-256 hash for valid input", () => {
       const hash = hashCredential("my-secret-token");
       expect(hash).toMatch(/^[0-9a-f]{64}$/);


### PR DESCRIPTION
## Summary
- Scope cross-sandbox messaging conflict detection to stored channel credential hashes instead of channel name alone.
- Preserve conservative warnings for legacy channel metadata when NemoClaw cannot prove credentials differ.
- Store/remove non-secret messaging credential hashes from host-side channel add/remove flows and document the supported multi-Telegram pattern.

## Validation
- npm run build:cli -- --pretty false
- npx vitest run --project cli src/lib/messaging-conflict.test.ts src/lib/inventory-commands.test.ts test/credential-rotation.test.ts
- npm run format:check
- npm run lint
- Focused nightly-e2e dispatched: messaging-providers-e2e, token-rotation-e2e

Fixes the false warning/blocking path for two Telegram-enabled sandboxes that use distinct TELEGRAM_BOT_TOKEN values while sharing TELEGRAM_ALLOWED_IDS.

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overlap detection now uses credential hashes to distinguish true credential-sharing from unknown-token cases; onboarding and channel operations record credential hashes to support this.

* **Bug Fixes**
  * Conflict warnings and guidance updated to show more specific reasons and to recommend channel stop/remove flows when appropriate.

* **Documentation**
  * Expanded cross-sandbox messaging guidance with examples, onboarding notes, and recommended refresh steps.

* **Tests**
  * Added and updated tests covering credential hashing and overlap reason cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->