### PR TITLE
test(onboard): cover runtime --env propagation for NEMOCLAW_PROXY_HOST/PORT (#1409)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2049,6 +2049,19 @@ function isValidProxyPort(value: string): boolean {
   return port >= 1 && port <= 65535;
 }
 
+function buildSandboxProxyEnvArgs(env: NodeJS.ProcessEnv = process.env): string[] {
+  const args: string[] = [];
+  const host = env.NEMOCLAW_PROXY_HOST;
+  if (host && isValidProxyHost(host)) {
+    args.push(formatEnvAssignment("NEMOCLAW_PROXY_HOST", host));
+  }
+  const port = env.NEMOCLAW_PROXY_PORT;
+  if (port && isValidProxyPort(port)) {
+    args.push(formatEnvAssignment("NEMOCLAW_PROXY_PORT", port));
+  }
+  return args;
+}
+
 function patchStagedDockerfile(
   dockerfilePath: string,
   model: string,
@@ -4880,14 +4893,7 @@ async function createSandbox(
   // build-time substitution and runtime env stay in sync as a result.
   // Fixes #2424. Uses the shared isValidProxyHost / isValidProxyPort
   // helpers so build-time and runtime validation stay aligned.
-  const sandboxProxyHost = process.env.NEMOCLAW_PROXY_HOST;
-  if (sandboxProxyHost && isValidProxyHost(sandboxProxyHost)) {
-    envArgs.push(formatEnvAssignment("NEMOCLAW_PROXY_HOST", sandboxProxyHost));
-  }
-  const sandboxProxyPort = process.env.NEMOCLAW_PROXY_PORT;
-  if (sandboxProxyPort && isValidProxyPort(sandboxProxyPort)) {
-    envArgs.push(formatEnvAssignment("NEMOCLAW_PROXY_PORT", sandboxProxyPort));
-  }
+  envArgs.push(...buildSandboxProxyEnvArgs());
   if (webSearchConfig?.fetchEnabled) {
     const braveKey =
       getCredential(webSearch.BRAVE_API_KEY_ENV) || process.env[webSearch.BRAVE_API_KEY_ENV];
@@ -9590,6 +9596,7 @@ module.exports = {
   shouldIncludeBuildContextPath,
   writeSandboxConfigSyncFile,
   patchStagedDockerfile,
+  buildSandboxProxyEnvArgs,
   ensureOllamaAuthProxy,
   fetchGatewayAuthTokenFromSandbox,
   getProbeAuthMode,

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -108,6 +108,7 @@ type OnboardTestInternals = {
   ) => string;
   parsePolicyPresetEnv: (value: string | null) => string[];
   patchStagedDockerfile: ShimFn<void>;
+  buildSandboxProxyEnvArgs: (env?: NodeJS.ProcessEnv) => string[];
   pullAndResolveBaseImageDigest: () => { digest: string; ref: string } | null;
   SANDBOX_BASE_IMAGE: string;
   printSandboxCreateRecoveryHints: ShimFn<void>;
@@ -201,6 +202,7 @@ const {
   normalizeProviderBaseUrl,
   parsePolicyPresetEnv,
   patchStagedDockerfile,
+  buildSandboxProxyEnvArgs,
   pullAndResolveBaseImageDigest,
   SANDBOX_BASE_IMAGE,
   printSandboxCreateRecoveryHints,
@@ -1278,6 +1280,46 @@ describe("onboard helpers", () => {
       }
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it("regression #1409: propagates NEMOCLAW_PROXY_HOST/PORT to sandbox runtime env", () => {
+    const args = buildSandboxProxyEnvArgs({
+      NEMOCLAW_PROXY_HOST: "1.2.3.4",
+      NEMOCLAW_PROXY_PORT: "9999",
+    });
+    assert.deepEqual(args, ["NEMOCLAW_PROXY_HOST=1.2.3.4", "NEMOCLAW_PROXY_PORT=9999"]);
+  });
+
+  it("regression #1409: emits no proxy runtime env args when host/port are unset", () => {
+    assert.deepEqual(buildSandboxProxyEnvArgs({}), []);
+    assert.deepEqual(
+      buildSandboxProxyEnvArgs({ NEMOCLAW_PROXY_HOST: "", NEMOCLAW_PROXY_PORT: "" }),
+      [],
+    );
+  });
+
+  it("regression #1409: rejects malformed NEMOCLAW_PROXY_HOST/PORT at runtime", () => {
+    assert.deepEqual(
+      buildSandboxProxyEnvArgs({
+        NEMOCLAW_PROXY_HOST: "1.2.3.4\nRUN rm -rf /",
+        NEMOCLAW_PROXY_PORT: "abcd",
+      }),
+      [],
+    );
+    assert.deepEqual(
+      buildSandboxProxyEnvArgs({
+        NEMOCLAW_PROXY_HOST: "1.2.3.4",
+        NEMOCLAW_PROXY_PORT: "70000",
+      }),
+      ["NEMOCLAW_PROXY_HOST=1.2.3.4"],
+    );
+    assert.deepEqual(
+      buildSandboxProxyEnvArgs({
+        NEMOCLAW_PROXY_HOST: "::1",
+        NEMOCLAW_PROXY_PORT: "9999",
+      }),
+      ["NEMOCLAW_PROXY_PORT=9999"],
+    );
   });
 
   it("#2281: bakes NEMOCLAW_AGENT_TIMEOUT env into the staged Dockerfile", () => {


### PR DESCRIPTION
## Summary

Closes the test coverage gap that allowed #1409 to be marked fixed twice before the runtime `--env` passthrough actually landed in #2581. Build-time and runtime now share the same validators and are both pinned by regression tests.

## Related Issue

Closes #1409.

## Changes

- Extract the proxy env-args block in `src/lib/onboard.ts` into a `buildSandboxProxyEnvArgs` helper next to the existing `isValidProxyHost` / `isValidProxyPort` validators. No behaviour change at the call site (`envArgs.push(...buildSandboxProxyEnvArgs())`).
- Export the helper from `src/lib/onboard.ts` so the test file can import it.
- Add three regression tests under the existing `regression #1409:` naming in `test/onboard.test.ts`:
  - propagates `NEMOCLAW_PROXY_HOST/PORT` to sandbox runtime env
  - emits no proxy runtime env args when host/port are unset
  - rejects malformed values at runtime (shell-injection host, non-numeric port, out-of-range port, IPv6 literal)

The original #1409 fix in #1563 only covered the build-time Dockerfile substitution. QA reproduced the bug on v0.0.11, v0.0.16, and v0.0.23 because the runtime `--env` passthrough that #2581 added was never pinned — the build-time test passed while the runtime path silently dropped the env. #2842 then hardened the build-time path to skip malformed numeric env vars; this PR mirrors that hardening on the runtime side via the shared validators. Coverage is now symmetric.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored proxy settings configuration for sandbox creation. Extracted proxy environment argument construction into a dedicated helper function for improved code modularity and reusability.

* **Tests**
  * Added comprehensive tests validating proxy environment argument generation under various configurations, including edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->