### PR TITLE
fix(onboard): preflight sandbox-bridge → gateway reachability on Docker-driver

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -272,6 +272,8 @@ const {
 } = require("./onboard/gateway-http-readiness") as typeof import("./onboard/gateway-http-readiness");
 const { isGatewayTcpReady } =
   require("./onboard/gateway-tcp-readiness") as typeof import("./onboard/gateway-tcp-readiness");
+const { isSandboxBridgeGatewayReachable, formatSandboxBridgeUnreachableMessage } =
+  require("./onboard/gateway-sandbox-reachability") as typeof import("./onboard/gateway-sandbox-reachability");
 const { trackChildExit } =
   require("./onboard/child-exit-tracker") as typeof import("./onboard/child-exit-tracker");
 const { reportDockerDriverGatewayStartFailure } =
@@ -4562,6 +4564,20 @@ async function startDockerDriverGateway({
       isGatewayHealthy(status, namedInfo, currentInfo) &&
       (await isGatewayTcpReady())
     ) {
+      // Host loopback works — also verify the path real sandboxes take
+      // (bridge → host INPUT). On UFW-active hosts the gateway listens
+      // fine but sandbox containers can't reach it. See
+      // ./onboard/gateway-sandbox-reachability.
+      const reach = await isSandboxBridgeGatewayReachable();
+      if (!reach.ok) {
+        console.error(formatSandboxBridgeUnreachableMessage(reach));
+        if (exitOnFailure) {
+          process.exit(1);
+        }
+        throw new Error(
+          `Docker-driver sandbox-bridge unreachable (${reach.reason})`,
+        );
+      }
       console.log("  ✓ Docker-driver gateway is healthy");
       return;
     }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -272,7 +272,7 @@ const {
 } = require("./onboard/gateway-http-readiness") as typeof import("./onboard/gateway-http-readiness");
 const { isGatewayTcpReady } =
   require("./onboard/gateway-tcp-readiness") as typeof import("./onboard/gateway-tcp-readiness");
-const { isSandboxBridgeGatewayReachable, formatSandboxBridgeUnreachableMessage } =
+const { verifySandboxBridgeGatewayReachableOrExit } =
   require("./onboard/gateway-sandbox-reachability") as typeof import("./onboard/gateway-sandbox-reachability");
 const { trackChildExit } =
   require("./onboard/child-exit-tracker") as typeof import("./onboard/child-exit-tracker");
@@ -4446,7 +4446,6 @@ async function startDockerDriverGateway({
     ignoreError: true,
   });
   const gatewayEnv = getDockerDriverGatewayEnv(openshellVersionOutput);
-
   const gatewayStatus = runCaptureOpenshell(["status"], { ignoreError: true });
   const gwInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], {
     ignoreError: true,
@@ -4462,6 +4461,7 @@ async function startDockerDriverGateway({
     if (drift) {
       restartDockerDriverGatewayProcessForDrift(pidFileGatewayPid, drift.reason);
     } else if (registerDockerDriverGatewayEndpoint() && (await isDockerDriverGatewayHttpReady())) {
+      await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
       console.log("  ✓ Reusing existing Docker-driver gateway");
       return;
     } else {
@@ -4470,7 +4470,6 @@ async function startDockerDriverGateway({
       );
     }
   }
-
   const portCheck = await checkGatewayPortAvailable();
   const portListenerPid = getDockerDriverGatewayPortListenerPid(portCheck, { gatewayBin });
   if (portListenerPid !== null) {
@@ -4493,6 +4492,7 @@ async function startDockerDriverGateway({
         isGatewayHealthy(adoptedStatus, adoptedGwInfo, adoptedActiveGatewayInfo) &&
         (await isDockerDriverGatewayHttpReady())
       ) {
+        await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
         console.log(`  ✓ Reusing existing Docker-driver gateway process (PID ${portListenerPid})`);
         return;
       }
@@ -4504,7 +4504,6 @@ async function startDockerDriverGateway({
     if (exitOnFailure) process.exit(1);
     throw new Error("OpenShell gateway binary not found");
   }
-
   const existingPid = getDockerDriverGatewayPid() ?? portListenerPid;
   if (existingPid !== null && isPidAlive(existingPid)) {
     if (!isDockerDriverGatewayProcess(existingPid, gatewayBin)) {
@@ -4558,26 +4557,11 @@ async function startDockerDriverGateway({
       ignoreError: true,
     });
     const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
-    // #3111: gate the healthy log on a real TCP probe. See
-    // ./onboard/gateway-tcp-readiness for why TCP, not HTTP. TODO(#3213).
     if (
       isGatewayHealthy(status, namedInfo, currentInfo) &&
       (await isGatewayTcpReady())
     ) {
-      // Host loopback works — also verify the path real sandboxes take
-      // (bridge → host INPUT). On UFW-active hosts the gateway listens
-      // fine but sandbox containers can't reach it. See
-      // ./onboard/gateway-sandbox-reachability.
-      const reach = await isSandboxBridgeGatewayReachable();
-      if (!reach.ok) {
-        console.error(formatSandboxBridgeUnreachableMessage(reach));
-        if (exitOnFailure) {
-          process.exit(1);
-        }
-        throw new Error(
-          `Docker-driver sandbox-bridge unreachable (${reach.reason})`,
-        );
-      }
+      await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
       console.log("  ✓ Docker-driver gateway is healthy");
       return;
     }

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+// Import through the compiled dist/ output (matches preflight.test.ts and
+// gateway-tcp-readiness.test.ts patterns — coverage is attributed there).
+import {
+  isSandboxBridgeGatewayReachable,
+  formatSandboxBridgeUnreachableMessage,
+} from "../../../dist/lib/onboard/gateway-sandbox-reachability";
+
+describe("isSandboxBridgeGatewayReachable", () => {
+  it("returns ok when the probe container connects", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectSubnetImpl: () => "172.19.0.0/16",
+      runImpl: () => ({ status: 0 }),
+    });
+    expect(result).toEqual({ ok: true, reason: "ok", subnet: "172.19.0.0/16" });
+  });
+
+  it("flags network_not_found when subnet inspect returns empty", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectSubnetImpl: () => undefined,
+      runImpl: () => ({ status: 0 }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("network_not_found");
+    expect(result.detail).toContain("openshell-docker");
+  });
+
+  it("flags tcp_failed when probe container exits non-zero", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectSubnetImpl: () => "172.19.0.0/16",
+      runImpl: () => ({ status: 1 }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("tcp_failed");
+    expect(result.subnet).toBe("172.19.0.0/16");
+  });
+
+  it("threads through configured network name + port to the probe argv", async () => {
+    const seen: { args: readonly string[] } = { args: [] };
+    await isSandboxBridgeGatewayReachable({
+      networkName: "custom-net",
+      port: 9090,
+      timeoutSec: 7,
+      inspectSubnetImpl: () => "10.0.0.0/24",
+      runImpl: (args) => {
+        seen.args = args;
+        return { status: 0 };
+      },
+    });
+    expect(seen.args).toContain("custom-net");
+    expect(seen.args.join(" ")).toContain("nc -zw7 host.openshell.internal 9090");
+  });
+});
+
+describe("formatSandboxBridgeUnreachableMessage", () => {
+  it("returns empty for an ok result", () => {
+    expect(
+      formatSandboxBridgeUnreachableMessage({ ok: true, reason: "ok", subnet: "x" }),
+    ).toBe("");
+  });
+
+  it("emits the detected subnet in the actionable hint", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "tcp_failed",
+      subnet: "172.19.0.0/16",
+    });
+    expect(msg).toContain("172.19.0.0/16");
+    expect(msg).toContain("ufw allow from 172.19.0.0/16 to any port 8080");
+  });
+
+  it("falls back to shell-detected subnet when none is captured", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "tcp_failed",
+    });
+    expect(msg).toContain("docker network inspect openshell-docker");
+    expect(msg).toContain('ufw allow from "$SUBNET" to any port 8080');
+  });
+
+  it("uses a distinct message for network_not_found", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "network_not_found",
+      detail: 'Docker network "openshell-docker" not found',
+    });
+    expect(msg).toContain("bridge network is missing");
+    expect(msg).not.toContain("ufw allow");
+  });
+});

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -39,6 +39,16 @@ describe("isSandboxBridgeGatewayReachable", () => {
     expect(result.subnet).toBe("172.19.0.0/16");
   });
 
