### PR TITLE
fix(e2e): add Docker-driver sandbox teardown helpers to prevent lifecycle races

### DIFF
--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -75,6 +75,30 @@ registry_has() {
   [ -f "$REGISTRY" ] && grep -q "$sandbox_name" "$REGISTRY"
 }
 
+# Force-remove a sandbox's Docker container by name prefix.  In
+# Docker-driver mode `openshell sandbox delete` acks the removal but
+# the underlying Docker container may linger for a moment — this
+# helper ensures it's truly gone so subsequent tests start from a
+# clean state.
+force_remove_sandbox_container() {
+  local sandbox_name="$1"
+  local cid
+  cid="$(docker ps -aqf "name=openshell-${sandbox_name}-" 2>/dev/null | head -1)"
+  if [ -n "$cid" ]; then
+    docker rm -f "$cid" >/dev/null 2>&1 || true
+  fi
+}
+
+# Full Docker-driver-aware sandbox teardown: delete from OpenShell,
+# force-remove the Docker container, and wait briefly for state to
+# converge.
+full_sandbox_delete() {
+  local sandbox_name="$1"
+  openshell sandbox delete "$sandbox_name" 2>/dev/null || true
+  force_remove_sandbox_container "$sandbox_name"
+  sleep 1
+}
+
 SANDBOX_A="e2e-double-a"
 SANDBOX_B="e2e-double-b"
 REGISTRY="$HOME/.nemoclaw/sandboxes.json"
@@ -239,9 +263,13 @@ info "Destroying any leftover test sandboxes/gateway from previous runs..."
 if [ -x "$REPO_ROOT/bin/nemoclaw.js" ] || command -v nemoclaw >/dev/null 2>&1; then
   run_nemoclaw "$SANDBOX_A" destroy --yes 2>/dev/null || true
   run_nemoclaw "$SANDBOX_B" destroy --yes 2>/dev/null || true
+  # Clean up the default sandbox left by the Install NemoClaw step so the
+  # Docker-driver gateway starts from a blank slate (#3034).
+  run_nemoclaw my-assistant destroy --yes 2>/dev/null || true
 fi
-openshell sandbox delete "$SANDBOX_A" 2>/dev/null || true
-openshell sandbox delete "$SANDBOX_B" 2>/dev/null || true
+full_sandbox_delete "$SANDBOX_A"
+full_sandbox_delete "$SANDBOX_B"
+full_sandbox_delete "my-assistant"
 openshell forward stop 18789 2>/dev/null || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 pass "Pre-cleanup complete"
@@ -473,6 +501,11 @@ section "Phase 5: Stale registry reconciliation"
 info "Deleting '$SANDBOX_A' directly in OpenShell to leave a stale NemoClaw registry entry..."
 
 openshell sandbox delete "$SANDBOX_A" 2>/dev/null || true
+# Docker-driver mode: the gateway acks the delete but the Docker
+# container can linger briefly.  Force-remove so the stale-registry
+# assertions below test NemoClaw reconciliation, not Docker latency.
+force_remove_sandbox_container "$SANDBOX_A"
+sleep 1
 
 if registry_has "$SANDBOX_A"; then
   pass "Registry still contains stale '$SANDBOX_A' entry"
@@ -548,8 +581,8 @@ section "Phase 7: Final cleanup"
 
 run_nemoclaw "$SANDBOX_A" destroy --yes 2>/dev/null || true
 run_nemoclaw "$SANDBOX_B" destroy --yes 2>/dev/null || true
-openshell sandbox delete "$SANDBOX_A" 2>/dev/null || true
-openshell sandbox delete "$SANDBOX_B" 2>/dev/null || true
+full_sandbox_delete "$SANDBOX_A"
+full_sandbox_delete "$SANDBOX_B"
 openshell forward stop 18789 2>/dev/null || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 

--- a/test/e2e/test-onboard-repair.sh
+++ b/test/e2e/test-onboard-repair.sh
@@ -60,6 +60,28 @@ run_nemoclaw() {
   node "$REPO/bin/nemoclaw.js" "$@"
 }
 
+# Force-remove a sandbox's Docker container by name prefix.  In
+# Docker-driver mode `openshell sandbox delete` acks the removal but
+# the underlying Docker container may linger for a moment — this
+# helper ensures it's truly gone so subsequent tests start from a
+# clean state.
+force_remove_sandbox_container() {
+  local sandbox_name="$1"
+  local cid
+  cid="$(docker ps -aqf "name=openshell-${sandbox_name}-" 2>/dev/null | head -1)"
+  if [ -n "$cid" ]; then
+    docker rm -f "$cid" >/dev/null 2>&1 || true
+  fi
+}
+
+# Full Docker-driver-aware sandbox teardown.
+full_sandbox_delete() {
+  local sandbox_name="$1"
+  openshell sandbox delete "$sandbox_name" 2>/dev/null || true
+  force_remove_sandbox_container "$sandbox_name"
+  sleep 1
+}
+
 SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-repair}"
 OTHER_SANDBOX_NAME="${NEMOCLAW_OTHER_SANDBOX_NAME:-e2e-other}"
 
