### PR TITLE
fix(cli): render dynamic banner boxes for long URLs

### DIFF
--- a/nemoclaw/src/banner.test.ts
+++ b/nemoclaw/src/banner.test.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { renderBox } from "./banner.js";
+
+describe("renderBox (plugin)", () => {
+  it("renders the registration banner with equal-width rows", () => {
+    const lines = renderBox(
+      [
+        "  NemoClaw registered",
+        null,
+        "  Endpoint:  https://integrate.api.nvidia.com/v1",
+        "  Provider:  NVIDIA Endpoints",
+        "  Model:     nvidia/nemotron-3-super-120b-a12b",
+        "  Slash:     /nemoclaw",
+      ],
+      { columns: 100 },
+    );
+
+    expect(new Set(lines.map((line) => line.length)).size).toBe(1);
+    expect(lines[3]).toMatch(/ {2,}│$/);
+  });
+
+  it("expands for long endpoint URLs", () => {
+    const endpoint =
+      "  Endpoint:  https://very-long-custom-endpoint.internal.nvidia.com/v1/completions";
+    const lines = renderBox([endpoint], { columns: 120 });
+
+    expect(lines[1]).toContain("very-long-custom-endpoint.internal.nvidia.com");
+    expect(lines[1]).toMatch(/ {2}│$/);
+  });
+
+  it("truncates in narrow terminals but keeps a border safety gap", () => {
+    const lines = renderBox(["x".repeat(200)], { columns: 80 });
+
+    expect(lines.every((line) => line.length <= 80)).toBe(true);
+    expect(lines[1]).toMatch(/ {2}│$/);
+  });
+});

--- a/nemoclaw/src/banner.ts
+++ b/nemoclaw/src/banner.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** A banner content row; null renders as a blank separator row. */
+export type BannerLine = string | null;
+
+/** Options for rendering a Unicode terminal banner box. */
+export interface RenderBoxOptions {
+  /** Minimum inner box width, excluding borders. */
+  minInner?: number;
+  /** Terminal width to respect. Defaults to process.stdout.columns, then 100. */
+  columns?: number;
+}
+
+/**
+ * Render content lines inside a dynamically-sized Unicode box.
+ *
+ * The renderer expands to fit long content when the terminal is wide enough and
+ * otherwise truncates content while preserving a two-space safety gap before the
+ * closing border. That gap prevents terminal link detectors from treating the
+ * box-drawing border as part of long URLs or endpoints.
+ */
+export function renderBox(
+  lines: BannerLine[],
+  { minInner = 53, columns }: RenderBoxOptions = {},
+): string[] {
+  const detectedColumns = columns ?? process.stdout.columns;
+  const terminalColumns =
+    Number.isFinite(detectedColumns) && detectedColumns > 0 ? detectedColumns : 100;
+  const maxInner = Math.max(0, Math.floor(terminalColumns) - 4);
+  const contentInner = lines.reduce<number>(
+    (max, line) => (line === null ? max : Math.max(max, line.length + 2)),
+    minInner,
+  );
+  const inner = Math.min(maxInner, Math.max(0, contentInner));
+
+  const pad = (line: string): string => {
+    if (line.length > inner) {
+      if (inner <= 2) return " ".repeat(inner);
+      return `${line.slice(0, inner - 2)}  `;
+    }
+    return line + " ".repeat(inner - line.length);
+  };
+
+  const hBar = "─".repeat(inner);
+  const blank = " ".repeat(inner);
+
+  return [
+    `  ┌${hBar}┐`,
+    ...lines.map((line) => (line === null ? `  │${blank}│` : `  │${pad(line)}│`)),
+    `  └${hBar}┘`,
+  ];
+}

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { renderBox } from "./banner.js";
 import { handleSlashCommand } from "./commands/slash.js";
 import {
   describeOnboardEndpoint,
@@ -422,14 +423,18 @@ export default function register(api: OpenClawPluginApi): void {
     );
   }
 
+  const bannerLines = [
+    "  NemoClaw registered",
+    null,
+    `  Endpoint:  ${bannerEndpoint}`,
+    `  Provider:  ${bannerProvider}`,
+    `  Model:     ${bannerModel}`,
+    "  Slash:     /nemoclaw",
+  ];
+
   api.logger.info("");
