### PR TITLE
fix(onboard): warn on under-provisioned container runtime in preflight

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -225,7 +225,7 @@ For example, if you picked an OpenAI-compatible endpoint, the summary looks like
   Web search:    disabled
   Messaging:     none
   Sandbox name:  my-gpt-claw
-  Note:          Sandbox build takes ~6 minutes on this host.
+  Note:          Sandbox build typically takes 5–15 minutes on this host.
   ──────────────────────────────────────────────────
   Web search and messaging channels will be prompted next.
   Apply this configuration? [Y/n]:

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -331,6 +331,23 @@ If neither is found, verify that Colima is running:
 $ colima status
 ```
 
+### Sandbox build is slow or hangs (under-provisioned container runtime)
+
+Default Colima ships with 2 vCPU and 2 GiB of memory, which is not enough headroom for the BuildKit-driven sandbox image build.
+On macOS Apple Silicon, the build can stall part-way through with no progress and no error, leaving the wizard waiting indefinitely.
+
+Preflight inspects `docker info` for `NCPU` and `MemTotal` and prints a warning when the runtime falls below 4 vCPU or 8 GiB.
+On Colima, raise the resources before re-running onboard:
+
+```console
+$ colima stop
+$ colima start --cpu 6 --memory 12 --disk 100
+```
+
+On Docker Desktop, raise CPU and memory limits in *Settings → Resources*, then apply and restart.
+
+To silence the warning when the host is intentionally small, set `NEMOCLAW_IGNORE_RUNTIME_RESOURCES=1` before running `nemoclaw onboard`.
+
 ### Re-onboard fails because port 18789 is held by SSH
 
 After destroying a sandbox and gateway, the SSH port-forward process for the

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3035,6 +3035,53 @@ async function preflight(): Promise<ReturnType<typeof nim.detectGpu>> {
     console.log("  ⓘ Running under WSL");
   }
 
+  if (
+    host.isContainerRuntimeUnderProvisioned &&
+    process.env.NEMOCLAW_IGNORE_RUNTIME_RESOURCES !== "1"
+  ) {
+    const detected: string[] = [];
+    if (typeof host.dockerCpus === "number") detected.push(`${host.dockerCpus} vCPU`);
+    if (typeof host.dockerMemTotalBytes === "number") {
+      const gib = host.dockerMemTotalBytes / 1024 ** 3;
+      detected.push(`${gib.toFixed(1)} GiB`);
+    }
+    const detectedStr = detected.length > 0 ? detected.join(" / ") : "unknown";
+    console.warn(
+      `  ⚠ Container runtime under-provisioned: ${detectedStr} detected ` +
+        `(recommended: ${preflightUtils.MIN_RECOMMENDED_DOCKER_CPUS} vCPU / ${preflightUtils.MIN_RECOMMENDED_DOCKER_MEM_GIB} GiB).`,
+    );
+    console.warn(
+      "    The sandbox build will be slow and may stall on default Colima settings.",
+    );
+    if (host.runtime === "colima") {
+      console.warn(
+        `    Suggested: colima stop && colima start --cpu ${preflightUtils.MIN_RECOMMENDED_DOCKER_CPUS} --memory ${preflightUtils.MIN_RECOMMENDED_DOCKER_MEM_GIB}`,
+      );
+    } else if (host.runtime === "docker-desktop") {
+      console.warn("    Suggested: Docker Desktop → Settings → Resources, raise CPU/memory.");
+    }
+    console.warn(
+      "    Set NEMOCLAW_IGNORE_RUNTIME_RESOURCES=1 to silence this check.",
+    );
+    if (!isNonInteractive()) {
+      const proceed = await promptYesNoOrDefault("  Continue with onboarding?", null, true);
+      if (!proceed) {
+        console.error("  Aborted by user. Resize your container runtime and rerun `nemoclaw onboard`.");
+        process.exit(1);
+      }
+    }
+  } else if (host.dockerReachable) {
+    const detected: string[] = [];
+    if (typeof host.dockerCpus === "number") detected.push(`${host.dockerCpus} vCPU`);
+    if (typeof host.dockerMemTotalBytes === "number") {
+      const gib = host.dockerMemTotalBytes / 1024 ** 3;
+      detected.push(`${gib.toFixed(1)} GiB`);
+    }
+    if (detected.length > 0) {
+      console.log(`  ✓ Container runtime resources: ${detected.join(" / ")}`);
+    }
+  }
+
   // OpenShell CLI — install if missing, upgrade if below minimum version.
   // MIN_VERSION in install-openshell.sh handles the version gate; calling it
   // when openshell already exists is safe (it exits early if version is OK).
@@ -3911,10 +3958,30 @@ type OnboardConfigSummary = {
  * - credentialEnv:    env-var name of the API key (e.g. "NVIDIA_API_KEY").
  *                     Rendered with the fixed credentials.json location so
  *                     users can see where the key was stored.
- * - notes:            additional bullet lines shown under the summary
- *                     (e.g. "~6 minutes on this host"). Each note rendered
- *                     as "Note: <text>" so it's visually distinct.
+ * - notes:            additional bullet lines shown under the summary,
+ *                     such as a sandbox build-time estimate. Each note is
+ *                     rendered as "Note: <text>" so it stays visually
+ *                     distinct.
  */
+function formatSandboxBuildEstimateNote(host: ReturnType<typeof assessHost>): string | null {
+  if (host.isContainerRuntimeUnderProvisioned) {
+    return (
+      "Container runtime is under-provisioned; the sandbox build may take 30+ minutes " +
+      "or stall. See preflight warning above."
+    );
+  }
+  const cpus = host.dockerCpus;
+  const memBytes = host.dockerMemTotalBytes;
+  if (typeof cpus === "number" && typeof memBytes === "number") {
+    const memGiB = memBytes / 1024 ** 3;
+    if (cpus >= 8 && memGiB >= 16) {
+      return "Sandbox build typically takes 3–8 minutes on this host.";
+    }
+    return "Sandbox build typically takes 5–15 minutes on this host.";
+  }
+  return null;
+}
+
 function formatOnboardConfigSummary({
   provider,
   model,
@@ -8858,6 +8925,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       if (!sandboxName) {
         sandboxName = await promptValidatedSandboxName(agent);
       }
+      const buildEstimateNote = formatSandboxBuildEstimateNote(assessHost());
       console.log(
         formatOnboardConfigSummary({
           provider,
@@ -8866,7 +8934,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
           webSearchConfig,
           enabledChannels: selectedMessagingChannels.length > 0 ? selectedMessagingChannels : null,
           sandboxName,
-          notes: ["Sandbox build takes ~6 minutes on this host."],
+          notes: buildEstimateNote ? [buildEstimateNote] : [],
         }),
       );
       console.log("  Web search and messaging channels will be prompted next.");
@@ -9232,6 +9300,7 @@ module.exports = {
   readRecordedModel,
   readRecordedNimContainer,
   formatOnboardConfigSummary,
+  formatSandboxBuildEstimateNote,
   isInferenceRouteReady,
   shouldRunCompatibleEndpointSandboxSmoke,
   isNonInteractive,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -8925,7 +8925,10 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       if (!sandboxName) {
         sandboxName = await promptValidatedSandboxName(agent);
       }
-      const buildEstimateNote = formatSandboxBuildEstimateNote(assessHost());
+      const buildEstimateNote =
+        process.env.NEMOCLAW_IGNORE_RUNTIME_RESOURCES === "1"
+          ? null
+          : formatSandboxBuildEstimateNote(assessHost());
       console.log(
         formatOnboardConfigSummary({
           provider,

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -11,6 +11,11 @@ import {
   getDockerBridgeGatewayIp,
   getMemoryInfo,
   ensureSwap,
+  isDockerUnderProvisioned,
+  MIN_RECOMMENDED_DOCKER_CPUS,
+  MIN_RECOMMENDED_DOCKER_MEM_GIB,
+  parseDockerInfoCpus,
+  parseDockerInfoMemTotalBytes,
   parseDockerStorageDriver,
   parseDockerUsesContainerdSnapshotter,
   planHostRemediation,
@@ -511,6 +516,7 @@ describe("planHostRemediation", () => {
       openshellInstalled: true,
       dockerCgroupVersion: "unknown",
       dockerDefaultCgroupnsMode: "unknown",
+      isContainerRuntimeUnderProvisioned: false,
       hasNestedOverlayConflict: false,
       requiresHostCgroupnsFix: false,
       isUnsupportedRuntime: false,
@@ -540,6 +546,7 @@ describe("planHostRemediation", () => {
       openshellInstalled: true,
       dockerCgroupVersion: "unknown",
       dockerDefaultCgroupnsMode: "unknown",
+      isContainerRuntimeUnderProvisioned: false,
       hasNestedOverlayConflict: false,
       requiresHostCgroupnsFix: false,
       isUnsupportedRuntime: false,
@@ -573,6 +580,7 @@ describe("planHostRemediation", () => {
       openshellInstalled: true,
       dockerCgroupVersion: "unknown",
       dockerDefaultCgroupnsMode: "unknown",
+      isContainerRuntimeUnderProvisioned: false,
       hasNestedOverlayConflict: false,
       requiresHostCgroupnsFix: false,
       isUnsupportedRuntime: true,
@@ -604,6 +612,7 @@ describe("planHostRemediation", () => {
       openshellInstalled: true,
       dockerCgroupVersion: "unknown",
       dockerDefaultCgroupnsMode: "unknown",
+      isContainerRuntimeUnderProvisioned: false,
       hasNestedOverlayConflict: false,
       requiresHostCgroupnsFix: false,
       isUnsupportedRuntime: false,
@@ -632,6 +641,7 @@ describe("planHostRemediation", () => {
       openshellInstalled: false,
       dockerCgroupVersion: "v2",
       dockerDefaultCgroupnsMode: "unknown",
+      isContainerRuntimeUnderProvisioned: false,
       hasNestedOverlayConflict: false,
       requiresHostCgroupnsFix: false,
       isUnsupportedRuntime: false,
@@ -944,5 +954,175 @@ describe("getDockerBridgeGatewayIp", () => {
     });
     expect(captured.slice(0, 4)).toEqual(["docker", "network", "inspect", "bridge"]);
     expect(captured).toContain("{{range .IPAM.Config}}{{.Gateway}}{{end}}");
+  });
+});
+
+describe("parseDockerInfoCpus", () => {
+  it("extracts NCPU from JSON docker info output", () => {
+    expect(parseDockerInfoCpus('{"NCPU":6}')).toBe(6);
+    expect(parseDockerInfoCpus('{"ServerVersion":"x","NCPU":12,"Other":"y"}')).toBe(12);
+  });
+
+  it("falls back to plain-text 'CPUs: <n>' form", () => {
+    const fixture = ["Server:", " Containers: 0", " CPUs: 8", ""].join("\n");
+    expect(parseDockerInfoCpus(fixture)).toBe(8);
+  });
+
+  it("returns undefined for empty or non-matching input", () => {
+    expect(parseDockerInfoCpus("")).toBeUndefined();
+    expect(parseDockerInfoCpus("nothing useful here")).toBeUndefined();
+  });
+
+  it("returns undefined for zero or negative values", () => {
+    expect(parseDockerInfoCpus('{"NCPU":0}')).toBeUndefined();
+  });
+});
+
+describe("parseDockerInfoMemTotalBytes", () => {
+  it("extracts MemTotal from JSON docker info output", () => {
+    expect(parseDockerInfoMemTotalBytes('{"MemTotal":2054303744}')).toBe(2054303744);
+  });
+
+  it("parses plain-text 'Total Memory: <n> GiB' form", () => {
+    const fixture = ["Server:", " Total Memory: 7.756GiB", ""].join("\n");
+    const result = parseDockerInfoMemTotalBytes(fixture);
+    expect(result).toBeDefined();
+    expect(result).toBeGreaterThan(7 * 1024 ** 3);
+    expect(result).toBeLessThan(8 * 1024 ** 3);
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(parseDockerInfoMemTotalBytes("")).toBeUndefined();
+  });
+});
+
+describe("isDockerUnderProvisioned", () => {
+  it("returns true when CPUs are below threshold", () => {
+    expect(isDockerUnderProvisioned(2, 16 * 1024 ** 3)).toBe(true);
+  });
+
+  it("returns true when memory is below threshold", () => {
+    expect(isDockerUnderProvisioned(8, 4 * 1024 ** 3)).toBe(true);
+  });
+
+  it("returns false when both at or above thresholds", () => {
+    expect(
+      isDockerUnderProvisioned(
+        MIN_RECOMMENDED_DOCKER_CPUS,
+        MIN_RECOMMENDED_DOCKER_MEM_GIB * 1024 ** 3,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when fields are missing (no signal)", () => {
+    expect(isDockerUnderProvisioned(undefined, undefined)).toBe(false);
+  });
+
+  it("returns true when only the missing-CPU side is fine but memory is low", () => {
+    expect(isDockerUnderProvisioned(undefined, 1 * 1024 ** 3)).toBe(true);
+  });
+});
+
+describe("assessHost — container runtime resource detection (regression #2514)", () => {
+  it("flags default Colima (2 CPU / 2 GiB) as under-provisioned", () => {
+    const result = assessHost({
+      platform: "darwin",
+      env: {},
+      dockerInfoOutput: JSON.stringify({
+        ServerVersion: "27.4.0",
+        OperatingSystem: "Colima",
+        NCPU: 2,
+        MemTotal: 2054303744,
+      }),
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+    expect(result.runtime).toBe("colima");
+    expect(result.dockerCpus).toBe(2);
+    expect(result.dockerMemTotalBytes).toBe(2054303744);
+    expect(result.isContainerRuntimeUnderProvisioned).toBe(true);
+  });
+
+  it("does not flag a resized Colima (6 CPU / 12 GiB) as under-provisioned", () => {
+    const result = assessHost({
+      platform: "darwin",
+      env: {},
+      dockerInfoOutput: JSON.stringify({
+        ServerVersion: "27.4.0",
+        OperatingSystem: "Colima",
+        NCPU: 6,
+        MemTotal: 12 * 1024 ** 3,
+      }),
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+    expect(result.dockerCpus).toBe(6);
+    expect(result.isContainerRuntimeUnderProvisioned).toBe(false);
+  });
+
+  it("does not surface CPU/mem fields when docker is not reachable", () => {
+    const result = assessHost({
+      platform: "linux",
+      env: {},
+      dockerInfoOutput: "",
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+    expect(result.dockerReachable).toBe(false);
+    expect(result.dockerCpus).toBeUndefined();
+    expect(result.dockerMemTotalBytes).toBeUndefined();
+    expect(result.isContainerRuntimeUnderProvisioned).toBe(false);
+  });
+});
+
+describe("planHostRemediation — under-provisioned runtime", () => {
+  it("emits a Colima-specific resize action when runtime is colima", () => {
+    const assessment = assessHost({
+      platform: "darwin",
+      env: {},
+      dockerInfoOutput: JSON.stringify({
+        ServerVersion: "27.4.0",
+        OperatingSystem: "Colima",
+        NCPU: 2,
+        MemTotal: 2 * 1024 ** 3,
+      }),
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+    const actions = planHostRemediation(assessment);
+    const action = actions.find((a) => a.id === "container_runtime_under_provisioned");
+    expect(action).toBeDefined();
+    expect(action?.blocking).toBe(false);
+    expect(action?.commands.some((c) => c.startsWith("colima start"))).toBe(true);
+  });
+
+  it("emits a Docker Desktop hint when runtime is docker-desktop", () => {
+    const assessment = assessHost({
+      platform: "darwin",
+      env: {},
+      dockerInfoOutput: JSON.stringify({
+        ServerVersion: "27.0.0",
+        OperatingSystem: "Docker Desktop",
+        NCPU: 2,
+        MemTotal: 2 * 1024 ** 3,
+      }),
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+    const actions = planHostRemediation(assessment);
+    const action = actions.find((a) => a.id === "container_runtime_under_provisioned");
+    expect(action).toBeDefined();
+    expect(action?.commands.some((c) => c.toLowerCase().includes("docker desktop"))).toBe(true);
+  });
+
+  it("emits no resource action when runtime is properly sized", () => {
+    const assessment = assessHost({
+      platform: "linux",
+      env: {},
+      dockerInfoOutput: JSON.stringify({
+        ServerVersion: "27.0.0",
+        OperatingSystem: "Ubuntu 24.04",
+        NCPU: 8,
+        MemTotal: 16 * 1024 ** 3,
+      }),
+      commandExistsImpl: (name: string) => name === "docker",
+    });
+    const actions = planHostRemediation(assessment);
+    expect(actions.find((a) => a.id === "container_runtime_under_provisioned")).toBeUndefined();
   });
 });

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -104,6 +104,9 @@ export interface HostAssessment {
   dockerDefaultCgroupnsMode?: "host" | "private" | "unknown";
   dockerStorageDriver?: string;
   dockerUsesContainerdSnapshotter?: boolean;
+  dockerCpus?: number;
+  dockerMemTotalBytes?: number;
+  isContainerRuntimeUnderProvisioned: boolean;
   hasNestedOverlayConflict: boolean;
   requiresHostCgroupnsFix: boolean;
   isUnsupportedRuntime: boolean;
@@ -207,6 +210,64 @@ export function parseDockerUsesContainerdSnapshotter(info = ""): boolean {
   // v1 plugin. Match either JSON or text form so we handle `--format '{{json
   // .}}'` output and plain `docker info` alike.
   return /io\.containerd\.snapshotter\.v1/.test(info);
