### PR TITLE
docs: clarify docker-driver gateway topology

### DIFF
--- a/docs/get-started/prerequisites.md
+++ b/docs/get-started/prerequisites.md
@@ -32,7 +32,7 @@ Before getting started, check the prerequisites to ensure you have the necessary
 | RAM      | 8 GB           | 16 GB            |
 | Disk     | 20 GB free     | 40 GB free       |
 
-The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon, k3s, and the OpenShell gateway run alongside the export pipeline. The pipeline buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer. If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
+The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon, OpenShell gateway runtime, and, on legacy k3s paths, the embedded k3s cluster run alongside the export pipeline. The pipeline buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer. If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
 
 ## Software
 
@@ -49,8 +49,8 @@ If you choose the native Linux Ollama install path, the onboard wizard also requ
 
 On Debian and Ubuntu, NemoClaw installs `zstd` with `apt-get` if it is missing; on other Linux distributions, install `zstd` before onboarding.
 
-On macOS, NemoClaw uses the Docker-driver OpenShell gateway path with Docker Desktop or Colima.
-You do not need to install or sign a separate OpenShell VM driver helper for standard macOS onboarding.
+On Apple Silicon macOS, NemoClaw uses the Docker-driver OpenShell gateway path with Docker Desktop or Colima.
+You do not need to install or sign a separate OpenShell VM driver helper for standard Apple Silicon macOS onboarding.
 
 :::{warning} OpenShell Lifecycle
 For NemoClaw-managed environments, use `nemoclaw onboard` when you need to create or recreate the OpenShell gateway or sandbox.
@@ -58,7 +58,7 @@ Avoid `openshell self-update`, `npm update -g openshell`, `openshell gateway sta
 :::
 
 :::{note} Docker storage driver
-On Linux hosts running Docker 26 or later with the [containerd image store](https://docs.docker.com/engine/storage/containerd/) enabled (the install-time default for fresh `docker-ce` installations on Ubuntu 24.04 and similar distros), `nemoclaw onboard` transparently builds a `fuse-overlayfs`-enabled cluster image to bypass a kernel-level nested-overlay limitation in k3s.
+On Linux hosts running Docker 26 or later with the [containerd image store](https://docs.docker.com/engine/storage/containerd/) enabled (the install-time default for fresh `docker-ce` installations on Ubuntu 24.04 and similar distros), `nemoclaw onboard` transparently builds a `fuse-overlayfs`-enabled cluster image to bypass a kernel-level nested-overlay limitation in the legacy OpenShell k3s gateway image when that path is used.
 No manual setup is required.
 See the [troubleshooting guide](../reference/troubleshooting.md) for the override knobs and a manual `daemon.json` alternative.
 :::

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -57,12 +57,12 @@ On Linux, the installer checks Docker before it installs NemoClaw.
 If Docker is missing, the installer downloads the official Docker convenience script, asks for `sudo`, installs Docker, and starts the Docker service when systemd is available.
 If Docker is installed but your current shell cannot use the Docker socket yet, the installer adds your user to the `docker` group when needed and exits with a recovery command.
 
-On macOS, the installer uses the Docker-driver OpenShell gateway path with Docker Desktop or Colima.
-
 ```console
 $ newgrp docker
 $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
+
+On Apple Silicon macOS, the installer uses the Docker-driver OpenShell gateway path with Docker Desktop or Colima.
 
 On DGX Spark and DGX Station, an interactive installer can offer express install after you accept the third-party software notice.
 Express install switches onboarding to non-interactive mode, allows `sudo` password prompts for required host changes, applies the suggested security policy, and selects the managed local inference path for that platform.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -90,8 +90,17 @@ graph LR
 The logical diagram above shows how components relate.
 This section shows what actually runs where on the host.
 NemoClaw uses a Docker daemon.
