### PR TITLE
test(cli): expand sandbox state helper coverage

### DIFF
--- a/src/lib/state/sandbox-extra.test.ts
+++ b/src/lib/state/sandbox-extra.test.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parseRestoreArgs,
+  rejectHardLinks,
+  safeTarExtract,
+  validateSnapshotName,
+  validateTarEntries,
+} from "../../../dist/lib/state/sandbox";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function tarBufferFrom(dir: string): Buffer {
+  return execFileSync("tar", ["-cf", "-", "-C", dir, "."]);
+}
+
+describe("sandbox state snapshot helpers", () => {
+  it("validates user-provided snapshot names", () => {
+    expect(validateSnapshotName("release_2026.05-rc1")).toBeNull();
+    expect(validateSnapshotName("bad name")).toContain("Invalid snapshot name");
+    expect(validateSnapshotName("v12")).toContain("conflicts with the auto-assigned version");
+    expect(validateSnapshotName("-bad")).toContain("Invalid snapshot name");
+  });
+
+  it("parses restore selectors and target sandbox overrides", () => {
+    expect(parseRestoreArgs("alpha", ["restore"])).toEqual({ ok: true, targetSandbox: "alpha", selector: null });
+    expect(parseRestoreArgs("alpha", ["restore", "v2"])).toEqual({ ok: true, targetSandbox: "alpha", selector: "v2" });
+    expect(parseRestoreArgs("alpha", ["restore", "snapshot-a", "--to", "beta"])).toEqual({
+      ok: true,
+      targetSandbox: "beta",
+      selector: "snapshot-a",
+    });
+    expect(parseRestoreArgs("alpha", ["restore", "--to"])).toEqual({
+      ok: false,
+      error: "--to requires a target sandbox name.",
+    });
+    expect(parseRestoreArgs("alpha", ["restore", "--to", "--bad"])).toEqual({
+      ok: false,
+      error: "--to requires a target sandbox name.",
+    });
+  });
+
+  it("validates and extracts safe tar archives", () => {
+    const source = tempDir("nemoclaw-state-source-");
+    const target = tempDir("nemoclaw-state-target-");
+    writeFileSync(join(source, "config.json"), JSON.stringify({ ok: true }));
+    const archive = tarBufferFrom(source);
+
+    const validation = validateTarEntries(archive, target);
+    expect(validation.safe).toBe(true);
+    expect(validation.entries).toContain("./config.json");
+    expect(rejectHardLinks(archive)).toEqual([]);
+
+    expect(safeTarExtract(archive, target)).toEqual({ success: true });
+    expect(existsSync(join(target, "config.json"))).toBe(true);
+    expect(JSON.parse(readFileSync(join(target, "config.json"), "utf-8"))).toEqual({ ok: true });
+  });
+
+  it("rejects invalid tar buffers before extraction", () => {
+    const target = tempDir("nemoclaw-state-bad-target-");
+    const result = validateTarEntries(Buffer.from("not a tar"), target);
+    expect(result.safe).toBe(false);
+    expect(result.violations.join("\n")).toContain("tar listing failed");
+
+    const extract = safeTarExtract(Buffer.from("not a tar"), target);
+    expect(extract.success).toBe(false);
+    expect(extract.error).toContain("tar entry validation failed");
+  });
+});


### PR DESCRIPTION
## Summary
Adds direct compiled-module coverage for sandbox state helper behavior on top of the policy coverage PR. The new tests exercise snapshot name validation, restore argument parsing, and safe tar validation/extraction paths.

## Changes
- Cover valid, invalid, and version-conflicting snapshot names.
- Cover restore selectors, target sandbox overrides, and missing `--to` values.
- Cover safe tar validation/extraction for normal archives and rejection of invalid tar buffers.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>