### PR TITLE
test(onboard): speed up dashboard curl mocks

### DIFF
--- a/src/lib/onboard/temp-files.test.ts
+++ b/src/lib/onboard/temp-files.test.ts
@@ -59,7 +59,7 @@ describe("onboard temp file helpers", () => {
   });
 
   it("does not remove matching-prefix directories outside os.tmpdir()", () => {
-    const outsideParent = fs.mkdtempSync(path.join(process.cwd(), "nemoclaw-cleanup-"));
+    const outsideParent = fs.mkdtempSync(path.join(os.homedir(), "nemoclaw-cleanup-"));
     createdParents.push(outsideParent);
     const filePath = path.join(outsideParent, "nemoclaw-cleanup.txt");
     fs.writeFileSync(filePath, "payload");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1465,7 +1465,7 @@ describe("CLI dispatch", () => {
     }
   });
 
-  it("sandbox inspection help keeps public sandbox-scoped usage", () => {
+  it("sandbox inspection help keeps public sandbox-scoped usage", testTimeoutOptions(15_000), () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-inspection-help-"));
     writeSandboxRegistry(home);
 
@@ -2139,7 +2139,7 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
   });
 
-  it("keeps logs --follow running when one log source exits", testTimeoutOptions(), async () => {
+  it("keeps logs --follow running when one log source exits", testTimeoutOptions(10_000), async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-source-exit-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -2217,7 +2217,7 @@ describe("CLI dispatch", () => {
     }
   });
 
-  it("waits for logs --follow children to stop after SIGTERM", testTimeoutOptions(), async () => {
+  it("waits for logs --follow children to stop after SIGTERM", testTimeoutOptions(10_000), async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-follow-sigterm-wait-"));
     const localBin = path.join(home, "bin");
     const markerFile = path.join(home, "logs-follow-sigterm-wait-args");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2194,7 +2194,8 @@ describe("CLI dispatch", () => {
 
     try {
       let calls: string[] = [];
-      const pollTimeoutMs = Math.min(testTimeout(10_000), Math.max(1_000, testTimeout() - 5_000));
+      const testBudgetMs = testTimeout(10_000);
+      const pollTimeoutMs = Math.min(testBudgetMs, Math.max(1_000, testBudgetMs - 5_000));
       const deadline = Date.now() + pollTimeoutMs;
       while (Date.now() < deadline) {
         calls = readCalls();
@@ -2258,7 +2259,8 @@ describe("CLI dispatch", () => {
 
     try {
       let calls: string[] = [];
-      const pollTimeoutMs = Math.min(testTimeout(10_000), Math.max(1_000, testTimeout() - 5_000));
+      const testBudgetMs = testTimeout(10_000);
+      const pollTimeoutMs = Math.min(testBudgetMs, Math.max(1_000, testBudgetMs - 5_000));
       const deadline = Date.now() + pollTimeoutMs;
       while (Date.now() < deadline) {
         calls = readCalls();
@@ -2275,7 +2277,8 @@ describe("CLI dispatch", () => {
       child.kill("SIGTERM");
 
       let callsAfterTerm: string[] = [];
-      const termDeadline = Date.now() + Math.min(testTimeout(5_000), Math.max(1_000, testTimeout() - 5_000));
+      const termTimeoutMs = Math.min(testBudgetMs, Math.max(1_000, testBudgetMs - 5_000));
+      const termDeadline = Date.now() + termTimeoutMs;
       while (Date.now() < termDeadline) {
         callsAfterTerm = readCalls();
         if (callsAfterTerm.some((call) => call.endsWith("term-start")) || hasExited) {

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+function normalizeCommand(command) {
+  return (Array.isArray(command) ? command.join(" ") : String(command)).replace(/'/g, "");
+}
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function mockSandboxExecCurl(command, options = {}) {
+  const normalized = normalizeCommand(command);
+  if (!normalized.includes("sandbox exec") || !normalized.includes("curl")) {
+    return null;
+  }
+
+  if (normalized.includes("/health") || normalized.includes("%{http_code}")) {
+    return options.dashboardHealthCode || "200";
+  }
+
+  if (hasOwn(options, "defaultCurlOutput")) {
+    return options.defaultCurlOutput;
+  }
+
+  return null;
+}
+
+module.exports = {
+  mockSandboxExecCurl,
+  normalizeCommand,
+};

--- a/test/helpers/timeouts.ts
+++ b/test/helpers/timeouts.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const DEFAULT_EXEC_TIMEOUT_MS = 10_000;
-const DEFAULT_TEST_TIMEOUT_MS = 15_000;
+const DEFAULT_TEST_TIMEOUT_MS = 5_000;
 
 function parsePositiveInt(value: string | undefined): number | null {
   if (!value) return null;

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -798,7 +798,7 @@ const { setupNim } = require(${onboardPath});
     );
   });
 
-  it("starts managed Ollama on loopback before exposing the auth proxy", () => {
+  it("starts managed Ollama on loopback before exposing the auth proxy", { timeout: 10_000 }, () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-ollama-loopback-"));
     const fakeBin = path.join(tmpDir, "bin");
@@ -3691,7 +3691,7 @@ const { setupNim } = require(${onboardPath});
     assert.ok(payload.lines.some((line: string) => line.includes("tool-call-parser requires")));
   });
 
-  it("offers install-ollama option on Linux when Ollama is not installed", () => {
+  it("offers install-ollama option on Linux when Ollama is not installed", { timeout: 10_000 }, () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-install-ollama-"));
     const fakeBin = path.join(tmpDir, "bin");
@@ -3941,7 +3941,7 @@ const { setupNim } = require(${onboardPath});
     assert.match(result.stderr, /Refusing to continue/);
   });
 
-  it("uses install-ollama for non-interactive NEMOCLAW_PROVIDER=ollama on fresh Linux", () => {
+  it("uses install-ollama for non-interactive NEMOCLAW_PROVIDER=ollama on fresh Linux", { timeout: 10_000 }, () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "nemoclaw-onboard-noninteractive-install-ollama-"),

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -310,6 +310,9 @@ const {
 } = onboardTestInternals;
 
 const repoRoot = path.join(import.meta.dirname, "..");
+const onboardScriptMocksPath = JSON.stringify(
+  path.join(repoRoot, "test", "helpers", "onboard-script-mocks.cjs"),
+);
 
 describe("onboard helpers", () => {
   it("resolves sandbox GPU auto/force/disable modes", () => {
@@ -5095,7 +5098,10 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("http://localhost:18789/health")) return "200";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command);
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   return "";
 };
@@ -5232,7 +5238,10 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("http://localhost:18789/health")) return "200";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command);
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   return "";
 };
@@ -5328,7 +5337,10 @@ runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
   // Custom port: dashboard readiness curl uses 19000 (DASHBOARD_PORT from env)
-  if (_n(command).includes("sandbox exec") && _n(command).includes("http://localhost:19000/health")) return "200";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command);
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 19000 12345 running";
   return "";
 };
@@ -5460,7 +5472,12 @@ runner.runCapture = (command) => {
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
   if (_n(command).includes("provider get")) return "Provider: discord-bridge";
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("curl")) return "ok";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   return "";
 };
 registry.registerSandbox = () => true;
@@ -5701,7 +5718,12 @@ runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("curl")) return "ok";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   return "";
 };
 registry.registerSandbox = (entry) => {
@@ -5876,7 +5898,10 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("http://localhost:18789/health")) return "200";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command);
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   return "";
 };
@@ -6283,7 +6308,12 @@ runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "my-assistant";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
   if (_n(command).includes("forward list")) return "";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("curl")) return "ok";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   return "";
 };
 registry.getSandbox = () => ({ name: "my-assistant", gpuEnabled: false });
@@ -6390,7 +6420,12 @@ runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "my-assistant";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
   if (_n(command).includes("forward list")) return "";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("curl")) return "ok";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   return "";
 };
 
@@ -6655,7 +6690,12 @@ runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "my-assistant";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
   if (_n(command).includes("forward list")) return "";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("curl")) return "ok";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   return "";
 };
 registry.getSandbox = () => ({ name: "my-assistant", gpuEnabled: false });
@@ -6780,7 +6820,12 @@ runner.runCapture = (command) => {
     return sandboxDeleted ? "my-assistant Ready" : "my-assistant NotReady";
   }
   if (_n(command).includes("forward list")) return "";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("curl")) return "ok";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   return "";
 };
 registry.getSandbox = () => ({ name: "my-assistant", gpuEnabled: false });
@@ -7269,7 +7314,10 @@ runner.runCapture = (command) => {
     sandboxListCalls += 1;
     return sandboxListCalls >= 2 ? "my-assistant Ready" : "my-assistant Pending";
   }
-  if (_n(command).includes("sandbox exec") && _n(command).includes("http://localhost:18789/health")) return "200";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command);
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   return "";
 };
@@ -7664,7 +7712,10 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("http://localhost:18789/health")) return "200";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command);
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   return "";
 };
