### PR TITLE
docs: prepare 0.0.35 release docs

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -205,7 +205,7 @@ For setup details, including GPU recommendations and starter model choices, refe
 These options appear when `NEMOCLAW_EXPERIMENTAL=1` is set and the prerequisites are met.
 
 - **Local NVIDIA NIM** requires a NIM-capable GPU. NemoClaw pulls and manages a NIM container.
-- **Local vLLM** requires a vLLM server already running on `localhost:8000`. NemoClaw auto-detects the loaded model.
+- **Local vLLM** uses a vLLM server already running on `localhost:8000`, or installs and starts a managed vLLM container on supported DGX Spark, DGX Station, and Linux NVIDIA GPU hosts. NemoClaw auto-detects the loaded model.
 
 For setup, refer to [Use a Local Inference Server](../inference/use-local-inference.md).
 :::

--- a/docs/inference/inference-options.md
+++ b/docs/inference/inference-options.md
@@ -58,6 +58,7 @@ NemoClaw uses provider-specific local tokens for those routes, and rebuilds of l
 The onboard wizard presents the following provider options by default.
 The first six are always available.
 Ollama appears when it is installed or running on the host.
+Experimental local vLLM appears when you opt in and NemoClaw detects either a running vLLM server or a supported NVIDIA GPU host profile.
 
 | Option | Description | Curated models |
 |--------|-------------|----------------|
@@ -90,7 +91,7 @@ The following local inference options require `NEMOCLAW_EXPERIMENTAL=1` and, whe
 | Option | Condition | Notes |
 |--------|-----------|-------|
 | Local NVIDIA NIM | NIM-capable GPU detected | Pulls and manages a NIM container. |
-| Local vLLM | vLLM running on `localhost:8000` | Auto-detects the loaded model. |
+| Local vLLM | vLLM running on `localhost:8000`, or a supported DGX Spark, DGX Station, or Linux NVIDIA GPU profile | Auto-detects the loaded model. Can install or start a managed vLLM container for supported profiles. |
 
 For setup instructions, refer to [Use a Local Inference Server](use-local-inference.md).
 

--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -25,7 +25,7 @@ status: published
 # Use a Local Inference Server
 
 NemoClaw can route inference to a model server running on your machine instead of a cloud API.
-This page covers Ollama, compatible-endpoint paths for other servers, and two experimental options for vLLM and NVIDIA NIM.
+This page covers Ollama, compatible-endpoint paths for other servers, and experimental managed options for vLLM and NVIDIA NIM.
 
 All approaches use the same `inference.local` routing model.
 The agent inside the sandbox never connects to your model server directly.
@@ -35,7 +35,7 @@ OpenShell intercepts inference traffic and forwards it to the local endpoint you
 
 - NemoClaw installed.
   Refer to the [Quickstart](../get-started/quickstart.md) if you have not installed yet.
-- A local model server running, or an Ollama setup that the NemoClaw onboard wizard can use, start, or install.
+- A local model server running, or a supported Ollama, vLLM, or NIM setup that the NemoClaw onboard wizard can use, start, or install.
 
 ## Ollama
 
@@ -223,9 +223,10 @@ $ NEMOCLAW_PROVIDER=anthropicCompatible \
   nemoclaw onboard --non-interactive
 ```
 
-## vLLM Auto-Detection (Experimental)
+## vLLM (Experimental)
 
 When vLLM is already running on `localhost:8000`, NemoClaw can detect it automatically and query the `/v1/models` endpoint to determine the loaded model.
+On supported Linux hosts with NVIDIA GPUs, the onboard wizard can also install or start a managed vLLM container for you.
 
 Set the experimental flag and run onboard.
 
@@ -234,7 +235,19 @@ $ NEMOCLAW_EXPERIMENTAL=1 nemoclaw onboard
 ```
 
 Select **Local vLLM [experimental]** from the provider list.
-NemoClaw detects the running model and validates the endpoint.
+If vLLM is already running, NemoClaw detects the running model and validates the endpoint.
+If vLLM is not running and your host matches a managed profile, select the **Install vLLM** or **Start vLLM** entry.
+NemoClaw pulls the vLLM image, downloads model weights into `~/.cache/huggingface`, starts the `nemoclaw-vllm` container on `localhost:8000`, and prints progress markers while the model loads.
+The first run can take 10 to 30 minutes.
+Later runs reuse the cached image and model weights.
+
+Managed vLLM uses these profiles:
+
+| Host profile | Default model |
+|---|---|
+| DGX Spark | `Qwen/Qwen3.6-27B-FP8` |
+| DGX Station | `Qwen/Qwen3.6-27B-FP8` |
+| Linux with an NVIDIA GPU | `nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8` |
 
 :::{note}
 NemoClaw forces the `chat/completions` API path for vLLM.
@@ -243,14 +256,24 @@ The vLLM `/v1/responses` endpoint does not run the `--tool-call-parser`, so tool
 
 ### Non-Interactive Setup
 
+Use an already-running vLLM server:
+
 ```console
 $ NEMOCLAW_EXPERIMENTAL=1 \
   NEMOCLAW_PROVIDER=vllm \
   nemoclaw onboard --non-interactive
 ```
 
-NemoClaw auto-detects the model from the running vLLM instance.
-To override the model, set `NEMOCLAW_MODEL`.
+Install or start managed vLLM when a supported profile is detected:
+
+```console
+$ NEMOCLAW_EXPERIMENTAL=1 \
+  NEMOCLAW_PROVIDER=install-vllm \
+  nemoclaw onboard --non-interactive
+```
+
+NemoClaw records the model returned by vLLM's `/v1/models` endpoint.
+Start vLLM with the model you want before onboarding if you manage the server yourself.
 
 ## NVIDIA NIM (Experimental)
 

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.34"}
+{"name": "nemoclaw", "version": "0.0.35"}

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -103,7 +103,7 @@ graph TB
     classDef pod fill:#444,stroke:#76b900,color:#fff,stroke-width:2px
     classDef external fill:#f5f5f5,stroke:#e0e0e0,color:#1a1a1a,stroke-width:1px
 
-    subgraph HOST["Host machine · Linux / macOS / WSL2 / DGX Spark"]
+    subgraph HOST["Host machine · Linux / macOS / WSL2 / DGX Spark / DGX Station"]
         direction TB
         CLI["nemoclaw CLI<br/><small>bin/nemoclaw.js → dist/<br/>onboard · connect · status · logs</small>"]:::cli
 

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
   {
     "preferred": true,
+    "version": "0.0.35",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.35/"
+  },
+  {
     "version": "0.0.34",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.34/"
   },


### PR DESCRIPTION
## Summary
Prepare the documentation set for the 0.0.35 release by updating the docs version metadata and documenting the managed local vLLM onboarding flow.

## Related Issue
None.

Related merged PRs:
- [#3007](https://github.com/NVIDIA/NemoClaw/pull/3007) added vLLM detection and managed install paths for DGX Spark and generic Linux.
- [#3054](https://github.com/NVIDIA/NemoClaw/pull/3054) added the DGX Station vLLM profile.

## Changes
- Added 0.0.35 as the preferred docs version while preserving 0.0.34 in the version switcher.
- Documented managed vLLM install/start behavior for DGX Spark, DGX Station, and Linux NVIDIA GPU hosts.
- Updated quickstart, inference options, and architecture references to reflect the supported vLLM host profiles.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local vLLM inference guidance with managed container deployment option for supported GPU platforms.
  * Added DGX Station support to deployment topology documentation.
  * Expanded local inference setup instructions with multi-path workflows and non-interactive provisioning guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->