### PR TITLE
fix(onboard): add minimal macOS OpenShell 0.0.37 gateway path

### DIFF
--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -81,7 +81,7 @@ required_driver_bins_present() {
       command -v openshell-gateway >/dev/null 2>&1 && command -v openshell-sandbox >/dev/null 2>&1
       ;;
     Darwin)
-      command -v openshell-gateway >/dev/null 2>&1
+      command -v openshell-gateway >/dev/null 2>&1 && command -v openshell-driver-vm >/dev/null 2>&1
       ;;
     *)
       return 0
@@ -140,10 +140,12 @@ case "$OS" in
     case "$ARCH_LABEL" in
       aarch64)
         ASSETS+=("openshell-gateway-aarch64-apple-darwin.tar.gz")
+        ASSETS+=("openshell-driver-vm-aarch64-apple-darwin.tar.gz")
         CHECKSUM_FILES+=("openshell-gateway-checksums-sha256.txt")
+        CHECKSUM_FILES+=("openshell-checksums-sha256.txt")
         ;;
       x86_64)
-        fail "OpenShell ${PIN_VERSION} does not publish a macOS x86_64 Docker-driver gateway asset."
+        fail "OpenShell ${PIN_VERSION} does not publish macOS x86_64 standalone gateway assets."
         ;;
     esac
     ;;
@@ -217,6 +219,9 @@ install_bins() {
   if [ -x "$tmpdir/openshell-sandbox" ]; then
     install -m 755 "$tmpdir/openshell-sandbox" "$dir/openshell-sandbox"
   fi
+  if [ -x "$tmpdir/openshell-driver-vm" ]; then
+    install -m 755 "$tmpdir/openshell-driver-vm" "$dir/openshell-driver-vm"
+  fi
 }
 
 if [ -w "$target_dir" ]; then
@@ -235,6 +240,9 @@ else
   fi
   if [ -x "$tmpdir/openshell-sandbox" ]; then
     sudo install -m 755 "$tmpdir/openshell-sandbox" "$target_dir/openshell-sandbox"
+  fi
+  if [ -x "$tmpdir/openshell-driver-vm" ]; then
+    sudo install -m 755 "$tmpdir/openshell-driver-vm" "$target_dir/openshell-driver-vm"
   fi
 fi
 

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -75,11 +75,18 @@ version_gte() {
   return 0
 }
 
-linux_driver_bins_present() {
-  if [ "$OS" != "Linux" ]; then
-    return 0
-  fi
-  command -v openshell-gateway >/dev/null 2>&1 && command -v openshell-sandbox >/dev/null 2>&1
+required_driver_bins_present() {
+  case "$OS" in
+    Linux)
+      command -v openshell-gateway >/dev/null 2>&1 && command -v openshell-sandbox >/dev/null 2>&1
+      ;;
+    Darwin)
+      command -v openshell-gateway >/dev/null 2>&1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
 }
 
 if command -v openshell >/dev/null 2>&1; then
@@ -97,7 +104,7 @@ if command -v openshell >/dev/null 2>&1; then
       if ! version_gte "$MAX_VERSION" "$INSTALLED_VERSION"; then
         fail "openshell $INSTALLED_VERSION is above the maximum ($MAX_VERSION) supported by this NemoClaw release. Upgrade NemoClaw first."
       fi
-      if ! linux_driver_bins_present; then
+      if ! required_driver_bins_present; then
         warn "openshell $INSTALLED_VERSION is missing Docker-driver binaries — reinstalling pinned OpenShell ${PIN_VERSION}..."
       else
         info "openshell already installed: $INSTALLED_VERSION (>= $MIN_VERSION, <= $MAX_VERSION)"
@@ -128,20 +135,33 @@ esac
 
 declare -a ASSETS=("$ASSET")
 declare -a CHECKSUM_FILES=("openshell-checksums-sha256.txt")
-if [ "$OS" = "Linux" ]; then
-  case "$ARCH_LABEL" in
-    x86_64)
-      ASSETS+=("openshell-gateway-x86_64-unknown-linux-gnu.tar.gz")
-      ASSETS+=("openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz")
-      ;;
-    aarch64)
-      ASSETS+=("openshell-gateway-aarch64-unknown-linux-gnu.tar.gz")
-      ASSETS+=("openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz")
-      ;;
-  esac
-  CHECKSUM_FILES+=("openshell-gateway-checksums-sha256.txt")
-  CHECKSUM_FILES+=("openshell-sandbox-checksums-sha256.txt")
-fi
+case "$OS" in
+  Darwin)
+    case "$ARCH_LABEL" in
+      aarch64)
+        ASSETS+=("openshell-gateway-aarch64-apple-darwin.tar.gz")
+        CHECKSUM_FILES+=("openshell-gateway-checksums-sha256.txt")
+        ;;
+      x86_64)
+        fail "OpenShell ${PIN_VERSION} does not publish a macOS x86_64 Docker-driver gateway asset."
+        ;;
+    esac
+    ;;
+  Linux)
+    case "$ARCH_LABEL" in
+      x86_64)
+        ASSETS+=("openshell-gateway-x86_64-unknown-linux-gnu.tar.gz")
+        ASSETS+=("openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz")
+        ;;
+      aarch64)
+        ASSETS+=("openshell-gateway-aarch64-unknown-linux-gnu.tar.gz")
+        ASSETS+=("openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz")
+        ;;
+    esac
+    CHECKSUM_FILES+=("openshell-gateway-checksums-sha256.txt")
+    CHECKSUM_FILES+=("openshell-sandbox-checksums-sha256.txt")
+    ;;
+esac
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1549,7 +1549,7 @@ function validateSandboxGpuPreflight(config: SandboxGpuConfig): void {
     process.exit(1);
   }
   if (!config.sandboxGpuEnabled) return;
-  if (!isLinuxDockerDriverGatewayEnabled()) return;
+  if (!isLinuxDockerDriverGatewayPlatform()) return;
 
   const cdiSpecDirs = getDockerCdiSpecDirs();
   const cdiSpecFiles = findReadableNvidiaCdiSpecFiles(cdiSpecDirs);
@@ -3790,6 +3790,12 @@ function isLinuxDockerDriverGatewayEnabled(
   return platform === "linux" || platform === "darwin";
 }
 
+function isLinuxDockerDriverGatewayPlatform(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === "linux";
+}
+
 function getDockerDriverGatewayEndpoint(): string {
   return `http://127.0.0.1:${GATEWAY_PORT}`;
 }
