### PR TITLE
fix(test): make installer atomicity test headless on WSL

### DIFF
--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -3038,16 +3038,19 @@ echo "docker $*" >> ${JSON.stringify(phaseLog)}
 exit 0`,
     );
 
-    // Run main() directly via the bash entrypoint check. We force stdin to
-    // /dev/null when stdinIsTty is false (default — simulates curl|bash).
+    // Run main() directly via the bash entrypoint check. We force stdin to a
+    // non-TTY pipe when stdinIsTty is false (default — simulates curl|bash).
+    // On Linux/WSL, spawnSync children can still inherit a controlling terminal
+    // even with pipe stdin, which leaves /dev/tty openable and correctly lets
+    // the installer prompt instead of fail fast. Use setsid to exercise the
+    // headless curl-pipe path where both stdin and /dev/tty are unavailable.
+    const useSetsid = !options.stdinIsTty && process.platform !== "darwin";
     const result = spawnSync(
-      "bash",
-      [INSTALLER_PAYLOAD],
+      useSetsid ? "setsid" : "bash",
+      useSetsid ? ["bash", INSTALLER_PAYLOAD] : [INSTALLER_PAYLOAD],
       {
         cwd: tmp,
         encoding: "utf-8",
-        // input: "" makes spawnSync attach a non-TTY stdin pipe — equivalent
-        // to curl|bash for the purposes of [ -t 0 ] and /dev/tty in CI.
         input: options.stdinIsTty ? undefined : "",
         env: {
           HOME: tmp,


### PR DESCRIPTION
## Summary
Updates the installer atomicity regression test so Linux/WSL runs execute the simulated curl-pipe path in a new session with no controlling TTY. This keeps the WSL workflow from incorrectly taking the `/dev/tty` fallback branch while testing the intended headless fail-fast behavior.

## Changes
- Wrap the `scripts/install.sh` atomicity test helper in `setsid` on non-macOS when simulating non-TTY stdin.
- Clarify the test comment to distinguish non-TTY stdin from an unavailable `/dev/tty`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test harness for installer to better simulate terminal conditions on non-darwin platforms, ensuring more accurate validation of license checks and installer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->