### PR TITLE
feat(hermes): populate slack allowed users

### DIFF
--- a/agents/hermes/config/messaging-config.ts
+++ b/agents/hermes/config/messaging-config.ts
@@ -30,6 +30,9 @@ export function buildMessagingEnvLines(
   if (allowedIds.telegram?.length) {
     envLines.push(`TELEGRAM_ALLOWED_USERS=${allowedIds.telegram.map(String).join(",")}`);
   }
+  if (allowedIds.slack?.length) {
+    envLines.push(`SLACK_ALLOWED_USERS=${allowedIds.slack.map(String).join(",")}`);
+  }
 
   return envLines;
 }

--- a/docs/manage-sandboxes/messaging-channels.md
+++ b/docs/manage-sandboxes/messaging-channels.md
@@ -46,7 +46,7 @@ For details, refer to [Commands](../reference/commands.md).
 |---------|-----------------|-------------------|
 | Telegram | `TELEGRAM_BOT_TOKEN` | `TELEGRAM_ALLOWED_IDS` for DM allowlisting, `TELEGRAM_REQUIRE_MENTION` for group-chat replies |
 | Discord | `DISCORD_BOT_TOKEN` | `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `DISCORD_REQUIRE_MENTION` |
-| Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | None |
+| Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | `SLACK_ALLOWED_USERS` for DM allowlisting |
 
 Telegram uses a bot token from [BotFather](https://t.me/BotFather).
 Open Telegram, send `/newbot` to [@BotFather](https://t.me/BotFather), follow the prompts, and copy the token.
@@ -63,6 +63,9 @@ Set `DISCORD_USER_ID` to restrict access to one user; otherwise, any member of t
 
 Slack uses Socket Mode and requires two tokens.
 Use `SLACK_BOT_TOKEN` for the bot user OAuth token (`xoxb-...`) and `SLACK_APP_TOKEN` for the app-level Socket Mode token (`xapp-...`).
+`SLACK_ALLOWED_USERS` is a comma-separated list of Slack member IDs (starting with `U...`, or `W...` on enterprise grid) that are authorized to DM the bot.
+Set it to `*` to allow any user in the installed workspace.
+Find a member ID by opening a user's profile in Slack, then **View full profile → ⋯ → Copy member ID**.
 
 ## Enable Channels During Onboarding
 
@@ -108,7 +111,7 @@ $ nemoclaw my-assistant channels add slack
 
 `channels add` prompts for missing credentials, registers the bridge with the OpenShell gateway, updates the sandbox registry, and asks whether to rebuild immediately.
 Choose the rebuild so the running sandbox image picks up the new channel.
-If you need optional channel settings such as `TELEGRAM_ALLOWED_IDS`, `TELEGRAM_REQUIRE_MENTION`, `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, or `DISCORD_REQUIRE_MENTION`, export them before the rebuild starts.
+If you need optional channel settings such as `TELEGRAM_ALLOWED_IDS`, `TELEGRAM_REQUIRE_MENTION`, `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `DISCORD_REQUIRE_MENTION`, or `SLACK_ALLOWED_USERS`, export them before the rebuild starts.
 If you defer the rebuild, apply the change later:
 
 ```console

--- a/src/lib/messaging-channel-config.test.ts
+++ b/src/lib/messaging-channel-config.test.ts
@@ -18,6 +18,7 @@ describe("messaging channel config", () => {
       "DISCORD_SERVER_ID",
       "DISCORD_USER_ID",
       "DISCORD_REQUIRE_MENTION",
+      "SLACK_ALLOWED_USERS",
     ]);
   });
 

--- a/src/lib/sandbox-channels.test.ts
+++ b/src/lib/sandbox-channels.test.ts
@@ -28,6 +28,15 @@ describe("sandbox-channels KNOWN_CHANNELS", () => {
     expect(getChannelDef("slack")?.appTokenEnvKey).toBe("SLACK_APP_TOKEN");
   });
 
