### PR TITLE
fix(policy): drop phantom /usr/bin/gh from github preset binaries (#2179)

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -99,7 +99,7 @@ flowchart TB
 * - Inference
   - Credential exposure, unauthorized model access, cost overruns.
   - OpenShell gateway
-  - Yes. Use `openshell inference set`.
+  - Yes. Use `nemoclaw inference set`.
 
 :::
 
@@ -130,7 +130,7 @@ If someone replaces a binary while the sandbox runs, the hash mismatch triggers 
 
 | Aspect | Detail |
 |---|---|
-| Default | Each endpoint restricts access to specific binaries. For example, the `github` preset restricts access so only `/usr/bin/gh` and `/usr/bin/git` can reach `github.com`. Binary paths support glob patterns (`*` matches one path component, `**` matches recursively). |
+| Default | Each endpoint restricts access to specific binaries. For example, the `github` preset restricts access so only `/usr/bin/git` can reach `github.com`. Binary paths support glob patterns (`*` matches one path component, `**` matches recursively). |
 | What you can change | Add binaries to an endpoint entry, or omit the `binaries` field to allow any executable. |
 | Risk if relaxed | Removing binary restrictions lets any process in the sandbox reach the endpoint. An agent could use `curl`, `wget`, or a Python script to exfiltrate data to an allowed host, bypassing the intended usage pattern. |
 | Recommendation | Always scope endpoints to the binaries that need them. If the agent needs a host from a new binary, add that binary explicitly rather than removing the restriction. |
@@ -178,7 +178,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 | `brave` | Brave Search API. | Agent can issue search queries. |
 | `brew` | Homebrew (Linuxbrew) package manager. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
-| `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `gh` and `git`. |
+| `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |
 | `jira` | Atlassian Jira API. | Gives agent read/write access to project issues and comments. |
 | `local-inference` | Local Ollama and vLLM through the host gateway. | Allows sandbox access to host-side local inference ports covered by the preset. |

--- a/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
@@ -145,7 +145,7 @@ $ nemoclaw my-assistant policy-add discord --yes
 
 ## GitHub and Jira
 
-Use `github` when the agent needs GitHub API, Git, or `gh` access.
+Use `github` when the agent needs GitHub API or Git access.
 Use `jira` when the agent needs Atlassian Jira access.
 
 Preview first:

--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -76,7 +76,9 @@ network_policies:
         port: 443
         access: full
     binaries:
-      - { path: /usr/bin/gh }
+      # `gh` was historically whitelisted here, but the Hermes sandbox base
+      # image (agents/hermes/Dockerfile.base) only apt-installs `git`, not
+      # `gh`, so the entry was a phantom — see #2179.
       - { path: /usr/bin/git }
       - { path: /opt/hermes/.venv/bin/python }
 

--- a/docs/network-policy/integration-policy-examples.md
+++ b/docs/network-policy/integration-policy-examples.md
@@ -165,7 +165,7 @@ $ nemoclaw my-assistant policy-add discord --yes
 
 ## GitHub and Jira
 
-Use `github` when the agent needs GitHub API, Git, or `gh` access.
+Use `github` when the agent needs GitHub API or Git access.
 Use `jira` when the agent needs Atlassian Jira access.
 
 Preview first:

--- a/docs/security/best-practices.md
+++ b/docs/security/best-practices.md
@@ -150,7 +150,7 @@ If someone replaces a binary while the sandbox runs, the hash mismatch triggers 
 
 | Aspect | Detail |
 |---|---|
-| Default | Each endpoint restricts access to specific binaries. For example, the `github` preset restricts access so only `/usr/bin/gh` and `/usr/bin/git` can reach `github.com`. Binary paths support glob patterns (`*` matches one path component, `**` matches recursively). |
+| Default | Each endpoint restricts access to specific binaries. For example, the `github` preset restricts access so only `/usr/bin/git` can reach `github.com`. Binary paths support glob patterns (`*` matches one path component, `**` matches recursively). |
 | What you can change | Add binaries to an endpoint entry, or omit the `binaries` field to allow any executable. |
 | Risk if relaxed | Removing binary restrictions lets any process in the sandbox reach the endpoint. An agent could use `curl`, `wget`, or a Python script to exfiltrate data to an allowed host, bypassing the intended usage pattern. |
 | Recommendation | Always scope endpoints to the binaries that need them. If the agent needs a host from a new binary, add that binary explicitly rather than removing the restriction. |
@@ -198,7 +198,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 | `brave` | Brave Search API. | Agent can issue search queries. |
 | `brew` | Homebrew (Linuxbrew) package manager. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
-| `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `gh` and `git`. |
+| `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |
 | `jira` | Atlassian Jira API. | Gives agent read/write access to project issues and comments. |
 | `local-inference` | Local Ollama and vLLM through the host gateway. | Allows sandbox access to host-side local inference ports covered by the preset. |

--- a/nemoclaw-blueprint/policies/presets/github.yaml
+++ b/nemoclaw-blueprint/policies/presets/github.yaml
@@ -3,17 +3,24 @@
 #
 # GitHub access preset.
 #
-# Until #1583 was fixed, github.com / api.github.com plus the git and gh
-# binaries were silently included in the base sandbox policy, so every
-# sandbox could clone, push, and call the GitHub API regardless of what
-# the user opted into. Moving the entry into a discoverable preset
-# restores least-privilege: a sandbox only gets GitHub if the user
-# explicitly selects this preset during `nemoclaw onboard` (or applies
-# it later via `openshell policy set`).
+# Until #1583 was fixed, github.com / api.github.com plus the git binary
+# were silently included in the base sandbox policy, so every sandbox
+# could clone, push, and call the GitHub API regardless of what the user
+# opted into. Moving the entry into a discoverable preset restores
+# least-privilege: a sandbox only gets GitHub if the user explicitly
+# selects this preset during `nemoclaw onboard` (or applies it later via
+# `openshell policy set`).
+#
+# The `gh` CLI was also whitelisted here historically (alongside `git`),
+# but the sandbox base image (Dockerfile.base) only apt-installs `git`,
+# not `gh`. Users selecting this preset and running `gh api …` would hit
+# `bash: gh: command not found`. Dropping `/usr/bin/gh` from the binaries
+# list and from the description keeps the preset surface honest about
+# what's actually usable in the shipped image. Closes #2179.
 
 preset:
   name: github
-  description: "GitHub.com and GitHub API access (git, gh)"
+  description: "GitHub.com and GitHub API access (git)"
 
 network_policies:
   github:
@@ -26,5 +33,4 @@ network_policies:
         port: 443
         access: full
     binaries:
-      - { path: /usr/bin/gh }
       - { path: /usr/bin/git }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -837,6 +837,20 @@ describe("policies", () => {
       expect(discordMutationRules.some((rule) => rule.path === "/**")).toBe(false);
     });
 
+    it("Hermes GitHub policy does not whitelist the absent gh CLI (#2179)", () => {
+      const content = fs.readFileSync(
+        path.join(REPO_ROOT, "agents/hermes/policy-additions.yaml"),
+        "utf8",
+      );
+      const parsed = YAML.parse(content);
+      const githubPolicy = parsed.network_policies?.github as
+        | { binaries?: Array<{ path?: string }> }
+        | undefined;
+      const binaries = (githubPolicy?.binaries ?? []).map((binary) => binary.path).sort();
+      expect(binaries).toEqual(["/opt/hermes/.venv/bin/python", "/usr/bin/git"]);
+      expect(binaries).not.toContain("/usr/bin/gh");
+    });
+
     it("REST policy YAML avoids deprecated tls: terminate", () => {
       const agentsDir = path.join(REPO_ROOT, "agents");
       const agentPolicyFiles = fs.existsSync(agentsDir)

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -433,6 +433,18 @@ describe("github preset", () => {
     const np = parsed.network_policies;
     expect(np && "github" in np).toBe(true);
   });
+
+  it("regression #2179: github preset only advertises the installed git binary", () => {
+    const parsed = loadYaml<PolicyPreset>(PRESET_PATH);
+    const meta = parsed.preset;
+    expect(meta?.description).toBe("GitHub.com and GitHub API access (git)");
+    expect(meta?.description ?? "").not.toMatch(/\bgh\b/);
+
+    const binaries = (parsed.network_policies?.github?.binaries ?? [])
+      .map((binary) => binary.path)
+      .sort();
+    expect(binaries).toEqual(["/usr/bin/git"]);
+  });
 });
 
 describe("huggingface preset", () => {


### PR DESCRIPTION
## Summary

Fixes #2179. The `github` policy preset whitelisted `/usr/bin/gh` in its `binaries:` list (and advertised it in the `(git, gh)` description), but the sandbox base image only apt-installs `git`, not `gh`. Users selecting `● github` and running `gh api …` hit `bash: gh: command not found`.

This is the 4th instance of the "phantom binary in preset whitelist" pattern (brew × 2, docker × 1, github × 1 — see issue body for the bug cross-references).

## Approach

Going with the reporter's recommended **option (b)**: drop `/usr/bin/gh` from the preset binary list and from the description text. The preset surface now honestly reflects what's actually usable in the shipped sandbox image.

The fuller fix (apt-install `gh` in the sandbox base image) trades size + supply-chain surface for the added capability and is intentionally out of scope. Users who want `gh` can still install it themselves inside the sandbox.

## Changes

- **`nemoclaw-blueprint/policies/presets/github.yaml`** — drop `/usr/bin/gh` binary entry; update description from `"(git, gh)"` → `"(git)"`; update header comment to explain why `gh` was dropped (pointer to #2179).
- **`agents/hermes/policy-additions.yaml`** — same drop in Hermes' `github` policy (Hermes inherits the same phantom-binary issue), with an inline comment pointing at #2179.
- **`docs/security/best-practices.md`** — two lines that mentioned `gh` as an example or available binary updated to reflect the actual preset binary set.
- **`.agents/skills/nemoclaw-user-configure-security/references/best-practices.md`** — regenerated via `scripts/docs-to-skills.py` to match the docs change.

## Verification

Empirically confirmed against v0.0.38 (current latest) on a fresh Brev box. Onboarded a sandbox, applied `● github`, verified inside the sandbox:

- `/usr/bin/gh` does not exist (only `/usr/bin/git` is present)
- `which gh` returns nothing
- `gh --version` → `bash: gh: command not found`
- `git` (the other preset binary) works as expected

After this PR, the preset surface matches reality.

## Test plan

- [ ] CI passes
- [ ] Onboard a sandbox, apply `● github` preset, confirm `nemoclaw <name> policy-list` shows the updated description `(git)` and `git` continues to work through the preset
- [ ] Verify the regenerated skill file stays in sync (CI `verify docs-to-skills` check)

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified GitHub access guidance and examples to state only git is available for GitHub.com interactions and updated preset descriptions to reflect least-privilege access.
* **Bug Fixes**
  * Removed a phantom gh binary from sandbox network policies so allowed tools match the shipped base image.
* **Tests**
  * Added regression tests to assert presets and policies reference git-only binaries and descriptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3377)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->