### PR TITLE
feat(onboard-vllm): pin DGX Station container to GB300 GPU

### DIFF
--- a/src/lib/nim.ts
+++ b/src/lib/nim.ts
@@ -78,6 +78,29 @@ export function detectNvidiaPlatform(): NvidiaPlatform {
   return "linux";
 }
 
+// Return the indices of NVIDIA GPUs whose name matches `pattern`. Returns
+// [] if nvidia-smi is unavailable or no GPU matches. Used to pin a Docker
+// container to a specific GPU on hosts with mixed configurations (e.g.
+// DGX Station's GB300 alongside other GPUs).
+export function getGpuIndicesByName(pattern: RegExp): number[] {
+  const out = runCapture(
+    ["nvidia-smi", "--query-gpu=index,name", "--format=csv,noheader,nounits"],
+    { ignoreError: true },
+  );
+  if (!out) return [];
+  const indices: number[] = [];
+  for (const line of out.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const idx = trimmed.indexOf(",");
+    if (idx === -1) continue;
+    const i = Number(trimmed.slice(0, idx).trim());
+    const name = trimmed.slice(idx + 1).trim();
+    if (!Number.isNaN(i) && pattern.test(name)) indices.push(i);
+  }
+  return indices;
+}
+
 export interface NimStatus {
   running: boolean;
   healthy?: boolean;

--- a/src/lib/onboard-vllm.ts
+++ b/src/lib/onboard-vllm.ts
@@ -103,7 +103,12 @@ const STATION_PROFILE: VllmProfile = {
   dockerRunFlags: SPARK_PROFILE.dockerRunFlags,
   buildDockerRunFlags: () => {
     const indices = getGpuIndicesByName(/GB300/i);
-    const gpuFlag = indices.length > 0 ? `device=${indices.join(",")}` : "all";
+    const gpuFlag =
+      indices.length === 0
+        ? "all"
+        : indices.length === 1
+          ? `device=${indices[0]}`
+          : `'"device=${indices.join(",")}"'`;
     return [
       "--gpus",
       gpuFlag,

--- a/src/lib/onboard-vllm.ts
+++ b/src/lib/onboard-vllm.ts
@@ -8,6 +8,7 @@
 const { runCapture, runShell } = require("./runner");
 const { dockerCapture, dockerSpawn } = require("./docker");
 const { VLLM_PORT } = require("./ports");
+const { getGpuIndicesByName } = require("./nim");
 
 // Per-platform install recipe. Add new platforms by appending an entry to
 // the profile table at the bottom of this file. The menu key in onboard.ts
@@ -20,6 +21,10 @@ interface VllmProfile {
   // docker run flags excluding the image and the entrypoint command. The
   // caller appends -p / --name / etc. that are not platform-specific.
   dockerRunFlags: string[];
+  // Optional dynamic flag builder. When present, its return value replaces
+  // dockerRunFlags at install time. Used by Station to pick the GB300 GPU
+  // out of a mixed-GPU host instead of using `--gpus all`.
+  buildDockerRunFlags?: () => string[];
   // bash -c command passed to docker run (pip install + vllm serve …)
   command: string;
   // Approximate first-run time shown in the confirmation prompt.
@@ -96,6 +101,19 @@ const STATION_PROFILE: VllmProfile = {
   model: SPARK_PROFILE.model,
   containerName: "nemoclaw-vllm",
   dockerRunFlags: SPARK_PROFILE.dockerRunFlags,
+  buildDockerRunFlags: () => {
+    const indices = getGpuIndicesByName(/GB300/i);
+    const gpuFlag = indices.length > 0 ? `device=${indices.join(",")}` : "all";
+    return [
+      "--gpus",
+      gpuFlag,
+      "--ipc=host",
+      "-v",
+      `${process.env.HOME}/.cache/huggingface:/root/.cache/huggingface`,
+      "-e",
+      "HF_HOME=/root/.cache/huggingface",
+    ];
+  },
   command: SPARK_PROFILE.command,
   estimatedMinutes: SPARK_PROFILE.estimatedMinutes,
   pullTimeoutSec: SPARK_PROFILE.pullTimeoutSec,
@@ -262,7 +280,10 @@ function startContainer(profile: VllmProfile): { ok: boolean; reason?: string } 
     ignoreError: true,
     suppressOutput: true,
   });
-  const flags = profile.dockerRunFlags.join(" ");
+  const resolvedFlags = profile.buildDockerRunFlags
+    ? profile.buildDockerRunFlags()
+    : profile.dockerRunFlags;
+  const flags = resolvedFlags.join(" ");
   const cmd =
     `docker run -d ${flags} -p ${String(VLLM_PORT)}:8000 ` +
     `--name ${profile.containerName} ${profile.image} bash -c ${JSON.stringify(profile.command)}`;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
On a DGX Station with mixed GPUs, exposing `--gpus all` to the vLLM container would route the model across every visible GPU including non-GB300 ones. This PR pins the Station container to the GB300(s) by detecting matching nvidia-smi indices at install time and  emitting `--gpus device=<idx>` instead.

## Changes
- `src/lib/nim.ts`: new `getGpuIndicesByName(pattern)` helper that runs `nvidia-smi --query-gpu=index,name` and returns indices whose name matches the pattern.
- `src/lib/onboard-vllm.ts`:
- Added optional `buildDockerRunFlags?: () => string[]` to `VllmProfile`. When present, its return value replaces `dockerRunFlags` at install time.
- `STATION_PROFILE` now sets a builder that finds GB300 indices via `getGpuIndicesByName(/GB300/i)` and emits `--gpus device=<idx>` (falls back to `--gpus all` if no GB300 found).
- `startContainer` calls the builder when present, otherwise uses the static `dockerRunFlags`.
- Spark and the generic Linux profile are unchanged — the builder is Station-only.
- No-op when vLLM is already running externally: onboard takes the reuse path and the builder is never invoked.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU detection and name-based filtering so users can select GPUs by pattern.
  * Enabled dynamic Docker run configuration for DGX Station systems so GPU flags are computed automatically at container startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->