### PR TITLE
fix(platform): detect Colima docker.sock at top-level path (#3503)

### DIFF
--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -77,6 +77,11 @@ function getColimaDockerSocketCandidates(opts: PlatformLookupOptions = {}): stri
   return [
     path.join(home, ".colima/default/docker.sock"),
     path.join(home, ".config/colima/default/docker.sock"),
+    // Some Colima profiles (and older layouts) place the socket at the
+    // top-level ~/.colima/docker.sock rather than under default/. Reported
+    // in #3503 — keep as a candidate so detection succeeds without the
+    // user having to symlink to /var/run/docker.sock.
+    path.join(home, ".colima/docker.sock"),
   ];
 }
 

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -63,6 +63,7 @@ describe("platform helpers", () => {
       expect(getDockerSocketCandidates({ platform: "darwin", home })).toEqual([
         path.join(home, ".colima/default/docker.sock"),
         path.join(home, ".config/colima/default/docker.sock"),
+        path.join(home, ".colima/docker.sock"),
         path.join(home, ".local/share/containers/podman/machine/podman.sock"),
         "/var/run/docker.sock",
         path.join(home, ".docker/run/docker.sock"),
@@ -206,6 +207,22 @@ describe("platform helpers", () => {
         dockerHost: `unix://${colimaSocket}`,
         source: "socket",
         socketPath: colimaSocket,
+      });
+    });
+
+    it("discovers the bare ~/.colima/docker.sock layout (regression for #3503)", () => {
+      // The reporter's Colima setup puts the socket at the top-level
+      // ~/.colima/docker.sock rather than under ~/.colima/default/. Before
+      // this fix, detection returned null and the gateway fell back to
+      // /var/run/docker.sock, breaking onboard.
+      const home = "/tmp/test-home";
+      const bareColimaSocket = path.join(home, ".colima/docker.sock");
+      const existsSync = (candidate: string) => candidate === bareColimaSocket;
+
+      expect(detectDockerHost({ env: {}, platform: "darwin", home, existsSync })).toEqual({
+        dockerHost: `unix://${bareColimaSocket}`,
+        source: "socket",
+        socketPath: bareColimaSocket,
       });
     });
   });


### PR DESCRIPTION
## Summary
`nemoclaw onboard` fails on macOS + Colima setups whose Docker socket lives at `~/.colima/docker.sock` rather than the default `~/.colima/default/docker.sock`. Detection returned `null`, `DOCKER_HOST` stayed unset, and the gateway fell back to its hardcoded `/var/run/docker.sock` and aborted with `FailedPrecondition`. This adds the top-level path to the Colima candidate list so onboard works without the symlink workaround.

## Related Issue
Fixes #3503.

## Changes
- `src/lib/platform.ts:getColimaDockerSocketCandidates` — append `~/.colima/docker.sock` to the candidate list, with a comment pointing at #3503.
- `test/platform.test.ts` — extend the macOS priority-order assertion to include the new path, and add a regression test (`discovers the bare ~/.colima/docker.sock layout (regression for #3503)`) that fails on `main`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Notes on verification

- `prek` was scoped to the changed files (`npx prek run --files src/lib/platform.ts test/platform.test.ts`), passes.
- The cli `npm test` project surfaced two pre-existing timeouts in `test/cli.test.ts` for the `NEMOCLAW_CLEANUP_GATEWAY` tests at the default 5000ms — same tests take ~5750ms / ~6345ms on unmodified `main`, so this is pre-existing flake unrelated to this change. Running the same tests at `--testTimeout 15000` passes on both `main` and this branch.
- `npm run typecheck:cli` passes.

### Out of scope / follow-up

For Colima users with custom profile names (e.g. `colima start --profile foo`), the socket would live at `~/.colima/foo/docker.sock` — which still isn't in the candidate list. The general fix is to probe `docker context inspect --format '{{.Endpoints.docker.Host}}'` for the authoritative endpoint. That introduces a subprocess call from `platform.ts` (currently I/O-free) which collides with `test/docker-abstraction-guard.test.ts` and the SSRF subprocess assertion in `test/config-set-nested-ssrf.test.ts`. The right home for that probe is the onboard gateway-launch path, not module-load time in `runner.ts` — filing as a follow-up.

---
Signed-off-by: jason <jama@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Docker host socket detection for Colima environments to recognize additional socket path configurations. The system now successfully detects Docker sockets across various Colima layouts, improving compatibility and eliminating the need for manual workarounds in certain installation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3505)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->