### PR TITLE
fix(e2e): reduce TC-SBX-06 gateway-recovery poll from 10 min to 6 min

### DIFF
--- a/test/e2e/test-runtime-overrides.sh
+++ b/test/e2e/test-runtime-overrides.sh
@@ -50,20 +50,8 @@ info "Logging Docker stderr to: $LOG_FILE"
 # Docker stderr is captured to the log file for CI artifact visibility.
 run_override() {
   local env_args=("$@")
-  local rc=0
-  local stderr_tmp
-  stderr_tmp="$(mktemp)"
   docker run --rm "${env_args[@]}" "$IMAGE" \
-    bash -c 'cat /sandbox/.openclaw/openclaw.json; printf "\n"' 2>"$stderr_tmp" || rc=$?
-  # Always append stderr to the CI log file for artifact capture
-  cat "$stderr_tmp" >>"$LOG_FILE"
-  if [ "$rc" -ne 0 ]; then
-    echo "── run_override failed (exit $rc) ── stderr:" >&2
-    tail -80 "$stderr_tmp" >&2
-    rm -f "$stderr_tmp"
-    return "$rc"
-  fi
-  rm -f "$stderr_tmp"
+    bash -c 'cat /sandbox/.openclaw/openclaw.json; printf "\n"' 2>>"$LOG_FILE"
 }
 
 # Helper: run entrypoint with env vars and capture stderr for validation messages.
@@ -122,9 +110,7 @@ fi
 
 info "2. NEMOCLAW_MODEL_OVERRIDE patches model"
 OVERRIDE_MODEL="anthropic/claude-sonnet-4-6"
-if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL"); then
-  fail "docker run failed for model override test"; exit 1
-fi
+CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL")
 ACTUAL=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 if [ "$ACTUAL" = "$OVERRIDE_MODEL" ]; then
   pass "model overridden to $OVERRIDE_MODEL"
@@ -146,9 +132,7 @@ fi
 # (standalone values are baked at build time). Ref: #2653 Phase 2.
 
 info "3. NEMOCLAW_CONTEXT_WINDOW patches contextWindow (with model override)"
-if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_CONTEXT_WINDOW=32768"); then
-  fail "docker run failed for context window override test"; exit 1
-fi
+CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_CONTEXT_WINDOW=32768")
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 if [ "$ACTUAL" = "32768" ]; then
   pass "contextWindow overridden to 32768"
@@ -159,9 +143,7 @@ fi
 # ── Test 4: Max tokens override ──────────────────────────────────
 
 info "4. NEMOCLAW_MAX_TOKENS patches maxTokens (with model override)"
-if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_MAX_TOKENS=16384"); then
-  fail "docker run failed for max tokens override test"; exit 1
-fi
+CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_MAX_TOKENS=16384")
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].maxTokens')
 if [ "$ACTUAL" = "16384" ]; then
   pass "maxTokens overridden to 16384"
@@ -172,9 +154,7 @@ fi
 # ── Test 5: Reasoning override ───────────────────────────────────
 
 info "5. NEMOCLAW_REASONING=true patches reasoning (with model override)"
-if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_REASONING=true"); then
-  fail "docker run failed for reasoning override test"; exit 1
-fi
+CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_REASONING=true")
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].reasoning')
 if [ "$ACTUAL" = "true" ]; then
   pass "reasoning overridden to true"
@@ -186,9 +166,7 @@ fi
 
 info "6. NEMOCLAW_CORS_ORIGIN adds to allowedOrigins"
 CORS="https://custom.example.com:9999"
-if ! CFG=$(run_override -e "NEMOCLAW_CORS_ORIGIN=$CORS"); then
-  fail "docker run failed for CORS origin override test"; exit 1
-fi
+CFG=$(run_override -e "NEMOCLAW_CORS_ORIGIN=$CORS")
 HAS_ORIGIN=$(echo "$CFG" | jq --arg o "$CORS" '.gateway.controlUi.allowedOrigins | index($o) != null')
 NEW_LEN=$(echo "$CFG" | jq '.gateway.controlUi.allowedOrigins | length')
 if [ "$HAS_ORIGIN" = "true" ] && [ "$NEW_LEN" -gt "$BASELINE_ORIGINS" ]; then
@@ -201,14 +179,12 @@ fi
 # ── Test 7: Combined overrides ───────────────────────────────────
 
 info "7. Multiple overrides applied together"
