### PR TITLE
fix(gateway-token): emit agent-aware UX for non-OpenClaw sandboxes (#3180)

### DIFF
--- a/src/lib/cli/oclif-runner.test.ts
+++ b/src/lib/cli/oclif-runner.test.ts
@@ -113,4 +113,44 @@ describe("runRegisteredOclifCommand", () => {
 
     await expect(runRegisteredOclifCommand("list", [], { rootDir: "/repo" })).rejects.toBe(error);
   });
+
+  it("exits cleanly without rethrowing when oclif Command.exit(code) bubbles up", async () => {
+    // NCQ #3180: throwing an ExitError out of the runner leaks a raw
+    // @oclif/core stack trace to the user. Treat any non-zero ExitError
+    // (carrying `oclif.exit`) as a graceful exit with that code.
+    class ExitError extends Error {
+      oclif = { exit: 1 };
+    }
+    runCommandMock.mockRejectedValue(new ExitError("EEXIT: 1"));
+    const errorLine = vi.fn();
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit:${code}`);
+    });
+
+    await expect(
+      runRegisteredOclifCommand("sandbox:gateway:token", ["hermes"], {
+        rootDir: "/repo",
+        error: errorLine,
+        exit,
+      }),
+    ).rejects.toThrow("exit:1");
+
+    expect(errorLine).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("rethrows other oclif error classes that carry oclif.exit", async () => {
+    // RequiredArgsError and friends ride the same `oclif.exit` channel as
+    // ExitError but carry a user-visible message that oclif's own handler
+    // is responsible for printing. Don't swallow those.
+    class RequiredArgsError extends Error {
+      oclif = { exit: 2 };
+    }
+    const error = new RequiredArgsError("Missing 1 required arg: path");
+    runCommandMock.mockRejectedValue(error);
+
+    await expect(runRegisteredOclifCommand("skill:install", [], { rootDir: "/repo" })).rejects.toBe(
+      error,
+    );
+  });
 });

--- a/src/lib/cli/oclif-runner.ts
+++ b/src/lib/cli/oclif-runner.ts
@@ -28,6 +28,14 @@ function isOclifParseError(error: unknown): boolean {
   return name === "NonExistentFlagsError" || name === "UnexpectedArgsError" || name === "CLIError";
 }
 
+function isOclifExitError(error: unknown): boolean {
+  const name =
+    error && typeof error === "object"
+      ? (error as { constructor?: { name?: string } }).constructor?.name
+      : "";
+  return name === "ExitError";
+}
+
 function formatOclifError(error: unknown): string {
   if (error instanceof Error) {
     return error.message.trim();
@@ -80,6 +88,15 @@ export async function runRegisteredOclifCommand(
     if (isOclifParseError(error)) {
       errorLine(`  ${formatOclifError(error)}`);
       exit(exitCode ?? 1);
+    }
+
+    // NCQ #3180: oclif's Command.exit(code) throws an ExitError carrying
+    // `oclif.exit`. Treat that as a graceful exit with the requested code
+    // so we don't leak a raw `at Object.exit (... /@oclif/core/...)` stack
+    // trace to the user. Other oclif error classes (e.g. RequiredArgsError)
+    // are left to bubble up so oclif's own handler still prints them.
+    if (isOclifExitError(error) && typeof exitCode === "number") {
+      exit(exitCode);
     }
 
     throw error;

--- a/src/lib/commands/gateway-token.ts
+++ b/src/lib/commands/gateway-token.ts
@@ -82,11 +82,10 @@ export default class GatewayTokenCliCommand extends Command {
     );
     // NCQ #3180: avoid this.exit(code), which throws @oclif/core ExitError.
     // The legacy `nemoclaw <name> gateway-token` dispatch did not catch the
-    // throw, leaking a raw JS stack trace to the user. Setting
-    // process.exitCode keeps the diagnostic output clean while still
-    // signalling failure to shell callers.
-    if (exitCode !== 0) {
-      process.exitCode = exitCode;
-    }
+    // throw, leaking a raw JS stack trace to the user. Always assigning
+    // process.exitCode keeps the diagnostic output clean and prevents a
+    // stale non-zero code from a prior run() in the same process from
+    // bleeding through on a successful invocation.
+    process.exitCode = exitCode;
   }
 }

--- a/src/lib/commands/gateway-token.ts
+++ b/src/lib/commands/gateway-token.ts
@@ -7,12 +7,28 @@ import { runGatewayTokenCommand } from "../gateway-token-command";
 
 type GatewayTokenRuntimeBridge = {
   fetchGatewayAuthTokenFromSandbox: (sandboxName: string) => string | null;
+  getSandboxAgent: (sandboxName: string) => string | null;
 };
 
 /* v8 ignore next -- source tests inject this bridge; CLI subprocess tests cover the real onboard module. */
 let runtimeBridgeFactory = (): GatewayTokenRuntimeBridge => {
-  const onboard = require("../onboard") as GatewayTokenRuntimeBridge;
-  return { fetchGatewayAuthTokenFromSandbox: onboard.fetchGatewayAuthTokenFromSandbox };
+  const onboard = require("../onboard") as Pick<
+    GatewayTokenRuntimeBridge,
+    "fetchGatewayAuthTokenFromSandbox"
+  >;
+  const registry = require("../state/registry") as {
+    getSandbox: (name: string) => { agent?: string | null } | null;
+  };
+  return {
+    fetchGatewayAuthTokenFromSandbox: onboard.fetchGatewayAuthTokenFromSandbox,
+    getSandboxAgent: (sandboxName: string) => {
+      try {
+        return registry.getSandbox(sandboxName)?.agent ?? null;
+      } catch {
+        return null;
+      }
+    },
+  };
 };
 
 export function setGatewayTokenRuntimeBridgeFactoryForTest(
@@ -59,8 +75,18 @@ export default class GatewayTokenCliCommand extends Command {
     const exitCode = runGatewayTokenCommand(
       args.sandboxName,
       { quiet: flags.quiet === true },
-      { fetchToken: runtime.fetchGatewayAuthTokenFromSandbox },
+      {
+        fetchToken: runtime.fetchGatewayAuthTokenFromSandbox,
+        getSandboxAgent: runtime.getSandboxAgent,
+      },
     );
-    if (exitCode !== 0) this.exit(exitCode);
+    // NCQ #3180: avoid this.exit(code), which throws @oclif/core ExitError.
+    // The legacy `nemoclaw <name> gateway-token` dispatch did not catch the
+    // throw, leaking a raw JS stack trace to the user. Setting
+    // process.exitCode keeps the diagnostic output clean while still
+    // signalling failure to shell callers.
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
   }
 }

--- a/src/lib/commands/simple-global-oclif-adapters.test.ts
+++ b/src/lib/commands/simple-global-oclif-adapters.test.ts
@@ -130,6 +130,24 @@ describe("simple global oclif adapters", () => {
     }
   });
 
+  it("clears a stale non-zero process.exitCode on a successful gateway-token run", async () => {
+    // CodeRabbit #3182: if a prior run() left process.exitCode = 1, a later
+    // successful invocation must still report success. Always overwrite.
+    mocks.runGatewayTokenCommand.mockReturnValueOnce(0);
+    setGatewayTokenRuntimeBridgeFactoryForTest(() => ({
+      fetchGatewayAuthTokenFromSandbox: mocks.fetchGatewayAuthTokenFromSandbox,
+      getSandboxAgent: () => "openclaw",
+    }));
+    const previousExitCode = process.exitCode;
+    process.exitCode = 1;
+    try {
+      await GatewayTokenCliCommand.run(["alpha", "--quiet"], rootDir);
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
   it("runs hidden root help and version adapters", async () => {
     await RootHelpCommand.run([], rootDir);
     await VersionCommand.run([], rootDir);

--- a/src/lib/commands/simple-global-oclif-adapters.test.ts
+++ b/src/lib/commands/simple-global-oclif-adapters.test.ts
@@ -96,8 +96,10 @@ describe("simple global oclif adapters", () => {
   });
 
   it("maps gateway-token flags to the gateway token action", async () => {
+    const getSandboxAgent = vi.fn(() => "openclaw");
     setGatewayTokenRuntimeBridgeFactoryForTest(() => ({
       fetchGatewayAuthTokenFromSandbox: mocks.fetchGatewayAuthTokenFromSandbox,
+      getSandboxAgent,
     }));
 
     await GatewayTokenCliCommand.run(["alpha", "--quiet"], rootDir);
@@ -105,8 +107,27 @@ describe("simple global oclif adapters", () => {
     expect(mocks.runGatewayTokenCommand).toHaveBeenCalledWith(
       "alpha",
       { quiet: true },
-      { fetchToken: mocks.fetchGatewayAuthTokenFromSandbox },
+      { fetchToken: mocks.fetchGatewayAuthTokenFromSandbox, getSandboxAgent },
     );
+  });
+
+  it("uses process.exitCode (no @oclif/core ExitError) when the gateway-token action fails", async () => {
+    // NCQ #3180: legacy dispatch did not catch the @oclif/core ExitError
+    // thrown by this.exit(1), surfacing a raw JS stack trace to the user.
+    // The adapter must signal failure via process.exitCode instead.
+    mocks.runGatewayTokenCommand.mockReturnValueOnce(1);
+    setGatewayTokenRuntimeBridgeFactoryForTest(() => ({
+      fetchGatewayAuthTokenFromSandbox: mocks.fetchGatewayAuthTokenFromSandbox,
+      getSandboxAgent: () => "hermes",
+    }));
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await expect(GatewayTokenCliCommand.run(["hermes"], rootDir)).resolves.toBeUndefined();
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 
   it("runs hidden root help and version adapters", async () => {

--- a/src/lib/gateway-token-command.test.ts
+++ b/src/lib/gateway-token-command.test.ts
@@ -143,7 +143,9 @@ describe("runGatewayTokenCommand", () => {
     expect(getSandboxAgent).toHaveBeenCalledWith("hermes");
     expect(fetchToken).not.toHaveBeenCalled();
     expect(sinks.out).toEqual([]);
-    const stderr = sinks.err.join("\n");
+    // Issue #3180 contract: a single agent-aware "not applicable" line.
+    expect(sinks.err).toHaveLength(1);
+    const stderr = sinks.err[0] ?? "";
     expect(stderr).toMatch(/hermes/);
     expect(stderr).toMatch(/OpenClaw/);
     expect(stderr).toMatch(/not applicable/i);

--- a/src/lib/gateway-token-command.test.ts
+++ b/src/lib/gateway-token-command.test.ts
@@ -126,4 +126,81 @@ describe("runGatewayTokenCommand", () => {
     expect(exitCode).toBe(1);
     expect(sinks.out).toEqual([]);
   });
+
+  // NCQ #3180: gateway-token is OpenClaw-specific. On non-OpenClaw agents
+  // (e.g. Hermes) the misleading "make sure the sandbox is running" message
+  // and the @oclif/core stack trace must NOT appear.
+  it("prints an agent-aware not-applicable message on hermes without invoking fetchToken", () => {
+    const sinks = makeSinks();
+    const fetchToken = vi.fn(() => "should-not-be-called");
+    const getSandboxAgent = vi.fn(() => "hermes");
+    const exitCode = runGatewayTokenCommand(
+      "hermes",
+      { quiet: false },
+      { fetchToken, getSandboxAgent, log: sinks.log, error: sinks.error },
+    );
+    expect(exitCode).toBe(1);
+    expect(getSandboxAgent).toHaveBeenCalledWith("hermes");
+    expect(fetchToken).not.toHaveBeenCalled();
+    expect(sinks.out).toEqual([]);
+    const stderr = sinks.err.join("\n");
+    expect(stderr).toMatch(/hermes/);
+    expect(stderr).toMatch(/OpenClaw/);
+    expect(stderr).toMatch(/not applicable/i);
+    expect(stderr).not.toMatch(/sandbox is running/i);
+    expect(stderr).not.toMatch(/ExitError|@oclif\/core|at Object\.exit/);
+  });
+
+  it("falls back to fetchToken when the agent lookup throws", () => {
+    const sinks = makeSinks();
+    const exitCode = runGatewayTokenCommand(
+      "alpha",
+      { quiet: true },
+      {
+        fetchToken: () => "openclaw-token",
+        getSandboxAgent: () => {
+          throw new Error("registry unavailable");
+        },
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+    expect(exitCode).toBe(0);
+    expect(sinks.out).toEqual(["openclaw-token"]);
+  });
+
+  it("uses the OpenClaw control path when the resolved agent is openclaw", () => {
+    const sinks = makeSinks();
+    const fetchToken = vi.fn(() => "openclaw-token");
+    const exitCode = runGatewayTokenCommand(
+      "alpha",
+      { quiet: true },
+      {
+        fetchToken,
+        getSandboxAgent: () => "openclaw",
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+    expect(exitCode).toBe(0);
+    expect(fetchToken).toHaveBeenCalledWith("alpha");
+    expect(sinks.out).toEqual(["openclaw-token"]);
+  });
+
+  it("uses the OpenClaw control path when getSandboxAgent returns null", () => {
+    // Sandbox registry pre-dates the agent field — treat as OpenClaw.
+    const sinks = makeSinks();
+    const exitCode = runGatewayTokenCommand(
+      "alpha",
+      { quiet: true },
+      {
+        fetchToken: () => "openclaw-token",
+        getSandboxAgent: () => null,
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+    expect(exitCode).toBe(0);
+    expect(sinks.out).toEqual(["openclaw-token"]);
+  });
 });

--- a/src/lib/gateway-token-command.ts
+++ b/src/lib/gateway-token-command.ts
@@ -15,6 +15,15 @@
 export interface GatewayTokenCommandDeps {
   /** Pull gateway.auth.token from the sandbox config (host-side helper). */
   fetchToken: (sandboxName: string) => string | null;
+  /**
+   * Resolve the agent name registered for the sandbox (e.g. "openclaw",
+   * "hermes"). When omitted -- or when the lookup throws -- the OpenClaw
+   * code path is used unchanged so callers without registry access keep
+   * working. Returning null is treated the same as "openclaw" since the
+   * registry stored that as the implicit default before the agent field
+   * existed.
+   */
+  getSandboxAgent?: (sandboxName: string) => string | null;
   /** Optional stdout sink -- defaults to console.log. */
   log?: (message: string) => void;
   /** Optional stderr sink -- defaults to console.error. */
@@ -41,6 +50,28 @@ export function runGatewayTokenCommand(
 ): number {
   const log = deps.log ?? ((m: string) => console.log(m));
   const error = deps.error ?? ((m: string) => console.error(m));
+
+  // NCQ #3180: gateway-token only applies to the OpenClaw agent. Hermes (and
+  // any other non-OpenClaw agent) does not store a gateway auth token, so
+  // skip the OpenClaw lookup entirely and surface an agent-aware message
+  // instead of the misleading "make sure the sandbox is running" hint.
+  let resolvedAgent: string | null = null;
+  if (deps.getSandboxAgent) {
+    try {
+      resolvedAgent = deps.getSandboxAgent(sandboxName);
+    } catch {
+      resolvedAgent = null;
+    }
+  }
+  if (resolvedAgent && resolvedAgent !== "openclaw") {
+    error(
+      `  gateway-token is not applicable for the '${resolvedAgent}' agent -- it is OpenClaw-specific.`,
+    );
+    error(
+      `  Sandbox '${sandboxName}' uses the ${resolvedAgent} agent, which does not expose an equivalent token.`,
+    );
+    return 1;
+  }
 
   let token: string | null;
   try {

--- a/src/lib/gateway-token-command.ts
+++ b/src/lib/gateway-token-command.ts
@@ -65,10 +65,7 @@ export function runGatewayTokenCommand(
   }
   if (resolvedAgent && resolvedAgent !== "openclaw") {
     error(
-      `  gateway-token is not applicable for the '${resolvedAgent}' agent -- it is OpenClaw-specific.`,
-    );
-    error(
-      `  Sandbox '${sandboxName}' uses the ${resolvedAgent} agent, which does not expose an equivalent token.`,
+      `  gateway-token is not applicable for sandbox '${sandboxName}': it uses the '${resolvedAgent}' agent, which does not expose a gateway auth token. This command only supports the OpenClaw agent.`,
     );
     return 1;
   }


### PR DESCRIPTION
## Summary

- `nemohermes <name> gateway-token` now exits cleanly with an agent-aware "not applicable" message instead of suggesting "make sure the sandbox is running" against a healthy Hermes sandbox.
- The CLI command signals failure via `process.exitCode` rather than `Command.exit(code)`, so the legacy sandbox dispatch path no longer leaks an uncaught `@oclif/core` `ExitError` stack trace to the terminal.
- Defensive belt-and-suspenders: `oclif-runner` now treats any `ExitError` reaching the runner as a graceful exit-with-code, so other commands can't regress into the same trap. `RequiredArgsError`/`CLIError`/etc. still propagate so oclif's own handler keeps printing them.

The OpenClaw control path (`nemoclaw <name> gateway-token`) is unchanged.

Fixes #3180.

## Root cause

`gateway-token` reads `cfg.gateway.auth.token` from `/sandbox/.openclaw/openclaw.json`. Hermes uses `/sandbox/.hermes/config.yaml` and has no equivalent token, so the OpenClaw lookup correctly returned `null` — but the downstream UX printed an OpenClaw-shaped failure hint and threw `Command.exit(1)`, whose `ExitError` was rethrown unhandled into the user's terminal.

## Test plan

- [x] `npx vitest run src/lib/gateway-token-command.test.ts` — 13/13 pass (4 new tests cover the Hermes UX contract + the registry-null fallback)
- [x] `npx vitest run src/lib/cli/oclif-runner.test.ts` — 6/6 pass (2 new tests cover ExitError handling + non-ExitError rethrow)
- [x] `npx vitest run src/lib/commands/simple-global-oclif-adapters.test.ts` — 7/7 pass (1 new test asserts the CLI uses `process.exitCode` rather than throwing `ExitError`)
- [x] `npx vitest run --project cli` — all 3092 cli tests pass
- [x] `npm run lint`
- [x] `npx tsc -p tsconfig.cli.json`

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sandbox agent detection for the gateway-token command to handle different sandbox types and short-circuit when incompatible.

* **Bug Fixes**
  * CLI now distinguishes graceful exits from user-facing errors and uses process exit code signaling for cleaner output.
  * Gateway-token avoids token retrieval for non-supported agents and emits agent-specific diagnostics.

* **Tests**
  * Added coverage for exit-code behavior, agent-aware control flow, and exitCode clearing on success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->