### PR TITLE
test(e2e): add model router routed guard for #3255

### DIFF
--- a/.github/workflows/regression-e2e.yaml
+++ b/.github/workflows/regression-e2e.yaml
@@ -247,4 +247,3 @@ jobs:
             /tmp/nemoclaw-e2e-model-router-health.log
             /tmp/nemoclaw-e2e-model-router-response.log
           if-no-files-found: ignore
-

--- a/.github/workflows/regression-e2e.yaml
+++ b/.github/workflows/regression-e2e.yaml
@@ -21,7 +21,7 @@ on:
       jobs:
         description: >-
           Comma-separated regression job names to run (empty = all).
-          Valid: dashboard-remote-bind-e2e,gateway-health-honest-e2e,gateway-drift-preflight-e2e,openshell-version-pin-e2e
+          Valid: dashboard-remote-bind-e2e,gateway-health-honest-e2e,gateway-drift-preflight-e2e,openshell-version-pin-e2e,model-router-provider-routed-inference-e2e
         required: false
         type: string
         default: ""
@@ -48,6 +48,7 @@ jobs:
       gateway: ${{ steps.select.outputs.gateway }}
       gateway_drift_preflight: ${{ steps.select.outputs.gateway_drift_preflight }}
       openshell_version_pin: ${{ steps.select.outputs.openshell_version_pin }}
+      model_router_provider_routed_inference: ${{ steps.select.outputs.model_router_provider_routed_inference }}
     steps:
       - id: select
         env:
@@ -85,6 +86,12 @@ jobs:
             echo "openshell_version_pin=true" >> "$GITHUB_OUTPUT"
           else
             echo "openshell_version_pin=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -z "$normalized" ] || includes_job "model-router-provider-routed-inference-e2e"; then
+            echo "model_router_provider_routed_inference=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "model_router_provider_routed_inference=false" >> "$GITHUB_OUTPUT"
           fi
 
   dashboard-remote-bind-e2e:
@@ -207,3 +214,37 @@ jobs:
           NEMOCLAW_NON_INTERACTIVE: "1"
           NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
         run: bash test/e2e/test-gateway-drift-preflight.sh
