### PR TITLE
ci(coverage): add source coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "preinstall": "node scripts/check-node-version.js",
     "test": "vitest run",
+    "coverage:cli:src": "vitest run --project cli --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli-src --coverage.include='src/**/*.ts' --coverage.include='bin/**/*.js' --coverage.exclude='**/*.test.ts' --coverage.exclude='dist/**'",
     "check": "npx prek run --all-files",
     "checks": "tsx scripts/checks/run.ts",
     "lint": "npx @biomejs/biome lint . && npm run checks",


### PR DESCRIPTION
## Summary
Adds a non-blocking source-oriented CLI coverage report command. The existing dist-based coverage ratchet remains unchanged while source coverage becomes visible for behavior-focused tests.

## Changes
- Add `npm run coverage:cli:src` to report coverage for `src/**/*.ts` and `bin/**/*.js` into `coverage/cli-src`.
- Keep the existing compiled CLI coverage ratchet untouched.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>