### PR TITLE
fix(macos): harden OpenShell VM DNS monkeypatch

### DIFF
--- a/agents/hermes/config/messaging-config.ts
+++ b/agents/hermes/config/messaging-config.ts
@@ -32,7 +32,10 @@ export function buildMessagingEnvLines(
   const discordAllowedUsers = collectDiscordAllowedUsers(allowedIds, discordGuilds);
   if (discordAllowedUsers.length > 0) {
     envLines.push(`DISCORD_ALLOWED_USERS=${discordAllowedUsers.join(",")}`);
-  } else if (enabledChannels.has("discord") && Object.keys(discordGuilds).length > 0) {
+  } else if (
+    enabledChannels.has("discord") &&
+    Object.keys(discordGuilds).filter((guildId) => guildId.trim()).length > 0
+  ) {
     envLines.push("DISCORD_ALLOW_ALL_USERS=true");
   }
   if (allowedIds.telegram?.length) {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -196,10 +196,16 @@ function repairSandboxInferenceRouteIfNeeded(
         }
         return true;
       }
-      if (!quiet && !patch.ok && patch.reason) {
-        console.error(
-          `  Warning: OpenShell VM DNS monkeypatch did not apply: ${patch.reason}`,
-        );
+      if (!quiet) {
+        if (!patch.ok && patch.reason) {
+          console.error(
+            `  Warning: OpenShell VM DNS monkeypatch did not apply: ${patch.reason}`,
+          );
+        } else if (patch.ok) {
+          console.error(
+            "  Warning: OpenShell VM DNS monkeypatch completed but inference.local is still unavailable.",
+          );
+        }
       }
     }
 

--- a/src/lib/actions/sandbox/vm-dns-monkeypatch.test.ts
+++ b/src/lib/actions/sandbox/vm-dns-monkeypatch.test.ts
@@ -11,7 +11,10 @@ vi.mock("../../adapters/openshell/runtime", () => ({
   captureOpenshell: vi.fn(),
 }));
 
-import { applyOpenShellVmDnsMonkeypatch } from "./vm-dns-monkeypatch";
+import {
+  applyOpenShellVmDnsMonkeypatch,
+  shouldApplyVmDnsMonkeypatch,
+} from "./vm-dns-monkeypatch";
 
 const tempDirs: string[] = [];
 
@@ -25,6 +28,32 @@ function sandboxRootfs(stateDir: string, sandboxId = "abc"): string {
   return path.join(stateDir, "vm-driver", "sandboxes", sandboxId, "rootfs");
 }
 
+function sandboxDir(stateDir: string, sandboxId = "abc"): string {
+  return path.join(stateDir, "vm-driver", "sandboxes", sandboxId);
+}
+
+function writeRecognizedInit(rootfs: string): void {
+  fs.mkdirSync(path.join(rootfs, "srv"), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootfs, "srv", "openshell-vm-sandbox-init.sh"),
+    [
+      "elif ip link show eth0 >/dev/null 2>&1; then",
+      "    if [ ! -s /etc/resolv.conf ]; then",
+      '        echo "nameserver 8.8.8.8" > /etc/resolv.conf',
+      '        echo "nameserver 8.8.4.4" >> /etc/resolv.conf',
+      "    fi",
+      "fi",
+      "",
+    ].join("\n"),
+  );
+}
+
+function writeRootfsFiles(rootfs: string, resolver: string): void {
+  fs.mkdirSync(path.join(rootfs, "etc"), { recursive: true });
+  fs.writeFileSync(path.join(rootfs, "etc", "resolv.conf"), resolver);
+  writeRecognizedInit(rootfs);
+}
+
 describe("OpenShell VM DNS monkeypatch", () => {
   afterEach(() => {
     for (const dir of tempDirs.splice(0)) {
@@ -32,10 +61,166 @@ describe("OpenShell VM DNS monkeypatch", () => {
     }
   });
 
-  it("returns a warning result instead of throwing when rootfs files cannot be patched", () => {
+  it("does not attempt non-VM sandboxes", () => {
+    const capture = vi.fn();
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "kubernetes" },
+      {
+        capture,
+        env: {},
+        platform: "darwin",
+        stateDir: makeTempDir(),
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: false,
+      changed: false,
+      ok: false,
+      status: "skipped",
+    });
+    expect(result.reason).toContain("not an OpenShell VM sandbox");
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt non-Darwin VM sandboxes unless force-enabled", () => {
+    const capture = vi.fn();
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        capture,
+        env: {},
+        platform: "linux",
+        stateDir: makeTempDir(),
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: false,
+      changed: false,
+      ok: false,
+      status: "skipped",
+    });
+    expect(result.reason).toContain("not running on macOS");
+    expect(capture).not.toHaveBeenCalled();
+    expect(shouldApplyVmDnsMonkeypatch({ openshellDriver: "vm" }, "linux", {})).toBe(false);
+    expect(
+      shouldApplyVmDnsMonkeypatch({ openshellDriver: "vm" }, "linux", {
+        NEMOCLAW_FORCE_VM_DNS_MONKEYPATCH: "1",
+      }),
+    ).toBe(true);
+  });
+
+  it("honors the VM DNS monkeypatch kill switch", () => {
+    const capture = vi.fn();
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        capture,
+        env: { NEMOCLAW_DISABLE_VM_DNS_MONKEYPATCH: "1" },
+        platform: "darwin",
+        stateDir: makeTempDir(),
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: false,
+      changed: false,
+      ok: false,
+      status: "skipped",
+    });
+    expect(result.reason).toContain("disabled");
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("puts gvproxy DNS first while preserving resolver options and private resolvers", () => {
     const stateDir = makeTempDir();
     const rootfs = sandboxRootfs(stateDir);
-    fs.mkdirSync(path.join(rootfs, "etc", "resolv.conf"), { recursive: true });
+    writeRootfsFiles(
+      rootfs,
+      [
+        "search corp.example",
+        "options ndots:5",
+        "nameserver 8.8.8.8",
+        "nameserver 10.0.0.2",
+        "nameserver 192.168.127.1",
+        "nameserver 10.0.0.2",
+        "nameserver 8.8.4.4",
+        "",
+      ].join("\n"),
+    );
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        capture: () => ({ status: 0, output: "Id: abc\n" }),
+        platform: "darwin",
+        stateDir,
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: true,
+      changed: true,
+      ok: true,
+      status: "applied",
+    });
+    expect(fs.readFileSync(path.join(rootfs, "etc", "resolv.conf"), "utf-8")).toBe(
+      [
+        "nameserver 192.168.127.1",
+        "search corp.example",
+        "options ndots:5",
+        "nameserver 10.0.0.2",
+        "",
+      ].join("\n"),
+    );
+    expect(
+      fs.readFileSync(path.join(rootfs, "srv", "openshell-vm-sandbox-init.sh"), "utf-8"),
+    ).toContain('echo "nameserver ${GVPROXY_GATEWAY_IP}" > /etc/resolv.conf');
+  });
+
+  it("is idempotent when resolver and init script are already patched", () => {
+    const stateDir = makeTempDir();
+    const rootfs = sandboxRootfs(stateDir);
+    fs.mkdirSync(path.join(rootfs, "etc"), { recursive: true });
+    fs.mkdirSync(path.join(rootfs, "srv"), { recursive: true });
+    fs.writeFileSync(
+      path.join(rootfs, "etc", "resolv.conf"),
+      "nameserver 192.168.127.1\nsearch corp.example\noptions ndots:5\n",
+    );
+    fs.writeFileSync(
+      path.join(rootfs, "srv", "openshell-vm-sandbox-init.sh"),
+      'echo "nameserver ${GVPROXY_GATEWAY_IP}" > /etc/resolv.conf\n',
+    );
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        capture: () => ({ status: 0, output: "Id: abc\n" }),
+        platform: "darwin",
+        stateDir,
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: true,
+      changed: false,
+      ok: true,
+      status: "already-present",
+    });
+  });
+
+  it("returns a soft failure when the VM rootfs is missing", () => {
+    const stateDir = makeTempDir();
+    fs.mkdirSync(sandboxDir(stateDir), { recursive: true });
 
     const result = applyOpenShellVmDnsMonkeypatch(
       "demo",
@@ -51,7 +236,118 @@ describe("OpenShell VM DNS monkeypatch", () => {
       attempted: true,
       changed: false,
       ok: false,
-      rootfs,
+      status: "failed",
+    });
+    expect(result.reason).toContain("VM rootfs not found");
+  });
+
+  it("returns a specific unsupported-layout reason for ext4-style VM root disks", () => {
+    const stateDir = makeTempDir();
+    const dir = sandboxDir(stateDir);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "rootfs.ext4"), "");
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        capture: () => ({ status: 0, output: "Id: abc\n" }),
+        platform: "darwin",
+        stateDir,
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: true,
+      changed: false,
+      ok: false,
+      status: "failed",
+    });
+    expect(result.reason).toContain("ext4 root disk layout");
+    expect(result.reason).toContain("rootfs DNS monkeypatch no longer applies");
+  });
+
+  it("refuses unknown init-script shapes without rewriting resolver files", () => {
+    const stateDir = makeTempDir();
+    const rootfs = sandboxRootfs(stateDir);
+    fs.mkdirSync(path.join(rootfs, "etc"), { recursive: true });
+    fs.mkdirSync(path.join(rootfs, "srv"), { recursive: true });
+    const resolverPath = path.join(rootfs, "etc", "resolv.conf");
+    const originalResolver = "nameserver 8.8.8.8\n";
+    fs.writeFileSync(resolverPath, originalResolver);
+    fs.writeFileSync(path.join(rootfs, "srv", "openshell-vm-sandbox-init.sh"), "echo unknown\n");
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        capture: () => ({ status: 0, output: "Id: abc\n" }),
+        platform: "darwin",
+        stateDir,
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: true,
+      changed: false,
+      ok: false,
+      status: "failed",
+    });
+    expect(result.reason).toContain("init script shape not recognized");
+    expect(fs.readFileSync(resolverPath, "utf-8")).toBe(originalResolver);
+  });
+
+  it("refuses resolver symlinks that escape the VM rootfs", () => {
+    const stateDir = makeTempDir();
+    const rootfs = sandboxRootfs(stateDir);
+    const outside = path.join(stateDir, "outside-resolv.conf");
+    fs.mkdirSync(path.join(rootfs, "etc"), { recursive: true });
+    fs.writeFileSync(outside, "nameserver 8.8.8.8\n");
+    fs.symlinkSync(outside, path.join(rootfs, "etc", "resolv.conf"));
+    writeRecognizedInit(rootfs);
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        capture: () => ({ status: 0, output: "Id: abc\n" }),
+        platform: "darwin",
+        stateDir,
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: true,
+      changed: false,
+      ok: false,
+      status: "failed",
+    });
+    expect(result.reason).toContain("resolves outside VM rootfs");
+    expect(fs.readFileSync(outside, "utf-8")).toBe("nameserver 8.8.8.8\n");
+  });
+
+  it("returns a warning result instead of throwing when rootfs files cannot be patched", () => {
+    const stateDir = makeTempDir();
+    const rootfs = sandboxRootfs(stateDir);
+    fs.mkdirSync(path.join(rootfs, "etc", "resolv.conf"), { recursive: true });
+    writeRecognizedInit(rootfs);
+
+    const result = applyOpenShellVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        capture: () => ({ status: 0, output: "Id: abc\n" }),
+        platform: "darwin",
+        stateDir,
+      },
+    );
+
+    expect(result).toMatchObject({
+      attempted: true,
+      changed: false,
+      ok: false,
+      rootfs: fs.realpathSync.native(rootfs),
+      status: "failed",
     });
     expect(result.reason).toContain("failed to patch VM DNS files");
   });

