### PR TITLE
fix(policy): add resolved python3.11 binary to github network policy

### DIFF
--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -77,6 +77,7 @@ network_policies:
     binaries:
       - { path: /usr/bin/gh }
       - { path: /usr/bin/git }
+      - { path: /usr/bin/python3.11 }
       - { path: /opt/hermes/.venv/bin/python }
 
   # ── Nous Research — Hermes auth, updates, portal ──────────────


### PR DESCRIPTION
## Summary

Adds `/usr/bin/python3.11` to the `github` network policy's binaries list so that Hermes venv Python can make outbound requests to GitHub endpoints (api.github.com, github.com).

## Problem

PR #3100 added `/opt/hermes/.venv/bin/python` to several network policies including `github`. However, on the Debian 13 sandbox image, the venv Python is a symlink chain:

```
/opt/hermes/.venv/bin/python → python3 → /usr/bin/python3.11
```

The OpenShell L7 proxy identifies calling processes via `/proc/PID/exe`, which dereferences all symlinks — returning `/usr/bin/python3.11`. Since `/usr/bin/python3.11` was not in the `github` policy's binaries list, requests to `api.github.com` from the venv Python were intercepted by the policy gate (producing empty stdout).

Other network policies (`nvidia`, `nous_research`, `pypi`, `telegram`, `discord`, `slack`) already list `/usr/bin/python3.11` — only `github` was missing it.

## Changes

- Added `{ path: /usr/bin/python3.11 }` to `github` network policy binaries

## Verification

- Confirmed `/usr/bin/python3.11` is present in all other agent-relevant policies
- Confirmed `github` was the only policy missing the resolved binary path
- The existing `/opt/hermes/.venv/bin/python` entry is preserved for environments using `--copies` venvs

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

Closes #3225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security policies to allow Python 3.11 to communicate with GitHub alongside existing development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->