### PR TITLE
test(cli): fix share mounted check on macOS

### DIFF
--- a/src/lib/share-command.test.ts
+++ b/src/lib/share-command.test.ts
@@ -270,13 +270,15 @@ describe("ShareCommand mount/status actions", () => {
 
   it("exits when the target local mount is already mounted", async () => {
     const deps = makeDeps();
+    const localMount = "/tmp/mounted";
     spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "sh" && args[1] === "command -v sshfs") return { status: 0, stdout: "sshfs\n" };
       if (cmd === "mountpoint") return { status: 0, stdout: "", stderr: "" };
+      if (cmd === "mount") return { status: 0, stdout: mountedAt(localMount), stderr: "" };
       return { status: 1, stdout: "", stderr: "" };
     });
 
-    await expect(runShareMount({ sandboxName: "alpha", localMount: "/tmp/mounted" }, deps)).rejects.toThrow(
+    await expect(runShareMount({ sandboxName: "alpha", localMount }, deps)).rejects.toThrow(
       "process.exit:1",
     );
     expect(deps.ensureLive).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- make the new share mounted preflight test simulate the macOS `mount` fallback path
- keep the existing Linux `mountpoint` success path covered
- fixes the macOS-only failure where `ensureLive` was called because Darwin skips `mountpoint`

## Validation
- npm run build:cli
- npx vitest run src/lib/share-command.test.ts --testTimeout 60000

## Context
This targets PR #3544, where the failing test was introduced, so dependent coverage PRs can inherit the fix.