### PR TITLE
test(cli): improve inventory domain command coverage

### DIFF
--- a/src/lib/actions/dev/npm-link-or-shim.test.ts
+++ b/src/lib/actions/dev/npm-link-or-shim.test.ts
@@ -6,8 +6,8 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
-import { DEV_SHIM_MARKER } from "../../domain/dev/npm-link-or-shim";
-import { runNpmLinkOrShim } from "./npm-link-or-shim";
+import { DEV_SHIM_MARKER } from "../../../../dist/lib/domain/dev/npm-link-or-shim";
+import { runNpmLinkOrShim } from "../../../../dist/lib/actions/dev/npm-link-or-shim";
 
 function setupRepo(): { binPath: string; homeDir: string; repoDir: string; tmpDir: string } {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dev-shim-action-"));

--- a/src/lib/actions/inference-set.test.ts
+++ b/src/lib/actions/inference-set.test.ts
@@ -27,12 +27,12 @@ vi.mock("../shields/audit", () => ({
   appendAuditEntry: vi.fn(),
 }));
 
+import type { InferenceSetDeps } from "./inference-set";
 import {
-  type InferenceSetDeps,
   patchHermesInferenceConfig,
   patchOpenClawInferenceConfig,
   runInferenceSet,
-} from "./inference-set";
+} from "../../../dist/lib/actions/inference-set";
 
 const OPENCLAW_TARGET: AgentConfigTarget = {
   agentName: "openclaw",

--- a/src/lib/actions/maintenance-action.test.ts
+++ b/src/lib/actions/maintenance-action.test.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+
+type MaintenanceModule = typeof import("../../../dist/lib/actions/maintenance");
+
+const maintenance = require("../../../dist/lib/actions/maintenance") as MaintenanceModule;
+const dockerImage = require("../../../dist/lib/adapters/docker/image") as typeof import("../../../dist/lib/adapters/docker/image");
+const openshellRuntime = require("../../../dist/lib/adapters/openshell/runtime") as typeof import("../../../dist/lib/adapters/openshell/runtime");
+const credentials = require("../../../dist/lib/credentials/store") as typeof import("../../../dist/lib/credentials/store");
+const registry = require("../../../dist/lib/state/registry") as typeof import("../../../dist/lib/state/registry");
+const sandboxState = require("../../../dist/lib/state/sandbox") as typeof import("../../../dist/lib/state/sandbox");
+
+const logs: string[] = [];
+const errors: string[] = [];
+
+beforeEach(() => {
+  logs.length = 0;
+  errors.length = 0;
+  vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+    logs.push(String(message ?? ""));
+  });
+  vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+    errors.push(String(message ?? ""));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("maintenance actions", () => {
+  it("reports when no registered sandboxes are available to back up", () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+
+    maintenance.backupAll();
+
+    expect(logs.join("\n")).toContain("No sandboxes registered");
+  });
+
+  it("backs up only live sandboxes and exits when a backup fails", () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+      output: "NAME\nalpha Ready\ngamma Ready\n",
+      status: 0,
+    });
+    vi.spyOn(sandboxState, "backupSandboxState").mockImplementation(((name: string) =>
+      name === "alpha"
+        ? {
+            backedUpDirs: ["memory"],
+            backedUpFiles: ["config"],
+            failedDirs: [],
+            failedFiles: [],
+            manifest: { backupPath: "/tmp/backup-alpha" },
+            success: true,
+          }
+        : {
+            backedUpDirs: [],
+            backedUpFiles: [],
+            failedDirs: ["memory"],
+            failedFiles: [],
+            manifest: null,
+            success: false,
+          }) as never);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    maintenance.backupAll();
+
+    expect(sandboxState.backupSandboxState).toHaveBeenCalledWith("alpha");
+    expect(sandboxState.backupSandboxState).not.toHaveBeenCalledWith("beta");
+    expect(sandboxState.backupSandboxState).toHaveBeenCalledWith("gamma");
+    expect(logs.join("\n")).toContain("1 backed up, 1 failed, 1 skipped");
+    expect(errors.join("\n")).toContain("gamma: backup failed");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("reports empty sandbox image inventory without registry lookup", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue("");
+    const registrySpy = vi.spyOn(registry, "listSandboxes");
+
+    await maintenance.garbageCollectImages({ yes: true });
+
+    expect(logs.join("\n")).toContain("No sandbox images found");
+    expect(registrySpy).not.toHaveBeenCalled();
+  });
+
+  it("dry-runs orphan sandbox image cleanup", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue(
+      "openshell/sandbox-from:used\t1GB\nopenshell/sandbox-from:old\t2GB\n",
+    );
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha", imageTag: "openshell/sandbox-from:used" }],
+    });
+    const rmi = vi.spyOn(dockerImage, "dockerRmi");
+
+    await maintenance.garbageCollectImages({ dryRun: true });
+
+    expect(logs.join("\n")).toContain("openshell/sandbox-from:old");
+    expect(logs.join("\n")).toContain("--dry-run: would remove 1 image");
+    expect(rmi).not.toHaveBeenCalled();
+  });
+
+  it("prompts and removes orphan sandbox images", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue("openshell/sandbox-from:old\t2GB\n");
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+    vi.spyOn(credentials, "prompt").mockResolvedValue("yes");
+    vi.spyOn(dockerImage, "dockerRmi").mockReturnValue({
+      error: undefined,
+      signal: null,
+      status: 0,
+      stderr: "",
+      stdout: "",
+    } as never);
+
+    await maintenance.garbageCollectImages({});
+
+    expect(credentials.prompt).toHaveBeenCalledWith(expect.stringContaining("Remove 1 orphaned image"));
+    expect(dockerImage.dockerRmi).toHaveBeenCalledWith(
+      "openshell/sandbox-from:old",
+      expect.objectContaining({ ignoreError: true, suppressOutput: true }),
+    );
+    expect(logs.join("\n")).toContain("Removed 1 orphaned image");
+  });
+});

