### PR TITLE
fix(onboard): mirror Docker host aliases in bridge probe

### DIFF
--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -39,6 +39,16 @@ describe("isSandboxBridgeGatewayReachable", () => {
     expect(result.subnet).toBe("172.19.0.0/16");
   });
 
+  it("treats host alias resolution failures as an inconclusive probe", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectSubnetImpl: () => "172.19.0.0/16",
+      runImpl: () => ({ status: 1, stderr: "nc: bad address 'host.openshell.internal'" }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("probe_unavailable");
+    expect(result.detail).toContain("did not resolve");
+  });
+
   it("flags probe_unavailable when docker cannot run the helper container", async () => {
     const result = await isSandboxBridgeGatewayReachable({
       inspectSubnetImpl: () => "172.19.0.0/16",
@@ -63,6 +73,8 @@ describe("isSandboxBridgeGatewayReachable", () => {
     });
     expect(seen.args).toContain("custom-net");
     expect(seen.args).toContain("--pull=missing");
+    expect(seen.args).toContain("host.openshell.internal:host-gateway");
+    expect(seen.args).toContain("host.docker.internal:host-gateway");
     expect(seen.args.join(" ")).toContain("nc -zw7 host.openshell.internal 9090");
   });
 });

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -22,6 +22,7 @@ const DEFAULT_PROBE_IMAGE =
   "busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662";
 const DEFAULT_NETWORK_NAME = "openshell-docker";
 const HOST_INTERNAL_NAME = "host.openshell.internal";
+const DOCKER_HOST_INTERNAL_NAME = "host.docker.internal";
 const DEFAULT_PROBE_TIMEOUT_SEC = 5;
 const PROBE_RUN_OVERHEAD_MS = 10_000;
 
@@ -103,6 +104,19 @@ function summarizeProbeUnavailable(result: SandboxBridgeProbeRunResult): string 
   return details[0] ?? "docker run did not complete the probe";
 }
 
+function isNameResolutionFailure(result: SandboxBridgeProbeRunResult): boolean {
+  const output = [result.error, outputTail(result.stderr), outputTail(result.stdout)]
+    .filter((item): item is string => Boolean(item))
+    .join("\n")
+    .toLowerCase();
+  return (
+    output.includes("bad address") ||
+    output.includes("name does not resolve") ||
+    output.includes("temporary failure in name resolution") ||
+    output.includes("no address associated with hostname")
+  );
+}
+
 export async function isSandboxBridgeGatewayReachable(
   opts: SandboxBridgeReachabilityOptions = {},
 ): Promise<SandboxBridgeReachabilityResult> {
@@ -125,7 +139,10 @@ export async function isSandboxBridgeGatewayReachable(
 
   const result = runImpl(
     [
-      "run", "--rm", "--pull=missing", "--network", networkName, probeImage,
+      "run", "--rm", "--pull=missing", "--network", networkName,
+      "--add-host", `${HOST_INTERNAL_NAME}:host-gateway`,
+      "--add-host", `${DOCKER_HOST_INTERNAL_NAME}:host-gateway`,
+      probeImage,
       "sh", "-c", `nc -zw${timeoutSec} ${HOST_INTERNAL_NAME} ${port}`,
     ],
     timeoutSec * 1000 + PROBE_RUN_OVERHEAD_MS,
@@ -139,6 +156,14 @@ export async function isSandboxBridgeGatewayReachable(
       reason: "probe_unavailable",
       subnet,
       detail: summarizeProbeUnavailable(result),
+    };
+  }
+  if (isNameResolutionFailure(result)) {
+    return {
+      ok: false,
+      reason: "probe_unavailable",
+      subnet,
+      detail: `${HOST_INTERNAL_NAME} did not resolve inside the probe container; cannot prove sandbox bridge reachability`,
     };
   }
   return {


### PR DESCRIPTION
## Summary
- keep the sandbox bridge reachability probe, but make its helper container match OpenShell Docker sandboxes by adding host.openshell.internal and host.docker.internal host-gateway aliases
- treat host alias/name-resolution failures as an inconclusive probe instead of blocking onboarding with a false firewall remediation
- add regression coverage for the host alias args and the DNS-failure classification

## Validation
- npm run build:cli
- npm run typecheck:cli
- npx vitest run src/lib/onboard/gateway-sandbox-reachability.test.ts test/gateway-liveness-probe.test.ts
- npx @biomejs/biome lint src/lib/onboard/gateway-sandbox-reachability.ts src/lib/onboard/gateway-sandbox-reachability.test.ts
- git diff --check
- live Docker sanity check: helper container without aliases fails with `nc: bad address host.openshell.internal`; with the OpenShell aliases, host.openshell.internal resolves and the probe command succeeds

## Context
This is the surgical follow-up to #3441. The new probe used the same Docker network as real sandboxes but did not include the host aliases that OpenShell adds to sandbox containers, so hostname-resolution failures could be misreported as a host firewall block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sandbox probe error handling to detect and properly report DNS/name-resolution failures within containers, distinguishing them from network connectivity issues with improved status messages.

* **Tests**
  * Added comprehensive test cases for gateway sandbox reachability probes, covering DNS failure scenarios and verifying host-gateway mapping configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3457)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->