@@ -7796,7 +7847,10 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("http://localhost:18789/health")) return "200";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command);
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   return "";
 };
@@ -8413,7 +8467,10 @@ runner.run = (command, opts = {}) => {
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get my-assistant")) return "";
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
-  if (_n(command).includes("sandbox exec") && _n(command).includes("http://localhost:18789/health")) return "200";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command);
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   return "";
 };


### PR DESCRIPTION
## Summary
Extracts shared onboard script curl mock handling and uses it across generated onboard child-process test scripts. The helper returns HTTP 200 for dashboard health probes so mocked createSandbox flows no longer burn the full dashboard readiness timeout. It also lowers the default CLI test timeout to 5s so future accidental sleeps fail fast, with explicit 10s allowances for the three known Ollama installer-selection outliers.

## Changes
- Added `test/helpers/onboard-script-mocks.cjs` with reusable command normalization and sandbox curl mock handling.
- Replaced duplicated inline `sandbox exec`/`curl` mock branches in `test/onboard.test.ts` with the shared helper.
- Preserved generic sandbox curl behavior via `defaultCurlOutput` while ensuring dashboard `/health` probes return an HTTP status code.
- Lowered the default CLI test timeout from 15s to 5s in `test/helpers/timeouts.ts`.
- Marked the three known `test/onboard-selection.test.ts` Ollama install-selection cases with explicit 10s timeouts.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
`npm test` was attempted but currently fails in `installer-integration` at `test/install-preflight.test.ts` (`skips onboarding when shared host preflight detects Docker is missing`), unrelated to this test-only change; leaving that box unchecked.

- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a reusable helper to mock sandbox-executed curl calls and standardize probe outputs across tests.
  * Reduced the default test timeout from 15s to 5s.
  * Added explicit timeouts to multiple onboarding and CLI tests (10s and 15s) to stabilize timing-sensitive scenarios.
  * Tightened CLI test deadline calculations for streaming/log-follow behavior.
  * Adjusted a temp-files test to validate behavior using the user home directory.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3374)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->