### PR TITLE
fix(onboard): model OpenShell Docker bridge route in preflight

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -272,6 +272,8 @@ const {
 } = require("./onboard/gateway-http-readiness") as typeof import("./onboard/gateway-http-readiness");
 const { isGatewayTcpReady } =
   require("./onboard/gateway-tcp-readiness") as typeof import("./onboard/gateway-tcp-readiness");
+const { verifySandboxBridgeGatewayReachableOrExit } =
+  require("./onboard/gateway-sandbox-reachability") as typeof import("./onboard/gateway-sandbox-reachability");
 const { trackChildExit } =
   require("./onboard/child-exit-tracker") as typeof import("./onboard/child-exit-tracker");
 const { reportDockerDriverGatewayStartFailure } =
@@ -4460,6 +4462,7 @@ async function startDockerDriverGateway({
     if (drift) {
       restartDockerDriverGatewayProcessForDrift(pidFileGatewayPid, drift.reason);
     } else if (registerDockerDriverGatewayEndpoint() && (await isDockerDriverGatewayHttpReady())) {
+      await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
       console.log("  ✓ Reusing existing Docker-driver gateway");
       return;
     } else {
@@ -4491,6 +4494,7 @@ async function startDockerDriverGateway({
         isGatewayHealthy(adoptedStatus, adoptedGwInfo, adoptedActiveGatewayInfo) &&
         (await isDockerDriverGatewayHttpReady())
       ) {
+        await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
         console.log(`  ✓ Reusing existing Docker-driver gateway process (PID ${portListenerPid})`);
         return;
       }
@@ -4562,6 +4566,7 @@ async function startDockerDriverGateway({
       isGatewayHealthy(status, namedInfo, currentInfo) &&
       (await isGatewayTcpReady())
     ) {
+      await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
       console.log("  ✓ Docker-driver gateway is healthy");
       return;
     }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -272,8 +272,6 @@ const {
 } = require("./onboard/gateway-http-readiness") as typeof import("./onboard/gateway-http-readiness");
 const { isGatewayTcpReady } =
   require("./onboard/gateway-tcp-readiness") as typeof import("./onboard/gateway-tcp-readiness");
-const { verifySandboxBridgeGatewayReachableOrExit } =
-  require("./onboard/gateway-sandbox-reachability") as typeof import("./onboard/gateway-sandbox-reachability");
 const { trackChildExit } =
   require("./onboard/child-exit-tracker") as typeof import("./onboard/child-exit-tracker");
 const { reportDockerDriverGatewayStartFailure } =
@@ -4446,6 +4444,8 @@ async function startDockerDriverGateway({
     ignoreError: true,
   });
   const gatewayEnv = getDockerDriverGatewayEnv(openshellVersionOutput);
+  const { verifySandboxBridgeGatewayReachableOrExit } =
+    require("./onboard/gateway-sandbox-reachability") as typeof import("./onboard/gateway-sandbox-reachability");
 
   const gatewayStatus = runCaptureOpenshell(["status"], { ignoreError: true });
   const gwInfo = runCaptureOpenshell(["gateway", "info", "-g", GATEWAY_NAME], {
@@ -4462,8 +4462,7 @@ async function startDockerDriverGateway({
     if (drift) {
       restartDockerDriverGatewayProcessForDrift(pidFileGatewayPid, drift.reason);
     } else if (registerDockerDriverGatewayEndpoint() && (await isDockerDriverGatewayHttpReady())) {
-      await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
-      console.log("  ✓ Reusing existing Docker-driver gateway");
+      await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure); console.log("  ✓ Reusing existing Docker-driver gateway");
       return;
     } else {
       console.log(
@@ -4494,8 +4493,7 @@ async function startDockerDriverGateway({
         isGatewayHealthy(adoptedStatus, adoptedGwInfo, adoptedActiveGatewayInfo) &&
         (await isDockerDriverGatewayHttpReady())
       ) {
-        await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
-        console.log(`  ✓ Reusing existing Docker-driver gateway process (PID ${portListenerPid})`);
+        await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure); console.log(`  ✓ Reusing existing Docker-driver gateway process (PID ${portListenerPid})`);
         return;
       }
     }
@@ -4560,14 +4558,11 @@ async function startDockerDriverGateway({
       ignoreError: true,
     });
     const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
-    // #3111: gate the healthy log on a real TCP probe. See
-    // ./onboard/gateway-tcp-readiness for why TCP, not HTTP. TODO(#3213).
     if (
       isGatewayHealthy(status, namedInfo, currentInfo) &&
       (await isGatewayTcpReady())
     ) {
-      await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure);
-      console.log("  ✓ Docker-driver gateway is healthy");
+      await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure); console.log("  ✓ Docker-driver gateway is healthy");
       return;
     }
     if (i < pollCount - 1) sleep(pollInterval);

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  __test,
+  isSandboxBridgeGatewayReachable,
+  formatSandboxBridgeUnreachableMessage,
+} from "../../../dist/lib/onboard/gateway-sandbox-reachability";
+
+describe("gateway sandbox reachability route modeling", () => {
+  it("parses Docker network IPAM config for subnet and gateway", () => {
+    expect(
+      __test.parseDockerNetworkIpamConfig(
+        '[{"Subnet":"fd00::/64","Gateway":"fd00::1"},{"Subnet":"172.19.0.0/16","Gateway":"172.19.0.1"}]',
+      ),
+    ).toEqual({ subnet: "172.19.0.0/16", gatewayIp: "172.19.0.1" });
+  });
+
+  it("mirrors OpenShell native Linux bridge host aliases", () => {
+    const route = __test.buildOpenShellDockerRoute(
+      "openshell-docker",
+      { subnet: "172.19.0.0/16", gatewayIp: "172.19.0.1" },
+      false,
+    );
+    expect(route?.routeKind).toBe("bridge_gateway");
+    expect(route?.addHosts).toEqual([
+      "host.docker.internal:172.19.0.1",
+      "host.openshell.internal:172.19.0.1",
+    ]);
+  });
+
+  it("mirrors OpenShell Docker Desktop and VM-backed host-gateway routing", () => {
+    const route = __test.buildOpenShellDockerRoute(
+      "openshell-docker",
+      { subnet: "172.19.0.0/16", gatewayIp: "172.19.0.1" },
+      true,
+    );
+    expect(route?.routeKind).toBe("host_gateway");
+    expect(route?.addHosts).toEqual(["host.openshell.internal:host-gateway"]);
+  });
+});
+
+describe("isSandboxBridgeGatewayReachable", () => {
+  it("returns ok when the correctly-routed helper connects", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectNetworkImpl: () => ({ subnet: "172.19.0.0/16", gatewayIp: "172.19.0.1" }),
+      usesHostGatewayRouteImpl: () => false,
+      runImpl: () => ({ status: 0 }),
+    });
+    expect(result).toEqual({
+      ok: true,
+      reason: "ok",
+      networkName: "openshell-docker",
+      subnet: "172.19.0.0/16",
+      gatewayIp: "172.19.0.1",
+      routeKind: "bridge_gateway",
+    });
+  });
+
+  it("uses add-host aliases before the probe image", async () => {
+    const seen: { args: readonly string[] } = { args: [] };
+    await isSandboxBridgeGatewayReachable({
+      networkName: "custom-net",
+      port: 9090,
+      timeoutSec: 7,
+      inspectNetworkImpl: () => ({ subnet: "10.0.0.0/24", gatewayIp: "10.0.0.1" }),
+      usesHostGatewayRouteImpl: () => false,
+      runImpl: (args) => {
+        seen.args = args;
+        return { status: 0 };
+      },
+    });
+    expect(seen.args).toContain("custom-net");
+    expect(seen.args).toContain("--pull=missing");
+    expect(seen.args).toContain("host.openshell.internal:10.0.0.1");
+    expect(seen.args.join(" ")).toContain("nc -zw7 host.openshell.internal 9090");
+  });
+
+  it("does not call a missing Docker network a firewall failure", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectNetworkImpl: () => undefined,
+      usesHostGatewayRouteImpl: () => false,
+      runImpl: () => ({ status: 0 }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("probe_unavailable");
+    expect(result.detail).toContain("not found");
+  });
+
+  it("does not call helper DNS failures firewall failures", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectNetworkImpl: () => ({ subnet: "172.19.0.0/16", gatewayIp: "172.19.0.1" }),
+      usesHostGatewayRouteImpl: () => false,
+      runImpl: () => ({ status: 1, stderr: "nc: bad address 'host.openshell.internal'" }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("probe_unavailable");
+  });
+
+  it("flags tcp_failed only after the OpenShell route was modeled", async () => {
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectNetworkImpl: () => ({ subnet: "172.19.0.0/16", gatewayIp: "172.19.0.1" }),
+      usesHostGatewayRouteImpl: () => false,
+      runImpl: () => ({ status: 1 }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("tcp_failed");
+    expect(result.gatewayIp).toBe("172.19.0.1");
+  });
+});
+
+describe("formatSandboxBridgeUnreachableMessage", () => {
+  it("emits a UFW command only for bridge-gateway TCP failures", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "tcp_failed",
+      routeKind: "bridge_gateway",
+      networkName: "openshell-docker",
+      subnet: "172.19.0.0/16",
+      gatewayIp: "172.19.0.1",
+    });
+    expect(msg).toContain("172.19.0.1:8080");
+    expect(msg).toContain("ufw allow from 172.19.0.0/16 to any port 8080");
+  });
+
+  it("does not emit a UFW command when the probe is unavailable", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "probe_unavailable",
+      detail: "Docker network not found",
+    });
+    expect(msg).toContain("Could not verify sandbox bridge reachability");
+    expect(msg).toContain("continuing");
+    expect(msg).not.toContain("ufw allow");
+  });
+
+  it("does not emit a UFW command for host-gateway routing failures", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "tcp_failed",
+      routeKind: "host_gateway",
+      networkName: "openshell-docker",
+      subnet: "172.19.0.0/16",
+    });
+    expect(msg).toContain("host-gateway");
+    expect(msg).not.toContain("ufw allow");
+  });
+});

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -75,6 +75,15 @@ describe("isSandboxBridgeGatewayReachable", () => {
     expect(seen.args).toContain("custom-net");
     expect(seen.args).toContain("--pull=missing");
     expect(seen.args).toContain("host.openshell.internal:10.0.0.1");
+    const addHostIndex = seen.args.findIndex((arg) =>
+      arg.includes("host.openshell.internal:10.0.0.1"),
+    );
+    const probeCommandIndex = seen.args.findIndex((arg) =>
+      arg.includes("nc -zw7 host.openshell.internal 9090"),
+    );
+    expect(addHostIndex).toBeGreaterThanOrEqual(0);
+    expect(probeCommandIndex).toBeGreaterThanOrEqual(0);
+    expect(addHostIndex).toBeLessThan(probeCommandIndex);
     expect(seen.args.join(" ")).toContain("nc -zw7 host.openshell.internal 9090");
   });
 

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Docker-driver sandbox -> gateway reachability probe.
+ *
+ * OpenShell 0.0.39 moved local Docker sandboxes onto a managed bridge network
+ * and gives real sandbox containers an explicit host.openshell.internal route.
+ * This probe must mirror that route before it can make a useful firewall
+ * diagnosis; a plain helper container on the bridge is not equivalent.
+ */
+
+import { dockerCapture, dockerRun } from "../adapters/docker/run";
+import { GATEWAY_PORT } from "../core/ports";
+
+const DEFAULT_PROBE_IMAGE =
+  "busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662";
+const DEFAULT_NETWORK_NAME = "openshell-docker";
+const HOST_INTERNAL_NAME = "host.openshell.internal";
+const HOST_DOCKER_INTERNAL_NAME = "host.docker.internal";
+const DEFAULT_PROBE_TIMEOUT_SEC = 5;
+const PROBE_RUN_OVERHEAD_MS = 10_000;
+
+export type SandboxBridgeReachabilityReason = "ok" | "tcp_failed" | "probe_unavailable";
+export type SandboxBridgeRouteKind = "bridge_gateway" | "host_gateway";
+
+export interface DockerBridgeNetworkInfo {
+  subnet?: string;
+  gatewayIp?: string;
+}
+
+export interface SandboxBridgeReachabilityResult {
+  ok: boolean;
+  reason: SandboxBridgeReachabilityReason;
+  networkName?: string;
+  subnet?: string;
+  gatewayIp?: string;
+  routeKind?: SandboxBridgeRouteKind;
+  detail?: string;
+}
+
+interface SandboxBridgeProbeRunResult {
+  status: number | null;
+  signal?: NodeJS.Signals | null;
+  error?: string;
+  stderr?: string | Buffer | null;
+  stdout?: string | Buffer | null;
+}
+
+interface OpenShellDockerRoute {
+  networkName: string;
+  subnet?: string;
+  gatewayIp?: string;
+  routeKind: SandboxBridgeRouteKind;
+  addHosts: string[];
+}
+
+export interface SandboxBridgeReachabilityOptions {
+  networkName?: string;
+  port?: number;
+  timeoutSec?: number;
+  probeImage?: string;
+  runImpl?: (args: readonly string[], timeoutMs: number) => SandboxBridgeProbeRunResult;
+  inspectNetworkImpl?: (networkName: string) => DockerBridgeNetworkInfo | undefined;
+  usesHostGatewayRouteImpl?: () => boolean;
+}
+
+function parseDockerNetworkIpamConfig(raw: string): DockerBridgeNetworkInfo | undefined {
+  const text = raw.trim();
+  if (!text || text === "<no value>") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parsed)) return undefined;
+  const candidates: DockerBridgeNetworkInfo[] = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    const subnet = typeof record.Subnet === "string" ? record.Subnet : undefined;
+    const gatewayIp = typeof record.Gateway === "string" ? record.Gateway : undefined;
+    if (subnet || gatewayIp) candidates.push({ subnet, gatewayIp });
+  }
+  return (
+    candidates.find((candidate) => candidate.gatewayIp && !candidate.gatewayIp.includes(":")) ??
+    candidates.find((candidate) => candidate.subnet && /^\d+\./.test(candidate.subnet)) ??
+    candidates[0]
+  );
+}
+
+function defaultInspectNetwork(networkName: string): DockerBridgeNetworkInfo | undefined {
+  const raw = dockerCapture(
+    ["network", "inspect", "--format", "{{json .IPAM.Config}}", networkName],
+    { ignoreError: true },
+  );
+  return parseDockerNetworkIpamConfig(raw);
+}
+
+function defaultUsesHostGatewayRoute(): boolean {
+  if (process.platform !== "linux") return true;
+  const info = dockerCapture(
+    ["info", "--format", "{{.OperatingSystem}}\n{{range .Labels}}{{.}}\n{{end}}"],
+    { ignoreError: true },
+  );
+  return /Docker Desktop|com\.docker\.desktop\./i.test(info);
+}
+
+function defaultRunImpl(args: readonly string[], timeoutMs: number): SandboxBridgeProbeRunResult {
+  const result = dockerRun(args, {
+    timeout: timeoutMs,
+    ignoreError: true,
+    suppressOutput: true,
+  });
+  return {
+    status: result.status ?? null,
+    signal: result.signal,
+    error: result.error?.message,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+function buildOpenShellDockerRoute(
+  networkName: string,
+  network: DockerBridgeNetworkInfo | undefined,
+  usesHostGatewayRoute: boolean,
+): OpenShellDockerRoute | undefined {
+  if (!network) return undefined;
+  if (usesHostGatewayRoute) {
+    return {
+      networkName,
+      subnet: network.subnet,
+      gatewayIp: network.gatewayIp,
+      routeKind: "host_gateway",
+      addHosts: [`${HOST_INTERNAL_NAME}:host-gateway`],
+    };
+  }
+  if (!network.gatewayIp) return undefined;
+  return {
+    networkName,
+    subnet: network.subnet,
+    gatewayIp: network.gatewayIp,
+    routeKind: "bridge_gateway",
+    addHosts: [
+      `${HOST_DOCKER_INTERNAL_NAME}:${network.gatewayIp}`,
+      `${HOST_INTERNAL_NAME}:${network.gatewayIp}`,
+    ],
+  };
+}
+
+function outputTail(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const raw = Buffer.isBuffer(value) ? value.toString("utf8") : String(value);
+  const text = raw.trim();
+  return text ? text.slice(-400) : undefined;
+}
+
+function summarizeProbeResult(result: SandboxBridgeProbeRunResult): string {
+  const details = [
+    result.error,
+    outputTail(result.stderr),
+    outputTail(result.stdout),
+    result.signal ? `signal ${result.signal}` : undefined,
+    result.status !== null ? `exit ${result.status}` : undefined,
+  ].filter((item): item is string => Boolean(item));
+  return details[0] ?? "docker run did not complete the probe";
+}
+
+function isNameResolutionFailure(detail: string): boolean {
+  return /bad address|name or service not known|temporary failure in name resolution|could not resolve|getaddrinfo/i.test(
+    detail,
+  );
+}
+
+function buildProbeArgs(
+  route: OpenShellDockerRoute,
+  probeImage: string,
+  timeoutSec: number,
+  port: number,
+): string[] {
+  const addHostArgs = route.addHosts.flatMap((host) => ["--add-host", host]);
+  return [
+    "run",
+    "--rm",
+    "--pull=missing",
+    "--network",
+    route.networkName,
+    ...addHostArgs,
+    probeImage,
+    "sh",
+    "-c",
+    `nc -zw${timeoutSec} ${HOST_INTERNAL_NAME} ${port}`,
+  ];
+}
+
+export async function isSandboxBridgeGatewayReachable(
+  opts: SandboxBridgeReachabilityOptions = {},
+): Promise<SandboxBridgeReachabilityResult> {
+  const networkName =
+    opts.networkName ?? process.env.OPENSHELL_DOCKER_NETWORK_NAME ?? DEFAULT_NETWORK_NAME;
+  const port = opts.port ?? GATEWAY_PORT;
+  const timeoutSec = opts.timeoutSec ?? DEFAULT_PROBE_TIMEOUT_SEC;
+  const probeImage = opts.probeImage ?? DEFAULT_PROBE_IMAGE;
+  const inspectNetwork = opts.inspectNetworkImpl ?? defaultInspectNetwork;
+  const usesHostGatewayRoute = opts.usesHostGatewayRouteImpl ?? defaultUsesHostGatewayRoute;
+  const runImpl = opts.runImpl ?? defaultRunImpl;
+
+  const network = inspectNetwork(networkName);
+  const route = buildOpenShellDockerRoute(networkName, network, usesHostGatewayRoute());
+  if (!route) {
+    return {
+      ok: false,
+      reason: "probe_unavailable",
+      networkName,
+      subnet: network?.subnet,
+      gatewayIp: network?.gatewayIp,
+      detail: network
+        ? `Docker network "${networkName}" does not expose an IPv4 gateway for the OpenShell route`
+        : `Docker network "${networkName}" not found`,
+    };
+  }
+
+  const result = runImpl(
+    buildProbeArgs(route, probeImage, timeoutSec, port),
+    timeoutSec * 1000 + PROBE_RUN_OVERHEAD_MS,
+  );
+  if (result.status === 0) {
+    return {
+      ok: true,
+      reason: "ok",
+      networkName,
+      subnet: route.subnet,
+      gatewayIp: route.gatewayIp,
+      routeKind: route.routeKind,
+    };
+  }
+
+  const detail = summarizeProbeResult(result);
+  if (result.status !== 1 || isNameResolutionFailure(detail)) {
+    return {
+      ok: false,
+      reason: "probe_unavailable",
+      networkName,
+      subnet: route.subnet,
+      gatewayIp: route.gatewayIp,
+      routeKind: route.routeKind,
+      detail,
+    };
+  }
+
+  return {
+    ok: false,
+    reason: "tcp_failed",
+    networkName,
+    subnet: route.subnet,
+    gatewayIp: route.gatewayIp,
+    routeKind: route.routeKind,
+    detail: `sandbox container on "${networkName}" could not reach ${HOST_INTERNAL_NAME}:${port}`,
+  };
+}
+
+export function formatSandboxBridgeUnreachableMessage(
+  result: SandboxBridgeReachabilityResult,
+  port: number = GATEWAY_PORT,
+): string {
+  if (result.ok) return "";
+  if (result.reason === "probe_unavailable") {
+    return [
+      "  ⚠ Could not verify sandbox bridge reachability.",
+      "    This does not prove the gateway is unreachable; continuing.",
+      result.detail ? `    ${result.detail}` : undefined,
+    ].filter((line): line is string => Boolean(line)).join("\n");
+  }
+
+  if (result.routeKind === "host_gateway") {
+    return [
+      `  ✗ Sandbox containers cannot reach the gateway at ${HOST_INTERNAL_NAME}:${port}.`,
+      "    The probe used Docker's host-gateway route, matching Docker Desktop/VM-backed Docker.",
+      "    Restart Docker and the OpenShell gateway, then re-run `nemoclaw onboard`.",
+    ].join("\n");
+  }
+
+  const allowCmd = result.subnet
+    ? `      sudo ufw allow from ${result.subnet} to any port ${port} proto tcp`
+    : [
+        `      SUBNET=$(docker network inspect ${result.networkName ?? DEFAULT_NETWORK_NAME} --format '{{(index .IPAM.Config 0).Subnet}}')`,
+        `      sudo ufw allow from "$SUBNET" to any port ${port} proto tcp`,
+      ].join("\n");
+  const target = result.gatewayIp
+    ? `${HOST_INTERNAL_NAME}:${port} (${result.gatewayIp}:${port})`
+    : `${HOST_INTERNAL_NAME}:${port}`;
+  return [
+    `  ✗ Sandbox containers cannot reach the gateway at ${target}.`,
+    "    A host firewall may be blocking traffic from the OpenShell Docker bridge.",
+    "    To allow it:",
+    allowCmd,
+    "    Then re-run `nemoclaw onboard`.",
+  ].join("\n");
+}
+
+export async function verifySandboxBridgeGatewayReachableOrExit(
+  exitOnFailure: boolean,
+): Promise<void> {
+  const reach = await isSandboxBridgeGatewayReachable();
+  if (reach.ok) return;
+
+  const message = formatSandboxBridgeUnreachableMessage(reach);
+  if (reach.reason === "probe_unavailable") {
+    console.warn(message);
+    return;
+  }
+
+  console.error(message);
+  if (exitOnFailure) {
+    process.exit(1);
+  }
+  throw new Error(`Docker-driver sandbox-bridge unreachable (${reach.reason})`);
+}
+
+export const __test = {
+  buildOpenShellDockerRoute,
+  buildProbeArgs,
+  parseDockerNetworkIpamConfig,
+};

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -165,7 +165,7 @@ function summarizeProbeResult(result: SandboxBridgeProbeRunResult): string {
     result.signal ? `signal ${result.signal}` : undefined,
     result.status !== null ? `exit ${result.status}` : undefined,
   ].filter((item): item is string => Boolean(item));
-  return details[0] ?? "docker run did not complete the probe";
+  return details.length > 0 ? details.join(" | ") : "docker run did not complete the probe";
 }
 
 function isNameResolutionFailure(detail: string): boolean {

--- a/test/gateway-liveness-probe.test.ts
+++ b/test/gateway-liveness-probe.test.ts
@@ -133,6 +133,31 @@ describe("gateway liveness probe (#2020)", () => {
     );
   });
 
+  it("Docker-driver gateway startup verifies sandbox bridge reachability before successful returns", () => {
+    const dockerStart = content.indexOf("async function startDockerDriverGateway(");
+    const dockerEnd = content.indexOf("\nasync function startGateway(", dockerStart);
+    expect(dockerStart).toBeGreaterThanOrEqual(0);
+    expect(dockerEnd).toBeGreaterThan(dockerStart);
+    const dockerSection = content.slice(dockerStart, dockerEnd);
+    const calls = dockerSection.match(
+      /verifySandboxBridgeGatewayReachableOrExit\(exitOnFailure\)/g,
+    );
+    expect(calls?.length).toBeGreaterThanOrEqual(3);
+
+    for (const marker of [
+      "Reusing existing Docker-driver gateway",
+      "Reusing existing Docker-driver gateway process",
+      "Docker-driver gateway is healthy",
+    ]) {
+      const markerIdx = dockerSection.indexOf(marker);
+      expect(markerIdx).toBeGreaterThan(0);
+      const before = dockerSection.slice(0, markerIdx);
+      expect(
+        before.lastIndexOf("verifySandboxBridgeGatewayReachableOrExit(exitOnFailure)"),
+      ).toBeGreaterThan(0);
+    }
+  });
+
   it("does not modify isGatewayHealthy() in src/lib/state/gateway.ts", () => {
     // isGatewayHealthy() must remain a pure function — no I/O.
     // Scope the check to the function body so unrelated helpers don't cause false failures.


### PR DESCRIPTION
## Summary
- supersede #3441 with a Docker-driver sandbox reachability probe that mirrors OpenShell's current Docker routing model
- inspect the managed Docker network IPAM config, prefer the IPv4 bridge gateway, and inject the same host.openshell.internal mapping real OpenShell sandboxes receive
- classify probe setup/DNS/network-inspect failures as non-blocking `probe_unavailable` instead of host-firewall failures
- keep the UFW remediation only for native bridge-gateway TCP failures after the exact OpenShell route has been modeled

## Why
#3441 tried to catch the real partner/Brev failure from #3439, but its helper container did not actually behave like an OpenShell Docker sandbox after OpenShell #1128. Real sandboxes get explicit `host.openshell.internal` routing: native Linux Docker maps it to the `openshell-docker` bridge gateway IP, while Docker Desktop/VM-backed Docker uses Docker's `host-gateway` route.

This replacement keeps the useful early diagnostic while avoiding the false DNS/host-gateway failures that forced the #3441 revert.

## Validation
- npm run build:cli
- npm run typecheck:cli
- npx vitest run src/lib/onboard/gateway-sandbox-reachability.test.ts test/gateway-liveness-probe.test.ts
- npm run checks
- git diff --check

Local Docker note: this checkout did not have an `openshell-docker` network, which now maps to `probe_unavailable` / continue rather than a firewall diagnosis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Docker gateway startup now performs sandbox-bridge reachability checks before reporting healthy, reducing startup surprises.

* **User-facing**
  * Clearer diagnostics and guidance when sandbox-to-gateway connectivity fails (including conditional firewall hints for TCP failures).

* **Tests**
  * Added tests covering gateway reachability checks and related messaging to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3459)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->