### PR TITLE
fix(policy): allow hermes to make outbound requests

### DIFF
--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -63,6 +63,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/hermes }
       - { path: /usr/bin/python3.11 }
+      - { path: /opt/hermes/.venv/bin/python }
 
   github:
     name: github
@@ -76,6 +77,7 @@ network_policies:
     binaries:
       - { path: /usr/bin/gh }
       - { path: /usr/bin/git }
+      - { path: /opt/hermes/.venv/bin/python }
 
   # ── Nous Research — Hermes auth, updates, portal ──────────────
   nous_research:
@@ -105,6 +107,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/hermes }
       - { path: /usr/bin/python3.11 }
+      - { path: /opt/hermes/.venv/bin/python }
 
   # ── PyPI — needed for pip install (skill/plugin deps) ─────────
   pypi:
@@ -125,6 +128,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/pip3 }
       - { path: /usr/bin/python3.11 }
+      - { path: /opt/hermes/.venv/bin/python }
 
   # ── Messaging — pre-allowed for agent notifications ───────────
   telegram:
@@ -141,6 +145,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/python3.11 }
+      - { path: /opt/hermes/.venv/bin/python }
 
   discord:
     name: discord
@@ -164,3 +169,4 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/python3.11 }
+      - { path: /opt/hermes/.venv/bin/python }


### PR DESCRIPTION
## Summary
The current Hermes policy is referring to the system installed Python binary, not the virtualenv binary. As such it blocks outbound requests

## Changes
- Adds `/opt/hermes/.venv/bin/python` to the default hermes policy

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ben Barclay <ben@nousresearch.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hermes agent runtime configuration and access policies to enable proper integration with essential external services and platforms. This allows the agent to operate seamlessly across research repositories, package management systems, development platforms, and communication channels. These updates ensure the agent has necessary permissions for extended functionality and improved inter-service operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->