### PR TITLE
fix(hermes): preinstall TUI deps for readonly sandbox

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -54,6 +54,11 @@ COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh
 COPY agents/hermes/start.sh /usr/local/bin/nemoclaw-start
 RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/sandbox-init.sh
 
+# Preinstall Hermes TUI dependencies before the sandbox becomes read-only.
+RUN cd /opt/hermes/ui-tui \
+    && npm ci --omit=dev --ignore-scripts \
+    && npm cache clean --force
+
 # Build args for config that varies per deployment.
 ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b
 ARG NEMOCLAW_PROVIDER_KEY=custom


### PR DESCRIPTION
## Summary
- preinstall Hermes TUI npm dependencies at image build time
- avoid runtime installs that fail in read-only sandboxes

## Testing
- not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build process for improved deployment efficiency by streamlining dependency installation and reducing build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->