### PR TITLE
fix(docker): force-enable BuildKit in dockerBuild

### DIFF
--- a/src/lib/adapters/docker/image.ts
+++ b/src/lib/adapters/docker/image.ts
@@ -10,7 +10,18 @@ export function dockerBuild(
   contextDir: string = ROOT,
   opts: DockerRunOptions = {},
 ) {
-  return dockerRun(["build", "-f", dockerfilePath, "-t", tag, contextDir], opts);
+  // Dockerfile.base relies on `RUN --mount=type=bind`, which is BuildKit-only.
+  // Hosts whose Docker daemon defaults to the legacy builder (e.g. fresh
+  // Debian/Ubuntu Docker 29 without /etc/docker/daemon.json) abort the
+  // sandbox-base local rebuild with "the --mount option requires BuildKit"
+  // (#3583). Force-enable BuildKit for every `dockerBuild` callsite so the
+  // rebuild path works regardless of daemon defaults.
+  const env: NodeJS.ProcessEnv = { ...(opts.env ?? {}) };
+  if (env.DOCKER_BUILDKIT === undefined) env.DOCKER_BUILDKIT = "1";
+  return dockerRun(["build", "-f", dockerfilePath, "-t", tag, contextDir], {
+    ...opts,
+    env,
+  });
 }
 
 export function dockerRmi(imageRef: string, opts: DockerRunOptions = {}) {

--- a/src/lib/adapters/docker/index.test.ts
+++ b/src/lib/adapters/docker/index.test.ts
@@ -41,11 +41,39 @@ describe("docker helpers", () => {
 
     expect(runMock.mock.calls).toEqual([
       [["docker", "pull", "ghcr.io/example/image:latest"], {}],
-      [["docker", "build", "-f", "Dockerfile", "-t", "example:tag", "/tmp/build"], {}],
+      [
+        ["docker", "build", "-f", "Dockerfile", "-t", "example:tag", "/tmp/build"],
+        { env: { DOCKER_BUILDKIT: "1" } },
+      ],
       [["docker", "run", "-d", "--name", "example", "busybox:latest"], {}],
       [["docker", "rename", "example", "example-backup"], {}],
       [["docker", "rmi", "example:tag"], {}],
     ]);
+  });
+
+  it("forces DOCKER_BUILDKIT=1 on dockerBuild so Dockerfile.base --mount works on legacy-builder hosts (#3583)", () => {
+    dockerBuild("Dockerfile.base", "sandbox-base:latest", "/repo/root", {
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+
+    expect(runMock).toHaveBeenCalledWith(
+      ["docker", "build", "-f", "Dockerfile.base", "-t", "sandbox-base:latest", "/repo/root"],
+      {
+        stdio: ["ignore", "inherit", "inherit"],
+        env: { DOCKER_BUILDKIT: "1" },
+      },
+    );
+  });
+
+  it("preserves a caller-supplied DOCKER_BUILDKIT value rather than overriding it", () => {
+    dockerBuild("Dockerfile", "example:tag", "/tmp/build", {
+      env: { DOCKER_BUILDKIT: "0", FOO: "bar" },
+    });
+
+    expect(runMock).toHaveBeenCalledWith(
+      ["docker", "build", "-f", "Dockerfile", "-t", "example:tag", "/tmp/build"],
+      { env: { DOCKER_BUILDKIT: "0", FOO: "bar" } },
+    );
   });
 
   it("prefixes docker argv for info/inspect capture helpers", () => {


### PR DESCRIPTION
## Summary
On hosts whose Docker daemon defaults to the legacy builder, `nemoclaw onboard` aborts when the sandbox-base local rebuild reaches Dockerfile.base's `RUN --mount=type=bind` step with "the --mount option requires BuildKit". Force-enable BuildKit inside `dockerBuild` so every callsite gets the BuildKit path regardless of daemon defaults.

## Related Issue
Fixes #3583

## Changes
- Inject `DOCKER_BUILDKIT=1` in `dockerBuild` before invoking `docker build`; preserve a caller-supplied value when one is already set.
- Update the existing docker-helper test to reflect the new env injection and add coverage for the BuildKit-enable path plus the caller-override path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] \`npx prek run --all-files\` passes
- [x] \`npm test\` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] \`make docs\` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker builds now default to using BuildKit when not explicitly configured. User-supplied Docker configurations remain respected.

* **Tests**
  * Updated tests to verify Docker BuildKit default behavior and that custom configurations are preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3585)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->