-The OpenShell gateway runs as a container that embeds a k3s cluster.
-The sandbox runs as a Kubernetes pod inside that embedded cluster.
+On Linux and tested Apple Silicon macOS hosts, onboarding uses the OpenShell Docker-driver gateway by default, so the sandbox runs as a Docker container under the same Docker daemon.
+On legacy k3s gateway paths, such as Windows through WSL2, the OpenShell gateway image embeds a k3s cluster and the sandbox runs as a Kubernetes pod inside that embedded cluster.
+
+| Platform | OpenShell compute model |
+|---|---|
+| Linux | Docker-driver gateway. The sandbox runs as a Docker container. |
+| macOS (Apple Silicon) | Docker-driver gateway. The sandbox runs as a Docker container. |
+| Windows / WSL2 | Legacy k3s gateway. The sandbox runs as a Kubernetes pod. |
+
+The topology below shows the legacy k3s path.
+On Docker-driver platforms, the `Sandbox pod` node is a sibling sandbox container under the Docker daemon instead of a pod under the embedded k3s cluster.
 
 ```{mermaid}
 graph TB
@@ -103,7 +112,7 @@ graph TB
     classDef pod fill:#444,stroke:#76b900,color:#fff,stroke-width:2px
     classDef external fill:#f5f5f5,stroke:#e0e0e0,color:#1a1a1a,stroke-width:1px
 
-    subgraph HOST["Host machine · Linux / macOS / WSL2 / DGX Spark / DGX Station"]
+    subgraph HOST["Host machine · legacy k3s gateway path"]
         direction TB
         CLI["nemoclaw CLI<br/><small>bin/nemoclaw.js → dist/<br/>onboard · connect · status · logs</small>"]:::cli
 
@@ -145,10 +154,11 @@ Layering from top to bottom:
 |---|---|---|
 | Host CLI | Host process (`nemoclaw` on Node.js) | Orchestrates OpenShell via `openshell` CLI calls. |
 | Docker daemon | Host service | Runs the OpenShell gateway container. |
-| Gateway container | Docker container | Hosts the credential store, the L7 proxy, and the embedded k3s control plane. |
-| k3s | Process tree inside the gateway container | Kubernetes control plane that schedules the sandbox pod. |
-| Sandbox pod | Pod in the embedded k3s cluster | Runs the OpenClaw agent and the NemoClaw plugin under Landlock + seccomp + netns. |
-| OpenShell L7 proxy | Process in the gateway container | Intercepts agent egress and rewrites `Authorization` headers (Bearer/Bot) and URL-path segments to inject the real credential at the network boundary. |
+| Gateway | Docker-driver process or legacy Docker container | Hosts the credential store, the L7 proxy, and policy enforcement. The legacy path also embeds the k3s control plane. |
+| k3s | Process tree inside the legacy gateway container | Kubernetes control plane that schedules the sandbox pod on legacy k3s paths. |
+| Sandbox container | Docker container on Linux and Apple Silicon macOS | Runs the OpenClaw agent and the NemoClaw plugin under Landlock + seccomp + netns. |
+| Sandbox pod | Pod in the embedded k3s cluster on legacy platforms | Runs the OpenClaw agent and the NemoClaw plugin under Landlock + seccomp + netns. |
+| OpenShell L7 proxy | Process in the gateway runtime | Intercepts agent egress and rewrites `Authorization` headers (Bearer/Bot) and URL-path segments to inject the real credential at the network boundary. |
 
 NemoClaw never gives the sandbox a raw provider key.
 At onboard time it registers credentials with OpenShell's provider/placeholder system, and the L7 proxy substitutes the real value into outbound requests at egress.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -71,7 +71,7 @@ Then re-run the installer.
 
 ### Image push fails with out-of-memory errors
 
-The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon, k3s, and the OpenShell gateway run alongside the export pipeline, which buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer.
+The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon, OpenShell gateway runtime, and, on legacy k3s paths, the embedded k3s cluster run alongside the export pipeline, which buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer.
 
 If you cannot add memory, configure at least 8 GB of swap to work around the issue at the cost of slower performance.
 


### PR DESCRIPTION
## Summary
Clarifies the deployment topology docs now that Linux and Apple Silicon macOS use the OpenShell Docker-driver gateway path by default, while legacy k3s wording only applies to legacy paths such as Windows through WSL2.

## Changes
- Add a platform-to-compute-model table to the architecture reference.
- Scope memory and Docker storage-driver notes so k3s is only described for legacy gateway paths.
- Align quickstart and prerequisites wording with the tested Apple Silicon macOS Docker-driver path.
- Move the Linux `newgrp docker` recovery command back under the Linux installer guidance.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional focused check: `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --dry-run`.

---
Signed-off-by: Intern Dev <dev@wukongai.io>