### PR TITLE
test: update OpenShell gateway upgrade stub features

### DIFF
--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -142,6 +142,8 @@ EOF
 
   cat >"$fake_bin/openshell" <<'EOF'
 #!/usr/bin/env bash
+# request-body-credential-rewrite
+# websocket-credential-rewrite
 if [ "${1:-}" = "--version" ]; then
   printf 'openshell 0.0.39\n'
   exit 0
@@ -229,6 +231,8 @@ EOF
 
   cat >"$fake_bin/openshell" <<'EOF'
 #!/usr/bin/env bash
+# request-body-credential-rewrite
+# websocket-credential-rewrite
 if [ "${1:-}" = "--version" ]; then
   printf 'openshell 0.0.39\n'
   exit 0


### PR DESCRIPTION
## Summary
- add the OpenShell 0.0.39 credential-rewrite feature markers to the fake macOS openshell stubs used by the gateway upgrade E2E
- keep the entitlement-repair regression test on the installer path instead of failing at the new feature-string gate

## Verification
- bash -n test/e2e/test-openshell-gateway-upgrade.sh scripts/install-openshell.sh
- shellcheck test/e2e/test-openshell-gateway-upgrade.sh scripts/install-openshell.sh
- local reproduction of exercise_macos_vm_driver_entitlement_repair passed: installer exited 0, codesign was called with entitlements, and no OpenShell release reinstall occurred

## Notes
- full local pre-commit CLI coverage was skipped for the final commit/push after unrelated local timeouts and an incomplete dist cleanup; PR CI should remain the gate for the broad suite
- fixes the openshell-gateway-upgrade-e2e failure seen in main nightly run https://github.com/NVIDIA/NemoClaw/actions/runs/25770642898/job/75692826795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated macOS installer test infrastructure to enhance regression test coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3429)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->