### PR TITLE
fix(hermes): restore share-mount package parity

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -35,10 +35,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-venv=3.11.2-1+b1 \
         curl=7.88.1-10+deb12u14 \
         git=1:2.39.5-0+deb12u3 \
+    gnupg=2.2.40-1.1+deb12u2 \
         ca-certificates=20230311+deb12u1 \
         iproute2=6.1.0-3 \
         iptables=1.8.9-2 \
         libcap2-bin=1:2.66-4+deb12u2+b2 \
+    procps=2:4.0.2-3 \
+    openssh-sftp-server=1:9.2p1-2+deb12u9 \
         socat=1.7.4.4-2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/test/hermes-share-mount-deps.test.ts
+++ b/test/hermes-share-mount-deps.test.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const HERMES_DOCKERFILE_BASE = path.join(ROOT, "agents", "hermes", "Dockerfile.base");
+
+function extractAptInstallCommand(dockerfile: string): string {
+  const match = dockerfile.match(
+    /RUN\s+apt-get update\s*&&\s*apt-get install -y --no-install-recommends[\s\S]*?&&\s*rm -rf \/var\/lib\/apt\/lists\/\*/m,
+  );
+  expect(match).not.toBeNull();
+  return match![0].replace(/^RUN\s+/, "").replace(/\\\n/g, " ");
+}
+
+function runLoggedShell(command: string, tmp: string) {
+  const logPath = path.join(tmp, "calls.log");
+  const scriptPath = path.join(tmp, "run-hermes-apt-layer.sh");
+  const script = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `call_log=${JSON.stringify(logPath)}`,
+    'apt-get() { printf "apt-get %s\\n" "$*" >> "$call_log"; }',
+    command,
+  ].join("\n");
+  fs.writeFileSync(scriptPath, script, { mode: 0o700 });
+  const result = spawnSync("bash", [scriptPath], { encoding: "utf-8", timeout: 5000 });
+  const calls = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf-8") : "";
+  return { result, calls };
+}
+
+describe("Hermes share mount package parity (#2947)", () => {
+  it("requests gnupg, procps, and openssh-sftp-server from the Hermes base apt layer", () => {
+    const dockerfile = fs.readFileSync(HERMES_DOCKERFILE_BASE, "utf-8");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-share-apt-"));
+    const lists = path.join(tmp, "apt-lists");
+    fs.mkdirSync(lists);
+
+    try {
+      const command = extractAptInstallCommand(dockerfile).replaceAll(
+        "/var/lib/apt/lists",
+        lists,
+      );
+      const { result, calls } = runLoggedShell(command, tmp);
+
+      expect(result.status).toBe(0);
+      expect(calls).toContain("apt-get update");
+      expect(calls).toContain("gnupg=2.2.40-1.1+deb12u2");
+      expect(calls).toContain("procps=2:4.0.2-3");
+      expect(calls).toContain("openssh-sftp-server=1:9.2p1-2+deb12u9");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replays #2975 from @Iamkewl / Suryaansh to restore Hermes share-mount package parity.
- Adds the pinned `gnupg`, `procps`, and `openssh-sftp-server` packages to `agents/hermes/Dockerfile.base`, matching the main sandbox base image package contract.
- Replaces the original source-text regression with a behavior-style test that executes the Hermes base apt layer under a stubbed `apt-get`, so the source-shape budget stays at zero.

## Attribution
This is a maintainer replay of #2975 for issue #2947 because the original contributor branch is cross-repo and not maintainer-writable. The original author and Signed-off-by trailer are preserved on the replay commit; the maintainer adjustment is limited to the test shape required by CI.

Closes #2947
Replaces #2975

## Verification
- `./node_modules/.bin/vitest run test/hermes-share-mount-deps.test.ts`
- `./node_modules/.bin/vitest run test/sandbox-provisioning.test.ts test/hermes-share-mount-deps.test.ts src/lib/share-command.test.ts`
- `npm run source-shape:check`
- `npm run typecheck:cli`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container base image to include additional system utilities.

* **Tests**
  * Added automated validation to verify system utilities are correctly installed in the container environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->