### PR TITLE
docs: prepare 0.0.37 release docs

### DIFF
--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -162,7 +162,8 @@ Skip this step when the user only asked for ordinary doc catch-up and no release
 If the user invoked this skill for release prep, finish the release-specific doc work before verification:
 
 1. Make any requested doc version bumps in `versions1.json` and `project.json` in the `docs/` directory.
-2. Refresh the NemoClaw user skills:
+2. Determine the release label from the release version. Release labels use `vX.Y.Z` format. For example, if `docs/project.json` has `"version": "0.0.37"`, the release label is `v0.0.37`. Use the version requested by the user if one was provided; otherwise use the version in `docs/project.json` after the bump.
+3. Refresh the NemoClaw user skills:
 
    ```bash
    python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user
@@ -191,7 +192,9 @@ Commit changes and open a pull request with a concise summary of the doc updates
 - #<doc-impacting-PR-number> -> `docs/path.md`: Description of the doc change reflecting the source code changes in the PR.
 ```
 
-Apply the `documentation` label so reviewers can identify doc-only changes.
+Apply the `documentation` label and the corresponding release label so reviewers can identify doc-only changes for the target release.
+When creating the PR with `gh pr create`, pass both labels, for example `--label documentation --label v0.0.37`.
+If the release label does not exist, report that instead of substituting another label.
 
 ## Tips
 
@@ -201,7 +204,7 @@ Apply the `documentation` label so reviewers can identify doc-only changes.
 - PRs that are purely internal refactors with no behavior change do not need doc updates, even if they touch high-signal directories.
 - To suppress documentation for a merged feature that is not ready for public docs, add it to `docs/.docs-skip`. Remove the entry once the feature is ready to document.
 
-## Example Usage
+## Summary of Steps
 
 User says: "Catch up the docs for everything merged since v0.1.0."
 
@@ -214,10 +217,10 @@ User says: "Catch up the docs for everything merged since v0.1.0."
 7. **Release prep only:** Run `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user`.
 8. Present the summary.
 9. Build with `make docs` to verify.
-10. **Release prep only:** Commit changes and open a pull request with a concise summary of the doc updates and a source summary that links each identified merged PR to its matching doc page. Include the PR number, affected doc page, links, and description of the doc change in this shape:
+10. **Release prep only:** Commit changes and open a pull request with the `documentation` label and the corresponding `vX.Y.Z` release label. Include a concise summary of the doc updates and a source summary that links each identified merged PR to its matching doc page. Include the PR number, affected doc page, links, and description of the doc change in this shape:
 
    ```markdown
    - #<doc-impacting-PR-number> -> `docs/path.md`: Description of the doc change reflecting the source code changes in the PR.
    ```
 
-11.Apply the `documentation` label so reviewers can identify doc-only changes.
+   If the release label does not exist, report that the PR was created without the release label or that PR creation failed because the label was missing.

--- a/.agents/skills/nemoclaw-user-deploy-remote/references/sandbox-hardening.md
+++ b/.agents/skills/nemoclaw-user-deploy-remote/references/sandbox-hardening.md
@@ -11,6 +11,11 @@ Build toolchains (`gcc`, `g++`, `make`) and network probes (`netcat`) are
 explicitly purged from the runtime image. These tools are not needed at runtime
 and would unnecessarily widen the attack surface.
 
+The runtime image keeps a small set of operational utilities for normal sandbox
+workflows, including `vi`, `jq`, and `dos2unix`. Use these for lightweight
+inspection and file cleanup inside the sandbox, but make durable image or policy
+changes in the NemoClaw source tree and rebuild the sandbox.
+
 If you need a compiler during build, use the existing multi-stage build
 (the `builder` stage has full Node.js tooling) and copy only artifacts into the
 runtime stage.

--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -168,7 +168,7 @@ Available presets:
 |--------|-----------|
 | `brave` | Brave Search API |
 | `brew` | Homebrew (Linuxbrew) package manager |
