### PR TITLE
fix(e2e): link advisor nightly dispatch runs

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -53,6 +53,8 @@
 # Only runs on schedule and manual dispatch — never on PRs (secret protection).
 
 name: E2E / Nightly
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch' && inputs.advisor_dispatch_id != '' && format('E2E / Nightly ({0})', inputs.advisor_dispatch_id) || 'E2E / Nightly' }}
 
 on:
   schedule:
@@ -95,6 +97,11 @@ on:
         default: ""
       pr_number:
         description: Optional PR number for selective-dispatch result comments.
+        required: false
+        type: string
+        default: ""
+      advisor_dispatch_id:
+        description: Optional correlation ID from e2e-advisor auto-dispatch.
         required: false
         type: string
         default: ""

--- a/test/e2e-advisor-dispatch.test.ts
+++ b/test/e2e-advisor-dispatch.test.ts
@@ -77,6 +77,8 @@ describe("E2E advisor auto-dispatch planning", () => {
       env: {
         GITHUB_EVENT_NAME: "pull_request",
         GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+        GITHUB_RUN_ID: "456789",
+        GITHUB_RUN_ATTEMPT: "2",
       },
     });
 
@@ -86,7 +88,9 @@ describe("E2E advisor auto-dispatch planning", () => {
       jobs: "network-policy-e2e",
       target_ref: "abc123def456",
       pr_number: "123",
+      advisor_dispatch_id: "advisor-123-456789-2",
     });
+    expect(plan.advisorDispatchId).toBe("advisor-123-456789-2");
   });
 
   it("plans dispatch for allowlisted authors whose private org membership appears as contributor", () => {
@@ -187,11 +191,13 @@ describe("E2E advisor auto-dispatch planning", () => {
         jobs: "network-policy-e2e,cloud_e2e",
         target_ref: "abc123def456",
         pr_number: "123",
+        advisor_dispatch_id: "advisor-123-456789",
       }),
     ).toEqual({
       jobs: "network-policy-e2e,cloud_e2e",
       target_ref: "abc123def456",
       pr_number: "123",
+      advisor_dispatch_id: "advisor-123-456789",
     });
   });
 