--- a/src/lib/actions/sandbox/vm-dns-monkeypatch.ts
+++ b/src/lib/actions/sandbox/vm-dns-monkeypatch.ts
@@ -13,16 +13,21 @@ import { captureOpenshell } from "../../adapters/openshell/runtime";
 import type { SandboxEntry } from "../../state/registry";
 
 const GVPROXY_DNS = "192.168.127.1";
-const LEGACY_PUBLIC_DNS_BLOCK = `    if [ ! -s /etc/resolv.conf ]; then
-        echo "nameserver 8.8.8.8" > /etc/resolv.conf
-        echo "nameserver 8.8.4.4" >> /etc/resolv.conf
-    fi`;
-const GVPROXY_DNS_BLOCK = `    echo "nameserver \${GVPROXY_GATEWAY_IP}" > /etc/resolv.conf`;
+const INIT_SCRIPT_RELATIVE_PATH = ["srv", "openshell-vm-sandbox-init.sh"] as const;
+const RESOLV_CONF_RELATIVE_PATH = ["etc", "resolv.conf"] as const;
+const GVPROXY_RESOLVER_LINE = "nameserver ${GVPROXY_GATEWAY_IP}";
+const PUBLIC_FALLBACK_DNS = new Set(["8.8.8.8", "8.8.4.4"]);
+const INIT_PUBLIC_FALLBACK_BLOCK_RE =
+  /^([ \t]*)if\s+\[\s*!\s+-s\s+\/etc\/resolv\.conf\s*\]\s*;\s*then\s*\r?\n[ \t]*(?:echo|printf)\b[^\n]*8\.8\.8\.8[^\n]*>\s*\/etc\/resolv\.conf[^\n]*\r?\n[ \t]*(?:echo|printf)\b[^\n]*8\.8\.4\.4[^\n]*>>\s*\/etc\/resolv\.conf[^\n]*\r?\n[ \t]*fi/gm;
+const INIT_ETH0_PUBLIC_FALLBACK_RE =
+  /ip\s+link\s+show\s+eth0[\s\S]{0,2000}nameserver\s+8\.8\.8\.8[\s\S]{0,2000}nameserver\s+8\.8\.4\.4/;
 
 type CaptureFn = (
   args: string[],
   opts: { ignoreError?: boolean; timeout?: number },
 ) => CaptureOpenshellResult;
