### PR TITLE
fix(sandbox): recover stale inference route on connect

### DIFF
--- a/nemoclaw/src/lib/subprocess-env.ts
+++ b/nemoclaw/src/lib/subprocess-env.ts
@@ -49,10 +49,10 @@ const ALLOWED_ENV_PREFIXES = ["LC_", "XDG_", "OPENSHELL_", "GRPC_"];
 // ── Public API ─────────────────────────────────────────────────
 
 /**
- * When any HTTP proxy is forwarded, ensure localhost and loopback traffic is
- * not routed through it. Without this, tools that respect HTTP_PROXY (curl,
- * Node.js http, Python requests) will tunnel loopback requests to the user's
- * proxy (e.g. Privoxy), which fails with HTTP 500.
+ * When any HTTP proxy is forwarded, ensure local host-bound traffic is not
+ * routed through it. Without this, tools that respect HTTP_PROXY (curl, Node.js
+ * http, Python requests) will tunnel loopback or WSL Windows-host requests to
+ * the user's proxy (e.g. Privoxy), which fails with HTTP 500.
  * See: #2616
  */
 export function withLocalNoProxy(env: Record<string, string>): void {
@@ -62,7 +62,7 @@ export function withLocalNoProxy(env: Record<string, string>): void {
     const current = env[key] ?? "";
     const parts = current ? current.split(",").map((s) => s.trim()) : [];
     let changed = false;
-    for (const host of ["localhost", "127.0.0.1"]) {
+    for (const host of ["localhost", "127.0.0.1", "host.docker.internal"]) {
       if (!parts.includes(host)) {
         parts.push(host);
         changed = true;

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -1,13 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
 import { spawnSync } from "node:child_process";
 import os from "node:os";
-
-import { CLI_NAME } from "../../cli/branding";
-import { parseGatewayInference } from "../../inference/config";
-import { ensureOllamaAuthProxy } from "../../inference/ollama/proxy";
+import { resolveOpenshell } from "../../adapters/openshell/resolve";
 import {
   captureOpenshell,
   getOpenshellBinary,
@@ -15,25 +11,34 @@ import {
 } from "../../adapters/openshell/runtime";
 import {
   OPENSHELL_INFERENCE_ROUTE_PROBE_TIMEOUT_MS,
+  OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "../../adapters/openshell/timeouts";
-import * as registry from "../../state/registry";
-import type { SandboxEntry } from "../../state/registry";
-import { ROOT } from "../../runner";
-import { runSetupDnsProxy } from "../dns";
-import { ensureLiveSandboxOrExit } from "./gateway-state";
+import { CLI_NAME } from "../../cli/branding";
+import { D, G, R, YW } from "../../cli/terminal-style";
+import { parseGatewayInference } from "../../inference/config";
+import { findReachableOllamaHost, probeLocalProviderHealth } from "../../inference/local";
 import {
-  applyOpenShellVmDnsMonkeypatch,
-  shouldApplyVmDnsMonkeypatch,
-} from "./vm-dns-monkeypatch";
+  ensureOllamaAuthProxy,
+  probeOllamaAuthProxyHealth,
+} from "../../inference/ollama/proxy";
+import { LOCAL_INFERENCE_TIMEOUT_SECS } from "../../onboard/env";
+import { isWsl } from "../../platform";
+import { ROOT } from "../../runner";
+import * as sandboxVersion from "../../sandbox/version";
+import type { SandboxEntry } from "../../state/registry";
+import * as registry from "../../state/registry";
 import {
   createSystemDeps as createSessionDeps,
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
+import { runSetupDnsProxy } from "../dns";
+import { ensureLiveSandboxOrExit } from "./gateway-state";
 import { checkAndRecoverSandboxProcesses } from "./process-recovery";
-import * as sandboxVersion from "../../sandbox/version";
-import { D, G, R, YW } from "../../cli/terminal-style";
-import { resolveOpenshell } from "../../adapters/openshell/resolve";
+import {
+  applyOpenShellVmDnsMonkeypatch,
+  shouldApplyVmDnsMonkeypatch,
+} from "./vm-dns-monkeypatch";
 
 const agentRuntime = require("../../../../bin/lib/agent-runtime");
 
@@ -46,6 +51,17 @@ export type SandboxConnectOptions = {
 type SpawnLikeResult = {
   status: number | null;
   signal?: NodeJS.Signals | null;
+};
+
+type SandboxInferenceRouteProbe = {
+  healthy: boolean;
+  broken: boolean;
+  detail: string;
+};
+
+type SandboxInferenceRouteEnsureResult = {
+  sandbox: SandboxEntry | null;
+  routeHealthy: boolean | null;
 };
 
 const SANDBOX_CONNECT_FLAGS = new Set([
@@ -112,7 +128,7 @@ function runSandboxConnectProbe(sandboxName: string): void {
     process.exit(1);
   }
   if (processCheck.wasRunning) {
-    ensureSandboxInferenceRoute(sandboxName, { quiet: false });
+    ensureSandboxInferenceRouteOrExit(sandboxName, { quiet: false });
     if (processCheck.forwardRecovered) {
       console.log(
         `  Probe complete: ${agentName} gateway is running in '${sandboxName}'; restored dashboard port forward.`,
@@ -123,11 +139,11 @@ function runSandboxConnectProbe(sandboxName: string): void {
     return;
   }
   if (processCheck.recovered) {
-    ensureSandboxInferenceRoute(sandboxName, { quiet: false });
+    ensureSandboxInferenceRouteOrExit(sandboxName, { quiet: false });
     console.log(`  Probe complete: recovered ${agentName} gateway in '${sandboxName}'.`);
     return;
   }
-  ensureSandboxInferenceRoute(sandboxName, { quiet: false });
+  ensureSandboxInferenceRouteOrExit(sandboxName, { quiet: false });
   console.error(
     `  Probe failed: ${agentName} gateway is not running in '${sandboxName}' and automatic recovery failed.`,
   );
@@ -135,7 +151,7 @@ function runSandboxConnectProbe(sandboxName: string): void {
   process.exit(1);
 }
 
-function isSandboxInferenceRouteHealthy(sandboxName: string): boolean {
+function probeSandboxInferenceRoute(sandboxName: string): SandboxInferenceRouteProbe {
   // Keep the shell string inside the sandbox: curl write-out, body capture,
   // and status classification must run as one bounded probe. sandboxName
   // remains an argv value, so no user input is interpolated into the script.
@@ -150,35 +166,67 @@ function isSandboxInferenceRouteHealthy(sandboxName: string): boolean {
       "-c",
       [
         "OUT=/tmp/nemoclaw-inference-route-probe.out",
-        "HTTP_CODE=$(curl -sk -o \"$OUT\" -w '%{http_code}' --connect-timeout 3 --max-time 8 https://inference.local/v1/models 2>/dev/null || printf '000')",
-        "case \"$HTTP_CODE\" in 000|5*) printf 'BROKEN %s ' \"$HTTP_CODE\"; head -c 160 \"$OUT\" 2>/dev/null ;; *) printf 'OK %s' \"$HTTP_CODE\" ;; esac",
+        "HTTP_CODE=$(curl -sk -o \"$OUT\" -w '%{http_code}' --connect-timeout 3 --max-time 8 https://inference.local/v1/models 2>/dev/null) || HTTP_CODE=000",
+        "case \"$HTTP_CODE\" in 000|5*) printf 'BROKEN %s ' \"$HTTP_CODE\"; head -c 160 \"$OUT\" 2>/dev/null || true ;; *) printf 'OK %s' \"$HTTP_CODE\" ;; esac",
       ].join("; "),
     ],
     { ignoreError: true, timeout: OPENSHELL_INFERENCE_ROUTE_PROBE_TIMEOUT_MS },
   );
-  return probe.status === 0 && /^OK\s+[0-9]{3}\b/.test(probe.output.trim());
+  const detail = probe.output.trim();
+  return {
+    healthy: probe.status === 0 && /^OK\s+[0-9]{3}\b/.test(detail),
+    broken: /^BROKEN\s+[0-9]{3}\b/.test(detail),
+    detail: detail || `openshell sandbox exec exited with status ${String(probe.status)}`,
+  };
 }
 
 function shouldUseLegacyDnsProxyRepair(sb: SandboxEntry | null): boolean {
   return sb?.openshellDriver !== "vm";
 }
 
-function reapplyVmInferenceRoute(sandboxName: string, sb: SandboxEntry | null): boolean {
-  if (!sb?.provider || !sb.model) return false;
-  runOpenshell(
-    ["inference", "set", "--provider", sb.provider, "--model", sb.model, "--no-verify"],
-    { ignoreError: true },
-  );
-  return isSandboxInferenceRouteHealthy(sandboxName);
+function buildInferenceSetArgs(provider: string, model: string): string[] {
+  const args = [
+    "inference",
+    "set",
+    "--provider",
+    provider,
+    "--model",
+    model,
+    "--no-verify",
+  ];
+  if (["compatible-endpoint", "ollama-local", "vllm-local"].includes(provider)) {
+    args.push("--timeout", String(LOCAL_INFERENCE_TIMEOUT_SECS));
+  }
+  return args;
+}
+
+function reapplyVmInferenceRoute(
+  sandboxName: string,
+  sb: SandboxEntry | null,
+): SandboxInferenceRouteProbe | null {
+  if (!sb?.provider || !sb.model) return null;
+  runOpenshell(buildInferenceSetArgs(sb.provider, sb.model), {
+    ignoreError: true,
+    timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
+  });
+  return probeSandboxInferenceRoute(sandboxName);
 }
 
 function repairSandboxInferenceRouteIfNeeded(
   sandboxName: string,
   sb: SandboxEntry | null,
   { quiet = false }: { quiet?: boolean } = {},
-): boolean {
-  if (process.env.NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR === "1") return false;
-  if (isSandboxInferenceRouteHealthy(sandboxName)) return false;
+): { healthy: boolean; repairAttempted: boolean; detail: string } {
+  if (process.env.NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR === "1") {
+    return { healthy: true, repairAttempted: false, detail: "route repair disabled" };
+  }
+  const initialProbe = probeSandboxInferenceRoute(sandboxName);
+  if (initialProbe.healthy) {
+    return { healthy: true, repairAttempted: false, detail: initialProbe.detail };
+  }
+  if (!initialProbe.broken) {
+    return { healthy: true, repairAttempted: false, detail: initialProbe.detail };
+  }
 
   if (!shouldUseLegacyDnsProxyRepair(sb)) {
     if (shouldApplyVmDnsMonkeypatch(sb)) {
@@ -189,18 +237,23 @@ function repairSandboxInferenceRouteIfNeeded(
         );
       }
       const patch = applyOpenShellVmDnsMonkeypatch(sandboxName, sb);
-      if (patch.ok && isSandboxInferenceRouteHealthy(sandboxName)) {
+      const patchedProbe = patch.ok ? probeSandboxInferenceRoute(sandboxName) : null;
+      if (patchedProbe?.healthy) {
         if (!quiet) {
           console.log("  inference.local route repaired.");
         }
-        return true;
+        return {
+          healthy: true,
+          repairAttempted: true,
+          detail: patchedProbe.detail,
+        };
       }
       if (!quiet) {
         if (!patch.ok && patch.reason) {
           console.error(
             `  Warning: OpenShell VM DNS monkeypatch did not apply: ${patch.reason}`,
           );
-        } else if (patch.ok) {
+        } else if (patchedProbe?.broken) {
           console.error(
             "  Warning: OpenShell VM DNS monkeypatch completed but inference.local is still unavailable.",
           );
@@ -212,17 +265,35 @@ function repairSandboxInferenceRouteIfNeeded(
       console.log("");
       console.log(`  inference.local is unavailable inside '${sandboxName}'. Reapplying OpenShell inference route...`);
     }
-    const healthy = reapplyVmInferenceRoute(sandboxName, sb);
+    const finalProbe = reapplyVmInferenceRoute(sandboxName, sb);
     if (!quiet) {
-      if (healthy) {
+      if (finalProbe?.healthy) {
         console.log("  inference.local route repaired.");
-      } else {
+      } else if (finalProbe?.broken) {
         console.error(
           `  Warning: inference.local is still unavailable through the OpenShell ${sb?.openshellDriver || "non-legacy"} gateway path.`,
         );
       }
     }
-    return healthy;
+    if (!finalProbe) {
+      return {
+        healthy: false,
+        repairAttempted: true,
+        detail: "missing sandbox provider or model",
+      };
+    }
+    if (!finalProbe.healthy && !finalProbe.broken) {
+      return {
+        healthy: true,
+        repairAttempted: true,
+        detail: finalProbe.detail,
+      };
+    }
+    return {
+      healthy: finalProbe.healthy,
+      repairAttempted: true,
+      detail: finalProbe.detail,
+    };
   }
 
   if (!quiet) {
@@ -238,24 +309,148 @@ function repairSandboxInferenceRouteIfNeeded(
       console.error("  Warning: failed to repair sandbox DNS proxy.");
       if (repair.message) console.error(`  ${repair.message}`);
     }
-    return false;
+    return {
+      healthy: false,
+      repairAttempted: true,
+      detail: repair.message || initialProbe.detail,
+    };
   }
 
-  const healthy = isSandboxInferenceRouteHealthy(sandboxName);
+  const repairedProbe = probeSandboxInferenceRoute(sandboxName);
   if (!quiet) {
-    if (healthy) {
+    if (repairedProbe.healthy) {
       console.log("  inference.local route repaired.");
-    } else {
+    } else if (repairedProbe.broken) {
       console.error("  Warning: inference.local is still unavailable after DNS proxy repair.");
     }
   }
-  return healthy;
+  if (!repairedProbe.healthy && !repairedProbe.broken) {
+    return {
+      healthy: true,
+      repairAttempted: true,
+      detail: repairedProbe.detail,
+    };
+  }
+  return {
+    healthy: repairedProbe.healthy,
+    repairAttempted: true,
+    detail: repairedProbe.detail,
+  };
+}
+
+function verifyLocalInferenceRouteDependencies(
+  provider: string,
+  { quiet = false }: { quiet?: boolean } = {},
+): boolean {
+  const isOllamaLocal = provider === "ollama-local";
+  if (isOllamaLocal) {
+    findReachableOllamaHost();
+    if (!isWsl()) {
+      ensureOllamaAuthProxy();
+    }
+  }
+  const localHealth = probeLocalProviderHealth(provider, {
+    skipOllamaAuthProxySubprobe: isOllamaLocal,
+  });
+  if (!localHealth) return true;
+  if (!localHealth.ok) {
+    if (!quiet) {
+      console.error(`  Error: ${localHealth.detail}`);
+    }
+    return false;
+  }
+
+  if (isOllamaLocal && !isWsl()) {
+    const proxyHealth = probeOllamaAuthProxyHealth();
+    if (!proxyHealth.ok) {
+      if (!quiet) {
+        console.error(`  Error: ${proxyHealth.detail}`);
+      }
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function printUnrecoverableInferenceRoute(
+  sandboxName: string,
+  sb: SandboxEntry,
+  detail: string,
+): void {
+  console.error(
+    `  Error: inference.local is still unavailable inside '${sandboxName}' after DNS and route repair.`,
+  );
+  console.error(`  Route: ${sb.provider}/${sb.model}`);
+  if (detail) {
+    console.error(`  Last probe: ${detail}`);
+  }
+  console.error(`  Run:  ${CLI_NAME} ${sandboxName} doctor`);
+  console.error("  Connect is stopping because the sandbox inference route is known to be broken.");
+}
+
+function resetManagedInferenceRoute(
+  sandboxName: string,
+  sb: SandboxEntry,
+  { detail, quiet = false }: { detail: string; quiet?: boolean },
+): boolean {
+  if (!sb.provider || !sb.model) return false;
+
+  if (!verifyLocalInferenceRouteDependencies(sb.provider, { quiet })) {
+    if (!quiet) {
+      printUnrecoverableInferenceRoute(sandboxName, sb, detail);
+    }
+    return false;
+  }
+
+  if (!quiet) {
+    console.log(`  Resetting inference route to ${sb.provider}/${sb.model}.`);
+  }
+  const resetResult = runOpenshell(buildInferenceSetArgs(sb.provider, sb.model), {
+    ignoreError: true,
+    timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
+  });
+  if (resetResult.status !== 0) {
+    const finalProbe = probeSandboxInferenceRoute(sandboxName);
+    if (finalProbe.healthy) {
+      if (!quiet) {
+        console.log("  inference.local route repaired.");
+      }
+      return true;
+    }
+
+    if (!quiet) {
+      console.error("  Error: failed to reset the OpenShell inference route.");
+      printUnrecoverableInferenceRoute(sandboxName, sb, finalProbe.detail || detail);
+    }
+    return false;
+  }
+
+  if (!verifyLocalInferenceRouteDependencies(sb.provider, { quiet })) {
+    if (!quiet) {
+      printUnrecoverableInferenceRoute(sandboxName, sb, detail);
+    }
+    return false;
+  }
+
+  const finalProbe = probeSandboxInferenceRoute(sandboxName);
+  if (finalProbe.healthy) {
+    if (!quiet) {
+      console.log("  inference.local route repaired.");
+    }
+    return true;
+  }
+
+  if (!quiet) {
+    printUnrecoverableInferenceRoute(sandboxName, sb, finalProbe.detail);
+  }
+  return false;
 }
 
 function ensureSandboxInferenceRoute(
   sandboxName: string,
   { quiet = false }: { quiet?: boolean } = {},
-): SandboxEntry | null {
+): SandboxInferenceRouteEnsureResult {
   let sb: SandboxEntry | null = null;
   try {
     sb = registry.getSandbox(sandboxName);
@@ -272,22 +467,48 @@ function ensureSandboxInferenceRoute(
             `  Switching inference route to ${sb.provider}/${sb.model} for sandbox '${sandboxName}'`,
           );
         }
-        const swapResult = runOpenshell(
-          ["inference", "set", "--provider", sb.provider, "--model", sb.model, "--no-verify"],
-          { ignoreError: true },
-        );
+        const swapResult = runOpenshell(buildInferenceSetArgs(sb.provider, sb.model), {
+          ignoreError: true,
+          timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
+        });
         if (swapResult.status !== 0 && !quiet) {
           console.error(
             `  ${YW}Warning: failed to switch inference route — connect will proceed anyway.${R}`,
           );
         }
       }
-      repairSandboxInferenceRouteIfNeeded(sandboxName, sb, { quiet });
+      const repairResult = repairSandboxInferenceRouteIfNeeded(sandboxName, sb, { quiet });
+      if (!repairResult.healthy && repairResult.repairAttempted) {
+        const resetResult = resetManagedInferenceRoute(sandboxName, sb, {
+          detail: repairResult.detail,
+          quiet,
+        });
+        return { sandbox: sb, routeHealthy: resetResult };
+      }
+      return { sandbox: sb, routeHealthy: repairResult.healthy };
     }
-  } catch {
-    /* non-fatal — don't block connect on inference route repair */
+  } catch (error) {
+    if (sb?.provider && sb.model) {
+      const detail = error instanceof Error && error.message ? error.message : String(error);
+      if (!quiet) {
+        console.error(`  Error: failed to verify or repair inference route: ${detail}`);
+        printUnrecoverableInferenceRoute(sandboxName, sb, detail);
+      }
+      return { sandbox: sb, routeHealthy: false };
+    }
   }
-  return sb;
+  return { sandbox: sb, routeHealthy: null };
+}
+
+function ensureSandboxInferenceRouteOrExit(
+  sandboxName: string,
+  { quiet = false }: { quiet?: boolean } = {},
+): SandboxEntry | null {
+  const result = ensureSandboxInferenceRoute(sandboxName, { quiet });
+  if (result.routeHealthy === false) {
+    process.exit(1);
+  }
+  return result.sandbox;
 }
 
 function exitWithSpawnResult(result: SpawnLikeResult): void {
@@ -346,11 +567,7 @@ export async function connectSandbox(
   // Ensure Ollama auth proxy is running (recovers from host reboots)
   ensureOllamaAuthProxy();
 
-  // ── Inference route swap (#1248) ──────────────────────────────────
-  // When the user has multiple sandboxes with different providers, the
-  // cluster-wide inference.local route may still point at the *other*
-  // provider. Re-set it to match this sandbox's persisted config.
-  const sb = ensureSandboxInferenceRoute(sandboxName);
+  let sb: SandboxEntry | null = null;
 
   const rawTimeout = process.env.NEMOCLAW_CONNECT_TIMEOUT;
   let timeout = 120;
@@ -437,6 +654,12 @@ export async function connectSandbox(
     console.log(`\r    Status: ${"Ready".padEnd(20)} (${elapsedSec()}s elapsed)`);
     console.log("  Sandbox is ready. Connecting...");
   }
+
+  // ── Inference route swap (#1248, #3390) ───────────────────────────
+  // When the user has multiple sandboxes with different providers, the
+  // cluster-wide inference.local route may still point at the other provider.
+  // After the sandbox is Ready, verify and recover the route before SSH.
+  sb = ensureSandboxInferenceRouteOrExit(sandboxName);
 
   // Print a one-shot hint before dropping the user into the sandbox
   // shell so a fresh user knows the first thing to type. Without this,

--- a/src/lib/adapters/http/probe.ts
+++ b/src/lib/adapters/http/probe.ts
@@ -1,26 +1,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+  spawnSync,
+} from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import {
-  spawnSync,
-  type SpawnSyncOptionsWithStringEncoding,
-  type SpawnSyncReturns,
-} from "node:child_process";
-
+import { isErrnoException } from "../../core/errno";
+import { compactText } from "../../core/url-utils";
 import type { ProbeResult } from "../../onboard/types";
 import { ROOT } from "../../state/paths";
-import { compactText } from "../../core/url-utils";
-
-import { isErrnoException } from "../../core/errno";
 
 export type CurlProbeResult = ProbeResult;
 
 export interface CurlProbeOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  replaceEnv?: boolean;
   timeoutMs?: number;
   spawnSyncImpl?: (
     command: string,
@@ -143,10 +142,7 @@ export function runCurlProbe(argv: string[], opts: CurlProbeOptions = {}): CurlP
         cwd: opts.cwd ?? ROOT,
         encoding: "utf8",
         timeout: opts.timeoutMs ?? 30_000,
-        env: {
-          ...process.env,
-          ...opts.env,
-        },
+        env: opts.replaceEnv ? (opts.env ?? {}) : { ...process.env, ...opts.env },
       },
     );
     const body = fs.existsSync(bodyFile) ? fs.readFileSync(bodyFile, "utf8") : "";

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -6,15 +6,16 @@
  * health checks, and command generators for vLLM and Ollama.
  */
 
-import type { CurlProbeResult } from "../adapters/http/probe";
-import { runCurlProbe } from "../adapters/http/probe";
 import fs from "node:fs";
 import os from "node:os";
 import nodePath from "node:path";
+import type { CurlProbeResult } from "../adapters/http/probe";
+import { runCurlProbe } from "../adapters/http/probe";
+import { buildSubprocessEnv } from "../subprocess-env";
 
 const { shellQuote, runCapture } = require("../runner");
 
-import { VLLM_PORT, OLLAMA_PORT, OLLAMA_PROXY_PORT } from "../core/ports";
+import { OLLAMA_PORT, OLLAMA_PROXY_PORT, VLLM_PORT } from "../core/ports";
 import { sleepSeconds } from "../core/wait";
 
 const { isWsl } = require("../platform");
@@ -136,6 +137,12 @@ export interface LocalProviderHealthStatus {
 export interface LocalProviderHealthProbeOptions {
   runCurlProbeImpl?: (argv: string[]) => CurlProbeResult;
   /**
+   * Lets callers that perform their own Ollama auth-proxy check avoid the
+   * legacy inline proxy subprobe. The inline subprobe is retained for status
+   * rendering paths that still need a combined backend/proxy result.
+   */
+  skipOllamaAuthProxySubprobe?: boolean;
+  /**
    * Reads the persisted Ollama auth-proxy bearer token. Injectable for tests.
    * Default reads from `~/.nemoclaw/ollama-proxy-token` (written by
    * inference/ollama/proxy.ts during onboard).
@@ -154,6 +161,10 @@ function defaultLoadOllamaProxyToken(): string | null {
     /* ignore — null means "no auth-proxy onboarded; skip the subprobe" */
   }
   return null;
+}
+
+function runLocalCurlProbe(argv: string[]): CurlProbeResult {
+  return runCurlProbe(argv, { env: buildSubprocessEnv(), replaceEnv: true });
 }
 
 export function validateOllamaPortConfiguration(): ValidationResult {
@@ -285,7 +296,7 @@ export function probeOllamaAuthProxyHealth(
     return null;
   }
   const endpoint = `http://127.0.0.1:${OLLAMA_PROXY_PORT}/api/tags`;
-  const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
+  const runCurlProbeImpl = options.runCurlProbeImpl ?? runLocalCurlProbe;
   const result = runCurlProbeImpl([
     "-sS",
     "--connect-timeout",
@@ -344,7 +355,7 @@ export function probeLocalProviderHealth(
     return null;
   }
 
-  const runCurlProbeImpl = options.runCurlProbeImpl ?? runCurlProbe;
+  const runCurlProbeImpl = options.runCurlProbeImpl ?? runLocalCurlProbe;
   const result = runCurlProbeImpl(["-sS", "--connect-timeout", "3", "--max-time", "5", endpoint]);
 
   // Per #3265 the status line is renamed `Inference (<backend>):` for local
@@ -355,7 +366,7 @@ export function probeLocalProviderHealth(
     provider === "vllm-local" ? "vllm backend" : undefined;
 
   const subprobes: LocalProviderHealthStatus[] = [];
-  if (provider === "ollama-local") {
+  if (provider === "ollama-local" && !options.skipOllamaAuthProxySubprobe) {
     const proxyProbe = probeOllamaAuthProxyHealth(options);
     if (proxyProbe) subprobes.push(proxyProbe);
   }

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -86,6 +86,39 @@ function loadPersistedProxyToken(): string | null {
   return null;
 }
 
+function curlAuthHeaderConfig(token: string): string {
+  const escaped = String(token).replace(/[\r\n]/g, "").replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `header = "Authorization: Bearer ${escaped}"\n`;
+}
+
+function runCurlWithAuthConfig(args: string[], endpoint: string, token: string | null = null) {
+  const curlArgs = [...args];
+  const options: {
+    cwd: string;
+    encoding: "utf8";
+    env: Record<string, string>;
+    input?: string;
+  } = {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: buildSubprocessEnv(),
+  };
+  if (token) {
+    curlArgs.push("--config", "-");
+    options.input = curlAuthHeaderConfig(token);
+  }
+  curlArgs.push(endpoint);
+
+  // The only dynamic value is a 0600 local auth token for a fixed loopback proxy endpoint.
+  // codeql[js/request-forgery]
+  return spawnSync("curl", curlArgs, options);
+}
+
+function runCurlCaptureWithAuthConfig(args: string[], endpoint: string, token: string | null = null): string {
+  const result = runCurlWithAuthConfig(args, endpoint, token);
+  return result.status === 0 ? String(result.stdout || "") : "";
+}
+
 // ── PID persistence ──────────────────────────────────────────────
 
 function persistProxyPid(pid: number | null | undefined): void {
@@ -199,8 +232,7 @@ function startOllamaAuthProxy(): boolean {
  * 502 still proves the token was accepted, while 401 means token mismatch.
  */
 function probeProxyToken(token: string): "accepted" | "rejected" | "unreachable" {
-  const result = spawnSync(
-    "curl",
+  const result = runCurlWithAuthConfig(
     [
       "-sS",
       "-o",
@@ -209,11 +241,9 @@ function probeProxyToken(token: string): "accepted" | "rejected" | "unreachable"
       "%{http_code}",
       "--max-time",
       "3",
-      "-H",
-      `Authorization: Bearer ${token}`,
-      `http://localhost:${OLLAMA_PROXY_PORT}/v1/models`,
     ],
-    { encoding: "utf8" },
+    `http://localhost:${OLLAMA_PROXY_PORT}/v1/models`,
+    token,
   );
   if (result.status !== 0) return "unreachable";
 
@@ -282,18 +312,93 @@ function isProxyHealthy(): boolean {
   //    is missing or stale (e.g., after a manual restart).
   const proxyUrl = `http://127.0.0.1:${OLLAMA_PROXY_PORT}/api/tags`;
   const token = loadPersistedProxyToken();
-  const probeCmd = token
-    ? ["curl", "-sf", "--connect-timeout", "3", "--max-time", "5",
-       "-H", `Authorization: Bearer ${token}`, proxyUrl]
-    : ["curl", "-sf", "--connect-timeout", "3", "--max-time", "5", proxyUrl];
-
-  const output = runCapture(probeCmd, { ignoreError: true });
+  const output = runCurlCaptureWithAuthConfig(
+    ["-sf", "--connect-timeout", "3", "--max-time", "5"],
+    proxyUrl,
+    token,
+  );
   if (output) return true;
 
   // HTTP probe failed — fall back to PID as a weaker signal.
   // This covers edge cases where the probe transiently fails but the
   // process is confirmed alive.
   return hasValidPid;
+}
+
+function probeOllamaAuthProxyHealth(): { ok: boolean; endpoint: string; detail: string } {
+  const endpoint = `http://127.0.0.1:${OLLAMA_PROXY_PORT}/v1/models`;
+  const token = loadPersistedProxyToken();
+  if (!token) {
+    return {
+      ok: false,
+      endpoint,
+      detail:
+        "Ollama auth proxy token is missing. Re-run NemoClaw onboarding for the Ollama-local sandbox.",
+    };
+  }
+
+  const result = runCurlWithAuthConfig(
+    [
+      "-sS",
+      "-o",
+      "/dev/null",
+      "-w",
+      "%{http_code}",
+      "--connect-timeout",
+      "3",
+      "--max-time",
+      "5",
+    ],
+    endpoint,
+    token,
+  );
+
+  const status = Number(String(result.stdout || "").trim());
+  if (result.status === 0 && Number.isFinite(status) && status >= 200 && status < 300) {
+    return {
+      ok: true,
+      endpoint,
+      detail: `Ollama auth proxy is reachable on ${endpoint}.`,
+    };
+  }
+
+  if (status === 401) {
+    return {
+      ok: false,
+      endpoint,
+      detail:
+        "Ollama auth proxy rejected the persisted token. Re-run NemoClaw onboarding for the Ollama-local sandbox.",
+    };
+  }
+
+  if (Number.isFinite(status) && status >= 300 && status < 500) {
+    return {
+      ok: false,
+      endpoint,
+      detail:
+        `Ollama auth proxy is reachable on ${endpoint}, but returned HTTP ${status}. ` +
+        "Check auth, route, and proxy configuration.",
+    };
+  }
+
+  if (Number.isFinite(status) && status >= 500) {
+    return {
+      ok: false,
+      endpoint,
+      detail:
+        `Ollama auth proxy is running on ${endpoint}, but its backend returned HTTP ${status}. ` +
+        `Verify host Ollama on localhost:${OLLAMA_PORT} and retry.`,
+    };
+  }
+
+  const failure = String(result.stderr || result.error?.message || "").trim();
+  return {
+    ok: false,
+    endpoint,
+    detail: failure
+      ? `Ollama auth proxy is not reachable on ${endpoint}. (${failure})`
+      : `Ollama auth proxy is not reachable on ${endpoint}.`,
+  };
 }
 
 async function promptOllamaModel(gpu = null) {
@@ -717,10 +822,11 @@ export {
   killStaleProxy,
   persistAndProbeOllamaProxy,
   persistProxyToken,
-  startOllamaAuthProxy,
-  promptOllamaModel,
-  printOllamaExposureWarning,
-  pullOllamaModel,
   prepareOllamaModel,
+  printOllamaExposureWarning,
+  probeOllamaAuthProxyHealth,
+  promptOllamaModel,
+  pullOllamaModel,
+  startOllamaAuthProxy,
   unloadOllamaModels,
 };

--- a/src/lib/subprocess-env.test.ts
+++ b/src/lib/subprocess-env.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withLocalNoProxy } from "../../dist/lib/subprocess-env";
 
 describe("withLocalNoProxy", () => {
@@ -11,58 +11,58 @@ describe("withLocalNoProxy", () => {
     expect(env).toEqual({ PATH: "/usr/bin" });
   });
 
-  it("adds localhost and 127.0.0.1 to NO_PROXY and no_proxy when HTTP_PROXY is set and NO_PROXY is absent", () => {
+  it("adds local host-bound names to NO_PROXY and no_proxy when HTTP_PROXY is set and NO_PROXY is absent", () => {
     const env: Record<string, string> = { HTTP_PROXY: "http://proxy:8888" };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal");
   });
 
-  it("adds localhost and 127.0.0.1 when HTTPS_PROXY is set", () => {
+  it("adds local host-bound names when HTTPS_PROXY is set", () => {
     const env: Record<string, string> = { HTTPS_PROXY: "http://proxy:8888" };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal");
   });
 
-  it("adds localhost and 127.0.0.1 when lowercase http_proxy is set", () => {
+  it("adds local host-bound names when lowercase http_proxy is set", () => {
     const env: Record<string, string> = { http_proxy: "http://proxy:8888" };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal");
   });
 
-  it("appends only the missing loopback entries when NO_PROXY already has localhost", () => {
+  it("appends only the missing local entries when NO_PROXY already has localhost", () => {
     const env: Record<string, string> = {
       HTTP_PROXY: "http://proxy:8888",
       NO_PROXY: "example.com,localhost",
       no_proxy: "example.com,localhost",
     };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("example.com,localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("example.com,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("example.com,localhost,127.0.0.1,host.docker.internal");
+    expect(env.no_proxy).toBe("example.com,localhost,127.0.0.1,host.docker.internal");
   });
 
-  it("does not duplicate entries when both loopback hosts are already present", () => {
+  it("does not duplicate entries when all local hosts are already present", () => {
     const env: Record<string, string> = {
       HTTP_PROXY: "http://proxy:8888",
-      NO_PROXY: "localhost,127.0.0.1,corp.internal",
-      no_proxy: "localhost,127.0.0.1,corp.internal",
+      NO_PROXY: "localhost,127.0.0.1,host.docker.internal,corp.internal",
+      no_proxy: "localhost,127.0.0.1,host.docker.internal,corp.internal",
     };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,corp.internal");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1,corp.internal");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal,corp.internal");
+    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal,corp.internal");
   });
 
-  it("preserves existing NO_PROXY entries and adds loopback hosts", () => {
+  it("preserves existing NO_PROXY entries and adds local hosts", () => {
     const env: Record<string, string> = {
       HTTP_PROXY: "http://proxy:8888",
       NO_PROXY: "corp.internal,.nvidia.com",
       no_proxy: "corp.internal,.nvidia.com",
     };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("corp.internal,.nvidia.com,localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("corp.internal,.nvidia.com,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("corp.internal,.nvidia.com,localhost,127.0.0.1,host.docker.internal");
+    expect(env.no_proxy).toBe("corp.internal,.nvidia.com,localhost,127.0.0.1,host.docker.internal");
   });
 });
 
@@ -78,26 +78,26 @@ describe("buildSubprocessEnv NO_PROXY injection", () => {
     process.env = originalEnv;
   });
 
-  it("injects NO_PROXY=localhost,127.0.0.1 when HTTP_PROXY is set and NO_PROXY is absent", async () => {
+  it("injects local host-bound names when HTTP_PROXY is set and NO_PROXY is absent", async () => {
     process.env.HTTP_PROXY = "http://proxy.example.com:8888";
     delete process.env.NO_PROXY;
     delete process.env.no_proxy;
 
     const { buildSubprocessEnv } = await import("../../dist/lib/subprocess-env");
     const env = buildSubprocessEnv();
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal");
   });
 
-  it("augments an existing NO_PROXY to add loopback hosts", async () => {
+  it("augments an existing NO_PROXY to add local hosts", async () => {
     process.env.HTTP_PROXY = "http://proxy.example.com:8888";
     process.env.NO_PROXY = "corp.internal";
     process.env.no_proxy = "corp.internal";
 
     const { buildSubprocessEnv } = await import("../../dist/lib/subprocess-env");
     const env = buildSubprocessEnv();
-    expect(env.NO_PROXY).toBe("corp.internal,localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("corp.internal,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("corp.internal,localhost,127.0.0.1,host.docker.internal");
+    expect(env.no_proxy).toBe("corp.internal,localhost,127.0.0.1,host.docker.internal");
   });
 
   it("does not add NO_PROXY when no proxy is set", async () => {
@@ -122,6 +122,6 @@ describe("buildSubprocessEnv NO_PROXY injection", () => {
     const { buildSubprocessEnv } = await import("../../dist/lib/subprocess-env");
     const env = buildSubprocessEnv({ MY_TOKEN: "abc123" });
     expect(env.MY_TOKEN).toBe("abc123");
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
   });
 });

--- a/src/lib/subprocess-env.ts
+++ b/src/lib/subprocess-env.ts
@@ -49,10 +49,10 @@ const ALLOWED_ENV_PREFIXES = ["LC_", "XDG_", "OPENSHELL_", "GRPC_"];
 // ── Public API ─────────────────────────────────────────────────
 
 /**
- * When any HTTP proxy is forwarded, ensure localhost and loopback traffic is
- * not routed through it. Without this, tools that respect HTTP_PROXY (curl,
- * Node.js http, Python requests) will tunnel loopback requests to the user's
- * proxy (e.g. Privoxy), which fails with HTTP 500.
+ * When any HTTP proxy is forwarded, ensure local host-bound traffic is not
+ * routed through it. Without this, tools that respect HTTP_PROXY (curl, Node.js
+ * http, Python requests) will tunnel loopback or WSL Windows-host requests to
+ * the user's proxy (e.g. Privoxy), which fails with HTTP 500.
  * See: #2616
  */
 export function withLocalNoProxy(env: Record<string, string>): void {
@@ -62,7 +62,7 @@ export function withLocalNoProxy(env: Record<string, string>): void {
     const current = env[key] ?? "";
     const parts = current ? current.split(",").map((s) => s.trim()) : [];
     let changed = false;
-    for (const host of ["localhost", "127.0.0.1"]) {
+    for (const host of ["localhost", "127.0.0.1", "host.docker.internal"]) {
       if (!parts.includes(host)) {
         parts.push(host);
         changed = true;

--- a/test/ollama-proxy-recovery.test.ts
+++ b/test/ollama-proxy-recovery.test.ts
@@ -127,6 +127,7 @@ const childProcess = require("child_process");
 const runner = require(${runnerPath});
 
 const proxySpawns = [];
+let curlEnv = null;
 childProcess.spawn = (...args) => {
   proxySpawns.push(args);
   return { pid: 5000, unref() {} };
@@ -141,7 +142,10 @@ runner.run = () => ({ status: 0, stdout: "", stderr: "" });
 
 const origSpawnSync = childProcess.spawnSync;
 childProcess.spawnSync = (...args) => {
-  if (args[0] === "curl") return { status: 0, stdout: "200", stderr: "" };
+  if (args[0] === "curl") {
+    curlEnv = args[2] && args[2].env;
+    return { status: 0, stdout: "200", stderr: "" };
+  }
   return origSpawnSync(...args);
 };
 
@@ -152,7 +156,7 @@ fs.writeFileSync(path.join(stateDir, "ollama-auth-proxy.pid"), "4242\n", { mode:
 
 const onboard = require(${onboardPath});
 onboard.ensureOllamaAuthProxy();
-console.log(JSON.stringify({ proxySpawns }));
+console.log(JSON.stringify({ proxySpawns, curlEnv }));
 `;
     fs.writeFileSync(scriptPath, script);
 
@@ -161,13 +165,23 @@ console.log(JSON.stringify({ proxySpawns }));
       encoding: "utf-8",
       env: {
         ...process.env,
+        HTTP_PROXY: "http://proxy.invalid:8888",
         HOME: tmpDir,
+        NVIDIA_API_KEY: "must-not-leak",
+        NO_PROXY: "",
       },
     });
 
     assert.equal(result.status, 0, result.stderr);
-    const payload = parseStdoutJson<{ proxySpawns: object[] }>(result.stdout);
+    const payload = parseStdoutJson<{
+      curlEnv: Record<string, string>;
+      proxySpawns: object[];
+    }>(result.stdout);
     assert.equal(payload.proxySpawns.length, 0);
+    assert.equal(payload.curlEnv.NVIDIA_API_KEY, undefined);
+    assert.equal(payload.curlEnv.HTTP_PROXY, "http://proxy.invalid:8888");
+    assert.match(payload.curlEnv.NO_PROXY, /(^|,)127\.0\.0\.1(,|$)/);
+    assert.match(payload.curlEnv.NO_PROXY, /(^|,)localhost(,|$)/);
   });
 
   it("keeps the existing proxy when the token is accepted but the backend is unavailable", () => {
@@ -225,6 +239,49 @@ console.log(JSON.stringify({ proxySpawns }));
     assert.equal(result.status, 0, result.stderr);
     const payload = parseStdoutJson<{ proxySpawns: object[] }>(result.stdout);
     assert.equal(payload.proxySpawns.length, 0);
+  });
+
+  it("reports reachable non-2xx proxy health responses distinctly", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-ollama-proxy-404-"));
+    const scriptPath = path.join(tmpDir, "proxy-health-404-check.js");
+    const proxyPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "inference", "ollama", "proxy.js"));
+
+    const script = String.raw`
+const fs = require("node:fs");
+const path = require("node:path");
+const childProcess = require("child_process");
+
+const origSpawnSync = childProcess.spawnSync;
+childProcess.spawnSync = (...args) => {
+  if (args[0] === "curl") return { status: 0, stdout: "404", stderr: "" };
+  return origSpawnSync(...args);
+};
+
+const stateDir = path.join(process.env.HOME, ".nemoclaw");
+fs.mkdirSync(stateDir, { recursive: true });
+fs.writeFileSync(path.join(stateDir, "ollama-proxy-token"), "persisted-token\n", { mode: 0o600 });
+
+const proxy = require(${proxyPath});
+console.log(JSON.stringify(proxy.probeOllamaAuthProxyHealth()));
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = parseStdoutJson<{ detail: string; ok: boolean }>(result.stdout);
+    assert.equal(payload.ok, false);
+    assert.match(payload.detail, /reachable/);
+    assert.match(payload.detail, /HTTP 404/);
+    assert.doesNotMatch(payload.detail, /not reachable/);
   });
 
   it("restarts the existing proxy when it rejects the persisted token", () => {

--- a/test/sandbox-connect-inference.test.ts
+++ b/test/sandbox-connect-inference.test.ts
@@ -26,9 +26,23 @@ type SandboxEntryFixture = {
 };
 
 type SetupFixtureOptions = {
+  curlExitCode?: number;
+  curlHttpStatus?: string;
+  curlStderr?: string;
+  inferenceProbeExitStatuses?: number[];
   inferenceProbeResponses?: string[];
   inferenceSetStatus?: number;
+  writeOllamaProxyState?: boolean;
 };
+
+function isHostWsl() {
+  return (
+    process.platform === "linux" &&
+    (Boolean(process.env.WSL_DISTRO_NAME) ||
+      Boolean(process.env.WSL_INTEROP) ||
+      /microsoft/i.test(os.release()))
+  );
+}
 
 function setupFixture(
   sandboxEntry: SandboxEntryFixture,
@@ -42,6 +56,8 @@ function setupFixture(
   const stateFile = path.join(tmpDir, "state.json");
   const openshellPath = path.join(homeLocalBin, "openshell");
   const dockerPath = path.join(homeLocalBin, "docker");
+  const curlPath = path.join(homeLocalBin, "curl");
+  const psPath = path.join(homeLocalBin, "ps");
   const sandboxName = String(sandboxEntry.name);
 
   fs.mkdirSync(homeLocalBin, { recursive: true });
@@ -56,6 +72,15 @@ function setupFixture(
     { mode: 0o600 },
   );
 
+  if (sandboxEntry.provider === "ollama-local" && options.writeOllamaProxyState !== false) {
+    fs.writeFileSync(path.join(registryDir, "ollama-proxy-token"), "test-token\n", {
+      mode: 0o600,
+    });
+    fs.writeFileSync(path.join(registryDir, "ollama-auth-proxy.pid"), "12345\n", {
+      mode: 0o600,
+    });
+  }
+
   // Build the Gateway inference section for `openshell inference get`
   let inferenceBlock;
   if (liveInferenceProvider && liveInferenceModel) {
@@ -68,8 +93,15 @@ function setupFixture(
     stateFile,
     JSON.stringify({
       dockerCalls: [],
+      curlExitCode: options.curlExitCode ?? 0,
+      curlHttpStatus: options.curlHttpStatus ?? "200",
+      curlStderr: options.curlStderr ?? "",
+      curlCalls: [],
+      curlEnvs: [],
+      inferenceProbeExitStatuses: options.inferenceProbeExitStatuses ?? [],
       inferenceProbeResponses: options.inferenceProbeResponses ?? ["OK 200"],
       inferenceSetCalls: [],
+      sandboxConnectCalls: [],
       sandboxExecCalls: [],
     }),
   );
@@ -112,13 +144,16 @@ if (args[0] === "sandbox" && args[1] === "exec") {
     process.exit(0);
   }
   const response = state.inferenceProbeResponses.shift() || "OK 200";
+  const exitStatus = Number(state.inferenceProbeExitStatuses.shift() || 0);
   fs.writeFileSync(stateFile, JSON.stringify(state));
   process.stdout.write(response);
-  process.exit(0);
+  process.exit(exitStatus);
 }
 
 if (args[0] === "sandbox" && args[1] === "connect") {
   // Don't actually drop into a shell — just exit successfully
+  state.sandboxConnectCalls.push(args);
+  fs.writeFileSync(stateFile, JSON.stringify(state));
   process.exit(0);
 }
 
@@ -212,6 +247,58 @@ process.exit(0);
     { mode: 0o755 },
   );
 
+  fs.writeFileSync(
+    curlPath,
+    `#!${process.execPath}
+const fs = require("fs");
+const args = process.argv.slice(2);
+const stateFile = ${JSON.stringify(stateFile)};
+const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+state.curlCalls.push(args);
+state.curlEnvs.push({
+  ALL_PROXY: process.env.ALL_PROXY || "",
+  HTTP_PROXY: process.env.HTTP_PROXY || "",
+  NO_PROXY: process.env.NO_PROXY || "",
+  all_proxy: process.env.all_proxy || "",
+  http_proxy: process.env.http_proxy || "",
+  no_proxy: process.env.no_proxy || "",
+});
+fs.writeFileSync(stateFile, JSON.stringify(state));
+const endpoint = args[args.length - 1] || "";
+if (
+  process.env.OPENSHELL_TEST_FAIL_LOCALHOST_OLLAMA === "1" &&
+  endpoint.includes("127.0.0.1:11434/api/tags")
+) {
+  process.exit(7);
+}
+const outIndex = args.indexOf("-o");
+const exitCode = Number(state.curlExitCode || 0);
+const status = String(state.curlHttpStatus || "200");
+if (outIndex >= 0 && args[outIndex + 1] && args[outIndex + 1] !== "/dev/null" && exitCode === 0) {
+  fs.writeFileSync(args[outIndex + 1], '{"models":[]}');
+}
+if (state.curlStderr) {
+  process.stderr.write(String(state.curlStderr));
+}
+if (args.includes("-w")) {
+  process.stdout.write(status);
+} else {
+  process.stdout.write('{"models":[]}');
+}
+process.exit(exitCode);
+`,
+    { mode: 0o755 },
+  );
+
+  fs.writeFileSync(
+    psPath,
+    `#!${process.execPath}
+process.stdout.write("node /tmp/ollama-auth-proxy.js\\n");
+process.exit(0);
+`,
+    { mode: 0o755 },
+  );
+
   return { tmpDir, stateFile, sandboxName };
 }
 
@@ -248,11 +335,16 @@ function createVmRootfs(tmpDir: string, sandboxId = "abc") {
   return rootfs;
 }
 
-function runConnect(tmpDir: string, sandboxName: string, extraEnv: NodeJS.ProcessEnv = {}) {
+function runConnect(
+  tmpDir: string,
+  sandboxName: string,
+  extraEnv: NodeJS.ProcessEnv = {},
+  connectArgs: string[] = [],
+) {
   const repoRoot = path.join(import.meta.dirname, "..");
   return spawnSync(
     process.execPath,
-    [path.join(repoRoot, "bin", "nemoclaw.js"), sandboxName, "connect"],
+    [path.join(repoRoot, "bin", "nemoclaw.js"), sandboxName, "connect", ...connectArgs],
     {
       cwd: repoRoot,
       encoding: "utf-8",
@@ -261,6 +353,8 @@ function runConnect(tmpDir: string, sandboxName: string, extraEnv: NodeJS.Proces
         HOME: tmpDir,
         PATH: `${path.join(tmpDir, ".local", "bin")}:/usr/bin:/bin`,
         NEMOCLAW_NO_CONNECT_HINT: "1",
+        NEMOCLAW_OLLAMA_PORT: "11434",
+        NEMOCLAW_OLLAMA_PROXY_PORT: "11435",
         ...extraEnv,
       },
       timeout: execTimeout(15_000),
@@ -414,6 +508,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
           inferenceProbeResponses: [
             'BROKEN 503 {"error":"inference service unavailable"}',
             'BROKEN 503 {"error":"inference service unavailable"}',
+            'BROKEN 503 {"error":"inference service unavailable"}',
           ],
         },
       );
@@ -421,16 +516,18 @@ describe("sandbox connect inference route swap (#1248)", () => {
       const result = runConnect(tmpDir, sandboxName, {
         NEMOCLAW_FORCE_VM_DNS_MONKEYPATCH: "1",
       });
-      expect(result.status).toBe(0);
+      expect(result.status).toBe(1);
 
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
-      expect(state.inferenceSetCalls.length).toBe(1);
+      expect(state.inferenceSetCalls.length).toBe(2);
       expect(state.dockerCalls.length).toBe(0);
+      expect(state.sandboxConnectCalls).toEqual([]);
 
       const combined = (result.stdout || "") + (result.stderr || "");
       expect(combined).toContain("OpenShell VM DNS monkeypatch did not apply");
       expect(combined).toContain("Reapplying OpenShell inference route");
       expect(combined).toContain("OpenShell vm gateway path");
+      expect(combined).toContain("Connect is stopping because the sandbox inference route is known to be broken");
     },
   );
 
@@ -574,6 +671,389 @@ describe("sandbox connect inference route swap (#1248)", () => {
       expect(combined).toContain("Reapplying OpenShell inference route");
       expect(combined).toContain("inference.local route repaired");
       expect(combined).not.toContain("OpenShell vm gateway path");
+    },
+  );
+
+  it(
+    "repairs the sandbox DNS proxy when inference.local returns 000 with a non-zero probe exit",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "dns-000-sandbox",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          provider: "nvidia-prod",
+          gpuEnabled: false,
+          policies: [],
+        },
+        "nvidia-prod",
+        "nvidia/nemotron-3-super-120b-a12b",
+        {
+          inferenceProbeExitStatuses: [1, 0],
+          inferenceProbeResponses: ["BROKEN 000 ", "OK 200"],
+        },
+      );
+
+      const result = runConnect(tmpDir, sandboxName);
+      expect(result.status).toBe(0);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      const dockerCalls = state.dockerCalls as string[][];
+      const inferenceExecCalls = state.sandboxExecCalls.filter((call: string[]) =>
+        JSON.stringify(call).includes("inference.local/v1/models"),
+      );
+      expect(state.inferenceSetCalls.length).toBe(0);
+      expect(inferenceExecCalls.length).toBe(2);
+      expect(dockerCalls.some((call) => call.join(" ").includes("get service kube-dns"))).toBe(true);
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("inference.local is unavailable inside 'dns-000-sandbox'");
+      expect(combined).toContain("inference.local route repaired");
+    },
+  );
+
+  it(
+    "checks the Ollama auth proxy before local provider health during probe-only route reset",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "probe-only-ollama-sandbox",
+          model: "qwen3:0.6b",
+          provider: "ollama-local",
+          gpuEnabled: false,
+          policies: [],
+        },
+        "ollama-local",
+        "qwen3:0.6b",
+        {
+          inferenceProbeResponses: [
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            "OK 200",
+          ],
+        },
+      );
+
+      const nonWslPlatformPreload = path.join(tmpDir, "force-non-wsl-platform.cjs");
+      fs.writeFileSync(
+        nonWslPlatformPreload,
+        [
+          'const os = require("node:os");',
+          'Object.defineProperty(process, "platform", { value: "linux" });',
+          'os.release = () => "6.8.0-generic";',
+          "delete process.env.WSL_DISTRO_NAME;",
+          "delete process.env.WSL_INTEROP;",
+          "",
+        ].join("\n"),
+        { mode: 0o600 },
+      );
+      const result = runConnect(
+        tmpDir,
+        sandboxName,
+        {
+          NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${nonWslPlatformPreload}`.trim(),
+        },
+        ["--probe-only"],
+      );
+      expect(result.status).toBe(0);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      const endpoints = (state.curlCalls as string[][]).map((call) => call[call.length - 1]);
+      const backendIndexes = endpoints
+        .map((endpoint, index) =>
+          endpoint.includes("127.0.0.1:11434/api/tags") ? index : -1,
+        )
+        .filter((index) => index >= 0);
+      const firstProxyIndex = endpoints.findIndex(
+        (endpoint) =>
+          endpoint.includes("127.0.0.1:11435/v1/models") ||
+          endpoint.includes("localhost:11435/v1/models"),
+      );
+      expect(firstProxyIndex).toBeGreaterThanOrEqual(0);
+      expect(backendIndexes.length).toBeGreaterThanOrEqual(2);
+      expect(firstProxyIndex).toBeLessThan(backendIndexes[1]);
+    },
+  );
+
+  it(
+    "resets matching inference route when DNS repair leaves inference.local broken",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "stale-route-sandbox",
+          model: "qwen3:0.6b",
+          provider: "ollama-local",
+          gpuEnabled: false,
+          policies: [],
+        },
+        "ollama-local",
+        "qwen3:0.6b",
+        {
+          inferenceProbeResponses: [
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            "OK 200",
+          ],
+        },
+      );
+
+      const result = runConnect(tmpDir, sandboxName, {
+        ALL_PROXY: "http://127.0.0.1:9",
+        NEMOCLAW_LOCAL_INFERENCE_TIMEOUT: "321",
+        NO_PROXY: "",
+        http_proxy: "http://127.0.0.1:9",
+        no_proxy: "",
+      });
+      expect(result.status).toBe(0);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      const curlCalls = state.curlCalls as string[][];
+      const curlEnvs = state.curlEnvs as Record<string, string>[];
+      const inferenceExecCalls = state.sandboxExecCalls.filter((call: string[]) =>
+        JSON.stringify(call).includes("inference.local/v1/models"),
+      );
+      expect(state.inferenceSetCalls).toEqual([
+        [
+          "--provider",
+          "ollama-local",
+          "--model",
+          "qwen3:0.6b",
+          "--no-verify",
+          "--timeout",
+          "321",
+        ],
+      ]);
+      expect(inferenceExecCalls.length).toBe(3);
+      if (!isHostWsl()) {
+        expect(
+          curlCalls.some((call) => call.join(" ").includes("127.0.0.1:11435/v1/models")),
+        ).toBe(true);
+      }
+      expect(curlCalls.flat().join(" ")).not.toContain("Authorization: Bearer");
+      for (const [index, call] of curlCalls.entries()) {
+        const endpoint = call[call.length - 1];
+        if (!endpoint.includes("127.0.0.1") && !endpoint.includes("localhost")) continue;
+        const proxyBypass = `${curlEnvs[index]?.NO_PROXY || ""},${curlEnvs[index]?.no_proxy || ""}`;
+        expect(proxyBypass).toContain("127.0.0.1");
+        expect(proxyBypass).toContain("localhost");
+        expect(curlEnvs[index]?.ALL_PROXY || "").toBe("");
+      }
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("Resetting inference route to ollama-local/qwen3:0.6b");
+      expect(combined).toContain("inference.local route repaired");
+    },
+  );
+
+  it(
+    "probes route health before failing a non-zero managed route reset",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "managed-route-set-nonzero",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          provider: "nvidia-prod",
+          gpuEnabled: false,
+          openshellDriver: "docker",
+          policies: [],
+        },
+        "nvidia-prod",
+        "nvidia/nemotron-3-super-120b-a12b",
+        {
+          inferenceProbeResponses: [
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            "OK 200",
+          ],
+          inferenceSetStatus: 1,
+        },
+      );
+
+      const result = runConnect(tmpDir, sandboxName);
+      expect(result.status).toBe(0);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      const inferenceExecCalls = state.sandboxExecCalls.filter((call: string[]) =>
+        JSON.stringify(call).includes("inference.local/v1/models"),
+      );
+      expect(state.inferenceSetCalls).toEqual([
+        [
+          "--provider",
+          "nvidia-prod",
+          "--model",
+          "nvidia/nemotron-3-super-120b-a12b",
+          "--no-verify",
+        ],
+      ]);
+      expect(inferenceExecCalls.length).toBe(3);
+      expect(state.sandboxConnectCalls).toEqual([["sandbox", "connect", sandboxName]]);
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain(
+        "Resetting inference route to nvidia-prod/nvidia/nemotron-3-super-120b-a12b",
+      );
+      expect(combined).toContain("inference.local route repaired");
+      expect(combined).not.toContain("failed to reset the OpenShell inference route");
+    },
+  );
+
+  it(
+    "stops before sandbox connect when inference.local is still broken after route reset",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "still-broken-sandbox",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          provider: "nvidia-prod",
+          gpuEnabled: false,
+          policies: [],
+        },
+        "nvidia-prod",
+        "nvidia/nemotron-3-super-120b-a12b",
+        {
+          inferenceProbeResponses: [
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            'BROKEN 503 {"error":"upstream unavailable"}',
+          ],
+        },
+      );
+
+      const result = runConnect(tmpDir, sandboxName);
+      expect(result.status).toBe(1);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      expect(state.inferenceSetCalls).toEqual([
+        [
+          "--provider",
+          "nvidia-prod",
+          "--model",
+          "nvidia/nemotron-3-super-120b-a12b",
+          "--no-verify",
+        ],
+      ]);
+      expect(state.sandboxConnectCalls).toEqual([]);
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("inference.local is still unavailable");
+      expect(combined).toContain("Connect is stopping because the sandbox inference route is known to be broken");
+    },
+  );
+
+  it(
+    "diagnoses host Ollama before resetting a broken ollama-local route",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "ollama-down-sandbox",
+          model: "qwen3:0.6b",
+          provider: "ollama-local",
+          gpuEnabled: false,
+          policies: [],
+        },
+        "ollama-local",
+        "qwen3:0.6b",
+        {
+          curlExitCode: 7,
+          curlHttpStatus: "000",
+          curlStderr: "curl: (7) Failed to connect to 127.0.0.1 port 11434\n",
+          inferenceProbeResponses: [
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            'BROKEN 503 {"error":"upstream unavailable"}',
+          ],
+          writeOllamaProxyState: false,
+        },
+      );
+
+      const result = runConnect(tmpDir, sandboxName);
+      expect(result.status).toBe(1);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      expect(state.inferenceSetCalls).toEqual([]);
+      expect(state.sandboxConnectCalls).toEqual([]);
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("Local Ollama is selected for inference");
+      expect(combined).toContain("Start Ollama and retry");
+      expect(combined).toContain("Connect is stopping because the sandbox inference route is known to be broken");
+    },
+  );
+
+  it(
+    "repairs WSL ollama-local routes without requiring the auth proxy",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "wsl-ollama-sandbox",
+          model: "qwen3:0.6b",
+          provider: "ollama-local",
+          gpuEnabled: false,
+          policies: [],
+        },
+        "ollama-local",
+        "qwen3:0.6b",
+        {
+          inferenceProbeResponses: [
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            'BROKEN 503 {"error":"upstream unavailable"}',
+            "OK 200",
+          ],
+          writeOllamaProxyState: false,
+        },
+      );
+
+      const wslPlatformPreload = path.join(tmpDir, "force-wsl-platform.cjs");
+      fs.writeFileSync(
+        wslPlatformPreload,
+        'Object.defineProperty(process, "platform", { value: "linux" });\n',
+        { mode: 0o600 },
+      );
+      const result = runConnect(tmpDir, sandboxName, {
+        ALL_PROXY: "http://127.0.0.1:9",
+        HTTP_PROXY: "http://127.0.0.1:9",
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${wslPlatformPreload}`.trim(),
+        NO_PROXY: "",
+        OPENSHELL_TEST_FAIL_LOCALHOST_OLLAMA: "1",
+        WSL_DISTRO_NAME: "Ubuntu",
+        no_proxy: "",
+      });
+      expect(result.status).toBe(0);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      const curlCalls = state.curlCalls as string[][];
+      const curlEnvs = state.curlEnvs as Record<string, string>[];
+      const windowsHostIndexes = curlCalls
+        .map((call, index) => (call.join(" ").includes("host.docker.internal:11434") ? index : -1))
+        .filter((index) => index >= 0);
+      expect(state.inferenceSetCalls).toEqual([
+        [
+          "--provider",
+          "ollama-local",
+          "--model",
+          "qwen3:0.6b",
+          "--no-verify",
+          "--timeout",
+          "180",
+        ],
+      ]);
+      expect(windowsHostIndexes.length).toBeGreaterThan(0);
+      for (const index of windowsHostIndexes) {
+        const proxyBypass = `${curlEnvs[index]?.NO_PROXY || ""},${curlEnvs[index]?.no_proxy || ""}`;
+        expect(proxyBypass).toContain("host.docker.internal");
+        expect(curlEnvs[index]?.ALL_PROXY || "").toBe("");
+      }
+      expect(state.sandboxConnectCalls).toEqual([["sandbox", "connect", sandboxName]]);
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("Resetting inference route to ollama-local/qwen3:0.6b");
+      expect(combined).toContain("inference.local route repaired");
+      expect(combined).not.toContain("Ollama auth proxy token is missing");
     },
   );
 });


### PR DESCRIPTION
## Summary
Recover stale `inference.local` routes during sandbox connect by revalidating the in-sandbox route after DNS repair and resetting the managed OpenShell inference route when provider/model still match but the route remains broken. Local Ollama providers now get host and auth-proxy health diagnostics before NemoClaw opens an SSH session into a sandbox with known-broken inference.

## Related Issue
Fixes #3390

## Changes
- Re-probes `inference.local` during connect and `--probe-only`, including `BROKEN 000` responses from failed sandbox curl probes.
- Re-runs `openshell inference set --provider <provider> --model <model> --no-verify` after DNS repair when the matching managed route is still unhealthy.
- Validates local provider host health and the Ollama auth proxy before route reset, then exits with precise diagnostics if the route remains broken.
- Adds focused connect regression coverage for route reset, final failure blocking, host Ollama diagnostics, WSL behavior, and `BROKEN 000` handling.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification notes:
- `npm run build:cli` passed.
- `npm run typecheck:cli` passed.
- `npm run lint` passed with an unrelated upstream warning in `src/lib/onboard/child-exit-tracker.test.ts`.
- `npx vitest run test/sandbox-connect-inference.test.ts` passed.
- `npm test -- --run test/cli.test.ts` passed during local review.
- `npm test` was run locally but remains red due unrelated local installer/source-checkout and Dockerfile fetch-guard permission failures; latest `main` GitHub checks were green for those suites before this PR.
- Live Ollama sandbox E2E was attempted through the worktree CLI after OpenShell setup; sandbox creation was blocked by host permission error writing under `/opt/nemoclaw-blueprint/...`, so the regression is covered by the focused connect tests.
- `codex review -c sandbox_mode="danger-full-access" --uncommitted` found no correctness issues.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable sandbox connect: improved detection, recovery, and abort-on-failure when local inference routes remain broken.

* **Improvements**
  * Structured health/repair statuses for inference routes and Ollama auth-proxy with clearer failure detail (including reachable non-2xx responses).
  * Additional verification of local inference dependencies and conditional handling when proxy state is absent; tighter timeout/operation handling.

* **Tests**
  * Expanded coverage for probe/curl behaviors, env forwarding, proxy-token scenarios, WSL cases, and repair edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3444)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->