-| `discord` | Discord webhook API |
+| `discord` | Discord API, gateway, and CDN access |
 | `github` | GitHub and GitHub REST API |
 | `huggingface` | Hugging Face Hub (download-only) and inference router |
 | `jira` | Atlassian Jira API |

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/references/messaging-channels.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/references/messaging-channels.md
@@ -47,6 +47,7 @@ Use `SLACK_BOT_TOKEN` for the bot user OAuth token (`xoxb-...`) and `SLACK_APP_T
 When the wizard reaches **Messaging channels**, it lists Telegram, Discord, and Slack.
 Press a channel number to toggle it on or off, then press **Enter** when done.
 If a token is not already in the environment or credential store, the wizard prompts for it and saves it.
+NemoClaw also selects the matching network policy preset during policy setup so the channel can reach its provider API.
 
 For scripted setup, export the credentials and optional settings for the channels you want to enable before you run onboarding:
 

--- a/.agents/skills/nemoclaw-user-reference/references/network-policies.md
+++ b/.agents/skills/nemoclaw-user-reference/references/network-policies.md
@@ -67,6 +67,9 @@ All endpoints use TLS termination and are enforced at port 443.
 > **Note:** GitHub access (`github.com`, `api.github.com`) is not included in the baseline policy.
 > Apply the `github` preset during onboarding if your agent needs GitHub access.
 > See Customize the Network Policy (use the `nemoclaw-user-manage-policy` skill).
+>
+> Messaging endpoints for Telegram, Discord, and Slack are not included in the baseline policy.
+> Enable the channel during onboarding or apply the matching messaging preset so the sandbox can reach that platform.
 
 (policy-tiers)=
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -895,6 +895,22 @@ GPU passthrough is not CI-tested on DGX Spark.
 It is expected to work when you pass `--gpu` and the NVIDIA Container Toolkit is configured.
 Verify the toolkit is configured by running `docker run --rm --runtime=nvidia --gpus all nvidia/cuda:12.8.0-base-ubuntu24.04 nvidia-smi` from the host.
 
+### `unresolvable CDI devices nvidia.com/gpu=all` during gateway start
+
+Recent NVIDIA Container Toolkit installs configure the Docker daemon for Container Device Interface (CDI) device injection, which OpenShell's `gateway start --gpu` then auto-selects.
+If no `nvidia.com/gpu` CDI spec has been generated on the host yet, gateway start fails with `Docker responded with status code 500: CDI device injection failed: unresolvable CDI devices nvidia.com/gpu=all`.
+`nemoclaw onboard` now detects this gap during preflight and prints the remediation up front, but the underlying fix is the same on any Docker host whose `docker info` advertises a non-empty `CDISpecDirs`.
+
+Generate the spec, verify it lists `nvidia.com/gpu` entries, then rerun onboarding:
+
+```console
+$ sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+$ nvidia-ctk cdi list
+$ nemoclaw onboard
+```
+
+If GPU passthrough is not required on this host, rerun onboarding with `--no-gpu` instead.
+
 ### `pip install` fails with a system-packages error
 
 Recent Ubuntu releases (including DGX Spark's Ubuntu 24.04) mark the system Python install as externally managed, so `pip install` without a virtual environment fails.

--- a/docs/deployment/sandbox-hardening.md
+++ b/docs/deployment/sandbox-hardening.md
@@ -31,6 +31,11 @@ Build toolchains (`gcc`, `g++`, `make`) and network probes (`netcat`) are
 explicitly purged from the runtime image. These tools are not needed at runtime
 and would unnecessarily widen the attack surface.
 
+The runtime image keeps a small set of operational utilities for normal sandbox
+workflows, including `vi`, `jq`, and `dos2unix`. Use these for lightweight
+inspection and file cleanup inside the sandbox, but make durable image or policy
+changes in the NemoClaw source tree and rebuild the sandbox.
+
 If you need a compiler during build, use the existing multi-stage build
 (the `builder` stage has full Node.js tooling) and copy only artifacts into the
 runtime stage.

--- a/docs/manage-sandboxes/messaging-channels.md
+++ b/docs/manage-sandboxes/messaging-channels.md
@@ -69,6 +69,7 @@ Use `SLACK_BOT_TOKEN` for the bot user OAuth token (`xoxb-...`) and `SLACK_APP_T
 When the wizard reaches **Messaging channels**, it lists Telegram, Discord, and Slack.
 Press a channel number to toggle it on or off, then press **Enter** when done.
 If a token is not already in the environment or credential store, the wizard prompts for it and saves it.
