### PR TITLE
fix(gateway-state): accept Running phase as alive alongside Ready

### DIFF
--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -328,7 +328,7 @@ export async function ensureLiveSandboxOrExit(
   const lookup = await getReconciledSandboxGatewayState(sandboxName);
   if (lookup.state === "present") {
     const phase = parseSandboxPhase(lookup.output || "");
-    if (!allowNonReadyPhase && phase && phase !== "Ready") {
+    if (!allowNonReadyPhase && phase && phase !== "Ready" && phase !== "Running") {
       console.error(`  Sandbox '${sandboxName}' is stuck in '${phase}' phase.`);
       console.error(
         "  This usually happens when a process crash inside the sandbox prevented clean startup.",

--- a/src/lib/state/gateway.ts
+++ b/src/lib/state/gateway.ts
@@ -41,15 +41,20 @@ export function parseSandboxStatus(output: string, sandboxName: string): string 
 }
 
 /**
- * Check if a sandbox is in Ready state from `openshell sandbox list` output.
+ * Check if a sandbox is in a live state from `openshell sandbox list` output.
  * Strips ANSI codes and exact-matches the sandbox name in the first column.
- * Checks all columns for "Ready" (not just column 2) because the column
- * layout of `openshell sandbox list` varies across OpenShell versions.
+ * Checks all columns for "Ready" or "Running" (not just column 2) because
+ * the column layout of `openshell sandbox list` varies across OpenShell versions.
+ *
+ * Both "Ready" and "Running" indicate the sandbox is alive and health
+ * checks should proceed. On some deployments (e.g. Brev launchables) the
+ * sandbox stays in "Running" phase which is functionally equivalent to
+ * "Ready" — the agent is live and the gateway is reachable inside.
  */
 export function isSandboxReady(output: string, sandboxName: string): boolean {
   const cols = parseSandboxRow(output, sandboxName);
   if (!cols) return false;
-  return cols.includes("Ready") && !cols.includes("NotReady");
+  return (cols.includes("Ready") || cols.includes("Running")) && !cols.includes("NotReady");
 }
 
 /**

--- a/test/onboard-readiness.test.ts
+++ b/test/onboard-readiness.test.ts
@@ -88,6 +88,16 @@ describe("sandbox readiness parsing", () => {
     ).toBeTruthy();
   });
 
+  it("treats Running phase as alive (Brev launchable deployments)", () => {
+    expect(isSandboxReady("my-assistant   Running   2m ago", "my-assistant")).toBeTruthy();
+  });
+
+  it("treats Running phase with ANSI codes as alive", () => {
+    expect(
+      isSandboxReady("\x1b[1mmy-assistant\x1b[0m   \x1b[33mRunning\x1b[0m   2m ago", "my-assistant"),
+    ).toBeTruthy();
+  });
+
   it("rejects when output only contains name in a URL or path", () => {
     expect(
       !isSandboxReady("Connecting to my-assistant.openshell.internal Ready", "my-assistant"),


### PR DESCRIPTION
## Summary

Fixes #3138 — On some deployments (e.g. Brev launchables) the sandbox stays in `Running` phase which is functionally equivalent to `Ready`. The CLI previously treated this as "not ready", causing false-negative health reports, dashboard showing the agent as stopped, and recovery logic not triggering.

## Changes

| File | Change |
|------|--------|
| `src/lib/state/gateway.ts` | `isSandboxReady()` now matches both `Ready` and `Running` columns |
| `src/lib/actions/sandbox/gateway-state.ts` | `ensureLiveSandboxOrExit()` no longer exits on `Running` phase |
| `test/onboard-readiness.test.ts` | +2 tests for Running phase detection (plain text + ANSI-wrapped) |

## Testing

- `test/onboard-readiness.test.ts` — 36/36 passed
- `test/gateway-state.test.ts` — 37/37 passed

## Context

This is the CLI-side prerequisite for [brevdev/nemoclaw-image#10](https://github.com/brevdev/nemoclaw-image/issues/10), which replaces the onboard-ui's reinvented health checks with NemoClaw CLI calls. Originated from #2258 (sub-item #4), which was closed with work redirected to the nemoclaw-image repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sandboxes in "Running" state are now recognized as operational, expanding support for different sandbox phase conditions.

* **Tests**
  * Added test coverage for sandbox readiness detection with "Running" state and ANSI-encoded outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->