### PR TITLE
ci(onboard): enforce entrypoint line budget

### DIFF
--- a/.github/workflows/onboard-entrypoint-budget.yaml
+++ b/.github/workflows/onboard-entrypoint-budget.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: onboard-entrypoint-budget
+
+# pull_request_target runs in the base repo context, so this policy cannot be
+# bypassed by editing workflow files or scripts in the PR. Keep this workflow
+# data-only: do not check out or execute PR code. It only reads GitHub's
+# file-level diff metadata.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  onboard-entrypoint-budget:
+    name: onboard-entrypoint-budget
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require src/lib/onboard.ts to be net-neutral or smaller
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          TARGET_FILE: src/lib/onboard.ts
+          EXTRACTION_DIR: src/lib/onboard/
+        run: |
+          set -euo pipefail
+
+          # Intentionally hard-code TARGET_FILE in the jq expression. gh's jq
+          # filter does not accept shell variables directly, and missing
+          # previous_filename values must not match every file.
+          rows="$(gh api --paginate "/repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | select(.filename == "src/lib/onboard.ts" or .previous_filename == "src/lib/onboard.ts") | [.additions, .deletions, .filename] | @tsv')"
+
+          if [ -z "$rows" ]; then
+            echo "${TARGET_FILE} was not changed. New modules under ${EXTRACTION_DIR} are allowed."
+            exit 0
+          fi
+
+          additions=0
+          deletions=0
+          while IFS=$'\t' read -r file_additions file_deletions _file_path; do
+            if [ -z "${file_additions:-}" ]; then
+              continue
+            fi
+            additions=$((additions + file_additions))
+            deletions=$((deletions + file_deletions))
+          done <<< "$rows"
+
+          net=$((additions - deletions))
+          echo "${TARGET_FILE}: +${additions}/-${deletions} (net ${net})"
+          echo "Growth under ${EXTRACTION_DIR} is allowed; this budget applies only to ${TARGET_FILE}."
+
+          if [ "$additions" -le "$deletions" ]; then
+            echo "PASS: ${TARGET_FILE} is net-neutral or smaller."
+            exit 0
+          fi
+
+          cat <<EOF
+          FAIL: ${TARGET_FILE} grew by ${net} line(s).
+
+          ${TARGET_FILE} is already about 12k lines. Please move new logic into
+          focused modules under ${EXTRACTION_DIR}, or reduce ${TARGET_FILE} by at
+          least as many lines as this PR adds there.
+
+          This check allows src/lib/onboard/** to grow. It only blocks net growth
+          in the top-level onboard entrypoint.
+          EOF
+          exit 1


### PR DESCRIPTION
## Summary
Adds a non-mutating PR policy check that blocks net growth in `src/lib/onboard.ts` while allowing extraction modules under `src/lib/onboard/` to grow. This gives maintainers a merge gate for the oversized onboard entrypoint without closing or modifying existing PRs.

## Changes
- Add `.github/workflows/onboard-entrypoint-budget.yaml` using safe `pull_request_target` metadata-only inspection.
- Fail PRs when `src/lib/onboard.ts` has more additions than deletions.
- Explicitly allow growth under `src/lib/onboard/**` so new logic can be extracted out of the top-level entrypoint.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
<!-- `npm test` was attempted but did not pass locally because existing `test/install-preflight.test.ts > skips onboarding when shared host preflight detects Docker is missing` failed; unrelated to this workflow-only change. -->
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow to enforce code organization standards during pull request reviews.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3380)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->