### PR TITLE
fix(onboard): prevent false-positive GPU drift on resume and destroy stale sandbox

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4759,9 +4759,14 @@ function getSandboxRuntimeRegistryFields(
 function hasSandboxGpuDrift(sandboxName: string, config: SandboxGpuConfig): boolean {
   const existingEntry: SandboxEntry | null = registry.getSandbox(sandboxName);
   if (!existingEntry) return false;
+  // Compare the effective GPU-enabled outcome rather than the raw mode string.
+  // During resume the saved gpuPassthrough=false is restored as flag="disable"
+  // which resolveSandboxGpuConfig converts to mode="0", while the first onboard
+  // stored mode="auto" (no GPU detected, no explicit flag).  Both resolve to
+  // sandboxGpuEnabled=false, so they are semantically identical — comparing mode
+  // strings would produce a false-positive drift.
   return (
     (existingEntry.sandboxGpuEnabled === true) !== config.sandboxGpuEnabled ||
-    (existingEntry.sandboxGpuMode || "auto") !== config.mode ||
     (existingEntry.sandboxGpuDevice || null) !== config.sandboxGpuDevice
   );
 }
@@ -10152,19 +10157,13 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       if (resume && session?.steps?.sandbox?.status === "complete") {
         if (webSearchConfigChanged) {
           note("  [resume] Web Search configuration changed; recreating sandbox.");
-          if (sandboxName) {
-            registry.removeSandbox(sandboxName);
-          }
+          repairRecordedSandbox(sandboxName);
         } else if (telegramConfigChanged) {
           note("  [resume] TELEGRAM_REQUIRE_MENTION changed; recreating sandbox.");
-          if (sandboxName) {
-            registry.removeSandbox(sandboxName);
-          }
+          repairRecordedSandbox(sandboxName);
         } else if (sandboxGpuConfigChanged) {
           note("  [resume] Sandbox GPU settings changed; recreating sandbox.");
-          if (sandboxName) {
-            registry.removeSandbox(sandboxName);
-          }
+          repairRecordedSandbox(sandboxName);
         } else if (sandboxReuseState === "not_ready") {
           note(
             `  [resume] Recorded sandbox '${sandboxName}' exists but is not ready; recreating it.`,


### PR DESCRIPTION
## Summary

Fix two bugs in the `--gpu` onboard-resume path introduced by the GPU passthrough feature (`feat(onboard): add --gpu flag for GPU passthrough into sandbox #2799`):

1. **False-positive GPU drift detection** — `hasSandboxGpuDrift()` compared the raw `sandboxGpuMode` string between the registry entry and the current config. During resume, the saved `gpuPassthrough=false` is restored as `SandboxGpuFlag="disable"`, which `resolveSandboxGpuConfig()` converts to `mode="0"`. The first onboard stored `mode="auto"` (no GPU detected, no explicit flag). Both resolve to `sandboxGpuEnabled=false` — semantically identical — but the mode string comparison (`"auto" != "0"`) produced a false-positive drift, triggering unnecessary sandbox recreation on every non-GPU resume.

2. **Incomplete sandbox cleanup on config-change branches** — The `webSearchConfigChanged`, `telegramConfigChanged`, and `sandboxGpuConfigChanged` resume branches called `registry.removeSandbox()` which only clears the local registry entry without actually deleting the OpenShell sandbox. The subsequent `createSandbox()` then found a stale sandbox and aborted with `Sandbox 'X' already exists as unknown`.

### Changes

- **`hasSandboxGpuDrift()`**: Remove the `sandboxGpuMode` string comparison. The `sandboxGpuEnabled` boolean already captures whether GPU passthrough is effectively on or off; the mode string is an implementation detail that can differ between `"auto"+no-GPU` and `"0"` while meaning the same thing.
- **Resume config-change branches**: Replace `registry.removeSandbox(sandboxName)` with `repairRecordedSandbox(sandboxName)` in the webSearch, telegram, and GPU config-change handlers so they properly stop the port forward, delete the OpenShell sandbox, and remove the registry entry before recreation.

### Failing jobs fixed

| Job | Failure | Root cause |
|-----|---------|-----------|
| [`onboard-resume-e2e`](https://github.com/NVIDIA/NemoClaw/actions/runs/25416038383/job/74552721383) | Resume aborted: "Sandbox already exists as unknown" | False GPU drift → `registry.removeSandbox()` (local-only) → stale sandbox → agent conflict |
| [`onboard-repair-e2e`](https://github.com/NVIDIA/NemoClaw/actions/runs/25416038383/job/74552721386) | Assertion `FAIL: Repair resume did not report missing sandbox recreation` | False GPU drift branch fires instead of the "unavailable" else branch → expected log message never emitted |

### Run context

- Workflow run: https://github.com/NVIDIA/NemoClaw/actions/runs/25416038383
- Commit: `b07dcc56ac066ef5f4e71dd9dc688241bf2afc7c`
- Branch: `codex/openshell-docker-gpu-onboard`

Signed-off-by: Hung Le <hple@nvidia.com>



Fixes #3093