### PR TITLE
refactor(cli): migrate commands to shared oclif base

### DIFF
--- a/src/commands/internal/dns/fix-coredns.ts
+++ b/src/commands/internal/dns/fix-coredns.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
 
 import { runFixCoreDns } from "../../../lib/actions/dns";
 
-export default class InternalDnsFixCoreDnsCommand extends Command {
+export default class InternalDnsFixCoreDnsCommand extends NemoClawCommand {
   static hidden = true;
   static strict = true;
   static summary = "Internal: patch CoreDNS for local gateway DNS";

--- a/src/commands/internal/dns/setup-proxy.ts
+++ b/src/commands/internal/dns/setup-proxy.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
 
 import { runSetupDnsProxy } from "../../../lib/actions/dns";
 
-export default class InternalDnsSetupProxyCommand extends Command {
+export default class InternalDnsSetupProxyCommand extends NemoClawCommand {
   static hidden = true;
   static strict = true;
   static summary = "Internal: configure sandbox DNS proxy";

--- a/src/commands/internal/installer/normalize-env.ts
+++ b/src/commands/internal/installer/normalize-env.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
 
 import { normalizeInstallerEnv } from "../../../lib/actions/installer/plan";
 
-export default class InternalInstallerNormalizeEnvCommand extends Command {
+export default class InternalInstallerNormalizeEnvCommand extends NemoClawCommand {
   static hidden = true;
   static strict = true;
   static summary = "Internal: normalize installer environment values";

--- a/src/commands/internal/installer/plan.ts
+++ b/src/commands/internal/installer/plan.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
 
 import { buildInstallerPlan } from "../../../lib/actions/installer/plan";
 
-export default class InternalInstallerPlanCommand extends Command {
+export default class InternalInstallerPlanCommand extends NemoClawCommand {
   static hidden = true;
   static strict = true;
   static summary = "Internal: build the NemoClaw installer plan";

--- a/src/commands/internal/installer/resolve-release-tag.ts
+++ b/src/commands/internal/installer/resolve-release-tag.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
 
 import { resolveInstallRef } from "../../../lib/domain/installer/ref";
 
-export default class InternalInstallerResolveReleaseTagCommand extends Command {
+export default class InternalInstallerResolveReleaseTagCommand extends NemoClawCommand {
   static hidden = true;
   static strict = true;
   static summary = "Internal: resolve the installer release ref";

--- a/src/commands/internal/uninstall/classify-shim.ts
+++ b/src/commands/internal/uninstall/classify-shim.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
 
 import { classifyShimPath } from "../../../lib/actions/uninstall/plan";
 
-export default class InternalUninstallClassifyShimCommand extends Command {
+export default class InternalUninstallClassifyShimCommand extends NemoClawCommand {
   static hidden = true;
   static strict = true;
   static summary = "Internal: classify a NemoClaw shim path";

--- a/src/commands/internal/uninstall/plan.ts
+++ b/src/commands/internal/uninstall/plan.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
 
 import { buildHostUninstallPlan } from "../../../lib/actions/uninstall/plan";
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../../lib/cli/branding";
 
-export default class InternalUninstallPlanCommand extends Command {
+export default class InternalUninstallPlanCommand extends NemoClawCommand {
   static hidden = true;
   static strict = true;
   static summary = `Internal: build the ${CLI_DISPLAY_NAME} uninstall plan`;

--- a/src/commands/internal/uninstall/run-plan.ts
+++ b/src/commands/internal/uninstall/run-plan.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
 
 import { runUninstallPlan } from "../../../lib/actions/uninstall/run-plan";
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../../lib/cli/branding";
 
-export default class InternalUninstallRunPlanCommand extends Command {
+export default class InternalUninstallRunPlanCommand extends NemoClawCommand {
   static hidden = true;
   static strict = true;
   static summary = `${CLI_DISPLAY_NAME} Uninstaller`;

--- a/src/lib/cli/oclif-command-metadata.test.ts
+++ b/src/lib/cli/oclif-command-metadata.test.ts
@@ -4,7 +4,29 @@
 import { Config as OclifConfig } from "@oclif/core";
 import { describe, expect, it } from "vitest";
 
+function extendsNemoClawCommand(commandClass: unknown): boolean {
+  if (typeof commandClass !== "function") return false;
+  let current = Object.getPrototypeOf(commandClass) as { name?: string } | null;
+  while (current) {
+    if (current.name === "NemoClawCommand") return true;
+    current = Object.getPrototypeOf(current) as { name?: string } | null;
+  }
+  return false;
+}
+
 describe("oclif command metadata", () => {
+  it("keeps discovered commands on the shared NemoClaw oclif base", async () => {
+    const config = await OclifConfig.load(process.cwd());
+    const nonConforming: string[] = [];
+
+    for (const command of config.commands) {
+      const commandClass = await command.load();
+      if (!extendsNemoClawCommand(commandClass)) nonConforming.push(command.id);
+    }
+
+    expect(nonConforming).toEqual([]);
+  });
+
   it("keeps public discovered commands documented in oclif statics", async () => {
     const config = await OclifConfig.load(process.cwd());
     const publicCommands = config.commands.filter((command) => command.hidden !== true);

--- a/src/lib/commands/credentials.ts
+++ b/src/lib/commands/credentials.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../cli/nemoclaw-oclif-command";
 
 import { printCredentialsUsage } from "./credentials/common";
 
-export default class CredentialsCommand extends Command {
+export default class CredentialsCommand extends NemoClawCommand {
   static id = "credentials";
   static strict = true;
   static summary = "Manage provider credentials";

--- a/src/lib/commands/credentials/list.ts
+++ b/src/lib/commands/credentials/list.ts
@@ -1,14 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { CLI_NAME } from "../../cli/branding";
 import { runOpenshellProviderCommand } from "../../actions/global";
 import { OPENSHELL_OPERATION_TIMEOUT_MS } from "../../adapters/openshell/timeouts";
 import { isBridgeProviderName, recoverGatewayOrExit } from "./common";
 
-export default class CredentialsListCommand extends Command {
+export default class CredentialsListCommand extends NemoClawCommand {
   static id = "credentials:list";
   static strict = true;
   static summary = "List stored credential providers";

--- a/src/lib/commands/credentials/reset.ts
+++ b/src/lib/commands/credentials/reset.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { CLI_NAME } from "../../cli/branding";
 import { prompt as askPrompt } from "../../credentials/store";
@@ -9,7 +10,7 @@ import { runOpenshellProviderCommand } from "../../actions/global";
 import { OPENSHELL_OPERATION_TIMEOUT_MS } from "../../adapters/openshell/timeouts";
 import { isBridgeProviderName, recoverGatewayOrExit } from "./common";
 
-export default class CredentialsResetCommand extends Command {
+export default class CredentialsResetCommand extends NemoClawCommand {
   static id = "credentials:reset";
   static strict = true;
   static summary = "Remove a provider credential";

--- a/src/lib/commands/debug.ts
+++ b/src/lib/commands/debug.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../cli/nemoclaw-oclif-command";
 
 import { CLI_NAME } from "../cli/branding";
 import { runDebug } from "../diagnostics/debug";
@@ -67,7 +68,7 @@ function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
   };
 }
 
-export default class DebugCliCommand extends Command {
+export default class DebugCliCommand extends NemoClawCommand {
   static id = "debug";
   static strict = true;
   static summary = "Collect diagnostics for bug reports";

--- a/src/lib/commands/deploy.ts
+++ b/src/lib/commands/deploy.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../cli/nemoclaw-oclif-command";
 
 import { runDeployAction } from "../actions/global";
 
-export default class DeployCliCommand extends Command {
+export default class DeployCliCommand extends NemoClawCommand {
   static id = "deploy";
   static strict = true;
   static summary = "Deprecated Brev-specific bootstrap path";

--- a/src/lib/commands/deprecated/start.ts
+++ b/src/lib/commands/deprecated/start.ts
@@ -1,14 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { CLI_NAME } from "../../cli/branding";
 import { startAll } from "../../tunnel/services";
 import { runStartCommand } from "../../tunnel/service-command";
 import { serviceDeps } from "../tunnel/common";
 
-export default class DeprecatedStartCommand extends Command {
+export default class DeprecatedStartCommand extends NemoClawCommand {
   static id = "start";
   static strict = true;
   static summary = "Deprecated alias for 'tunnel start'";

--- a/src/lib/commands/deprecated/stop.ts
+++ b/src/lib/commands/deprecated/stop.ts
@@ -1,14 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { CLI_NAME } from "../../cli/branding";
 import { stopAll } from "../../tunnel/services";
 import { runStopCommand } from "../../tunnel/service-command";
 import { serviceDeps } from "../tunnel/common";
 
-export default class DeprecatedStopCommand extends Command {
+export default class DeprecatedStopCommand extends NemoClawCommand {
   static id = "stop";
   static strict = true;
   static summary = "Deprecated alias for 'tunnel stop'";

--- a/src/lib/commands/gateway-token.ts
+++ b/src/lib/commands/gateway-token.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../cli/nemoclaw-oclif-command";
 
 import { runGatewayTokenCommand } from "../gateway-token-command";
 
@@ -40,7 +41,7 @@ function getRuntimeBridge(): GatewayTokenRuntimeBridge {
   return runtimeBridgeFactory();
 }
 
-export default class GatewayTokenCliCommand extends Command {
+export default class GatewayTokenCliCommand extends NemoClawCommand {
   static id = "sandbox:gateway:token";
   static strict = true;
   static summary = "Print the OpenClaw gateway auth token to stdout";

--- a/src/lib/commands/onboard.ts
+++ b/src/lib/commands/onboard.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../cli/nemoclaw-oclif-command";
 
 import { runOnboardAction } from "../actions/global";
 import {
@@ -12,7 +12,7 @@ import {
   toLegacyOnboardArgs,
 } from "./onboard/common";
 
-export default class OnboardCliCommand extends Command {
+export default class OnboardCliCommand extends NemoClawCommand {
   static id = "onboard";
   static strict = true;
   static summary = "Configure inference endpoint and credentials";

--- a/src/lib/commands/sandbox/channels/add.ts
+++ b/src/lib/commands/sandbox/channels/add.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import {
   buildChannelArgs,
@@ -10,7 +10,7 @@ import {
   getChannelsRuntimeBridge,
 } from "./common";
 
-export default class ChannelsAddCommand extends Command {
+export default class ChannelsAddCommand extends NemoClawCommand {
   static id = "sandbox:channels:add";
   static strict = true;
   static summary = "Save messaging channel credentials and rebuild";

--- a/src/lib/commands/sandbox/channels/list.ts
+++ b/src/lib/commands/sandbox/channels/list.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { listSandboxChannels } from "../../../actions/sandbox/policy-channel";
 import { sandboxNameArg } from "../common";
 
-export default class SandboxChannelsListCommand extends Command {
+export default class SandboxChannelsListCommand extends NemoClawCommand {
   static id = "sandbox:channels:list";
   static strict = true;
   static summary = "List supported messaging channels";

--- a/src/lib/commands/sandbox/channels/remove.ts
+++ b/src/lib/commands/sandbox/channels/remove.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import {
   buildChannelArgs,
@@ -10,7 +10,7 @@ import {
   getChannelsRuntimeBridge,
 } from "./common";
 
-export default class ChannelsRemoveCommand extends Command {
+export default class ChannelsRemoveCommand extends NemoClawCommand {
   static id = "sandbox:channels:remove";
   static strict = true;
   static summary = "Clear messaging channel credentials and rebuild";

--- a/src/lib/commands/sandbox/channels/start.ts
+++ b/src/lib/commands/sandbox/channels/start.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import {
   buildChannelArgs,
@@ -10,7 +10,7 @@ import {
   getChannelsRuntimeBridge,
 } from "./common";
 
-export default class ChannelsStartCommand extends Command {
+export default class ChannelsStartCommand extends NemoClawCommand {
   static id = "sandbox:channels:start";
   static strict = true;
   static summary = "Re-enable a stopped messaging channel";

--- a/src/lib/commands/sandbox/channels/stop.ts
+++ b/src/lib/commands/sandbox/channels/stop.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import {
   buildChannelArgs,
@@ -10,7 +10,7 @@ import {
   getChannelsRuntimeBridge,
 } from "./common";
 
-export default class ChannelsStopCommand extends Command {
+export default class ChannelsStopCommand extends NemoClawCommand {
   static id = "sandbox:channels:stop";
   static strict = true;
   static summary = "Disable channel without wiping credentials";

--- a/src/lib/commands/sandbox/config/get.ts
+++ b/src/lib/commands/sandbox/config/get.ts
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { CLI_NAME } from "../../../cli/branding";
 import * as sandboxConfig from "../../../sandbox/config";
 import { sandboxNameArg } from "../common";
 
-export default class SandboxConfigGetCommand extends Command {
+export default class SandboxConfigGetCommand extends NemoClawCommand {
   static id = "sandbox:config:get";
   static strict = true;
   static summary = "Get sandbox configuration";

--- a/src/lib/commands/sandbox/config/set.ts
+++ b/src/lib/commands/sandbox/config/set.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import * as sandboxConfig from "../../../sandbox/config";
 
@@ -12,7 +13,7 @@ const sandboxNameArg = Args.string({
   required: true,
 });
 
-export default class SandboxConfigSetCommand extends Command {
+export default class SandboxConfigSetCommand extends NemoClawCommand {
   static id = "sandbox:config:set";
   static strict = true;
   static summary = "Set sandbox configuration";

--- a/src/lib/commands/sandbox/connect.ts
+++ b/src/lib/commands/sandbox/connect.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { CLI_NAME } from "../../cli/branding";
 import { connectSandbox } from "../../actions/sandbox/connect";
 
-export default class ConnectCliCommand extends Command {
+export default class ConnectCliCommand extends NemoClawCommand {
   static id = "sandbox:connect";
   static strict = true;
   static summary = "Shell into a running sandbox";

--- a/src/lib/commands/sandbox/doctor.ts
+++ b/src/lib/commands/sandbox/doctor.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { runSandboxDoctor } from "../../actions/sandbox/doctor";
 
-export default class SandboxDoctorCliCommand extends Command {
+export default class SandboxDoctorCliCommand extends NemoClawCommand {
   static id = "sandbox:doctor";
   static strict = true;
   static summary = "Diagnose sandbox and gateway health";

--- a/src/lib/commands/sandbox/hosts/add.ts
+++ b/src/lib/commands/sandbox/hosts/add.ts
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { buildHostAliasArgs, getHostsRuntimeBridge, hostAliasAddArgs, hostAliasMutationFlags } from "./common";
 
-export default class HostsAddCommand extends Command {
+export default class HostsAddCommand extends NemoClawCommand {
   static id = "sandbox:hosts:add";
   static strict = true;
   static summary = "Add a sandbox /etc/hosts alias";

--- a/src/lib/commands/sandbox/hosts/list.ts
+++ b/src/lib/commands/sandbox/hosts/list.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { getHostsRuntimeBridge, hostAliasSandboxArgs } from "./common";
 
-export default class HostsListCommand extends Command {
+export default class HostsListCommand extends NemoClawCommand {
   static id = "sandbox:hosts:list";
   static strict = true;
   static summary = "List sandbox host aliases";

--- a/src/lib/commands/sandbox/hosts/remove.ts
+++ b/src/lib/commands/sandbox/hosts/remove.ts
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { buildHostAliasArgs, getHostsRuntimeBridge, hostAliasMutationArgs, hostAliasMutationFlags } from "./common";
 
-export default class HostsRemoveCommand extends Command {
+export default class HostsRemoveCommand extends NemoClawCommand {
   static id = "sandbox:hosts:remove";
   static strict = true;
   static summary = "Remove a sandbox /etc/hosts alias";

--- a/src/lib/commands/sandbox/logs.ts
+++ b/src/lib/commands/sandbox/logs.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { logsSinceDurationFlag } from "../../cli/duration-flags";
 import type { SandboxLogsOptions } from "../../domain/sandbox/log-options";
@@ -31,7 +32,7 @@ function getRuntimeBridge() {
   return runtimeBridgeFactory();
 }
 
-export default class SandboxLogsCommand extends Command {
+export default class SandboxLogsCommand extends NemoClawCommand {
   static id = "sandbox:logs";
   static strict = true;
   static summary = "Stream sandbox logs";

--- a/src/lib/commands/sandbox/policy/add.ts
+++ b/src/lib/commands/sandbox/policy/add.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import {
   appendCommonPolicyFlags,
@@ -10,7 +11,7 @@ import {
   policyMutationFlags,
 } from "./common";
 
-export default class PolicyAddCommand extends Command {
+export default class PolicyAddCommand extends NemoClawCommand {
   static id = "sandbox:policy:add";
   static strict = true;
   static summary = "Add a network or filesystem policy preset";

--- a/src/lib/commands/sandbox/policy/list.ts
+++ b/src/lib/commands/sandbox/policy/list.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { listSandboxPolicies } from "../../../actions/sandbox/policy-channel";
 import { sandboxNameArg } from "../common";
 
-export default class SandboxPolicyListCommand extends Command {
+export default class SandboxPolicyListCommand extends NemoClawCommand {
   static id = "sandbox:policy:list";
   static strict = true;
   static summary = "List policy presets";

--- a/src/lib/commands/sandbox/policy/remove.ts
+++ b/src/lib/commands/sandbox/policy/remove.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import {
   appendCommonPolicyFlags,
@@ -10,7 +10,7 @@ import {
   policyMutationFlags,
 } from "./common";
 
-export default class PolicyRemoveCommand extends Command {
+export default class PolicyRemoveCommand extends NemoClawCommand {
   static id = "sandbox:policy:remove";
   static strict = true;
   static summary = "Remove an applied policy preset";

--- a/src/lib/commands/sandbox/share.ts
+++ b/src/lib/commands/sandbox/share.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { printShareUsageAndExit } from "../../share-command";
 import { sandboxNameArg } from "./common";
 
-export default class ShareCommand extends Command {
+export default class ShareCommand extends NemoClawCommand {
   static id = "sandbox:share";
   static strict = true;
   static summary = "Mount/unmount sandbox filesystem on the host via SSHFS";

--- a/src/lib/commands/sandbox/share/mount.ts
+++ b/src/lib/commands/sandbox/share/mount.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { runShareMount } from "../../../share-command";
 import { sandboxNameArg } from "../common";
 
-export default class ShareMountCommand extends Command {
+export default class ShareMountCommand extends NemoClawCommand {
   static id = "sandbox:share:mount";
   static strict = true;
   static summary = "Mount sandbox filesystem on the host";

--- a/src/lib/commands/sandbox/share/status.ts
+++ b/src/lib/commands/sandbox/share/status.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { runShareStatus } from "../../../share-command";
 import { sandboxNameArg } from "../common";
 
-export default class ShareStatusCommand extends Command {
+export default class ShareStatusCommand extends NemoClawCommand {
   static id = "sandbox:share:status";
   static strict = true;
   static summary = "Show sandbox share mount status";

--- a/src/lib/commands/sandbox/share/unmount.ts
+++ b/src/lib/commands/sandbox/share/unmount.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { runShareUnmount } from "../../../share-command";
 import { sandboxNameArg } from "../common";
 
-export default class ShareUnmountCommand extends Command {
+export default class ShareUnmountCommand extends NemoClawCommand {
   static id = "sandbox:share:unmount";
   static strict = true;
   static summary = "Unmount a shared sandbox filesystem";

--- a/src/lib/commands/sandbox/shields/down.ts
+++ b/src/lib/commands/sandbox/shields/down.ts
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { shieldsTimeoutDurationFlag } from "../../../cli/duration-flags";
 import * as shields from "../../../shields";
 import { sandboxNameArg } from "../common";
 
-export default class ShieldsDownCommand extends Command {
+export default class ShieldsDownCommand extends NemoClawCommand {
   static id = "sandbox:shields:down";
   static hidden = true;
   static strict = true;

--- a/src/lib/commands/sandbox/shields/status.ts
+++ b/src/lib/commands/sandbox/shields/status.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import * as shields from "../../../shields";
 import { sandboxNameArg } from "../common";
 
-export default class ShieldsStatusCommand extends Command {
+export default class ShieldsStatusCommand extends NemoClawCommand {
   static id = "sandbox:shields:status";
   static hidden = true;
   static strict = true;

--- a/src/lib/commands/sandbox/shields/up.ts
+++ b/src/lib/commands/sandbox/shields/up.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import * as shields from "../../../shields";
 import { sandboxNameArg } from "../common";
 
-export default class ShieldsUpCommand extends Command {
+export default class ShieldsUpCommand extends NemoClawCommand {
   static id = "sandbox:shields:up";
   static hidden = true;
   static strict = true;

--- a/src/lib/commands/sandbox/skill/install.ts
+++ b/src/lib/commands/sandbox/skill/install.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { getSkillInstallRuntimeBridge } from "./common";
 
-export default class SkillInstallCliCommand extends Command {
+export default class SkillInstallCliCommand extends NemoClawCommand {
   static id = "sandbox:skill:install";
   static strict = true;
   static summary = "Deploy a skill directory to the sandbox";

--- a/src/lib/commands/sandbox/snapshot/create.ts
+++ b/src/lib/commands/sandbox/snapshot/create.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { getSnapshotRuntimeBridge, sandboxNameArg } from "./common";
 
-export default class SnapshotCreateCommand extends Command {
+export default class SnapshotCreateCommand extends NemoClawCommand {
   static id = "sandbox:snapshot:create";
   static strict = true;
   static summary = "Create a snapshot of sandbox state";

--- a/src/lib/commands/sandbox/snapshot/list.ts
+++ b/src/lib/commands/sandbox/snapshot/list.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { getSnapshotRuntimeBridge, sandboxNameArg } from "./common";
 
-export default class SnapshotListCommand extends Command {
+export default class SnapshotListCommand extends NemoClawCommand {
   static id = "sandbox:snapshot:list";
   static strict = true;
   static summary = "List available snapshots";

--- a/src/lib/commands/sandbox/snapshot/restore.ts
+++ b/src/lib/commands/sandbox/snapshot/restore.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../../cli/nemoclaw-oclif-command";
 
 import { getSnapshotRuntimeBridge, sandboxNameArg } from "./common";
 
-export default class SnapshotRestoreCommand extends Command {
+export default class SnapshotRestoreCommand extends NemoClawCommand {
   static id = "sandbox:snapshot:restore";
   static strict = true;
   static summary = "Restore state from a snapshot";

--- a/src/lib/commands/sandbox/status.ts
+++ b/src/lib/commands/sandbox/status.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { showSandboxStatus } from "../../actions/sandbox/status";
 import { sandboxNameArg } from "./common";
 
-export default class SandboxStatusCommand extends Command {
+export default class SandboxStatusCommand extends NemoClawCommand {
   static id = "sandbox:status";
   static strict = true;
   static summary = "Sandbox health and NIM status";

--- a/src/lib/commands/setup-spark.ts
+++ b/src/lib/commands/setup-spark.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../cli/nemoclaw-oclif-command";
 
 import { runSetupSparkAction } from "../actions/global";
 import { buildOnboardFlags, type OnboardFlags, toLegacyOnboardArgs } from "./onboard/common";
 
-export default class SetupSparkCliCommand extends Command {
+export default class SetupSparkCliCommand extends NemoClawCommand {
   static id = "setup-spark";
   static strict = true;
   static summary = "Deprecated alias for nemoclaw onboard";

--- a/src/lib/commands/setup.ts
+++ b/src/lib/commands/setup.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command } from "@oclif/core";
+import { NemoClawCommand } from "../cli/nemoclaw-oclif-command";
 
 import { runSetupAction } from "../actions/global";
 import { buildOnboardFlags, type OnboardFlags, toLegacyOnboardArgs } from "./onboard/common";
 
-export default class SetupCliCommand extends Command {
+export default class SetupCliCommand extends NemoClawCommand {
   static id = "setup";
   static strict = true;
   static summary = "Deprecated alias for nemoclaw onboard";

--- a/src/lib/commands/tunnel/start.ts
+++ b/src/lib/commands/tunnel/start.ts
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { startAll } from "../../tunnel/services";
 import { runStartCommand } from "../../tunnel/service-command";
 import { serviceDeps } from "./common";
 
-export default class TunnelStartCommand extends Command {
+export default class TunnelStartCommand extends NemoClawCommand {
   static id = "tunnel:start";
   static strict = true;
   static summary = "Start the cloudflared public-URL tunnel";

--- a/src/lib/commands/tunnel/stop.ts
+++ b/src/lib/commands/tunnel/stop.ts
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../../cli/nemoclaw-oclif-command";
 
 import { stopAll } from "../../tunnel/services";
 import { runStopCommand } from "../../tunnel/service-command";
 import { serviceDeps } from "./common";
 
-export default class TunnelStopCommand extends Command {
+export default class TunnelStopCommand extends NemoClawCommand {
   static id = "tunnel:stop";
   static strict = true;
   static summary = "Stop the cloudflared public-URL tunnel";

--- a/src/lib/commands/uninstall.ts
+++ b/src/lib/commands/uninstall.ts
@@ -3,12 +3,13 @@
 
 import { spawnSync } from "node:child_process";
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { NemoClawCommand } from "../cli/nemoclaw-oclif-command";
 
 import { getVersion } from "../core/version";
 import { buildVersionedUninstallUrl, runUninstallCommand } from "../uninstall-command";
 
-export default class UninstallCliCommand extends Command {
+export default class UninstallCliCommand extends NemoClawCommand {
   static id = "uninstall";
   static strict = false;
   static summary = "Run uninstall.sh";

--- a/src/lib/recover-cli-command.ts
+++ b/src/lib/recover-cli-command.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
 
 import { connectSandbox } from "./actions/sandbox/connect";
+import { NemoClawCommand } from "./cli/nemoclaw-oclif-command";
 
-export default class RecoverCliCommand extends Command {
+export default class RecoverCliCommand extends NemoClawCommand {
   static id = "sandbox:recover";
   static strict = true;
   static summary = "Restart the sandbox gateway and dashboard port-forward";


### PR DESCRIPTION
## Summary
Migrates the remaining oclif command classes onto `NemoClawCommand` so CLI-wide parser and output conventions have a single base class. Adds a metadata guard that loads every discovered oclif command and fails if any command bypasses the shared NemoClaw base.

## Changes
- Migrated global, compatibility, credentials, tunnel, onboarding, and debug commands to `NemoClawCommand`.
- Migrated sandbox inspection, recovery, mutation, nested feature, and internal commands to `NemoClawCommand`.
- Added an oclif metadata test that verifies every discovered command extends the shared NemoClaw oclif base.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal command infrastructure to improve code organization and maintainability. All command functionality remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3611)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->