### PR TITLE
fix(install): fail fast on unsupported Node before prepare runs (#2399)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "bundleDependencies": [
         "p-retry"
       ],
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^4.10.5",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     }
   },
   "scripts": {
+    "preinstall": "node scripts/check-node-version.js",
     "test": "vitest run",
     "lint": "biome lint . && npm run check:credential-env",
     "lint:fix": "biome lint --write . && npm run check:credential-env",

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// preinstall guard: refuse to install on a Node major older than the
+// minimum declared in package.json engines.node, with a clear actionable
+// error. Without this, npm install proceeds on Node 18/20 and fails
+// partway through prepare with a wall of unrelated errors that look like
+// the repo is broken (see #2399).
+
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const pkgPath = path.join(__dirname, "..", "package.json");
+let pkg;
+try {
+  pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+} catch (err) {
+  console.error(`[preinstall] could not read package.json: ${err.message}`);
+  process.exit(1);
+}
+
+const range = pkg && pkg.engines && pkg.engines.node;
+if (!range || typeof range !== "string") {
+  // Nothing to enforce. Pass through quietly so consumer trees that
+  // strip engines metadata are not blocked.
+  process.exit(0);
+}
+
+// Pull the first \d+\.\d+\.\d+ from the range. Any of "22.16.0",
+// ">=22.16.0", "^22.16.0", "22.16.0 || 24.0.0" all yield 22.16.0.
+const match = /(\d+)\.(\d+)\.(\d+)/.exec(range);
+if (!match) {
+  process.exit(0);
+}
+const minMajor = parseInt(match[1], 10);
+const minMinor = parseInt(match[2], 10);
+const minPatch = parseInt(match[3], 10);
+
+const current = process.versions.node;
+const currentMatch = /(\d+)\.(\d+)\.(\d+)/.exec(current);
+if (!currentMatch) {
+  process.exit(0);
+}
+const currentMajor = parseInt(currentMatch[1], 10);
+const currentMinor = parseInt(currentMatch[2], 10);
+const currentPatch = parseInt(currentMatch[3], 10);
+
+const tooOld =
+  currentMajor < minMajor ||
+  (currentMajor === minMajor && currentMinor < minMinor) ||
+  (currentMajor === minMajor && currentMinor === minMinor && currentPatch < minPatch);
+
+if (tooOld) {
+  console.error("");
+  console.error(
+    `  NemoClaw requires Node ${minMajor}.${minMinor}.${minPatch} or newer. Detected Node ${current}.`,
+  );
+  console.error("");
+  console.error("  Upgrade Node, then re-run `npm install`. For example, with nvm:");
+  console.error(`    nvm install ${minMajor} && nvm use ${minMajor}`);
+  console.error("");
+  console.error("  See package.json engines.node for the required range.");
+  console.error("");
+  process.exit(1);
+}

--- a/test/preinstall-node-version.test.ts
+++ b/test/preinstall-node-version.test.ts
@@ -3,6 +3,7 @@
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -53,7 +54,7 @@ describe("preinstall node-version guard (#2399)", () => {
     // before requiring the script. We use --require to inject the override
     // before any user code runs, so the script reads the patched value.
     const tmpDir = fs.mkdtempSync(
-      path.join(require("node:os").tmpdir(), "preinstall-guard-"),
+      path.join(os.tmpdir(), "preinstall-guard-"),
     );
     try {
       const overridePath = path.join(tmpDir, "fake-node-18.js");
@@ -84,7 +85,7 @@ describe("preinstall node-version guard (#2399)", () => {
     // path.join(__dirname, '..', 'package.json'), so we copy the
     // script next to a custom package.json.
     const tmpDir = fs.mkdtempSync(
-      path.join(require("node:os").tmpdir(), "preinstall-guard-no-engines-"),
+      path.join(os.tmpdir(), "preinstall-guard-no-engines-"),
     );
     try {
       const scriptsDir = path.join(tmpDir, "scripts");

--- a/test/preinstall-node-version.test.ts
+++ b/test/preinstall-node-version.test.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const SCRIPT_PATH = path.join(REPO_ROOT, "scripts/check-node-version.js");
+const PACKAGE_JSON_PATH = path.join(REPO_ROOT, "package.json");
+
+function readPackageJson(): {
+  scripts?: Record<string, string>;
+  engines?: { node?: string };
+} {
+  return JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, "utf-8"));
+}
+
+describe("preinstall node-version guard (#2399)", () => {
+  it("scripts/check-node-version.js exists and is executable", () => {
+    expect(fs.existsSync(SCRIPT_PATH)).toBe(true);
+    const stat = fs.statSync(SCRIPT_PATH);
+    // 0o111 covers any-user-executable. We only need it to be runnable; the
+    // exact mode bits vary across umask defaults.
+    expect(stat.mode & 0o111).toBeGreaterThan(0);
+  });
+
+  it("package.json wires the script as preinstall", () => {
+    const pkg = readPackageJson();
+    expect(pkg.scripts?.preinstall).toBe("node scripts/check-node-version.js");
+  });
+
+  it("package.json declares engines.node so the guard has something to enforce", () => {
+    const pkg = readPackageJson();
+    expect(pkg.engines?.node).toBeDefined();
+    expect(pkg.engines?.node).toMatch(/\d+\.\d+\.\d+/);
+  });
+
+  it("guard exits 0 on a Node version that satisfies the declared range", () => {
+    // The current process is the same Node version that npm install uses, and
+    // the repo is installable in this Node, so the guard must accept it.
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("guard exits 1 with an actionable error when a fake Node 18 is simulated", () => {
+    // Run the guard under Node, but trick it by overriding process.versions.node
+    // before requiring the script. We use --require to inject the override
+    // before any user code runs, so the script reads the patched value.
+    const tmpDir = fs.mkdtempSync(
+      path.join(require("node:os").tmpdir(), "preinstall-guard-"),
+    );
+    try {
+      const overridePath = path.join(tmpDir, "fake-node-18.js");
+      fs.writeFileSync(
+        overridePath,
+        "Object.defineProperty(process.versions, 'node', { value: '18.20.0', configurable: true });\n",
+      );
+      const result = spawnSync(
+        process.execPath,
+        ["--require", overridePath, SCRIPT_PATH],
+        {
+          encoding: "utf-8",
+          timeout: 5000,
+        },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/NemoClaw requires Node \d+\.\d+\.\d+/);
+      expect(result.stderr).toContain("Detected Node 18.20.0");
+      expect(result.stderr).toContain("nvm install");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("guard tolerates package.json without engines.node by exiting 0", () => {
+    // Synthesize a package.json fixture without engines and run the script
+    // pointed at it via a sibling tmp dir. The script reads
+    // path.join(__dirname, '..', 'package.json'), so we copy the
+    // script next to a custom package.json.
+    const tmpDir = fs.mkdtempSync(
+      path.join(require("node:os").tmpdir(), "preinstall-guard-no-engines-"),
+    );
+    try {
+      const scriptsDir = path.join(tmpDir, "scripts");
+      fs.mkdirSync(scriptsDir);
+      fs.copyFileSync(SCRIPT_PATH, path.join(scriptsDir, "check-node-version.js"));
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "fixture", version: "0.0.0" }, null, 2),
+      );
+      const result = spawnSync(
+        process.execPath,
+        [path.join(scriptsDir, "check-node-version.js")],
+        {
+          encoding: "utf-8",
+          timeout: 5000,
+        },
+      );
+      expect(result.status).toBe(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

#2399 reports that `npm install` fails with confusing mid-prepare errors on hosts running Node 18 / npm 9 (Omnistation base image and similar managed dev environments) even though `package.json` declares `engines.node: ">=22.16.0"`. The build proceeds, hits the heavy `prepare` step (build CLI, nested `npm install`, `npm link`, prek hook setup), and dies with `tsc not found` / `prek not found` errors that look like the repo is broken when the actual cause is a Node version mismatch.

This PR adds a preinstall guard that refuses to install on a Node major below the declared minimum, with an actionable error pointing at the required version and an `nvm install` recovery hint.

## Problem

The reporter cites two compounding issues:

1. `prepare` is heavy and produces unrelated-looking errors when its prerequisites are missing.
2. `engines.node` is declared but not enforced.

This PR addresses (2). The textbook fix (`engine-strict=true` in `.npmrc`) is unavailable here because `.npmrc` is gitignored at the repo root so contributors can keep private-registry auth tokens local. A `preinstall` script works regardless of `.npmrc` state and lets us produce a custom error message with concrete recovery steps. Slimming `prepare` itself (the reporter's second suggestion) is left for a follow-up.

## Changes

- New `scripts/check-node-version.js`: reads `engines.node` from `package.json`, parses the first `\d+\.\d+\.\d+` from the range, and exits 1 with a clear error if the running Node `major.minor.patch` is below it. Tolerates missing or unparseable engines metadata by exiting 0 so consumer trees that strip engines do not break.
- `package.json` wires the script as `preinstall`.
- `package-lock.json` gets the matching `hasInstallScript: true` flag (the only legitimate consequence of the new install-time hook).
- `test/preinstall-node-version.test.ts` covers: script exists and is executable, preinstall is wired in `package.json`, `engines.node` is declared, guard exits 0 on the running Node, guard exits 1 with the required-version + nvm hint when a fake Node 18 is simulated via `--require` patching `process.versions.node`, and guard exits 0 when run against a fixture `package.json` lacking `engines.node`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Test plan

- [x] `npx vitest run test/preinstall-node-version.test.ts` (6/6 pass)
- [x] `npm ci --include=dev` completes cleanly with the new hook in place
- [x] No secrets, API keys, or credentials committed
- [x] Tests added for new behavior

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a preinstall check that enforces the repository's minimum Node.js version and shows clear, actionable upgrade instructions when the current Node is too old.
* **Tests**
  * Added automated tests validating the preinstall guard is present, executable, respects the declared Node engine range, and fails/passes with expected exit codes and messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->