### PR TITLE
fix: brand NemoHermes uninstall goodbye

### DIFF
--- a/src/commands/internal/uninstall/plan.ts
+++ b/src/commands/internal/uninstall/plan.ts
@@ -4,19 +4,20 @@
 import { Command, Flags } from "@oclif/core";
 
 import { buildHostUninstallPlan } from "../../../lib/actions/uninstall/plan";
+import { CLI_DISPLAY_NAME, CLI_NAME } from "../../../lib/cli/branding";
 
 export default class InternalUninstallPlanCommand extends Command {
   static hidden = true;
   static strict = true;
-  static summary = "Internal: build the NemoClaw uninstall plan";
+  static summary = `Internal: build the ${CLI_DISPLAY_NAME} uninstall plan`;
   static description = "Build a deterministic uninstall plan without applying it.";
   static usage = ["internal uninstall plan [--json] [--delete-models] [--keep-openshell]"];
-  static examples = ["<%= config.bin %> internal uninstall plan --json --yes"];
+  static examples = [`${CLI_NAME} internal uninstall plan --json --yes`];
   static flags = {
     help: Flags.help({ char: "h" }),
     json: Flags.boolean({ description: "Print the uninstall plan as JSON" }),
     yes: Flags.boolean({ description: "Accepted for parity with run-plan; ignored while planning" }),
-    "delete-models": Flags.boolean({ description: "Plan removal of NemoClaw-pulled Ollama models" }),
+    "delete-models": Flags.boolean({ description: `Plan removal of ${CLI_DISPLAY_NAME}-pulled Ollama models` }),
     "keep-openshell": Flags.boolean({ description: "Keep the openshell binary installed" }),
     gateway: Flags.string({ description: "Gateway name", default: "nemoclaw" }),
   };

--- a/src/commands/internal/uninstall/run-plan.ts
+++ b/src/commands/internal/uninstall/run-plan.ts
@@ -4,19 +4,20 @@
 import { Command, Flags } from "@oclif/core";
 
 import { runUninstallPlan } from "../../../lib/actions/uninstall/run-plan";
+import { CLI_DISPLAY_NAME, CLI_NAME } from "../../../lib/cli/branding";
 
 export default class InternalUninstallRunPlanCommand extends Command {
   static hidden = true;
   static strict = true;
-  static summary = "NemoClaw Uninstaller";
-  static description = "Remove host-side NemoClaw resources.";
+  static summary = `${CLI_DISPLAY_NAME} Uninstaller`;
+  static description = `Remove host-side ${CLI_DISPLAY_NAME} resources.`;
   static usage = ["internal uninstall run-plan [--yes] [--keep-openshell] [--delete-models]"];
-  static examples = ["<%= config.bin %> internal uninstall run-plan --yes"];
+  static examples = [`${CLI_NAME} internal uninstall run-plan --yes`];
   static flags = {
     help: Flags.help({ char: "h" }),
     yes: Flags.boolean({ description: "Skip the confirmation prompt" }),
     "keep-openshell": Flags.boolean({ description: "Leave the openshell binary installed" }),
-    "delete-models": Flags.boolean({ description: "Remove NemoClaw-pulled Ollama models" }),
+    "delete-models": Flags.boolean({ description: `Remove ${CLI_DISPLAY_NAME}-pulled Ollama models` }),
     gateway: Flags.string({ description: "Gateway name", default: "nemoclaw" }),
   };
 

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Command from "../lib/commands/uninstall";
+import { CLI_NAME } from "../lib/cli/branding";
 import { withCommandDisplay } from "../lib/cli/command-display";
 
 export default withCommandDisplay(Command, [
   {
-    usage: "nemoclaw uninstall",
+    usage: `${CLI_NAME} uninstall`,
     description: "Run uninstall.sh (local only; no remote fallback)",
     group: "Cleanup",
     scope: "global",

--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -59,16 +59,21 @@ describe("uninstall run plan", () => {
     );
 
     expect(result.exitCode).toBe(0);
+    expect(logs).toContain("NemoClaw Uninstaller");
+    expect(logs).toContain("This will remove all NemoClaw resources.");
+    expect(logs).toContain("[3/6] NemoClaw CLI");
+    expect(logs).toContain("Removed global NemoClaw CLI package");
     expect(logs).toContain("Claws retracted. Until next time.");
     expect(dockerCalls).toEqual(expect.arrayContaining([["rm", "-f", "abc"], ["rmi", "-f", "img1"]]));
     expect(dockerCalls.some((args) => args.join(" ") === "volume rm -f openshell-cluster-nemoclaw")).toBe(true);
   });
 
-  it("uses NemoHermes completion copy when Hermes is the active agent", () => {
+  it("uses NemoHermes uninstall copy when Hermes is the active agent", () => {
     const logs: string[] = [];
+    const warnings: string[] = [];
 
     const result = runUninstallPlan(
-      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      { assumeYes: false, deleteModels: false, keepOpenShell: true },
       {
         commandExists: () => false,
         env: {
@@ -76,9 +81,11 @@ describe("uninstall run plan", () => {
           NEMOCLAW_AGENT: "hermes",
           TMPDIR: "/tmp/nemohermes-uninstall-test",
         } as NodeJS.ProcessEnv,
+        error: (line) => warnings.push(line),
         existsSync: () => false,
-        isTty: false,
+        isTty: true,
         log: (line) => logs.push(line),
+        readLine: () => "yes",
         rmSync: vi.fn(),
         run: vi.fn(),
         runDocker: () => ok(""),
@@ -86,8 +93,16 @@ describe("uninstall run plan", () => {
     );
 
     expect(result.exitCode).toBe(0);
+    expect(logs).toContain("NemoHermes Uninstaller");
+    expect(logs).toContain("This will remove all NemoHermes resources.");
+    expect(logs).toContain("  · All OpenShell sandboxes, gateway, and NemoHermes providers");
+    expect(logs).toContain("  · Global NemoHermes CLI (npm package: nemoclaw)");
+    expect(logs).toContain("[3/6] NemoHermes CLI");
+    expect(warnings).toContain("npm not found; skipping NemoHermes CLI uninstall.");
     expect(logs).toContain("NemoHermes");
     expect(logs).toContain("Hermes has left the tidepool.");
+    expect(logs).not.toContain("NemoClaw Uninstaller");
+    expect(logs).not.toContain("[3/6] NemoClaw CLI");
     expect(logs).not.toContain("Claws retracted. Until next time.");
   });
 
@@ -114,6 +129,8 @@ describe("uninstall run plan", () => {
 
     expect(result.exitCode).toBe(0);
     expect(logs).toContain("Proceed? [y/N]");
+    expect(logs).toContain("  · All OpenShell sandboxes, gateway, and NemoClaw providers");
+    expect(logs).toContain("  · Global NemoClaw CLI (npm package: nemoclaw)");
     expect(logs).toContain("Claws retracted. Until next time.");
   });
 

--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -64,6 +64,33 @@ describe("uninstall run plan", () => {
     expect(dockerCalls.some((args) => args.join(" ") === "volume rm -f openshell-cluster-nemoclaw")).toBe(true);
   });
 
+  it("uses NemoHermes completion copy when Hermes is the active agent", () => {
+    const logs: string[] = [];
+
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: () => false,
+        env: {
+          HOME: "/tmp/nemohermes-uninstall-test",
+          NEMOCLAW_AGENT: "hermes",
+          TMPDIR: "/tmp/nemohermes-uninstall-test",
+        } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        isTty: false,
+        log: (line) => logs.push(line),
+        rmSync: vi.fn(),
+        run: vi.fn(),
+        runDocker: () => ok(""),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(logs).toContain("NemoHermes");
+    expect(logs).toContain("Hermes has left the tidepool.");
+    expect(logs).not.toContain("Claws retracted. Until next time.");
+  });
+
   it("accepts typed interactive confirmation", () => {
     const logs: string[] = [];
     const run = vi.fn((_command: string, args: string[]) => {

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -178,7 +178,7 @@ function printBanner(log: (message: string) => void): void {
 function printBye(runtime: UninstallRuntime): void {
   const branding = getAgentBranding(runtime.env.NEMOCLAW_AGENT);
   runtime.log(branding.display);
-  runtime.log(branding.product === "Hermes" ? "Hermes has left the tidepool." : "Claws retracted. Until next time.");
+  runtime.log(branding.uninstallGoodbye);
 }
 
 function confirm(options: UninstallRunOptions, runtime: UninstallRuntime): boolean {

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { dockerSpawnSync } from "../../adapters/docker/exec";
-import { getAgentBranding } from "../../cli/branding";
+import { getAgentBranding, type AgentBranding } from "../../cli/branding";
 import { defaultUninstallPaths, NEMOCLAW_OLLAMA_MODELS, NEMOCLAW_PROVIDERS, type UninstallPaths } from "../../domain/uninstall/paths";
 import { buildUninstallPlan, type UninstallPlan } from "../../domain/uninstall/plan";
 import { classifyShimPath, type FileSystemDeps } from "./plan";
@@ -170,24 +170,34 @@ function buildRuntime(deps: UninstallRunDeps): UninstallRuntime {
   };
 }
 
-function printBanner(log: (message: string) => void): void {
-  log("NemoClaw Uninstaller");
-  log("This will remove all NemoClaw resources.");
+function runtimeBranding(runtime: UninstallRuntime): AgentBranding {
+  return getAgentBranding(runtime.env.NEMOCLAW_AGENT);
+}
+
+function planStepDisplayName(stepName: string, branding: AgentBranding): string {
+  return stepName === "NemoClaw CLI" ? `${branding.display} CLI` : stepName;
+}
+
+function printBanner(runtime: UninstallRuntime): void {
+  const branding = runtimeBranding(runtime);
+  runtime.log(`${branding.display} Uninstaller`);
+  runtime.log(`This will remove all ${branding.display} resources.`);
 }
 
 function printBye(runtime: UninstallRuntime): void {
-  const branding = getAgentBranding(runtime.env.NEMOCLAW_AGENT);
+  const branding = runtimeBranding(runtime);
   runtime.log(branding.display);
   runtime.log(branding.uninstallGoodbye);
 }
 
 function confirm(options: UninstallRunOptions, runtime: UninstallRuntime): boolean {
+  const branding = runtimeBranding(runtime);
   if (options.assumeYes) return true;
   runtime.log("What will be removed:");
-  runtime.log("  · All OpenShell sandboxes, gateway, and NemoClaw providers");
+  runtime.log(`  · All OpenShell sandboxes, gateway, and ${branding.display} providers`);
   runtime.log("  · Related Docker containers, images, and volumes");
   runtime.log("  · ~/.nemoclaw  ~/.config/openshell  ~/.config/nemoclaw");
-  runtime.log("  · Global nemoclaw npm package");
+  runtime.log(`  · Global ${branding.display} CLI (npm package: nemoclaw)`);
   runtime.log(options.deleteModels ? `  · Ollama models: ${NEMOCLAW_OLLAMA_MODELS.join(" ")}` : "  · Ollama models: kept");
   runtime.log("Proceed? [y/N]");
   const reply = runtime.readLine();
@@ -204,7 +214,7 @@ function runOptional(runtime: UninstallRuntime, description: string, command: st
 
 function stopHelperServices(paths: UninstallPaths, runtime: UninstallRuntime): void {
   const startServices = path.join(paths.repoRoot, "scripts", "start-services.sh");
-  if (runtime.existsSync(startServices)) runOptional(runtime, "Stopped NemoClaw helper services", startServices, ["--stop"]);
+  if (runtime.existsSync(startServices)) runOptional(runtime, `Stopped ${runtimeBranding(runtime).display} helper services`, startServices, ["--stop"]);
 }
 
 function stopMatchingPids(pattern: string, runtime: UninstallRuntime, label: string): void {
@@ -270,7 +280,7 @@ function removeAliases(paths: UninstallPaths, runtime: UninstallRuntime): void {
         .replace(/^# NemoClaw CLI alias\n.*\n?/gm, "");
       if (updated !== original) {
         fs.writeFileSync(profile, updated);
-        runtime.log(`Removed NemoClaw PATH entries from ${profile}`);
+        runtime.log(`Removed ${runtimeBranding(runtime).display} PATH entries from ${profile}`);
       }
     } catch {
       runtime.warn(`Failed to update ${profile}`);
@@ -303,16 +313,17 @@ function removeNvmLeftovers(paths: UninstallPaths, runtime: UninstallRuntime): v
 }
 
 function removeNemoclawCli(paths: UninstallPaths, runtime: UninstallRuntime): void {
+  const branding = runtimeBranding(runtime);
   if (runtime.commandExists("npm")) {
     runtime.run("npm", ["unlink", "-g", "nemoclaw"], { env: runtime.env, stdio: "ignore" });
     const result = runtime.run("npm", ["uninstall", "-g", "--loglevel=error", "nemoclaw"], {
       env: runtime.env,
       stdio: "ignore",
     });
-    if (result.status === 0) runtime.log("Removed global nemoclaw npm package");
-    else runtime.warn("Global nemoclaw npm package not found or already removed");
+    if (result.status === 0) runtime.log(`Removed global ${branding.display} CLI package`);
+    else runtime.warn(`Global ${branding.display} CLI package not found or already removed`);
   } else {
-    runtime.warn("npm not found; skipping nemoclaw npm uninstall.");
+    runtime.warn(`npm not found; skipping ${branding.display} CLI uninstall.`);
   }
 
   const shim = classifyShimPath(paths.nemoclawShimPath);
@@ -342,7 +353,7 @@ function removeDockerContainers(runtime: UninstallRuntime): void {
     .filter((line) => /openshell-cluster|openshell|openclaw|nemoclaw/i.test(line))
     .map((line) => line.split(/\s+/)[0]);
   if (ids.length === 0) {
-    runtime.log("No NemoClaw/OpenShell Docker containers found");
+    runtime.log(`No ${runtimeBranding(runtime).display}/OpenShell Docker containers found`);
     return;
   }
   for (const id of [...new Set(ids)]) {
@@ -357,7 +368,7 @@ function removeDockerImages(runtime: UninstallRuntime): void {
     .filter((line) => /openshell|openclaw|nemoclaw/i.test(line))
     .map((line) => line.split(/\s+/)[0]);
   if (ids.length === 0) {
-    runtime.log("No NemoClaw/OpenShell Docker images found");
+    runtime.log(`No ${runtimeBranding(runtime).display}/OpenShell Docker images found`);
     return;
   }
   for (const id of [...new Set(ids)]) {
@@ -393,7 +404,7 @@ function removeManagedSwap(paths: UninstallPaths, runtime: UninstallRuntime): vo
     return;
   }
   if (!runtime.existsSync(paths.managedSwapMarkerPath)) {
-    runtime.warn("No NemoClaw-managed swap marker found, skipping swap cleanup.");
+    runtime.warn(`No ${runtimeBranding(runtime).display}-managed swap marker found, skipping swap cleanup.`);
     return;
   }
   if (runtime.env.NEMOCLAW_NON_INTERACTIVE === "1" || !runtime.isTty) {
@@ -411,8 +422,9 @@ function removeManagedSwap(paths: UninstallPaths, runtime: UninstallRuntime): vo
 }
 
 function executePlan(plan: UninstallPlan, paths: UninstallPaths, options: UninstallRunOptions, runtime: UninstallRuntime): void {
+  const branding = runtimeBranding(runtime);
   for (const [index, step] of plan.steps.entries()) {
-    runtime.log(`[${index + 1}/${plan.steps.length}] ${step.name}`);
+    runtime.log(`[${index + 1}/${plan.steps.length}] ${planStepDisplayName(step.name, branding)}`);
     if (step.name === "Stopping services") {
       stopHelperServices(paths, runtime);
       removeGlob(paths.helperServiceGlob, runtime);
@@ -463,7 +475,7 @@ export function buildRunPlan(options: UninstallRunOptions, deps: UninstallRunDep
 export function runUninstallPlan(options: UninstallRunOptions, deps: UninstallRunDeps = {}): UninstallRunOutcome {
   const runtime = buildRuntime(deps);
   const { paths, plan } = buildRunPlan(options, { ...deps, env: runtime.env });
-  printBanner(runtime.log);
+  printBanner(runtime);
   if (!confirm(options, runtime)) return { exitCode: 0, plan };
   executePlan(plan, paths, options, runtime);
   printBye(runtime);

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { dockerSpawnSync } from "../../adapters/docker/exec";
+import { getAgentBranding } from "../../cli/branding";
 import { defaultUninstallPaths, NEMOCLAW_OLLAMA_MODELS, NEMOCLAW_PROVIDERS, type UninstallPaths } from "../../domain/uninstall/paths";
 import { buildUninstallPlan, type UninstallPlan } from "../../domain/uninstall/plan";
 import { classifyShimPath, type FileSystemDeps } from "./plan";
@@ -174,9 +175,10 @@ function printBanner(log: (message: string) => void): void {
   log("This will remove all NemoClaw resources.");
 }
 
-function printBye(log: (message: string) => void): void {
-  log("NemoClaw");
-  log("Claws retracted. Until next time.");
+function printBye(runtime: UninstallRuntime): void {
+  const branding = getAgentBranding(runtime.env.NEMOCLAW_AGENT);
+  runtime.log(branding.display);
+  runtime.log(branding.product === "Hermes" ? "Hermes has left the tidepool." : "Claws retracted. Until next time.");
 }
 
 function confirm(options: UninstallRunOptions, runtime: UninstallRuntime): boolean {
@@ -464,7 +466,7 @@ export function runUninstallPlan(options: UninstallRunOptions, deps: UninstallRu
   printBanner(runtime.log);
   if (!confirm(options, runtime)) return { exitCode: 0, plan };
   executePlan(plan, paths, options, runtime);
-  printBye(runtime.log);
+  printBye(runtime);
   return { exitCode: 0, plan };
 }
 /* v8 ignore stop */

--- a/src/lib/cli/branding.ts
+++ b/src/lib/cli/branding.ts
@@ -3,7 +3,8 @@
 
 /**
  * Central agent branding — maps the active agent to CLI name, display name,
- * and product name so every user-visible string can stay agent-neutral.
+ * product name, and product-specific copy so every user-visible string can stay
+ * agent-neutral.
  *
  * `nemohermes` is a thin alias launcher that sets `NEMOCLAW_AGENT` before
  * requiring the compiled CLI.  The exported constants cover normal startup,
@@ -18,17 +19,25 @@ export interface AgentBranding {
   display: string;
   /** The agent product name shown in messages, e.g. "OpenClaw" or "Hermes". */
   product: string;
+  /** Final line shown when uninstall completes. */
+  uninstallGoodbye: string;
 }
 
 const DEFAULT_BRANDING: AgentBranding = {
   cli: "nemoclaw",
   display: "NemoClaw",
   product: "OpenClaw",
+  uninstallGoodbye: "Claws retracted. Until next time.",
 };
 
 const AGENT_BRANDING: Record<string, AgentBranding> = {
   openclaw: DEFAULT_BRANDING,
-  hermes: { cli: "nemohermes", display: "NemoHermes", product: "Hermes" },
+  hermes: {
+    cli: "nemohermes",
+    display: "NemoHermes",
+    product: "Hermes",
+    uninstallGoodbye: "Hermes has left the tidepool.",
+  },
 };
 
 const DEFAULT_AGENT = "openclaw";

--- a/test/uninstall.test.ts
+++ b/test/uninstall.test.ts
@@ -10,6 +10,15 @@ import { spawnSync } from "node:child_process";
 const UNINSTALL_SCRIPT = path.join(import.meta.dirname, "..", "uninstall.sh");
 
 describe("uninstall CLI flags", () => {
+  function writeFakeTools(fakeBin: string) {
+    fs.mkdirSync(fakeBin);
+    for (const cmd of ["npm", "openshell", "docker", "ollama", "pgrep"]) {
+      fs.writeFileSync(path.join(fakeBin, cmd), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+    }
+  }
+
   it("--help exits 0 and shows usage", () => {
     const result = spawnSync("bash", [UNINSTALL_SCRIPT, "--help"], {
       cwd: path.join(import.meta.dirname, ".."),
@@ -24,18 +33,31 @@ describe("uninstall CLI flags", () => {
     expect(output).toMatch(/--delete-models/);
   });
 
+  it("--help uses NemoHermes branding when Hermes is the active agent", () => {
+    const result = spawnSync("bash", [UNINSTALL_SCRIPT, "--help"], {
+      cwd: path.join(import.meta.dirname, ".."),
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NEMOCLAW_AGENT: "hermes",
+        NEMOCLAW_NODE: process.execPath,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toMatch(/NemoHermes Uninstaller/);
+    expect(output).toMatch(/Remove host-side NemoHermes resources/);
+    expect(output).toMatch(/Remove NemoHermes-pulled Ollama models/);
+    expect(output).not.toMatch(/NemoClaw Uninstaller/);
+  });
+
   it("--yes skips the confirmation prompt and completes successfully", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-yes-"));
     const fakeBin = path.join(tmp, "bin");
-    fs.mkdirSync(fakeBin);
+    writeFakeTools(fakeBin);
 
     try {
-      for (const cmd of ["npm", "openshell", "docker", "ollama", "pgrep"]) {
-        fs.writeFileSync(path.join(fakeBin, cmd), "#!/usr/bin/env bash\nexit 0\n", {
-          mode: 0o755,
-        });
-      }
-
       const result = spawnSync("bash", [UNINSTALL_SCRIPT, "--yes"], {
         cwd: path.join(import.meta.dirname, ".."),
         encoding: "utf-8",
@@ -54,6 +76,38 @@ describe("uninstall CLI flags", () => {
       const output = `${result.stdout}${result.stderr}`;
       expect(output).toMatch(/NemoClaw/);
       expect(output).toMatch(/Claws retracted/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it("--yes uses NemoHermes branding when Hermes is the active agent", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemohermes-uninstall-yes-"));
+    const fakeBin = path.join(tmp, "bin");
+    writeFakeTools(fakeBin);
+
+    try {
+      const result = spawnSync("bash", [UNINSTALL_SCRIPT, "--yes"], {
+        cwd: path.join(import.meta.dirname, ".."),
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmp,
+          NEMOCLAW_AGENT: "hermes",
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          NEMOCLAW_NODE: process.execPath,
+          TMPDIR: tmp,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      const output = `${result.stdout}${result.stderr}`;
+      expect(output).toMatch(/NemoHermes Uninstaller/);
+      expect(output).toMatch(/\[3\/6\] NemoHermes CLI/);
+      expect(output).toMatch(/Removed global NemoHermes CLI package/);
+      expect(output).toMatch(/Hermes has left the tidepool/);
+      expect(output).not.toMatch(/NemoClaw Uninstaller/);
+      expect(output).not.toMatch(/\[3\/6\] NemoClaw CLI/);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- use active agent branding for the uninstall completion header
- end NemoHermes uninstall with “Hermes has left the tidepool.”
- keep the default NemoClaw goodbye unchanged

## Tests
- npm ci --ignore-scripts
- npx vitest run src/lib/actions/uninstall/run-plan.test.ts
- npm run build:cli
- npm run typecheck:cli
- npm run source-shape:check
- npm run format:check -- src/lib/actions/uninstall/run-plan.ts src/lib/actions/uninstall/run-plan.test.ts
- git diff --check

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uninstaller now uses agent-specific branding and farewell messages (e.g., Hermes) instead of static product text.

* **Refactor**
  * Command help, usage and flag descriptions now derive from CLI branding constants for consistent messaging.

* **Tests**
  * Added/updated tests to verify agent-specific uninstall output and ensure absence of incorrect branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->