### PR TITLE
fix(onboard): honor NEMOCLAW_SANDBOX_NAME as interactive prompt default (#3060)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3860,7 +3860,21 @@ function getDefaultSandboxNameForAgent(agent: AgentDefinition | null | undefined
 }
 
 function getSandboxPromptDefault(agent: AgentDefinition | null | undefined): string {
-  return getDefaultSandboxNameForAgent(agent);
+  // #3060: when NEMOCLAW_SANDBOX_NAME is set in the user's environment,
+  // pre-populate the interactive prompt with it (and use it as the
+  // empty-enter fallback). Other env vars (e.g. NEMOCLAW_ENDPOINT_URL)
+  // already pre-populate; the sandbox name was the inconsistent case.
+  // If the env value is non-empty but invalid (rejected by validateName),
+  // fall back to the agent default so the prompt does not get stuck on a
+  // value the user cannot accept by hitting enter.
+  const envName = (process.env.NEMOCLAW_SANDBOX_NAME ?? "").trim();
+  const agentDefault = getDefaultSandboxNameForAgent(agent);
+  if (!envName) return agentDefault;
+  try {
+    return validateName(envName, "sandbox name");
+  } catch {
+    return agentDefault;
+  }
 }
 
 function getEffectiveSandboxAgent(agent: AgentDefinition | null | undefined): AgentDefinition {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -226,7 +226,18 @@ describe("onboard helpers", () => {
       expect(getDefaultSandboxNameForAgent(hermes)).toBe("hermes");
       expect(getSandboxPromptDefault(hermes)).toBe("hermes");
 
+      // #3060: NEMOCLAW_SANDBOX_NAME set in the environment is honored as
+      // the prompt default when valid.
       process.env.NEMOCLAW_SANDBOX_NAME = "custom-hermes";
+      expect(getSandboxPromptDefault(hermes)).toBe("custom-hermes");
+
+      // #3060: an invalid env value falls back to the agent default rather
+      // than getting the user stuck on a value validateName() will reject.
+      process.env.NEMOCLAW_SANDBOX_NAME = "123-leading-digit-invalid";
+      expect(getSandboxPromptDefault(hermes)).toBe("hermes");
+
+      // Empty NEMOCLAW_SANDBOX_NAME also falls back.
+      process.env.NEMOCLAW_SANDBOX_NAME = "";
       expect(getSandboxPromptDefault(hermes)).toBe("hermes");
     } finally {
       if (previousSandboxName === undefined) {


### PR DESCRIPTION
## Summary

#3060 reports that NEMOCLAW_SANDBOX_NAME, exported in the user's environment, is silently ignored when nemoclaw onboard runs interactively. Other env vars (e.g. NEMOCLAW_ENDPOINT_URL) already pre-populate the prompt; the sandbox name was the inconsistent case. Reporter:

```
export NEMOCLAW_SANDBOX_NAME=mythos
nemoclaw onboard
# Prompt shows the agent default ("my-assistant"), not "mythos"
```

This PR makes the interactive default consistent.

## Problem

`getSandboxPromptDefault(agent)` returned `getDefaultSandboxNameForAgent(agent)` unconditionally, never consulting `process.env.NEMOCLAW_SANDBOX_NAME`. The non-interactive path inside `promptOrDefault` did read the env var, so the env-var contract was honored in non-interactive mode but quietly broken in interactive mode.

## Changes

- `src/lib/onboard.ts:getSandboxPromptDefault` resolves `NEMOCLAW_SANDBOX_NAME` first; falls back to the agent default if unset, empty, or rejected by `validateName`. Falling back on invalid keeps the user from getting stuck on a value they cannot accept by hitting enter.
- `test/onboard.test.ts`: the existing test asserted the buggy behavior (env var ignored). Updated to assert the env value is now returned, plus added cases for invalid value (leading digit) and empty string falling back to the agent default.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Test plan

- [x] `npx vitest run test/onboard.test.ts -t "onboard helpers"` (174/174 pass)
- [x] No secrets, API keys, or credentials committed
- [x] Tests updated for new behavior

Closes #3060

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pre-filling sandbox name during onboarding from an environment variable, with automatic fallback to agent-specific defaults if the variable is not set or invalid.

* **Tests**
  * Extended test coverage for environment variable handling in sandbox prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->