### PR TITLE
fix(inference): make Kimi health checks model-aware

### DIFF
--- a/src/lib/actions/sandbox/status.test.ts
+++ b/src/lib/actions/sandbox/status.test.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import type { ProviderHealthProbeOptions } from "../../../../dist/lib/inference/health";
+import { getSandboxStatusInferenceHealth } from "../../../../dist/lib/actions/sandbox/status";
+
+describe("sandbox status inference health", () => {
+  it("passes the current model with the current provider", () => {
+    let observed: { provider: string; options?: ProviderHealthProbeOptions } | null = null;
+
+    const result = getSandboxStatusInferenceHealth(
+      true,
+      "nvidia-prod",
+      "moonshotai/kimi-k2.6",
+      (provider, options) => {
+        observed = { provider, options };
+        return {
+          ok: true,
+          probed: true,
+          providerLabel: "NVIDIA Endpoints",
+          endpoint: "https://integrate.api.nvidia.com/v1/chat/completions",
+          detail: "healthy",
+        };
+      },
+    );
+
+    expect(result?.ok).toBe(true);
+    expect(observed).toEqual({
+      provider: "nvidia-prod",
+      options: { model: "moonshotai/kimi-k2.6" },
+    });
+  });
+
+  it("does not probe when the sandbox gateway is not present", () => {
+    let called = false;
+
+    const result = getSandboxStatusInferenceHealth(
+      false,
+      "nvidia-prod",
+      "moonshotai/kimi-k2.6",
+      () => {
+        called = true;
+        return null;
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(called).toBe(false);
+  });
+});

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -7,7 +7,11 @@ import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
 import { parseSandboxPhase } from "../../state/gateway";
 import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
 import { parseGatewayInference } from "../../inference/config";
-import { probeProviderHealth } from "../../inference/health";
+import {
+  probeProviderHealth,
+  type ProviderHealthProbeOptions,
+  type ProviderHealthStatus,
+} from "../../inference/health";
 import * as nim from "../../inference/nim";
 import * as onboardSession from "../../state/onboard-session";
 import type { Session } from "../../state/onboard-session";
@@ -34,6 +38,23 @@ import { D, G, R, RD, YW } from "../../cli/terminal-style";
 
 const agentRuntime = require("../../../../bin/lib/agent-runtime");
 
+type ProbeProviderHealth = (
+  provider: string,
+  options?: ProviderHealthProbeOptions,
+) => ProviderHealthStatus | null;
+
+export function getSandboxStatusInferenceHealth(
+  gatewayPresent: boolean,
+  currentProvider: unknown,
+  currentModel: unknown,
+  probeProviderHealthImpl: ProbeProviderHealth = probeProviderHealth,
+): ProviderHealthStatus | null {
+  if (!gatewayPresent || typeof currentProvider !== "string") return null;
+  return probeProviderHealthImpl(currentProvider, {
+    model: typeof currentModel === "string" ? currentModel : undefined,
+  });
+}
+
 // eslint-disable-next-line complexity
 export async function showSandboxStatus(sandboxName: string): Promise<void> {
   const sb = registry.getSandbox(sandboxName);
@@ -50,10 +71,11 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
     liveResult && !isCommandTimeout(liveResult) ? parseGatewayInference(liveResult.output) : null;
   const currentModel = (live && live.model) || (sb && sb.model) || "unknown";
   const currentProvider = (live && live.provider) || (sb && sb.provider) || "unknown";
-  const inferenceHealth =
-    lookup.state === "present" && typeof currentProvider === "string"
-      ? probeProviderHealth(currentProvider)
-      : null;
+  const inferenceHealth = getSandboxStatusInferenceHealth(
+    lookup.state === "present",
+    currentProvider,
+    currentModel,
+  );
   if (sb) {
     console.log("");
     console.log(`  Sandbox: ${sb.name}`);
@@ -65,7 +87,9 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
       } else if (inferenceHealth.ok) {
         console.log(`    Inference: ${G}healthy${R} (${inferenceHealth.endpoint})`);
       } else {
-        console.log(`    Inference: ${RD}unreachable${R} (${inferenceHealth.endpoint})`);
+        console.log(
+          `    Inference: ${RD}${inferenceHealth.failureLabel || "unreachable"}${R} (${inferenceHealth.endpoint})`,
+        );
         console.log(`      ${inferenceHealth.detail}`);
       }
     }

--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+
 import { describe, it, expect } from "vitest";
 
 // Import from compiled dist/ for correct coverage attribution.
@@ -200,11 +202,16 @@ describe("inference health", () => {
 
     it("uses Kimi chat completions for NVIDIA managed inference when a credential is available", () => {
       let capturedArgv: string[] = [];
+      let authConfigPath = "";
+      let authConfigContent = "";
       const result = probeRemoteProviderHealth("nvidia-prod", {
         model: "moonshotai/kimi-k2.6",
         getCredentialImpl: (envName) => (envName === "NVIDIA_API_KEY" ? "nvapi-test" : null),
         runCurlProbeImpl: (argv) => {
           capturedArgv = argv;
+          const configIndex = argv.indexOf("--config");
+          authConfigPath = configIndex >= 0 ? argv[configIndex + 1] : "";
+          authConfigContent = authConfigPath ? fs.readFileSync(authConfigPath, "utf8") : "";
           return {
             ok: true,
             httpStatus: 200,
@@ -219,9 +226,15 @@ describe("inference health", () => {
       expect(result?.ok).toBe(true);
       expect(result?.probed).toBe(true);
       expect(result?.endpoint).toBe(`${BUILD_ENDPOINT_URL}/chat/completions`);
-      expect(capturedArgv).toContain("Authorization: Bearer nvapi-test");
+      expect(capturedArgv.join(" ")).not.toContain("nvapi-test");
+      expect(capturedArgv.join(" ")).not.toContain("Authorization: Bearer");
+      expect(capturedArgv).toContain("--config");
+      expect(authConfigContent).toContain("Authorization: Bearer nvapi-test");
+      expect(fs.existsSync(authConfigPath)).toBe(false);
+      expect(capturedArgv).toContain("--connect-timeout");
+      expect(capturedArgv[capturedArgv.indexOf("--connect-timeout") + 1]).toBe("3");
       expect(capturedArgv).toContain("--max-time");
-      expect(capturedArgv[capturedArgv.indexOf("--max-time") + 1]).toBe("60");
+      expect(capturedArgv[capturedArgv.indexOf("--max-time") + 1]).toBe("5");
       expect(capturedArgv.at(-1)).toBe(`${BUILD_ENDPOINT_URL}/chat/completions`);
 
       const payload = JSON.parse(capturedArgv[capturedArgv.indexOf("-d") + 1]);

--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -197,6 +197,92 @@ describe("inference health", () => {
         "https://api.openai.com/v1/models",
       ]);
     });
+
+    it("uses Kimi chat completions for NVIDIA managed inference when a credential is available", () => {
+      let capturedArgv: string[] = [];
+      const result = probeRemoteProviderHealth("nvidia-prod", {
+        model: "moonshotai/kimi-k2.6",
+        getCredentialImpl: (envName) => (envName === "NVIDIA_API_KEY" ? "nvapi-test" : null),
+        runCurlProbeImpl: (argv) => {
+          capturedArgv = argv;
+          return {
+            ok: true,
+            httpStatus: 200,
+            curlStatus: 0,
+            body: '{"choices":[{"message":{"content":"OK"}}]}',
+            stderr: "",
+            message: "HTTP 200",
+          };
+        },
+      });
+
+      expect(result?.ok).toBe(true);
+      expect(result?.probed).toBe(true);
+      expect(result?.endpoint).toBe(`${BUILD_ENDPOINT_URL}/chat/completions`);
+      expect(capturedArgv).toContain("Authorization: Bearer nvapi-test");
+      expect(capturedArgv).toContain("--max-time");
+      expect(capturedArgv[capturedArgv.indexOf("--max-time") + 1]).toBe("60");
+      expect(capturedArgv.at(-1)).toBe(`${BUILD_ENDPOINT_URL}/chat/completions`);
+
+      const payload = JSON.parse(capturedArgv[capturedArgv.indexOf("-d") + 1]);
+      expect(payload).toEqual({
+        model: "moonshotai/kimi-k2.6",
+        messages: [{ role: "user", content: "Reply with exactly: OK" }],
+        max_tokens: 8,
+      });
+    });
+
+    it("does not fall back to provider-level NVIDIA /models for Kimi without a credential", () => {
+      let called = false;
+      const result = probeRemoteProviderHealth("nvidia-prod", {
+        model: "moonshotai/kimi-k2.6",
+        getCredentialImpl: () => null,
+        runCurlProbeImpl: () => {
+          called = true;
+          return {
+            ok: false,
+            httpStatus: 0,
+            curlStatus: 28,
+            body: "",
+            stderr: "Operation timed out",
+            message: "curl failed (exit 28): Operation timed out",
+          };
+        },
+      });
+
+      expect(called).toBe(false);
+      expect(result?.ok).toBe(true);
+      expect(result?.probed).toBe(false);
+      expect(result?.endpoint).toBe(`${BUILD_ENDPOINT_URL}/chat/completions`);
+      expect(result?.detail).toContain("NVIDIA_API_KEY");
+      expect(result?.detail).toContain("provider-level /models");
+    });
+
+    it("reports Kimi health as not probed when credential lookup fails", () => {
+      let called = false;
+      const result = probeRemoteProviderHealth("nvidia-prod", {
+        model: "moonshotai/kimi-k2.6",
+        getCredentialImpl: () => {
+          throw new Error("credential store unavailable");
+        },
+        runCurlProbeImpl: () => {
+          called = true;
+          return {
+            ok: false,
+            httpStatus: 0,
+            curlStatus: 28,
+            body: "",
+            stderr: "Operation timed out",
+            message: "curl failed (exit 28): Operation timed out",
+          };
+        },
+      });
+
+      expect(called).toBe(false);
+      expect(result?.ok).toBe(true);
+      expect(result?.probed).toBe(false);
+      expect(result?.detail).toContain("credential store unavailable");
+    });
   });
 
   describe("probeProviderHealth (unified)", () => {
@@ -233,6 +319,54 @@ describe("inference health", () => {
       expect(result?.ok).toBe(true);
       expect(result?.probed).toBe(true);
       expect(result?.providerLabel).toBe("OpenAI");
+    });
+
+    it("keeps non-Kimi NVIDIA models on the provider reachability probe", () => {
+      let capturedArgv: string[] = [];
+      const result = probeProviderHealth("nvidia-prod", {
+        model: "minimaxai/minimax-m2.7",
+        runCurlProbeImpl: (argv) => {
+          capturedArgv = argv;
+          return {
+            ok: false,
+            httpStatus: 401,
+            curlStatus: 0,
+            body: "",
+            stderr: "",
+            message: "HTTP 401",
+          };
+        },
+      });
+
+      expect(result?.ok).toBe(true);
+      expect(result?.endpoint).toBe(`${BUILD_ENDPOINT_URL}/models`);
+      expect(capturedArgv.at(-1)).toBe(`${BUILD_ENDPOINT_URL}/models`);
+      expect(capturedArgv).not.toContain(`${BUILD_ENDPOINT_URL}/chat/completions`);
+    });
+
+    it("uses model-aware Kimi probing through the unified health entry point", () => {
+      let capturedArgv: string[] = [];
+      const result = probeProviderHealth("nvidia-nim", {
+        model: "moonshotai/kimi-k2.6",
+        getCredentialImpl: () => "nvapi-test",
+        runCurlProbeImpl: (argv) => {
+          capturedArgv = argv;
+          return {
+            ok: false,
+            httpStatus: 401,
+            curlStatus: 0,
+            body: '{"error":"unauthorized"}',
+            stderr: "",
+            message: "HTTP 401: unauthorized",
+          };
+        },
+      });
+
+      expect(result?.ok).toBe(false);
+      expect(result?.probed).toBe(true);
+      expect(result?.failureLabel).toBe("unhealthy");
+      expect(result?.endpoint).toBe(`${BUILD_ENDPOINT_URL}/chat/completions`);
+      expect(capturedArgv.at(-1)).toBe(`${BUILD_ENDPOINT_URL}/chat/completions`);
     });
 
     it("returns not-probed for compatible-endpoint", () => {

--- a/src/lib/inference/health.ts
+++ b/src/lib/inference/health.ts
@@ -7,6 +7,10 @@
  * and performs lightweight reachability checks for remote cloud providers.
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import type { CurlProbeResult } from "../http-probe";
 import { runCurlProbe } from "../http-probe";
 import { getProviderSelectionConfig } from "./config";
@@ -47,6 +51,9 @@ const COMPATIBLE_PROVIDERS = new Set(["compatible-endpoint", "compatible-anthrop
 const NVIDIA_MANAGED_PROVIDERS = new Set(["nvidia-prod", "nvidia-nim"]);
 const NVIDIA_HEALTH_CREDENTIAL_ENV = "NVIDIA_API_KEY";
 const KIMI_K26_MODEL = "moonshotai/kimi-k2.6";
+const KIMI_STATUS_CONNECT_TIMEOUT_SECONDS = "3";
+const KIMI_STATUS_MAX_TIME_SECONDS = "5";
+const KIMI_HEALTH_CURL_CONFIG_PREFIX = "nemoclaw-kimi-health-curl";
 
 function normalizeModel(model: string | null | undefined): string | null {
   if (typeof model !== "string") return null;
@@ -63,6 +70,69 @@ function resolveProbeCredential(envName: string, options: ProviderHealthProbeOpt
     ? options.getCredentialImpl(envName)
     : resolveProviderCredential(envName);
   return normalizeCredentialValue(raw);
+}
+
+function replaceCurlArgValue(argv: string[], name: string, value: string): string[] {
+  const next = [...argv];
+  const index = next.indexOf(name);
+  if (index >= 0 && index + 1 < next.length) {
+    next[index + 1] = value;
+    return next;
+  }
+  return [name, value, ...next];
+}
+
+function useStatusProbeTiming(argv: string[]): string[] {
+  return replaceCurlArgValue(
+    replaceCurlArgValue(argv, "--connect-timeout", KIMI_STATUS_CONNECT_TIMEOUT_SECONDS),
+    "--max-time",
+    KIMI_STATUS_MAX_TIME_SECONDS,
+  );
+}
+
+function quoteCurlConfigValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/[\r\n]+/g, " ");
+}
+
+function createAuthCurlConfig(headerValue: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${KIMI_HEALTH_CURL_CONFIG_PREFIX}-`));
+  try {
+    fs.chmodSync(dir, 0o700);
+    const configPath = path.join(dir, "auth.conf");
+    fs.writeFileSync(configPath, `header = "${quoteCurlConfigValue(headerValue)}"\n`, {
+      mode: 0o600,
+      encoding: "utf8",
+    });
+    return configPath;
+  } catch (error) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function cleanupAuthCurlConfig(configPath: string): void {
+  const dir = path.dirname(configPath);
+  if (dir !== os.tmpdir() && path.basename(dir).startsWith(`${KIMI_HEALTH_CURL_CONFIG_PREFIX}-`)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function buildKimiStatusProbeCurlArgs(
+  model: string,
+  endpoint: string,
+  configPath: string,
+  isWsl?: boolean,
+): string[] {
+  const args = useStatusProbeTiming(
+    getChatCompletionsProbeCurlArgs({
+      authHeader: [],
+      model,
+      url: endpoint,
+      isWsl,
+    }),
+  );
+  const url = args.pop() || endpoint;
+  return [...args, "--config", configPath, url];
 }
 
 /**
@@ -154,14 +224,31 @@ function probeNvidiaKimiK26Health(
   }
 
   const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
-  const result = runCurlProbeImpl(
-    getChatCompletionsProbeCurlArgs({
-      authHeader: ["-H", `Authorization: Bearer ${apiKey}`],
-      model,
-      url: endpoint,
-      isWsl: options.isWsl,
-    }),
-  );
+  let authConfigPath = "";
+  try {
+    authConfigPath = createAuthCurlConfig(`Authorization: Bearer ${apiKey}`);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return {
+      ok: true,
+      probed: false,
+      providerLabel,
+      endpoint,
+      detail:
+        `Could not prepare ${NVIDIA_HEALTH_CREDENTIAL_ENV} for Kimi K2.6 health; ` +
+        `skipping model-specific chat-completions probe. (${reason})`,
+    };
+  }
+
+  const result = (() => {
+    try {
+      return runCurlProbeImpl(
+        buildKimiStatusProbeCurlArgs(model, endpoint, authConfigPath, options.isWsl),
+      );
+    } finally {
+      cleanupAuthCurlConfig(authConfigPath);
+    }
+  })();
   const healthy = result.ok;
 
   return {

--- a/src/lib/inference/health.ts
+++ b/src/lib/inference/health.ts
@@ -13,23 +13,12 @@ import path from "node:path";
 
 import type { CurlProbeResult } from "../http-probe";
 import { runCurlProbe } from "../http-probe";
+import { normalizeCredentialValue, resolveProviderCredential } from "../credentials/store";
 import { getProviderSelectionConfig } from "./config";
 import type { LocalProviderHealthProbeOptions } from "./local";
 import { probeLocalProviderHealth } from "./local";
+import { getChatCompletionsProbeCurlArgs } from "./onboard-probes";
 import { BUILD_ENDPOINT_URL } from "./provider-models";
-
-const { normalizeCredentialValue, resolveProviderCredential } = require("../credentials/store") as {
-  normalizeCredentialValue: (value: string | null | undefined) => string;
-  resolveProviderCredential: (envName: string) => string | null;
-};
-const { getChatCompletionsProbeCurlArgs } = require("./onboard-probes") as {
-  getChatCompletionsProbeCurlArgs: (opts: {
-    authHeader: string[];
-    model: string;
-    url: string;
-    isWsl?: boolean;
-  }) => string[];
-};
 
 export interface ProviderHealthStatus {
   ok: boolean;

--- a/src/lib/inference/health.ts
+++ b/src/lib/inference/health.ts
@@ -14,19 +14,56 @@ import type { LocalProviderHealthProbeOptions } from "./local";
 import { probeLocalProviderHealth } from "./local";
 import { BUILD_ENDPOINT_URL } from "./provider-models";
 
+const { normalizeCredentialValue, resolveProviderCredential } = require("../credentials/store") as {
+  normalizeCredentialValue: (value: string | null | undefined) => string;
+  resolveProviderCredential: (envName: string) => string | null;
+};
+const { getChatCompletionsProbeCurlArgs } = require("./onboard-probes") as {
+  getChatCompletionsProbeCurlArgs: (opts: {
+    authHeader: string[];
+    model: string;
+    url: string;
+    isWsl?: boolean;
+  }) => string[];
+};
+
 export interface ProviderHealthStatus {
   ok: boolean;
   probed: boolean;
   providerLabel: string;
   endpoint: string;
   detail: string;
+  failureLabel?: "unreachable" | "unhealthy";
 }
 
 export interface ProviderHealthProbeOptions {
   runCurlProbeImpl?: (argv: string[]) => CurlProbeResult;
+  model?: string | null;
+  getCredentialImpl?: (envName: string) => string | null | undefined;
+  isWsl?: boolean;
 }
 
 const COMPATIBLE_PROVIDERS = new Set(["compatible-endpoint", "compatible-anthropic-endpoint"]);
+const NVIDIA_MANAGED_PROVIDERS = new Set(["nvidia-prod", "nvidia-nim"]);
+const NVIDIA_HEALTH_CREDENTIAL_ENV = "NVIDIA_API_KEY";
+const KIMI_K26_MODEL = "moonshotai/kimi-k2.6";
+
+function normalizeModel(model: string | null | undefined): string | null {
+  if (typeof model !== "string") return null;
+  const trimmed = model.trim();
+  return trimmed || null;
+}
+
+function isKimiK26Model(model: string | null | undefined): model is string {
+  return normalizeModel(model)?.toLowerCase() === KIMI_K26_MODEL;
+}
+
+function resolveProbeCredential(envName: string, options: ProviderHealthProbeOptions): string {
+  const raw = options.getCredentialImpl
+    ? options.getCredentialImpl(envName)
+    : resolveProviderCredential(envName);
+  return normalizeCredentialValue(raw);
+}
 
 /**
  * Maps remote provider names to their health-check endpoints.
@@ -64,6 +101,79 @@ function buildRemoteProbeDetail(
   );
 }
 
+function buildKimiChatCompletionsDetail(
+  providerLabel: string,
+  endpoint: string,
+  healthy: boolean,
+  result: CurlProbeResult,
+): string {
+  const route = `${providerLabel} Kimi K2.6 chat-completions route`;
+  if (healthy) {
+    return `${route} is healthy at ${endpoint}.`;
+  }
+  return (
+    `${route} at ${endpoint} is not healthy. ` +
+    `Check your network connection or ${NVIDIA_HEALTH_CREDENTIAL_ENV}. (${result.message})`
+  );
+}
+
+function probeNvidiaKimiK26Health(
+  provider: string,
+  model: string,
+  options: ProviderHealthProbeOptions,
+): ProviderHealthStatus {
+  const config = getProviderSelectionConfig(provider, model);
+  const providerLabel = config?.providerLabel ?? provider;
+  const endpoint = `${BUILD_ENDPOINT_URL}/chat/completions`;
+  let apiKey = "";
+  try {
+    apiKey = resolveProbeCredential(NVIDIA_HEALTH_CREDENTIAL_ENV, options);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return {
+      ok: true,
+      probed: false,
+      providerLabel,
+      endpoint,
+      detail:
+        `Could not resolve ${NVIDIA_HEALTH_CREDENTIAL_ENV} for Kimi K2.6 health; ` +
+        `skipping model-specific chat-completions probe. (${reason})`,
+    };
+  }
+
+  if (!apiKey) {
+    return {
+      ok: true,
+      probed: false,
+      providerLabel,
+      endpoint,
+      detail:
+        `Kimi K2.6 health requires ${NVIDIA_HEALTH_CREDENTIAL_ENV}; ` +
+        "skipping model-specific chat-completions probe instead of using provider-level /models reachability.",
+    };
+  }
+
+  const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
+  const result = runCurlProbeImpl(
+    getChatCompletionsProbeCurlArgs({
+      authHeader: ["-H", `Authorization: Bearer ${apiKey}`],
+      model,
+      url: endpoint,
+      isWsl: options.isWsl,
+    }),
+  );
+  const healthy = result.ok;
+
+  return {
+    ok: healthy,
+    probed: true,
+    providerLabel,
+    endpoint,
+    detail: buildKimiChatCompletionsDetail(providerLabel, endpoint, healthy, result),
+    ...(healthy ? {} : { failureLabel: result.curlStatus === 0 ? "unhealthy" : "unreachable" }),
+  };
+}
+
 /**
  * Probes a remote provider endpoint for reachability.
  * Any HTTP response (including 401/403) counts as reachable — we are
@@ -76,7 +186,8 @@ export function probeRemoteProviderHealth(
   provider: string,
   options: ProviderHealthProbeOptions = {},
 ): ProviderHealthStatus | null {
-  const config = getProviderSelectionConfig(provider);
+  const model = normalizeModel(options.model);
+  const config = getProviderSelectionConfig(provider, model || undefined);
   const providerLabel = config?.providerLabel ?? provider;
 
   if (COMPATIBLE_PROVIDERS.has(provider)) {
@@ -87,6 +198,10 @@ export function probeRemoteProviderHealth(
       endpoint: "",
       detail: "Endpoint URL is not known; skipping reachability check.",
     };
+  }
+
+  if (NVIDIA_MANAGED_PROVIDERS.has(provider) && isKimiK26Model(model)) {
+    return probeNvidiaKimiK26Health(provider, model, options);
   }
 
   const endpoint = getRemoteProviderHealthEndpoint(provider);

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -253,7 +253,12 @@ function getChatCompletionsProbePayload(model) {
   return payload;
 }
 
-function getChatCompletionsProbeCurlArgs({ authHeader, model, url, isWsl: isWslOverride }) {
+export function getChatCompletionsProbeCurlArgs({
+  authHeader,
+  model,
+  url,
+  isWsl: isWslOverride,
+}) {
   const platformOptions =
     typeof isWslOverride === "boolean" ? { isWsl: isWslOverride } : undefined;
   const timingArgs = (() => {


### PR DESCRIPTION
## Summary
Makes sandbox status inference health model-aware for Kimi K2.6 so status checks the NVIDIA chat-completions route the agent uses instead of the generic provider `/models` endpoint. When authenticated model-specific probing cannot run, status reports `not probed` instead of a misleading provider-level `unreachable` result.

## Related Issue
Fixes #3176

## Changes
- Pass the current sandbox model along with the provider from sandbox status into inference health probing.
- Add a Kimi K2.6 NVIDIA managed inference health path that reuses the Kimi chat-completions payload and timeout shape from onboarding.
- Return `not probed` for Kimi when `NVIDIA_API_KEY` is unavailable or cannot be resolved, avoiding the generic `/models` fallback.
- Add unit coverage for provider/model health selection and sandbox status model propagation.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification performed:
- `npm exec --package=node@22.16.0 -- npm run build:cli` passed.
- `cd nemoclaw && npm exec --package=node@22.16.0 -- npm run build` passed.
- `npm exec --package=node@22.16.0 -- vitest run --project cli src/lib/inference/health.test.ts src/lib/actions/sandbox/status.test.ts` passed.
- `npm exec --package=node@22.16.0 -- npm run typecheck:cli` passed.
- Worktree CLI E2E for `nemoclaw <sandbox> status` with `moonshotai/kimi-k2.6` and `nvidia-prod` passed against the real NVIDIA chat-completions endpoint using a local E2E credential; output reported `Inference: healthy (https://integrate.api.nvidia.com/v1/chat/completions)`.

Known verification caveats:
- `npx prek run --all-files` stopped at `hadolint` because `hadolint` is not installed in this environment; earlier hooks in that run passed.
- `npm test` was run and did not pass due failures outside this Kimi/status change: installer-integration failures, a standalone `test/fetch-guard-patch-regression.test.ts` failure, and one full-suite `test/cli.test.ts` timeout that passed when rerun by itself.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved model-aware health checks with specialized handling for NVIDIA Kimi models and clearer outcomes when provider credentials are missing.
  * More reliable sandbox status inference when gateway probing is enabled or disabled.

* **Tests**
  * Expanded test coverage for inference health and sandbox probing, covering Kimi routing, credential edge cases, and probe/no-probe outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->