### PR TITLE
docs(reference): consolidate user-tunable environment variable reference

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -985,7 +985,7 @@ These variables seed the onboarding inference selection and let non-interactive 
 
 ### Local inference
 
-For onboards that route through a host-side Ollama, vLLM, or NIM instance.
+Use these variables for onboards that route through a host-side Ollama, vLLM, or NIM instance.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -901,6 +901,12 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 
 ## Environment Variables
 
+NemoClaw reads environment variables to override interactive prompts, route to alternate inference or storage backends, and expose runtime knobs that the CLI does not surface as flags.
+This section covers the user-tunable variables grouped by topic.
+Internal scaffolding, installer-handoff, and test-only variables are intentionally omitted; additional advanced overrides exist in the source.
+
+### Service ports
+
 NemoClaw reads the following environment variables to configure service ports.
 Set them before running `nemoclaw onboard` or any command that starts services.
 All ports must be non-privileged integers between 1024 and 65535.
@@ -929,7 +935,8 @@ Pass `--control-ui-port <N>` to require a specific port.
 
 ### Onboard timeouts
 
-The following environment variables tune onboard-time wall-clock limits. Set them before running `nemoclaw onboard` if a slow connection or large model pull risks tripping the default.
+The following environment variables tune onboard-time wall-clock limits.
+Set them before running `nemoclaw onboard` if a slow connection or large model pull risks tripping the default.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
@@ -941,6 +948,105 @@ $ nemoclaw onboard
 ```
 
 If the pull exceeds the limit, onboarding emits the timeout in minutes plus a hint to raise this variable, and the partial download is preserved for the next attempt.
+
+### Onboarding control
+
+These variables let scripted (CI/CD) and headless onboards skip prompts that an interactive user would normally answer.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_NON_INTERACTIVE` | unset | Run onboarding without interactive prompts; missing required inputs fail fast. Equivalent to passing `--non-interactive`. |
+| `NEMOCLAW_YES` | unset | Auto-answer "yes" to confirmation prompts. Equivalent to passing `--yes`. |
+| `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE` | unset | Auto-accept the third-party software notice without prompting. Equivalent to passing `--yes-i-accept-third-party-software`. |
+| `NEMOCLAW_FRESH` | unset | Discard any existing onboard state and start over. Equivalent to passing `--fresh`. |
+| `NEMOCLAW_RECREATE_SANDBOX` | unset | Force the sandbox to be recreated even when no drift is detected. |
+| `NEMOCLAW_SANDBOX_NAME` | `my-assistant` (or `hermes` for the Hermes agent) | Name of the sandbox to create or reuse. |
+| `NEMOCLAW_AGENT` | unset | Agent type to onboard, e.g. `openclaw` or `hermes`. Equivalent to passing `--agent`. |
+| `NEMOCLAW_FROM_DOCKERFILE` | unset | Path to a custom Dockerfile when building from `--from` in non-interactive mode. |
+| `NEMOCLAW_INSTALL_REF` | `latest` | Git ref the installer fetches when bootstrapping NemoClaw. |
+| `NEMOCLAW_INSTALL_TAG` | `latest` | Git tag the installer fetches when `NEMOCLAW_INSTALL_REF` is unset. |
+
+### Inference and provider
+
+These variables seed the onboarding inference selection and let non-interactive runs skip the provider/model picker.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_PROVIDER` | unset | Inference provider, e.g. `openai-api`, `nvidia-prod`, or `ollama-local`. |
+| `NEMOCLAW_PROVIDER_KEY` | unset | Name of the environment variable that holds the provider's API key. |
+| `NEMOCLAW_MODEL` | unset | Inference model id, e.g. `nvidia/nemotron-3-super-120b-a12b`. |
+| `NEMOCLAW_INFERENCE_API` | unset | Inference API variant, e.g. `openai-completions`, `openai-chat-completions`, or `anthropic-messages`. |
+| `NEMOCLAW_INFERENCE_BASE_URL` | unset | Custom base URL for inference calls. |
+| `NEMOCLAW_INFERENCE_INPUTS` | unset | JSON-formatted inference parameters to pass to the model. |
+| `NEMOCLAW_CONTEXT_WINDOW` | unset | Override the model's context window in tokens without rebuilding. |
+| `NEMOCLAW_MAX_TOKENS` | unset | Override the model's max output tokens without rebuilding. |
+| `NEMOCLAW_REASONING` | unset | Enable reasoning/thinking mode for supported models, e.g. o1 or Claude with extended thinking. |
+| `NEMOCLAW_ENDPOINT_URL` | unset | Custom inference endpoint URL for self-hosted or non-standard providers. |
+
+### Local inference
+
+For onboards that route through a host-side Ollama, vLLM, or NIM instance.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | `180` (seconds) | How long to wait for a local inference provider to become ready before failing onboard. |
+| `NEMOCLAW_OLLAMA_REQUIRE_TOOLS` | unset | Reject Ollama models that lack tool/function calling support. |
+| `NEMOCLAW_OLLAMA_PROXY_TOKEN` | unset | Auth token for the local Ollama auth proxy. |
+| `NEMOCLAW_VLLM_LOCAL_TOKEN` | unset | Auth token for the local vLLM instance. |
+
+### Runtime overrides
+
+These variables are read inside the sandbox at sandbox-start time and let users switch model or API at runtime without rebuilding.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_MODEL_OVERRIDE` | unset | Override the primary model at sandbox runtime. Must match a model the gateway is configured to route to. |
+| `NEMOCLAW_INFERENCE_API_OVERRIDE` | unset | Override the inference API variant at sandbox runtime. |
+
+### Security policy
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_POLICY_TIER` | `balanced` | Default sandbox security tier. One of `permissive`, `balanced`, or `strict`. |
+| `NEMOCLAW_POLICY_MODE` | `suggested` | How non-interactive onboarding reconciles tier-derived suggestions against the sandbox's currently-applied presets. One of `suggested`, `additive`, or `custom`. |
+| `NEMOCLAW_POLICY_PRESETS` | unset | Comma-separated list of preset names. Required when `NEMOCLAW_POLICY_MODE=custom`. |
+
+### Sandbox lifecycle
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_REBUILD_VERBOSE` | unset | Enable verbose output during `nemoclaw <name> rebuild`. |
+
+### Remote deployment
+
+These variables apply to the `nemoclaw deploy` and `nemoclaw onboard --remote` flows that provision a Brev instance.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_BREV_PROVIDER` | `gcp` | Cloud provider for Brev instance creation. |
+| `NEMOCLAW_GPU` | `a2-highgpu-1g:nvidia-tesla-a100:1` | GPU specification (instance type and GPU model) for Brev instance creation. |
+| `NEMOCLAW_DEPLOY_NO_CONNECT` | unset | Skip the automatic `connect` step after the remote deploy completes. |
+| `NEMOCLAW_DEPLOY_NO_START_SERVICES` | unset | Skip starting services automatically after the remote deploy. |
+
+### HTTP proxy
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_PROXY_HOST` | unset | HTTP proxy host for outbound requests from the sandbox. |
+| `NEMOCLAW_PROXY_PORT` | unset | HTTP proxy port paired with `NEMOCLAW_PROXY_HOST`. |
+
+### Channel integrations
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_SKIP_TELEGRAM_REACHABILITY` | unset | Skip the Telegram API reachability test during onboard, for environments without internet egress to `api.telegram.org`. |
+
+### Advanced
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_EXPERIMENTAL` | unset | Enable experimental features and behaviors that are subject to change between releases. |
+| `NEMOCLAW_DISABLE_DEVICE_AUTH` | unset | Skip device-pairing authentication during sandbox build. Intended for headless or development hosts; do not use in production. |
 
 ## NemoHermes Alias
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -937,6 +937,12 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 
 ## Environment Variables
 
