### PR TITLE
fix(hermes): restore share-mount package parity

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -35,10 +35,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-venv=3.11.2-1+b1 \
         curl=7.88.1-10+deb12u14 \
         git=1:2.39.5-0+deb12u3 \
+    gnupg=2.2.40-1.1+deb12u2 \
         ca-certificates=20230311+deb12u1 \
         iproute2=6.1.0-3 \
         iptables=1.8.9-2 \
         libcap2-bin=1:2.66-4+deb12u2+b2 \
+    procps=2:4.0.2-3 \
+    openssh-sftp-server=1:9.2p1-2+deb12u9 \
         socat=1.7.4.4-2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/test/hermes-share-mount-deps.test.ts
+++ b/test/hermes-share-mount-deps.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const HERMES_DOCKERFILE_BASE = path.join(ROOT, "agents", "hermes", "Dockerfile.base");
+
+function extractAptInstallBlock(dockerfile: string): string {
+  const match = dockerfile.match(
+    /RUN\s+apt-get update\s*&&\s*apt-get install -y --no-install-recommends[\s\S]*?&&\s*rm -rf \/var\/lib\/apt\/lists\/\*/m,
+  );
+  expect(match).not.toBeNull();
+  return match![0];
+}
+
+describe("Hermes share mount package parity (#2947)", () => {
+  it("includes gnupg, procps, and openssh-sftp-server in Hermes base apt packages", () => {
+    const dockerfile = fs.readFileSync(HERMES_DOCKERFILE_BASE, "utf-8");
+    const aptBlock = extractAptInstallBlock(dockerfile);
+
+    expect(aptBlock).toContain("gnupg=2.2.40-1.1+deb12u2");
+    expect(aptBlock).toContain("procps=2:4.0.2-3");
+    expect(aptBlock).toContain("openssh-sftp-server=1:9.2p1-2+deb12u9");
+  });
+});


### PR DESCRIPTION
## Summary
Restore Hermes sandbox base-image package parity required for share mount support.

Issue #2947 reported that share mount support added earlier was not mirrored in the Hermes base image, causing SSHFS mount failures with:
SSHFS mount failed. remote host has disconnected.

## Related Issue
Closes #2947

## Root Cause
The Hermes base image did not include the package set expected by share mount support, specifically the SFTP server dependency and related parity packages that exist in the main base image.

## Changes
- Added missing pinned apt packages to Hermes base image:
  - gnupg=2.2.40-1.1+deb12u2
  - procps=2:4.0.2-3
  - openssh-sftp-server=1:9.2p1-2+deb12u9
- Added a focused regression test to ensure these Hermes base-image packages remain present.

## Why This Solution
- Minimal blast radius: package-layer only, no runtime logic changes.
- Aligns Hermes with existing base-image package policy and pinned versions.
- Prevents recurrence via explicit regression coverage.

## Verification
- [x] npm test -- test/hermes-share-mount-deps.test.ts
- [x] Tests added for changed behavior
- [x] No secrets or credentials committed
- [ ] npx prek run --all-files (comprehensive linting pending maintainer CI)

---
Signed-off-by: Suryaansh <Suryaansh.aa@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Base Hermes container image now includes additional system packages for improved functionality and compatibility.

* **Tests**
  * New test coverage verifies the presence and pinning of the added system packages in the container image build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->