### PR TITLE
fix(install): drop Ollama bootstrap, let onboard own install and pulls

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -961,91 +961,18 @@ install_nodejs() {
 }
 
 # ---------------------------------------------------------------------------
-# 2. Ollama
+# 2. Ollama — handled entirely by `nemoclaw onboard` (binary install, model
+# pulls, daemon binding). install.sh used to bootstrap Ollama here, but that
+# duplicated onboard's own install-ollama branch and pulled a hardcoded
+# nemotron model regardless of NEMOCLAW_MODEL. Removed in favour of letting
+# onboard own the policy.
 # ---------------------------------------------------------------------------
-OLLAMA_MIN_VERSION="0.18.0"
-# IMPORTANT: update OLLAMA_INSTALL_SHA256 when changing OLLAMA_MIN_VERSION
-# Pattern: pin hash and verify, same as NVM_SHA256 above (line ~656).
-OLLAMA_INSTALL_SHA256="25f64b810b947145095956533e1bdf56eacea2673c55a7e586be4515fc882c9f"
-
-get_ollama_version() {
-  # `ollama --version` outputs something like "ollama version 0.18.0"
-  ollama --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
-}
-
 detect_gpu() {
-  # Returns 0 if a GPU is detected
+  # Returns 0 if a GPU is detected. Used by the vLLM bootstrap below.
   if command_exists nvidia-smi; then
     nvidia-smi &>/dev/null && return 0
   fi
   return 1
-}
-
-get_vram_mb() {
-  # Returns total VRAM in MiB (NVIDIA only). Falls back to 0.
-  if command_exists nvidia-smi; then
-    nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null \
-      | awk '{s += $1} END {print s+0}'
-    return
-  fi
-  # macOS — report unified memory as VRAM
-  if [[ "$(uname -s)" == "Darwin" ]] && command_exists sysctl; then
-    local bytes
-    bytes=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
-    echo $((bytes / 1024 / 1024))
-    return
-  fi
-  echo 0
-}
-
-install_or_upgrade_ollama() {
-  if detect_gpu && command_exists ollama; then
-    local current
-    current=$(get_ollama_version)
-    if [[ -n "$current" ]] && version_gte "$current" "$OLLAMA_MIN_VERSION"; then
-      info "Ollama v${current} meets minimum requirement (>= v${OLLAMA_MIN_VERSION})"
-    else
-      info "Ollama v${current:-unknown} is below v${OLLAMA_MIN_VERSION} — upgrading…"
-      (
-        tmpdir="$(mktemp -d)"
-        trap 'rm -rf "$tmpdir"' EXIT
-        curl -fsSL https://ollama.com/install.sh -o "$tmpdir/install_ollama.sh"
-        verify_downloaded_script "$tmpdir/install_ollama.sh" "Ollama" "$OLLAMA_INSTALL_SHA256"
-        sh "$tmpdir/install_ollama.sh"
-      )
-      info "Ollama upgraded to $(get_ollama_version)"
-    fi
-  else
-    # No ollama — only install if a GPU is present
-    if detect_gpu; then
-      info "GPU detected — installing Ollama…"
-      (
-        tmpdir="$(mktemp -d)"
-        trap 'rm -rf "$tmpdir"' EXIT
-        curl -fsSL https://ollama.com/install.sh -o "$tmpdir/install_ollama.sh"
-        verify_downloaded_script "$tmpdir/install_ollama.sh" "Ollama" "$OLLAMA_INSTALL_SHA256"
-        sh "$tmpdir/install_ollama.sh"
-      )
-      info "Ollama installed: v$(get_ollama_version)"
-    else
-      warn "No GPU detected — skipping Ollama installation."
-      return
-    fi
-  fi
-
-  # Pull the appropriate model based on VRAM
-  local vram_mb
-  vram_mb=$(get_vram_mb)
-  local vram_gb=$((vram_mb / 1024))
-  info "Detected ${vram_gb} GB VRAM"
-
-  if ((vram_gb >= 120)); then
-    info "Pulling nemotron-3-super:120b…"
-    ollama pull nemotron-3-super:120b
-  else
-    info "Pulling nemotron-3-nano:30b…"
-    ollama pull nemotron-3-nano:30b
-  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -1681,12 +1608,9 @@ main() {
   ensure_supported_runtime
 
   step 2 "${_CLI_DISPLAY} CLI"
-  # Local inference setup is opt-in via NEMOCLAW_PROVIDER. Both functions
-  # short-circuit when the env var doesn't match, so the regular cloud-only
-  # install path runs unchanged.
-  if [[ "${NEMOCLAW_PROVIDER:-}" == "ollama" ]]; then
-    install_or_upgrade_ollama
-  fi
+  # Ollama install/upgrade and model pulls are owned by `nemoclaw onboard`
+  # (its `install-ollama` branch runs the official installer when the user
+  # picks it). install.sh stays focused on dependency setup.
   # Fail fast when vLLM was explicitly requested — silently continuing leaves
   # onboarding pointed at an unavailable localhost:8000, which is the failure
   # mode this PR exists to fix. For other providers, install_or_start_vllm

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5452,6 +5452,8 @@ async function setupNim(
           // fall back to the existing ollama option silently
           if (providerKey === "install-ollama") {
             selected = options.find((o) => o.key === "ollama");
+          } else if (providerKey === "ollama") {
+            selected = options.find((o) => o.key === "install-ollama");
           }
           if (!selected) {
             console.error(

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -3731,6 +3731,134 @@ const { setupNim } = require(${onboardPath});
     );
   });
 
+  it("uses install-ollama for non-interactive NEMOCLAW_PROVIDER=ollama on fresh Linux", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-noninteractive-install-ollama-"),
+    );
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "noninteractive-install-ollama-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "registry.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+body='{"id":"ok"}'
+status="200"
+outfile=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) outfile="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$outfile" ]; then
+  printf '%s' "$body" > "$outfile"
+  printf '%s' "$status"
+else
+  printf '%s' "$body"
+fi
+`,
+      { mode: 0o755 },
+    );
+
+    const script = String.raw`
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const child_process = require("child_process");
+
+child_process.spawn = () => ({ pid: 99999, unref() {}, on() {} });
+
+const originalSpawnSync = child_process.spawnSync;
+child_process.spawnSync = (cmd, args, opts) => {
+  const command = [cmd, ...(args || [])].join(" ");
+  if (command.includes("ollama pull")) {
+    return { status: 0, stdout: "", stderr: "", signal: null };
+  }
+  if (cmd === "ps") {
+    return { status: 0, stdout: "node ollama-auth-proxy.js", stderr: "", signal: null };
+  }
+  return originalSpawnSync(cmd, args, opts);
+};
+
+let promptCalls = 0;
+const updates = [];
+const runCommands = [];
+
+credentials.prompt = async () => {
+  promptCalls += 1;
+  return "";
+};
+credentials.ensureApiKey = async () => {};
+runner.runCapture = (command) => {
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "";
+  if (cmd.includes("127.0.0.1:11434/api/tags")) return "";
+  if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
+  if (cmd.includes("ollama list")) return "qwen3:8b  abc  5 GB  now";
+  if (cmd.includes("ps")) return "node ollama-auth-proxy.js";
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  return "";
+};
+runner.run = (command) => {
+  runCommands.push(typeof command === "string" ? command : command.join(" "));
+};
+runner.runShell = (command) => {
+  runCommands.push(command);
+};
+registry.updateSandbox = (_name, update) => updates.push(update);
+
+Object.defineProperty(process, "platform", { value: "linux" });
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  const originalLog = console.log;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim("noninteractive-install-test", null);
+    originalLog(JSON.stringify({ result, promptCalls, updates, lines, runCommands }));
+  } finally {
+    console.log = originalLog;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_PROVIDER: "ollama",
+        NEMOCLAW_YES: "1",
+      },
+    });
+
+    assert.equal(result.status, 0, `Process failed: ${result.stderr}`);
+    assert.notEqual(result.stdout.trim(), "", result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+
+    assert.equal(payload.promptCalls, 0);
+    assert.equal(payload.result.provider, "ollama-local");
+    assert.ok(
+      payload.runCommands.some((cmd: string) => cmd.includes("ollama.com/install.sh")),
+      "Should use the Ollama installer when requested non-interactively on a fresh host",
+    );
+  });
+
   it("honours NEMOCLAW_LOCAL_INFERENCE_TIMEOUT for compatible-endpoint during inference setup (#2403)", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`scripts/install.sh` was bootstrapping Ollama (binary install/upgrade plus a hardcoded VRAM-keyed pull of nemotron-3-super:120b or nemotron-3-nano:30b) whenever `NEMOCLAW_PROVIDER=ollama` was set. That duplicated `nemoclaw onboard`'s own install-ollama branch and ignored `NEMOCLAW_MODEL`, so users who set `NEMOCLAW_MODEL=qwen3.5:4b` still saw nemotron get pulled before  onboard pulled their requested model. This PR removes the bootstrap entirely and lets onboard own all Ollama install + pull policy.

## Changes
 - Deleted `install_or_upgrade_ollama` function and its caller gate.
 - Deleted now-orphaned helpers: `get_ollama_version`, `get_vram_mb`, and the constants `OLLAMA_MIN_VERSION` / `OLLAMA_INSTALL_SHA256`.
 - Replaced the section header with a comment documenting the layering: install.sh handles dependencies, `nemoclaw onboard` handles inference policy.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Delegated Ollama installation/setup to the onboard flow; simplified installer and clearer error messaging when provider init fails.
  * vLLM path now fails fast with an explicit error if startup/install doesn't succeed.

* **Onboarding**
  * Non-interactive onboarding now falls back to an "install Ollama" option when Ollama is requested but not present.

* **Tests**
  * Added an integration test covering the non-interactive Ollama install/selection path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->