### PR TITLE
fix(e2e): re-add ~/.local/bin to PATH after .bashrc sourcing

### DIFF
--- a/test/e2e/lib/install-path-refresh.sh
+++ b/test/e2e/lib/install-path-refresh.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared install-path-refresh helper for e2e test scripts. Meant to be sourced;
+# the shebang and executable bit satisfy repo shell-file conventions.
+#
+# Why: install.sh places the openshell/nemoclaw binaries under ~/.local/bin.
+# Sourcing ~/.bashrc on GitHub runners triggers nvm.sh, which rebuilds $PATH
+# from scratch and drops ~/.local/bin — so a post-install `command -v
+# nemoclaw` check fails with "nemoclaw not found". This helper centralises
+# the recovery so every e2e test script applies the same guard.
+#
+# Usage:
+#   . "$(dirname "${BASH_SOURCE[0]}")/lib/install-path-refresh.sh"
+#
+#   # After running install.sh, reload the shell profile and pick up the
+#   # binaries it installed:
+#   nemoclaw_refresh_install_env
+#
+#   # If you only need to defensively ensure ~/.local/bin is on PATH:
+#   nemoclaw_ensure_local_bin_on_path
+
+# Prepend ~/.local/bin to PATH if it exists and isn't already there.
+nemoclaw_ensure_local_bin_on_path() {
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
+}
+
+# Source ~/.bashrc (best-effort) and then ensure ~/.local/bin is on PATH.
+# Needed after running install.sh because nvm.sh (loaded via .bashrc) rebuilds
+# PATH from scratch and can drop the directory where install.sh places the
+# openshell/nemoclaw binaries.
+nemoclaw_refresh_install_env() {
+  if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.bashrc" 2>/dev/null || true
+  fi
+  nemoclaw_ensure_local_bin_on_path
+}

--- a/test/e2e/test-cloud-inference-e2e.sh
+++ b/test/e2e/test-cloud-inference-e2e.sh
@@ -88,6 +88,8 @@ CLOUD_MODEL="${NEMOCLAW_CLOUD_EXPERIMENTAL_MODEL:-nvidia/nemotron-3-super-120b-a
 # Source shared teardown helper
 # shellcheck source=test/e2e/lib/sandbox-teardown.sh
 . "${E2E_DIR}/lib/sandbox-teardown.sh"
+# shellcheck source=test/e2e/lib/install-path-refresh.sh
+. "${E2E_DIR}/lib/install-path-refresh.sh"
 register_sandbox_for_teardown "$SANDBOX_NAME"
 
 # ══════════════════════════════════════════════════════════════════════
@@ -127,14 +129,11 @@ kill "$tail_pid" 2>/dev/null || true
 wait "$tail_pid" 2>/dev/null || true
 
 # Source shell profile
-if [ -f "$HOME/.bashrc" ]; then
-  # shellcheck source=/dev/null
-  source "$HOME/.bashrc" 2>/dev/null || true
-fi
+nemoclaw_refresh_install_env
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 # shellcheck source=/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && export PATH="$HOME/.local/bin:$PATH"
+nemoclaw_ensure_local_bin_on_path
 
 if [ "$install_exit" -ne 0 ]; then
   fail "install.sh failed (exit $install_exit)"

--- a/test/e2e/test-cloud-onboard-e2e.sh
+++ b/test/e2e/test-cloud-onboard-e2e.sh
@@ -85,6 +85,8 @@ PUBLIC_INSTALL_CWD="${NEMOCLAW_PUBLIC_INSTALL_CWD:-}"
 # Source shared teardown helper
 # shellcheck source=test/e2e/lib/sandbox-teardown.sh
 . "${E2E_DIR}/lib/sandbox-teardown.sh"
+# shellcheck source=test/e2e/lib/install-path-refresh.sh
+. "${E2E_DIR}/lib/install-path-refresh.sh"
 register_sandbox_for_teardown "$SANDBOX_NAME"
 
 # ══════════════════════════════════════════════════════════════════════
@@ -202,16 +204,11 @@ else
 fi
 
 # Source shell profile to pick up nvm/PATH changes
-if [ -f "$HOME/.bashrc" ]; then
-  # shellcheck source=/dev/null
-  source "$HOME/.bashrc" 2>/dev/null || true
-fi
+nemoclaw_refresh_install_env
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 # shellcheck source=/dev/null
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-  export PATH="$HOME/.local/bin:$PATH"
-fi
+nemoclaw_ensure_local_bin_on_path
 
 if [ "$install_exit" -eq 0 ]; then
   pass "Public install completed (exit 0)"

