### PR TITLE
fix(cli): add missing --yes flag to oclif onboard command

### DIFF
--- a/src/lib/onboard-cli-commands.ts
+++ b/src/lib/onboard-cli-commands.ts
@@ -11,7 +11,7 @@ import { NOTICE_ACCEPT_FLAG } from "./usage-notice";
 const acceptFlagName = NOTICE_ACCEPT_FLAG.replace(/^--/, "");
 
 const onboardUsage = [
-  `onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [${NOTICE_ACCEPT_FLAG}]`,
+  `onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [--yes | -y] [${NOTICE_ACCEPT_FLAG}]`,
 ];
 
 const onboardExamples = [
@@ -21,6 +21,7 @@ const onboardExamples = [
   "<%= config.bin %> onboard --fresh",
   "<%= config.bin %> onboard --from ./Dockerfile --name alpha",
   `<%= config.bin %> onboard --non-interactive --name alpha ${NOTICE_ACCEPT_FLAG}`,
+  `<%= config.bin %> onboard --non-interactive --yes ${NOTICE_ACCEPT_FLAG}`,
 ];
 
 type OnboardFlags = {
@@ -32,6 +33,7 @@ type OnboardFlags = {
   name?: string;
   agent?: string;
   "control-ui-port"?: number;
+  yes?: boolean;
   [acceptFlagName]?: boolean;
 };
 
@@ -56,6 +58,10 @@ function buildOnboardFlags(): Record<string, any> {
       max: 65535,
       min: 1024,
     }),
+    yes: Flags.boolean({
+      char: "y",
+      description: "Auto-confirm prompts (e.g. Ollama download size)",
+    }),
     [acceptFlagName]: Flags.boolean({ description: "Accept the third-party software notice" }),
   } as Record<string, any>;
 }
@@ -72,6 +78,7 @@ function toLegacyOnboardArgs(flags: OnboardFlags): string[] {
   if (flags["control-ui-port"] !== undefined) {
     args.push("--control-ui-port", String(flags["control-ui-port"]));
   }
+  if (flags.yes) args.push("--yes");
   if (flags[acceptFlagName]) args.push(NOTICE_ACCEPT_FLAG);
   return args;
 }


### PR DESCRIPTION
## Summary

The installer's `run_onboard()` forwards `--yes` to `nemoclaw onboard` in non-interactive mode so the Ollama download-size gate auto-confirms. The legacy `parseOnboardArgs()` in `onboard-command.ts` handles `--yes`, but the oclif-based `OnboardCliCommand` (with `strict=true`) did not declare it — oclif rejected the flag with `Nonexistent flag: --yes` before the legacy parser ran, causing **cloud-onboard-e2e** to fail in [nightly-e2e run 25398263536](https://github.com/NVIDIA/NemoClaw/actions/runs/25398263536).

This PR adds the `yes` flag (with `-y` alias) to `buildOnboardFlags()` and forwards it through `toLegacyOnboardArgs()`.

## Related Issue

Fixes #3057

## Changes

- Added `yes: Flags.boolean({ char: "y", description: "Auto-confirm prompts (e.g. Ollama download size)" })` to `buildOnboardFlags()` in `src/lib/onboard-cli-commands.ts`
- Added `if (flags.yes) args.push("--yes")` to `toLegacyOnboardArgs()` so the flag reaches the legacy `parseOnboardArgs` → `autoYes`
- Updated `OnboardFlags` type to include `yes?: boolean`
- Updated `onboardUsage` and `onboardExamples` to document the new flag

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [x] `npm test` — TypeScript type-check (`tsc --noEmit -p tsconfig.src.json`) passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>