### PR TITLE
fix(onboard): suppress sandbox-base local build log on success

### DIFF
--- a/src/lib/adapters/docker/image.ts
+++ b/src/lib/adapters/docker/image.ts
@@ -4,13 +4,25 @@
 import { ROOT } from "../../runner";
 import { dockerCapture, dockerRun, type DockerCaptureOptions, type DockerRunOptions } from "./run";
 
+export type DockerBuildOptions = DockerRunOptions & { quiet?: boolean };
+
 export function dockerBuild(
   dockerfilePath: string,
   tag: string,
   contextDir: string = ROOT,
-  opts: DockerRunOptions = {},
+  opts: DockerBuildOptions = {},
 ) {
-  return dockerRun(["build", "-f", dockerfilePath, "-t", tag, contextDir], opts);
+  const { quiet, ...rest } = opts;
+  const args = [
+    "build",
+    ...(quiet ? ["--quiet"] : []),
+    "-f",
+    dockerfilePath,
+    "-t",
+    tag,
+    contextDir,
+  ];
+  return dockerRun(args, rest);
 }
 
 export function dockerRmi(imageRef: string, opts: DockerRunOptions = {}) {

--- a/src/lib/adapters/docker/index.test.ts
+++ b/src/lib/adapters/docker/index.test.ts
@@ -48,6 +48,37 @@ describe("docker helpers", () => {
     ]);
   });
 
+  it("adds --quiet to dockerBuild argv and drops the quiet key from options (#3584)", () => {
+    dockerBuild("Dockerfile.base", "sandbox-base:latest", "/repo/root", {
+      quiet: true,
+      ignoreError: true,
+      suppressOutput: true,
+    });
+
+    expect(runMock).toHaveBeenCalledWith(
+      [
+        "docker",
+        "build",
+        "--quiet",
+        "-f",
+        "Dockerfile.base",
+        "-t",
+        "sandbox-base:latest",
+        "/repo/root",
+      ],
+      { ignoreError: true, suppressOutput: true },
+    );
+  });
+
+  it("omits --quiet by default", () => {
+    dockerBuild("Dockerfile", "example:tag", "/tmp/build", { ignoreError: true });
+
+    expect(runMock).toHaveBeenCalledWith(
+      ["docker", "build", "-f", "Dockerfile", "-t", "example:tag", "/tmp/build"],
+      { ignoreError: true },
+    );
+  });
+
   it("prefixes docker argv for info/inspect capture helpers", () => {
     dockerInfoFormat("{{.KernelVersion}}", { ignoreError: true });
     dockerContainerInspectFormat("{{.State.Status}}", "example-container", {

--- a/src/lib/sandbox-base-image.test.ts
+++ b/src/lib/sandbox-base-image.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  formatBuildFailureDiagnostics,
   getSourceShortShaTags,
   parseGlibcVersion,
   versionGte,
@@ -26,5 +27,52 @@ describe("sandbox base image helpers", () => {
       GITHUB_SHA: "1E94F2E207C5456EBC35E2BD5BB380D4430292C6",
     } as NodeJS.ProcessEnv);
     expect(tags).toEqual(["1e94f2e2", "1e94f2e"]);
+  });
+
+  it("surfaces stderr build diagnostics on failure (#3584)", () => {
+    const output = formatBuildFailureDiagnostics({
+      stderr: "the --mount option requires BuildKit",
+      stdout: "",
+    });
+    expect(output).toContain("the --mount option requires BuildKit");
+  });
+
+  it("surfaces stdout-only build diagnostics — BuildKit can land errors there (Codex review on #3584)", () => {
+    const output = formatBuildFailureDiagnostics({
+      stderr: "",
+      stdout: "ERROR: failed to solve: process \"/bin/sh -c apt-get install\" did not complete successfully",
+    });
+    expect(output).toContain("ERROR: failed to solve");
+  });
+
+  it("combines stderr and stdout when both carry build output", () => {
+    const output = formatBuildFailureDiagnostics({
+      stderr: "build error line A",
+      stdout: "build error line B",
+    });
+    expect(output).toBe("build error line A\nbuild error line B");
+  });
+
+  it("returns empty string when both streams are empty", () => {
+    expect(formatBuildFailureDiagnostics({ stderr: "", stdout: "" })).toBe("");
+    expect(formatBuildFailureDiagnostics({})).toBe("");
+  });
+
+  it("redacts captured build output before returning it", () => {
+    // The runner's redact() pass strips Bearer tokens, NVIDIA API keys, etc.
+    // Anything that looks like a secret in build output must not leak.
+    const output = formatBuildFailureDiagnostics({
+      stderr: "auth: Bearer sk-abcdef0123456789abcdef0123456789abcdef0123456789 failed",
+      stdout: "",
+    });
+    expect(output).not.toContain("sk-abcdef0123456789abcdef0123456789abcdef0123456789");
+  });
+
+  it("accepts Buffer streams from spawnSync", () => {
+    const output = formatBuildFailureDiagnostics({
+      stderr: Buffer.from("buffered build error", "utf8"),
+      stdout: null,
+    });
+    expect(output).toContain("buffered build error");
   });
 });

