### PR TITLE
fix(installer): prefer sha256sum over shasum for checksum verification (#3170)

### DIFF
--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -364,10 +364,17 @@ else
 fi
 
 info "Verifying SHA-256 checksum..."
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA_CMD="shasum -a 256"
+else
+  fail "No SHA-256 tool available (sha256sum/shasum)"
+fi
 for i in "${!ASSETS[@]}"; do
   asset_name="${ASSETS[$i]}"
   checksum_file="${CHECKSUM_FILES[$i]}"
-  (cd "$tmpdir" && grep -F "$asset_name" "$checksum_file" | shasum -a 256 -c -) \
+  (cd "$tmpdir" && grep -F "$asset_name" "$checksum_file" | $SHA_CMD -c -) \
     || fail "SHA-256 checksum verification failed for $asset_name"
 done
 

--- a/test/install-openshell-version-check.test.ts
+++ b/test/install-openshell-version-check.test.ts
@@ -248,7 +248,7 @@ fi
 exit 0`,
       );
       writeExecutable(
-        path.join(fakeBin, "shasum"),
+        path.join(fakeBin, "sha256sum"),
         `#!/usr/bin/env bash
 cat >/dev/null
 echo "checksum OK"
@@ -352,7 +352,7 @@ fi
 exit 0`,
       );
       writeExecutable(
-        path.join(fakeBin, "shasum"),
+        path.join(fakeBin, "sha256sum"),
         `#!/usr/bin/env bash
 cat >/dev/null
 echo "checksum OK"

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -740,8 +740,8 @@ describe("regression guards", () => {
           return 0
         }
         export -f curl
-        shasum() { cat >/dev/null; echo "checksum OK"; return 0; }
-        export -f shasum
+        sha256sum() { cat >/dev/null; echo "checksum OK"; return 0; }
+        export -f sha256sum
         strings() { echo "request-body-credential-rewrite websocket-credential-rewrite"; }
         export -f strings
         tar() { return 0; }; export -f tar
@@ -765,7 +765,7 @@ describe("regression guards", () => {
     it("install-openshell.sh gh-present-but-fails path falls back to curl", () => {
       const scriptPath = path.join(import.meta.dirname, "..", "scripts", "install-openshell.sh");
       const tmpBin = fs.mkdtempSync(path.join(os.tmpdir(), "gh-stub-"));
-      const checksumLog = path.join(tmpBin, "shasum.log");
+      const checksumLog = path.join(tmpBin, "sha256sum.log");
       const ghStub = path.join(tmpBin, "gh");
       fs.writeFileSync(ghStub, "#!/bin/sh\nexit 4\n");
       fs.chmodSync(ghStub, 0o755);
@@ -777,8 +777,8 @@ describe("regression guards", () => {
         export PATH="${tmpBin}:/usr/bin:/bin"
         curl() { echo "CURL_FALLBACK $*"; return 0; }
         export -f curl
-        shasum() { echo "SHASUM $*" >> ${JSON.stringify(checksumLog)}; echo "checksum OK"; return 0; }
-        export -f shasum
+        sha256sum() { echo "SHA256SUM $*" >> ${JSON.stringify(checksumLog)}; echo "checksum OK"; return 0; }
+        export -f sha256sum
         strings() { echo "request-body-credential-rewrite websocket-credential-rewrite"; }
         export -f strings
         tar() { return 0; }; export -f tar
@@ -793,7 +793,7 @@ describe("regression guards", () => {
         const out = (result.stdout || "") + (result.stderr || "");
         expect(out).toContain("falling back to curl");
         expect(out).toContain("CURL_FALLBACK");
-        expect(fs.readFileSync(checksumLog, "utf-8")).toContain("SHASUM -a 256 -c -");
+        expect(fs.readFileSync(checksumLog, "utf-8")).toContain("SHA256SUM -c -");
       } finally {
         fs.rmSync(tmpBin, { recursive: true, force: true });
       }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The install-openshell.sh script hardcoded shasum, which is less common on Linux. Use sha256sum when available, fall back to shasum, and fail with a clear error if neither is found — matching the existing pattern in check-installer-hash.sh.

## Related Issue
Fixes #3170 

## Changes
- Update scripts/install-openshell.sh to prefer sha256sum, fallback to shasum, fail otherwise
<!-- Bullet list of key changes. -->

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Oliver Walsh <owalsh@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer checksum verification now auto-selects an available checksum utility at runtime and aborts if none are found, improving reliability across environments.

* **Tests**
  * Updated installation tests to validate the new checksum selection behavior and adjusted expected verification logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->