### PR TITLE
fix(e2e): surface docker stderr on run_override failure in runtime-overrides test

### DIFF
--- a/test/e2e/test-runtime-overrides.sh
+++ b/test/e2e/test-runtime-overrides.sh
@@ -50,8 +50,20 @@ info "Logging Docker stderr to: $LOG_FILE"
 # Docker stderr is captured to the log file for CI artifact visibility.
 run_override() {
   local env_args=("$@")
+  local rc=0
+  local stderr_tmp
+  stderr_tmp="$(mktemp)"
   docker run --rm "${env_args[@]}" "$IMAGE" \
-    bash -c 'cat /sandbox/.openclaw/openclaw.json; printf "\n"' 2>>"$LOG_FILE"
+    bash -c 'cat /sandbox/.openclaw/openclaw.json; printf "\n"' 2>"$stderr_tmp" || rc=$?
+  # Always append stderr to the CI log file for artifact capture
+  cat "$stderr_tmp" >>"$LOG_FILE"
+  if [ "$rc" -ne 0 ]; then
+    echo "── run_override failed (exit $rc) ── stderr:" >&2
+    tail -80 "$stderr_tmp" >&2
+    rm -f "$stderr_tmp"
+    return "$rc"
+  fi
+  rm -f "$stderr_tmp"
 }
 
 # Helper: run entrypoint with env vars and capture stderr for validation messages.
@@ -110,7 +122,9 @@ fi
 
 info "2. NEMOCLAW_MODEL_OVERRIDE patches model"
 OVERRIDE_MODEL="anthropic/claude-sonnet-4-6"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL"); then
+  fail "docker run failed for model override test"; exit 1
+fi
 ACTUAL=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 if [ "$ACTUAL" = "$OVERRIDE_MODEL" ]; then
   pass "model overridden to $OVERRIDE_MODEL"
@@ -132,7 +146,9 @@ fi
 # (standalone values are baked at build time). Ref: #2653 Phase 2.
 
 info "3. NEMOCLAW_CONTEXT_WINDOW patches contextWindow (with model override)"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_CONTEXT_WINDOW=32768")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_CONTEXT_WINDOW=32768"); then
+  fail "docker run failed for context window override test"; exit 1
+fi
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 if [ "$ACTUAL" = "32768" ]; then
   pass "contextWindow overridden to 32768"
@@ -143,7 +159,9 @@ fi
 # ── Test 4: Max tokens override ──────────────────────────────────
 
 info "4. NEMOCLAW_MAX_TOKENS patches maxTokens (with model override)"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_MAX_TOKENS=16384")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_MAX_TOKENS=16384"); then
+  fail "docker run failed for max tokens override test"; exit 1
+fi
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].maxTokens')
 if [ "$ACTUAL" = "16384" ]; then
   pass "maxTokens overridden to 16384"
@@ -154,7 +172,9 @@ fi
 # ── Test 5: Reasoning override ───────────────────────────────────
 
 info "5. NEMOCLAW_REASONING=true patches reasoning (with model override)"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_REASONING=true")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_REASONING=true"); then
+  fail "docker run failed for reasoning override test"; exit 1
+fi
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].reasoning')
 if [ "$ACTUAL" = "true" ]; then
   pass "reasoning overridden to true"
@@ -166,7 +186,9 @@ fi
 
 info "6. NEMOCLAW_CORS_ORIGIN adds to allowedOrigins"
 CORS="https://custom.example.com:9999"
-CFG=$(run_override -e "NEMOCLAW_CORS_ORIGIN=$CORS")
+if ! CFG=$(run_override -e "NEMOCLAW_CORS_ORIGIN=$CORS"); then
+  fail "docker run failed for CORS origin override test"; exit 1
+fi
 HAS_ORIGIN=$(echo "$CFG" | jq --arg o "$CORS" '.gateway.controlUi.allowedOrigins | index($o) != null')
 NEW_LEN=$(echo "$CFG" | jq '.gateway.controlUi.allowedOrigins | length')
 if [ "$HAS_ORIGIN" = "true" ] && [ "$NEW_LEN" -gt "$BASELINE_ORIGINS" ]; then
@@ -179,12 +201,14 @@ fi
 # ── Test 7: Combined overrides ───────────────────────────────────
 
 info "7. Multiple overrides applied together"
-CFG=$(run_override \
+if ! CFG=$(run_override \
   -e "NEMOCLAW_MODEL_OVERRIDE=nvidia/llama-3.3-nemotron-super-49b-v1.5" \
   -e "NEMOCLAW_CONTEXT_WINDOW=65536" \
   -e "NEMOCLAW_MAX_TOKENS=8192" \
   -e "NEMOCLAW_REASONING=true" \
-  -e "NEMOCLAW_CORS_ORIGIN=https://multi.example.com")
+  -e "NEMOCLAW_CORS_ORIGIN=https://multi.example.com"); then
+  fail "docker run failed for combined overrides test"; exit 1
+fi
 M=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 C=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 T=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].maxTokens')
@@ -251,7 +275,9 @@ fi
 # ── Test 14: Original config unchanged after rejected override ───
 
 info "14. Config unchanged after rejected override"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=test" -e "NEMOCLAW_CONTEXT_WINDOW=notanumber")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=test" -e "NEMOCLAW_CONTEXT_WINDOW=notanumber"); then
+  fail "docker run failed for rejected override test"; exit 1
+fi
 ACTUAL_CTX=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 ACTUAL_MODEL=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 if [ "$ACTUAL_CTX" = "$BASELINE_CTX" ] && [ "$ACTUAL_MODEL" = "$BASELINE_MODEL" ]; then


### PR DESCRIPTION
## Summary

The `runtime-overrides-e2e` job in the nightly E2E run [#25244372371](https://github.com/NVIDIA/NemoClaw/actions/runs/25244372371) failed silently because `run_override()` in `test/e2e/test-runtime-overrides.sh` redirects Docker stderr to the log file but never surfaces it when `docker run` exits non-zero. Under `set -euo pipefail`, bare `CFG=$(run_override …)` assignments cause the script to abort immediately with no diagnostic output, making CI failures impossible to triage.

This PR modifies `run_override()` to capture stderr in a tempfile, always append it to the CI log, and dump the tail to stderr on failure. All bare `CFG=$(run_override …)` calls are wrapped in `if-!` guards so failures route through `fail()` with a descriptive message instead of a silent exit.

## Related Issue

Fixes #2977

## Changes

- `run_override()`: capture stderr to a tempfile; always append to `$LOG_FILE`; on non-zero exit, dump the last 80 lines to stderr before returning the exit code
- Tests 2–7 and 14: wrap `CFG=$(run_override …)` in `if-!` guards with descriptive `fail` messages, matching the pattern already used by the baseline capture

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

---
Signed-off-by: Hai Nguyen <haingu@nvidia.com>

