### PR TITLE
fix(onboard): tighten UFW reachability remediation

### DIFF
--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   __test,
-  isSandboxBridgeGatewayReachable,
   formatSandboxBridgeUnreachableMessage,
+  isSandboxBridgeGatewayReachable,
 } from "../../../dist/lib/onboard/gateway-sandbox-reachability";
 
 describe("gateway sandbox reachability route modeling", () => {
@@ -131,6 +131,17 @@ describe("formatSandboxBridgeUnreachableMessage", () => {
       gatewayIp: "172.19.0.1",
     });
     expect(msg).toContain("172.19.0.1:8080");
+    expect(msg).toContain("ufw allow from 172.19.0.0/16 to 172.19.0.1 port 8080");
+  });
+
+  it("falls back to a subnet-only UFW command when the gateway IP is unavailable", () => {
+    const msg = formatSandboxBridgeUnreachableMessage({
+      ok: false,
+      reason: "tcp_failed",
+      routeKind: "bridge_gateway",
+      networkName: "openshell-docker",
+      subnet: "172.19.0.0/16",
+    });
     expect(msg).toContain("ufw allow from 172.19.0.0/16 to any port 8080");
   });
 

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -282,12 +282,15 @@ export function formatSandboxBridgeUnreachableMessage(
     ].join("\n");
   }
 
-  const allowCmd = result.subnet
-    ? `      sudo ufw allow from ${result.subnet} to any port ${port} proto tcp`
-    : [
-        `      SUBNET=$(docker network inspect ${result.networkName ?? DEFAULT_NETWORK_NAME} --format '{{(index .IPAM.Config 0).Subnet}}')`,
-        `      sudo ufw allow from "$SUBNET" to any port ${port} proto tcp`,
-      ].join("\n");
+  const allowCmd =
+    result.subnet && result.gatewayIp
+      ? `      sudo ufw allow from ${result.subnet} to ${result.gatewayIp} port ${port} proto tcp`
+      : result.subnet
+        ? `      sudo ufw allow from ${result.subnet} to any port ${port} proto tcp`
+        : [
+            `      SUBNET=$(docker network inspect ${result.networkName ?? DEFAULT_NETWORK_NAME} --format '{{(index .IPAM.Config 0).Subnet}}')`,
+            `      sudo ufw allow from "$SUBNET" to any port ${port} proto tcp`,
+          ].join("\n");
   const target = result.gatewayIp
     ? `${HOST_INTERNAL_NAME}:${port} (${result.gatewayIp}:${port})`
     : `${HOST_INTERNAL_NAME}:${port}`;

