### PR TITLE
fix(uninstall): remove openshell helper binaries alongside the wrapper

### DIFF
--- a/src/lib/domain/uninstall/paths.test.ts
+++ b/src/lib/domain/uninstall/paths.test.ts
@@ -18,7 +18,16 @@ describe("uninstall paths", () => {
     expect(paths.openshellConfigDir).toBe(path.join("/home/test", ".config", "openshell"));
     expect(paths.nemoclawConfigDir).toBe(path.join("/home/test", ".config", "nemoclaw"));
     expect(paths.nemoclawShimPath).toBe(path.join("/home/test", ".local", "bin", "nemoclaw"));
-    expect(paths.openshellInstallPaths).toEqual(["/usr/local/bin/openshell", path.join("/xdg/bin", "openshell")]);
+    expect(paths.openshellInstallPaths).toEqual([
+      "/usr/local/bin/openshell",
+      path.join("/xdg/bin", "openshell"),
+      "/usr/local/bin/openshell-gateway",
+      path.join("/xdg/bin", "openshell-gateway"),
+      "/usr/local/bin/openshell-sandbox",
+      path.join("/xdg/bin", "openshell-sandbox"),
+      "/usr/local/bin/openshell-driver-vm",
+      path.join("/xdg/bin", "openshell-driver-vm"),
+    ]);
     expect(paths.helperServiceGlob).toBe(path.join("/tmp/nemo", "nemoclaw-services-*"));
     expect(paths.runtimeTempGlobs).toEqual([
       path.join("/tmp/nemo", "nemoclaw-create-*.log"),

--- a/src/lib/domain/uninstall/paths.ts
+++ b/src/lib/domain/uninstall/paths.ts
@@ -13,6 +13,19 @@ export const NEMOCLAW_PROVIDERS = [
 ] as const;
 export const NEMOCLAW_OLLAMA_MODELS = ["nemotron-3-super:120b", "nemotron-3-nano:30b"] as const;
 
+// install-openshell.sh ships the CLI wrapper plus one or two helper binaries
+// into the same directory: `openshell-gateway` on every platform, plus
+// `openshell-sandbox` on Linux or `openshell-driver-vm` on macOS. All three
+// names need to be enumerated here so that `nemoclaw uninstall` cleans up
+// every artefact it installed, rather than leaving the helpers behind to
+// trip the version-mismatch guard on the next install.
+const OPENSHELL_BINARY_BASENAMES = [
+  "openshell",
+  "openshell-gateway",
+  "openshell-sandbox",
+  "openshell-driver-vm",
+] as const;
+
 export interface UninstallPathOptions {
   home: string;
   repoRoot?: string;
@@ -48,7 +61,10 @@ export function defaultUninstallPaths(options: UninstallPathOptions): UninstallP
     nemoclawShimPath: path.join(options.home, ".local", "bin", "nemoclaw"),
     nemoclawStateDir: path.join(options.home, ".nemoclaw"),
     openshellConfigDir: path.join(options.home, ".config", "openshell"),
-    openshellInstallPaths: ["/usr/local/bin/openshell", path.join(xdgBinHome, "openshell")],
+    openshellInstallPaths: OPENSHELL_BINARY_BASENAMES.flatMap((name) => [
+      `/usr/local/bin/${name}`,
+      path.join(xdgBinHome, name),
+    ]),
     repoRoot: options.repoRoot || path.resolve(__dirname, "..", "..", "..", ".."),
     runtimeTempGlobs: [path.join(tmpDir, "nemoclaw-create-*.log"), path.join(tmpDir, "nemoclaw-tg-ssh-*.conf")],
     shellProfilePaths: [

--- a/src/lib/domain/uninstall/plan.test.ts
+++ b/src/lib/domain/uninstall/plan.test.ts
@@ -34,6 +34,9 @@ describe("uninstall plan", () => {
         { kind: "preserve-ollama-models", names: ["nemotron-3-super:120b", "nemotron-3-nano:30b"] },
         { kind: "delete-managed-swap" },
         { kind: "delete-openshell-binary", path: "/usr/local/bin/openshell" },
+        { kind: "delete-openshell-binary", path: "/usr/local/bin/openshell-gateway" },
+        { kind: "delete-openshell-binary", path: "/usr/local/bin/openshell-sandbox" },
+        { kind: "delete-openshell-binary", path: "/usr/local/bin/openshell-driver-vm" },
         { kind: "stop-ollama-auth-proxy" },
       ]),
     );
@@ -62,7 +65,21 @@ describe("uninstall plan", () => {
     expect(actions).toEqual(expect.arrayContaining([{ kind: "delete-docker-volume", name: "openshell-cluster-custom" }]));
     expect(actions).toEqual(expect.arrayContaining([{ kind: "delete-ollama-model", name: "nemotron-3-super:120b" }]));
     expect(actions).toEqual(
-      expect.arrayContaining([{ kind: "preserve-openshell-binary", paths: ["/usr/local/bin/openshell", "/bin/openshell"] }]),
+      expect.arrayContaining([
+        {
+          kind: "preserve-openshell-binary",
+          paths: [
+            "/usr/local/bin/openshell",
+            "/bin/openshell",
+            "/usr/local/bin/openshell-gateway",
+            "/bin/openshell-gateway",
+            "/usr/local/bin/openshell-sandbox",
+            "/bin/openshell-sandbox",
+            "/usr/local/bin/openshell-driver-vm",
+            "/bin/openshell-driver-vm",
+          ],
+        },
+      ]),
     );
     expect(actions).toEqual(
       expect.arrayContaining([{ kind: "preserve-shim", reason: "regular file is not an installer-managed shim" }]),


### PR DESCRIPTION
## Summary
`nemoclaw uninstall` reported success but only removed the `openshell` CLI wrapper from `~/.local/bin/`. The helper binaries `install-openshell.sh` plants in the same directory (`openshell-gateway` on every platform plus `openshell-sandbox` on Linux or `openshell-driver-vm` on macOS) survived the uninstall and blocked subsequent installs of older NemoClaw releases at the version-mismatch guard.

## Related Issue
Fixes #3455

## Changes
- `src/lib/domain/uninstall/paths.ts`: enumerate every binary `install-openshell.sh` may install (`openshell`, `openshell-gateway`, `openshell-sandbox`, `openshell-driver-vm`) and resolve each at both `/usr/local/bin/` and the XDG bin home. The plan generator and run-plan loop already iterate `openshellInstallPaths`, so the existing delete-or-preserve logic now covers every helper.
- `src/lib/domain/uninstall/paths.test.ts`: assert all eight resolved paths.
- `src/lib/domain/uninstall/plan.test.ts`: extend the delete-binary case to include the three helpers and the preserve-binary case (under `--keep-openshell`) to confirm every helper is preserved together.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstall process now comprehensively removes all related application binaries and helper components (gateway, sandbox, and driver-vm variants) from both standard system and user-specific binary directories, providing more thorough cleanup.

* **Tests**
  * Expanded test coverage to validate uninstall behavior across multiple binary variants and installation paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3460)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->