### PR TITLE
docs(cli): sync commands.md + install.sh --help and add per-PR parity check (#3224)

### DIFF
--- a/.github/workflows/docs-cli-parity-pr.yaml
+++ b/.github/workflows/docs-cli-parity-pr.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Docs CLI Parity PR
+
+# Catches drift between the actual `nemoclaw --help` command list and the
+# command headings in `docs/reference/commands.md`. The same check runs in
+# nightly E2E (`docs-validation-e2e`); this workflow runs it on every PR
+# that touches CLI source so drift is caught before merge instead of next
+# morning. Ref: NVIDIA/NemoClaw#3224.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+    paths:
+      - "src/**"
+      - "bin/**"
+      - "install.sh"
+      - "docs/reference/commands.md"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.src.json"
+      - "test/e2e/e2e-cloud-experimental/check-docs.sh"
+      - ".github/workflows/docs-cli-parity-pr.yaml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-cli-parity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli-parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Build CLI
+        run: npm run build:cli
+
+      - name: Run CLI/docs parity check
+        run: bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli

--- a/.github/workflows/docs-cli-parity-pr.yaml
+++ b/.github/workflows/docs-cli-parity-pr.yaml
@@ -17,6 +17,7 @@ on:
       - "src/**"
       - "bin/**"
       - "install.sh"
+      - "scripts/install.sh"
       - "docs/reference/commands.md"
       - "package.json"
       - "package-lock.json"
@@ -50,5 +51,8 @@ jobs:
       - name: Build CLI
         run: npm run build:cli
 
-      - name: Run CLI/docs parity check
+      - name: Run CLI/docs parity check (command + flag level)
         run: bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli
+
+      - name: Run install.sh provider parity check
+        run: bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-install

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -828,7 +828,7 @@ The `nemoclaw setup` command is deprecated.
 Use `nemoclaw onboard` instead.
 :::
 
-This command remains as a compatibility alias to `nemoclaw onboard`.
+This command remains as a compatibility alias to `nemoclaw onboard` and accepts the same flags: `--non-interactive`, `--resume`, `--fresh`, `--recreate-sandbox`, `--gpu` / `--no-gpu`, `--from`, `--name`, `--agent`, `--control-ui-port`, `--yes` / `-y`, `--yes-i-accept-third-party-software`.
 
 ```console
 $ nemoclaw setup
@@ -841,7 +841,7 @@ The `nemoclaw setup-spark` command is deprecated.
 Use the standard installer and run `nemoclaw onboard` instead, because current OpenShell releases handle the older DGX Spark cgroup behavior.
 :::
 
-This command remains as a compatibility alias to `nemoclaw onboard`.
+This command remains as a compatibility alias to `nemoclaw onboard` and accepts the same flags: `--non-interactive`, `--resume`, `--fresh`, `--recreate-sandbox`, `--gpu` / `--no-gpu`, `--from`, `--name`, `--agent`, `--control-ui-port`, `--yes` / `-y`, `--yes-i-accept-third-party-software`.
 
 ```console
 $ nemoclaw setup-spark
@@ -919,9 +919,10 @@ Earlier releases only stopped `openshell forward` processes, so those orphans ac
 | `--yes` | Skip the confirmation prompt |
 | `--keep-openshell` | Leave the `openshell` binary installed |
 | `--delete-models` | Also remove NemoClaw-pulled Ollama models |
+| `--gateway <name>` | Override the gateway name to remove (default: `nemoclaw`) |
 
 ```console
-$ nemoclaw uninstall [--yes] [--keep-openshell] [--delete-models]
+$ nemoclaw uninstall [--yes] [--keep-openshell] [--delete-models] [--gateway <name>]
 ```
 
 #### `nemoclaw uninstall` vs. the hosted `uninstall.sh`

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -65,7 +65,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```console
-$ nemoclaw onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--gpu | --no-gpu] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [--yes-i-accept-third-party-software]
+$ nemoclaw onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--gpu | --no-gpu] [--from <Dockerfile>] [--name <sandbox>] [--agent <name>] [--control-ui-port <N>] [--yes | -y] [--yes-i-accept-third-party-software]
 ```
 
 :::{warning}
@@ -268,7 +268,7 @@ Sandboxes with an active SSH session are marked with a `●` indicator so you ca
 When a sandbox has a recorded dashboard port, the output includes its local dashboard URL.
 
 ```console
-$ nemoclaw list
+$ nemoclaw list [--json]
 $ nemoclaw list --json
 ```
 
@@ -305,8 +305,12 @@ After a host reboot, the OpenShell gateway rotates its SSH host keys.
 You no longer need to re-run `nemoclaw onboard` after a reboot in this case.
 
 ```console
-$ nemoclaw my-assistant connect
+$ nemoclaw my-assistant connect [--probe-only]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--probe-only` | Verify the sandbox is reachable over SSH, then exit without dropping into a shell. Useful for health checks and scripted readiness probes. |
 
 ### `nemoclaw <name> recover`
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -418,9 +418,11 @@ If you want to upgrade the sandbox while preserving state, use `nemoclaw <name> 
 
 If another terminal has an active SSH session to the sandbox, `destroy` prints an active-session warning and requires a second confirmation before it proceeds.
 Pass `--yes`, `-y`, or `--force` to skip the prompt in scripted workflows.
+By default, `destroy` preserves the shared NemoClaw gateway.
+Pass `--cleanup-gateway` to remove the shared gateway when destroying the last sandbox, or `--no-cleanup-gateway` to force preservation when environment defaults request cleanup.
 
 ```console
-$ nemoclaw my-assistant destroy
+$ nemoclaw my-assistant destroy [--yes|-y|--force] [--cleanup-gateway|--no-cleanup-gateway]
 ```
 
 ### `nemoclaw <name> policy-add`

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -308,9 +308,8 @@ You no longer need to re-run `nemoclaw onboard` after a reboot in this case.
 $ nemoclaw my-assistant connect [--probe-only]
 ```
 
-| Flag | Description |
-|------|-------------|
-| `--probe-only` | Verify the sandbox is reachable over SSH, then exit without dropping into a shell. Useful for health checks and scripted readiness probes. |
+The `--probe-only` flag verifies the sandbox is reachable over SSH and exits without opening a shell.
+Use it for health checks and scripted readiness probes.
 
 ### `nemoclaw <name> recover`
 

--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ bootstrap_usage() {
   printf "    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 Same as --yes-i-accept-third-party-software\n"
   printf "    NEMOCLAW_SANDBOX_NAME        Sandbox name to create/use\n"
   printf "    NEMOCLAW_PROVIDER            build | openai | anthropic | anthropicCompatible\n"
-  printf "                                 | gemini | ollama | custom | nim-local | vllm\n"
+  printf "                                 | gemini | ollama | custom | nim-local | vllm | routed\n"
   printf "                                 (aliases: cloud -> build, nim -> nim-local)\n"
   printf "    NEMOCLAW_POLICY_MODE         suggested | custom | skip\n"
   printf "\n"

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -251,8 +251,13 @@ run_cli_check() {
     # element to node — avoids SC2086 and any quoting surprises.
     local -a _invoke_args
     read -ra _invoke_args <<<"$invoke"
+    # Redirect stdin to /dev/null. The outer `while read` is consuming
+    # `$_tmp/help.txt` via `done <` redirection; any inner command that
+    # touches stdin (some node startup paths do) would eat subsequent
+    # lines, silently truncating the iteration. Negative-tested by
+    # mutating commands.md and confirming drift is now reported.
     local _help_text
-    _help_text="$("$NODE" "$CLI_JS" "${_invoke_args[@]}" --help 2>/dev/null || true)"
+    _help_text="$("$NODE" "$CLI_JS" "${_invoke_args[@]}" --help </dev/null 2>/dev/null || true)"
     [[ -z "$_help_text" ]] && continue
 
     local _flags

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -462,7 +462,7 @@ run_install_check() {
       | grep -v '(aliases:' \
       | sed 's/\\n//g' \
       | tr '"`,()|' '\n' \
-      | sed 's/[[:space:]]\+/\n/g' \
+      | awk '{ for (i = 1; i <= NF; i++) print $i }' \
       | grep -E '^[a-zA-Z][a-zA-Z0-9-]*$' \
       | grep -vxE 'printf|NEMOCLAW_PROVIDER' \
       | LC_ALL=C sort -u

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -350,12 +350,17 @@ run_install_check() {
   # interactive wizard exposes, not values a user is expected to set
   # NEMOCLAW_PROVIDER to from the installer entrypoint.
   extract_provider_block() {
+    # Order matters: check the boundary BEFORE printing so the next
+    # NEMOCLAW_* printf line (e.g. NEMOCLAW_POLICY_MODE) does not bleed
+    # into the block. `custom` is both a canonical provider value and a
+    # POLICY_MODE token, so a leaked POLICY line would falsely make it
+    # appear that `custom` is documented even after removal.
     awk '
-      /printf .*NEMOCLAW_PROVIDER/ { in_block = 1 }
-      in_block { print }
-      in_block && /printf .*NEMOCLAW_(POLICY|MODEL|EXPERIMENTAL|SANDBOX_NAME|FROM_DOCKERFILE)/ && !/NEMOCLAW_PROVIDER/ {
+      /printf .*NEMOCLAW_PROVIDER/ { in_block = 1; print; next }
+      in_block && /printf .*NEMOCLAW_/ && !/NEMOCLAW_PROVIDER/ {
         in_block = 0
       }
+      in_block { print }
     ' "$1"
   }
 
@@ -369,17 +374,39 @@ run_install_check() {
     _payload_block="$(extract_provider_block "$PAYLOAD_SH")"
   fi
 
+  # Tokenize each block into the discrete provider identifiers it mentions
+  # so we can exact-match (not substring-match) against the canonical list.
+  # Substring matching would let `anthropic` falsely pass when only
+  # `anthropicCompatible` appears.
+  # The pattern allows camelCase since `anthropicCompatible` is canonical.
+  # `\n` literals in printf strings are stripped first so tokens at line
+  # ends (e.g. `routed\n"`) reduce to the bare identifier.
+  tokenize_provider_block() {
+    printf '%s\n' "$1" \
+      | sed 's/\\n//g' \
+      | tr '"`,()|' '\n' \
+      | sed 's/[[:space:]]\+/\n/g' \
+      | grep -E '^[a-zA-Z][a-zA-Z0-9-]*$' \
+      | LC_ALL=C sort -u
+  }
+
+  local _bootstrap_values _payload_values=""
+  _bootstrap_values="$(tokenize_provider_block "$_bootstrap_block")"
+  if [[ -n "${_payload_block:-}" ]]; then
+    _payload_values="$(tokenize_provider_block "$_payload_block")"
+  fi
+
   IFS=',' read -ra _values <<<"$_canonical"
   for _raw in "${_values[@]}"; do
     local v
     v="$(echo "$_raw" | tr -d '[:space:]')"
     [[ -z "$v" ]] && continue
     case "$v" in install-*|start-windows-ollama) continue ;; esac
-    if ! grep -qF -- "$v" <<<"$_bootstrap_block"; then
+    if ! grep -qxF -- "$v" <<<"$_bootstrap_values"; then
       echo "check-docs: [install] provider \"$v\" canonical but absent from $BOOTSTRAP_SH bootstrap_usage" >&2
       _drift=1
     fi
-    if [[ -n "$_payload_block" ]] && ! grep -qF -- "$v" <<<"$_payload_block"; then
+    if [[ -n "$_payload_values" ]] && ! grep -qxF -- "$v" <<<"$_payload_values"; then
       echo "check-docs: [install] provider \"$v\" canonical but absent from $PAYLOAD_SH usage()" >&2
       _drift=1
     fi

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -147,6 +147,11 @@ run_cli_check() {
 
   local _tmp
   _tmp="$(mktemp -d)"
+  local _cli_home="$_tmp/home"
+  mkdir -p "$_cli_home/.nemoclaw"
+  cat >"$_cli_home/.nemoclaw/sandboxes.json" <<'JSON'
+{"defaultSandbox":"placeholder-sandbox","sandboxes":{"placeholder-sandbox":{"name":"placeholder-sandbox"}}}
+JSON
 
   log "[cli] comparing: $NODE bin/nemoclaw.js --dump-commands"
   # shellcheck disable=SC2016
@@ -154,8 +159,9 @@ run_cli_check() {
   log '[cli]        vs: docs/reference/commands.md (### `nemoclaw …` headings only)'
 
   log "[cli] phase 1/2: dump canonical command list from registry"
-  if ! "$NODE" "$CLI_JS" --dump-commands >"$_tmp/help.txt" 2>"$_tmp/help.err"; then
+  if ! HOME="$_cli_home" "$NODE" "$CLI_JS" --dump-commands >"$_tmp/help.txt" 2>"$_tmp/help.err"; then
     cat "$_tmp/help.err" >&2
+    rm -rf "$_tmp"
     return 1
   fi
   LC_ALL=C sort -u -o "$_tmp/help.txt" "$_tmp/help.txt"
@@ -209,13 +215,10 @@ run_cli_check() {
   # Word-boundary regex avoids false positives where `--yes` is contained
   # in `--yes-i-accept-third-party-software`. Skips global -h/--help/--version.
   #
-  # Coverage caveat: most `nemoclaw <name> ...` commands (channels add,
-  # destroy, rebuild, doctor, skill install) gate `--help` behind
-  # sandbox-name validation that requires a registered sandbox. On a CI
-  # runner with no sandbox they emit only an error and we skip the empty
-  # help text. Flag drift on those commands is therefore not caught here;
-  # it would be caught by the existing E2E suite which runs against a real
-  # sandbox. Tracked as a follow-up to NemoClaw#3224.
+  # The check runs with an isolated HOME that contains a fake
+  # `placeholder-sandbox` registry entry. That keeps CI deterministic and lets
+  # sandbox-scoped commands print `--help` without touching the user's real
+  # ~/.nemoclaw state.
   log "[cli] phase 3/3: flag-level parity"
 
   # Awk extractor: print lines belonging to the section whose heading
@@ -249,6 +252,39 @@ run_cli_check() {
     ' "$md"
   }
 
+  extract_help_flags() {
+    printf '%s\n' "$1" | LC_ALL=C perl -CS -ne '
+      sub emit_flags {
+        my ($s) = @_;
+        while ($s =~ /--(?:\[no-\])?([a-z][a-z0-9-]+)/g) {
+          my $flag = $1;
+          my $matched = $&;
+          print "--$flag\n";
+          print "--no-$flag\n" if $matched =~ /^\Q--[no-]\E/;
+        }
+      }
+
+      if (/^\s*Usage:\s*(.*)$/i) {
+        $mode = "usage";
+        emit_flags($1);
+        next;
+      }
+      if (/^\s*USAGE\s*$/) {
+        $mode = "usage";
+        next;
+      }
+      if (/^\s*(FLAGS|GLOBAL FLAGS|Options):?\s*$/i) {
+        $mode = "flags";
+        next;
+      }
+      if (/^\s*(ARGUMENTS|DESCRIPTION|EXAMPLES)\s*$/i || /^\s*$/) {
+        $mode = "";
+        next;
+      }
+      emit_flags($_) if $mode;
+    ' | LC_ALL=C sort -u
+  }
+
   local _flag_drift=0
   while IFS= read -r cmd_line || [[ -n "$cmd_line" ]]; do
     [[ -z "$cmd_line" ]] && continue
@@ -276,16 +312,11 @@ run_cli_check() {
     #
     # Capture exit code separately so a real failure (broken command path,
     # crashed loader, etc.) propagates instead of being swallowed by
-    # `|| true`. Sandbox-name validation is the only expected failure mode
-    # on a CI runner with no registered sandbox; other non-zero exits abort.
+    # `|| true`.
     local _help_text _help_err _help_rc=0
     _help_err="$(mktemp)"
-    _help_text="$("$NODE" "$CLI_JS" "${_invoke_args[@]}" --help </dev/null 2>"$_help_err")" || _help_rc=$?
+    _help_text="$(HOME="$_cli_home" "$NODE" "$CLI_JS" "${_invoke_args[@]}" --help </dev/null 2>"$_help_err")" || _help_rc=$?
     if [[ "$_help_rc" -ne 0 ]]; then
-      if [[ "$cmd_line" == *"<name>"* ]] && grep -qi 'sandbox' "$_help_err"; then
-        rm -f "$_help_err"
-        continue
-      fi
       cat "$_help_err" >&2
       rm -f "$_help_err"
       rm -rf "$_tmp"
@@ -295,7 +326,7 @@ run_cli_check() {
     [[ -z "$_help_text" ]] && continue
 
     local _flags
-    _flags="$(echo "$_help_text" | grep -oE -- '--[a-z][a-z0-9-]+' | LC_ALL=C sort -u || true)"
+    _flags="$(extract_help_flags "$_help_text")"
     [[ -z "$_flags" ]] && continue
 
     local _section

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -218,21 +218,33 @@ run_cli_check() {
   # sandbox. Tracked as a follow-up to NemoClaw#3224.
   log "[cli] phase 3/3: flag-level parity"
 
-  # Awk extractor: print lines belonging to the section whose heading is
-  # exactly `### \`<cmd>\`` (with optional MyST anchor). Stops at the next
-  # ### heading.
+  # Awk extractor: print lines belonging to the section whose heading
+  # canonicalizes to <cmd> after the same trailing-placeholder strip phase 2
+  # applies (`### \`nemoclaw foo <ARG>\`` → `nemoclaw foo`). Stops at the
+  # next ### heading. MyST anchors after the closing backtick are tolerated.
   extract_md_section() {
     local cmd="$1"
     local md="$2"
-    LC_ALL=C awk -v target="### \`$cmd\`" '
-      index($0, target) == 1 {
-        rest = substr($0, length(target) + 1)
-        if (rest == "" || rest ~ /^[[:space:]]*\{[^}]+\}[[:space:]]*$/) {
-          in_sec = 1
-          next
+    LC_ALL=C awk -v target="$cmd" '
+      # End the section when a new top-level heading appears (h1, h2, or
+      # h3). h4+ are kept since they are sub-sections of the same command.
+      # Explicit alternation since traditional awk treats `{n,m}` literally.
+      in_sec && /^(# |## |### )/ { exit }
+      /^### `/ {
+        line = $0
+        sub(/^### `/, "", line)
+        bt = index(line, "`")
+        if (bt > 0) {
+          cand = substr(line, 1, bt - 1)
+          while (sub(/[[:space:]]*\[[^]]*\][[:space:]]*$/, "", cand)) {}
+          while (sub(/[[:space:]]+<[^>]+>[[:space:]]*$/, "", cand)) {}
+          sub(/[[:space:]]+$/, "", cand)
+          if (cand == target) {
+            in_sec = 1
+            next
+          }
         }
       }
-      in_sec && /^### `/ { exit }
       in_sec { print }
     ' "$md"
   }
@@ -240,6 +252,11 @@ run_cli_check() {
   local _flag_drift=0
   while IFS= read -r cmd_line || [[ -n "$cmd_line" ]]; do
     [[ -z "$cmd_line" ]] && continue
+    # Skip "command-line variant" entries like `nemoclaw onboard --from`
+    # — those describe a flagged invocation of a parent command (here
+    # `nemoclaw onboard`) that is iterated separately. Re-invoking them
+    # with `--help` would just trigger flag-value parsing errors.
+    case "$cmd_line" in *" --"*) continue ;; esac
     # `--dump-commands` lines start with `nemoclaw `; strip that since we
     # re-invoke via `node bin/nemoclaw.js`. Then replace <name> with a
     # sandbox name that passes name validation (lowercase, starts with
@@ -256,8 +273,25 @@ run_cli_check() {
     # touches stdin (some node startup paths do) would eat subsequent
     # lines, silently truncating the iteration. Negative-tested by
     # mutating commands.md and confirming drift is now reported.
-    local _help_text
-    _help_text="$("$NODE" "$CLI_JS" "${_invoke_args[@]}" --help </dev/null 2>/dev/null || true)"
+    #
+    # Capture exit code separately so a real failure (broken command path,
+    # crashed loader, etc.) propagates instead of being swallowed by
+    # `|| true`. Sandbox-name validation is the only expected failure mode
+    # on a CI runner with no registered sandbox; other non-zero exits abort.
+    local _help_text _help_err _help_rc=0
+    _help_err="$(mktemp)"
+    _help_text="$("$NODE" "$CLI_JS" "${_invoke_args[@]}" --help </dev/null 2>"$_help_err")" || _help_rc=$?
+    if [[ "$_help_rc" -ne 0 ]]; then
+      if [[ "$cmd_line" == *"<name>"* ]] && grep -qi 'sandbox' "$_help_err"; then
+        rm -f "$_help_err"
+        continue
+      fi
+      cat "$_help_err" >&2
+      rm -f "$_help_err"
+      rm -rf "$_tmp"
+      return 1
+    fi
+    rm -f "$_help_err"
     [[ -z "$_help_text" ]] && continue
 
     local _flags
@@ -283,6 +317,37 @@ run_cli_check() {
         _flag_drift=1
       fi
     done <<<"$_flags"
+
+    # Reverse direction: extract long flags mentioned in the doc section
+    # and confirm each appears in the actual --help. Catches stale docs
+    # (flag removed from CLI but still listed in commands.md).
+    #
+    # Scoping rule: inside fenced code blocks (where USAGE lines live like
+    # `[--non-interactive]`), any `--foo` counts. Outside fences, only
+    # backtick-bounded `\`--foo\`` mentions count, so prose references to
+    # other tools (e.g. `\`openshell gateway start --recreate\``) don't get
+    # mistaken for nemoclaw flag documentation.
+    local _doc_flags
+    _doc_flags="$(
+      printf '%s\n' "$_section" \
+        | LC_ALL=C perl -CS -ne '
+            if (/^```/) { $in_fence = !$in_fence; next; }
+            if ($in_fence) {
+              while (/--([a-z][a-z0-9-]+)/g) { print "--$1\n"; }
+            } else {
+              while (/`--([a-z][a-z0-9-]+)/g) { print "--$1\n"; }
+            }
+          ' \
+        | grep -vxE -- '--help|--version' \
+        | LC_ALL=C sort -u || true
+    )"
+    while IFS= read -r flag; do
+      [[ -z "$flag" ]] && continue
+      if ! grep -qxF -- "$flag" <<<"$_flags"; then
+        echo "check-docs: [cli] flag $flag documented under \`$cmd_line\` but absent from \`$cmd_line --help\`" >&2
+        _flag_drift=1
+      fi
+    done <<<"$_doc_flags"
   done <"$_tmp/help.txt"
 
   if [[ "$_flag_drift" -ne 0 ]]; then
@@ -387,11 +452,19 @@ run_install_check() {
   # `\n` literals in printf strings are stripped first so tokens at line
   # ends (e.g. `routed\n"`) reduce to the bare identifier.
   tokenize_provider_block() {
+    # Drop `(aliases: cloud -> build, ...)` lines (alias keys aren't
+    # canonical providers and would falsely fail the bidirectional check)
+    # and the shell tokens `printf` / `NEMOCLAW_PROVIDER` that appear
+    # because the block opens with a `printf "    NEMOCLAW_PROVIDER ..."`
+    # line. Both filters exist solely to clean up tokenization artifacts;
+    # they don't relax the actual provider-name check.
     printf '%s\n' "$1" \
+      | grep -v '(aliases:' \
       | sed 's/\\n//g' \
       | tr '"`,()|' '\n' \
       | sed 's/[[:space:]]\+/\n/g' \
       | grep -E '^[a-zA-Z][a-zA-Z0-9-]*$' \
+      | grep -vxE 'printf|NEMOCLAW_PROVIDER' \
       | LC_ALL=C sort -u
   }
 
@@ -416,6 +489,36 @@ run_install_check() {
       _drift=1
     fi
   done
+
+  # Reverse direction: tokens appearing in either install help block but
+  # not on the canonical list mean the script is advertising a provider
+  # that the CLI no longer accepts. Build the canonical set with the same
+  # exemptions used above.
+  local _canonical_values
+  _canonical_values="$(
+    printf '%s\n' "$_canonical" \
+      | tr ',' '\n' \
+      | sed 's/[[:space:]]//g' \
+      | grep -vxE 'install-.*|start-windows-ollama' \
+      | grep -E '^[a-zA-Z][a-zA-Z0-9-]*$' \
+      | LC_ALL=C sort -u
+  )"
+  while IFS= read -r v; do
+    [[ -z "$v" ]] && continue
+    if ! grep -qxF -- "$v" <<<"$_canonical_values"; then
+      echo "check-docs: [install] provider \"$v\" appears in $BOOTSTRAP_SH bootstrap_usage but is not canonical" >&2
+      _drift=1
+    fi
+  done <<<"$_bootstrap_values"
+  if [[ -n "$_payload_values" ]]; then
+    while IFS= read -r v; do
+      [[ -z "$v" ]] && continue
+      if ! grep -qxF -- "$v" <<<"$_canonical_values"; then
+        echo "check-docs: [install] provider \"$v\" appears in $PAYLOAD_SH usage() but is not canonical" >&2
+        _drift=1
+      fi
+    done <<<"$_payload_values"
+  fi
 
   if [[ "$_drift" -ne 0 ]]; then
     return 1

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -274,7 +274,7 @@ run_cli_check() {
 
     while IFS= read -r flag; do
       [[ -z "$flag" ]] && continue
-      case "$flag" in --help|--version) continue ;; esac
+      case "$flag" in --help | --version) continue ;; esac
       # Word-boundary regex: treat letters/digits/_/- as continuation chars
       # so `--yes` does not match inside `--yes-i-accept-third-party-software`.
       local _pat="(^|[^a-zA-Z0-9_-])${flag}([^a-zA-Z0-9_-]|$)"
@@ -406,7 +406,7 @@ run_install_check() {
     local v
     v="$(echo "$_raw" | tr -d '[:space:]')"
     [[ -z "$v" ]] && continue
-    case "$v" in install-*|start-windows-ollama) continue ;; esac
+    case "$v" in install-* | start-windows-ollama) continue ;; esac
     if ! grep -qxF -- "$v" <<<"$_bootstrap_values"; then
       echo "check-docs: [install] provider \"$v\" canonical but absent from $BOOTSTRAP_SH bootstrap_usage" >&2
       _drift=1

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -198,30 +198,83 @@ run_cli_check() {
   log "[cli] command-level parity OK (${_n_help} nemoclaw command(s))"
 
   # ── Phase 3/3: flag-level parity (NemoClaw#3224) ──────────────────────────
-  # For each command, run `nemoclaw <cmd> --help`, extract long-form flag
-  # names from the FLAGS section, and confirm each appears in commands.md.
-  # Skips global flags (-h/--help/--version) and sandbox-name placeholders.
+  # For each command, run its `--help`, extract every long-form flag mentioned,
+  # and confirm each appears within that command's own section in
+  # commands.md (between its `### \`nemoclaw <cmd>\`` heading and the next
+  # ### heading). Two help formats coexist: oclif global commands use a
+  # USAGE/FLAGS layout; `nemoclaw <name> ...` commands use a custom
+  # Options: section. Greping the full help output handles both formats.
+  # Section-scoped grep avoids false negatives where a flag like `--yes`
+  # appears in many sections but is missing from the one being audited.
+  # Word-boundary regex avoids false positives where `--yes` is contained
+  # in `--yes-i-accept-third-party-software`. Skips global -h/--help/--version.
+  #
+  # Coverage caveat: most `nemoclaw <name> ...` commands (channels add,
+  # destroy, rebuild, doctor, skill install) gate `--help` behind
+  # sandbox-name validation that requires a registered sandbox. On a CI
+  # runner with no sandbox they emit only an error and we skip the empty
+  # help text. Flag drift on those commands is therefore not caught here;
+  # it would be caught by the existing E2E suite which runs against a real
+  # sandbox. Tracked as a follow-up to NemoClaw#3224.
   log "[cli] phase 3/3: flag-level parity"
+
+  # Awk extractor: print lines belonging to the section whose heading is
+  # exactly `### \`<cmd>\`` (with optional MyST anchor). Stops at the next
+  # ### heading.
+  extract_md_section() {
+    local cmd="$1"
+    local md="$2"
+    LC_ALL=C awk -v target="### \`$cmd\`" '
+      index($0, target) == 1 {
+        rest = substr($0, length(target) + 1)
+        if (rest == "" || rest ~ /^[[:space:]]*\{[^}]+\}[[:space:]]*$/) {
+          in_sec = 1
+          next
+        }
+      }
+      in_sec && /^### `/ { exit }
+      in_sec { print }
+    ' "$md"
+  }
+
   local _flag_drift=0
   while IFS= read -r cmd_line || [[ -n "$cmd_line" ]]; do
     [[ -z "$cmd_line" ]] && continue
-    # Replace <name> placeholder with a dummy sandbox name so help can run.
+    # `--dump-commands` lines start with `nemoclaw `; strip that since we
+    # re-invoke via `node bin/nemoclaw.js`. Then replace <name> with a
+    # sandbox name that passes name validation (lowercase, starts with
+    # letter, only letters/digits/hyphens — underscores are rejected).
     local invoke
-    invoke="${cmd_line//<name>/_check_docs_sandbox_}"
-    # Collect FLAGS block; tolerate commands that take no flags.
+    invoke="${cmd_line#nemoclaw }"
+    invoke="${invoke//<name>/placeholder-sandbox}"
+    # Read into an array so each space-separated token is a distinct argv
+    # element to node — avoids SC2086 and any quoting surprises.
+    local -a _invoke_args
+    read -ra _invoke_args <<<"$invoke"
+    local _help_text
+    _help_text="$("$NODE" "$CLI_JS" "${_invoke_args[@]}" --help 2>/dev/null || true)"
+    [[ -z "$_help_text" ]] && continue
+
     local _flags
-    _flags="$("$NODE" "$CLI_JS" $invoke --help 2>/dev/null | awk '
-      /^FLAGS$/        { in_flags = 1; next }
-      /^[A-Z]/ && in_flags { exit }
-      in_flags         { print }
-    ' | grep -oE -- '--[a-z][a-z0-9-]+' | LC_ALL=C sort -u || true)"
+    _flags="$(echo "$_help_text" | grep -oE -- '--[a-z][a-z0-9-]+' | LC_ALL=C sort -u || true)"
     [[ -z "$_flags" ]] && continue
+
+    local _section
+    _section="$(extract_md_section "$cmd_line" "$COMMANDS_MD")"
+    if [[ -z "$_section" ]]; then
+      # Phase 2 already enforces the heading exists; if the section is
+      # somehow empty here, fall back to the full doc rather than skipping.
+      _section="$(cat "$COMMANDS_MD")"
+    fi
 
     while IFS= read -r flag; do
       [[ -z "$flag" ]] && continue
       case "$flag" in --help|--version) continue ;; esac
-      if ! grep -qF -- "$flag" "$COMMANDS_MD"; then
-        echo "check-docs: [cli] flag $flag (from \`$cmd_line --help\`) not mentioned in $COMMANDS_MD" >&2
+      # Word-boundary regex: treat letters/digits/_/- as continuation chars
+      # so `--yes` does not match inside `--yes-i-accept-third-party-software`.
+      local _pat="(^|[^a-zA-Z0-9_-])${flag}([^a-zA-Z0-9_-]|$)"
+      if ! grep -qE -- "$_pat" <<<"$_section"; then
+        echo "check-docs: [cli] flag $flag (from \`$cmd_line --help\`) not in '$cmd_line' section of $COMMANDS_MD" >&2
         _flag_drift=1
       fi
     done <<<"$_flags"

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -34,6 +34,7 @@ NODE="${NODE:-node}"
 
 RUN_LINKS=1
 RUN_CLI=1
+RUN_INSTALL=1
 LOCAL_ONLY=0
 EXTRA_FILES=()
 VERBOSE="${CHECK_DOC_LINKS_VERBOSE:-0}"
@@ -41,13 +42,16 @@ WITH_SKILLS=0
 
 usage() {
   cat <<'EOF'
-Documentation checks: Markdown links + nemoclaw --help vs commands reference.
+Documentation checks: Markdown links + nemoclaw --help vs commands reference
++ install.sh --help vs canonical provider list.
 
 Usage: test/e2e/e2e-cloud-experimental/check-docs.sh [options] [extra.md ...]
 
 Options:
   --only-links     Run only the Markdown link check.
-  --only-cli       Run only the CLI help vs docs/reference/commands.md check.
+  --only-cli       Run only the CLI help vs docs/reference/commands.md check
+                   (includes both command-level and flag-level parity).
+  --only-install   Run only the install.sh --help vs canonical provider check.
   --local-only     Do not curl http(s) URLs (same as CHECK_DOC_LINKS_REMOTE=0).
   --with-skills    Also scan .agents/skills/**/*.md (link check).
   --verbose        Log each URL while curling (link check).
@@ -62,10 +66,17 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --only-links)
       RUN_CLI=0
+      RUN_INSTALL=0
       shift
       ;;
     --only-cli)
       RUN_LINKS=0
+      RUN_INSTALL=0
+      shift
+      ;;
+    --only-install)
+      RUN_LINKS=0
+      RUN_CLI=0
       shift
       ;;
     --local-only)
@@ -101,8 +112,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "$RUN_LINKS" -eq 0 && "$RUN_CLI" -eq 0 ]]; then
-  echo "check-docs: use at least one of default (both), --only-links, or --only-cli" >&2
+if [[ "$RUN_LINKS" -eq 0 && "$RUN_CLI" -eq 0 && "$RUN_INSTALL" -eq 0 ]]; then
+  echo "check-docs: use at least one of default (all), --only-links, --only-cli, or --only-install" >&2
   exit 2
 fi
 
@@ -172,26 +183,162 @@ run_cli_check() {
   _n_doc="$(wc -l <"$_tmp/doc.txt" | tr -d " ")"
   log "[cli] phase 2: extracted ${_n_doc} heading(s) from ${COMMANDS_MD#"$REPO_ROOT"/}"
 
-  if cmp -s "$_tmp/help.txt" "$_tmp/doc.txt"; then
-    log "[cli] parity OK (${_n_help} nemoclaw command(s))"
-    while IFS= read -r line || [[ -n "$line" ]]; do
-      [[ -z "$line" ]] && continue
-      log "[cli]   $line"
-    done <"$_tmp/help.txt"
-    log "[cli] done."
+  if ! cmp -s "$_tmp/help.txt" "$_tmp/doc.txt"; then
+    echo "check-docs: [cli] mismatch between --help and $COMMANDS_MD" >&2
+    echo "" >&2
+    echo "Only in --help (add ### to commands.md or fix help):" >&2
+    comm -23 "$_tmp/help.txt" "$_tmp/doc.txt" | sed 's/^/  /' >&2 || true
+    echo "" >&2
+    echo "Only in commands.md (add to help() in bin/nemoclaw.js or fix heading):" >&2
+    comm -13 "$_tmp/help.txt" "$_tmp/doc.txt" | sed 's/^/  /' >&2 || true
     rm -rf "$_tmp"
-    return 0
+    return 1
   fi
 
-  echo "check-docs: [cli] mismatch between --help and $COMMANDS_MD" >&2
-  echo "" >&2
-  echo "Only in --help (add ### to commands.md or fix help):" >&2
-  comm -23 "$_tmp/help.txt" "$_tmp/doc.txt" | sed 's/^/  /' >&2 || true
-  echo "" >&2
-  echo "Only in commands.md (add to help() in bin/nemoclaw.js or fix heading):" >&2
-  comm -13 "$_tmp/help.txt" "$_tmp/doc.txt" | sed 's/^/  /' >&2 || true
+  log "[cli] command-level parity OK (${_n_help} nemoclaw command(s))"
+
+  # ── Phase 3/3: flag-level parity (NemoClaw#3224) ──────────────────────────
+  # For each command, run `nemoclaw <cmd> --help`, extract long-form flag
+  # names from the FLAGS section, and confirm each appears in commands.md.
+  # Skips global flags (-h/--help/--version) and sandbox-name placeholders.
+  log "[cli] phase 3/3: flag-level parity"
+  local _flag_drift=0
+  while IFS= read -r cmd_line || [[ -n "$cmd_line" ]]; do
+    [[ -z "$cmd_line" ]] && continue
+    # Replace <name> placeholder with a dummy sandbox name so help can run.
+    local invoke
+    invoke="${cmd_line//<name>/_check_docs_sandbox_}"
+    # Collect FLAGS block; tolerate commands that take no flags.
+    local _flags
+    _flags="$("$NODE" "$CLI_JS" $invoke --help 2>/dev/null | awk '
+      /^FLAGS$/        { in_flags = 1; next }
+      /^[A-Z]/ && in_flags { exit }
+      in_flags         { print }
+    ' | grep -oE -- '--[a-z][a-z0-9-]+' | LC_ALL=C sort -u || true)"
+    [[ -z "$_flags" ]] && continue
+
+    while IFS= read -r flag; do
+      [[ -z "$flag" ]] && continue
+      case "$flag" in --help|--version) continue ;; esac
+      if ! grep -qF -- "$flag" "$COMMANDS_MD"; then
+        echo "check-docs: [cli] flag $flag (from \`$cmd_line --help\`) not mentioned in $COMMANDS_MD" >&2
+        _flag_drift=1
+      fi
+    done <<<"$_flags"
+  done <"$_tmp/help.txt"
+
+  if [[ "$_flag_drift" -ne 0 ]]; then
+    rm -rf "$_tmp"
+    return 1
+  fi
+
+  log "[cli] flag-level parity OK"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" ]] && continue
+    log "[cli]   $line"
+  done <"$_tmp/help.txt"
+  log "[cli] done."
   rm -rf "$_tmp"
-  return 1
+  return 0
+}
+
+# --- Install: install.sh --help vs canonical provider list (NemoClaw#3224) ----
+
+run_install_check() {
+  # Two installer entry points need to stay in sync with the canonical
+  # provider list:
+  #   1. install.sh (bootstrap_usage) — what users see via `curl | bash --help`
+  #   2. scripts/install.sh — what the bootstrap sources locally; what users
+  #      see when they run `bash install.sh --help` from a clone
+  local BOOTSTRAP_SH="$REPO_ROOT/install.sh"
+  local PAYLOAD_SH="$REPO_ROOT/scripts/install.sh"
+
+  # The providers list has moved between layouts; tolerate both the legacy
+  # flat path and the post-refactor layered path.
+  local PROVIDERS_TS=""
+  for _candidate in \
+    "$REPO_ROOT/src/lib/onboard/providers.ts" \
+    "$REPO_ROOT/src/lib/onboard-providers.ts"; do
+    if [[ -f "$_candidate" ]]; then
+      PROVIDERS_TS="$_candidate"
+      break
+    fi
+  done
+
+  if [[ ! -f "$BOOTSTRAP_SH" ]]; then
+    echo "check-docs: [install] missing $BOOTSTRAP_SH" >&2
+    return 1
+  fi
+  if [[ -z "$PROVIDERS_TS" ]]; then
+    echo "check-docs: [install] could not locate onboard providers TS source" >&2
+    return 1
+  fi
+
+  log "[install] comparing: NEMOCLAW_PROVIDER values in install.sh + scripts/install.sh"
+  log "[install]        vs: ${PROVIDERS_TS#"$REPO_ROOT"/} canonical 'Valid values' list"
+
+  # The canonical values live in a single error-message line that lists every
+  # accepted NEMOCLAW_PROVIDER input. Extract the comma-separated payload.
+  local _canonical
+  _canonical="$(grep -oE 'Valid values: [^"]+' "$PROVIDERS_TS" | head -1 | sed 's/^Valid values: //')"
+  if [[ -z "$_canonical" ]]; then
+    echo "check-docs: [install] could not locate canonical provider list in $PROVIDERS_TS" >&2
+    return 1
+  fi
+
+  # Extract the NEMOCLAW_PROVIDER usage block from each script (the printf
+  # lines starting at NEMOCLAW_PROVIDER through the next NEMOCLAW_ entry or
+  # blank-line printf), then verify each canonical value appears within that
+  # block. Grepping the whole script would match unrelated mentions of
+  # `gemini` / `ollama` in helper text, prompts, etc.
+  #
+  # Skip the install-helper / wizard-only keys (install-vllm, install-ollama,
+  # install-windows-ollama, start-windows-ollama). They are option keys the
+  # interactive wizard exposes, not values a user is expected to set
+  # NEMOCLAW_PROVIDER to from the installer entrypoint.
+  extract_provider_block() {
+    awk '
+      /printf .*NEMOCLAW_PROVIDER/ { in_block = 1 }
+      in_block { print }
+      in_block && /printf .*NEMOCLAW_(POLICY|MODEL|EXPERIMENTAL|SANDBOX_NAME|FROM_DOCKERFILE)/ && !/NEMOCLAW_PROVIDER/ {
+        in_block = 0
+      }
+    ' "$1"
+  }
+
+  local _bootstrap_block _payload_block _drift=0
+  _bootstrap_block="$(extract_provider_block "$BOOTSTRAP_SH")"
+  if [[ -z "$_bootstrap_block" ]]; then
+    echo "check-docs: [install] no NEMOCLAW_PROVIDER block found in $BOOTSTRAP_SH" >&2
+    return 1
+  fi
+  if [[ -f "$PAYLOAD_SH" ]]; then
+    _payload_block="$(extract_provider_block "$PAYLOAD_SH")"
+  fi
+
+  IFS=',' read -ra _values <<<"$_canonical"
+  for _raw in "${_values[@]}"; do
+    local v
+    v="$(echo "$_raw" | tr -d '[:space:]')"
+    [[ -z "$v" ]] && continue
+    case "$v" in install-*|start-windows-ollama) continue ;; esac
+    if ! grep -qF -- "$v" <<<"$_bootstrap_block"; then
+      echo "check-docs: [install] provider \"$v\" canonical but absent from $BOOTSTRAP_SH bootstrap_usage" >&2
+      _drift=1
+    fi
+    if [[ -n "$_payload_block" ]] && ! grep -qF -- "$v" <<<"$_payload_block"; then
+      echo "check-docs: [install] provider \"$v\" canonical but absent from $PAYLOAD_SH usage()" >&2
+      _drift=1
+    fi
+  done
+
+  if [[ "$_drift" -ne 0 ]]; then
+    return 1
+  fi
+
+  log "[install] parity OK"
+  log "[install] done."
+  return 0
 }
 
 # --- Markdown links -------------------------------------------------------------
@@ -520,16 +667,21 @@ run_links_check() {
 
 # --- main ---------------------------------------------------------------------
 
-if [[ "$RUN_LINKS" -eq 1 && "$RUN_CLI" -eq 1 ]]; then
-  log "running both: [cli] then [links] (--only-links / --only-cli for one)"
-elif [[ "$RUN_LINKS" -eq 1 ]]; then
-  log "running: [links] only"
-else
-  log "running: [cli] only"
-fi
+_planned=()
+[[ "$RUN_CLI" -eq 1 ]] && _planned+=("[cli]")
+[[ "$RUN_INSTALL" -eq 1 ]] && _planned+=("[install]")
+[[ "$RUN_LINKS" -eq 1 ]] && _planned+=("[links]")
+log "running: ${_planned[*]}"
+unset _planned
 
 if [[ "$RUN_CLI" -eq 1 ]]; then
   if ! run_cli_check; then
+    exit 1
+  fi
+fi
+
+if [[ "$RUN_INSTALL" -eq 1 ]]; then
+  if ! run_install_check; then
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

Close the recurring CLI/docs drift surfaced by NV QA's vitest pipeline (TC5882289 fired on v0.0.31, .34, .35, .36) and prevent it from re-occurring.

1. **Sync the current drifts** in `docs/reference/commands.md` and `install.sh` --help.
2. **Wire the `check-docs.sh` parity script into PR CI** so future drift is caught before merge instead of overnight.
3. **Tighten the parity script itself** so the kind of drift NemoClaw#3224 describes is actually flagged. The original `--only-cli` mode only caught command-level drift (a missing `### nemoclaw foo` heading); flag-level drift, install.sh provider drift, and stdin races silently passed.

Locally negative-tested: removing `--probe-only`, `--json`, `--yes`, `--gateway`, `routed`, or `anthropicCompatible` is now reported by the script. Restoring each makes the check pass cleanly.

## Related Issue

Fixes #3224

## Changes

### Docs sync

* `c5ce4614 docs(cli)` — `nemoclaw onboard` USAGE adds `[--yes | -y]`; `nemoclaw list` USAGE adds `[--json]`; `nemoclaw <name> connect` adds `--probe-only`; `install.sh` `bootstrap_usage` adds `routed` to `NEMOCLAW_PROVIDER`.
* `853cb05e docs(cli)` — split `--probe-only` description into prose per the one-sentence-per-line guideline (CodeRabbit nit).
* `9477d6ba docs(cli)` — close three more drift instances surfaced once flag-level parity actually iterated every command: `nemoclaw setup` and `nemoclaw setup-spark` (deprecated aliases that pass through all onboard flags) now list those flags inline; `nemoclaw uninstall` flag table adds `--gateway <name>`.

### CI workflow

* `51c5ac4e ci(docs)` — new `.github/workflows/docs-cli-parity-pr.yaml`. Runs `check-docs.sh --only-cli` and `--only-install` on every PR touching `src/**`, `bin/**`, `install.sh`, `scripts/install.sh`, `docs/reference/commands.md`, `package.json`, `package-lock.json`, `tsconfig.src.json`, the parity script itself, or this workflow file. Same Node 22 + `npm install --ignore-scripts` + `npm run build:cli` recipe as the rest of PR CI.

### Parity script tightening

* `c288aa2d test(docs)` — added flag-level parity (phase 3) and `--only-install` mode that compares `install.sh` + `scripts/install.sh` `NEMOCLAW_PROVIDER` blocks against `src/lib/onboard/providers.ts`.
* `ab391834 fix(test)` — flag check is now section-scoped (per `### \`nemoclaw <cmd>\`` heading) with word-boundary regex, so `--yes` documented under one command no longer hides drift in another, and `--yes` does not match inside `--yes-i-accept-third-party-software`. Loop invocation switched to argv array (clears SC2086). Sandbox-name limitation documented inline. Addresses CodeRabbit "scope flag checks to the matching command section" feedback.
* `61d03afe fix(test)` — install provider check switched from `grep -qF` (substring) to `grep -qxF` against tokenized identifiers, so `anthropic` no longer falsely passes when only `anthropicCompatible` is present. Awk block-extractor boundary tightened so `NEMOCLAW_POLICY_MODE` no longer bleeds into the provider block (would have hidden `custom` drift). Addresses CodeRabbit "compare provider names as exact values, not substrings" feedback.
* `3a3fbd94 fix(test)` — redirect inner `node ... --help` stdin to `/dev/null`. The outer `while read` consumed `$_tmp/help.txt` via `done <` redirection, and node startup paths were reading a byte from that stdin, silently jumping the outer loop past `debug`, `deploy`, `gc`, `list`, `onboard`, etc. This was the most material bug — without it phase 3 only covered the alphabetic prefix of commands. Negative-tested.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli` passes on the branch.
- [x] `bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-install` passes on the branch.
- [x] Negative tests: removing `--probe-only`, `--json`, `--yes`, `--gateway`, `routed`, `anthropicCompatible` each cause the relevant phase to fail with a clear "not in section" or "absent from" message.
- [x] No secrets, API keys, or credentials committed.
- [x] Docs updated for user-facing behavior changes.

## Test plan

- [x] `bash install.sh --help | grep routed` shows the new entry in the bootstrap `NEMOCLAW_PROVIDER` list.
- [x] `bash scripts/install.sh --help` (the local-payload path) was already current — confirmed.
- [x] YAML validates: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs-cli-parity-pr.yaml'))"`.
- [ ] PR CI run validates the new workflow triggers correctly on this PR (this PR touches `install.sh` and `docs/reference/commands.md`, so the new workflow itself should run).
- [ ] NV QA's TC5882289 / TC5956310 vitest assertions reflagged on the branch — expected to drop from 2 failures to 0.

## Known limitation

For sandbox-prefixed commands (`nemoclaw <name> channels add`, `destroy`, `rebuild`, `doctor`, `skill install`), `--help` is gated behind sandbox-name validation that requires a registered sandbox to bypass. On a CI runner with no sandbox they emit only an error and we skip the empty help text — flag drift on those specific commands is not caught by the per-PR check. The existing E2E suite (which runs against a real sandbox) covers them. Documented inline in `check-docs.sh` and tracked as a follow-up to provision a placeholder sandbox in CI or add a CLI mode that bypasses name validation for `--help`.

---

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--probe-only` to verify SSH reachability without opening a shell.
  * Added "routed" as a supported provider option.

* **Documentation**
  * Updated CLI command reference to reflect current flag syntax, onboarding options, and list command usage.
  * Deprecated setup aliases documented to accept onboarding flags.

* **Tests**
  * Improved automated parity checks to verify command and flag alignment and install-provider coverage.

* **Chores**
  * Added a PR pipeline to run docs/CLI/install parity checks on main-bound PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->