### PR TITLE
fix(cli): document maintenance yes aliases

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -604,14 +604,14 @@ NemoClaw resolves the digest of `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` fr
 Sandboxes that match the current digest are left alone.
 
 ```console
-$ nemoclaw upgrade-sandboxes [--check] [--auto] [--yes]
+$ nemoclaw upgrade-sandboxes [--check] [--auto] [--yes|-y]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--check` | List stale sandboxes without rebuilding any of them. Exits non-zero if any are stale. |
 | `--auto` | Rebuild every stale sandbox without prompting. Used by the installer to upgrade in place. |
-| `--yes` | Skip the confirmation prompt for the rebuild plan. |
+| `--yes`, `-y` | Skip the confirmation prompt for the rebuild plan. |
 
 Each rebuild reuses the same workspace backup-and-restore flow as `nemoclaw <name> rebuild`, so workspace files survive the upgrade.
 If the registry is unreachable (offline or firewalled hosts), NemoClaw falls back to the unpinned `:latest` tag and reports that the digest could not be resolved instead of failing.
@@ -872,13 +872,13 @@ The `destroy` and `rebuild` commands clean up the image automatically, but image
 This command lists all `openshell/sandbox-from:*` images, cross-references the sandbox registry, and removes any that are no longer associated with a registered sandbox.
 
 ```console
-$ nemoclaw gc [--dry-run] [--yes|--force]
+$ nemoclaw gc [--dry-run] [--yes|-y|--force]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--dry-run` | List orphaned images without removing them |
-| `--yes`, `--force` | Skip the confirmation prompt |
+| `--yes`, `-y`, `--force` | Skip the confirmation prompt |
 
 ### `nemoclaw uninstall`
 

--- a/src/lib/command-registry.ts
+++ b/src/lib/command-registry.ts
@@ -400,7 +400,7 @@ export const COMMANDS: readonly CommandDef[] = [
   {
     usage: "nemoclaw upgrade-sandboxes",
     description: "Detect and rebuild stale sandboxes",
-    flags: "(--check, --auto)",
+    flags: "(--check, --auto, --yes|-y)",
     group: "Upgrade",
     scope: "global",
   },
@@ -409,7 +409,7 @@ export const COMMANDS: readonly CommandDef[] = [
   {
     usage: "nemoclaw gc",
     description: "Remove orphaned sandbox Docker images",
-    flags: "(--yes|--force, --dry-run)",
+    flags: "(--yes|-y|--force, --dry-run)",
     group: "Cleanup",
     scope: "global",
   },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -360,6 +360,10 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("Sandbox Management")).toBeTruthy();
     expect(r.out.includes("Policy Presets")).toBeTruthy();
     expect(r.out.includes("Compatibility Commands")).toBeTruthy();
+    expect(r.out).toContain("nemoclaw upgrade-sandboxes");
+    expect(r.out).toContain("(--check, --auto, --yes|-y)");
+    expect(r.out).toContain("nemoclaw gc");
+    expect(r.out).toContain("(--yes|-y|--force, --dry-run)");
   });
 
   it("--help exits 0", () => {


### PR DESCRIPTION
## Summary
Keep root help and docs in sync with the accepted `-y` aliases for maintenance commands.

## Changes
- Document `--yes|-y` in root help for `upgrade-sandboxes`.
- Document `--yes|-y|--force` in root help and docs for `gc`.
- Add root-help assertions so the top-level help text keeps these aliases visible.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files --stage pre-push` passes
- [x] `npm run build:cli`
- [x] `npx vitest run test/cli.test.ts -t "help exits 0 and shows sections|maintenance command help"`
- [x] `node bin/nemoclaw.js --help | rg "upgrade-sandboxes|nemoclaw gc"`
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-y` short flag as an alias for the `--yes` confirmation-skip flag in the `upgrade-sandboxes` and `gc` commands.

* **Documentation**
  * Updated CLI reference documentation for the new `-y` flag options.

* **Tests**
  * Added test coverage for updated command documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->