### PR TITLE
fix(e2e): restore backup directories file-by-file

### DIFF
--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -41,6 +41,45 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "'$1' is required but not found in PATH."
 }
 
+shell_quote() {
+  printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\\\''/g")"
+}
+
+RESTORE_DIR_COUNT=0
+restore_directory() {
+  local sandbox="$1"
+  local src_dir="$2"
+  local dir_name="$3"
+  local failed=0
+  RESTORE_DIR_COUNT=0
+
+  while IFS= read -r -d '' file; do
+    local rel="${file#"${src_dir}/"}"
+    local rel_parent
+    rel_parent="$(dirname "$rel")"
+
+    local remote_parent="${WORKSPACE_PATH}/${dir_name}"
+    if [ "$rel_parent" != "." ]; then
+      remote_parent="${remote_parent}/${rel_parent}"
+    fi
+
+    if ! openshell sandbox exec --name "$sandbox" -- sh -c "mkdir -p $(shell_quote "$remote_parent")"; then
+      warn "Failed to create restore directory ${remote_parent}"
+      failed=1
+      continue
+    fi
+
+    if openshell sandbox upload "$sandbox" "$file" "${remote_parent}/"; then
+      RESTORE_DIR_COUNT=$((RESTORE_DIR_COUNT + 1))
+    else
+      warn "Failed to restore ${dir_name}/${rel}"
+      failed=1
+    fi
+  done < <(find "$src_dir" -type f -print0)
+
+  return "$failed"
+}
+
 do_backup() {
   local sandbox="$1"
   local ts
@@ -108,10 +147,15 @@ do_restore() {
 
   for d in "${DIRS[@]}"; do
     if [ -d "${src}/${d}" ]; then
-      if openshell sandbox upload "$sandbox" "${src}/${d}/" "${WORKSPACE_PATH}/${d}/"; then
-        count=$((count + 1))
+      if restore_directory "$sandbox" "${src}/${d}" "$d"; then
+        if [ "$RESTORE_DIR_COUNT" -gt 0 ]; then
+          count=$((count + RESTORE_DIR_COUNT))
+        else
+          warn "Skipped empty restore directory ${d}/"
+        fi
       else
-        warn "Failed to restore ${d}/"
+        count=$((count + RESTORE_DIR_COUNT))
+        warn "Failed to restore one or more files from ${d}/"
       fi
     fi
   done

--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -56,7 +56,7 @@ restore_directory() {
   while IFS= read -r -d '' file; do
     local rel="${file#"${src_dir}/"}"
     local rel_parent
-    rel_parent="$(dirname "$rel")"
+    rel_parent="$(dirname -- "$rel")"
 
     local remote_parent="${WORKSPACE_PATH}/${dir_name}"
     if [ "$rel_parent" != "." ]; then


### PR DESCRIPTION
## Summary
- restore backup workspace directories by creating remote parents and uploading each file individually
- preserve nested paths like `memory/2026-04-20.md` instead of relying on ambiguous `openshell sandbox upload` directory semantics
- keep restore counts accurate for partially restored directories

## Validation
- `bash -n scripts/backup-workspace.sh`
- `npm test -- --run test/snapshot.test.ts`
- local mocked `openshell` restore verified nested files land under `/sandbox/.openclaw/workspace/memory/...`

## Context
Addresses nightly `state-backup-restore-e2e` failure where backup captured `memory/2026-04-20.md` but restore dropped the nested directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace restore reliability with per-file upload handling and clearer warnings when restores partially or fully fail.

* **Chores**
  * Enhanced backup script diagnostics and tracking so restore progress and outcomes are reported more accurately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3619)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->