-if ! CFG=$(run_override \
+CFG=$(run_override \
   -e "NEMOCLAW_MODEL_OVERRIDE=nvidia/llama-3.3-nemotron-super-49b-v1.5" \
   -e "NEMOCLAW_CONTEXT_WINDOW=65536" \
   -e "NEMOCLAW_MAX_TOKENS=8192" \
   -e "NEMOCLAW_REASONING=true" \
-  -e "NEMOCLAW_CORS_ORIGIN=https://multi.example.com"); then
-  fail "docker run failed for combined overrides test"; exit 1
-fi
+  -e "NEMOCLAW_CORS_ORIGIN=https://multi.example.com")
 M=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 C=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 T=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].maxTokens')
@@ -275,9 +251,7 @@ fi
 # ── Test 14: Original config unchanged after rejected override ───
 
 info "14. Config unchanged after rejected override"
-if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=test" -e "NEMOCLAW_CONTEXT_WINDOW=notanumber"); then
-  fail "docker run failed for rejected override test"; exit 1
-fi
+CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=test" -e "NEMOCLAW_CONTEXT_WINDOW=notanumber")
 ACTUAL_CTX=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 ACTUAL_MODEL=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 if [ "$ACTUAL_CTX" = "$BASELINE_CTX" ] && [ "$ACTUAL_MODEL" = "$BASELINE_MODEL" ]; then

--- a/test/e2e/test-runtime-overrides.sh
+++ b/test/e2e/test-runtime-overrides.sh
@@ -50,8 +50,20 @@ info "Logging Docker stderr to: $LOG_FILE"
 # Docker stderr is captured to the log file for CI artifact visibility.
 run_override() {
   local env_args=("$@")
+  local rc=0
+  local stderr_tmp
+  stderr_tmp="$(mktemp)"
   docker run --rm "${env_args[@]}" "$IMAGE" \
-    bash -c 'cat /sandbox/.openclaw/openclaw.json; printf "\n"' 2>>"$LOG_FILE"
+    bash -c 'cat /sandbox/.openclaw/openclaw.json; printf "\n"' 2>"$stderr_tmp" || rc=$?
+  # Always append stderr to the CI log file for artifact capture
+  cat "$stderr_tmp" >>"$LOG_FILE"
+  if [ "$rc" -ne 0 ]; then
+    echo "── run_override failed (exit $rc) ── stderr:" >&2
+    tail -80 "$stderr_tmp" >&2
+    rm -f "$stderr_tmp"
+    return "$rc"
+  fi
+  rm -f "$stderr_tmp"
 }
 
 # Helper: run entrypoint with env vars and capture stderr for validation messages.
@@ -110,7 +122,9 @@ fi
 
 info "2. NEMOCLAW_MODEL_OVERRIDE patches model"
 OVERRIDE_MODEL="anthropic/claude-sonnet-4-6"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL"); then
+  fail "docker run failed for model override test"; exit 1
+fi
 ACTUAL=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 if [ "$ACTUAL" = "$OVERRIDE_MODEL" ]; then
   pass "model overridden to $OVERRIDE_MODEL"
@@ -132,7 +146,9 @@ fi
 # (standalone values are baked at build time). Ref: #2653 Phase 2.
 
 info "3. NEMOCLAW_CONTEXT_WINDOW patches contextWindow (with model override)"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_CONTEXT_WINDOW=32768")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_CONTEXT_WINDOW=32768"); then
+  fail "docker run failed for context window override test"; exit 1
+fi
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 if [ "$ACTUAL" = "32768" ]; then
   pass "contextWindow overridden to 32768"
@@ -143,7 +159,9 @@ fi
 # ── Test 4: Max tokens override ──────────────────────────────────
 
 info "4. NEMOCLAW_MAX_TOKENS patches maxTokens (with model override)"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_MAX_TOKENS=16384")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_MAX_TOKENS=16384"); then
+  fail "docker run failed for max tokens override test"; exit 1
+fi
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].maxTokens')
 if [ "$ACTUAL" = "16384" ]; then
   pass "maxTokens overridden to 16384"
@@ -154,7 +172,9 @@ fi
 # ── Test 5: Reasoning override ───────────────────────────────────
 
 info "5. NEMOCLAW_REASONING=true patches reasoning (with model override)"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_REASONING=true")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=$OVERRIDE_MODEL" -e "NEMOCLAW_REASONING=true"); then
+  fail "docker run failed for reasoning override test"; exit 1
+fi
 ACTUAL=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].reasoning')
 if [ "$ACTUAL" = "true" ]; then
   pass "reasoning overridden to true"
