### PR TITLE
feat(install): add express install prompt for DGX Spark and Station

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1717,7 +1717,7 @@ maybe_offer_express_install() {
     return 0
   fi
   info "Detected ${platform}."
-  printf "  Run express install (accepts third-party software notice, auto-configures inference, applies suggested security policy)? [Y/n]: "
+  printf "  Run express install (auto-configures inference and applies suggested security policy)? [Y/n]: "
   local reply=""
   read -r reply </dev/tty || true
   reply="$(printf "%s" "$reply" | tr '[:upper:]' '[:lower:]')"
@@ -1725,9 +1725,7 @@ maybe_offer_express_install() {
     "" | y | yes)
       info "Using express install for ${platform}."
       NON_INTERACTIVE=1
-      ACCEPT_THIRD_PARTY_SOFTWARE=1
       export NEMOCLAW_NON_INTERACTIVE=1
-      export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1
       export NEMOCLAW_YES=1
       export NEMOCLAW_POLICY_MODE=suggested
       case "$platform" in
@@ -1779,11 +1777,6 @@ main() {
   ACCEPT_THIRD_PARTY_SOFTWARE="${ACCEPT_THIRD_PARTY_SOFTWARE:-${NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE:-}}"
   FRESH="${FRESH:-${NEMOCLAW_FRESH:-}}"
 
-  # Offer express install on supported platforms (DGX Spark / Station). When
-  # accepted, sets non-interactive + accept-notice + provider/model env vars
-  # so the rest of the run is fully unattended.
-  maybe_offer_express_install
-
   # If the user explicitly accepted the third-party-software notice, treat
   # that as non-interactive intent for the rest of the run too — show_usage_notice
   # is only one of several phase-3 steps that need a TTY or --non-interactive
@@ -1802,6 +1795,13 @@ main() {
   # a real terminal are different: stdin is the script pipe, but /dev/tty can
   # still collect acceptance before Node.js or the CLI are installed.
   preflight_usage_notice_prompt
+
+  # Offer express install on supported platforms (DGX Spark / Station). Runs
+  # AFTER the third-party notice so the user has explicitly accepted the
+  # license before opting into the unattended path. Express only sets the
+  # provider/model/policy + non-interactive vars; license acceptance is
+  # already recorded by preflight above.
+  maybe_offer_express_install
 
   _INSTALL_START=$SECONDS
   print_banner

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1723,7 +1723,10 @@ maybe_offer_express_install() {
   info "Detected ${platform}."
   printf "  Run express install (auto-configures inference and applies suggested security policy)? [Y/n]: "
   local reply=""
-  read -r reply </dev/tty || true
+  if ! read -r reply </dev/tty; then
+    info "Skipping express install (unable to read from TTY)."
+    return 0
+  fi
   reply="$(printf "%s" "$reply" | tr '[:upper:]' '[:lower:]')"
   case "$reply" in
     "" | y | yes)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1673,6 +1673,79 @@ run_onboard() {
   fi
 }
 
+# Detect DGX Spark / DGX Station from firmware (DMI first, devicetree fallback).
+# Echoes "DGX Spark", "DGX Station", or empty. Used to gate the express
+# install prompt; only platforms with a known sensible default are offered.
+detect_express_platform() {
+  local model=""
+  if [ -r /sys/class/dmi/id/product_name ]; then
+    model="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+  fi
+  if [ -z "$model" ] && [ -r /sys/firmware/devicetree/base/model ]; then
+    model="$(tr -d '\0' </sys/firmware/devicetree/base/model 2>/dev/null || true)"
+  fi
+  case "$model" in
+    *DGX*Spark*) printf "DGX Spark" ;;
+    *DGX*Station*) printf "DGX Station" ;;
+    *) ;;
+  esac
+}
+
+# Prompt the user to opt into express install on Spark/Station. Sets the
+# non-interactive + provider/model env vars when accepted. Skipped when
+# the user already passed --non-interactive, set NEMOCLAW_PROVIDER, or has
+# no TTY.
+maybe_offer_express_install() {
+  local platform
+  platform="$(detect_express_platform)"
+  # Not on a platform we have an express recipe for — say nothing.
+  if [ -z "$platform" ]; then
+    return 0
+  fi
+  # On a supported platform but a skip condition applies — explain why so
+  # the user understands they could have gotten express otherwise.
+  if [ "${NON_INTERACTIVE:-}" = "1" ]; then
+    info "Detected ${platform}. Skipping express prompt (--non-interactive set)."
+    return 0
+  fi
+  if [ -n "${NEMOCLAW_PROVIDER:-}" ]; then
+    info "Detected ${platform}. Skipping express prompt (NEMOCLAW_PROVIDER=${NEMOCLAW_PROVIDER} already set)."
+    return 0
+  fi
+  if [ ! -t 0 ]; then
+    info "Detected ${platform}. Skipping express prompt (no TTY)."
+    return 0
+  fi
+  info "Detected ${platform}."
+  printf "  Run express install (accepts third-party software notice, auto-configures inference, applies suggested security policy)? [Y/n]: "
+  local reply=""
+  read -r reply </dev/tty || true
+  reply="$(printf "%s" "$reply" | tr '[:upper:]' '[:lower:]')"
+  case "$reply" in
+    "" | y | yes)
+      info "Using express install for ${platform}."
+      NON_INTERACTIVE=1
+      ACCEPT_THIRD_PARTY_SOFTWARE=1
+      export NEMOCLAW_NON_INTERACTIVE=1
+      export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1
+      export NEMOCLAW_YES=1
+      export NEMOCLAW_POLICY_MODE=suggested
+      case "$platform" in
+        "DGX Spark")
+          export NEMOCLAW_PROVIDER=install-ollama
+          export NEMOCLAW_MODEL=qwen3.6:35b
+          ;;
+        "DGX Station")
+          export NEMOCLAW_PROVIDER=install-vllm
+          ;;
+      esac
+      ;;
+    *)
+      info "Skipping express install. Continuing with interactive flow."
+      ;;
+  esac
+}
+
 # Main
 # ---------------------------------------------------------------------------
 main() {
@@ -1705,6 +1778,11 @@ main() {
   NON_INTERACTIVE="${NON_INTERACTIVE:-${NEMOCLAW_NON_INTERACTIVE:-}}"
   ACCEPT_THIRD_PARTY_SOFTWARE="${ACCEPT_THIRD_PARTY_SOFTWARE:-${NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE:-}}"
   FRESH="${FRESH:-${NEMOCLAW_FRESH:-}}"
+
+  # Offer express install on supported platforms (DGX Spark / Station). When
+  # accepted, sets non-interactive + accept-notice + provider/model env vars
+  # so the rest of the run is fully unattended.
+  maybe_offer_express_install
 
   # If the user explicitly accepted the third-party-software notice, treat
   # that as non-interactive intent for the rest of the run too — show_usage_notice

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1716,15 +1716,25 @@ maybe_offer_express_install() {
     info "Detected ${platform}. Skipping express prompt (NEMOCLAW_PROVIDER=${NEMOCLAW_PROVIDER} already set)."
     return 0
   fi
-  if [ ! -t 0 ]; then
-    info "Detected ${platform}. Skipping express prompt (no TTY)."
-    return 0
-  fi
-  info "Detected ${platform}."
-  printf "  Run express install (auto-configures inference and applies suggested security policy)? [Y/n]: "
   local reply=""
-  if ! read -r reply </dev/tty; then
-    info "Skipping express install (unable to read from TTY)."
+  if [ -t 0 ]; then
+    info "Detected ${platform}."
+    printf "  Run express install (auto-configures inference and applies suggested security policy)? [Y/n]: "
+    if ! IFS= read -r reply; then
+      info "Skipping express install (unable to read from TTY)."
+      return 0
+    fi
+  elif { exec 3</dev/tty; } 2>/dev/null; then
+    info "Detected ${platform}."
+    printf "  Run express install (auto-configures inference and applies suggested security policy)? [Y/n]: "
+    if ! IFS= read -r reply <&3; then
+      exec 3<&-
+      info "Skipping express install (unable to read from TTY)."
+      return 0
+    fi
+    exec 3<&-
+  else
+    info "Detected ${platform}. Skipping express prompt (no TTY)."
     return 0
   fi
   reply="$(printf "%s" "$reply" | tr '[:upper:]' '[:lower:]')"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1704,6 +1704,10 @@ maybe_offer_express_install() {
   fi
   # On a supported platform but a skip condition applies — explain why so
   # the user understands they could have gotten express otherwise.
+  if [ "${NEMOCLAW_NO_EXPRESS:-}" = "1" ]; then
+    info "Detected ${platform}. Skipping express prompt (NEMOCLAW_NO_EXPRESS=1)."
+    return 0
+  fi
   if [ "${NON_INTERACTIVE:-}" = "1" ]; then
     info "Detected ${platform}. Skipping express prompt (--non-interactive set)."
     return 0

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -2750,6 +2750,151 @@ exit 0`,
   });
 });
 
+describe("installer express install prompt (sourced)", () => {
+  function runExpressPromptWithTty(answer: string, stdinMode: "pipe" | "tty") {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-express-prompt-"));
+    const python =
+      spawnSync("bash", ["-lc", "command -v python3"], { encoding: "utf-8" }).stdout.trim() ||
+      "python3";
+    const ptyRunner = `
+import os
+import pty
+import select
+import signal
+import sys
+import time
+
+installer = sys.argv[1]
+answer = sys.argv[2].encode()
+stdin_mode = sys.argv[3]
+script = r'''
+source "$INSTALLER_UNDER_TEST" >/dev/null
+detect_express_platform() { printf "DGX Spark"; }
+NON_INTERACTIVE=""
+NEMOCLAW_PROVIDER=""
+NEMOCLAW_NO_EXPRESS=""
+maybe_offer_express_install
+printf "RESULT NON_INTERACTIVE=%s PROVIDER=%s MODEL=%s POLICY=%s YES=%s\\n" \\
+  "\${NON_INTERACTIVE:-}" "\${NEMOCLAW_PROVIDER:-}" "\${NEMOCLAW_MODEL:-}" \\
+  "\${NEMOCLAW_POLICY_MODE:-}" "\${NEMOCLAW_YES:-}"
+'''
+env = dict(os.environ)
+env["INSTALLER_UNDER_TEST"] = installer
+pid, fd = pty.fork()
+if pid == 0:
+    if stdin_mode == "pipe":
+        devnull = os.open(os.devnull, os.O_RDONLY)
+        os.dup2(devnull, 0)
+        os.close(devnull)
+    os.execvpe("bash", ["bash", "-c", script], env)
+
+output = bytearray()
+os.set_blocking(fd, False)
+sent = False
+exit_code = 124
+deadline = time.time() + 10
+while True:
+    ready, _, _ = select.select([fd], [], [], 0.1)
+    if ready:
+        try:
+            chunk = os.read(fd, 4096)
+        except BlockingIOError:
+            chunk = b""
+        except OSError:
+            chunk = b""
+        if chunk:
+            output.extend(chunk)
+        if (not sent) and b"[Y/n]" in output:
+            os.write(fd, answer)
+            sent = True
+    waited = os.waitpid(pid, os.WNOHANG)
+    if waited[0] == pid:
+        exit_code = os.waitstatus_to_exitcode(waited[1])
+        break
+    if time.time() > deadline:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+        break
+
+try:
+    os.close(fd)
+except OSError:
+    pass
+sys.stdout.buffer.write(output)
+sys.exit(exit_code)
+`;
+    return spawnSync(python, ["-c", ptyRunner, INSTALLER_PAYLOAD, answer, stdinMode], {
+      cwd: tmp,
+      encoding: "utf-8",
+      timeout: 15_000,
+      killSignal: "SIGKILL",
+      env: {
+        HOME: tmp,
+        PATH: TEST_SYSTEM_PATH,
+      },
+    });
+  }
+
+  it("offers express install when curl-piped stdin still has a controlling TTY", () => {
+    const result = runExpressPromptWithTty("y\n", "pipe");
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.status, output).toBe(0);
+    expect(output).toMatch(/Detected DGX Spark/);
+    expect(output).toMatch(/Run express install/);
+    expect(output).toMatch(/Using express install for DGX Spark/);
+    expect(output).toMatch(
+      /RESULT NON_INTERACTIVE=1 PROVIDER=install-ollama MODEL=qwen3\.6:35b POLICY=suggested YES=1/,
+    );
+  });
+
+  it("skips express install without a controlling TTY", () => {
+    if (process.platform === "darwin") {
+      return;
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-express-no-tty-"));
+    const result = spawnSync(
+      "setsid",
+      [
+        "bash",
+        "-c",
+        `
+source "$INSTALLER_UNDER_TEST" >/dev/null
+detect_express_platform() { printf "DGX Spark"; }
+NON_INTERACTIVE=""
+NEMOCLAW_PROVIDER=""
+NEMOCLAW_NO_EXPRESS=""
+maybe_offer_express_install
+printf "RESULT NON_INTERACTIVE=%s PROVIDER=%s MODEL=%s POLICY=%s YES=%s\\n" \\
+  "\${NON_INTERACTIVE:-}" "\${NEMOCLAW_PROVIDER:-}" "\${NEMOCLAW_MODEL:-}" \\
+  "\${NEMOCLAW_POLICY_MODE:-}" "\${NEMOCLAW_YES:-}"
+`,
+      ],
+      {
+        cwd: tmp,
+        encoding: "utf-8",
+        input: "",
+        env: {
+          HOME: tmp,
+          PATH: TEST_SYSTEM_PATH,
+          INSTALLER_UNDER_TEST: INSTALLER_PAYLOAD,
+        },
+      },
+    );
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.status, output).toBe(0);
+    expect(output).toMatch(/Detected DGX Spark/);
+    expect(output).toMatch(/Skipping express prompt \(no TTY\)/);
+    expect(output).not.toMatch(/Run express install/);
+    expect(output).toMatch(/RESULT NON_INTERACTIVE= PROVIDER= MODEL= POLICY= YES=/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // scripts/install.sh (curl-pipe installer) release-tag resolution
 // ---------------------------------------------------------------------------

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -3270,6 +3270,11 @@ sys.exit(exit_code)
       env: {
         HOME: tmp,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+        // These tests verify the third-party-license flow on non-Spark
+        // hardware. On real DGX Spark/Station the express prompt would
+        // also fire and consume the test's input. Skip it explicitly
+        // so the tests stay focused on what they're verifying.
+        NEMOCLAW_NO_EXPRESS: "1",
         ...env,
       },
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
On DGX Spark and DGX Station, install.sh now offers an "express install" that auto-configures local inference and applies the suggested security policy after the user has accepted the third-party software notice. The license prompt is unbundled from express — the user is shown the third-party notice first, types `yes` to accept it, and only then sees the express prompt. Skipped silently on other platforms; users who already set `--non-interactive` or `NEMOCLAW_PROVIDER` are unaffected.

## Changes
 - `scripts/install.sh`:
    - New `detect_express_platform()` reads `/sys/class/dmi/id/product_name` (DMI) with a `/sys/firmware/devicetree/base/model` fallback. Echoes "DGX Spark", "DGX Station", or empty.
    - New `maybe_offer_express_install()` skips silently when not on a supported platform. On Spark/Station, prints the skip reason if `--non-interactive`, `NEMOCLAW_PROVIDER`, or no TTY would block the prompt; otherwise asks: `Run express install (auto-configures inference and applies suggested security policy)? [Y/n]`.
    - On Y, exports `NEMOCLAW_NON_INTERACTIVE=1`, `NEMOCLAW_YES=1`, `NEMOCLAW_POLICY_MODE=suggested`, plus `NEMOCLAW_PROVIDER=install-ollama` + `NEMOCLAW_MODEL=qwen3.6:35b` for Spark, or `NEMOCLAW_PROVIDER=install-vllm` for Station. Does **not** auto-accept the third-party notice; that's handled by the existing preflight prompt.
    - Reordered `main()` so `preflight_usage_notice_prompt` runs **before** `maybe_offer_express_install`. The user always sees and explicitly accepts the third-party notice (or pre-accepts via env var) before the express question.
 - `test/install-preflight.test.ts`:
    - `runInstallerWithTty` (and its piped/interactive wrappers) now sets `NEMOCLAW_NO_EXPRESS=1` in the test env so the existing license-flow tests stay focused on what they're verifying when run on real Spark/Station hardware.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer detects DGX Spark and DGX Station and offers an optional "express install" after third‑party license acceptance.
  * Express install applies platform-specific defaults (provider/model) and is skipped when non‑interactive, when explicit overrides exist, or when no TTY is present.

* **Tests**
  * Preflight tests disable the express prompt for deterministic license/atomic flows and add tests verifying prompt behavior (offer when interactive, skip without a TTY).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3317)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->