### PR TITLE
fix: repair onboard duplicate import and gateway upgrade check

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -54,9 +54,6 @@ const {
   verifyWebSearchInsideSandbox: verifyWebSearchInsideSandboxWithDeps,
 }: typeof import("./onboard/web-search-verify") = require("./onboard/web-search-verify");
 const {
-  verifyWebSearchInsideSandbox: verifyWebSearchInsideSandboxWithDeps,
-}: typeof import("./onboard/web-search-verify") = require("./onboard/web-search-verify");
-const {
   buildDirectGpuPolicyYaml,
   buildDirectSandboxGpuProofCommands,
   prepareInitialSandboxCreatePolicy,

--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -301,8 +301,8 @@ EOF
 exercise_macos_vm_rootfs_permission_regression() {
   grep -q "ARG NEMOCLAW_DARWIN_VM_COMPAT=0" Dockerfile \
     || fail "Dockerfile is missing the macOS VM rootfs compatibility ARG"
-  grep -Fq "NEMOCLAW_DARWIN_VM_COMPAT=\${darwinVmCompat" src/lib/onboard.ts \
-    || fail "onboard does not patch the macOS VM rootfs compatibility ARG"
+  grep -Fq "ARG NEMOCLAW_DARWIN_VM_COMPAT=\${sanitizeDockerArg(darwinVmCompat ? \"1\" : \"0\")}" src/lib/onboard/dockerfile-patch.ts \
+    || fail "Dockerfile patch helper does not patch the macOS VM rootfs compatibility ARG"
   grep -q 'process.platform === "darwin"' src/lib/onboard.ts \
     || fail "onboard does not enable macOS VM rootfs compatibility for Darwin sandbox builds"
   grep -q "chmod -R a+rwX /sandbox/.openclaw" Dockerfile \


### PR DESCRIPTION
## Summary
Related: #3203

This PR now carries two small forward fixes needed after updating from current main:

- updates the OpenShell gateway upgrade E2E to check the extracted Dockerfile patch helper in src/lib/onboard/dockerfile-patch.ts instead of the old implementation location in src/lib/onboard.ts
- removes the duplicate web-search verifier require block that current main introduced in src/lib/onboard.ts and that breaks npm run build:cli with TS2451

## Validation
- bash -n test/e2e/test-openshell-gateway-upgrade.sh
- shellcheck test/e2e/test-openshell-gateway-upgrade.sh
- exact E2E guard grep checks for Dockerfile, dockerfile-patch.ts, onboard.ts, and OpenClaw state permissions
- npm run source-shape:check
- npm test -- src/lib/onboard/dockerfile-patch.test.ts
- npm test -- test/onboard.test.ts -t "macOS VM rootfs ownership compatibility"
- npm run build:cli

## Nightly Evidence
- Failing current main run before this PR: https://github.com/NVIDIA/NemoClaw/actions/runs/25778840380 at 0a828dad
- Same failure on prior run: https://github.com/NVIDIA/NemoClaw/actions/runs/25776685308 at d4ae22d
- Focused OpenShell gateway upgrade E2E passed before the main update: https://github.com/NVIDIA/NemoClaw/actions/runs/25780226018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved macOS VM compatibility regression testing to validate that the compatibility build argument is injected in sanitized form, ensuring the environment argument is applied correctly during image preparation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3438)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->