### PR TITLE
fix: support local vLLM inference routing

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -901,11 +901,20 @@ PYAUTOPAIR
 #
 # NEMOCLAW_PROXY_HOST / NEMOCLAW_PROXY_PORT can be overridden at sandbox
 # creation time if the gateway IP or port changes in a future OpenShell release.
+# NEMOCLAW_NO_PROXY_EXTRA appends additional direct-connect hosts for local
+# inference runtimes such as vLLM/Ollama on the Docker host. Set it to an empty
+# string to disable the default host aliases.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/626
 PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
 PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
+NO_PROXY_EXTRA="${NEMOCLAW_NO_PROXY_EXTRA-host.openshell.internal,host.docker.internal}"
+NO_PROXY_EXTRA="${NO_PROXY_EXTRA#,}"
+NO_PROXY_EXTRA="${NO_PROXY_EXTRA%,}"
 _PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"
 _NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"
+if [ -n "$NO_PROXY_EXTRA" ]; then
+  _NO_PROXY_VAL="${_NO_PROXY_VAL},${NO_PROXY_EXTRA}"
+fi
 export HTTP_PROXY="$_PROXY_URL"
 export HTTPS_PROXY="$_PROXY_URL"
 export NO_PROXY="$_NO_PROXY_VAL"

--- a/src/lib/inference/config.test.ts
+++ b/src/lib/inference/config.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 // Import from compiled dist/ for correct coverage attribution.
 import {
@@ -9,13 +9,14 @@ import {
   DEFAULT_OLLAMA_MODEL,
   DEFAULT_ROUTE_CREDENTIAL_ENV,
   DEFAULT_ROUTE_PROFILE,
+  DEFAULT_VLLM_MODEL,
+  getOpenClawPrimaryModel,
+  getProviderSelectionConfig,
   INFERENCE_ROUTE_URL,
   MANAGED_PROVIDER_ID,
   OLLAMA_LOCAL_CREDENTIAL_ENV,
-  VLLM_LOCAL_CREDENTIAL_ENV,
-  getOpenClawPrimaryModel,
-  getProviderSelectionConfig,
   parseGatewayInference,
+  VLLM_LOCAL_CREDENTIAL_ENV,
 } from "../../../dist/lib/inference/config";
 
 describe("inference selection config", () => {
@@ -166,7 +167,7 @@ describe("inference selection config", () => {
     expect(getProviderSelectionConfig("compatible-anthropic-endpoint")?.model).toBe(
       "custom-anthropic-model",
     );
-    expect(getProviderSelectionConfig("vllm-local")?.model).toBe("vllm-local");
+    expect(getProviderSelectionConfig("vllm-local")?.model).toBe(DEFAULT_VLLM_MODEL);
   });
 
   it("builds a qualified OpenClaw primary model for ollama-local", () => {
@@ -178,6 +179,9 @@ describe("inference selection config", () => {
   it("builds a default OpenClaw primary model for non-ollama providers", () => {
     expect(getOpenClawPrimaryModel("nvidia-prod")).toBe(
       `${MANAGED_PROVIDER_ID}/nvidia/nemotron-3-super-120b-a12b`,
+    );
+    expect(getOpenClawPrimaryModel("vllm-local")).toBe(
+      `${MANAGED_PROVIDER_ID}/${DEFAULT_VLLM_MODEL}`,
     );
     expect(getOpenClawPrimaryModel("ollama-local")).toBe(
       `${MANAGED_PROVIDER_ID}/${DEFAULT_OLLAMA_MODEL}`,

--- a/src/lib/inference/config.ts
+++ b/src/lib/inference/config.ts
@@ -10,6 +10,7 @@ import { DEFAULT_OLLAMA_MODEL } from "./local";
 
 export const INFERENCE_ROUTE_URL = "https://inference.local/v1";
 export const DEFAULT_CLOUD_MODEL = "nvidia/nemotron-3-super-120b-a12b";
+export const DEFAULT_VLLM_MODEL = "vllm-local";
 export const CLOUD_MODEL_OPTIONS = [
   { id: "nvidia/nemotron-3-super-120b-a12b", label: "Nemotron 3 Super 120B" },
   { id: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning", label: "Nemotron 3 Nano Omni 30B" },
@@ -104,7 +105,7 @@ export function getProviderSelectionConfig(
     case "vllm-local":
       return {
         ...base,
-        model: model || "vllm-local",
+        model: model || DEFAULT_VLLM_MODEL,
         credentialEnv: VLLM_LOCAL_CREDENTIAL_ENV,
         providerLabel: "Local vLLM",
       };
@@ -121,8 +122,16 @@ export function getProviderSelectionConfig(
 }
 
 export function getOpenClawPrimaryModel(provider: string, model?: string): string {
-  const resolvedModel =
-    model || (provider === "ollama-local" ? DEFAULT_OLLAMA_MODEL : DEFAULT_CLOUD_MODEL);
+  let resolvedModel = model;
+  if (!resolvedModel) {
+    if (provider === "ollama-local") {
+      resolvedModel = DEFAULT_OLLAMA_MODEL;
+    } else if (provider === "vllm-local") {
+      resolvedModel = DEFAULT_VLLM_MODEL;
+    } else {
+      resolvedModel = DEFAULT_CLOUD_MODEL;
+    }
+  }
   return `${MANAGED_PROVIDER_ID}/${resolvedModel}`;
 }
 

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -260,7 +260,7 @@ describe("service environment", () => {
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
-          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST},host.openshell.internal,host.docker.internal"',
           "_TOOL_REDIRECTS=()",
           `_AXIOS_FIX_SCRIPT="/nonexistent/axios-proxy-fix.js"`,
           `_WS_FIX_SCRIPT="/nonexistent/ws-proxy-fix.js"`,
@@ -300,7 +300,7 @@ describe("service environment", () => {
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
-          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST},host.openshell.internal,host.docker.internal"',
           "_TOOL_REDIRECTS=()",
           `_AXIOS_FIX_SCRIPT="/nonexistent/axios-proxy-fix.js"`,
           `_WS_FIX_SCRIPT="/nonexistent/ws-proxy-fix.js"`,
@@ -469,12 +469,14 @@ describe("service environment", () => {
       expect(vars.HTTPS_PROXY).toBe("http://10.200.0.1:8080");
     });
 
-    it("NO_PROXY includes loopback only, not inference.local", () => {
+    it("NO_PROXY includes loopback and local host aliases, not inference.local", () => {
       const vars = extractProxyVars();
       const noProxy = vars.NO_PROXY.split(",");
       expect(noProxy).toContain("localhost");
       expect(noProxy).toContain("127.0.0.1");
       expect(noProxy).toContain("::1");
+      expect(noProxy).toContain("host.openshell.internal");
+      expect(noProxy).toContain("host.docker.internal");
       expect(noProxy).not.toContain("inference.local");
     });
 
@@ -492,6 +494,17 @@ describe("service environment", () => {
       expect(noProxy).toContain("10.200.0.1");
     });
 
+    it("NEMOCLAW_NO_PROXY_EXTRA appends custom bypass hosts", () => {
+      const vars = extractProxyVars({
+        NEMOCLAW_NO_PROXY_EXTRA: "172.17.0.1,vllm.local",
+      });
+      const noProxy = vars.NO_PROXY.split(",");
+      expect(noProxy).toContain("10.200.0.1");
+      expect(noProxy).toContain("172.17.0.1");
+      expect(noProxy).toContain("vllm.local");
+      expect(noProxy).not.toContain("host.openshell.internal");
+    });
+
     it("entrypoint writes proxy-env.sh to writable data dir", () => {
       const fakeDataDir = join(tmpdir(), `nemoclaw-data-test-${process.pid}`);
       execFileSync("mkdir", ["-p", fakeDataDir]);
@@ -506,7 +519,7 @@ describe("service environment", () => {
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
-          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST},host.openshell.internal,host.docker.internal"',
           'export OPENCLAW_GATEWAY_TOKEN="test-token-123"',
           // Override the hardcoded path to use our temp dir
           persistBlock
@@ -617,7 +630,7 @@ describe("service environment", () => {
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
-          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST},host.openshell.internal,host.docker.internal"',
           persistBlock
             .trimEnd()
             .replaceAll("/tmp/nemoclaw-proxy-env.sh", `${fakeDataDir}/proxy-env.sh`),
@@ -662,7 +675,7 @@ describe("service environment", () => {
             `PROXY_HOST="${host}"`,
             'PROXY_PORT="3128"',
             '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
-            '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+            '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST},host.openshell.internal,host.docker.internal"',
             persistBlock
               .trimEnd()
               .replaceAll("/tmp/nemoclaw-proxy-env.sh", `${fakeDataDir}/proxy-env.sh`),
@@ -710,7 +723,7 @@ describe("service environment", () => {
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
-          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST},host.openshell.internal,host.docker.internal"',
           persistBlock.trimEnd().replaceAll("/tmp/nemoclaw-proxy-env.sh", proxyEnvPath),
         ].join("\n");
         writeFileSync(tmpFile, wrapper, { mode: 0o700 });
@@ -739,10 +752,10 @@ describe("service environment", () => {
         const envContent = [
           'export HTTP_PROXY="http://10.200.0.1:3128"',
           'export HTTPS_PROXY="http://10.200.0.1:3128"',
-          'export NO_PROXY="localhost,127.0.0.1,::1,10.200.0.1"',
+          'export NO_PROXY="localhost,127.0.0.1,::1,10.200.0.1,host.openshell.internal,host.docker.internal"',
           'export http_proxy="http://10.200.0.1:3128"',
           'export https_proxy="http://10.200.0.1:3128"',
-          'export no_proxy="localhost,127.0.0.1,::1,10.200.0.1"',
+          'export no_proxy="localhost,127.0.0.1,::1,10.200.0.1,host.openshell.internal,host.docker.internal"',
         ].join("\n");
         writeFileSync(join(fakeDataDir, "proxy-env.sh"), envContent);
 
@@ -762,8 +775,8 @@ describe("service environment", () => {
           { encoding: "utf-8" },
         ).trim();
 
-        expect(out).toContain("NO_PROXY=localhost,127.0.0.1,::1,10.200.0.1");
-        expect(out).toContain("no_proxy=localhost,127.0.0.1,::1,10.200.0.1");
+        expect(out).toContain("NO_PROXY=localhost,127.0.0.1,::1,10.200.0.1,host.openshell.internal,host.docker.internal");
+        expect(out).toContain("no_proxy=localhost,127.0.0.1,::1,10.200.0.1,host.openshell.internal,host.docker.internal");
       } finally {
         try {
           execFileSync("rm", ["-rf", fakeDataDir]);
@@ -787,7 +800,7 @@ describe("service environment", () => {
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
-          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST},host.openshell.internal,host.docker.internal"',
           "NODE_USE_ENV_PROXY=1",
           "_TOOL_REDIRECTS=()",
           `_PROXY_FIX_SCRIPT="${fakeFixPath}"`,
@@ -831,7 +844,7 @@ describe("service environment", () => {
           'PROXY_HOST="10.200.0.1"',
           'PROXY_PORT="3128"',
           '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
-          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST},host.openshell.internal,host.docker.internal"',
           // NODE_USE_ENV_PROXY intentionally NOT set
           "_TOOL_REDIRECTS=()",
           `_PROXY_FIX_SCRIPT="/tmp/nemoclaw-http-proxy-fix.js"`,
@@ -875,7 +888,7 @@ describe("service environment", () => {
           `PROXY_HOST="10.200.0.1"`,
           `PROXY_PORT="3128"`,
           `_PROXY_URL="http://\${PROXY_HOST}:\${PROXY_PORT}"`,
-          `_NO_PROXY_VAL="localhost,127.0.0.1,::1,\${PROXY_HOST}"`,
+          `_NO_PROXY_VAL="localhost,127.0.0.1,::1,\${PROXY_HOST},host.openshell.internal,host.docker.internal"`,
           `_PROXY_FIX_SCRIPT="/tmp/nemoclaw-http-proxy-fix.js"`,
           `_WS_FIX_SCRIPT="${fakeWsFixScript}"`,
           `_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"`,
@@ -915,7 +928,7 @@ describe("service environment", () => {
           `PROXY_HOST="10.200.0.1"`,
           `PROXY_PORT="3128"`,
           `_PROXY_URL="http://\${PROXY_HOST}:\${PROXY_PORT}"`,
-          `_NO_PROXY_VAL="localhost,127.0.0.1,::1,\${PROXY_HOST}"`,
+          `_NO_PROXY_VAL="localhost,127.0.0.1,::1,\${PROXY_HOST},host.openshell.internal,host.docker.internal"`,
           `_PROXY_FIX_SCRIPT="/tmp/nemoclaw-http-proxy-fix.js"`,
           `_WS_FIX_SCRIPT="/nonexistent/ws-proxy-fix.js"`,
           `_NEMOTRON_FIX_SCRIPT="/tmp/nemoclaw-nemotron-inference-fix.js"`,


### PR DESCRIPTION
Summary
- keep this PR open because upstream `latest` still routes sandbox requests for `host.openshell.internal` through the policy proxy unless the host alias is in `NO_PROXY`
- add default no_proxy bypasses for `host.openshell.internal` and `host.docker.internal`, plus `NEMOCLAW_NO_PROXY_EXTRA` for additional local inference bypass hosts
- use the `vllm-local` default model when building the OpenClaw primary model while preserving the dedicated local vLLM credential env

Related Issue
- Fixes #3190

Supersession check
- upstream `latest`/`v0.0.36` already carries the larger DGX/vLLM onboarding work, so this branch was force-updated down to the one still-needed functional commit
- verified in a live sandbox that upstream-style `NO_PROXY=localhost,127.0.0.1,::1,10.200.0.1` causes `GET host.openshell.internal:8000/v1/models` to be denied by policy, while the updated bypass list reaches vLLM successfully

Tests
- `npm run build:cli`
- `npm test -- src/lib/inference-config.test.ts test/service-env.test.ts`
- `npm run format:check`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional hosts to bypass proxy via the `NEMOCLAW_NO_PROXY_EXTRA` environment variable. Defaults to Docker and OpenShell internal hosts when unset.

* **Tests**
  * Updated proxy configuration tests to cover the expanded host bypass list and new environment variable support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
