### PR TITLE
fix: validate snapshot restore sandbox names (Fixes #3282)

### DIFF
--- a/nemoclaw/src/blueprint/snapshot.test.ts
+++ b/nemoclaw/src/blueprint/snapshot.test.ts
@@ -239,6 +239,15 @@ describe("snapshot", () => {
       expect(await restoreIntoSandbox(SNAP)).toBe(false);
     });
 
+    it("rejects invalid sandbox names before invoking openshell", async () => {
+      addDir(`${SNAP}/openclaw`);
+
+      await expect(restoreIntoSandbox(SNAP, "bad:name")).rejects.toThrow(/Invalid sandbox name/);
+      await expect(restoreIntoSandbox(SNAP, "BadName")).rejects.toThrow(/Invalid sandbox name/);
+      await expect(restoreIntoSandbox(SNAP, "-bad")).rejects.toThrow(/Invalid sandbox name/);
+      expect(mockExeca).not.toHaveBeenCalled();
+    });
+
     it("uses default sandbox name 'openclaw'", async () => {
       addDir(`${SNAP}/openclaw`);
       mockExeca.mockResolvedValue({ exitCode: 0 });

--- a/nemoclaw/src/blueprint/snapshot.ts
+++ b/nemoclaw/src/blueprint/snapshot.ts
@@ -33,6 +33,7 @@ const HOME = homedir();
 const OPENCLAW_DIR = join(HOME, ".openclaw");
 const NEMOCLAW_DIR = join(HOME, ".nemoclaw");
 const SNAPSHOTS_DIR = join(NEMOCLAW_DIR, "snapshots");
+const SANDBOX_NAME_RE = /^[a-z]([a-z0-9-]*[a-z0-9])?$/;
 
 function compactTimestamp(): string {
   return new Date()
@@ -73,6 +74,19 @@ function rejectSymlinksOnPath(targetPath: string): void {
     }
     current = dirname(current);
   }
+}
+
+function validateSandboxName(sandboxName: string): string {
+  if (
+    typeof sandboxName !== "string" ||
+    !SANDBOX_NAME_RE.test(sandboxName) ||
+    sandboxName.length > 63
+  ) {
+    throw new Error(
+      `Invalid sandbox name: '${String(sandboxName)}'. Allowed format: lowercase, starts with a letter, letters/numbers/internal hyphens only, ends with letter/number.`,
+    );
+  }
+  return sandboxName;
 }
 
 function collectFiles(dir: string): { files: string[]; symlinks: string[] } {
@@ -135,6 +149,7 @@ export async function restoreIntoSandbox(
   snapshotDir: string,
   sandboxName = "openclaw",
 ): Promise<boolean> {
+  const validatedSandboxName = validateSandboxName(sandboxName);
   const source = join(snapshotDir, "openclaw");
   if (!existsSync(source)) {
     return false;
@@ -142,7 +157,7 @@ export async function restoreIntoSandbox(
 
   const result = await execa(
     "openshell",
-    ["sandbox", "cp", source, `${sandboxName}:/sandbox/.openclaw`],
+    ["sandbox", "cp", source, `${validatedSandboxName}:/sandbox/.openclaw`],
     { reject: false },
   );
   if (result.exitCode !== 0) {
@@ -154,7 +169,7 @@ export async function restoreIntoSandbox(
     [
       "sandbox",
       "exec",
-      sandboxName,
+      validatedSandboxName,
       "--",
       "bash",
       "-lc",
@@ -187,7 +202,7 @@ done`,
   );
   if (repairLegacyLinks.exitCode !== 0) {
     console.debug(
-      `legacy symlink repair in sandbox ${sandboxName} exited ${String(repairLegacyLinks.exitCode)}: ${repairLegacyLinks.stderr}`,
+      `legacy symlink repair in sandbox ${validatedSandboxName} exited ${String(repairLegacyLinks.exitCode)}: ${repairLegacyLinks.stderr}`,
     );
   }
 
@@ -200,12 +215,21 @@ done`,
   // doesn't trip on a missing chown binary or a tightened exec policy.
   const chownResult = await execa(
     "openshell",
-    ["sandbox", "exec", sandboxName, "--", "chown", "-R", "sandbox:sandbox", "/sandbox/.openclaw"],
+    [
+      "sandbox",
+      "exec",
+      validatedSandboxName,
+      "--",
+      "chown",
+      "-R",
+      "sandbox:sandbox",
+      "/sandbox/.openclaw",
+    ],
     { reject: false },
   );
   if (chownResult.exitCode !== 0) {
     console.debug(
-      `chown in sandbox ${sandboxName} exited ${String(chownResult.exitCode)}: ${chownResult.stderr}`,
+      `chown in sandbox ${validatedSandboxName} exited ${String(chownResult.exitCode)}: ${chownResult.stderr}`,
     );
   }
   return true;

--- a/nemoclaw/src/blueprint/snapshot.ts
+++ b/nemoclaw/src/blueprint/snapshot.ts
@@ -76,6 +76,9 @@ function rejectSymlinksOnPath(targetPath: string): void {
   }
 }
 
+/**
+ * Validate sandbox names before interpolating them into OpenShell commands.
+ */
 function validateSandboxName(sandboxName: string): string {
   if (
     typeof sandboxName !== "string" ||


### PR DESCRIPTION
## Summary

Snapshot restore now validates the target sandbox name before building any `openshell sandbox cp` or repair commands. Invalid names fail locally with the same format rules used elsewhere in the CLI, instead of reaching OpenShell as an unsafe or confusing argument.

Fixes #3282.

## Changes

- Added sandbox-name validation in `nemoclaw/src/blueprint/snapshot.ts` before restore command construction.
- Reused the validated name for copy, symlink repair, ownership repair, and debug messages.
- Added a snapshot test that verifies invalid names are rejected before `execa` is called.

## Testing

- `cd nemoclaw && npm run build` passed.
- `npm run build:cli` passed.
- `npx vitest run nemoclaw/src/blueprint/snapshot.test.ts` passed.
- `HOME=/private/tmp/nemoclaw-test-home-3282 npm test -- --reporter=dot` was attempted. The local full suite still fails in existing installer/preinstall and unrelated CLI/onboard tests, including `test/install-preflight.test.ts`, `test/preinstall-node-version.test.ts`, `test/cli.test.ts`, and `test/onboard-selection.test.ts`.

## Evidence it works

The new unit test covers the exact failure boundary: invalid sandbox names are rejected before any OpenShell command is invoked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate sandbox names during restore and ensure only well-formed, lowercase hyphenated names (max 63 chars) are accepted. Restore steps (copy, in-sandbox repair, ownership changes) now consistently use the validated name and log it correctly.

* **Tests**
  * Added tests verifying invalid sandbox names are rejected with appropriate errors and no restore actions are invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->