### PR TITLE
docs(reference): document Docker-driver compute path alongside legacy k3s

### DIFF
--- a/docs/get-started/prerequisites.mdx
+++ b/docs/get-started/prerequisites.mdx
@@ -19,7 +19,11 @@ Before getting started, check the prerequisites to ensure you have the necessary
 | RAM      | 8 GB           | 16 GB            |
 | Disk     | 20 GB free     | 40 GB free       |
 
-The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon, k3s, and the OpenShell gateway run alongside the export pipeline. The pipeline buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer. If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
+The sandbox image is approximately 2.4 GB compressed.
+During image push, the Docker daemon, the OpenShell gateway container, and the sandbox runtime run alongside the export pipeline.
+The pipeline buffers decompressed layers in memory.
+On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer.
+If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
 
 ## Software
 
@@ -45,7 +49,7 @@ Avoid `openshell self-update`, `npm update -g openshell`, `openshell gateway sta
 </Warning>
 
 <Note title="Docker storage driver">
-On Linux hosts running Docker 26 or later with the [containerd image store](https://docs.docker.com/engine/storage/containerd/) enabled (the install-time default for fresh `docker-ce` installations on Ubuntu 24.04 and similar distros), `nemoclaw onboard` transparently builds a `fuse-overlayfs`-enabled cluster image to bypass a kernel-level nested-overlay limitation in k3s.
+On Linux hosts running Docker 26 or later with the [containerd image store](https://docs.docker.com/engine/storage/containerd/) enabled (the install-time default for fresh `docker-ce` installations on Ubuntu 24.04 and similar distros), `nemoclaw onboard` transparently builds a `fuse-overlayfs`-enabled cluster image to bypass a kernel-level nested-overlay limitation in the OpenShell gateway image.
 No manual setup is required.
 See the [troubleshooting guide](/reference/troubleshooting) for the override knobs and a manual `daemon.json` alternative.
 </Note>

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -76,9 +76,19 @@ graph LR
 
 The logical diagram above shows how components relate.
 This section shows what actually runs where on the host.
-NemoClaw uses a Docker daemon.
-The OpenShell gateway runs as a container that embeds a k3s cluster.
-The sandbox runs as a Kubernetes pod inside that embedded cluster.
+NemoClaw uses a Docker daemon, and the OpenShell gateway runs as a container.
+The sandbox runs as a sibling Docker container or as a pod inside an embedded `k3s` cluster, depending on the host platform.
+
+| Platform | Compute path | Sandbox runs as |
+|---|---|---|
+| Linux (any arch, including DGX Spark / Station) | Docker driver | Sibling Docker container |
+| Windows WSL2 (Docker Desktop, WSL backend) | Docker driver | Sibling Docker container (WSL2 reports `platform === "linux"`) |
+| macOS Apple Silicon (Colima or Docker Desktop) | Docker driver | Sibling Docker container |
+
+Every platform currently listed in [`ci/platform-matrix.json`](https://github.com/NVIDIA/NemoClaw/blob/main/ci/platform-matrix.json) selects the Docker driver compute path; the dispatch is `platform === "linux" || (platform === "darwin" && arch === "arm64")` in [`src/lib/onboard/docker-driver-platform.ts`](https://github.com/NVIDIA/NemoClaw/blob/main/src/lib/onboard/docker-driver-platform.ts).
+On the Docker driver path, the embedded `k3s` cluster and the sandbox pod are replaced by a sibling Docker container that hosts the OpenClaw agent under the same `Landlock`, `seccomp`, and `netns` confinement.
+
+The diagram below describes the legacy `k3s` path, kept for historical context: when a platform fell outside the dispatch rule above the gateway embedded a `k3s` cluster and scheduled the sandbox as a pod inside it.
 
 ```mermaid
 graph TB
@@ -132,9 +142,10 @@ Layering from top to bottom:
 |---|---|---|
 | Host CLI | Host process (`nemoclaw` on Node.js) | Orchestrates OpenShell via `openshell` CLI calls. |
 | Docker daemon | Host service | Runs the OpenShell gateway container. |
-| Gateway container | Docker container | Hosts the credential store, the L7 proxy, and the embedded k3s control plane. |
-| k3s | Process tree inside the gateway container | Kubernetes control plane that schedules the sandbox pod. |
-| Sandbox pod | Pod in the embedded k3s cluster | Runs the OpenClaw agent and the NemoClaw plugin under Landlock + seccomp + netns. |
+| Gateway container | Docker container | Hosts the credential store and the L7 proxy. On the legacy `k3s` path, also hosts the embedded `k3s` control plane. |
+| `k3s` (legacy path only) | Process tree inside the gateway container | Kubernetes control plane that schedules the sandbox pod. |
+| Sandbox container (Docker driver path) | Sibling Docker container managed by the gateway | Runs the OpenClaw agent and the NemoClaw plugin under `Landlock` + `seccomp` + `netns`. |
+| Sandbox pod (legacy `k3s` path) | Pod in the embedded `k3s` cluster | Runs the OpenClaw agent and the NemoClaw plugin under `Landlock` + `seccomp` + `netns`. |
 | OpenShell L7 proxy | Process in the gateway container | Intercepts agent egress and rewrites `Authorization` headers (Bearer/Bot) and URL-path segments to inject the real credential at the network boundary. |
 
 NemoClaw never gives the sandbox a raw provider key.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Refresh `docs/reference/architecture.mdx` so it reflects the dual-path compute model that landed in 0.0.39 (Linux via #3001, macOS Apple Silicon via #3383). The page previously described the OpenShell sandbox exclusively as a Kubernetes pod inside a gateway-embedded k3s cluster, which is no longer accurate for the platforms most NemoClaw users run on.

## Problem

`isLinuxDockerDriverGatewayEnabled` returns true for `platform === "linux"` and for `platform === "darwin" && arch === "arm64"`, so the Docker-driver path is the default with no opt-in on those platforms. The legacy k3s path still applies to macOS Intel and a few other fallback cases. The 0.0.39 release notes call out the Docker-driver migration, but architecture.mdx was not refreshed at the time and still told readers the sandbox is always a Kubernetes pod. New users reading the architecture page formed the wrong mental model on day one.

See #3432 for the original gap analysis with verified-against-code reproduction steps.

## Changes

`docs/reference/architecture.mdx`:

- Replace the universal "embeds a k3s cluster" prose at the top of Deployment Topology with a paragraph that names both compute paths.
- Add a platform table mapping each platform to its compute path:
  - Linux (any arch, including DGX Spark / Station): Docker driver, sibling Docker container
  - Windows WSL2 (Docker Desktop, WSL backend): Docker driver, sibling Docker container (WSL2 reports `platform === "linux"`)
  - macOS Apple Silicon (Colima or Docker Desktop): Docker driver, sibling Docker container
- Update the layer-by-layer table to call out both the legacy k3s sandbox-pod row and the Docker-driver sandbox-container row.
- Keep the legacy k3s diagram for historical context with a clear "legacy path" frame.

`docs/get-started/prerequisites.mdx`:

- After rebasing past the Fern MDX migration, the only relevant edit upstream already had landed in the `<Note>` form; no additional change carried in this PR.

## Related Issue

Closes #3432.

## Test plan

- [x] `prek run` clean
- [x] Platform table cross-checked against `src/lib/onboard/docker-driver-platform.ts` dispatch (`platform === "linux" || (platform === "darwin" && arch === "arm64")`)
- [x] Rendered locally; tables render correctly under Fern

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>
