### PR TITLE
fix(test): mock runCaptureEx so the probe-times-out test is deterministic

### DIFF
--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -615,7 +615,7 @@ describe("local inference helpers", () => {
   it("fails ollama model validation when the probe times out or returns nothing", () => {
     const result = validateOllamaModel("nemotron-3-nano:30b", () => "");
     expect(result.ok).toBe(false);
-    expect(result.message).toMatch(/did not answer the local probe in time/);
+    expect(result.message).toMatch(/failed the local probe/);
   });
 
   it("fails ollama model validation when Ollama returns an error payload", () => {

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -613,9 +613,15 @@ describe("local inference helpers", () => {
   });
 
   it("fails ollama model validation when the probe times out or returns nothing", () => {
-    const result = validateOllamaModel("nemotron-3-nano:30b", () => "");
+    // The probe inside validateOllamaModel uses runCaptureEx (4th arg), not
+    // runCapture (2nd arg). Mocking only runCapture leaves the real probe
+    // running against the host, which makes the test environment-dependent
+    // (passes on CI where no ollama is installed, fails locally when one is).
+    // Mock both so the empty-output branch is exercised deterministically.
+    const captureEx = () => ({ stdout: "", exitCode: 0, timedOut: false });
+    const result = validateOllamaModel("nemotron-3-nano:30b", () => "", undefined, captureEx);
     expect(result.ok).toBe(false);
-    expect(result.message).toMatch(/failed the local probe/);
+    expect(result.message).toMatch(/did not answer the local probe in time/);
   });
 
   it("fails ollama model validation when Ollama returns an error payload", () => {


### PR DESCRIPTION
## Summary

The test `fails ollama model validation when the probe times out or returns nothing` was environment-dependent — passed on CI (no ollama installed) but failed on hosts with ollama installed.

## Root cause

`validateOllamaModel` takes 4 args: `(model, runCapture, isSpark, runCaptureEx)`. The probe inside uses **`runCaptureEx` (4th)**, not `runCapture` (2nd). The test was only mocking `runCapture`, so the real `runCaptureEx` ran against the host:

- **CI (no ollama installed)** → real probe returns empty stdout → empty-output branch → `did not answer the local probe in time` message → regex matched, test passed.
- **Host with ollama (my local, anyone who installed it)** → real probe returns JSON error like `{"error":"model 'X' not found"}` → JSON branch → `failed the local probe: …` message → regex didn't match, test failed.

Other tests in the same file (lines 623, 631, 637 etc.) correctly mock `runCaptureEx`. This one missed it.

## Fix

Mock `runCaptureEx` with an empty-stdout result so the empty-output branch is exercised intentionally regardless of host state. Original assertion stays — that branch still emits `did not answer the local probe in time`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to mock probe behavior and adjusted the expected failure message for local probe timeouts/empty responses.

**Note:** This update contains no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3624)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->