### PR TITLE
fix(share): pre-flight remote path before invoking sshfs

### DIFF
--- a/src/lib/share-command-deps.ts
+++ b/src/lib/share-command-deps.ts
@@ -10,6 +10,15 @@ export interface ShareCommandDeps {
   getSshConfig: (sandboxName: string) => { status: number | null; output: string };
   /** Ensure the sandbox is live, exit process if not. */
   ensureLive: (sandboxName: string) => Promise<void>;
+  /**
+   * Check whether `remotePath` exists inside the sandbox via
+   * `openshell sandbox exec <name> -- test -e <remotePath>`. Returns true when
+   * the path exists; false when it is missing, when the sandbox is unreachable,
+   * or when the exec itself fails. Used by `share mount` as a pre-flight
+   * before invoking `sshfs`, which exits non-zero with empty stderr on a
+   * missing remote path and leaves the user with nothing actionable. See #3414.
+   */
+  checkSandboxPathExists: (sandboxName: string, remotePath: string) => boolean;
   /** NVIDIA-green ANSI code (empty string if color disabled). */
   colorGreen: string;
   /** ANSI reset code (empty string if color disabled). */
@@ -37,6 +46,13 @@ export function buildShareCommandDeps(): ShareCommandDeps {
       }),
     ensureLive: async (sandboxName: string) => {
       await ensureLiveSandboxOrExit(sandboxName);
+    },
+    checkSandboxPathExists: (sandboxName: string, remotePath: string) => {
+      const result = captureOpenshell(
+        ["sandbox", "exec", sandboxName, "--", "test", "-e", remotePath],
+        { ignoreError: true, timeout: OPENSHELL_PROBE_TIMEOUT_MS },
+      );
+      return result.status === 0;
     },
     colorGreen: G,
     colorReset: R,

--- a/src/lib/share-command.test.ts
+++ b/src/lib/share-command.test.ts
@@ -29,6 +29,7 @@ function makeDeps(overrides: Partial<ShareCommandDeps> = {}): ShareCommandDeps {
       output: "Host openshell-alpha\n  HostName 127.0.0.1\n",
     })),
     ensureLive: vi.fn(async () => undefined),
+    checkSandboxPathExists: vi.fn(() => true),
     colorGreen: "",
     colorReset: "",
     cliName: "nemoclaw",