+NemoClaw reads environment variables to override interactive prompts, route to alternate inference or storage backends, and expose runtime knobs that the CLI does not surface as flags.
+This section covers the user-tunable variables grouped by topic.
+Internal scaffolding, installer-handoff, and test-only variables are intentionally omitted; additional advanced overrides exist in the source.
+
+### Service ports
+
 NemoClaw reads the following environment variables to configure service ports.
 Set them before running `nemoclaw onboard` or any command that starts services.
 All ports must be non-privileged integers between 1024 and 65535.
@@ -965,7 +971,8 @@ Pass `--control-ui-port <N>` to require a specific port.
 
 ### Onboard timeouts
 
-The following environment variables tune onboard-time wall-clock limits. Set them before running `nemoclaw onboard` if a slow connection or large model pull risks tripping the default.
+The following environment variables tune onboard-time wall-clock limits.
+Set them before running `nemoclaw onboard` if a slow connection or large model pull risks tripping the default.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
@@ -977,6 +984,105 @@ $ nemoclaw onboard
 ```
 
 If the pull exceeds the limit, onboarding emits the timeout in minutes plus a hint to raise this variable, and the partial download is preserved for the next attempt.
+
+### Onboarding control
+
+These variables let scripted (CI/CD) and headless onboards skip prompts that an interactive user would normally answer.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_NON_INTERACTIVE` | unset | Run onboarding without interactive prompts; missing required inputs fail fast. Equivalent to passing `--non-interactive`. |
+| `NEMOCLAW_YES` | unset | Auto-answer "yes" to confirmation prompts. Equivalent to passing `--yes`. |
+| `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE` | unset | Auto-accept the third-party software notice without prompting. Equivalent to passing `--yes-i-accept-third-party-software`. |
+| `NEMOCLAW_FRESH` | unset | Discard any existing onboard state and start over. Equivalent to passing `--fresh`. |
+| `NEMOCLAW_RECREATE_SANDBOX` | unset | Force the sandbox to be recreated even when no drift is detected. |
+| `NEMOCLAW_SANDBOX_NAME` | `my-assistant` (or `hermes` for the Hermes agent) | Name of the sandbox to create or reuse. |
+| `NEMOCLAW_AGENT` | unset | Agent type to onboard, e.g. `openclaw` or `hermes`. Equivalent to passing `--agent`. |
+| `NEMOCLAW_FROM_DOCKERFILE` | unset | Path to a custom Dockerfile when building from `--from` in non-interactive mode. |
+| `NEMOCLAW_INSTALL_REF` | `latest` | Git ref the installer fetches when bootstrapping NemoClaw. |
+| `NEMOCLAW_INSTALL_TAG` | `latest` | Git tag the installer fetches when `NEMOCLAW_INSTALL_REF` is unset. |
+
+### Inference and provider
+
+These variables seed the onboarding inference selection and let non-interactive runs skip the provider/model picker.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_PROVIDER` | unset | Inference provider, e.g. `openai-api`, `nvidia-prod`, or `ollama-local`. |
+| `NEMOCLAW_PROVIDER_KEY` | unset | Name of the environment variable that holds the provider's API key. |
+| `NEMOCLAW_MODEL` | unset | Inference model id, e.g. `nvidia/nemotron-3-super-120b-a12b`. |
+| `NEMOCLAW_INFERENCE_API` | unset | Inference API variant, e.g. `openai-completions`, `openai-chat-completions`, or `anthropic-messages`. |
+| `NEMOCLAW_INFERENCE_BASE_URL` | unset | Custom base URL for inference calls. |
+| `NEMOCLAW_INFERENCE_INPUTS` | unset | JSON-formatted inference parameters to pass to the model. |
+| `NEMOCLAW_CONTEXT_WINDOW` | unset | Override the model's context window in tokens without rebuilding. |
+| `NEMOCLAW_MAX_TOKENS` | unset | Override the model's max output tokens without rebuilding. |
+| `NEMOCLAW_REASONING` | unset | Enable reasoning/thinking mode for supported models, e.g. o1 or Claude with extended thinking. |
+| `NEMOCLAW_ENDPOINT_URL` | unset | Custom inference endpoint URL for self-hosted or non-standard providers. |
+
+### Local inference
+
+For onboards that route through a host-side Ollama, vLLM, or NIM instance.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | `180` (seconds) | How long to wait for a local inference provider to become ready before failing onboard. |
+| `NEMOCLAW_OLLAMA_REQUIRE_TOOLS` | unset | Reject Ollama models that lack tool/function calling support. |
+| `NEMOCLAW_OLLAMA_PROXY_TOKEN` | unset | Auth token for the local Ollama auth proxy. |
+| `NEMOCLAW_VLLM_LOCAL_TOKEN` | unset | Auth token for the local vLLM instance. |
+
+### Runtime overrides
+
+These variables are read inside the sandbox at sandbox-start time and let users switch model or API at runtime without rebuilding.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_MODEL_OVERRIDE` | unset | Override the primary model at sandbox runtime. Must match a model the gateway is configured to route to. |
+| `NEMOCLAW_INFERENCE_API_OVERRIDE` | unset | Override the inference API variant at sandbox runtime. |
+
+### Security policy
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_POLICY_TIER` | `balanced` | Default sandbox security tier. One of `permissive`, `balanced`, or `strict`. |
+| `NEMOCLAW_POLICY_MODE` | `suggested` | How non-interactive onboarding reconciles tier-derived suggestions against the sandbox's currently-applied presets. One of `suggested`, `additive`, or `custom`. |
+| `NEMOCLAW_POLICY_PRESETS` | unset | Comma-separated list of preset names. Required when `NEMOCLAW_POLICY_MODE=custom`. |
+
+### Sandbox lifecycle
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_REBUILD_VERBOSE` | unset | Enable verbose output during `nemoclaw <name> rebuild`. |
+
+### Remote deployment
+
+These variables apply to the `nemoclaw deploy` and `nemoclaw onboard --remote` flows that provision a Brev instance.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_BREV_PROVIDER` | `gcp` | Cloud provider for Brev instance creation. |
+| `NEMOCLAW_GPU` | `a2-highgpu-1g:nvidia-tesla-a100:1` | GPU specification (instance type and GPU model) for Brev instance creation. |
+| `NEMOCLAW_DEPLOY_NO_CONNECT` | unset | Skip the automatic `connect` step after the remote deploy completes. |
+| `NEMOCLAW_DEPLOY_NO_START_SERVICES` | unset | Skip starting services automatically after the remote deploy. |
+
+### HTTP proxy
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_PROXY_HOST` | unset | HTTP proxy host for outbound requests from the sandbox. |
+| `NEMOCLAW_PROXY_PORT` | unset | HTTP proxy port paired with `NEMOCLAW_PROXY_HOST`. |
+
+### Channel integrations
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_SKIP_TELEGRAM_REACHABILITY` | unset | Skip the Telegram API reachability test during onboard, for environments without internet egress to `api.telegram.org`. |
+
+### Advanced
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEMOCLAW_EXPERIMENTAL` | unset | Enable experimental features and behaviors that are subject to change between releases. |
+| `NEMOCLAW_DISABLE_DEVICE_AUTH` | unset | Skip device-pairing authentication during sandbox build. Intended for headless or development hosts; do not use in production. |
 
 ## NemoHermes Alias
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1021,7 +1021,7 @@ These variables seed the onboarding inference selection and let non-interactive 
 
 ### Local inference
 
