### PR TITLE
test(cli): cover remaining action helpers

### DIFF
--- a/src/lib/actions/dev/npm-link-or-shim.test.ts
+++ b/src/lib/actions/dev/npm-link-or-shim.test.ts
@@ -6,8 +6,8 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
-import { DEV_SHIM_MARKER } from "../../domain/dev/npm-link-or-shim";
-import { runNpmLinkOrShim } from "./npm-link-or-shim";
+import { DEV_SHIM_MARKER } from "../../../../dist/lib/domain/dev/npm-link-or-shim";
+import { runNpmLinkOrShim } from "../../../../dist/lib/actions/dev/npm-link-or-shim";
 
 function setupRepo(): { binPath: string; homeDir: string; repoDir: string; tmpDir: string } {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dev-shim-action-"));

--- a/src/lib/actions/maintenance-action.test.ts
+++ b/src/lib/actions/maintenance-action.test.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+
+type MaintenanceModule = typeof import("../../../dist/lib/actions/maintenance");
+
+const maintenance = require("../../../dist/lib/actions/maintenance") as MaintenanceModule;
+const dockerImage = require("../../../dist/lib/adapters/docker/image") as typeof import("../../../dist/lib/adapters/docker/image");
+const openshellRuntime = require("../../../dist/lib/adapters/openshell/runtime") as typeof import("../../../dist/lib/adapters/openshell/runtime");
+const credentials = require("../../../dist/lib/credentials/store") as typeof import("../../../dist/lib/credentials/store");
+const registry = require("../../../dist/lib/state/registry") as typeof import("../../../dist/lib/state/registry");
+const sandboxState = require("../../../dist/lib/state/sandbox") as typeof import("../../../dist/lib/state/sandbox");
+
+const logs: string[] = [];
+const errors: string[] = [];
+
+beforeEach(() => {
+  logs.length = 0;
+  errors.length = 0;
+  vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+    logs.push(String(message ?? ""));
+  });
+  vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+    errors.push(String(message ?? ""));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("maintenance actions", () => {
+  it("reports when no registered sandboxes are available to back up", () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+
+    maintenance.backupAll();
+
+    expect(logs.join("\n")).toContain("No sandboxes registered");
+  });
+
+  it("backs up only live sandboxes and exits when a backup fails", () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+      output: "NAME\nalpha Ready\ngamma Ready\n",
+      status: 0,
+    });
+    vi.spyOn(sandboxState, "backupSandboxState").mockImplementation(((name: string) =>
+      name === "alpha"
+        ? {
+            backedUpDirs: ["memory"],
+            backedUpFiles: ["config"],
+            failedDirs: [],
+            failedFiles: [],
+            manifest: { backupPath: "/tmp/backup-alpha" },
+            success: true,
+          }
+        : {
+            backedUpDirs: [],
+            backedUpFiles: [],
+            failedDirs: ["memory"],
+            failedFiles: [],
+            manifest: null,
+            success: false,
+          }) as never);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    maintenance.backupAll();
+
+    expect(sandboxState.backupSandboxState).toHaveBeenCalledWith("alpha");
+    expect(sandboxState.backupSandboxState).not.toHaveBeenCalledWith("beta");
+    expect(sandboxState.backupSandboxState).toHaveBeenCalledWith("gamma");
+    expect(logs.join("\n")).toContain("1 backed up, 1 failed, 1 skipped");
+    expect(errors.join("\n")).toContain("gamma: backup failed");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("reports empty sandbox image inventory without registry lookup", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue("");
+    const registrySpy = vi.spyOn(registry, "listSandboxes");
+
+    await maintenance.garbageCollectImages({ yes: true });
+
+    expect(logs.join("\n")).toContain("No sandbox images found");
+    expect(registrySpy).not.toHaveBeenCalled();
+  });
+
+  it("dry-runs orphan sandbox image cleanup", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue(
+      "openshell/sandbox-from:used\t1GB\nopenshell/sandbox-from:old\t2GB\n",
+    );
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha", imageTag: "openshell/sandbox-from:used" }],
+    });
+    const rmi = vi.spyOn(dockerImage, "dockerRmi");
+
+    await maintenance.garbageCollectImages({ dryRun: true });
+
+    expect(logs.join("\n")).toContain("openshell/sandbox-from:old");
+    expect(logs.join("\n")).toContain("--dry-run: would remove 1 image");
+    expect(rmi).not.toHaveBeenCalled();
+  });
+
+  it("prompts and removes orphan sandbox images", async () => {
+    vi.spyOn(dockerImage, "dockerListImagesFormat").mockReturnValue("openshell/sandbox-from:old\t2GB\n");
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+    vi.spyOn(credentials, "prompt").mockResolvedValue("yes");
+    vi.spyOn(dockerImage, "dockerRmi").mockReturnValue({
+      error: undefined,
+      signal: null,
+      status: 0,
+      stderr: "",
+      stdout: "",
+    } as never);
+
+    await maintenance.garbageCollectImages({});
+
+    expect(credentials.prompt).toHaveBeenCalledWith(expect.stringContaining("Remove 1 orphaned image"));
+    expect(dockerImage.dockerRmi).toHaveBeenCalledWith(
+      "openshell/sandbox-from:old",
+      expect.objectContaining({ ignoreError: true, suppressOutput: true }),
+    );
+    expect(logs.join("\n")).toContain("Removed 1 orphaned image");
+  });
+});