--- a/test/e2e/test-credential-migration.sh
+++ b/test/e2e/test-credential-migration.sh
@@ -103,6 +103,14 @@ if ! command -v openshell >/dev/null 2>&1; then
     fail "install.sh failed; see /tmp/nemoclaw-e2e-install.log"
     exit 1
   }
+  # Refresh PATH so install.sh-managed binaries are visible
+  if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.bashrc" 2>/dev/null || true
+  fi
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
 fi
 
 command -v openshell >/dev/null 2>&1 || {

--- a/test/e2e/test-credential-migration.sh
+++ b/test/e2e/test-credential-migration.sh
@@ -85,6 +85,9 @@ SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-cred-migration}"
 . "$(dirname "${BASH_SOURCE[0]}")/lib/sandbox-teardown.sh"
 register_sandbox_for_teardown "$SANDBOX_NAME"
 
+# shellcheck source=test/e2e/lib/install-path-refresh.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/install-path-refresh.sh"
+
 # ══════════════════════════════════════════════════════════════════
 # Phase 0: Prerequisites
 # ══════════════════════════════════════════════════════════════════
@@ -104,13 +107,7 @@ if ! command -v openshell >/dev/null 2>&1; then
     exit 1
   }
   # Refresh PATH so install.sh-managed binaries are visible
