### PR TITLE
fix(cli): retry inference probe on HTTP 502/503

### DIFF
--- a/src/lib/onboard-inference-probes.ts
+++ b/src/lib/onboard-inference-probes.ts
@@ -117,7 +117,7 @@ function getProbeProcessTimeoutMs(args) {
   return (getCurlMaxTimeSeconds(args) + 5) * 1000;
 }
 
-const RETRIABLE_HTTP_PROBE_STATUSES = new Set([429]);
+const RETRIABLE_HTTP_PROBE_STATUSES = new Set([429, 502, 503]);
 const HTTP_PROBE_RETRY_DELAYS_MS = [5_000, 15_000, 30_000];
 
 function sleepSync(ms) {


### PR DESCRIPTION
## Summary

The `sandbox-operations-e2e` job in [nightly-e2e run #25458633748](https://github.com/NVIDIA/NemoClaw/actions/runs/25458633748) failed because the NVIDIA Endpoints API returned a transient HTTP 503 during the inference endpoint validation probe. The existing retry logic in `onboard-inference-probes.ts` only retried on HTTP 429 (rate limit), so the probe failed immediately instead of retrying.

This PR adds HTTP 502 (Bad Gateway) and 503 (Service Temporarily Unavailable) to `RETRIABLE_HTTP_PROBE_STATUSES`, so the existing backoff retry loop (5s → 15s → 30s) covers these common transient gateway errors.

## Related Issue

Fixes #3140

## Changes

- **`src/lib/onboard-inference-probes.ts`**: Added 502 and 503 to `RETRIABLE_HTTP_PROBE_STATUSES` (was `[429]`, now `[429, 502, 503]`)

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>