### PR TITLE
fix(e2e): use correct SSH host prefix in device-auth-health test

### DIFF
--- a/test/e2e/test-device-auth-health.sh
+++ b/test/e2e/test-device-auth-health.sh
@@ -106,7 +106,7 @@ sandbox_exec() {
     -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 \
     -o LogLevel=ERROR \
-    "$SANDBOX_NAME" "$cmd" 2>/dev/null
+    "openshell-${SANDBOX_NAME}" "$cmd" 2>/dev/null
 }
 
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fix the `device-auth-health-e2e` nightly failure caused by `sandbox_exec()` using the wrong SSH host name. The function was SSHing to `"$SANDBOX_NAME"` (e.g., `e2e-health-auth`) but `openshell sandbox ssh-config` generates entries with the `openshell-` prefix (e.g., `Host openshell-e2e-health-auth`). This mismatch caused all in-sandbox health probes to return empty output, failing Phase 2 and Phase 5 recovery checks.

## Related Issue

Fixes #3130

## Changes

- Change SSH target in `sandbox_exec()` from `"$SANDBOX_NAME"` to `"openshell-${SANDBOX_NAME}"` in `test/e2e/test-device-auth-health.sh`, matching the convention used by every other E2E test in the repo

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## Evidence

**Failing run:** https://github.com/NVIDIA/NemoClaw/actions/runs/25446693015

**Root cause:** In `test/e2e/test-device-auth-health.sh`, `sandbox_exec()` (line 109) passed `"$SANDBOX_NAME"` to `ssh -F "$SSH_CONFIG"`, but the SSH config generated by `openshell sandbox ssh-config` creates `Host openshell-<name>` entries. SSH couldn't find a matching host entry, fell back to resolving the bare name as a hostname, failed silently (stderr suppressed by `2>/dev/null`), and returned empty output. All 10 retry attempts in Phase 2 saw "empty" instead of an HTTP status code.

**Cross-validation:** Every other E2E test that uses SSH sandbox exec uses the `openshell-${SANDBOX_NAME}` pattern:
- `test-network-policy.sh` → `"openshell-${SANDBOX_NAME}"`
- `test-hermes-discord-e2e.sh` → `"openshell-${SANDBOX_NAME}"`
- `test-sandbox-survival.sh` → `SSH_TARGET="openshell-${SANDBOX_NAME}"`
- `test-full-e2e.sh` → `"openshell-${SANDBOX_NAME}"`
- All 15+ other E2E tests follow the same convention

**Validation note:** Custom-e2e run on fork was blocked by missing `NVIDIA_API_KEY` secret (fork-specific infra limitation); fix correctness confirmed by source analysis.

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

---

Signed-off-by: Hung Le <hple@nvidia.com>


Fixes #3130
