### PR TITLE
test(e2e): add gateway drift preflight guard for #3423

### DIFF
--- a/.github/workflows/regression-e2e.yaml
+++ b/.github/workflows/regression-e2e.yaml
@@ -21,7 +21,7 @@ on:
       jobs:
         description: >-
           Comma-separated regression job names to run (empty = all).
-          Valid: dashboard-remote-bind-e2e,gateway-health-honest-e2e
+          Valid: dashboard-remote-bind-e2e,gateway-health-honest-e2e,gateway-drift-preflight-e2e
         required: false
         type: string
         default: ""
@@ -46,6 +46,7 @@ jobs:
     outputs:
       dashboard: ${{ steps.select.outputs.dashboard }}
       gateway: ${{ steps.select.outputs.gateway }}
+      gateway_drift_preflight: ${{ steps.select.outputs.gateway_drift_preflight }}
     steps:
       - id: select
         env:
@@ -71,6 +72,12 @@ jobs:
             echo "gateway=true" >> "$GITHUB_OUTPUT"
           else
             echo "gateway=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -z "$normalized" ] || includes_job "gateway-drift-preflight-e2e"; then
+            echo "gateway_drift_preflight=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "gateway_drift_preflight=false" >> "$GITHUB_OUTPUT"
           fi
 
   dashboard-remote-bind-e2e:
@@ -137,3 +144,30 @@ jobs:
             /tmp/nemoclaw-e2e-gateway-health-honest-start.log
             /tmp/nemoclaw-e2e-gateway-health-honest-process.log
           if-no-files-found: ignore
+
+
+  # ── Gateway drift preflight E2E ─────────────────────────────
+  # Coverage guard for #3399 / #3423. A stale OpenShell gateway image can
+  # make sandbox-state RPCs fail with protobuf invalid-wire decode errors.
+  # NemoClaw must fail closed instead of trusting or misclassifying that state.
+  gateway-drift-preflight-e2e:
+    needs: select_regression_jobs
+    if: >-
+      github.repository == 'NVIDIA/NemoClaw' &&
+      needs.select_regression_jobs.outputs.gateway_drift_preflight == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Run gateway drift preflight E2E test
+        env:
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+        run: bash test/e2e/test-gateway-drift-preflight.sh

--- a/test/e2e/test-gateway-drift-preflight.sh
+++ b/test/e2e/test-gateway-drift-preflight.sh
@@ -144,9 +144,9 @@ run_backup_case() {
 
   local output="$CASE_DIR/command.out"
   HOME="$home" \
-  PATH="$bin_dir:$PATH" \
-  NEMOCLAW_FAKE_CASE_DIR="$CASE_DIR" \
-  "$@" >"$output" 2>&1
+    PATH="$bin_dir:$PATH" \
+    NEMOCLAW_FAKE_CASE_DIR="$CASE_DIR" \
+    "$@" >"$output" 2>&1
   return $?
 }
 

