### PR TITLE
fix(onboard): use per-group requireMention instead of invalid groupPolicy enum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -268,8 +268,8 @@ ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=
 # Used to enable guild-channel responses for native Discord. Default: empty map.
 ARG NEMOCLAW_DISCORD_GUILDS_B64=e30=
 # Base64-encoded JSON Telegram config (e.g. {"requireMention":true}).
-# When requireMention is true, Telegram groups get groupPolicy: mentions;
-# otherwise groupPolicy: open (existing default). See #1737. Default: empty map.
+# When requireMention is true, Telegram groups get groups: {"*": {"requireMention": true}}
+# with groupPolicy: open. See #1737, #3022. Default: empty map.
 ARG NEMOCLAW_TELEGRAM_CONFIG_B64=e30=
 # Set to "1" to force-disable device-pairing auth. Also auto-disabled when
 # CHAT_UI_URL is a non-loopback address (Brev Launchable, remote deployments)

--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -169,9 +169,7 @@ def build_config(env: dict | None = None) -> dict:
         if ch in ("telegram", "discord"):
             account["proxy"] = proxy_url
         if ch == "telegram":
-            account["groupPolicy"] = (
-                "mentions" if _telegram_config.get("requireMention") else "open"
-            )
+            account["groupPolicy"] = "open"
         if ch in _allowed_ids and _allowed_ids[ch]:
             account["dmPolicy"] = "allowlist"
             account["allowFrom"] = _allowed_ids[ch]
@@ -181,6 +179,9 @@ def build_config(env: dict | None = None) -> dict:
         _ch_cfg["discord"].update(
             {"groupPolicy": "allowlist", "guilds": _discord_guilds}
         )
+
+    if "telegram" in _ch_cfg and _telegram_config.get("requireMention"):
+        _ch_cfg["telegram"]["groups"] = {"*": {"requireMention": True}}
 
     # Normalize schemeless URLs before parsing — urlparse("remote-host:18789")
     # misclassifies hostname as scheme. Mirrors ensureScheme() in dashboard-contract.ts.

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -158,6 +158,37 @@ describe("generate-openclaw-config.py: config generation", () => {
     expect(config.channels.telegram).toBeDefined();
   });
 
+  it("emits groups with requireMention when TELEGRAM_REQUIRE_MENTION is true (#3022)", () => {
+    const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
+    const telegramConfig = Buffer.from(JSON.stringify({ requireMention: true })).toString("base64");
+    const config = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+      NEMOCLAW_TELEGRAM_CONFIG_B64: telegramConfig,
+    });
+    expect(config.channels.telegram.accounts.default.groupPolicy).toBe("open");
+    expect(config.channels.telegram.groups).toEqual({ "*": { requireMention: true } });
+  });
+
+  it("keeps groupPolicy open with no groups stanza when requireMention is false (#3022)", () => {
+    const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
+    const telegramConfig = Buffer.from(JSON.stringify({ requireMention: false })).toString("base64");
+    const config = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+      NEMOCLAW_TELEGRAM_CONFIG_B64: telegramConfig,
+    });
+    expect(config.channels.telegram.accounts.default.groupPolicy).toBe("open");
+    expect(config.channels.telegram.groups).toBeUndefined();
+  });
+
+  it("defaults Telegram groupPolicy to 'open' with no groups stanza when telegramConfig is empty (#3022)", () => {
+    const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
+    const config = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    });
+    expect(config.channels.telegram.accounts.default.groupPolicy).toBe("open");
+    expect(config.channels.telegram.groups).toBeUndefined();
+  });
+
   it("emits canonical openshell:resolve:env: placeholders for non-Slack channels", () => {
     const channels = Buffer.from(JSON.stringify(["telegram", "discord"])).toString("base64");
     const config = runConfigScript({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });


### PR DESCRIPTION
## Summary

The config generator (`scripts/generate-openclaw-config.py`) emitted `groupPolicy: "mentions"` when `TELEGRAM_REQUIRE_MENTION=1` was set during onboard. However, the OpenClaw gateway schema only accepts `"open"`, `"disabled"`, or `"allowlist"` — causing the gateway to crash on startup.

**Root cause:** PR #2417 conflated two independent OpenClaw controls. Per the [Telegram docs](https://docs.openclaw.ai/channels/telegram#access-control-and-activation):
- `groupPolicy` controls **group access** (`"open"` / `"allowlist"` / `"disabled"`)
- `groups.*.requireMention` controls **mention-gating** (whether the bot replies to all messages or only when @mentioned)

The old code tried to express "mention-only" as `groupPolicy: "mentions"`, which was never a valid enum value.

**Fix:** Keep `groupPolicy: "open"` (groups remain accessible) and emit `groups: { "*": { requireMention: true } }` when the user enables mention mode. This matches the documented OpenClaw config pattern.

### Before (broken — v0.0.34)
```json
{
  "channels": {
    "telegram": {
      "accounts": { "default": { "groupPolicy": "mentions" } }
    }
  }
}
```
Gateway crashes: `groupPolicy: invalid config`

### After (fixed)
```json
{
  "channels": {
    "telegram": {
      "accounts": { "default": { "groupPolicy": "open" } },
      "groups": { "*": { "requireMention": true } }
    }
  }
}
```
Gateway starts. Bot replies only when @mentioned in groups.

## Changes

| File | Change |
|------|--------|
| `scripts/generate-openclaw-config.py` | Always set `groupPolicy: "open"` for Telegram; add `groups: { "*": { requireMention: true } }` when `requireMention` is enabled |
| `Dockerfile` | Updated comment to reflect correct config shape |
| `test/generate-openclaw-config.test.ts` | 3 new tests verify both `groupPolicy` and `groups` stanza for requireMention=true, false, and empty config |

## Testing

- **Unit tests:** 49/49 passed (`npx vitest run test/generate-openclaw-config.test.ts`)
- **Reproduction (before fix):** Onboarded on Brev GCP (n2-standard-4) with v0.0.34 + `TELEGRAM_REQUIRE_MENTION=1`. Gateway failed:
  ```
  Gateway failed to start: Error: Invalid config at /sandbox/.openclaw/openclaw.json.
  channels.telegram.accounts.default.groupPolicy: invalid config:
  must be equal to one of the allowed values (allowed: "open", "disabled", "allowlist")
  ```
- **`openclaw doctor --fix`** does NOT auto-correct the invalid `groupPolicy` value

## Related

- Fixes #3022
- Regression from #2417 (feat: Telegram mention-only mode, merged May 1 2026)
- Prior art: #1737 (original feature request)

## What this does NOT fix

- If a user already has a sandbox built with the bad config, they need to `nemoclaw <name> destroy --force` and re-onboard. `openclaw doctor --fix` does not repair the invalid `groupPolicy` value.

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Telegram group access control when "require mention" is enabled so the mention requirement is preserved while aligning the group policy setting.

* **Documentation**
  * Clarified inline documentation describing how Telegram mention requirements are handled.

* **Tests**
  * Added tests covering Telegram group policy/config generation with and without mention requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->