### PR TITLE
fix(onboard): resolve resume GPU drift, gateway env, and sandbox recreation signaling

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -9818,7 +9818,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
     const resumedSandboxGpuFlag: SandboxGpuFlag = resumeHasResolvedGpuIntent
       ? session?.gpuPassthrough === true
         ? "enable"
-        : "disable"
+        : null
       : null;
     const effectiveSandboxGpuFlag = explicitSandboxGpuFlag ?? resumedSandboxGpuFlag;
     let gpu;
@@ -9940,6 +9940,9 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       resume && session?.steps?.gateway?.status === "complete" && canReuseHealthyGateway;
     if (resumeGateway) {
       skippedStepMessage("gateway", "running");
+      if (isLinuxDockerDriverGatewayEnabled()) {
+        registerDockerDriverGatewayEndpoint();
+      }
     } else if (!resume && canReuseHealthyGateway) {
       skippedStepMessage("gateway", "running", "reuse");
       note("  Reusing healthy NemoClaw gateway.");
@@ -10160,16 +10163,19 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
           if (sandboxName) {
             registry.removeSandbox(sandboxName);
           }
+          RECREATE_SANDBOX = true;
         } else if (telegramConfigChanged) {
           note("  [resume] TELEGRAM_REQUIRE_MENTION changed; recreating sandbox.");
           if (sandboxName) {
             registry.removeSandbox(sandboxName);
           }
+          RECREATE_SANDBOX = true;
         } else if (sandboxGpuConfigChanged) {
           note("  [resume] Sandbox GPU settings changed; recreating sandbox.");
           if (sandboxName) {
             registry.removeSandbox(sandboxName);
           }
+          RECREATE_SANDBOX = true;
         } else if (sandboxReuseState === "not_ready") {
           note(
             `  [resume] Recorded sandbox '${sandboxName}' exists but is not ready; recreating it.`,
@@ -10180,6 +10186,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
           if (sandboxName) {
             registry.removeSandbox(sandboxName);
           }
+          RECREATE_SANDBOX = true;
         }
       }
       let nextWebSearchConfig = webSearchConfig;


### PR DESCRIPTION
## Summary

Fix three related bugs in the onboard resume flow that caused `onboard-resume-e2e` and `onboard-repair-e2e` to fail in [nightly-e2e run 25437682864](https://github.com/NVIDIA/NemoClaw/actions/runs/25437682864).

### Bug 1 — Spurious GPU drift during resume (onboard-resume-e2e)

When resuming a session without GPU passthrough, the resumed GPU flag was set to `"disable"` which produced `mode="0"`, conflicting with the original `mode="auto"` stored in the registry. Both modes are functionally identical on a non-GPU machine (neither enables GPU), but the string comparison in `hasSandboxGpuDrift` reports drift. This triggers sandbox recreation, which then aborts due to Bug 3.

**Fix:** Use `null` instead of `"disable"` when `session.gpuPassthrough` is `false`, so `resolveSandboxGpuConfig` produces the same `mode="auto"` as the original onboard.

### Bug 2 — Missing `OPENSHELL_GATEWAY` env var during resume gateway skip (onboard-repair-e2e)

`process.env.OPENSHELL_GATEWAY` is unconditionally deleted at the start of `onboard()` (line 9507). When the gateway step is skipped during resume (`resumeGateway=true`), `registerDockerDriverGatewayEndpoint()` is never called, so the env var remains unset. Subsequent `openshell sandbox get` calls in `getSandboxReuseState` fail to reach the gateway, causing the sandbox to be classified as `"not_ready"` instead of `"missing"`. The test expects the `"missing"` branch message.

**Fix:** Call `registerDockerDriverGatewayEndpoint()` on the Docker driver path when the gateway step is skipped during resume.

### Bug 3 — Resume drift handlers don't signal `createSandbox` for recreation

All resume drift handlers (web search, Telegram, GPU, state unavailable) call `registry.removeSandbox()` then fall through to `createSandbox()`. With the registry entry removed, `getSandboxAgentDrift` returns `{changed: true, existingAgentName: "unknown"}`, and without `RECREATE_SANDBOX` being set, the agent-drift guard aborts in non-interactive mode.

**Fix:** Set `RECREATE_SANDBOX = true` in each drift branch that calls `registry.removeSandbox()` so `isRecreateSandbox()` returns `true` and the agent-drift guard is bypassed.

## Test plan

- [ ] `onboard-resume-e2e` passes (Bug 1 + 3 fix)
- [ ] `onboard-repair-e2e` passes (Bug 2 fix)
- [ ] Existing nightly-e2e jobs unaffected (change is scoped to resume paths)
- [ ] Manual: run `nemoclaw onboard --resume` after a GPU-less first onboard — no spurious "GPU settings changed" message

Signed-off-by: Hung Le <hple@nvidia.com>


Fixes #3126
