### PR TITLE
fix(onboard): accept reasoning-mode models in the inference smoke probe

### DIFF
--- a/src/lib/onboard/compatible-endpoint-smoke.test.ts
+++ b/src/lib/onboard/compatible-endpoint-smoke.test.ts
@@ -55,7 +55,9 @@ describe("compatible endpoint sandbox smoke helpers", () => {
     const script = buildCompatibleEndpointSandboxSmokeScript("Qwen/Qwen3.6-27B");
 
     expect(script).toContain('"max_tokens": 256');
-    expect(script).not.toContain('"max_tokens": 32,');
+    // Regex (not substring) so a regression to `"max_tokens": 32` without the
+    // trailing comma also fails the test, per CR review on PR #3356.
+    expect(script).not.toMatch(/"max_tokens":\s*32\b/);
   });
 
   it("accepts a reasoning-only response as a valid smoke signal (#3341)", () => {

--- a/src/lib/onboard/compatible-endpoint-smoke.test.ts
+++ b/src/lib/onboard/compatible-endpoint-smoke.test.ts
@@ -51,6 +51,36 @@ describe("compatible endpoint sandbox smoke helpers", () => {
     expect(script).toContain("MODEL='provider/model'\\'''");
   });
 
+  it("budgets enough max_tokens for reasoning-mode models (#3341)", () => {
+    const script = buildCompatibleEndpointSandboxSmokeScript("Qwen/Qwen3.6-27B");
+
+    expect(script).toContain('"max_tokens": 256');
+    expect(script).not.toContain('"max_tokens": 32,');
+  });
+
+  it("accepts a reasoning-only response as a valid smoke signal (#3341)", () => {
+    const script = buildCompatibleEndpointSandboxSmokeScript("Qwen/Qwen3.6-27B");
+
+    // Fallback lookup walks both `reasoning` and `reasoning_content` and only
+    // accepts non-empty STRING payloads, so a truthy non-string value in one
+    // field cannot mask a valid string in the other.
+    expect(script).toContain('message.get("reasoning")');
+    expect(script).toContain('message.get("reasoning_content")');
+    expect(script).toContain("reasoning-only response");
+    expect(script).toMatch(/isinstance\(value,\s*str\)\s+and\s+value\.strip\(\)/);
+  });
+
+  it("guards against empty or malformed choices arrays (#3341)", () => {
+    const script = buildCompatibleEndpointSandboxSmokeScript("Qwen/Qwen3.6-27B");
+
+    // The parser must verify choices is a non-empty list of dicts before
+    // indexing, instead of relying on data.get("choices", [{}])[0] which
+    // crashed on choices=[] with IndexError.
+    expect(script).toContain("not isinstance(choices, list) or not choices");
+    expect(script).toContain("not isinstance(choices[0], dict)");
+    expect(script).not.toContain('data.get("choices", [{}])[0]');
+  });
+
   it("wraps the script as a base64 decoded temporary shell command", () => {
     const command = buildCompatibleEndpointSandboxSmokeCommand("nvidia/model");
 

--- a/src/lib/onboard/compatible-endpoint-smoke.ts
+++ b/src/lib/onboard/compatible-endpoint-smoke.ts
@@ -83,13 +83,17 @@ python3 - "$MODEL" >"$payload_file" <<'PYPAYLOAD'
 import json
 import sys
 
+# max_tokens=256 covers short reasoning-chain models (e.g. Qwen3.6 in thinking
+# mode via vLLM with --reasoning-parser) that would otherwise spend their entire
+# budget on the reasoning field and return content=null with finish_reason=length
+# during the smoke probe. See GH #3341.
 model = sys.argv[1]
 print(json.dumps({
     "model": model,
     "messages": [
         {"role": "user", "content": "Reply with exactly: PONG"}
     ],
-    "max_tokens": 32,
+    "max_tokens": 256,
 }))
 PYPAYLOAD
 
@@ -121,16 +125,39 @@ except Exception as exc:
     print("inference.local returned non-JSON response: %s; body=%s" % (exc, body), file=sys.stderr)
     sys.exit(1)
 
-content = (
-    data.get("choices", [{}])[0]
-    .get("message", {})
-    .get("content")
-)
-if not isinstance(content, str) or not content.strip():
-    print("inference.local response did not contain choices[0].message.content: %s" % json.dumps(data)[:1000], file=sys.stderr)
+choices = data.get("choices")
+if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+    print("inference.local response did not contain a choices[0] dict: %s" % json.dumps(data)[:1000], file=sys.stderr)
     sys.exit(1)
+message = choices[0].get("message", {})
+if not isinstance(message, dict):
+    message = {}
 
-print("INFERENCE_SMOKE_OK " + content.strip()[:200])
+content = message.get("content")
+if isinstance(content, str) and content.strip():
+    print("INFERENCE_SMOKE_OK " + content.strip()[:200])
+    sys.exit(0)
+
+# Some reasoning-mode models (e.g. Qwen3.6 via vLLM --reasoning-parser, OpenAI
+# o1-style endpoints) return content=null with the response carried under
+# "reasoning" or "reasoning_content". Treat that as a valid liveness signal for
+# the smoke probe: the endpoint round-tripped a chat completion, just under a
+# different field name. Pick the first non-empty string from either field so a
+# non-string value in one does not mask a valid string in the other. See GH #3341.
+reasoning_text = next(
+    (
+        value.strip()
+        for value in (message.get("reasoning"), message.get("reasoning_content"))
+        if isinstance(value, str) and value.strip()
+    ),
+    None,
+)
+if reasoning_text:
+    print("INFERENCE_SMOKE_OK (reasoning-only response, %d chars)" % len(reasoning_text))
+    sys.exit(0)
+
+print("inference.local response did not contain choices[0].message.content: %s" % json.dumps(data)[:1000], file=sys.stderr)
+sys.exit(1)
 PYRESP
 `.trim();
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Closes #3341. The Option-3 compatible-endpoint smoke probe sent `max_tokens=32` and required `choices[0].message.content` to be a non-empty string. Thinking-mode models like Qwen3.6 in vLLM with `--reasoning-parser qwen3` exhaust the entire 32-token budget on the reasoning chain and return `content=null` with `finish_reason="length"`, even though the endpoint is healthy and the round-trip succeeded. Onboard then rejected the response and exited at step `[7/8] Validating inference`.

## Related Issue

Closes #3341

## Changes

Two changes in the embedded smoke script in `src/lib/onboard.ts`:

- **Bump `max_tokens` from 32 to 256** so short reasoning chains have room to finish before content starts. 256 is still a cheap probe (~$0.001 on most paid providers for a single "say PONG") but gives a thinking model enough headroom to emit a content token.
- **Treat a non-empty `message.reasoning` or `message.reasoning_content` as a valid smoke signal** when `content` is null or empty. vLLM emits `reasoning` (per the qwen3 reasoning parser, observed in the #3341 trace) and OpenAI o1-style endpoints emit `reasoning_content`; both indicate the endpoint round-tripped a chat completion. The probe is a liveness check, not a response-shape contract, so a reasoning-only response is enough to declare the model reachable. The success line becomes `INFERENCE_SMOKE_OK (reasoning-only response, N chars)` so the distinction is visible in onboard logs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes for the staged files.
- [x] Two new test cases in `test/onboard.test.ts` (`#3341`): one asserts the bumped `max_tokens` is in the generated script, one asserts the reasoning-fallback branch is present.
- [x] `npx vitest run -t 'smoke|reasoning|max_tokens' test/onboard.test.ts` — 6/6 pass (4 existing smoke tests + the 2 new ones).
- [x] Embedded Python parser exercised against four sample payloads (normal content, reasoning-only Qwen3.6 shape, `reasoning_content` o1 shape, empty response). The first three pass with `INFERENCE_SMOKE_OK`, the empty payload fails as expected. Output:

```
[OK] normal content -> exit=0: INFERENCE_SMOKE_OK PONG
[OK] reasoning only (Qwen3.6 case) -> exit=0: INFERENCE_SMOKE_OK (reasoning-only response, 11 chars)
[OK] reasoning_content (o1 style) -> exit=0: INFERENCE_SMOKE_OK (reasoning-only response, 3 chars)
[FAIL] empty response (should fail) -> exit=1: FAIL: no content or reasoning
```

- [x] `npm run build:cli` clean.
- [x] No secrets, API keys, or credentials committed.
- [x] Tests added for new behavior.

Rebased on current `upstream/main` (commit `eb15e55e`).

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added targeted tests for the endpoint smoke script to verify robust response handling and reasoning-mode signals.

* **Improvements**
  * Increased token allocation for smoke probes.
  * Strengthened response validation to tolerate malformed or reasoning-only outputs and avoid crashes on empty or unexpected structures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3356)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->