### PR TITLE
fix(onboard): preserve user-added presets on non-interactive re-onboard

### DIFF
--- a/docs/manage-sandboxes/lifecycle.md
+++ b/docs/manage-sandboxes/lifecycle.md
@@ -187,6 +187,10 @@ $ nemoclaw <sandbox-name> policy-add
 
 Refer to [`nemoclaw <name> policy-add`](../reference/commands.md#nemoclaw-name-policy-add) for usage details and flags.
 
+Presets added this way are preserved across non-interactive re-onboards in the default `suggested` policy mode.
+To make a re-onboard authoritative — replacing the applied set with an exact list and removing anything else — set `NEMOCLAW_POLICY_MODE=custom` with `NEMOCLAW_POLICY_PRESETS`.
+See [`NEMOCLAW_POLICY_MODE`](../reference/commands.md#nemoclaw-onboard) for the full table.
+
 ## Update to the Latest Version
 
 When a new NemoClaw release becomes available, update the `nemoclaw` CLI on your host and check existing sandboxes for stale agent/runtime versions.

--- a/docs/manage-sandboxes/lifecycle.md
+++ b/docs/manage-sandboxes/lifecycle.md
@@ -187,8 +187,8 @@ $ nemoclaw <sandbox-name> policy-add
 
 Refer to [`nemoclaw <name> policy-add`](../reference/commands.md#nemoclaw-name-policy-add) for usage details and flags.
 
-Presets added this way are preserved across non-interactive re-onboards in the default `suggested` policy mode.
-To make a re-onboard authoritative — replacing the applied set with an exact list and removing anything else — set `NEMOCLAW_POLICY_MODE=custom` with `NEMOCLAW_POLICY_PRESETS`.
+Non-interactive re-onboards in the default `suggested` policy mode preserve presets added this way.
+To make a re-onboard authoritative, set `NEMOCLAW_POLICY_MODE=custom` and provide `NEMOCLAW_POLICY_PRESETS` with the exact list to apply; onboarding removes anything else.
 See [`NEMOCLAW_POLICY_MODE`](../reference/commands.md#nemoclaw-onboard) for the full table.
 
 ## Update to the Latest Version

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -103,6 +103,17 @@ In non-interactive mode, set the tier with `NEMOCLAW_POLICY_TIER` (default: `bal
 $ NEMOCLAW_POLICY_TIER=restricted nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
 ```
 
+`NEMOCLAW_POLICY_MODE` controls how non-interactive onboarding reconciles the tier-derived suggestions against the sandbox's currently-applied presets.
+The default is `suggested`, which is *additive*: tier defaults are applied and any presets you previously added with [`nemoclaw <name> policy-add`](#nemoclaw-name-policy-add) are preserved across re-onboards.
+Use `custom` with `NEMOCLAW_POLICY_PRESETS` when you want the explicit list to be authoritative — presets not in the list are removed.
+`skip` leaves the applied set untouched and does not apply tier defaults.
+
+| Value | Behaviour |
+|-------|-----------|
+| `suggested` (default) | Apply tier defaults and preserve any extra presets already applied. Aliases: `default`, `auto`. |
+| `custom` | Apply exactly `NEMOCLAW_POLICY_PRESETS`. Previously-applied presets not in the list are removed. Alias: `list`. |
+| `skip` | Skip the policy step entirely. Aliases: `none`, `no`. |
+
 If you enable Brave Search during onboarding, NemoClaw currently stores the Brave API key in the sandbox's OpenClaw configuration.
 That means the OpenClaw agent can read the key.
 NemoClaw explores an OpenShell-hosted credential path first, but the current OpenClaw Brave runtime does not consume that path end to end yet.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -104,8 +104,10 @@ $ NEMOCLAW_POLICY_TIER=restricted nemoclaw onboard --non-interactive --yes-i-acc
 ```
 
 `NEMOCLAW_POLICY_MODE` controls how non-interactive onboarding reconciles the tier-derived suggestions against the sandbox's currently-applied presets.
-The default is `suggested`, which is *additive*: tier defaults are applied and any presets you previously added with [`nemoclaw <name> policy-add`](#nemoclaw-name-policy-add) are preserved across re-onboards.
-Use `custom` with `NEMOCLAW_POLICY_PRESETS` when you want the explicit list to be authoritative — presets not in the list are removed.
+The default is `suggested`, which is *additive*.
+Onboarding applies tier defaults and preserves any presets you previously added with [`nemoclaw <name> policy-add`](#nemoclaw-name-policy-add) across re-onboards.
+Use `custom` with `NEMOCLAW_POLICY_PRESETS` when you want the explicit list to be authoritative.
+Onboarding removes any preset that is not in the list.
 `skip` leaves the applied set untouched and does not apply tier defaults.
 
 | Value | Behaviour |

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -7513,6 +7513,7 @@ async function setupPoliciesWithSelection(
   if (isNonInteractive()) {
     const policyMode = (process.env.NEMOCLAW_POLICY_MODE || "suggested").trim().toLowerCase();
     chosen = suggestions;
+    let isAuthoritative = false;
 
     if (policyMode === "skip" || policyMode === "none" || policyMode === "no") {
       note("  [non-interactive] Skipping policy presets.");
@@ -7525,6 +7526,7 @@ async function setupPoliciesWithSelection(
         console.error("  NEMOCLAW_POLICY_PRESETS is required when NEMOCLAW_POLICY_MODE=custom.");
         process.exit(1);
       }
+      isAuthoritative = true;
     } else if (policyMode === "suggested" || policyMode === "default" || policyMode === "auto") {
       const envPresets = parsePolicyPresetEnv(process.env.NEMOCLAW_POLICY_PRESETS || "");
       if (envPresets.length > 0) chosen = envPresets;
@@ -7549,6 +7551,28 @@ async function setupPoliciesWithSelection(
     if (invalidPresets.length > 0) {
       console.error(`  Unknown policy preset(s): ${invalidPresets.join(", ")}`);
       process.exit(1);
+    }
+
+    // Suggested mode is additive: presets the user added beyond the tier
+    // defaults (typically via `nemoclaw <name> policy-add`, including custom
+    // presets loaded with `--from-file`/`--from-dir`) must survive a
+    // re-onboard. `applied` comes from the registry and is the source of
+    // truth for what is currently on the sandbox, so trust it directly
+    // instead of intersecting with the built-in list. Custom mode remains
+    // authoritative — the operator-supplied list is exactly what the
+    // sandbox ends up with, and deselected presets are removed.
+    if (!isAuthoritative) {
+      const chosenSet = new Set(chosen);
+      const preserved: string[] = [];
+      for (const name of applied) {
+        if (chosenSet.has(name)) continue;
+        chosen.push(name);
+        chosenSet.add(name);
+        preserved.push(name);
+      }
+      if (preserved.length > 0) {
+        note(`  [non-interactive] Preserving previously-applied presets: ${preserved.join(", ")}`);
+      }
     }
 
     if (onSelection) onSelection(chosen);

--- a/test/onboard-preset-diff.test.ts
+++ b/test/onboard-preset-diff.test.ts
@@ -148,6 +148,92 @@ console.log = () => {};
     );
   });
 
+  // Re-onboarding in the default `suggested` mode must not silently remove
+  // presets the user added via `nemoclaw <name> policy-add` after the original
+  // onboard. Tier defaults are recomputed against the current provider, so a
+  // user-added preset such as `local-inference` is not in `suggestions` on a
+  // cloud-provider sandbox — without the additive guard it would be removed.
+  it("non-interactive suggested re-onboard preserves user-added presets", () => {
+    const script =
+      buildPreamble({
+        policyMode: "suggested",
+        policyPresets: "",
+        // Balanced defaults plus a manually-added preset.
+        alreadyApplied: ["npm", "pypi", "huggingface", "brew", "brave", "local-inference"],
+      }) +
+      String.raw`
+console.log = () => {};
+(async () => {
+  try {
+    const chosen = await setupPoliciesWithSelection("test-sb", { provider: "openai" });
+    process.stdout.write(JSON.stringify({ chosen, appliedCalls, removedCalls, finalApplied: appliedState }) + "\n");
+  } catch (err) {
+    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
+  }
+})();
+`;
+    const result = runScript(script);
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
+
+    // The user-added preset must still be in the chosen list.
+    assert.ok(
+      payload.chosen.includes("local-inference"),
+      `expected chosen to preserve local-inference, got ${JSON.stringify(payload.chosen)}`,
+    );
+
+    // Nothing should be removed — every applied preset is either a tier
+    // default or a user-added extra that the additive policy preserves.
+    assert.deepEqual(
+      payload.removedCalls,
+      [],
+      `expected no removals, got ${JSON.stringify(payload.removedCalls)}`,
+    );
+
+    // Final state should still contain every previously-applied preset.
+    const finalSorted = payload.finalApplied.slice().sort();
+    assert.deepEqual(finalSorted, ["brave", "brew", "huggingface", "local-inference", "npm", "pypi"]);
+  });
+
+  // Custom presets loaded via `policy-add --from-file` / `--from-dir` are
+  // recorded on the sandbox alongside built-in presets. They must survive a
+  // non-interactive re-onboard the same way named built-ins do — even though
+  // they do not appear in `policies.listPresets()`.
+  it("non-interactive suggested re-onboard preserves custom presets", () => {
+    const script =
+      buildPreamble({
+        policyMode: "suggested",
+        policyPresets: "",
+        alreadyApplied: ["npm", "pypi", "huggingface", "brew", "brave", "my-internal-api"],
+      }) +
+      String.raw`
+console.log = () => {};
+(async () => {
+  try {
+    const chosen = await setupPoliciesWithSelection("test-sb", { provider: "openai" });
+    process.stdout.write(JSON.stringify({ chosen, appliedCalls, removedCalls, finalApplied: appliedState }) + "\n");
+  } catch (err) {
+    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
+  }
+})();
+`;
+    const result = runScript(script);
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
+
+    assert.ok(
+      payload.chosen.includes("my-internal-api"),
+      `expected chosen to preserve my-internal-api, got ${JSON.stringify(payload.chosen)}`,
+    );
+    assert.deepEqual(
+      payload.removedCalls,
+      [],
+      `expected no removals, got ${JSON.stringify(payload.removedCalls)}`,
+    );
+  });
+
   // Widening the selection (user re-enables a preset they'd previously dropped)
   // must apply the new one and not re-apply things that are already applied.
   it("non-interactive widen selection applies only new presets", () => {


### PR DESCRIPTION
## Summary

Non-interactive `nemoclaw onboard` in the default `suggested` policy mode silently removed presets the user had added beyond the tier defaults (typically via `nemoclaw <name> policy-add`, including custom presets loaded with `--from-file`/`--from-dir`). This PR makes `suggested` mode additive — tier defaults are still applied, and previously-applied presets are preserved across re-onboards. `custom` mode keeps its authoritative semantic.

## Related Issue

Fixes #2761

## Changes

- `src/lib/onboard.ts`: in the non-interactive branch of `setupPoliciesWithSelection`, union the chosen list with the registry's currently-applied presets when the mode is not authoritative; emit a `note(...)` listing what was preserved.
- `test/onboard-preset-diff.test.ts`: add two regression cases covering a user-added built-in preset (`local-inference`) and a user-added custom preset.
- `docs/reference/commands.md`: document `NEMOCLAW_POLICY_MODE` semantics with a value table.
- `docs/manage-sandboxes/lifecycle.md`: note that `policy-add` additions survive non-interactive re-onboards in `suggested` mode and point to `custom` mode for authoritative narrowing.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `NEMOCLAW_POLICY_MODE` environment variable to control preset behavior during re-onboarding with three options: `suggested` (preserves previously applied presets), `custom` (uses only specified presets), and `skip` (leaves presets unchanged).

* **Documentation**
  * Added reference documentation for `NEMOCLAW_POLICY_MODE` and clarified how presets persist across re-onboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->