### PR TITLE
ci(workflows): standardize display names

### DIFF
--- a/.github/workflows/assign-linked-issue-author.yaml
+++ b/.github/workflows/assign-linked-issue-author.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: assign-linked-issue-author
+name: Automation / Assign Linked Issue Author
 
 # pull_request_target runs in the base repo context, giving the token write
 # access even for fork PRs. This workflow is safe because it only reads PR

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -11,7 +11,7 @@
 # user setup, openclaw CLI). The production Dockerfile layers PR-specific
 # code on top via: FROM ghcr.io/nvidia/nemoclaw/sandbox-base:<tag>
 
-name: base-image
+name: Images / Base Images
 
 on:
   push:

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -4,7 +4,7 @@
 # Dedicated security reporting workflow for NemoClaw.
 # CodeQL and ShellCheck publish findings to GitHub code scanning while the
 # existing PR and main workflows remain the merge-gating CI path.
-name: code-scanning
+name: Security / Code Scanning
 
 on:
   pull_request:

--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: commit-lint
+name: CI / Commit Lint
 
 on:
   pull_request:

--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: dco-check
+name: CI / DCO Check
 
 on:
   pull_request:

--- a/.github/workflows/docker-pin-check.yaml
+++ b/.github/workflows/docker-pin-check.yaml
@@ -4,7 +4,7 @@
 # Weekly check that the pinned Dockerfile base-image digest is still current.
 # Fails with an actionable message when a newer node:22-trixie-slim is available.
 
-name: docker-pin-check
+name: Security / Docker Pin Check
 
 on:
   schedule:

--- a/.github/workflows/docs-cli-parity-pr.yaml
+++ b/.github/workflows/docs-cli-parity-pr.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Docs CLI Parity PR
+name: Docs / CLI Parity
 
 # Catches drift between the actual `nemoclaw --help` command list and the
 # command headings in `docs/reference/commands.md`. The same check runs in

--- a/.github/workflows/docs-links-pr.yaml
+++ b/.github/workflows/docs-links-pr.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Docs Links PR
+name: Docs / Link Check
 
 on:
   pull_request:

--- a/.github/workflows/docs-preview-deploy.yaml
+++ b/.github/workflows/docs-preview-deploy.yaml
@@ -6,11 +6,11 @@
 # Only deploys previews for same-repo PRs to prevent fork PRs from
 # publishing arbitrary content to the GitHub Pages domain.
 
-name: Docs PR Preview Deploy
+name: Docs / Preview Deploy
 
 on:
   workflow_run:
