### PR TITLE
fix(onboard): bump default sandbox-ready timeout to 300s for GPU images

### DIFF
--- a/src/lib/onboard/env.ts
+++ b/src/lib/onboard/env.ts
@@ -16,5 +16,12 @@ export function envInt(
 /** Inference timeout (seconds) for local providers (Ollama, vLLM, NIM). */
 export const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIMEOUT", 180);
 
-/** Sandbox Ready wait after OpenShell create returns but k3s is still converging. */
-export const SANDBOX_READY_TIMEOUT_SECS = envInt("NEMOCLAW_SANDBOX_READY_TIMEOUT", 180);
+/**
+ * Sandbox Ready wait after OpenShell create returns but k3s is still converging.
+ * 300s default (was 180s) so GPU sandboxes whose image extraction + GPU device
+ * attach can take 3-5 minutes on RTX-class hardware do not surface a confusing
+ * "did not become ready within 180s" failure on a gateway that is actually
+ * healthy (#3344). Hosts with slower disks or larger images can still extend
+ * the wait via NEMOCLAW_SANDBOX_READY_TIMEOUT.
+ */
+export const SANDBOX_READY_TIMEOUT_SECS = envInt("NEMOCLAW_SANDBOX_READY_TIMEOUT", 300);

--- a/src/lib/onboard/env.ts
+++ b/src/lib/onboard/env.ts
@@ -18,10 +18,9 @@ export const LOCAL_INFERENCE_TIMEOUT_SECS = envInt("NEMOCLAW_LOCAL_INFERENCE_TIM
 
 /**
  * Sandbox Ready wait after OpenShell create returns but k3s is still converging.
- * 300s default (was 180s) so GPU sandboxes whose image extraction + GPU device
- * attach can take 3-5 minutes on RTX-class hardware do not surface a confusing
- * "did not become ready within 180s" failure on a gateway that is actually
- * healthy (#3344). Hosts with slower disks or larger images can still extend
- * the wait via NEMOCLAW_SANDBOX_READY_TIMEOUT.
+ * 180s baseline default for non-GPU sandboxes. GPU sandboxes use a 300s default
+ * via getSandboxReadyTimeoutSecs (sandbox-gpu-create.ts) because image extract
+ * + GPU device attach can take 3-5 minutes on RTX-class hardware (#3344).
+ * NEMOCLAW_SANDBOX_READY_TIMEOUT overrides both paths.
  */
-export const SANDBOX_READY_TIMEOUT_SECS = envInt("NEMOCLAW_SANDBOX_READY_TIMEOUT", 300);
+export const SANDBOX_READY_TIMEOUT_SECS = envInt("NEMOCLAW_SANDBOX_READY_TIMEOUT", 180);

--- a/src/lib/onboard/sandbox-gpu-create.ts
+++ b/src/lib/onboard/sandbox-gpu-create.ts
@@ -21,14 +21,24 @@ export function buildSandboxGpuCreateArgs(
   return args;
 }
 
+/**
+ * GPU sandboxes need extra readiness headroom because image extract + GPU device
+ * attach can take 3-5 minutes on RTX-class hardware (#3344). Non-GPU sandboxes
+ * keep the baseline SANDBOX_READY_TIMEOUT_SECS default.
+ */
+const GPU_SANDBOX_READY_TIMEOUT_SECS = 300;
+
 export function getSandboxReadyTimeoutSecs(
-  _config: Pick<SandboxGpuCreateConfig, "sandboxGpuEnabled">,
+  config: Pick<SandboxGpuCreateConfig, "sandboxGpuEnabled">,
   env: NodeJS.ProcessEnv = process.env,
   _platform: NodeJS.Platform = process.platform,
   _arch: NodeJS.Architecture = process.arch,
 ): number {
+  const defaultSecs = config.sandboxGpuEnabled
+    ? GPU_SANDBOX_READY_TIMEOUT_SECS
+    : SANDBOX_READY_TIMEOUT_SECS;
   if (String(env.NEMOCLAW_SANDBOX_READY_TIMEOUT || "").trim()) {
-    return envInt("NEMOCLAW_SANDBOX_READY_TIMEOUT", SANDBOX_READY_TIMEOUT_SECS, env);
+    return envInt("NEMOCLAW_SANDBOX_READY_TIMEOUT", defaultSecs, env);
   }
-  return SANDBOX_READY_TIMEOUT_SECS;
+  return defaultSecs;
 }

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -2935,7 +2935,11 @@ const { loadAgent } = require(${agentDefsPath});
       "utf-8",
     );
 
-    assert.match(envSource, /NEMOCLAW_SANDBOX_READY_TIMEOUT", 180/);
+    // 300s default (bumped from 180s in #3344) so GPU sandboxes whose image
+    // extraction + GPU device attach can take 3-5 minutes on RTX-class hardware
+    // do not hit a false-positive readiness timeout. NEMOCLAW_SANDBOX_READY_TIMEOUT
+    // still lets users with slower hardware extend further.
+    assert.match(envSource, /NEMOCLAW_SANDBOX_READY_TIMEOUT", 300/);
     assert.match(source, /Math\.ceil\(sandboxReadyTimeoutSecs \/ 2\)/);
     assert.match(source, /within \$\{sandboxReadyTimeoutSecs\}s/);
     assert.doesNotMatch(source, /DOCKER_DRIVER_GPU_SANDBOX_READY_TIMEOUT_SECS = 600/);

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -416,8 +416,8 @@ describe("onboard helpers", () => {
 
   it("keeps the default sandbox readiness timeout unless explicitly overridden", () => {
     expect(getSandboxReadyTimeoutSecs({ sandboxGpuEnabled: false }, {}, "linux")).toBe(180);
-    expect(getSandboxReadyTimeoutSecs({ sandboxGpuEnabled: true }, {}, "linux")).toBe(180);
-    expect(getSandboxReadyTimeoutSecs({ sandboxGpuEnabled: true }, {}, "win32")).toBe(180);
+    expect(getSandboxReadyTimeoutSecs({ sandboxGpuEnabled: true }, {}, "linux")).toBe(300);
+    expect(getSandboxReadyTimeoutSecs({ sandboxGpuEnabled: true }, {}, "win32")).toBe(300);
   });
 
   it("honors explicit sandbox readiness timeout overrides", () => {
@@ -2935,11 +2935,11 @@ const { loadAgent } = require(${agentDefsPath});
       "utf-8",
     );
 
-    // 300s default (bumped from 180s in #3344) so GPU sandboxes whose image
-    // extraction + GPU device attach can take 3-5 minutes on RTX-class hardware
-    // do not hit a false-positive readiness timeout. NEMOCLAW_SANDBOX_READY_TIMEOUT
-    // still lets users with slower hardware extend further.
-    assert.match(envSource, /NEMOCLAW_SANDBOX_READY_TIMEOUT", 300/);
+    // 180s baseline default for non-GPU sandboxes. GPU sandboxes get a 300s
+    // default via getSandboxReadyTimeoutSecs (sandbox-gpu-create.ts) because
+    // image extract + GPU device attach can take 3-5 minutes on RTX-class
+    // hardware (#3344). NEMOCLAW_SANDBOX_READY_TIMEOUT overrides both paths.
+    assert.match(envSource, /NEMOCLAW_SANDBOX_READY_TIMEOUT", 180/);
     assert.match(source, /Math\.ceil\(sandboxReadyTimeoutSecs \/ 2\)/);
     assert.match(source, /within \$\{sandboxReadyTimeoutSecs\}s/);
     assert.doesNotMatch(source, /DOCKER_DRIVER_GPU_SANDBOX_READY_TIMEOUT_SECS = 600/);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Closes #3344. Raises the default `NEMOCLAW_SANDBOX_READY_TIMEOUT` from 180s to 300s. The wait runs between `openshell sandbox create` returning and k3s reporting the pod Ready, and 180s is too aggressive when the sandbox image is GPU-attached and the host just spent several minutes uploading it to the gateway. wangericnv (NV QA) reported a fresh `nemoclaw onboard --fresh` on Ubuntu 24.04 / RTX 6000 Ada hitting "Sandbox 'brave-test' was created but did not become ready within 180s. The orphaned sandbox has been removed" after a healthy 525s image upload and a sandbox that was actually fine moments later; the wizard then deleted the working sandbox.

## Related Issue

Closes #3344

## Changes

- `src/lib/onboard.ts:26` — `envInt("NEMOCLAW_SANDBOX_READY_TIMEOUT", 180)` → `envInt("NEMOCLAW_SANDBOX_READY_TIMEOUT", 300)`. 67% headroom covers the typical GPU + image-extract + GPU-device-attach case (3-5 min on RTX-class hardware) while still aborting cleanly on truly broken pods. The env var override path is unchanged, so hosts with even slower disks or larger custom images can extend further.
- Updated the JSDoc comment to record the bump rationale and point at #3344.
- `test/onboard.test.ts` — the existing "allows slow sandbox create recovery to wait beyond 60 seconds" test asserted the 180s literal; updated to assert 300s with a comment explaining the bump.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only

## Verification

- [x] `npx prek run --all-files` passes for the staged files.
- [x] `npx vitest run -t 'slow sandbox create recovery' test/onboard.test.ts` passes (1/1).
- [x] `npm run build:cli` clean.
- [x] No secrets, API keys, or credentials committed.

Rebased on current `upstream/main` (commit `eb15e55e`).

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default sandbox readiness timeout clarified: GPU-enabled sandboxes now use 300s, non-GPU remain at 180s, reducing spurious readiness failures for longer GPU setups. Environment variable override still honored.
* **Tests**
  * Updated tests to expect the revised GPU timeout behavior and added explanatory test comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3357)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->