### PR TITLE
fix(policies): deep-merge network_policies groups so agent-declared binaries survive preset application

### DIFF
--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -207,13 +207,127 @@ function textBasedMerge(currentPolicy: string, presetEntries: string): string {
 }
 
 /**
+ * Type guard — narrow a PolicyValue to a plain object (excludes arrays/scalars).
+ */
+function isPlainPolicyObject(value: PolicyValue): value is PolicyObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Canonical key used for de-duplicating a single `binaries:` entry.
+ * Binaries are YAML objects like `{ path: /usr/bin/python3.11 }`. Dedup by
+ * the `path` field when it is a string; fall back to the stringified entry
+ * so unusual shapes still dedupe exactly.
+ */
+function binaryEntryKey(entry: PolicyValue): string {
+  if (isPlainPolicyObject(entry) && typeof entry.path === "string") {
+    return `path:${entry.path}`;
+  }
+  return JSON.stringify(entry);
+}
+
+/**
+ * Canonical key used for de-duplicating a single `endpoints:` entry.
+ * Endpoints are YAML objects keyed by (host, port). Duplicate definitions
+ * of the same host+port pair collapse to the last-seen entry so the more
+ * specific / later definition wins (matches preset-overrides-base semantics
+ * at the endpoint level even when doing a union merge at the group level).
+ */
+function endpointEntryKey(entry: PolicyValue): string {
+  if (isPlainPolicyObject(entry)) {
+    const host = typeof entry.host === "string" ? entry.host : "";
+    const port = typeof entry.port === "number" ? String(entry.port) : "";
+    if (host) return `hostport:${host}:${port}`;
+  }
+  return JSON.stringify(entry);
+}
+
+/**
+ * Union two arrays of policy list entries (binaries, endpoints) preserving
+ * order, de-duplicating by a caller-supplied key function, and letting the
+ * later occurrence win when keys collide.
+ *
+ * Passing `unionList(base, overlay, key)` keeps everything in `base` that
+ * isn't superseded by `overlay`, then appends the overlay entries. This
+ * means preset-side definitions override base-policy definitions for the
+ * same identity (path, or host+port) while still retaining any base-only
+ * entries the preset didn't mention.
+ */
+function unionList(
+  base: PolicyValue[] | undefined,
+  overlay: PolicyValue[] | undefined,
+  key: (entry: PolicyValue) => string,
+): PolicyValue[] {
+  const overlayArr = Array.isArray(overlay) ? overlay : [];
+  const baseArr = Array.isArray(base) ? base : [];
+  const overlayKeys = new Set(overlayArr.map(key));
+  const result: PolicyValue[] = [];
+  const seen = new Set<string>();
+  for (const entry of baseArr) {
+    const k = key(entry);
+    if (overlayKeys.has(k)) continue;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    result.push(entry);
+  }
+  for (const entry of overlayArr) {
+    const k = key(entry);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    result.push(entry);
+  }
+  return result;
+}
+
+/**
+ * Merge a single policy group (e.g. `discord:`) from a preset into its
+ * counterpart from the base policy.
+ *
+ * Semantics:
+ *   - `binaries` and `endpoints` are UNIONED across base and preset so
+ *     additions in one side are not clobbered by the other. Dedup keys:
+ *     `path` for binaries, `(host, port)` for endpoints; on a key
+ *     collision the preset (overlay) entry wins.
+ *   - Every other key in the group (e.g. `name`, ad-hoc metadata) uses
+ *     preset-overrides-base semantics via a shallow spread. Presets remain
+ *     the source of truth for group identity and shape.
+ *
+ * Before this change the whole group was replaced wholesale on name
+ * collision, which silently dropped user-added entries in
+ * `policy-additions.yaml` (notably binaries) as soon as a built-in preset
+ * with the same group name was applied at onboarding time.
+ */
+function mergePolicyGroup(baseGroup: PolicyObject, presetGroup: PolicyObject): PolicyObject {
+  const merged: PolicyObject = { ...baseGroup, ...presetGroup };
+
+  const baseBinaries = Array.isArray(baseGroup.binaries) ? baseGroup.binaries : undefined;
+  const presetBinaries = Array.isArray(presetGroup.binaries) ? presetGroup.binaries : undefined;
+  if (baseBinaries || presetBinaries) {
+    merged.binaries = unionList(baseBinaries, presetBinaries, binaryEntryKey);
+  }
+
+  const baseEndpoints = Array.isArray(baseGroup.endpoints) ? baseGroup.endpoints : undefined;
+  const presetEndpoints = Array.isArray(presetGroup.endpoints) ? presetGroup.endpoints : undefined;
+  if (baseEndpoints || presetEndpoints) {
+    merged.endpoints = unionList(baseEndpoints, presetEndpoints, endpointEntryKey);
+  }
+
+  return merged;
+}
+
+/**
  * Merge preset entries into existing policy YAML using structured YAML
  * parsing. Replaces the previous text-based manipulation which could
  * produce invalid YAML when indentation or ordering varied.
  *
  * Behavior:
  *   - Parses both current policy and preset entries as YAML
- *   - Merges network_policies by name (preset overrides on collision)
+ *   - Merges network_policies by group name. On name collision:
+ *       * `binaries` and `endpoints` are UNIONED (so agent-declared
+ *         binaries in policy-additions.yaml survive preset application;
+ *         see mergePolicyGroup for identity/dedup rules).
+ *       * Other keys in the group (name, metadata) use preset-overrides
+ *         semantics via shallow spread.
  *   - Preserves all non-network sections (filesystem_policy, process, etc.)
  *   - Ensures version: 1 exists
  *
@@ -257,13 +371,26 @@ function mergePresetIntoPolicy(currentPolicy: string, presetEntries: string): st
     return textBasedMerge(normalizedCurrentPolicy, presetEntries);
   }
 
-  // Structured merge: preset entries override existing on name collision.
+  // Structured merge: on name collision, deep-merge the group so binaries
+  // and endpoints unify across base and preset. Presets still override for
+  // any group the base policy doesn't define.
   // Guard: network_policies may be an array in legacy policies — only
   // object-merge when both sides are plain objects.
   const existingNp = current.network_policies;
-  let mergedNp;
+  let mergedNp: PolicyObject;
   if (existingNp && typeof existingNp === "object" && !Array.isArray(existingNp)) {
-    mergedNp = { ...existingNp, ...presetPolicies };
+    mergedNp = { ...existingNp };
+    for (const [groupName, rawPresetGroup] of Object.entries(presetPolicies as PolicyObject)) {
+      const existingGroup = mergedNp[groupName];
+      const presetGroup: PolicyValue = rawPresetGroup;
+      if (isPlainPolicyObject(existingGroup) && isPlainPolicyObject(presetGroup)) {
+        mergedNp[groupName] = mergePolicyGroup(existingGroup, presetGroup);
+      } else {
+        // New group, or one side is not a plain object — fall back to
+        // preset-overrides-base (pre-existing behaviour).
+        mergedNp[groupName] = presetGroup;
+      }
+    }
   } else {
     mergedNp = presetPolicies;
   }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -619,7 +619,14 @@ describe("policies", () => {
       expect(merged).toContain("version: 1");
     });
 
-    it("deduplicates on policy name collision (preset overrides existing)", () => {
+    it("unions endpoints and binaries on policy name collision (base + preset)", () => {
+      // Base policy declares its own `pypi_access` group with an extra
+      // private mirror host and an agent-specific binary path. Merging in
+      // the preset (which also defines `pypi_access`) must PRESERVE the
+      // base entries and ADD the preset's pypi.org + binaries rather than
+      // wholesale-replacing the group. Regression test for the bug where
+      // agent-declared `binaries:` in policy-additions.yaml were silently
+      // dropped during the "Widening sandbox egress" onboarding step.
       const current =
         "version: 1\n\n" +
         "network_policies:\n" +
@@ -630,10 +637,51 @@ describe("policies", () => {
         "        port: 443\n" +
         "        access: full\n" +
         "    binaries:\n" +
-        "      - { path: /usr/bin/pip* }\n";
+        "      - { path: /usr/bin/pip3 }\n" +
+        "      - { path: /opt/hermes/.venv/bin/python }\n";
       const merged = policies.mergePresetIntoPolicy(current, realisticEntries);
+      // Preset's endpoints and binaries must be present
       expect(merged).toContain("pypi.org");
-      expect(merged).not.toContain("old-pypi.example.com");
+      expect(merged).toContain("/usr/bin/python3*");
+      // Base-only endpoints and binaries must survive the merge
+      expect(merged).toContain("old-pypi.example.com");
+      expect(merged).toContain("/opt/hermes/.venv/bin/python");
+      expect(merged).toContain("/usr/bin/pip3");
+    });
+
+    it("dedupes binaries by path when base and preset declare the same binary", () => {
+      // Same binary path on both sides should appear exactly once in the
+      // merged output — we preserve the preset's (overlay) entry so any
+      // additional fields on the preset side win on key collision.
+      const current =
+        "version: 1\n\n" +
+        "network_policies:\n" +
+        "  pypi_access:\n" +
+        "    name: pypi_access\n" +
+        "    binaries:\n" +
+        "      - { path: /usr/bin/python3* }\n";
+      const merged = policies.mergePresetIntoPolicy(current, realisticEntries);
+      const occurrences = merged.match(/\/usr\/bin\/python3\*/g) ?? [];
+      expect(occurrences.length).toBe(1);
+    });
+
+    it("dedupes endpoints by (host, port) on collision, preset wins", () => {
+      // If base and preset both declare pypi.org:443 with different access
+      // modes, the (host, port) pair collapses to a single entry and the
+      // preset (overlay) definition is the one that survives.
+      const current =
+        "version: 1\n\n" +
+        "network_policies:\n" +
+        "  pypi_access:\n" +
+        "    name: pypi_access\n" +
+        "    endpoints:\n" +
+        "      - host: pypi.org\n" +
+        "        port: 443\n" +
+        "        access: full\n";
+      const merged = policies.mergePresetIntoPolicy(current, realisticEntries);
+      // Exactly one pypi.org entry remains (preset's).
+      const occurrences = merged.match(/host:\s*pypi\.org\b/g) ?? [];
+      expect(occurrences.length).toBe(1);
     });
 
     it("preserves non-network sections during structured merge", () => {


### PR DESCRIPTION
## Summary

When a built-in preset (e.g. discord) and the agent's policy-additions.yaml both declare a network_policies group with the same name, the previous shallow spread in mergePresetIntoPolicy replaced the whole group with the preset's version — silently dropping any binaries or endpoints the agent had added. I came across this by adding a new python binary path to policy-additions.yaml and finding it absent from the running sandbox after the 'Widening sandbox egress' onboarding step.

## Changes

- binaries[] are unioned, deduped by path
- endpoints[] are unioned, deduped by (host, port)
- preset entries win on key collision (preserves 'preset is source of truth' for endpoint shape while still allowing agents to declare additional binaries and hosts in policy-additions.yaml)
- other group fields fall back to the pre-existing preset-overrides shallow-spread behaviour
- replaces the previous 'preset overrides existing endpoints' test case (which asserted the old replace-whole-group behaviour) with a 'unions endpoints and binaries on policy name collision' case reflecting the new semantics.
- adds 'dedupes binaries by path' and 'dedupes endpoints by (host, port)' test cases to cover the identity/collision rules.


## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes - Not Found - GET https://registry.npmjs.org/prek - Not found
- [ ] `npm test` passes -  vitest: command not found
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ben Barclay <ben@nousresearch.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy preset merging behavior improved: endpoints and binaries from presets are now combined with existing entries rather than overwriting them. Duplicate entries are deduplicated while preserving original user-provided values during merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->