+
+export type VmDnsMonkeypatchStatus = "skipped" | "applied" | "already-present" | "failed";
 
 export type VmDnsMonkeypatchResult = {
   attempted: boolean;
@@ -30,6 +35,7 @@ export type VmDnsMonkeypatchResult = {
   ok: boolean;
   reason?: string;
   rootfs?: string;
+  status?: VmDnsMonkeypatchStatus;
 };
 
 export function shouldApplyVmDnsMonkeypatch(
@@ -66,14 +72,186 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function patchGuestInit(initPath: string): boolean {
+function isPathInside(childPath: string, parentPath: string): boolean {
+  const relative = path.relative(parentPath, childPath);
+  return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function realpathIfPresent(filePath: string): string | null {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function fail(reason: string, rootfs?: string, changed = false): VmDnsMonkeypatchResult {
+  return {
+    attempted: true,
+    changed,
+    ok: false,
+    reason,
+    rootfs,
+    status: "failed",
+  };
+}
+
+function skipped(reason: string): VmDnsMonkeypatchResult {
+  return {
+    attempted: false,
+    changed: false,
+    ok: false,
+    reason,
+    status: "skipped",
+  };
+}
+
+function shouldSkipVmDnsMonkeypatch(
+  entry: Pick<SandboxEntry, "openshellDriver"> | null | undefined,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (env.NEMOCLAW_DISABLE_VM_DNS_MONKEYPATCH === "1") {
+    return "disabled by NEMOCLAW_DISABLE_VM_DNS_MONKEYPATCH=1";
+  }
+  if (entry?.openshellDriver !== "vm") return "not an OpenShell VM sandbox";
+  if (platform !== "darwin" && env.NEMOCLAW_FORCE_VM_DNS_MONKEYPATCH !== "1") {
+    return "not running on macOS";
+  }
+  return null;
+}
+
+function ext4RootDiskCandidates(sandboxDir: string): string[] {
+  try {
+    return fs
+      .readdirSync(sandboxDir)
+      .filter((entry) => /(?:^|[-_.])(?:rootfs|root|disk).*(?:ext4|\.img$|\.raw$)/i.test(entry));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function resolveTargetInsideRootfs(
+  rootfsReal: string,
+  relativePath: readonly string[],
+  opts: { mustExist?: boolean } = {},
+): { ok: true; path: string } | { ok: false; reason: string } {
+  const target = path.join(rootfsReal, ...relativePath);
+  const targetReal = realpathIfPresent(target);
+  if (targetReal) {
+    if (!isPathInside(targetReal, rootfsReal)) {
+      return {
+        ok: false,
+        reason: `refusing to patch ${path.join(...relativePath)} because it resolves outside VM rootfs: ${targetReal}`,
+      };
+    }
+    return { ok: true, path: targetReal };
+  }
+
+  if (opts.mustExist) {
+    return {
+      ok: false,
+      reason: `OpenShell VM file not found: ${target}`,
+    };
+  }
+
+  const parentReal = realpathIfPresent(path.dirname(target));
+  if (!parentReal) {
+    return {
+      ok: false,
+      reason: `OpenShell VM directory not found: ${path.dirname(target)}`,
+    };
+  }
+  const resolvedTarget = path.join(parentReal, path.basename(target));
+  if (!isPathInside(resolvedTarget, rootfsReal)) {
+    return {
+      ok: false,
+      reason: `refusing to patch ${path.join(...relativePath)} because its parent resolves outside VM rootfs: ${resolvedTarget}`,
+    };
+  }
+  return { ok: true, path: resolvedTarget };
+}
+
+function normalizeResolver(current: string): string {
+  const lines = current.replace(/\r\n/g, "\n").split("\n");
+  const next: string[] = [`nameserver ${GVPROXY_DNS}`];
+  const seenNameservers = new Set([GVPROXY_DNS, ...PUBLIC_FALLBACK_DNS]);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const nameserverMatch = trimmed.match(/^nameserver\s+(\S+)(?:\s+.*)?$/);
+    if (nameserverMatch) {
+      const resolver = nameserverMatch[1];
+      if (seenNameservers.has(resolver)) continue;
+      seenNameservers.add(resolver);
+      next.push(line.trimEnd());
+      continue;
+    }
+
+    next.push(line.trimEnd());
+  }
+
+  return `${next.join("\n")}\n`;
+}
+
+function buildGvproxyDnsBlock(indent: string): string {
+  return [
+    `${indent}if [ -n "\${GVPROXY_GATEWAY_IP:-}" ]; then`,
+    `${indent}    echo "${GVPROXY_RESOLVER_LINE}" > /etc/resolv.conf`,
+    `${indent}else`,
+    `${indent}    echo "nameserver ${GVPROXY_DNS}" > /etc/resolv.conf`,
+    `${indent}fi`,
+  ].join("\n");
+}
+
+function buildGuestInitPatch(initPath: string):
+  | { ok: true; changed: boolean; content?: string }
+  | { ok: false; reason: string } {
+  if (path.basename(initPath) !== INIT_SCRIPT_RELATIVE_PATH.at(-1)) {
+    return {
+      ok: false,
+      reason: `refusing to patch unexpected OpenShell VM init script path: ${initPath}`,
+    };
+  }
+
   const original = readTextFileIfPresent(initPath);
-  if (original === null) return false;
-  if (original.includes('nameserver ${GVPROXY_GATEWAY_IP}')) return false;
-  const patched = original.replace(LEGACY_PUBLIC_DNS_BLOCK, GVPROXY_DNS_BLOCK);
-  if (patched === original) return false;
-  fs.writeFileSync(initPath, patched);
-  return true;
+  if (original === null) {
+    return {
+      ok: false,
+      reason: `OpenShell VM init script not found: ${initPath}`,
+    };
+  }
+  if (original.includes(GVPROXY_RESOLVER_LINE)) return { ok: true, changed: false };
+
+  const hasGvproxyEvidence =
+    original.includes("GVPROXY_GATEWAY_IP") || INIT_ETH0_PUBLIC_FALLBACK_RE.test(original);
+  if (!hasGvproxyEvidence) {
+    return {
+      ok: false,
+      reason: "OpenShell VM init script shape not recognized; no gvproxy DNS evidence found",
+    };
+  }
+
+  const patched = original.replace(INIT_PUBLIC_FALLBACK_BLOCK_RE, (match, indent: string) =>
+    buildGvproxyDnsBlock(indent),
+  );
+  if (patched === original) {
+    return {
+      ok: false,
+      reason: "OpenShell VM init script public-DNS fallback block was not recognized",
+    };
+  }
+  if (!patched.includes(GVPROXY_RESOLVER_LINE)) {
+    return {
+      ok: false,
+      reason: "OpenShell VM init script patch did not produce the gvproxy resolver line",
+    };
+  }
+  return { ok: true, changed: true, content: patched };
 }
 
 export function applyOpenShellVmDnsMonkeypatch(
@@ -88,13 +266,10 @@ export function applyOpenShellVmDnsMonkeypatch(
   } = {},
 ): VmDnsMonkeypatchResult {
   const env = deps.env ?? process.env;
-  if (!shouldApplyVmDnsMonkeypatch(entry, deps.platform ?? process.platform, env)) {
-    return {
-      attempted: false,
-      changed: false,
-      ok: false,
-      reason: "not a macOS OpenShell VM sandbox",
-    };
+  const platform = deps.platform ?? process.platform;
+  const skipReason = shouldSkipVmDnsMonkeypatch(entry, platform, env);
+  if (skipReason) {
+    return skipped(skipReason);
   }
 
   const capture = deps.capture ?? captureOpenshell;
@@ -104,47 +279,99 @@ export function applyOpenShellVmDnsMonkeypatch(
   });
   const sandboxId = parseSandboxIdFromGetOutput(get.output || "");
   if (!sandboxId) {
-    return {
-      attempted: true,
-      changed: false,
-      ok: false,
-      reason: "could not resolve OpenShell sandbox id",
-    };
+    return fail("could not resolve OpenShell sandbox id");
   }
 
   const stateDir =
     deps.stateDir ?? dockerDriverGatewayStateDir(env, deps.homeDir ?? os.homedir());
-  const rootfs = path.join(stateDir, "vm-driver", "sandboxes", sandboxId, "rootfs");
-  const resolvConf = path.join(rootfs, "etc", "resolv.conf");
-  if (!fs.existsSync(rootfs)) {
-    return {
-      attempted: true,
-      changed: false,
-      ok: false,
-      reason: `VM rootfs not found: ${rootfs}`,
-    };
+  const stateDirPath = path.resolve(stateDir);
+  const stateDirReal = realpathIfPresent(stateDirPath);
+  if (!stateDirReal) {
+    return fail(`OpenShell VM state directory not found: ${stateDirPath}`);
   }
 
   let changed = false;
+  let rootfsContext: string | undefined;
   try {
-    fs.mkdirSync(path.dirname(resolvConf), { recursive: true });
-    const desired = `nameserver ${GVPROXY_DNS}\n`;
-    const current = readTextFileIfPresent(resolvConf) ?? "";
-    changed = current !== desired;
-    if (changed) {
-      fs.writeFileSync(resolvConf, desired);
+    const sandboxDir = path.join(stateDirReal, "vm-driver", "sandboxes", sandboxId);
+    const sandboxDirReal = realpathIfPresent(sandboxDir);
+    if (!sandboxDirReal) {
+      return fail(`OpenShell VM sandbox directory not found: ${sandboxDir}`);
     }
-    changed =
-      patchGuestInit(path.join(rootfs, "srv", "openshell-vm-sandbox-init.sh")) || changed;
 
-    return { attempted: true, changed, ok: true, rootfs };
+    const sandboxesDirReal = path.join(stateDirReal, "vm-driver", "sandboxes");
+    if (!isPathInside(sandboxDirReal, sandboxesDirReal)) {
+      return fail(
+        `refusing to patch VM sandbox because its directory resolves outside OpenShell state: ${sandboxDirReal}`,
+      );
+    }
+
+    const rootfs = path.join(sandboxDirReal, "rootfs");
+    const rootfsReal = realpathIfPresent(rootfs);
+    if (!rootfsReal) {
+      const diskCandidates = ext4RootDiskCandidates(sandboxDirReal);
+      if (diskCandidates.length > 0) {
+        return fail(
+          `OpenShell VM sandbox appears to use an ext4 root disk layout (${diskCandidates.join(", ")}); NemoClaw's rootfs DNS monkeypatch no longer applies`,
+        );
+      }
+      return fail(`VM rootfs not found: ${rootfs}`);
+    }
+    rootfsContext = rootfsReal;
+    if (!isPathInside(rootfsReal, sandboxDirReal)) {
+      return fail(
+        `refusing to patch VM DNS because rootfs resolves outside OpenShell sandbox directory: ${rootfsReal}`,
+        rootfsReal,
+      );
+    }
+
+    const initScript = resolveTargetInsideRootfs(rootfsReal, INIT_SCRIPT_RELATIVE_PATH, {
+      mustExist: true,
+    });
+    if (!initScript.ok) return fail(initScript.reason, rootfsReal);
+
+    const resolvConf = resolveTargetInsideRootfs(rootfsReal, RESOLV_CONF_RELATIVE_PATH);
+    if (!resolvConf.ok) return fail(resolvConf.reason, rootfsReal);
+
+    const initPatch = buildGuestInitPatch(initScript.path);
+    if (!initPatch.ok) return fail(initPatch.reason, rootfsReal);
+
+    const currentResolver = readTextFileIfPresent(resolvConf.path) ?? "";
+    const desiredResolver = normalizeResolver(currentResolver);
+    if (currentResolver !== desiredResolver) {
+      fs.writeFileSync(resolvConf.path, desiredResolver);
+      changed = true;
+    }
+
+    if (initPatch.changed && initPatch.content !== undefined) {
+      fs.writeFileSync(initScript.path, initPatch.content);
+      changed = true;
+    }
+
+    const verifiedInit = readTextFileIfPresent(initScript.path) ?? "";
+    if (!verifiedInit.includes(GVPROXY_RESOLVER_LINE)) {
+      return fail(
+        "OpenShell VM init script patch verification failed: gvproxy resolver line missing",
+        rootfsReal,
+        changed,
+      );
+    }
+
+    return {
+      attempted: true,
+      changed,
+      ok: true,
+      rootfs: rootfsReal,
+      status: changed ? "applied" : "already-present",
+    };
   } catch (error) {
     return {
       attempted: true,
       changed,
       ok: false,
       reason: `failed to patch VM DNS files: ${errorMessage(error)}`,
-      rootfs,
+      rootfs: rootfsContext,
+      status: "failed",
     };
   }
 }

--- a/src/lib/onboard/messaging-reuse.test.ts
+++ b/src/lib/onboard/messaging-reuse.test.ts
@@ -51,4 +51,20 @@ describe("onboard messaging reuse", () => {
 
     expect(reusedChannels).toEqual(["slack"]);
   });
+
+  it("normalizes empty resume messaging channels to null", () => {
+    const reusedChannels = getNonInteractiveStoredMessagingChannels(
+      true,
+      ["unknown"],
+      "assistant",
+      messagingChannels,
+      () => false,
+      () => ({ messagingChannels: ["discord"] }),
+      () => [],
+      () => true,
+      true,
+    );
+
+    expect(reusedChannels).toBeNull();
+  });
 });

--- a/src/lib/onboard/messaging-reuse.ts
+++ b/src/lib/onboard/messaging-reuse.ts
@@ -33,7 +33,8 @@ export function getNonInteractiveStoredMessagingChannels(
 ): string[] | null {
   if (!nonInteractive) return null;
   if (resume && Array.isArray(sessionChannels)) {
-    return getKnownMessagingChannels(sessionChannels, messagingChannels);
+    const knownSessionChannels = getKnownMessagingChannels(sessionChannels, messagingChannels);
+    return knownSessionChannels.length > 0 ? knownSessionChannels : null;
   }
   if (resume || !sandboxName || messagingChannels.some((channel) => hasMessagingToken(channel.envKey))) {
     return null;

--- a/src/lib/onboard/vm-dns-monkeypatch.ts
+++ b/src/lib/onboard/vm-dns-monkeypatch.ts
@@ -1,18 +1,39 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { applyOpenShellVmDnsMonkeypatch } from "../actions/sandbox/vm-dns-monkeypatch";
+import {
+  applyOpenShellVmDnsMonkeypatch,
+  type VmDnsMonkeypatchResult,
+} from "../actions/sandbox/vm-dns-monkeypatch";
+
+type OnboardVmDnsMonkeypatchDeps = {
+  apply?: typeof applyOpenShellVmDnsMonkeypatch;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+};
 
 export function applyOnboardVmDnsMonkeypatch(
   sandboxName: string,
   runtime: { openshellDriver?: string | null },
+  deps: OnboardVmDnsMonkeypatchDeps = {},
 ): void {
-  const vmDnsPatch = applyOpenShellVmDnsMonkeypatch(sandboxName, {
+  const apply = deps.apply ?? applyOpenShellVmDnsMonkeypatch;
+  const log = deps.log ?? console.log;
+  const warn = deps.warn ?? console.error;
+  const vmDnsPatch: VmDnsMonkeypatchResult = apply(sandboxName, {
     openshellDriver: runtime.openshellDriver,
   });
   if (vmDnsPatch.ok && vmDnsPatch.changed) {
-    console.log("  ✓ Applied OpenShell VM DNS monkeypatch");
+    log("  ✓ Applied OpenShell VM DNS monkeypatch");
+  } else if (vmDnsPatch.ok && vmDnsPatch.attempted) {
+    log("  OpenShell VM DNS monkeypatch already present");
+  } else if (
+    vmDnsPatch.status === "skipped" &&
+    runtime.openshellDriver === "vm" &&
+    vmDnsPatch.reason
+  ) {
+    log(`  OpenShell VM DNS monkeypatch skipped: ${vmDnsPatch.reason}`);
   } else if (vmDnsPatch.attempted && !vmDnsPatch.ok && vmDnsPatch.reason) {
-    console.error(`  Warning: OpenShell VM DNS monkeypatch did not apply: ${vmDnsPatch.reason}`);
+    warn(`  Warning: OpenShell VM DNS monkeypatch did not apply: ${vmDnsPatch.reason}`);
   }
 }

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -176,6 +176,20 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).not.toContain("DISCORD_ALLOWED_USERS=");
   });
 
+  it("does not allow all Discord users for empty guild config keys", () => {
+    const { envFile } = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["discord"]),
+      NEMOCLAW_DISCORD_GUILDS_B64: encodeJson({
+        " ": {
+          requireMention: false,
+        },
+      }),
+    });
+
+    expect(envFile).not.toContain("DISCORD_ALLOW_ALL_USERS=true\n");
+    expect(envFile).not.toContain("DISCORD_ALLOWED_USERS=");
+  });
+
   it("does not emit generic platforms blocks for Telegram or Slack messaging tokens", () => {
     const { config, envFile } = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["telegram", "slack"]),

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -15,6 +15,7 @@ import { loadAgent } from "../dist/lib/agent/defs.js";
 import { buildChain, buildControlUiUrls } from "../dist/lib/dashboard/contract.js";
 import { NAME_ALLOWED_FORMAT } from "../dist/lib/name-validation.js";
 import { stageOptimizedSandboxBuildContext } from "../dist/lib/sandbox/build-context.js";
+import { applyOnboardVmDnsMonkeypatch } from "../dist/lib/onboard/vm-dns-monkeypatch.js";
 import { testTimeoutOptions } from "./helpers/timeouts";
 
 type ShimScalar = string | number | boolean | null | undefined;
@@ -3090,6 +3091,106 @@ startGateway(null).catch(() => {});
     ).toBe(false);
   });
 
+  it("runs the OpenShell VM DNS monkeypatch after sandbox registration", () => {
+    const onboardSource = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf8",
+    );
+
+    assert.match(
+      onboardSource,
+      /registry\.setDefault\(sandboxName\);[\s\S]*applyOnboardVmDnsMonkeypatch\(sandboxName, sandboxRuntimeFields\)/,
+    );
+  });
+
+  it("logs applied only when the onboard VM DNS monkeypatch changes files", () => {
+    const changedLogs: string[] = [];
+    applyOnboardVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        apply: () => ({
+          attempted: true,
+          changed: true,
+          ok: true,
+          status: "applied",
+        }),
+        log: (message) => changedLogs.push(message),
+        warn: (message) => changedLogs.push(message),
+      },
+    );
+
+    const unchangedLogs: string[] = [];
+    applyOnboardVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        apply: () => ({
+          attempted: true,
+          changed: false,
+          ok: true,
+          status: "already-present",
+        }),
+        log: (message) => unchangedLogs.push(message),
+        warn: (message) => unchangedLogs.push(message),
+      },
+    );
+
+    expect(changedLogs).toEqual(["  ✓ Applied OpenShell VM DNS monkeypatch"]);
+    expect(unchangedLogs).toEqual(["  OpenShell VM DNS monkeypatch already present"]);
+    expect(unchangedLogs.join("\n")).not.toContain("Applied");
+  });
+
+  it("logs skipped VM DNS monkeypatch state for VM sandboxes", () => {
+    const logs: string[] = [];
+
+    applyOnboardVmDnsMonkeypatch(
+      "demo",
+      { openshellDriver: "vm" },
+      {
+        apply: () => ({
+          attempted: false,
+          changed: false,
+          ok: false,
+          reason: "disabled by NEMOCLAW_DISABLE_VM_DNS_MONKEYPATCH=1",
+          status: "skipped",
+        }),
+        log: (message) => logs.push(message),
+        warn: (message) => logs.push(message),
+      },
+    );
+
+    expect(logs).toEqual([
+      "  OpenShell VM DNS monkeypatch skipped: disabled by NEMOCLAW_DISABLE_VM_DNS_MONKEYPATCH=1",
+    ]);
+  });
+
+  it("warns without aborting when the onboard VM DNS monkeypatch fails", () => {
+    const warnings: string[] = [];
+
+    expect(() =>
+      applyOnboardVmDnsMonkeypatch(
+        "demo",
+        { openshellDriver: "vm" },
+        {
+          apply: () => ({
+            attempted: true,
+            changed: false,
+            ok: false,
+            reason: "VM rootfs not found",
+            status: "failed",
+          }),
+          log: (message) => warnings.push(message),
+          warn: (message) => warnings.push(message),
+        },
+      ),
+    ).not.toThrow();
+
+    expect(warnings).toEqual([
+      "  Warning: OpenShell VM DNS monkeypatch did not apply: VM rootfs not found",
+    ]);
+  });
+
   it("writes sandbox sync scripts to a temp file for stdin redirection", () => {
     const scriptFile = writeSandboxConfigSyncFile("echo test");
     try {
@@ -3522,7 +3623,7 @@ const { setupInference } = require(${onboardPath});
     );
   });
 
