### PR TITLE
fix(ci): unblock nightly startup after Brev reusable workflow merge

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1806,11 +1806,17 @@ jobs:
       fail-fast: false
       matrix:
         test_suite: [all, messaging-providers, full]
+    # Re-enable once BREV_API_KEY/BREV_ORG_ID are installed in the upstream
+    # NVIDIA/NemoClaw repo. Referencing a reusable workflow that requires
+    # missing secrets causes GitHub to fail the entire workflow at startup
+    # (zero jobs/logs), which is what broke nightly after #3350 merged.
+    if: false
     uses: ./.github/workflows/e2e-branch-validation.yaml
     with:
-      # Respect the selected ref for manual dispatches; scheduled runs execute
-      # on main, so this remains main there.
-      branch: ${{ github.ref_name }}
+      # Scheduled nightly runs should validate main. Manual dispatches in this
+      # workflow also only run against main in the upstream repo; branch-specific
+      # Brev validation should use e2e-branch-validation.yaml directly.
+      branch: main
       test_suite: ${{ matrix.test_suite }}
       use_launchable: true
       # Provision from the published NemoClaw launchable image (pre-baked
@@ -1819,10 +1825,7 @@ jobs:
       use_published_launchable: true
       launchable_id: ""
       keep_alive: false
-    secrets:
-      BREV_API_KEY: ${{ secrets.BREV_API_KEY }}
-      BREV_ORG_ID: ${{ secrets.BREV_ORG_ID }}
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+    secrets: inherit
 
   # ── GPU E2E (Ollama local inference) ──────────────────────────
   # Runs on an NVKS ephemeral GPU runner (RTX Pro 6000, 36 GB VRAM).


### PR DESCRIPTION
## Summary

Nightly E2E started failing with `startup_failure` after #3350 merged. These runs have zero jobs and no logs, which means GitHub failed to instantiate the workflow graph before any test job could start.

Root cause: #3350 added a new `brev-e2e` reusable workflow call whose callee declares required `BREV_API_KEY` and `BREV_ORG_ID` secrets. Those secrets were validated in the fork, but they are **not yet installed in the upstream `NVIDIA/NemoClaw` repo** (only legacy `BREV_API_TOKEN` and `NVIDIA_API_KEY` are present there). A reusable workflow with missing required secrets fails during workflow startup, which aborts the entire nightly workflow graph.

This PR restores nightly startup immediately by disabling the `brev-e2e` job until the upstream secrets are installed. It also keeps the caller conservative:

- `if: false` on `brev-e2e` until upstream `BREV_API_KEY` / `BREV_ORG_ID` exist.
- `branch: main` for nightly runs. Branch-specific Brev validation should use `e2e-branch-validation.yaml` directly.
- `secrets: inherit` for the same-repo reusable workflow call once it is re-enabled.

## Validation

- YAML parses locally for `.github/workflows/nightly-e2e.yaml`.
- The failed nightly runs are startup failures with zero jobs/logs, matching missing-required-secret/reusable-workflow graph instantiation failure rather than product test failures.
- Confirmed upstream secrets currently lack `BREV_API_KEY` and `BREV_ORG_ID`; fork has them.

## Follow-up

After adding upstream repo/org secrets:

1. `BREV_API_KEY`
2. `BREV_ORG_ID`

remove the temporary `if: false` and re-enable the nightly `brev-e2e` matrix.

## Related

- Fixes fallout from #3350


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly end-to-end CI workflow: temporarily disabled the reusable job to avoid startup failures.
  * Standardized the workflow branch source to "main".
  * Changed secrets handling to inherit secrets from the calling workflow.

---

Note: Internal infrastructure updates only; no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3376)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->