### PR TITLE
fix(onboard): avoid literal proc wildcard in GPU sandbox policy

### DIFF
--- a/src/lib/onboard/initial-policy.ts
+++ b/src/lib/onboard/initial-policy.ts
@@ -17,7 +17,12 @@ const CREATE_TIME_POLICY_PRESETS_BY_CHANNEL: Record<string, string[]> = {
   slack: ["slack"],
 };
 
-const PROC_COMM_READ_WRITE_PATH = "/proc/self/task/*/comm";
+const PROC_PATH = "/proc";
+const STALE_PROC_COMM_READ_WRITE_PATH = "/proc/self/task/*/comm";
+
+function isProcEntryOwnedByOpenShell(entry: string): boolean {
+  return entry === PROC_PATH || entry === STALE_PROC_COMM_READ_WRITE_PATH;
+}
 
 export function buildDirectGpuPolicyYaml(basePolicy: string): string {
   const parsed = YAML.parse(basePolicy);
@@ -26,39 +31,40 @@ export function buildDirectGpuPolicyYaml(basePolicy: string): string {
   }
   parsed.filesystem_policy = parsed.filesystem_policy || {};
   const fsPolicy = parsed.filesystem_policy;
-  fsPolicy.read_only = Array.isArray(fsPolicy.read_only)
+  // OpenShell adds /proc as read-write only after GPU devices are present.
+  // Remove entries that would block that enrichment or be treated as literal paths.
+  const readOnly = Array.isArray(fsPolicy.read_only)
     ? fsPolicy.read_only.map((entry: unknown) => String(entry))
     : [];
-  if (!fsPolicy.read_only.includes("/proc")) {
-    fsPolicy.read_only.push("/proc");
-  }
+  fsPolicy.read_only = readOnly.filter((entry: string) => !isProcEntryOwnedByOpenShell(entry));
   const readWrite = Array.isArray(fsPolicy.read_write)
     ? fsPolicy.read_write.map((entry: unknown) => String(entry))
     : [];
-  fsPolicy.read_write = readWrite.filter((entry: string) => entry !== "/proc");
-  if (!fsPolicy.read_write.includes(PROC_COMM_READ_WRITE_PATH)) {
-    fsPolicy.read_write.push(PROC_COMM_READ_WRITE_PATH);
-  }
+  fsPolicy.read_write = readWrite.filter((entry: string) => !isProcEntryOwnedByOpenShell(entry));
   return YAML.stringify(parsed);
 }
 
-const PROC_COMM_WRITE_PROBE = `
-set -eu
-tid="$(ls /proc/self/task | head -n 1)"
-old="$(cat "/proc/self/task/\${tid}/comm" 2>/dev/null || true)"
-printf nemoclaw-gpu >"/proc/self/task/\${tid}/comm"
-if [ -n "$old" ]; then printf "%s" "$old" >"/proc/self/task/\${tid}/comm" || true; fi
-`;
+const PROC_COMM_WRITE_PROBE = [
+  "set -eu;",
+  'comm="/proc/$$/task/$$/comm";',
+  'old="$(cat "$comm" 2>/dev/null || true)";',
+  'printf nemoclaw-gpu >"$comm";',
+  'if [ -n "$old" ]; then',
+  'printf "%s" "$old" >"$comm" || true;',
+  "fi",
+].join(" ");
 