--- a/src/lib/share-command.ts
+++ b/src/lib/share-command.ts
@@ -51,8 +51,9 @@ export function defaultShareMountDir(sandboxName: string): string {
  * Pre-flight: confirm the remote source path actually exists inside the
  * sandbox. sshfs exits non-zero with empty stderr when the remote path is
  * missing (e.g. a typo), and the bare "SSHFS mount failed." line we used to
- * emit left the user with nothing actionable. Returns true when the path
- * exists; emits a structured error and exits non-zero when it does not.
+ * emit left the user with nothing actionable. Returns normally when the path
+ * can be verified; emits a structured error and exits the process non-zero
+ * when it cannot. The success path has no return value.
  * Exported so the behavior is testable without driving the full sshfs
  * lifecycle. See #3414.
  */

--- a/src/lib/share-command.ts
+++ b/src/lib/share-command.ts
@@ -48,6 +48,29 @@ export function defaultShareMountDir(sandboxName: string): string {
 }
 
 /**
+ * Pre-flight: confirm the remote source path actually exists inside the
+ * sandbox. sshfs exits non-zero with empty stderr when the remote path is
+ * missing (e.g. a typo), and the bare "SSHFS mount failed." line we used to
+ * emit left the user with nothing actionable. Returns true when the path
+ * exists; emits a structured error and exits non-zero when it does not.
+ * Exported so the behavior is testable without driving the full sshfs
+ * lifecycle. See #3414.
+ */
+export function assertSandboxPathExistsOrExit(
+  deps: ShareCommandDeps,
+  sandboxName: string,
+  remotePath: string,
+): void {
+  if (deps.checkSandboxPathExists(sandboxName, remotePath)) return;
+  console.error(`  Sandbox path '${remotePath}' does not exist in sandbox '${sandboxName}'.`);
+  console.error(
+    `  Verify the path with: ${deps.cliName} ${sandboxName} connect, then ls ${remotePath}`,
+  );
+  console.error(`  The default is /sandbox; check for typos in any custom path you passed.`);
+  process.exit(1);
+}
+
+/**
  * Resolve the fusermount binary for Linux. FUSE 3 ships `fusermount3`;
  * older FUSE 2 ships `fusermount`. Probe both, preferring v3.
  */
@@ -114,6 +137,9 @@ export async function runShareMount(
 
   // Verify sandbox is running
   await deps.ensureLive(sandboxName);
+
+  // Pre-flight: confirm the remote source path actually exists. See #3414.
+  assertSandboxPathExistsOrExit(deps, sandboxName, remotePath);
 
   // Get SSH config
   const sshConfigResult = deps.getSshConfig(sandboxName);

--- a/src/lib/share-command.ts
+++ b/src/lib/share-command.ts
@@ -62,7 +62,13 @@ export function assertSandboxPathExistsOrExit(
   remotePath: string,
 ): void {
   if (deps.checkSandboxPathExists(sandboxName, remotePath)) return;
-  console.error(`  Sandbox path '${remotePath}' does not exist in sandbox '${sandboxName}'.`);
+  // The probe returns false for both "path is missing" and "exec itself
+  // failed" (transient gRPC, sandbox just restarted, etc.), so phrase the
+  // headline as a verification failure rather than a definitive claim that
+  // the path is missing.
+  console.error(
+    `  Could not verify sandbox path '${remotePath}' in sandbox '${sandboxName}' (missing path or probe failure).`,
+  );
   console.error(
     `  Verify the path with: ${deps.cliName} ${sandboxName} connect, then ls ${remotePath}`,
   );

--- a/test/share-command-remote-path.test.ts
+++ b/test/share-command-remote-path.test.ts
@@ -63,7 +63,13 @@ describe("assertSandboxPathExistsOrExit (#3414)", () => {
     expect(pathChecked).toEqual({ sandboxName: "my-assistant", remotePath: "/sandbox/typo" });
 
     const errorOutput = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
-    expect(errorOutput).toContain("Sandbox path '/sandbox/typo' does not exist in sandbox 'my-assistant'");
+    // The headline is phrased as a verification failure rather than a
+    // definitive missing-path claim because the dep returns false for both
+    // missing paths and probe failures (CR feedback on #3415).
+    expect(errorOutput).toContain(
+      "Could not verify sandbox path '/sandbox/typo' in sandbox 'my-assistant'",
+    );
+    expect(errorOutput).toContain("missing path or probe failure");
     expect(errorOutput).toContain("Verify the path with: nemoclaw my-assistant connect");
     expect(errorOutput).toContain("ls /sandbox/typo");
     expect(errorOutput).toContain("check for typos");

--- a/test/share-command-remote-path.test.ts
+++ b/test/share-command-remote-path.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { assertSandboxPathExistsOrExit } from "../dist/lib/share-command.js";
+import type { ShareCommandDeps } from "../dist/lib/share-command-deps.js";
+
+class ProcessExitError extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+function makeDeps(overrides: Partial<ShareCommandDeps> = {}): ShareCommandDeps {
+  return {
+    getSshConfig: () => ({ status: 0, output: "" }),
+    ensureLive: async () => undefined,
+    checkSandboxPathExists: () => true,
+    colorGreen: "",
+    colorReset: "",
+    cliName: "nemoclaw",
+    ...overrides,
+  };
+}
+
+describe("assertSandboxPathExistsOrExit (#3414)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns without writing to stderr when the remote path exists", () => {
+    const deps = makeDeps({ checkSandboxPathExists: () => true });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("should not exit");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    assertSandboxPathExistsOrExit(deps, "my-assistant", "/sandbox");
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits 1 with a structured error when the remote path does not exist", () => {
+    let pathChecked: { sandboxName?: string; remotePath?: string } = {};
+    const deps = makeDeps({
+      checkSandboxPathExists: (sandboxName, remotePath) => {
+        pathChecked = { sandboxName, remotePath };
+        return false;
+      },
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new ProcessExitError(typeof code === "number" ? code : 1);
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(() => assertSandboxPathExistsOrExit(deps, "my-assistant", "/sandbox/typo")).toThrow(
+      ProcessExitError,
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(pathChecked).toEqual({ sandboxName: "my-assistant", remotePath: "/sandbox/typo" });
+
+    const errorOutput = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(errorOutput).toContain("Sandbox path '/sandbox/typo' does not exist in sandbox 'my-assistant'");
+    expect(errorOutput).toContain("Verify the path with: nemoclaw my-assistant connect");
+    expect(errorOutput).toContain("ls /sandbox/typo");
+    expect(errorOutput).toContain("check for typos");
+  });
+
+  it("uses the configured cliName in the verify-with hint (supports nemohermes alias)", () => {
+    const deps = makeDeps({
+      cliName: "nemohermes",
+      checkSandboxPathExists: () => false,
+    });
+    vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new ProcessExitError(1);
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(() => assertSandboxPathExistsOrExit(deps, "hermes", "/sandbox/missing")).toThrow(
+      ProcessExitError,
+    );
+
+    const errorOutput = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(errorOutput).toContain("nemohermes hermes connect");
+    expect(errorOutput).not.toContain("nemoclaw hermes connect");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Closes #3414. `nemoclaw <sandbox> share mount` exits non-zero with no stderr when the remote sandbox path does not exist (e.g. a typo). sshfs is silent in this case, so the CLI surfaced only the bare `SSHFS mount failed.` line and the user had no signal that the source path was the problem. Reported by @SeseMueller in [#3235](https://github.com/NVIDIA/NemoClaw/pull/3235#issuecomment-4432508782) as a follow-up to the writable-fs error fix.

## Related Issue

Closes #3414

## Changes

- New `checkSandboxPathExists` dep on `ShareCommandDeps` (`src/lib/share-command-deps.ts`). Default impl runs `openshell sandbox exec <name> -- test -e <remotePath>` with the same `OPENSHELL_PROBE_TIMEOUT_MS` budget as the existing `getSshConfig` probe, and treats a zero exit status as "path exists" (everything else is missing or unreachable).
- New exported helper `assertSandboxPathExistsOrExit(deps, sandboxName, remotePath)` in `src/lib/share-command.ts`. Consults the dep, emits a structured error when the probe returns non-zero, and exits 1. The error is phrased as a verification failure rather than a definitive "path is missing" claim, because the probe also returns false on transient exec failures (sandbox just restarted, gRPC hiccup), and a wrong-cause message wastes the user's time. Extracted so the behavior is testable without driving the full sshfs lifecycle.
- `runShareMount` calls the helper after `ensureLive` and before `getSshConfig`, so a non-verifiable remote path fails fast with:

```
  Could not verify sandbox path '/sandbox/typo' in sandbox 'my-assistant' (missing path or probe failure).
  Verify the path with: nemoclaw my-assistant connect, then ls /sandbox/typo
  The default is /sandbox; check for typos in any custom path you passed.
```

  No SSH config is written, no sshfs binary is invoked, no local mount directory is created when the pre-flight fails.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only

## Verification

- [x] `npx prek run --all-files` passes for the staged files (includes the source-shape test budget gate).
- [x] Three behavior tests in `test/share-command-remote-path.test.ts` cover the happy path (no exit, no stderr), the missing-path exit (verifies error contents and that the dep was called with the right args), and the `cliName` branding hint (so the `nemohermes` alias surfaces `nemohermes hermes connect` rather than `nemoclaw hermes connect`).
- [x] `npx vitest run test/share-command-remote-path.test.ts` - 3/3 pass.
- [x] `npx tsx scripts/find-source-shape-tests.ts` - 0 source-shape cases (no source-text assertions).
- [x] `npm run build:cli` clean.
- [x] No secrets, API keys, or credentials committed.

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Share mount operations now perform pre-flight validation to confirm the remote path exists in the sandbox before attempting to mount, preventing failed mount operations and displaying detailed troubleshooting guidance if the path is invalid or missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3415)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->