### PR TITLE
fix(onboard): allow proc writes for Docker GPU patch

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5633,10 +5633,17 @@ async function createSandbox(
       ...reusableMessagingChannels,
     ]),
   ];
+  const useDockerGpuPatch = dockerGpuSandboxCreate.shouldUseDockerGpuPatchForCreate(
+    effectiveSandboxGpuConfig,
+    { dockerDriverGateway: isLinuxDockerDriverGatewayEnabled(), log: console.log },
+  );
   const initialSandboxPolicy = prepareInitialSandboxCreatePolicy(
     basePolicyPath,
     activeMessagingChannels,
-    { directGpu: effectiveSandboxGpuConfig.sandboxGpuEnabled },
+    {
+      directGpu: effectiveSandboxGpuConfig.sandboxGpuEnabled,
+      dockerGpuPatch: useDockerGpuPatch,
+    },
   );
   if (initialSandboxPolicy.cleanup) {
     process.on("exit", initialSandboxPolicy.cleanup);
@@ -5647,12 +5654,12 @@ async function createSandbox(
     );
   }
   if (effectiveSandboxGpuConfig.sandboxGpuEnabled) {
-    console.log("  Direct sandbox GPU enabled; allowing only /proc task comm writes.");
+    console.log(
+      useDockerGpuPatch
+        ? "  Direct sandbox GPU enabled; allowing /proc writes required by Docker GPU initialization."
+        : "  Direct sandbox GPU enabled; allowing OpenShell GPU policy enrichment.",
+    );
   }
-  const useDockerGpuPatch = dockerGpuSandboxCreate.shouldUseDockerGpuPatchForCreate(
-    effectiveSandboxGpuConfig,
-    { dockerDriverGateway: isLinuxDockerDriverGatewayEnabled(), log: console.log },
-  );
   const createArgs = [
     "--from",
     `${buildCtx}/Dockerfile`,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5633,17 +5633,14 @@ async function createSandbox(
       ...reusableMessagingChannels,
     ]),
   ];
-  const useDockerGpuPatch = dockerGpuSandboxCreate.shouldUseDockerGpuPatchForCreate(
-    effectiveSandboxGpuConfig,
-    { dockerDriverGateway: isLinuxDockerDriverGatewayEnabled(), log: console.log },
-  );
+  const { useDockerGpuPatch, logMessage: sandboxGpuLogMessage } =
+    dockerGpuSandboxCreate.resolveDockerGpuSandboxCreatePlan(effectiveSandboxGpuConfig, {
+      dockerDriverGateway: isLinuxDockerDriverGatewayEnabled(),
+    });
   const initialSandboxPolicy = prepareInitialSandboxCreatePolicy(
     basePolicyPath,
     activeMessagingChannels,
-    {
-      directGpu: effectiveSandboxGpuConfig.sandboxGpuEnabled,
-      dockerGpuPatch: useDockerGpuPatch,
-    },
+    { directGpu: effectiveSandboxGpuConfig.sandboxGpuEnabled, dockerGpuPatch: useDockerGpuPatch },
   );
   if (initialSandboxPolicy.cleanup) {
     process.on("exit", initialSandboxPolicy.cleanup);
@@ -5653,13 +5650,7 @@ async function createSandbox(
       `  Including policy preset(s) at sandbox boot: ${initialSandboxPolicy.appliedPresets.join(", ")}`,
     );
   }
