### PR TITLE
fix(onboard): include portless origin in allowedOrigins for reverse-proxy access

### DIFF
--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -194,7 +194,23 @@ def build_config(env: dict | None = None) -> dict:
         if parsed.scheme and parsed.netloc
         else "http://127.0.0.1:18789"
     )
-    origins = list(dict.fromkeys(["http://127.0.0.1:18789", chat_origin]))
+    # When onboard injects an internal port (e.g. :18789) into a URL that the
+    # user provided without an explicit port, the browser origin from a reverse
+    # proxy (Brev Cloudflare Tunnel, nginx, Caddy, etc.) will not carry that
+    # port.  Include the portless origin so both direct and proxied access work.
+    # Skip for loopback — no reverse proxy in front of localhost.
+    try:
+        _has_explicit_port = parsed.port is not None
+    except ValueError:
+        _has_explicit_port = False
+    if parsed.scheme and parsed.hostname and _has_explicit_port and not is_loopback(parsed.hostname):
+        host_part = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        portless_origin = f"{parsed.scheme}://{host_part}"
+    else:
+        portless_origin = None
+    origins = list(dict.fromkeys(
+        filter(None, ["http://127.0.0.1:18789", chat_origin, portless_origin])
+    ))
 
     # Auto-disable device auth when CHAT_UI_URL is non-loopback — terminal-based
     # pairing is impossible when the user only has web access (Brev Launchable,

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -105,11 +105,50 @@ describe("generate-openclaw-config.py: config generation", () => {
     expect(config.gateway.controlUi.allowedOrigins).toContain(
       "https://nemoclaw0-xxx.brevlab.com:18789",
     );
+    expect(config.gateway.controlUi.allowedOrigins).toContain(
+      "https://nemoclaw0-xxx.brevlab.com",
+    );
   });
 
   it("includes only loopback origin for loopback URL", () => {
     const config = runConfigScript({ CHAT_UI_URL: "http://127.0.0.1:18789" });
     expect(config.gateway.controlUi.allowedOrigins).toEqual(["http://127.0.0.1:18789"]);
+  });
+
+  it("includes portless origin for reverse-proxy access (Fixes #3000)", () => {
+    const config = runConfigScript({
+      CHAT_UI_URL: "https://nemoclaw0-abc123.brevlab.com:18789",
+    });
+    const origins = config.gateway.controlUi.allowedOrigins;
+    expect(origins).toContain("https://nemoclaw0-abc123.brevlab.com:18789");
+    expect(origins).toContain("https://nemoclaw0-abc123.brevlab.com");
+  });
+
+  it("preserves brackets in portless origin for public IPv6 addresses", () => {
+    const config = runConfigScript({
+      CHAT_UI_URL: "https://[2606:4700::1]:18789",
+    });
+    const origins = config.gateway.controlUi.allowedOrigins;
+    expect(origins).toContain("https://[2606:4700::1]:18789");
+    expect(origins).toContain("https://[2606:4700::1]");
+  });
+
+  it("does not add portless origin for IPv6 loopback", () => {
+    const config = runConfigScript({
+      CHAT_UI_URL: "http://[::1]:18789",
+    });
+    const origins = config.gateway.controlUi.allowedOrigins;
+    expect(origins).toContain("http://[::1]:18789");
+    expect(origins).not.toContain("http://[::1]");
+  });
+
+  it("does not crash on malformed port in CHAT_UI_URL", () => {
+    const config = runConfigScript({
+      CHAT_UI_URL: "https://example.com:abc",
+    });
+    const origins = config.gateway.controlUi.allowedOrigins;
+    expect(origins).toContain("http://127.0.0.1:18789");
+    expect(origins).not.toContain("https://example.com");
   });
 
   it("parses messaging channels from base64", () => {


### PR DESCRIPTION
## Summary

When `CHAT_UI_URL` is set to an HTTPS URL without an explicit port — as [documented](https://docs.nvidia.com/nemoclaw/latest/deployment/deploy-to-remote-gpu.html#remote-dashboard-access) for Brev deployments — onboard injects the internal dashboard port (`:18789`) into the origin via `onboard.ts:4002`. Reverse proxies (Brev Cloudflare Tunnel, nginx, Caddy, Tailscale Funnel) serve on standard `:443`, so the browser sends origin `https://host` which doesn't match `https://host:18789` in `allowedOrigins` — causing "origin not allowed" on the dashboard.

**Root cause:** `generate-openclaw-config.py` builds `allowedOrigins` from the port-overridden URL only.

**Fix:** Also include the portless origin for non-loopback URLs. This is safe (same host) and covers both direct and reverse-proxy access.

## Prior art

PR #812 and PR #2440 fixed the `CHAT_UI_URL` plumbing but the port-override gap remained. This PR closes the remaining gap from the #795 / #20 lineage.

## Changes

| File | Change |
|------|--------|
| `scripts/generate-openclaw-config.py` | Add portless origin to `allowedOrigins` for non-loopback URLs when a port is present |
| `test/generate-openclaw-config.test.ts` | Update existing test to expect portless origin; add new test for reverse-proxy case |

## Testing

- **Unit tests:** 43/43 passing (`vitest run test/generate-openclaw-config.test.ts`)
- **Manual verification:** On Brev GCP (`nemoclaw-gcp`, n2-standard-4), confirmed that adding the portless origin to `allowedOrigins` resolves the CORS error when accessing `https://brev-nc-xxx.brevlab.com/chat?session=main`

## What this does NOT fix

- `onboard.ts:4002` still unconditionally overrides the port. A future improvement could skip the port override when the URL is HTTPS with no explicit port, but this config-level fix is sufficient and lower-risk.

## Related

- Fixes #3000
- Ref: #795 (Brev dashboard inaccessible — closed)
- Ref: #20 (Remote dashboard access — closed)
- Ref: PR #812 (bake CHAT_UI_URL into Docker build — merged)
- Ref: PR #2440 (inject NEMOCLAW_DASHBOARD_PORT — merged)

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved origin handling: when a configured UI URL includes an explicit port and is non-loopback, the app accepts both the full origin (with port) and a portless origin; IPv6 hostnames keep bracket formatting and duplicate entries are removed. Loopback behavior is unchanged.

* **Tests**
  * Expanded tests to cover ported and portless origins, reverse-proxy scenarios, IPv6 behavior (including loopback) and resilience to malformed port values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->