### PR TITLE
fix(hermes): enable macOS VM rootfs compat

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -69,6 +69,7 @@ ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=
 ARG NEMOCLAW_DISCORD_GUILDS_B64=e30=
 ARG NEMOCLAW_TELEGRAM_CONFIG_B64=e30=
 ARG NEMOCLAW_BUILD_ID=default
+ARG NEMOCLAW_DARWIN_VM_COMPAT=0
 
 # Promote build-args to env vars for the config generation script.
 ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
@@ -252,6 +253,16 @@ RUN sha256sum /sandbox/.hermes/config.yaml /sandbox/.hermes/.env \
     > /sandbox/.hermes/.config-hash \
     && chmod 600 /sandbox/.hermes/.config-hash \
     && chown sandbox:sandbox /sandbox/.hermes/.config-hash
+
+# OpenShell's macOS VM backend currently remaps extracted rootfs ownership to
+# the host uid/gid before startup. Hermes uses /sandbox as a read_write path, so
+# that repair walks the trusted rc files too; keep this Darwin-only so Linux
+# Docker-driver sandboxes retain the tighter default permissions.
+RUN if [ "$NEMOCLAW_DARWIN_VM_COMPAT" = "1" ]; then \
+        chmod -R a+rwX /sandbox/.hermes; \
+        find /sandbox/.hermes -type d -exec chmod a+rwx {} +; \
+        chmod a+rw /sandbox/.bashrc /sandbox/.profile; \
+    fi
 
 # start.sh handles privilege separation: runs as root initially, then drops
 # to 'gateway' user via gosu for the agent process. See start.sh.

--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -307,7 +307,13 @@ exercise_macos_vm_rootfs_permission_regression() {
     || fail "onboard does not enable macOS VM rootfs compatibility for Darwin sandbox builds"
   grep -q "chmod -R a+rwX /sandbox/.openclaw" Dockerfile \
     || fail "Dockerfile does not relax OpenClaw state permissions for macOS VM rootfs remapping"
-  pass "macOS VM sandbox builds enable rootfs ownership compatibility"
+  grep -q "ARG NEMOCLAW_DARWIN_VM_COMPAT=0" agents/hermes/Dockerfile \
+    || fail "Hermes Dockerfile is missing the macOS VM rootfs compatibility ARG"
+  grep -q "chmod -R a+rwX /sandbox/.hermes" agents/hermes/Dockerfile \
+    || fail "Hermes Dockerfile does not relax Hermes state permissions for macOS VM rootfs remapping"
+  grep -q "chmod a+rw /sandbox/.bashrc /sandbox/.profile" agents/hermes/Dockerfile \
+    || fail "Hermes Dockerfile does not relax trusted rc files for macOS VM ownership repair"
+  pass "macOS VM sandbox builds enable OpenClaw and Hermes rootfs ownership compatibility"
 }
 
 wait_for_survivor_ready() {


### PR DESCRIPTION
## Summary
- add the Darwin VM compatibility ARG to the Hermes sandbox Dockerfile
- relax Hermes mutable state and trusted rc files only when `NEMOCLAW_DARWIN_VM_COMPAT=1`, matching the macOS OpenShell VM ownership-repair path while preserving Linux/Docker defaults
- extend the OpenShell gateway upgrade regression guard so Hermes is checked alongside OpenClaw

## Validation
- `git diff --check`
- `bash -n test/e2e/test-openshell-gateway-upgrade.sh`
- `shellcheck test/e2e/test-openshell-gateway-upgrade.sh`
- `docker build -f agents/hermes/Dockerfile --build-arg NEMOCLAW_DARWIN_VM_COMPAT=1 -t nemoclaw-hermes-darwin-compat-test:local .`
- `docker run --rm --entrypoint /bin/sh nemoclaw-hermes-darwin-compat-test:local -lc 'stat -c "%a %U:%G %n" /sandbox/.bashrc /sandbox/.profile /sandbox/.hermes /sandbox/.hermes/config.yaml /sandbox/.hermes/.env /sandbox/.hermes/.config-hash /sandbox/.hermes/runtime'`\n\n## Notes\nThe observed macOS failure happened after the image build completed: OpenShell VM rootfs ownership repair exited on root-owned read-only `/sandbox/.bashrc` and `/sandbox/.profile` in the Hermes image. Ubuntu Docker nightly coverage does not hit this VM repair path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced macOS virtual machine backend support with improved permission handling for platform-specific environments.

* **Tests**
  * Expanded end-to-end tests to verify macOS virtual machine environment compatibility requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3442)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->