### PR TITLE
fix: disable thinking for GLM OpenClaw inference turns

### DIFF
--- a/nemoclaw-blueprint/scripts/nemotron-inference-fix.js
+++ b/nemoclaw-blueprint/scripts/nemotron-inference-fix.js
@@ -18,8 +18,8 @@
 //   or thinking blocks.
 //
 //   Also inject `chat_template_kwargs: { thinking: false }` for
-//   deepseek-ai/deepseek-v4-pro and moonshotai/kimi-k2.6, matching NVIDIA
-//   Build's tested invocation shape for the OpenAI-compatible
+//   deepseek-ai/deepseek-v4-pro, moonshotai/kimi-k2.6, and z-ai/glm-5.x,
+//   matching NVIDIA Build's tested invocation shape for the OpenAI-compatible
 //   chat-completions endpoint.
 //
 //   Scoped strictly to known affected models — all other requests pass
@@ -35,6 +35,7 @@
   var NEMOTRON_RE = /nemotron/i;
   var DEEPSEEK_V4_PRO_RE = /^deepseek-ai\/deepseek-v4-pro$/i;
   var KIMI_K26_RE = /^moonshotai\/kimi-k2\.6$/i;
+  var GLM_5_RE = /^z-ai\/glm-5(?:[./:-]|$)/i;
   var COMPLETIONS_RE = /\/v1\/chat\/completions/;
 
   function hasObjectChatTemplateKwargs(body) {
@@ -93,7 +94,8 @@
             body && body.model &&
             (NEMOTRON_RE.test(body.model) ||
               DEEPSEEK_V4_PRO_RE.test(body.model) ||
-              KIMI_K26_RE.test(body.model))
+              KIMI_K26_RE.test(body.model) ||
+              GLM_5_RE.test(body.model))
           ) {
             if (!hasObjectChatTemplateKwargs(body)) {
               body.chat_template_kwargs = {};
@@ -101,7 +103,11 @@
             if (NEMOTRON_RE.test(body.model)) {
               body.chat_template_kwargs.force_nonempty_content = true;
             }
-            if (DEEPSEEK_V4_PRO_RE.test(body.model) || KIMI_K26_RE.test(body.model)) {
+            if (
+              DEEPSEEK_V4_PRO_RE.test(body.model) ||
+              KIMI_K26_RE.test(body.model) ||
+              GLM_5_RE.test(body.model)
+            ) {
               body.chat_template_kwargs.thinking = false;
             }
             intercepted = true;

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1300,7 +1300,7 @@ fi
 # kwarg `force_nonempty_content` prevents this by ensuring the template
 # always emits a non-empty content field.
 #
-# DeepSeek V4 Pro and Kimi K2.6 on NVIDIA Build expect chat template
+# DeepSeek V4 Pro, Kimi K2.6, and GLM-5.x on NVIDIA Build expect chat template
 # thinking mode disabled for NemoClaw's OpenAI-compatible
 # chat-completions path.
 #

--- a/test/nemotron-inference-fix.test.ts
+++ b/test/nemotron-inference-fix.test.ts
@@ -106,6 +106,7 @@ function send(mod, options, body) {
 send(http, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'NVIDIA/NEMOTRON-4', messages: [] }));
 send(https, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'deepseek-ai/deepseek-v4-pro', messages: [], chat_template_kwargs: { existing: true, thinking: true } }));
 send(https, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'moonshotai/kimi-k2.6', messages: [], chat_template_kwargs: { existing: true, thinking: true } }));
+send(https, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'z-ai/glm-5.1', messages: [], chat_template_kwargs: { existing: true, thinking: true } }));
 send(https, { method: 'POST', path: '/v1/chat/completions' }, JSON.stringify({ model: 'other-model', messages: [] }));
 send(http, { method: 'POST', path: '/v1/chat/completions' }, '{not json');
 send(http, { method: 'GET', path: '/v1/chat/completions' }, JSON.stringify({ model: 'nemotron' }));
@@ -143,10 +144,19 @@ console.log(JSON.stringify(records));
     expect(records[2].removed).toContain("content-length");
     expect(Number(records[2].headers["Content-Length"])).toBeGreaterThan(0);
 
-    const otherBody = JSON.parse(records[3].writes[0]);
+    const glmBody = JSON.parse(records[3].writes[0]);
+    expect(glmBody.chat_template_kwargs).toEqual({
+      existing: true,
+      thinking: false,
+    });
+    expect(glmBody.chat_template_kwargs.force_nonempty_content).toBeUndefined();
+    expect(records[3].removed).toContain("content-length");
+    expect(Number(records[3].headers["Content-Length"])).toBeGreaterThan(0);
+
+    const otherBody = JSON.parse(records[4].writes[0]);
     expect(otherBody.chat_template_kwargs).toBeUndefined();
-    expect(records[4].writes[0]).toBe("{not json");
-    expect(JSON.parse(records[5].writes[0]).chat_template_kwargs).toBeUndefined();
+    expect(records[5].writes[0]).toBe("{not json");
     expect(JSON.parse(records[6].writes[0]).chat_template_kwargs).toBeUndefined();
+    expect(JSON.parse(records[7].writes[0]).chat_template_kwargs).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- extend the existing NVIDIA endpoint preload to inject `chat_template_kwargs.thinking=false` for `z-ai/glm-5.x` chat-completions requests
- keep the change scoped to the affected GLM family, matching the existing Kimi/DeepSeek treatment
- cover the request-body mutation in the preload unit test

## Why
- main nightly on OpenShell 0.0.39 passed route/config/hash/direct `inference.local` checks after switching to `z-ai/glm-5.1`, but OpenClaw agent turns failed twice after the switch
- the last green main run used OpenShell 0.0.37 and passed the same GLM agent-turn test

## Verification
- bash -n scripts/nemoclaw-start.sh
- shellcheck scripts/nemoclaw-start.sh
- npx vitest run --project cli test/nemotron-inference-fix.test.ts
- git diff --check
- npm run build:cli

## Notes
- local broad `test-cli` hook was skipped because this checkout has been producing unrelated local CLI coverage timeouts; PR CI remains the broad gate
- focused `openclaw-inference-switch-e2e` will be run on this branch before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Extended inference compatibility to support GLM-5.x models with proper chat template handling.

* **Tests**
  * Added test coverage for GLM-5.x model request behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3430)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->