### PR TITLE
fix(share): give a clear error when the local mount path is on a read-only filesystem

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -807,6 +807,8 @@ Prerequisites:
 - `sshfs` must be installed on the host (`sudo apt-get install sshfs` on Linux, `brew install macfuse && brew install sshfs` on macOS).
 - The sandbox must be running.
 - Sandboxes created before the `openssh-sftp-server` base image update must be rebuilt with `nemoclaw <name> rebuild`.
+- The local mount path must be on a writable filesystem; FUSE creates the mount on the host side.
+  If the default `~/.nemoclaw/mounts/<name>` lives on a read-only filesystem, pass an explicit writable path as the second positional argument.
 
 ```console
 # mount a specific path to a custom local directory

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -838,6 +838,8 @@ Prerequisites:
 - `sshfs` must be installed on the host (`sudo apt-get install sshfs` on Linux, `brew install macfuse && brew install sshfs` on macOS).
 - The sandbox must be running.
 - Sandboxes created before the `openssh-sftp-server` base image update must be rebuilt with `nemoclaw <name> rebuild`.
+- The local mount path must be on a writable filesystem; FUSE creates the mount on the host side.
+  If the default `~/.nemoclaw/mounts/<name>` lives on a read-only filesystem, pass an explicit writable path as the second positional argument.
 
 ```console
 # mount a specific path to a custom local directory

--- a/src/lib/share-command.ts
+++ b/src/lib/share-command.ts
@@ -64,6 +64,31 @@ export function resolveLinuxUnmount(): string | null {
   return null;
 }
 
+/**
+ * Verify that `localMount` exists and is writable so FUSE can mount onto it.
+ * Creates the directory (recursive) if missing, and reports the specific
+ * failure reason (read-only filesystem, permission denied, etc.) when the
+ * mount target is unusable. Returning a structured result instead of
+ * throwing keeps the helper unit-testable; the caller decides how to surface
+ * the error to the user.
+ */
+export function checkLocalMountWritable(localMount: string): { writable: boolean; reason?: string } {
+  try {
+    fs.mkdirSync(localMount, { recursive: true });
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EROFS") return { writable: false, reason: "parent filesystem is read-only" };
+    if (code === "EACCES") return { writable: false, reason: "permission denied creating the directory" };
+    return { writable: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    fs.accessSync(localMount, fs.constants.W_OK);
+  } catch {
+    return { writable: false, reason: "directory is not writable" };
+  }
+  return { writable: true };
+}
+
 export type ShareMountOptions = {
   sandboxName: string;
   remotePath?: string;
@@ -126,7 +151,23 @@ export async function runShareMount(
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sshfs-"));
   const tmpFile = path.join(tmpDir, `${sandboxName}.conf`);
   fs.writeFileSync(tmpFile, sshConfigResult.output, { mode: 0o600, flag: "wx" });
-  fs.mkdirSync(localMount, { recursive: true });
+
+  const writable = checkLocalMountWritable(localMount);
+  if (!writable.writable) {
+    console.error(`  Local mount path '${localMount}' is not usable: ${writable.reason}.`);
+    console.error("  share mount projects sandbox files onto a host directory via SSHFS,");
+    console.error("  so the local target must be on a writable filesystem.");
+    console.error(
+      `  Pick a writable directory: ${deps.cliName} ${sandboxName} share mount ${remotePath} <writable-path>`,
+    );
+    try {
+      fs.unlinkSync(tmpFile);
+      fs.rmdirSync(tmpDir);
+    } catch {
+      /* ignore */
+    }
+    process.exit(1);
+  }
 
   let mountFailed = false;
   try {

--- a/src/lib/share-command.ts
+++ b/src/lib/share-command.ts
@@ -83,8 +83,11 @@ export function checkLocalMountWritable(localMount: string): { writable: boolean
   }
   try {
     fs.accessSync(localMount, fs.constants.W_OK);
-  } catch {
-    return { writable: false, reason: "directory is not writable" };
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EROFS") return { writable: false, reason: "filesystem is read-only" };
+    if (code === "EACCES") return { writable: false, reason: "directory is not writable" };
+    return { writable: false, reason: err instanceof Error ? err.message : String(err) };
   }
   return { writable: true };
 }

--- a/test/share-command-writable.test.ts
+++ b/test/share-command-writable.test.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { checkLocalMountWritable } from "../dist/lib/share-command.js";
+
+describe("checkLocalMountWritable (#3192)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns writable=true when mkdirSync and accessSync both succeed", () => {
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync").mockReturnValue(undefined);
+    const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
+
+    const result = checkLocalMountWritable("/some/writable/path");
+
+    expect(result).toEqual({ writable: true });
+    expect(mkdirSpy).toHaveBeenCalledWith("/some/writable/path", { recursive: true });
+    expect(accessSpy).toHaveBeenCalledWith("/some/writable/path", fs.constants.W_OK);
+  });
+
+  it("reports a read-only filesystem when mkdirSync raises EROFS", () => {
+    const err = new Error("EROFS: read-only file system, mkdir '/ro/mount'") as NodeJS.ErrnoException;
+    err.code = "EROFS";
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => {
+      throw err;
+    });
+
+    expect(checkLocalMountWritable("/ro/mount")).toEqual({
+      writable: false,
+      reason: "parent filesystem is read-only",
+    });
+  });
+
+  it("reports permission denied when mkdirSync raises EACCES", () => {
+    const err = new Error("EACCES: permission denied, mkdir '/restricted'") as NodeJS.ErrnoException;
+    err.code = "EACCES";
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => {
+      throw err;
+    });
+
+    expect(checkLocalMountWritable("/restricted")).toEqual({
+      writable: false,
+      reason: "permission denied creating the directory",
+    });
+  });
+
+  it("falls back to the underlying error message for unexpected mkdirSync failures", () => {
+    const err = new Error("ENOSPC: no space left on device") as NodeJS.ErrnoException;
+    err.code = "ENOSPC";
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => {
+      throw err;
+    });
+
+    expect(checkLocalMountWritable("/full-disk")).toEqual({
+      writable: false,
+      reason: "ENOSPC: no space left on device",
+    });
+  });
+
+  it("catches a pre-existing directory on a read-only filesystem (mkdir succeeds, access fails)", () => {
+    vi.spyOn(fs, "mkdirSync").mockReturnValue(undefined);
+    vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+
+    expect(checkLocalMountWritable("/preexisting/ro/mount")).toEqual({
+      writable: false,
+      reason: "directory is not writable",
+    });
+  });
+});

