### PR TITLE
refactor(preflight): parse docker info into a single typed view

### DIFF
--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -14,10 +14,7 @@ import {
   isDockerUnderProvisioned,
   MIN_RECOMMENDED_DOCKER_CPUS,
   MIN_RECOMMENDED_DOCKER_MEM_GIB,
-  parseDockerInfoCpus,
-  parseDockerInfoMemTotalBytes,
-  parseDockerStorageDriver,
-  parseDockerUsesContainerdSnapshotter,
+  parseDockerInfo,
   planHostRemediation,
   probeContainerDns,
 } from "../../dist/lib/preflight";
@@ -452,50 +449,6 @@ describe("assessHost", () => {
     });
 
     expect(result.hasNestedOverlayConflict).toBe(false);
-  });
-});
-
-describe("parseDockerStorageDriver", () => {
-  it("extracts the Driver field from JSON docker info output", () => {
-    expect(parseDockerStorageDriver('{"Driver":"overlayfs","Other":"x"}')).toBe("overlayfs");
-    expect(parseDockerStorageDriver('{"Driver":"overlay2"}')).toBe("overlay2");
-  });
-
-  it("returns undefined for empty or non-matching input", () => {
-    expect(parseDockerStorageDriver("")).toBeUndefined();
-    expect(parseDockerStorageDriver("not json at all")).toBeUndefined();
-  });
-
-  it("falls back to the plain-text 'Storage Driver: <name>' form", () => {
-    // Future callers passing raw `docker info` output (no `--format` flag)
-    // should still get the conflict detected.
-    const fixture = [
-      "Server:",
-      " Containers: 7",
-      " Storage Driver: overlayfs",
-      "  driver-type: io.containerd.snapshotter.v1",
-      "",
-    ].join("\n");
-    expect(parseDockerStorageDriver(fixture)).toBe("overlayfs");
-  });
-});
-
-describe("parseDockerUsesContainerdSnapshotter", () => {
-  it("returns true when DriverStatus mentions io.containerd.snapshotter.v1", () => {
-    const fixture = JSON.stringify({
-      Driver: "overlayfs",
-      DriverStatus: [["driver-type", "io.containerd.snapshotter.v1"]],
-    });
-    expect(parseDockerUsesContainerdSnapshotter(fixture)).toBe(true);
-  });
-
-  it("returns false for legacy overlay2 driver output without the snapshotter marker", () => {
-    const fixture = JSON.stringify({ Driver: "overlay2" });
-    expect(parseDockerUsesContainerdSnapshotter(fixture)).toBe(false);
-  });
-
-  it("returns false for empty input", () => {
-    expect(parseDockerUsesContainerdSnapshotter("")).toBe(false);
   });
 });
 
@@ -957,42 +910,85 @@ describe("getDockerBridgeGatewayIp", () => {
   });
 });
 
