### PR TITLE
fix(onboard): normalize openclaw config perms after gateway readiness

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -8406,7 +8406,44 @@ async function setupOpenclaw(sandboxName: string, model: string, provider: strin
     }
   }
 
+  // The gateway may rewrite openclaw.json after the sync script, resetting
+  // permissions to its default umask (600/700). Wait for the gateway to
+  // finish initializing, then re-normalize so the mutable-default state
+  // (660/2770) is what downstream tests and shields-up/down observe.
+  normalizeOpenclawConfigPerms(sandboxName);
+
   console.log(`  ✓ ${agentProductName()} gateway launched inside sandbox`);
+}
+
+/**
+ * Poll for gateway readiness, then re-apply the mutable-default permission
+ * set on /sandbox/.openclaw. This closes the race where the gateway's own
+ * config write lands after {@link buildSandboxConfigSyncScript} has already
+ * set 660/2770, reverting the directory to 600/700.
+ */
+function normalizeOpenclawConfigPerms(sandboxName: string): void {
+  // Give the gateway up to ~30 s to finish its initial config write.
+  for (let i = 0; i < 15; i += 1) {
+    if (isOpenclawReady(sandboxName)) break;
+    sleep(2);
+  }
+  const permsScript = `
+set -euo pipefail
+config_dir=/sandbox/.openclaw
+if [ -d "$config_dir" ]; then
+  config_dir_owner="$(stat -c '%U' "$config_dir" 2>/dev/null || echo unknown)"
+  if [ "$config_dir_owner" != "root" ]; then
+    chmod -R g+rwX,o-rwx "$config_dir" 2>/dev/null || true
+    find "$config_dir" -type d -exec chmod g+s {} + 2>/dev/null || true
+    chmod 2770 "$config_dir" 2>/dev/null || true
+    chmod 660 "$config_dir/openclaw.json" "$config_dir/.config-hash" 2>/dev/null || true
+  fi
+fi
+exit`.trim();
+  run(openshellArgv(["sandbox", "connect", sandboxName]), {
+    stdio: ["pipe", "ignore", "inherit"],
+    input: permsScript,
+  });
 }
 
 // ── Step 7: Policy presets ───────────────────────────────────────


### PR DESCRIPTION
## Summary

The shields-config-e2e test fails in Phase 2 ("Config is writable — mutable default") because it observes permissions 600/700 on `openclaw.json` / `.openclaw/` instead of the expected 660/2770. The OpenClaw gateway rewrites `openclaw.json` during its startup initialization using its default umask *after* `buildSandboxConfigSyncScript` has already set the correct mutable-default permissions, reverting them.

This PR adds `normalizeOpenclawConfigPerms()` which polls `isOpenclawReady()` (up to ~30 s) before re-applying the 660/2770 permission set, closing the race condition.

**Diagnosed from nightly-e2e run [#25468013036](https://github.com/NVIDIA/NemoClaw/actions/runs/25468013036)** (commit `c25df40`).

## Related Issue

<!-- Fixes #NNN — will be updated after tracking issue is filed -->

## Changes

- `src/lib/onboard.ts` — add `normalizeOpenclawConfigPerms()` function that:
  1. Polls `isOpenclawReady()` up to 15 × 2 s to wait for the gateway's initial config write
  2. Re-runs the same `chmod -R g+rwX,o-rwx` / `chmod 2770` / `chmod 660` permission normalization inside the sandbox
- Call site added in `setupOpenclaw()` after the config sync script completes

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Evidence

**Failing job:** shields-config-e2e

**Log excerpt:**
```
Config perms (default): 600 sandbox:sandbox
FAIL: Config file should start as mode 660: 600 sandbox:sandbox
Config dir perms (default): 700 sandbox:sandbox
FAIL: Config directory should be mode 2770: 700 sandbox:sandbox
```

**Root cause:** `buildSandboxConfigSyncScript` (onboard.ts Step 7) sets 660/2770 *before* the gateway finishes initializing. The gateway's startup config write produces 600/700 (process umask), clobbering the permissions. After `shields down` (which re-runs normalization), permissions are correctly 660/2770 — confirming the timing hypothesis.

**Fix approach:** Uses the same `isOpenclawReady()` + `sleep()` polling pattern already used by `waitForSandboxReady()` elsewhere in onboard.ts, and the same `sandbox connect` piped-script pattern used by the original sync script.

## Verification
- [x] Function signature and call site validated
- [x] No secrets, API keys, or credentials committed
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes

---
Signed-off-by: Hung Le <hple@nvidia.com>