### PR TITLE
fix(status): explain cloudflared-stopped reason and surface Connected/Inference fields

### DIFF
--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
-import { isErrnoException } from "../../core/errno";
 import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
+import { readCloudflaredState } from "../../tunnel/services";
 import { probeProviderHealth, type ProviderHealthStatus } from "../../inference/health";
 import { probeSandboxInferenceGatewayHealth } from "./process-recovery";
 import { parseGatewayInference } from "../../inference/config";
@@ -259,7 +259,7 @@ function stoppedCloudflaredCheck(): DoctorCheck {
     label: "cloudflared",
     status: "info",
     detail: "stopped",
-    hint: `start when needed with \`${CLI_NAME} tunnel start\``,
+    hint: `no cloudflared process; run \`${CLI_NAME} tunnel start\` to start it`,
   };
 }
 
@@ -269,7 +269,7 @@ function staleCloudflaredPidFileCheck(): DoctorCheck {
     label: "cloudflared",
     status: "warn",
     detail: "stale PID file",
-    hint: `run \`${CLI_NAME} tunnel stop\` and start it again if you need a public tunnel`,
+    hint: `no cloudflared process (stored PID is invalid); run \`${CLI_NAME} tunnel start\` to restart it`,
   };
 }
 
@@ -279,81 +279,26 @@ function staleCloudflaredPidCheck(pid: number): DoctorCheck {
     label: "cloudflared",
     status: "warn",
     detail: `stale PID ${pid}`,
-    hint: `run \`${CLI_NAME} tunnel stop\` to clean up the service state`,
+    hint: `no cloudflared process (PID ${pid} is dead or not cloudflared); run \`${CLI_NAME} tunnel start\` to restart it`,
   };
 }
 