--- a/test/e2e/test-gateway-drift-preflight.sh
+++ b/test/e2e/test-gateway-drift-preflight.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -uo pipefail
+
+section() { printf '\n=== %s ===\n' "$1"; }
+pass() { echo "PASS: $1"; }
+info() { echo "INFO: $1"; }
+fail() {
+  echo "FAIL: $1" >&2
+  if [ -n "${CASE_DIR:-}" ] && [ -d "$CASE_DIR" ]; then
+    echo "--- fake openshell calls ---" >&2
+    cat "$CASE_DIR/openshell-calls.log" 2>/dev/null >&2 || true
+    echo "--- fake docker calls ---" >&2
+    cat "$CASE_DIR/docker-calls.log" 2>/dev/null >&2 || true
+    echo "--- command output ---" >&2
+    cat "$CASE_DIR/command.out" 2>/dev/null >&2 || true
+  fi
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORK_ROOT="$(mktemp -d -t nemoclaw-gateway-drift-preflight.XXXXXX)"
+export NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT=0
+
+cleanup() {
+  rm -rf "$WORK_ROOT"
+}
+trap cleanup EXIT
+
+load_shell_path() {
+  if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.bashrc" 2>/dev/null || true
+  fi
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$NVM_DIR/nvm.sh"
+  fi
+}
+
+write_registry() {
+  local home="$1"
+  mkdir -p "$home/.nemoclaw"
+  cat >"$home/.nemoclaw/sandboxes.json" <<'JSON'
+{
+  "sandboxes": {
+    "alpha": {
+      "name": "alpha",
+      "model": "test-model",
+      "provider": "nvidia-prod",
+      "gpuEnabled": false,
+      "policies": [],
+      "agent": "openclaw",
+      "agentVersion": "test-version"
+    }
+  },
+  "defaultSandbox": "alpha"
+}
+JSON
+  chmod 600 "$home/.nemoclaw/sandboxes.json"
+}
+
+write_fake_openshell() {
+  local bin_dir="$1"
+  cat >"$bin_dir/openshell" <<'SH'
+#!/usr/bin/env bash
+set -uo pipefail
+: "${NEMOCLAW_FAKE_CASE_DIR:?}"
+printf '%s\n' "$*" >> "$NEMOCLAW_FAKE_CASE_DIR/openshell-calls.log"
+case "${1:-}" in
+  --version|-V)
+    printf 'openshell 0.0.37\n'
+    exit 0
+    ;;
+  status)
+    printf 'Server Status\n\n  Gateway: nemoclaw\n  Status: Connected\n'
+    exit 0
+    ;;
+  gateway)
+    if [ "${2:-}" = "info" ]; then
+      printf 'Gateway Info\n\n  Gateway: nemoclaw\n  Gateway endpoint: http://127.0.0.1:8080\n'
+      exit 0
+    fi
+    ;;
+  sandbox)
+    if [ "${2:-}" = "list" ]; then
+      printf '%s\n' 'Error: status: Internal, message: "failed to decode Protobuf message: Sandbox.metadata: SandboxResponse.sandbox: invalid wire type value: 6"' >&2
+      exit "${NEMOCLAW_FAKE_SANDBOX_LIST_EXIT:-1}"
+    fi
+    ;;
+esac
+printf 'unexpected openshell args: %s\n' "$*" >&2
+exit 9
+SH
+  chmod +x "$bin_dir/openshell"
+}
+
+write_fake_docker() {
+  local bin_dir="$1"
+  cat >"$bin_dir/docker" <<'SH'
+#!/usr/bin/env bash
+set -uo pipefail
+: "${NEMOCLAW_FAKE_CASE_DIR:?}"
+printf '%s\n' "$*" >> "$NEMOCLAW_FAKE_CASE_DIR/docker-calls.log"
+if [ "${1:-}" = "inspect" ] && [ "${2:-}" = "--type" ] && [ "${3:-}" = "container" ] && [ "${4:-}" = "--format" ]; then
+  format="${5:-}"
+  case "$format" in
+    '{{.State.Running}}')
+      printf '%s\n' "${NEMOCLAW_FAKE_GATEWAY_RUNNING:-true}"
+      exit 0
+      ;;
+    '{{json .NetworkSettings.Ports}}')
+      printf '%s\n' "${NEMOCLAW_FAKE_GATEWAY_PORTS:-{\"30051/tcp\":[{\"HostIp\":\"0.0.0.0\",\"HostPort\":\"8080\"}]}}"
+      exit 0
+      ;;
+    '{{.Config.Image}}')
+      printf '%s\n' "${NEMOCLAW_FAKE_GATEWAY_IMAGE:-ghcr.io/nvidia/openshell/cluster:0.0.37}"
+      exit 0
+      ;;
+  esac
+fi
+printf 'unexpected docker args: %s\n' "$*" >&2
+exit 9
+SH
+  chmod +x "$bin_dir/docker"
+}
+
+run_backup_case() {
+  local name="$1"
+  shift
+  CASE_DIR="$WORK_ROOT/$name"
+  local home="$CASE_DIR/home"
+  local bin_dir="$CASE_DIR/bin"
+  mkdir -p "$home" "$bin_dir"
+  : >"$CASE_DIR/openshell-calls.log"
+  : >"$CASE_DIR/docker-calls.log"
+  write_registry "$home"
+  write_fake_openshell "$bin_dir"
+  write_fake_docker "$bin_dir"
+
+  local output="$CASE_DIR/command.out"
+  HOME="$home" \
+  PATH="$bin_dir:$PATH" \
+  NEMOCLAW_FAKE_CASE_DIR="$CASE_DIR" \
+  "$@" >"$output" 2>&1
+  return $?
+}
+
+assert_contains() {
+  local file="$1" pattern="$2" description="$3"
+  if grep -qiE "$pattern" "$file"; then
+    pass "$description"
+  else
+    fail "$description (missing pattern: $pattern)"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" pattern="$2" description="$3"
+  if grep -qiE "$pattern" "$file"; then
+    fail "$description (unexpected pattern: $pattern)"
+  else
+    pass "$description"
+  fi
+}
+
+section "Prepare CLI build"
+cd "$REPO_ROOT"
+load_shell_path
+if [ ! -d node_modules ]; then
+  npm ci --ignore-scripts || fail "npm ci failed"
+fi
+npm run build:cli || fail "CLI build failed"
+
+section "Protobuf mismatch from sandbox list fails closed"
+set +e
+run_backup_case protobuf-mismatch \
+  env NEMOCLAW_FAKE_GATEWAY_RUNNING=false NEMOCLAW_FAKE_GATEWAY_IMAGE=ghcr.io/nvidia/openshell/cluster:0.0.37 \
+  node "$REPO_ROOT/bin/nemoclaw.js" backup-all
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  pass "backup-all exits non-zero on protobuf mismatch"
+else
+  info "backup-all exited 0; checking that it did not silently treat the RPC failure as stopped"
+fi
+assert_contains "$CASE_DIR/command.out" 'protobuf|schema mismatch|invalid wire type|Skipping '\''?alpha'\''? \(not running\)' "protobuf failure is not silently swallowed"
+assert_contains "$CASE_DIR/command.out" 'No sandbox data was changed|Refusing to trust OpenShell sandbox state' "fail-closed no-mutation guidance is printed"
+assert_not_contains "$CASE_DIR/command.out" "Skipping '?alpha'? \\(not running\\)" "running sandbox is not misclassified as stopped"
+assert_not_contains "$CASE_DIR/command.out" 'Backup complete' "backup does not proceed after unsafe state RPC"
+
+section "Patched stale gateway image fails before sandbox list"
+set +e
+run_backup_case patched-image-drift \
+  env NEMOCLAW_FAKE_GATEWAY_IMAGE=nemoclaw-cluster:0.0.36-fuse-overlayfs-aa8b8487 \
+  node "$REPO_ROOT/bin/nemoclaw.js" backup-all
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "backup-all unexpectedly succeeded with stale patched gateway image"
+pass "backup-all exits non-zero on stale patched gateway image"
+assert_contains "$CASE_DIR/command.out" 'schema preflight failed|gateway schema preflight failed|image.*does not match|Running gateway image' "gateway image drift preflight is surfaced"
+assert_contains "$CASE_DIR/command.out" '0\.0\.37' "installed OpenShell version is reported"
+assert_contains "$CASE_DIR/command.out" 'nemoclaw-cluster:0\.0\.36-fuse-overlayfs-aa8b8487|0\.0\.36' "patched stale gateway image/version is reported"
+if grep -qx 'sandbox list' "$CASE_DIR/openshell-calls.log"; then
+  fail "sandbox list was called despite preflight image drift"
+fi
+pass "preflight image drift blocks sandbox list"
+
+section "Summary"
+pass "Gateway drift preflight regression guard completed"