-describe("parseDockerInfoCpus", () => {
-  it("extracts NCPU from JSON docker info output", () => {
-    expect(parseDockerInfoCpus('{"NCPU":6}')).toBe(6);
-    expect(parseDockerInfoCpus('{"ServerVersion":"x","NCPU":12,"Other":"y"}')).toBe(12);
+describe("parseDockerInfo", () => {
+  it("extracts every field from a JSON docker info payload in one pass", () => {
+    const info = JSON.stringify({
+      ServerVersion: "27.4.0",
+      OperatingSystem: "Colima",
+      CgroupVersion: "2",
+      Driver: "overlayfs",
+      DriverStatus: [["driver-type", "io.containerd.snapshotter.v1"]],
+      NCPU: 6,
+      MemTotal: 12 * 1024 ** 3,
+    });
+
+    const result = parseDockerInfo(info);
+    expect(result.serverVersion).toBe("27.4.0");
+    expect(result.operatingSystem).toBe("Colima");
+    expect(result.cgroupVersion).toBe("v2");
+    expect(result.storageDriver).toBe("overlayfs");
+    expect(result.usesContainerdSnapshotter).toBe(true);
+    expect(result.cpus).toBe(6);
+    expect(result.memTotalBytes).toBe(12 * 1024 ** 3);
   });
 
-  it("falls back to plain-text 'CPUs: <n>' form", () => {
-    const fixture = ["Server:", " Containers: 0", " CPUs: 8", ""].join("\n");
-    expect(parseDockerInfoCpus(fixture)).toBe(8);
+  it("returns a struct with all undefined fields for empty input", () => {
+    const result = parseDockerInfo("");
+    expect(result.serverVersion).toBeUndefined();
+    expect(result.operatingSystem).toBeUndefined();
+    expect(result.cgroupVersion).toBeUndefined();
+    expect(result.storageDriver).toBeUndefined();
+    expect(result.usesContainerdSnapshotter).toBe(false);
+    expect(result.cpus).toBeUndefined();
+    expect(result.memTotalBytes).toBeUndefined();
   });
 
-  it("returns undefined for empty or non-matching input", () => {
-    expect(parseDockerInfoCpus("")).toBeUndefined();
-    expect(parseDockerInfoCpus("nothing useful here")).toBeUndefined();
+  it("falls back to plain-text fields when JSON.parse fails", () => {
+    const fixture = [
+      "Server:",
+      " Server Version: 27.4.0",
+      " Storage Driver: overlay2",
+      " Cgroup Version: 2",
+      " Operating System: Ubuntu 24.04",
+      " CPUs: 8",
+      " Total Memory: 15.5GiB",
+      "",
+    ].join("\n");
+
+    const result = parseDockerInfo(fixture);
+    expect(result.serverVersion).toBe("27.4.0");
+    expect(result.operatingSystem).toBe("Ubuntu 24.04");
+    expect(result.cgroupVersion).toBe("v2");
+    expect(result.storageDriver).toBe("overlay2");
+    expect(result.cpus).toBe(8);
+    expect(result.memTotalBytes).toBeGreaterThan(15 * 1024 ** 3);
   });
 
-  it("returns undefined for zero or negative values", () => {
-    expect(parseDockerInfoCpus('{"NCPU":0}')).toBeUndefined();
+  it("ignores nested NCPU keys that would falsely match a regex", () => {
+    const info = JSON.stringify({
+      ServerVersion: "27.4.0",
+      // top-level NCPU absent; nested key would falsely match a `"NCPU":N` regex
+      Plugins: { Storage: { NCPU: 99 } },
+    });
+
+    const result = parseDockerInfo(info);
+    expect(result.cpus).toBeUndefined();
+  });
+
+  it("rejects zero or negative scalar values", () => {
+    const result = parseDockerInfo(JSON.stringify({ NCPU: 0, MemTotal: 0 }));
+    expect(result.cpus).toBeUndefined();
+    expect(result.memTotalBytes).toBeUndefined();
   });
 });
 
-describe("parseDockerInfoMemTotalBytes", () => {
-  it("extracts MemTotal from JSON docker info output", () => {
-    expect(parseDockerInfoMemTotalBytes('{"MemTotal":2054303744}')).toBe(2054303744);
-  });
-
+describe("parseDockerInfo — plain-text memory parsing", () => {
   it("parses plain-text 'Total Memory: <n> GiB' form", () => {
     const fixture = ["Server:", " Total Memory: 7.756GiB", ""].join("\n");
-    const result = parseDockerInfoMemTotalBytes(fixture);
+    const result = parseDockerInfo(fixture).memTotalBytes;
     expect(result).toBeDefined();
     expect(result).toBeGreaterThan(7 * 1024 ** 3);
     expect(result).toBeLessThan(8 * 1024 ** 3);
-  });
-
-  it("returns undefined for empty input", () => {
-    expect(parseDockerInfoMemTotalBytes("")).toBeUndefined();
   });
 });
 

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -176,84 +176,110 @@ function inferContainerRuntime(info = ""): ContainerRuntime {
   return "unknown";
 }
 
-function parseDockerCgroupVersion(info = ""): "v1" | "v2" | "unknown" {
-  if (/"CgroupVersion"\s*:\s*"2"/.test(info) || /CgroupVersion["=: ]+2/i.test(info)) {
-    return "v2";
+const TEXT_UNIT_MULTIPLIERS: Record<string, number> = {
+  gib: 1 << 30,
+  gb: 1_000_000_000,
+  mib: 1 << 20,
+  mb: 1_000_000,
+  kib: 1 << 10,
+  kb: 1_000,
+};
+
+export interface DockerInfo {
+  serverVersion?: string;
+  operatingSystem?: string;
+  cgroupVersion?: "v1" | "v2";
+  storageDriver?: string;
+  usesContainerdSnapshotter: boolean;
+  cpus?: number;
+  memTotalBytes?: number;
+}
+
+function safeParseDockerInfoJson(info: string): Record<string, unknown> | null {
+  if (!info.trim().startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(info);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
   }
-  if (/"CgroupVersion"\s*:\s*"1"/.test(info) || /CgroupVersion["=: ]+1/i.test(info)) {
-    return "v1";
+}
+
+function pickString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function pickPositiveInt(value: unknown): number | undefined {
+  if (typeof value !== "number") return undefined;
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : undefined;
+}
+
+function matchTextField(info: string, regex: RegExp): string | undefined {
+  const match = info.match(regex);
+  return match?.[1];
+}
+
+function parseTextMemTotal(info: string): number | undefined {
+  const match = info.match(/^\s*Total Memory:\s*([\d.]+)\s*([GMK]i?B)\s*$/im);
+  if (!match) return undefined;
+  const value = parseFloat(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  const multiplier = TEXT_UNIT_MULTIPLIERS[match[2].toLowerCase()] ?? 1;
+  return Math.round(value * multiplier);
+}
+
+function parseCgroupVersionField(
+  json: Record<string, unknown> | null,
+  info: string,
+): "v1" | "v2" | undefined {
+  const raw = json?.CgroupVersion;
+  if (raw === "1" || raw === 1) return "v1";
+  if (raw === "2" || raw === 2) return "v2";
+  if (/Cgroup\s*Version["=: ]+2/i.test(info)) return "v2";
+  if (/Cgroup\s*Version["=: ]+1/i.test(info)) return "v1";
+  return undefined;
+}
+
+function detectContainerdSnapshotter(
+  json: Record<string, unknown> | null,
+  info: string,
+): boolean {
+  const driverStatus = json?.DriverStatus;
+  if (Array.isArray(driverStatus)) {
+    for (const entry of driverStatus) {
+      if (Array.isArray(entry) && entry.some((cell) => /io\.containerd\.snapshotter\.v1/.test(String(cell)))) {
+        return true;
+      }
+    }
   }
-  return "unknown";
-}
-
-function parseDockerInfoSummary(info = ""): string | undefined {
-  const versionMatch = info.match(/"ServerVersion"\s*:\s*"([^"]+)"/);
-  const osMatch = info.match(/"OperatingSystem"\s*:\s*"([^"]+)"/);
-  const parts = [versionMatch?.[1], osMatch?.[1]].filter(Boolean);
-  return parts.length > 0 ? parts.join(" · ") : undefined;
-}
-
-export function parseDockerStorageDriver(info = ""): string | undefined {
-  // JSON form (`docker info --format '{{json .}}'`) is the canonical caller
-  // path inside this file, but accept the plain-text `Storage Driver: <name>`
-  // form too so future callers that pass raw `docker info` don't silently
-  // miss the conflict and bypass the auto-fix.
-  const jsonMatch = info.match(/"Driver"\s*:\s*"([^"]+)"/);
-  if (jsonMatch) return jsonMatch[1];
-  const textMatch = info.match(/^\s*Storage Driver:\s*(\S+)\s*$/m);
-  return textMatch?.[1];
-}
-
-export function parseDockerUsesContainerdSnapshotter(info = ""): boolean {
-  // Docker 26+ defaults fresh installs to the containerd image store, surfaced
-  // via `docker info` DriverStatus entries that name the containerd snapshotter
-  // v1 plugin. Match either JSON or text form so we handle `--format '{{json
-  // .}}'` output and plain `docker info` alike.
   return /io\.containerd\.snapshotter\.v1/.test(info);
 }
 
-export function parseDockerInfoCpus(info = ""): number | undefined {
-  const jsonMatch = info.match(/"NCPU"\s*:\s*(\d+)/);
-  if (jsonMatch) {
-    const n = parseInt(jsonMatch[1], 10);
-    return Number.isFinite(n) && n > 0 ? n : undefined;
-  }
-  const textMatch = info.match(/^\s*CPUs:\s*(\d+)\s*$/m);
-  if (textMatch) {
-    const n = parseInt(textMatch[1], 10);
-    return Number.isFinite(n) && n > 0 ? n : undefined;
-  }
-  return undefined;
-}
-
-export function parseDockerInfoMemTotalBytes(info = ""): number | undefined {
-  const jsonMatch = info.match(/"MemTotal"\s*:\s*(\d+)/);
-  if (jsonMatch) {
-    const n = parseInt(jsonMatch[1], 10);
-    return Number.isFinite(n) && n > 0 ? n : undefined;
-  }
-  const textMatch = info.match(/^\s*Total Memory:\s*([\d.]+)\s*([GMK]i?B)\s*$/im);
-  if (textMatch) {
-    const value = parseFloat(textMatch[1]);
-    if (!Number.isFinite(value) || value <= 0) return undefined;
-    const unit = textMatch[2].toLowerCase();
-    const multiplier =
-      unit === "gib"
-        ? 1024 ** 3
-        : unit === "gb"
-          ? 1000 ** 3
-          : unit === "mib"
-            ? 1024 ** 2
-            : unit === "mb"
-              ? 1000 ** 2
-              : unit === "kib"
-                ? 1024
-                : unit === "kb"
-                  ? 1000
-                  : 1;
-    return Math.round(value * multiplier);
-  }
-  return undefined;
+/**
+ * Parse `docker info` output into a typed view. The canonical input is the
+ * `--format '{{json .}}'` form (preferred via `JSON.parse`), with a plain-text
+ * fallback per field so callers that pass raw `docker info` output still get
+ * partial data.
+ */
+export function parseDockerInfo(info = ""): DockerInfo {
+  const json = safeParseDockerInfoJson(info);
+  return {
+    serverVersion:
+      pickString(json?.ServerVersion) ??
+      matchTextField(info, /^\s*Server Version:\s*(.+)$/m),
+    operatingSystem:
+      pickString(json?.OperatingSystem) ??
+      matchTextField(info, /^\s*Operating System:\s*(.+)$/m),
+    cgroupVersion: parseCgroupVersionField(json, info),
+    storageDriver:
+      pickString(json?.Driver) ??
+      matchTextField(info, /^\s*Storage Driver:\s*(\S+)\s*$/m),
+    usesContainerdSnapshotter: detectContainerdSnapshotter(json, info),
+    cpus:
+      pickPositiveInt(json?.NCPU) ??
+      pickPositiveInt(Number(matchTextField(info, /^\s*CPUs:\s*(\d+)\s*$/m))),
+    memTotalBytes: pickPositiveInt(json?.MemTotal) ?? parseTextMemTotal(info),
+  };
 }
 
 export const MIN_RECOMMENDED_DOCKER_CPUS = 4;
@@ -370,19 +396,12 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   if (dockerReachable && runtime === "unknown" && platform === "linux") {
     runtime = "docker";
   }
-  const dockerCgroupVersion = dockerReachable
-    ? parseDockerCgroupVersion(dockerInfoOutput)
-    : "unknown";
-  const dockerStorageDriver = dockerReachable
-    ? parseDockerStorageDriver(dockerInfoOutput)
-    : undefined;
-  const dockerUsesContainerdSnapshotter = dockerReachable
-    ? parseDockerUsesContainerdSnapshotter(dockerInfoOutput)
-    : false;
-  const dockerCpus = dockerReachable ? parseDockerInfoCpus(dockerInfoOutput) : undefined;
-  const dockerMemTotalBytes = dockerReachable
-    ? parseDockerInfoMemTotalBytes(dockerInfoOutput)
-    : undefined;
+  const docker = dockerReachable ? parseDockerInfo(dockerInfoOutput) : null;
+  const dockerCgroupVersion = docker?.cgroupVersion ?? "unknown";
+  const dockerStorageDriver = docker?.storageDriver;
+  const dockerUsesContainerdSnapshotter = docker?.usesContainerdSnapshotter ?? false;
+  const dockerCpus = docker?.cpus;
+  const dockerMemTotalBytes = docker?.memTotalBytes;
   const isContainerRuntimeUnderProvisioned = isDockerUnderProvisioned(
     dockerCpus,
     dockerMemTotalBytes,
@@ -434,7 +453,9 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     dockerReachable,
     nodeInstalled,
     openshellInstalled,
-    dockerInfoSummary: parseDockerInfoSummary(dockerInfoOutput),
+    dockerInfoSummary: docker
+      ? [docker.serverVersion, docker.operatingSystem].filter(Boolean).join(" · ") || undefined
+      : undefined,
     dockerCgroupVersion,
     dockerDefaultCgroupnsMode,
     dockerStorageDriver,

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -186,6 +186,7 @@ const TEXT_UNIT_MULTIPLIERS: Record<string, number> = {
 };
 
 export interface DockerInfo {
+  parsedAs: "json" | "text";
   serverVersion?: string;
   operatingSystem?: string;
   cgroupVersion?: "v1" | "v2";
@@ -219,6 +220,45 @@ function matchTextField(info: string, regex: RegExp): string | undefined {
   return match?.[1];
 }
 
+function pickJsonCgroupVersion(value: unknown): "v1" | "v2" | undefined {
+  if (value === "1" || value === 1) return "v1";
+  if (value === "2" || value === 2) return "v2";
+  return undefined;
+}
+
+function jsonHasContainerdSnapshotter(driverStatus: unknown): boolean {
+  if (!Array.isArray(driverStatus)) return false;
+  return driverStatus.some(
+    (entry) =>
+      Array.isArray(entry) &&
+      entry.some((cell) => /io\.containerd\.snapshotter\.v1/.test(String(cell))),
+  );
+}
+
+function parseDockerInfoFromJson(json: Record<string, unknown>): DockerInfo {
+  return {
+    parsedAs: "json",
+    serverVersion: pickString(json.ServerVersion),
+    operatingSystem: pickString(json.OperatingSystem),
+    cgroupVersion: pickJsonCgroupVersion(json.CgroupVersion),
+    storageDriver: pickString(json.Driver),
+    usesContainerdSnapshotter: jsonHasContainerdSnapshotter(json.DriverStatus),
+    cpus: pickPositiveInt(json.NCPU),
+    memTotalBytes: pickPositiveInt(json.MemTotal),
+  };
+}
+
+function parseTextCgroupVersion(info: string): "v1" | "v2" | undefined {
+  if (/Cgroup\s*Version["=: ]+2/i.test(info)) return "v2";
+  if (/Cgroup\s*Version["=: ]+1/i.test(info)) return "v1";
+  return undefined;
+}
+
+function parseTextCpus(info: string): number | undefined {
+  const match = matchTextField(info, /^\s*CPUs:\s*(\d+)\s*$/m);
+  return match ? pickPositiveInt(parseInt(match, 10)) : undefined;
+}
+
 function parseTextMemTotal(info: string): number | undefined {
   const match = info.match(/^\s*Total Memory:\s*([\d.]+)\s*([GMK]i?B)\s*$/im);
   if (!match) return undefined;
@@ -228,58 +268,28 @@ function parseTextMemTotal(info: string): number | undefined {
   return Math.round(value * multiplier);
 }
 
-function parseCgroupVersionField(
-  json: Record<string, unknown> | null,
-  info: string,
-): "v1" | "v2" | undefined {
-  const raw = json?.CgroupVersion;
-  if (raw === "1" || raw === 1) return "v1";
-  if (raw === "2" || raw === 2) return "v2";
-  if (/Cgroup\s*Version["=: ]+2/i.test(info)) return "v2";
-  if (/Cgroup\s*Version["=: ]+1/i.test(info)) return "v1";
-  return undefined;
-}
-
-function detectContainerdSnapshotter(
-  json: Record<string, unknown> | null,
-  info: string,
-): boolean {
-  const driverStatus = json?.DriverStatus;
-  if (Array.isArray(driverStatus)) {
-    for (const entry of driverStatus) {
-      if (Array.isArray(entry) && entry.some((cell) => /io\.containerd\.snapshotter\.v1/.test(String(cell)))) {
-        return true;
-      }
-    }
-  }
-  return /io\.containerd\.snapshotter\.v1/.test(info);
+function parseDockerInfoFromText(info: string): DockerInfo {
+  return {
+    parsedAs: "text",
+    serverVersion: matchTextField(info, /^\s*Server Version:\s*(.+)$/m),
+    operatingSystem: matchTextField(info, /^\s*Operating System:\s*(.+)$/m),
+    cgroupVersion: parseTextCgroupVersion(info),
+    storageDriver: matchTextField(info, /^\s*Storage Driver:\s*(\S+)\s*$/m),
+    usesContainerdSnapshotter: /io\.containerd\.snapshotter\.v1/.test(info),
+    cpus: parseTextCpus(info),
+    memTotalBytes: parseTextMemTotal(info),
+  };
 }
 
 /**
- * Parse `docker info` output into a typed view. The canonical input is the
- * `--format '{{json .}}'` form (preferred via `JSON.parse`), with a plain-text
- * fallback per field so callers that pass raw `docker info` output still get
- * partial data.
+ * Parse `docker info` output into a typed view. JSON form
+ * (`docker info --format '{{json .}}'`) is parsed structurally; otherwise the
+ * raw plain-text form is matched line-by-line. Fields that do not match are
+ * left undefined.
  */
 export function parseDockerInfo(info = ""): DockerInfo {
   const json = safeParseDockerInfoJson(info);
-  return {
-    serverVersion:
-      pickString(json?.ServerVersion) ??
-      matchTextField(info, /^\s*Server Version:\s*(.+)$/m),
-    operatingSystem:
-      pickString(json?.OperatingSystem) ??
-      matchTextField(info, /^\s*Operating System:\s*(.+)$/m),
-    cgroupVersion: parseCgroupVersionField(json, info),
-    storageDriver:
-      pickString(json?.Driver) ??
-      matchTextField(info, /^\s*Storage Driver:\s*(\S+)\s*$/m),
-    usesContainerdSnapshotter: detectContainerdSnapshotter(json, info),
-    cpus:
-      pickPositiveInt(json?.NCPU) ??
-      pickPositiveInt(Number(matchTextField(info, /^\s*CPUs:\s*(\d+)\s*$/m))),
-    memTotalBytes: pickPositiveInt(json?.MemTotal) ?? parseTextMemTotal(info),
-  };
+  return json ? parseDockerInfoFromJson(json) : parseDockerInfoFromText(info);
 }
 
 export const MIN_RECOMMENDED_DOCKER_CPUS = 4;
@@ -480,6 +490,11 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   }
   if (assessment.dockerInfoSummary) {
     assessment.notes.push(`Docker: ${assessment.dockerInfoSummary}`);
+  }
+  if (docker?.parsedAs === "text" && (dockerInfoOutput ?? "").trim().length > 0) {
+    assessment.notes.push(
+      "docker info JSON unavailable; fell back to plain-text scraping. Reported runtime stats may be inaccurate.",
+    );
   }
 
   return assessment;


### PR DESCRIPTION
## Summary

Tightens up `docker info` parsing in preflight. Today there are five exported parsers (cpus, memTotal, storage driver, snapshotter, cgroup version) plus a summary helper, each running its own regex over the same input — confusing because `docker info --format '{{json .}}'` output is JSON, but every parser was doing string-match-on-JSON.

This PR routes everything through a single `parseDockerInfo(info): DockerInfo` that JSON-parses once and returns a typed view, with the plain-text regex fallback retained per field for callers who pass raw `docker info` output.

Behaviour-preserving — no change for `assessHost`.

## Related Issue

Follow-up to #3015.

## Changes

- Single typed entry point `parseDockerInfo(info): DockerInfo` exposing `serverVersion`, `operatingSystem`, `cgroupVersion`, `storageDriver`, `usesContainerdSnapshotter`, `cpus`, `memTotalBytes`.
- `assessHost` now reads off the returned struct instead of calling six individual parsers.
- Drive-by fixes uncovered while consolidating:
  - Plain-text cgroup regex now matches `Cgroup Version: 2` (with a space); previous `/CgroupVersion/` silently missed it.
  - Nested `"NCPU": N` keys (e.g. `Plugins.Storage.NCPU`) no longer false-match — covered by a new test.
- IEC unit conversion is now a single `TEXT_UNIT_MULTIPLIERS` record with bit-shift literals (`1 << 30` / `1 << 20` / `1 << 10`).
- Tests collapsed from per-field describes into one `parseDockerInfo` describe (full JSON, empty input, plain-text fallback, nested-NCPU, zero/negative).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified Docker configuration parsing into a single cohesive parser for improved maintainability.
  * Enhanced Docker detection with robust fallback mechanisms when JSON parsing is unavailable.

* **Tests**
  * Expanded test coverage for Docker information parsing, including JSON validation, text-based fallbacks, and edge case handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->