### PR TITLE
fix(installer): show working curl|bash recovery examples on TTY-required error (#3058)

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -30,3 +30,28 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026. Use the f
 | [Release comparison](https://github.com/NVIDIA/NemoClaw/compare) | Diff between any two tags or branches. |
 | [Merged pull requests](https://github.com/NVIDIA/NemoClaw/pulls?q=is%3Apr+is%3Amerged) | Individual changes with review discussion. |
 | [Commit history](https://github.com/NVIDIA/NemoClaw/commits/main) | Full commit log on `main`. |
+
+## Behavior Changes
+
+### v0.0.34 — Installer requires explicit acceptance in non-TTY environments
+
+Starting with NemoClaw v0.0.34, the `curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash` installer pipeline no longer auto-accepts the third-party software notice when stdin is piped and `/dev/tty` is unavailable (for example, deeply detached SSH sessions or some container shells).
+In environments without a TTY, accept upfront in the pipe:
+
+```console
+$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
+```
+
+Or pass the flag through to the installer:
+
+```console
+$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software
+```
+
+Or re-run from a terminal with a controlling TTY:
+
+```console
+$ bash <(curl -fsSL https://www.nvidia.com/nemoclaw.sh)
+```
+
+The installer error message in v0.0.35+ surfaces all three invocations directly so users can copy-paste a recovery without leaving the terminal.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -155,6 +155,27 @@ error() {
 }
 ok() { printf "  ${C_GREEN}✓${C_RESET}  %s\n" "$*"; }
 
+# Common TTY-required error message for the third-party software notice.
+# Used by both show_usage_notice() and preflight_usage_notice_prompt() so
+# the recovery hint stays in sync (#3058).
+tty_required_error_message() {
+  cat <<'EOF'
+Interactive third-party software acceptance requires a TTY.
+
+  Three ways to proceed (#3058):
+    1. Re-run in a terminal:
+         bash <(curl -fsSL https://www.nvidia.com/nemoclaw.sh)
+
+    2. Accept upfront in the curl|bash pipe:
+         curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
+
+    3. Pass the flag through to the installer:
+         curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software
+
+  See docs/reference/commands.md for the full non-interactive install reference.
+EOF
+}
+
 verify_downloaded_script() {
   local file="$1" label="${2:-script}" expected_hash="${3:-}"
   if [ ! -s "$file" ]; then
@@ -575,19 +596,7 @@ show_usage_notice() {
     exec 3<&-
     return "$status"
   else
-    error "Interactive third-party software acceptance requires a TTY.
-
-  Three ways to proceed (#3058):
-    1. Re-run in a terminal:
-         bash <(curl -fsSL https://www.nvidia.com/nemoclaw.sh)
-
-    2. Accept upfront in the curl|bash pipe:
-         curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
-
-    3. Pass the flag through to the installer:
-         curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software
-
-  See docs/reference/commands.md for the full non-interactive install reference."
+    error "$(tty_required_error_message)"
   fi
 }
 
@@ -722,19 +731,7 @@ preflight_usage_notice_prompt() {
     return "$status"
   fi
 
-  error "Interactive third-party software acceptance requires a TTY.
-
-  Three ways to proceed (#3058):
-    1. Re-run in a terminal:
-         bash <(curl -fsSL https://www.nvidia.com/nemoclaw.sh)
-
-    2. Accept upfront in the curl|bash pipe:
-         curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
-
-    3. Pass the flag through to the installer:
-         curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software
-
-  See docs/reference/commands.md for the full non-interactive install reference."
+  error "$(tty_required_error_message)"
 }
 
 # spin "label" cmd [args...]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -575,7 +575,19 @@ show_usage_notice() {
     exec 3<&-
     return "$status"
   else
-    error "Interactive third-party software acceptance requires a TTY. Re-run in a terminal or pass --yes-i-accept-third-party-software (or set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1)."
+    error "Interactive third-party software acceptance requires a TTY.
+
+  Three ways to proceed (#3058):
+    1. Re-run in a terminal:
+         bash <(curl -fsSL https://www.nvidia.com/nemoclaw.sh)
+
+    2. Accept upfront in the curl|bash pipe:
+         curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
+
+    3. Pass the flag through to the installer:
+         curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software
+
+  See docs/reference/commands.md for the full non-interactive install reference."
   fi
 }
 
@@ -710,7 +722,19 @@ preflight_usage_notice_prompt() {
     return "$status"
   fi
 
-  error "Interactive third-party software acceptance requires a TTY. Re-run in a terminal or pass --yes-i-accept-third-party-software (or set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1)."
+  error "Interactive third-party software acceptance requires a TTY.
+
+  Three ways to proceed (#3058):
+    1. Re-run in a terminal:
+         bash <(curl -fsSL https://www.nvidia.com/nemoclaw.sh)
+
+    2. Accept upfront in the curl|bash pipe:
+         curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
+
+    3. Pass the flag through to the installer:
+         curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software
+
+  See docs/reference/commands.md for the full non-interactive install reference."
 }
 
 # spin "label" cmd [args...]

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -2735,6 +2735,19 @@ exit 0`,
     // — the friendly hint is the only TTY-related output we expect.
     expect(output).not.toMatch(/\/dev\/tty/);
   });
+
+  it("#3058: error message includes a working curl|bash example users can copy-paste", () => {
+    // The reporter on #3058 hit this error with `curl ... | bash` on a
+    // non-TTY box and was left guessing how to combine the env var with
+    // the documented one-liner. The fix surfaces the exact invocations
+    // (terminal, env-var-in-pipe, flag-via-bash-s) so users can resolve
+    // the failure without leaving the terminal output.
+    const { result } = callShowUsageNotice({});
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toMatch(/NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash/);
+    expect(output).toMatch(/bash -s -- --yes-i-accept-third-party-software/);
+    expect(output).toMatch(/bash <\(curl/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The pre-install third-party-software notice fails in non-TTY environments (`curl ... | bash` on remote/SSH boxes without `/dev/tty` fallback). The existing error told users *what* to do (`--yes-i-accept-third-party-software` or `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1`) but never showed *how* to combine that with the documented `curl|bash` one-liner. Reporters on #3058 ended up guessing.

## Related Issue

Closes #3058

## Changes

Both error sites in `scripts/install.sh` (the early `show_usage_notice` path at line 578 and the `show_usage_notice_with_tty_fallback` path at line 713) now emit the same multi-line block listing three concrete copy-pasteable invocations:

1. Re-run in a terminal: `bash <(curl -fsSL https://www.nvidia.com/nemoclaw.sh)`
2. Accept upfront in the curl|bash pipe: `curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash`
3. Pass the flag through: `curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software`

The block also references `docs/reference/commands.md` for the full non-interactive install reference (the docs already cover this; the error just didn't link there).

## Tests

`test/install-preflight.test.ts`:
- Existing `errors with the friendly hint when neither flag is set in non-TTY mode` test continues to pass.
- New `#3058: error message includes a working curl|bash example users can copy-paste` asserts each of the three working invocations is present in the error output.

Run via `NEMOCLAW_RUN_INSTALLER_TESTS=1 npx vitest run --project installer-integration test/install-preflight.test.ts`.

## Out of scope

- The hard error itself stays — auto-accepting the third-party-software notice without explicit consent would defeat its purpose. This PR makes the error self-serve so users can recover in one copy-paste.
- The analogous `Interactive onboarding requires a TTY` error in `src/lib/onboard/usage-notice.ts` (post-install onboarding path) is a separate code path; deferring to a follow-up if QA reports a similar UX gap there.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `NEMOCLAW_RUN_INSTALLER_TESTS=1 npx vitest run --project installer-integration test/install-preflight.test.ts` — both relevant tests pass.
- [x] Tests added for the new behavior.
- [x] No secrets, API keys, or credentials committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Installer messages for third‑party software acceptance now provide expanded, user‑friendly guidance with multiple resolution options and copy‑pastable invocation examples for non‑interactive/automated scenarios.

* **Behavior Changes**
  * Installer no longer auto‑accepts the third‑party notice in non‑TTY environments; guidance covers accepting upfront via env var, passing an acceptance flag, or rerunning from a TTY.

* **Tests**
  * Added test verifying the expanded non‑TTY acceptance error output and copy‑paste examples.

* **Documentation**
  * Release notes updated to document the new behavior and recovery options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->