### PR DESCRIPTION
## Summary

Adds a failing-test-first regression guard for #3423 / #3399 in the dedicated `regression-e2e.yaml` holding pen.

The guard exercises the CLI boundary with fake `openshell` and `docker` shims so it catches the real failure mode that unit-level mocks can miss:

1. `openshell sandbox list` exits non-zero with the #3399 protobuf `invalid wire type` decode error.
2. A stale patched gateway image reports as `nemoclaw-cluster:0.0.36-fuse-overlayfs-aa8b8487` while installed OpenShell is `0.0.37`.

## Expected red/green behavior

- 🔴 On current main / unfixed code, `gateway-drift-preflight-e2e` fails because NemoClaw either treats the protobuf failure as a stopped sandbox or misses the patched-image drift.
- 🟢 On #3423 after the fix, the same job should pass by failing closed with schema-drift recovery guidance and by detecting patched stale gateway images before trusting sandbox state.

## Regression workflow

This is **not** added to scheduled nightly. It lives in `.github/workflows/regression-e2e.yaml` and can be dispatched explicitly:

```bash
gh workflow run regression-e2e.yaml -f jobs=gateway-drift-preflight-e2e --ref <branch>
```

## Verification

- `bash -n test/e2e/test-gateway-drift-preflight.sh`
- `bash test/e2e/test-gateway-drift-preflight.sh` currently fails on the expected missing fail-closed guidance (red guard) before #3423 lands.

Related: #3423


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end regression that validates gateway-drift preflight behavior, ensuring schema mismatches and stale gateway images fail safely and report correct diagnostics.

* **Chores**
  * Updated CI workflow to include and dispatch the new gateway-drift preflight regression job.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3463)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->