--- a/src/lib/actions/sandbox/connect-args.test.ts
+++ b/src/lib/actions/sandbox/connect-args.test.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isSandboxConnectFlag,
+  parseSandboxConnectArgs,
+  printSandboxConnectHelp,
+} from "../../../../dist/lib/actions/sandbox/connect";
+
+describe("sandbox connect argument helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockExit() {
+    return vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code}`);
+    }) as typeof process.exit);
+  }
+
+  it("recognizes supported connect flags", () => {
+    expect(isSandboxConnectFlag("--probe-only")).toBe(true);
+    expect(isSandboxConnectFlag("--help")).toBe(true);
+    expect(isSandboxConnectFlag("-h")).toBe(true);
+    expect(isSandboxConnectFlag("--dangerously-skip-permissions")).toBe(true);
+    expect(isSandboxConnectFlag("--unknown")).toBe(false);
+    expect(isSandboxConnectFlag(undefined)).toBe(false);
+  });
+
+  it("parses probe-only options", () => {
+    expect(parseSandboxConnectArgs("alpha", ["--probe-only"])).toEqual({ probeOnly: true });
+    expect(parseSandboxConnectArgs("alpha", [])).toEqual({});
+  });
+
+  it("prints help with the sandbox-scoped usage", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    printSandboxConnectHelp("alpha");
+    expect(log.mock.calls.map((call) => call.join(" ")).join("\n")).toContain(
+      "nemoclaw alpha connect [--probe-only]",
+    );
+  });
+
+  it("exits after printing help flags", () => {
+    mockExit();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(() => parseSandboxConnectArgs("alpha", ["--help"])).toThrow("exit:0");
+    expect(() => parseSandboxConnectArgs("alpha", ["-h"])).toThrow("exit:0");
+  });
+
+  it("rejects unknown and removed flags", () => {
+    mockExit();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(() => parseSandboxConnectArgs("alpha", ["--bad"])).toThrow("exit:1");
+    expect(error.mock.calls.flat().join("\n")).toContain("Unknown flag for connect: --bad");
+
+    expect(() =>
+      parseSandboxConnectArgs("alpha", ["--dangerously-skip-permissions"]),
+    ).toThrow("exit:1");
+    expect(error.mock.calls.flat().join("\n")).toContain(
+      "--dangerously-skip-permissions was removed",
+    );
+  });
+});

--- a/src/lib/actions/sandbox/destroy-helpers.test.ts
+++ b/src/lib/actions/sandbox/destroy-helpers.test.ts
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  cleanupSandboxServices,
+  cleanupShieldsDestroyArtifacts,
+  removeSandboxImage,
+  removeSandboxRegistryEntry,
+  removeShieldsState,
+} from "../../../../dist/lib/actions/sandbox/destroy";
+
+describe("sandbox destroy helper actions", () => {
+  it("stops host services without double-unloading Ollama models", () => {
+    const stopAll = vi.fn();
+    const unloadOllamaModels = vi.fn();
+    const runOpenshell = vi.fn((_args: string[], _opts?: Record<string, unknown>) => ({ status: 0 }));
+    const removed: string[] = [];
+
+    cleanupSandboxServices(
+      "alpha",
+      { stopHostServices: true },
+      {
+        stopAll,
+        unloadOllamaModels,
+        runOpenshell,
+        rmSync: (target) => removed.push(String(target)),
+      },
+    );
+
+    expect(stopAll).toHaveBeenCalledWith({ sandboxName: "alpha" });
+    expect(unloadOllamaModels).not.toHaveBeenCalled();
+    expect(removed).toEqual(["/tmp/nemoclaw-services-alpha"]);
+    expect(runOpenshell.mock.calls.map(([args]) => args)).toEqual([
+      ["provider", "delete", "alpha-telegram-bridge"],
+      ["provider", "delete", "alpha-discord-bridge"],
+      ["provider", "delete", "alpha-slack-bridge"],
+      ["provider", "delete", "alpha-slack-app"],
+    ]);
+  });
+
+  it("unloads Ollama models when destroying an Ollama-backed sandbox only", () => {
+    const unloadOllamaModels = vi.fn();
+    const runOpenshell = vi.fn((_args: string[], _opts?: Record<string, unknown>) => ({ status: 0 }));
+
+    cleanupSandboxServices(
+      "alpha",
+      {},
+      {
+        getSandbox: () => ({ name: "alpha", provider: "ollama-local" }),
+        unloadOllamaModels,
+        runOpenshell,
+        rmSync: () => {
+          throw new Error("ignore missing pid dir");
+        },
+      },
+    );
+    expect(unloadOllamaModels).toHaveBeenCalledTimes(1);
+
+    cleanupSandboxServices("beta", {}, {
+      getSandbox: () => ({ name: "beta", provider: "nvidia-prod" }),
+      unloadOllamaModels,
+      runOpenshell,
+      rmSync: () => undefined,
+    });
+    expect(unloadOllamaModels).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes shields state files and warns on real removal failures", () => {
+    const removed: string[] = [];
+    const warnings: string[] = [];
+    removeShieldsState("alpha", "/tmp/nemoclaw-state", {
+      rmSync: (target) => {
+        removed.push(String(target));
+        if (String(target).includes("shields-timer")) {
+          const err = new Error("permission denied") as NodeJS.ErrnoException;
+          err.code = "EPERM";
+          throw err;
+        }
+      },
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(removed).toEqual([
+      "/tmp/nemoclaw-state/shields-alpha.json",
+      "/tmp/nemoclaw-state/shields-timer-alpha.json",
+    ]);
+    expect(warnings.join("\n")).toContain("permission denied");
+  });
+
+  it("does not warn when shields state files are already absent", () => {
+    const warn = vi.fn();
+    removeShieldsState("alpha", "/tmp/nemoclaw-state", {
+      rmSync: () => {
+        const err = new Error("missing") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      },
+      warn,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("removes sandbox images and reports success or cleanup guidance", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    removeSandboxImage("alpha", {
+      getSandbox: () => ({ name: "alpha", imageTag: "nemoclaw/alpha:latest" }),
+      dockerRmi: () => ({ status: 0 }),
+    });
+    expect(log.mock.calls.flat().join("\n")).toContain("Removed Docker image nemoclaw/alpha:latest");
+
+    removeSandboxImage("beta", {
+      getSandbox: () => ({ name: "beta", imageTag: "nemoclaw/beta:latest" }),
+      dockerRmi: () => ({ status: 1 }),
+    });
+    expect(warn.mock.calls.flat().join("\n")).toContain("Failed to remove Docker image nemoclaw/beta:latest");
+
+    const dockerRmi = vi.fn(() => ({ status: 0 }));
+    removeSandboxImage("gamma", { getSandbox: () => null, dockerRmi });
+    expect(dockerRmi).not.toHaveBeenCalled();
+
+    log.mockRestore();
+    warn.mockRestore();
+  });
+
+  it("removes image before removing registry entries", () => {
+    const calls: string[] = [];
+    const result = removeSandboxRegistryEntry("alpha", {
+      removeImage: (sandboxName) => calls.push(`image:${sandboxName}`),
+      removeSandbox: (sandboxName) => {
+        calls.push(`registry:${sandboxName}`);
+        return true;
+      },
+    });
+    expect(result).toBe(true);
+    expect(calls).toEqual(["image:alpha", "registry:alpha"]);
+  });
+
+  it("cleans shields timers and artifacts together", () => {
+    const warnings: string[] = [];
+    const removed: string[] = [];
+    cleanupShieldsDestroyArtifacts("alpha", {
+      stateDir: "/tmp/nemoclaw-state",
+      killShieldsTimer: () => ({ warnings: ["timer warning"] }),
+      warn: (message) => warnings.push(message),
+      rmSync: (target) => removed.push(String(target)),
+    });
+
+    expect(warnings).toEqual(["timer warning"]);
+    expect(removed).toEqual([
+      "/tmp/nemoclaw-state/shields-alpha.json",
+      "/tmp/nemoclaw-state/shields-timer-alpha.json",
+    ]);
+  });
+});

--- a/src/lib/actions/sandbox/doctor-action.test.ts
+++ b/src/lib/actions/sandbox/doctor-action.test.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const getSandbox = vi.fn();
+
+let runSandboxDoctor: typeof import("../../../../dist/lib/actions/sandbox/doctor").runSandboxDoctor;
+
+function loadDoctorAction(): void {
+  const mocks = {
+    "../../../../dist/lib/adapters/openshell/resolve": { resolveOpenshell: () => null },
+    "../../../../dist/lib/gateway-runtime-action": { recoverNamedGatewayRuntime: vi.fn() },
+    "../../../../dist/lib/state/registry": { getSandbox },
+    "../../../../dist/lib/tunnel/services": { readCloudflaredState: () => ({ kind: "stopped" }) },
+  };
+  for (const [id, exports] of Object.entries(mocks)) {
+    const resolved = require.resolve(id);
+    delete require.cache[resolved];
+    require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports, children: [], paths: [] } as unknown as NodeJS.Module;
+  }
+  const actionPath = require.resolve("../../../../dist/lib/actions/sandbox/doctor");
+  delete require.cache[actionPath];
+  ({ runSandboxDoctor } = require(actionPath));
+}
+
+describe("sandbox doctor action", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getSandbox.mockReturnValue(null);
+    loadDoctorAction();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockExit() {
+    return vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+  }
+
+  it("prints usage for help", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await runSandboxDoctor("alpha", ["--help"]);
+    expect(log.mock.calls.flat().join("\n")).toContain("nemoclaw <name> doctor [--json]");
+  });
+
+  it("rejects unknown arguments", async () => {
+    mockExit();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await expect(runSandboxDoctor("alpha", ["--bad", "extra"])).rejects.toThrow("exit:1");
+    expect(error.mock.calls.flat().join("\n")).toContain("Unknown doctor arguments: --bad extra");
+  });
+
+  it("emits JSON diagnostics and exits nonzero when host checks fail", async () => {
+    mockExit();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(runSandboxDoctor("alpha", ["--json"])).rejects.toThrow(/exit:/);
+
+    const payload = JSON.parse(log.mock.calls.at(-1)?.[0] as string);
+    expect(payload).toMatchObject({ schemaVersion: 1, sandbox: "alpha" });
+    expect(Array.isArray(payload.checks)).toBe(true);
+    expect(payload.checks.map((check: { label: string }) => check.label)).toContain("CLI build");
+    expect(payload.checks.map((check: { label: string }) => check.label)).toContain("Docker daemon");
+    expect(payload.checks.map((check: { label: string }) => check.label)).toContain("cloudflared");
+  });
+});

--- a/src/lib/actions/sandbox/gateway-state-helpers.test.ts
+++ b/src/lib/actions/sandbox/gateway-state-helpers.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getReconciledSandboxGatewayState,
+  mergeLivePolicyIntoSandboxOutput,
+  printGatewayLifecycleHint,
+  printWrongGatewayActiveGuidance,
+} from "../../../../dist/lib/actions/sandbox/gateway-state";
+
+describe("sandbox gateway-state helpers", () => {
+  it("leaves sandbox output unchanged when no policy section exists", () => {
+    expect(mergeLivePolicyIntoSandboxOutput("Sandbox:\n  Name: alpha\n", "version: 1\n")).toBe(
+      "Sandbox:\n  Name: alpha\n",
+    );
+  });
+
+  it("merges live policy YAML and rewrites version from Active metadata", () => {
+    const output = "Sandbox:\n  Name: alpha\nPolicy:\n  stale: true\nStatus: Ready\n";
+    const livePolicy = "Active: 7\n---\nversion: 1\nnetwork_policies:\n  - name: web\n";
+    expect(mergeLivePolicyIntoSandboxOutput(output, livePolicy)).toBe(
+      "Sandbox:\n  Name: alpha\nPolicy:\n\n  version: 7\n  network_policies:\n    - name: web\n",
+    );
+  });
+
+  it("rejects empty, error-like, and non-yaml live policy output", () => {
+    const output = "Sandbox:\nPolicy:\n  old: true\n";
+    expect(mergeLivePolicyIntoSandboxOutput(output, "---\n\n")).toBe(output);
+    expect(mergeLivePolicyIntoSandboxOutput(output, "---\nError: unavailable\n")).toBe(output);
+    expect(mergeLivePolicyIntoSandboxOutput(output, "---\njust text\n")).toBe(output);
+  });
+
+  it("prints wrong active gateway guidance", () => {
+    const lines: string[] = [];
+    printWrongGatewayActiveGuidance("alpha", "other", (line) => lines.push(line));
+    expect(lines.join("\n")).toContain("currently active OpenShell gateway is 'other'");
+    expect(lines.join("\n")).toContain("openshell gateway select nemoclaw");
+
+    const defaultLines: string[] = [];
+    printWrongGatewayActiveGuidance("alpha", "nemoclaw", (line) => defaultLines.push(line));
+    expect(defaultLines.join("\n")).toContain("currently active OpenShell gateway is 'another gateway'");
+  });
+
+  it("prints lifecycle hints for common gateway failure modes", () => {
+    const cases = [
+      {
+        output: "No gateway configured",
+        expected: "no longer configured",
+      },
+      {
+        output: "Gateway: nemoclaw\nError: Connection refused",
+        expected: "API is refusing connections",
+      },
+      {
+        output: "handshake verification failed",
+        expected: "gateway identity drift",
+      },
+      {
+        output: "transport error",
+        expected: "current gateway/runtime is not reachable",
+      },
+      {
+        output: "Missing gateway auth token",
+        expected: "auth or device identity state is not usable",
+      },
+    ];
+
+    for (const { output, expected } of cases) {
+      const lines: string[] = [];
+      printGatewayLifecycleHint(output, "alpha", (line) => lines.push(line));
+      expect(lines.join("\n")).toContain(expected);
+    }
+  });
+
+  it("returns present and passthrough non-reconciled states without gateway recovery", async () => {
+    await expect(
+      getReconciledSandboxGatewayState("alpha", {
+        getState: async () => ({ state: "present", output: "Ready" }),
+      }),
+    ).resolves.toEqual({ state: "present", output: "Ready" });
+
+    await expect(
+      getReconciledSandboxGatewayState("alpha", {
+        getState: async () => ({ state: "unknown_error", output: "boom" }),
+      }),
+    ).resolves.toEqual({ state: "unknown_error", output: "boom" });
+  });
+});

--- a/src/lib/actions/sandbox/host-aliases.test.ts
+++ b/src/lib/actions/sandbox/host-aliases.test.ts
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const dockerExecFileSync = vi.fn();
+
+let addSandboxHostAlias: typeof import("../../../../dist/lib/actions/sandbox/host-aliases").addSandboxHostAlias;
+let listSandboxHostAliases: typeof import("../../../../dist/lib/actions/sandbox/host-aliases").listSandboxHostAliases;
+let removeSandboxHostAlias: typeof import("../../../../dist/lib/actions/sandbox/host-aliases").removeSandboxHostAlias;
+
+function loadActionsWithMockedDocker(): void {
+  const dockerPath = require.resolve("../../../../dist/lib/adapters/docker");
+  const actionPath = require.resolve("../../../../dist/lib/actions/sandbox/host-aliases");
+  delete require.cache[dockerPath];
+  delete require.cache[actionPath];
+  require.cache[dockerPath] = {
+    id: dockerPath,
+    filename: dockerPath,
+    loaded: true,
+    exports: { dockerExecFileSync },
+    children: [],
+    paths: [],
+  } as unknown as NodeJS.Module;
+  ({ addSandboxHostAlias, listSandboxHostAliases, removeSandboxHostAlias } = require(actionPath));
+}
+
+function sandboxResource(hostAliases: unknown[] = [], resourceVersion = "7"): string {
+  return JSON.stringify({
+    metadata: { resourceVersion },
+    spec: { podTemplate: { spec: { hostAliases } } },
+  });
+}
+
+describe("sandbox host alias actions", () => {
+  let logs: string[];
+  let errors: string[];
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logs = [];
+    errors = [];
+    dockerExecFileSync.mockReset();
+    loadActionsWithMockedDocker();
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+      logs.push(String(message));
+    });
+    vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+      errors.push(String(message));
+    });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists empty host aliases", () => {
+    dockerExecFileSync.mockReturnValueOnce(sandboxResource([]));
+
+    listSandboxHostAliases("alpha");
+
+    expect(logs).toEqual(["  No host aliases configured for 'alpha'."]);
+    expect(dockerExecFileSync).toHaveBeenCalledWith(
+      [
+        "openshell-cluster-nemoclaw",
+        "kubectl",
+        "-n",
+        "openshell",
+        "get",
+        "sandbox",
+        "alpha",
+        "-o",
+        "json",
+      ],
+      expect.objectContaining({ timeout: 10_000 }),
+    );
+  });
+
+  it("lists configured host aliases", () => {
+    dockerExecFileSync.mockReturnValueOnce(
+      sandboxResource([{ ip: "192.168.1.10", hostnames: ["search.local", "api.local"] }]),
+    );
+
+    listSandboxHostAliases("alpha");
+
+    expect(logs).toEqual([
+      "  Host aliases for 'alpha':",
+      "    192.168.1.10  search.local, api.local",
+    ]);
+  });
+
+  it("previews add patches with normalized hostnames", () => {
+    dockerExecFileSync.mockReturnValueOnce(sandboxResource([], "42"));
+
+    addSandboxHostAlias("alpha", ["Search.Local", "192.168.1.10", "--dry-run"]);
+
+    const patch = JSON.parse(logs[0]);
+    expect(patch).toEqual([
+      { op: "test", path: "/metadata/resourceVersion", value: "42" },
+      {
+        op: "replace",
+        path: "/spec/podTemplate/spec/hostAliases",
+        value: [{ ip: "192.168.1.10", hostnames: ["search.local"] }],
+      },
+    ]);
+  });
+
+  it("previews remove patches and drops empty IP entries", () => {
+    dockerExecFileSync.mockReturnValueOnce(
+      sandboxResource([
+        { ip: "192.168.1.10", hostnames: ["search.local"] },
+        { ip: "192.168.1.11", hostnames: ["api.local", "admin.local"] },
+      ]),
+    );
+
+    removeSandboxHostAlias("alpha", ["API.Local", "--dry-run"]);
+
+    const patch = JSON.parse(logs[0]);
+    expect(patch.at(-1)).toEqual({
+      op: "replace",
+      path: "/spec/podTemplate/spec/hostAliases",
+      value: [
+        { ip: "192.168.1.10", hostnames: ["search.local"] },
+        { ip: "192.168.1.11", hostnames: ["admin.local"] },
+      ],
+    });
+  });
+
+  it("rejects malformed add requests before reading cluster state", () => {
+    expect(() => addSandboxHostAlias("alpha", ["bad_host", "192.168.1.10"])).toThrow("exit:1");
+    expect(errors).toContain("  Invalid hostname 'bad_host'.");
+    expect(dockerExecFileSync).not.toHaveBeenCalled();
+
+    errors = [];
+    expect(() => addSandboxHostAlias("alpha", ["search.local", "not-an-ip"])).toThrow("exit:1");
+    expect(errors).toContain("  Invalid IP address 'not-an-ip'.");
+  });
+
+  it("rejects duplicate aliases case-insensitively", () => {
+    dockerExecFileSync.mockReturnValueOnce(
+      sandboxResource([{ ip: "192.168.1.10", hostnames: ["search.local"] }]),
+    );
+
+    expect(() => addSandboxHostAlias("alpha", ["SEARCH.Local", "192.168.1.11"])).toThrow(
+      "exit:1",
+    );
+
+    expect(errors).toContain("  Host alias 'search.local' already exists.");
+  });
+
+  it("reports invalid sandbox resource JSON", () => {
+    dockerExecFileSync.mockReturnValueOnce("not json");
+
+    expect(() => listSandboxHostAliases("alpha")).toThrow("exit:1");
+
+    expect(errors.join("\n")).toContain("Failed to parse sandbox resource");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/lib/actions/sandbox/logs-action.test.ts
+++ b/src/lib/actions/sandbox/logs-action.test.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const runOpenshell = vi.fn();
+
+let showSandboxLogs: typeof import("../../../../dist/lib/actions/sandbox/logs").showSandboxLogs;
+
+function loadLogsAction(): void {
+  const runtimePath = require.resolve("../../../../dist/lib/adapters/openshell/runtime");
+  const actionPath = require.resolve("../../../../dist/lib/actions/sandbox/logs");
+  delete require.cache[runtimePath];
+  delete require.cache[actionPath];
+  require.cache[runtimePath] = {
+    id: runtimePath,
+    filename: runtimePath,
+    loaded: true,
+    exports: { getOpenshellBinary: () => "openshell", runOpenshell },
+    children: [],
+    paths: [],
+  } as unknown as NodeJS.Module;
+  ({ showSandboxLogs } = require(actionPath));
+}
+
+describe("sandbox logs action", () => {
+  let errors: string[];
+
+  beforeEach(() => {
+    errors = [];
+    vi.resetAllMocks();
+    runOpenshell.mockReturnValue({ status: 0, stdout: "", stderr: "", signal: null });
+    vi.spyOn(console, "error").mockImplementation((message?: unknown) => errors.push(String(message ?? "")));
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+    loadLogsAction();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("enables audit logs, probes OpenClaw logs, and then runs OpenShell logs", () => {
+    expect(() => showSandboxLogs("alpha", false)).toThrow("exit:0");
+    expect(runOpenshell.mock.calls.map((call) => call[0])).toEqual([
+      ["settings", "set", "alpha", "--key", "ocsf_json_enabled", "--value", "true"],
+      ["sandbox", "exec", "-n", "alpha", "--", "tail", "-n", "200", "/tmp/gateway.log"],
+      ["logs", "alpha", "-n", "200", "--source", "all"],
+    ]);
+  });
+
+  it("skips OpenClaw log probing for since-filtered logs", () => {
+    expect(() => showSandboxLogs("alpha", { since: "10m", follow: false, lines: "200" })).toThrow("exit:0");
+    expect(runOpenshell.mock.calls.map((call) => call[0])).toEqual([
+      ["settings", "set", "alpha", "--key", "ocsf_json_enabled", "--value", "true"],
+      ["logs", "alpha", "-n", "200", "--source", "all", "--since", "10m"],
+    ]);
+  });
+
+  it("warns when audit and OpenClaw log probes fail", () => {
+    runOpenshell
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "audit denied", signal: null })
+      .mockReturnValueOnce({ status: 124, stdout: "", stderr: "", signal: null })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "", signal: null });
+
+    expect(() => showSandboxLogs("alpha", false)).toThrow("exit:0");
+
+    const output = errors.join("\n");
+    expect(output).toContain("failed to enable OpenShell audit logs");
+    expect(output).toContain("audit denied");
+    expect(output).toContain("OpenClaw log source unavailable");
+  });
+
+  it("exits with the OpenShell logs command status", () => {
+    runOpenshell
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "", signal: null })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "", signal: null })
+      .mockReturnValueOnce({ status: 7, stdout: "", stderr: "", signal: null });
+
+    expect(() => showSandboxLogs("alpha", false)).toThrow("exit:7");
+    expect(errors.join("\n")).toContain("Command failed (exit 7)");
+  });
+});

--- a/src/lib/actions/sandbox/policy-channel-action.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-action.test.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const listPresets = vi.fn();
+const getAppliedPresets = vi.fn();
+const getGatewayPresets = vi.fn();
+const listCustomPresets = vi.fn();
+const loadPreset = vi.fn();
+const getPresetEndpoints = vi.fn();
+const applyPreset = vi.fn();
+const removePreset = vi.fn();
+const selectFromList = vi.fn();
+const selectForRemoval = vi.fn();
+const getMessagingPresetWarning = vi.fn();
+const prompt = vi.fn();
+const getDisabledChannels = vi.fn();
+const setChannelDisabled = vi.fn();
+
+let actions: typeof import("../../../../dist/lib/actions/sandbox/policy-channel");
+
+function loadPolicyChannelActions(): void {
+  const mocks = {
+    "../../../../dist/lib/policy": {
+      listPresets,
+      getAppliedPresets,
+      getGatewayPresets,
+      listCustomPresets,
+      loadPreset,
+      getPresetEndpoints,
+      applyPreset,
+      removePreset,
+      selectFromList,
+      selectForRemoval,
+      getMessagingPresetWarning,
+      loadPresetFromFile: vi.fn(),
+      applyPresetContent: vi.fn(),
+    },
+    "../../../../dist/lib/credentials/store": { prompt, getCredential: vi.fn() },
+    "../../../../dist/lib/state/registry": {
+      getDisabledChannels,
+      setChannelDisabled,
+      getSandbox: vi.fn(),
+      updateSandbox: vi.fn(),
+      getCustomPolicies: () => [],
+    },
+    "../../../../dist/lib/gateway-runtime-action": { recoverNamedGatewayRuntime: vi.fn() },
+    "../../../../dist/lib/adapters/openshell/runtime": { runOpenshell: vi.fn() },
+    "../../../../dist/lib/actions/sandbox/rebuild": { rebuildSandbox: vi.fn() },
+    "../../../../dist/lib/onboard": { isNonInteractive: () => process.env.NEMOCLAW_NON_INTERACTIVE === "1" },
+    "../../../../dist/lib/onboard/providers": { upsertMessagingProviders: vi.fn() },
+    "../../../../dist/lib/sandbox/channels": require("../../../../dist/lib/sandbox/channels"),
+  };
+  for (const [id, exports] of Object.entries(mocks)) {
+    const resolved = require.resolve(id);
+    delete require.cache[resolved];
+    require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports, children: [], paths: [] } as unknown as NodeJS.Module;
+  }
+  const actionPath = require.resolve("../../../../dist/lib/actions/sandbox/policy-channel");
+  delete require.cache[actionPath];
+  actions = require(actionPath);
+}
+
+describe("sandbox policy/channel actions", () => {
+  let logs: string[];
+  let errors: string[];
+
+  beforeEach(() => {
+    logs = [];
+    errors = [];
+    delete process.env.NEMOCLAW_NON_INTERACTIVE;
+    vi.resetAllMocks();
+    listPresets.mockReturnValue([{ name: "github", description: "GitHub" }]);
+    listCustomPresets.mockReturnValue([]);
+    getAppliedPresets.mockReturnValue([]);
+    getGatewayPresets.mockReturnValue([]);
+    loadPreset.mockReturnValue("allow:\n- github.com");
+    getPresetEndpoints.mockReturnValue(["github.com"]);
+    getMessagingPresetWarning.mockReturnValue(null);
+    applyPreset.mockReturnValue(true);
+    removePreset.mockReturnValue(true);
+    prompt.mockResolvedValue("y");
+    getDisabledChannels.mockReturnValue([]);
+    setChannelDisabled.mockReturnValue(true);
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => logs.push(String(message ?? "")));
+    vi.spyOn(console, "error").mockImplementation((message?: unknown) => errors.push(String(message ?? "")));
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+    loadPolicyChannelActions();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.NEMOCLAW_NON_INTERACTIVE;
+  });
+
+  it("lists policy registry/gateway drift", () => {
+    getAppliedPresets.mockReturnValue(["github"]);
+    getGatewayPresets.mockReturnValue([]);
+    actions.listSandboxPolicies("alpha");
+    expect(logs.join("\n")).toContain("recorded locally, not active on gateway");
+  });
+
+  it("adds a named policy with endpoint preview and confirmation", async () => {
+    await actions.addSandboxPolicy("alpha", ["github"]);
+    expect(prompt).toHaveBeenCalledWith("  Apply 'github' to sandbox 'alpha'? [Y/n]: ");
+    expect(applyPreset).toHaveBeenCalledWith("alpha", "github");
+    expect(logs.join("\n")).toContain("Endpoints that would be opened: github.com");
+  });
+
+  it("supports policy dry-run without applying", async () => {
+    await actions.addSandboxPolicy("alpha", ["github", "--dry-run"]);
+    expect(applyPreset).not.toHaveBeenCalled();
+    expect(logs.join("\n")).toContain("--dry-run: no changes applied");
+  });
+
+  it("rejects non-interactive policy add without a preset", async () => {
+    process.env.NEMOCLAW_NON_INTERACTIVE = "1";
+    await expect(actions.addSandboxPolicy("alpha", [])).rejects.toThrow("exit:1");
+    expect(errors.join("\n")).toContain("Non-interactive mode requires a preset name");
+  });
+
+  it("removes a policy with endpoint preview", async () => {
+    getAppliedPresets.mockReturnValue(["github"]);
+    await actions.removeSandboxPolicy("alpha", ["github", "--yes"]);
+    expect(removePreset).toHaveBeenCalledWith("alpha", "github");
+    expect(logs.join("\n")).toContain("Endpoints that would be removed: github.com");
+  });
+
+  it("lists known messaging channels", () => {
+    actions.listSandboxChannels("alpha");
+    expect(logs.join("\n")).toContain("Known messaging channels for sandbox 'alpha'");
+    expect(logs.join("\n")).toContain("slack");
+  });
+
+  it("validates channel names for add/remove", async () => {
+    await expect(actions.addSandboxChannel("alpha", [])).rejects.toThrow("exit:1");
+    await expect(actions.removeSandboxChannel("alpha", ["unknown"])).rejects.toThrow("exit:1");
+    expect(errors.join("\n")).toContain("Valid channels");
+  });
+
+  it("supports channel add/remove dry-run", async () => {
+    await actions.addSandboxChannel("alpha", ["slack", "--dry-run"]);
+    await actions.removeSandboxChannel("alpha", ["slack", "--dry-run"]);
+    expect(logs.join("\n")).toContain("would enable channel 'slack'");
+    expect(logs.join("\n")).toContain("would remove channel 'slack'");
+  });
+
+  it("starts and stops channels through registry flags", async () => {
+    await actions.stopSandboxChannel("alpha", ["slack", "--dry-run"]);
+    expect(logs.join("\n")).toContain("would stop channel 'slack'");
+
+    logs = [];
+    getDisabledChannels.mockReturnValue(["slack"]);
+    await actions.startSandboxChannel("alpha", ["slack"]);
+    expect(setChannelDisabled).toHaveBeenCalledWith("alpha", "slack", false);
+    expect(logs.join("\n")).toContain("Marked slack enabled");
+  });
+});

--- a/src/lib/actions/sandbox/process-recovery-extra.test.ts
+++ b/src/lib/actions/sandbox/process-recovery-extra.test.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyForwardHealthWithReachability,
+  classifySandboxForwardHealth,
+  resolveSandboxDashboardPort,
+} from "../../../../dist/lib/actions/sandbox/process-recovery";
+
+describe("sandbox process recovery helper coverage", () => {
+  const entries = [
+    { sandboxName: "alpha", port: "18789", status: "running" },
+    { sandboxName: "beta", port: "19000", status: "dead" },
+  ];
+
+  it("resolves dashboard ports from agent, registry, or default", () => {
+    expect(
+      resolveSandboxDashboardPort("alpha", {
+        getSessionAgent: () => ({ forwardPort: 19191 }),
+        getSandbox: () => ({ name: "alpha", dashboardPort: 18790 }),
+      }),
+    ).toBe(19191);
+    expect(
+      resolveSandboxDashboardPort("alpha", {
+        getSessionAgent: () => null,
+        getSandbox: () => ({ name: "alpha", dashboardPort: 18790 }),
+      }),
+    ).toBe(18790);
+    expect(
+      resolveSandboxDashboardPort("alpha", {
+        getSessionAgent: () => ({ forwardPort: 0 }),
+        getSandbox: () => ({ name: "alpha", dashboardPort: Number.NaN }),
+      }),
+    ).toBe(18789);
+  });
+
+  it("classifies forward ownership and status", () => {
+    expect(classifySandboxForwardHealth(entries, "alpha", "18789")).toBe(true);
+    expect(classifySandboxForwardHealth(entries, "alpha", "19000")).toBe("occupied");
+    expect(classifySandboxForwardHealth(entries, "beta", "19000")).toBe(false);
+    expect(classifySandboxForwardHealth(entries, "alpha", "19999")).toBe(false);
+  });
+
+  it("uses local reachability to override stale forward-list status", () => {
+    expect(classifyForwardHealthWithReachability(entries, "beta", "19000", () => true)).toBe(true);
+    expect(classifyForwardHealthWithReachability(entries, "beta", "19000", () => false)).toBe(false);
+    expect(classifyForwardHealthWithReachability(entries, "alpha", "19000", () => true)).toBe("occupied");
+  });
+});

--- a/src/lib/actions/sandbox/rebuild-action.test.ts
+++ b/src/lib/actions/sandbox/rebuild-action.test.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const getSandbox = vi.fn();
+const prompt = vi.fn();
+const checkAgentVersion = vi.fn();
+
+let rebuildSandbox: typeof import("../../../../dist/lib/actions/sandbox/rebuild").rebuildSandbox;
+
+function loadRebuildAction(): void {
+  const mocks = {
+    "../../../../dist/lib/state/registry": { getSandbox, updateSandbox: vi.fn(), registerSandbox: vi.fn() },
+    "../../../../dist/lib/credentials/store": { prompt },
+    "../../../../dist/lib/sandbox/version": { checkAgentVersion },
+    "../../../../dist/lib/adapters/openshell/resolve": { resolveOpenshell: () => null },
+    "../../../../dist/lib/state/onboard-session": { loadSession: () => null, updateSession: vi.fn() },
+    "../../../../dist/lib/state/sandbox-session": { createSystemDeps: () => ({}), getActiveSandboxSessions: () => ({ detected: false, sessions: [] }) },
+    "../../../../dist/lib/inference/nim": { stopNimContainer: vi.fn(), nimStatus: () => ({ running: false }) },
+    "../../../../dist/lib/policy": { getAppliedPresets: () => [], applyPreset: vi.fn() },
+    "../../../../dist/lib/actions/sandbox/destroy": { removeSandboxRegistryEntry: vi.fn() },
+    "../../../../dist/lib/actions/sandbox/process-recovery": { executeSandboxCommand: vi.fn() },
+    "../../../../dist/lib/agent/onboard": { ensureAgentBaseImage: () => ({ built: false, imageTag: null }) },
+    "../../../../dist/lib/agent/defs": { loadAgent: () => null },
+    "../../../../dist/lib/adapters/openshell/runtime": { captureOpenshell: vi.fn(), runOpenshell: vi.fn() },
+    "../../../../dist/lib/domain/sandbox/destroy": { getSandboxDeleteOutcome: () => ({ deleted: true }) },
+    "../../../../dist/lib/state/sandbox": { backupSandboxState: vi.fn(), restoreSandboxState: vi.fn() },
+  };
+  for (const [id, exports] of Object.entries(mocks)) {
+    const resolved = require.resolve(id);
+    delete require.cache[resolved];
+    require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports, children: [], paths: [] } as unknown as NodeJS.Module;
+  }
+  const actionPath = require.resolve("../../../../dist/lib/actions/sandbox/rebuild");
+  delete require.cache[actionPath];
+  ({ rebuildSandbox } = require(actionPath));
+}
+
+describe("sandbox rebuild action early paths", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    checkAgentVersion.mockReturnValue({ sandboxVersion: "1.0.0", expectedVersion: "1.0.0", isStale: false });
+    prompt.mockResolvedValue("n");
+    loadRebuildAction();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  it("throws instead of exiting when the sandbox is missing and throwOnError is set", async () => {
+    getSandbox.mockReturnValue(null);
+    await expect(rebuildSandbox("missing", {}, { throwOnError: true })).rejects.toThrow("not found in registry");
+  });
+
+  it("rejects multi-agent sandboxes before destructive work", async () => {
+    getSandbox.mockReturnValue({ name: "alpha", agents: [{ name: "a" }, { name: "b" }] });
+    await expect(rebuildSandbox("alpha", { yes: true }, { throwOnError: true })).rejects.toThrow(
+      "Multi-agent sandbox rebuild is not yet supported",
+    );
+  });
+
+  it("returns without destructive work when the confirmation is declined", async () => {
+    getSandbox.mockReturnValue({ name: "alpha", provider: "openai", policies: [] });
+    await rebuildSandbox("alpha", {}, { throwOnError: true });
+    expect(prompt).toHaveBeenCalledWith("  Proceed? [y/N]: ");
+  });
+});

--- a/src/lib/actions/sandbox/skill-install-action.test.ts
+++ b/src/lib/actions/sandbox/skill-install-action.test.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  installSandboxSkill,
+  looksLikeOpenClawPlugin,
+  printSkillInstallUsage,
+} from "../../../../dist/lib/actions/sandbox/skill-install";
+
+describe("sandbox skill install action", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempDir(): string {
+    const dir = join(tmpdir(), `nemoclaw-skill-action-${process.pid}-${tempDirs.length}`);
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function mockExit() {
+    return vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+  }
+
+  it("prints skill install usage", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    printSkillInstallUsage();
+    expect(log.mock.calls.flat().join("\n")).toContain("skill install <path>");
+  });
+
+  it("detects OpenClaw plugin markers", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "openclaw.plugin.json"), "{}");
+    expect(looksLikeOpenClawPlugin(dir)).toBe(true);
+  });
+
+  it("detects OpenClaw plugin package metadata", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ openclaw: { extensions: ["./dist/index.js"] } }));
+    expect(looksLikeOpenClawPlugin(join(dir, "missing.md"))).toBe(true);
+  });
+
+  it("ignores invalid package metadata", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "package.json"), "{");
+    expect(looksLikeOpenClawPlugin(dir)).toBe(false);
+    expect(looksLikeOpenClawPlugin(join(dir, "missing.md"))).toBe(false);
+  });
+
+  it("prints usage for help forms", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await installSandboxSkill("alpha", []);
+    await installSandboxSkill("alpha", ["help"]);
+    await installSandboxSkill("alpha", ["install", "--help"]);
+    expect(log.mock.calls.flat().join("\n")).toContain("nemoclaw <sandbox> skill install <path>");
+  });
+
+  it("rejects unknown subcommands and extra arguments", async () => {
+    mockExit();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await expect(installSandboxSkill("alpha", ["remove"])).rejects.toThrow("exit:1");
+    await expect(installSandboxSkill("alpha", ["install", "somewhere", "--bad"])).rejects.toThrow("exit:1");
+    expect(error.mock.calls.flat().join("\n")).toContain("Unknown skill subcommand: remove");
+    expect(error.mock.calls.flat().join("\n")).toContain("Unknown argument(s) for skill install: --bad");
+  });
+
+  it("points plugin-shaped paths at plugin guidance", async () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "openclaw.plugin.json"), "{}");
+    mockExit();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(installSandboxSkill("alpha", ["install", dir])).rejects.toThrow("exit:1");
+
+    const output = error.mock.calls.flat().join("\n");
+    expect(output).toContain("No SKILL.md found");
+    expect(output).toContain("OpenClaw plugin");
+  });
+});

--- a/src/lib/actions/sandbox/snapshot-action.test.ts
+++ b/src/lib/actions/sandbox/snapshot-action.test.ts
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const captureOpenshell = vi.fn();
+const dockerInspect = vi.fn();
+const listBackups = vi.fn();
+const backupSandboxState = vi.fn();
+const findBackup = vi.fn();
+const parseRestoreArgs = vi.fn();
+const getLatestBackup = vi.fn();
+const restoreSandboxState = vi.fn();
+const getAppliedPresets = vi.fn();
+const applyPreset = vi.fn();
+const removePreset = vi.fn();
+const getSandbox = vi.fn();
+
+let runSandboxSnapshot: typeof import("../../../../dist/lib/actions/sandbox/snapshot").runSandboxSnapshot;
+
+function loadSnapshotAction(): void {
+  const modules = {
+    "../../../../dist/lib/adapters/openshell/runtime": { captureOpenshell, getOpenshellBinary: () => "openshell" },
+    "../../../../dist/lib/adapters/docker": { dockerInspect, dockerCapture: vi.fn() },
+    "../../../../dist/lib/state/sandbox": {
+      listBackups,
+      backupSandboxState,
+      findBackup,
+      parseRestoreArgs,
+      getLatestBackup,
+      restoreSandboxState,
+    },
+    "../../../../dist/lib/policy": { getAppliedPresets, applyPreset, removePreset },
+    "../../../../dist/lib/state/registry": { getSandbox, registerSandbox: vi.fn() },
+  };
+  for (const [id, exports] of Object.entries(modules)) {
+    const resolved = require.resolve(id);
+    delete require.cache[resolved];
+    require.cache[resolved] = {
+      id: resolved,
+      filename: resolved,
+      loaded: true,
+      exports,
+      children: [],
+      paths: [],
+    } as unknown as NodeJS.Module;
+  }
+  const actionPath = require.resolve("../../../../dist/lib/actions/sandbox/snapshot");
+  delete require.cache[actionPath];
+  ({ runSandboxSnapshot } = require(actionPath));
+}
+
+describe("sandbox snapshot action", () => {
+  let logs: string[];
+  let errors: string[];
+
+  beforeEach(() => {
+    logs = [];
+    errors = [];
+    vi.resetAllMocks();
+    dockerInspect.mockReturnValue({ status: 0, stdout: "true\n" });
+    captureOpenshell.mockReturnValue({ status: 0, output: "alpha Ready\n" });
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => logs.push(String(message ?? "")));
+    vi.spyOn(console, "error").mockImplementation((message?: unknown) => errors.push(String(message ?? "")));
+    vi.spyOn(console, "warn").mockImplementation((message?: unknown) => errors.push(String(message ?? "")));
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+    loadSnapshotAction();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints usage for help/default subcommands", async () => {
+    await runSandboxSnapshot("alpha", []);
+    expect(logs.join("\n")).toContain("nemoclaw alpha snapshot create");
+  });
+
+  it("lists no snapshots", async () => {
+    listBackups.mockReturnValue([]);
+    await runSandboxSnapshot("alpha", ["list"]);
+    expect(logs).toEqual(["  No snapshots found for 'alpha'."]);
+  });
+
+  it("renders snapshot list rows", async () => {
+    listBackups.mockReturnValue([
+      { snapshotVersion: 2, name: "daily", timestamp: "2026-05-14T00:00:00Z", backupPath: "/tmp/snap" },
+    ]);
+    await runSandboxSnapshot("alpha", ["list"]);
+    expect(logs.join("\n")).toContain("Snapshots for 'alpha'");
+    expect(logs.join("\n")).toContain("v2");
+    expect(logs.join("\n")).toContain("daily");
+  });
+
+  it("rejects invalid create flags", async () => {
+    await expect(runSandboxSnapshot("alpha", ["create", "--bad"])).rejects.toThrow("exit:1");
+    expect(errors.join("\n")).toContain("Unknown flag: --bad");
+  });
+
+  it("creates a named snapshot", async () => {
+    backupSandboxState.mockReturnValue({
+      success: true,
+      manifest: { timestamp: "ts-1", backupPath: "/tmp/backup", name: "before" },
+      backedUpDirs: ["memory"],
+      backedUpFiles: ["user.md"],
+      failedDirs: [],
+      failedFiles: [],
+    });
+    findBackup.mockReturnValue({
+      match: { snapshotVersion: 3, timestamp: "ts-1", backupPath: "/tmp/backup", name: "before" },
+    });
+
+    await runSandboxSnapshot("alpha", ["create", "--name", "before"]);
+
+    expect(backupSandboxState).toHaveBeenCalledWith("alpha", { name: "before" });
+    expect(logs.join("\n")).toContain("Snapshot v3 name=before created");
+  });
+
+  it("restores the latest snapshot and reconciles policy presets", async () => {
+    const latest = {
+      snapshotVersion: 1,
+      timestamp: "ts-1",
+      backupPath: "/tmp/backup",
+      policyPresets: ["slack", "github"],
+    };
+    parseRestoreArgs.mockReturnValue({ ok: true, targetSandbox: "alpha", selector: null });
+    getLatestBackup.mockReturnValue(latest);
+    restoreSandboxState.mockReturnValue({
+      success: true,
+      restoredDirs: ["memory"],
+      restoredFiles: ["user.md"],
+      failedDirs: [],
+      failedFiles: [],
+    });
+    getAppliedPresets.mockReturnValue(["slack", "old"]);
+    applyPreset.mockReturnValue(true);
+    removePreset.mockReturnValue(true);
+
+    await runSandboxSnapshot("alpha", ["restore"]);
+
+    expect(restoreSandboxState).toHaveBeenCalledWith("alpha", "/tmp/backup");
+    expect(removePreset).toHaveBeenCalledWith("alpha", "old");
+    expect(applyPreset).toHaveBeenCalledWith("alpha", "github");
+    expect(logs.join("\n")).toContain("Reconciling policy presets");
+  });
+
+  it("reports restore selector misses", async () => {
+    parseRestoreArgs.mockReturnValue({ ok: true, targetSandbox: "alpha", selector: "missing" });
+    findBackup.mockReturnValue({ match: null });
+
+    await expect(runSandboxSnapshot("alpha", ["restore", "missing"])).rejects.toThrow("exit:1");
+    expect(errors.join("\n")).toContain("No snapshot matching 'missing'");
+  });
+});

--- a/src/lib/actions/sandbox/status-action.test.ts
+++ b/src/lib/actions/sandbox/status-action.test.ts
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const getReconciledSandboxGatewayState = vi.fn();
+const getSandboxGatewayStateForStatus = vi.fn();
+const printGatewayLifecycleHint = vi.fn();
+const printWrongGatewayActiveGuidance = vi.fn();
+const getNamedGatewayLifecycleState = vi.fn();
+const captureOpenshellForStatus = vi.fn();
+const getSandbox = vi.fn();
+const removeSandbox = vi.fn();
+const loadSession = vi.fn();
+const updateSession = vi.fn();
+const isSandboxGatewayRunningForStatus = vi.fn();
+const probeProviderHealth = vi.fn();
+
+let showSandboxStatus: typeof import("../../../../dist/lib/actions/sandbox/status").showSandboxStatus;
+
+function loadStatusAction(): void {
+  const mocks = {
+    "../../../../dist/lib/actions/sandbox/gateway-state": {
+      getReconciledSandboxGatewayState,
+      getSandboxGatewayStateForStatus,
+      printGatewayLifecycleHint,
+      printWrongGatewayActiveGuidance,
+    },
+    "../../../../dist/lib/gateway-runtime-action": { getNamedGatewayLifecycleState },
+    "../../../../dist/lib/adapters/openshell/runtime": {
+      captureOpenshellForStatus,
+      isCommandTimeout: () => false,
+    },
+    "../../../../dist/lib/state/registry": { getSandbox, removeSandbox },
+    "../../../../dist/lib/state/onboard-session": { loadSession, updateSession },
+    "../../../../dist/lib/actions/sandbox/process-recovery": {
+      isSandboxGatewayRunningForStatus,
+      probeSandboxInferenceGatewayHealth: vi.fn(),
+    },
+    "../../../../dist/lib/inference/health": { probeProviderHealth },
+    "../../../../dist/lib/inference/nim": {
+      nimStatusByName: () => ({ running: false, healthy: false, container: "nim" }),
+      nimStatus: () => ({ running: false, healthy: false, container: "nim" }),
+      shouldShowNimLine: () => false,
+    },
+    "../../../../dist/lib/sandbox/version": {
+      checkAgentVersion: () => ({ sandboxVersion: "1.0.0", expectedVersion: "1.0.0", isStale: false }),
+    },
+    "../../../../dist/lib/shields": { isShieldsDown: () => false },
+    "../../../../dist/lib/adapters/openshell/resolve": { resolveOpenshell: () => null },
+    "../../../../dist/lib/state/sandbox-session": {
+      createSystemDeps: () => ({}),
+      getActiveSandboxSessions: () => ({ detected: false, sessions: [] }),
+    },
+  };
+  for (const [id, exports] of Object.entries(mocks)) {
+    const resolved = require.resolve(id);
+    delete require.cache[resolved];
+    require.cache[resolved] = { id: resolved, filename: resolved, loaded: true, exports, children: [], paths: [] } as unknown as NodeJS.Module;
+  }
+  const actionPath = require.resolve("../../../../dist/lib/actions/sandbox/status");
+  delete require.cache[actionPath];
+  ({ showSandboxStatus } = require(actionPath));
+}
+
+describe("sandbox status action", () => {
+  let logs: string[];
+
+  beforeEach(() => {
+    logs = [];
+    vi.resetAllMocks();
+    vi.spyOn(console, "log").mockImplementation((message?: unknown) => logs.push(String(message ?? "")));
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+    getSandbox.mockReturnValue({
+      name: "alpha",
+      model: "m",
+      provider: "openai",
+      policies: ["github"],
+      hostGpuDetected: false,
+      sandboxGpuEnabled: false,
+      openshellDriver: "docker",
+      openshellVersion: "0.0.1",
+    });
+    captureOpenshellForStatus.mockResolvedValue({ status: 0, output: "Provider: openai\nModel: live-model\n" });
+    isSandboxGatewayRunningForStatus.mockResolvedValue(true);
+    probeProviderHealth.mockReturnValue({ ok: true, probed: true, endpoint: "https://example", detail: "ok" });
+    loadStatusAction();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints present sandbox status and process health", async () => {
+    getReconciledSandboxGatewayState.mockResolvedValue({ state: "present", output: "alpha Ready" });
+    await showSandboxStatus("alpha");
+    const output = logs.join("\n");
+    expect(output).toContain("Sandbox: alpha");
+    expect(output).toContain("Provider: openai");
+    expect(output).toContain("healthy");
+    expect(output).toContain("running");
+  });
+
+  it("removes stale local registry entries when the named gateway is healthy", async () => {
+    getReconciledSandboxGatewayState.mockResolvedValue({ state: "missing", output: "missing" });
+    getNamedGatewayLifecycleState.mockReturnValue({ state: "healthy_named" });
+    loadSession.mockReturnValue({ sandboxName: "alpha" });
+
+    await expect(showSandboxStatus("alpha")).rejects.toThrow("exit:1");
+
+    expect(removeSandbox).toHaveBeenCalledWith("alpha");
+    expect(updateSession).toHaveBeenCalled();
+    expect(logs.join("\n")).toContain("Removed stale local registry entry");
+  });
+
+  it("prints wrong-gateway guidance", async () => {
+    getReconciledSandboxGatewayState.mockResolvedValue({ state: "wrong_gateway_active", activeGateway: "other" });
+    printWrongGatewayActiveGuidance.mockImplementation((sandbox, gateway, log) => log(`${sandbox}:${gateway}`));
+
+    await expect(showSandboxStatus("alpha")).rejects.toThrow("exit:1");
+
+    expect(logs.join("\n")).toContain("alpha:other");
+  });
+});

--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -7,7 +7,8 @@ import path from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { buildRunPlan, runUninstallPlan, type RunResult } from "./run-plan";
+import type { RunResult } from "./run-plan";
+import { buildRunPlan, runUninstallPlan } from "../../../../dist/lib/actions/uninstall/run-plan";
 
 function ok(stdout = ""): RunResult {
   return { status: 0, stdout, stderr: "" };

--- a/src/lib/actions/update.test.ts
+++ b/src/lib/actions/update.test.ts
@@ -12,7 +12,7 @@ import {
   getLatestNemoClawVersionFromGitLatestTag,
   NEMOCLAW_UPDATE_COMMAND,
   runUpdateAction,
-} from "./update";
+} from "../../../dist/lib/actions/update";
 
 describe("runUpdateAction", () => {
   it("--check reports update availability without running the installer", async () => {

--- a/src/lib/actions/upgrade-sandboxes-action.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-action.test.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+
+type UpgradeModule = typeof import("../../../dist/lib/actions/upgrade-sandboxes");
+
+const action = require("../../../dist/lib/actions/upgrade-sandboxes") as UpgradeModule;
+const openshellRuntime = require("../../../dist/lib/adapters/openshell/runtime") as typeof import("../../../dist/lib/adapters/openshell/runtime");
+const credentials = require("../../../dist/lib/credentials/store") as typeof import("../../../dist/lib/credentials/store");
+const registry = require("../../../dist/lib/state/registry") as typeof import("../../../dist/lib/state/registry");
+const sandboxVersion = require("../../../dist/lib/sandbox/version") as typeof import("../../../dist/lib/sandbox/version");
+const rebuild = require("../../../dist/lib/actions/sandbox/rebuild") as typeof import("../../../dist/lib/actions/sandbox/rebuild");
+
+const logs: string[] = [];
+const errors: string[] = [];
+
+beforeEach(() => {
+  logs.length = 0;
+  errors.length = 0;
+  vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+    logs.push(String(message ?? ""));
+  });
+  vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+    errors.push(String(message ?? ""));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function liveSandboxList(names: string[]): { output: string; status: number } {
+  return { output: `NAME\n${names.map((name) => `${name} Ready`).join("\n")}\n`, status: 0 };
+}
+
+describe("upgradeSandboxes action", () => {
+  it("returns when no sandboxes are registered", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(logs.join("\n")).toContain("No sandboxes found");
+  });
+
+  it("exits when live sandbox lookup fails", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+      output: "boom",
+      status: 7,
+    });
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(errors.join("\n")).toContain("Failed to query running sandboxes");
+    expect(exit).toHaveBeenCalledWith(7);
+  });
+
+  it("reports current sandboxes as up to date", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: false,
+      sandboxVersion: "2.0.0",
+    });
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(logs.join("\n")).toContain("All sandboxes are up to date");
+  });
+
+  it("prints stale and unknown sandboxes in check mode", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockImplementation((name: string) =>
+      name === "alpha"
+        ? { detectionMethod: "registry", expectedVersion: "2.0.0", isStale: true, sandboxVersion: "1.0.0" }
+        : { detectionMethod: "unavailable", expectedVersion: "2.0.0", isStale: false, sandboxVersion: null },
+    );
+
+    await action.upgradeSandboxes({ check: true });
+
+    const output = logs.join("\n");
+    expect(output).toContain("Stale sandboxes");
+    expect(output).toContain("alpha");
+    expect(output).toContain("Unknown version");
+    expect(output).toContain("beta");
+    expect(output).toContain("Run `nemoclaw upgrade-sandboxes`");
+  });
+
+  it("skips stopped stale sandboxes when no running stale sandbox remains", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList([]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: true,
+      sandboxVersion: "1.0.0",
+    });
+    const rebuildSpy = vi.spyOn(rebuild, "rebuildSandbox");
+
+    await action.upgradeSandboxes({ yes: true });
+
+    expect(logs.join("\n")).toContain("No running stale sandboxes");
+    expect(rebuildSpy).not.toHaveBeenCalled();
+  });
+
+  it("prompts before rebuilding and tracks failures", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha", "beta", "gamma"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: true,
+      sandboxVersion: "1.0.0",
+    });
+    vi.spyOn(credentials, "prompt")
+      .mockResolvedValueOnce("no")
+      .mockResolvedValueOnce("yes")
+      .mockResolvedValueOnce("yes");
+    vi.spyOn(rebuild, "rebuildSandbox").mockImplementation(async (name: string) => {
+      if (name === "gamma") throw new Error("boom");
+    });
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await action.upgradeSandboxes({});
+
+    expect(credentials.prompt).toHaveBeenCalledWith(expect.stringContaining("Rebuild 'alpha'"));
+    expect(rebuild.rebuildSandbox).not.toHaveBeenCalledWith("alpha", expect.anything(), expect.anything());
+    expect(rebuild.rebuildSandbox).toHaveBeenCalledWith("beta", ["--yes"], { throwOnError: true });
+    expect(rebuild.rebuildSandbox).toHaveBeenCalledWith("gamma", ["--yes"], { throwOnError: true });
+    expect(errors.join("\n")).toContain("Failed to rebuild 'gamma': boom");
+    expect(logs.join("\n")).toContain("1 sandbox(es) rebuilt");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/lib/adapters/openshell/client.test.ts
+++ b/src/lib/adapters/openshell/client.test.ts
@@ -14,7 +14,7 @@ import {
   runOpenshellCommand,
   stripAnsi,
   versionGte,
-} from "./client";
+} from "../../../../dist/lib/adapters/openshell/client";
 
 interface SpawnResultSpec {
   status: number | null;

--- a/src/lib/commands/command-common-coverage.test.ts
+++ b/src/lib/commands/command-common-coverage.test.ts
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  onboardExamples,
+  onboardUsage,
+  toLegacyOnboardArgs,
+} from "../../../dist/lib/commands/onboard/common";
+import {
+  appendCommonPolicyFlags,
+  getPolicyRuntimeBridge,
+  policyMutationArgs,
+  policyMutationFlags,
+  setPolicyRuntimeBridgeFactoryForTest,
+} from "../../../dist/lib/commands/sandbox/policy/common";
+import {
+  buildChannelArgs,
+  channelMutationArgs,
+  channelMutationFlags,
+  getChannelsRuntimeBridge,
+  setChannelsRuntimeBridgeFactoryForTest,
+} from "../../../dist/lib/commands/sandbox/channels/common";
+import {
+  buildHostAliasArgs,
+  getHostsRuntimeBridge,
+  hostAliasAddArgs,
+  hostAliasMutationFlags,
+  hostAliasSandboxArgs,
+  setHostsRuntimeBridgeFactoryForTest,
+} from "../../../dist/lib/commands/sandbox/hosts/common";
+import {
+  getSkillInstallRuntimeBridge,
+  setSkillInstallRuntimeBridgeFactoryForTest,
+} from "../../../dist/lib/commands/sandbox/skill/common";
+import {
+  getSnapshotRuntimeBridge,
+  sandboxNameArg,
+  setSnapshotRuntimeBridgeFactoryForTest,
+} from "../../../dist/lib/commands/sandbox/snapshot/common";
+
+describe("command common helpers", () => {
+  it("maps onboard flags to legacy argv order", () => {
+    expect(onboardUsage[0]).toContain("onboard");
+    expect(onboardExamples.length).toBeGreaterThan(0);
+    const flags = {
+      "non-interactive": true,
+      resume: true,
+      fresh: true,
+      "recreate-sandbox": true,
+      gpu: true,
+      "no-gpu": true,
+      from: "Dockerfile",
+      name: "alpha",
+      "sandbox-gpu": true,
+      "no-sandbox-gpu": true,
+      "sandbox-gpu-device": "nvidia.com/gpu=0",
+      agent: "hermes",
+      "control-ui-port": 19000,
+      yes: true,
+      "yes-i-accept-third-party-software": true,
+    } as Parameters<typeof toLegacyOnboardArgs>[0];
+
+    expect(toLegacyOnboardArgs(flags)).toEqual([
+      "--non-interactive",
+      "--resume",
+      "--fresh",
+      "--recreate-sandbox",
+      "--gpu",
+      "--no-gpu",
+      "--from",
+      "Dockerfile",
+      "--name",
+      "alpha",
+      "--sandbox-gpu",
+      "--no-sandbox-gpu",
+      "--sandbox-gpu-device",
+      "nvidia.com/gpu=0",
+      "--agent",
+      "hermes",
+      "--control-ui-port",
+      "19000",
+      "--yes",
+      "--yes-i-accept-third-party-software",
+    ]);
+    expect(toLegacyOnboardArgs({})).toEqual([]);
+  });
+
+  it("builds policy mutation args and exposes policy runtime bridges", async () => {
+    const args: string[] = ["preset"];
+    appendCommonPolicyFlags(args, { yes: true, force: true, "dry-run": true });
+    expect(args).toEqual(["preset", "--yes", "--force", "--dry-run"]);
+    expect(policyMutationArgs.sandboxName.required).toBe(true);
+    expect(policyMutationFlags.yes.char).toBe("y");
+
+    const sandboxPolicyAdd = vi.fn();
+    const sandboxPolicyRemove = vi.fn();
+    setPolicyRuntimeBridgeFactoryForTest(() => ({ sandboxPolicyAdd, sandboxPolicyRemove }));
+    await getPolicyRuntimeBridge().sandboxPolicyAdd("alpha", ["preset"]);
+    await getPolicyRuntimeBridge().sandboxPolicyRemove("alpha", ["preset"]);
+    expect(sandboxPolicyAdd).toHaveBeenCalledWith("alpha", ["preset"]);
+    expect(sandboxPolicyRemove).toHaveBeenCalledWith("alpha", ["preset"]);
+  });
+
+  it("builds channel args and exposes channel runtime bridges", async () => {
+    expect(buildChannelArgs("telegram", { "dry-run": true })).toEqual(["telegram", "--dry-run"]);
+    expect(buildChannelArgs(undefined, {})).toEqual([]);
+    expect(channelMutationArgs.channel.required).toBe(true);
+    expect(channelMutationFlags["dry-run"].description).toContain("Preview");
+
+    const bridge = {
+      sandboxChannelsAdd: vi.fn(),
+      sandboxChannelsRemove: vi.fn(),
+      sandboxChannelsStart: vi.fn(),
+      sandboxChannelsStop: vi.fn(),
+    };
+    setChannelsRuntimeBridgeFactoryForTest(() => bridge);
+    await getChannelsRuntimeBridge().sandboxChannelsAdd("alpha", ["telegram"]);
+    await getChannelsRuntimeBridge().sandboxChannelsRemove("alpha", ["telegram"]);
+    await getChannelsRuntimeBridge().sandboxChannelsStart("alpha", ["telegram"]);
+    await getChannelsRuntimeBridge().sandboxChannelsStop("alpha", ["telegram"]);
+    expect(bridge.sandboxChannelsAdd).toHaveBeenCalledWith("alpha", ["telegram"]);
+    expect(bridge.sandboxChannelsRemove).toHaveBeenCalledWith("alpha", ["telegram"]);
+    expect(bridge.sandboxChannelsStart).toHaveBeenCalledWith("alpha", ["telegram"]);
+    expect(bridge.sandboxChannelsStop).toHaveBeenCalledWith("alpha", ["telegram"]);
+  });
+
+  it("builds host alias args and exposes host runtime bridges", () => {
+    expect(buildHostAliasArgs(["api.local", undefined, "10.0.0.1"], { "dry-run": true })).toEqual([
+      "api.local",
+      "10.0.0.1",
+      "--dry-run",
+    ]);
+    expect(hostAliasSandboxArgs.sandboxName.required).toBe(true);
+    expect(hostAliasAddArgs.ip.required).toBe(true);
+    expect(hostAliasMutationFlags["dry-run"].description).toContain("Preview");
+
+    const bridge = {
+      addSandboxHostAlias: vi.fn(),
+      listSandboxHostAliases: vi.fn(),
+      removeSandboxHostAlias: vi.fn(),
+    };
+    setHostsRuntimeBridgeFactoryForTest(() => bridge);
+    getHostsRuntimeBridge().addSandboxHostAlias("alpha", ["api.local"]);
+    getHostsRuntimeBridge().listSandboxHostAliases("alpha");
+    getHostsRuntimeBridge().removeSandboxHostAlias("alpha", ["api.local"]);
+    expect(bridge.addSandboxHostAlias).toHaveBeenCalledWith("alpha", ["api.local"]);
+    expect(bridge.listSandboxHostAliases).toHaveBeenCalledWith("alpha");
+    expect(bridge.removeSandboxHostAlias).toHaveBeenCalledWith("alpha", ["api.local"]);
+  });
+
+  it("exposes skill install and snapshot runtime bridges", async () => {
+    const sandboxSkillInstall = vi.fn();
+    setSkillInstallRuntimeBridgeFactoryForTest(() => ({ sandboxSkillInstall }));
+    await getSkillInstallRuntimeBridge().sandboxSkillInstall("alpha", ["skill"]);
+    expect(sandboxSkillInstall).toHaveBeenCalledWith("alpha", ["skill"]);
+
+    const sandboxSnapshot = vi.fn();
+    setSnapshotRuntimeBridgeFactoryForTest(() => ({ sandboxSnapshot }));
+    await getSnapshotRuntimeBridge().sandboxSnapshot("alpha", ["list"]);
+    expect(sandboxSnapshot).toHaveBeenCalledWith("alpha", ["list"]);
+    expect(sandboxNameArg.required).toBe(true);
+  });
+});

--- a/src/lib/credentials/store-extra.test.ts
+++ b/src/lib/credentials/store-extra.test.ts
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { chmodSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const STORE_DIST_PATH = require.resolve("../../../dist/lib/credentials/store");
+const originalHome = process.env.HOME;
+const trackedKeys = ["NVIDIA_API_KEY", "OPENAI_API_KEY", "PATH"];
+let tempDirs: string[] = [];
+
+type StoreModule = typeof import("../../../dist/lib/credentials/store");
+
+function loadStore(home: string): StoreModule {
+  process.env.HOME = home;
+  delete require.cache[STORE_DIST_PATH];
+  return require(STORE_DIST_PATH) as StoreModule;
+}
+
+function makeHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "nemoclaw-creds-home-"));
+  tempDirs.push(home);
+  mkdirSync(join(home, ".nemoclaw"), { recursive: true });
+  return home;
+}
+
+afterEach(() => {
+  delete require.cache[STORE_DIST_PATH];
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  for (const key of trackedKeys) delete process.env[key];
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("credential store helpers", () => {
+  it("normalizes, stages, lists, resolves, and deletes process credentials", () => {
+    const store = loadStore(makeHome());
+    expect(store.normalizeCredentialValue("  abc\r\n")).toBe("abc");
+    expect(store.normalizeCredentialValue(null)).toBe("");
+
+    store.saveCredential("NVIDIA_API_KEY", "  nv-key  ");
+    store.saveCredential("PATH", "not listed");
+    expect(store.getCredential("NVIDIA_API_KEY")).toBe("nv-key");
+    expect(store.loadCredentials()).toEqual({ NVIDIA_API_KEY: "nv-key" });
+    expect(store.listCredentialKeys()).toEqual(["NVIDIA_API_KEY"]);
+    expect(store.resolveProviderCredential("NVIDIA_API_KEY")).toBe("nv-key");
+    expect(store.deleteCredential("NVIDIA_API_KEY")).toBe(true);
+    expect(store.deleteCredential("NVIDIA_API_KEY")).toBe(false);
+  });
+
+  it("stages only allowlisted legacy credentials without overriding explicit env", () => {
+    const home = makeHome();
+    process.env.NVIDIA_API_KEY = "explicit";
+    writeFileSync(
+      join(home, ".nemoclaw", "credentials.json"),
+      JSON.stringify({ NVIDIA_API_KEY: "legacy", OPENAI_API_KEY: " openai ", PATH: "evil" }),
+    );
+    const store = loadStore(home);
+
+    expect(store.stageLegacyCredentialsToEnv()).toEqual(["OPENAI_API_KEY"]);
+    expect(process.env.NVIDIA_API_KEY).toBe("explicit");
+    expect(process.env.OPENAI_API_KEY).toBe("openai");
+    expect(process.env.PATH).not.toBe("evil");
+  });
+
+  it("refuses unsafe HOME directories", () => {
+    const store = loadStore("/tmp");
+    expect(() => store.resolveHomeDir()).toThrow(/world-readable/);
+  });
+
+  it("securely removes legacy credentials files and dangling credential symlinks", () => {
+    const home = makeHome();
+    const legacyFile = join(home, ".nemoclaw", "credentials.json");
+    writeFileSync(legacyFile, JSON.stringify({ NVIDIA_API_KEY: "legacy" }));
+    const store = loadStore(home);
+
+    store.removeLegacyCredentialsFile();
+    expect(() => lstatSync(legacyFile)).toThrow();
+
+    const target = join(home, "target-secret");
+    writeFileSync(target, "do-not-touch");
+    symlinkSync(target, legacyFile);
+    store.removeLegacyCredentialsFile();
+    expect(readFileSync(target, "utf-8")).toBe("do-not-touch");
+    expect(() => lstatSync(legacyFile)).toThrow();
+  });
+
+  it("removes empty legacy credentials but preserves migratable or malformed files", () => {
+    const home = makeHome();
+    const legacyFile = join(home, ".nemoclaw", "credentials.json");
+    const store = loadStore(home);
+
+    writeFileSync(legacyFile, "  ");
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(true);
+
+    writeFileSync(legacyFile, JSON.stringify({ PATH: "ignored", NVIDIA_API_KEY: "" }));
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(true);
+
+    writeFileSync(legacyFile, JSON.stringify({ NVIDIA_API_KEY: "legacy" }));
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(false);
+    expect(readFileSync(legacyFile, "utf-8")).toContain("NVIDIA_API_KEY");
+
+    writeFileSync(legacyFile, "not-json");
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(false);
+  });
+
+  it("leaves oversized legacy credential files for manual inspection", () => {
+    const home = makeHome();
+    const legacyFile = join(home, ".nemoclaw", "credentials.json");
+    writeFileSync(legacyFile, " ".repeat(1024 * 1024 + 1));
+    chmodSync(legacyFile, 0o600);
+    const store = loadStore(home);
+
+    expect(store.stageLegacyCredentialsToEnv()).toEqual([]);
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(false);
+  });
+});

--- a/src/lib/diagnostics/debug.test.ts
+++ b/src/lib/diagnostics/debug.test.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 // Import from compiled dist/ so coverage is attributed correctly.
-import { createTarball, getDebugCompletionMessages, redact } from "../../../dist/lib/diagnostics/debug";
+import { createTarball, getDebugCompletionMessages, redact, runDebug } from "../../../dist/lib/diagnostics/debug";
 
 describe("redact", () => {
   it("redacts NVIDIA_API_KEY=value patterns", () => {
@@ -87,6 +87,70 @@ describe("createTarball", () => {
     expect(ok).toBe(true);
     expect(process.exitCode).toBeUndefined();
     expect(existsSync(output)).toBe(true);
+  });
+});
+
+describe("runDebug", () => {
+  const originalPath = process.env.PATH;
+  let fakeBin: string | undefined;
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    vi.restoreAllMocks();
+    if (fakeBin) rmSync(fakeBin, { recursive: true, force: true });
+    fakeBin = undefined;
+  });
+
+  function installFakeCommand(name: string, body: string): void {
+    fakeBin ??= mkdtempSync(join(tmpdir(), "debug-bin-"));
+    const file = join(fakeBin, name);
+    writeFileSync(file, `#!/bin/sh\n${body}`);
+    chmodSync(file, 0o755);
+    process.env.PATH = `${fakeBin}:${originalPath ?? ""}`;
+  }
+
+  it("collects diagnostics and redacts command output", () => {
+    for (const name of [
+      "date",
+      "uname",
+      "uptime",
+      "free",
+      "df",
+      "nvidia-smi",
+      "top",
+      "ss",
+      "ip",
+      "nslookup",
+      "lsof",
+      "vmstat",
+      "iostat",
+      "dmesg",
+      "ssh",
+    ]) {
+      installFakeCommand(name, `echo ${name}-ok`);
+    }
+    installFakeCommand("curl", "echo 200");
+    installFakeCommand(
+      "docker",
+      'case "$*" in *"--format {{.Names}}"*) echo container-one; exit 0;; esac\necho "docker $* API_KEY=secret"\n',
+    );
+    installFakeCommand(
+      "openshell",
+      'if [ "$1 $2" = "sandbox list" ]; then echo "Name"; echo "alpha Ready"; exit 0; fi\nif [ "$1 $2" = "sandbox ssh-config" ]; then echo "Host openshell-alpha"; echo "  HostName 127.0.0.1"; exit 0; fi\necho "openshell $*"\n',
+    );
+
+    const output: string[] = [];
+    const log = vi.spyOn(console, "log").mockImplementation((message = "") => output.push(String(message)));
+    const err = vi.spyOn(console, "error").mockImplementation((message = "") => output.push(String(message)));
+
+    runDebug({ sandboxName: "alpha", quick: false });
+
+    expect(log).toHaveBeenCalled();
+    expect(err).not.toHaveBeenCalled();
+    expect(output.join("\n")).toContain("Collecting diagnostics for sandbox 'alpha'");
+    expect(output.join("\n")).toContain("docker ps -a API_KEY=<REDACTED>");
+    expect(output.join("\n")).toContain("ssh-ok");
+    expect(output.join("\n")).toContain("Done. If filing a bug");
   });
 });
 

