### PR TITLE
test(cli): harden state and credential coverage

### DIFF
--- a/src/lib/actions/dev/npm-link-or-shim.test.ts
+++ b/src/lib/actions/dev/npm-link-or-shim.test.ts
@@ -6,8 +6,8 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
-import { DEV_SHIM_MARKER } from "../../domain/dev/npm-link-or-shim";
-import { runNpmLinkOrShim } from "./npm-link-or-shim";
+import { DEV_SHIM_MARKER } from "../../../../dist/lib/domain/dev/npm-link-or-shim";
+import { runNpmLinkOrShim } from "../../../../dist/lib/actions/dev/npm-link-or-shim";
 
 function setupRepo(): { binPath: string; homeDir: string; repoDir: string; tmpDir: string } {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dev-shim-action-"));

--- a/src/lib/actions/maintenance-action.test.ts
+++ b/src/lib/actions/maintenance-action.test.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+
+type MaintenanceModule = typeof import("../../../dist/lib/actions/maintenance");
+
+const maintenance = require("../../../dist/lib/actions/maintenance") as MaintenanceModule;
+const dockerImage = require("../../../dist/lib/adapters/docker/image") as typeof import("../../../dist/lib/adapters/docker/image");
+const openshellRuntime = require("../../../dist/lib/adapters/openshell/runtime") as typeof import("../../../dist/lib/adapters/openshell/runtime");
+const credentials = require("../../../dist/lib/credentials/store") as typeof import("../../../dist/lib/credentials/store");
+const registry = require("../../../dist/lib/state/registry") as typeof import("../../../dist/lib/state/registry");
+const sandboxState = require("../../../dist/lib/state/sandbox") as typeof import("../../../dist/lib/state/sandbox");
+
+const logs: string[] = [];
+const errors: string[] = [];
+
+beforeEach(() => {
+  logs.length = 0;
+  errors.length = 0;
+  vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+    logs.push(String(message ?? ""));
+  });
+  vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+    errors.push(String(message ?? ""));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("maintenance actions", () => {
+  it("reports when no registered sandboxes are available to back up", () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+
+    maintenance.backupAll();
+
+    expect(logs.join("\n")).toContain("No sandboxes registered");
+  });
+
+  it("backs up only live sandboxes and exits when a backup fails", () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+      output: "NAME\nalpha Ready\ngamma Ready\n",
+      status: 0,
+    });
+    vi.spyOn(sandboxState, "backupSandboxState").mockImplementation(((name: string) =>
+      name === "alpha"
+        ? {
+            backedUpDirs: ["memory"],
+            backedUpFiles: ["config"],
+            failedDirs: [],
+            failedFiles: [],
+            manifest: { backupPath: "/tmp/backup-alpha" },
+            success: true,
+          }
+        : {
+            backedUpDirs: [],
+            backedUpFiles: [],
+            failedDirs: ["memory"],
+            failedFiles: [],
+            manifest: null,
+            success: false,
+          }) as never);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    maintenance.backupAll();
+
+    expect(sandboxState.backupSandboxState).toHaveBeenCalledWith("alpha");
+    expect(sandboxState.backupSandboxState).not.toHaveBeenCalledWith("beta");
+    expect(sandboxState.backupSandboxState).toHaveBeenCalledWith("gamma");
+    expect(logs.join("\n")).toContain("1 backed up, 1 failed, 1 skipped");
+    expect(errors.join("\n")).toContain("gamma: backup failed");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("reports empty sandbox image inventory without registry lookup", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue("");
+    const registrySpy = vi.spyOn(registry, "listSandboxes");
+
+    await maintenance.garbageCollectImages({ yes: true });
+
+    expect(logs.join("\n")).toContain("No sandbox images found");
+    expect(registrySpy).not.toHaveBeenCalled();
+  });
+
+  it("dry-runs orphan sandbox image cleanup", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue(
+      "openshell/sandbox-from:used\t1GB\nopenshell/sandbox-from:old\t2GB\n",
+    );
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha", imageTag: "openshell/sandbox-from:used" }],
+    });
+    const rmi = vi.spyOn(dockerImage, "dockerRmi");
+
+    await maintenance.garbageCollectImages({ dryRun: true });
+
+    expect(logs.join("\n")).toContain("openshell/sandbox-from:old");
+    expect(logs.join("\n")).toContain("--dry-run: would remove 1 image");
+    expect(rmi).not.toHaveBeenCalled();
+  });
+
+  it("prompts and removes orphan sandbox images", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue("openshell/sandbox-from:old\t2GB\n");
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+    vi.spyOn(credentials, "prompt").mockResolvedValue("yes");
+    vi.spyOn(dockerImage, "dockerRmi").mockReturnValue({
+      error: undefined,
+      signal: null,
+      status: 0,
+      stderr: "",
+      stdout: "",
+    } as never);
+
+    await maintenance.garbageCollectImages({});
+
+    expect(credentials.prompt).toHaveBeenCalledWith(expect.stringContaining("Remove 1 orphaned image"));
+    expect(dockerImage.dockerRmi).toHaveBeenCalledWith(
+      "openshell/sandbox-from:old",
+      expect.objectContaining({ ignoreError: true, suppressOutput: true }),
+    );
+    expect(logs.join("\n")).toContain("Removed 1 orphaned image");
+  });
+});

