### PR TITLE
fix(onboard): enforce mutable-default 660/2770 after gateway init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -383,7 +383,7 @@ path = os.path.expanduser('~/.openclaw/openclaw.json'); \
 cfg = json.load(open(path)); \
 cfg.setdefault('gateway', {}).setdefault('auth', {})['token'] = ''; \
 json.dump(cfg, open(path, 'w'), indent=2); \
-os.chmod(path, 0o600)"
+os.chmod(path, 0o660)"
 
 # Flatten stale published base images that still contain the old
 # .openclaw-data symlink bridge. OpenShell starts the sandbox as the sandbox

--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -350,10 +350,16 @@ def main() -> None:
     """Generate openclaw.json from environment variables."""
     config = build_config()
     path = os.path.expanduser("~/.openclaw/openclaw.json")
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    config_dir = os.path.dirname(path)
+    os.makedirs(config_dir, exist_ok=True)
     with open(path, "w") as f:
         json.dump(config, f, indent=2)
-    os.chmod(path, 0o600)
+    # Mutable-default contract (#2681): config files are group-writable (660)
+    # and directories are setgid (2770) so the sandbox group can read/write
+    # them at runtime. The Dockerfile's final chmod layer reinforces this,
+    # but keeping the generator consistent avoids a window of wrong perms.
+    os.chmod(path, 0o660)
+    os.chmod(config_dir, 0o2770)
 
 
 if __name__ == "__main__":

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -10232,6 +10232,27 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       ensureAgentDashboardForward(sandboxName, agent);
     }
 
+    // Final mutable-default permission normalization (#2681).
+    // The OpenClaw gateway atomically rewrites openclaw.json during its
+    // init sequence, resetting file permissions from 660 to 600. By the
+    // time we reach this point all startup writes (Step 7 config sync,
+    // Step 8 policy presets, gateway init) have landed, so a single
+    // trailing chmod pass is sufficient to restore the group-writable
+    // contract before the user's first interaction.
+    runOpenshell(
+      [
+        "sandbox",
+        "exec",
+        "-n",
+        sandboxName,
+        "--",
+        "sh",
+        "-lc",
+        'cd=/sandbox/.openclaw; [ -d "$cd" ] && o="$(stat -c %U "$cd" 2>/dev/null || echo unknown)" && [ "$o" != root ] && { chmod -R g+rwX,o-rwx "$cd" 2>/dev/null; find "$cd" -type d -exec chmod g+s {} + 2>/dev/null; chmod 2770 "$cd" 2>/dev/null; chmod 660 "$cd/openclaw.json" "$cd/.config-hash" 2>/dev/null; } || true',
+      ],
+      { ignoreError: true, suppressOutput: true, stdio: ["ignore", "ignore", "ignore"], timeout: 15_000 },
+    );
+
     onboardSession.completeSession(toSessionUpdates({ sandboxName, provider, model }));
     completed = true;
     // Onboarding finished successfully. Delete the legacy plaintext

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -300,12 +300,12 @@ describe("generate-openclaw-config.py: config generation", () => {
     expect(config.plugins.entries.xai.enabled).toBe(false);
   });
 
-  it("creates file with 0600 permissions", () => {
+  it("creates file with 0660 (group-writable mutable-default) permissions", () => {
     runConfigScript();
     const configPath = path.join(tmpDir, ".openclaw", "openclaw.json");
     const stats = fs.statSync(configPath);
-    // 0o600 = owner read/write only (octal 600 = decimal 384)
-    expect(stats.mode & 0o777).toBe(0o600);
+    // 0o660 = owner + group read/write (mutable-default contract, #2681)
+    expect(stats.mode & 0o777).toBe(0o660);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the shields-config E2E failure in nightly run [#25413934171](https://github.com/NVIDIA/NemoClaw/actions/runs/25413934171) where the `shields-config-e2e` job fails because initial OpenClaw config permissions are 600/700 instead of the mutable-default 660/2770.

**Root cause:** The OpenClaw gateway atomically rewrites `openclaw.json` during its init sequence, resetting permissions from 660 to umask-derived 600. Three sources all wrote 0600 instead of 0660:
1. `scripts/generate-openclaw-config.py` — `os.chmod(path, 0o600)`
2. `Dockerfile` inline token-clear — `os.chmod(path, 0o600)`
3. Gateway init's atomic rewrite — inherits process umask (0022 → 0644, then further restricted)

Even though the entrypoint's `normalize_mutable_config_perms` and Step 7's sync script set 660/2770, the gateway's async init races and overwrites after both normalizations complete.

## Changes

| File | Change |
|------|--------|
| `scripts/generate-openclaw-config.py` | `os.chmod(path, 0o660)` + `os.chmod(config_dir, 0o2770)` |
| `Dockerfile` | Inline token-clear uses `0o660` |
| `src/lib/onboard.ts` | Final `sandbox exec` chmod pass after all steps complete |
| `test/generate-openclaw-config.test.ts` | Updated permission expectation 0600 → 0660 |

## Test plan

- [ ] `npm test` — unit tests pass with updated 0660 expectation
- [ ] `shields-config-e2e` job passes on this branch (initial perms now 660/2770)
- [ ] `make check` — linters and type checks pass
- [ ] Manual: `nemoclaw onboard` → verify `stat -c '%a' /sandbox/.openclaw/openclaw.json` returns `660`

## Evidence

**Failing log excerpt** (job 74541283045):
```
FAIL: Config file should start as mode 660: 600 sandbox:sandbox
FAIL: Config directory should be mode 2770: 700 sandbox:sandbox
```

**After shields-down** (same run): permissions correctly restored to 660/2770 — proving the normalization logic works, just runs too early.

Fixes #3085

Signed-off-by: Hung Le <hple@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)