### PR TITLE
fix(uninstall): kill orphan openshell-gateway host process on uninstall (#3516)

### DIFF
--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -619,4 +619,48 @@ describe("uninstall run plan", () => {
       "Destroyed gateway 'nemoclaw' skipped",
     );
   });
+
+  it("#3516: kills the orphan openshell-gateway host process during uninstall", () => {
+    // When the host glibc satisfies the gateway requirement, NemoClaw spawns
+    // /usr/local/bin/openshell-gateway directly without a container wrapper
+    // (see src/lib/onboard/docker-driver-gateway-launch.ts shouldUseContainerizedGateway).
+    // `openshell gateway destroy` does not terminate this host-process variant,
+    // so the process keeps binding port 8080 after uninstall. Uninstall must
+    // pgrep for the binary and SIGTERM/SIGKILL any survivors.
+    const logs: string[] = [];
+    const killed: number[] = [];
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: () => true,
+        env: { HOME: "/home/test", LOGNAME: "testuser" } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        isTty: false,
+        kill: (pid) => {
+          killed.push(pid);
+          return true;
+        },
+        log: (line) => logs.push(line),
+        rmSync: vi.fn(),
+        run: (command, args) => {
+          if (
+            command === "pgrep" &&
+            args[0] === "-f" &&
+            typeof args[1] === "string" &&
+            args[1].includes("openshell-gateway")
+          ) {
+            return ok("8888\n");
+          }
+          if (args[0] === "-f") return ok("");
+          if (args[0] === "-c") return ok("/fake/bin/tool\n");
+          return ok();
+        },
+        runDocker: () => ok(""),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(killed).toContain(8888);
+    expect(logs).toContain("Stopped openshell-gateway host process 8888");
+  });
 });

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -582,6 +582,7 @@ function executePlan(plan: UninstallPlan, paths: UninstallPaths, options: Uninst
         commandExists: runtime.commandExists,
       });
       stopOrphanedOpenShell(runtime);
+      stopMatchingPids("/openshell-gateway( |$)", runtime, "openshell-gateway host process");
       stopOllamaAuthProxy(paths, runtime);
     } else if (step.name === "OpenShell resources") {
       removeOpenShellResources(options, runtime);


### PR DESCRIPTION
## Summary

`nemoclaw uninstall --yes` left the host-process `openshell-gateway` running and bound to port 8080 on hosts where glibc satisfies the gateway requirement (Ubuntu 24.04 in the report). `openshell gateway destroy` only tears down the container-wrapped variant; the host-process needs a separate pgrep + SIGTERM/SIGKILL pass.

## Acceptance criteria mapping

| Clause from #3516 | Evidence |
|---|---|
| After uninstall, port 8080 is free | `src/lib/actions/uninstall/run-plan.ts:585` — new `stopMatchingPids("/openshell-gateway( \|$)", runtime, "openshell-gateway host process")` call in the "Stopping services" step terminates the listener |
| No `openshell-gateway` process running after uninstall | Same — `stopMatchingPids` already does SIGTERM with SIGKILL fallback (existing pattern, lines 230-235) |
| Regression-safe | `src/lib/actions/uninstall/run-plan.test.ts` — new test `#3516: kills the orphan openshell-gateway host process during uninstall`, plus all 16 existing tests pass |

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Container-wrapped gateway | killed by `openshell gateway destroy` | unchanged (still killed) |
| Host-process gateway (glibc ≥ requirement) | survives uninstall, holds :8080 | SIGTERM → SIGKILL via new pgrep pass |
| `pgrep` missing | n/a | warns and skips (existing `stopMatchingPids` behavior) |
| No orphan present | n/a | logs "No openshell-gateway host process found", no-op |

## Test plan

```
npx vitest run src/lib/actions/uninstall/run-plan.test.ts
```
17/17 pass.

## Notes for reviewers

- Pattern `"/openshell-gateway( |$)"` is an ERE that anchors to the binary as a path segment, not a substring — avoids false-positiving on `openshell-gateway.log` references in other process argv.
- Placed alongside the other process-stop helpers in the "Stopping services" step (sibling to `stopOrphanedOpenShell`) rather than inside `removeOpenShellResources`, so it runs even if the `openshell` CLI binary has already been removed in a partial-state scenario.
- The kill is unprivileged. If the gateway was launched via sudo (root-owned, as shown in the issue's `ps` output), the user needs to run `nemoclaw uninstall` with sudo — mirrors how `removeFileWithOptionalSudo` already handles root-owned `/usr/local/bin/openshell`.

Closes #3516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed uninstall process to properly terminate any remaining openshell-gateway host processes during service shutdown, ensuring complete cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3539)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->