### PR TITLE
fix(inference): suppress kimi reasoning output

### DIFF
--- a/nemoclaw-blueprint/model-specific-setup/openclaw/kimi-k2.6-managed-inference.json
+++ b/nemoclaw-blueprint/model-specific-setup/openclaw/kimi-k2.6-managed-inference.json
@@ -2,7 +2,7 @@
   "$schema": "../schema.json",
   "id": "kimi-k2.6-managed-inference",
   "agent": "openclaw",
-  "description": "Preserves OpenClaw request and tool-call compatibility for moonshotai/kimi-k2.6 through NemoClaw managed inference.local chat completions.",
+  "description": "Preserves OpenClaw request, tool-call, and reasoning-output compatibility for moonshotai/kimi-k2.6 through NemoClaw managed inference.local chat completions.",
   "match": {
     "modelIds": ["moonshotai/kimi-k2.6"],
     "providerKey": "inference",

--- a/nemoclaw-blueprint/openclaw-plugins/kimi-inference-compat/index.js
+++ b/nemoclaw-blueprint/openclaw-plugins/kimi-inference-compat/index.js
@@ -24,6 +24,105 @@ function emptyParameters() {
 }
 
 const SAFE_SPLIT_EXEC_COMMANDS = new Set(["hostname", "date", "uptime"]);
+const REASONING_FIELD_NAMES = [
+  "reasoning",
+  "reasoningContent",
+  "reasoning_content",
+  "reasoningDetails",
+  "reasoning_details",
+  "thinking",
+  "thinkingContent",
+  "thinking_content",
+];
+const REASONING_EVENT_TYPES = new Set([
+  "reasoning",
+  "reasoning_delta",
+  "reasoning.content.delta",
+  "thinking",
+  "thinking_delta",
+  "thinking.content.delta",
+]);
+const REASONING_CONTENT_TYPES = new Set([
+  "reasoning",
+  "reasoning_delta",
+  "reasoningcontent",
+  "reasoning_content",
+  "thinking",
+  "thinking_delta",
+  "thinkingcontent",
+  "thinking_content",
+]);
+
+function isObjectRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function stripReasoningFields(value) {
+  if (!isObjectRecord(value)) return false;
+  let changed = false;
+  for (const key of REASONING_FIELD_NAMES) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
+      delete value[key];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function isReasoningContentBlock(value) {
+  if (!isObjectRecord(value)) return false;
+  const type = normalize(value.type);
+  return REASONING_CONTENT_TYPES.has(type) || type.includes("reasoning") || type.includes("thinking");
+}
+
+function stripReasoningContentBlocks(value) {
+  if (!Array.isArray(value)) return value;
+  return value
+    .filter((block) => !isReasoningContentBlock(block))
+    .map((block) => {
+      stripReasoningFields(block);
+      return block;
+    });
+}
+
+function stripReasoningFromMessage(message) {
+  if (!isObjectRecord(message)) return false;
+  let changed = stripReasoningFields(message);
+  if (Array.isArray(message.content)) {
+    const filtered = stripReasoningContentBlocks(message.content);
+    if (filtered.length !== message.content.length) changed = true;
+    message.content = filtered;
+  }
+  return changed;
+}
+
+function stripReasoningFromChoice(choice) {
+  if (!isObjectRecord(choice)) return false;
+  let changed = stripReasoningFields(choice);
+  changed = stripReasoningFromMessage(choice.message) || changed;
+  changed = stripReasoningFromMessage(choice.delta) || changed;
+  return changed;
+}
+
+function isReasoningEvent(event) {
+  if (!isObjectRecord(event)) return false;
+  const type = normalize(event.type);
+  return REASONING_EVENT_TYPES.has(type) || type.includes("reasoning") || type.includes("thinking");
+}
+
+function filterReasoningFromEvent(event) {
+  if (!isObjectRecord(event)) return event;
+  if (isReasoningEvent(event)) return null;
+
+  stripReasoningFields(event);
+  stripReasoningFromMessage(event.message);
+  stripReasoningFromMessage(event.partial);
+  stripReasoningFromMessage(event.delta);
+  if (Array.isArray(event.choices)) {
+    for (const choice of event.choices) stripReasoningFromChoice(choice);
+  }
+  return event;
+}
 
 function decodeToolCallArguments(value) {
   if (value && typeof value === "object" && !Array.isArray(value)) return value;
@@ -148,6 +247,7 @@ function wrapStreamFinalMessages(stream) {
     stream.result = async () => {
       const message = await originalResult();
       rewriteSafeCombinedExecToolCallInMessage(message);
+      stripReasoningFromMessage(message);
       return message;
     };
   }
@@ -158,11 +258,15 @@ function wrapStreamFinalMessages(stream) {
       const iterator = originalAsyncIterator();
       return {
         async next() {
-          const result = await iterator.next();
-          if (!result.done && result.value && typeof result.value === "object") {
+          while (true) {
+            const result = await iterator.next();
+            if (result.done || !result.value || typeof result.value !== "object") {
+              return result;
+            }
             rewriteSafeCombinedExecToolCallInEvent(result.value);
+            const filtered = filterReasoningFromEvent(result.value);
+            if (filtered !== null) return { ...result, value: filtered };
           }
-          return result;
         },
         async return(value) {
           if (typeof iterator.return === "function") return iterator.return(value);
@@ -194,7 +298,8 @@ module.exports = {
   id: "nemoclaw-kimi-inference-compat",
   name: "NemoClaw Kimi Inference Compatibility",
   version: "0.1.0",
-  description: "Normalizes managed inference.local Kimi tool schemas for NemoClaw sandboxes.",
+  description:
+    "Normalizes managed inference.local Kimi tool schemas and reasoning output for NemoClaw sandboxes.",
   register(api) {
     api.registerProvider({
       id: "inference",
@@ -219,8 +324,10 @@ module.exports = {
   },
   __testing: {
     createSafeExecSplitterWrapper,
+    filterReasoningFromEvent,
     rewriteSafeCombinedExecToolCallInEvent,
     rewriteSafeCombinedExecToolCallInMessage,
+    stripReasoningFromMessage,
     splitSafeExecCommand,
   },
 };

--- a/nemoclaw-blueprint/scripts/nemotron-inference-fix.js
+++ b/nemoclaw-blueprint/scripts/nemotron-inference-fix.js
@@ -18,8 +18,9 @@
 //   or thinking blocks.
 //
 //   Also inject `chat_template_kwargs: { thinking: false }` for
-//   deepseek-ai/deepseek-v4-pro, matching NVIDIA Build's tested invocation
-//   shape for the OpenAI-compatible chat-completions endpoint.
+//   deepseek-ai/deepseek-v4-pro and moonshotai/kimi-k2.6, matching NVIDIA
+//   Build's tested invocation shape for the OpenAI-compatible
+//   chat-completions endpoint.
 //
 //   Scoped strictly to known affected models — all other requests pass
 //   through untouched. Backends that do not support chat_template_kwargs
@@ -33,7 +34,16 @@
 
   var NEMOTRON_RE = /nemotron/i;
   var DEEPSEEK_V4_PRO_RE = /^deepseek-ai\/deepseek-v4-pro$/i;
+  var KIMI_K26_RE = /^moonshotai\/kimi-k2\.6$/i;
   var COMPLETIONS_RE = /\/v1\/chat\/completions/;
+
+  function hasObjectChatTemplateKwargs(body) {
+    return (
+      body.chat_template_kwargs &&
+      typeof body.chat_template_kwargs === 'object' &&
+      !Array.isArray(body.chat_template_kwargs)
+    );
+  }
 
   function wrapModule(mod) {
     var origRequest = mod.request;
@@ -79,14 +89,19 @@
         var raw = Buffer.concat(chunks);
         try {
           var body = JSON.parse(raw.toString('utf-8'));
-          if (body && body.model && (NEMOTRON_RE.test(body.model) || DEEPSEEK_V4_PRO_RE.test(body.model))) {
-            if (!body.chat_template_kwargs) {
+          if (
+            body && body.model &&
+            (NEMOTRON_RE.test(body.model) ||
+              DEEPSEEK_V4_PRO_RE.test(body.model) ||
+              KIMI_K26_RE.test(body.model))
+          ) {
+            if (!hasObjectChatTemplateKwargs(body)) {
               body.chat_template_kwargs = {};
             }
             if (NEMOTRON_RE.test(body.model)) {
               body.chat_template_kwargs.force_nonempty_content = true;
             }
-            if (DEEPSEEK_V4_PRO_RE.test(body.model)) {
+            if (DEEPSEEK_V4_PRO_RE.test(body.model) || KIMI_K26_RE.test(body.model)) {
               body.chat_template_kwargs.thinking = false;
             }
             intercepted = true;

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -978,8 +978,9 @@ fi
 # kwarg `force_nonempty_content` prevents this by ensuring the template
 # always emits a non-empty content field.
 #
-# DeepSeek V4 Pro on NVIDIA Build expects its chat template thinking mode
-# disabled for NemoClaw's OpenAI-compatible chat-completions path.
+# DeepSeek V4 Pro and Kimi K2.6 on NVIDIA Build expect chat template
+# thinking mode disabled for NemoClaw's OpenAI-compatible
+# chat-completions path.
 #
 # The preload wraps http.request() — the lowest common denominator every
 # HTTP client bottoms out at — buffers the JSON body for POST requests

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -41,6 +41,7 @@ describe("OpenAI-compatible inference probes", () => {
       model: "moonshotai/kimi-k2.6",
       messages: [{ role: "user", content: "Reply with exactly: OK" }],
       max_tokens: 8,
+      chat_template_kwargs: { thinking: false },
     });
 
     expect(getKimiK26ValidationProbeCurlArgs({ isWsl: false })).toEqual([

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -247,6 +247,7 @@ function getChatCompletionsProbePayload(model) {
     return {
       ...payload,
       max_tokens: 8,
+      chat_template_kwargs: { thinking: false },
     };
   }
 

--- a/test/kimi-inference-compat-plugin.test.ts
+++ b/test/kimi-inference-compat-plugin.test.ts
@@ -54,6 +54,39 @@ function toolMessage(command: string, overrides: Record<string, unknown> = {}) {
   };
 }
 
+function failedToolContext() {
+  return {
+    messages: [
+      {
+        role: "toolResult",
+        content: [
+          {
+            type: "toolResult",
+            toolCallId: "call_kimi_exec",
+            isError: true,
+            text: "exec failed: command not found",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function failedToolAssistantMessage() {
+  return {
+    role: "assistant",
+    stopReason: "stop",
+    reasoning: "PRIVATE reasoning after the exec tool failed",
+    reasoning_content: "PRIVATE chain-of-thought after the tool failure",
+    reasoningDetails: [{ text: "PRIVATE detailed reasoning" }],
+    thinking: "PRIVATE thinking content",
+    content: [
+      { type: "thinking", text: "PRIVATE streamed thinking block" },
+      { type: "text", text: "The exec tool failed: command not found." },
+    ],
+  };
+}
+
 describe("nemoclaw Kimi inference compat plugin", () => {
   it("splits the safe combined exec diagnostics into separate tool calls", () => {
     const message = toolMessage("hostname; date; uptime");
@@ -184,6 +217,84 @@ describe("nemoclaw Kimi inference compat plugin", () => {
       expect(plugin.__testing.rewriteSafeCombinedExecToolCallInMessage(message)).toBe(false);
       expect(message).toEqual(before);
     }
+  });
+
+  it("filters Kimi reasoning fields from final assistant messages after tool failures", async () => {
+    const provider = makeProvider();
+    const wrapper = provider.wrapStreamFn(
+      managedKimiCtx(() => ({
+        async result() {
+          return failedToolAssistantMessage();
+        },
+      })),
+    );
+
+    expect(wrapper).toEqual(expect.any(Function));
+
+    const stream = wrapper({}, failedToolContext(), {});
+    const result = await stream.result();
+
+    expect(result).toEqual({
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: "The exec tool failed: command not found." }],
+    });
+    expect(JSON.stringify(result)).not.toContain("PRIVATE");
+  });
+
+  it("drops Kimi reasoning stream events while preserving content and tool-call deltas", async () => {
+    const provider = makeProvider();
+    const finalMessage = failedToolAssistantMessage();
+    const wrapper = provider.wrapStreamFn(
+      managedKimiCtx(() => ({
+        async result() {
+          return finalMessage;
+        },
+        async *[Symbol.asyncIterator]() {
+          yield { type: "reasoning_delta", delta: "PRIVATE stream reasoning after tool failure" };
+          yield {
+            type: "content_delta",
+            delta: "The exec tool failed: command not found.",
+            reasoning_content: "PRIVATE event reasoning",
+            partial: failedToolAssistantMessage(),
+          };
+          yield {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: JSON.stringify({ command: "hostname" }),
+            reasoning: "PRIVATE tool-call event reasoning",
+            partial: toolMessage("hostname"),
+          };
+          yield { type: "done", message: finalMessage };
+        },
+      })),
+    );
+
+    expect(wrapper).toEqual(expect.any(Function));
+
+    const stream = wrapper({}, failedToolContext(), {});
+    const events = [];
+    for await (const event of stream) events.push(event);
+    const result = await stream.result();
+
+    expect(events.map((event: any) => event.type)).toEqual([
+      "content_delta",
+      "toolcall_delta",
+      "done",
+    ]);
+    expect(events[0].partial.content).toEqual([
+      { type: "text", text: "The exec tool failed: command not found." },
+    ]);
+    expect(events[0].delta).toBe("The exec tool failed: command not found.");
+    expect(events[1].delta).toBe(JSON.stringify({ command: "hostname" }));
+    expect(events[1].partial.content[0].arguments.command).toBe("hostname");
+    expect(events[2].message.content).toEqual([
+      { type: "text", text: "The exec tool failed: command not found." },
+    ]);
+    expect(result.content).toEqual([
+      { type: "text", text: "The exec tool failed: command not found." },
+    ]);
+    expect(JSON.stringify({ events, result })).not.toContain("PRIVATE");
   });
 
   it("wraps managed Kimi streams and rewrites partial and final assistant messages", async () => {

--- a/test/nemotron-inference-fix.test.ts
+++ b/test/nemotron-inference-fix.test.ts
@@ -105,6 +105,7 @@ function send(mod, options, body) {
 }
 send(http, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'NVIDIA/NEMOTRON-4', messages: [] }));
 send(https, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'deepseek-ai/deepseek-v4-pro', messages: [], chat_template_kwargs: { existing: true, thinking: true } }));
+send(https, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'moonshotai/kimi-k2.6', messages: [], chat_template_kwargs: { existing: true, thinking: true } }));
 send(https, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'other-model', messages: [] }));
 send(http, { method: 'POST', path: '/v1/chat/completions' }, '{not json');
 send(http, { method: 'GET', path: '/v1/chat/completions' }, JSON.stringify({ model: 'nemotron' }));
@@ -133,10 +134,19 @@ console.log(JSON.stringify(records));
     expect(records[1].removed).toContain("content-length");
     expect(Number(records[1].headers["Content-Length"])).toBeGreaterThan(0);
 
-    const otherBody = JSON.parse(records[2].writes[0]);
+    const kimiBody = JSON.parse(records[2].writes[0]);
+    expect(kimiBody.chat_template_kwargs).toEqual({
+      existing: true,
+      thinking: false,
+    });
+    expect(kimiBody.chat_template_kwargs.force_nonempty_content).toBeUndefined();
+    expect(records[2].removed).toContain("content-length");
+    expect(Number(records[2].headers["Content-Length"])).toBeGreaterThan(0);
+
+    const otherBody = JSON.parse(records[3].writes[0]);
     expect(otherBody.chat_template_kwargs).toBeUndefined();
-    expect(records[3].writes[0]).toBe("{not json");
-    expect(JSON.parse(records[4].writes[0]).chat_template_kwargs).toBeUndefined();
+    expect(records[4].writes[0]).toBe("{not json");
     expect(JSON.parse(records[5].writes[0]).chat_template_kwargs).toBeUndefined();
+    expect(JSON.parse(records[6].writes[0]).chat_template_kwargs).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
Suppresses Kimi K2.6 managed inference thinking/reasoning output so failed tool-call turns do not leak provider reasoning into user-visible agent output. The runtime request patch now disables Kimi thinking and the Kimi OpenClaw compatibility plugin defensively strips reasoning fields/events.

## Related Issue
Fixes #3177

## Changes
- Add Kimi K2.6 to the managed inference request preload and merge `chat_template_kwargs.thinking=false`.
- Filter Kimi reasoning/thinking fields, blocks, and stream events in the Kimi compatibility plugin while preserving text and tool-call deltas.
- Align Kimi onboarding probes with the runtime thinking suppression payload.
- Add regression tests for non-streaming and streaming failed-tool-call responses with reasoning fields.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Targeted tests and the Kimi compatibility E2E passed. Full hook/test suites were run but are not marked passing because unrelated environment/test failures remain (`test/fetch-guard-patch-regression.test.ts` host permission issue; earlier installer-preflight failures in the full run).

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification run:
- `npm test -- test/kimi-inference-compat-plugin.test.ts test/nemotron-inference-fix.test.ts src/lib/inference/onboard-probes.test.ts test/generate-openclaw-config.test.ts test/validate-config-schemas.test.ts`
- `npm run typecheck:cli`
- `NEMOCLAW_SANDBOX_NAME=e2e-kimi-3177 NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 NEMOCLAW_YES=1 bash test/e2e/test-kimi-inference-compat.sh`

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning and thinking content filtering for Kimi K2.6 model outputs to ensure cleaner responses.

* **Bug Fixes**
  * Disabled thinking mode for Kimi K2.6 to prevent thinking-only outputs and improve response quality.
  * Enhanced compatibility for Kimi K2.6 managed inference integration.

* **Tests**
  * Updated test coverage for Kimi K2.6 payload validation and reasoning output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->