-For onboards that route through a host-side Ollama, vLLM, or NIM instance.
+Use these variables for onboards that route through a host-side Ollama, vLLM, or NIM instance.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Consolidate the user-tunable `NEMOCLAW_*` environment variables under a single `## Environment Variables` reference grouped by topic, so users can scan the docs portal for the knob they need instead of grepping the source. Driven by #3059, which flagged that env vars were scattered across the docs and asked for a first-class reference table similar to the Hermes agent's `environment-variables` page.

## Related Issue

Closes #3059

## Changes

- The existing service-port and onboard-timeout content moves under explicit `### Service ports` and `### Onboard timeouts` subsections (no content change). The parent section gains a one-paragraph intro framing the scope (user-tunable variables, not internal scaffolding).
- Eight new `### ...` subsections cover the rest of the user-facing surface: **Onboarding control** (10 vars: `NEMOCLAW_NON_INTERACTIVE`, `_YES`, `_ACCEPT_THIRD_PARTY_SOFTWARE`, `_FRESH`, `_RECREATE_SANDBOX`, `_SANDBOX_NAME`, `_AGENT`, `_FROM_DOCKERFILE`, `_INSTALL_REF`, `_INSTALL_TAG`); **Inference and provider** (10: `_PROVIDER`, `_PROVIDER_KEY`, `_MODEL`, `_INFERENCE_API`, `_INFERENCE_BASE_URL`, `_INFERENCE_INPUTS`, `_CONTEXT_WINDOW`, `_MAX_TOKENS`, `_REASONING`, `_ENDPOINT_URL`); **Local inference** (4: `_LOCAL_INFERENCE_TIMEOUT`, `_OLLAMA_REQUIRE_TOOLS`, `_OLLAMA_PROXY_TOKEN`, `_VLLM_LOCAL_TOKEN`); **Runtime overrides** (2: `_MODEL_OVERRIDE`, `_INFERENCE_API_OVERRIDE`); **Security policy** (3: `_POLICY_TIER`, `_POLICY_MODE`, `_POLICY_PRESETS`); **Sandbox lifecycle** (1: `_REBUILD_VERBOSE`); **Remote deployment** (4: `_BREV_PROVIDER`, `_GPU`, `_DEPLOY_NO_CONNECT`, `_DEPLOY_NO_START_SERVICES`); **HTTP proxy** (2: `_PROXY_HOST`, `_PROXY_PORT`); **Channel integrations** (1: `_SKIP_TELEGRAM_REACHABILITY`); **Advanced** (2: `_EXPERIMENTAL`, `_DISABLE_DEVICE_AUTH`).
- Each row gives variable name, default, and a one-line purpose. Defaults were verified against `src/lib/onboard.ts`, `src/lib/deploy.ts`, `src/lib/inference-config.ts`, and `scripts/install.sh`.
- Internal scaffolding, installer-handoff, and test-only variables (e.g. `NEMOCLAW_BOOTSTRAP_PAYLOAD`, `NEMOCLAW_TEST_SOCKET_PATHS`, `NEMOCLAW_AGENT_BINARY_CHECK`, `NEMOCLAW_BACK_TO_SELECTION__`) are intentionally omitted; the section intro flags that additional advanced overrides exist in the source so maintainers can still grep for them.
- Mirrored to the agent-skill reference at `.agents/skills/nemoclaw-user-reference/references/commands.md` to keep docs-to-skills conversion in sync.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes (commitlint, gitleaks, biome, markdownlint, source-shape, skills YAML, dist-sourcemaps).
- [x] `npx vitest run test/check-docs-links.test.ts` 7/7 passes; the docs-link test exercises the updated `commands.md` and skill mirror.
- [x] Defaults sourced from `src/lib/onboard.ts`, `src/lib/deploy.ts`, `src/lib/inference-config.ts`, and `scripts/install.sh`; spot-checked `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT=180`, `NEMOCLAW_BREV_PROVIDER=gcp`, `NEMOCLAW_GPU=a2-highgpu-1g:nvidia-tesla-a100:1`, `NEMOCLAW_POLICY_TIER=balanced`, `NEMOCLAW_POLICY_MODE=suggested` against the source.
- [x] No secrets, API keys, or credentials committed.
- [x] Docs updated for user-facing behavior changes.

---
Signed-off-by: latenighthackathon <support@latenighthackathon.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI documentation with a new, structured "Environment Variables" section. Adds grouped topics and tables for service port overrides, onboarding controls (timeouts, non-interactive modes, acceptance flags), inference/provider selection, local inference routing/auth, sandbox runtime overrides, security-policy tiers/presets, rebuild verbosity, remote deployment settings, HTTP proxy and channel reachability toggles, plus advanced/experimental flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->