### PR TITLE
docs(onboard): document NEMOCLAW_SANDBOX_READY_TIMEOUT

### DIFF
--- a/docs/deployment/deploy-to-remote-gpu.md
+++ b/docs/deployment/deploy-to-remote-gpu.md
@@ -127,6 +127,25 @@ When `CHAT_UI_URL` points at a non-loopback origin, NemoClaw disables OpenClaw d
 Any device that can reach the configured dashboard origin can connect without pairing, so avoid exposing that origin on internet-reachable or shared-network deployments.
 :::
 
+## First-Run Readiness Budget
+
+On a remote GPU host, the first `nemoclaw onboard` typically does the slowest work of the lifecycle: the sandbox image is built locally and uploaded into the OpenShell gateway, which can stream hundreds of MiB over the VM's link before the readiness wait even starts.
+The post-create readiness wait defaults to 180 seconds (`NEMOCLAW_SANDBOX_READY_TIMEOUT`), which is sized for warm-cache, workstation-class onboarding and can be exceeded on:
+
+- DGX Station first runs with large quantised models (70B+ parameter footprints, NVFP4 weights).
+- Cloud VMs where the local image-build cache is cold and the upload runs over the public network.
+- Hosts onboarding the Brave Web Search preset on the first run (the egress policy stack adds boot work).
+
+Raise the budget before re-running onboard:
+
+```console
+$ export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
+$ nemoclaw onboard
+```
+
+If onboard ends with `Sandbox '<name>' was created but did not become ready within 180s`, the partially-created sandbox is deleted first, so the next attempt with the raised budget starts from a clean state.
+For the inference-probe budget that runs earlier in onboarding, see [`NEMOCLAW_LOCAL_INFERENCE_TIMEOUT`](../inference/use-local-inference.md#timeout-configuration).
+
 ## Proxy Configuration
 
 NemoClaw routes sandbox traffic through a gateway proxy that defaults to `10.200.0.1:3128`.

--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -342,6 +342,18 @@ The value is in seconds.
 This setting is baked into the sandbox at build time.
 Changing it after onboarding requires re-running `nemoclaw onboard`.
 
+`NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` only governs the inference-server validation probe.
+The post-create readiness wait (image build, gateway upload, in-sandbox boot) has its own budget, `NEMOCLAW_SANDBOX_READY_TIMEOUT`, also defaulting to 180 seconds.
+On hosts where the sandbox image takes minutes to build or upload — large quantised models, DGX Station first runs, or remote VMs over a slow link — raise both together:
+
+```console
+$ export NEMOCLAW_LOCAL_INFERENCE_TIMEOUT=300
+$ export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
+$ nemoclaw onboard
+```
+
+If onboard ends with `Sandbox '<name>' was created but did not become ready within 180s`, refer to [Troubleshooting](../reference/troubleshooting.md#sandbox-onboard-times-out-with-did-not-become-ready-within-ns).
+
 ## Verify the Configuration
 
 After onboarding completes, confirm the active provider and model.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1155,13 +1155,16 @@ Set them before running `nemoclaw onboard` if a slow connection or large model p
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `NEMOCLAW_OLLAMA_PULL_TIMEOUT` | `1800` (30 minutes) | Wall-clock timeout for `ollama pull` during onboard, in seconds. Accepts integer or float values. Already-downloaded layers are kept; re-running the pull resumes them. |
+| `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | `180` | Wall-clock timeout for the inference-server validation probe during onboard, in seconds. Raise on slow networks or for very large prompts. |
+| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | `180` | Wall-clock timeout for the post-create readiness wait, in seconds. Raise when the sandbox image build, gateway upload, or in-sandbox boot exceeds the default (typical on 70B+ models, first-time gateway uploads over slow links, or DGX Station / remote-VM first runs). When the deadline expires onboarding deletes the orphaned sandbox and prints the retry hint. |
 
 ```console
 $ export NEMOCLAW_OLLAMA_PULL_TIMEOUT=3600
+$ export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
 $ nemoclaw onboard
 ```
 
-If the pull exceeds the limit, onboarding emits the timeout in minutes plus a hint to raise this variable, and the partial download is preserved for the next attempt.
+If a timeout fires, onboarding emits the elapsed budget plus a hint to raise the relevant variable. The Ollama pull preserves its partial download for the next attempt; the readiness wait deletes the orphaned sandbox first so the next `nemoclaw onboard` starts clean.
 
 ### Lifecycle Behavior Flags
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -604,6 +604,41 @@ $ nemoclaw onboard
 For local Ollama and vLLM, onboarding retries the container reachability check and can fall back to the host-side health check when the local backend is healthy.
 If all attempts fail, the error includes container reachability diagnostics such as HTTP status and host gateway resolution.
 
+`NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` only covers the inference-server validation probe.
+The post-create readiness wait has its own budget (`NEMOCLAW_SANDBOX_READY_TIMEOUT`); see [Sandbox onboard times out with "did not become ready within Ns"](#sandbox-onboard-times-out-with-did-not-become-ready-within-ns) for the readiness path.
+
+### Sandbox onboard times out with "did not become ready within Ns"
+
+Onboarding ends with:
+
+```text
+  Sandbox 'my-assistant' was created but did not become ready within 180s.
+  The orphaned sandbox has been removed — you can safely retry.
+```
+
+This is a separate budget from `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` — it covers the readiness wait that follows sandbox creation (in-sandbox boot, OpenClaw start, policy load), not the inference probe.
+The 180-second default fits typical workstations but can be exceeded when:
+
+- The host is building or uploading the sandbox image for the first time (cold caches, slow link).
+- The selected model is large (70B+ parameters or 4-bit/8-bit quantisations that take time to memory-map).
+- Onboarding runs on a remote VM where image upload to the gateway streams over the network (for example DGX Station first-run installer).
+
+Raise the budget before re-running onboard:
+
+```console
+$ export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
+$ nemoclaw onboard
+```
+
+The variable accepts seconds and applies to the readiness wait only.
+When the deadline expires, NemoClaw deletes the partially-created sandbox before printing the retry hint, so the next `nemoclaw onboard` starts from a clean state.
+If readiness still fails after the extended budget, inspect the gateway and sandbox status:
+
+```console
+$ openshell sandbox list
+$ nemoclaw <name> status
+```
+
 ### Agent fails at runtime after onboarding succeeds with a compatible endpoint
 
 Some OpenAI-compatible servers (such as SGLang) expose `/v1/responses` but their


### PR DESCRIPTION
## Summary
`NEMOCLAW_SANDBOX_READY_TIMEOUT` (the post-create readiness wait, default 180s) was undocumented anywhere in `docs/`, so users hitting `Sandbox '<name>' was created but did not become ready within 180s` on heavy first runs had no doc-grep path to the workaround. This closes the gap and pairs the variable with `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` (the inference-probe budget the two are easy to conflate).

## Related Issue
Resolves #3344
Resolves #3416

## Changes
- `docs/reference/commands.md`: add `NEMOCLAW_SANDBOX_READY_TIMEOUT` and `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` to the Onboard Timeouts table.
- `docs/reference/troubleshooting.md`: new entry "Sandbox onboard times out with 'did not become ready within Ns'" distinguishing the readiness wait from the inference-probe budget, with a worked example.
- `docs/inference/use-local-inference.md`: cross-link the two timeouts from the existing `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` section so readers of either knob land on the other.
- `docs/deployment/deploy-to-remote-gpu.md`: new "First-Run Readiness Budget" section calling out DGX Station / cloud-VM / large-quantised-model conditions that exceed the default and showing how to raise it.

No code changes — the readiness behaviour is unchanged.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [x] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated onboarding documentation with clearer guidance on configurable timeout settings for remote GPU deployment scenarios.
  * Added troubleshooting section addressing timeout issues that may occur during initial sandbox setup.
  * Expanded deployment, inference, and reference documentation with configuration examples and best practices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3435)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->