### PR TITLE
docs(reference,quickstart): explain --fresh/--yes and the curl|bash flag form

### DIFF
--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -180,6 +180,20 @@ If a host firewall blocks that sandbox path, onboarding exits with a `sudo ufw a
 Tune the wait via `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
 The poll count is clamped to a minimum of `1` so the probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).
 
+#### `--fresh` and `--resume`
+
+By default, `nemoclaw onboard` resumes any saved onboarding session for the same sandbox so a transient failure (network, credential typo, etc.) does not force you to redo earlier steps.
+Pass `--fresh` to ignore any saved session and start the wizard from the first prompt; use this when the saved session is stale or you want to change selections made in an earlier attempt.
+Pass `--resume` to require that a saved session exist and resume from where it left off; the command exits non-zero if no session is found.
+`--fresh` and `--resume` are mutually exclusive.
+
+#### `--yes` / `-y`
+
+Auto-confirm prompts that are safe for unattended onboarding.
+Equivalent to setting `NEMOCLAW_YES=1`.
+Use together with `--non-interactive` (or `NEMOCLAW_NON_INTERACTIVE=1`) for fully scripted runs.
+This flag does not bypass the third-party software notice; use `--yes-i-accept-third-party-software` (or `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1`) for that.
+
 #### `--from <Dockerfile>`
 
 Build the sandbox image from a custom Dockerfile instead of the stock NemoClaw image.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -30,11 +30,18 @@ NemoClaw creates a fresh OpenClaw instance inside the sandbox during the onboard
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
-The piped installer prompts through your terminal. In headless scripts or CI,
-pass explicit acceptance to the `bash` side of the pipe:
+The piped installer prompts through your terminal.
+Piping `curl` into `bash` strips the TTY, so in headless scripts or CI you must pass explicit acceptance of the third-party software notice or the installer exits before installing anything.
+Either pass the env vars to the `bash` side of the pipe:
 
 ```console
 $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
+```
+
+or pass the flag form via `bash -s --`:
+
+```console
+$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software
 ```
 
 If you use nvm or fnm to manage Node.js, the installer might not update your current shell's PATH.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -187,6 +187,20 @@ If a host firewall blocks that sandbox path, onboarding exits with a `sudo ufw a
 Tune the wait via `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).
 The poll count is clamped to a minimum of `1` so the probe always runs at least once, and the interval is clamped to a minimum of `0` (no sleep between attempts).
 
+#### `--fresh` and `--resume`
+
+By default, `nemoclaw onboard` resumes any saved onboarding session for the same sandbox so a transient failure (network, credential typo, etc.) does not force you to redo earlier steps.
+Pass `--fresh` to ignore any saved session and start the wizard from the first prompt; use this when the saved session is stale or you want to change selections made in an earlier attempt.
+Pass `--resume` to require that a saved session exist and resume from where it left off; the command exits non-zero if no session is found.
+`--fresh` and `--resume` are mutually exclusive.
+
+#### `--yes` / `-y`
+
+Auto-confirm prompts that are safe for unattended onboarding.
+Equivalent to setting `NEMOCLAW_YES=1`.
+Use together with `--non-interactive` (or `NEMOCLAW_NON_INTERACTIVE=1`) for fully scripted runs.
+This flag does not bypass the third-party software notice; use `--yes-i-accept-third-party-software` (or `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1`) for that.
+
 #### `--from <Dockerfile>`
 
 Build the sandbox image from a custom Dockerfile instead of the stock NemoClaw image.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Two related doc gaps reported in the same week. Adds an `### nemoclaw onboard` flag-explainer block for `--fresh` / `--resume` / `--yes` to the commands reference, and adds the `bash -s -- --yes-i-accept-third-party-software` flag form to the quickstart curl|bash example.

## Related Issue

Closes #3275. Closes #3233 (partial, see verification notes).

## Changes

- `docs/reference/commands.mdx`: new `#### --fresh and --resume` subsection mirroring the existing `#### --from <Dockerfile>` pattern. Explains the default resume-saved-session behavior, contrasts `--fresh` against `--resume` (mutually exclusive), and clarifies the failure mode if no saved session exists for `--resume`. Also adds a `#### --yes / -y` subsection clarifying that `--yes` is for safe-for-unattended prompts and is **not** equivalent to `--yes-i-accept-third-party-software` for the licensing notice.
- `docs/get-started/quickstart.mdx`: adds the `bash -s -- --yes-i-accept-third-party-software` flag form alongside the existing env-var form, plus a one-sentence note that piping `curl` into `bash` strips the TTY so explicit acceptance is required.
- `.agents/skills/nemoclaw-user-reference/references/commands.md`: same `#### --fresh and --resume` and `#### --yes / -y` subsections added to keep the auto-generated skill in sync. The onboard synopsis at the top of the file already lists `[--yes | -y]`.

## Test plan

- [x] `prek run` clean
- [x] Behavior verified against current `nemoclaw onboard --help` output for the flag names + descriptions
- [x] curl|bash form verified against the installer source for accepted invocation patterns

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>
