### PR TITLE
fix(install): address #3316 review feedback (tests, warn formatting, ready-now comment)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1476,6 +1476,13 @@ verify_nemoclaw() {
       # current shell's PATH cache is stale. The user-facing PATH-refresh
       # hint is still emitted so future shells pick the binary up by name
       # (#3276).
+      #
+      # Deliberately leave NEMOCLAW_READY_NOW=false here: that flag means
+      # "the calling shell can resolve $_CLI_BIN by name", which is exactly
+      # what's not true on this branch. print_done() routes through ONBOARD_RAN
+      # + _needs_cli_refresh to render the "refresh PATH before using the CLI"
+      # message; flipping READY_NOW=true would short-circuit that and falsely
+      # advertise the CLI as immediately runnable by name.
       _CLI_PATH="$npm_bin/$_CLI_BIN"
       NEMOCLAW_CURRENT_SHELL_NEEDS_PATH_REFRESH=true
       NEMOCLAW_RECOVERY_PROFILE="$(detect_shell_profile)"
@@ -1493,19 +1500,23 @@ verify_nemoclaw() {
     fi
   fi
 
+  # Single warn header, then plain printf for each bullet. warn() prefixes
+  # every line with "[warn]" + colour codes, which would render the bulleted
+  # diagnostic table as six separate warnings rather than one structured block.
   warn "Could not locate the ${_CLI_BIN} executable after install. Searched:"
   if command_exists "$_CLI_BIN"; then
-    warn "  - PATH lookup ('command -v ${_CLI_BIN}'):  $(command -v "$_CLI_BIN")  (rejected — not the real CLI)"
+    printf '    - PATH lookup (command -v %s):  %s  (rejected — not the real CLI)\n' \
+      "$_CLI_BIN" "$(command -v "$_CLI_BIN")"
   else
-    warn "  - PATH lookup ('command -v ${_CLI_BIN}'):  not found"
+    printf '    - PATH lookup (command -v %s):  not found\n' "$_CLI_BIN"
   fi
   if [[ -n "$npm_bin" ]]; then
-    warn "  - npm prefix bin:                          ${npm_bin}/${_CLI_BIN}"
+    printf '    - npm prefix bin:    %s/%s\n' "$npm_bin" "$_CLI_BIN"
   else
-    warn "  - npm prefix bin:                          (npm not configured)"
+    printf '    - npm prefix bin:    (npm not configured)\n'
   fi
-  warn "  - User shim dir:                           ${NEMOCLAW_SHIM_DIR}/${_CLI_BIN}"
-  warn "  Active PATH: ${PATH:-(empty)}"
+  printf '    - User shim dir:     %s/%s\n' "$NEMOCLAW_SHIM_DIR" "$_CLI_BIN"
+  printf '    Active PATH: %s\n' "${PATH:-(empty)}"
   warn "Try re-running:  curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash"
   error "Installation failed: ${_CLI_BIN} binary not found."
 }

--- a/test/install-onboard-yes.test.ts
+++ b/test/install-onboard-yes.test.ts
@@ -10,7 +10,15 @@ import { describe, expect, it } from "vitest";
 
 const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
 
