### PR TITLE
fix(e2e): avoid stale nemoclaw command hash

### DIFF
--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -1587,7 +1587,7 @@
         },
         {
           "script": "test/e2e/test-deployment-services.sh",
-          "line": 447,
+          "line": 448,
           "text": "TC-DEPLOY-03: openshell binary still in PATH after uninstall",
           "polarity": "pass",
           "normalized_id": "tc.deploy.03.openshell.binary.still.in.path.after.uninstall",
@@ -1595,7 +1595,7 @@
         },
         {
           "script": "test/e2e/test-deployment-services.sh",
-          "line": 449,
+          "line": 450,
           "text": "TC-DEPLOY-03: openshell",
           "polarity": "fail",
           "normalized_id": "tc.deploy.03.openshell",
@@ -1603,7 +1603,7 @@
         },
         {
           "script": "test/e2e/test-deployment-services.sh",
-          "line": 454,
+          "line": 457,
           "text": "TC-DEPLOY-03: nemoclaw removed after uninstall",
           "polarity": "pass",
           "normalized_id": "tc.deploy.03.nemoclaw.removed.after.uninstall",
@@ -1627,7 +1627,7 @@
         },
         {
           "script": "test/e2e/test-deployment-services.sh",
-          "line": 483,
+          "line": 482,
           "text": "$PASS${NC}",
           "polarity": "pass",
           "normalized_id": "pass.nc",
@@ -1635,7 +1635,7 @@
         },
         {
           "script": "test/e2e/test-deployment-services.sh",
-          "line": 484,
+          "line": 483,
           "text": "$FAIL${NC}",
           "polarity": "fail",
           "normalized_id": "fail.nc",

--- a/test/e2e/test-deployment-services.sh
+++ b/test/e2e/test-deployment-services.sh
@@ -440,6 +440,7 @@ test_deploy_03_uninstall_keep_openshell() {
   else
     uninstall_output=$(nemoclaw uninstall --keep-openshell --yes 2>&1) || true
   fi
+  hash -r 2>/dev/null || true
   log "  Uninstall output: ${uninstall_output:0:400}"
 
   log "  Step 3: Verifying openshell still present..."
@@ -450,16 +451,14 @@ test_deploy_03_uninstall_keep_openshell() {
   fi
 
   log "  Step 4: Verifying nemoclaw removed..."
-  if ! command -v nemoclaw >/dev/null 2>&1; then
+  local nemoclaw_path
+  nemoclaw_path=$(command -v nemoclaw 2>/dev/null || true)
+  if [[ -z "$nemoclaw_path" || ! -e "$nemoclaw_path" ]]; then
     pass "TC-DEPLOY-03: nemoclaw removed after uninstall"
+  elif [[ "$nemoclaw_path" == "$REPO_ROOT"* ]]; then
+    pass "TC-DEPLOY-03: uninstall completed (nemoclaw in source tree is expected)"
   else
-    local nemoclaw_path
-    nemoclaw_path=$(command -v nemoclaw)
-    if [[ "$nemoclaw_path" == "$REPO_ROOT"* ]]; then
-      pass "TC-DEPLOY-03: uninstall completed (nemoclaw in source tree is expected)"
-    else
-      fail "TC-DEPLOY-03: nemoclaw" "nemoclaw still found at $nemoclaw_path after uninstall"
-    fi
+    fail "TC-DEPLOY-03: nemoclaw" "nemoclaw still found at $nemoclaw_path"
   fi
 }
 


### PR DESCRIPTION
## Summary
- Clear Bash's command hash after `nemoclaw uninstall --keep-openshell --yes` in `deployment-services-e2e`
- Treat a resolved-but-missing `nemoclaw` path as removed, so stale shell resolution does not fail TC-DEPLOY-03

Fixes #3490

## Testing
- `bash -n test/e2e/test-deployment-services.sh`

## E2E
- Recommended: `deployment-services-e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved uninstall verification: clears the shell command cache after uninstall, makes path checks more defensive and tolerant of missing/invalid entries, and refines pass/fail messaging.
  * Updated test assertion metadata to reflect shifted line numbers for related uninstall checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3491)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->