### PR TITLE
fix(ci): grant pull-requests:write so advisor can post PR comments

### DIFF
--- a/.github/workflows/e2e-advisor.yaml
+++ b/.github/workflows/e2e-advisor.yaml
@@ -49,7 +49,14 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  # `pull-requests: write` is required for the advisor to post (or update) a
+  # comment on a PR via POST /repos/:o/:r/issues/:n/comments. Even though the
+  # endpoint lives under `/issues/`, for GITHUB_TOKEN the permission that
+  # actually gates PR comments is `pull-requests`, not `issues`. With only
+  # `pull-requests: read`, the endpoint returns 403 "Resource not accessible
+  # by integration" despite `issues: write`. See the comment step below and
+  # https://github.com/orgs/community/discussions/56632.
+  pull-requests: write
   issues: write
 
 concurrency:


### PR DESCRIPTION
## Summary

Adds `pull-requests: write` to the `e2e-advisor` workflow so the advisor can actually post its recommendation comment on PRs.

## What's broken on `main` today

Since PR #3289 merged ~2 hours ago, the advisor workflow has been running successfully on same-repo PRs — but the `Post E2E advisor PR comment` step silently skips every time:

```
403 {"message":"Resource not accessible by integration"}
```

Concrete evidence on PR #3364:

| Run | Job | Comment posted? |
|---|---|---|
| [25697796461](https://github.com/NVIDIA/NemoClaw/actions/runs/25697796461) | ✅ success | ❌ no |
| [25699366979](https://github.com/NVIDIA/NemoClaw/actions/runs/25699366979) | ✅ success | ❌ no |

The runs look green because `comment.mjs` catches the 403 as a permission error (a defensive path added during the #3289 review) and keeps the job passing, but the user-visible artifact — the comment on the PR — never materializes.

## Root cause

The `permissions:` block on `main` currently declares:

```yaml
permissions:
  contents: read
  pull-requests: read
  issues: write
```

The token effective permissions confirm this takes effect (from the `Set up job` log group):

```
GITHUB_TOKEN Permissions
  Contents: read
  Issues: write
  Metadata: read
  PullRequests: read
```

Even so, `POST /repos/NVIDIA/NemoClaw/issues/3364/comments` returns `403 Resource not accessible by integration`.

The reason is a well-documented GitHub Actions permission-name trap: for `GITHUB_TOKEN`, **PR comments are gated by `pull-requests: write`, not `issues: write`** — even though the REST endpoint lives under `/issues/:n/comments`. The `issues` permission only applies to true issues; PRs fall under `pull-requests`. This is tracked in [community discussion #56632](https://github.com/orgs/community/discussions/56632) and has bitten many workflows.

## Fix

Flip `pull-requests` from `read` to `write`, and drop an inline comment on the permissions block so the next reviewer doesn't have to rediscover this.

`issues: write` is kept for now — it's unused on the PR-comment path but it's dirt-cheap to leave in case we ever want the advisor to post on true issues.

## Defense in depth

The graceful permission-error handling in `tools/e2e-advisor/comment.mjs` (added in #3289 per @ericksoa's review) stays in place unchanged. This PR just ensures that for a correctly-configured repo the 403 path is no longer hit on normal same-repo PRs.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-advisor.yaml'))"` — workflow still parses.
- Non-code change, so local unit tests are unaffected.
- The real verification is the next same-repo PR after merge — expected behavior is an advisor comment appearing within a few minutes.

## Out of scope for this PR

There's a second gap visible on upstream: `PI_E2E_ADVISOR_API_KEY` is not set on `NVIDIA/NemoClaw`, so the analysis step currently degrades to:

> `Skipped: No Pi provider credential was available in this workflow environment`

That's an admin configuration task (Settings → Secrets and variables → Actions → New repository secret), not a code change, so handling it separately.

## Related

- PR #3289 (merged): introduced the advisor + the trust-boundary restructure.
- Observed on PR #3364 (same-repo, member-authored, fresh push — exactly the case the advisor is designed for).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request workflow permissions to enable advisor to post and update comments on pull requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3366)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->