@@ -4651,7 +4657,7 @@ async function preflight(
   if (host.runtime !== "unknown") {
     console.log(`  ✓ Container runtime: ${host.runtime}`);
   }
-  if (isLinuxDockerDriverGatewayEnabled() && host.runtime === "podman") {
+  if (isLinuxDockerDriverGatewayPlatform() && host.runtime === "podman") {
     console.error("  ✗ NemoClaw Linux onboarding now uses OpenShell's Docker driver.");
     console.error("    Podman is not supported for this NemoClaw integration path.");
     console.error("    Switch to Docker Engine and rerun onboarding.");
@@ -5768,7 +5774,11 @@ function getSandboxRuntimeRegistryFields(
     sandboxGpuEnabled: config.sandboxGpuEnabled,
     sandboxGpuMode: config.mode,
     sandboxGpuDevice: config.sandboxGpuDevice,
-    openshellDriver: isLinuxDockerDriverGatewayEnabled() ? "docker" : "kubernetes",
+    openshellDriver: process.platform === "darwin"
+      ? "vm"
+      : isLinuxDockerDriverGatewayEnabled()
+        ? "docker"
+        : "kubernetes",
     openshellVersion: getInstalledOpenshellVersion(
       runCaptureOpenshell(["--version"], { ignoreError: true }),
     ),
@@ -6994,7 +7004,7 @@ async function createSandbox(
 
   // DNS proxy — run a forwarder in the sandbox pod so the isolated
   // sandbox namespace can resolve hostnames (fixes #626).
-  if (!isLinuxDockerDriverGatewayEnabled()) {
+  if (!isLinuxDockerDriverGatewayPlatform()) {
     console.log("  Setting up sandbox DNS proxy...");
     runFile("bash", [path.join(SCRIPTS, "setup-dns-proxy.sh"), GATEWAY_NAME, sandboxName], {
       ignoreError: true,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3786,8 +3786,9 @@ function getGatewayLocalEndpoint(): string {
 
 function isLinuxDockerDriverGatewayEnabled(
   platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
 ): boolean {
-  return platform === "linux" || platform === "darwin";
+  return platform === "linux" || (platform === "darwin" && arch === "arm64");
 }
 
 function isLinuxDockerDriverGatewayPlatform(
@@ -3876,20 +3877,20 @@ function areRequiredDockerDriverBinariesPresent(
     sandboxBin?: string | null;
     vmDriverBin?: string | null;
   } = {},
+  arch: NodeJS.Architecture = process.arch,
 ): boolean {
-  if (!isLinuxDockerDriverGatewayEnabled(platform)) return true;
+  if (!isLinuxDockerDriverGatewayEnabled(platform, arch)) return true;
   const gatewayBin = Object.prototype.hasOwnProperty.call(binaries, "gatewayBin")
     ? binaries.gatewayBin
     : resolveOpenShellGatewayBinary();
   const sandboxBin = Object.prototype.hasOwnProperty.call(binaries, "sandboxBin")
     ? binaries.sandboxBin
     : resolveOpenShellSandboxBinary();
-  const vmDriverBin = Object.prototype.hasOwnProperty.call(binaries, "vmDriverBin")
-    ? binaries.vmDriverBin
-    : resolveOpenShellVmDriverBinary();
+  const hasVmDriverBin = Object.prototype.hasOwnProperty.call(binaries, "vmDriverBin");
+  const vmDriverBin = hasVmDriverBin ? binaries.vmDriverBin : resolveOpenShellVmDriverBinary();
   if (!gatewayBin) return false;
   if (platform === "linux" && !sandboxBin) return false;
-  if (platform === "darwin" && !vmDriverBin) return false;
+  if (platform === "darwin" && hasVmDriverBin && !vmDriverBin) return false;
   return true;
 }
 
@@ -5774,11 +5775,11 @@ function getSandboxRuntimeRegistryFields(
     sandboxGpuEnabled: config.sandboxGpuEnabled,
     sandboxGpuMode: config.mode,
     sandboxGpuDevice: config.sandboxGpuDevice,
-    openshellDriver: process.platform === "darwin"
-      ? "vm"
-      : isLinuxDockerDriverGatewayEnabled()
-        ? "docker"
-        : "kubernetes",
+    openshellDriver: isLinuxDockerDriverGatewayEnabled()
+      ? process.platform === "darwin"
+        ? "vm"
+        : "docker"
+      : "kubernetes",
     openshellVersion: getInstalledOpenshellVersion(
       runCaptureOpenshell(["--version"], { ignoreError: true }),
     ),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3842,12 +3842,48 @@ function resolveOpenShellSandboxBinary(): string | null {
   return null;
 }
 
+function resolveOpenShellVmDriverBinary(): string | null {
+  const configuredDir = process.env.OPENSHELL_DRIVER_DIR;
+  if (configuredDir && configuredDir.trim()) {
+    const configured = path.join(path.resolve(configuredDir.trim()), "openshell-driver-vm");
+    if (fs.existsSync(configured)) return configured;
+  }
+  const sibling = resolveSiblingBinary("openshell-driver-vm");
+  if (sibling) return sibling;
+  for (const candidate of [
+    path.join(os.homedir(), ".local", "bin", "openshell-driver-vm"),
+    path.join(os.homedir(), ".local", "libexec", "openshell", "openshell-driver-vm"),
+    "/usr/local/bin/openshell-driver-vm",
+    "/usr/local/libexec/openshell/openshell-driver-vm",
+    "/usr/local/libexec/openshell-driver-vm",
+    "/usr/bin/openshell-driver-vm",
+  ]) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
 function areRequiredDockerDriverBinariesPresent(
   platform: NodeJS.Platform = process.platform,
+  binaries: {
+    gatewayBin?: string | null;
+    sandboxBin?: string | null;
+    vmDriverBin?: string | null;
+  } = {},
 ): boolean {
   if (!isLinuxDockerDriverGatewayEnabled(platform)) return true;
-  if (!resolveOpenShellGatewayBinary()) return false;
-  if (platform === "linux" && !resolveOpenShellSandboxBinary()) return false;
+  const gatewayBin = Object.prototype.hasOwnProperty.call(binaries, "gatewayBin")
+    ? binaries.gatewayBin
+    : resolveOpenShellGatewayBinary();
+  const sandboxBin = Object.prototype.hasOwnProperty.call(binaries, "sandboxBin")
+    ? binaries.sandboxBin
+    : resolveOpenShellSandboxBinary();
+  const vmDriverBin = Object.prototype.hasOwnProperty.call(binaries, "vmDriverBin")
+    ? binaries.vmDriverBin
+    : resolveOpenShellVmDriverBinary();
+  if (!gatewayBin) return false;
+  if (platform === "linux" && !sandboxBin) return false;
+  if (platform === "darwin" && !vmDriverBin) return false;
   return true;
 }
 
@@ -3865,25 +3901,37 @@ function getOpenShellDockerSupervisorImage(versionOutput: string | null = null):
 
 function getDockerDriverGatewayEnv(
   versionOutput: string | null = null,
+  platform: NodeJS.Platform = process.platform,
 ): Record<string, string> {
   const stateDir = getDockerDriverGatewayStateDir();
   const env: Record<string, string> = {
-    OPENSHELL_DRIVERS: "docker",
+    OPENSHELL_DRIVERS: platform === "darwin" ? "vm" : "docker",
     OPENSHELL_BIND_ADDRESS: "127.0.0.1",
     OPENSHELL_SERVER_PORT: String(GATEWAY_PORT),
     OPENSHELL_DISABLE_TLS: "true",
     OPENSHELL_DISABLE_GATEWAY_AUTH: "true",
     OPENSHELL_DB_URL: `sqlite:${path.join(stateDir, "openshell.db")}`,
-    OPENSHELL_GRPC_ENDPOINT: getDockerDriverGatewayEndpoint(),
+    OPENSHELL_GRPC_ENDPOINT:
+      platform === "darwin"
+        ? `http://host.containers.internal:${GATEWAY_PORT}`
+        : getDockerDriverGatewayEndpoint(),
     OPENSHELL_SSH_GATEWAY_HOST: "127.0.0.1",
     OPENSHELL_SSH_GATEWAY_PORT: String(GATEWAY_PORT),
-    OPENSHELL_DOCKER_NETWORK_NAME:
-      process.env.OPENSHELL_DOCKER_NETWORK_NAME || "openshell-docker",
-    OPENSHELL_DOCKER_SUPERVISOR_IMAGE: getOpenShellDockerSupervisorImage(versionOutput),
   };
-  const sandboxBin = resolveOpenShellSandboxBinary();
-  if (sandboxBin) {
-    env.OPENSHELL_DOCKER_SUPERVISOR_BIN = sandboxBin;
+  if (platform === "darwin") {
+    env.OPENSHELL_VM_DRIVER_STATE_DIR = path.join(stateDir, "vm-driver");
+    const vmDriverBin = resolveOpenShellVmDriverBinary();
+    if (vmDriverBin) {
+      env.OPENSHELL_DRIVER_DIR = path.dirname(vmDriverBin);
+    }
+  } else {
+    env.OPENSHELL_DOCKER_NETWORK_NAME =
+      process.env.OPENSHELL_DOCKER_NETWORK_NAME || "openshell-docker";
+    env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE = getOpenShellDockerSupervisorImage(versionOutput);
+    const sandboxBin = resolveOpenShellSandboxBinary();
+    if (sandboxBin) {
+      env.OPENSHELL_DOCKER_SUPERVISOR_BIN = sandboxBin;
+    }
   }
   return env;
 }
@@ -3957,6 +4005,10 @@ function normalizeGatewayExecutablePath(value: string | null | undefined): strin
 
 type DockerDriverGatewayRuntimeDrift = { reason: string };
 
+function shouldRequireDockerDriverEnv(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "linux";
+}
+
 const DOCKER_DRIVER_GATEWAY_RUNTIME_ENV_KEYS = [
   "OPENSHELL_DRIVERS",
   "OPENSHELL_BIND_ADDRESS",
@@ -4013,7 +4065,9 @@ function getDockerDriverGatewayRuntimeDrift(
   pid: number,
   desiredEnv: Record<string, string>,
   gatewayBin?: string | null,
+  platform: NodeJS.Platform = process.platform,
 ): DockerDriverGatewayRuntimeDrift | null {
+  if (!shouldRequireDockerDriverEnv(platform)) return null;
   return getDockerDriverGatewayRuntimeDriftFromSnapshot({
     processEnv: readProcessEnv(pid),
     processExe: readProcessExe(pid),
@@ -4052,7 +4106,7 @@ function isDockerDriverGatewayProcessAlive(): boolean {
   const pid = getDockerDriverGatewayPid();
   if (pid === null || !isPidAlive(pid)) return false;
   if (!isDockerDriverGatewayProcess(pid, resolveOpenShellGatewayBinary(), {
-    requireDockerDriverEnv: true,
+    requireDockerDriverEnv: shouldRequireDockerDriverEnv(),
   })) {
     fs.rmSync(getDockerDriverGatewayPidFile(), { force: true });
     return false;
@@ -4090,7 +4144,9 @@ function getDockerDriverGatewayPortListenerPid(
   const isGateway =
     opts.isDockerDriverGatewayProcessFn ??
     ((candidatePid: number, gatewayBin?: string | null) =>
-      isDockerDriverGatewayProcess(candidatePid, gatewayBin, { requireDockerDriverEnv: true }));
+      isDockerDriverGatewayProcess(candidatePid, gatewayBin, {
+        requireDockerDriverEnv: shouldRequireDockerDriverEnv(opts.platform ?? process.platform),
+      }));
   if (!isGateway(pid, opts.gatewayBin)) return null;
   return pid;
 }
@@ -4703,9 +4759,14 @@ async function preflight(
         if (needsDevChannel) {
           console.log("  OpenShell Docker-driver onboarding requires the dev channel. Upgrading...");
         } else if (needsDockerDriverBinaries) {
-          const required = process.platform === "linux" ? "gateway and sandbox" : "gateway";
+          const required =
+            process.platform === "linux"
+              ? "gateway and sandbox"
+              : process.platform === "darwin"
+                ? "gateway and VM driver"
+                : "gateway";
           console.log(
-            `  OpenShell Docker-driver onboarding requires the ${required} binaries. Reinstalling...`,
+            `  OpenShell standalone gateway onboarding requires the ${required} binaries. Reinstalling...`,
           );
         } else {
           console.log(
@@ -11898,6 +11959,7 @@ module.exports = {
   formatEnvAssignment,
   getFutureShellPathHint,
   areRequiredDockerDriverBinariesPresent,
+  shouldRequireDockerDriverEnv,
   getGatewayBootstrapRepairPlan,
   getGatewayLocalEndpoint,
   getGatewayStartEnv,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4135,13 +4135,20 @@ function getDockerDriverGatewayPortListenerPid(
   portCheck: import("./onboard/preflight").PortProbeResult,
   opts: {
     platform?: NodeJS.Platform;
+    arch?: NodeJS.Architecture;
     gatewayBin?: string | null;
     isPidAliveFn?: (pid: number) => boolean;
     isDockerDriverGatewayProcessFn?: (pid: number, gatewayBin?: string | null) => boolean;
   } = {},
 ): number | null {
   if (portCheck.ok) return null;
-  if (!isLinuxDockerDriverGatewayEnabled(opts.platform ?? process.platform)) return null;
+  if (
+    !isLinuxDockerDriverGatewayEnabled(
+      opts.platform ?? process.platform,
+      opts.arch ?? process.arch,
+    )
+  )
+    return null;
   const pid = Number(portCheck.pid);
   if (!Number.isInteger(pid) || pid <= 0) return null;
   const proc = String(portCheck.process || "").toLowerCase();

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3787,7 +3787,7 @@ function getGatewayLocalEndpoint(): string {
 function isLinuxDockerDriverGatewayEnabled(
   platform: NodeJS.Platform = process.platform,
 ): boolean {
-  return platform === "linux";
+  return platform === "linux" || platform === "darwin";
 }
 
 function getDockerDriverGatewayEndpoint(): string {
@@ -3840,6 +3840,15 @@ function resolveOpenShellSandboxBinary(): string | null {
     if (fs.existsSync(candidate)) return candidate;
   }
   return null;
+}
+
+function areRequiredDockerDriverBinariesPresent(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (!isLinuxDockerDriverGatewayEnabled(platform)) return true;
+  if (!resolveOpenShellGatewayBinary()) return false;
+  if (platform === "linux" && !resolveOpenShellSandboxBinary()) return false;
+  return true;
 }
 
 function getOpenShellDockerSupervisorImage(versionOutput: string | null = null): string {
@@ -4685,8 +4694,7 @@ async function preflight(
         shouldUseOpenshellDevChannel() &&
         !isOpenshellDevVersion(currentVersionOutput);
       const needsDockerDriverBinaries =
-        isLinuxDockerDriverGatewayEnabled() &&
-        (!resolveOpenShellGatewayBinary() || !resolveOpenShellSandboxBinary());
+        isLinuxDockerDriverGatewayEnabled() && !areRequiredDockerDriverBinariesPresent();
       const needsUpgrade =
         !versionGte(currentVersion, minOpenshellVersion) ||
         needsDevChannel ||
@@ -4695,8 +4703,9 @@ async function preflight(
         if (needsDevChannel) {
           console.log("  OpenShell Docker-driver onboarding requires the dev channel. Upgrading...");
         } else if (needsDockerDriverBinaries) {
+          const required = process.platform === "linux" ? "gateway and sandbox" : "gateway";
           console.log(
-            "  OpenShell Docker-driver onboarding requires the gateway and sandbox binaries. Reinstalling...",
+            `  OpenShell Docker-driver onboarding requires the ${required} binaries. Reinstalling...`,
           );
         } else {
           console.log(
@@ -11888,6 +11897,7 @@ module.exports = {
   ensureValidatedBraveSearchCredential,
   formatEnvAssignment,
   getFutureShellPathHint,
+  areRequiredDockerDriverBinariesPresent,
   getGatewayBootstrapRepairPlan,
   getGatewayLocalEndpoint,
   getGatewayStartEnv,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1292,7 +1292,7 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("--sandbox");
   });
 
-  it("debug warns when default sandbox is stale", testTimeoutOptions(), () => {
+  it("debug warns when default sandbox is stale", testTimeoutOptions(30_000), () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-stale-"));
     fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
     fs.writeFileSync(
@@ -1300,7 +1300,7 @@ describe("CLI dispatch", () => {
       JSON.stringify({ sandboxes: {}, defaultSandbox: "ghost" }),
       { mode: 0o600 },
     );
-    const r = runWithEnv("debug --quick 2>&1", { HOME: home });
+    const r = runWithEnv("debug --quick 2>&1", { HOME: home }, 30000);
     expect(r.code).toBe(0);
     expect(r.out).toContain("Warning");
     expect(r.out).toContain("ghost");

--- a/test/install-openshell-version-check.test.ts
+++ b/test/install-openshell-version-check.test.ts
@@ -129,11 +129,97 @@ describe("install-openshell.sh version check", { timeout: 15_000 }, () => {
     expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.37'/);
   });
 
-  it("declares the macOS arm64 gateway helper asset", () => {
-    const source = fs.readFileSync(SCRIPT, "utf-8");
-    expect(source).toContain("openshell-gateway-aarch64-apple-darwin.tar.gz");
-    expect(source).toContain("openshell-driver-vm-aarch64-apple-darwin.tar.gz");
-    expect(source).toContain("openshell-gateway-checksums-sha256.txt");
+  it("downloads the macOS arm64 gateway and VM helper assets during reinstall", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openshell-macos-assets-"));
+    try {
+      const fakeBin = path.join(tmp, "bin");
+      const downloadLog = path.join(tmp, "downloads.log");
+      fs.mkdirSync(fakeBin);
+
+      writeExecutable(
+        path.join(fakeBin, "uname"),
+        `#!/usr/bin/env bash
+if [ "\${1:-}" = "-m" ]; then echo "arm64"; else echo "Darwin"; fi`,
+      );
+      writeExecutable(
+        path.join(fakeBin, "openshell"),
+        `#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then echo "openshell 0.0.36"; exit 0; fi
+exit 99`,
+      );
+      writeExecutable(
+        path.join(fakeBin, "gh"),
+        `#!/usr/bin/env bash
+exit 1`,
+      );
+      writeExecutable(
+        path.join(fakeBin, "curl"),
+        `#!/usr/bin/env bash
+echo "$@" >> ${JSON.stringify(downloadLog)}
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift || true
+done
+if [ -n "$out" ]; then
+  case "$(basename "$out")" in
+  openshell-checksums-sha256.txt)
+    printf '%s\n' \
+      'ignored  openshell-aarch64-apple-darwin.tar.gz' \
+      'ignored  openshell-driver-vm-aarch64-apple-darwin.tar.gz' > "$out"
+    ;;
+  openshell-gateway-checksums-sha256.txt)
+    printf '%s\n' \
+      'ignored  openshell-gateway-aarch64-apple-darwin.tar.gz' > "$out"
+    ;;
+  *)
+    : > "$out"
+    ;;
+  esac
+fi
+exit 0`,
+      );
+      writeExecutable(
+        path.join(fakeBin, "shasum"),
+        `#!/usr/bin/env bash
+cat >/dev/null
+echo "checksum OK"
+exit 0`,
+      );
+      writeExecutable(
+        path.join(fakeBin, "tar"),
+        `#!/usr/bin/env bash
+exit 0`,
+      );
+      writeExecutable(
+        path.join(fakeBin, "install"),
+        `#!/usr/bin/env bash
+exit 0`,
+      );
+
+      const result = spawnSync("bash", [SCRIPT], {
+        env: {
+          ...process.env,
+          HOME: tmp,
+          XDG_BIN_HOME: path.join(tmp, "local-bin"),
+          NEMOCLAW_OPENSHELL_CHANNEL: "stable",
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+        },
+        encoding: "utf8",
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      const downloads = fs.readFileSync(downloadLog, "utf-8");
+      expect(downloads).toContain("openshell-aarch64-apple-darwin.tar.gz");
+      expect(downloads).toContain("openshell-gateway-aarch64-apple-darwin.tar.gz");
+      expect(downloads).toContain("openshell-driver-vm-aarch64-apple-darwin.tar.gz");
+      expect(downloads).toContain("openshell-gateway-checksums-sha256.txt");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("triggers upgrade when openshell 0.0.36 is installed (below current floor)", () => {

--- a/test/install-openshell-version-check.test.ts
+++ b/test/install-openshell-version-check.test.ts
@@ -22,20 +22,18 @@ function writeExecutable(target: string, contents: string) {
 function runWithInstalledVersion(
   version: string,
   extraEnv: NodeJS.ProcessEnv = {},
-  options: { driverBins?: boolean | "gateway"; os?: string; arch?: string } = {},
+  options: { driverBins?: boolean | "gateway" | "gateway-vm"; os?: string; arch?: string } = {},
 ) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openshell-ver-"));
   try {
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
 
-    if (options.os || options.arch) {
-      writeExecutable(
-        path.join(fakeBin, "uname"),
-        `#!/usr/bin/env bash
+    writeExecutable(
+      path.join(fakeBin, "uname"),
+      `#!/usr/bin/env bash
 if [ "\${1:-}" = "-m" ]; then echo "${options.arch ?? "x86_64"}"; else echo "${options.os ?? "Linux"}"; fi`,
-      );
-    }
+    );
 
     // Fake openshell that reports the given version
     writeExecutable(
@@ -55,6 +53,13 @@ exit 0`,
     if (options.driverBins !== false && options.driverBins !== "gateway") {
       writeExecutable(
         path.join(fakeBin, "openshell-sandbox"),
+        `#!/usr/bin/env bash
+exit 0`,
+      );
+    }
+    if (options.driverBins === "gateway-vm") {
+      writeExecutable(
+        path.join(fakeBin, "openshell-driver-vm"),
         `#!/usr/bin/env bash
 exit 0`,
       );
@@ -103,9 +108,9 @@ describe("install-openshell.sh version check", { timeout: 15_000 }, () => {
     expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.37'/);
   });
 
-  it("accepts macOS openshell 0.0.37 when the gateway binary is installed", () => {
+  it("accepts macOS openshell 0.0.37 when the gateway and VM driver binaries are installed", () => {
     const result = runWithInstalledVersion("0.0.37", {}, {
-      driverBins: "gateway",
+      driverBins: "gateway-vm",
       os: "Darwin",
       arch: "arm64",
     });
@@ -127,6 +132,7 @@ describe("install-openshell.sh version check", { timeout: 15_000 }, () => {
   it("declares the macOS arm64 gateway helper asset", () => {
     const source = fs.readFileSync(SCRIPT, "utf-8");
     expect(source).toContain("openshell-gateway-aarch64-apple-darwin.tar.gz");
+    expect(source).toContain("openshell-driver-vm-aarch64-apple-darwin.tar.gz");
     expect(source).toContain("openshell-gateway-checksums-sha256.txt");
   });
 

--- a/test/install-openshell-version-check.test.ts
+++ b/test/install-openshell-version-check.test.ts
@@ -22,7 +22,7 @@ function writeExecutable(target: string, contents: string) {
 function runWithInstalledVersion(
   version: string,
   extraEnv: NodeJS.ProcessEnv = {},
-  options: { driverBins?: boolean; os?: string; arch?: string } = {},
+  options: { driverBins?: boolean | "gateway"; os?: string; arch?: string } = {},
 ) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openshell-ver-"));
   try {
@@ -51,6 +51,8 @@ exit 99`,
         `#!/usr/bin/env bash
 exit 0`,
       );
+    }
+    if (options.driverBins !== false && options.driverBins !== "gateway") {
       writeExecutable(
         path.join(fakeBin, "openshell-sandbox"),
         `#!/usr/bin/env bash
@@ -99,6 +101,33 @@ describe("install-openshell.sh version check", { timeout: 15_000 }, () => {
     expect(result.status).not.toBe(0);
     expect(result.stdout).toMatch(/missing Docker-driver binaries/);
     expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.37'/);
+  });
+
+  it("accepts macOS openshell 0.0.37 when the gateway binary is installed", () => {
+    const result = runWithInstalledVersion("0.0.37", {}, {
+      driverBins: "gateway",
+      os: "Darwin",
+      arch: "arm64",
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/already installed.*0\.0\.37/);
+  });
+
+  it("triggers reinstall when macOS openshell 0.0.37 is missing the gateway binary", () => {
+    const result = runWithInstalledVersion("0.0.37", {}, {
+      driverBins: false,
+      os: "Darwin",
+      arch: "arm64",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toMatch(/missing Docker-driver binaries/);
+    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.37'/);
+  });
+
+  it("declares the macOS arm64 gateway helper asset", () => {
+    const source = fs.readFileSync(SCRIPT, "utf-8");
+    expect(source).toContain("openshell-gateway-aarch64-apple-darwin.tar.gz");
+    expect(source).toContain("openshell-gateway-checksums-sha256.txt");
   });
 
   it("triggers upgrade when openshell 0.0.36 is installed (below current floor)", () => {

--- a/test/onboard-preset-diff.test.ts
+++ b/test/onboard-preset-diff.test.ts
@@ -66,8 +66,11 @@ resolver.resolveOpenshell = () => "/fake/openshell";
 
 const runner = require(${runnerPath});
 runner.run = () => {};
-// Return "Running" so waitForSandboxReady passes immediately.
-runner.runCapture = () => "Running";
+runner.runCapture = (command) => {
+  const text = Array.isArray(command) ? command.join(" ") : String(command);
+  if (text.includes("sandbox list")) return "test-sb Ready";
+  return "Running";
+};
 
 const credentials = require(${credPath});
 credentials.prompt = async (msg) => { throw new Error("unexpected prompt: " + msg); };

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -421,7 +421,8 @@ network_policies:
 
   it("models the OpenShell standalone gateway environment", () => {
     expect(isLinuxDockerDriverGatewayEnabled("linux")).toBe(true);
-    expect(isLinuxDockerDriverGatewayEnabled("darwin")).toBe(true);
+    expect(isLinuxDockerDriverGatewayEnabled("darwin", "arm64")).toBe(true);
+    expect(isLinuxDockerDriverGatewayEnabled("darwin", "x64")).toBe(false);
     expect(isLinuxDockerDriverGatewayEnabled("win32")).toBe(false);
     const linuxEnv = getDockerDriverGatewayEnv("openshell 0.0.37", "linux");
     expect(linuxEnv.OPENSHELL_DRIVERS).toBe("docker");
@@ -438,11 +439,15 @@ network_policies:
 
   it("requires platform-specific Docker-driver binaries", () => {
     expect(
-      areRequiredDockerDriverBinariesPresent("darwin", {
-        gatewayBin: "/tmp/openshell-gateway",
-        sandboxBin: null,
-        vmDriverBin: "/tmp/openshell-driver-vm",
-      }),
+      areRequiredDockerDriverBinariesPresent(
+        "darwin",
+        {
+          gatewayBin: "/tmp/openshell-gateway",
+          sandboxBin: null,
+          vmDriverBin: "/tmp/openshell-driver-vm",
+        },
+        "arm64",
+      ),
     ).toBe(true);
     expect(
       areRequiredDockerDriverBinariesPresent("linux", {
@@ -459,19 +464,47 @@ network_policies:
       }),
     ).toBe(true);
     expect(
-      areRequiredDockerDriverBinariesPresent("darwin", {
-        gatewayBin: "/tmp/openshell-gateway",
-        sandboxBin: null,
-        vmDriverBin: null,
-      }),
+      areRequiredDockerDriverBinariesPresent(
+        "darwin",
+        {
+          gatewayBin: "/tmp/openshell-gateway",
+          sandboxBin: null,
+        },
+        "arm64",
+      ),
+    ).toBe(true);
+    expect(
+      areRequiredDockerDriverBinariesPresent(
+        "darwin",
+        {
+          gatewayBin: "/tmp/openshell-gateway",
+          sandboxBin: null,
+          vmDriverBin: null,
+        },
+        "arm64",
+      ),
     ).toBe(false);
     expect(
-      areRequiredDockerDriverBinariesPresent("darwin", {
-        gatewayBin: null,
-        sandboxBin: "/tmp/openshell-sandbox",
-        vmDriverBin: "/tmp/openshell-driver-vm",
-      }),
+      areRequiredDockerDriverBinariesPresent(
+        "darwin",
+        {
+          gatewayBin: null,
+          sandboxBin: "/tmp/openshell-sandbox",
+          vmDriverBin: "/tmp/openshell-driver-vm",
+        },
+        "arm64",
+      ),
     ).toBe(false);
+    expect(
+      areRequiredDockerDriverBinariesPresent(
+        "darwin",
+        {
+          gatewayBin: null,
+          sandboxBin: null,
+        },
+        "x64",
+      ),
+    ).toBe(true);
   });
 
   it("requires Docker-driver process env verification only where /proc is available", () => {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -116,6 +116,7 @@ type OnboardTestInternals = {
     },
     opts?: {
       platform?: NodeJS.Platform;
+      arch?: NodeJS.Architecture;
       gatewayBin?: string | null;
       isPidAliveFn?: (pid: number) => boolean;
       isDockerDriverGatewayProcessFn?: (pid: number, gatewayBin?: string | null) => boolean;
@@ -582,7 +583,7 @@ network_policies:
     expect(
       isDockerDriverGatewayPortListener(
         { ok: false, process: "openshell", pid: 1234 },
-        { ...opts, platform: "darwin" },
+        { ...opts, platform: "darwin", arch: "arm64" },
       ),
     ).toBe(true);
     expect(

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -84,8 +84,19 @@ type OnboardTestInternals = {
   getInstalledOpenshellVersion: (versionOutput?: string | null) => string | null;
   getBlueprintMinOpenshellVersion: (rootDir?: string) => string | null;
   getBlueprintMaxOpenshellVersion: (rootDir?: string) => string | null;
-  getDockerDriverGatewayEnv: (versionOutput?: string | null) => Record<string, string>;
-  areRequiredDockerDriverBinariesPresent: (platform?: NodeJS.Platform) => boolean;
+  getDockerDriverGatewayEnv: (
+    versionOutput?: string | null,
+    platform?: NodeJS.Platform,
+  ) => Record<string, string>;
+  areRequiredDockerDriverBinariesPresent: (
+    platform?: NodeJS.Platform,
+    binaries?: {
+      gatewayBin?: string | null;
+      sandboxBin?: string | null;
+      vmDriverBin?: string | null;
+    },
+  ) => boolean;
+  shouldRequireDockerDriverEnv: (platform?: NodeJS.Platform) => boolean;
   getDockerDriverGatewayRuntimeDriftFromSnapshot: (snapshot: {
     processEnv: Record<string, string> | null;
     processExe: string | null;
@@ -209,6 +220,7 @@ function isOnboardTestInternals(
     typeof value.classifySandboxCreateFailure === "function" &&
     typeof value.getDockerDriverGatewayEnv === "function" &&
     typeof value.areRequiredDockerDriverBinariesPresent === "function" &&
+    typeof value.shouldRequireDockerDriverEnv === "function" &&
     typeof value.getDockerDriverGatewayRuntimeDriftFromSnapshot === "function" &&
     typeof value.isLinuxDockerDriverGatewayEnabled === "function" &&
     typeof value.isDockerDriverGatewayPortListener === "function" &&
@@ -266,6 +278,7 @@ const {
   getBlueprintMaxOpenshellVersion,
   getDockerDriverGatewayEnv,
   areRequiredDockerDriverBinariesPresent,
+  shouldRequireDockerDriverEnv,
   getDockerDriverGatewayRuntimeDriftFromSnapshot,
   isLinuxDockerDriverGatewayEnabled,
   isDockerDriverGatewayPortListener,
@@ -406,47 +419,69 @@ network_policies:
     ]);
   });
 
-  it("models the OpenShell Docker-driver gateway environment", () => {
+  it("models the OpenShell standalone gateway environment", () => {
     expect(isLinuxDockerDriverGatewayEnabled("linux")).toBe(true);
     expect(isLinuxDockerDriverGatewayEnabled("darwin")).toBe(true);
     expect(isLinuxDockerDriverGatewayEnabled("win32")).toBe(false);
-    const env = getDockerDriverGatewayEnv("openshell 0.0.37");
-    expect(env.OPENSHELL_DRIVERS).toBe("docker");
-    expect(env.OPENSHELL_GRPC_ENDPOINT).toBe("http://127.0.0.1:8080");
-    expect(env.OPENSHELL_CLUSTER_IMAGE).toBeUndefined();
-    expect(env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE).toContain(":0.0.37");
+    const linuxEnv = getDockerDriverGatewayEnv("openshell 0.0.37", "linux");
+    expect(linuxEnv.OPENSHELL_DRIVERS).toBe("docker");
+    expect(linuxEnv.OPENSHELL_GRPC_ENDPOINT).toBe("http://127.0.0.1:8080");
+    expect(linuxEnv.OPENSHELL_CLUSTER_IMAGE).toBeUndefined();
+    expect(linuxEnv.OPENSHELL_DOCKER_SUPERVISOR_IMAGE).toContain(":0.0.37");
+
+    const darwinEnv = getDockerDriverGatewayEnv("openshell 0.0.37", "darwin");
+    expect(darwinEnv.OPENSHELL_DRIVERS).toBe("vm");
+    expect(darwinEnv.OPENSHELL_GRPC_ENDPOINT).toBe("http://host.containers.internal:8080");
+    expect(darwinEnv.OPENSHELL_VM_DRIVER_STATE_DIR).toContain("vm-driver");
+    expect(darwinEnv.OPENSHELL_DOCKER_SUPERVISOR_IMAGE).toBeUndefined();
   });
 
   it("requires platform-specific Docker-driver binaries", () => {
-    const oldGateway = process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN;
-    const oldSandbox = process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN;
-    try {
-      process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN = "/tmp/openshell-gateway";
-      delete process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN;
-      expect(areRequiredDockerDriverBinariesPresent("darwin")).toBe(true);
-      expect(areRequiredDockerDriverBinariesPresent("linux")).toBe(false);
+    expect(
+      areRequiredDockerDriverBinariesPresent("darwin", {
+        gatewayBin: "/tmp/openshell-gateway",
+        sandboxBin: null,
+        vmDriverBin: "/tmp/openshell-driver-vm",
+      }),
+    ).toBe(true);
+    expect(
+      areRequiredDockerDriverBinariesPresent("linux", {
+        gatewayBin: "/tmp/openshell-gateway",
+        sandboxBin: null,
+        vmDriverBin: null,
+      }),
+    ).toBe(false);
+    expect(
+      areRequiredDockerDriverBinariesPresent("linux", {
+        gatewayBin: "/tmp/openshell-gateway",
+        sandboxBin: "/tmp/openshell-sandbox",
+        vmDriverBin: null,
+      }),
+    ).toBe(true);
+    expect(
+      areRequiredDockerDriverBinariesPresent("darwin", {
+        gatewayBin: "/tmp/openshell-gateway",
+        sandboxBin: null,
+        vmDriverBin: null,
+      }),
+    ).toBe(false);
+    expect(
+      areRequiredDockerDriverBinariesPresent("darwin", {
+        gatewayBin: null,
+        sandboxBin: "/tmp/openshell-sandbox",
+        vmDriverBin: "/tmp/openshell-driver-vm",
+      }),
+    ).toBe(false);
+  });
 
-      process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN = "/tmp/openshell-sandbox";
-      expect(areRequiredDockerDriverBinariesPresent("linux")).toBe(true);
-
-      delete process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN;
-      expect(areRequiredDockerDriverBinariesPresent("darwin")).toBe(false);
-    } finally {
-      if (oldGateway === undefined) {
-        delete process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN;
-      } else {
-        process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN = oldGateway;
-      }
-      if (oldSandbox === undefined) {
-        delete process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN;
-      } else {
-        process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN = oldSandbox;
-      }
-    }
+  it("requires Docker-driver process env verification only where /proc is available", () => {
+    expect(shouldRequireDockerDriverEnv("linux")).toBe(true);
+    expect(shouldRequireDockerDriverEnv("darwin")).toBe(false);
+    expect(shouldRequireDockerDriverEnv("win32")).toBe(false);
   });
 
   it("detects stale Docker-driver gateway runtime state before reuse", () => {
-    const desiredEnv = getDockerDriverGatewayEnv("openshell 0.0.37");
+    const desiredEnv = getDockerDriverGatewayEnv("openshell 0.0.37", "linux");
     const gatewayBin = process.execPath;
 
     expect(

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -95,6 +95,7 @@ type OnboardTestInternals = {
       sandboxBin?: string | null;
       vmDriverBin?: string | null;
     },
+    arch?: NodeJS.Architecture,
   ) => boolean;
   shouldRequireDockerDriverEnv: (platform?: NodeJS.Platform) => boolean;
   getDockerDriverGatewayRuntimeDriftFromSnapshot: (snapshot: {
@@ -103,7 +104,10 @@ type OnboardTestInternals = {
     desiredEnv: Record<string, string>;
     gatewayBin?: string | null;
   }) => { reason: string } | null;
-  isLinuxDockerDriverGatewayEnabled: (platform?: NodeJS.Platform) => boolean;
+  isLinuxDockerDriverGatewayEnabled: (
+    platform?: NodeJS.Platform,
+    arch?: NodeJS.Architecture,
+  ) => boolean;
   isDockerDriverGatewayPortListener: (
     portCheck: {
       ok: boolean;

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -85,6 +85,7 @@ type OnboardTestInternals = {
   getBlueprintMinOpenshellVersion: (rootDir?: string) => string | null;
   getBlueprintMaxOpenshellVersion: (rootDir?: string) => string | null;
   getDockerDriverGatewayEnv: (versionOutput?: string | null) => Record<string, string>;
+  areRequiredDockerDriverBinariesPresent: (platform?: NodeJS.Platform) => boolean;
   getDockerDriverGatewayRuntimeDriftFromSnapshot: (snapshot: {
     processEnv: Record<string, string> | null;
     processExe: string | null;
@@ -207,6 +208,7 @@ function isOnboardTestInternals(
     typeof value.buildDirectSandboxGpuProofCommands === "function" &&
     typeof value.classifySandboxCreateFailure === "function" &&
     typeof value.getDockerDriverGatewayEnv === "function" &&
+    typeof value.areRequiredDockerDriverBinariesPresent === "function" &&
     typeof value.getDockerDriverGatewayRuntimeDriftFromSnapshot === "function" &&
     typeof value.isLinuxDockerDriverGatewayEnabled === "function" &&
     typeof value.isDockerDriverGatewayPortListener === "function" &&
@@ -263,6 +265,7 @@ const {
   getBlueprintMinOpenshellVersion,
   getBlueprintMaxOpenshellVersion,
   getDockerDriverGatewayEnv,
+  areRequiredDockerDriverBinariesPresent,
   getDockerDriverGatewayRuntimeDriftFromSnapshot,
   isLinuxDockerDriverGatewayEnabled,
   isDockerDriverGatewayPortListener,
@@ -403,14 +406,43 @@ network_policies:
     ]);
   });
 
-  it("models the Linux OpenShell Docker-driver gateway environment", () => {
+  it("models the OpenShell Docker-driver gateway environment", () => {
     expect(isLinuxDockerDriverGatewayEnabled("linux")).toBe(true);
-    expect(isLinuxDockerDriverGatewayEnabled("darwin")).toBe(false);
+    expect(isLinuxDockerDriverGatewayEnabled("darwin")).toBe(true);
+    expect(isLinuxDockerDriverGatewayEnabled("win32")).toBe(false);
     const env = getDockerDriverGatewayEnv("openshell 0.0.37");
     expect(env.OPENSHELL_DRIVERS).toBe("docker");
     expect(env.OPENSHELL_GRPC_ENDPOINT).toBe("http://127.0.0.1:8080");
     expect(env.OPENSHELL_CLUSTER_IMAGE).toBeUndefined();
     expect(env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE).toContain(":0.0.37");
+  });
+
+  it("requires platform-specific Docker-driver binaries", () => {
+    const oldGateway = process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN;
+    const oldSandbox = process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN;
+    try {
+      process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN = "/tmp/openshell-gateway";
+      delete process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN;
+      expect(areRequiredDockerDriverBinariesPresent("darwin")).toBe(true);
+      expect(areRequiredDockerDriverBinariesPresent("linux")).toBe(false);
+
+      process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN = "/tmp/openshell-sandbox";
+      expect(areRequiredDockerDriverBinariesPresent("linux")).toBe(true);
+
+      delete process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN;
+      expect(areRequiredDockerDriverBinariesPresent("darwin")).toBe(false);
+    } finally {
+      if (oldGateway === undefined) {
+        delete process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN;
+      } else {
+        process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN = oldGateway;
+      }
+      if (oldSandbox === undefined) {
+        delete process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN;
+      } else {
+        process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN = oldSandbox;
+      }
+    }
   });
 
   it("detects stale Docker-driver gateway runtime state before reuse", () => {
@@ -479,6 +511,12 @@ network_policies:
       isDockerDriverGatewayPortListener(
         { ok: false, process: "openshell", pid: 1234 },
         { ...opts, platform: "darwin" },
+      ),
+    ).toBe(true);
+    expect(
+      isDockerDriverGatewayPortListener(
+        { ok: false, process: "openshell", pid: 1234 },
+        { ...opts, platform: "win32" },
       ),
     ).toBe(false);
     expect(
@@ -2484,7 +2522,7 @@ mod._load = function(req, parent, isMain) {
   }
   return origLoad.call(this, req, parent, isMain);
 };
-Object.defineProperty(process, "platform", { value: "darwin" });
+Object.defineProperty(process, "platform", { value: "freebsd" });
 const { startGateway } = require(${onboardPath});
 startGateway(null).catch(() => {});
 `;

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -76,7 +76,11 @@ credentials.prompt = async (msg) => { throw new Error("unexpected prompt: " + ms
 credentials.ensureApiKey = async () => {};
 credentials.getCredential = () => null;
 runner.run = () => {};
-runner.runCapture = () => ${JSON.stringify(runCaptureReturn)};
+runner.runCapture = (command) => {
+  const text = Array.isArray(command) ? command.join(" ") : String(command);
+  if (text.includes("sandbox list")) return "test-sb Ready";
+  return ${JSON.stringify(runCaptureReturn)};
+};
 ${openshellStub}
 
 const updates = [];

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -667,12 +667,14 @@ describe("regression guards", () => {
                 'ignored  openshell-x86_64-unknown-linux-musl.tar.gz' \
                 'ignored  openshell-aarch64-unknown-linux-musl.tar.gz' \
                 'ignored  openshell-x86_64-apple-darwin.tar.gz' \
-                'ignored  openshell-aarch64-apple-darwin.tar.gz' > "$out"
+                'ignored  openshell-aarch64-apple-darwin.tar.gz' \
+                'ignored  openshell-driver-vm-aarch64-apple-darwin.tar.gz' > "$out"
               ;;
             openshell-gateway-checksums-sha256.txt)
               printf '%s\n' \
                 'ignored  openshell-gateway-x86_64-unknown-linux-gnu.tar.gz' \
-                'ignored  openshell-gateway-aarch64-unknown-linux-gnu.tar.gz' > "$out"
+                'ignored  openshell-gateway-aarch64-unknown-linux-gnu.tar.gz' \
+                'ignored  openshell-gateway-aarch64-apple-darwin.tar.gz' > "$out"
               ;;
             openshell-sandbox-checksums-sha256.txt)
               printf '%s\n' \


### PR DESCRIPTION
## Summary
- route macOS through the OpenShell 0.0.37 standalone gateway path without calling the removed `openshell gateway start` command
- use the VM driver on Darwin (`OPENSHELL_DRIVERS=vm`) while keeping Linux on the Docker driver path
- repair platform-specific helper installs: Linux requires `openshell-gateway` + `openshell-sandbox`; macOS arm64 requires `openshell-gateway` + `openshell-driver-vm`
- add focused installer/onboard tests for platform helper requirements, Darwin gateway env, and Linux-only `/proc` env verification

## Scope
This is the limited macOS 0.0.37 compatibility path only. It intentionally leaves the broader legacy-upgrade cleanup and survivor e2e work out of this PR.

## Validation
- `npm run build:cli`
- `npm run typecheck:cli`
- `npx vitest run test/install-openshell-version-check.test.ts test/onboard.test.ts --testTimeout 60000`
- `bash -n scripts/install-openshell.sh`
- `git diff --check`
- local macOS/Colima smoke: temp `openshell-driver-vm` from OpenShell v0.0.37 + `openshell-gateway` with `OPENSHELL_DRIVERS=vm` listened on `127.0.0.1:18080`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now validates required driver binaries per OS/arch and installs macOS ARM64 gateway + VM driver (including sudo flow).
* **Bug Fixes**
  * Missing-driver detection and reinstall prompts fixed for macOS; installer chooses OS/arch-specific release assets and rejects unsupported macOS x86_64.
* **Tests**
  * Added/updated tests and stubs for macOS ARM64 driver presence, asset selection, and platform-specific runtime behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3391)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->