-  it("configures Model Router as a host provider while sandboxes keep inference.local", () => {
+  it("configures Model Router as a host provider while sandboxes keep inference.local", testTimeoutOptions(60_000), () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-router-inference-"));
     const fakeBin = path.join(tmpDir, "bin");
@@ -3931,7 +4032,7 @@ const { setupInference } = require(${onboardPath});
     }
   });
 
-  it("prefers the managed Model Router command over PATH", () => {
+  it("prefers the managed Model Router command over PATH", testTimeoutOptions(60_000), () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-router-managed-"));
     const fakeBin = path.join(tmpDir, "bin");
@@ -4112,7 +4213,7 @@ const { setupInference } = require(${onboardPath});
     }
   });
 
-  it("refreshes stale managed Model Router command when source fingerprint changes", () => {
+  it("refreshes stale managed Model Router command when source fingerprint changes", testTimeoutOptions(60_000), () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-router-refresh-"));
     const fakeBin = path.join(tmpDir, "bin");
@@ -8874,7 +8975,7 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
     }
   });
 
-  it("uses the custom Dockerfile parent directory as build context when --from is given", async () => {
+  it("uses the custom Dockerfile parent directory as build context when --from is given", testTimeoutOptions(60_000), async () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-from-dockerfile-"));
     const fakeBin = path.join(tmpDir, "bin");

--- a/test/sandbox-connect-inference.test.ts
+++ b/test/sandbox-connect-inference.test.ts
@@ -416,7 +416,9 @@ describe("sandbox connect inference route swap (#1248)", () => {
         },
       );
 
-      const result = runConnect(tmpDir, sandboxName);
+      const result = runConnect(tmpDir, sandboxName, {
+        NEMOCLAW_FORCE_VM_DNS_MONKEYPATCH: "1",
+      });
       expect(result.status).toBe(0);
 
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
@@ -424,13 +426,14 @@ describe("sandbox connect inference route swap (#1248)", () => {
       expect(state.dockerCalls.length).toBe(0);
 
       const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("OpenShell VM DNS monkeypatch did not apply");
       expect(combined).toContain("Reapplying OpenShell inference route");
       expect(combined).toContain("OpenShell vm gateway path");
     },
   );
 
   it(
-    "applies the macOS VM DNS monkeypatch before falling back to route reapply",
+    "uses the macOS VM DNS monkeypatch without legacy DNS repair or route reset when it restores inference.local",
     testTimeoutOptions(20_000),
     () => {
       const { tmpDir, stateFile, sandboxName } = setupFixture(
@@ -470,6 +473,55 @@ describe("sandbox connect inference route swap (#1248)", () => {
 
       const combined = (result.stdout || "") + (result.stderr || "");
       expect(combined).toContain("Applying OpenShell VM DNS monkeypatch");
+      expect(combined).toContain("inference.local route repaired");
+      expect(combined).not.toContain("Reapplying OpenShell inference route");
+      expect(combined).not.toContain("Repairing sandbox DNS proxy");
+    },
+  );
+
+  it(
+    "falls back to OpenShell inference route reapply when the VM DNS monkeypatch applies but inference.local stays broken",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "vm-dns-still-broken",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          provider: "nvidia-prod",
+          gpuEnabled: false,
+          openshellDriver: "vm",
+          policies: [],
+        },
+        "nvidia-prod",
+        "nvidia/nemotron-3-super-120b-a12b",
+        {
+          inferenceProbeResponses: [
+            'BROKEN 503 {"error":"inference service unavailable"}',
+            'BROKEN 503 {"error":"inference service unavailable"}',
+            "OK 200",
+          ],
+        },
+      );
+      const rootfs = createVmRootfs(tmpDir);
+
+      const result = runConnect(tmpDir, sandboxName, {
+        NEMOCLAW_FORCE_VM_DNS_MONKEYPATCH: "1",
+      });
+      expect(result.status).toBe(0);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      expect(state.inferenceSetCalls.length).toBe(1);
+      expect(state.dockerCalls.length).toBe(0);
+      expect(fs.readFileSync(path.join(rootfs, "etc", "resolv.conf"), "utf-8")).toBe(
+        "nameserver 192.168.127.1\n",
+      );
+
+      const combined = (result.stdout || "") + (result.stderr || "");
+      expect(combined).toContain("Applying OpenShell VM DNS monkeypatch");
+      expect(combined).toContain(
+        "OpenShell VM DNS monkeypatch completed but inference.local is still unavailable",
+      );
+      expect(combined).toContain("Reapplying OpenShell inference route");
       expect(combined).toContain("inference.local route repaired");
     },
   );


### PR DESCRIPTION
## Summary
- make the macOS OpenShell VM DNS shim preserve resolver metadata while putting gvproxy DNS first
- add rootfs realpath guardrails, symlink escape refusal, init-script shape checks, and ext4 root-disk layout diagnostics
- improve connect/onboard observability and fallback coverage around VM DNS repair

## Tests
- npx vitest run src/lib/actions/sandbox/vm-dns-monkeypatch.test.ts test/sandbox-connect-inference.test.ts test/onboard.test.ts
- npm run build:cli
- git diff --check

Stacked on #3445 while that PR remains open.