### PR TITLE
fix: preserve reused messaging provider hashes

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4221,9 +4221,12 @@ async function createSandbox(
       token: getCredential(webSearch.BRAVE_API_KEY_ENV),
     });
   }
+  const previousProviderCredentialHashes =
+    registry.getSandbox(sandboxName)?.providerCredentialHashes ?? {};
   const hasMessagingTokens = messagingTokenDefs.some(({ token }) => !!token);
   const reusableMessagingProviders: string[] = [];
   const reusableMessagingChannels: string[] = [];
+  const reusableMessagingEnvKeys = new Set<string>();
   if (enabledChannels != null) {
     for (const { name, envKey, token } of messagingTokenDefs) {
       if (token) continue;
@@ -4232,6 +4235,7 @@ async function createSandbox(
       if (!channel || !enabledChannels.includes(channel)) continue;
       if (!providerExistsInGateway(name)) continue;
       reusableMessagingProviders.push(name);
+      reusableMessagingEnvKeys.add(envKey);
       if (!reusableMessagingChannels.includes(channel)) {
         reusableMessagingChannels.push(channel);
       }
@@ -4986,6 +4990,12 @@ async function createSandbox(
     const hash = token ? hashCredential(token) : null;
     if (hash) {
       providerCredentialHashes[envKey] = hash;
+    }
+  }
+  for (const envKey of reusableMessagingEnvKeys) {
+    const previousHash = previousProviderCredentialHashes[envKey];
+    if (typeof previousHash === "string" && previousHash) {
+      providerCredentialHashes[envKey] = previousHash;
     }
   }
   // openshell tags images with seconds; buildId is ms. Parse actual tag from output. Fixes #2672.

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -3920,6 +3920,16 @@ const fs = require("node:fs");
 
 const commands = [];
 const registerCalls = [];
+registry.registerSandbox({
+  name: "my-assistant",
+  messagingChannels: ["discord", "slack"],
+  providerCredentialHashes: {
+    DISCORD_BOT_TOKEN: "hash-discord",
+    SLACK_BOT_TOKEN: "hash-slack-bot",
+    SLACK_APP_TOKEN: "hash-slack-app",
+    TELEGRAM_BOT_TOKEN: "hash-telegram",
+  },
+});
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
@@ -4037,6 +4047,11 @@ const { createSandbox } = require(${onboardPath});
       const channels = JSON.parse(Buffer.from(channelsLine.split("=")[1], "base64").toString());
       assert.deepEqual(channels, ["discord", "slack"]);
       assert.deepEqual(payload.registerCalls[0]?.messagingChannels, ["discord", "slack"]);
+      assert.deepEqual(payload.registerCalls[0]?.providerCredentialHashes, {
+        DISCORD_BOT_TOKEN: "hash-discord",
+        SLACK_BOT_TOKEN: "hash-slack-bot",
+        SLACK_APP_TOKEN: "hash-slack-app",
+      });
     },
   );
 


### PR DESCRIPTION
## Summary
- Preserve stored providerCredentialHashes for messaging providers reused during tokenless non-interactive rebuilds.
- Track the reused messaging env keys and merge their previous registry hashes into the recreated sandbox entry.
- Add regression coverage that keeps reused Discord and Slack hashes while not carrying an unrelated Telegram hash.

Follow-up to CodeRabbit feedback left on #3040.

## Validation
- npm run build:cli
- npx vitest run test/onboard.test.ts -t "reuses existing messaging providers during non-interactive recreate"
- npx vitest run test/onboard.test.ts test/rebuild-credential-preflight.test.ts
- npx biome check src/lib/onboard.ts test/onboard.test.ts
- npm run source-shape:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential loss for messaging providers when recreating or reusing sandboxes
  * Improved credential rotation detection accuracy during sandbox recreation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->