+}
+
+export function parseDockerInfoCpus(info = ""): number | undefined {
+  const jsonMatch = info.match(/"NCPU"\s*:\s*(\d+)/);
+  if (jsonMatch) {
+    const n = parseInt(jsonMatch[1], 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  }
+  const textMatch = info.match(/^\s*CPUs:\s*(\d+)\s*$/m);
+  if (textMatch) {
+    const n = parseInt(textMatch[1], 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  }
+  return undefined;
+}
+
+export function parseDockerInfoMemTotalBytes(info = ""): number | undefined {
+  const jsonMatch = info.match(/"MemTotal"\s*:\s*(\d+)/);
+  if (jsonMatch) {
+    const n = parseInt(jsonMatch[1], 10);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  }
+  const textMatch = info.match(/^\s*Total Memory:\s*([\d.]+)\s*([GMK]i?B)\s*$/im);
+  if (textMatch) {
+    const value = parseFloat(textMatch[1]);
+    if (!Number.isFinite(value) || value <= 0) return undefined;
+    const unit = textMatch[2].toLowerCase();
+    const multiplier =
+      unit === "gib"
+        ? 1024 ** 3
+        : unit === "gb"
+          ? 1000 ** 3
+          : unit === "mib"
+            ? 1024 ** 2
+            : unit === "mb"
+              ? 1000 ** 2
+              : unit === "kib"
+                ? 1024
+                : unit === "kb"
+                  ? 1000
+                  : 1;
+    return Math.round(value * multiplier);
+  }
+  return undefined;
+}
+
+export const MIN_RECOMMENDED_DOCKER_CPUS = 4;
+export const MIN_RECOMMENDED_DOCKER_MEM_GIB = 8;
+
+export function isDockerUnderProvisioned(
+  cpus: number | undefined,
+  memTotalBytes: number | undefined,
+): boolean {
+  const cpuLow = typeof cpus === "number" && cpus < MIN_RECOMMENDED_DOCKER_CPUS;
+  const memLow =
+    typeof memTotalBytes === "number" &&
+    memTotalBytes < MIN_RECOMMENDED_DOCKER_MEM_GIB * 1024 ** 3;
+  return cpuLow || memLow;
 }
 
 function readDockerDefaultCgroupnsMode(
@@ -318,6 +379,14 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   const dockerUsesContainerdSnapshotter = dockerReachable
     ? parseDockerUsesContainerdSnapshotter(dockerInfoOutput)
     : false;
+  const dockerCpus = dockerReachable ? parseDockerInfoCpus(dockerInfoOutput) : undefined;
+  const dockerMemTotalBytes = dockerReachable
+    ? parseDockerInfoMemTotalBytes(dockerInfoOutput)
+    : undefined;
+  const isContainerRuntimeUnderProvisioned = isDockerUnderProvisioned(
+    dockerCpus,
+    dockerMemTotalBytes,
+  );
   // Nested-overlay break: Docker 26+ on Linux with the containerd image store
   // (Driver=overlayfs + DriverStatus mentions io.containerd.snapshotter.v1)
   // does not allow k3s-in-Docker to mount its own overlay snapshots. The
@@ -370,6 +439,9 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     dockerDefaultCgroupnsMode,
     dockerStorageDriver,
     dockerUsesContainerdSnapshotter,
+    dockerCpus,
+    dockerMemTotalBytes,
+    isContainerRuntimeUnderProvisioned,
     hasNestedOverlayConflict,
     // Current OpenShell sets host cgroupns on its own cluster container.
     requiresHostCgroupnsFix: false,
@@ -452,6 +524,47 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
         blocking: true,
       });
     }