--- a/src/lib/domain/dev/npm-link-or-shim.test.ts
+++ b/src/lib/domain/dev/npm-link-or-shim.test.ts
@@ -8,7 +8,7 @@ import {
   buildDevShimContents,
   classifyDevShim,
   pathContainsDirectory,
-} from "./npm-link-or-shim";
+} from "../../../../dist/lib/domain/dev/npm-link-or-shim";
 
 describe("dev shim domain helpers", () => {
   it("classifies absent, managed, and foreign shims", () => {

--- a/src/lib/domain/dns/coredns.test.ts
+++ b/src/lib/domain/dns/coredns.test.ts
@@ -10,7 +10,7 @@ import {
   isSafeDnsUpstream,
   resolveCoreDnsUpstream,
   selectOpenshellClusterContainer,
-} from "./coredns";
+} from "../../../../dist/lib/domain/dns/coredns";
 
 describe("CoreDNS domain helpers", () => {
   it("classifies Docker host socket runtimes", () => {

--- a/src/lib/domain/duration.test.ts
+++ b/src/lib/domain/duration.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { parseDuration, MAX_SECONDS, DEFAULT_SECONDS } from "./duration";
+import { parseDuration, MAX_SECONDS, DEFAULT_SECONDS } from "../../../dist/lib/domain/duration";
 
 describe("parseDuration", () => {
   it("parses minutes", () => {

--- a/src/lib/domain/installer/npm.test.ts
+++ b/src/lib/domain/installer/npm.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { npmGlobalBin, npmLinkTargetPaths, npmLinkTargetsWritable, pathWithPrependedEntries } from "./npm";
+import { npmGlobalBin, npmLinkTargetPaths, npmLinkTargetsWritable, pathWithPrependedEntries } from "../../../../dist/lib/domain/installer/npm";
 
 function state(options: { existing?: string[]; writable?: string[] }) {
   const existing = new Set(options.existing ?? []);

--- a/src/lib/domain/installer/provider.test.ts
+++ b/src/lib/domain/installer/provider.test.ts
@@ -9,7 +9,7 @@ import {
   installerProviderHelpValues,
   installerProviderUsageLines,
   normalizeInstallerProvider,
-} from "./provider";
+} from "../../../../dist/lib/domain/installer/provider";
 
 describe("installer provider helpers", () => {
   it("normalizes installer provider aliases and case variants", () => {

--- a/src/lib/domain/installer/ref.test.ts
+++ b/src/lib/domain/installer/ref.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { resolveInstallerVersion, resolveInstallRef } from "./ref";
+import { resolveInstallerVersion, resolveInstallRef } from "../../../../dist/lib/domain/installer/ref";
 
 describe("installer ref helpers", () => {
   it("resolves install refs with the same priority as install.sh", () => {

--- a/src/lib/domain/installer/version.test.ts
+++ b/src/lib/domain/installer/version.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { checkInstallerRuntime, versionGte, versionMajor } from "./version";
+import { checkInstallerRuntime, versionGte, versionMajor } from "../../../../dist/lib/domain/installer/version";
 
 describe("installer version helpers", () => {
   it("matches shell version_gte semantics", () => {

--- a/src/lib/domain/lifecycle/options.test.ts
+++ b/src/lib/domain/lifecycle/options.test.ts
@@ -8,7 +8,7 @@ import {
   normalizeGarbageCollectImagesOptions,
   normalizeRebuildSandboxOptions,
   normalizeUpgradeSandboxesOptions,
-} from "./options";
+} from "../../../../dist/lib/domain/lifecycle/options";
 
 describe("lifecycle option normalization", () => {
   it("preserves typed destroy options and still accepts compatibility argv", () => {

--- a/src/lib/domain/maintenance/images.test.ts
+++ b/src/lib/domain/maintenance/images.test.ts
@@ -7,7 +7,7 @@ import {
   findOrphanedSandboxImages,
   getRegisteredImageTags,
   parseSandboxImageRows,
-} from "./images";
+} from "../../../../dist/lib/domain/maintenance/images";
 
 describe("maintenance image helpers", () => {
   it("parses Docker image rows and fills missing sizes", () => {

--- a/src/lib/domain/maintenance/upgrade.test.ts
+++ b/src/lib/domain/maintenance/upgrade.test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipUpgradeConfirmation,
   splitRebuildableSandboxes,
   type SandboxVersionCheck,
-} from "./upgrade";
+} from "../../../../dist/lib/domain/maintenance/upgrade";
 
 describe("upgrade sandboxes helpers", () => {
   it("detects upgrade confirmation bypass modes", () => {

--- a/src/lib/domain/policy-channel.test.ts
+++ b/src/lib/domain/policy-channel.test.ts
@@ -7,7 +7,7 @@ import {
   parseCustomPolicySource,
   parsePolicyAddArgs,
   shouldSkipPolicyConfirmation,
-} from "./policy-channel";
+} from "../../../dist/lib/domain/policy-channel";
 
 describe("policy channel helpers", () => {
   it("parses custom policy source flags", () => {

--- a/src/lib/domain/sandbox/destroy.test.ts
+++ b/src/lib/domain/sandbox/destroy.test.ts
@@ -8,7 +8,7 @@ import {
   isMissingSandboxDeleteOutput,
   shouldCleanupGatewayAfterDestroy,
   shouldStopHostServicesAfterDestroy,
-} from "./destroy";
+} from "../../../../dist/lib/domain/sandbox/destroy";
 
 describe("sandbox destroy helpers", () => {
   it("detects missing sandbox delete output", () => {

--- a/src/lib/domain/sandbox/logs.test.ts
+++ b/src/lib/domain/sandbox/logs.test.ts
@@ -11,7 +11,7 @@ import {
   exitCodeFromSignal,
   getLogsProbeTimeoutMs,
   normalizeSandboxLogsOptions,
-} from "./logs";
+} from "../../../../dist/lib/domain/sandbox/logs";
 
 describe("sandbox logs helpers", () => {
   it("normalizes boolean and partial logs options", () => {

--- a/src/lib/domain/uninstall/paths.test.ts
+++ b/src/lib/domain/uninstall/paths.test.ts
@@ -9,7 +9,7 @@ import {
   gatewayVolumeCandidates,
   OPENSHELL_MANAGED_BINARIES,
   uninstallStatePaths,
-} from "./paths";
+} from "../../../../dist/lib/domain/uninstall/paths";
 
 describe("uninstall paths", () => {
   it("returns the gateway volume candidate used by uninstall.sh", () => {

--- a/src/lib/domain/uninstall/plan.test.ts
+++ b/src/lib/domain/uninstall/plan.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, it } from "vitest";
 
 import path from "node:path";
 
-import { defaultUninstallPaths, OPENSHELL_MANAGED_BINARIES } from "./paths";
-import { buildUninstallPlan, flattenUninstallPlan } from "./plan";
+import { defaultUninstallPaths, OPENSHELL_MANAGED_BINARIES } from "../../../../dist/lib/domain/uninstall/paths";
+import { buildUninstallPlan, flattenUninstallPlan } from "../../../../dist/lib/domain/uninstall/plan";
 
 describe("uninstall plan", () => {
   it("models the six uninstall.sh cleanup steps", () => {

--- a/src/lib/domain/uninstall/shims.test.ts
+++ b/src/lib/domain/uninstall/shims.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { classifyNemoclawShim, DEV_SHIM_MARKER, isDevShimContents, isInstallerManagedWrapperContents } from "./shims";
+import { classifyNemoclawShim, DEV_SHIM_MARKER, isDevShimContents, isInstallerManagedWrapperContents } from "../../../../dist/lib/domain/uninstall/shims";
 
 function wrapper(extra = ""): string {
   return ["#!/usr/bin/env bash", 'export PATH="/tmp/node-bin:$PATH"', 'exec "/tmp/prefix/bin/nemoclaw" "$@"', extra]

--- a/src/lib/inference/ollama/proxy-extra.test.ts
+++ b/src/lib/inference/ollama/proxy-extra.test.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const PROXY_DIST_PATH = require.resolve("../../../../dist/lib/inference/ollama/proxy");
+const RUNNER_DIST_PATH = require.resolve("../../../../dist/lib/runner");
+const CHILD_PROCESS_ID = "child_process";
+
+type ProxyModule = typeof import("../../../../dist/lib/inference/ollama/proxy");
+
+function loadProxyWithMocks({
+  runCapture = vi.fn(() => ""),
+  run = vi.fn(),
+  spawnSync = vi.fn(() => ({ status: 0, stdout: "200" })),
+}: {
+  runCapture?: ReturnType<typeof vi.fn>;
+  run?: ReturnType<typeof vi.fn>;
+  spawnSync?: ReturnType<typeof vi.fn>;
+} = {}): { proxy: ProxyModule; restore: () => void; mocks: { runCapture: typeof runCapture; run: typeof run; spawnSync: typeof spawnSync } } {
+  const runner = require(RUNNER_DIST_PATH);
+  const childProcess = require(CHILD_PROCESS_ID);
+  const originals = {
+    runCapture: runner.runCapture,
+    run: runner.run,
+    spawnSync: childProcess.spawnSync,
+  };
+  delete require.cache[PROXY_DIST_PATH];
+  runner.runCapture = runCapture;
+  runner.run = run;
+  childProcess.spawnSync = spawnSync;
+  const proxy = require(PROXY_DIST_PATH) as ProxyModule;
+  return {
+    proxy,
+    mocks: { runCapture, run, spawnSync },
+    restore: () => {
+      delete require.cache[PROXY_DIST_PATH];
+      runner.runCapture = originals.runCapture;
+      runner.run = originals.run;
+      childProcess.spawnSync = originals.spawnSync;
+    },
+  };
+}
+
+afterEach(() => {
+  delete require.cache[PROXY_DIST_PATH];
+  delete process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT;
+  vi.restoreAllMocks();
+});
+
+describe("ollama proxy helpers", () => {
+  it("uses default pull timeout for unset, empty, invalid, or non-positive values", () => {
+    const { proxy, restore } = loadProxyWithMocks();
+    try {
+      expect(proxy.getOllamaPullTimeoutMs()).toBe(30 * 60 * 1000);
+      process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT = "";
+      expect(proxy.getOllamaPullTimeoutMs()).toBe(30 * 60 * 1000);
+      process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT = "bogus";
+      expect(proxy.getOllamaPullTimeoutMs()).toBe(30 * 60 * 1000);
+      process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT = "0";
+      expect(proxy.getOllamaPullTimeoutMs()).toBe(30 * 60 * 1000);
+    } finally {
+      restore();
+    }
+  });
+
+  it("converts positive pull timeout seconds to milliseconds", () => {
+    process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT = "12.9";
+    const { proxy, restore } = loadProxyWithMocks();
+    try {
+      expect(proxy.getOllamaPullTimeoutMs()).toBe(12_900);
+    } finally {
+      restore();
+    }
+  });
+
+  it("unloads each running Ollama model with keep_alive zero", () => {
+    const spawnSync = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0, stdout: JSON.stringify({ models: [{ name: "qwen" }, {}, { name: "llama" }] }) })
+      .mockReturnValue({ status: 0, stdout: "" });
+    const { proxy, restore } = loadProxyWithMocks({ spawnSync });
+    try {
+      proxy.unloadOllamaModels();
+      expect(spawnSync).toHaveBeenCalledTimes(3);
+      const firstGenerateArgs = spawnSync.mock.calls[1][1] as string[];
+      const secondGenerateArgs = spawnSync.mock.calls[2][1] as string[];
+      expect(JSON.parse(firstGenerateArgs[firstGenerateArgs.indexOf("-d") + 1])).toEqual({
+        model: "qwen",
+        keep_alive: 0,
+      });
+      expect(JSON.parse(secondGenerateArgs[secondGenerateArgs.indexOf("-d") + 1])).toEqual({
+        model: "llama",
+        keep_alive: 0,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("ignores ps failures and malformed ps output while unloading", () => {
+    for (const firstResult of [
+      { status: 7, stdout: "" },
+      { status: 0, stdout: "not-json" },
+    ]) {
+      const spawnSync = vi.fn().mockReturnValue(firstResult);
+      const { proxy, restore } = loadProxyWithMocks({ spawnSync });
+      try {
+        expect(() => proxy.unloadOllamaModels()).not.toThrow();
+        expect(spawnSync).toHaveBeenCalledTimes(1);
+      } finally {
+        restore();
+      }
+    }
+  });
+
+  it("reports healthy when the HTTP probe succeeds even without a matching PID", () => {
+    const runCapture = vi.fn((cmd: string[]) => (cmd[0] === "curl" ? "{}" : ""));
+    const { proxy, mocks, restore } = loadProxyWithMocks({ runCapture });
+    try {
+      expect(proxy.isProxyHealthy()).toBe(true);
+      expect(mocks.runCapture).toHaveBeenCalledWith(
+        expect.arrayContaining(["curl", "-sf"]),
+        { ignoreError: true },
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("falls back to process identity when the HTTP probe fails", () => {
+    const runCapture = vi.fn((cmd: string[]) => {
+      if (cmd[0] === "ps") return "node /tmp/ollama-auth-proxy.js";
+      return "";
+    });
+    const { proxy, restore } = loadProxyWithMocks({ runCapture });
+    try {
+      // No persisted PID is present in the test home, so this should stay false.
+      expect(proxy.isProxyHealthy()).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/lib/inference/vllm-install.test.ts
+++ b/src/lib/inference/vllm-install.test.ts
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { detectVllmProfile, installVllm } from "../../../dist/lib/inference/vllm";
+
+const originalEnv = { ...process.env };
+let binDir: string;
+
+function installFakeCommand(name: string, body: string): void {
+  const file = join(binDir, name);
+  writeFileSync(file, `#!/bin/sh\n${body}`);
+  chmodSync(file, 0o755);
+}
+
+beforeEach(() => {
+  binDir = mkdtempSync(join(tmpdir(), "nemoclaw-vllm-test-bin-"));
+  process.env = { ...originalEnv, PATH: `${binDir}:${originalEnv.PATH ?? ""}` };
+  installFakeCommand("nvidia-smi", "echo NVIDIA GB300\n");
+  installFakeCommand(
+    "docker",
+    `STATE_DIR=${JSON.stringify("__STATE_DIR__")}
+STATE_DIR=${JSON.stringify(binDir)}
+read_file() { [ -f "$STATE_DIR/$1" ] && cat "$STATE_DIR/$1"; }
+case "$1" in
+  pull) exit "$(read_file pull-exit || echo 0)" ;;
+  run)
+    if [ "$2" = "--rm" ]; then
+      echo "Fetching 4 files: 25%|##"
+      exit "$(read_file hf-exit || echo 0)"
+    fi
+    echo fake-container-id
+    exit "$(read_file run-exit || echo 0)"
+    ;;
+  logs)
+    if [ -f "$STATE_DIR/logs-output" ]; then cat "$STATE_DIR/logs-output"; else echo "Application startup complete"; fi
+    exit "$(read_file logs-exit || echo 0)"
+    ;;
+  ps)
+    if [ -f "$STATE_DIR/ps-output" ]; then cat "$STATE_DIR/ps-output"; else echo "nemoclaw-vllm"; fi
+    ;;
+  rm|stop) exit 0 ;;
+  *) exit 0 ;;
+esac
+`,
+  );
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  rmSync(binDir, { recursive: true, force: true });
+});
+
+describe("installVllm", () => {
+  it("returns false when an interactive user declines", async () => {
+    const profile = detectVllmProfile({ type: "nvidia" });
+    await expect(
+      installVllm(profile!, {
+        hasImage: false,
+        nonInteractive: false,
+        promptFn: async () => "no",
+      }),
+    ).resolves.toEqual({ ok: false });
+  });
+
+  it("fails before pulling when docker is missing", async () => {
+    const noDockerDir = mkdtempSync(join(tmpdir(), "nemoclaw-vllm-no-docker-"));
+    try {
+      const nvidiaSmi = join(noDockerDir, "nvidia-smi");
+      writeFileSync(nvidiaSmi, "#!/bin/sh\necho NVIDIA GB300\n");
+      chmodSync(nvidiaSmi, 0o755);
+      process.env.PATH = noDockerDir;
+      const profile = detectVllmProfile({ type: "nvidia" });
+      await expect(
+        installVllm(profile!, { hasImage: true, nonInteractive: true, promptFn: async () => "" }),
+      ).resolves.toEqual({ ok: false });
+    } finally {
+      rmSync(noDockerDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails when docker pull exits nonzero", async () => {
+    writeFileSync(join(binDir, "pull-exit"), "17");
+    const profile = detectVllmProfile({ type: "nvidia" });
+    await expect(
+      installVllm(profile!, { hasImage: false, nonInteractive: true, promptFn: async () => "" }),
+    ).resolves.toEqual({ ok: false });
+  });
+
+  it("returns true after model download, container start, log readiness, and running check", async () => {
+    const profile = detectVllmProfile({ type: "nvidia" });
+    await expect(
+      installVllm(profile!, { hasImage: true, nonInteractive: true, promptFn: async () => "" }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("stops the container when readiness sees a fatal log marker", async () => {
+    writeFileSync(join(binDir, "logs-output"), "CUDA out of memory\n");
+    const profile = detectVllmProfile({ type: "nvidia" });
+    await expect(
+      installVllm(profile!, { hasImage: true, nonInteractive: true, promptFn: async () => "" }),
+    ).resolves.toEqual({ ok: false });
+  });
+
+  it("fails when the container exits after reporting ready", async () => {
+    writeFileSync(join(binDir, "ps-output"), "");
+    const profile = detectVllmProfile({ type: "nvidia" });
+    await expect(
+      installVllm(profile!, { hasImage: true, nonInteractive: true, promptFn: async () => "" }),
+    ).resolves.toEqual({ ok: false });
+  });
+});

--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { getSandboxInventory, listSandboxesCommand, showStatusCommand } from "./index";
+import { getSandboxInventory, listSandboxesCommand, showStatusCommand } from "../../../dist/lib/inventory/index";
 
 describe("inventory commands", () => {
   it("returns structured empty inventory for JSON consumers", async () => {

--- a/src/lib/policy/index.test.ts
+++ b/src/lib/policy/index.test.ts
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildPolicyGetCommand,
+  buildPolicySetCommand,
+  clampSetupPolicyPresetNames,
+  extractPresetEntries,
+  filterSetupPolicyPresets,
+  getMessagingPresetWarning,
+  getPresetEndpoints,
+  loadPreset,
+  loadPresetFromFile,
+  mergePresetIntoPolicy,
+  parseCurrentPolicy,
+  removePresetFromPolicy,
+  setupPolicyPresetSupported,
+} from "../../../dist/lib/policy/index.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+  delete process.env.NEMOCLAW_OPENSHELL_BIN;
+});
+
+function tempFile(name: string, content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "nemoclaw-policy-test-"));
+  tempDirs.push(dir);
+  const file = join(dir, name);
+  writeFileSync(file, content);
+  return file;
+}
+
+describe("policy preset pure helpers", () => {
+  it("extracts endpoint hosts and messaging warnings", () => {
+    const endpoints = getPresetEndpoints(`
+network_policies:
+  allow_one:
+    host: "api.example.com"
+  allow_two:
+    host: slack.com
+`);
+    expect(endpoints).toEqual(["api.example.com", "slack.com"]);
+    expect(getMessagingPresetWarning("telegram")).toContain("Telegram");
+    expect(getMessagingPresetWarning("not-messaging")).toBeNull();
+  });
+
+  it("filters setup presets based on web-search support", () => {
+    const presets = [{ name: "brave" }, { name: "github" }, { name: "custom" }];
+    expect(setupPolicyPresetSupported("brave", { webSearchSupported: false })).toBe(false);
+    expect(setupPolicyPresetSupported("brave", { webSearchSupported: true })).toBe(true);
+    expect(filterSetupPolicyPresets(presets, { webSearchSupported: false })).toEqual([
+      { name: "github" },
+      { name: "custom" },
+    ]);
+    expect(
+      clampSetupPolicyPresetNames(["brave", "github", "missing", "custom"], presets, {
+        webSearchSupported: false,
+      }),
+    ).toEqual(["github", "custom"]);
+    expect(
+      clampSetupPolicyPresetNames(
+        ["brave", "github", "custom"],
+        presets,
+        { webSearchSupported: false },
+        new Set(["brave"]),
+      ),
+    ).toEqual(["brave", "github", "custom"]);
+  });
+
+  it("parses gateway policy output defensively", () => {
+    expect(parseCurrentPolicy(null)).toBe("");
+    expect(parseCurrentPolicy("Version: 1\n---\nversion: 1\nnetwork_policies: {}\n")).toContain(
+      "network_policies",
+    );
+    expect(parseCurrentPolicy("error: gateway unavailable")).toBe("");
+    expect(parseCurrentPolicy("just some text")).toBe("");
+    expect(parseCurrentPolicy("version: [")).toBe("");
+  });
+
+  it("extracts network policy entries from preset YAML", () => {
+    expect(extractPresetEntries(null)).toBeNull();
+    expect(extractPresetEntries("preset:\n  name: demo\n")).toBeNull();
+    expect(
+      extractPresetEntries(`preset:
+  name: demo
+network_policies:
+  demo:
+    host: example.com
+`),
+    ).toBe("  demo:\n    host: example.com");
+  });
+
+  it("builds policy commands with the configured OpenShell binary", () => {
+    process.env.NEMOCLAW_OPENSHELL_BIN = "/opt/openshell";
+    expect(buildPolicyGetCommand("alpha")).toEqual(["/opt/openshell", "policy", "get", "--full", "alpha"]);
+    expect(buildPolicySetCommand("/tmp/policy.yaml", "alpha")).toEqual([
+      "/opt/openshell",
+      "policy",
+      "set",
+      "--policy",
+      "/tmp/policy.yaml",
+      "--wait",
+      "alpha",
+    ]);
+  });
+});
+
+describe("policy preset merge/remove helpers", () => {
+  const presetEntries = `  allow_api:
+    host: api.example.com
+    port: 443
+`;
+
+  it("merges structured preset entries into empty and existing policies", () => {
+    expect(mergePresetIntoPolicy("", presetEntries)).toContain("allow_api");
+    const merged = mergePresetIntoPolicy(
+      `Version: 1
+---
+version: 2
+filesystem_policy:
+  read_only: true
+network_policies:
+  keep_me:
+    host: keep.example.com
+`,
+      presetEntries,
+    );
+    expect(merged).toContain("filesystem_policy");
+    expect(merged).toContain("keep_me");
+    expect(merged).toContain("allow_api");
+  });
+
+  it("handles versionless policies and legacy non-map network policies while merging", () => {
+    const versionless = mergePresetIntoPolicy("filesystem_policy:\n  read_only: true\n", presetEntries);
+    expect(versionless).toMatch(/^version: 1/m);
+    expect(versionless).toContain("filesystem_policy");
+    expect(versionless).toContain("allow_api");
+
+    const legacyList = mergePresetIntoPolicy("version: 2\nnetwork_policies:\n  - legacy\n", presetEntries);
+    expect(legacyList).toContain("version: 2");
+    expect(legacyList).toContain("allow_api");
+    expect(legacyList).not.toContain("- legacy");
+  });
+
+  it("lets preset entries override existing network policy keys", () => {
+    const merged = mergePresetIntoPolicy(
+      `version: 1
+network_policies:
+  allow_api:
+    host: old.example.com
+    port: 80
+`,
+      presetEntries,
+    );
+    expect(merged).toContain("host: api.example.com");
+    expect(merged).toContain("port: 443");
+    expect(merged).not.toContain("old.example.com");
+  });
+
+  it("falls back to text merging for unparseable preset entries", () => {
+    expect(mergePresetIntoPolicy("version: 1\n", "  - not-a-map")).toContain("network_policies:");
+    expect(mergePresetIntoPolicy("", "")).toBe("version: 1\n\nnetwork_policies:\n");
+  });
+
+  it("removes structured preset entries from existing policies", () => {
+    const current = `version: 1
+network_policies:
+  allow_api:
+    host: api.example.com
+  keep_me:
+    host: keep.example.com
+`;
+    const removed = removePresetFromPolicy(current, presetEntries);
+    expect(removed).not.toContain("allow_api");
+    expect(removed).toContain("keep_me");
+    expect(removePresetFromPolicy(current, null)).toBe(current.trimEnd());
+    expect(removePresetFromPolicy("", presetEntries)).toBe("version: 1\n\nnetwork_policies:\n");
+  });
+
+  it("leaves removal unchanged for legacy non-map policies and unparsable current policy", () => {
+    const legacyList = "version: 1\nnetwork_policies:\n  - legacy\n";
+    expect(removePresetFromPolicy(legacyList, presetEntries)).toBe(legacyList.trimEnd());
+    expect(removePresetFromPolicy("version: [", presetEntries)).toBe("version: 1\n\nnetwork_policies:\n");
+  });
+
+  it("leaves policies unchanged when preset entries cannot identify keys", () => {
+    const current = "version: 1\nnetwork_policies:\n  keep_me:\n    host: keep.example.com\n";
+    expect(removePresetFromPolicy(current, "  - not-a-map")).toBe(current);
+  });
+});
+
+describe("loadPresetFromFile", () => {
+  it("loads a valid custom preset file", () => {
+    const file = tempFile(
+      "custom.yaml",
+      `preset:
+  name: custom-egress
+network_policies:
+  custom_egress:
+    host: custom.example.com
+`,
+    );
+    expect(loadPresetFromFile(file)).toEqual({
+      presetName: "custom-egress",
+      content: expect.stringContaining("custom.example.com"),
+    });
+  });
+
+  it("rejects invalid custom preset files", () => {
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((message) => errors.push(String(message)));
+
+    expect(loadPresetFromFile(tempFile("not-text.txt", "preset:\n  name: bad\n"))).toBeNull();
+    expect(loadPresetFromFile(join(tmpdir(), "missing-policy.yaml"))).toBeNull();
+    expect(loadPresetFromFile(tempFile("bad.yaml", "preset: ["))).toBeNull();
+    expect(loadPresetFromFile(tempFile("array.yaml", "- item\n"))).toBeNull();
+    expect(loadPresetFromFile(tempFile("missing-name.yaml", "network_policies: {}\n"))).toBeNull();
+    expect(
+      loadPresetFromFile(tempFile("missing-network.yaml", "preset:\n  name: custom-egress\n")),
+    ).toBeNull();
+
+    expect(errors.join("\n")).toContain("Preset file must be .yaml or .yml");
+    expect(errors.join("\n")).toContain("Preset file not found");
+    expect(errors.join("\n")).toContain("Invalid YAML");
+    expect(errors.join("\n")).toContain("Preset must be a YAML mapping");
+    expect(errors.join("\n")).toContain("Preset must declare preset.name");
+    expect(errors.join("\n")).toContain("Preset missing network_policies section");
+  });
+
+  it("keeps built-in presets on the built-in path", () => {
+    expect(loadPreset("../../etc/passwd")).toBeNull();
+    expect(loadPreset("definitely-missing-preset")).toBeNull();
+  });
+});

--- a/src/lib/sandbox/config-extra.test.ts
+++ b/src/lib/sandbox/config-extra.test.ts
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyNewKeyGate,
+  extractDotpath,
+  findClobberingAncestor,
+  formatConfigValueForLogs,
+  parseConfig,
+  privilegedSandboxExecArgv,
+  selectDockerDriverSandboxContainer,
+  setDotpath,
+  validateConfigDotpath,
+  validateUrlValue,
+  validateUrlValueWithDns,
+  rewriteConfigUrlsWithDnsPinning,
+} from "../../../dist/lib/sandbox/config";
+
+describe("sandbox config helpers", () => {
+  it("extracts nested object and array dotpaths", () => {
+    const config = { a: { b: [{ c: 3 }] } };
+    expect(extractDotpath(config, "a.b.0.c")).toBe(3);
+    expect(extractDotpath(config, "a.b.x.c")).toBeUndefined();
+    expect(extractDotpath(config, "a.missing.value")).toBeUndefined();
+  });
+
+  it("sets missing object ancestors without clobbering siblings", () => {
+    const config = { existing: true };
+    setDotpath(config, "a.b.c", 3);
+    expect(config).toEqual({ existing: true, a: { b: { c: 3 } } });
+  });
+
+  it("validates dotpath syntax and reserved segments", () => {
+    expect(validateConfigDotpath("model.name")).toEqual({ ok: true });
+    expect(validateConfigDotpath("")).toMatchObject({ ok: false, reason: "key is empty" });
+    expect(validateConfigDotpath("model..name")).toMatchObject({ ok: false });
+    expect(validateConfigDotpath("model.__proto__.polluted")).toMatchObject({ ok: false });
+  });
+
+  it("detects array and scalar ancestors that config set would clobber", () => {
+    expect(findClobberingAncestor({ list: [] }, "list.0.name")).toMatchObject({
+      segment: "list.0",
+    });
+    expect(findClobberingAncestor({ model: "qwen" }, "model.name")).toMatchObject({
+      segment: "model",
+    });
+    expect(findClobberingAncestor({ model: { name: "qwen" } }, "model.name")).toBeNull();
+    expect(findClobberingAncestor("root-scalar", "model.name")).toMatchObject({ segment: "(root)" });
+  });
+
+  it("classifies new-key gates from explicit override, TTY, and non-interactive inputs", () => {
+    expect(classifyNewKeyGate({ acceptNewPath: true })).toEqual({ mode: "accept" });
+    expect(classifyNewKeyGate({ acceptEnv: "1" })).toEqual({ mode: "accept" });
+    expect(classifyNewKeyGate({ isTTY: true })).toEqual({ mode: "prompt" });
+    expect(classifyNewKeyGate({ isTTY: true, nonInteractiveEnv: "1" })).toEqual({ mode: "refuse" });
+    expect(classifyNewKeyGate({ isTTY: false })).toEqual({ mode: "refuse" });
+  });
+
+  it("parses JSON and YAML config objects and rejects non-objects", () => {
+    expect(parseConfig('{"model":"qwen"}', "json")).toEqual({ model: "qwen" });
+    expect(parseConfig("model: qwen\n", "yaml")).toEqual({ model: "qwen" });
+    expect(() => parseConfig("[]", "json")).toThrow(/Config is not an object/);
+  });
+
+  it("redacts strings, URLs, and credential fields in config previews", () => {
+    expect(formatConfigValueForLogs(undefined)).toBe("(not set)");
+    expect(formatConfigValueForLogs("secret")).toBe('"[REDACTED_STRING]"');
+    expect(formatConfigValueForLogs("https://example.com/token?q=1")).toBe('"[REDACTED_URL]"');
+    expect(formatConfigValueForLogs({ apiKey: "secret", nested: ["safe"] })).toBe(
+      '{"apiKey":"[REDACTED]","nested":["[REDACTED_STRING]"]}',
+    );
+  });
+
+  it("validates URL hosts before config writes", async () => {
+    expect(() => validateUrlValue("not-a-url")).not.toThrow();
+    expect(() => validateUrlValue("https://example.com/path")).not.toThrow();
+    expect(() => validateUrlValue("http://127.0.0.1:8080")).toThrow(/private\/internal/);
+
+    await expect(
+      validateUrlValueWithDns("https://public.example", async () => [{ address: "93.184.216.34", family: 4 }]),
+    ).resolves.toBeUndefined();
+    await expect(
+      validateUrlValueWithDns("https://private.example", async () => [{ address: "10.0.0.5", family: 4 }]),
+    ).rejects.toThrow(/resolves to private/);
+  });
+
+  it("pins HTTP URLs after DNS validation but preserves HTTPS hostnames", async () => {
+    const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+    await expect(rewriteConfigUrlsWithDnsPinning("http://example.com/path", lookup)).resolves.toBe(
+      "http://93.184.216.34/path",
+    );
+    await expect(rewriteConfigUrlsWithDnsPinning("https://example.com/path", lookup)).resolves.toBe(
+      "https://example.com/path",
+    );
+    await expect(rewriteConfigUrlsWithDnsPinning({ urls: ["not-a-url"] }, lookup)).resolves.toEqual({
+      urls: ["not-a-url"],
+    });
+  });
+
+  it("selects docker-driver sandbox containers by exact name or prefix", () => {
+    expect(selectDockerDriverSandboxContainer("alpha", "vm", "openshell-alpha")).toBeNull();
+    expect(selectDockerDriverSandboxContainer("alpha", "docker", "other\nopenshell-alpha-worker")).toBe(
+      "openshell-alpha-worker",
+    );
+    expect(selectDockerDriverSandboxContainer("alpha", "docker", "openshell-alpha\nother")).toBe(
+      "openshell-alpha",
+    );
+  });
+
+  it("builds kubectl fallback argv when no docker-driver container resolves", () => {
+    expect(privilegedSandboxExecArgv("alpha", ["cat", "/config"], true)).toEqual([
+      "exec",
+      "-i",
+      "openshell-cluster-nemoclaw",
+      "kubectl",
+      "exec",
+      "-n",
+      "openshell",
+      "alpha",
+      "-c",
+      "agent",
+      "-i",
+      "--",
+      "cat",
+      "/config",
+    ]);
+  });
+});

--- a/src/lib/sandbox/create-stream.test.ts
+++ b/src/lib/sandbox/create-stream.test.ts
@@ -9,7 +9,7 @@ import {
   type StreamableChildProcess,
   type StreamableReadable,
   streamSandboxCreate,
-} from "./create-stream";
+} from "../../../dist/lib/sandbox/create-stream";
 
 class FakeReadable extends EventEmitter implements StreamableReadable {
   destroy(): void {}

--- a/src/lib/shields/index-dist-coverage.test.ts
+++ b/src/lib/shields/index-dist-coverage.test.ts
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import Module from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dockerExecFileSyncMock = vi.fn((argv: string[]): string => {
+  const command = argv.join(" ");
+  if (command.includes("stat -c %a %U:%G")) {
+    if (command.includes(".openclaw/openclaw.json") || command.includes(".openclaw/.env")) {
+      return "444 root:root";
+    }
+    return "755 root:root";
+  }
+  if (command.includes("lsattr -d")) return "----i--------e------- /sandbox/.openclaw/openclaw.json";
+  return "";
+});
+const dockerCaptureMock = vi.fn(() => "openshell-alpha-1\nother\n");
+const validateNameMock = vi.fn((name: string) => name);
+const appendAuditEntryMock = vi.fn();
+
+const runnerMock = () => ({
+  run: vi.fn(() => ({ status: 0 })),
+  runCapture: vi.fn(() => "version: 1\nnetwork_policies: {}\n"),
+  validateName: validateNameMock,
+  shellQuote: vi.fn((value: string) => `'${value}'`),
+});
+
+const dockerExecMock = () => ({ dockerExecFileSync: dockerExecFileSyncMock });
+const dockerRunMock = () => ({ dockerCapture: dockerCaptureMock });
+const registryMock = () => ({
+  getSandbox: vi.fn((name: string) => (name === "alpha" ? { openshellDriver: "docker" } : null)),
+});
+const policyMock = () => ({
+  buildPolicyGetCommand: vi.fn((name: string) => ["openshell", "policy", "get", name]),
+  buildPolicySetCommand: vi.fn((file: string, name: string) => ["openshell", "policy", "set", file, name]),
+  parseCurrentPolicy: vi.fn((raw: string) => raw),
+  resolvePermissivePolicyPath: vi.fn(() => "/tmp/permissive.yaml"),
+});
+const timerControlMock = () => ({
+  timerMarkerPath: vi.fn((name: string) => `/tmp/shields-timer-${name}.json`),
+  readTimerMarker: vi.fn(() => null),
+  clearTimerMarker: vi.fn(),
+  isProcessAlive: vi.fn(() => false),
+  verifyTimerMarkerIdentity: vi.fn(() => false),
+  killTimer: vi.fn(),
+});
+const auditMock = () => ({ appendAuditEntry: appendAuditEntryMock });
+const sandboxConfigMock = () => ({
+  resolveAgentConfig: vi.fn(() => ({
+    agentName: "openclaw",
+    configPath: "/sandbox/.openclaw/openclaw.json",
+    configDir: "/sandbox/.openclaw",
+    sensitiveFiles: ["/sandbox/.openclaw/.env"],
+  })),
+});
+
+type ShieldsModule = typeof import("../../../dist/lib/shields/index.js");
+
+let tmpHome: string;
+let shields: ShieldsModule;
+const originalLoad = (Module as unknown as { _load: unknown })._load as (
+  request: string,
+  parent: unknown,
+  isMain: boolean,
+) => unknown;
+
+function stateDir(): string {
+  return path.join(tmpHome, ".nemoclaw", "state");
+}
+
+function writeState(sandboxName: string, state: Record<string, unknown> | string): void {
+  fs.mkdirSync(stateDir(), { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir(), `shields-${sandboxName}.json`),
+    typeof state === "string" ? state : JSON.stringify(state, null, 2),
+  );
+}
+
+beforeEach(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "shields-dist-"));
+  vi.stubEnv("HOME", tmpHome);
+  vi.resetModules();
+  vi.clearAllMocks();
+  (Module as unknown as { _load: typeof originalLoad })._load = (request, parent, isMain) => {
+    if (request === "../runner") return runnerMock();
+    if (request === "../adapters/docker/exec") return dockerExecMock();
+    if (request === "../adapters/docker/run") return dockerRunMock();
+    if (request === "../state/registry") return registryMock();
+    if (request === "../policy") return policyMock();
+    if (request === "./timer-control") return timerControlMock();
+    if (request === "./audit") return auditMock();
+    if (request === "../sandbox/config") return sandboxConfigMock();
+    return originalLoad(request, parent, isMain);
+  };
+  shields = await import("../../../dist/lib/shields/index.js");
+});
+
+afterEach(() => {
+  (Module as unknown as { _load: typeof originalLoad })._load = originalLoad;
+  vi.unstubAllEnvs();
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("dist shields coverage", () => {
+  it("derives all persisted shields modes", () => {
+    expect(shields.deriveShieldsMode({}, false)).toBe("mutable_default");
+    expect(shields.deriveShieldsMode({}, true)).toBe("mutable_default");
+    expect(shields.deriveShieldsMode({ shieldsDown: true }, true)).toBe("temporarily_unlocked");
+    expect(shields.deriveShieldsMode({ shieldsDown: false }, true)).toBe("locked");
+  });
+
+  it("reports default, locked, down, and corrupt states", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`exit:${String(code ?? 0)}`);
+    });
+
+    shields.shieldsStatus("fresh", false);
+    expect(log.mock.calls.flat().join("\n")).toContain("NOT CONFIGURED");
+
+    writeState("locked", { shieldsDown: false, shieldsPolicySnapshotPath: "/tmp/snapshot.yaml" });
+    shields.shieldsStatus("locked", false);
+    expect(log.mock.calls.flat().join("\n")).toContain("UP (lockdown active)");
+
+    writeState("down", {
+      shieldsDown: true,
+      shieldsDownAt: new Date().toISOString(),
+      shieldsDownTimeout: 300,
+      shieldsDownReason: "test",
+      shieldsDownPolicy: "permissive",
+    });
+    shields.shieldsStatus("down", false);
+    expect(log.mock.calls.flat().join("\n")).toContain("DOWN (temporarily unlocked)");
+
+    writeState("corrupt", "not json");
+    expect(() => shields.shieldsStatus("corrupt", false)).toThrow("exit:1");
+    expect(error.mock.calls.flat().join("\n")).toContain("state file is corrupt");
+
+    exit.mockRestore();
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it("answers whether shields are down from persisted state", () => {
+    expect(shields.isShieldsDown("fresh", false)).toBe(true);
+    writeState("locked", { shieldsDown: false });
+    expect(shields.isShieldsDown("locked", false)).toBe(false);
+    writeState("down", { shieldsDown: true });
+    expect(shields.isShieldsDown("down", false)).toBe(true);
+    writeState("corrupt", "not json");
+    expect(shields.isShieldsDown("corrupt", false)).toBe(false);
+  });
+
+  it("locks and unlocks OpenClaw config trees with sensitive files", () => {
+    shields.lockAgentConfig("alpha", {
+      configPath: "/sandbox/.openclaw/openclaw.json",
+      configDir: "/sandbox/.openclaw",
+      sensitiveFiles: ["/sandbox/.openclaw/.env"],
+    });
+
+    expect(dockerCaptureMock).toHaveBeenCalled();
+    expect(dockerExecFileSyncMock.mock.calls.some(([argv]) => argv.includes("openshell-alpha-1"))).toBe(true);
+    expect(dockerExecFileSyncMock.mock.calls.some(([argv]) => argv.includes("chattr") && argv.includes("+i"))).toBe(true);
+
+    dockerExecFileSyncMock.mockImplementation((argv: string[]): string => {
+      const command = argv.join(" ");
+      if (command.includes("stat -c %a %U:%G")) {
+        if (command.includes(".openclaw/openclaw.json") || command.includes(".openclaw/.env")) {
+          return "660 sandbox:sandbox";
+        }
+        return "2770 sandbox:sandbox";
+      }
+      if (command.includes("lsattr -d")) return "---------------- /sandbox/.openclaw/openclaw.json";
+      return "";
+    });
+
+    shields.unlockAgentConfig("alpha", {
+      configPath: "/sandbox/.openclaw/openclaw.json",
+      configDir: "/sandbox/.openclaw",
+      sensitiveFiles: ["/sandbox/.openclaw/.env"],
+    });
+
+    expect(dockerExecFileSyncMock.mock.calls.some(([argv]) => argv.includes("chattr") && argv.includes("-i"))).toBe(true);
+    expect(dockerExecFileSyncMock.mock.calls.some(([argv]) => argv.includes("chmod") && argv.includes("2770"))).toBe(true);
+  });
+});

--- a/src/lib/shields/timer-dist-coverage.test.ts
+++ b/src/lib/shields/timer-dist-coverage.test.ts
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import Module from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runMock = vi.fn(() => ({ status: 0 }));
+const lockAgentConfigMock = vi.fn();
+const appendAuditEntryMock = vi.fn();
+const resolveAgentConfigMock = vi.fn(() => ({
+  configPath: "/sandbox/.openclaw/openclaw.json",
+  configDir: "/sandbox/.openclaw",
+}));
+const defaultAgentConfig = { configPath: "/sandbox/.openclaw/openclaw.json", configDir: "/sandbox/.openclaw" };
+const originalLoad = (Module as unknown as { _load: unknown })._load as (
+  request: string,
+  parent: unknown,
+  isMain: boolean,
+) => unknown;
+
+type TimerModule = typeof import("../../../dist/lib/shields/timer.js");
+
+let tmpHome: string;
+let timer: TimerModule;
+
+function stateDir(): string {
+  return path.join(tmpHome, ".nemoclaw", "state");
+}
+
+function invokeTimer(args: NonNullable<ReturnType<TimerModule["parseTimerArgs"]>>): number {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
+    throw new Error(`exit:${String(code ?? 0)}`);
+  });
+  try {
+    timer.runRestoreTimer(args);
+    throw new Error("expected exit");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    expect(message.startsWith("exit:")).toBe(true);
+    return Number.parseInt(message.slice("exit:".length), 10);
+  } finally {
+    exitSpy.mockRestore();
+  }
+}
+
+beforeEach(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "shields-timer-dist-"));
+  vi.stubEnv("HOME", tmpHome);
+  vi.resetModules();
+  vi.clearAllMocks();
+  (Module as unknown as { _load: typeof originalLoad })._load = (request, parent, isMain) => {
+    if (request === "../runner") return { run: runMock };
+    if (request === "../policy") {
+      return { buildPolicySetCommand: (file: string, name: string) => ["policy", "set", file, name] };
+    }
+    if (request === "../sandbox/config") {
+      return {
+        DEFAULT_AGENT_CONFIG: defaultAgentConfig,
+        resolveAgentConfig: resolveAgentConfigMock,
+      };
+    }
+    if (request === "./index") return { lockAgentConfig: lockAgentConfigMock };
+    if (request === "./audit") return { appendAuditEntry: appendAuditEntryMock };
+    return originalLoad(request, parent, isMain);
+  };
+  timer = await import("../../../dist/lib/shields/timer.js");
+});
+
+afterEach(() => {
+  (Module as unknown as { _load: typeof originalLoad })._load = originalLoad;
+  vi.unstubAllEnvs();
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("dist shields timer coverage", () => {
+  it("parses valid and invalid timer arguments", () => {
+    expect(timer.parseTimerArgs([])).toBeNull();
+    expect(timer.parseTimerArgs(["alpha", "/tmp/snapshot.yaml", "not-a-date"])).toBeNull();
+
+    const restoreAtIso = new Date(Date.now() + 60_000).toISOString();
+    const args = timer.parseTimerArgs(["alpha", "/tmp/snapshot.yaml", restoreAtIso, "/cfg.json", "/cfg", "tok"]);
+    expect(args).toMatchObject({ sandboxName: "alpha", snapshotPath: "/tmp/snapshot.yaml", restoreAtIso });
+    expect(args?.delayMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not restore when marker is missing", () => {
+    fs.mkdirSync(stateDir(), { recursive: true });
+    const snapshot = path.join(stateDir(), "snapshot.yaml");
+    const restoreAtIso = new Date(Date.now() + 60_000).toISOString();
+    fs.writeFileSync(snapshot, "version: 1\n");
+    const args = timer.parseTimerArgs(["alpha", snapshot, restoreAtIso, "/cfg.json", "/cfg", "tok"]);
+    expect(args).not.toBeNull();
+
+    expect(invokeTimer(args!)).toBe(0);
+    expect(runMock).not.toHaveBeenCalled();
+    expect(lockAgentConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("restores policy, locks config, updates state, and removes owned marker", () => {
+    fs.mkdirSync(stateDir(), { recursive: true });
+    const sandboxName = "alpha";
+    const snapshot = path.join(stateDir(), "snapshot.yaml");
+    const restoreAtIso = new Date(Date.now() + 60_000).toISOString();
+    const markerPath = path.join(stateDir(), `shields-timer-${sandboxName}.json`);
+    const stateFile = path.join(stateDir(), `shields-${sandboxName}.json`);
+    fs.writeFileSync(snapshot, "version: 1\n");
+    fs.writeFileSync(stateFile, JSON.stringify({ shieldsDown: true }));
+    fs.writeFileSync(
+      markerPath,
+      JSON.stringify({ pid: process.pid, sandboxName, snapshotPath: snapshot, restoreAt: restoreAtIso, processToken: "tok" }),
+    );
+    const args = timer.parseTimerArgs([sandboxName, snapshot, restoreAtIso, "/cfg.json", "/cfg", "tok"]);
+    expect(args).not.toBeNull();
+
+    expect(invokeTimer(args!)).toBe(0);
+    expect(runMock).toHaveBeenCalledWith(["policy", "set", snapshot, sandboxName], { ignoreError: true });
+    expect(lockAgentConfigMock).toHaveBeenCalled();
+    expect(JSON.parse(fs.readFileSync(stateFile, "utf-8"))).toMatchObject({ shieldsDown: false });
+    expect(fs.existsSync(markerPath)).toBe(false);
+  });
+
+  it("keeps shields down and audits when policy restore fails", () => {
+    runMock.mockReturnValueOnce({ status: 42 });
+    fs.mkdirSync(stateDir(), { recursive: true });
+    const sandboxName = "alpha";
+    const snapshot = path.join(stateDir(), "snapshot.yaml");
+    const restoreAtIso = new Date(Date.now() + 60_000).toISOString();
+    const markerPath = path.join(stateDir(), `shields-timer-${sandboxName}.json`);
+    const stateFile = path.join(stateDir(), `shields-${sandboxName}.json`);
+    fs.writeFileSync(snapshot, "version: 1\n");
+    fs.writeFileSync(stateFile, JSON.stringify({ shieldsDown: true }));
+    fs.writeFileSync(
+      markerPath,
+      JSON.stringify({ pid: process.pid, sandboxName, snapshotPath: snapshot, restoreAt: restoreAtIso, processToken: "tok" }),
+    );
+    const args = timer.parseTimerArgs([sandboxName, snapshot, restoreAtIso, "/cfg.json", "/cfg", "tok"]);
+
+    expect(invokeTimer(args!)).toBe(1);
+    expect(appendAuditEntryMock).toHaveBeenCalledWith(expect.objectContaining({ action: "shields_up_failed" }));
+    expect(lockAgentConfigMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/state/sandbox-extra.test.ts
+++ b/src/lib/state/sandbox-extra.test.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parseRestoreArgs,
+  rejectHardLinks,
+  safeTarExtract,
+  validateSnapshotName,
+  validateTarEntries,
+} from "../../../dist/lib/state/sandbox";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function tarBufferFrom(dir: string): Buffer {
+  return execFileSync("tar", ["-cf", "-", "-C", dir, "."]);
+}
+
+describe("sandbox state snapshot helpers", () => {
+  it("validates user-provided snapshot names", () => {
+    expect(validateSnapshotName("release_2026.05-rc1")).toBeNull();
+    expect(validateSnapshotName("bad name")).toContain("Invalid snapshot name");
+    expect(validateSnapshotName("v12")).toContain("conflicts with the auto-assigned version");
+    expect(validateSnapshotName("-bad")).toContain("Invalid snapshot name");
+  });
+
+  it("parses restore selectors and target sandbox overrides", () => {
+    expect(parseRestoreArgs("alpha", ["restore"])).toEqual({ ok: true, targetSandbox: "alpha", selector: null });
+    expect(parseRestoreArgs("alpha", ["restore", "v2"])).toEqual({ ok: true, targetSandbox: "alpha", selector: "v2" });
+    expect(parseRestoreArgs("alpha", ["restore", "snapshot-a", "--to", "beta"])).toEqual({
+      ok: true,
+      targetSandbox: "beta",
+      selector: "snapshot-a",
+    });
+    expect(parseRestoreArgs("alpha", ["restore", "--to"])).toEqual({
+      ok: false,
+      error: "--to requires a target sandbox name.",
+    });
+    expect(parseRestoreArgs("alpha", ["restore", "--to", "--bad"])).toEqual({
+      ok: false,
+      error: "--to requires a target sandbox name.",
+    });
+  });
+
+  it("validates and extracts safe tar archives", () => {
+    const source = tempDir("nemoclaw-state-source-");
+    const target = tempDir("nemoclaw-state-target-");
+    writeFileSync(join(source, "config.json"), JSON.stringify({ ok: true }));
+    const archive = tarBufferFrom(source);
+
+    const validation = validateTarEntries(archive, target);
+    expect(validation.safe).toBe(true);
+    expect(validation.entries).toContain("./config.json");
+    expect(rejectHardLinks(archive)).toEqual([]);
+
+    expect(safeTarExtract(archive, target)).toEqual({ success: true });
+    expect(existsSync(join(target, "config.json"))).toBe(true);
+    expect(JSON.parse(readFileSync(join(target, "config.json"), "utf-8"))).toEqual({ ok: true });
+  });
+
+  it("rejects invalid tar buffers before extraction", () => {
+    const target = tempDir("nemoclaw-state-bad-target-");
+    const result = validateTarEntries(Buffer.from("not a tar"), target);
+    expect(result.safe).toBe(false);
+    expect(result.violations.join("\n")).toContain("tar listing failed");
+
+    const extract = safeTarExtract(Buffer.from("not a tar"), target);
+    expect(extract.success).toBe(false);
+    expect(extract.error).toContain("tar entry validation failed");
+  });
+});

--- a/src/lib/state/sandbox-session.test.ts
+++ b/src/lib/state/sandbox-session.test.ts
@@ -12,7 +12,7 @@ import {
   type ForwardEntry,
   type SessionClassification,
   type SessionDetectionDeps,
-} from "./sandbox-session";
+} from "../../../dist/lib/state/sandbox-session";
 
 describe("parseForwardList", () => {
   it("returns empty array for empty/null input", () => {


### PR DESCRIPTION
## Summary
Adds the M4 stacked coverage pass for CLI inventory, domain, and command helper areas. The change routes existing domain/inventory tests through compiled dist modules for accurate CLI coverage attribution and adds focused command common-helper coverage.

## Changes
- Attribute inventory and domain helper tests to compiled CLI modules under `dist/lib/**`.
- Add command common-helper tests for onboard argument mapping, policy/channel/host helpers, and skill/snapshot runtime bridges.
- Verified CLI coverage moved upward in the M4 target areas, with domain/inventory coverage now much closer to the 80% target.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>