### PR TITLE
fix(e2e): retry sandbox destroy in TC-STATE-02 for transient gRPC errors

### DIFF
--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -228,9 +228,15 @@ test_state_02_backup_restore() {
   local destroy_ok=0
   for destroy_attempt in 1 2 3; do
     nemoclaw "$SANDBOX_NAME" destroy --yes 2>&1 | tee -a "$LOG_FILE" || true
-    if ! nemoclaw list 2>/dev/null | grep -q "$SANDBOX_NAME"; then
-      destroy_ok=1
-      break
+    local list_output list_rc=0
+    list_output=$(nemoclaw list 2>&1) || list_rc=$?
+    if [[ $list_rc -eq 0 ]]; then
+      if ! printf '%s\n' "$list_output" | grep -Fq -- "$SANDBOX_NAME"; then
+        destroy_ok=1
+        break
+      fi
+    else
+      log "  Destroy attempt $destroy_attempt: unable to read sandbox list (exit $list_rc), retrying..."
     fi
     if [[ $destroy_attempt -lt 3 ]]; then
       log "  Destroy attempt $destroy_attempt failed (sandbox still listed), retrying in 10s..."

--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -225,10 +225,21 @@ test_state_02_backup_restore() {
   log "  Backup dir: $backup_dir"
 
   log "  Step 3: Destroying sandbox..."
-  nemoclaw "$SANDBOX_NAME" destroy --yes 2>&1 | tee -a "$LOG_FILE" || true
+  local destroy_ok=0
+  for destroy_attempt in 1 2 3; do
+    nemoclaw "$SANDBOX_NAME" destroy --yes 2>&1 | tee -a "$LOG_FILE" || true
+    if ! nemoclaw list 2>/dev/null | grep -q "$SANDBOX_NAME"; then
+      destroy_ok=1
+      break
+    fi
+    if [[ $destroy_attempt -lt 3 ]]; then
+      log "  Destroy attempt $destroy_attempt failed (sandbox still listed), retrying in 10s..."
+      sleep 10
+    fi
+  done
 
-  if nemoclaw list 2>/dev/null | grep -q "$SANDBOX_NAME"; then
-    fail "TC-STATE-02: Destroy" "Sandbox still exists after destroy"
+  if [[ $destroy_ok -eq 0 ]]; then
+    fail "TC-STATE-02: Destroy" "Sandbox still exists after 3 destroy attempts"
     return
   fi
   pass "TC-STATE-02: Sandbox destroyed"


### PR DESCRIPTION
## Summary

Add a 3-attempt retry loop around the `nemoclaw destroy` call in TC-STATE-02 (backup-workspace lifecycle test) to handle transient gRPC `ServiceError: client error (SendRequest)` errors from the OpenShell gateway. Without retry the sandbox is left in a broken state, which cascades into a TC-DEPLOY-01b tunnel 502 failure.

## Related Issue

Fixes #3326

## Changes

- **`test/e2e/test-deployment-services.sh`**: Replace the single-shot `nemoclaw destroy --yes` in `test_state_02_backup_restore()` Step 3 (line 228) with a retry loop that:
  - Attempts up to 3 destroys with 10 s delays between attempts
  - Checks `nemoclaw list` after each attempt to confirm the sandbox is actually gone
  - Fails with an updated message ("after 3 destroy attempts") only if all retries are exhausted

## Validation

A focused `custom-e2e.yaml` workflow was run on a sibling branch to confirm this fix repairs the regression. The workflow re-runs **only** the jobs from the original nightly that this PR targets, on `ubuntu-latest`, off the same fix commit as this PR.

- Validation branch: [`fix/nightly-e2e-destroy-grpc-retry-118541a-custom-e2e`](https://github.com/hunglp6d/NemoClaw/tree/fix/nightly-e2e-destroy-grpc-retry-118541a-custom-e2e) on `hunglp6d/NemoClaw`
- Validation run: [#25663836712](https://github.com/hunglp6d/NemoClaw/actions/runs/25663836712)
- Targeted jobs: `deployment-services-e2e`
- Original failing run: [25643728773](https://github.com/NVIDIA/NemoClaw/actions/runs/25643728773) on `118541a7c7fac1ad57cdb824f9e1b522b2cbb0cf`

The validation branch is intentionally **not** the head of this PR — it carries an extra `.github/workflows/custom-e2e.yaml` commit that is scaffolding, not part of the fix. Re-run the validation by pushing any commit to the validation branch.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by adding a multi-attempt sandbox teardown with intervaled retries and a clear failure message if teardown repeatedly fails, reducing flakiness and improving stability of deployment-related test runs.
  * Retries are limited and paced to ensure deterministic cleanup, speeding up failure detection and overall test feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3325)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->