### PR TITLE
feat(vllm): add NEMOCLAW_VLLM_MODEL override + gated-model check

### DIFF
--- a/docs/inference/use-local-inference.md
+++ b/docs/inference/use-local-inference.md
@@ -305,6 +305,34 @@ $ NEMOCLAW_EXPERIMENTAL=1 \
 NemoClaw records the model returned by vLLM's `/v1/models` endpoint.
 Start vLLM with the model you want before onboarding if you manage the server yourself.
 
+### Override the Managed-vLLM Model
+
+Managed vLLM serves the profile default by, well, default.
+Export `NEMOCLAW_VLLM_MODEL=<slug>` before invoking the installer to swap in a different model from the registry; NemoClaw uses the matching `vllm serve` flags (reasoning parser, tool-call parser, `--max-model-len`).
+Recognised slugs:
+
+| Slug | Hugging Face model | Notes |
+|---|---|---|
+| `qwen3.6-27b` | `Qwen/Qwen3.6-27B-FP8` | Default on DGX Spark and DGX Station profiles |
+| `nemotron-3-nano-4b` | `nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8` | Default on the generic Linux + NVIDIA GPU profile |
+| `deepseek-r1-distill-70b` | `deepseek-ai/DeepSeek-R1-Distill-Llama-70B` | Gated — requires Hugging Face license acceptance |
+
+The slug is case-insensitive; the full Hugging Face id is also accepted.
+An unrecognised value fails fast with a list of valid slugs.
+
+Gated models require a Hugging Face token; export it before onboarding so NemoClaw can forward it into the managed vLLM container:
+
+```console
+$ export HF_TOKEN=<your-hf-token>
+$ NEMOCLAW_EXPERIMENTAL=1 \
+  NEMOCLAW_PROVIDER=install-vllm \
+  NEMOCLAW_VLLM_MODEL=deepseek-r1-distill-70b \
+  nemoclaw onboard --non-interactive
+```
+
+`HUGGING_FACE_HUB_TOKEN` is accepted as an alternative.
+The token check runs on the host before any docker pull, so a missing or empty token aborts onboarding before bandwidth is spent on a 401.
+
 ## NVIDIA NIM (Experimental)
 
 NemoClaw can pull, start, and manage a NIM container on hosts with a NIM-capable NVIDIA GPU.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1153,6 +1153,7 @@ Set them before running `nemoclaw onboard`.
 | `NEMOCLAW_SANDBOX` | sandbox name | Alternate spelling of `NEMOCLAW_SANDBOX_NAME`; used by `services` and `debug` lookups when neither a flag nor `NEMOCLAW_SANDBOX_NAME` is set. |
 | `NEMOCLAW_INSTALL_REF` | git ref | For internal installer commands: the git ref to install from. Overridden by the `--install-ref` flag. |
 | `NEMOCLAW_INSTALL_TAG` | release tag | For internal installer commands: the release tag to install. Overridden by the `--install-tag` flag. |
