### PR TITLE
fix(cli): include IPv6 loopback in NO_PROXY

### DIFF
--- a/nemoclaw/src/lib/subprocess-env.ts
+++ b/nemoclaw/src/lib/subprocess-env.ts
@@ -62,7 +62,7 @@ export function withLocalNoProxy(env: Record<string, string>): void {
     const current = env[key] ?? "";
     const parts = current ? current.split(",").map((s) => s.trim()) : [];
     let changed = false;
-    for (const host of ["localhost", "127.0.0.1", "host.docker.internal"]) {
+    for (const host of ["localhost", "127.0.0.1", "host.docker.internal", "::1", "0.0.0.0"]) {
       if (!parts.includes(host)) {
         parts.push(host);
         changed = true;

--- a/src/lib/subprocess-env.test.ts
+++ b/src/lib/subprocess-env.test.ts
@@ -4,6 +4,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withLocalNoProxy } from "../../dist/lib/subprocess-env";
 
+const LOCAL_NO_PROXY = "localhost,127.0.0.1,host.docker.internal,::1,0.0.0.0";
+
 describe("withLocalNoProxy", () => {
   it("does nothing when no proxy vars are present", () => {
     const env: Record<string, string> = { PATH: "/usr/bin" };
@@ -14,22 +16,22 @@ describe("withLocalNoProxy", () => {
   it("adds local host-bound names to NO_PROXY and no_proxy when HTTP_PROXY is set and NO_PROXY is absent", () => {
     const env: Record<string, string> = { HTTP_PROXY: "http://proxy:8888" };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.NO_PROXY).toBe(LOCAL_NO_PROXY);
+    expect(env.no_proxy).toBe(LOCAL_NO_PROXY);
   });
 
   it("adds local host-bound names when HTTPS_PROXY is set", () => {
     const env: Record<string, string> = { HTTPS_PROXY: "http://proxy:8888" };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.NO_PROXY).toBe(LOCAL_NO_PROXY);
+    expect(env.no_proxy).toBe(LOCAL_NO_PROXY);
   });
 
   it("adds local host-bound names when lowercase http_proxy is set", () => {
     const env: Record<string, string> = { http_proxy: "http://proxy:8888" };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.NO_PROXY).toBe(LOCAL_NO_PROXY);
+    expect(env.no_proxy).toBe(LOCAL_NO_PROXY);
   });
 
   it("appends only the missing local entries when NO_PROXY already has localhost", () => {
@@ -39,19 +41,19 @@ describe("withLocalNoProxy", () => {
       no_proxy: "example.com,localhost",
     };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("example.com,localhost,127.0.0.1,host.docker.internal");
-    expect(env.no_proxy).toBe("example.com,localhost,127.0.0.1,host.docker.internal");
+    expect(env.NO_PROXY).toBe("example.com,localhost,127.0.0.1,host.docker.internal,::1,0.0.0.0");
+    expect(env.no_proxy).toBe("example.com,localhost,127.0.0.1,host.docker.internal,::1,0.0.0.0");
   });
 
   it("does not duplicate entries when all local hosts are already present", () => {
     const env: Record<string, string> = {
       HTTP_PROXY: "http://proxy:8888",
-      NO_PROXY: "localhost,127.0.0.1,host.docker.internal,corp.internal",
-      no_proxy: "localhost,127.0.0.1,host.docker.internal,corp.internal",
+      NO_PROXY: `${LOCAL_NO_PROXY},corp.internal`,
+      no_proxy: `${LOCAL_NO_PROXY},corp.internal`,
     };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal,corp.internal");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal,corp.internal");
+    expect(env.NO_PROXY).toBe(`${LOCAL_NO_PROXY},corp.internal`);
+    expect(env.no_proxy).toBe(`${LOCAL_NO_PROXY},corp.internal`);
   });
 
   it("preserves existing NO_PROXY entries and adds local hosts", () => {
@@ -61,8 +63,8 @@ describe("withLocalNoProxy", () => {
       no_proxy: "corp.internal,.nvidia.com",
     };
     withLocalNoProxy(env);
-    expect(env.NO_PROXY).toBe("corp.internal,.nvidia.com,localhost,127.0.0.1,host.docker.internal");
-    expect(env.no_proxy).toBe("corp.internal,.nvidia.com,localhost,127.0.0.1,host.docker.internal");
+    expect(env.NO_PROXY).toBe(`corp.internal,.nvidia.com,${LOCAL_NO_PROXY}`);
+    expect(env.no_proxy).toBe(`corp.internal,.nvidia.com,${LOCAL_NO_PROXY}`);
   });
 });
 
@@ -85,8 +87,8 @@ describe("buildSubprocessEnv NO_PROXY injection", () => {
 
     const { buildSubprocessEnv } = await import("../../dist/lib/subprocess-env");
     const env = buildSubprocessEnv();
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
-    expect(env.no_proxy).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.NO_PROXY).toBe(LOCAL_NO_PROXY);
+    expect(env.no_proxy).toBe(LOCAL_NO_PROXY);
   });
 
   it("augments an existing NO_PROXY to add local hosts", async () => {
@@ -96,8 +98,8 @@ describe("buildSubprocessEnv NO_PROXY injection", () => {
 
     const { buildSubprocessEnv } = await import("../../dist/lib/subprocess-env");
     const env = buildSubprocessEnv();
-    expect(env.NO_PROXY).toBe("corp.internal,localhost,127.0.0.1,host.docker.internal");
-    expect(env.no_proxy).toBe("corp.internal,localhost,127.0.0.1,host.docker.internal");
+    expect(env.NO_PROXY).toBe(`corp.internal,${LOCAL_NO_PROXY}`);
+    expect(env.no_proxy).toBe(`corp.internal,${LOCAL_NO_PROXY}`);
   });
 
   it("does not add NO_PROXY when no proxy is set", async () => {
@@ -122,6 +124,6 @@ describe("buildSubprocessEnv NO_PROXY injection", () => {
     const { buildSubprocessEnv } = await import("../../dist/lib/subprocess-env");
     const env = buildSubprocessEnv({ MY_TOKEN: "abc123" });
     expect(env.MY_TOKEN).toBe("abc123");
-    expect(env.NO_PROXY).toBe("localhost,127.0.0.1,host.docker.internal");
+    expect(env.NO_PROXY).toBe(LOCAL_NO_PROXY);
   });
 });

--- a/src/lib/subprocess-env.ts
+++ b/src/lib/subprocess-env.ts
@@ -62,7 +62,7 @@ export function withLocalNoProxy(env: Record<string, string>): void {
     const current = env[key] ?? "";
     const parts = current ? current.split(",").map((s) => s.trim()) : [];
     let changed = false;
-    for (const host of ["localhost", "127.0.0.1", "host.docker.internal"]) {
+    for (const host of ["localhost", "127.0.0.1", "host.docker.internal", "::1", "0.0.0.0"]) {
       if (!parts.includes(host)) {
         parts.push(host);
         changed = true;

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -12,7 +12,11 @@ import path from "node:path";
 import { createRequire } from "node:module";
 import { describe, it, expect } from "vitest";
 import { buildSubprocessEnv as buildCliSubprocessEnv } from "../src/lib/subprocess-env";
-import { buildSubprocessEnv as buildPluginSubprocessEnv } from "../nemoclaw/src/lib/subprocess-env";
+import {
+  buildSubprocessEnv as buildPluginSubprocessEnv,
+  withLocalNoProxy as withPluginLocalNoProxy,
+} from "../nemoclaw/src/lib/subprocess-env";
+import { withLocalNoProxy as withCliLocalNoProxy } from "../src/lib/subprocess-env";
 import { getCurlTimingArgs } from "../src/lib/adapters/http/probe";
 
 const require = createRequire(import.meta.url);
@@ -139,6 +143,21 @@ describe("credential exposure in process arguments", () => {
           process.env[key] = value;
         }
       }
+    }
+  });
+
+  it("subprocess-env NO_PROXY local hosts are in sync for CLI and plugin", () => {
+    for (const withLocalNoProxy of [withCliLocalNoProxy, withPluginLocalNoProxy]) {
+      const env: Record<string, string> = {
+        HTTP_PROXY: "http://proxy.example.com:8888",
+        NO_PROXY: "corp.internal,localhost",
+        no_proxy: "corp.internal,localhost",
+      };
+
+      withLocalNoProxy(env);
+
+      expect(env.NO_PROXY).toBe("corp.internal,localhost,127.0.0.1,host.docker.internal,::1,0.0.0.0");
+      expect(env.no_proxy).toBe("corp.internal,localhost,127.0.0.1,host.docker.internal,::1,0.0.0.0");
     }
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR updates NemoClaw’s subprocess environment handling so local traffic is not accidentally routed through a forwarded proxy when tools target IPv6 loopback. The existing helper already protected `localhost` and `127.0.0.1`; this extends the same behavior to `::1` and `0.0.0.0` in both mirrored subprocess environment helpers.

## Related Issue

Fixes #3485 

## Changes

- Added `::1` and `0.0.0.0` to the local host list injected into `NO_PROXY` and `no_proxy`.
- Kept the CLI and plugin copies of `subprocess-env.ts` in sync.
- Updated subprocess environment tests to cover the expanded local bypass list.
- Added a parity regression test so the CLI and plugin helpers do not drift on this behavior again.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] npx prek run --all-files passes
- [ ] npm test passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] make docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Focused verification run:

```text
npm run build:cli
npx vitest run --project cli src/lib/subprocess-env.test.ts test/credential-exposure.test.ts
npm run typecheck:cli
cd nemoclaw && npm run build
```

The focused regression tests passed locally:

<img width="806" height="350" alt="image(1)" src="https://github.com/user-attachments/assets/ee4b7971-8b5f-4f7a-bbbf-78d5f0cd2685" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent local traffic from being routed through forwarded HTTP proxies by adding additional loopback/local addresses (::1, 0.0.0.0) to NO_PROXY/no_proxy when proxy variables are present.

* **Tests**
  * Expanded tests to verify the broader local-address exclusion, augmentation/no-duplication behavior, and consistent results across implementations.

* **Documentation**
  * Clarified wording to describe "local traffic" proxy exclusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3486)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Signed-off-by: 1PoPTRoN <vrxn.arp1traj@gmail.com>