+  }
+
+  if (assessment.dockerReachable && assessment.isContainerRuntimeUnderProvisioned) {
+    const cpus = assessment.dockerCpus;
+    const memGiB =
+      typeof assessment.dockerMemTotalBytes === "number"
+        ? assessment.dockerMemTotalBytes / 1024 ** 3
+        : undefined;
+    const detected: string[] = [];
+    if (typeof cpus === "number") detected.push(`${cpus} vCPU`);
+    if (typeof memGiB === "number") detected.push(`${memGiB.toFixed(1)} GiB`);
+    const detectedStr = detected.length > 0 ? detected.join(" / ") : "unknown";
+    const recommendedStr = `${MIN_RECOMMENDED_DOCKER_CPUS} vCPU / ${MIN_RECOMMENDED_DOCKER_MEM_GIB} GiB`;
+    const isColima = assessment.runtime === "colima";
+    const isDockerDesktop = assessment.runtime === "docker-desktop";
+    const reason =
+      `Container runtime is under-provisioned (detected ${detectedStr}; recommended ${recommendedStr}). ` +
+      "Sandbox build will be slow and may deadlock on default Colima settings.";
+    const commands: string[] = [];
+    if (isColima) {
+      commands.push(
+        "colima stop",
+        `colima start --cpu ${MIN_RECOMMENDED_DOCKER_CPUS} --memory ${MIN_RECOMMENDED_DOCKER_MEM_GIB} --disk 100`,
+      );
+    } else if (isDockerDesktop) {
+      commands.push(
+        `Open Docker Desktop → Settings → Resources and raise CPUs to ≥ ${MIN_RECOMMENDED_DOCKER_CPUS} and memory to ≥ ${MIN_RECOMMENDED_DOCKER_MEM_GIB} GiB.`,
+      );
+    } else {
+      commands.push(
+        `Raise your container runtime's resource limits to ≥ ${MIN_RECOMMENDED_DOCKER_CPUS} vCPU and ≥ ${MIN_RECOMMENDED_DOCKER_MEM_GIB} GiB of memory before retrying.`,
+      );
+    }
+    actions.push({
+      id: "container_runtime_under_provisioned",
+      title: "Increase container runtime resources",
+      kind: "manual",
+      reason,
+      commands,
+      blocking: false,
+    });
   }
 
   if (assessment.isUnsupportedRuntime) {

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -541,7 +541,7 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
     const isDockerDesktop = assessment.runtime === "docker-desktop";
     const reason =
       `Container runtime is under-provisioned (detected ${detectedStr}; recommended ${recommendedStr}). ` +
-      "Sandbox build will be slow and may deadlock on default Colima settings.";
+      "Sandbox build will be slow and may stall when runtime resources are too low.";
     const commands: string[] = [];
     if (isColima) {
       commands.push(

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -56,6 +56,11 @@ type OnboardTestInternals = {
     portToStop: string,
   ) => string | null;
   formatOnboardConfigSummary: ShimFn<string>;
+  formatSandboxBuildEstimateNote: (host: {
+    isContainerRuntimeUnderProvisioned: boolean;
+    dockerCpus?: number;
+    dockerMemTotalBytes?: number;
+  }) => string | null;
   getDashboardAccessInfo: ShimFn<DashboardAccess[]>;
   getDashboardForwardStartCommand: ShimFn<string>;
   getNavigationChoice: (value?: string | null) => string | null;
@@ -203,6 +208,7 @@ const {
   writeSandboxConfigSyncFile,
   findDashboardForwardOwner,
   formatOnboardConfigSummary,
+  formatSandboxBuildEstimateNote,
 } = onboardTestInternals;
 
 describe("onboard helpers", () => {
@@ -7047,7 +7053,7 @@ const { createSandbox } = require(${onboardPath});
       webSearchConfig: { fetchEnabled: true },
       enabledChannels: ["telegram", "slack"],
       sandboxName: "my-assistant",
-      notes: ["Sandbox build takes ~6 minutes on this host."],
+      notes: ["Sandbox build typically takes 5–15 minutes on this host."],
     });
 
     assert.ok(summary.includes("Review configuration"), "summary has review heading");
@@ -7061,7 +7067,7 @@ const { createSandbox } = require(${onboardPath});
     assert.ok(summary.includes("telegram, slack"), "summary lists enabled channels");
     assert.ok(summary.includes("my-assistant"), "summary shows sandbox name");
     assert.ok(
-      summary.includes("Note:          Sandbox build takes ~6 minutes on this host."),
+      summary.includes("Note:          Sandbox build typically takes 5–15 minutes on this host."),
       "summary renders notes under sandbox name",
     );
 
@@ -7104,5 +7110,31 @@ const { createSandbox } = require(${onboardPath});
     });
     assert.ok(!orphanSummary.includes("undefined"), "null fields never render as 'undefined'");
     assert.ok(orphanSummary.includes("(unset)"), "null fields fall back to '(unset)'");
+  });
+
+  it("formatSandboxBuildEstimateNote warns when runtime is under-provisioned (#2514)", () => {
+    const note = formatSandboxBuildEstimateNote({
+      isContainerRuntimeUnderProvisioned: true,
+      dockerCpus: 2,
+      dockerMemTotalBytes: 2 * 1024 ** 3,
+    });
+    assert.ok(note != null && note.length > 0, "returns a note");
+    assert.match(note as string, /under-provisioned/i, "note flags under-provisioned host");
+  });
+
+  it("formatSandboxBuildEstimateNote returns a tighter range on a generous host (#2514)", () => {
+    const note = formatSandboxBuildEstimateNote({
+      isContainerRuntimeUnderProvisioned: false,
+      dockerCpus: 12,
+      dockerMemTotalBytes: 32 * 1024 ** 3,
+    });
+    assert.ok(note != null && note.includes("3"), "tight range starts at 3 minutes");
+  });
+
+  it("formatSandboxBuildEstimateNote returns null when no runtime resource signal is available (#2514)", () => {
+    const note = formatSandboxBuildEstimateNote({
+      isContainerRuntimeUnderProvisioned: false,
+    });
+    assert.strictEqual(note, null);
   });
 });

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -145,6 +145,7 @@ function isOnboardTestInternals(
     typeof value.normalizeSandboxAgentName === "function" &&
     typeof value.agentSupportsWebSearch === "function" &&
     typeof value.configureWebSearch === "function" &&
+    typeof value.formatSandboxBuildEstimateNote === "function" &&
     typeof value.shouldRunCompatibleEndpointSandboxSmoke === "function" &&
     typeof value.writeSandboxConfigSyncFile === "function"
   );
