### PR TITLE
fix(onboard): accept --yes flag on oclif onboard command

### DIFF
--- a/src/lib/onboard-cli-commands.ts
+++ b/src/lib/onboard-cli-commands.ts
@@ -9,7 +9,7 @@ import { NOTICE_ACCEPT_FLAG } from "./usage-notice";
 const acceptFlagName = NOTICE_ACCEPT_FLAG.replace(/^--/, "");
 
 const onboardUsage = [
-  `onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [${NOTICE_ACCEPT_FLAG}]`,
+  `onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [--yes | -y] [${NOTICE_ACCEPT_FLAG}]`,
 ];
 
 const onboardExamples = [
@@ -30,6 +30,7 @@ type OnboardFlags = {
   name?: string;
   agent?: string;
   "control-ui-port"?: number;
+  yes?: boolean;
   [acceptFlagName]?: boolean;
 };
 
@@ -54,6 +55,10 @@ function buildOnboardFlags(): Record<string, any> {
       max: 65535,
       min: 1024,
     }),
+    yes: Flags.boolean({
+      char: "y",
+      description: "Auto-accept the Ollama model-download size confirmation",
+    }),
     [acceptFlagName]: Flags.boolean({ description: "Accept the third-party software notice" }),
   } as Record<string, any>;
 }
@@ -70,6 +75,7 @@ function toLegacyOnboardArgs(flags: OnboardFlags): string[] {
   if (flags["control-ui-port"] !== undefined) {
     args.push("--control-ui-port", String(flags["control-ui-port"]));
   }
+  if (flags.yes) args.push("--yes");
   if (flags[acceptFlagName]) args.push(NOTICE_ACCEPT_FLAG);
   return args;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The oclif-migrated `nemoclaw onboard` command was missing a `--yes` flag declaration, so any non-interactive install through `scripts/install.sh` failed with `Nonexistent flag: --yes`. install.sh has appended `--yes` to onboard since before the migration to auto-accept the Ollama model-download size prompt; this PR adds the flag to the oclif command and forwards it to the legacy parser, restoring non-interactive installs end-to-end.

# Changes
- `src/lib/onboard-cli-commands.ts`: add `yes` boolean flag (with `-y` short form) to `OnboardFlags`, `buildOnboardFlags()`, and the usage string. Forward as `--yes` in `toLegacyOnboardArgs()` so the legacy `onboard-command.ts` parser sets `autoYes`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--yes` / `-y` flag to the onboard CLI to automatically accept Ollama model-download size confirmation during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->