@@ -166,7 +186,9 @@ fi
 
 info "6. NEMOCLAW_CORS_ORIGIN adds to allowedOrigins"
 CORS="https://custom.example.com:9999"
-CFG=$(run_override -e "NEMOCLAW_CORS_ORIGIN=$CORS")
+if ! CFG=$(run_override -e "NEMOCLAW_CORS_ORIGIN=$CORS"); then
+  fail "docker run failed for CORS origin override test"; exit 1
+fi
 HAS_ORIGIN=$(echo "$CFG" | jq --arg o "$CORS" '.gateway.controlUi.allowedOrigins | index($o) != null')
 NEW_LEN=$(echo "$CFG" | jq '.gateway.controlUi.allowedOrigins | length')
 if [ "$HAS_ORIGIN" = "true" ] && [ "$NEW_LEN" -gt "$BASELINE_ORIGINS" ]; then
@@ -179,12 +201,14 @@ fi
 # ── Test 7: Combined overrides ───────────────────────────────────
 
 info "7. Multiple overrides applied together"
-CFG=$(run_override \
+if ! CFG=$(run_override \
   -e "NEMOCLAW_MODEL_OVERRIDE=nvidia/llama-3.3-nemotron-super-49b-v1.5" \
   -e "NEMOCLAW_CONTEXT_WINDOW=65536" \
   -e "NEMOCLAW_MAX_TOKENS=8192" \
   -e "NEMOCLAW_REASONING=true" \
-  -e "NEMOCLAW_CORS_ORIGIN=https://multi.example.com")
+  -e "NEMOCLAW_CORS_ORIGIN=https://multi.example.com"); then
+  fail "docker run failed for combined overrides test"; exit 1
+fi
 M=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 C=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 T=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].maxTokens')
@@ -251,7 +275,9 @@ fi
 # ── Test 14: Original config unchanged after rejected override ───
 
 info "14. Config unchanged after rejected override"
-CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=test" -e "NEMOCLAW_CONTEXT_WINDOW=notanumber")
+if ! CFG=$(run_override -e "NEMOCLAW_MODEL_OVERRIDE=test" -e "NEMOCLAW_CONTEXT_WINDOW=notanumber"); then
+  fail "docker run failed for rejected override test"; exit 1
+fi
 ACTUAL_CTX=$(echo "$CFG" | jq -r '.models.providers | to_entries[0].value.models[0].contextWindow')
 ACTUAL_MODEL=$(echo "$CFG" | jq -r '.agents.defaults.model.primary')
 if [ "$ACTUAL_CTX" = "$BASELINE_CTX" ] && [ "$ACTUAL_MODEL" = "$BASELINE_MODEL" ]; then

--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -598,7 +598,7 @@ test_sbx_06_gateway_recovery() {
 
   local recovered=false
   local docker_restarted=false
-  for i in $(seq 1 40); do
+  for i in $(seq 1 24); do
     sleep 15
     local cstate
     cstate=$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo "removed")
@@ -617,7 +617,7 @@ test_sbx_06_gateway_recovery() {
   done
 
   if kill -0 "$status_pid" 2>/dev/null; then
-    log "  nemoclaw status still running after 10 min — killing"
+    log "  nemoclaw status still running after 6 min — killing"
     kill "$status_pid" 2>/dev/null || true
     wait "$status_pid" 2>/dev/null || true
   fi


### PR DESCRIPTION
## Summary

The `sandbox-operations-e2e` job in nightly run [#25244372371](https://github.com/NVIDIA/NemoClaw/actions/runs/25244372371) timed out. `test_sbx_06_gateway_recovery()` polls 40×15 s = 600 s (10 min) for Docker gateway recovery — nearly a quarter of the 2700 s e2e-timeout budget. After prior tests (sandbox creation ~14 min per sandbox × 2, plus other TC-SBX cases), the cumulative runtime exceeds the timeout, killing the entire suite before it finishes.

This PR reduces the TC-SBX-06 poll from 40 to 24 iterations (360 s / 6 min), which is still well above the ~90 s typical recovery window but frees ~4 min for the rest of the suite.

## Related Issue

Fixes #2978

## Changes

- `test/e2e/test-sandbox-operations.sh`: reduce `test_sbx_06_gateway_recovery()` poll loop from `seq 1 40` to `seq 1 24` (600 s → 360 s)
- Update timeout message from "10 min" to "6 min"

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

---
Signed-off-by: Hai Nguyen <haingu@nvidia.com>

