### PR TITLE
fix(cli): cap sandbox name length validation

### DIFF
--- a/src/lib/deploy/index.test.ts
+++ b/src/lib/deploy/index.test.ts
@@ -241,7 +241,7 @@ describe("executeDeploy", () => {
     expect(errorText).toContain("Invalid sandbox name: 'bad name'");
     expect(errorText).toContain("Sandbox names cannot contain spaces.");
     expect(errorText).toContain(
-      "Allowed format: lowercase, starts with a letter, letters/numbers/internal hyphens only, ends with letter/number.",
+      "Allowed format: 1-63 characters, lowercase, starts with a letter, letters/numbers/internal hyphens only, ends with letter/number.",
     );
     expect(errorText).toContain(
       "Brev deploy is non-interactive and cannot prompt for a corrected sandbox name.",

--- a/src/lib/name-validation.ts
+++ b/src/lib/name-validation.ts
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+export const NAME_MAX_LENGTH = 63;
 export const NAME_ALLOWED_FORMAT =
-  "lowercase, starts with a letter, letters/numbers/internal hyphens only, ends with letter/number";
+  `1-${NAME_MAX_LENGTH} characters, lowercase, starts with a letter, ` +
+  "letters/numbers/internal hyphens only, ends with letter/number";
 
 function validationSubject(label: string): string {
   const normalized = label.trim().toLowerCase();
@@ -20,6 +22,9 @@ export function getNameValidationGuidance(
   const lines: string[] = [];
   if (/\s/.test(value)) {
     lines.push(`${validationSubject(label)} cannot contain spaces.`);
+  }
+  if (value.length > NAME_MAX_LENGTH) {
+    lines.push(`${validationSubject(label)} must be ${NAME_MAX_LENGTH} characters or fewer.`);
   }
   if (opts.includeAllowedFormat !== false) {
     lines.push(`Allowed format: ${NAME_ALLOWED_FORMAT}.`);

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -6,7 +6,7 @@ import type {
   SpawnSyncOptionsWithStringEncoding,
   SpawnSyncReturns,
 } from "node:child_process";
-import { NAME_ALLOWED_FORMAT } from "./name-validation";
+import { NAME_ALLOWED_FORMAT, NAME_MAX_LENGTH } from "./name-validation";
 
 const { spawnSync } = require("child_process");
 const path = require("path");
@@ -318,9 +318,9 @@ function validateName(name: string, label = "name"): string {
   if (!name || typeof name !== "string") {
     throw new Error(`${label} is required. Allowed format: ${NAME_ALLOWED_FORMAT}.`);
   }
-  if (name.length > 63) {
+  if (name.length > NAME_MAX_LENGTH) {
     throw new Error(
-      `${label} too long (max 63 chars): '${name.slice(0, 20)}...'. Allowed format: ${NAME_ALLOWED_FORMAT}.`,
+      `${label} too long (max ${NAME_MAX_LENGTH} chars): '${name.slice(0, 20)}...'. Allowed format: ${NAME_ALLOWED_FORMAT}.`,
     );
   }
   if (!/^[a-z]([a-z0-9-]*[a-z0-9])?$/.test(name)) {
@@ -333,15 +333,15 @@ function validateName(name: string, label = "name"): string {
 
 export {
   ROOT,
-  SCRIPTS,
   redact,
   run,
-  runShell,
   runCapture,
   runCaptureEx,
   runFile,
   runInteractive,
   runInteractiveShell,
+  runShell,
+  SCRIPTS,
   shellQuote,
   validateName,
 };

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -976,7 +976,7 @@ describe("Brev deploy input validation", () => {
     expect(output).toContain("Invalid sandbox name: 'bad name'");
     expect(output).toContain("Sandbox names cannot contain spaces.");
     expect(output).toContain(
-      "Allowed format: lowercase, starts with a letter, letters/numbers/internal hyphens only, ends with letter/number.",
+      "Allowed format: 1-63 characters, lowercase, starts with a letter, letters/numbers/internal hyphens only, ends with letter/number.",
     );
     expect(output).not.toContain("brev CLI not found");
     expect(output).not.toContain("Creating Brev instance");

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -9854,7 +9854,7 @@ const { createSandbox } = require(${onboardPath});
       "utf-8",
     );
     expect(NAME_ALLOWED_FORMAT).toBe(
-      "lowercase, starts with a letter, letters/numbers/internal hyphens only, ends with letter/number",
+      "1-63 characters, lowercase, starts with a letter, letters/numbers/internal hyphens only, ends with letter/number",
     );
     assert.match(source, /Sandbox name \(\$\{NAME_ALLOWED_FORMAT\}\)/);
   });

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -283,6 +283,14 @@ describe("validateName", () => {
     expect(() => validateName("a".repeat(64))).toThrow(/too long/);
   });
 
+  it("rejects excessively long valid-looking names before spawning OpenShell", () => {
+    const { validateName } = require(runnerPath);
+    expect(validateName("a".repeat(63))).toBe("a".repeat(63));
+    expect(() => validateName("a".repeat(64 * 1024), "sandbox name")).toThrow(
+      /sandbox name too long \(max 63 chars\)/,
+    );
+  });
+
   it("rejects uppercase and special characters", () => {
     const { validateName } = require(runnerPath);
     expect(() => validateName("1sandbox")).toThrow(/Invalid/);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR makes the sandbox-name length limit explicit in the shared CLI validation path. Names that otherwise match the lowercase/hyphen format are now clearly constrained to 63 characters, so oversized values are rejected before they can reach OpenShell or runtime-facing paths.

## Related Issue

Fixes #3638

## Changes

- Added a shared `NAME_MAX_LENGTH` constant set to 63 characters.
- Updated `validateName()` to use the shared maximum instead of an inline value.
- Updated validation guidance so users can see the length limit in prompts and error help.
- Added a regression test for an extremely long, valid-looking sandbox name.
- Kept related snapshot validation messaging aligned with the same 63-character rule.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification run locally:

- [x] `npm run build:cli`
- [x] `cd nemoclaw && npm run build`
- [x] `npx vitest run test/runner.test.ts --project cli`
- [x] `npx vitest run nemoclaw/src/blueprint/snapshot.test.ts --project plugin`
- [x] Targeted onboarding/deploy validation tests
- [x] `npx biome check` on changed files
- [x] `git diff --check`

Note: `npm run typecheck:cli` is currently blocked by unrelated missing `@earendil-works/pi-coding-agent` types in `tools/e2e-advisor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Name validation now enforces and clearly communicates a 1–63 character maximum for sandbox names.

* **Tests**
  * Updated and added tests to verify the 1–63 character name constraint and the revised error messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Signed-off-by: 1PoPTRoN <vrxn.arp1traj@gmail.com>
