### PR TITLE
fix: add qwen3.6 Ollama starter for large GPUs (Fixes #3250)

### DIFF
--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import {
   CONTAINER_REACHABILITY_IMAGE,
   DEFAULT_OLLAMA_MODEL,
+  DGX_SPARK_OLLAMA_MODEL,
   LARGE_OLLAMA_MIN_MEMORY_MB,
   OLLAMA_CONTAINER_PORT,
   getDefaultOllamaModel,
@@ -402,9 +403,13 @@ describe("local inference helpers", () => {
     ).toEqual(["qwen2.5:7b"]);
     expect(getBootstrapOllamaModelOptions({ totalMemoryMB: LARGE_OLLAMA_MIN_MEMORY_MB })).toEqual([
       "qwen2.5:7b",
+      DGX_SPARK_OLLAMA_MODEL,
       DEFAULT_OLLAMA_MODEL,
     ]);
     expect(getDefaultOllamaModel({ totalMemoryMB: 16384 }, () => "")).toBe("qwen2.5:7b");
+    expect(getDefaultOllamaModel({ totalMemoryMB: LARGE_OLLAMA_MIN_MEMORY_MB }, () => "")).toBe(
+      DGX_SPARK_OLLAMA_MODEL,
+    );
   });
 
   it("builds a background warmup command for ollama models", () => {

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -22,6 +22,7 @@ export const OLLAMA_CONTAINER_PORT = isWsl() ? OLLAMA_PORT : OLLAMA_PROXY_PORT;
 export const HOST_GATEWAY_URL = "http://host.openshell.internal";
 export const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
 export const DEFAULT_OLLAMA_MODEL = "nemotron-3-nano:30b";
+export const DGX_SPARK_OLLAMA_MODEL = "qwen3.6:35b";
 export const SMALL_OLLAMA_MODEL = "qwen2.5:7b";
 export const LARGE_OLLAMA_MIN_MEMORY_MB = 32768;
 
@@ -463,6 +464,7 @@ export function getOllamaModelOptions(runCaptureImpl?: RunCaptureFn): string[] {
 export function getBootstrapOllamaModelOptions(gpu: GpuInfo | null): string[] {
   const options = [SMALL_OLLAMA_MODEL];
   if (gpu && gpu.totalMemoryMB >= LARGE_OLLAMA_MIN_MEMORY_MB) {
+    options.push(DGX_SPARK_OLLAMA_MODEL);
     options.push(DEFAULT_OLLAMA_MODEL);
   }
   return options;
@@ -475,6 +477,9 @@ export function getDefaultOllamaModel(
   const models = getOllamaModelOptions(runCaptureImpl);
   if (models.length === 0) {
     const bootstrap = getBootstrapOllamaModelOptions(gpu);
+    if (bootstrap.includes(DGX_SPARK_OLLAMA_MODEL)) {
+      return DGX_SPARK_OLLAMA_MODEL;
+    }
     return bootstrap[0];
   }
   return models.includes(DEFAULT_OLLAMA_MODEL) ? DEFAULT_OLLAMA_MODEL : models[0];

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -22,6 +22,7 @@ export const OLLAMA_CONTAINER_PORT = isWsl() ? OLLAMA_PORT : OLLAMA_PROXY_PORT;
 export const HOST_GATEWAY_URL = "http://host.openshell.internal";
 export const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
 export const DEFAULT_OLLAMA_MODEL = "nemotron-3-nano:30b";
+/** Preferred Ollama starter model for DGX Spark-class GPUs. */
 export const DGX_SPARK_OLLAMA_MODEL = "qwen3.6:35b";
 export const SMALL_OLLAMA_MODEL = "qwen2.5:7b";
 export const LARGE_OLLAMA_MIN_MEMORY_MB = 32768;
@@ -461,6 +462,9 @@ export function getOllamaModelOptions(runCaptureImpl?: RunCaptureFn): string[] {
   return parseOllamaList(listOutput);
 }
 
+/**
+ * Return Ollama models NemoClaw should offer/pull before the daemon has local models.
+ */
 export function getBootstrapOllamaModelOptions(gpu: GpuInfo | null): string[] {
   const options = [SMALL_OLLAMA_MODEL];
   if (gpu && gpu.totalMemoryMB >= LARGE_OLLAMA_MIN_MEMORY_MB) {
@@ -470,6 +474,9 @@ export function getBootstrapOllamaModelOptions(gpu: GpuInfo | null): string[] {
   return options;
 }
 
+/**
+ * Pick the default Ollama model, preferring installed models over bootstrap fallbacks.
+ */
 export function getDefaultOllamaModel(
   gpu: GpuInfo | null = null,
   runCaptureImpl?: RunCaptureFn,


### PR DESCRIPTION
## Summary

DGX Spark-class systems now see `qwen3.6:35b` in the Ollama starter choices when no local models are installed. For large-memory GPUs, NemoClaw also defaults to that model instead of the smaller general default.

Fixes #3250.

## Changes

- Added a DGX Spark Ollama starter model constant for `qwen3.6:35b`.
- Included it in the high-memory bootstrap model list.
- Updated default model selection so large-memory systems without installed Ollama models pick the DGX Spark starter.
- Added tests for the bootstrap list and default selection behavior.

## Testing

- `npm run build:cli` passed.
- `npm test -- src/lib/inference/local.test.ts` passed.
- `HOME=/private/tmp/nemoclaw-test-home-3250 npm test -- --reporter=dot` was attempted. The local full suite still fails in existing installer/preinstall and unrelated CLI/onboard tests, including `test/install-preflight.test.ts`, `test/preinstall-node-version.test.ts`, `test/cli.test.ts`, and `test/onboard-selection.test.ts`.

## Evidence it works

The focused inference test now verifies that high-memory Ollama bootstrap includes `qwen3.6:35b` and selects it when no installed models are available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a high-performance Ollama model for systems with larger GPU memory.
  * Improved model selection to prefer the high-performance model when GPU memory meets the high-memory threshold.

* **Tests**
  * Enhanced test coverage for model selection, including behavior when GPU memory is exactly at the threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->