+| `NEMOCLAW_VLLM_MODEL` | registry slug or Hugging Face model id | Selects the model the managed-vLLM install path serves. Recognised slugs: `qwen3.6-27b`, `nemotron-3-nano-4b`, `deepseek-r1-distill-70b`. Unset uses the per-platform profile default. Gated models (e.g. `deepseek-r1-distill-70b`) require `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN`. |
 
 ### Onboarding Behavior Flags
 

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_VLLM_MODEL,
+  VLLM_MODELS,
+  assertGatedModelAccess,
+  buildVllmServeCommand,
+  selectVllmModelFromEnv,
+} from "../../../dist/lib/inference/vllm-models";
+
+describe("vllm model registry", () => {
+  it("returns the default model when NEMOCLAW_VLLM_MODEL is unset", () => {
+    expect(selectVllmModelFromEnv({} as NodeJS.ProcessEnv)).toBe(DEFAULT_VLLM_MODEL);
+  });
+
+  it("resolves a model by its env slug (case-insensitive)", () => {
+    const deepseek = VLLM_MODELS.find((m) => m.envValue === "deepseek-r1-distill-70b");
+    expect(deepseek).toBeDefined();
+    expect(
+      selectVllmModelFromEnv({ NEMOCLAW_VLLM_MODEL: "DeepSeek-R1-Distill-70B" } as NodeJS.ProcessEnv),
+    ).toEqual(deepseek);
+  });
+
+  it("resolves a model by its full Hugging Face id", () => {
+    const deepseek = VLLM_MODELS.find((m) => m.envValue === "deepseek-r1-distill-70b");
+    expect(
+      selectVllmModelFromEnv({
+        NEMOCLAW_VLLM_MODEL: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+      } as NodeJS.ProcessEnv),
+    ).toEqual(deepseek);
+  });
+
+  it("rejects an unknown NEMOCLAW_VLLM_MODEL with a helpful message", () => {
+    expect(() =>
+      selectVllmModelFromEnv({ NEMOCLAW_VLLM_MODEL: "made-up-model" } as NodeJS.ProcessEnv),
+    ).toThrow(/Unknown NEMOCLAW_VLLM_MODEL='made-up-model'/);
+  });
+
+  it("treats an empty NEMOCLAW_VLLM_MODEL the same as unset", () => {
+    expect(selectVllmModelFromEnv({ NEMOCLAW_VLLM_MODEL: "   " } as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_VLLM_MODEL,
+    );
+  });
+
+  it("passes the gated check when HF_TOKEN is present", () => {
+    const deepseek = VLLM_MODELS.find((m) => m.envValue === "deepseek-r1-distill-70b");
+    expect(() =>
+      assertGatedModelAccess(deepseek!, { HF_TOKEN: "hf_abc" } as NodeJS.ProcessEnv),
+    ).not.toThrow();
+  });
+
+  it("accepts HUGGING_FACE_HUB_TOKEN as an equivalent token", () => {
+    const deepseek = VLLM_MODELS.find((m) => m.envValue === "deepseek-r1-distill-70b");
+    expect(() =>
+      assertGatedModelAccess(deepseek!, { HUGGING_FACE_HUB_TOKEN: "hf_abc" } as NodeJS.ProcessEnv),
+    ).not.toThrow();
+  });
+
+  it("rejects a gated model when no Hugging Face token is set", () => {
+    const deepseek = VLLM_MODELS.find((m) => m.envValue === "deepseek-r1-distill-70b");
+    expect(() => assertGatedModelAccess(deepseek!, {} as NodeJS.ProcessEnv)).toThrow(
+      /gated on Hugging Face/,
+    );
+  });
+
+  it("never rejects a non-gated model regardless of token state", () => {
+    const qwen = VLLM_MODELS.find((m) => m.envValue === "qwen3.6-27b");
+    expect(() => assertGatedModelAccess(qwen!, {} as NodeJS.ProcessEnv)).not.toThrow();
+  });
+
+  it("builds a vllm serve command that includes both shared and model-specific flags", () => {
+    const qwen = VLLM_MODELS.find((m) => m.envValue === "qwen3.6-27b");
+    const cmd = buildVllmServeCommand(qwen!);
+    expect(cmd).toContain("pip install vllm[fastsafetensors]");
+    expect(cmd).toContain("vllm serve Qwen/Qwen3.6-27B-FP8");
+    expect(cmd).toContain("--gpu-memory-utilization 0.7");
+    expect(cmd).toContain("--port 8000");
+    expect(cmd).toContain("--max-model-len 262144");
+    expect(cmd).toContain("--reasoning-parser qwen3");
+    expect(cmd).toContain("--tool-call-parser qwen3_coder");
+    expect(cmd).toContain("--load-format fastsafetensors");
+  });
+
+  it("uses model-specific max-model-len when building the command", () => {
+    const deepseek = VLLM_MODELS.find((m) => m.envValue === "deepseek-r1-distill-70b");
+    const cmd = buildVllmServeCommand(deepseek!);
+    expect(cmd).toContain("vllm serve deepseek-ai/DeepSeek-R1-Distill-Llama-70B");
+    expect(cmd).toContain("--max-model-len 32768");
+    expect(cmd).toContain("--reasoning-parser deepseek_r1");
+    expect(cmd).toContain("--tool-call-parser hermes");
+    expect(cmd).not.toContain("--reasoning-parser qwen3");
+  });
+});

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -12,8 +12,15 @@ import {
 } from "../../../dist/lib/inference/vllm-models";
 
 describe("vllm model registry", () => {
-  it("returns the default model when NEMOCLAW_VLLM_MODEL is unset", () => {
-    expect(selectVllmModelFromEnv({} as NodeJS.ProcessEnv)).toBe(DEFAULT_VLLM_MODEL);
+  it("returns null when NEMOCLAW_VLLM_MODEL is unset so the caller can fall back to the profile default", () => {
+    expect(selectVllmModelFromEnv({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it("exposes a global DEFAULT_VLLM_MODEL for callers that need a baseline", () => {
+    // The platform-specific default is chosen by the profile (Spark/Station
+    // use Qwen, generic Linux uses Nemotron-Nano-4B); this constant only
+    // documents the registry's first entry.
+    expect(DEFAULT_VLLM_MODEL.envValue).toBe("qwen3.6-27b");
   });
 
   it("resolves a model by its env slug (case-insensitive)", () => {
@@ -40,9 +47,7 @@ describe("vllm model registry", () => {
   });
 
   it("treats an empty NEMOCLAW_VLLM_MODEL the same as unset", () => {
-    expect(selectVllmModelFromEnv({ NEMOCLAW_VLLM_MODEL: "   " } as NodeJS.ProcessEnv)).toBe(
-      DEFAULT_VLLM_MODEL,
-    );
+    expect(selectVllmModelFromEnv({ NEMOCLAW_VLLM_MODEL: "   " } as NodeJS.ProcessEnv)).toBeNull();
   });
 
   it("passes the gated check when HF_TOKEN is present", () => {

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Registry of models the express vLLM install path knows how to serve.
+ *
+ * Each entry pins the model-specific `vllm serve` flags (reasoning parser,
+ * tool-call parser, max model length, load format) so the express path can
+ * swap models without leaving the wrong flags behind. Users select a model
+ * via `NEMOCLAW_VLLM_MODEL=<envValue>` before invoking the installer; the
+ * default (when the env var is unset) is the first entry.
+ *
+ * Gated entries (e.g. DeepSeek-R1 Distill Llama 70B) require the operator
+ * to have accepted the model's licence on Hugging Face AND export a
+ * compatible `HF_TOKEN`; `assertGatedModelAccess` enforces the token check
+ * before the wizard pulls the model weights so the failure is fast and the
+ * user knows exactly which token to provision.
+ *
+ * The registry is deliberately small and additive — extend it when QA
+ * adds a model to the express coverage matrix (related: NemoClaw issue
+ * tracking the express vLLM model picker).
+ */
+
+export interface VllmModelDef {
+  /** Hugging Face model id (also passed to `vllm serve`). */
+  id: string;
+  /** Human-readable label shown in wizard summaries. */
+  label: string;
+  /** Stable identifier accepted via `NEMOCLAW_VLLM_MODEL`. */
+  envValue: string;
+  /** `--max-model-len` flag value. */
+  maxModelLen: number;
+  /** Model-specific flags appended after the shared serving flags. */
+  modelArgs: string[];
+  /** True when the upstream HF repo requires accepting a licence. */
+  gated: boolean;
+}
+
+export const VLLM_MODELS: readonly VllmModelDef[] = [
+  {
+    id: "Qwen/Qwen3.6-27B-FP8",
+    label: "Qwen3.6 27B FP8",
+    envValue: "qwen3.6-27b",
+    maxModelLen: 262144,
+    modelArgs: [
+      "--max-num-seqs",
+      "4",
+      "--reasoning-parser",
+      "qwen3",
+      "--enable-auto-tool-choice",
+      "--tool-call-parser",
+      "qwen3_coder",
+      "--load-format",
+      "fastsafetensors",
+      "--enable-prefix-caching",
+    ],
+    gated: false,
+  },
+  {
+    id: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+    label: "DeepSeek-R1 Distill Llama 70B",
+    envValue: "deepseek-r1-distill-70b",
+    maxModelLen: 32768,
+    modelArgs: [
+      "--max-num-seqs",
+      "4",
+      "--reasoning-parser",
+      "deepseek_r1",
+      "--enable-auto-tool-choice",
+      "--tool-call-parser",
+      "hermes",
+    ],
+    gated: true,
+  },
+  {
+    id: "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8",
+    label: "NVIDIA Nemotron-3 Nano 4B FP8",
+    envValue: "nemotron-3-nano-4b",
+    maxModelLen: 262000,
+    modelArgs: ["--load-format", "fastsafetensors"],
+    gated: false,
+  },
+] as const;
+
+export const DEFAULT_VLLM_MODEL: VllmModelDef = VLLM_MODELS[0];
+
+const HF_TOKEN_ENV_KEYS = ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"] as const;
+
+/**
+ * Look up the requested express-vLLM model from `NEMOCLAW_VLLM_MODEL`, or
+ * return the default entry when the env var is empty. Match is
+ * case-insensitive against either the `envValue` slug or the full HF id.
+ * Throws when the env var names something not in the registry so the user
+ * gets a single clear message instead of a downstream vLLM startup failure.
+ */
+export function selectVllmModelFromEnv(env: NodeJS.ProcessEnv = process.env): VllmModelDef {
+  const requested = String(env.NEMOCLAW_VLLM_MODEL ?? "").trim().toLowerCase();
+  if (!requested) return DEFAULT_VLLM_MODEL;
+  const match = VLLM_MODELS.find(
+    (model) => model.envValue.toLowerCase() === requested || model.id.toLowerCase() === requested,
+  );
+  if (match) return match;
+  const choices = VLLM_MODELS.map((model) => `'${model.envValue}'`).join(", ");
+  throw new Error(
+    `Unknown NEMOCLAW_VLLM_MODEL='${env.NEMOCLAW_VLLM_MODEL}'. ` +
+      `Recognised values: ${choices} (or the full Hugging Face model id).`,
+  );
+}
+
+/**
+ * Fail fast when a gated model is requested without a Hugging Face token.
+ * The check runs before `vllm serve` starts pulling weights so we don't
+ * burn 10+ minutes of bandwidth on a 401 the user will hit later.
+ */
+export function assertGatedModelAccess(
+  model: VllmModelDef,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!model.gated) return;
+  const hasToken = HF_TOKEN_ENV_KEYS.some((key) => String(env[key] ?? "").trim().length > 0);
+  if (hasToken) return;
+  throw new Error(
+    `Model '${model.id}' is gated on Hugging Face. ` +
+      `Accept the model's licence on its HF page, then export a token in one of: ` +
+      `${HF_TOKEN_ENV_KEYS.join(", ")}.`,
+  );
+}
+
+const SHARED_VLLM_ARGS: readonly string[] = [
+  "--gpu-memory-utilization",
+  "0.7",
+  "--tensor-parallel-size",
+  "1",
+  "--pipeline-parallel-size",
+  "1",
+  "--data-parallel-size",
+  "1",
+  "--port",
+  "8000",
+  "--trust-remote-code",
+] as const;
+
+/**
+ * Build the `vllm serve` command line for the supplied model, with the
+ * shared serving flags merged with the model-specific args from the
+ * registry. The command starts with the `pip install` that pulls the
+ * `fastsafetensors` extra so existing express scripts keep working.
+ */
+export function buildVllmServeCommand(model: VllmModelDef): string {
+  const args = [
+    ...SHARED_VLLM_ARGS,
+    "--max-model-len",
+    String(model.maxModelLen),
+    ...model.modelArgs,
+  ];
+  return `pip install vllm[fastsafetensors] && vllm serve ${model.id} ${args.join(" ")}`;
+}

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -87,15 +87,19 @@ export const DEFAULT_VLLM_MODEL: VllmModelDef = VLLM_MODELS[0];
 const HF_TOKEN_ENV_KEYS = ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"] as const;
 
 /**
- * Look up the requested express-vLLM model from `NEMOCLAW_VLLM_MODEL`, or
- * return the default entry when the env var is empty. Match is
- * case-insensitive against either the `envValue` slug or the full HF id.
- * Throws when the env var names something not in the registry so the user
- * gets a single clear message instead of a downstream vLLM startup failure.
+ * Look up the requested express-vLLM model from `NEMOCLAW_VLLM_MODEL`.
+ * Returns `null` when the env var is empty so the caller can fall back to
+ * the per-platform profile default (Spark/Station prefer Qwen3.6-27B, the
+ * generic Linux profile prefers Nemotron-Nano-4B for VRAM headroom).
+ *
+ * Match is case-insensitive against either the `envValue` slug or the full
+ * HF id. Throws when the env var names something not in the registry so the
+ * user gets a single clear message instead of a downstream vLLM startup
+ * failure.
  */
-export function selectVllmModelFromEnv(env: NodeJS.ProcessEnv = process.env): VllmModelDef {
+export function selectVllmModelFromEnv(env: NodeJS.ProcessEnv = process.env): VllmModelDef | null {
   const requested = String(env.NEMOCLAW_VLLM_MODEL ?? "").trim().toLowerCase();
-  if (!requested) return DEFAULT_VLLM_MODEL;
+  if (!requested) return null;
   const match = VLLM_MODELS.find(
     (model) => model.envValue.toLowerCase() === requested || model.id.toLowerCase() === requested,
   );

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -76,7 +76,10 @@ export const VLLM_MODELS: readonly VllmModelDef[] = [
     id: "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8",
     label: "NVIDIA Nemotron-3 Nano 4B FP8",
     envValue: "nemotron-3-nano-4b",
-    maxModelLen: 262000,
+    // Matches the model card's `max_position_embeddings` and the vLLM
+    // example NVIDIA publishes for this checkpoint. The previous value
+    // (262000) was an undocumented round-down with no headroom rationale.
+    maxModelLen: 262144,
     modelArgs: ["--load-format", "fastsafetensors"],
     gated: false,
   },

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -9,6 +9,14 @@ const { runCapture, runShell } = require("../runner");
 const { dockerCapture, dockerSpawn } = require("../adapters/docker");
 const { VLLM_PORT } = require("../core/ports");
 const { getGpuIndicesByName } = require("./nim");
+import {
+  DEFAULT_VLLM_MODEL,
+  VLLM_MODELS,
+  assertGatedModelAccess,
+  buildVllmServeCommand,
+  selectVllmModelFromEnv,
+  type VllmModelDef,
+} from "./vllm-models";
 
 // Per-platform install recipe. Add new platforms by appending an entry to
 // the profile table at the bottom of this file. The menu key in onboard.ts
@@ -16,7 +24,11 @@ const { getGpuIndicesByName } = require("./nim");
 interface VllmProfile {
   name: string;            // human label, e.g. "DGX Spark"
   image: string;           // container image
-  model: string;           // model id pulled at first run
+  // Default model when NEMOCLAW_VLLM_MODEL is unset. Per-platform default
+  // because Spark/Station can host a 27B model, but generic discrete-GPU
+  // Linux falls back to the small Nemotron-Nano-4B that fits on consumer
+  // cards.
+  defaultModel: VllmModelDef;
   containerName: string;
   // docker run flags excluding the image and the entrypoint command. The
   // caller appends -p / --name / etc. that are not platform-specific.
@@ -25,8 +37,6 @@ interface VllmProfile {
   // dockerRunFlags at install time. Used by Station to pick the GB300 GPU
   // out of a mixed-GPU host instead of using `--gpus all`.
   buildDockerRunFlags?: () => string[];
-  // bash -c command passed to docker run (pip install + vllm serve …)
-  command: string;
   // Approximate first-run time shown in the confirmation prompt.
   estimatedMinutes: string;
   // Image-pull deadline. First run on a slow link can be several minutes.
@@ -43,10 +53,16 @@ interface VllmProfile {
   loadTimeoutSec: number;
 }
 
+function nemotronNanoModel(): VllmModelDef {
+  const match = VLLM_MODELS.find((m) => m.envValue === "nemotron-3-nano-4b");
+  if (!match) throw new Error("vllm-models registry is missing the nemotron-3-nano-4b entry");
+  return match;
+}
+
 const SPARK_PROFILE: VllmProfile = {
   name: "DGX Spark",
   image: "nvcr.io/nvidia/vllm:26.03.post1-py3",
-  model: "Qwen/Qwen3.6-27B-FP8",
+  defaultModel: DEFAULT_VLLM_MODEL,
   containerName: "nemoclaw-vllm",
   dockerRunFlags: [
     "--gpus",
@@ -57,21 +73,6 @@ const SPARK_PROFILE: VllmProfile = {
     "-e",
     "HF_HOME=/root/.cache/huggingface",
   ],
-  command:
-    "pip install vllm[fastsafetensors] && vllm serve Qwen/Qwen3.6-27B-FP8 " +
-    "--gpu-memory-utilization 0.7 " +
-    "--tensor-parallel-size 1 " +
-    "--pipeline-parallel-size 1 " +
-    "--data-parallel-size 1 " +
-    "--max-model-len 262144 " +
-    "--port 8000 " +
-    "--max-num-seqs 4 " +
-    "--trust-remote-code " +
-    "--reasoning-parser qwen3 " +
-    "--enable-auto-tool-choice " +
-    "--tool-call-parser qwen3_coder " +
-    "--load-format fastsafetensors " +
-    "--enable-prefix-caching",
   estimatedMinutes: "10–30 minutes",
   pullTimeoutSec: 900,
   loadTimeoutSec: 1800,
@@ -98,7 +99,7 @@ const SPARK_PROFILE: VllmProfile = {
 const STATION_PROFILE: VllmProfile = {
   name: "DGX Station",
   image: SPARK_PROFILE.image,
-  model: SPARK_PROFILE.model,
+  defaultModel: SPARK_PROFILE.defaultModel,
   containerName: "nemoclaw-vllm",
   dockerRunFlags: SPARK_PROFILE.dockerRunFlags,
   buildDockerRunFlags: () => {
@@ -119,7 +120,6 @@ const STATION_PROFILE: VllmProfile = {
       "HF_HOME=/root/.cache/huggingface",
     ];
   },
-  command: SPARK_PROFILE.command,
   estimatedMinutes: SPARK_PROFILE.estimatedMinutes,
   pullTimeoutSec: SPARK_PROFILE.pullTimeoutSec,
   loadTimeoutSec: SPARK_PROFILE.loadTimeoutSec,
@@ -133,18 +133,9 @@ const STATION_PROFILE: VllmProfile = {
 const GENERIC_LINUX_PROFILE: VllmProfile = {
   name: "Linux + NVIDIA GPU",
   image: SPARK_PROFILE.image,
-  model: "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8",
+  defaultModel: nemotronNanoModel(),
   containerName: "nemoclaw-vllm",
   dockerRunFlags: SPARK_PROFILE.dockerRunFlags,
-  command:
-    "pip install vllm[fastsafetensors] && " +
-    "vllm serve nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8 " +
-    "--gpu-memory-utilization 0.7 " +
-    "--tensor-parallel-size 1 " +
-    "--pipeline-parallel-size 1 " +
-    "--data-parallel-size 1 " +
-    "--max-model-len 262000 " +
-    "--port 8000 --trust-remote-code --load-format fastsafetensors",
   estimatedMinutes: SPARK_PROFILE.estimatedMinutes,
   pullTimeoutSec: SPARK_PROFILE.pullTimeoutSec,
   loadTimeoutSec: SPARK_PROFILE.loadTimeoutSec,
@@ -205,8 +196,11 @@ function pullImage(profile: VllmProfile): { ok: boolean; reason?: string } {
 }
 
 // Run `hf download <model>` inside a one-shot container of the same image.
-function downloadModel(profile: VllmProfile): Promise<{ ok: boolean; reason?: string }> {
-  emit(`Pre-downloading model with hf: ${profile.model}`);
+function downloadModel(
+  profile: VllmProfile,
+  model: VllmModelDef,
+): Promise<{ ok: boolean; reason?: string }> {
+  emit(`Pre-downloading model with hf: ${model.id}`);
   return new Promise((resolve) => {
     const proc = dockerSpawn(
       [
@@ -219,7 +213,7 @@ function downloadModel(profile: VllmProfile): Promise<{ ok: boolean; reason?: st
         profile.image,
         "hf",
         "download",
-        profile.model,
+        model.id,
       ],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
@@ -278,7 +272,10 @@ function downloadModel(profile: VllmProfile): Promise<{ ok: boolean; reason?: st
   });
 }
 
-function startContainer(profile: VllmProfile): { ok: boolean; reason?: string } {
+function startContainer(
+  profile: VllmProfile,
+  model: VllmModelDef,
+): { ok: boolean; reason?: string } {
   emit(`Starting vLLM container (${profile.containerName})`);
   // Idempotent: tear down any prior container by the same name first.
   runShell(`docker rm -f ${profile.containerName}`, {
@@ -291,7 +288,7 @@ function startContainer(profile: VllmProfile): { ok: boolean; reason?: string } 
   const flags = resolvedFlags.join(" ");
   const cmd =
     `docker run -d ${flags} -p ${String(VLLM_PORT)}:8000 ` +
-    `--name ${profile.containerName} ${profile.image} bash -c ${JSON.stringify(profile.command)}`;
+    `--name ${profile.containerName} ${profile.image} bash -c ${JSON.stringify(buildVllmServeCommand(model))}`;
   const result = runShell(cmd, { ignoreError: true, suppressOutput: true });
   if (result.status !== 0) {
     return { ok: false, reason: `docker run failed (exit ${String(result.status)})` };
@@ -408,10 +405,24 @@ export async function installVllm(
   profile: VllmProfile,
   opts: InstallVllmOptions,
 ): Promise<{ ok: boolean }> {
+  // Resolve the model to serve: `NEMOCLAW_VLLM_MODEL` override if set, else
+  // the platform default. Validate gated-model access (HF_TOKEN required for
+  // models like DeepSeek-R1 Distill 70B) before touching docker so the user
+  // does not burn a multi-minute pull on a 401.
+  let model: VllmModelDef;
+  try {
+    const requested = selectVllmModelFromEnv();
+    model = requested.id === profile.defaultModel.id ? profile.defaultModel : requested;
+    assertGatedModelAccess(model);
+  } catch (err) {
+    console.error(`  vLLM install failed: ${(err as Error).message}`);
+    return { ok: false };
+  }
+
   console.log("");
   console.log(`  vLLM (${profile.name}):`);
   console.log(`    Image: ${profile.image}`);
-  console.log(`    Model: ${profile.model}`);
+  console.log(`    Model: ${model.id}${model.id === profile.defaultModel.id ? "" : " (NEMOCLAW_VLLM_MODEL override)"}`);
   if (!opts.hasImage) console.log("    Image download on first run, cached after");
   console.log("    Model download on first run, cached after");
   console.log("");
@@ -438,13 +449,13 @@ export async function installVllm(
     return { ok: false };
   }
 
-  const modelDownload = await downloadModel(profile);
+  const modelDownload = await downloadModel(profile, model);
   if (!modelDownload.ok) {
     console.error(`  vLLM install failed: ${String(modelDownload.reason)}`);
     return { ok: false };
   }
 
-  const start = startContainer(profile);
+  const start = startContainer(profile, model);
   if (!start.ok) {
     console.error(`  vLLM install failed: ${String(start.reason)}`);
     return { ok: false };

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -59,18 +59,48 @@ function nemotronNanoModel(): VllmModelDef {
   return match;
 }
 
+const HF_TOKEN_ENV_KEYS = ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"] as const;
+
+function pickHfTokenEntry(
+  env: NodeJS.ProcessEnv = process.env,
+): { key: (typeof HF_TOKEN_ENV_KEYS)[number]; value: string } | null {
+  for (const key of HF_TOKEN_ENV_KEYS) {
+    const value = String(env[key] ?? "").trim();
+    if (value) return { key, value };
+  }
+  return null;
+}
+
 /**
  * Forward a Hugging Face token from the host into the vLLM/hf container so
- * `hf download` and `vllm serve` can pull weights for gated models. Returns
- * the `docker run -e KEY=value` argv fragment, or an empty array when no
- * token is available in the host environment.
+ * `hf download` and `vllm serve` can pull weights for gated models.
+ *
+ * Returns the bare `-e KEY` form (no `=value`) so the token never lands in
+ * the host process list. Docker reads the actual value from its own
+ * environment, which the caller is responsible for populating via
+ * `buildHfTokenForwardEnv` when spawning through the runner allowlist.
+ * The `hf download` container can live for several minutes during a cold
+ * pull and `vllm serve` runs for the lifetime of the sandbox; argv-embedded
+ * secrets would be visible via `ps` for that whole window.
  */
 export function buildHfTokenDockerArgs(env: NodeJS.ProcessEnv = process.env): string[] {
-  for (const key of ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"] as const) {
-    const value = String(env[key] ?? "").trim();
-    if (value) return ["-e", `${key}=${value}`];
-  }
-  return [];
+  const entry = pickHfTokenEntry(env);
+  return entry ? ["-e", entry.key] : [];
+}
+
+/**
+ * Companion to `buildHfTokenDockerArgs`: returns the `{ KEY: value }` map
+ * that has to be merged into the subprocess env so docker can see the
+ * token when `-e KEY` (key-only) tells it to forward by name. The CLI's
+ * `runShell` strips non-allowlisted env names by default (see
+ * subprocess-env.ts), so callers that go through that path must pass
+ * this map via the runner's `env` option.
+ */
+export function buildHfTokenForwardEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const entry = pickHfTokenEntry(env);
+  return entry ? { [entry.key]: entry.value } : {};
 }
 
 const SPARK_PROFILE: VllmProfile = {
@@ -302,13 +332,20 @@ function startContainer(
     : profile.dockerRunFlags;
   // Forward HF_TOKEN/HUGGING_FACE_HUB_TOKEN so the long-lived `vllm serve`
   // pull can authenticate against gated repos when the model weights are
-  // not already in the mounted cache.
+  // not already in the mounted cache. The runner allowlist strips the
+  // token from the docker subprocess env by default, so we have to put it
+  // back via the `env:` option; the docker argv only carries `-e KEY` so
+  // the value stays out of /proc/<pid>/cmdline.
   const hfTokenFlags = buildHfTokenDockerArgs().join(" ");
   const flags = [resolvedFlags.join(" "), hfTokenFlags].filter(Boolean).join(" ");
   const cmd =
     `docker run -d ${flags} -p ${String(VLLM_PORT)}:8000 ` +
     `--name ${profile.containerName} ${profile.image} bash -c ${JSON.stringify(buildVllmServeCommand(model))}`;
-  const result = runShell(cmd, { ignoreError: true, suppressOutput: true });
+  const result = runShell(cmd, {
+    ignoreError: true,
+    suppressOutput: true,
+    env: buildHfTokenForwardEnv(),
+  });
   if (result.status !== 0) {
     return { ok: false, reason: `docker run failed (exit ${String(result.status)})` };
   }

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -59,6 +59,20 @@ function nemotronNanoModel(): VllmModelDef {
   return match;
 }
 
+/**
+ * Forward a Hugging Face token from the host into the vLLM/hf container so
+ * `hf download` and `vllm serve` can pull weights for gated models. Returns
+ * the `docker run -e KEY=value` argv fragment, or an empty array when no
+ * token is available in the host environment.
+ */
+export function buildHfTokenDockerArgs(env: NodeJS.ProcessEnv = process.env): string[] {
+  for (const key of ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"] as const) {
+    const value = String(env[key] ?? "").trim();
+    if (value) return ["-e", `${key}=${value}`];
+  }
+  return [];
+}
+
 const SPARK_PROFILE: VllmProfile = {
   name: "DGX Spark",
   image: "nvcr.io/nvidia/vllm:26.03.post1-py3",
@@ -210,6 +224,7 @@ function downloadModel(
         `${process.env.HOME}/.cache/huggingface:/root/.cache/huggingface`,
         "-e",
         "HF_HOME=/root/.cache/huggingface",
+        ...buildHfTokenDockerArgs(),
         profile.image,
         "hf",
         "download",
@@ -285,7 +300,11 @@ function startContainer(
   const resolvedFlags = profile.buildDockerRunFlags
     ? profile.buildDockerRunFlags()
     : profile.dockerRunFlags;
-  const flags = resolvedFlags.join(" ");
+  // Forward HF_TOKEN/HUGGING_FACE_HUB_TOKEN so the long-lived `vllm serve`
+  // pull can authenticate against gated repos when the model weights are
+  // not already in the mounted cache.
+  const hfTokenFlags = buildHfTokenDockerArgs().join(" ");
+  const flags = [resolvedFlags.join(" "), hfTokenFlags].filter(Boolean).join(" ");
   const cmd =
     `docker run -d ${flags} -p ${String(VLLM_PORT)}:8000 ` +
     `--name ${profile.containerName} ${profile.image} bash -c ${JSON.stringify(buildVllmServeCommand(model))}`;
@@ -406,13 +425,14 @@ export async function installVllm(
   opts: InstallVllmOptions,
 ): Promise<{ ok: boolean }> {
   // Resolve the model to serve: `NEMOCLAW_VLLM_MODEL` override if set, else
-  // the platform default. Validate gated-model access (HF_TOKEN required for
-  // models like DeepSeek-R1 Distill 70B) before touching docker so the user
-  // does not burn a multi-minute pull on a 401.
+  // the per-platform profile default. The generic-Linux profile defaults to
+  // Nemotron-Nano-4B for VRAM headroom; Spark/Station to Qwen3.6-27B.
+  // Validate gated-model access (HF_TOKEN required for models like
+  // DeepSeek-R1 Distill 70B) before touching docker so the user does not
+  // burn a multi-minute pull on a 401.
   let model: VllmModelDef;
   try {
-    const requested = selectVllmModelFromEnv();
-    model = requested.id === profile.defaultModel.id ? profile.defaultModel : requested;
+    model = selectVllmModelFromEnv() ?? profile.defaultModel;
     assertGatedModelAccess(model);
   } catch (err) {
     console.error(`  vLLM install failed: ${(err as Error).message}`);

--- a/test/detect-vllm-profile.test.ts
+++ b/test/detect-vllm-profile.test.ts
@@ -10,7 +10,7 @@ describe("detectVllmProfile", () => {
     const profile = detectVllmProfile({ platform: "spark", type: "nvidia" });
     expect(profile).not.toBeNull();
     expect(profile!.name).toBe("DGX Spark");
-    expect(profile!.model).toBe("Qwen/Qwen3.6-27B-FP8");
+    expect(profile!.defaultModel.id).toBe("Qwen/Qwen3.6-27B-FP8");
   });
 
   it("returns the Spark profile when legacy gpu.spark is true", () => {
@@ -29,7 +29,7 @@ describe("detectVllmProfile", () => {
     const profile = detectVllmProfile({ type: "nvidia" });
     expect(profile).not.toBeNull();
     expect(profile!.name).toBe("Linux + NVIDIA GPU");
-    expect(profile!.model).toContain("Nemotron-3-Nano-4B");
+    expect(profile!.defaultModel.id).toContain("Nemotron-3-Nano-4B");
   });
 
   it("prefers Spark over generic when both flags qualify", () => {

--- a/test/detect-vllm-profile.test.ts
+++ b/test/detect-vllm-profile.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { detectVllmProfile } from "../dist/lib/inference/vllm.js";
+import { buildHfTokenDockerArgs, detectVllmProfile } from "../dist/lib/inference/vllm.js";
 
 describe("detectVllmProfile", () => {
   it("returns the Spark profile when gpu.platform === 'spark'", () => {
@@ -68,5 +68,41 @@ describe("detectVllmProfile", () => {
     // Generic profile reuses Spark's marker tables.
     expect(generic!.readyMarker).toBe(spark!.readyMarker);
     expect(generic!.fatalMarkers).toBe(spark!.fatalMarkers);
+  });
+});
+
+describe("buildHfTokenDockerArgs", () => {
+  it("returns no extra env when neither HF token is set", () => {
+    expect(buildHfTokenDockerArgs({} as NodeJS.ProcessEnv)).toEqual([]);
+  });
+
+  it("forwards HF_TOKEN as a docker -e arg so the container can authenticate gated pulls", () => {
+    expect(
+      buildHfTokenDockerArgs({ HF_TOKEN: "hf_abc123" } as NodeJS.ProcessEnv),
+    ).toEqual(["-e", "HF_TOKEN=hf_abc123"]);
+  });
+
+  it("falls back to HUGGING_FACE_HUB_TOKEN when HF_TOKEN is empty", () => {
+    expect(
+      buildHfTokenDockerArgs({
+        HF_TOKEN: "",
+        HUGGING_FACE_HUB_TOKEN: "hf_xyz",
+      } as NodeJS.ProcessEnv),
+    ).toEqual(["-e", "HUGGING_FACE_HUB_TOKEN=hf_xyz"]);
+  });
+
+  it("prefers HF_TOKEN when both env vars are set", () => {
+    expect(
+      buildHfTokenDockerArgs({
+        HF_TOKEN: "hf_primary",
+        HUGGING_FACE_HUB_TOKEN: "hf_secondary",
+      } as NodeJS.ProcessEnv),
+    ).toEqual(["-e", "HF_TOKEN=hf_primary"]);
+  });
+
+  it("ignores tokens that are whitespace-only", () => {
+    expect(
+      buildHfTokenDockerArgs({ HF_TOKEN: "   " } as NodeJS.ProcessEnv),
+    ).toEqual([]);
   });
 });

--- a/test/detect-vllm-profile.test.ts
+++ b/test/detect-vllm-profile.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, it, expect } from "vitest";
 
-import { buildHfTokenDockerArgs, detectVllmProfile } from "../dist/lib/inference/vllm.js";
+import {
+  buildHfTokenDockerArgs,
+  buildHfTokenForwardEnv,
+  detectVllmProfile,
+} from "../dist/lib/inference/vllm.js";
 
 describe("detectVllmProfile", () => {
   it("returns the Spark profile when gpu.platform === 'spark'", () => {
@@ -76,10 +80,13 @@ describe("buildHfTokenDockerArgs", () => {
     expect(buildHfTokenDockerArgs({} as NodeJS.ProcessEnv)).toEqual([]);
   });
 
-  it("forwards HF_TOKEN as a docker -e arg so the container can authenticate gated pulls", () => {
+  it("emits the bare `-e KEY` form so the token never enters the docker run argv", () => {
+    // Docker reads the value from its inherited environment when -e is given
+    // without =value; this keeps the secret out of /proc/<pid>/cmdline for
+    // the multi-minute hf-download and long-lived vllm-serve containers.
     expect(
       buildHfTokenDockerArgs({ HF_TOKEN: "hf_abc123" } as NodeJS.ProcessEnv),
-    ).toEqual(["-e", "HF_TOKEN=hf_abc123"]);
+    ).toEqual(["-e", "HF_TOKEN"]);
   });
 
   it("falls back to HUGGING_FACE_HUB_TOKEN when HF_TOKEN is empty", () => {
@@ -88,7 +95,7 @@ describe("buildHfTokenDockerArgs", () => {
         HF_TOKEN: "",
         HUGGING_FACE_HUB_TOKEN: "hf_xyz",
       } as NodeJS.ProcessEnv),
-    ).toEqual(["-e", "HUGGING_FACE_HUB_TOKEN=hf_xyz"]);
+    ).toEqual(["-e", "HUGGING_FACE_HUB_TOKEN"]);
   });
 
   it("prefers HF_TOKEN when both env vars are set", () => {
@@ -97,12 +104,44 @@ describe("buildHfTokenDockerArgs", () => {
         HF_TOKEN: "hf_primary",
         HUGGING_FACE_HUB_TOKEN: "hf_secondary",
       } as NodeJS.ProcessEnv),
-    ).toEqual(["-e", "HF_TOKEN=hf_primary"]);
+    ).toEqual(["-e", "HF_TOKEN"]);
   });
 
   it("ignores tokens that are whitespace-only", () => {
     expect(
       buildHfTokenDockerArgs({ HF_TOKEN: "   " } as NodeJS.ProcessEnv),
     ).toEqual([]);
+  });
+});
+
+describe("buildHfTokenForwardEnv", () => {
+  it("returns an empty map when no HF token is set", () => {
+    expect(buildHfTokenForwardEnv({} as NodeJS.ProcessEnv)).toEqual({});
+  });
+
+  it("re-exports HF_TOKEN so runner-allowlisted subprocesses can see it", () => {
+    // The runner's allowlist (subprocess-env.ts) drops HF_TOKEN by default;
+    // this map is what callers pass via `env:` so docker can pick the
+    // value up when the argv only carries `-e HF_TOKEN` (key-only).
+    expect(
+      buildHfTokenForwardEnv({ HF_TOKEN: "hf_abc" } as NodeJS.ProcessEnv),
+    ).toEqual({ HF_TOKEN: "hf_abc" });
+  });
+
+  it("falls back to HUGGING_FACE_HUB_TOKEN when HF_TOKEN is missing", () => {
+    expect(
+      buildHfTokenForwardEnv({
+        HUGGING_FACE_HUB_TOKEN: "hf_xyz",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ HUGGING_FACE_HUB_TOKEN: "hf_xyz" });
+  });
+
+  it("only forwards one key when both are set, matching the argv builder", () => {
+    expect(
+      buildHfTokenForwardEnv({
+        HF_TOKEN: "hf_primary",
+        HUGGING_FACE_HUB_TOKEN: "hf_secondary",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ HF_TOKEN: "hf_primary" });
   });
 });


### PR DESCRIPTION
## Summary
Adds a scoped escape hatch on the express vLLM install path: setting `NEMOCLAW_VLLM_MODEL=<slug>` picks a different entry from a small new registry, swaps in the right `vllm serve` flags, and fails fast when a gated model is requested without a Hugging Face token (which is now forwarded into the managed-vLLM container so `hf download` and `vllm serve` can authenticate). An interactive model picker on the express path is not part of this PR — that remains a separate design item; the env-var path covers the gated-model coverage QA was trying to exercise.

## Related Issue
Fixes #3566
Fixes #3572

## Changes
- Introduce `src/lib/inference/vllm-models.ts` with a typed registry, env-var resolver, gated-access check, and a shared `buildVllmServeCommand` that merges common flags with the model-specific args.
- Seed the registry with Qwen3.6 27B FP8 (Spark/Station default), Nemotron-3 Nano 4B FP8 (generic-Linux default), and DeepSeek-R1 Distill Llama 70B (gated).
- Resolver returns `null` when `NEMOCLAW_VLLM_MODEL` is unset so the caller can keep the per-platform profile default (the generic-Linux profile must stay on Nemotron-Nano-4B for VRAM headroom).
- Refactor `VllmProfile` to carry a `defaultModel: VllmModelDef` instead of static `model`/`command` strings; `installVllm` resolves the model per call, validates gated access, builds the serve command on the fly, and forwards `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` into both the `hf download` one-shot and the long-lived `vllm serve` container using the `-e KEY` (key-only) form so the secret stays out of the docker argv; the value is added back via the runner's `env` option so docker can inherit it without breaking the subprocess-env allowlist.
- Document the env var, the recognised slugs, and the gated-model HF token requirement under the Managed vLLM section of `use-local-inference.md`; add it to the env-var reference table in `commands.md` to satisfy the env-var doc gate.
- Update `detect-vllm-profile.test.ts` to assert against `profile.defaultModel.id` and add coverage for `buildHfTokenDockerArgs` + `buildHfTokenForwardEnv` (HF_TOKEN preferred, HUGGING_FACE_HUB_TOKEN fallback, empty/whitespace handled).
- Add `vllm-models.test.ts` covering the env-var resolver (slug + HF id forms, unset-returns-null), unknown-value error, gated-access check, and command-builder output.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] \`npx prek run --all-files\` passes
- [x] \`npm test\` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] \`make docs\` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to select custom vLLM models via environment configuration, with support for Hugging Face authentication for gated models.

* **Documentation**
  * Added guides for configuring vLLM models, managing authentication credentials, and available model options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->