### PR TITLE
fix(onboard,uninstall): clearer diagnostics when no sandbox is registered

### DIFF
--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -533,4 +533,37 @@ describe("uninstall run plan", () => {
     expect(warnings).toContain("Failed to disable /swapfile; skipping swap cleanup.");
     expect(logs).not.toContain("Swap file removed");
   });
+
+  it("reports skipped openshell cleanup without the contradictory past-tense wording", () => {
+    const logs: string[] = [];
+    const warnings: string[] = [];
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: () => true,
+        env: { HOME: "/tmp/nemoclaw-uninstall-test-skip-wording" } as NodeJS.ProcessEnv,
+        error: (line) => warnings.push(line),
+        existsSync: () => false,
+        isTty: false,
+        kill: () => true,
+        log: (line) => logs.push(line),
+        rmSync: vi.fn(),
+        run: (command, args) => {
+          if (command === "openshell") {
+            return { status: 1, stdout: "", stderr: "" };
+          }
+          if (args[0] === "-c") return ok("/fake/bin/tool\n");
+          if (args[0] === "-f") return ok("");
+          return ok();
+        },
+        runDocker: () => ok(""),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(warnings).toContain("Skipped gateway 'nemoclaw' (already absent or unavailable)");
+    expect(warnings).toContain("Skipped all OpenShell sandboxes (already absent or unavailable)");
+    expect(warnings.every((line) => !/^Destroyed .+ skipped$/.test(line))).toBe(true);
+    expect(warnings.every((line) => !/^Deleted .+ skipped$/.test(line))).toBe(true);
+  });
 });

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -209,8 +209,12 @@ function confirm(options: UninstallRunOptions, runtime: UninstallRuntime): boole
 
 function runOptional(runtime: UninstallRuntime, description: string, command: string, args: string[]): void {
   const result = runtime.run(command, args, { env: runtime.env, stdio: "ignore" });
-  if (result.status === 0) runtime.log(description);
-  else runtime.warn(`${description} skipped`);
+  if (result.status === 0) {
+    runtime.log(description);
+    return;
+  }
+  const target = description.replace(/^(Destroyed|Deleted|Stopped|Removed)\s+/i, "");
+  runtime.warn(`Skipped ${target} (already absent or unavailable)`);
 }
 
 function stopHelperServices(paths: UninstallPaths, runtime: UninstallRuntime): void {

--- a/src/lib/onboard.test.ts
+++ b/src/lib/onboard.test.ts
@@ -3,14 +3,14 @@
 
 import { describe, expect, it } from "vitest";
 
-import { gpuPassthroughRecoveryLines } from "./onboard/gpu-recovery";
+import { gpuPassthroughRecoveryLines, reportGpuPassthroughRecovery } from "./onboard/gpu-recovery";
 
 describe("gpuPassthroughRecoveryLines", () => {
   it("suggests uninstall when no sandboxes are registered (no actionable destroy target)", () => {
     const lines = gpuPassthroughRecoveryLines([]);
     expect(lines).toEqual([
       "  Existing gateway was started without GPU passthrough.",
-      "  No sandboxes are registered, so there is nothing for `nemoclaw <name> destroy` to act on.",
+      "  No sandboxes are registered, so there is nothing to destroy.",
       "  To enable GPU, clear the stale gateway state and re-onboard:",
       "    nemoclaw uninstall && nemoclaw onboard --gpu",
     ]);
@@ -38,7 +38,27 @@ describe("gpuPassthroughRecoveryLines", () => {
   });
 
   it("never emits the literal `<name>` placeholder in any suggestion", () => {
-    expect(gpuPassthroughRecoveryLines([]).every((l) => !l.includes("nemoclaw <name> destroy --yes"))).toBe(true);
-    expect(gpuPassthroughRecoveryLines(["x"]).every((l) => !l.includes("nemoclaw <name> destroy --yes"))).toBe(true);
+    expect(gpuPassthroughRecoveryLines([]).join("\n")).not.toContain("<name>");
+    expect(gpuPassthroughRecoveryLines(["x"]).join("\n")).not.toContain("<name>");
+    expect(gpuPassthroughRecoveryLines(["alpha", "beta"]).join("\n")).not.toContain("<name>");
+  });
+});
+
+describe("reportGpuPassthroughRecovery", () => {
+  it("routes the registered sandbox names through the printer", () => {
+    const printed: string[] = [];
+    reportGpuPassthroughRecovery((line) => printed.push(line), () => ["alpha"]);
+    expect(printed).toEqual(gpuPassthroughRecoveryLines(["alpha"]));
+  });
+
+  it("falls back to the no-sandbox guidance when the registry lookup throws", () => {
+    const printed: string[] = [];
+    reportGpuPassthroughRecovery(
+      (line) => printed.push(line),
+      () => {
+        throw new Error("registry unreachable");
+      },
+    );
+    expect(printed).toEqual(gpuPassthroughRecoveryLines([]));
   });
 });

--- a/src/lib/onboard.test.ts
+++ b/src/lib/onboard.test.ts
@@ -6,41 +6,55 @@ import { describe, expect, it } from "vitest";
 import { gpuPassthroughRecoveryLines, reportGpuPassthroughRecovery } from "./onboard/gpu-recovery";
 
 describe("gpuPassthroughRecoveryLines", () => {
-  it("suggests uninstall when no sandboxes are registered (no actionable destroy target)", () => {
+  it("clears the gateway directly when no sandboxes are registered (no NemoClaw uninstall, so the CLI survives)", () => {
     const lines = gpuPassthroughRecoveryLines([]);
     expect(lines).toEqual([
       "  Existing gateway was started without GPU passthrough.",
       "  No sandboxes are registered, so there is nothing to destroy.",
-      "  To enable GPU, clear the stale gateway state and re-onboard:",
-      "    nemoclaw uninstall && nemoclaw onboard --gpu",
-    ]);
-  });
-
-  it("names the registered sandbox in the destroy command (singular form)", () => {
-    const lines = gpuPassthroughRecoveryLines(["my-assistant"]);
-    expect(lines).toEqual([
-      "  Existing gateway was started without GPU passthrough.",
-      "  To enable GPU, destroy the registered sandbox (`my-assistant`) and re-onboard:",
-      "    nemoclaw my-assistant destroy --yes",
+      "  To enable GPU, clear the stale gateway and re-onboard:",
+      "    openshell gateway destroy -g nemoclaw",
       "    nemoclaw onboard --gpu",
     ]);
   });
 
-  it("lists every registered sandbox (plural form)", () => {
+  it("falls back to a direct gateway-removal hint when the registry cannot be read", () => {
+    const lines = gpuPassthroughRecoveryLines(null);
+    expect(lines).toEqual([
+      "  Existing gateway was started without GPU passthrough.",
+      "  Could not read the NemoClaw sandbox registry; cannot enumerate sandboxes.",
+      "  To enable GPU, clear the stale gateway directly and re-onboard:",
+      "    openshell gateway destroy -g nemoclaw",
+      "    nemoclaw onboard --gpu",
+    ]);
+  });
+
+  it("appends --cleanup-gateway to the single destroy command so the stale gateway is actually removed", () => {
+    const lines = gpuPassthroughRecoveryLines(["my-assistant"]);
+    expect(lines).toEqual([
+      "  Existing gateway was started without GPU passthrough.",
+      "  To enable GPU, destroy the registered sandbox (`my-assistant`) and re-onboard:",
+      "    nemoclaw my-assistant destroy --yes --cleanup-gateway",
+      "    nemoclaw onboard --gpu",
+    ]);
+  });
+
+  it("only puts --cleanup-gateway on the last destroy command when more than one sandbox is registered", () => {
     const lines = gpuPassthroughRecoveryLines(["alpha", "beta"]);
     expect(lines).toEqual([
       "  Existing gateway was started without GPU passthrough.",
       "  To enable GPU, destroy the registered sandboxes (`alpha`, `beta`) and re-onboard:",
       "    nemoclaw alpha destroy --yes",
-      "    nemoclaw beta destroy --yes",
+      "    nemoclaw beta destroy --yes --cleanup-gateway",
       "    nemoclaw onboard --gpu",
     ]);
   });
 
-  it("never emits the literal `<name>` placeholder in any suggestion", () => {
-    expect(gpuPassthroughRecoveryLines([]).join("\n")).not.toContain("<name>");
-    expect(gpuPassthroughRecoveryLines(["x"]).join("\n")).not.toContain("<name>");
-    expect(gpuPassthroughRecoveryLines(["alpha", "beta"]).join("\n")).not.toContain("<name>");
+  it("never emits the literal `<name>` placeholder or a `nemoclaw uninstall && nemoclaw onboard` chain in any branch", () => {
+    for (const names of [null, [], ["x"], ["alpha", "beta"]] as const) {
+      const joined = gpuPassthroughRecoveryLines(names).join("\n");
+      expect(joined).not.toContain("<name>");
+      expect(joined).not.toContain("nemoclaw uninstall && nemoclaw onboard");
+    }
   });
 });
 
@@ -51,7 +65,7 @@ describe("reportGpuPassthroughRecovery", () => {
     expect(printed).toEqual(gpuPassthroughRecoveryLines(["alpha"]));
   });
 
-  it("falls back to the no-sandbox guidance when the registry lookup throws", () => {
+  it("falls back to the registry-unreadable guidance when the lookup throws (does not collapse to 'no sandboxes')", () => {
     const printed: string[] = [];
     reportGpuPassthroughRecovery(
       (line) => printed.push(line),
@@ -59,6 +73,7 @@ describe("reportGpuPassthroughRecovery", () => {
         throw new Error("registry unreachable");
       },
     );
-    expect(printed).toEqual(gpuPassthroughRecoveryLines([]));
+    expect(printed).toEqual(gpuPassthroughRecoveryLines(null));
+    expect(printed.join("\n")).toContain("Could not read the NemoClaw sandbox registry");
   });
 });

--- a/src/lib/onboard.test.ts
+++ b/src/lib/onboard.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { gpuPassthroughRecoveryLines } from "./onboard/gpu-recovery";
+
+describe("gpuPassthroughRecoveryLines", () => {
+  it("suggests uninstall when no sandboxes are registered (no actionable destroy target)", () => {
+    const lines = gpuPassthroughRecoveryLines([]);
+    expect(lines).toEqual([
+      "  Existing gateway was started without GPU passthrough.",
+      "  No sandboxes are registered, so there is nothing for `nemoclaw <name> destroy` to act on.",
+      "  To enable GPU, clear the stale gateway state and re-onboard:",
+      "    nemoclaw uninstall && nemoclaw onboard --gpu",
+    ]);
+  });
+
+  it("names the registered sandbox in the destroy command (singular form)", () => {
+    const lines = gpuPassthroughRecoveryLines(["my-assistant"]);
+    expect(lines).toEqual([
+      "  Existing gateway was started without GPU passthrough.",
+      "  To enable GPU, destroy the registered sandbox (`my-assistant`) and re-onboard:",
+      "    nemoclaw my-assistant destroy --yes",
+      "    nemoclaw onboard --gpu",
+    ]);
+  });
+
+  it("lists every registered sandbox (plural form)", () => {
+    const lines = gpuPassthroughRecoveryLines(["alpha", "beta"]);
+    expect(lines).toEqual([
+      "  Existing gateway was started without GPU passthrough.",
+      "  To enable GPU, destroy the registered sandboxes (`alpha`, `beta`) and re-onboard:",
+      "    nemoclaw alpha destroy --yes",
+      "    nemoclaw beta destroy --yes",
+      "    nemoclaw onboard --gpu",
+    ]);
+  });
+
+  it("never emits the literal `<name>` placeholder in any suggestion", () => {
+    expect(gpuPassthroughRecoveryLines([]).every((l) => !l.includes("nemoclaw <name> destroy --yes"))).toBe(true);
+    expect(gpuPassthroughRecoveryLines(["x"]).every((l) => !l.includes("nemoclaw <name> destroy --yes"))).toBe(true);
+  });
+});

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -354,7 +354,7 @@ let OPENSHELL_BIN: string | null = null;
 const GATEWAY_NAME = "nemoclaw";
 const BACK_TO_SELECTION = "__NEMOCLAW_BACK_TO_SELECTION__";
 
-const { gpuPassthroughRecoveryLines }: typeof import("./onboard/gpu-recovery") = require("./onboard/gpu-recovery");
+const { reportGpuPassthroughRecovery }: typeof import("./onboard/gpu-recovery") = require("./onboard/gpu-recovery");
 type HermesAuthMethod = "oauth" | "api_key";
 const HERMES_AUTH_METHOD_OAUTH: HermesAuthMethod = "oauth";
 const HERMES_AUTH_METHOD_API_KEY: HermesAuthMethod = "api_key";
@@ -10414,16 +10414,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       const gpuOutput = String(gpuCheck.stdout || "").trim();
       const gatewayHasGpu = gpuCheck.status === 0 && gpuOutput !== "null" && gpuOutput !== "[]";
       if (!gatewayHasGpu) {
-        const registeredNames = (() => {
-          try {
-            return registry.listSandboxes().sandboxes.map((s) => s.name).filter(Boolean);
-          } catch {
-            return [];
-          }
-        })();
-        for (const line of gpuPassthroughRecoveryLines(registeredNames)) {
-          console.error(line);
-        }
+        reportGpuPassthroughRecovery();
         process.exit(1);
       }
     }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -353,6 +353,8 @@ const RESET = USE_COLOR ? "\x1b[0m" : "";
 let OPENSHELL_BIN: string | null = null;
 const GATEWAY_NAME = "nemoclaw";
 const BACK_TO_SELECTION = "__NEMOCLAW_BACK_TO_SELECTION__";
+
+const { gpuPassthroughRecoveryLines }: typeof import("./onboard/gpu-recovery") = require("./onboard/gpu-recovery");
 type HermesAuthMethod = "oauth" | "api_key";
 const HERMES_AUTH_METHOD_OAUTH: HermesAuthMethod = "oauth";
 const HERMES_AUTH_METHOD_API_KEY: HermesAuthMethod = "api_key";
@@ -10412,9 +10414,16 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       const gpuOutput = String(gpuCheck.stdout || "").trim();
       const gatewayHasGpu = gpuCheck.status === 0 && gpuOutput !== "null" && gpuOutput !== "[]";
       if (!gatewayHasGpu) {
-        console.error("  Existing gateway was started without GPU passthrough.");
-        console.error("  To enable GPU, destroy the existing sandbox and gateway, then re-onboard:");
-        console.error(`    nemoclaw <name> destroy --yes && nemoclaw onboard --gpu`);
+        const registeredNames = (() => {
+          try {
+            return registry.listSandboxes().sandboxes.map((s) => s.name).filter(Boolean);
+          } catch {
+            return [];
+          }
+        })();
+        for (const line of gpuPassthroughRecoveryLines(registeredNames)) {
+          console.error(line);
+        }
         process.exit(1);
       }
     }

--- a/src/lib/onboard/gpu-recovery.ts
+++ b/src/lib/onboard/gpu-recovery.ts
@@ -4,9 +4,7 @@
 export function gpuPassthroughRecoveryLines(registeredNames: readonly string[]): string[] {
   const lines: string[] = ["  Existing gateway was started without GPU passthrough."];
   if (registeredNames.length === 0) {
-    lines.push(
-      "  No sandboxes are registered, so there is nothing for `nemoclaw <name> destroy` to act on.",
-    );
+    lines.push("  No sandboxes are registered, so there is nothing to destroy.");
     lines.push("  To enable GPU, clear the stale gateway state and re-onboard:");
     lines.push("    nemoclaw uninstall && nemoclaw onboard --gpu");
     return lines;
@@ -17,4 +15,26 @@ export function gpuPassthroughRecoveryLines(registeredNames: readonly string[]):
   for (const name of registeredNames) lines.push(`    nemoclaw ${name} destroy --yes`);
   lines.push("    nemoclaw onboard --gpu");
   return lines;
+}
+
+function defaultRegisteredSandboxNames(): readonly string[] {
+  try {
+    const registry = require("../state/registry") as typeof import("../state/registry");
+    return registry.listSandboxes().sandboxes.map((s) => s.name).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+export function reportGpuPassthroughRecovery(
+  emit: (line: string) => void = console.error,
+  listRegisteredSandboxes: () => readonly string[] = defaultRegisteredSandboxNames,
+): void {
+  let names: readonly string[] = [];
+  try {
+    names = listRegisteredSandboxes();
+  } catch {
+    names = [];
+  }
+  for (const line of gpuPassthroughRecoveryLines(names)) emit(line);
 }

--- a/src/lib/onboard/gpu-recovery.ts
+++ b/src/lib/onboard/gpu-recovery.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function gpuPassthroughRecoveryLines(registeredNames: readonly string[]): string[] {
+  const lines: string[] = ["  Existing gateway was started without GPU passthrough."];
+  if (registeredNames.length === 0) {
+    lines.push(
+      "  No sandboxes are registered, so there is nothing for `nemoclaw <name> destroy` to act on.",
+    );
+    lines.push("  To enable GPU, clear the stale gateway state and re-onboard:");
+    lines.push("    nemoclaw uninstall && nemoclaw onboard --gpu");
+    return lines;
+  }
+  const plural = registeredNames.length === 1 ? "" : "es";
+  const list = registeredNames.map((n) => `\`${n}\``).join(", ");
+  lines.push(`  To enable GPU, destroy the registered sandbox${plural} (${list}) and re-onboard:`);
+  for (const name of registeredNames) lines.push(`    nemoclaw ${name} destroy --yes`);
+  lines.push("    nemoclaw onboard --gpu");
+  return lines;
+}

--- a/src/lib/onboard/gpu-recovery.ts
+++ b/src/lib/onboard/gpu-recovery.ts
@@ -1,40 +1,55 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export function gpuPassthroughRecoveryLines(registeredNames: readonly string[]): string[] {
+const GATEWAY_REMOVAL_COMMAND = "openshell gateway destroy -g nemoclaw";
+const ONBOARD_GPU_COMMAND = "nemoclaw onboard --gpu";
+
+export function gpuPassthroughRecoveryLines(registeredNames: readonly string[] | null): string[] {
   const lines: string[] = ["  Existing gateway was started without GPU passthrough."];
+  if (registeredNames === null) {
+    lines.push("  Could not read the NemoClaw sandbox registry; cannot enumerate sandboxes.");
+    lines.push("  To enable GPU, clear the stale gateway directly and re-onboard:");
+    lines.push(`    ${GATEWAY_REMOVAL_COMMAND}`);
+    lines.push(`    ${ONBOARD_GPU_COMMAND}`);
+    return lines;
+  }
   if (registeredNames.length === 0) {
     lines.push("  No sandboxes are registered, so there is nothing to destroy.");
-    lines.push("  To enable GPU, clear the stale gateway state and re-onboard:");
-    lines.push("    nemoclaw uninstall && nemoclaw onboard --gpu");
+    lines.push("  To enable GPU, clear the stale gateway and re-onboard:");
+    lines.push(`    ${GATEWAY_REMOVAL_COMMAND}`);
+    lines.push(`    ${ONBOARD_GPU_COMMAND}`);
     return lines;
   }
   const plural = registeredNames.length === 1 ? "" : "es";
   const list = registeredNames.map((n) => `\`${n}\``).join(", ");
   lines.push(`  To enable GPU, destroy the registered sandbox${plural} (${list}) and re-onboard:`);
-  for (const name of registeredNames) lines.push(`    nemoclaw ${name} destroy --yes`);
-  lines.push("    nemoclaw onboard --gpu");
+  registeredNames.forEach((name, index) => {
+    const isLast = index === registeredNames.length - 1;
+    const flags = isLast ? " --yes --cleanup-gateway" : " --yes";
+    lines.push(`    nemoclaw ${name} destroy${flags}`);
+  });
+  lines.push(`    ${ONBOARD_GPU_COMMAND}`);
   return lines;
 }
 
-function defaultRegisteredSandboxNames(): readonly string[] {
+function defaultRegisteredSandboxNames(): readonly string[] | null {
   try {
     const registry = require("../state/registry") as typeof import("../state/registry");
     return registry.listSandboxes().sandboxes.map((s) => s.name).filter(Boolean);
   } catch {
-    return [];
+    return null;
   }
 }
 
 export function reportGpuPassthroughRecovery(
   emit: (line: string) => void = console.error,
-  listRegisteredSandboxes: () => readonly string[] = defaultRegisteredSandboxNames,
+  listRegisteredSandboxes: () => readonly string[] | null = defaultRegisteredSandboxNames,
 ): void {
-  let names: readonly string[] = [];
+  let names: readonly string[] | null;
   try {
     names = listRegisteredSandboxes();
   } catch {
-    names = [];
+    names = null;
   }
   for (const line of gpuPassthroughRecoveryLines(names)) emit(line);
 }


### PR DESCRIPTION
## Summary
Resolve the two misleading-output threads in #3456: the GPU-passthrough recovery suggestion that prints a literal `<name>` placeholder and assumes a sandbox is registered, and the `nemoclaw uninstall` log line that reads `Destroyed gateway 'nemoclaw' skipped` (a self-contradiction).

## Related Issue
Refs #3456 — partially addresses. This PR fixes only the State B "destroy --yes" suggestion and the uninstall "skipped" wording. The State A bridge-reachability / "host firewall is blocking" hint and the underlying GLIBC mismatch are out of scope; the bridge-route work in #3459 covers the install loop, and the GLIBC binary baseline sits on the OpenShell side. Do not auto-close #3456 with this PR alone.

## Changes
- `src/lib/onboard/gpu-recovery.ts`: new helper module exposing `gpuPassthroughRecoveryLines(names: readonly string[] | null)` (pure line-builder) and `reportGpuPassthroughRecovery(emit, listRegisteredSandboxes)` (registry-lookup + print wrapper with injectable deps for tests). Three branches:
  - **One or more sandboxes registered**: prints each as `nemoclaw <name> destroy --yes` with `--cleanup-gateway` appended to the last one (since `destroy --yes` otherwise preserves the gateway and would re-loop on the next onboard).
  - **No sandboxes registered**: prints `openshell gateway destroy -g nemoclaw` followed by `nemoclaw onboard --gpu`. Uses the bare gateway-removal command rather than `nemoclaw uninstall` because the latter `npm uninstall -g nemoclaw`s the CLI, after which `nemoclaw onboard --gpu` would no longer exist.
  - **Registry unreadable** (lookup threw): prints `Could not read the NemoClaw sandbox registry` and the same direct gateway-removal recipe, so a registry failure is not silently rebranded as "no sandboxes registered".
- `src/lib/onboard.ts`: when the reusable gateway is missing GPU passthrough, replace the literal `nemoclaw <name> destroy --yes && nemoclaw onboard --gpu` line with a call to `reportGpuPassthroughRecovery()`. Diff is net-neutral against the entrypoint-budget check.
- `src/lib/actions/uninstall/run-plan.ts`: when an `openshell` cleanup step returns non-zero, drop the past-tense verb so the warning reads `Skipped <target> (already absent or unavailable)` instead of `Destroyed gateway 'nemoclaw' skipped`.
- Unit tests: `src/lib/onboard.test.ts` covers the four input branches (`null` / `[]` / one / many), asserts `--cleanup-gateway` lands only on the last destroy, asserts the joined output never contains `<name>` or the broken `nemoclaw uninstall && nemoclaw onboard` chain, and exercises `reportGpuPassthroughRecovery` for both the happy and registry-throws paths. `src/lib/actions/uninstall/run-plan.test.ts` adds a case that forces every `openshell` call non-zero and asserts the warnings use the new wording (and no warning matches `/^Destroyed .+ skipped$/`).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced GPU passthrough recovery guidance with step-by-step cleanup and re-onboard instructions that adapt to registry state.

* **Bug Fixes**
  * More consistent uninstall warnings: standardized "Skipped ..." messages and clearer reporting when cleanup steps are omitted.

* **Tests**
  * Added tests covering uninstall skip reporting and expanded GPU recovery guidance scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3464)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
