### PR TITLE
fix(e2e): increase compatible-endpoint agent-turn timeout to 180 s

### DIFF
--- a/test/e2e/test-messaging-compatible-endpoint.sh
+++ b/test/e2e/test-messaging-compatible-endpoint.sh
@@ -508,7 +508,13 @@ check_openclaw_agent_turn() {
   hop_count_before=$(grep -c "proxy_hop_headers=" "$COMPAT_MOCK_LOG" 2>/dev/null) || hop_count_before=0
 
   # 2>/dev/null drops openclaw progress/log lines so stdout is JSON-only.
-  raw=$(run_with_timeout 90 ssh -F "$ssh_cfg" \
+  # NemoClaw#3632: increased from 90 → 180 s. OpenClaw 2026.4.24 defers
+  # plugin/channel initialisation until the first agent turn. On slower CI
+  # runners the gateway event loop may be blocked for >60 s by
+  # openclaw-weixin staging + Telegram channel setup, pushing the first
+  # turn past the 90 s budget.  The mock responds in <1 s (C5 proves it),
+  # so the extra headroom only covers gateway boot, not inference latency.
+  raw=$(run_with_timeout 180 ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 \
@@ -664,6 +670,28 @@ fi
 check_openclaw_config
 check_gateway_ready
 check_sandbox_inference
+
+# NemoClaw#3632: Wait for the gateway to finish deferred plugin/channel
+# initialisation before sending the first openclaw-agent turn.  OpenClaw
+# 2026.4.24 defers openclaw-weixin staging and Telegram channel setup until
+# after the gateway port is listening, so the C4 TCP check and C5 curl
+# both pass while the event loop is still busy.  A short health-check poll
+# avoids the intermittent C8 timeout on slower CI runners.
+_gw_ready=0
+for _gwi in $(seq 1 30); do
+  if openshell sandbox exec --name "$SANDBOX_NAME" -- sh -lc \
+      "curl -sf --max-time 5 http://127.0.0.1:18789/api/health" >/dev/null 2>&1; then
+    _gw_ready=1
+    break
+  fi
+  sleep 2
+done
+if [ "$_gw_ready" -eq 1 ]; then
+  pass "C4b: Gateway health endpoint reachable (plugin init complete)"
+else
+  info "C4b: Gateway health endpoint not reachable after 60 s — proceeding anyway"
+fi
+
 check_openclaw_agent_turn
 
 if grep -q "POST /v1/chat/completions auth=ok" "$COMPAT_MOCK_LOG" 2>/dev/null; then


### PR DESCRIPTION
Fixes #3656

## Summary

The `messaging-compatible-endpoint-e2e` job failed on the [2026-05-17 nightly](https://github.com/NVIDIA/NemoClaw/actions/runs/25976663740) with check C8 timing out after 90 s (`exit 124`, empty stdout). All other checks (C0–C7, C9) passed — including C5 (direct `curl` to `inference.local`) and C9 (mock received the agent's `/v1/chat/completions` request with correct auth and no leaked hop headers).

### Root cause

OpenClaw 2026.4.24 defers plugin and channel initialisation until after the gateway port is listening. The existing C4 TCP-connect check and C5 `curl` check both pass while the gateway event loop is still busy with `openclaw-weixin` staging and Telegram channel setup. On slower CI runners the deferred init can exceed 60 s, pushing the first `openclaw agent --json` turn past the 90 s `run_with_timeout` budget.

### Changes

| Change | Why |
|--------|-----|
| Increased C8 `run_with_timeout` from 90 → 180 s | The mock responds in <1 s (C5 proves it), so the extra headroom covers gateway boot overhead, not inference latency |
| Added C4b gateway health poll between C5 and C8 | Polls `http://127.0.0.1:18789/api/health` for up to 60 s, letting deferred plugin init complete before the agent turn starts |

### Evidence from the failed run

- **Job**: [`messaging-compatible-endpoint-e2e`](https://github.com/NVIDIA/NemoClaw/actions/runs/25976663740/job/76357827582)
- **C5 PASS** at `00:24:00` — `curl` to `inference.local` returns mock content
- **C8 FAIL** at `00:25:30` — `openclaw agent --json` timed out (exit 124); reply='', raw=''
- **C9 PASS** — mock logged `proxy_hop_headers=none` for the agent's request, confirming the inference call reached the mock and the proxy-hop strip worked
- **C6 PASS** — mock received `POST /v1/chat/completions auth=ok`
- **Previous nightly** (May 16, commit `fdae3016`) **passed** — no NemoClaw code change between the two runs affects this test's code path

### Validation

- `bash -n test/e2e/test-messaging-compatible-endpoint.sh` — syntax OK
- Pushed a [`-custom-e2e` validation branch](https://github.com/NVIDIA/NemoClaw/tree/fix/nightly-e2e-25976663740-compat-endpoint-timeout-custom-e2e) for a focused nightly run

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `bash -n` syntax check passes
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] No secrets, API keys, or credentials committed
- [x] Tests added or updated for new or changed behavior

---
Signed-off-by: Hung Le <hple@nvidia.com>