--- a/src/lib/actions/update.test.ts
+++ b/src/lib/actions/update.test.ts
@@ -12,7 +12,7 @@ import {
   getLatestNemoClawVersionFromGitLatestTag,
   NEMOCLAW_UPDATE_COMMAND,
   runUpdateAction,
-} from "./update";
+} from "../../../dist/lib/actions/update";
 
 describe("runUpdateAction", () => {
   it("--check reports update availability without running the installer", async () => {

--- a/src/lib/actions/upgrade-sandboxes-action.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-action.test.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+
+type UpgradeModule = typeof import("../../../dist/lib/actions/upgrade-sandboxes");
+
+const action = require("../../../dist/lib/actions/upgrade-sandboxes") as UpgradeModule;
+const openshellRuntime = require("../../../dist/lib/adapters/openshell/runtime") as typeof import("../../../dist/lib/adapters/openshell/runtime");
+const credentials = require("../../../dist/lib/credentials/store") as typeof import("../../../dist/lib/credentials/store");
+const registry = require("../../../dist/lib/state/registry") as typeof import("../../../dist/lib/state/registry");
+const sandboxVersion = require("../../../dist/lib/sandbox/version") as typeof import("../../../dist/lib/sandbox/version");
+const rebuild = require("../../../dist/lib/actions/sandbox/rebuild") as typeof import("../../../dist/lib/actions/sandbox/rebuild");
+
+const logs: string[] = [];
+const errors: string[] = [];
+
+beforeEach(() => {
+  logs.length = 0;
+  errors.length = 0;
+  vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+    logs.push(String(message ?? ""));
+  });
+  vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+    errors.push(String(message ?? ""));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function liveSandboxList(names: string[]): { output: string; status: number } {
+  return { output: `NAME\n${names.map((name) => `${name} Ready`).join("\n")}\n`, status: 0 };
+}
+
+describe("upgradeSandboxes action", () => {
+  it("returns when no sandboxes are registered", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(logs.join("\n")).toContain("No sandboxes found");
+  });
+
+  it("exits when live sandbox lookup fails", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+      output: "boom",
+      status: 7,
+    });
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(errors.join("\n")).toContain("Failed to query running sandboxes");
+    expect(exit).toHaveBeenCalledWith(7);
+  });
+
+  it("reports current sandboxes as up to date", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: false,
+      sandboxVersion: "2.0.0",
+    });
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(logs.join("\n")).toContain("All sandboxes are up to date");
+  });
+
+  it("prints stale and unknown sandboxes in check mode", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockImplementation((name: string) =>
+      name === "alpha"
+        ? { detectionMethod: "registry", expectedVersion: "2.0.0", isStale: true, sandboxVersion: "1.0.0" }
+        : { detectionMethod: "unavailable", expectedVersion: "2.0.0", isStale: false, sandboxVersion: null },
+    );
+
+    await action.upgradeSandboxes({ check: true });
+
+    const output = logs.join("\n");
+    expect(output).toContain("Stale sandboxes");
+    expect(output).toContain("alpha");
+    expect(output).toContain("Unknown version");
+    expect(output).toContain("beta");
+    expect(output).toContain("Run `nemoclaw upgrade-sandboxes`");
+  });
+
+  it("skips stopped stale sandboxes when no running stale sandbox remains", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList([]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: true,
+      sandboxVersion: "1.0.0",
+    });
+    const rebuildSpy = vi.spyOn(rebuild, "rebuildSandbox");
+
+    await action.upgradeSandboxes({ yes: true });
+
+    expect(logs.join("\n")).toContain("No running stale sandboxes");
+    expect(rebuildSpy).not.toHaveBeenCalled();
+  });
+
+  it("prompts before rebuilding and tracks failures", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha", "beta", "gamma"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: true,
+      sandboxVersion: "1.0.0",
+    });
+    vi.spyOn(credentials, "prompt")
+      .mockResolvedValueOnce("no")
+      .mockResolvedValueOnce("yes")
+      .mockResolvedValueOnce("yes");
+    vi.spyOn(rebuild, "rebuildSandbox").mockImplementation(async (name: string) => {
+      if (name === "gamma") throw new Error("boom");
+    });
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await action.upgradeSandboxes({});
+
+    expect(credentials.prompt).toHaveBeenCalledWith(expect.stringContaining("Rebuild 'alpha'"));
+    expect(rebuild.rebuildSandbox).not.toHaveBeenCalledWith("alpha", expect.anything(), expect.anything());
+    expect(rebuild.rebuildSandbox).toHaveBeenCalledWith("beta", ["--yes"], { throwOnError: true });
+    expect(rebuild.rebuildSandbox).toHaveBeenCalledWith("gamma", ["--yes"], { throwOnError: true });
+    expect(errors.join("\n")).toContain("Failed to rebuild 'gamma': boom");
+    expect(logs.join("\n")).toContain("1 sandbox(es) rebuilt");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/lib/credentials/store-extra.test.ts
+++ b/src/lib/credentials/store-extra.test.ts
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { chmodSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const STORE_DIST_PATH = require.resolve("../../../dist/lib/credentials/store");
+const originalHome = process.env.HOME;
+const trackedKeys = ["NVIDIA_API_KEY", "OPENAI_API_KEY", "PATH"];
+let tempDirs: string[] = [];
+
+type StoreModule = typeof import("../../../dist/lib/credentials/store");
+
+function loadStore(home: string): StoreModule {
+  process.env.HOME = home;
+  delete require.cache[STORE_DIST_PATH];
+  return require(STORE_DIST_PATH) as StoreModule;
+}
+
+function makeHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "nemoclaw-creds-home-"));
+  tempDirs.push(home);
+  mkdirSync(join(home, ".nemoclaw"), { recursive: true });
+  return home;
+}
+
+afterEach(() => {
+  delete require.cache[STORE_DIST_PATH];
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  for (const key of trackedKeys) delete process.env[key];
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("credential store helpers", () => {
+  it("normalizes, stages, lists, resolves, and deletes process credentials", () => {
+    const store = loadStore(makeHome());
+    expect(store.normalizeCredentialValue("  abc\r\n")).toBe("abc");
+    expect(store.normalizeCredentialValue(null)).toBe("");
+
+    store.saveCredential("NVIDIA_API_KEY", "  nv-key  ");
+    store.saveCredential("PATH", "not listed");
+    expect(store.getCredential("NVIDIA_API_KEY")).toBe("nv-key");
+    expect(store.loadCredentials()).toEqual({ NVIDIA_API_KEY: "nv-key" });
+    expect(store.listCredentialKeys()).toEqual(["NVIDIA_API_KEY"]);
+    expect(store.resolveProviderCredential("NVIDIA_API_KEY")).toBe("nv-key");
+    expect(store.deleteCredential("NVIDIA_API_KEY")).toBe(true);
+    expect(store.deleteCredential("NVIDIA_API_KEY")).toBe(false);
+  });
+
+  it("stages only allowlisted legacy credentials without overriding explicit env", () => {
+    const home = makeHome();
+    process.env.NVIDIA_API_KEY = "explicit";
+    writeFileSync(
+      join(home, ".nemoclaw", "credentials.json"),
+      JSON.stringify({ NVIDIA_API_KEY: "legacy", OPENAI_API_KEY: " openai ", PATH: "evil" }),
+    );
+    const store = loadStore(home);
+
+    expect(store.stageLegacyCredentialsToEnv()).toEqual(["OPENAI_API_KEY"]);
+    expect(process.env.NVIDIA_API_KEY).toBe("explicit");
+    expect(process.env.OPENAI_API_KEY).toBe("openai");
+    expect(process.env.PATH).not.toBe("evil");
+  });
+
+  it("refuses unsafe HOME directories", () => {
+    const store = loadStore("/tmp");
+    expect(() => store.resolveHomeDir()).toThrow(/world-readable/);
+  });
+
+  it("securely removes legacy credentials files and dangling credential symlinks", () => {
+    const home = makeHome();
+    const legacyFile = join(home, ".nemoclaw", "credentials.json");
+    writeFileSync(legacyFile, JSON.stringify({ NVIDIA_API_KEY: "legacy" }));
+    const store = loadStore(home);
+
+    store.removeLegacyCredentialsFile();
+    expect(() => lstatSync(legacyFile)).toThrow();
+
+    const target = join(home, "target-secret");
+    writeFileSync(target, "do-not-touch");
+    symlinkSync(target, legacyFile);
+    store.removeLegacyCredentialsFile();
+    expect(readFileSync(target, "utf-8")).toBe("do-not-touch");
+    expect(() => lstatSync(legacyFile)).toThrow();
+  });
+
+  it("removes empty legacy credentials but preserves migratable or malformed files", () => {
+    const home = makeHome();
+    const legacyFile = join(home, ".nemoclaw", "credentials.json");
+    const store = loadStore(home);
+
+    writeFileSync(legacyFile, "  ");
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(true);
+
+    writeFileSync(legacyFile, JSON.stringify({ PATH: "ignored", NVIDIA_API_KEY: "" }));
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(true);
+
+    writeFileSync(legacyFile, JSON.stringify({ NVIDIA_API_KEY: "legacy" }));
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(false);
+    expect(readFileSync(legacyFile, "utf-8")).toContain("NVIDIA_API_KEY");
+
+    writeFileSync(legacyFile, "not-json");
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(false);
+  });
+
+  it("leaves oversized legacy credential files for manual inspection", () => {
+    const home = makeHome();
+    const legacyFile = join(home, ".nemoclaw", "credentials.json");
+    writeFileSync(legacyFile, " ".repeat(1024 * 1024 + 1));
+    chmodSync(legacyFile, 0o600);
+    const store = loadStore(home);
+
+    expect(store.stageLegacyCredentialsToEnv()).toEqual([]);
+    expect(store.removeLegacyCredentialsFileIfEmpty()).toBe(false);
+  });
+});

--- a/src/lib/policy/index.test.ts
+++ b/src/lib/policy/index.test.ts
@@ -140,6 +140,33 @@ network_policies:
     expect(merged).toContain("allow_api");
   });
 
