### PR TITLE
fix(onboard): persist credentialEnv clears when switching remote→local (#2625)

### DIFF
--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -178,12 +178,17 @@ export async function rebuildSandbox(
   } else {
     rebuildCredentialEnv = session?.credentialEnv || null;
   }
-  // Legacy migration: pre-fix local-inference sandboxes (GH #2519) recorded
-  // credentialEnv="OPENAI_API_KEY" in onboard-session.json even though the
-  // sandbox does not actually need a host OpenAI key (ollama-local uses an
-  // auth proxy with an internal token; vllm-local accepts a static dummy
-  // bearer). Treat the legacy value as null so rebuild does not demand a
-  // credential that was never actually used.
+  // Legacy migration: pre-fix local-inference sandboxes (GH #2519, GH #2625)
+  // recorded credentialEnv="OPENAI_API_KEY" in onboard-session.json even
+  // though the sandbox does not actually need a host OpenAI key (ollama-local
+  // uses an auth proxy with an internal token; vllm-local accepts a static
+  // dummy bearer). Treat the legacy value as null so rebuild does not demand
+  // a credential that was never actually used.
+  //
+  // Post-#2625 the write path persists credentialEnv=null directly when the
+  // wizard selects a local provider, so fresh sessions no longer need this
+  // migration. We retain it for users whose session.json on disk predates
+  // the fix.
   if (
     (session?.provider === "ollama-local" || session?.provider === "vllm-local") &&
     rebuildCredentialEnv === "OPENAI_API_KEY"

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -9341,6 +9341,17 @@ function toOptionalString(value: string | null | undefined): string | undefined 
   return value ?? undefined;
 }
 
+// Preserve the nullable contract end-to-end: `null` means "clear this
+// field on the persisted session", `undefined` means "leave unchanged".
+// Collapsing `null`→`undefined` (as toOptionalString does) silently drops
+// explicit clears such as the credentialEnv reset during a remote→local
+// provider switch — the exact bug in GH #2625.
+function toNullableString(value: string | null | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return value;
+}
+
 function toSessionUpdates(
   updates: {
     sandboxName?: string | null;
@@ -9358,18 +9369,18 @@ function toSessionUpdates(
 ): SessionUpdates {
   const normalized: SessionUpdates = {};
   if (updates.sandboxName !== undefined)
-    normalized.sandboxName = toOptionalString(updates.sandboxName);
-  if (updates.provider !== undefined) normalized.provider = toOptionalString(updates.provider);
-  if (updates.model !== undefined) normalized.model = toOptionalString(updates.model);
+    normalized.sandboxName = toNullableString(updates.sandboxName);
+  if (updates.provider !== undefined) normalized.provider = toNullableString(updates.provider);
+  if (updates.model !== undefined) normalized.model = toNullableString(updates.model);
   if (updates.endpointUrl !== undefined)
-    normalized.endpointUrl = toOptionalString(updates.endpointUrl);
+    normalized.endpointUrl = toNullableString(updates.endpointUrl);
   if (updates.credentialEnv !== undefined)
-    normalized.credentialEnv = toOptionalString(updates.credentialEnv);
+    normalized.credentialEnv = toNullableString(updates.credentialEnv);
   if (updates.preferredInferenceApi !== undefined) {
-    normalized.preferredInferenceApi = toOptionalString(updates.preferredInferenceApi);
+    normalized.preferredInferenceApi = toNullableString(updates.preferredInferenceApi);
   }
   if (updates.nimContainer !== undefined)
-    normalized.nimContainer = toOptionalString(updates.nimContainer);
+    normalized.nimContainer = toNullableString(updates.nimContainer);
   if (updates.webSearchConfig !== undefined) normalized.webSearchConfig = updates.webSearchConfig;
   if (updates.policyPresets) normalized.policyPresets = updates.policyPresets;
   if (updates.messagingChannels) normalized.messagingChannels = updates.messagingChannels;

--- a/src/lib/state/onboard-session.test.ts
+++ b/src/lib/state/onboard-session.test.ts
@@ -153,6 +153,122 @@ describe("onboard session", () => {
     expect("token" in loaded.metadata).toBe(false);
   });
 
+  // ── GH #2625: provider switch from remote→local must clear stale fields ──
+  //
+  // Before the fix, filterSafeUpdates only accepted `typeof === "string"` for
+  // nullable session fields, so passing `null` (as the wizard does when a
+  // local provider is selected) silently dropped the clear. A prior
+  // remote-provider session's `credentialEnv: "OPENAI_API_KEY"` survived to
+  // disk and the next rebuild preflight demanded a credential the current
+  // sandbox did not need.
+
+  it("clears credentialEnv when provider-selection update passes null (GH #2625)", () => {
+    // Seed with a prior remote-provider onboard state.
+    session.saveSession(session.createSession());
+    session.markStepComplete("provider_selection", {
+      provider: "openai",
+      model: "gpt-4o",
+      endpointUrl: "https://api.openai.com/v1",
+      credentialEnv: "OPENAI_API_KEY",
+      preferredInferenceApi: "openai-completions",
+      nimContainer: null,
+    });
+    let loaded = requireLoadedSession(session.loadSession());
+    expect(loaded.credentialEnv).toBe("OPENAI_API_KEY");
+
+    // User re-runs onboard and picks local Ollama. The wizard emits
+    // credentialEnv=null and nimContainer=null alongside the new provider.
+    session.markStepComplete("provider_selection", {
+      provider: "ollama-local",
+      model: "qwen3:14b",
+      endpointUrl: "http://host.docker.internal:11434/v1",
+      credentialEnv: null,
+      preferredInferenceApi: "openai-completions",
+      nimContainer: null,
+    });
+
+    loaded = requireLoadedSession(session.loadSession());
+    expect(loaded.provider).toBe("ollama-local");
+    expect(loaded.model).toBe("qwen3:14b");
+    expect(loaded.credentialEnv).toBeNull();
+    expect(loaded.nimContainer).toBeNull();
+  });
+
+  it("leaves credentialEnv unchanged when the update does not supply it", () => {
+    // Regression guard: undefined must mean "leave unchanged", distinct from
+    // null ("clear"). Partial updates must not accidentally wipe fields.
+    session.saveSession(session.createSession());
+    session.markStepComplete("provider_selection", {
+      provider: "openai",
+      model: "gpt-4o",
+      credentialEnv: "OPENAI_API_KEY",
+    });
+    session.markStepComplete("provider_selection", { model: "gpt-4o-mini" });
+
+    const loaded = requireLoadedSession(session.loadSession());
+    expect(loaded.model).toBe("gpt-4o-mini");
+    expect(loaded.credentialEnv).toBe("OPENAI_API_KEY");
+    expect(loaded.provider).toBe("openai");
+  });
+
+  it("accepts null as an explicit clear for every nullable string field", () => {
+    // All six nullable fields that travel through filterSafeUpdates must
+    // support the null-clear contract. If any regresses to the old
+    // string-only guard, the test below catches it.
+    session.saveSession(session.createSession());
+    session.markStepComplete("provider_selection", {
+      sandboxName: "stale-sandbox",
+      provider: "openai",
+      model: "gpt-4o",
+      endpointUrl: "https://api.openai.com/v1",
+      credentialEnv: "OPENAI_API_KEY",
+      preferredInferenceApi: "openai-completions",
+      nimContainer: "nim-abc",
+    });
+
+    session.markStepComplete("provider_selection", {
+      sandboxName: null,
+      provider: null,
+      model: null,
+      endpointUrl: null,
+      credentialEnv: null,
+      preferredInferenceApi: null,
+      nimContainer: null,
+    });
+
+    const loaded = requireLoadedSession(session.loadSession());
+    expect(loaded.sandboxName).toBeNull();
+    expect(loaded.provider).toBeNull();
+    expect(loaded.model).toBeNull();
+    expect(loaded.endpointUrl).toBeNull();
+    expect(loaded.credentialEnv).toBeNull();
+    expect(loaded.preferredInferenceApi).toBeNull();
+    expect(loaded.nimContainer).toBeNull();
+  });
+
+  it("clears credentialEnv via completeSession when the wizard finishes on a local provider", () => {
+    // Matches the terminal path at end of onboard(): completeSession is what
+    // finalizes the session for a successful run. A local-provider onboard
+    // must not leave a stale credentialEnv on the "complete" record either.
+    session.saveSession(session.createSession());
+    session.markStepComplete("provider_selection", {
+      provider: "openai",
+      credentialEnv: "OPENAI_API_KEY",
+    });
+    session.completeSession({
+      provider: "ollama-local",
+      model: "qwen3:14b",
+      credentialEnv: null,
+      nimContainer: null,
+    });
+
+    const loaded = requireLoadedSession(session.loadSession());
+    expect(loaded.status).toBe("complete");
+    expect(loaded.provider).toBe("ollama-local");
+    expect(loaded.credentialEnv).toBeNull();
+    expect(loaded.nimContainer).toBeNull();
+  });
+
   it("persists messagingChannels across save/load roundtrips", () => {
     const created = session.createSession();
     created.messagingChannels = ["telegram", "slack"];

--- a/src/lib/state/onboard-session.ts
+++ b/src/lib/state/onboard-session.ts
@@ -121,13 +121,16 @@ export interface LockResult {
 }
 
 export interface SessionUpdates {
-  sandboxName?: string;
-  provider?: string;
-  model?: string;
-  endpointUrl?: string;
-  credentialEnv?: string;
-  preferredInferenceApi?: string;
-  nimContainer?: string;
+  // Nullable fields accept `null` as an explicit clear (e.g. a provider
+  // switch from remote→local clears `credentialEnv`). `undefined` means
+  // "leave unchanged". See filterSafeUpdates(). GH #2625.
+  sandboxName?: string | null;
+  provider?: string | null;
+  model?: string | null;
+  endpointUrl?: string | null;
+  credentialEnv?: string | null;
+  preferredInferenceApi?: string | null;
+  nimContainer?: string | null;
   routerPid?: number;
   routerCredentialHash?: string;
   webSearchConfig?: WebSearchConfig | null;
@@ -700,17 +703,53 @@ export function releaseOnboardLock(): void {
 
 // ── Step management ──────────────────────────────────────────────
 
+// Apply an explicit-clear-aware update for a nullable session field.
+//
+//   value === "string"  → assign (after optional normalizer)
+//   value === null      → explicit clear (persisted as null)
+//   value === undefined → leave unchanged (caller didn't supply this field)
+//
+// Before GH #2625 the persistence layer only accepted strings, which meant
+// a provider switch from remote (credentialEnv="OPENAI_API_KEY") to local
+// (credentialEnv=null) silently dropped the clear and left the stale value
+// on disk. The rebuild preflight then demanded a credential the current
+// sandbox does not actually need.
+function assignNullableString<K extends keyof Session>(
+  safe: Partial<Session>,
+  key: K,
+  value: unknown,
+  normalize?: (v: string) => string | null,
+): void {
+  if (value === undefined) return;
+  if (value === null) {
+    (safe as Record<K, Session[K] | null>)[key] = null as Session[K] & null;
+    return;
+  }
+  if (typeof value === "string") {
+    const normalized = normalize ? normalize(value) : value;
+    if (normalized === null) {
+      // A normalizer that returned null means the input was unredactable;
+      // treat the same as an explicit clear rather than dropping silently.
+      (safe as Record<K, Session[K] | null>)[key] = null as Session[K] & null;
+      return;
+    }
+    (safe as Record<K, Session[K]>)[key] = normalized as Session[K];
+  }
+  // Non-string, non-null, non-undefined values are silently dropped —
+  // matches the pre-#2625 behavior for malformed input (e.g. numbers via
+  // JSON re-entry).
+}
+
 export function filterSafeUpdates(updates: SessionUpdates): Partial<Session> {
   const safe: Partial<Session> = {};
   if (!isObject(updates)) return safe;
-  if (typeof updates.sandboxName === "string") safe.sandboxName = updates.sandboxName;
-  if (typeof updates.provider === "string") safe.provider = updates.provider;
-  if (typeof updates.model === "string") safe.model = updates.model;
-  if (typeof updates.endpointUrl === "string") safe.endpointUrl = redactUrl(updates.endpointUrl);
-  if (typeof updates.credentialEnv === "string") safe.credentialEnv = updates.credentialEnv;
-  if (typeof updates.preferredInferenceApi === "string")
-    safe.preferredInferenceApi = updates.preferredInferenceApi;
-  if (typeof updates.nimContainer === "string") safe.nimContainer = updates.nimContainer;
+  assignNullableString(safe, "sandboxName", updates.sandboxName);
+  assignNullableString(safe, "provider", updates.provider);
+  assignNullableString(safe, "model", updates.model);
+  assignNullableString(safe, "endpointUrl", updates.endpointUrl, redactUrl);
+  assignNullableString(safe, "credentialEnv", updates.credentialEnv);
+  assignNullableString(safe, "preferredInferenceApi", updates.preferredInferenceApi);
+  assignNullableString(safe, "nimContainer", updates.nimContainer);
   if (typeof updates.routerPid === "number" && Number.isInteger(updates.routerPid) && updates.routerPid > 0) {
     safe.routerPid = updates.routerPid;
   }


### PR DESCRIPTION
## Summary

Fixes the upgrade-sandboxes / per-sandbox rebuild preflight incorrectly demanding a stale provider credential (e.g. `OPENAI_API_KEY`) after the user switches from a remote provider to a local one (Ollama / vLLM / local NIM). The wizard already emits `credentialEnv=null` on local-provider selection, but the session-update pipeline silently dropped the clear, so the stale value survived in `~/.nemoclaw/onboard-session.json` and the next rebuild preflight bailed out.

## Related Issue

Closes #2625
Related: #2306 (credential resolution canonicalization umbrella), #2519 (local Ollama caching OPENAI_API_KEY — pre-fix migration retained as safety net for on-disk sessions)

## Changes

Two halves of the write path were broken for nullable session fields. Both fixed together:

- **`src/lib/state/onboard-session.ts`** — new `assignNullableString` helper in `filterSafeUpdates` treats `null` as an explicit clear, `string` as assign (with optional normalizer), and `undefined` as leave-unchanged. Applied uniformly to all six nullable string fields on `Session`: `sandboxName`, `provider`, `model`, `endpointUrl`, `credentialEnv`, `preferredInferenceApi`, `nimContainer`. `SessionUpdates` widened to `string | null` for those fields.
- **`src/lib/onboard.ts`** — new `toNullableString` helper in `toSessionUpdates` preserves `null` instead of collapsing to `undefined` via `toOptionalString`. `toOptionalString` stays for genuinely optional (non-clearable) fields.
- **`src/lib/actions/sandbox/rebuild.ts`** — comment-only. Noted the #2519 legacy-migration block is still needed for users whose session.json predates this fix; fresh sessions no longer need it.
- **`src/lib/state/onboard-session.test.ts`** — 4 new cases:
  - Provider switch OpenAI → Ollama clears `credentialEnv`.
  - `undefined` regression guard: partial updates do not accidentally wipe fields.
  - `null`-clear contract holds for every nullable field in one shot.
  - `completeSession` honors the clear on terminal finalize.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm test` passes for the affected areas:
  - `src/lib/state/onboard-session.test.ts` — 42/42 (4 new + 38 existing)
  - `test/rebuild-credential-preflight.test.ts` + `test/rebuild-credential-hydration.test.ts` — 16/16 (including #2519 legacy-migration guards)
  - `src/lib/onboard-command.test.ts`, `src/lib/onboard-inference-probes.test.ts` — unchanged, pass
- [x] Tests added for the new behavior (null-clear contract at the write layer)
- [x] No secrets, API keys, or credentials committed
- [x] `npm run build:cli` clean (`tsc -p tsconfig.src.json` + blueprint)
- [x] `biome lint` clean on touched files
- [ ] `make docs` — not applicable (no user-facing doc changes; rebuild error path is the same on the failure case)

### Test plan for reviewers

The reporter's exact repro from the issue body is covered by the unit tests but is worth the manual check too:

1. `nemoclaw onboard` with OpenAI, complete.
2. `unset OPENAI_API_KEY && nemoclaw credentials reset OPENAI_API_KEY`.
3. `nemoclaw onboard` selecting local Ollama (or any local provider).
4. Inspect `~/.nemoclaw/onboard-session.json` — `credentialEnv` should now be `null` (pre-fix it stayed as `"OPENAI_API_KEY"`).
5. `nemoclaw upgrade-sandboxes` should no longer abort with `Missing credential: OPENAI_API_KEY`.

### Follow-up (not in this PR)

Phase 3 from the dev plan — downgrade the rebuild preflight to a warning when `credentialEnv` is set but no env/saved value is found — would generalize the narrow #2519 migration into defense-in-depth for any stale remote-provider session on disk. Intentionally deferred to a separate PR to keep this one tightly scoped to the write-path root cause.

---

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session updates to properly distinguish between clearing a field (null) and leaving it unchanged (undefined). Several onboarding settings—including sandbox name, provider, model, endpoint URL, and inference preferences—now correctly persist explicit clear operations.

* **Tests**
  * Added test coverage for field-clearing behavior in onboarding sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->