### PR TITLE
fix(docker): refresh trixie apt package pins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN set -eu; \
             apt-get install -y --no-install-recommends procps=2:4.0.4-9; \
         fi; \
         if [ "$needs_chattr" = "1" ]; then \
-            apt-get install -y --no-install-recommends e2fsprogs=1.47.2-3+b10; \
+            apt-get install -y --no-install-recommends e2fsprogs=1.47.2-3+b11; \
         fi; \
     fi; \
     rm -rf /var/lib/apt/lists/*; \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -55,19 +55,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3=3.13.5-1 \
         python3-pip=25.1.1+dfsg-1 \
         python3-venv=3.13.5-1 \
-        curl=8.14.1-2+deb13u2 \
+        curl=8.14.1-2+deb13u3 \
         git=1:2.47.3-0+deb13u1 \
         gnupg=2.4.7-21+deb13u1 \
         ca-certificates=20250419 \
         iproute2=6.15.0-1 \
         iptables=1.8.11-2 \
-        libcap2-bin=1:2.75-10+b8 \
+        libcap2-bin=1:2.75-10+deb13u1+b1 \
         procps=2:4.0.4-9 \
-        e2fsprogs=1.47.2-3+b10 \
+        e2fsprogs=1.47.2-3+b11 \
         "dos2unix=7.5.2-1*" \
-        jq=1.7.1-6+deb13u1 \
+        jq=1.7.1-6+deb13u2 \
         vim-tiny=2:9.1.1230-2 \
-        openssh-sftp-server=1:10.0p1-7+deb13u2 \
+        openssh-sftp-server=1:10.0p1-7+deb13u4 \
     && rm -rf /var/lib/apt/lists/*
 
 # gosu for privilege separation (gateway vs sandbox user).

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -33,19 +33,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3=3.13.5-1 \
         python3-pip=25.1.1+dfsg-1 \
         python3-venv=3.13.5-1 \
-        curl=8.14.1-2+deb13u2 \
+        curl=8.14.1-2+deb13u3 \
         git=1:2.47.3-0+deb13u1 \
         gnupg=2.4.7-21+deb13u1 \
         ca-certificates=20250419 \
         iproute2=6.15.0-1 \
         iptables=1.8.11-2 \
-        libcap2-bin=1:2.75-10+b8 \
+        libcap2-bin=1:2.75-10+deb13u1+b1 \
         procps=2:4.0.4-9 \
-        e2fsprogs=1.47.2-3+b10 \
-        openssh-sftp-server=1:10.0p1-7+deb13u2 \
+        e2fsprogs=1.47.2-3+b11 \
+        openssh-sftp-server=1:10.0p1-7+deb13u4 \
         socat=1.8.0.3-1 \
         "dos2unix=7.5.2-1*" \
-        jq=1.7.1-6+deb13u1 \
+        jq=1.7.1-6+deb13u2 \
         vim-tiny=2:9.1.1230-2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/test/hermes-share-mount-deps.test.ts
+++ b/test/hermes-share-mount-deps.test.ts
@@ -52,8 +52,8 @@ describe("Hermes share mount package parity (#2947)", () => {
       expect(calls).toContain("apt-get update");
       expect(calls).toContain("gnupg=2.4.7-21+deb13u1");
       expect(calls).toContain("procps=2:4.0.4-9");
-      expect(calls).toContain("e2fsprogs=1.47.2-3+b10");
-      expect(calls).toContain("openssh-sftp-server=1:10.0p1-7+deb13u2");
+      expect(calls).toContain("e2fsprogs=1.47.2-3+b11");
+      expect(calls).toContain("openssh-sftp-server=1:10.0p1-7+deb13u4");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -199,8 +199,8 @@ describe("sandbox provisioning: base runtime tools", () => {
       expect(result.status).toBe(0);
       expect(calls).toContain("apt-get update");
       expect(calls).toContain("procps=2:4.0.4-9");
-      expect(calls).toContain("e2fsprogs=1.47.2-3+b10");
-      expect(calls).toContain("openssh-sftp-server=1:10.0p1-7+deb13u2");
+      expect(calls).toContain("e2fsprogs=1.47.2-3+b11");
+      expect(calls).toContain("openssh-sftp-server=1:10.0p1-7+deb13u4");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -226,7 +226,7 @@ describe("sandbox provisioning: base runtime tools", () => {
       `ps_marker=${JSON.stringify(marker)}`,
       `chattr_marker=${JSON.stringify(chattrMarker)}`,
       'apt-mark() { printf "apt-mark %s\\n" "$*" >> "$call_log"; }',
-      'apt-get() { printf "apt-get %s\\n" "$*" >> "$call_log"; if [[ "$*" == *"install"* && "$*" == *"procps=2:4.0.4-9"* ]]; then touch "$ps_marker"; fi; if [[ "$*" == *"install"* && "$*" == *"e2fsprogs=1.47.2-3+b10"* ]]; then touch "$chattr_marker"; fi; }',
+      'apt-get() { printf "apt-get %s\\n" "$*" >> "$call_log"; if [[ "$*" == *"install"* && "$*" == *"procps=2:4.0.4-9"* ]]; then touch "$ps_marker"; fi; if [[ "$*" == *"install"* && "$*" == *"e2fsprogs=1.47.2-3+b11"* ]]; then touch "$chattr_marker"; fi; }',
       'command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "ps" ]; then [ -f "$ps_marker" ]; elif [ "${1:-}" = "-v" ] && [ "${2:-}" = "chattr" ]; then [ -f "$chattr_marker" ]; else builtin command "$@"; fi; }',
       'ps() { [ -f "$ps_marker" ] || return 127; printf "procps test version\\n"; }',
       command,
@@ -243,7 +243,7 @@ describe("sandbox provisioning: base runtime tools", () => {
       expect(calls).toContain(
         "apt-get install -y --no-install-recommends procps=2:4.0.4-9",
       );
-      expect(calls).toContain("apt-get install -y --no-install-recommends e2fsprogs=1.47.2-3+b10");
+      expect(calls).toContain("apt-get install -y --no-install-recommends e2fsprogs=1.47.2-3+b11");
       expect(result.stdout).toContain("procps test version");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
Refreshes Debian trixie package pins used by the OpenClaw and Hermes sandbox base images after the upstream package index rotated to newer point releases. This fixes rebuild/upgrade E2E jobs that force local base-image builds and were failing during `apt-get install` before sandbox creation.

## Changes
<!-- Bullet list of key changes. -->
- Updated current trixie pins for `curl`, `libcap2-bin`, `e2fsprogs`, `jq`, and `openssh-sftp-server` in `Dockerfile.base`.
- Applied the same refreshed pins to `agents/hermes/Dockerfile.base`.
- Updated the stale-base runtime hardening fallback in `Dockerfile` to install the current `e2fsprogs` pin.
- Updated Dockerfile parity tests to assert the refreshed base/runtime package versions.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image system dependencies with newer Debian package versions for essential utilities, filesystem management, security components, and network services across all container images.
  * Updated sandbox provisioning and Hermes base image regression tests to validate the updated system dependency versions in all provisioning and deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->