### PR TITLE
chore(scripts): track upstream openclaw#81056 prompt-bloat fix (#2598)

### DIFF
--- a/scripts/check-openclaw-upstream-fix.sh
+++ b/scripts/check-openclaw-upstream-fix.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Polls openclaw/openclaw#81056 (the prompt-bloat regression report we filed
+# upstream from NemoClaw#2598) and reports whether the upstream fix has
+# landed. When it has, the operator should:
+#   1. Look up the openclaw release that contains the fix
+#   2. Bump `min_openclaw_version` in `nemoclaw-blueprint/blueprint.yaml`
+#      past that version
+#   3. Verify a fresh sandbox at the bumped version meets the <5s AC on a
+#      trivial agent turn
+#   4. Close NemoClaw#2598 (and the linked #2600, #3261 if still relevant)
+#
+# Distinguishes a real upstream fix (closed by a human or merge bot with a
+# linked PR) from a `clawsweeper[bot]` stale-close, since the latter is just
+# inbox hygiene and means nothing was fixed.
+#
+# Usage:
+#   scripts/check-openclaw-upstream-fix.sh           # print status
+#   scripts/check-openclaw-upstream-fix.sh --check   # exit 0 if no action
+#                                                    # needed, exit 1 if a
+#                                                    # real fix appears to
+#                                                    # have landed
+
+set -euo pipefail
+
+UPSTREAM_REPO="openclaw/openclaw"
+UPSTREAM_ISSUE="81056"
+TRACKED_BY_PIN="nemoclaw-blueprint/blueprint.yaml"
+NEMOCLAW_ISSUES="NemoClaw#2598 NemoClaw#2600 NemoClaw#3261"
+# Stale-bot accounts whose closing event does NOT indicate a real fix.
+STALE_CLOSERS=("clawsweeper[bot]" "stale[bot]" "github-actions[bot]")
+
+MODE="status"
+case "${1:-}" in
+  "") MODE="status" ;;
+  --check) MODE="check" ;;
+  -h | --help)
+    sed -n '3,21p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "Usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: 'gh' (GitHub CLI) is required. install: https://cli.github.com/" >&2
+  exit 2
+fi
+
+if ! issue_state=$(gh api "repos/${UPSTREAM_REPO}/issues/${UPSTREAM_ISSUE}" --jq '.state' 2>/dev/null); then
+  echo "error: failed to query ${UPSTREAM_REPO}#${UPSTREAM_ISSUE} (network or auth?)" >&2
+  exit 2
+fi
+
+closed_by=$(gh api "repos/${UPSTREAM_REPO}/issues/${UPSTREAM_ISSUE}" --jq '.closed_by.login // ""' 2>/dev/null || echo "")
+
+# A real fix lands via a linked PR or commit; stale-bot closes have neither.
+closure_has_pr="no"
+if [ "$issue_state" = "closed" ]; then
+  commit_count=$(gh api "repos/${UPSTREAM_REPO}/issues/${UPSTREAM_ISSUE}/events" --paginate \
+    --jq '[.[] | select(.commit_id != null)] | length' 2>/dev/null || echo "0")
+  if [ "${commit_count:-0}" -gt 0 ]; then
+    closure_has_pr="yes"
+  fi
+fi
+
+is_stale_close="no"
+for stale in "${STALE_CLOSERS[@]}"; do
+  if [ "$closed_by" = "$stale" ]; then
+    is_stale_close="yes"
+    break
+  fi
+done
+
+case "$issue_state" in
+  open)
+    if [ "$MODE" = "check" ]; then exit 0; fi
+    cat <<EOF
+${UPSTREAM_REPO}#${UPSTREAM_ISSUE} is OPEN.
+
+No action needed. ${NEMOCLAW_ISSUES} stay blocked on the upstream fix.
+
+Track: https://github.com/${UPSTREAM_REPO}/issues/${UPSTREAM_ISSUE}
+EOF
+    exit 0
+    ;;
+  closed)
+    if [ "$is_stale_close" = "yes" ] && [ "$closure_has_pr" = "no" ]; then
+      if [ "$MODE" = "check" ]; then exit 0; fi
+      cat <<EOF
+${UPSTREAM_REPO}#${UPSTREAM_ISSUE} is closed by ${closed_by} with no linked
+PR or commit — looks like a stale-bot close, NOT a real fix.
+
+No action needed. ${NEMOCLAW_ISSUES} are still blocked on a real upstream fix.
+
+If you think this is a mistake, reopen at:
+  https://github.com/${UPSTREAM_REPO}/issues/${UPSTREAM_ISSUE}
+EOF
+      exit 0
+    fi
+
+    cat <<EOF
+${UPSTREAM_REPO}#${UPSTREAM_ISSUE} appears CLOSED with real work
+  closed_by=${closed_by:-unknown}, linked-pr/commit=${closure_has_pr}
+
+The prompt-bloat fix likely landed upstream. Next steps:
+
+  1. Read the upstream issue to find the openclaw release tag that
+     includes the fix:
+       https://github.com/${UPSTREAM_REPO}/issues/${UPSTREAM_ISSUE}
+
+  2. Bump min_openclaw_version in ${TRACKED_BY_PIN} past that version.
+
+  3. Verify the AC on a fresh sandbox (trivial turn <5s).
+
+  4. Close ${NEMOCLAW_ISSUES} once verified.
+EOF
+    if [ "$MODE" = "check" ]; then exit 1; fi
+    exit 0
+    ;;
+  *)
+    echo "error: unexpected issue state '$issue_state' for ${UPSTREAM_REPO}#${UPSTREAM_ISSUE}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds `scripts/check-openclaw-upstream-fix.sh` to poll upstream openclaw/openclaw#81056 (the prompt-bloat regression we filed from #2598) and report whether a real fix has landed.

The script distinguishes a stale-bot close (e.g. `clawsweeper[bot]`) from a real fix by checking whether the closure event has a linked PR or commit. As of writing, the upstream issue shows `closed` but the closer is `clawsweeper[bot]` with zero linked work — the script correctly reports "stale-bot close, NOT a real fix" so we don't bump `min_openclaw_version` prematurely.

Example (current output):

```
$ scripts/check-openclaw-upstream-fix.sh
openclaw/openclaw#81056 is closed by clawsweeper[bot] with no linked
PR or commit — looks like a stale-bot close, NOT a real fix.

No action needed. NemoClaw#2598 NemoClaw#2600 NemoClaw#3261 are still blocked on a real upstream fix.
```

## Why only this, not observability

#3412 (status surfacing) and #3413 (tool-set bypass) were closed yesterday as preemptive. This PR honors that scope decision and ships only the pin-tracking automation. No CLI/product surface changes.

## Why this is useful

- Catches the moment a real upstream fix lands without manual polling.
- `--check` exits 1 only on a real fix (suitable for a weekly cron / GH Action).
- Won't false-positive on stale-bot closes (the current state of #81056).

## Verification

- [x] `npm run typecheck:cli` passes (unrelated; PR is shell only)
- [x] Script runs locally and correctly reports stale-bot close
- [x] `--check` mode returns exit 0 against the current upstream state
- [x] Shellcheck-clean

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only

Refs #2598, #2600, #3261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a development utility script to monitor upstream issue resolution status and automatically determine whether local action is required. The script intelligently distinguishes between genuine upstream fixes and automated issue closures, enabling maintainers to efficiently assess the need for local remediation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3476)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->