### PR TITLE
fix(policy): allow local inference host gateway

### DIFF
--- a/nemoclaw-blueprint/policies/presets/local-inference.yaml
+++ b/nemoclaw-blueprint/policies/presets/local-inference.yaml
@@ -13,6 +13,12 @@ network_policies:
         port: 11434
         protocol: rest
         enforcement: enforce
+        allowed_ips:
+          # OpenShell's SSRF guard rejects private host-gateway IPs unless
+          # the policy explicitly allowlists the resolved address.
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -20,6 +26,10 @@ network_policies:
         port: 11435
         protocol: rest
         enforcement: enforce
+        allowed_ips:
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
@@ -27,6 +37,10 @@ network_policies:
         port: 8000
         protocol: rest
         enforcement: enforce
+        allowed_ips:
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
         rules:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -14,6 +14,7 @@ import { execTimeout } from "./helpers/timeouts";
 
 const requireForTest = createRequire(import.meta.url);
 const readline = requireForTest("node:readline") as typeof import("node:readline");
+const YAML = requireForTest("yaml");
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const CLI_PATH = JSON.stringify(path.join(REPO_ROOT, "dist", "nemoclaw.js"));
 const CREDENTIALS_PATH = JSON.stringify(path.join(REPO_ROOT, "dist", "lib", "credentials.js"));
@@ -188,6 +189,22 @@ describe("policies", () => {
       expect(content).toContain("port: 11434");
       expect(content).toContain("port: 11435");
       expect(content).toContain("port: 8000");
+    });
+
+    it("local-inference preset allowlists private host-gateway IP ranges", () => {
+      const content = requirePresetContent(policies.loadPreset("local-inference"));
+      const parsed = YAML.parse(content);
+      const endpoints = parsed.network_policies.local_inference.endpoints;
+      const expectedRanges = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"];
+
+      for (const port of [11434, 11435, 8000]) {
+        const endpoint = endpoints.find(
+          (item: { host?: string; port?: number; allowed_ips?: string[] }) =>
+            item.host === "host.openshell.internal" && item.port === port,
+        );
+        expect(endpoint, `missing host-gateway endpoint for port ${port}`).toBeDefined();
+        expect(endpoint?.allowed_ips).toEqual(expectedRanges);
+      }
     });
 
     it("local-inference preset includes openclaw and common tool binaries", () => {


### PR DESCRIPTION
## Summary
- allowlist private RFC1918 host-gateway IP ranges on the `local-inference` preset endpoints for Ollama, the auth proxy, and vLLM
- keep the existing host/port/binary restrictions in place for `host.openshell.internal`
- add a regression test so the Ollama/proxy/vLLM endpoints cannot lose those `allowed_ips` entries silently

## Root cause
PR #2295 added the missing binaries, but OpenShell v0.0.36 performs a second SSRF check after the policy endpoint/binary match. `host.openshell.internal` resolves to a Docker/Colima/WSL host-gateway address, which is private by design. Without `allowed_ips`, OpenShell still returns `403 ssrf_denied` for `host.openshell.internal:11434` and `:11435` even when `local-inference` appears active.

## Live OpenShell validation
Tested with OpenShell `0.0.36` on dedicated gateway `issue2199test`. Host services were reachable before sandbox testing:

- host `127.0.0.1:11434/api/tags` -> `200`
- host `127.0.0.1:11435/api/tags` -> `200`

Using the `origin/main` local-inference policy reproduced the reopened issue:

- sandbox `host.openshell.internal:11434/api/tags` -> `403`, `{"error":"ssrf_denied"}`
- sandbox `host.openshell.internal:11435/api/tags` -> `403`, `{"error":"ssrf_denied"}`

Using this PR's local-inference policy fixed the same calls:

- sandbox `host.openshell.internal:11434/api/tags` -> `200`
- sandbox `host.openshell.internal:11435/api/tags` -> `200`

## Other validation
- `npm ci --ignore-scripts`
- `npm run build:cli`
- `npx vitest run test/policies.test.ts test/validate-blueprint.test.ts`
- `git diff --check`

Closes #2199


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced local-inference network policy: added explicit allowlisting of RFC1918 private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) for host endpoints on ports 11434, 11435, and 8000.
  * Included a note clarifying SSRF guard behavior for the 11434 endpoint.

* **Tests**
  * Added tests validating the local-inference preset now enforces the expected IP allowlists for the specified endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->