### PR TITLE
fix(ci): address post-stack review followups

### DIFF
--- a/scripts/check-layer-import-boundaries.ts
+++ b/scripts/check-layer-import-boundaries.ts
@@ -80,6 +80,13 @@ function collectImportRefs(absPath: string): ImportRef[] {
     ) {
       add(node.moduleSpecifier.text, node.moduleSpecifier);
     } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteralLike(node.moduleReference.expression)
+    ) {
+      add(node.moduleReference.expression.text, node.moduleReference.expression);
+    } else if (
       ts.isCallExpression(node) &&
       ((ts.isIdentifier(node.expression) && node.expression.text === "require") ||
         node.expression.kind === ts.SyntaxKind.ImportKeyword) &&
@@ -256,7 +263,10 @@ function checkCommandFile(absPath: string, repoPath: string, violations: Violati
   function visit(node: ts.Node): void {
     if (
       ts.isClassDeclaration(node) &&
-      node.heritageClauses?.some((clause) => clause.types.some(isCommandBase))
+      node.heritageClauses?.some(
+        (clause) =>
+          clause.token === ts.SyntaxKind.ExtendsKeyword && clause.types.some(isCommandBase),
+      )
     ) {
       commandClassCount += 1;
     }

--- a/src/lib/actions/dns.test.ts
+++ b/src/lib/actions/dns.test.ts
@@ -38,6 +38,25 @@ describe("runFixCoreDns", () => {
     expect(log).toHaveBeenCalledWith("Skipping CoreDNS patch: no supported Colima or Podman Docker socket found.");
   });
 
+  it("does not treat the Docker Desktop socket as Podman on macOS", () => {
+    const log = vi.fn();
+    const runDocker = vi.fn();
+    const result = runFixCoreDns(
+      {},
+      {
+        env: { HOME: "/Users/test" },
+        existsSocket: (socketPath) => socketPath === "/var/run/docker.sock",
+        log,
+        platform: "darwin",
+        runDocker,
+      },
+    );
+
+    expect(result).toEqual({ exitCode: 0, runtime: "unknown", skipped: true });
+    expect(runDocker).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith("Skipping CoreDNS patch: no supported Colima or Podman Docker socket found.");
+  });
+
   it("patches CoreDNS through docker with JSON-escaped Corefile payload", () => {
     const calls: Array<[string, string[]]> = [];
     const log = vi.fn();

--- a/src/lib/actions/dns.ts
+++ b/src/lib/actions/dns.ts
@@ -117,7 +117,7 @@ function detectDockerHost(env: NodeJS.ProcessEnv, deps: FixCoreDnsDeps): { docke
 
   const podmanCandidates =
     (deps.platform ?? process.platform) === "darwin"
-      ? [path.join(home, ".local/share/containers/podman/machine/podman.sock"), "/var/run/docker.sock"]
+      ? [path.join(home, ".local/share/containers/podman/machine/podman.sock")]
       : [
           path.join(env.XDG_RUNTIME_DIR || `/run/user/${deps.uid?.() ?? "1000"}`, "podman/podman.sock"),
           `/run/user/${deps.uid?.() ?? "1000"}/podman/podman.sock`,

--- a/test/layer-import-boundaries.test.ts
+++ b/test/layer-import-boundaries.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -19,5 +20,45 @@ describe("CLI layer import boundaries", () => {
 
     expect(`${result.stdout}${result.stderr}`).toContain("Layer import boundaries passed.");
     expect(result.status).toBe(0);
+  });
+
+  it("collects TypeScript import-equals references", () => {
+    const fixture = path.join(REPO_ROOT, "src", "lib", "domain", `__boundary-import-equals-${process.pid}.ts`);
+    try {
+      fs.writeFileSync(
+        fixture,
+        'import adapter = require("../adapters/openshell/client");\nexport const value = adapter;\n',
+      );
+      const result = spawnSync(TSX, [BOUNDARY_SCRIPT], {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+      });
+
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}${result.stderr}`).toContain("domain must not import src/lib/adapters/openshell/client.ts");
+    } finally {
+      fs.rmSync(fixture, { force: true });
+    }
+  });
+
+  it("counts only classes that extend Command as oclif command classes", () => {
+    const fixture = path.join(REPO_ROOT, "src", "lib", "commands", `__boundary-implements-${process.pid}.ts`);
+    try {
+      fs.writeFileSync(
+        fixture,
+        'import { Command } from "@oclif/core";\nclass NotACommand implements Command {}\n',
+      );
+      const result = spawnSync(TSX, [BOUNDARY_SCRIPT], {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+      });
+
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        "command files must define exactly one registered oclif command class; found 0",
+      );
+    } finally {
+      fs.rmSync(fixture, { force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
Addresses still-valid follow-up comments from the recently merged stack by tightening the layer boundary checker and correcting macOS CoreDNS runtime detection.

## Changes
- Teach `scripts/check-layer-import-boundaries.ts` to collect `import foo = require(...)` references.
- Count only `extends Command` heritage clauses as oclif command classes in the layer checker.
- Stop treating `/var/run/docker.sock` as a Podman socket on macOS during CoreDNS patch runtime detection.
- Add regression coverage for the boundary checker edge cases and macOS Docker Desktop socket handling.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined DNS host-detection logic on macOS to improve container runtime socket discovery and prevent misidentification.

* **Tests**
  * Added test coverage for macOS-specific DNS socket handling scenarios.
  * Enhanced validation testing for internal tooling to ensure stricter component detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->