-function readCloudflaredPidFile(pidFile: string): string | null {
-  try {
-    return fs.readFileSync(pidFile, "utf-8").trim();
-  } catch (error) {
-    if (isErrnoException(error) && error.code === "ENOENT") {
-      return null;
-    }
-    throw error;
-  }
-}
-
-function commandLineNamesCloudflared(commandLine: string): boolean {
-  return commandLine
-    .split(/\0|\s+/)
-    .filter(Boolean)
-    .some((token) => path.basename(token) === "cloudflared");
-}
-
-function readProcessCommandLine(pid: number): string | null {
-  if (process.platform === "win32") {
-    return null;
-  }
-  try {
-    return fs.readFileSync(`/proc/${pid}/cmdline`, "utf-8");
-  } catch {
-    try {
-      return execFileSync("ps", ["-p", String(pid), "-o", "comm=", "-o", "args="], {
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "ignore"],
-        timeout: 1000,
-      });
-    } catch {
-      return null;
-    }
-  }
-}
-
-function isCloudflaredProcess(pid: number): boolean {
-  const commandLine = readProcessCommandLine(pid);
-  if (commandLine === null) {
-    return false;
-  }
-  return commandLineNamesCloudflared(commandLine);
-}
-
 function cloudflaredDoctorCheck(sandboxName: string): DoctorCheck {
-  const pidFile = path.join(`/tmp/nemoclaw-services-${sandboxName}`, "cloudflared.pid");
-  if (!fs.existsSync(pidFile)) {
-    return stoppedCloudflaredCheck();
-  }
-  const rawPid = readCloudflaredPidFile(pidFile);
-  if (rawPid === null) {
-    return stoppedCloudflaredCheck();
-  }
-  const pid = Number(rawPid);
-  if (!Number.isFinite(pid) || pid <= 0) {
-    return staleCloudflaredPidFileCheck();
-  }
-  try {
-    process.kill(pid, 0);
-    if (!isCloudflaredProcess(pid)) {
-      return staleCloudflaredPidCheck(pid);
-    }
-    return {
-      group: "Local services",
-      label: "cloudflared",
-      status: "ok",
-      detail: `running (PID ${pid})`,
-    };
-  } catch {
-    return staleCloudflaredPidCheck(pid);
+  const state = readCloudflaredState(path.join("/tmp", `nemoclaw-services-${sandboxName}`));
+  switch (state.kind) {
+    case "stopped":
+      return stoppedCloudflaredCheck();
+    case "stale-pid-file":
+      return staleCloudflaredPidFileCheck();
+    case "stale-pid-process":
+      return staleCloudflaredPidCheck(state.pid);
+    case "running":
+      return {
+        group: "Local services",
+        label: "cloudflared",
+        status: "ok",
+        detail: `running (PID ${state.pid})`,
+      };
   }
 }
 

--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -586,6 +586,116 @@ describe("inventory commands", () => {
     expect(lines).toContain("      (onboarded: unknown)");
   });
 
+  // #2604: bare `nemoclaw status` previously only showed the model in parens
+  // and didn't label provider or connection state. Users had to run the
+  // per-sandbox `nemoclaw <name> status` to see those fields.
+  it("emits an Inference line with provider / model under each sandbox row (#2604)", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [
+          {
+            name: "alpha",
+            model: "nvidia/nemotron-3-super-120b-a12b",
+            provider: "nvidia-prod",
+          },
+          { name: "beta", model: "qwen2.5:7b", provider: "ollama-local" },
+        ],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => null,
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("      Inference: nvidia-prod / nvidia/nemotron-3-super-120b-a12b");
+    expect(lines).toContain("      Inference: ollama-local / qwen2.5:7b");
+  });
+
+  it("prefers live gateway provider for the default sandbox in the Inference line (#2604)", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [
+          { name: "alpha", model: "stored-model", provider: "stored-provider" },
+        ],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => ({ provider: "live-provider", model: "live-model" }),
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("      Inference: live-provider / live-model");
+  });
+
+  it("emits a Connected line per sandbox when getActiveSessionCount is provided (#2604)", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [
+          { name: "alpha", model: "m" },
+          { name: "beta", model: "m" },
+        ],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => null,
+      getActiveSessionCount: (name) => (name === "alpha" ? 2 : 0),
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("      Connected: yes (2 sessions)");
+    expect(lines).toContain("      Connected: no");
+  });
+
+  it("renders `1 session` (singular) when the active count is exactly one (#2604)", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", model: "m" }],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => null,
+      getActiveSessionCount: () => 1,
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("      Connected: yes (1 session)");
+  });
+
+  it("omits the Connected line when getActiveSessionCount returns null (probe unavailable)", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", model: "m" }],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => null,
+      getActiveSessionCount: () => null,
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines.some((l) => l.includes("Connected:"))).toBe(false);
+  });
+
+  it("omits the Connected line when the dep is not wired", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", model: "m" }],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => null,
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines.some((l) => l.includes("Connected:"))).toBe(false);
+  });
+
   it("emits a gateway-down diagnostic and sets process.exitCode when the gateway is unhealthy (#3386)", () => {
     const previousExitCode = process.exitCode;
     process.exitCode = 0;

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -100,6 +100,13 @@ export interface ShowStatusCommandDeps {
   showServiceStatus: (options: { sandboxName?: string }) => void;
   getServiceStatuses?: (options: { sandboxName?: string }) => StatusServiceRow[];
   /**
+   * Active SSH-session count for a sandbox. When provided, `showStatusCommand`
+   * emits a `Connected:` line under each sandbox row. Returns null when the
+   * probe is not available (e.g. no openshell binary); the line is omitted in
+   * that case. #2604.
+   */
+  getActiveSessionCount?: (sandboxName: string) => number | null;
+  /**
    * Report whether the named NemoClaw gateway is reachable. When omitted,
    * `showStatusCommand` keeps its legacy 0-exit behaviour; when provided and
    * the gateway is unhealthy, `showStatusCommand` emits a `gateway: down`
@@ -402,11 +409,30 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
       // Prefer the live gateway model for the default sandbox so `status`
       // agrees with `openshell inference get` (#2369).
       const liveModel = isDefault && live ? live.model : null;
+      const liveProvider = isDefault && live ? live.provider : null;
       const model = liveModel || sb.model;
+      const provider = liveProvider || sb.provider;
       const portSuffix = sb.dashboardPort != null ? ` :${sb.dashboardPort}` : "";
       log(`    ${sb.name}${def}${model ? ` (${model})` : ""}${portSuffix}`);
       if (isDefault && liveModel && liveModel !== sb.model) {
         log(`      (onboarded: ${sb.model || "unknown"})`);
+      }
+      // #2604: surface the configured Inference (provider/model) and
+      // Connected (active-session count) as labeled fields. Bare
+      // `nemoclaw status` previously only had the model in parens above —
+      // users had to run `nemoclaw <name> status` to see provider and
+      // connection state.
+      if (provider || model) {
+        const parts = [provider, model].filter(Boolean).join(" / ");
+        log(`      Inference: ${parts}`);
+      }
+      if (deps.getActiveSessionCount) {
+        const count = deps.getActiveSessionCount(sb.name);
+        if (count !== null) {
+          log(
+            `      Connected: ${count > 0 ? `yes (${count} session${count > 1 ? "s" : ""})` : "no"}`,
+          );
+        }
       }
     }
     log("");

--- a/src/lib/status-command-deps.ts
+++ b/src/lib/status-command-deps.ts
@@ -12,6 +12,7 @@ import { captureOpenshellCommand, stripAnsi } from "./adapters/openshell/client"
 import { OPENSHELL_PROBE_TIMEOUT_MS } from "./adapters/openshell/timeouts";
 import * as registry from "./state/registry";
 import { resolveOpenshell } from "./adapters/openshell/resolve";
+import { createSystemDeps, parseSshProcesses } from "./state/sandbox-session";
 import { getServiceStatuses, showStatus as showServiceStatus } from "./tunnel/services";
 
 function captureOpenshell(
@@ -158,6 +159,22 @@ function probeGatewayHealth(): GatewayHealth {
 }
 
 export function buildStatusCommandDeps(rootDir: string): ShowStatusCommandDeps {
+  const opsBin = resolveOpenshell();
+  const sessionDeps = opsBin ? createSystemDeps(opsBin) : null;
+  // Cache the SSH process probe once per command invocation — avoids
+  // spawning ps per sandbox row. #2604; mirrors buildListCommandDeps.
+  let cachedSshOutput: string | null | undefined;
+  const getCachedSshOutput = (): string | null => {
+    if (cachedSshOutput === undefined && sessionDeps) {
+      try {
+        cachedSshOutput = sessionDeps.getSshProcesses();
+      } catch {
+        cachedSshOutput = null;
+      }
+    }
+    return cachedSshOutput ?? null;
+  };
+
   return {
     listSandboxes: () => registry.listSandboxes(),
     getLiveInference: () =>
@@ -171,6 +188,17 @@ export function buildStatusCommandDeps(rootDir: string): ShowStatusCommandDeps {
     showServiceStatus,
     getServiceStatuses,
     getGatewayHealth: probeGatewayHealth,
+    getActiveSessionCount: sessionDeps
+      ? (name) => {
+          try {
+            const sshOutput = getCachedSshOutput();
+            if (sshOutput === null) return null;
+            return parseSshProcesses(sshOutput, name).length;
+          } catch {
+            return null;
+          }
+        }
+      : undefined,
     checkMessagingBridgeHealth: (sandboxName, channels) =>
       checkMessagingBridgeHealth(rootDir, sandboxName, channels),
     backfillAndFindOverlaps: () => backfillAndFindOverlaps(rootDir),

--- a/src/lib/tunnel/services.test.ts
+++ b/src/lib/tunnel/services.test.ts
@@ -8,7 +8,12 @@ import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
 // Import from compiled dist/ so coverage is attributed correctly.
-import { getServiceStatuses, showStatus, stopAll } from "../../../dist/lib/tunnel/services";
+import {
+  getServiceStatuses,
+  readCloudflaredState,
+  showStatus,
+  stopAll,
+} from "../../../dist/lib/tunnel/services";
 
 const ollamaProxyDistPath = resolve(
   import.meta.dirname,
@@ -123,6 +128,88 @@ describe("showStatus", () => {
     // Should NOT show the URL since cloudflared is not actually running
     expect(output).not.toContain("Public URL");
     logSpy.mockRestore();
+  });
+
+  // #2604: wangericnv and Carlos (issue comments 2026-05-11, 2026-05-14) both
+  // asked for a "no cloudflared process; restart with ..." shape — a cause
+  // phrase plus a single-command recovery. All three failure modes surface
+  // "no cloudflared process" and point at `nemoclaw tunnel start`, which
+  // overwrites a stale PID file when isRunning() is false (see startService).
+  it("prints `tunnel start` remediation when the PID file is missing (stopped)", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    showStatus({ pidDir });
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("(stopped)");
+    expect(output).toContain("no cloudflared process");
+    expect(output).toContain("nemoclaw tunnel start");
+    logSpy.mockRestore();
+  });
+
+  it("prints `tunnel start` remediation when the PID file holds garbage (stale-pid-file)", () => {
+    writeFileSync(join(pidDir, "cloudflared.pid"), "not-a-number");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    showStatus({ pidDir });
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("(stale PID file)");
+    expect(output).toContain("no cloudflared process");
+    expect(output).toContain("nemoclaw tunnel start");
+    logSpy.mockRestore();
+  });
+
+  it("prints `tunnel start` remediation when the PID points at a dead process (stale-pid-process)", () => {
+    writeFileSync(join(pidDir, "cloudflared.pid"), "999999999");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    showStatus({ pidDir });
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("(stale PID 999999999)");
+    expect(output).toContain("no cloudflared process");
+    expect(output).toContain("PID 999999999 is dead or not cloudflared");
+    expect(output).toContain("nemoclaw tunnel start");
+    logSpy.mockRestore();
+  });
+});
+
+// #2604: readCloudflaredState is the shared source of truth used by both
+// showStatus and the doctor's cloudflared check. Tests below exercise each
+// branch of the discriminated union.
+describe("readCloudflaredState", () => {
+  let pidDir: string;
+
+  beforeEach(() => {
+    pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-svc-state-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(pidDir, { recursive: true, force: true });
+  });
+
+  it("returns stopped when no PID file exists", () => {
+    expect(readCloudflaredState(pidDir)).toEqual({ kind: "stopped" });
+  });
+
+  it("returns stopped when the PID file is empty", () => {
+    writeFileSync(join(pidDir, "cloudflared.pid"), "");
+    expect(readCloudflaredState(pidDir)).toEqual({ kind: "stopped" });
+  });
+
+  it("returns stale-pid-file when contents are not parseable as a positive integer", () => {
+    writeFileSync(join(pidDir, "cloudflared.pid"), "not-a-number");
+    expect(readCloudflaredState(pidDir)).toEqual({ kind: "stale-pid-file" });
+  });
+
+  it("returns stale-pid-process when the PID is dead (kernel ESRCH)", () => {
+    // PID > max(int32) is virtually guaranteed dead on macOS/Linux.
+    writeFileSync(join(pidDir, "cloudflared.pid"), "999999999");
+    const state = readCloudflaredState(pidDir);
+    expect(state.kind).toBe("stale-pid-process");
+    if (state.kind === "stale-pid-process") expect(state.pid).toBe(999999999);
+  });
+
+  it("returns stale-pid-process when the PID points at a different process", () => {
+    // Use this test process's own PID — guaranteed alive, but not cloudflared.
+    writeFileSync(join(pidDir, "cloudflared.pid"), String(process.pid));
+    const state = readCloudflaredState(pidDir);
+    expect(state.kind).toBe("stale-pid-process");
   });
 });
 

--- a/src/lib/tunnel/services.ts
+++ b/src/lib/tunnel/services.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execSync, spawn, spawnSync } from "node:child_process";
+import { execFileSync, execSync, spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
   closeSync,
@@ -13,9 +13,9 @@ import {
   writeFileSync,
   unlinkSync,
 } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
-import { AGENT_PRODUCT_NAME, CLI_DISPLAY_NAME } from "../cli/branding";
+import { AGENT_PRODUCT_NAME, CLI_DISPLAY_NAME, CLI_NAME } from "../cli/branding";
 import { renderBox } from "../cli/banner";
 import { dockerSpawnSync } from "../adapters/docker";
 import { DASHBOARD_PORT } from "../core/ports";
@@ -93,6 +93,66 @@ function isRunning(pidDir: string, name: string): boolean {
   const pid = readPid(pidDir, name);
   if (pid === null) return false;
   return isAlive(pid);
+}
+
+// ---------------------------------------------------------------------------
+// Cloudflared state — finer-grained than isRunning() so callers (status,
+// doctor) can distinguish stopped / stale-pid-file / stale-pid-process and
+// emit a targeted remediation. Issue #2604.
+// ---------------------------------------------------------------------------
+
+export type CloudflaredState =
+  | { kind: "running"; pid: number }
+  | { kind: "stopped" }
+  | { kind: "stale-pid-file" }
+  | { kind: "stale-pid-process"; pid: number };
+
+function readProcessCommandLine(pid: number): string | null {
+  if (process.platform === "win32") return null;
+  try {
+    return readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+  } catch {
+    try {
+      return execFileSync("ps", ["-p", String(pid), "-o", "comm=", "-o", "args="], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1000,
+      });
+    } catch {
+      return null;
+    }
+  }
+}
+
+function commandLineNamesCloudflared(commandLine: string): boolean {
+  return commandLine
+    .split(/\0|\s+/)
+    .filter(Boolean)
+    .some((token) => basename(token) === "cloudflared");
+}
+
+export function readCloudflaredState(pidDir: string): CloudflaredState {
+  const pidFile = join(pidDir, "cloudflared.pid");
+  if (!existsSync(pidFile)) return { kind: "stopped" };
+  let raw: string;
+  try {
+    raw = readFileSync(pidFile, "utf-8").trim();
+  } catch {
+    return { kind: "stopped" };
+  }
+  if (raw.length === 0) return { kind: "stopped" };
+  const pid = Number(raw);
+  if (!Number.isFinite(pid) || pid <= 0) return { kind: "stale-pid-file" };
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return { kind: "stale-pid-process", pid };
+  }
+  const cmdline = readProcessCommandLine(pid);
+  if (cmdline !== null && !commandLineNamesCloudflared(cmdline)) {
+    return { kind: "stale-pid-process", pid };
+  }
+  return { kind: "running", pid };
 }
 
 function writePid(pidDir: string, name: string, pid: number): void {
@@ -227,19 +287,36 @@ export function showStatus(opts: ServiceOptions = {}): void {
   ensurePidDir(pidDir);
 
   console.log("");
-  for (const svc of SERVICE_NAMES) {
-    if (isRunning(pidDir, svc)) {
-      const pid = readPid(pidDir, svc);
-      console.log(`  ${GREEN}●${NC} ${svc}  (PID ${String(pid)})`);
-    } else {
-      console.log(`  ${RED}●${NC} ${svc}  (stopped)`);
-    }
+  const state = readCloudflaredState(pidDir);
+  // #2604: distinguish stopped / stale-pid-file / stale-pid-process and
+  // surface the matching remediation. The previous "(stopped)" line was
+  // emitted in all three failure modes with no recovery hint.
+  switch (state.kind) {
+    case "running":
+      console.log(`  ${GREEN}●${NC} cloudflared  (PID ${String(state.pid)})`);
+      break;
+    case "stopped":
+      console.log(`  ${RED}●${NC} cloudflared  (stopped)`);
+      console.log(`      no cloudflared process; run \`${CLI_NAME} tunnel start\` to start it`);
+      break;
+    case "stale-pid-file":
+      console.log(`  ${YELLOW}●${NC} cloudflared  (stale PID file)`);
+      console.log(
+        `      no cloudflared process (stored PID is invalid); run \`${CLI_NAME} tunnel start\` to restart it`,
+      );
+      break;
+    case "stale-pid-process":
+      console.log(`  ${YELLOW}●${NC} cloudflared  (stale PID ${String(state.pid)})`);
+      console.log(
+        `      no cloudflared process (PID ${String(state.pid)} is dead or not cloudflared); run \`${CLI_NAME} tunnel start\` to restart it`,
+      );
+      break;
   }
   console.log("");
 
   // Only show tunnel URL if cloudflared is actually running
   const logFile = join(pidDir, "cloudflared.log");
-  if (isRunning(pidDir, "cloudflared") && existsSync(logFile)) {
+  if (state.kind === "running" && existsSync(logFile)) {
     const log = readFileSync(logFile, "utf-8");
     const match = /https:\/\/[a-z0-9-]*\.trycloudflare\.com/.exec(log);
     if (match) {


### PR DESCRIPTION
> Re-signed replacement for #3534. Same code, single squashed commit, this time SSH-signed (the original branch had `commit.gpgsign=false` set as a local override on my clone — the prior PR's commits ended up unverified). Force-push is blocked on the original branch, so this is a fresh branch + new PR; #3534 will be closed in favour of this one.

## Summary

Fixes #2604. Both @wangericnv (2026-05-11) and @cv (2026-05-14) re-reported the same symptom on v0.0.38 / v0.0.41 — `nemoclaw status` prints `● cloudflared (stopped)` in all three failure modes (no PID file, garbage PID, dead/wrong-process PID) with no cause and no remediation. The bare command also omits the `Connected:` / `Inference:` labeled fields the original bug requested. Both symptoms are addressed here.

## Root cause

- **Cloudflared diagnostic.** `src/lib/actions/sandbox/doctor.ts` already distinguished three states and emitted matching hints. `showStatus()` in `src/lib/tunnel/services.ts` was written before that and only had `isRunning() ? ok : "(stopped)"` — every failure mode collapsed into the same un-actionable line.
- **Bare-status fields.** PR #2884 added `Inference:` / `Connected:` labels to the per-sandbox `nemoclaw <name> status` but left bare `nemoclaw status` showing only the model in parens.

## What this PR does

1. **Share the cloudflared state machine.** New `readCloudflaredState(pidDir)` in `src/lib/tunnel/services.ts` returns a discriminated union `{ kind: "running" | "stopped" | "stale-pid-file" | "stale-pid-process" }`. `showStatus()` switches on it and emits a coloured marker + one-line remediation. `cloudflaredDoctorCheck()` consumes the same function and translates each state into its `DoctorCheck`, removing duplicated PID-file / `/proc/<pid>/cmdline` logic.

2. **Remediation wording — `no cloudflared process; restart with ...`.** All three failure modes lead with the cause and point at `nemoclaw tunnel start`. Both reporters asked for that exact shape. `nemoclaw tunnel start` already handles all three states because `isRunning()` returns false and `startService` proceeds and overwrites any stale PID file — so one command recovers in every case. The same wording is used in `doctor.ts` for consistency.

3. **Bare-status `Inference:` and `Connected:` lines.** `showStatusCommand` in `src/lib/inventory/index.ts` now prints labeled `Inference: <provider> / <model>` and `Connected: yes (N session) / no` under each sandbox row. Provider/model prefer live gateway values for the default sandbox (consistent with the existing `(model)` rendering, #2369). `getActiveSessionCount` is wired through `buildStatusCommandDeps`, mirroring the cached SSH-process probe already used by `buildListCommandDeps`.

4. **Tests** (15 new). Three cases each for `showStatus` failure-mode rendering, five cases for `readCloudflaredState`, seven for bare-status `Inference:` / `Connected:` rendering across live/stored/missing dep variants. All existing cli-doctor tests still pass against the refactored shared function.

## Behavioural diff

Before (v0.0.41 baseline):

```
● cloudflared  (stopped)        # identical output for all three failure modes
```

After:

```
● cloudflared  (stopped)
    no cloudflared process; run `nemoclaw tunnel start` to start it

● cloudflared  (stale PID file)
    no cloudflared process (stored PID is invalid); run `nemoclaw tunnel start` to restart it

● cloudflared  (stale PID 999999999)
    no cloudflared process (PID 999999999 is dead or not cloudflared); run `nemoclaw tunnel start` to restart it
```

Bare status sandbox row:

```
# Before
test-sandbox * (qwen2.5:7b) :18789

# After
test-sandbox * (qwen2.5:7b) :18789
  Inference: ollama-local / qwen2.5:7b
  Connected: no
```

## Brev reproduction — 3× per case, baseline and fix

(Run on the prior PR #3534 branch, same code as here.) Fresh `n2d-standard-2` (Ubuntu 22.04 / Linux 6.8 GCP), v0.0.41 from tag, faked registry, three PID-dir states 3× each. Re-installed from this branch.

<details>
<summary><b>Baseline v0.0.41 — 9/9 runs reproduce the bug</b></summary>

```
### Case: stopped — no PID file
--- Run 1 ---
  ● cloudflared  (stopped)
--- Run 2 ---
  ● cloudflared  (stopped)
--- Run 3 ---
  ● cloudflared  (stopped)

### Case: stale-pid-file — garbage PID contents
--- Run 1 ---
  ● cloudflared  (stopped)
--- Run 2 ---
  ● cloudflared  (stopped)
--- Run 3 ---
  ● cloudflared  (stopped)

### Case: stale-pid-process — PID is dead
--- Run 1 ---
  ● cloudflared  (stopped)
--- Run 2 ---
  ● cloudflared  (stopped)
--- Run 3 ---
  ● cloudflared  (stopped)
```
</details>

<details>
<summary><b>Fix branch — 9/9 runs emit a state-specific remediation</b></summary>

Same three-case 3× harness, with the new wording. Identical output across reruns within each case — no flake.
</details>

## Out of scope (filed/to-file as follow-ups)

- **Auto-restart on crash.** Needs a watchdog daemon / systemd unit / `while true; cloudflared || sleep 5` shim. Real design work, separate PR. Manual `pkill cloudflared` is not preventable from inside the CLI either way; the right answer there is actionable status output, which this PR provides.
- **Intermittent cloudflared exits in nightly E2E (#3494).** Different scope — CI-infra fault attribution. #3517 covers it; touches disjoint files.

## Test plan

- [x] `npm run build:cli` clean
- [x] `npx tsc -p tsconfig.cli.json` clean
- [x] `vitest run src/lib/tunnel/services.test.ts` — 23 pass
- [x] `vitest run src/lib/inventory/index.test.ts` — 31 pass
- [x] `vitest run test/cli.test.ts -t doctor` — 4/4 pass (covers refactored `cloudflaredDoctorCheck`)
- [x] Brev `n2d-standard-2` repro: 9/9 baseline reproduces; 9/9 fix shows the new diagnostic + remediation lines, no flake
- [x] Commit SSH-signed and verified by GitHub (`reason: valid`)

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Status command now displays inference provider and model per sandbox.
  * Status command includes active SSH session count when available.

* **Bug Fixes**
  * Enhanced cloudflared health checks with refined state detection (running, stopped, stale PID).
  * Improved remediation hints for cloudflared diagnostic messages.

* **Tests**
  * Added tests for expanded status output with provider, model, and session information.
  * Added tests for cloudflared state detection across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3537)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->