+NemoClaw also selects the matching network policy preset during policy setup so the channel can reach its provider API.
 
 For scripted setup, export the credentials and optional settings for the channels you want to enable before you run onboarding:
 

--- a/docs/network-policy/customize-network-policy.md
+++ b/docs/network-policy/customize-network-policy.md
@@ -43,7 +43,7 @@ See [Agent cannot reach a host-side HTTP service](../reference/troubleshooting.m
 
 > [!IMPORTANT]
 > Make static policy edits on the host, not inside the sandbox.
-> The sandbox image is intentionally minimal and may not include editors or package-management tools.
+> The sandbox image includes a small set of operational tools such as `vi`, `jq`, and `dos2unix`, but host-side policy files remain the durable source of truth.
 > Changes made only inside the sandbox are also ephemeral and are lost when the sandbox is recreated.
 
 ## Static Changes
@@ -187,7 +187,7 @@ Available presets:
 |--------|-----------|
 | `brave` | Brave Search API |
 | `brew` | Homebrew (Linuxbrew) package manager |
-| `discord` | Discord webhook API |
+| `discord` | Discord API, gateway, and CDN access |
 | `github` | GitHub and GitHub REST API |
 | `huggingface` | Hugging Face Hub (download-only) and inference router |
 | `jira` | Atlassian Jira API |

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemoclaw", "version": "0.0.36"}
+{"name": "nemoclaw", "version": "0.0.37"}

--- a/docs/reference/network-policies.md
+++ b/docs/reference/network-policies.md
@@ -90,6 +90,9 @@ All endpoints use TLS termination and are enforced at port 443.
 GitHub access (`github.com`, `api.github.com`) is not included in the baseline policy.
 Apply the `github` preset during onboarding if your agent needs GitHub access.
 See [Customize the Network Policy](../network-policy/customize-network-policy.md).
+
+Messaging endpoints for Telegram, Discord, and Slack are not included in the baseline policy.
+Enable the channel during onboarding or apply the matching messaging preset so the sandbox can reach that platform.
 :::
 
 (policy-tiers)=

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,10 @@
 [
   {
     "preferred": true,
+    "version": "0.0.37",
+    "url": "https://docs.nvidia.com/nemoclaw/0.0.37/"
+  },
+  {
     "version": "0.0.36",
     "url": "https://docs.nvidia.com/nemoclaw/0.0.36/"
   },


### PR DESCRIPTION
## Summary
- Bump the docs release metadata to `0.0.37`.
- Document release-prep updates for messaging policy presets, sandbox runtime utilities, and the GPU CDI troubleshooting path.
- Refresh generated `nemoclaw-user-*` skills from the updated docs.

## Source summary
- #3159 -> `docs/reference/troubleshooting.md`: Documents the GPU CDI preflight warning and remediation for `nvidia.com/gpu=all` gateway start failures.
- #2415 -> `docs/reference/network-policies.md`, `docs/manage-sandboxes/messaging-channels.md`, `docs/network-policy/customize-network-policy.md`: Clarifies that Telegram, Discord, and Slack egress comes from opt-in messaging presets, not the baseline policy.
- #3091 -> `docs/deployment/sandbox-hardening.md`, `docs/network-policy/customize-network-policy.md`: Documents the retained sandbox utilities `vi`, `jq`, and `dos2unix` while keeping host-side policy files as the durable source of truth.

## Test plan
- `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user`
- `make docs`
- `npm run build:cli`
- `npm run typecheck:cli`
- Commit and pre-push hooks: markdownlint, docs-to-skills verification, gitleaks, commitlint, CLI typecheck

## Skipped
- #3193 and #3191 matched `docs/.docs-skip` entries for experimental shields/config paths.
- #3200 and #3183 were test-only fixes.
- #3189 and #3163 were internal documentation/refactor changes with no public docs impact.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified which utilities remain in the sandbox runtime for lightweight inspection and cleanup
  * Noted that messaging endpoints (Discord, Slack, Telegram) are not in the baseline policy and that channel presets are applied during onboarding
  * Added GPU passthrough troubleshooting for gateway startup
  * Updated release/version bump and release-prep workflow guidance, including Discord preset description updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->