--- a/src/lib/actions/update.test.ts
+++ b/src/lib/actions/update.test.ts
@@ -12,7 +12,7 @@ import {
   getLatestNemoClawVersionFromGitLatestTag,
   NEMOCLAW_UPDATE_COMMAND,
   runUpdateAction,
-} from "./update";
+} from "../../../dist/lib/actions/update";
 
 describe("runUpdateAction", () => {
   it("--check reports update availability without running the installer", async () => {

--- a/src/lib/actions/upgrade-sandboxes-action.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-action.test.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+
+type UpgradeModule = typeof import("../../../dist/lib/actions/upgrade-sandboxes");
+
+const action = require("../../../dist/lib/actions/upgrade-sandboxes") as UpgradeModule;
+const openshellRuntime = require("../../../dist/lib/adapters/openshell/runtime") as typeof import("../../../dist/lib/adapters/openshell/runtime");
+const credentials = require("../../../dist/lib/credentials/store") as typeof import("../../../dist/lib/credentials/store");
+const registry = require("../../../dist/lib/state/registry") as typeof import("../../../dist/lib/state/registry");
+const sandboxVersion = require("../../../dist/lib/sandbox/version") as typeof import("../../../dist/lib/sandbox/version");
+const rebuild = require("../../../dist/lib/actions/sandbox/rebuild") as typeof import("../../../dist/lib/actions/sandbox/rebuild");
+
+const logs: string[] = [];
+const errors: string[] = [];
+
+beforeEach(() => {
+  logs.length = 0;
+  errors.length = 0;
+  vi.spyOn(console, "log").mockImplementation((message?: unknown) => {
+    logs.push(String(message ?? ""));
+  });
+  vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+    errors.push(String(message ?? ""));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function liveSandboxList(names: string[]): { output: string; status: number } {
+  return { output: `NAME\n${names.map((name) => `${name} Ready`).join("\n")}\n`, status: 0 };
+}
+
+describe("upgradeSandboxes action", () => {
+  it("returns when no sandboxes are registered", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({ defaultSandbox: null, sandboxes: [] });
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(logs.join("\n")).toContain("No sandboxes found");
+  });
+
+  it("exits when live sandbox lookup fails", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+      output: "boom",
+      status: 7,
+    });
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(errors.join("\n")).toContain("Failed to query running sandboxes");
+    expect(exit).toHaveBeenCalledWith(7);
+  });
+
+  it("reports current sandboxes as up to date", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: false,
+      sandboxVersion: "2.0.0",
+    });
+
+    await action.upgradeSandboxes({ check: true });
+
+    expect(logs.join("\n")).toContain("All sandboxes are up to date");
+  });
+
+  it("prints stale and unknown sandboxes in check mode", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockImplementation((name: string) =>
+      name === "alpha"
+        ? { detectionMethod: "registry", expectedVersion: "2.0.0", isStale: true, sandboxVersion: "1.0.0" }
+        : { detectionMethod: "unavailable", expectedVersion: "2.0.0", isStale: false, sandboxVersion: null },
+    );
+
+    await action.upgradeSandboxes({ check: true });
+
+    const output = logs.join("\n");
+    expect(output).toContain("Stale sandboxes");
+    expect(output).toContain("alpha");
+    expect(output).toContain("Unknown version");
+    expect(output).toContain("beta");
+    expect(output).toContain("Run `nemoclaw upgrade-sandboxes`");
+  });
+
+  it("skips stopped stale sandboxes when no running stale sandbox remains", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList([]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: true,
+      sandboxVersion: "1.0.0",
+    });
+    const rebuildSpy = vi.spyOn(rebuild, "rebuildSandbox");
+
+    await action.upgradeSandboxes({ yes: true });
+
+    expect(logs.join("\n")).toContain("No running stale sandboxes");
+    expect(rebuildSpy).not.toHaveBeenCalled();
+  });
+
+  it("prompts before rebuilding and tracks failures", async () => {
+    vi.spyOn(registry, "listSandboxes").mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }, { name: "beta" }, { name: "gamma" }],
+    });
+    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue(liveSandboxList(["alpha", "beta", "gamma"]));
+    vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+      detectionMethod: "registry",
+      expectedVersion: "2.0.0",
+      isStale: true,
+      sandboxVersion: "1.0.0",
+    });
+    vi.spyOn(credentials, "prompt")
+      .mockResolvedValueOnce("no")
+      .mockResolvedValueOnce("yes")
+      .mockResolvedValueOnce("yes");
+    vi.spyOn(rebuild, "rebuildSandbox").mockImplementation(async (name: string) => {
+      if (name === "gamma") throw new Error("boom");
+    });
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await action.upgradeSandboxes({});
+
+    expect(credentials.prompt).toHaveBeenCalledWith(expect.stringContaining("Rebuild 'alpha'"));
+    expect(rebuild.rebuildSandbox).not.toHaveBeenCalledWith("alpha", expect.anything(), expect.anything());
+    expect(rebuild.rebuildSandbox).toHaveBeenCalledWith("beta", ["--yes"], { throwOnError: true });
+    expect(rebuild.rebuildSandbox).toHaveBeenCalledWith("gamma", ["--yes"], { throwOnError: true });
+    expect(errors.join("\n")).toContain("Failed to rebuild 'gamma': boom");
+    expect(logs.join("\n")).toContain("1 sandbox(es) rebuilt");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/lib/policy/index.test.ts
+++ b/src/lib/policy/index.test.ts
@@ -140,6 +140,33 @@ network_policies:
     expect(merged).toContain("allow_api");
   });
 