+  it("handles versionless policies and legacy non-map network policies while merging", () => {
+    const versionless = mergePresetIntoPolicy("filesystem_policy:\n  read_only: true\n", presetEntries);
+    expect(versionless).toMatch(/^version: 1/m);
+    expect(versionless).toContain("filesystem_policy");
+    expect(versionless).toContain("allow_api");
+
+    const legacyList = mergePresetIntoPolicy("version: 2\nnetwork_policies:\n  - legacy\n", presetEntries);
+    expect(legacyList).toContain("version: 2");
+    expect(legacyList).toContain("allow_api");
+    expect(legacyList).not.toContain("- legacy");
+  });
+
+  it("lets preset entries override existing network policy keys", () => {
+    const merged = mergePresetIntoPolicy(
+      `version: 1
+network_policies:
+  allow_api:
+    host: old.example.com
+    port: 80
+`,
+      presetEntries,
+    );
+    expect(merged).toContain("host: api.example.com");
+    expect(merged).toContain("port: 443");
+    expect(merged).not.toContain("old.example.com");
+  });
+
   it("falls back to text merging for unparseable preset entries", () => {
     expect(mergePresetIntoPolicy("version: 1\n", "  - not-a-map")).toContain("network_policies:");
     expect(mergePresetIntoPolicy("", "")).toBe("version: 1\n\nnetwork_policies:\n");
@@ -158,6 +185,12 @@ network_policies:
     expect(removed).toContain("keep_me");
     expect(removePresetFromPolicy(current, null)).toBe(current.trimEnd());
     expect(removePresetFromPolicy("", presetEntries)).toBe("version: 1\n\nnetwork_policies:\n");
+  });
+
+  it("leaves removal unchanged for legacy non-map policies and unparsable current policy", () => {
+    const legacyList = "version: 1\nnetwork_policies:\n  - legacy\n";
+    expect(removePresetFromPolicy(legacyList, presetEntries)).toBe(legacyList.trimEnd());
+    expect(removePresetFromPolicy("version: [", presetEntries)).toBe("version: 1\n\nnetwork_policies:\n");
   });
 
   it("leaves policies unchanged when preset entries cannot identify keys", () => {

--- a/src/lib/shields/index-dist-coverage.test.ts
+++ b/src/lib/shields/index-dist-coverage.test.ts
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import Module from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const dockerExecFileSyncMock = vi.fn((argv: string[]): string => {
+  const command = argv.join(" ");
+  if (command.includes("stat -c %a %U:%G")) {
+    if (command.includes(".openclaw/openclaw.json") || command.includes(".openclaw/.env")) {
+      return "444 root:root";
+    }
+    return "755 root:root";
+  }
+  if (command.includes("lsattr -d")) return "----i--------e------- /sandbox/.openclaw/openclaw.json";
+  return "";
+});
+const dockerCaptureMock = vi.fn(() => "openshell-alpha-1\nother\n");
+const validateNameMock = vi.fn((name: string) => name);
+const appendAuditEntryMock = vi.fn();
+
+const runnerMock = () => ({
+  run: vi.fn(() => ({ status: 0 })),
+  runCapture: vi.fn(() => "version: 1\nnetwork_policies: {}\n"),
+  validateName: validateNameMock,
+  shellQuote: vi.fn((value: string) => `'${value}'`),
+});
+
+const dockerExecMock = () => ({ dockerExecFileSync: dockerExecFileSyncMock });
+const dockerRunMock = () => ({ dockerCapture: dockerCaptureMock });
+const registryMock = () => ({
+  getSandbox: vi.fn((name: string) => (name === "alpha" ? { openshellDriver: "docker" } : null)),
+});
+const policyMock = () => ({
+  buildPolicyGetCommand: vi.fn((name: string) => ["openshell", "policy", "get", name]),
+  buildPolicySetCommand: vi.fn((file: string, name: string) => ["openshell", "policy", "set", file, name]),
+  parseCurrentPolicy: vi.fn((raw: string) => raw),
+  resolvePermissivePolicyPath: vi.fn(() => "/tmp/permissive.yaml"),
+});
+const timerControlMock = () => ({
+  timerMarkerPath: vi.fn((name: string) => `/tmp/shields-timer-${name}.json`),
+  readTimerMarker: vi.fn(() => null),
+  clearTimerMarker: vi.fn(),
+  isProcessAlive: vi.fn(() => false),
+  verifyTimerMarkerIdentity: vi.fn(() => false),
+  killTimer: vi.fn(),
+});
+const auditMock = () => ({ appendAuditEntry: appendAuditEntryMock });
+const sandboxConfigMock = () => ({
+  resolveAgentConfig: vi.fn(() => ({
+    agentName: "openclaw",
+    configPath: "/sandbox/.openclaw/openclaw.json",
+    configDir: "/sandbox/.openclaw",
+    sensitiveFiles: ["/sandbox/.openclaw/.env"],
+  })),
+});
+
+type ShieldsModule = typeof import("../../../dist/lib/shields/index.js");
+
+let tmpHome: string;
+let shields: ShieldsModule;
+const originalLoad = (Module as unknown as { _load: unknown })._load as (
+  request: string,
+  parent: unknown,
+  isMain: boolean,
+) => unknown;
+
+function stateDir(): string {
+  return path.join(tmpHome, ".nemoclaw", "state");
+}
+
+function writeState(sandboxName: string, state: Record<string, unknown> | string): void {
+  fs.mkdirSync(stateDir(), { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir(), `shields-${sandboxName}.json`),
+    typeof state === "string" ? state : JSON.stringify(state, null, 2),
+  );
+}
+
+beforeEach(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "shields-dist-"));
+  vi.stubEnv("HOME", tmpHome);
+  vi.resetModules();
+  vi.clearAllMocks();
+  (Module as unknown as { _load: typeof originalLoad })._load = (request, parent, isMain) => {
+    if (request === "../runner") return runnerMock();
+    if (request === "../adapters/docker/exec") return dockerExecMock();
+    if (request === "../adapters/docker/run") return dockerRunMock();
+    if (request === "../state/registry") return registryMock();
+    if (request === "../policy") return policyMock();
+    if (request === "./timer-control") return timerControlMock();
+    if (request === "./audit") return auditMock();
+    if (request === "../sandbox/config") return sandboxConfigMock();
+    return originalLoad(request, parent, isMain);
+  };
+  shields = await import("../../../dist/lib/shields/index.js");
+});
+
+afterEach(() => {
+  (Module as unknown as { _load: typeof originalLoad })._load = originalLoad;
+  vi.unstubAllEnvs();
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("dist shields coverage", () => {
+  it("derives all persisted shields modes", () => {
+    expect(shields.deriveShieldsMode({}, false)).toBe("mutable_default");
+    expect(shields.deriveShieldsMode({}, true)).toBe("mutable_default");
+    expect(shields.deriveShieldsMode({ shieldsDown: true }, true)).toBe("temporarily_unlocked");
+    expect(shields.deriveShieldsMode({ shieldsDown: false }, true)).toBe("locked");
+  });
+
+  it("reports default, locked, down, and corrupt states", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`exit:${String(code ?? 0)}`);
+    });
+
+    shields.shieldsStatus("fresh", false);
+    expect(log.mock.calls.flat().join("\n")).toContain("NOT CONFIGURED");
+
+    writeState("locked", { shieldsDown: false, shieldsPolicySnapshotPath: "/tmp/snapshot.yaml" });
+    shields.shieldsStatus("locked", false);
+    expect(log.mock.calls.flat().join("\n")).toContain("UP (lockdown active)");
+
+    writeState("down", {
+      shieldsDown: true,
+      shieldsDownAt: new Date().toISOString(),
+      shieldsDownTimeout: 300,
+      shieldsDownReason: "test",
+      shieldsDownPolicy: "permissive",
+    });
+    shields.shieldsStatus("down", false);
+    expect(log.mock.calls.flat().join("\n")).toContain("DOWN (temporarily unlocked)");
+
+    writeState("corrupt", "not json");
+    expect(() => shields.shieldsStatus("corrupt", false)).toThrow("exit:1");
+    expect(error.mock.calls.flat().join("\n")).toContain("state file is corrupt");
+
+    exit.mockRestore();
+    error.mockRestore();
+    log.mockRestore();
+  });
+
+  it("answers whether shields are down from persisted state", () => {
+    expect(shields.isShieldsDown("fresh", false)).toBe(true);
+    writeState("locked", { shieldsDown: false });
+    expect(shields.isShieldsDown("locked", false)).toBe(false);
+    writeState("down", { shieldsDown: true });
+    expect(shields.isShieldsDown("down", false)).toBe(true);
+    writeState("corrupt", "not json");
+    expect(shields.isShieldsDown("corrupt", false)).toBe(false);
+  });
+
+  it("locks and unlocks OpenClaw config trees with sensitive files", () => {
+    shields.lockAgentConfig("alpha", {
+      configPath: "/sandbox/.openclaw/openclaw.json",
+      configDir: "/sandbox/.openclaw",
+      sensitiveFiles: ["/sandbox/.openclaw/.env"],
+    });
+
+    expect(dockerCaptureMock).toHaveBeenCalled();
+    expect(dockerExecFileSyncMock.mock.calls.some(([argv]) => argv.includes("openshell-alpha-1"))).toBe(true);
+    expect(dockerExecFileSyncMock.mock.calls.some(([argv]) => argv.includes("chattr") && argv.includes("+i"))).toBe(true);
+
+    dockerExecFileSyncMock.mockImplementation((argv: string[]): string => {
+      const command = argv.join(" ");
+      if (command.includes("stat -c %a %U:%G")) {
+        if (command.includes(".openclaw/openclaw.json") || command.includes(".openclaw/.env")) {
+          return "660 sandbox:sandbox";
+        }
+        return "2770 sandbox:sandbox";
+      }
+      if (command.includes("lsattr -d")) return "---------------- /sandbox/.openclaw/openclaw.json";
+      return "";
+    });
+
+    shields.unlockAgentConfig("alpha", {
+      configPath: "/sandbox/.openclaw/openclaw.json",
+      configDir: "/sandbox/.openclaw",
+      sensitiveFiles: ["/sandbox/.openclaw/.env"],
+    });
+
+    expect(dockerExecFileSyncMock.mock.calls.some(([argv]) => argv.includes("chattr") && argv.includes("-i"))).toBe(true);
+    expect(dockerExecFileSyncMock.mock.calls.some(([argv]) => argv.includes("chmod") && argv.includes("2770"))).toBe(true);
+  });
+});

