### PR TITLE
fix(e2e): pre-pull Docker base image with retries in crash-loop-recovery test

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -452,26 +452,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Pre-pull Docker base images
-        run: |
-          # Pre-pull the sandbox base image with retries to avoid Docker Hub
-          # unauthenticated rate-limit failures during the build step.
-          # See: https://docs.docker.com/docker-hub/download-rate-limit/
-          image="node:22-trixie-slim@sha256:2d9f5c76c8f4dd36e8f253bee5d828a83a6c09f36188f0b0414325232e0b175d"
-          for attempt in 1 2 3 4 5; do
-            if docker pull "$image"; then
-              echo "Pre-pull succeeded on attempt $attempt"
-              break
-            fi
-            if [ "$attempt" -eq 5 ]; then
-              echo "::warning::All 5 pre-pull attempts failed — build will retry inline"
-              break
-            fi
-            sleep_sec=$((attempt * 15))
-            echo "Pre-pull attempt $attempt failed, retrying in ${sleep_sec}s..."
-            sleep "$sleep_sec"
-          done
-
       - name: Run #2478 crash-loop recovery E2E test
         env:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -452,6 +452,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Pre-pull Docker base images
+        run: |
+          # Pre-pull the sandbox base image with retries to avoid Docker Hub
+          # unauthenticated rate-limit failures during the build step.
+          # See: https://docs.docker.com/docker-hub/download-rate-limit/
+          image="node:22-trixie-slim@sha256:2d9f5c76c8f4dd36e8f253bee5d828a83a6c09f36188f0b0414325232e0b175d"
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$image"; then
+              echo "Pre-pull succeeded on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::warning::All 5 pre-pull attempts failed — build will retry inline"
+              break
+            fi
+            sleep_sec=$((attempt * 15))
+            echo "Pre-pull attempt $attempt failed, retrying in ${sleep_sec}s..."
+            sleep "$sleep_sec"
+          done
+
       - name: Run #2478 crash-loop recovery E2E test
         env:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}

--- a/test/e2e/test-issue-2478-crash-loop-recovery.sh
+++ b/test/e2e/test-issue-2478-crash-loop-recovery.sh
@@ -300,6 +300,29 @@ if [ "${NEMOCLAW_NON_INTERACTIVE:-}" != "1" ] || [ "${NEMOCLAW_ACCEPT_THIRD_PART
 fi
 pass "Required env vars set"
 
+# Pre-pull Docker base images used by install.sh's sandbox build.
+# GitHub Actions runners share egress IPs, so unauthenticated Docker Hub
+# pulls can hit the 429 rate limit intermittently. Pulling ahead of time
+# with retries ensures the image is in the local cache before the build.
+NODE_IMAGE="node:22-trixie-slim@sha256:2d9f5c76c8f4dd36e8f253bee5d828a83a6c09f36188f0b0414325232e0b175d"
+pull_ok=false
+for attempt in 1 2 3 4 5; do
+  if docker pull "$NODE_IMAGE" >/dev/null 2>&1; then
+    pull_ok=true
+    break
+  fi
+  if [ "$attempt" -lt 5 ]; then
+    sleep_sec=$((attempt * 15))
+    info "Docker pre-pull attempt $attempt failed, retrying in ${sleep_sec}s..."
+    sleep "$sleep_sec"
+  fi
+done
+if $pull_ok; then
+  pass "Docker base image pre-pulled"
+else
+  info "WARNING: all 5 Docker pre-pull attempts failed — build will retry inline"
+fi
+
 # ══════════════════════════════════════════════════════════════════
 # Phase 1: Pre-cleanup + onboard
 # ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fix intermittent Docker Hub rate-limit failure in the `issue-2478-crash-loop-recovery-e2e` nightly job by pre-pulling the `node:22-trixie-slim` base image with exponential-backoff retries before `install.sh` builds the sandbox.

## Related Issue
Fixes #3142

## Changes

- Add a Docker base-image pre-pull step with 5 retry attempts (15–75 s backoff) in Phase 0 (Preflight) of `test/e2e/test-issue-2478-crash-loop-recovery.sh`
- The step is non-fatal: if all retries fail, the build still attempts the pull inline (matching current behavior)
- Pre-pulling caches the `node:22-trixie-slim@sha256:2d9f5c76...` layer locally so that `docker build` in `install.sh` finds it without hitting Docker Hub

**Root cause:** GitHub Actions runners share egress IPs, which makes Docker Hub's unauthenticated pull rate limit (100 pulls / 6 hours per IP) intermittent. The sandbox build's `FROM node:22-trixie-slim` directive triggers an unauthenticated pull that failed with `toomanyrequests` in [run 25459964655](https://github.com/NVIDIA/NemoClaw/actions/runs/25459964655/job/74699326540).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

---

Signed-off-by: Hung Le <hple@nvidia.com>