--- a/src/lib/onboard/ollama-proxy-reachability.test.ts
+++ b/src/lib/onboard/ollama-proxy-reachability.test.ts
@@ -16,10 +16,10 @@ vi.mock("../adapters/docker/run", () => ({
 
 import { OLLAMA_PROXY_PORT } from "../core/ports";
 import {
+  __test,
   DEFAULT_OLLAMA_PROBE_NETWORK,
   formatOllamaProxyUnreachableMessage,
   probeOllamaProxySandboxReachability,
-  __test,
 } from "./ollama-proxy-reachability";
 
 const { parseNetworkIpamConfig } = __test;
@@ -274,18 +274,31 @@ describe("formatOllamaProxyUnreachableMessage", () => {
     ).toBe("");
   });
 
-  it("includes subnet-specific ufw command when subnet is known", () => {
+  it("includes gateway-specific ufw command when subnet and gateway are known", () => {
+    const msg = formatOllamaProxyUnreachableMessage({
+      ok: false,
+      reason: "tcp_failed",
+      networkName: "openshell-docker",
+      subnet: "172.20.0.0/16",
+      gatewayIp: "172.20.0.1",
+    });
+    expect(msg).toContain("172.20.0.0/16");
+    expect(msg).toContain("172.20.0.1");
+    expect(msg).toContain("ufw allow from 172.20.0.0/16 to 172.20.0.1 port 11435");
+    expect(msg).toContain(String(OLLAMA_PROXY_PORT));
+    expect(msg).toContain("sudo ufw allow");
+    expect(msg).toContain("host.openshell.internal");
+    expect(msg).toContain("nemoclaw onboard");
+  });
+
+  it("falls back to a subnet-only UFW command when the gateway IP is unavailable", () => {
     const msg = formatOllamaProxyUnreachableMessage({
       ok: false,
       reason: "tcp_failed",
       networkName: "openshell-docker",
       subnet: "172.20.0.0/16",
     });
-    expect(msg).toContain("172.20.0.0/16");
-    expect(msg).toContain(String(OLLAMA_PROXY_PORT));
-    expect(msg).toContain("sudo ufw allow");
-    expect(msg).toContain("host.openshell.internal");
-    expect(msg).toContain("nemoclaw onboard");
+    expect(msg).toContain("ufw allow from 172.20.0.0/16 to any port 11435");
   });
 
   it("includes dynamic SUBNET= fallback when subnet is unknown", () => {

--- a/src/lib/onboard/ollama-proxy-reachability.ts
+++ b/src/lib/onboard/ollama-proxy-reachability.ts
@@ -15,8 +15,8 @@
  * ufw remediation before declaring onboard successful.
  */
 
-import { OLLAMA_PROXY_PORT } from "../core/ports";
 import { dockerCapture, dockerRun } from "../adapters/docker/run";
+import { OLLAMA_PROXY_PORT } from "../core/ports";
 
 export const DEFAULT_OLLAMA_PROBE_NETWORK = "openshell-docker";
 const HOST_INTERNAL_NAME = "host.openshell.internal";
@@ -235,12 +235,15 @@ export function formatOllamaProxyUnreachableMessage(
 ): string {
   if (result.ok || result.reason !== "tcp_failed") return "";
 
-  const allowCmd = result.subnet
-    ? `      sudo ufw allow from ${result.subnet} to any port ${port} proto tcp`
-    : [
-        `      SUBNET=$(docker network inspect ${result.networkName ?? DEFAULT_OLLAMA_PROBE_NETWORK} --format '{{(index .IPAM.Config 0).Subnet}}')`,
-        `      sudo ufw allow from "$SUBNET" to any port ${port} proto tcp`,
-      ].join("\n");
+  const allowCmd =
+    result.subnet && result.gatewayIp
+      ? `      sudo ufw allow from ${result.subnet} to ${result.gatewayIp} port ${port} proto tcp`
+      : result.subnet
+        ? `      sudo ufw allow from ${result.subnet} to any port ${port} proto tcp`
+        : [
+            `      SUBNET=$(docker network inspect ${result.networkName ?? DEFAULT_OLLAMA_PROBE_NETWORK} --format '{{(index .IPAM.Config 0).Subnet}}')`,
+            `      sudo ufw allow from "$SUBNET" to any port ${port} proto tcp`,
+          ].join("\n");
 
   return [
     `  ✗ Sandbox containers cannot reach the Ollama auth proxy at ${HOST_INTERNAL_NAME}:${port}.`,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Narrows the UFW remediation shown for sandbox reachability failures when NemoClaw knows both the Docker bridge subnet and gateway IP.
The existing broader subnet-only fallback remains in place when the gateway IP is unavailable.

## Related Issue
Related to #3456.

## Changes
- Use `sudo ufw allow from <subnet> to <gateway-ip> port <port> proto tcp` for gateway and Ollama proxy reachability messages when the probed Docker gateway IP is known.
- Preserve the current `to any port` remediation when only the subnet is known or must be looked up dynamically.
- Update formatter tests to cover the gateway-specific command and subnet-only fallback.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Focused checks passed locally under Node 22.22.3:
- `npm run typecheck:cli`
- `npx @biomejs/biome check src/lib/onboard/gateway-sandbox-reachability.ts src/lib/onboard/gateway-sandbox-reachability.test.ts src/lib/onboard/ollama-proxy-reachability.ts src/lib/onboard/ollama-proxy-reachability.test.ts`
- `npm test -- src/lib/onboard/gateway-sandbox-reachability.test.ts src/lib/onboard/ollama-proxy-reachability.test.ts`

Attempted full local gates. `npm test`, `make check`, and `npx prek run --from-ref origin/main --to-ref HEAD` did not pass cleanly on this macOS workstation due failures outside the touched reachability files, mostly coverage-run per-test timeouts. The touched reachability tests passed in focused runs and during larger CLI coverage runs.

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: stevenrick <srick@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Firewall command generation tightened: when gateway IP is available, suggested rules target that specific gateway; otherwise they fall back to subnet-to-any or dynamic subnet resolution.

* **Tests**
  * Unit tests expanded to cover both gateway-present and gateway-missing scenarios, validating specific and fallback firewall rule outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3533)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->