### PR TITLE
fix(ci): verify current Hermes config path

### DIFF
--- a/.github/workflows/sandbox-images-and-e2e.yaml
+++ b/.github/workflows/sandbox-images-and-e2e.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           set -euo pipefail
           docker run --rm --user sandbox nemoclaw-hermes-production \
-            test -r /opt/nemoclaw-generate-config.ts
+            test -r /opt/nemoclaw-hermes-config/generate-config.ts
           docker run --rm --user sandbox nemoclaw-hermes-production \
             test -r /opt/nemoclaw-hermes-plugin/plugin.yaml
           docker run --rm --user sandbox nemoclaw-hermes-production \

--- a/test/hermes-sandbox-workflow.test.ts
+++ b/test/hermes-sandbox-workflow.test.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+describe("Hermes sandbox image workflow", () => {
+  it("checks the current generated config path copied into the image", () => {
+    const workflow = fs.readFileSync(
+      path.join(repoRoot, ".github/workflows/sandbox-images-and-e2e.yaml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain("test -r /opt/nemoclaw-hermes-config/generate-config.ts");
+    expect(workflow).not.toContain("/opt/nemoclaw-generate-config.ts");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the main `sandbox-images-and-e2e / build-hermes-sandbox-image` failure that started after the Hermes config generator moved under `/opt/nemoclaw-hermes-config`. The workflow was still checking the old `/opt/nemoclaw-generate-config.ts` path after building the Hermes sandbox image.

## Changes
- Update `.github/workflows/sandbox-images-and-e2e.yaml` to verify `/opt/nemoclaw-hermes-config/generate-config.ts`.
- Add `test/hermes-sandbox-workflow.test.ts` so the workflow does not regress to the stale path.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification run:
- `npm run build:cli`
- `npx vitest run test/hermes-sandbox-workflow.test.ts`
- `npm run source-shape:check`
- commit/push hooks except `test-cli`; `test-cli` still fails locally on unrelated host-specific `src/lib/nim.test.ts` Orin/Spark assertions

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite to verify sandbox workflow YAML configuration path handling.

* **Chores**
  * Updated sandbox workflow configuration path for config generation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->