+
+  # ── Model Router provider-routed inference E2E ─────────────────
+  # Coverage guard for #3255. Model Router onboard must generate a routed
+  # provider that can answer through inference.local instead of returning
+  # HTTP 503 / "inference service unavailable" after a successful onboard.
+  model-router-provider-routed-inference-e2e:
+    needs: select_regression_jobs
+    if: >-
+      github.repository == 'NVIDIA/NemoClaw' &&
+      needs.select_regression_jobs.outputs.model_router_provider_routed_inference == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run Model Router provider-routed inference E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+        run: bash test/e2e/test-model-router-provider-routed-inference.sh
+
+      - name: Upload Model Router provider-routed inference logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: model-router-provider-routed-inference-logs
+          path: |
+            /tmp/nemoclaw-e2e-model-router-onboard.log
+            /tmp/nemoclaw-e2e-model-router-health.log
+            /tmp/nemoclaw-e2e-model-router-response.log
+          if-no-files-found: ignore
+

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -9079,7 +9079,7 @@
       "assertions": [
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 82,
+          "line": 93,
           "text": "Docker is running",
           "polarity": "pass",
           "normalized_id": "docker.is.running",
@@ -9087,7 +9087,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 84,
+          "line": 95,
           "text": "Docker is not running",
           "polarity": "fail",
           "normalized_id": "docker.is.not.running",
@@ -9095,7 +9095,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 89,
+          "line": 100,
           "text": "NVIDIA_API_KEY is set",
           "polarity": "pass",
           "normalized_id": "nvidia.api.key.is.set",
@@ -9103,7 +9103,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 91,
+          "line": 102,
           "text": "NVIDIA_API_KEY is required and must start with nvapi-",
           "polarity": "fail",
           "normalized_id": "nvidia.api.key.is.required.and.must.start.with.nvapi",
@@ -9111,7 +9111,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 104,
+          "line": 115,
           "text": "nemoclaw is available: $(nemoclaw --version 2>/dev/null || echo unknown)",
           "polarity": "pass",
           "normalized_id": "nemoclaw.is.available.nemoclaw.version.2.dev.null.echo.unknown",
@@ -9119,7 +9119,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 106,
+          "line": 117,
           "text": "nemoclaw not found after install",
           "polarity": "fail",
           "normalized_id": "nemoclaw.not.found.after.install",
@@ -9127,7 +9127,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 127,
+          "line": 138,
           "text": "Model Router onboard completed",
           "polarity": "pass",
           "normalized_id": "model.router.onboard.completed",
@@ -9135,7 +9135,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 129,
+          "line": 140,
           "text": "Model Router onboard failed (exit ${onboard_rc}); see ${ONBOARD_LOG}",
           "polarity": "fail",
           "normalized_id": "model.router.onboard.failed.exit.onboard.rc.see.onboard.log",
@@ -9143,7 +9143,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 140,
+          "line": 151,
           "text": "model-router reports at least one healthy endpoint",
           "polarity": "pass",
           "normalized_id": "model.router.reports.at.least.one.healthy.endpoint",
@@ -9151,7 +9151,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 146,
+          "line": 157,
           "text": "model-router has no healthy endpoints; expected #3255 main-equivalent failure",
           "polarity": "fail",
           "normalized_id": "model.router.has.no.healthy.endpoints.expected.3255.main.equivalent.failure",
@@ -9159,7 +9159,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 162,
+          "line": 173,
           "text": "inference.local returned a routed Model Router completion",
           "polarity": "pass",
           "normalized_id": "inference.local.returned.a.routed.model.router.completion",
@@ -9167,7 +9167,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 174,
+          "line": 185,
           "text": "Model Router inference.local did not return a routed completion; expected #3255 main-equivalent failure",
           "polarity": "fail",
           "normalized_id": "model.router.inference.local.did.not.return.a.routed.completion.expected.3255.main.equivalent.failure",
@@ -9175,7 +9175,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 181,
+          "line": 192,
           "text": "Model Router provider-routed inference guard passed",
           "polarity": "pass",
           "normalized_id": "model.router.provider.routed.inference.guard.passed",

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -9079,22 +9079,6 @@
       "assertions": [
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 14,
-          "text": "%s\\033[0m\\n",
-          "polarity": "pass",
-          "normalized_id": "s.033.0m.n",
-          "mapping_status": "unmapped"
-        },
-        {
-          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 15,
-          "text": "%s\\033[0m\\n",
-          "polarity": "fail",
-          "normalized_id": "s.033.0m.n",
-          "mapping_status": "unmapped"
-        },
-        {
-          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
           "line": 82,
           "text": "Docker is running",
           "polarity": "pass",
@@ -16474,7 +16458,7 @@
   ],
   "totals": {
     "scripts": 52,
-    "assertions": 2026,
+    "assertions": 2024,
     "zero_assertion_scripts": 1
   }
 }

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -9079,7 +9079,7 @@
       "assertions": [
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 93,
+          "line": 94,
           "text": "Docker is running",
           "polarity": "pass",
           "normalized_id": "docker.is.running",
@@ -9087,7 +9087,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 95,
+          "line": 96,
           "text": "Docker is not running",
           "polarity": "fail",
           "normalized_id": "docker.is.not.running",
@@ -9095,7 +9095,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 100,
+          "line": 101,
           "text": "NVIDIA_API_KEY is set",
           "polarity": "pass",
           "normalized_id": "nvidia.api.key.is.set",
@@ -9103,7 +9103,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 102,
+          "line": 103,
           "text": "NVIDIA_API_KEY is required and must start with nvapi-",
           "polarity": "fail",
           "normalized_id": "nvidia.api.key.is.required.and.must.start.with.nvapi",
@@ -9111,7 +9111,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 115,
+          "line": 116,
           "text": "nemoclaw is available: $(nemoclaw --version 2>/dev/null || echo unknown)",
           "polarity": "pass",
           "normalized_id": "nemoclaw.is.available.nemoclaw.version.2.dev.null.echo.unknown",
@@ -9119,7 +9119,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 117,
+          "line": 118,
           "text": "nemoclaw not found after install",
           "polarity": "fail",
           "normalized_id": "nemoclaw.not.found.after.install",
@@ -9127,7 +9127,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 138,
+          "line": 139,
           "text": "Model Router onboard completed",
           "polarity": "pass",
           "normalized_id": "model.router.onboard.completed",
@@ -9135,7 +9135,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 140,
+          "line": 141,
           "text": "Model Router onboard failed (exit ${onboard_rc}); see ${ONBOARD_LOG}",
           "polarity": "fail",
           "normalized_id": "model.router.onboard.failed.exit.onboard.rc.see.onboard.log",
@@ -9143,7 +9143,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 151,
+          "line": 152,
           "text": "model-router reports at least one healthy endpoint",
           "polarity": "pass",
           "normalized_id": "model.router.reports.at.least.one.healthy.endpoint",
@@ -9151,7 +9151,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 157,
+          "line": 158,
           "text": "model-router has no healthy endpoints; expected #3255 main-equivalent failure",
           "polarity": "fail",
           "normalized_id": "model.router.has.no.healthy.endpoints.expected.3255.main.equivalent.failure",
@@ -9159,7 +9159,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 173,
+          "line": 174,
           "text": "inference.local returned a routed Model Router completion",
           "polarity": "pass",
           "normalized_id": "inference.local.returned.a.routed.model.router.completion",
@@ -9167,7 +9167,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 185,
+          "line": 186,
           "text": "Model Router inference.local did not return a routed completion; expected #3255 main-equivalent failure",
           "polarity": "fail",
           "normalized_id": "model.router.inference.local.did.not.return.a.routed.completion.expected.3255.main.equivalent.failure",
@@ -9175,7 +9175,7 @@
         },
         {
           "script": "test/e2e/test-model-router-provider-routed-inference.sh",
-          "line": 192,
+          "line": 193,
           "text": "Model Router provider-routed inference guard passed",
           "polarity": "pass",
           "normalized_id": "model.router.provider.routed.inference.guard.passed",

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -16473,8 +16473,8 @@
     }
   ],
   "totals": {
-    "scripts": 51,
-    "assertions": 2022,
+    "scripts": 52,
+    "assertions": 2026,
     "zero_assertion_scripts": 1
   }
 }

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -9075,6 +9075,131 @@
       ]
     },
     {
+      "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+      "assertions": [
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 14,
+          "text": "%s\\033[0m\\n",
+          "polarity": "pass",
+          "normalized_id": "s.033.0m.n",
+          "mapping_status": "unmapped"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 15,
+          "text": "%s\\033[0m\\n",
+          "polarity": "fail",
+          "normalized_id": "s.033.0m.n",
+          "mapping_status": "unmapped"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 82,
+          "text": "Docker is running",
+          "polarity": "pass",
+          "normalized_id": "docker.is.running",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 84,
+          "text": "Docker is not running",
+          "polarity": "fail",
+          "normalized_id": "docker.is.not.running",
+          "mapping_status": "retired"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 89,
+          "text": "NVIDIA_API_KEY is set",
+          "polarity": "pass",
+          "normalized_id": "nvidia.api.key.is.set",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 91,
+          "text": "NVIDIA_API_KEY is required and must start with nvapi-",
+          "polarity": "fail",
+          "normalized_id": "nvidia.api.key.is.required.and.must.start.with.nvapi",
+          "mapping_status": "retired"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 104,
+          "text": "nemoclaw is available: $(nemoclaw --version 2>/dev/null || echo unknown)",
+          "polarity": "pass",
+          "normalized_id": "nemoclaw.is.available.nemoclaw.version.2.dev.null.echo.unknown",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 106,
+          "text": "nemoclaw not found after install",
+          "polarity": "fail",
+          "normalized_id": "nemoclaw.not.found.after.install",
+          "mapping_status": "retired"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 127,
+          "text": "Model Router onboard completed",
+          "polarity": "pass",
+          "normalized_id": "model.router.onboard.completed",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 129,
+          "text": "Model Router onboard failed (exit ${onboard_rc}); see ${ONBOARD_LOG}",
+          "polarity": "fail",
+          "normalized_id": "model.router.onboard.failed.exit.onboard.rc.see.onboard.log",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 140,
+          "text": "model-router reports at least one healthy endpoint",
+          "polarity": "pass",
+          "normalized_id": "model.router.reports.at.least.one.healthy.endpoint",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 146,
+          "text": "model-router has no healthy endpoints; expected #3255 main-equivalent failure",
+          "polarity": "fail",
+          "normalized_id": "model.router.has.no.healthy.endpoints.expected.3255.main.equivalent.failure",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 162,
+          "text": "inference.local returned a routed Model Router completion",
+          "polarity": "pass",
+          "normalized_id": "inference.local.returned.a.routed.model.router.completion",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 174,
+          "text": "Model Router inference.local did not return a routed completion; expected #3255 main-equivalent failure",
+          "polarity": "fail",
+          "normalized_id": "model.router.inference.local.did.not.return.a.routed.completion.expected.3255.main.equivalent.failure",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-model-router-provider-routed-inference.sh",
+          "line": 181,
+          "text": "Model Router provider-routed inference guard passed",
+          "polarity": "pass",
+          "normalized_id": "model.router.provider.routed.inference.guard.passed",
+          "mapping_status": "deferred"
+        }
+      ]
+    },
+    {
       "script": "test/e2e/test-network-policy.sh",
       "assertions": [
         {
@@ -16311,8 +16436,8 @@
     }
   ],
   "totals": {
-    "scripts": 50,
-    "assertions": 2007,
+    "scripts": 51,
+    "assertions": 2022,
     "zero_assertion_scripts": 1
   }
 }

