### PR TITLE
fix(e2e): add --thinking off to openclaw agent smoke tests

### DIFF
--- a/test/e2e/test-full-e2e.sh
+++ b/test/e2e/test-full-e2e.sh
@@ -389,7 +389,7 @@ if openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_config" 2>/dev/null; then
     -o ConnectTimeout=10 \
     -o LogLevel=ERROR \
     "openshell-${SANDBOX_NAME}" \
-    "openclaw agent --agent main --json --session-id '${agent_session_id}' -m 'What is 6 multiplied by 7? Reply with only the integer, no extra words.'" \
+    "openclaw agent --agent main --json --thinking off --session-id '${agent_session_id}' -m 'What is 6 multiplied by 7? Reply with only the integer, no extra words.'" \
     2>/dev/null) || true
 fi
 rm -f "$ssh_config"

--- a/test/e2e/test-launchable-smoke.sh
+++ b/test/e2e/test-launchable-smoke.sh
@@ -510,7 +510,7 @@ if openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_config" 2>/dev/null; then
     -o ConnectTimeout=10 \
     -o LogLevel=ERROR \
     "openshell-${SANDBOX_NAME}" \
-    "openclaw agent --agent main --json --session-id '${agent_session_id}' -m 'What is 6 multiplied by 7? Reply with only the integer, no extra words.'" \
+    "openclaw agent --agent main --json --thinking off --session-id '${agent_session_id}' -m 'What is 6 multiplied by 7? Reply with only the integer, no extra words.'" \
     2>/dev/null) || true
 fi
 rm -f "$ssh_config"


### PR DESCRIPTION
## Summary

Fix the `launchable-smoke-e2e` nightly failure ([run 25528818973](https://github.com/NVIDIA/NemoClaw/actions/runs/25528818973)) by adding `--thinking off` to the `openclaw agent` calls in the two E2E test scripts that were missing it.

### Root cause

The `openclaw agent` call in `test/e2e/test-launchable-smoke.sh` (and `test/e2e/test-full-e2e.sh`) omits `--thinking off`. When `nvidia/nemotron-3-super-120b-a12b` has model-catalog inferred reasoning defaults active, the agent spends ~113 s in reasoning mode, nearly exhausting the 120 s timeout, and returns content in a structure the JSON parser (`result.payloads[].text`) does not extract — producing an empty `agent_reply`.

The equivalent call in `test-sandbox-operations.sh:382` already pins `--thinking off` with an explanatory comment:

> *Pins `--thinking off` so the first-turn smoke contract is not delayed by model-catalog inferred reasoning defaults.*

### Changes

| File | Change |
|------|--------|
| `test/e2e/test-launchable-smoke.sh` | Add `--thinking off` to the `openclaw agent` command (line 513) |
| `test/e2e/test-full-e2e.sh` | Add `--thinking off` to the `openclaw agent` command (line 392) |

### Validation

- [x] Both scripts pass `bash -n` syntax check
- [ ] Re-run `launchable-smoke-e2e` on this branch to confirm the fix

Signed-off-by: Hung Le <hple@nvidia.com>

Fixes #3218