-    workflows: ["Docs PR Preview"]
+    workflows: ["Docs / Preview Build"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -5,7 +5,7 @@
 # Step 2 (deploy) runs in docs-preview-deploy.yaml via workflow_run,
 # which has write access to gh-pages regardless of PR origin.
 
-name: Docs PR Preview
+name: Docs / Preview Build
 
 on:
   pull_request:

--- a/.github/workflows/e2e-advisor.yaml
+++ b/.github/workflows/e2e-advisor.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: e2e-advisor
+name: E2E / Advisor
 
 on:
   pull_request:

--- a/.github/workflows/e2e-branch-validation.yaml
+++ b/.github/workflows/e2e-branch-validation.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: e2e-branch-validation
+name: E2E / Branch Validation
 
 # ─── Branch Validation E2E ───────────────────────────────────────────────────
 #

--- a/.github/workflows/e2e-parity-compare.yaml
+++ b/.github/workflows/e2e-parity-compare.yaml
@@ -11,7 +11,7 @@
 # workflow for every scenario it introduces and records zero-divergence
 # before marking the phase complete.
 
-name: e2e-parity-compare
+name: E2E / Parity Compare
 
 on:
   workflow_dispatch:

--- a/.github/workflows/e2e-scenarios.yaml
+++ b/.github/workflows/e2e-scenarios.yaml
@@ -7,7 +7,7 @@
 # Manual-only (workflow_dispatch) while scenario-based coverage migrates.
 # Existing nightly-e2e / macos-e2e / wsl-e2e workflows remain unchanged.
 
-name: e2e-scenarios
+name: E2E / Scenario Runner
 
 on:
   workflow_dispatch:

--- a/.github/workflows/installer-hash-check.yaml
+++ b/.github/workflows/installer-hash-check.yaml
@@ -5,7 +5,7 @@
 # Checked: Ollama installer.
 # Runs on every PR and push to main, plus a weekly scheduled check.
 
-name: installer-hash-check
+name: Security / Installer Hash Check
 
 on:
   pull_request:

--- a/.github/workflows/legacy-path-guard.yaml
+++ b/.github/workflows/legacy-path-guard.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: legacy-path-guard
+name: CI / Legacy Path Guard
 
 on:
   pull_request:

--- a/.github/workflows/macos-e2e.yaml
+++ b/.github/workflows/macos-e2e.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: macos-e2e
+name: E2E / macOS
 
 on:
   workflow_dispatch:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: main
+name: CI / Main
 
 on:
   push:

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -52,7 +52,7 @@
 #     variable empty in the job — repository secrets and environment secrets are separate.)
 # Only runs on schedule and manual dispatch — never on PRs (secret protection).
 
-name: nightly-e2e
+name: E2E / Nightly
 
 on:
   schedule:

--- a/.github/workflows/ollama-proxy-e2e.yaml
+++ b/.github/workflows/ollama-proxy-e2e.yaml
@@ -7,10 +7,10 @@
 # end-to-end: token auth, real inference, persistence, recovery, and
 # container reachability.
 #
-# Trigger manually: Actions → "Ollama Auth Proxy E2E" → Run workflow
+# Trigger manually: Actions → "E2E / Ollama Auth Proxy" → Run workflow
 # Or via CLI: gh workflow run ollama-proxy-e2e.yaml
 
-name: Ollama Auth Proxy E2E
+name: E2E / Ollama Auth Proxy
 
 on:
   workflow_dispatch:

--- a/.github/workflows/onboard-entrypoint-budget.yaml
+++ b/.github/workflows/onboard-entrypoint-budget.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: onboard-entrypoint-budget
+name: CI / Onboard Entrypoint Budget
 
 # pull_request_target runs in the base repo context, so this policy cannot be
 # bypassed by editing workflow files or scripts in the PR. Keep this workflow

--- a/.github/workflows/pr-limit.yaml
+++ b/.github/workflows/pr-limit.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: pr-limit
+name: Automation / PR Limit
 
 # pull_request_target runs in the base repo context, giving the token write
 # access even for fork PRs. This is safe here because this workflow never

--- a/.github/workflows/pr-self-hosted.yaml
+++ b/.github/workflows/pr-self-hosted.yaml
@@ -13,7 +13,7 @@
 #
 # See: https://docs.gha-runners.nvidia.com/platform/onboarding/pull-request-testing/
 
-name: pr-self-hosted
+name: CI / Self-Hosted PR
 
 on:
   push:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: pr
+name: CI / Pull Request
 
 on:
   pull_request:

--- a/.github/workflows/regression-e2e.yaml
+++ b/.github/workflows/regression-e2e.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: regression-e2e
+name: E2E / Regression Runner
 
 # Regression E2E holding pen.
 #

--- a/.github/workflows/sandbox-images-and-e2e.yaml
+++ b/.github/workflows/sandbox-images-and-e2e.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: sandbox-images-and-e2e
+name: Images / Sandbox Images and E2E
 
 on:
   workflow_call:

--- a/.github/workflows/wsl-e2e.yaml
+++ b/.github/workflows/wsl-e2e.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: wsl-e2e
+name: E2E / WSL
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
Standardizes GitHub Actions workflow display names using category/purpose prefixes so related workflows group together in the Actions UI. The workflow files keep their existing filenames.

## Changes
- Rename workflow `name:` values under `.github/workflows/` to consistent `CI /`, `Docs /`, `E2E /`, `Security /`, `Images /`, and `Automation /` display names.
- Update the docs preview deploy `workflow_run` dependency to follow the renamed docs preview build workflow.
- Refresh the Ollama proxy E2E manual-trigger comment to match the new display name.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Note: `npm test` was run but did not pass because `test/install-preflight.test.ts` currently fails in `skips onboarding when shared host preflight detects Docker is missing` with exit status `1` instead of expected `0`. The failure is unrelated to this workflow-name-only change.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow display names to follow a new organizational naming convention (e.g., "CI / Main", "E2E / Advisor", "Security / Code Scanning") for improved clarity in CI/CD status visibility.

* **Tests**
  * Enhanced E2E scenario test execution with improved runner selection logic to route tests to appropriate execution environments based on scenario prefixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3489)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->