### PR TITLE
fix(e2e): use openshell- prefix for SSH target in device-auth-health test

### DIFF
--- a/test/e2e/test-device-auth-health.sh
+++ b/test/e2e/test-device-auth-health.sh
@@ -93,6 +93,8 @@ setup_ssh() {
   SSH_CONFIG="$(mktemp)"
   if ! openshell sandbox ssh-config "$SANDBOX_NAME" >"$SSH_CONFIG" 2>/dev/null; then
     info "Failed to get SSH config for '$SANDBOX_NAME'"
+    rm -f "$SSH_CONFIG"
+    SSH_CONFIG=""
     return 1
   fi
 }
@@ -106,7 +108,7 @@ sandbox_exec() {
     -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 \
     -o LogLevel=ERROR \
-    "$SANDBOX_NAME" "$cmd" 2>/dev/null
+    "openshell-${SANDBOX_NAME}" "$cmd" 2>/dev/null
 }
 
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fix the `device-auth-health-e2e` nightly failure caused by a wrong SSH target in `sandbox_exec()`.

**Root cause**: `sandbox_exec()` connects via SSH to `$SANDBOX_NAME` (`e2e-health-auth`) instead of `openshell-$SANDBOX_NAME` (`openshell-e2e-health-auth`). The `openshell sandbox ssh-config` command generates a config with `Host openshell-<name>`, so without the prefix SSH finds no matching Host entry, falls back to a direct hostname lookup, fails silently (`2>/dev/null`), and returns empty output. This causes the Phase 2 health probes to always report empty and fail.

**Evidence**: Every other E2E test using SSH for in-sandbox commands (test-sandbox-survival.sh, test-network-policy.sh, test-telegram-injection.sh, test-kimi-inference-compat.sh, etc.) correctly uses the `openshell-` prefix. This test missed it when SSH support was added in commit 2f47f5e.

### Changes

1. **`test/e2e/test-device-auth-health.sh`** — Fix SSH target from `"$SANDBOX_NAME"` → `"openshell-${SANDBOX_NAME}"` (line 109)
2. **`test/e2e/test-device-auth-health.sh`** — Harden `setup_ssh()` to reset `SSH_CONFIG=""` on failure (matching `test-sandbox-survival.sh` pattern) so `sandbox_exec()` retries instead of reusing a broken config

### Validation

- Validation run on fork (custom-e2e): failed due to missing `NVIDIA_API_KEY` secret on fork — the fix itself was not exercised. The change is mechanical (prefix addition) matching the pattern in 10+ existing E2E tests.
- `bash -n` syntax check: passed

### Nightly failure

- **Run**: https://github.com/NVIDIA/NemoClaw/actions/runs/25447435353
- **Failed job**: `device-auth-health-e2e` — [job link](https://github.com/NVIDIA/NemoClaw/actions/runs/25447435353/job/74655329180)
- **Failure**: Phase 2 health probes returned empty (SSH to wrong target), 2 test assertions failed

Signed-off-by: Hung Le <hple@nvidia.com>

Fixes #3132