### PR TITLE
fix(e2e): add inference retry loop to TC-NET-07 in network-policy test

### DIFF
--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -382,21 +382,36 @@ fetch('$target_url', {signal: AbortSignal.timeout(15000)})
 test_net_07_inference_exemption() {
   log "=== TC-NET-07: Inference Exemption + Direct Provider Blocked ==="
 
+  # Step 1: Send prompt via inference.local (should succeed).
+  # Retry up to 3 times — the gateway proxy can return empty or unexpected
+  # responses on the first attempt after policy changes (#1969), matching
+  # the retry pattern used in test-full-e2e.sh.
   log "  Step 1: Send prompt via inference.local (should succeed)..."
-  local inference_response
-  inference_response=$(sandbox_exec "curl -s --max-time 60 https://inference.local/v1/chat/completions \
-    -H 'Content-Type: application/json' \
-    -d '{\"model\":\"nvidia/nemotron-3-super-120b-a12b\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":50}'" 2>&1) || true
+  local content=""
+  local inference_response=""
+  local attempt
+  for attempt in 1 2 3; do
+    inference_response=$(sandbox_exec "curl -s --max-time 60 https://inference.local/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d '{\"model\":\"nvidia/nemotron-3-super-120b-a12b\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: PONG\"}],\"max_tokens\":50}'" 2>&1) || true
 
-  log "  Inference response: ${inference_response:0:200}"
+    log "  Inference attempt ${attempt}/3 response: ${inference_response:0:200}"
 
-  local content
-  content=$(echo "$inference_response" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['choices'][0]['message']['content'])" 2>/dev/null) || true
+    content=$(echo "$inference_response" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['choices'][0]['message']['content'])" 2>/dev/null) || true
+
+    if [[ -n "$content" ]]; then
+      break
+    fi
+    if [[ $attempt -lt 3 ]]; then
+      log "  Empty or unparseable response, retrying in 5s..."
+      sleep 5
+    fi
+  done
 
   if [[ -n "$content" ]]; then
-    pass "TC-NET-07: Inference via inference.local succeeded"
+    pass "TC-NET-07: Inference via inference.local succeeded (attempt $attempt)"
   else
-    fail "TC-NET-07: Inference" "No response from inference.local: ${inference_response:0:200}"
+    fail "TC-NET-07: Inference" "No response from inference.local after 3 attempts: ${inference_response:0:200}"
     return
   fi
 


### PR DESCRIPTION
## Summary

TC-NET-07 ("Inference Exemption + Direct Provider Blocked") in the
network-policy E2E test makes a single `curl` call to `inference.local`
and fails immediately if the response is empty. The gateway proxy can
return empty or unexpected responses on the first attempt after policy
changes (tracked in #1969); `test-full-e2e.sh` already retries inference
calls up to 3 times with 5 s backoff but `test-network-policy.sh` did not.

This PR adds the same retry loop so TC-NET-07 is resilient to transient
proxy warm-up delays.

## Related Issue

Fixes #3227

## Changes

- `test/e2e/test-network-policy.sh` — wrap the inference `curl` call in
  TC-NET-07 with a 3-attempt retry loop (5 s sleep between attempts),
  matching the pattern in `test-full-e2e.sh` lines 319–355.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>