-function runOnboardWithMockCli(env: Record<string, string>): string[] {
+type StubAssignments = {
+  cliBin?: string;
+  cliPath?: string;
+};
+
+function runOnboardWithMockCli(
+  env: Record<string, string>,
+  assignments: StubAssignments = {},
+): string[] {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-onboard-yes-"));
   const stubBin = path.join(tmp, "stub-cli");
   const argvLog = path.join(tmp, "argv.txt");
@@ -21,10 +29,18 @@ function runOnboardWithMockCli(env: Record<string, string>): string[] {
     { mode: 0o755 },
   );
 
+  const cliBin = assignments.cliBin ?? stubBin;
+  // Quote each assignment so an empty string survives the heredoc — `_CLI_PATH=`
+  // with nothing after it is a valid bash assignment to empty, but reads more
+  // ambiguously than the explicit `_CLI_PATH=""` form.
+  const cliPathAssignment =
+    assignments.cliPath !== undefined ? `_CLI_PATH="${assignments.cliPath}"` : "";
+
   const snippet = `
     set -e
     source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1 || true
-    _CLI_BIN="${stubBin}"
+    _CLI_BIN="${cliBin}"
+    ${cliPathAssignment}
     info() { :; }
     warn() { :; }
     error() { return 0; }
@@ -44,6 +60,48 @@ function runOnboardWithMockCli(env: Record<string, string>): string[] {
   return captured.split("\n").filter((line) => line.length > 0);
 }
 
+function runOnboardWithStubAtPath(
+  env: Record<string, string>,
+  cliBinName: string,
+): { argv: string[]; argvLog: string; stubBin: string } {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-onboard-clipath-"));
+  const stubBin = path.join(tmp, "stub-cli");
+  const argvLog = path.join(tmp, "argv.txt");
+
+  fs.writeFileSync(
+    stubBin,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > "${argvLog}"\nexit 0\n`,
+    { mode: 0o755 },
+  );
+
+  const snippet = `
+    set -e
+    source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1 || true
+    _CLI_BIN="${cliBinName}"
+    _CLI_PATH="${stubBin}"
+    info() { :; }
+    warn() { :; }
+    error() { return 0; }
+    command_exists() { return 1; }
+    run_onboard >/dev/null 2>&1 || true
+  `;
+
+  const result = spawnSync("bash", ["-c", snippet], {
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+  });
+  if (result.status !== 0) {
+    throw new Error(`shell exit ${result.status}: ${result.stderr}`);
+  }
+
+  const captured = fs.existsSync(argvLog) ? fs.readFileSync(argvLog, "utf-8") : "";
+  return {
+    argv: captured.split("\n").filter((line) => line.length > 0),
+    argvLog,
+    stubBin,
+  };
+}
+
 describe("install.sh run_onboard", () => {
   it("forwards --yes to nemoclaw onboard in non-interactive mode", () => {
     const argv = runOnboardWithMockCli({ NON_INTERACTIVE: "1" });
@@ -58,6 +116,32 @@ describe("install.sh run_onboard", () => {
       ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     });
     expect(argv).toContain("--yes-i-accept-third-party-software");
+    expect(argv).toContain("--yes");
+  });
+});
+
+describe("install.sh run_onboard — _CLI_PATH precedence (#3276)", () => {
+  it("invokes via _CLI_PATH (absolute path) when set, ignoring _CLI_BIN", () => {
+    // Repro: stale PATH cache. _CLI_BIN does not resolve by name, but
+    // _CLI_PATH points at the real binary on disk. The fallback
+    // `"${_CLI_PATH:-$_CLI_BIN}"` must pick _CLI_PATH so auto-onboarding
+    // doesn't silently skip.
+    const { argv, argvLog } = runOnboardWithStubAtPath(
+      { NON_INTERACTIVE: "1" },
+      "nemoclaw-not-on-path",
+    );
+    expect(fs.existsSync(argvLog)).toBe(true);
+    expect(argv).toContain("onboard");
+    expect(argv).toContain("--non-interactive");
+    expect(argv).toContain("--yes");
+  });
+
+  it("falls back to _CLI_BIN when _CLI_PATH is empty (pin the fallback)", () => {
+    // Explicit empty _CLI_PATH must route through _CLI_BIN so a future
+    // refactor cannot silently drop the `"${_CLI_PATH:-$_CLI_BIN}"` form.
+    const argv = runOnboardWithMockCli({ NON_INTERACTIVE: "1" }, { cliPath: "" });
+    expect(argv).toContain("onboard");
+    expect(argv).toContain("--non-interactive");
     expect(argv).toContain("--yes");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #3316. Addresses three review items from the merged PR:
- Adds the missing test coverage the original PR ticked but did not include.
- Restores the structured "Searched:" diagnostic table by replacing per-line `warn` with one `warn` header plus plain `printf` bullets — previously each row rendered as a separate `[warn]` line.
- Documents why the absolute-path fallback branch deliberately leaves `NEMOCLAW_READY_NOW=false`, so a future reader doesn't "fix" the asymmetry by flipping it.

## Related Issue

Related to #3276 and #3316.

## Changes

- [test/install-onboard-yes.test.ts](test/install-onboard-yes.test.ts): two new cases under `install.sh run_onboard — _CLI_PATH precedence (#3276)`:
  - `_CLI_PATH` takes precedence over `_CLI_BIN` when set (the stale-PATH-cache repro).
  - Explicit empty `_CLI_PATH` falls back to `_CLI_BIN` — pins the `"${_CLI_PATH:-$_CLI_BIN}"` form so a future refactor can't silently drop it.
- [scripts/install.sh:1496-1514](scripts/install.sh#L1496-L1514): single `warn` header + `printf` bullets for the not-found diagnostic table, with a leading comment explaining why.
- [scripts/install.sh:1473-1486](scripts/install.sh#L1473-L1486): comment block explaining why `NEMOCLAW_READY_NOW` stays `false` on the `_CLI_PATH` fallback branch (preserves the "refresh PATH before using the CLI by name" messaging in `print_done()`).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI installation verification logic to accurately reflect installation status.
  * Enhanced error messaging format for CLI installation failures with clearer diagnostic output.

* **Chores**
  * Extended test coverage for CLI installation scenarios and path resolution behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3379)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->