### PR TITLE
fix: clean final gateway failure state after diagnostics

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2594,6 +2594,7 @@ function handleFinalGatewayStartFailure({
   collectDiagnostics = () =>
     runCaptureOpenshell(["doctor", "logs", "--name", GATEWAY_NAME], {
       ignoreError: true,
+      timeout: 10_000,
     }),
   cleanupGateway = destroyGateway,
   exitProcess = (code) => process.exit(code),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2581,6 +2581,66 @@ function destroyGateway() {
   dockerRemoveVolumesByPrefix(`openshell-cluster-${GATEWAY_NAME}`, { ignoreError: true });
 }
 
+type FinalGatewayStartFailureOptions = {
+  retries: number;
+  collectDiagnostics?: () => string | null | undefined;
+  cleanupGateway?: () => void;
+  exitProcess?: (code: number) => never;
+  printError?: (message?: string) => void;
+};
+
+function handleFinalGatewayStartFailure({
+  retries,
+  collectDiagnostics = () =>
+    runCaptureOpenshell(["doctor", "logs", "--name", GATEWAY_NAME], {
+      ignoreError: true,
+    }),
+  cleanupGateway = destroyGateway,
+  exitProcess = (code) => process.exit(code),
+  printError = (message = "") => console.error(message),
+}: FinalGatewayStartFailureOptions): never {
+  printError(`  Gateway failed to start after ${retries + 1} attempts.`);
+  printError("  Gateway state preserved until diagnostics are collected.");
+  printError("");
+
+  try {
+    const logs = redact(collectDiagnostics() || "");
+    if (logs) {
+      printError("  Gateway logs:");
+      for (const line of String(logs)
+        .split("\n")
+        .map((l) => l.replace(/\r/g, "").replace(ANSI_RE, ""))
+        .filter(Boolean)) {
+        printError(`    ${line}`);
+      }
+      printError("");
+    }
+  } catch {
+    // doctor logs unavailable — continue to best-effort cleanup and manual instructions
+  }
+
+  printError("  Cleaning up failed gateway state...");
+  try {
+    cleanupGateway();
+    printError("  Cleanup attempted.");
+  } catch (err) {
+    const message = compactText(err instanceof Error ? err.message : String(err));
+    printError(message ? `  Cleanup attempt failed: ${message}` : "  Cleanup attempt failed.");
+  }
+  printError("");
+  printError("  Diagnostic command attempted before cleanup:");
+  printError(`    openshell doctor logs --name ${GATEWAY_NAME}`);
+  printError("    openshell doctor check");
+  printError("");
+  printError("  If gateway cleanup did not complete, run:");
+  printError(`    openshell gateway destroy -g ${GATEWAY_NAME}`);
+  printError(
+    `    docker volume ls -q --filter "name=openshell-cluster-${GATEWAY_NAME}" | xargs -r docker volume rm`,
+  );
+  printError(`    nemoclaw onboard --resume`);
+  return exitProcess(1);
+}
+
 function getGatewayClusterContainerState(): string {
   const containerName = getGatewayClusterContainerName();
   const state = dockerContainerInspectFormat(
@@ -3573,32 +3633,7 @@ async function startGatewayWithOptions(
     );
   } catch {
     if (exitOnFailure) {
-      console.error(`  Gateway failed to start after ${retries + 1} attempts.`);
-      console.error("  Gateway state preserved for diagnostics.");
-      console.error("");
-      try {
-        const logs = redact(
-          runCaptureOpenshell(["doctor", "logs", "--name", GATEWAY_NAME], {
-            ignoreError: true,
-          }),
-        );
-        if (logs) {
-          console.error("  Gateway logs:");
-          for (const line of String(logs)
-            .split("\n")
-            .map((l) => l.replace(/\r/g, "").replace(ANSI_RE, ""))
-            .filter(Boolean)) {
-            console.error(`    ${line}`);
-          }
-          console.error("");
-        }
-      } catch {
-        // doctor logs unavailable — fall through to manual instructions
-      }
-      console.error("  Troubleshooting:");
-      console.error("    openshell doctor logs --name nemoclaw");
-      console.error("    openshell doctor check");
-      process.exit(1);
+      handleFinalGatewayStartFailure({ retries });
     }
     throw new Error("Gateway failed to start");
   }
@@ -9258,6 +9293,7 @@ module.exports = {
   getGatewayClusterContainerState,
   getGatewayHealthWaitConfig,
   getGatewayReuseState,
+  handleFinalGatewayStartFailure,
   getNavigationChoice,
   getSandboxInferenceConfig,
   getInstalledOpenshellVersion,

--- a/test/gateway-final-failure-cleanup.test.ts
+++ b/test/gateway-final-failure-cleanup.test.ts
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+type FinalGatewayStartFailureOptions = {
+  retries: number;
+  collectDiagnostics?: () => string | null | undefined;
+  cleanupGateway?: () => void;
+  exitProcess?: (code: number) => never;
+  printError?: (message?: string) => void;
+};
+
+type OnboardGatewayFailureInternals = {
+  handleFinalGatewayStartFailure: (options: FinalGatewayStartFailureOptions) => never;
+};
+
+function isOnboardGatewayFailureInternals(
+  value: object | null,
+): value is OnboardGatewayFailureInternals {
+  return (
+    value !== null &&
+    typeof Reflect.get(value, "handleFinalGatewayStartFailure") === "function"
+  );
+}
+
+const loadedOnboardInternals = require("../dist/lib/onboard");
+const onboardInternals =
+  typeof loadedOnboardInternals === "object" && loadedOnboardInternals !== null
+    ? loadedOnboardInternals
+    : null;
+if (!isOnboardGatewayFailureInternals(onboardInternals)) {
+  throw new Error("Expected onboard internals to expose handleFinalGatewayStartFailure");
+}
+const { handleFinalGatewayStartFailure } = onboardInternals;
+
+describe("final gateway startup failure cleanup", () => {
+  it("collects diagnostics before cleanup, then exits", () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+
+    expect(() =>
+      handleFinalGatewayStartFailure({
+        retries: 2,
+        collectDiagnostics: () => {
+          calls.push("diagnostics");
+          return "gateway log line\n";
+        },
+        cleanupGateway: () => {
+          calls.push("cleanup");
+        },
+        exitProcess: (code: number): never => {
+          calls.push(`exit:${code}`);
+          throw new Error(`exit ${code}`);
+        },
+        printError: (message = "") => {
+          errors.push(message);
+        },
+      }),
+    ).toThrow("exit 1");
+
+    expect(calls).toEqual(["diagnostics", "cleanup", "exit:1"]);
+    expect(errors).toContain("  Gateway failed to start after 3 attempts.");
+    expect(errors).toContain("  Gateway logs:");
+    expect(errors).toContain("    gateway log line");
+    expect(errors).toContain("  Cleanup attempted.");
+    expect(errors).toContain("    openshell gateway destroy -g nemoclaw");
+    expect(errors).toContain(
+      '    docker volume ls -q --filter "name=openshell-cluster-nemoclaw" | xargs -r docker volume rm',
+    );
+    expect(errors).toContain("    nemoclaw onboard --resume");
+  });
+
+  it("still cleans up after the diagnostic command is attempted and fails", () => {
+    const calls: string[] = [];
+    const errors: string[] = [];
+
+    expect(() =>
+      handleFinalGatewayStartFailure({
+        retries: 0,
+        collectDiagnostics: () => {
+          calls.push("diagnostics");
+          throw new Error("doctor unavailable");
+        },
+        cleanupGateway: () => {
+          calls.push("cleanup");
+        },
+        exitProcess: (code: number): never => {
+          calls.push(`exit:${code}`);
+          throw new Error(`exit ${code}`);
+        },
+        printError: (message = "") => {
+          errors.push(message);
+        },
+      }),
+    ).toThrow("exit 1");
+
+    expect(calls).toEqual(["diagnostics", "cleanup", "exit:1"]);
+    expect(errors).toContain("  Gateway failed to start after 1 attempts.");
+    expect(errors).toContain("  Diagnostic command attempted before cleanup:");
+    expect(errors).toContain("    openshell doctor logs --name nemoclaw");
+    expect(errors).toContain("  If gateway cleanup did not complete, run:");
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve final gateway-start diagnostics first, then run `destroyGateway()` before exiting the exhausted-retry path.
- Keep intermediate retry cleanup behavior unchanged.
- Print accurate best-effort manual recovery commands for the `nemoclaw` gateway if cleanup still needs help.
- Add focused regression coverage for diagnostics-before-cleanup ordering.

## Tests
- `npm run build:cli`
- `npm run typecheck:cli`
- `npx vitest run test/gateway-final-failure-cleanup.test.ts test/gateway-cleanup.test.ts`

Supersedes #2280. Addresses the remaining cleanup gap from #17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway startup failure handling with clearer multi-attempt messaging, automated diagnostic collection (with sensitive data redaction), and standardized cleanup and manual remediation guidance.

* **Tests**
  * Added tests covering gateway startup failure flows, diagnostic collection (including fallback when diagnostics fail), cleanup execution, and verification of error output and remediation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->