--- a/test/e2e/docs/parity-map.yaml
+++ b/test/e2e/docs/parity-map.yaml
@@ -9912,6 +9912,76 @@ scripts:
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers
       runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+  test-model-router-provider-routed-inference.sh:
+    scenario: ubuntu-repo-cloud-openclaw
+    status: migrated
+    bucket: providers-messaging
+    assertions:
+    - legacy: Docker is running
+      status: deferred
+      reason: live regression guard requires Docker and external Model Router credentials; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs and NVIDIA_API_KEY
+    - legacy: Docker is not running
+      status: retired
+      reason: prerequisite failure path; not product behavior coverage
+      reviewer: e2e-maintainers
+      approved_at: '2026-05-15'
+    - legacy: NVIDIA_API_KEY is set
+      status: deferred
+      reason: live regression guard requires external Model Router credentials; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NVIDIA_API_KEY
+    - legacy: NVIDIA_API_KEY is required and must start with nvapi-
+      status: retired
+      reason: prerequisite failure path; not product behavior coverage
+      reviewer: e2e-maintainers
+      approved_at: '2026-05-15'
+    - legacy: 'nemoclaw is available: $(nemoclaw --version 2>/dev/null || echo unknown)'
+      status: deferred
+      reason: live install behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: nemoclaw not found after install
+      status: retired
+      reason: prerequisite failure path; not product behavior coverage
+      reviewer: e2e-maintainers
+      approved_at: '2026-05-15'
+    - legacy: Model Router onboard completed
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs and NVIDIA_API_KEY
+    - legacy: Model Router onboard failed (exit ${onboard_rc}); see ${ONBOARD_LOG}
+      status: deferred
+      reason: live regression guard failure evidence for #3255 path; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs and NVIDIA_API_KEY
+    - legacy: model-router reports at least one healthy endpoint
+      status: deferred
+      reason: live regression guard requires external Model Router health; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NVIDIA_API_KEY
+    - legacy: "model-router has no healthy endpoints; expected #3255 main-equivalent failure"
+      status: deferred
+      reason: live regression guard failure evidence for #3255; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NVIDIA_API_KEY
+    - legacy: inference.local returned a routed Model Router completion
+      status: deferred
+      reason: live regression guard assertion for #3255 routed inference; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs and NVIDIA_API_KEY
+    - legacy: "Model Router inference.local did not return a routed completion; expected #3255 main-equivalent failure"
+      status: deferred
+      reason: live regression guard failure evidence for #3255; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs and NVIDIA_API_KEY
+    - legacy: Model Router provider-routed inference guard passed
+      status: deferred
+      reason: live regression guard success assertion for #3255; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs and NVIDIA_API_KEY
   test-openshell-version-pin.sh:
     scenario: ubuntu-repo-cloud-openclaw
     status: migrated

