### PR TITLE
fix(e2e): re-add ~/.local/bin to PATH after .bashrc sourcing

### DIFF
--- a/test/e2e/test-credential-migration.sh
+++ b/test/e2e/test-credential-migration.sh
@@ -103,6 +103,14 @@ if ! command -v openshell >/dev/null 2>&1; then
     fail "install.sh failed; see /tmp/nemoclaw-e2e-install.log"
     exit 1
   }
+  # Refresh PATH so install.sh-managed binaries are visible
+  if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.bashrc" 2>/dev/null || true
+  fi
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
 fi
 
 command -v openshell >/dev/null 2>&1 || {

--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -95,6 +95,10 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     source "$HOME/.bashrc" 2>/dev/null || true
   fi
+  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1

--- a/test/e2e/test-diagnostics.sh
+++ b/test/e2e/test-diagnostics.sh
@@ -106,6 +106,10 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     source "$HOME/.bashrc" 2>/dev/null || true
   fi
+  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -97,6 +97,10 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     source "$HOME/.bashrc" 2>/dev/null || true
   fi
+  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1


### PR DESCRIPTION
## Summary

Four E2E test scripts fail during `ensure_install()` / Phase 0 because `source ~/.bashrc` triggers `nvm.sh`, which rebuilds `$PATH` from scratch and drops `~/.local/bin` — the directory where `install.sh` places the `openshell` and `nemoclaw` binaries. The `command -v` check immediately after `.bashrc` sourcing cannot find the binaries and exits with "nemoclaw not found" / "openshell still missing after install".

This PR applies the same PATH-refresh guard already used by the passing `test-cloud-onboard-e2e.sh`: re-add `~/.local/bin` immediately after sourcing `.bashrc`.

**Diagnosed from nightly-e2e run [#25468013036](https://github.com/NVIDIA/NemoClaw/actions/runs/25468013036)** (commit `c25df40`).

## Related Issue

<!-- Fixes #NNN — will be updated after tracking issue is filed -->

## Changes

- `test/e2e/test-deployment-services.sh` — add PATH refresh after `.bashrc` sourcing in `install_nemoclaw()`
- `test/e2e/test-diagnostics.sh` — same fix in `install_nemoclaw()`
- `test/e2e/test-network-policy.sh` — same fix in `install_nemoclaw()`
- `test/e2e/test-credential-migration.sh` — add `.bashrc` sourcing + PATH refresh after `install.sh` call in Phase 0

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Evidence

**Failing jobs (4):**
| Job | Error |
|-----|-------|
| deployment-services-e2e | `nemoclaw not found` after install.sh |
| diagnostics-e2e | `nemoclaw not found` after install.sh |
| network-policy-e2e | `nemoclaw not found` after install.sh |
| credential-migration-e2e | `openshell still missing after install` |

**Root cause:** `nvm.sh` (loaded via `.bashrc`) reconstructs `$PATH` without preserving `~/.local/bin`, so `install.sh`-managed binaries become invisible.

**Passing reference:** `test-cloud-onboard-e2e.sh` lines 204-214 already guard against this with:
```bash
if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
  export PATH="$HOME/.local/bin:$PATH"
fi
```

## Verification
- [x] `bash -n` passes on all four edited scripts
- [x] No secrets, API keys, or credentials committed
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes

---
Signed-off-by: Hung Le <hple@nvidia.com>