-const CUDA_INIT_PROBE = `
-python3 - <<'PY'
-import ctypes
-lib = ctypes.CDLL("libcuda.so.1")
-rc = lib.cuInit(0)
-print(f"cuInit(0)={rc}")
-raise SystemExit(0 if rc == 0 else 1)
-PY
-`;
+const CUDA_INIT_PROBE = [
+  "python3",
+  "-c",
+  [
+    "'import ctypes;",
+    'lib = ctypes.CDLL("libcuda.so.1");',
+    "rc = lib.cuInit(0);",
+    'print(f"cuInit(0)={rc}");',
+    "raise SystemExit(0 if rc == 0 else 1)'",
+  ].join(" "),
+].join(" ");
 
 export function buildDirectSandboxGpuProofCommands(
   sandboxName: string,
@@ -69,7 +75,7 @@ export function buildDirectSandboxGpuProofCommands(
       args: ["sandbox", "exec", "-n", sandboxName, "--", "nvidia-smi"],
     },
     {
-      label: "/proc/self/task/<tid>/comm write",
+      label: "/proc/<pid>/task/<tid>/comm write",
       args: ["sandbox", "exec", "-n", sandboxName, "--", "sh", "-lc", PROC_COMM_WRITE_PROBE],
     },
     {

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -383,31 +383,39 @@ describe("onboard helpers", () => {
     ).toEqual(["--gpu", "--gpu-device", "nvidia.com/gpu=0"]);
   });
 
-  it("keeps /proc read-only and narrows GPU proc writes to comm", () => {
-    const basePolicy = fs.readFileSync(
-      path.join(repoRoot, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"),
-      "utf-8",
-    );
-    const gpuPolicy = buildDirectGpuPolicyYaml(basePolicy);
-    const baseDoc = YAML.parse(basePolicy);
-    const gpuDoc = YAML.parse(gpuPolicy);
+  it(
+    "removes /proc from direct GPU create policy so OpenShell can own GPU enrichment",
+    () => {
+      const basePolicy = fs.readFileSync(
+        path.join(repoRoot, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"),
+        "utf-8",
+      );
+      const gpuPolicy = buildDirectGpuPolicyYaml(basePolicy);
+      const baseDoc = YAML.parse(basePolicy);
+      const gpuDoc = YAML.parse(gpuPolicy);
 
-    expect(baseDoc.filesystem_policy.read_only).toContain("/proc");
-    expect(gpuDoc.filesystem_policy.read_only).toContain("/proc");
-    expect(gpuDoc.filesystem_policy.read_write).not.toContain("/proc");
-    expect(gpuDoc.filesystem_policy.read_write).toContain("/proc/self/task/*/comm");
-  });
+      // /proc is added at runtime by OpenShell's GPU enrichment;
+      // create-time must not pre-declare it.
+      expect(baseDoc.filesystem_policy.read_only).toContain("/proc");
+      expect(gpuDoc.filesystem_policy.read_only).not.toContain("/proc");
+      expect(gpuDoc.filesystem_policy.read_write).not.toContain("/proc");
+      expect(gpuDoc.filesystem_policy.read_write).not.toContain("/proc/self/task/*/comm");
+    },
+  );
 
-  it("removes stale broad /proc write entries from GPU policy input", () => {
+  it("removes stale proc entries from GPU policy input", () => {
     const gpuPolicy = buildDirectGpuPolicyYaml(`
 version: 1
 filesystem_policy:
   include_workdir: true
   read_only:
     - /usr
+    - /proc
+    - /proc/self/task/*/comm
   read_write:
     - /tmp
     - /proc
+    - /proc/self/task/*/comm
 network_policies:
   nvidia:
     name: nvidia
@@ -417,11 +425,8 @@ network_policies:
 `);
     const gpuDoc = YAML.parse(gpuPolicy);
 
-    expect(gpuDoc.filesystem_policy.read_only).toContain("/proc");
-    expect(gpuDoc.filesystem_policy.read_write).toEqual([
-      "/tmp",
-      "/proc/self/task/*/comm",
-    ]);
+    expect(gpuDoc.filesystem_policy.read_only).toEqual(["/usr"]);
+    expect(gpuDoc.filesystem_policy.read_write).toEqual(["/tmp"]);
   });
 
   it("models the OpenShell standalone gateway environment", () => {
@@ -640,12 +645,18 @@ network_policies:
     const commands = buildDirectSandboxGpuProofCommands("alpha");
     expect(commands.map((entry) => entry.label)).toEqual([
       "nvidia-smi",
-      "/proc/self/task/<tid>/comm write",
+      "/proc/<pid>/task/<tid>/comm write",
       "cuInit(0) via libcuda.so.1",
     ]);
     expect(commands[0].args).toEqual(["sandbox", "exec", "-n", "alpha", "--", "nvidia-smi"]);
-    expect(commands[1].args.join(" ")).toContain("/proc/self/task/${tid}/comm");
+    expect(commands[1].args.join(" ")).toContain("/proc/$$/task/$$/comm");
+    expect(commands[1].args.join(" ")).not.toContain("ls /proc/self/task");
     expect(commands[2].args.join(" ")).toContain("cuInit(0)");
+    for (const command of commands) {
+      for (const arg of command.args) {
+        assert.doesNotMatch(arg, /[\r\n]/);
+      }
+    }
   });
 
   it("uses Hermes-oriented sandbox defaults when NemoHermes selects Hermes", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fix direct-GPU sandbox onboarding by removing NemoClaw’s create-time procfs entries that OpenShell should own at runtime. This avoids the literal `/proc/self/task/*/comm` policy path crash and makes GPU verification compatible with newer OpenShell command validation.

## Related Issue
Fixes #3416

## Changes
- Remove `/proc` and `/proc/self/task/*/comm` from direct-GPU create policies so OpenShell can apply GPU procfs enrichment.
- Convert GPU proof shell payloads to single-line commands for OpenShell 0.0.39 compatibility.
- Fix the proc comm write proof to target the shell’s own `/proc/<pid>/task/<tid>/comm` entry instead of a short-lived child process.
- Update onboarding tests for the proc policy behavior and GPU proof command shape.


## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * GPU policy generation now properly excludes `/proc` filesystem entries based on actual usage patterns rather than static paths.
  * GPU proof command generation includes improved path handling and validation.

* **Tests**
  * Expanded test coverage for GPU policy generation with validation of `/proc` entry removal from policies.
  * Enhanced test assertions for GPU proof command formatting and correctness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3436)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->