### PR TITLE
fix(uninstall): clean Linux gateway state dir on uninstall (#3535)

### DIFF
--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -585,6 +585,7 @@ function executePlan(plan: UninstallPlan, paths: UninstallPaths, options: Uninst
       if (options.keepOpenShell) runtime.log("Keeping OpenShell binaries as requested.");
       else for (const target of paths.openshellInstallPaths) removeFileWithOptionalSudo(target, runtime);
       removePath(paths.nemoclawStateDir, runtime);
+      removePath(paths.gatewayLocalStateDir, runtime);
       removePath(paths.openshellConfigDir, runtime);
       removePath(paths.nemoclawConfigDir, runtime);
     }

--- a/src/lib/domain/uninstall/paths.test.ts
+++ b/src/lib/domain/uninstall/paths.test.ts
@@ -44,8 +44,18 @@ describe("uninstall paths", () => {
     const paths = defaultUninstallPaths({ home: "/home/test" });
     expect(uninstallStatePaths(paths)).toEqual([
       path.join("/home/test", ".nemoclaw"),
+      path.join("/home/test", ".local", "state", "nemoclaw"),
       path.join("/home/test", ".config", "openshell"),
       path.join("/home/test", ".config", "nemoclaw"),
     ]);
+  });
+  it("#3456: exposes the Linux Docker-driver gateway state dir so uninstall can clean it", () => {
+    // ~/.local/state/nemoclaw/ holds the openshell-gateway PID file, SQLite
+    // database, audit log, and vm-driver/ state. Documented as
+    // NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR in docs/reference/commands.md.
+    // Before this fix, uninstall left it behind (#3456 hulynn comment).
+    const paths = defaultUninstallPaths({ home: "/home/test" });
+    expect(paths.gatewayLocalStateDir).toBe(path.join("/home/test", ".local", "state", "nemoclaw"));
+    expect(uninstallStatePaths(paths)).toContain(path.join("/home/test", ".local", "state", "nemoclaw"));
   });
 });

--- a/src/lib/domain/uninstall/paths.ts
+++ b/src/lib/domain/uninstall/paths.ts
@@ -32,6 +32,7 @@ export interface UninstallPaths {
   nemoclawConfigDir: string;
   nemoclawShimPath: string;
   nemoclawStateDir: string;
+  gatewayLocalStateDir: string;
   openshellConfigDir: string;
   openshellInstallPaths: string[];
   repoRoot: string;
@@ -57,6 +58,7 @@ export function defaultUninstallPaths(options: UninstallPathOptions): UninstallP
     nemoclawConfigDir: path.join(options.home, ".config", "nemoclaw"),
     nemoclawShimPath: path.join(options.home, ".local", "bin", "nemoclaw"),
     nemoclawStateDir: path.join(options.home, ".nemoclaw"),
+    gatewayLocalStateDir: path.join(options.home, ".local", "state", "nemoclaw"),
     openshellConfigDir: path.join(options.home, ".config", "openshell"),
     openshellInstallPaths: openshellInstallPathsForBinDirs(["/usr/local/bin", xdgBinHome]),
     repoRoot: options.repoRoot || path.resolve(__dirname, "..", "..", "..", ".."),
@@ -73,6 +75,6 @@ export function defaultUninstallPaths(options: UninstallPathOptions): UninstallP
   };
 }
 
-export function uninstallStatePaths(paths: Pick<UninstallPaths, "nemoclawConfigDir" | "nemoclawStateDir" | "openshellConfigDir">): string[] {
-  return [paths.nemoclawStateDir, paths.openshellConfigDir, paths.nemoclawConfigDir];
+export function uninstallStatePaths(paths: Pick<UninstallPaths, "nemoclawConfigDir" | "nemoclawStateDir" | "openshellConfigDir" | "gatewayLocalStateDir">): string[] {
+  return [paths.nemoclawStateDir, paths.gatewayLocalStateDir, paths.openshellConfigDir, paths.nemoclawConfigDir];
 }


### PR DESCRIPTION
## Summary

Adds `~/.local/state/nemoclaw/` to the uninstall plan so `nemoclaw uninstall` cleans the Linux Docker-driver gateway's state directory (pid file, SQLite db, audit log, `vm-driver/` state). Closes #3535 — the verified residual sub-bug #5c from #3456, which auto-closed when #3520 merged.

## Acceptance criteria mapping

| Clause from #3535 | Evidence |
|---|---|
| `~/.local/state/nemoclaw/` is removed by `nemoclaw uninstall` on Linux | `src/lib/actions/uninstall/run-plan.ts:588` adds `removePath(paths.gatewayLocalStateDir, runtime)` to the `executePlan` removal block |
| `paths.test.ts` confirms the path is in `uninstallStatePaths()` return | `src/lib/domain/uninstall/paths.test.ts` — new test `#3456: exposes the Linux Docker-driver gateway state dir so uninstall can clean it` |
| No regression in existing uninstall tests | `npx vitest run src/lib/domain/uninstall/paths.test.ts src/lib/domain/uninstall/plan.test.ts src/lib/actions/uninstall/run-plan.test.ts` — 22 pass (1 new + 21 existing) |

## Behavior matrix

| Before | After |
|---|---|
| `uninstallStatePaths()` returns 3 dirs: `~/.nemoclaw`, `~/.config/openshell`, `~/.config/nemoclaw` | Returns 4: adds `~/.local/state/nemoclaw` |
| `executePlan` removes 3 of 4 NemoClaw-owned dirs; leaves Linux gateway state behind | Removes all 4 |
| `defaultUninstallPaths()` does not surface `gatewayLocalStateDir` | Surfaces it (matches `NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR` doc) |

## Test plan

```
npm run typecheck:cli
npx vitest run src/lib/domain/uninstall/paths.test.ts src/lib/domain/uninstall/plan.test.ts src/lib/actions/uninstall/run-plan.test.ts
```

Result: 22/22 pass.

## Notes for reviewers

- Path source-of-truth: `docs/reference/commands.md:1150` documents `NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR` as `~/.local/state/nemoclaw/openshell-docker-gateway`. The parent dir (`~/.local/state/nemoclaw/`) is what we own; cleaning the parent removes the gateway dir + `vm-driver/` + future siblings.
- The `Pick<>` on `uninstallStatePaths` was extended to include the new field; existing callers in `executePlan` already pass full `UninstallPaths` so they pick it up automatically.
- Out of scope: sub-bug #5d (`.openshell-installed-version`). My follow-up comment on #3456 explains — no source in NemoClaw writes that sentinel on current `main`, so filing a speculative fix isn't appropriate yet.

Closes #3535
Refs #3456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstall now also removes the Linux gateway local state directory, ensuring more complete cleanup on uninstall.

* **Tests**
  * Added a regression test to verify the gateway local state directory is exposed and included in uninstall cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3536)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->