--- a/test/e2e/test-model-router-provider-routed-inference.sh
+++ b/test/e2e/test-model-router-provider-routed-inference.sh
@@ -64,6 +64,7 @@ open(path, "w").write(text)
 PY
 }
 
+# shellcheck disable=SC2329 # Invoked indirectly by the EXIT trap.
 cleanup() {
   local rc=$?
   redact_file "$ONBOARD_LOG"
@@ -74,7 +75,7 @@ cleanup() {
   fi
   exit "$rc"
 }
-trap cleanup EXIT
+trap cleanup EXIT # invoked by EXIT trap
 
 section "Prerequisites"
 if docker info >/dev/null 2>&1; then
@@ -110,13 +111,14 @@ section "Onboard with Model Router provider"
 rm -f "$HOME/.nemoclaw/onboard.lock" 2>/dev/null || true
 nemoclaw "$SANDBOX_NAME" destroy --yes >/dev/null 2>&1 || true
 
-NEMOCLAW_SANDBOX_NAME="$SANDBOX_NAME" \
+env \
+  NEMOCLAW_PROVIDER_KEY="$NVIDIA_API_KEY" \
+  NEMOCLAW_SANDBOX_NAME="$SANDBOX_NAME" \
   NEMOCLAW_NON_INTERACTIVE=1 \
   NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
   NEMOCLAW_POLICY_TIER="open" \
   NEMOCLAW_PROVIDER="routed" \
-  NEMOCLAW_PROVIDER_KEY="${NVIDIA_API_KEY}" \
-  NVIDIA_API_KEY="${NVIDIA_API_KEY}" \
+  NVIDIA_API_KEY="$NVIDIA_API_KEY" \
   "$TIMEOUT_CMD" 1500 nemoclaw onboard --fresh --non-interactive --yes-i-accept-third-party-software \
   >"$ONBOARD_LOG" 2>&1
 onboard_rc=$?

--- a/test/e2e/test-model-router-provider-routed-inference.sh
+++ b/test/e2e/test-model-router-provider-routed-inference.sh
@@ -11,8 +11,8 @@ PASS=0
 FAIL=0
 TOTAL=0
 
-pass() { ((PASS++)); ((TOTAL++)); printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
-fail() { ((FAIL++)); ((TOTAL++)); printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+pass() { ((PASS++)); ((TOTAL++)); echo "  OK: $1"; }
+fail() { ((FAIL++)); ((TOTAL++)); echo "  ERROR: $1"; }
 section() { echo ""; printf '\033[1;36m=== %s ===\033[0m\n' "$1"; }
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 

--- a/test/e2e/test-model-router-provider-routed-inference.sh
+++ b/test/e2e/test-model-router-provider-routed-inference.sh
@@ -16,6 +16,26 @@ fail() { ((FAIL++)); ((TOTAL++)); printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
 section() { echo ""; printf '\033[1;36m=== %s ===\033[0m\n' "$1"; }
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 
+is_routed_pong_response() {
+  python3 - <<'PY'
+import json, re, sys
+raw = sys.stdin.read()
+try:
+    data = json.loads(raw)
+except Exception:
+    raise SystemExit(1)
+model = str(data.get("model", ""))
+choices = data.get("choices") or []
+content = ""
+if choices and isinstance(choices[0], dict):
+    message = choices[0].get("message") or {}
+    content = str(message.get("content", ""))
+ok_model = model == "nvidia-routed" or model.startswith("nvidia-routed")
+ok_content = re.search(r"\bPONG\b", content, re.IGNORECASE) is not None
+raise SystemExit(0 if ok_model and ok_content else 1)
+PY
+}
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-model-router}"
@@ -136,7 +156,7 @@ for _ in $(seq 1 3); do
     2>&1 || true)"
   printf '%s\n' "$response" >"$RESPONSE_LOG"
   redact_file "$RESPONSE_LOG"
-  if echo "$response" | grep -qi 'PONG'; then
+  if is_routed_pong_response <<<"$response"; then
     pass "inference.local returned a routed Model Router completion"
     break
   fi
@@ -146,7 +166,7 @@ for _ in $(seq 1 3); do
   sleep 5
 done
 
-if echo "$response" | grep -qi 'PONG'; then
+if is_routed_pong_response <<<"$response"; then
   :
 else
   fail "Model Router inference.local did not return a routed completion; expected #3255 main-equivalent failure"

--- a/test/e2e/test-model-router-provider-routed-inference.sh
+++ b/test/e2e/test-model-router-provider-routed-inference.sh
@@ -11,9 +11,20 @@ PASS=0
 FAIL=0
 TOTAL=0
 
-pass() { ((PASS++)); ((TOTAL++)); echo "  OK: $1"; }
-fail() { ((FAIL++)); ((TOTAL++)); echo "  ERROR: $1"; }
-section() { echo ""; printf '\033[1;36m=== %s ===\033[0m\n' "$1"; }
+pass() {
+  ((PASS++))
+  ((TOTAL++))
+  echo "  OK: $1"
+}
+fail() {
+  ((FAIL++))
+  ((TOTAL++))
+  echo "  ERROR: $1"
+}
+section() {
+  echo ""
+  printf '\033[1;36m=== %s ===\033[0m\n' "$1"
+}
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 
 is_routed_pong_response() {
@@ -153,8 +164,8 @@ response=""
 for _ in $(seq 1 3); do
   response="$(openshell sandbox exec --name "$SANDBOX_NAME" -- \
     curl -sk --max-time 90 https://inference.local/v1/chat/completions \
-      -H 'Content-Type: application/json' \
-      -d '{"model":"nvidia-routed","messages":[{"role":"user","content":"Reply with exactly one word: PONG"}],"max_tokens":50}' \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"nvidia-routed","messages":[{"role":"user","content":"Reply with exactly one word: PONG"}],"max_tokens":50}' \
     2>&1 || true)"
   printf '%s\n' "$response" >"$RESPONSE_LOG"
   redact_file "$RESPONSE_LOG"

--- a/test/e2e/test-model-router-provider-routed-inference.sh
+++ b/test/e2e/test-model-router-provider-routed-inference.sh
@@ -28,9 +28,10 @@ section() {
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 
 is_routed_pong_response() {
-  python3 - <<'PY'
+  local raw="$1"
+  python3 - "$raw" <<'PY'
 import json, re, sys
-raw = sys.stdin.read()
+raw = sys.argv[1]
 try:
     data = json.loads(raw)
 except Exception:
@@ -169,7 +170,7 @@ for _ in $(seq 1 3); do
     2>&1 || true)"
   printf '%s\n' "$response" >"$RESPONSE_LOG"
   redact_file "$RESPONSE_LOG"
-  if is_routed_pong_response <<<"$response"; then
+  if is_routed_pong_response "$response"; then
     pass "inference.local returned a routed Model Router completion"
     break
   fi
@@ -179,7 +180,7 @@ for _ in $(seq 1 3); do
   sleep 5
 done
 
-if is_routed_pong_response <<<"$response"; then
+if is_routed_pong_response "$response"; then
   :
 else
   fail "Model Router inference.local did not return a routed completion; expected #3255 main-equivalent failure"

--- a/test/e2e/test-model-router-provider-routed-inference.sh
+++ b/test/e2e/test-model-router-provider-routed-inference.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Coverage guard for #3255 — Model Router (Provider Routed) onboard must
+# produce a working inference.local route instead of HTTP 503.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { ((PASS++)); ((TOTAL++)); printf '\033[32m  PASS: %s\033[0m\n' "$1"; }
+fail() { ((FAIL++)); ((TOTAL++)); printf '\033[31m  FAIL: %s\033[0m\n' "$1"; }
+section() { echo ""; printf '\033[1;36m=== %s ===\033[0m\n' "$1"; }
+info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-model-router}"
+ONBOARD_LOG="${E2E_MODEL_ROUTER_ONBOARD_LOG:-/tmp/nemoclaw-e2e-model-router-onboard.log}"
+RESPONSE_LOG="${E2E_MODEL_ROUTER_RESPONSE_LOG:-/tmp/nemoclaw-e2e-model-router-response.log}"
+HEALTH_LOG="${E2E_MODEL_ROUTER_HEALTH_LOG:-/tmp/nemoclaw-e2e-model-router-health.log}"
+TIMEOUT_CMD="${TIMEOUT_CMD:-timeout}"
+
+# shellcheck source=test/e2e/lib/install-path-refresh.sh
+. "${SCRIPT_DIR}/lib/install-path-refresh.sh"
+# shellcheck source=test/e2e/lib/sandbox-teardown.sh
+. "${SCRIPT_DIR}/lib/sandbox-teardown.sh"
+register_sandbox_for_teardown "$SANDBOX_NAME"
+
+redact_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  python3 - "$file" <<'PY'
+import os, sys
+path = sys.argv[1]
+secrets = [os.environ.get("NVIDIA_API_KEY", ""), os.environ.get("NEMOCLAW_PROVIDER_KEY", "")]
+text = open(path, "r", errors="replace").read()
+for secret in filter(None, secrets):
+    text = text.replace(secret, "<REDACTED>")
+open(path, "w").write(text)
+PY
+}
+
+cleanup() {
+  local rc=$?
+  redact_file "$ONBOARD_LOG"
+  redact_file "$RESPONSE_LOG"
+  redact_file "$HEALTH_LOG"
+  if [ "${NEMOCLAW_E2E_KEEP_SANDBOX:-0}" != "1" ]; then
+    nemoclaw "$SANDBOX_NAME" destroy --yes >/dev/null 2>&1 || true
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+section "Prerequisites"
+if docker info >/dev/null 2>&1; then
+  pass "Docker is running"
+else
+  fail "Docker is not running"
+  exit 1
+fi
+
+if [ -n "${NVIDIA_API_KEY:-}" ] && [[ "${NVIDIA_API_KEY}" == nvapi-* ]]; then
+  pass "NVIDIA_API_KEY is set"
+else
+  fail "NVIDIA_API_KEY is required and must start with nvapi-"
+  exit 1
+fi
+
+section "Install NemoClaw from checkout"
+if ! command -v nemoclaw >/dev/null 2>&1; then
+  NEMOCLAW_NON_INTERACTIVE=1 \
+    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
+    bash "${REPO}/install.sh" --non-interactive --yes-i-accept-third-party-software >"$ONBOARD_LOG" 2>&1 || true
+  nemoclaw_refresh_install_env
+fi
+
+if command -v nemoclaw >/dev/null 2>&1; then
+  pass "nemoclaw is available: $(nemoclaw --version 2>/dev/null || echo unknown)"
+else
+  fail "nemoclaw not found after install"
+  exit 1
+fi
+
+section "Onboard with Model Router provider"
+rm -f "$HOME/.nemoclaw/onboard.lock" 2>/dev/null || true
+nemoclaw "$SANDBOX_NAME" destroy --yes >/dev/null 2>&1 || true
+
+NEMOCLAW_SANDBOX_NAME="$SANDBOX_NAME" \
+  NEMOCLAW_NON_INTERACTIVE=1 \
+  NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
+  NEMOCLAW_POLICY_TIER="open" \
+  NEMOCLAW_PROVIDER="routed" \
+  NEMOCLAW_PROVIDER_KEY="${NVIDIA_API_KEY}" \
+  NVIDIA_API_KEY="${NVIDIA_API_KEY}" \
+  "$TIMEOUT_CMD" 1500 nemoclaw onboard --fresh --non-interactive --yes-i-accept-third-party-software \
+  >"$ONBOARD_LOG" 2>&1
+onboard_rc=$?
+redact_file "$ONBOARD_LOG"
+if [ "$onboard_rc" -eq 0 ]; then
+  pass "Model Router onboard completed"
+else
+  fail "Model Router onboard failed (exit ${onboard_rc}); see ${ONBOARD_LOG}"
+  exit 1
+fi
+
+section "Host model-router health"
+health=""
+for _ in $(seq 1 20); do
+  health="$(curl -s --max-time 10 http://127.0.0.1:4000/health 2>&1 || true)"
+  printf '%s\n' "$health" >"$HEALTH_LOG"
+  redact_file "$HEALTH_LOG"
+  if echo "$health" | grep -Eq '"healthy_count"[[:space:]]*:[[:space:]]*[1-9]'; then
+    pass "model-router reports at least one healthy endpoint"
+    break
+  fi
+  sleep 3
+done
+if ! echo "$health" | grep -Eq '"healthy_count"[[:space:]]*:[[:space:]]*[1-9]'; then
+  fail "model-router has no healthy endpoints; expected #3255 main-equivalent failure"
+  info "Health excerpt: $(head -c 500 "$HEALTH_LOG")"
+  exit 1
+fi
+
+section "Sandbox inference.local routed completion"
+response=""
+for _ in $(seq 1 3); do
+  response="$(openshell sandbox exec --name "$SANDBOX_NAME" -- \
+    curl -sk --max-time 90 https://inference.local/v1/chat/completions \
+      -H 'Content-Type: application/json' \
+      -d '{"model":"nvidia-routed","messages":[{"role":"user","content":"Reply with exactly one word: PONG"}],"max_tokens":50}' \
+    2>&1 || true)"
+  printf '%s\n' "$response" >"$RESPONSE_LOG"
+  redact_file "$RESPONSE_LOG"
+  if echo "$response" | grep -qi 'PONG'; then
+    pass "inference.local returned a routed Model Router completion"
+    break
+  fi
+  if echo "$response" | grep -qi 'inference service unavailable\|HTTP 503\|healthy_count.*0'; then
+    break
+  fi
+  sleep 5
+done
+
+if echo "$response" | grep -qi 'PONG'; then
+  :
+else
+  fail "Model Router inference.local did not return a routed completion; expected #3255 main-equivalent failure"
+  info "Response excerpt: $(head -c 500 "$RESPONSE_LOG")"
+  exit 1
+fi
+
+section "Summary"
+if [ "$FAIL" -eq 0 ]; then
+  pass "Model Router provider-routed inference guard passed"
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary
Adds a regression E2E guard for model-router provider-routed inference so the routed inference path is covered in the regression workflow. This replaces closed PR #3594 from the rebased branch because repository rules blocked force-pushing the original PR branch.

## Related Issue
Refs #3255

## Changes
- Adds `test/e2e/test-model-router-provider-routed-inference.sh` for provider-routed inference coverage.
- Updates `.github/workflows/regression-e2e.yaml` to include the new regression guard.
- Updates E2E parity metadata in `test/e2e/docs/parity-map.yaml` and `test/e2e/docs/parity-inventory.generated.json`.
- Carries the rebased compatibility cleanup currently present on `pr-3594-rebased-main`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end coverage guard that verifies provider-routed Model Router onboarding and routed completions, including health checks, routed response validation, redacted log capture, and failure reporting.

* **Chores**
  * CI regression workflow updated to include a selectable job for the new E2E guard and conditionally run it; model-router-specific artifacts are uploaded on failures.

* **Documentation**
  * Test inventory and mapping updated to include the new script, assertions, and revised totals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3601)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->