--- a/src/lib/shields/timer-dist-coverage.test.ts
+++ b/src/lib/shields/timer-dist-coverage.test.ts
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import Module from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runMock = vi.fn(() => ({ status: 0 }));
+const lockAgentConfigMock = vi.fn();
+const appendAuditEntryMock = vi.fn();
+const resolveAgentConfigMock = vi.fn(() => ({
+  configPath: "/sandbox/.openclaw/openclaw.json",
+  configDir: "/sandbox/.openclaw",
+}));
+const defaultAgentConfig = { configPath: "/sandbox/.openclaw/openclaw.json", configDir: "/sandbox/.openclaw" };
+const originalLoad = (Module as unknown as { _load: unknown })._load as (
+  request: string,
+  parent: unknown,
+  isMain: boolean,
+) => unknown;
+
+type TimerModule = typeof import("../../../dist/lib/shields/timer.js");
+
+let tmpHome: string;
+let timer: TimerModule;
+
+function stateDir(): string {
+  return path.join(tmpHome, ".nemoclaw", "state");
+}
+
+function invokeTimer(args: NonNullable<ReturnType<TimerModule["parseTimerArgs"]>>): number {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
+    throw new Error(`exit:${String(code ?? 0)}`);
+  });
+  try {
+    timer.runRestoreTimer(args);
+    throw new Error("expected exit");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    expect(message.startsWith("exit:")).toBe(true);
+    return Number.parseInt(message.slice("exit:".length), 10);
+  } finally {
+    exitSpy.mockRestore();
+  }
+}
+
+beforeEach(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "shields-timer-dist-"));
+  vi.stubEnv("HOME", tmpHome);
+  vi.resetModules();
+  vi.clearAllMocks();
+  (Module as unknown as { _load: typeof originalLoad })._load = (request, parent, isMain) => {
+    if (request === "../runner") return { run: runMock };
+    if (request === "../policy") {
+      return { buildPolicySetCommand: (file: string, name: string) => ["policy", "set", file, name] };
+    }
+    if (request === "../sandbox/config") {
+      return {
+        DEFAULT_AGENT_CONFIG: defaultAgentConfig,
+        resolveAgentConfig: resolveAgentConfigMock,
+      };
+    }
+    if (request === "./index") return { lockAgentConfig: lockAgentConfigMock };
+    if (request === "./audit") return { appendAuditEntry: appendAuditEntryMock };
+    return originalLoad(request, parent, isMain);
+  };
+  timer = await import("../../../dist/lib/shields/timer.js");
+});
+
+afterEach(() => {
+  (Module as unknown as { _load: typeof originalLoad })._load = originalLoad;
+  vi.unstubAllEnvs();
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("dist shields timer coverage", () => {
+  it("parses valid and invalid timer arguments", () => {
+    expect(timer.parseTimerArgs([])).toBeNull();
+    expect(timer.parseTimerArgs(["alpha", "/tmp/snapshot.yaml", "not-a-date"])).toBeNull();
+
+    const restoreAtIso = new Date(Date.now() + 60_000).toISOString();
+    const args = timer.parseTimerArgs(["alpha", "/tmp/snapshot.yaml", restoreAtIso, "/cfg.json", "/cfg", "tok"]);
+    expect(args).toMatchObject({ sandboxName: "alpha", snapshotPath: "/tmp/snapshot.yaml", restoreAtIso });
+    expect(args?.delayMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not restore when marker is missing", () => {
+    fs.mkdirSync(stateDir(), { recursive: true });
+    const snapshot = path.join(stateDir(), "snapshot.yaml");
+    const restoreAtIso = new Date(Date.now() + 60_000).toISOString();
+    fs.writeFileSync(snapshot, "version: 1\n");
+    const args = timer.parseTimerArgs(["alpha", snapshot, restoreAtIso, "/cfg.json", "/cfg", "tok"]);
+    expect(args).not.toBeNull();
+
+    expect(invokeTimer(args!)).toBe(0);
+    expect(runMock).not.toHaveBeenCalled();
+    expect(lockAgentConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("restores policy, locks config, updates state, and removes owned marker", () => {
+    fs.mkdirSync(stateDir(), { recursive: true });
+    const sandboxName = "alpha";
+    const snapshot = path.join(stateDir(), "snapshot.yaml");
+    const restoreAtIso = new Date(Date.now() + 60_000).toISOString();
+    const markerPath = path.join(stateDir(), `shields-timer-${sandboxName}.json`);
+    const stateFile = path.join(stateDir(), `shields-${sandboxName}.json`);
+    fs.writeFileSync(snapshot, "version: 1\n");
+    fs.writeFileSync(stateFile, JSON.stringify({ shieldsDown: true }));
+    fs.writeFileSync(
+      markerPath,
+      JSON.stringify({ pid: process.pid, sandboxName, snapshotPath: snapshot, restoreAt: restoreAtIso, processToken: "tok" }),
+    );
+    const args = timer.parseTimerArgs([sandboxName, snapshot, restoreAtIso, "/cfg.json", "/cfg", "tok"]);
+    expect(args).not.toBeNull();
+
+    expect(invokeTimer(args!)).toBe(0);
+    expect(runMock).toHaveBeenCalledWith(["policy", "set", snapshot, sandboxName], { ignoreError: true });
+    expect(lockAgentConfigMock).toHaveBeenCalled();
+    expect(JSON.parse(fs.readFileSync(stateFile, "utf-8"))).toMatchObject({ shieldsDown: false });
+    expect(fs.existsSync(markerPath)).toBe(false);
+  });
+
+  it("keeps shields down and audits when policy restore fails", () => {
+    runMock.mockReturnValueOnce({ status: 42 });
+    fs.mkdirSync(stateDir(), { recursive: true });
+    const sandboxName = "alpha";
+    const snapshot = path.join(stateDir(), "snapshot.yaml");
+    const restoreAtIso = new Date(Date.now() + 60_000).toISOString();
+    const markerPath = path.join(stateDir(), `shields-timer-${sandboxName}.json`);
+    const stateFile = path.join(stateDir(), `shields-${sandboxName}.json`);
+    fs.writeFileSync(snapshot, "version: 1\n");
+    fs.writeFileSync(stateFile, JSON.stringify({ shieldsDown: true }));
+    fs.writeFileSync(
+      markerPath,
+      JSON.stringify({ pid: process.pid, sandboxName, snapshotPath: snapshot, restoreAt: restoreAtIso, processToken: "tok" }),
+    );
+    const args = timer.parseTimerArgs([sandboxName, snapshot, restoreAtIso, "/cfg.json", "/cfg", "tok"]);
+
+    expect(invokeTimer(args!)).toBe(1);
+    expect(appendAuditEntryMock).toHaveBeenCalledWith(expect.objectContaining({ action: "shields_up_failed" }));
+    expect(lockAgentConfigMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/state/sandbox-extra.test.ts
+++ b/src/lib/state/sandbox-extra.test.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parseRestoreArgs,
+  rejectHardLinks,
+  safeTarExtract,
+  validateSnapshotName,
+  validateTarEntries,
+} from "../../../dist/lib/state/sandbox";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function tarBufferFrom(dir: string): Buffer {
+  return execFileSync("tar", ["-cf", "-", "-C", dir, "."]);
+}
+
+describe("sandbox state snapshot helpers", () => {
+  it("validates user-provided snapshot names", () => {
+    expect(validateSnapshotName("release_2026.05-rc1")).toBeNull();
+    expect(validateSnapshotName("bad name")).toContain("Invalid snapshot name");
+    expect(validateSnapshotName("v12")).toContain("conflicts with the auto-assigned version");
+    expect(validateSnapshotName("-bad")).toContain("Invalid snapshot name");
+  });
+
+  it("parses restore selectors and target sandbox overrides", () => {
+    expect(parseRestoreArgs("alpha", ["restore"])).toEqual({ ok: true, targetSandbox: "alpha", selector: null });
+    expect(parseRestoreArgs("alpha", ["restore", "v2"])).toEqual({ ok: true, targetSandbox: "alpha", selector: "v2" });
+    expect(parseRestoreArgs("alpha", ["restore", "snapshot-a", "--to", "beta"])).toEqual({
+      ok: true,
+      targetSandbox: "beta",
+      selector: "snapshot-a",
+    });
+    expect(parseRestoreArgs("alpha", ["restore", "--to"])).toEqual({
+      ok: false,
+      error: "--to requires a target sandbox name.",
+    });
+    expect(parseRestoreArgs("alpha", ["restore", "--to", "--bad"])).toEqual({
+      ok: false,
+      error: "--to requires a target sandbox name.",
+    });
+  });
+
+  it("validates and extracts safe tar archives", () => {
+    const source = tempDir("nemoclaw-state-source-");
+    const target = tempDir("nemoclaw-state-target-");
+    writeFileSync(join(source, "config.json"), JSON.stringify({ ok: true }));
+    const archive = tarBufferFrom(source);
+
+    const validation = validateTarEntries(archive, target);
+    expect(validation.safe).toBe(true);
+    expect(validation.entries).toContain("./config.json");
+    expect(rejectHardLinks(archive)).toEqual([]);
+
+    expect(safeTarExtract(archive, target)).toEqual({ success: true });
+    expect(existsSync(join(target, "config.json"))).toBe(true);
+    expect(JSON.parse(readFileSync(join(target, "config.json"), "utf-8"))).toEqual({ ok: true });
+  });
+
+  it("rejects invalid tar buffers before extraction", () => {
+    const target = tempDir("nemoclaw-state-bad-target-");
+    const result = validateTarEntries(Buffer.from("not a tar"), target);
+    expect(result.safe).toBe(false);
+    expect(result.violations.join("\n")).toContain("tar listing failed");
+
+    const extract = safeTarExtract(Buffer.from("not a tar"), target);
+    expect(extract.success).toBe(false);
+    expect(extract.error).toContain("tar entry validation failed");
+  });
+});

--- a/src/lib/state/sandbox-session.test.ts
+++ b/src/lib/state/sandbox-session.test.ts
@@ -12,7 +12,7 @@ import {
   type ForwardEntry,
   type SessionClassification,
   type SessionDetectionDeps,
-} from "./sandbox-session";
+} from "../../../dist/lib/state/sandbox-session";
 
 describe("parseForwardList", () => {
   it("returns empty array for empty/null input", () => {


### PR DESCRIPTION
## Summary
Adds state and credential coverage on top of the sandbox internals PR. The tests cover credential staging/removal safety and route sandbox session parsing through compiled CLI modules for accurate coverage attribution.

## Changes
- Route sandbox session tests through `dist/lib/state/sandbox-session`.
- Add credential store tests for env staging/listing/deletion, legacy credential migration allowlisting, unsafe HOME rejection, secure removal, empty-file cleanup, and oversized-file refusal.
- Preserve explicit environment credentials over legacy file values in coverage tests.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>