+  it("handles versionless policies and legacy non-map network policies while merging", () => {
+    const versionless = mergePresetIntoPolicy("filesystem_policy:\n  read_only: true\n", presetEntries);
+    expect(versionless).toMatch(/^version: 1/m);
+    expect(versionless).toContain("filesystem_policy");
+    expect(versionless).toContain("allow_api");
+
+    const legacyList = mergePresetIntoPolicy("version: 2\nnetwork_policies:\n  - legacy\n", presetEntries);
+    expect(legacyList).toContain("version: 2");
+    expect(legacyList).toContain("allow_api");
+    expect(legacyList).not.toContain("- legacy");
+  });
+
+  it("lets preset entries override existing network policy keys", () => {
+    const merged = mergePresetIntoPolicy(
+      `version: 1
+network_policies:
+  allow_api:
+    host: old.example.com
+    port: 80
+`,
+      presetEntries,
+    );
+    expect(merged).toContain("host: api.example.com");
+    expect(merged).toContain("port: 443");
+    expect(merged).not.toContain("old.example.com");
+  });
+
   it("falls back to text merging for unparseable preset entries", () => {
     expect(mergePresetIntoPolicy("version: 1\n", "  - not-a-map")).toContain("network_policies:");
     expect(mergePresetIntoPolicy("", "")).toBe("version: 1\n\nnetwork_policies:\n");
@@ -158,6 +185,12 @@ network_policies:
     expect(removed).toContain("keep_me");
     expect(removePresetFromPolicy(current, null)).toBe(current.trimEnd());
     expect(removePresetFromPolicy("", presetEntries)).toBe("version: 1\n\nnetwork_policies:\n");
+  });
+
+  it("leaves removal unchanged for legacy non-map policies and unparsable current policy", () => {
+    const legacyList = "version: 1\nnetwork_policies:\n  - legacy\n";
+    expect(removePresetFromPolicy(legacyList, presetEntries)).toBe(legacyList.trimEnd());
+    expect(removePresetFromPolicy("version: [", presetEntries)).toBe("version: 1\n\nnetwork_policies:\n");
   });
 
   it("leaves policies unchanged when preset entries cannot identify keys", () => {

--- a/src/lib/state/sandbox-extra.test.ts
+++ b/src/lib/state/sandbox-extra.test.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parseRestoreArgs,
+  rejectHardLinks,
+  safeTarExtract,
+  validateSnapshotName,
+  validateTarEntries,
+} from "../../../dist/lib/state/sandbox";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function tarBufferFrom(dir: string): Buffer {
+  return execFileSync("tar", ["-cf", "-", "-C", dir, "."]);
+}
+
+describe("sandbox state snapshot helpers", () => {
+  it("validates user-provided snapshot names", () => {
+    expect(validateSnapshotName("release_2026.05-rc1")).toBeNull();
+    expect(validateSnapshotName("bad name")).toContain("Invalid snapshot name");
+    expect(validateSnapshotName("v12")).toContain("conflicts with the auto-assigned version");
+    expect(validateSnapshotName("-bad")).toContain("Invalid snapshot name");
+  });
+
+  it("parses restore selectors and target sandbox overrides", () => {
+    expect(parseRestoreArgs("alpha", ["restore"])).toEqual({ ok: true, targetSandbox: "alpha", selector: null });
+    expect(parseRestoreArgs("alpha", ["restore", "v2"])).toEqual({ ok: true, targetSandbox: "alpha", selector: "v2" });
+    expect(parseRestoreArgs("alpha", ["restore", "snapshot-a", "--to", "beta"])).toEqual({
+      ok: true,
+      targetSandbox: "beta",
+      selector: "snapshot-a",
+    });
+    expect(parseRestoreArgs("alpha", ["restore", "--to"])).toEqual({
+      ok: false,
+      error: "--to requires a target sandbox name.",
+    });
+    expect(parseRestoreArgs("alpha", ["restore", "--to", "--bad"])).toEqual({
+      ok: false,
+      error: "--to requires a target sandbox name.",
+    });
+  });
+
+  it("validates and extracts safe tar archives", () => {
+    const source = tempDir("nemoclaw-state-source-");
+    const target = tempDir("nemoclaw-state-target-");
+    writeFileSync(join(source, "config.json"), JSON.stringify({ ok: true }));
+    const archive = tarBufferFrom(source);
+
+    const validation = validateTarEntries(archive, target);
+    expect(validation.safe).toBe(true);
+    expect(validation.entries).toContain("./config.json");
+    expect(rejectHardLinks(archive)).toEqual([]);
+
+    expect(safeTarExtract(archive, target)).toEqual({ success: true });
+    expect(existsSync(join(target, "config.json"))).toBe(true);
+    expect(JSON.parse(readFileSync(join(target, "config.json"), "utf-8"))).toEqual({ ok: true });
+  });
+
+  it("rejects invalid tar buffers before extraction", () => {
+    const target = tempDir("nemoclaw-state-bad-target-");
+    const result = validateTarEntries(Buffer.from("not a tar"), target);
+    expect(result.safe).toBe(false);
+    expect(result.violations.join("\n")).toContain("tar listing failed");
+
+    const extract = safeTarExtract(Buffer.from("not a tar"), target);
+    expect(extract.success).toBe(false);
+    expect(extract.error).toContain("tar entry validation failed");
+  });
+});


### PR DESCRIPTION
## Summary
Adds direct compiled-module coverage for remaining CLI action helper paths. This continues the stacked coverage work above the M11 shields coverage PR.

## Changes
- Route update and dev shim action tests through `dist/lib/**` for CLI coverage attribution.
- Add maintenance action coverage for backup and sandbox image garbage-collection flows.
- Add upgrade-sandboxes action coverage for empty registries, live lookup failures, check mode, stopped stale sandboxes, prompted rebuilds, and rebuild failures.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>