### PR TITLE
ci(nightly): migrate E2E jobs to NVIDIA self-hosted runners

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -84,7 +84,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',cloud-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -118,7 +118,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',cloud-onboard-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -154,7 +154,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',cloud-inference-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -186,7 +186,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',skill-agent-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -218,7 +218,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',docs-validation-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -253,7 +253,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',messaging-providers-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -291,7 +291,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',messaging-compatible-endpoint-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -325,7 +325,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',kimi-inference-compat-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -375,7 +375,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',token-rotation-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -413,7 +413,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',sandbox-survival-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -446,7 +446,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',issue-2478-crash-loop-recovery-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -479,7 +479,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',hermes-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -514,7 +514,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',hermes-discord-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -554,7 +554,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',sandbox-operations-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -800,7 +800,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',inference-routing-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -831,7 +831,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',network-policy-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -864,7 +864,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',deployment-services-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -896,7 +896,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',diagnostics-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -930,7 +930,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',credential-migration-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -963,7 +963,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',snapshot-commands-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -995,7 +995,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',shields-config-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -1027,7 +1027,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',rebuild-openclaw-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -1060,7 +1060,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',upgrade-stale-sandbox-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -1093,7 +1093,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',rebuild-hermes-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -1126,7 +1126,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',rebuild-hermes-stale-base-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -1158,7 +1158,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',double-onboard-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -1195,7 +1195,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',onboard-repair-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -1232,7 +1232,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',onboard-resume-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -1269,7 +1269,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',runtime-overrides-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -1307,7 +1307,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',credential-sanitization-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -1348,7 +1348,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',telegram-injection-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -1392,7 +1392,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',overlayfs-autofix-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -1430,7 +1430,7 @@ jobs:
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',launchable-smoke-e2e,'))
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -3,7 +3,7 @@
 #
 # Nightly E2E tests:
 #
-#   cloud-e2e                Cloud inference (NVIDIA Endpoint API) on ubuntu-latest.
+#   cloud-e2e                Cloud inference (NVIDIA Endpoint API) on linux-amd64-cpu4.
 #   messaging-providers-e2e  Validates messaging credential provider/placeholder/L7-proxy chain
 #                            for Telegram + Discord + Slack. Uses fake tokens. Slack additionally
 #                            exercises the slack-token-rewriter Bolt-shape → canonical placeholder
@@ -26,7 +26,7 @@
 #   credential-migration-e2e Validates legacy ~/.nemoclaw/credentials.json migration to the
 #                            OpenShell gateway, secure zero-fill on unlink, allowlist filter
 #                            on non-credential env keys, and symlink-safe deletion.
-#   launchable-smoke-e2e     Community install path (brev-launchable-ci-cpu.sh) on ubuntu-latest.
+#   launchable-smoke-e2e     Community install path (brev-launchable-ci-cpu.sh) on linux-amd64-cpu4.
 #   gpu-e2e                  Local Ollama inference on an NVKS ephemeral GPU runner.
 #   gpu-double-onboard-e2e   Ollama proxy token consistency after re-onboard (#2553).
 #   notify-on-failure        Auto-creates a GitHub issue when any E2E job fails.


### PR DESCRIPTION
Switch all 33 nightly E2E jobs from `ubuntu-latest` (GitHub-hosted, 2 vCPU) to `linux-amd64-cpu4` (NVIDIA self-hosted, 4 vCPU). Meta jobs (notify-on-failure, report-to-pr, scorecard) stay on `ubuntu-latest` since they only make API calls.

**Motivation:** Full sandbox onboard E2E tests spend most of their time on Docker image builds. The NVIDIA runners have more CPU and should reduce per-job runtime. The `pr-self-hosted` workflow already uses these runners successfully for image builds on every PR.

**Validated:** The `device-auth-health-e2e` job was tested on `linux-amd64-cpu4` during PR #3128 development and completed in ~16 minutes (vs timing out at 15m on `ubuntu-latest`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly end-to-end test workflow updated to use the standardized Linux CPU runner (linux-amd64-cpu4) for most non-GPU jobs; GPU tests continue using dedicated GPU runners.
  * Reference for the launchable-smoke job updated to the new CPU runner.
  * Failure notification and scorecard jobs retain the same E2E job dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->