@@ -85,8 +107,12 @@ section "Phase 0: Pre-cleanup"
 info "Destroying any leftover sandbox/gateway from previous runs..."
 run_nemoclaw "$SANDBOX_NAME" destroy 2>/dev/null || true
 run_nemoclaw "$OTHER_SANDBOX_NAME" destroy 2>/dev/null || true
-openshell sandbox delete "$SANDBOX_NAME" 2>/dev/null || true
-openshell sandbox delete "$OTHER_SANDBOX_NAME" 2>/dev/null || true
+# Clean up the default sandbox left by the Install NemoClaw step so the
+# Docker-driver gateway starts from a blank slate (#3034).
+run_nemoclaw my-assistant destroy 2>/dev/null || true
+full_sandbox_delete "$SANDBOX_NAME"
+full_sandbox_delete "$OTHER_SANDBOX_NAME"
+full_sandbox_delete "my-assistant"
 openshell forward stop 18789 2>/dev/null || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 rm -f "$SESSION_FILE"
@@ -186,6 +212,11 @@ section "Phase 3: Repair missing sandbox"
 info "Deleting the recorded sandbox under the session, then resuming..."
 
 openshell sandbox delete "$SANDBOX_NAME" >/dev/null 2>&1 || true
+# Docker-driver mode: the gateway acks the delete but the Docker
+# container can linger briefly.  Force-remove so the missing-sandbox
+# assertions below test NemoClaw repair logic, not Docker latency.
+force_remove_sandbox_container "$SANDBOX_NAME"
+sleep 1
 openshell forward stop 18789 >/dev/null 2>&1 || true
 
 if openshell sandbox get "$SANDBOX_NAME" >/dev/null 2>&1; then
@@ -335,8 +366,8 @@ if [[ "${NEMOCLAW_E2E_KEEP_SANDBOX:-}" != "1" ]]; then
   run_nemoclaw "$SANDBOX_NAME" destroy 2>/dev/null || true
   run_nemoclaw "$OTHER_SANDBOX_NAME" destroy 2>/dev/null || true
 fi
-openshell sandbox delete "$SANDBOX_NAME" 2>/dev/null || true
-openshell sandbox delete "$OTHER_SANDBOX_NAME" 2>/dev/null || true
+full_sandbox_delete "$SANDBOX_NAME"
+full_sandbox_delete "$OTHER_SANDBOX_NAME"
 openshell forward stop 18789 2>/dev/null || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 rm -f "$SESSION_FILE"


### PR DESCRIPTION
## Summary

Fixes #3034.

In Docker-driver gateway mode, `openshell sandbox delete` returns immediately but the underlying Docker container lingers briefly. Add `force_remove_sandbox_container()` + `full_sandbox_delete()` helpers to both test scripts, and use them in Phase 0 cleanup, mid-test deletion points, and final cleanup.

Also destroys the orphaned `my-assistant` sandbox left by the installer step, which was blocking gateway startup on port 18789.

## Root cause

Two issues in `test-double-onboard.sh` and `test-onboard-repair.sh`:

1. **Orphaned `my-assistant` sandbox** — The `Install NemoClaw` workflow step creates a default `my-assistant` sandbox. Phase 0 cleanup did not destroy it, so the Docker-driver gateway detected an existing sandbox on port 18789 and failed the test onboard immediately.

2. **Async Docker container removal** — `openshell sandbox delete` acks the removal but the Docker container lingers briefly. Test phases that deleted a sandbox and immediately asserted it was gone raced against Docker cleanup and failed intermittently.

## Changes

**Both scripts:** Add `force_remove_sandbox_container()` and `full_sandbox_delete()` helpers.

**`test-double-onboard.sh`:**
- Phase 0: add `my-assistant` teardown; use `full_sandbox_delete` for all sandboxes
- Phase 5: add `force_remove_sandbox_container` + `sleep 1` after stale-registry delete
- Phase 7: use `full_sandbox_delete` for final cleanup

**`test-onboard-repair.sh`:**
- Phase 0: add `my-assistant` teardown; use `full_sandbox_delete` for all sandboxes  
- Phase 3: add `force_remove_sandbox_container` + `sleep 1` after forced sandbox deletion
- Phase 6: use `full_sandbox_delete` for final cleanup

## Validation

Changes are isolated to E2E test scripts. The fix mirrors the approach documented in the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced end-to-end test infrastructure for onboarding flows with improved sandbox cleanup procedures.
  * Added helper functions for robust Docker container management and consistent sandbox teardown across test phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->