### PR TITLE
fix(test): restore port-resolution assertions in nimStatusByName tests

### DIFF
--- a/src/lib/nim.test.ts
+++ b/src/lib/nim.test.ts
@@ -456,6 +456,9 @@ describe("nim", () => {
 
           expect(st).toMatchObject({ running: true, healthy: true, container: "foo", state: "running" });
           expect(commands.some((c) => c[0] === "docker" && c.includes("port"))).toBe(true);
+          expect(commands.some((c) => c.includes("http://127.0.0.1:9000/v1/models"))).toBe(
+            true,
+          );
           expect(
             timeoutForCommand(
               runCapture,
@@ -486,7 +489,13 @@ describe("nim", () => {
 
       try {
         const st = nimModule.nimStatusByName("foo");
+        const commands = runCapture.mock.calls.map(([c]: [string | string[]]) => c);
+
         expect(st).toMatchObject({ running: true, healthy: true, container: "foo", state: "running" });
+        expect(commands.some((c) => c[0] === "docker" && c.includes("port"))).toBe(true);
+        expect(commands.some((c) => c.includes("http://127.0.0.1:8000/v1/models"))).toBe(
+          true,
+        );
       } finally {
         restore();
       }


### PR DESCRIPTION
## Summary
Restore the curl-URL assertions in two `nimStatusByName` tests so they actually verify the port-resolution logic instead of only the boolean health result.

## Related Issue
Closes #1280

## Changes
- `src/lib/nim.test.ts`:
  - "uses published docker port when no port is provided" — assert the curl call used `http://127.0.0.1:9000/v1/models`.
  - "falls back to 8000 when docker port lookup fails" — assert the curl call used `http://127.0.0.1:8000/v1/models`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for health-probe verification scenarios to ensure proper command execution validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->