@@ -7128,7 +7129,8 @@ const { createSandbox } = require(${onboardPath});
       dockerCpus: 12,
       dockerMemTotalBytes: 32 * 1024 ** 3,
     });
-    assert.ok(note != null && note.includes("3"), "tight range starts at 3 minutes");
+    assert.ok(note != null, "returns a note");
+    assert.match(note ?? "", /\b3[–-]\d+\s+minutes\b/, "tight range starts at 3 minutes");
   });
 
   it("formatSandboxBuildEstimateNote returns null when no runtime resource signal is available (#2514)", () => {


### PR DESCRIPTION
## Summary
Surface a runtime-resource warning during preflight when `docker info` reports fewer than 4 vCPU or less than 8 GiB of memory, and replace the hardcoded `~6 minute` build estimate with a tiered note derived from the same fields. Together these cover items A and B of #2514; item C (no-progress timeout in `openshell sandbox create`) was merged upstream in NVIDIA/OpenShell#1109 and will reach NemoClaw via the next OpenShell version bump.

## Related Issue
Resolves #2514

## Changes
- `assessHost` parses `NCPU` / `MemTotal` from JSON or plain-text `docker info` output and exposes `dockerCpus`, `dockerMemTotalBytes`, and `isContainerRuntimeUnderProvisioned` on `HostAssessment`.
- Preflight prints a clear `⚠ Container runtime under-provisioned: ...` line, surfaces detected vs recommended values, suggests a Colima or Docker Desktop resize, and (interactive only) prompts the user to abort. `NEMOCLAW_IGNORE_RUNTIME_RESOURCES=1` silences the check.
- `planHostRemediation` emits a non-blocking `container_runtime_under_provisioned` action with runtime-specific resize commands.
- Replace the hardcoded `"Sandbox build takes ~6 minutes on this host."` summary note with `formatSandboxBuildEstimateNote(host)`, which returns a warning when the runtime is under-provisioned, a tighter `3–8 minute` range on generously sized hosts, a `5–15 minute` range otherwise, and `null` when no `docker info` signal is available.
- Quickstart and troubleshooting docs updated; new troubleshooting entry covers Colima/Docker Desktop resize steps and the silence env var.
- New unit tests cover the parsers, threshold helper, `assessHost` resource detection (including the default-Colima reproducer), `planHostRemediation` runtime branches, and the build-estimate note tiering.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated sandbox build-time estimates in quickstart guide to reflect realistic ranges.
  * Added troubleshooting section for slow or hanging sandbox builds on under-provisioned container runtimes.

* **New Features**
  * Container runtime now detects insufficient resources (CPU/memory) during preflight checks.
  * Added interactive confirmation gate when resources fall below recommended minimums.
  * Sandbox build-time estimates now adjust dynamically based on detected resource availability.
  * Optional bypass flag available for advanced users to skip resource validation.

* **Tests**
  * Added comprehensive test coverage for container runtime resource detection and validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->