--- a/src/lib/sandbox-base-image.ts
+++ b/src/lib/sandbox-base-image.ts
@@ -4,7 +4,7 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 
-import { ROOT } from "./runner";
+import { ROOT, redact } from "./runner";
 import {
   dockerBuild,
   dockerCapture,
@@ -36,6 +36,27 @@ export type SandboxBaseImageResolution = {
   source: "override" | "source-sha" | "latest" | "local";
   glibcVersion: string | null;
 };
+
+/**
+ * Combine stderr + stdout from a captured `dockerBuild` failure and pass them
+ * through the runner's redaction so secrets in build output never reach the
+ * terminal. BuildKit splits diagnostics across both streams depending on the
+ * backend and progress mode, so taking only stderr can hide the actual reason
+ * a build failed.
+ */
+export function formatBuildFailureDiagnostics(
+  buildResult: { stderr?: unknown; stdout?: unknown },
+): string {
+  const streams = [buildResult.stderr, buildResult.stdout]
+    .map((stream) => {
+      if (stream == null) return "";
+      if (Buffer.isBuffer(stream)) return stream.toString("utf8");
+      return String(stream);
+    })
+    .map((text) => text.trim())
+    .filter((text) => text.length > 0);
+  return streams.length > 0 ? redact(streams.join("\n")) : "";
+}
 
 export function parseGlibcVersion(output: string | null | undefined): string | null {
   const text = String(output || "");
@@ -204,8 +225,8 @@ function resolveLocalCandidate(
     suppressOutput: true,
   });
   if (buildResult.error || buildResult.status !== 0) {
-    const stderrText = String(buildResult.stderr ?? "").trim();
-    if (stderrText) console.error(stderrText);
+    const diagnostics = formatBuildFailureDiagnostics(buildResult);
+    if (diagnostics) console.error(diagnostics);
     const detail = buildResult.error
       ? `: ${buildResult.error.message}`
       : ` (exit ${buildResult.status ?? "unknown"})`;

--- a/src/lib/sandbox-base-image.ts
+++ b/src/lib/sandbox-base-image.ts
@@ -187,20 +187,38 @@ function resolveLocalCandidate(
 
   if (!localBuildAllowed(options.env)) return null;
 
+  const label = options.label || "sandbox base image";
   console.warn(
-    `  Building ${options.label || "sandbox base image"} locally because no compatible ` +
-      `published base image was found.`,
+    `  Building ${label} locally because no compatible published base image was found.`,
   );
-  dockerBuild(options.dockerfilePath, imageRef, options.rootDir || ROOT, {
-    stdio: ["ignore", "inherit", "inherit"],
+  console.warn("  This is a one-time step and can take several minutes.");
+  // Suppress the full BuildKit log (apt-get output, layer hashes, debconf
+  // warnings) on success — same approach as #3311 for the [2/8] gateway
+  // setup leak. `--quiet` collapses normal output to just the image hash;
+  // `suppressOutput` keeps captured stdio out of the user's terminal.
+  // On failure, surface the captured stderr so the user still gets a
+  // useful diagnostic.
+  const buildResult = dockerBuild(options.dockerfilePath, imageRef, options.rootDir || ROOT, {
+    quiet: true,
+    ignoreError: true,
+    suppressOutput: true,
   });
+  if (buildResult.error || buildResult.status !== 0) {
+    const stderrText = String(buildResult.stderr ?? "").trim();
+    if (stderrText) console.error(stderrText);
+    const detail = buildResult.error
+      ? `: ${buildResult.error.message}`
+      : ` (exit ${buildResult.status ?? "unknown"})`;
+    console.error(`  Failed to build ${label}${detail}`);
+    return null;
+  }
 
   const check = options.requireOpenshellSandboxAbi
     ? imageMeetsMinimumGlibc(imageRef, options.minGlibcVersion || OPENSHELL_SANDBOX_MIN_GLIBC)
     : { ok: true, version: null };
   if (!check.ok) {
     console.error(
-      `  Local ${options.label || "sandbox base image"} ${imageRef} has glibc ` +
+      `  Local ${label} ${imageRef} has glibc ` +
         `${check.version || "unknown"}; expected >= ` +
         `${options.minGlibcVersion || OPENSHELL_SANDBOX_MIN_GLIBC}.`,
     );


### PR DESCRIPTION
## Summary
At step [6/8], when the published sandbox-base image is incompatible (glibc < 2.39) and NemoClaw rebuilds locally, the full Docker build log (~200 lines: apt-get output, debconf warnings, dpkg messages, layer hashes) is forwarded to the user terminal. #3311 already fixed the [2/8] gateway setup leak the same way; the [6/8] sandbox-base rebuild path was not covered.

## Related Issue
Fixes #3584

## Changes
- Add a `quiet?: boolean` option to `dockerBuild` that prepends `--quiet` to the build argv.
- Switch the sandbox-base local rebuild to `quiet: true` + `suppressOutput: true` + `ignoreError: true`, and surface the captured stderr (plus a one-line failure summary) when the build does not succeed.
- Add a "This is a one-time step and can take several minutes" notice so users do not mistake the silent build window for a hang.
- Add docker-helper tests covering `--quiet` argv injection on `dockerBuild` and the default-omit behaviour.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] \`npx prek run --all-files\` passes
- [x] \`npm test\` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] \`make docs\` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker build accepts an optional quiet flag to suppress build output.

* **Bug Fixes**
  * Improved handling of build failures: capture and present combined diagnostics, suppress streaming output on failure, and return a clear failure result.
  * Diagnostics now redact sensitive information before display.

* **Tests**
  * Added tests for quiet-flag behavior and comprehensive build-failure diagnostics (including binary stream handling).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3586)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->