### PR TITLE
test: drop bash login/rc loading in spawnSync invocations

### DIFF
--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -633,7 +633,7 @@ describe("prompt machinery (unchanged)", () => {
       ${JSON.stringify(process.execPath)} -e 'const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "bin", "lib", "credentials"))}); (async()=>{ await prompt("first: "); await prompt("second: "); })().catch(err=>{ console.error(err); process.exit(1); });' < "$pipe"
     `;
 
-    const result = spawnSync("bash", ["-lc", script], {
+    const result = spawnSync("bash", ["--noprofile", "--norc", "-c", script], {
       cwd: path.join(import.meta.dirname, ".."),
       encoding: "utf-8",
       timeout: 5000,
@@ -722,7 +722,7 @@ ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptFile)} < "$pipe"
 `;
     let result: ReturnType<typeof spawnSync>;
     try {
-      result = spawnSync("bash", ["-lc", bash], {
+      result = spawnSync("bash", ["--noprofile", "--norc", "-c", bash], {
         encoding: "utf-8",
         env: { ...process.env, NVIDIA_API_KEY: "" },
         timeout: 5000,

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -2906,7 +2906,7 @@ describe("installer express install prompt (sourced)", () => {
   function runExpressPromptWithTty(answer: string, stdinMode: "pipe" | "tty") {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-express-prompt-"));
     const python =
-      spawnSync("bash", ["-lc", "command -v python3"], { encoding: "utf-8" }).stdout.trim() ||
+      spawnSync("bash", ["--noprofile", "--norc", "-c", "command -v python3"], { encoding: "utf-8" }).stdout.trim() ||
       "python3";
     const ptyRunner = `
 import os
@@ -3470,7 +3470,7 @@ exit 0`,
     );
 
     const python =
-      spawnSync("bash", ["-lc", "command -v python3"], { encoding: "utf-8" }).stdout.trim() ||
+      spawnSync("bash", ["--noprofile", "--norc", "-c", "command -v python3"], { encoding: "utf-8" }).stdout.trim() ||
       "python3";
     const ptyRunner = `
 import os

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -520,8 +520,9 @@ describe("nemoclaw-start configure guard behavior", () => {
     return spawnSync(
       "bash",
       [
+        "--noprofile",
         "--norc",
-        "-lc",
+        "-c",
         [
           `source ${JSON.stringify(setup.proxyEnv)}`,
           ["openclaw", ...args.map((arg) => JSON.stringify(arg))].join(" "),

--- a/test/runtime-shell.test.ts
+++ b/test/runtime-shell.test.ts
@@ -13,7 +13,7 @@ function runShell(
   script: string,
   env: Record<string, string | undefined> = {},
 ): SpawnSyncReturns<string> {
-  return spawnSync("bash", ["-lc", script], {
+  return spawnSync("bash", ["--noprofile", "--norc", "-c", script], {
     cwd: path.join(import.meta.dirname, ".."),
     encoding: "utf-8",
     env: { ...process.env, ...env },

--- a/test/secret-redaction.test.ts
+++ b/test/secret-redaction.test.ts
@@ -115,7 +115,7 @@ describe("secret redaction consistency (#1736)", () => {
         "uptime",
       ]) {
         try {
-          const target = spawnSync("bash", ["-lc", `command -v ${name}`], {
+          const target = spawnSync("bash", ["--noprofile", "--norc", "-c", `command -v ${name}`], {
             encoding: "utf-8",
           }).stdout.trim();
           if (target) symlinkSync(target, join(fakeBin, name));

--- a/test/smoke-macos-install.test.ts
+++ b/test/smoke-macos-install.test.ts
@@ -102,7 +102,7 @@ describe.skip("macOS smoke install script guardrails", () => {
       wait "$feeder_pid"
     `;
 
-    const result = spawnSync("bash", ["-lc", script], {
+    const result = spawnSync("bash", ["--noprofile", "--norc", "-c", script], {
       cwd: path.join(import.meta.dirname, ".."),
       encoding: "utf-8",
       env: { ...process.env, NVIDIA_API_KEY: "nvapi-test" },


### PR DESCRIPTION
## Summary
Several test files use `bash -lc` / `bash --norc -lc` for one-off helpers (`command -v` lookups, sourcing local helper scripts, piping into mkfifo). The `-l` flag loads the user's login profile (`/etc/profile`, `~/.bash_profile`, etc.). On developer machines whose shells source heavier per-login customisations, that adds noticeable startup cost per invocation, and with N invocations per test the cumulative wall time can exceed vitest's default 5s test timeout — even though each spawn does no useful work in login mode. Other invocations in the suite are paying the same tax silently because their per-test timeouts are higher than the wall time they currently use.

Switch host-side test spawns to `bash --noprofile --norc -c`: no login, no rc, equivalent functionality. Production code paths that intentionally run user-facing commands in login mode (`onboard.ts`, `create-stream.ts`, `actions/update.ts`) are left untouched, as are `sandbox exec ... -- sh -lc` invocations (those run inside the sandbox where login mode is required for correct PATH).

## Changes
- `test/secret-redaction.test.ts`: `bash -lc 'command -v <name>'` inside the 10-iteration symlink-building loop in the debug.sh wrapper test.
- `test/nemoclaw-start.test.ts`: `runGuardedOpenclaw` helper. Already passes `env: { ...process.env, PATH: ... }`, so it never needed profile loading.
- `test/credentials.test.ts`: two pipe-based prompt tests.
- `test/runtime-shell.test.ts`: `runShell` helper used by many runtime-shell assertions.
- `test/smoke-macos-install.test.ts`: mkfifo/IFS pipe pattern.
- `test/install-preflight.test.ts`: two `command -v python3` lookups.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined shell initialization behavior across test suites to improve test consistency and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3393)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->