-  api.logger.info("  ┌─────────────────────────────────────────────────────┐");
-  api.logger.info("  │  NemoClaw registered                                │");
-  api.logger.info("  │                                                     │");
-  api.logger.info(`  │  Endpoint:  ${bannerEndpoint.padEnd(40)}│`);
-  api.logger.info(`  │  Provider:  ${bannerProvider.padEnd(40)}│`);
-  api.logger.info(`  │  Model:     ${bannerModel.padEnd(40)}│`);
-  api.logger.info("  │  Slash:     /nemoclaw                               │");
-  api.logger.info("  └─────────────────────────────────────────────────────┘");
+  for (const line of renderBox(bannerLines)) {
+    api.logger.info(line);
+  }
   api.logger.info("");
 }

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -107,7 +107,7 @@ render_box() {
   fi
 
   local inner="$min_inner"
-  local line needed visible hbar blank padded
+  local line needed visible pad_len pad hbar blank padded
   for line in "$@"; do
     needed=$((${#line} + 2))
     if [ "$needed" -gt "$inner" ]; then
@@ -135,7 +135,12 @@ render_box() {
       if [ "$visible" -lt 0 ]; then
         visible=0
       fi
-      padded="${line:0:$visible}  "
+      pad_len=$((inner - visible))
+      if [ "$pad_len" -lt 0 ]; then
+        pad_len=0
+      fi
+      printf -v pad '%*s' "$pad_len" ''
+      padded="${line:0:$visible}${pad}"
     else
       printf -v padded '%-*s' "$inner" "$line"
     fi

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -94,6 +94,58 @@ stop_service() {
   fi
 }
 
+render_box() {
+  local columns="${COLUMNS:-100}"
+  if ! [[ "$columns" =~ ^[0-9]+$ ]] || [ "$columns" -le 0 ]; then
+    columns=100
+  fi
+
+  local min_inner=53
+  local max_inner=$((columns - 4))
+  if [ "$max_inner" -lt 0 ]; then
+    max_inner=0
+  fi
+
+  local inner="$min_inner"
+  local line needed visible hbar blank padded
+  for line in "$@"; do
+    needed=$((${#line} + 2))
+    if [ "$needed" -gt "$inner" ]; then
+      inner="$needed"
+    fi
+  done
+  if [ "$inner" -gt "$max_inner" ]; then
+    inner="$max_inner"
+  fi
+
+  printf -v hbar '%*s' "$inner" ''
+  hbar=${hbar// /─}
+  printf -v blank '%*s' "$inner" ''
+
+  printf '  ┌%s┐
+' "$hbar"
+  for line in "$@"; do
+    if [ -z "$line" ]; then
+      printf '  │%s│
+' "$blank"
+      continue
+    fi
+    if [ "${#line}" -gt "$inner" ]; then
+      visible=$((inner - 2))
+      if [ "$visible" -lt 0 ]; then
+        visible=0
+      fi
+      padded="${line:0:$visible}  "
+    else
+      printf -v padded '%-*s' "$inner" "$line"
+    fi
+    printf '  │%s│
+' "$padded"
+  done
+  printf '  └%s┘
+' "$hbar"
+}
+
 show_status() {
   mkdir -p "$PIDDIR"
   echo ""
@@ -143,25 +195,26 @@ do_start() {
     done
   fi
 
-  # Print banner
-  echo ""
-  echo "  ┌─────────────────────────────────────────────────────┐"
-  echo "  │  NemoClaw Services                                  │"
-  echo "  │                                                     │"
-
   local tunnel_url=""
   if [ -f "$PIDDIR/cloudflared.log" ]; then
     tunnel_url="$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$PIDDIR/cloudflared.log" 2>/dev/null | head -1 || true)"
   fi
 
+  local banner_lines=(
+    "  NemoClaw Services"
+    ""
+  )
   if [ -n "$tunnel_url" ]; then
-    printf "  │  Public URL:  %-40s│\n" "$tunnel_url"
+    banner_lines+=("  Public URL:  $tunnel_url")
   fi
+  banner_lines+=(
+    "  Messaging:   via OpenClaw native channels (if configured)"
+    ""
+    "  Run 'openshell term' to monitor egress approvals"
+  )
 
-  echo "  │  Messaging:   via OpenClaw native channels (if configured) │"
-  echo "  │                                                     │"
-  echo "  │  Run 'openshell term' to monitor egress approvals   │"
-  echo "  └─────────────────────────────────────────────────────┘"
+  echo ""
+  render_box "${banner_lines[@]}"
   echo ""
 }
 

--- a/src/lib/cli/banner.test.ts
+++ b/src/lib/cli/banner.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { renderBox } from "./banner";
+
+describe("renderBox", () => {
+  it("renders a default-width box", () => {
+    const lines = renderBox(["  Hello"], { columns: 100 });
+
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toMatch(/^  ┌─+┐$/);
+    expect(lines[2]).toMatch(/^  └─+┘$/);
+    expect(lines[0].length).toBeGreaterThanOrEqual(57);
+  });
+
+  it("expands for long URLs and leaves a safety gap before the border", () => {
+    const url = "  Public URL:  https://very-long-subdomain-name.trycloudflare.com";
+    const lines = renderBox([url], { columns: 120 });
+
+    expect(lines[1]).toContain("very-long-subdomain-name.trycloudflare.com");
+    expect(lines[1]).toMatch(/ {2}│$/);
+  });
+
+  it("caps every row at terminal columns while preserving URL safety gap", () => {
+    const lines = renderBox(["x".repeat(200)], { columns: 80 });
+
+    expect(lines.every((line) => line.length <= 80)).toBe(true);
+    expect(lines[1]).toMatch(/ {2}│$/);
+  });
+
+  it("renders null entries as blank separator rows", () => {
+    const lines = renderBox(["  Title", null, "  Content"], { columns: 100 });
+
+    expect(lines[2]).toMatch(/^  │ +│$/);
+    expect(new Set(lines.map((line) => line.length)).size).toBe(1);
+  });
+
+  it("handles very narrow terminals without overflowing", () => {
+    const lines = renderBox(["abcdef"], { columns: 5 });
+
+    expect(lines.every((line) => line.length <= 5)).toBe(true);
+    expect(lines[1]).toBe("  │ │");
+  });
+});

--- a/src/lib/cli/banner.ts
+++ b/src/lib/cli/banner.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** A banner content row; null renders as a blank separator row. */
+export type BannerLine = string | null;
+
+/** Options for rendering a Unicode terminal banner box. */
+export interface RenderBoxOptions {
+  /** Minimum inner box width, excluding borders. */
+  minInner?: number;
+  /** Terminal width to respect. Defaults to process.stdout.columns, then 100. */
+  columns?: number;
+}
+
+/**
+ * Render content lines inside a dynamically-sized Unicode box.
+ *
+ * The renderer expands to fit long content when the terminal is wide enough and
+ * otherwise truncates content while preserving a two-space safety gap before the
+ * closing border. That gap prevents terminal link detectors from treating the
+ * box-drawing border as part of long URLs such as trycloudflare.com links.
+ */
+export function renderBox(
+  lines: BannerLine[],
+  { minInner = 53, columns }: RenderBoxOptions = {},
+): string[] {
+  const detectedColumns = columns ?? process.stdout.columns;
+  const terminalColumns = Number.isFinite(detectedColumns) && detectedColumns > 0 ? detectedColumns : 100;
+  const maxInner = Math.max(0, Math.floor(terminalColumns) - 4);
+  const contentInner = lines.reduce<number>(
+    (max, line) => (line === null ? max : Math.max(max, line.length + 2)),
+    minInner,
+  );
+  const inner = Math.min(maxInner, Math.max(0, contentInner));
+
+  const pad = (line: string): string => {
+    if (line.length > inner) {
+      if (inner <= 2) return " ".repeat(inner);
+      return `${line.slice(0, inner - 2)}  `;
+    }
+    return line + " ".repeat(inner - line.length);
+  };
+
+  const hBar = "─".repeat(inner);
+  const blank = " ".repeat(inner);
+
+  return [
+    `  ┌${hBar}┐`,
+    ...lines.map((line) => (line === null ? `  │${blank}│` : `  │${pad(line)}│`)),
+    `  └${hBar}┘`,
+  ];
+}

--- a/src/lib/tunnel/services.ts
+++ b/src/lib/tunnel/services.ts
@@ -16,6 +16,7 @@ import {
 import { join } from "node:path";
 
 import { AGENT_PRODUCT_NAME, CLI_DISPLAY_NAME } from "../cli/branding";
+import { renderBox } from "../cli/banner";
 import { dockerSpawnSync } from "../adapters/docker";
 import { DASHBOARD_PORT } from "../core/ports";
 import { resolveOpenshell } from "../adapters/openshell/resolve";
@@ -481,12 +482,6 @@ export async function startAll(opts: ServiceOptions = {}): Promise<void> {
     }
   }
 
-  // Banner
-  console.log("");
-  console.log("  ┌─────────────────────────────────────────────────────┐");
-  console.log(`  │  ${(CLI_DISPLAY_NAME + " Services").padEnd(52)}│`);
-  console.log("  │                                                     │");
-
   let tunnelUrl = "";
   const cfLogFile = join(pidDir, "cloudflared.log");
   if (isRunning(pidDir, "cloudflared") && existsSync(cfLogFile)) {
@@ -497,15 +492,19 @@ export async function startAll(opts: ServiceOptions = {}): Promise<void> {
     }
   }
 
-  if (tunnelUrl) {
-    console.log(`  │  Public URL:  ${tunnelUrl.padEnd(40)}│`);
+  const bannerLines = [
+    `  ${CLI_DISPLAY_NAME} Services`,
+    null,
+    ...(tunnelUrl ? [`  Public URL:  ${tunnelUrl}`] : []),
+    `  Messaging:   via ${AGENT_PRODUCT_NAME} native channels (if configured)`,
+    null,
+    "  Run 'openshell term' to monitor egress approvals",
+  ];
+
+  console.log("");
+  for (const line of renderBox(bannerLines)) {
+    console.log(line);
   }
-
-  console.log(`  │  ${("Messaging:   via " + AGENT_PRODUCT_NAME + " native channels (if configured)").padEnd(52)}│`);
-
-  console.log("  │                                                     │");
-  console.log("  │  Run 'openshell term' to monitor egress approvals   │");
-  console.log("  └─────────────────────────────────────────────────────┘");
   console.log("");
 }
 


### PR DESCRIPTION
## Summary

Fresh replacement for stale PR #2720. Fixes #2716 by replacing fixed-width banner rows with dynamic Unicode box renderers that preserve a space buffer before closing borders.

## Changes

- Add a CLI `renderBox()` helper under `src/lib/cli/banner.ts` with unit coverage.
- Add the plugin-side equivalent under `nemoclaw/src/banner.ts` with unit coverage.
- Use dynamic banner rendering in:
  - `src/lib/tunnel/services.ts` for the cloudflared Public URL banner.
  - `nemoclaw/src/index.ts` for endpoint/provider/model registration output.
  - `scripts/start-services.sh` legacy helper path.
- Preserve a two-space safety gap before the closing `│` even when terminal width forces truncation.

## Testing

- [x] `npm run build:cli`
- [x] `npm run typecheck:cli`
- [x] `cd nemoclaw && npm run build`
- [x] `npx vitest run src/lib/cli/banner.test.ts src/lib/tunnel/services.test.ts nemoclaw/src/banner.test.ts`
- [x] `npm run lint -- src/lib/cli/banner.ts src/lib/cli/banner.test.ts src/lib/tunnel/services.ts nemoclaw/src/banner.ts nemoclaw/src/banner.test.ts nemoclaw/src/index.ts`
- [x] `bash -n scripts/start-services.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified Unicode terminal banner renderer used across CLI, startup scripts, and services; banners adapt to terminal width and conditionally include the public URL.

* **Bug Fixes**
  * Proper truncation for narrow terminals while preserving a safety gap before the right border and ensuring long URLs are displayed when space allows.

* **Tests**
  * Added comprehensive tests validating rendering, padding, truncation, blank separators, and width behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3370)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->