### PR TITLE
fix(e2e): suppress Node.js proxy warning in Discord egress check

### DIFF
--- a/test/e2e/test-hermes-discord-e2e.sh
+++ b/test/e2e/test-hermes-discord-e2e.sh
@@ -430,7 +430,7 @@ fi
 
 section "Phase 6: Discord placeholder egress"
 
-dc_api=$(sandbox_exec 'node -e "
+dc_api=$(sandbox_exec 'node --no-warnings -e "
 const fs = require(\"fs\");
 const https = require(\"https\");
 const env = fs.readFileSync(\"/sandbox/.hermes/.env\", \"utf8\");


### PR DESCRIPTION
## Summary

Fix the `hermes-discord-e2e` nightly failure caused by Node.js 22's experimental `EnvHttpProxyAgent` warning corrupting the Discord egress check's JSON output.

## Related Issue

Fixes #3049

## Changes

- Add `--no-warnings` to the `node` invocation in Phase 6 (Discord placeholder egress) of `test/e2e/test-hermes-discord-e2e.sh`

### Root Cause

Node.js 22 inside the sandbox detects the L7 egress proxy environment variables (`http_proxy`/`https_proxy`) and emits an `[UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental` warning on stderr. The `sandbox_exec()` helper merges stderr into stdout via SSH `2>&1`, so the warning text prepends the JSON response:

```
(node:490) [UNDICI-EHPA] Warning: EnvHttpProxyAgent is experimental, expect them to change at any time.
(Use `node --trace-warnings ...` to show where the warning was created)
{"statusCode":401,"body":"{\"message\": \"401: Unauthorized\", \"code\": 0}"}
```

The downstream Python JSON parser (`json.load(sys.stdin)`) chokes on the multi-line input because the first line isn't JSON. Both `dc_status` and `dc_error` end up as empty strings, which falls through to the catch-all `FAIL` assertion.

### Fix

`--no-warnings` is Node.js's standard flag for suppressing non-error diagnostic output. It prevents the `EnvHttpProxyAgent` warning from being emitted, so the JSON response is the only stdout content and the parser succeeds.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] No secrets, API keys, or credentials committed
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>