### PR TITLE
fix(sandbox): tighten bounding-set caps

### DIFF
--- a/scripts/lib/sandbox-init.sh
+++ b/scripts/lib/sandbox-init.sh
@@ -200,9 +200,22 @@ lock_config_after_write() {
 # at startup using capsh. The bounding set limits what caps any child process
 # (gateway, sandbox, agent) can ever acquire.
 #
-# Kept: cap_chown, cap_setuid, cap_setgid, cap_fowner, cap_kill
-#   — required by the entrypoint for gosu privilege separation and chown.
+# Dropped (issue #3280): cap_sys_admin, cap_sys_ptrace plus the historical
+# set (cap_net_raw, cap_dac_override, cap_sys_chroot, cap_fsetid,
+# cap_setfcap, cap_mknod, cap_audit_write, cap_net_bind_service).
+# Dashboard listens on a high port (default 18789, validated >=1024 in
+# nemoclaw-start.sh), so cap_net_bind_service is unconditionally unused.
+#
+# Kept (each load-bearing — do not drop without an entrypoint refactor):
+#   cap_chown, cap_fowner — needed to chown/chmod files we did not create
+#     after dropping cap_dac_override (see #2659).
+#   cap_setuid, cap_setgid — required by gosu to step down from root into
+#     the sandbox/gateway UIDs during entrypoint privilege separation.
+#   cap_kill — sandbox user signals gateway-user processes via the UID
+#     separation enforced by the entrypoint (see test 13 in
+#     e2e-gateway-isolation.sh).
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/797
+#      https://github.com/NVIDIA/NemoClaw/issues/3280
 #
 # Usage:
 #   drop_capabilities /usr/local/bin/nemoclaw-start "$@"
@@ -219,13 +232,48 @@ drop_capabilities() {
     if capsh --has-p=cap_setpcap 2>/dev/null; then
       export NEMOCLAW_CAPS_DROPPED=1
       exec capsh \
-        --drop=cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
+        --drop=cap_sys_admin,cap_sys_ptrace,cap_net_raw,cap_dac_override,cap_sys_chroot,cap_fsetid,cap_setfcap,cap_mknod,cap_audit_write,cap_net_bind_service \
         -- -c "exec $entrypoint \"\$@\"" -- "$@"
     else
-      echo "[SECURITY] CAP_SETPCAP not available — runtime already restricts capabilities" >&2
+      report_residual_capabilities
     fi
   elif [ "${NEMOCLAW_CAPS_DROPPED:-}" != "1" ]; then
     echo "[SECURITY WARNING] capsh not available — running with default capabilities" >&2
+  fi
+}
+
+# Emit a loud diagnostic when capsh-based dropping is unavailable so that
+# residual dangerous bounding-set caps surface in logs instead of being
+# silently inherited from the container runtime. Called from the
+# CAP_SETPCAP-missing fallback path of drop_capabilities() (issue #3280).
+report_residual_capabilities() {
+  echo "[SECURITY] CAP_SETPCAP not available — cannot drop bounding-set caps via capsh" >&2
+
+  local cap_bnd_hex val name bit present_caps=""
+  if ! cap_bnd_hex=$(awk '/^CapBnd:/{print $2}' /proc/self/status 2>/dev/null) \
+    || [ -z "$cap_bnd_hex" ]; then
+    echo "[SECURITY] Could not read /proc/self/status — residual caps unknown" >&2
+    return 0
+  fi
+  echo "[SECURITY] Residual CapBnd=${cap_bnd_hex}" >&2
+
+  # Bash arithmetic handles 64-bit ints on 64-bit platforms; CAP_LAST_CAP
+  # is ~41 today, well within range. Avoids a gawk-strtonum dependency.
+  val=$((16#$cap_bnd_hex))
+  for entry in \
+    "21:cap_sys_admin" \
+    "19:cap_sys_ptrace" \
+    "13:cap_net_raw" \
+    "1:cap_dac_override" \
+    "10:cap_net_bind_service"; do
+    bit="${entry%%:*}"
+    name="${entry#*:}"
+    if [ $(((val >> bit) & 1)) -ne 0 ]; then
+      present_caps="${present_caps:+$present_caps,}$name"
+    fi
+  done
+  if [ -n "$present_caps" ]; then
+    echo "[SECURITY] Dangerous caps remain in bounding set: ${present_caps}" >&2
   fi
 }
 

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -207,33 +207,75 @@ fi
 
 # ── Test 14: Dangerous capabilities are dropped by entrypoint ────
 
-info "14. Entrypoint drops dangerous capabilities from bounding set"
+info "14. Entrypoint drops the issue #3280 dangerous-cap inventory from bounding set"
 # Run capsh directly with the same --drop flags as the entrypoint, then
-# check CapBnd. This avoids running the full entrypoint which starts
-# gateway services that fail in CI without a running OpenShell environment.
-# Extract the --drop list from the shared sandbox-init library to stay in sync.
-# The drop_capabilities() function lives in sandbox-init.sh (not the entrypoint).
-DROP_LIST=$(run_as_root "grep -oP '(?<=--drop=)[^ \\\\]+' /usr/local/lib/nemoclaw/sandbox-init.sh")
+# decode every dangerous cap named in issue #3280 from CapBnd in
+# /proc/self/status. This catches both an incomplete drop list and a
+# silent skip of the drop step (CAP_SETPCAP missing) — the original test
+# only checked CAP_NET_RAW and would pass either failure mode.
+#
+# IMPORTANT: docker's default bounding set already excludes CAP_SYS_ADMIN
+# and CAP_SYS_PTRACE, so a plain "docker run" cannot reproduce the issue
+# #3280 condition (permissive OpenShell runtime). We --cap-add those two
+# caps here so the bounding set entering capsh resembles the runtime that
+# triggered the original report. If the entrypoint's --drop list omits
+# either cap, this test will see it PRESENT and fail — matching the
+# T6002104 failure mode.
+#
+# The drop list is extracted from the shared sandbox-init library to stay
+# in sync with drop_capabilities(); each entry below is "bit:name".
+# Caps documented as load-bearing in sandbox-init.sh (CAP_FOWNER,
+# CAP_SETUID, CAP_SETGID) are inventoried but do not fail the test — see
+# the kept-caps comment in sandbox-init.sh and the follow-up tracked
+# under issue #3280.
+DROP_LIST=$(docker run --rm --entrypoint "" "$IMAGE" \
+  bash -c "grep -oP '(?<=--drop=)[^ \\\\]+' /usr/local/lib/nemoclaw/sandbox-init.sh" 2>&1)
 if [ -z "$DROP_LIST" ]; then
   fail "could not extract --drop list from entrypoint"
 else
-  OUT=$(run_as_root "capsh --drop=${DROP_LIST} -- -c '
-    CAP_BND=\$(grep \"^CapBnd:\" /proc/self/status | awk \"{print \\\$2}\")
+  OUT=$(docker run --rm --entrypoint "" \
+    --cap-add=CAP_SYS_ADMIN --cap-add=CAP_SYS_PTRACE \
+    "$IMAGE" \
+    bash -c "capsh --drop=${DROP_LIST} -- -c '
+    CAP_BND=\$(awk \"/^CapBnd:/{print \\\$2}\" /proc/self/status)
     echo \"CapBnd=\$CAP_BND\"
-    BND_DEC=\$((16#\$CAP_BND))
-    NET_RAW_BIT=\$((1 << 13))
-    if [ \$((BND_DEC & NET_RAW_BIT)) -ne 0 ]; then
-      echo \"DANGEROUS: cap_net_raw present\"
-    else
-      echo \"SAFE: cap_net_raw dropped\"
-    fi
+    val=\$((16#\$CAP_BND))
+    for entry in \
+      21:CAP_SYS_ADMIN:must-drop \
+      19:CAP_SYS_PTRACE:must-drop \
+      13:CAP_NET_RAW:must-drop \
+      10:CAP_NET_BIND_SERVICE:must-drop \
+      1:CAP_DAC_OVERRIDE:must-drop \
+      3:CAP_FOWNER:allowed \
+      7:CAP_SETUID:allowed \
+      6:CAP_SETGID:allowed; do
+      bit=\${entry%%:*}
+      rest=\${entry#*:}
+      name=\${rest%%:*}
+      class=\${rest#*:}
+      if [ \$(( (val >> bit) & 1 )) -ne 0 ]; then
+        echo \"\$name:\$class:PRESENT\"
+      else
+        echo \"\$name:\$class:ABSENT\"
+      fi
+    done
   '")
-  if echo "$OUT" | grep -q "SAFE: cap_net_raw dropped"; then
-    pass "entrypoint drops dangerous capabilities (cap_net_raw not in bounding set)"
-  elif echo "$OUT" | grep -q "DANGEROUS"; then
-    fail "cap_net_raw still present after capsh drop: $OUT"
-  else
-    fail "could not verify capability state: $OUT"
+  echo "$OUT"
+
+  bad=0
+  while IFS= read -r line; do
+    case "$line" in
+      *:must-drop:PRESENT)
+        bad=$((bad + 1))
+        fail "${line%%:*} still present in CapBnd after capsh drop"
+        ;;
+    esac
+  done <<EOF
+$OUT
+EOF
+
+  if [ "$bad" -eq 0 ]; then
+    pass "entrypoint drops the issue #3280 dangerous-cap inventory (5 must-drop caps absent from CapBnd; 3 documented load-bearing caps allowed)"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Partial fix for #3280 — drop the two caps that are cleanly droppable today, surface residuals when the drop step is silently skipped, and rewrite the cap test so it actually exercises the regression.

- Append `cap_sys_admin` and `cap_sys_ptrace` to the `capsh --drop` list in `scripts/lib/sandbox-init.sh`. Verified live: in a permissive runtime (`--cap-add CAP_SYS_ADMIN --cap-add CAP_SYS_PTRACE`), pre-drop `CapBnd=0xa82c25fb`, post-drop `CapBnd=0x1e9` — only load-bearing caps remain.
- Replace the misleading "runtime already restricts capabilities" message on the `CAP_SETPCAP`-missing fallback with `report_residual_capabilities()`, which reads `CapBnd:` from `/proc/self/status` and names which of the 5 must-drop caps remain. Uses bash 64-bit arithmetic (no gawk-strtonum dependency).
- Rewrite `test/e2e-gateway-isolation.sh` test 14 to inventory all 8 caps named in the issue against `CapBnd`. 5 are classified `must-drop`; 3 (`CAP_FOWNER`, `CAP_SETUID`, `CAP_SETGID`) are classified `allowed` because dropping them requires an entrypoint refactor (see below). The test container now starts with `--cap-add CAP_SYS_ADMIN --cap-add CAP_SYS_PTRACE` so the bounding set entering capsh matches the permissive runtime that triggered T6002104. Without this, docker's default bounding set already excludes those caps and the test would have been a no-op for the very regression we care about.

## Scope: why this is 5/8, not 8/8

The issue names eight caps that must be absent from the bounding set: `CAP_SYS_ADMIN`, `CAP_NET_RAW`, `CAP_NET_BIND_SERVICE`, `CAP_SYS_PTRACE`, `CAP_DAC_OVERRIDE`, `CAP_FOWNER`, `CAP_SETUID`, `CAP_SETGID`.

This PR fully drops 5 of them. The remaining 3 — `CAP_FOWNER`, `CAP_SETUID`, `CAP_SETGID` — can't be dropped without an entrypoint refactor:

1. The entrypoint runs as root and uses `gosu` to step down to the sandbox/gateway user.
2. `gosu` performs the `setuid()` syscall, which requires `CAP_SETUID` in the process's permitted set.
3. Dropping `CAP_SETUID` from the bounding set causes the next `exec` to strip it from permitted — but the bounding set can only be modified with `CAP_SETPCAP`, which only root has.
4. So the drop must happen *before* gosu (which breaks gosu) or *after* gosu (which is too late — we're no longer root and can't modify the bounding set).

The proper fix is to replace `gosu` with `setpriv` (`setpriv --reuid=sandbox --regid=sandbox --bounding-set=-cap_setuid,-cap_setgid,-cap_fowner -- $cmd`), which does reuid + bounding-set drop atomically in one process. `setpriv` is already present in the image, but the refactor affects 4 gosu call sites in `scripts/nemoclaw-start.sh` plus the parallel entrypoint in `agents/hermes/start.sh` (same shared library), plus the no-new-privileges special case at `scripts/nemoclaw-start.sh:1490`. That's a different shape of change than "tighten bounding set" and needs its own design and review cycle.

**Residual-risk note.** The practical exploit path for these 3 caps from the sandbox user's bounding set requires (a) execing a setuid-root binary that carries those file caps, but the image ships none and (b) the user creating a new one, which is blocked by Landlock + `no-new-privs` + lack of `CAP_DAC_OVERRIDE` on root-owned paths. So the residual is a defense-in-depth gap, not a directly exploitable one.

**Follow-up.** I'll file an issue titled "refactor(entrypoint): replace gosu with setpriv to drop CAP_FOWNER/SETUID/SETGID from sandbox bounding set (#3280 follow-up)" and link it from here so T6002104 can track the second half.

## Test plan

- [x] **Forward case (live container).** Built `nemoclaw-isolation-test` = `nemoclaw-production` + new `sandbox-init.sh`. Ran test 14 logic with `--cap-add CAP_SYS_ADMIN --cap-add CAP_SYS_PTRACE`: all 5 must-drop caps `ABSENT`, all 3 load-bearing caps `PRESENT`, test passes.
- [x] **Negative case (live container).** Rebuilt the image with `cap_sys_admin` removed from the drop list. Test correctly fails with "CAP_SYS_ADMIN still present in CapBnd after capsh drop". `CapBnd=0x2001e9` (bit 21 set) — exactly the T6002104 signature.
- [x] **Synthetic bit-decode harness.** Replayed the decode loop over fabricated `CapBnd` values (ideal post-drop, single-cap regressions, full-skip case) — classifier correctly identifies each failure mode by name.
- [x] `npx vitest run test/sandbox-init.test.ts` — 36/36 pass (no-capsh fall-through and `NEMOCLAW_CAPS_DROPPED=1` short-circuit unchanged).
- [x] `shfmt -d -i 2 -ci -bn` clean on both touched files.
- [x] `bash -n` clean.
- [ ] CI to run full `e2e-gateway-isolation.sh` against a freshly-built sandbox image.

## Notes for review

- Drop list scope is intentionally narrowed per maintainer guidance; further hardening (CAP_SYS_MODULE, CAP_SYS_RAWIO, CAP_BPF, CAP_PERFMON, CAP_SYS_BOOT, CAP_SYSLOG, CAP_NET_ADMIN, …) is a candidate follow-up beyond this PR's issue.
- Each kept cap (cap_chown, cap_fowner, cap_setuid, cap_setgid, cap_kill) now has an inline justification with a pointer to its load-bearing call site, so a future contributor can audit them without rediscovering #797 and #2659.
- `report_residual_capabilities()` is new code, but it only runs on the existing `CAP_SETPCAP`-missing fallback path — same trigger as the previous one-line warning, just with structured diagnostics. The happy path is unchanged.

Closes #3280 *(partial — see scope section above; full closure depends on the setpriv follow-up)*.

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced sandbox security by dropping additional dangerous system capabilities.
  * Improved security diagnostics to detect and report residual dangerous capabilities in the runtime environment.
  * Strengthened validation testing to comprehensively verify that dangerous capabilities are properly restricted during sandbox initialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3328)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->