### PR TITLE
fix(router): correct NVIDIA routed endpoints

### DIFF
--- a/nemoclaw-blueprint/router/pool-config.yaml
+++ b/nemoclaw-blueprint/router/pool-config.yaml
@@ -23,14 +23,14 @@ routing:
 models:
   - name: nemotron-3-nano-reasoning
     display_name: "Nemotron 3 Nano (Reasoning)"
-    litellm_model: "openai/nvidia/nvidia/Nemotron-3-Nano-30B-A3B"
+    litellm_model: "openai/nvidia/nemotron-3-nano-30b-a3b"
     cost_per_m_input_tokens: 0.05
     cost_per_m_output_tokens: 0.20
-    api_base: "https://inference-api.nvidia.com"
+    api_base: "https://integrate.api.nvidia.com/v1"
 
   - name: nemotron-3-super
     display_name: "Nemotron 3 Super 120B"
-    litellm_model: "openai/nvidia/nvidia/nemotron-3-super-v3"
+    litellm_model: "openai/nvidia/nemotron-3-super-120b-a12b"
     cost_per_m_input_tokens: 0.10
     cost_per_m_output_tokens: 0.40
-    api_base: "https://inference-api.nvidia.com"
+    api_base: "https://integrate.api.nvidia.com/v1"

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -13,6 +13,10 @@ import { describe, it, expect } from "vitest";
 import YAML from "yaml";
 
 const BLUEPRINT_PATH = new URL("../nemoclaw-blueprint/blueprint.yaml", import.meta.url);
+const ROUTER_POOL_CONFIG_PATH = new URL(
+  "../nemoclaw-blueprint/router/pool-config.yaml",
+  import.meta.url,
+);
 const BASE_POLICY_PATH = new URL(
   "../nemoclaw-blueprint/policies/openclaw-sandbox.yaml",
   import.meta.url,
@@ -40,6 +44,16 @@ type Blueprint = {
     sandbox?: { image?: string | null };
     inference?: { profiles?: Record<string, BlueprintProfile> };
   };
+};
+
+type RouterPoolModel = {
+  name?: string;
+  litellm_model?: string;
+  api_base?: string;
+};
+
+type RouterPoolConfig = {
+  models?: RouterPoolModel[];
 };
 
 type Rule = { allow?: { method?: string; path?: string } };
@@ -161,6 +175,32 @@ describe("blueprint.yaml", () => {
       expect(declared).toContain(name);
     });
   }
+});
+
+describe("Model Router pool config", () => {
+  const pool = loadYaml<RouterPoolConfig>(ROUTER_POOL_CONFIG_PATH);
+
+  it("regression #3255: routes NVIDIA API keys to the public NVIDIA Build endpoint", () => {
+    const apiBases = new Set((pool.models ?? []).map((model) => model.api_base));
+    expect(apiBases).toEqual(new Set(["https://integrate.api.nvidia.com/v1"]));
+  });
+
+  it("regression #3255: uses valid LiteLLM NVIDIA model identifiers", () => {
+    const modelsByName = new Map(
+      (pool.models ?? []).map((model) => [model.name, model.litellm_model]),
+    );
+    expect(modelsByName.get("nemotron-3-nano-reasoning")).toBe(
+      "openai/nvidia/nemotron-3-nano-30b-a3b",
+    );
+    expect(modelsByName.get("nemotron-3-super")).toBe(
+      "openai/nvidia/nemotron-3-super-120b-a12b",
+    );
+    for (const litellmModel of modelsByName.values()) {
+      expect(litellmModel).not.toMatch(/nvidia\/nvidia\//);
+      expect(litellmModel).not.toContain("Nemotron-3-Nano-30B-A3B");
+      expect(litellmModel).not.toContain("nemotron-3-super-v3");
+    }
+  });
 });
 
 describe("base sandbox policy", () => {


### PR DESCRIPTION
## Summary

Fixes #3255 by correcting the Model Router pool config used by the Provider Routed path:

- routes `nvapi-*` keys to `https://integrate.api.nvidia.com/v1`
- fixes the Nemotron 3 Nano LiteLLM model ID
- fixes the Nemotron 3 Super LiteLLM model ID
- adds unit regression coverage so these config values do not drift back

## Validation

- `npm test -- --run test/validate-blueprint.test.ts`
- `npm test -- --run test/onboard.test.ts -t "Model Router"`
- `npm run build:cli`

## E2E guard

Failing-test-first guard: #3594

RED evidence on main-equivalent code: https://github.com/NVIDIA/NemoClaw/actions/runs/25922557128

After this PR is open, dispatch:

```bash
gh workflow run regression-e2e.yaml \
  --repo NVIDIA/NemoClaw \
  -f jobs=model-router-provider-routed-inference-e2e \
  --ref issue-3255-model-router-provider-routed-503
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Nemotron model configurations with revised identifiers and API endpoint settings.

* **Tests**
  * Added validation tests to ensure model routing and identifier configurations function correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3614)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->