+  it("exposes a DM allowlist env key for slack", () => {
+    const slack = getChannelDef("slack");
+    expect(slack?.userIdEnvKey).toBe("SLACK_ALLOWED_USERS");
+    expect(slack?.allowIdsMode).toBe("dm");
+    // No serverIdEnvKey — Slack gates on workspace install + user allowlist,
+    // not on a server/guild selection like Discord.
+    expect(slack?.serverIdEnvKey).toBeUndefined();
+  });
+
   it("normalises case and whitespace when resolving a channel name", () => {
     expect(getChannelDef("  Telegram  ")).toBe(KNOWN_CHANNELS.telegram);
     expect(getChannelDef("DISCORD")).toBe(KNOWN_CHANNELS.discord);

--- a/src/lib/sandbox-channels.ts
+++ b/src/lib/sandbox-channels.ts
@@ -64,12 +64,16 @@ export const KNOWN_CHANNELS: Record<string, ChannelDef> = {
     help: "Slack API → Your Apps → OAuth & Permissions → Bot User OAuth Token (xoxb-...).",
     label: "Slack Bot Token",
     tokenFormat: /^xoxb-[A-Za-z0-9_-]+$/,
-    tokenFormatHint: "Slack bot tokens start with 'xoxb-' (e.g. xoxb-1234-5678-abcdef).",
+    tokenFormatHint: "Slack bot tokens start with 'xoxb-' (e.g. xoxb-1...cdef).",
     appTokenEnvKey: "SLACK_APP_TOKEN",
     appTokenHelp: "Slack API → Your Apps → Basic Information → App-Level Tokens (xapp-...).",
     appTokenLabel: "Slack App Token (Socket Mode)",
     appTokenFormat: /^xapp-[A-Za-z0-9_-]+$/,
     appTokenFormatHint: "Slack app tokens start with 'xapp-' (e.g. xapp-1-A0000-12345-abcdef).",
+    userIdEnvKey: "SLACK_ALLOWED_USERS",
+    userIdHelp: "Slack → View full profile → ⋯ → Copy member ID",
+    userIdLabel: "Slack User ID (for DM access)",
+    allowIdsMode: "dm",
   },
 };
 

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -177,6 +177,42 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).toContain("SLACK_APP_TOKEN=openshell:resolve:env:SLACK_APP_TOKEN\n");
   });
 
+  it("writes SLACK_ALLOWED_USERS to .env when slack allowed IDs are provided", () => {
+    const { envFile } = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["slack"]),
+      NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: encodeJson({
+        slack: ["U01ABCDEF", "U02GHIJKL"],
+      }),
+    });
+
+    expect(envFile).toContain("SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN\n");
+    expect(envFile).toContain("SLACK_APP_TOKEN=openshell:resolve:env:SLACK_APP_TOKEN\n");
+    expect(envFile).toContain("SLACK_ALLOWED_USERS=U01ABCDEF,U02GHIJKL\n");
+  });
+
+  it("omits SLACK_ALLOWED_USERS when no slack allowed IDs are provided", () => {
+    const { envFile } = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["slack"]),
+      NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: encodeJson({}),
+    });
+
+    expect(envFile).not.toContain("SLACK_ALLOWED_USERS=");
+  });
+
+  it("passes a slack '*' wildcard through to SLACK_ALLOWED_USERS unchanged", () => {
+    const { envFile } = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["slack"]),
+      NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: encodeJson({
+        slack: ["*"],
+      }),
+    });
+
+    // Hermes' slack platform treats '*' as "any workspace user" — see
+    // gateway/platforms/slack.py. The NemoClaw config builder must not
+    // rewrite or filter the wildcard.
+    expect(envFile).toContain("SLACK_ALLOWED_USERS=*\n");
+  });
+
   it("omits Telegram behavior config when requireMention is not boolean", () => {
     const { config, envFile } = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["telegram"]),


### PR DESCRIPTION
## Summary
The Slack integration in Hermes Agent requires one of:
- A pre-populated list of allowed User IDs
- Configuration to allow global access
- Per user approval on an ad-hoc basis

Without one of those options, the integration doesn't really do anything.

This change brings Slack in line with the Discord and Telegram platforms by prompting the user for a slack user ID during the onboarding flow, then pre-populating the allowed user ids.

## Changes
- Prompts for Discord User ID during onboard
- Configured Hermes Agent to use that User ID at runtime
- Implements some unit tests for the behaviour

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes - just the unit test failure mentioned below
- [ ] `npm test` passes - I have a single test failure in a seemingly unrelated test file
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ben Barclay <ben@nousresearch.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack Direct Message allowlisting is now configurable using the `SLACK_ALLOWED_USERS` environment variable to restrict messaging access to specific team members
  * Wildcard support (`*`) allows unrestricted access when needed

* **Documentation**
  * Updated setup documentation with Slack member ID retrieval instructions and allowlist configuration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->