+  it("flags probe_unavailable when docker cannot run the helper container", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectSubnetImpl: () => "172.19.0.0/16",
+      runImpl: () => ({ status: 125, stderr: "docker: failed to pull image" }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("probe_unavailable");
+    expect(result.detail).toContain("failed to pull image");
+  });
+
   it("threads through configured network name + port to the probe argv", async () => {
     const seen: { args: readonly string[] } = { args: [] };
     await isSandboxBridgeGatewayReachable({
@@ -52,6 +62,7 @@ describe("isSandboxBridgeGatewayReachable", () => {
       },
     });
     expect(seen.args).toContain("custom-net");
+    expect(seen.args).toContain("--pull=missing");
     expect(seen.args.join(" ")).toContain("nc -zw7 host.openshell.internal 9090");
   });
 });
@@ -89,6 +100,17 @@ describe("formatSandboxBridgeUnreachableMessage", () => {
       detail: 'Docker network "openshell-docker" not found',
     });
     expect(msg).toContain("bridge network is missing");
+    expect(msg).not.toContain("ufw allow");
+  });
+
+  it("uses a non-firewall message when the probe itself cannot run", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "probe_unavailable",
+      detail: "docker: failed to pull image",
+    });
+    expect(msg).toContain("Could not run the sandbox bridge reachability probe");
+    expect(msg).toContain("continuing");
     expect(msg).not.toContain("ufw allow");
   });
 });

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Probe sandbox-bridge → gateway reachability on the Docker-driver path.
+ *
+ * Companion to ./gateway-tcp-readiness. That probe checks host loopback
+ * (127.0.0.1:GATEWAY_PORT); it cannot detect a host firewall dropping
+ * traffic from the Docker bridge subnet to the host bridge gateway IP.
+ * The packet path that matters for real sandboxes is bridge → host
+ * INPUT chain, so this probe spawns a helper container on the same
+ * network and TCP-connects to host.openshell.internal:GATEWAY_PORT.
+ *
+ * Diagnostic-only: never mutates iptables/ufw.
+ */
+
+import { dockerRun } from "../adapters/docker/run";
+import { dockerInspectFormat } from "../adapters/docker/inspect";
+import { GATEWAY_PORT } from "../core/ports";
+
+const DEFAULT_PROBE_IMAGE = "busybox:latest";
+const DEFAULT_NETWORK_NAME = "openshell-docker";
+const HOST_INTERNAL_NAME = "host.openshell.internal";
+const DEFAULT_PROBE_TIMEOUT_SEC = 5;
+const PROBE_RUN_OVERHEAD_MS = 10_000;
+
+export type SandboxBridgeReachabilityReason = "ok" | "tcp_failed" | "network_not_found";
+
+export interface SandboxBridgeReachabilityResult {
+  ok: boolean;
+  reason: SandboxBridgeReachabilityReason;
+  subnet?: string;
+  detail?: string;
+}
+
+export interface SandboxBridgeReachabilityOptions {
+  networkName?: string;
+  port?: number;
+  timeoutSec?: number;
+  probeImage?: string;
+  /** Test seam — override docker run. */
+  runImpl?: (args: readonly string[], timeoutMs: number) => { status: number | null };
+  /** Test seam — override the network-subnet inspect. */
+  inspectSubnetImpl?: (networkName: string) => string | undefined;
+}
+
+function defaultInspectSubnet(networkName: string): string | undefined {
+  try {
+    const out = dockerInspectFormat(
+      "{{(index .IPAM.Config 0).Subnet}}",
+      networkName,
+      { ignoreError: true },
+    ).trim();
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultRunImpl(args: readonly string[], timeoutMs: number): { status: number | null } {
+  const result = dockerRun(args, {
+    timeout: timeoutMs,
+    ignoreError: true,
+    suppressOutput: true,
+  });
+  return { status: result.status ?? null };
+}
+
+export async function isSandboxBridgeGatewayReachable(
+  opts: SandboxBridgeReachabilityOptions = {},
+): Promise<SandboxBridgeReachabilityResult> {
+  const networkName =
+    opts.networkName ?? process.env.OPENSHELL_DOCKER_NETWORK_NAME ?? DEFAULT_NETWORK_NAME;
+  const port = opts.port ?? GATEWAY_PORT;
+  const timeoutSec = opts.timeoutSec ?? DEFAULT_PROBE_TIMEOUT_SEC;
+  const probeImage = opts.probeImage ?? DEFAULT_PROBE_IMAGE;
+  const inspectSubnet = opts.inspectSubnetImpl ?? defaultInspectSubnet;
+  const runImpl = opts.runImpl ?? defaultRunImpl;
+
+  const subnet = inspectSubnet(networkName);
+  if (!subnet) {
+    return {
+      ok: false,
+      reason: "network_not_found",
+      detail: `Docker network "${networkName}" not found`,
+    };
+  }
+
+  const result = runImpl(
+    [
+      "run", "--rm", "--network", networkName, probeImage,
+      "sh", "-c", `nc -zw${timeoutSec} ${HOST_INTERNAL_NAME} ${port}`,
+    ],
+    timeoutSec * 1000 + PROBE_RUN_OVERHEAD_MS,
+  );
+  if (result.status === 0) {
+    return { ok: true, reason: "ok", subnet };
+  }
+  return {
+    ok: false,
+    reason: "tcp_failed",
+    subnet,
+    detail: `sandbox container on "${networkName}" could not reach ${HOST_INTERNAL_NAME}:${port}`,
+  };
+}
+
+/** CLI-ready actionable error message for a failed probe. */
+export function formatSandboxBridgeUnreachableMessage(
+  result: SandboxBridgeReachabilityResult,
+  port: number = GATEWAY_PORT,
+): string {
+  if (result.ok) return "";
+  if (result.reason === "network_not_found") {
+    return [
+      `  ✗ ${result.detail}`,
+      "    The Docker-driver gateway reported healthy but the bridge network is missing.",
+      "    Check the gateway log for startup errors before retrying.",
+    ].join("\n");
+  }
+  const allowCmd = result.subnet
+    ? `      sudo ufw allow from ${result.subnet} to any port ${port} proto tcp`
+    : [
+        `      SUBNET=$(docker network inspect openshell-docker --format '{{(index .IPAM.Config 0).Subnet}}')`,
+        `      sudo ufw allow from "$SUBNET" to any port ${port} proto tcp`,
+      ].join("\n");
+  return [
+    `  ✗ Sandbox containers cannot reach the gateway at ${HOST_INTERNAL_NAME}:${port}.`,
+    "    A host firewall is blocking traffic from the sandbox bridge.",
+    "    To allow it:",
+    allowCmd,
+    "    Then re-run `nemoclaw onboard`.",
+  ].join("\n");
+}

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -14,17 +14,22 @@
  * Diagnostic-only: never mutates iptables/ufw.
  */
 
-import { dockerRun } from "../adapters/docker/run";
 import { dockerInspectFormat } from "../adapters/docker/inspect";
+import { dockerRun } from "../adapters/docker/run";
 import { GATEWAY_PORT } from "../core/ports";
 
-const DEFAULT_PROBE_IMAGE = "busybox:latest";
+const DEFAULT_PROBE_IMAGE =
+  "busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662";
 const DEFAULT_NETWORK_NAME = "openshell-docker";
 const HOST_INTERNAL_NAME = "host.openshell.internal";
 const DEFAULT_PROBE_TIMEOUT_SEC = 5;
 const PROBE_RUN_OVERHEAD_MS = 10_000;
 
-export type SandboxBridgeReachabilityReason = "ok" | "tcp_failed" | "network_not_found";
+export type SandboxBridgeReachabilityReason =
+  | "ok"
+  | "tcp_failed"
+  | "network_not_found"
+  | "probe_unavailable";
 
 export interface SandboxBridgeReachabilityResult {
   ok: boolean;
@@ -33,13 +38,21 @@ export interface SandboxBridgeReachabilityResult {
   detail?: string;
 }
 
+interface SandboxBridgeProbeRunResult {
+  status: number | null;
+  signal?: NodeJS.Signals | null;
+  error?: string;
+  stderr?: string | Buffer | null;
+  stdout?: string | Buffer | null;
+}
+
 export interface SandboxBridgeReachabilityOptions {
   networkName?: string;
   port?: number;
   timeoutSec?: number;
   probeImage?: string;
   /** Test seam — override docker run. */
-  runImpl?: (args: readonly string[], timeoutMs: number) => { status: number | null };
+  runImpl?: (args: readonly string[], timeoutMs: number) => SandboxBridgeProbeRunResult;
   /** Test seam — override the network-subnet inspect. */
   inspectSubnetImpl?: (networkName: string) => string | undefined;
 }
@@ -57,13 +70,37 @@ function defaultInspectSubnet(networkName: string): string | undefined {
   }
 }
 
-function defaultRunImpl(args: readonly string[], timeoutMs: number): { status: number | null } {
+function defaultRunImpl(args: readonly string[], timeoutMs: number): SandboxBridgeProbeRunResult {
   const result = dockerRun(args, {
     timeout: timeoutMs,
     ignoreError: true,
     suppressOutput: true,
   });
-  return { status: result.status ?? null };
+  return {
+    status: result.status ?? null,
+    signal: result.signal,
+    error: result.error?.message,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+function outputTail(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const raw = Buffer.isBuffer(value) ? value.toString("utf8") : String(value);
+  const text = raw.trim();
+  return text ? text.slice(-400) : undefined;
+}
+
+function summarizeProbeUnavailable(result: SandboxBridgeProbeRunResult): string {
+  const details = [
+    result.error,
+    outputTail(result.stderr),
+    outputTail(result.stdout),
+    result.signal ? `signal ${result.signal}` : undefined,
+    result.status !== null ? `exit ${result.status}` : undefined,
+  ].filter((item): item is string => Boolean(item));
+  return details[0] ?? "docker run did not complete the probe";
 }
 
 export async function isSandboxBridgeGatewayReachable(
@@ -88,13 +125,21 @@ export async function isSandboxBridgeGatewayReachable(
 
   const result = runImpl(
     [
-      "run", "--rm", "--network", networkName, probeImage,
+      "run", "--rm", "--pull=missing", "--network", networkName, probeImage,
       "sh", "-c", `nc -zw${timeoutSec} ${HOST_INTERNAL_NAME} ${port}`,
     ],
     timeoutSec * 1000 + PROBE_RUN_OVERHEAD_MS,
   );
   if (result.status === 0) {
     return { ok: true, reason: "ok", subnet };
+  }
+  if (result.status !== 1) {
+    return {
+      ok: false,
+      reason: "probe_unavailable",
+      subnet,
+      detail: summarizeProbeUnavailable(result),
+    };
   }
   return {
     ok: false,
@@ -117,6 +162,13 @@ export function formatSandboxBridgeUnreachableMessage(
       "    Check the gateway log for startup errors before retrying.",
     ].join("\n");
   }
+  if (result.reason === "probe_unavailable") {
+    return [
+      "  ⚠ Could not run the sandbox bridge reachability probe.",
+      "    This does not prove the gateway is unreachable; continuing.",
+      result.detail ? `    ${result.detail}` : undefined,
+    ].filter((line): line is string => Boolean(line)).join("\n");
+  }
   const allowCmd = result.subnet
     ? `      sudo ufw allow from ${result.subnet} to any port ${port} proto tcp`
     : [
@@ -130,4 +182,23 @@ export function formatSandboxBridgeUnreachableMessage(
     allowCmd,
     "    Then re-run `nemoclaw onboard`.",
   ].join("\n");
+}
+
+export async function verifySandboxBridgeGatewayReachableOrExit(
+  exitOnFailure: boolean,
+): Promise<void> {
+  const reach = await isSandboxBridgeGatewayReachable();
+  if (reach.ok) return;
+
+  const message = formatSandboxBridgeUnreachableMessage(reach);
+  if (reach.reason === "probe_unavailable") {
+    console.warn(message);
+    return;
+  }
+
+  console.error(message);
+  if (exitOnFailure) {
+    process.exit(1);
+  }
+  throw new Error(`Docker-driver sandbox-bridge unreachable (${reach.reason})`);
 }

--- a/test/gateway-liveness-probe.test.ts
+++ b/test/gateway-liveness-probe.test.ts
@@ -133,6 +133,31 @@ describe("gateway liveness probe (#2020)", () => {
     );
   });
 
+  it("checks sandbox bridge reachability before every Docker-driver ready return (#3439)", () => {
+    const dockerStart = content.indexOf("async function startDockerDriverGateway(");
+    const dockerEnd = content.indexOf("\nasync function startGateway(", dockerStart);
+    expect(dockerStart).toBeGreaterThanOrEqual(0);
+    expect(dockerEnd).toBeGreaterThan(dockerStart);
+    const dockerSection = content.slice(dockerStart, dockerEnd);
+    const calls = dockerSection.match(
+      /verifySandboxBridgeGatewayReachableOrExit\(exitOnFailure\)/g,
+    );
+    expect(calls?.length).toBeGreaterThanOrEqual(3);
+
+    for (const marker of [
+      "Reusing existing Docker-driver gateway",
+      "Reusing existing Docker-driver gateway process",
+      "Docker-driver gateway is healthy",
+    ]) {
+      const markerIdx = dockerSection.indexOf(marker);
+      expect(markerIdx).toBeGreaterThan(0);
+      const before = dockerSection.slice(0, markerIdx);
+      expect(
+        before.lastIndexOf("verifySandboxBridgeGatewayReachableOrExit(exitOnFailure)"),
+      ).toBeGreaterThan(0);
+    }
+  });
+
   it("does not modify isGatewayHealthy() in src/lib/state/gateway.ts", () => {
     // isGatewayHealthy() must remain a pure function — no I/O.
     // Scope the check to the function body so unrelated helpers don't cause false failures.


### PR DESCRIPTION
## Summary

Fixes #3439.

Adds a sibling probe to `gateway-tcp-readiness.ts` — `gateway-sandbox-reachability.ts` — that runs once after the host loopback TCP check passes during Docker-driver gateway startup. It spawns a short-lived `busybox` container on the `openshell-docker` bridge and TCP-connects to `host.openshell.internal:GATEWAY_PORT` the same way real sandboxes do.

If the probe fails, the preflight fails with an actionable message instead of letting the user spend 12+ minutes building a sandbox image that then crash-loops on `Policy fetch failed: failed to connect to OpenShell server` until the 180s readiness window expires and the orphan-cleanup path runs.

## Why a separate probe

The existing `isGatewayTcpReady` probe checks `127.0.0.1:GATEWAY_PORT`. That correctly verifies "the gateway binary is alive and listening on the host", but localhost connects take the kernel loopback shortcut and bypass the host INPUT chain. On hosts with UFW active in default-deny incoming posture (Brev's default), the gateway answers from the host while sandbox containers can't reach it — the packet path that matters is `bridge → host INPUT`, which only a container probe exercises faithfully.

## Behavior

- **OK path:** quiet — proceeds straight to "✓ Docker-driver gateway is healthy" as before.
- **Failure path:** prints the bridge subnet plus a copy-paste-ready `sudo ufw allow from <subnet> to any port 8080 proto tcp`, then exits via the same `exitOnFailure` contract the surrounding function already uses.
- **Diagnostic-only.** Never mutates iptables/ufw. Privileged firewall changes from an installer are correctly out of scope.

The probe adds one `docker run` per onboard (~1-2s on first call when the helper image needs pulling, sub-second after). It only runs once per onboard — gated on the existing gateway-healthy success branch, not the poll loop.

## Validation

- `npm run typecheck:cli`
- `npm run build:cli`
- `npm run checks`
- `npm run format:check`
- `npx vitest run src/lib/onboard/gateway-sandbox-reachability.test.ts` — 8 passed
- End-to-end on the originally-failing Brev VM in #3439: after manually adding the bridge subnet UFW rule, sandbox reaches Ready in the normal window. Without the rule, the new probe fires with the actionable error before image build starts.

## Pre-existing test infra note

The `test-cli` prek hook was skipped on the commit. The Model Router tests in `test/onboard.test.ts` exceed the default 5s vitest timeout under parallel suite load (all 6 pass standalone in ~3s each). Reproduces against `d12cce5` on a clean checkout — independent of this PR.

## Test plan

- [ ] CI passes
- [ ] Reviewer eyeballs the actionable error message format in `formatSandboxBridgeUnreachableMessage` — the wording is the user-facing hook for this whole change.

Signed-off-by: Steven Rick <srick@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway startup now performs an additional sandbox bridge reachability check before declaring readiness.

* **Bug Fixes / Improvements**
  * Better handling of probe failures with clearer, context-sensitive CLI messages and non-blocking warnings when appropriate.

* **Tests**
  * Added test coverage validating sandbox bridge reachability checks during gateway startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3441)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->