### PR TITLE
fix(e2e): raise token-rotation-e2e timeout from 2400s to 3000s

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -324,7 +324,7 @@ jobs:
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',token-rotation-e2e,'))
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 55
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/test/e2e/test-token-rotation.sh
+++ b/test/e2e/test-token-rotation.sh
@@ -33,7 +33,7 @@
 
 set -uo pipefail
 
-export NEMOCLAW_E2E_DEFAULT_TIMEOUT=2400
+export NEMOCLAW_E2E_DEFAULT_TIMEOUT=3000
 SCRIPT_DIR_TIMEOUT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=test/e2e/e2e-timeout.sh
 source "${SCRIPT_DIR_TIMEOUT}/e2e-timeout.sh"


### PR DESCRIPTION
## Summary

The `token-rotation-e2e` nightly job timed out during Phase 6 (Slack
token rotation) because the script-level timeout of 2400 s (40 min) is
insufficient for the four sandbox rebuild cycles the test performs
(initial install ≈12 min, Telegram rotation ≈9 min, Discord rotation
≈11 min, Slack rotation ≈10 min → total ≈42 min).

- Raise `NEMOCLAW_E2E_DEFAULT_TIMEOUT` from **2400** to **3000** (50 min)
  in `test/e2e/test-token-rotation.sh`.
- Raise `timeout-minutes` from **45** to **55** for the `token-rotation-e2e`
  job in `.github/workflows/nightly-e2e.yaml` to stay above the new
  script-level ceiling.

Fixes #3087

## Related Issue
Fixes #3087

## Changes
- `test/e2e/test-token-rotation.sh`: `NEMOCLAW_E2E_DEFAULT_TIMEOUT` 2400 → 3000
- `.github/workflows/nightly-e2e.yaml`: `timeout-minutes` 45 → 55 for `token-rotation-e2e`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] No secrets, API keys, or credentials committed
- [ ] Tests added or updated for new or changed behavior
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>