-  if [ -f "$HOME/.bashrc" ]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.bashrc" 2>/dev/null || true
-  fi
-  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$HOME/.local/bin:$PATH"
-  fi
+  nemoclaw_refresh_install_env
 fi
 
 command -v openshell >/dev/null 2>&1 || {

--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -28,6 +28,8 @@ export NEMOCLAW_E2E_DEFAULT_TIMEOUT=3600
 SCRIPT_DIR_TIMEOUT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=test/e2e/e2e-timeout.sh
 source "${SCRIPT_DIR_TIMEOUT}/e2e-timeout.sh"
+# shellcheck source=test/e2e/lib/install-path-refresh.sh
+source "${SCRIPT_DIR_TIMEOUT}/lib/install-path-refresh.sh"
 
 # ── Colors ───────────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'
@@ -76,9 +78,7 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     . "$NVM_DIR/nvm.sh"
   fi
-  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$HOME/.local/bin:$PATH"
-  fi
+  nemoclaw_ensure_local_bin_on_path
 
   if command -v nemoclaw >/dev/null 2>&1; then
     log "nemoclaw already installed: $(nemoclaw --version 2>/dev/null || echo unknown)"
@@ -91,14 +91,7 @@ install_nemoclaw() {
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
     bash "$REPO_ROOT/install.sh" --non-interactive --yes-i-accept-third-party-software \
     2>&1 | tee -a "$LOG_FILE"
-  if [ -f "$HOME/.bashrc" ]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.bashrc" 2>/dev/null || true
-  fi
-  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
-  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$HOME/.local/bin:$PATH"
-  fi
+  nemoclaw_refresh_install_env
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1

--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -95,6 +95,10 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     source "$HOME/.bashrc" 2>/dev/null || true
   fi
+  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1

--- a/test/e2e/test-diagnostics.sh
+++ b/test/e2e/test-diagnostics.sh
@@ -106,6 +106,10 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     source "$HOME/.bashrc" 2>/dev/null || true
   fi
+  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1

--- a/test/e2e/test-diagnostics.sh
+++ b/test/e2e/test-diagnostics.sh
@@ -80,6 +80,9 @@ skip() {
 # ── Resolve repo root ────────────────────────────────────────────────────────
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# shellcheck source=test/e2e/lib/install-path-refresh.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/install-path-refresh.sh"
+
 # ── Install NemoClaw if not present ──────────────────────────────────────────
 install_nemoclaw() {
   export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
@@ -87,9 +90,7 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     . "$NVM_DIR/nvm.sh"
   fi
-  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$HOME/.local/bin:$PATH"
-  fi
+  nemoclaw_ensure_local_bin_on_path
 
   if command -v nemoclaw >/dev/null 2>&1; then
     log "nemoclaw already installed: $(nemoclaw --version 2>/dev/null || echo unknown)"
@@ -102,14 +103,7 @@ install_nemoclaw() {
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
     bash "$REPO_ROOT/install.sh" --non-interactive --yes-i-accept-third-party-software \
     2>&1 | tee -a "$LOG_FILE"
-  if [ -f "$HOME/.bashrc" ]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.bashrc" 2>/dev/null || true
-  fi
-  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
-  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$HOME/.local/bin:$PATH"
-  fi
+  nemoclaw_refresh_install_env
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -97,6 +97,10 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     source "$HOME/.bashrc" 2>/dev/null || true
   fi
+  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
+  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -29,6 +29,8 @@ export NEMOCLAW_E2E_DEFAULT_TIMEOUT=3600
 SCRIPT_DIR_TIMEOUT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=test/e2e/e2e-timeout.sh
 source "${SCRIPT_DIR_TIMEOUT}/e2e-timeout.sh"
+# shellcheck source=test/e2e/lib/install-path-refresh.sh
+source "${SCRIPT_DIR_TIMEOUT}/lib/install-path-refresh.sh"
 
 # ── Config ───────────────────────────────────────────────────────────────────
 SANDBOX_NAME="e2e-net-policy"
@@ -77,9 +79,7 @@ install_nemoclaw() {
     # shellcheck source=/dev/null
     . "$NVM_DIR/nvm.sh"
   fi
-  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$HOME/.local/bin:$PATH"
-  fi
+  nemoclaw_ensure_local_bin_on_path
 
   if command -v nemoclaw >/dev/null 2>&1; then
     log "nemoclaw already installed: $(nemoclaw --version 2>/dev/null || echo unknown)"
@@ -93,14 +93,7 @@ install_nemoclaw() {
     NEMOCLAW_POLICY_TIER="restricted" \
     bash "$REPO_ROOT/install.sh" --non-interactive --yes-i-accept-third-party-software \
     2>&1 | tee -a "$LOG_FILE"
-  if [ -f "$HOME/.bashrc" ]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.bashrc" 2>/dev/null || true
-  fi
-  # Re-add ~/.local/bin after .bashrc — nvm.sh may rebuild PATH, dropping it
-  if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$HOME/.local/bin:$PATH"
-  fi
+  nemoclaw_refresh_install_env
   if ! command -v nemoclaw >/dev/null 2>&1; then
     log "ERROR: install.sh failed — nemoclaw not found"
     exit 1


### PR DESCRIPTION
## Summary

The e2e test harness sources `~/.bashrc` to pick up the freshly-installed `nemoclaw` CLI, but on images whose `.bashrc` resets `PATH` (or unconditionally prepends system paths) this wipes the `~/.local/bin` entry that `install.sh` just added, breaking every downstream `nemoclaw ...` invocation. This PR re-adds `~/.local/bin` to `PATH` after `.bashrc` sourcing and extracts the pattern into a shared helper so it stays consistent as more scripts adopt it.

## Related Issue

Supersedes #3156 (cherry-picked with author credit preserved to Hung Le).

## Changes

- **Fix (cherry-picked from #3156, attribution preserved):** re-add `~/.local/bin` to `PATH` after sourcing `~/.bashrc` in the cloud e2e test scripts, so the installed `nemoclaw` CLI remains resolvable on images whose `.bashrc` rewrites `PATH`.
- **Refactor:** extract the PATH-refresh pattern into `test/e2e/lib/install-path-refresh.sh` with two helpers:
  - `nemoclaw_refresh_install_env` — source `.bashrc` then guarantee `~/.local/bin` is on `PATH`
  - `nemoclaw_ensure_local_bin_on_path` — idempotent prepend of `~/.local/bin`
- Migrate 6 scripts (4 PR-touched + 2 adjacent references) to the helper: `test-cloud-inference-e2e.sh`, `test-cloud-onboard-e2e.sh`, `test-credential-migration.sh`, `test-deployment-services.sh`, `test-diagnostics.sh`, `test-network-policy.sh`.
- Net diff: +67 / −33 lines across 7 files (including the new 41-line helper).

**Follow-up (not in this PR):** ~23 additional e2e scripts also carry a copy of the inline `.local/bin on PATH` guard. Intentionally left out to keep this PR scoped to the scripts flagged in the original review. Tracked in #3201.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

**Verification notes:**
- `bash -n` syntax check passes on the new helper and all 6 migrated scripts.
- Helper is sourceable via all three patterns the scripts use: `dirname "${BASH_SOURCE[0]}"/lib/`, `${E2E_DIR}/lib/`, and `${SCRIPT_DIR_TIMEOUT}/lib/`.
- Functional test of `nemoclaw_ensure_local_bin_on_path` confirmed: prepends `~/.local/bin` when missing, is idempotent when already present.
- Zero inline leftovers of the old pattern in the 6 migrated scripts.
- `npm test` has 18 unrelated timeout failures in `test/install-preflight.test.ts` (installer integration suite) on this machine; this PR does not touch that file (0 diff lines against it) and does not modify any code path it exercises. The actual e2e scripts changed here run in the Brev cloud suite, which is out of the `npm test` scope.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