-  if (effectiveSandboxGpuConfig.sandboxGpuEnabled) {
-    console.log(
-      useDockerGpuPatch
-        ? "  Direct sandbox GPU enabled; allowing /proc writes required by Docker GPU initialization."
-        : "  Direct sandbox GPU enabled; allowing OpenShell GPU policy enrichment.",
-    );
-  }
+  if (sandboxGpuLogMessage) console.log(sandboxGpuLogMessage);
   const createArgs = [
     "--from",
     `${buildCtx}/Dockerfile`,

--- a/src/lib/onboard/docker-gpu-patch.test.ts
+++ b/src/lib/onboard/docker-gpu-patch.test.ts
@@ -396,7 +396,7 @@ describe("docker-gpu-patch", () => {
     );
     expect(runOpenshell).toHaveBeenCalledWith(
       ["sandbox", "exec", "-n", "alpha", "--", "true"],
-      expect.objectContaining({ ignoreError: true }),
+      expect.objectContaining({ ignoreError: true, suppressOutput: true }),
     );
     const dockerRmCalls = dockerRm.mock.calls as unknown[][];
     const backupRmCall = dockerRmCalls.findIndex((call) =>

--- a/src/lib/onboard/docker-gpu-patch.ts
+++ b/src/lib/onboard/docker-gpu-patch.ts
@@ -658,7 +658,7 @@ function waitForOpenShellSandboxExec(
   while (Date.now() <= deadline) {
     const result = deps.runOpenshell(
       ["sandbox", "exec", "-n", sandboxName, "--", "true"],
-      { ignoreError: true, timeout: DOCKER_GPU_PATCH_TIMEOUT_MS },
+      { ignoreError: true, suppressOutput: true, timeout: DOCKER_GPU_PATCH_TIMEOUT_MS },
     );
     if (isZeroStatus(result)) return true;
     d.sleep(2);

--- a/src/lib/onboard/docker-gpu-sandbox-create.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create.ts
@@ -34,6 +34,11 @@ type DockerGpuSandboxConfig = {
   sandboxGpuDevice?: string | null;
 };
 
+type DockerGpuSandboxCreatePlan = {
+  useDockerGpuPatch: boolean;
+  logMessage: string | null;
+};
+
 export type DockerGpuSandboxCreatePatch = {
   maybeApplyDuringCreate: () => void;
   createFailureMessage: () => string | null;
@@ -142,4 +147,17 @@ export function shouldUseDockerGpuPatchForCreate(
     );
   }
   return enabled;
+}
+
+export function resolveDockerGpuSandboxCreatePlan(
+  config: DockerGpuSandboxConfig,
+  options: { dockerDriverGateway: boolean },
+): DockerGpuSandboxCreatePlan {
+  const useDockerGpuPatch = shouldUseDockerGpuPatchForCreate(config, options);
+  const logMessage = config.sandboxGpuEnabled
+    ? useDockerGpuPatch
+      ? "  Docker-driver GPU patch active; allowing /proc writes required by Docker GPU initialization."
+      : "  Direct sandbox GPU enabled; allowing OpenShell GPU policy enrichment."
+    : null;
+  return { useDockerGpuPatch, logMessage };
 }

--- a/src/lib/onboard/initial-policy.ts
+++ b/src/lib/onboard/initial-policy.ts
@@ -24,7 +24,14 @@ function isProcEntryOwnedByOpenShell(entry: string): boolean {
   return entry === PROC_PATH || entry === STALE_PROC_COMM_READ_WRITE_PATH;
 }
 
-export function buildDirectGpuPolicyYaml(basePolicy: string): string {
+type DirectGpuPolicyOptions = {
+  procReadWrite?: boolean;
+};
+
+export function buildDirectGpuPolicyYaml(
+  basePolicy: string,
+  options: DirectGpuPolicyOptions = {},
+): string {
   const parsed = YAML.parse(basePolicy);
   if (!parsed || typeof parsed !== "object") {
     throw new Error("Cannot prepare direct GPU sandbox policy; base policy is not a YAML mapping.");
@@ -41,6 +48,14 @@ export function buildDirectGpuPolicyYaml(basePolicy: string): string {
     ? fsPolicy.read_write.map((entry: unknown) => String(entry))
     : [];
   fsPolicy.read_write = readWrite.filter((entry: string) => !isProcEntryOwnedByOpenShell(entry));
+  if (options.procReadWrite && !fsPolicy.read_write.includes(PROC_PATH)) {
+    // Linux Docker-driver GPU patching recreates the container with GPU flags
+    // after `openshell sandbox create`, so OpenShell never sees `--gpu` and
+    // cannot add its native /proc GPU enrichment. Mirror that enrichment here
+    // for the patched path; without it Landlock denies the NVIDIA runtime's
+    // /proc/<pid>/task/<tid>/comm write even though Docker GPU access works.
+    fsPolicy.read_write.push(PROC_PATH);
+  }
   return YAML.stringify(parsed);
 }
 
@@ -93,10 +108,13 @@ export function buildDirectSandboxGpuProofCommands(
   ];
 }
 
-function prepareDirectGpuSandboxPolicy(basePolicyPath: string): InitialSandboxPolicy {
+function prepareDirectGpuSandboxPolicy(
+  basePolicyPath: string,
+  options: DirectGpuPolicyOptions = {},
+): InitialSandboxPolicy {
   const basePolicy = fs.readFileSync(basePolicyPath, "utf-8");
   const policyPath = secureTempFile("nemoclaw-gpu-policy", ".yaml");
-  fs.writeFileSync(policyPath, buildDirectGpuPolicyYaml(basePolicy), {
+  fs.writeFileSync(policyPath, buildDirectGpuPolicyYaml(basePolicy, options), {
     encoding: "utf-8",
     mode: 0o600,
   });
@@ -134,9 +152,13 @@ export function getNetworkPolicyNames(policyContent: string): Set<string> | null
 export function prepareInitialSandboxCreatePolicy(
   basePolicyPath: string,
   activeMessagingChannels: string[],
-  options: { directGpu?: boolean } = {},
+  options: { directGpu?: boolean; dockerGpuPatch?: boolean } = {},
 ): InitialSandboxPolicy {
-  const directGpuPolicy = options.directGpu ? prepareDirectGpuSandboxPolicy(basePolicyPath) : null;
+  const directGpuPolicy = options.directGpu
+    ? prepareDirectGpuSandboxPolicy(basePolicyPath, {
+        procReadWrite: options.dockerGpuPatch === true,
+      })
+    : null;
   const effectiveBasePolicyPath = directGpuPolicy?.policyPath || basePolicyPath;
   const cleanupFns = directGpuPolicy?.cleanup ? [directGpuPolicy.cleanup] : [];
   const requestedCreateTimePresets = [

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -60,7 +60,7 @@ type OnboardTestInternals = {
     },
     options?: { suppressGpuFlag?: boolean },
   ) => string[];
-  buildDirectGpuPolicyYaml: (basePolicy: string) => string;
+  buildDirectGpuPolicyYaml: (basePolicy: string, options?: { procReadWrite?: boolean }) => string;
   buildDirectSandboxGpuProofCommands: (sandboxName: string) => { label: string; args: string[] }[];
   classifySandboxCreateFailure: (output?: string) => { kind: string; uploadedToGateway: boolean };
   compactText: (value?: string) => string;
@@ -446,6 +446,22 @@ describe("onboard helpers", () => {
       expect(baseDoc.filesystem_policy.read_only).toContain("/proc");
       expect(gpuDoc.filesystem_policy.read_only).not.toContain("/proc");
       expect(gpuDoc.filesystem_policy.read_write).not.toContain("/proc");
+      expect(gpuDoc.filesystem_policy.read_write).not.toContain("/proc/self/task/*/comm");
+    },
+  );
+
+  it(
+    "adds /proc read-write when Docker GPU patch must own GPU enrichment",
+    () => {
+      const basePolicy = fs.readFileSync(
+        path.join(repoRoot, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"),
+        "utf-8",
+      );
+      const gpuPolicy = buildDirectGpuPolicyYaml(basePolicy, { procReadWrite: true });
+      const gpuDoc = YAML.parse(gpuPolicy);
+
+      expect(gpuDoc.filesystem_policy.read_only).not.toContain("/proc");
+      expect(gpuDoc.filesystem_policy.read_write).toContain("/proc");
       expect(gpuDoc.filesystem_policy.read_write).not.toContain("/proc/self/task/*/comm");
     },
   );

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -5521,7 +5521,7 @@ ${webSearchVerifySource}`;
       "utf-8",
     );
 
-    assert.match(source, /useDockerGpuPatch = dockerGpuSandboxCreate\.shouldUseDockerGpuPatchForCreate/);
+    assert.match(source, /resolveDockerGpuSandboxCreatePlan\(effectiveSandboxGpuConfig/);
     assert.match(source, /suppressGpuFlag: useDockerGpuPatch/);
     assert.match(source, /maybeApplyDuringCreate/);
     assert.match(source, /printDockerGpuReadinessFailure/);


### PR DESCRIPTION
## Summary
Allow the Linux Docker GPU patch path to mirror OpenShell's `/proc` GPU policy enrichment when NemoClaw recreates a sandbox container with GPU flags. This fixes DGX Spark installs where `nvidia-smi` succeeds but the direct GPU proof fails on `/proc/<pid>/task/<tid>/comm` with `Permission denied`.

## Changes
- Thread the Docker GPU patch decision into initial sandbox policy generation.
- Add `/proc` to `filesystem_policy.read_write` only for the Docker GPU patch path, while preserving the native OpenShell `--gpu` policy behavior.
- Add regression coverage for the Docker GPU patch policy shape.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU patch detection is now resolved during sandbox creation and emits conditional GPU-related log messages.
  * Initial sandbox policy generation can optionally allow /proc as read-write for certain GPU patch scenarios.

* **Improvements**
  * Supervisor exec readiness now suppresses execution output during the GPU patch probe.

* **Tests**
  * Added/updated tests for /proc read-write policy behavior and GPU patch decision logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3543)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->