### PR TITLE
fix(cli): hint openshell-only commands

### DIFF
--- a/src/nemoclaw.ts
+++ b/src/nemoclaw.ts
@@ -63,6 +63,22 @@ function hasHelpFlag(args: readonly string[]): boolean {
   return args.includes("--help") || args.includes("-h");
 }
 
+function openshellOnlyCommandHint(argv: readonly string[]): string | null {
+  const [cmd, sub] = argv;
+  if (cmd === "term") return "openshell term";
+  if (cmd === "policy" && sub === "set") {
+    return "openshell policy set --policy <policy-file> <sandbox-name>";
+  }
+  if (cmd === "gateway" && sub === "stop") return "openshell gateway stop -g nemoclaw";
+  return null;
+}
+
+function printOpenshellOnlyCommandHint(invocation: string): void {
+  console.error("  This command lives under openshell. Run:");
+  console.error(`      ${invocation}`);
+  console.error(`  See \`${CLI_NAME} --help\` for the full list of openshell-only operations.`);
+}
+
 function findRegisteredSandboxName(tokens: string[]): string | null {
   const registered = new Set(
     registry.listSandboxes().sandboxes.map((s: { name: string }) => s.name),
@@ -204,6 +220,11 @@ async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
     validateName(cmd, "sandbox name");
     await recoverRegistryEntries({ requestedSandboxName: cmd });
     if (!registry.getSandbox(cmd)) {
+      const openshellHint = openshellOnlyCommandHint(argv);
+      if (openshellHint) {
+        printOpenshellOnlyCommandHint(openshellHint);
+        process.exit(1);
+      }
       if (args.length === 0) {
         const suggestion = suggestGlobalCommand(cmd);
         if (suggestion) {
@@ -232,6 +253,11 @@ async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
   }
 
   if (!registry.getSandbox(cmd)) {
+    const openshellHint = openshellOnlyCommandHint(argv);
+    if (openshellHint) {
+      printOpenshellOnlyCommandHint(openshellHint);
+      process.exit(1);
+    }
     const suggestion = suggestGlobalCommand(cmd);
     if (suggestion) {
       console.error(`  Unknown command: ${cmd}`);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -525,6 +525,34 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("Did you mean: nemoclaw alpha connect?");
   });
 
+  it("points openshell-only commands at the openshell invocation", () => {
+    const cases = [
+      ["term", "openshell term"],
+      ["policy set", "openshell policy set --policy <policy-file> <sandbox-name>"],
+      ["gateway stop", "openshell gateway stop -g nemoclaw"],
+    ];
+
+    for (const [args, invocation] of cases) {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-openshell-hint-"));
+      const localBin = path.join(home, "bin");
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.writeFileSync(path.join(localBin, "openshell"), "#!/usr/bin/env bash\nexit 1\n", {
+        mode: 0o755,
+      });
+      const r = runWithEnv(args, {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_HEALTH_POLL_COUNT: "0",
+      });
+
+      expect(r.code).toBe(1);
+      expect(r.out).toContain("This command lives under openshell. Run:");
+      expect(r.out).toContain(invocation);
+      expect(r.out).toContain("See `nemoclaw --help`");
+      expect(r.out).not.toContain("Try: nemoclaw <sandbox-name> connect");
+    }
+  });
+
   it("list exits 0", () => {
     const r = run("list");
     expect(r.code).toBe(0);


### PR DESCRIPTION
## Summary
- detect natural NemoClaw forms for OpenShell-only commands before falling back to generic unknown-command guidance
- print the matching `openshell` invocation for `term`, `policy set`, and `gateway stop`
- cover the hints with a CLI regression test

Fixes #3388.

## Verification
- `npm run build:cli`
- `npm test -- test/cli.test.ts -t "points openshell-only commands"`
- `git diff --check`

Signed-off-by: Intern Dev <dev@wukongai.io>
