### PR TITLE
docs(reference): document remote-deploy env vars

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -1251,6 +1251,19 @@ These flags change defaults for commands that manage existing sandboxes.
 | `NEMOCLAW_CLEANUP_GATEWAY` | `1`, `true`, or `yes` to enable; `0`, `false`, or `no` to disable | Sets the default for whether `nemoclaw <name> destroy` removes the shared gateway when destroying the last sandbox. Command-line `--cleanup-gateway` and `--no-cleanup-gateway` still take precedence. |
 | `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips the automatic DNS-proxy repair for stale `inference.local` routes during `nemoclaw <name> connect` and `nemoclaw <name> connect --probe-only`. Use only as a troubleshooting escape hatch. |
 
+### Remote Deployment
+
+These variables seed defaults for `nemoclaw deploy` and `nemoclaw onboard --remote`, which provision a sandbox on a Brev instance.
+Each has a flag equivalent on `deploy`; the env var lets non-interactive runs skip the prompt.
+For narrative how-to coverage of `NEMOCLAW_BREV_PROVIDER` and `NEMOCLAW_GPU`, see [Deploy to Remote GPU](https://github.com/NVIDIA/NemoClaw/blob/main/docs/deployment/deploy-to-remote-gpu.md).
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `NEMOCLAW_BREV_PROVIDER` | `gcp` | Cloud provider for Brev instance creation. |
+| `NEMOCLAW_GPU` | `a2-highgpu-1g:nvidia-tesla-a100:1` | GPU specification (instance type and GPU model) for the Brev instance. |
+| `NEMOCLAW_DEPLOY_NO_CONNECT` | unset | When set to `1`, skips the automatic `connect` step after the remote deploy completes. |
+| `NEMOCLAW_DEPLOY_NO_START_SERVICES` | unset | When set to `1`, skips starting services automatically after the remote deploy. |
+
 ## NemoHermes Alias
 
 `nemohermes` is a convenience alias that pre-selects the Hermes agent.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1258,6 +1258,19 @@ These flags change defaults for commands that manage existing sandboxes.
 | `NEMOCLAW_CLEANUP_GATEWAY` | `1`, `true`, or `yes` to enable; `0`, `false`, or `no` to disable | Sets the default for whether `nemoclaw <name> destroy` removes the shared gateway when destroying the last sandbox. Command-line `--cleanup-gateway` and `--no-cleanup-gateway` still take precedence. |
 | `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips the automatic DNS-proxy repair for stale `inference.local` routes during `nemoclaw <name> connect` and `nemoclaw <name> connect --probe-only`. Use only as a troubleshooting escape hatch. |
 
+### Remote Deployment
+
+These variables seed defaults for `nemoclaw deploy` and `nemoclaw onboard --remote`, which provision a sandbox on a Brev instance.
+Each has a flag equivalent on `deploy`; the env var lets non-interactive runs skip the prompt.
+For narrative how-to coverage of `NEMOCLAW_BREV_PROVIDER` and `NEMOCLAW_GPU`, see [Deploy to Remote GPU](../deployment/deploy-to-remote-gpu.md).
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `NEMOCLAW_BREV_PROVIDER` | `gcp` | Cloud provider for Brev instance creation. |
+| `NEMOCLAW_GPU` | `a2-highgpu-1g:nvidia-tesla-a100:1` | GPU specification (instance type and GPU model) for the Brev instance. |
+| `NEMOCLAW_DEPLOY_NO_CONNECT` | unset | When set to `1`, skips the automatic `connect` step after the remote deploy completes. |
+| `NEMOCLAW_DEPLOY_NO_START_SERVICES` | unset | When set to `1`, skips starting services automatically after the remote deploy. |
+
 ## NemoHermes Alias
 
 `nemohermes` is a convenience alias that pre-selects the Hermes agent.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds a `### Remote Deployment` subsection to the `## Environment Variables` reference, documenting the four env vars that `src/lib/deploy/index.ts` reads for the `nemoclaw deploy` / `nemoclaw onboard --remote` flow. Follow-up to #3184: the env-var doc gate currently passes because these vars are accessed via a destructured `env.NEMOCLAW_*` local that the AST extractor does not flag, but the same users who hit the new gate-enforced sections also hit these deploy knobs and had no doc entry to find them.

## Related Issue

Follow-up to #3184. Original umbrella issue #3059 was already substantively addressed by #3184; this PR closes the four remaining deploy-vars gaps from that audit.

## Changes

- `docs/reference/commands.mdx`: new `### Remote Deployment` subsection between `### Lifecycle Behavior Flags` and `## NemoHermes Alias`. One table with four rows: `NEMOCLAW_BREV_PROVIDER` (default `gcp`), `NEMOCLAW_GPU` (default `a2-highgpu-1g:nvidia-tesla-a100:1`), `NEMOCLAW_DEPLOY_NO_CONNECT`, `NEMOCLAW_DEPLOY_NO_START_SERVICES`. Defaults verified against `src/lib/deploy/index.ts:295-303`.
- `.agents/skills/nemoclaw-user-reference/references/commands.md`: same subsection added at the corresponding position to keep the auto-generated skill in sync.

## Test plan

- [x] `prek run` clean
- [x] Defaults cross-checked against the current `env.NEMOCLAW_*` reads in `src/lib/deploy/index.ts` (the file moved from `src/lib/deploy.ts` to `src/lib/deploy/index.ts` upstream)

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>