--- a/test/share-command-writable.test.ts
+++ b/test/share-command-writable.test.ts
@@ -61,13 +61,31 @@ describe("checkLocalMountWritable (#3192)", () => {
     });
   });
 
-  it("catches a pre-existing directory on a read-only filesystem (mkdir succeeds, access fails)", () => {
+  it("preserves EROFS on a pre-existing directory whose filesystem is read-only", () => {
+    const err = new Error(
+      "EROFS: read-only file system, access '/preexisting/ro/mount'",
+    ) as NodeJS.ErrnoException;
+    err.code = "EROFS";
     vi.spyOn(fs, "mkdirSync").mockReturnValue(undefined);
     vi.spyOn(fs, "accessSync").mockImplementation(() => {
-      throw new Error("EACCES");
+      throw err;
     });
 
     expect(checkLocalMountWritable("/preexisting/ro/mount")).toEqual({
+      writable: false,
+      reason: "filesystem is read-only",
+    });
+  });
+
+  it("reports a generic permission failure on EACCES from accessSync", () => {
+    const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+    err.code = "EACCES";
+    vi.spyOn(fs, "mkdirSync").mockReturnValue(undefined);
+    vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw err;
+    });
+
+    expect(checkLocalMountWritable("/preexisting/no-write")).toEqual({
       writable: false,
       reason: "directory is not writable",
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw <name> share mount` now fails fast with a structured, actionable error when the local mount path is on a read-only filesystem, instead of leaking the low-level `fusermount3: user has no write access to mountpoint` line that #3192 reported on AlmaLinux 9.7.

## Related Issue

Closes #3192

## Changes

- New `checkLocalMountWritable(localMount)` helper in `src/lib/share-command.ts` recursively creates the mount directory and verifies the resulting path is writable, distinguishing EROFS (parent on read-only fs), EACCES (permission denied), and other failures and returning a structured `{ writable, reason }` result.
- `runShareMount` consults this helper after writing the temporary SSH config and before invoking `sshfs`. A non-writable target now exits with the offending path, the underlying reason, and a suggested writable-path invocation; the temporary SSH config file is cleaned up before the early exit so we don't leave an orphan in `/tmp`. Sample output for a read-only target: `Local mount path '/ro/mounts/my-assistant' is not usable: parent filesystem is read-only. share mount projects sandbox files onto a host directory via SSHFS, so the local target must be on a writable filesystem. Pick a writable directory: nemoclaw my-assistant share mount /sandbox <writable-path>`.
- `docs/reference/commands.md` and the agent-skill mirror in `.agents/skills/nemoclaw-user-reference/references/commands.md` now include the writable-mount-target requirement in the `share mount` prerequisites, so users hitting the default `~/.nemoclaw/mounts/<name>` on a read-only filesystem know they can pass an explicit local path as the second positional argument.
- New `test/share-command-writable.test.ts` covers five cases for the helper: success, EROFS from `mkdirSync`, EACCES from `mkdirSync`, an unexpected `mkdirSync` failure (ENOSPC), and a pre-existing directory whose `accessSync` fails.

## Type of Change

- [x] Code change with doc updates
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes (commitlint, gitleaks, biome, TypeScript, source-shape, skills YAML, dist-sourcemaps)
- [x] `npm test` (`npx vitest run`) passes for the new file: 5/5 in `test/share-command-writable.test.ts`. Full suite was 3525 passed / 4 pre-existing timing flakes (sandbox-stuck-recovery, cli timing assertion) / 13 skipped; flakes are unrelated to `share-command.ts` and pass 4/4 in isolation.
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `nemoclaw <name> share mount` requires the local mount path to be on a writable host filesystem and how to supply an explicit writable destination.

* **Bug Fixes**
  * Mount now validates the local target before attempting the mount and shows clearer, actionable errors when the path is not writable.

* **Tests**
  * Added automated tests covering writable-check scenarios and failure messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3235)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->