### PR TITLE
fix(install): add download retry with backoff to install-openshell.sh

### DIFF
--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -16,6 +16,30 @@ fail() {
   exit 1
 }
 
+# Retry a command with exponential backoff.
+# The OpenShell "dev" release is a rolling pre-release whose assets are
+# periodically deleted and re-uploaded by CI.  A download attempt that
+# lands in that transition window gets a transient HTTP 404.  Retrying
+# a handful of times with backoff is enough to ride it out.
+#
+# Usage: with_retry <max_attempts> <initial_delay_secs> <command...>
+with_retry() {
+  local max_attempts=$1 delay=$2; shift 2
+  local attempt=1
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if ((attempt >= max_attempts)); then
+      return 1
+    fi
+    warn "Attempt $attempt/$max_attempts failed — retrying in ${delay}s…"
+    sleep "$delay"
+    ((attempt++))
+    ((delay *= 2))
+  done
+}
+
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
@@ -142,8 +166,10 @@ trap 'rm -rf "$tmpdir"' EXIT
 download_with_curl() {
   local name
   for name in "${ASSETS[@]}" "${CHECKSUM_FILES[@]}"; do
-    curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/download/${RELEASE_TAG}/$name" \
-      -o "$tmpdir/$name"
+    with_retry 4 5 curl -fsSL \
+      "https://github.com/NVIDIA/OpenShell/releases/download/${RELEASE_TAG}/$name" \
+      -o "$tmpdir/$name" \
+    || fail "Failed to download $name from release '$RELEASE_TAG' after retries"
   done
 }
 


### PR DESCRIPTION
## Summary

Add download retry with exponential backoff to `scripts/install-openshell.sh` to handle transient HTTP 404s during OpenShell `dev` release asset re-publishing.

### Root cause

The OpenShell `dev` release is a rolling pre-release whose CI periodically deletes old assets and uploads new ones.  Nightly-e2e run [#25464591543](https://github.com/NVIDIA/NemoClaw/actions/runs/25464591543) started at 22:25 UTC and three jobs attempted the OpenShell download between 22:28:07–22:28:23 UTC — exactly when the `dev` release was being re-published (new assets uploaded at 22:28:11 UTC).  Both the `gh release download` path and the `curl` fallback returned 404 immediately with no retry, failing:

| Job | Failing step |
|-----|-------------|
| `cloud-onboard-e2e` | Run cloud onboard E2E test |
| `rebuild-hermes-e2e` | Run Hermes rebuild upgrade E2E test |
| `telegram-injection-e2e` | Install NemoClaw and onboard sandbox |

### Fix

A new `with_retry` shell helper wraps `curl` calls inside `download_with_curl()` with **4 attempts** and **exponential backoff** (5 s → 10 s → 20 s).  This gives ~35 s of tolerance — more than enough to ride out a release asset rotation.

### Files changed

- `scripts/install-openshell.sh` — added `with_retry` helper, wrapped `download_with_curl` curl calls

### Validation

The custom-e2e validation branch could not be pushed due to missing `workflow` scope on the token.  The fix is a mechanical bash-level retry wrapper; the three affected jobs now pass on the re-published assets (the transient 404 window has closed).

Signed-off-by: Hung Le <hple@nvidia.com>

Fixes #3148