### PR TITLE
fix(runtime): use POSIX cntrl class and return 0 for control-char validation

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -372,9 +372,16 @@ apply_model_override() {
   local api_override="${NEMOCLAW_INFERENCE_API_OVERRIDE:-}"
 
   # SECURITY: Validate inputs — reject control characters and enforce length limit.
-  if printf '%s' "$model_override" | grep -qP '[\x00-\x1f\x7f]'; then
+  # Use POSIX [[:cntrl:]] instead of grep -P (PCRE) for portability — slim
+  # container images may lack libpcre2 and grep -P silently returns 2, making
+  # the check a no-op.  return 0 (skip override) instead of return 1 (abort
+  # script) so the validation message reaches Docker stderr before the
+  # container exits; return 1 triggers set -e which races the exec 2>>(tee)
+  # process substitution and can lose the message.  Consistent with every
+  # other validation check in this function.
+  if printf '%s' "$model_override" | LC_ALL=C grep -q '[[:cntrl:]]'; then
     printf '[SECURITY] NEMOCLAW_MODEL_OVERRIDE contains control characters — refusing\n' >&2
-    return 1
+    return 0
   fi
   if [ "${#model_override}" -gt 256 ]; then
     printf '[SECURITY] NEMOCLAW_MODEL_OVERRIDE exceeds 256 characters — refusing\n' >&2
@@ -505,9 +512,10 @@ apply_cors_override() {
 
   local cors_origin="$NEMOCLAW_CORS_ORIGIN"
 
-  if printf '%s' "$cors_origin" | grep -qP '[\x00-\x1f\x7f]'; then
+  # Same portability + race-condition fix as apply_model_override above.
+  if printf '%s' "$cors_origin" | LC_ALL=C grep -q '[[:cntrl:]]'; then
     printf '[SECURITY] NEMOCLAW_CORS_ORIGIN contains control characters — refusing\n' >&2
-    return 1
+    return 0
   fi
   if [ "${#cors_origin}" -gt 256 ]; then
     printf '[SECURITY] NEMOCLAW_CORS_ORIGIN exceeds 256 characters — refusing\n' >&2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The `runtime-overrides-e2e` test 8 ("NEMOCLAW_MODEL_OVERRIDE with control chars is rejected") has been failing since its introduction because the control-character validation in `apply_model_override()` uses `return 1`, which triggers `set -e` and aborts the entrypoint. The `exec 2> >(tee …)` stderr redirect means the validation message is written to a pipe, but the `tee` subprocess is killed by Docker when PID 1 exits before it can flush — so the test never sees "control characters" on stderr and reports FAIL.

Additionally, the validation uses `grep -qP` (PCRE) which silently returns exit-code 2 when `libpcre2` is absent, making the security check a no-op on minimal images.

This PR switches to POSIX `[[:cntrl:]]` character class and `return 0` (skip-override) to match every other validation check in the same functions.

## Related Issue

Fixes #3303

## Changes

- **`scripts/nemoclaw-start.sh`**: In `apply_model_override()`, replace `grep -qP '[\x00-\x1f\x7f]'` with `LC_ALL=C grep -q '[[:cntrl:]]'` and change `return 1` to `return 0`.
- **`scripts/nemoclaw-start.sh`**: Same fix in `apply_cors_override()` for consistency.
- Override is still rejected (function returns before config write), and the warning is still emitted to stderr.

## Validation

A focused `custom-e2e.yaml` workflow was run on a sibling branch to confirm this fix repairs the regression. The workflow re-runs **only** the jobs from the original nightly that this PR targets, on `ubuntu-latest`, off the same fix commit as this PR.

- Validation branch: [`fix/nightly-e2e-ctrl-char-validation-e0ab181-custom-e2e`](https://github.com/hunglp6d/NemoClaw/tree/fix/nightly-e2e-ctrl-char-validation-e0ab181-custom-e2e) on `hunglp6d/NemoClaw`
- Validation run: [#25587313321](https://github.com/hunglp6d/NemoClaw/actions/runs/25587313321) — **failure** (missing `NVIDIA_API_KEY` secret on fork; the test never reached the runtime-overrides step)
- Targeted jobs: `runtime-overrides-e2e (#75114312447)`
- Original failing run: [25585926257](https://github.com/NVIDIA/NemoClaw/actions/runs/25585926257) on `e0ab181dbca32e0caafab7a7c8ca810d2aded8bd`

The validation branch is intentionally **not** the head of this PR — it carries an extra `.github/workflows/custom-e2e.yaml` commit that is scaffolding, not part of the fix. Re-run the validation by pushing any commit to the validation branch.

> **Note**: The validation run failed during the "Install NemoClaw" onboarding step because `NVIDIA_API_KEY` is not available as a secret on the fork repo. This is an inherent limitation of cross-repo validation — the runtime-overrides test requires full NemoClaw installation with API key. The fix will be validated when the next nightly-e2e runs on `NVIDIA/NemoClaw` after merge.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>