@@ -237,6 +243,12 @@ describe("E2E advisor auto-dispatch planning", () => {
       jobs: "network-policy-e2e",
       target_ref: "abc123def456",
       pr_number: "123abc",
+    },
+    {
+      jobs: "network-policy-e2e",
+      target_ref: "abc123def456",
+      pr_number: "123",
+      advisor_dispatch_id: "advisor/123",
     },
   ])("rejects unsafe dispatch inputs %#", (inputs) => {
     expect(() => validateDispatchInputs(inputs)).toThrow(/Refusing to dispatch unsafe/);

--- a/tools/e2e-advisor/comment.mts
+++ b/tools/e2e-advisor/comment.mts
@@ -29,6 +29,7 @@ type DispatchResult = {
   jobs?: string[];
   workflow?: string;
   targetRef?: string;
+  runUrl?: string;
   reason?: string;
 };
 
@@ -176,7 +177,8 @@ function renderAutoDispatch(dispatch: DispatchResult | undefined): string {
       : "_unknown_";
     const workflow = dispatch.workflow ? ` via \`${dispatch.workflow}\`` : "";
     const target = dispatch.targetRef ? ` at \`${dispatch.targetRef}\`` : "";
-    return `\n\n**Auto-dispatched E2E:** ${jobs}${workflow}${target}`;
+    const run = dispatch.runUrl ? ` — [nightly run](${dispatch.runUrl})` : "";
+    return `\n\n**Auto-dispatched E2E:** ${jobs}${workflow}${target}${run}`;
   }
   if (dispatch.status === "failed") {
     return `\n\n**Auto-dispatch:** failed — ${dispatch.reason || "unknown error"}`;

--- a/tools/e2e-advisor/dispatch.mts
+++ b/tools/e2e-advisor/dispatch.mts
@@ -44,6 +44,7 @@ type DispatchInputs = {
   jobs: string;
   target_ref: string;
   pr_number: string;
+  advisor_dispatch_id?: string;
 };
 
 type DispatchPlan = {
@@ -59,6 +60,9 @@ type DispatchPlan = {
   dispatchableJobCount?: number;
   prNumber?: number;
   targetRef?: string;
+  advisorDispatchId?: string;
+  runId?: number;
+  runUrl?: string;
   authorAssociation?: string;
   authorLogin?: string;
   allowedAuthorAssociations?: string[];
@@ -117,10 +121,24 @@ async function main(): Promise<void> {
           inputs: plan.inputs,
           token,
         });
+        let run: { id: number; url: string } | undefined;
+        try {
+          run = await findDispatchedWorkflowRun({
+            repo: plan.repository || "",
+            workflow: plan.workflow,
+            ref: plan.ref,
+            advisorDispatchId: plan.advisorDispatchId || "",
+            token,
+          });
+        } catch (error: unknown) {
+          console.warn(`Could not look up dispatched nightly run: ${error instanceof Error ? error.message : String(error)}`);
+        }
         output = {
           ...plan,
           status: "dispatched",
           reason: `Dispatched ${plan.workflow} for ${plan.jobs?.length || 0} required E2E job(s)`,
+          runId: run?.id,
+          runUrl: run?.url,
         };
       }
     }
@@ -296,10 +314,12 @@ export function planAutoDispatch({
 
   const targetRef = pr.head?.sha || pr.head?.ref || "";
   const dispatchRef = env.E2E_ADVISOR_AUTO_DISPATCH_REF || pr.base?.ref || DEFAULT_DISPATCH_REF;
+  const advisorDispatchId = buildAdvisorDispatchId(pr.number, env);
   const inputs = {
     jobs: jobs.join(","),
     target_ref: targetRef,
     pr_number: String(pr.number || ""),
+    advisor_dispatch_id: advisorDispatchId,
   };
 
   return {
@@ -314,6 +334,7 @@ export function planAutoDispatch({
     dispatchableJobCount: dispatchableJobs.length,
     prNumber: pr.number,
     targetRef,
+    advisorDispatchId,
     authorAssociation,
     authorLogin,
     allowedAuthorAssociations: allowedAssociations,
@@ -373,6 +394,12 @@ function normalizeLogin(login: string): string {
   return login.trim().toLowerCase();
 }
 
+function buildAdvisorDispatchId(prNumber: number | undefined, env: StringMap): string {
+  const runId = env.GITHUB_RUN_ID || "local";
+  const attempt = env.GITHUB_RUN_ATTEMPT ? `-${env.GITHUB_RUN_ATTEMPT}` : "";
+  return `advisor-${prNumber || "unknown"}-${runId}${attempt}`;
+}
+
 async function dispatchWorkflow({
   repo,
   workflow,
@@ -414,6 +441,69 @@ async function dispatchWorkflow({
   }
 }
 
+type WorkflowRunSearchResult = {
+  workflow_runs?: Array<{
+    id?: number;
+    html_url?: string;
+    display_title?: string;
+    event?: string;
+  }>;
+};
+
+async function findDispatchedWorkflowRun({
+  repo,
+  workflow,
+  ref,
+  advisorDispatchId,
+  token,
+}: {
+  repo: string;
+  workflow: string;
+  ref: string;
+  advisorDispatchId: string;
+  token: string;
+}): Promise<{ id: number; url: string } | undefined> {
+  if (!advisorDispatchId) return undefined;
+
+  const safeRepo = validateRepository(repo);
+  const safeWorkflow = validateWorkflowFile(workflow);
+  const safeRef = validateGitRef(ref);
+  const params = new URLSearchParams({
+    event: "workflow_dispatch",
+    branch: safeRef,
+    per_page: "20",
+  });
+  const runsUrl = `https://api.github.com/repos/${safeRepo}/actions/workflows/${encodeURIComponent(safeWorkflow)}/runs?${params}`;
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    if (attempt > 0) await delay(2000);
+    const response = await fetch(runsUrl, {
+      headers: {
+        "Accept": "application/vnd.github+json",
+        "Authorization": `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "nemoclaw-e2e-advisor-dispatcher",
+      },
+    });
+    if (!response.ok) {
+      console.warn(`Could not look up dispatched nightly run: GitHub API HTTP ${response.status}`);
+      return undefined;
+    }
+
+    const data = await response.json() as WorkflowRunSearchResult;
+    const match = data.workflow_runs?.find(
+      (run) => run.event === "workflow_dispatch" && run.display_title?.includes(advisorDispatchId),
+    );
+    if (match?.id && match.html_url) return { id: match.id, url: match.html_url };
+  }
+
+  return undefined;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function validateRepository(repo: string): string {
   if (repo !== "NVIDIA/NemoClaw") {
     throw new Error("Refusing to dispatch outside NVIDIA/NemoClaw");
@@ -441,10 +531,15 @@ export function validateDispatchInputs(inputs: DispatchInputs): DispatchInputs {
   if (!/^\d+$/.test(inputs.pr_number)) {
     throw new Error("Refusing to dispatch unsafe pr_number input");
   }
+  const advisorDispatchId = inputs.advisor_dispatch_id;
+  if (advisorDispatchId !== undefined && !/^[A-Za-z0-9_-]{1,100}$/.test(advisorDispatchId)) {
+    throw new Error("Refusing to dispatch unsafe advisor_dispatch_id input");
+  }
   return {
     jobs: jobs.join(","),
     target_ref: inputs.target_ref,
     pr_number: inputs.pr_number,
+    ...(advisorDispatchId ? { advisor_dispatch_id: advisorDispatchId } : {}),
   };
 }
 
@@ -465,6 +560,8 @@ function renderDispatchSummary(result: DispatchPlan): string {
   if (result.workflow) lines.push(`Workflow: \`${result.workflow}\``);
   if (result.ref) lines.push(`Dispatch ref: \`${result.ref}\``);
   if (result.targetRef) lines.push(`Target ref: \`${result.targetRef}\``);
+  if (result.advisorDispatchId) lines.push(`Trace ID: \`${result.advisorDispatchId}\``);
+  if (result.runUrl) lines.push(`Nightly run: ${result.runUrl}`);
   if (Array.isArray(result.jobs) && result.jobs.length > 0) {
     lines.push(`Jobs: ${result.jobs.map((job) => `\`${job}\``).join(", ")}`);
   }


### PR DESCRIPTION
## Summary
Adds a lightweight correlation ID to e2e-advisor nightly workflow dispatches so the advisor can find and link the exact dispatched nightly run. The advisor summary and PR comment now include that run link when lookup succeeds.

## Changes
- Add an optional `advisor_dispatch_id` workflow input and include it in `nightly-e2e.yaml` run names.
- Pass a generated advisor dispatch ID through `tools/e2e-advisor/dispatch.mts` and poll recent nightly runs for the matching run URL after dispatch.
- Surface the nightly run URL in advisor dispatch summaries and PR comments.
- Update advisor dispatch tests for the new correlation input validation.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual E2E workflow dispatches now support optional dispatch ID tracking for improved run correlation
  * Auto-dispatch result comments now include direct links to triggered nightly test runs

* **Tests**
  * Enhanced E2E advisor dispatch test coverage for new dispatch ID validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3538)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->