### PR TITLE
test(e2e): prove Discord proxy binary whitelist

### DIFF
--- a/test/e2e-advisor-dispatch.test.ts
+++ b/test/e2e-advisor-dispatch.test.ts
@@ -93,6 +93,33 @@ describe("E2E advisor auto-dispatch planning", () => {
     expect(plan.advisorDispatchId).toBe("advisor-123-456789-2");
   });
 
+  it("dispatches all required jobs without applying the retired max-jobs cap", () => {
+    const workflowText = fs.readFileSync(
+      path.join(ROOT, ".github/workflows/nightly-e2e.yaml"),
+      "utf8",
+    );
+    const plan = planAutoDispatch({
+      result: {
+        confidence: "high",
+        requiredTests: [
+          { id: "network-policy-e2e", workflow: "nightly-e2e.yaml" },
+          { id: "cloud-e2e", workflow: "nightly-e2e.yaml" },
+        ],
+      },
+      workflowText,
+      event: pullRequest("MEMBER"),
+      env: {
+        GITHUB_EVENT_NAME: "pull_request",
+        GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+        E2E_ADVISOR_AUTO_DISPATCH_MAX_JOBS: "1",
+      },
+    });
+
+    expect(plan.status).toBe("ready");
+    expect(plan.jobs).toEqual(["network-policy-e2e", "cloud-e2e"]);
+    expect(plan.inputs?.jobs).toBe("network-policy-e2e,cloud-e2e");
+  });
+
   it("plans dispatch for allowlisted authors whose private org membership appears as contributor", () => {
     const workflowText = fs.readFileSync(
       path.join(ROOT, ".github/workflows/nightly-e2e.yaml"),

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -7770,7 +7770,7 @@
       "assertions": [
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 200,
+          "line": 202,
           "text": "NVIDIA_API_KEY not set",
           "polarity": "fail",
           "normalized_id": "nvidia.api.key.not.set",
@@ -7778,7 +7778,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 203,
+          "line": 205,
           "text": "NVIDIA_API_KEY is set",
           "polarity": "pass",
           "normalized_id": "nvidia.api.key.is.set",
@@ -7786,7 +7786,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 206,
+          "line": 208,
           "text": "Docker is not running",
           "polarity": "fail",
           "normalized_id": "docker.is.not.running",
@@ -7794,7 +7794,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 209,
+          "line": 211,
           "text": "Docker is running",
           "polarity": "pass",
           "normalized_id": "docker.is.running",
@@ -7802,7 +7802,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 234,
+          "line": 236,
           "text": "Pre-cleanup complete",
           "polarity": "pass",
           "normalized_id": "pre.cleanup.complete",
@@ -7810,7 +7810,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 314,
+          "line": 316,
           "text": "Failed to append Slack policy to base sandbox policy",
           "polarity": "fail",
           "normalized_id": "failed.to.append.slack.policy.to.base.sandbox.policy",
@@ -7818,7 +7818,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 317,
+          "line": 319,
           "text": "Slack network policy pre-merged into base policy",
           "polarity": "pass",
           "normalized_id": "slack.network.policy.pre.merged.into.base.policy",
@@ -7826,7 +7826,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 322,
+          "line": 324,
           "text": "Cannot pre-merge Slack policy: missing base policy or preset file",
           "polarity": "fail",
           "normalized_id": "cannot.pre.merge.slack.policy.missing.base.policy.or.preset.file",
@@ -7834,7 +7834,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 363,
+          "line": 365,
           "text": "M0: install.sh completed (exit 0)",
           "polarity": "pass",
           "normalized_id": "m0.install.sh.completed.exit.0",
@@ -7842,7 +7842,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 365,
+          "line": 367,
           "text": "M0: install.sh failed (exit $install_exit)",
           "polarity": "fail",
           "normalized_id": "m0.install.sh.failed.exit.install.exit",
@@ -7850,7 +7850,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 373,
+          "line": 375,
           "text": "openshell not found on PATH after install",
           "polarity": "fail",
           "normalized_id": "openshell.not.found.on.path.after.install",
@@ -7858,7 +7858,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 376,
+          "line": 378,
           "text": "openshell installed ($(openshell --version 2>&1 || echo unknown))",
           "polarity": "pass",
           "normalized_id": "openshell.installed.openshell.version.2.1.echo.unknown",
@@ -7866,7 +7866,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 379,
+          "line": 381,
           "text": "nemoclaw not found on PATH after install",
           "polarity": "fail",
           "normalized_id": "nemoclaw.not.found.on.path.after.install",
@@ -7874,7 +7874,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 382,
+          "line": 384,
           "text": "nemoclaw installed at $(command -v nemoclaw)",
           "polarity": "pass",
           "normalized_id": "nemoclaw.installed.at.command.v.nemoclaw",
@@ -7882,7 +7882,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 387,
+          "line": 389,
           "text": "M0b: Sandbox '$SANDBOX_NAME' is Ready",
           "polarity": "pass",
           "normalized_id": "m0b.sandbox.sandbox.name.is.ready",
@@ -7890,7 +7890,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 389,
+          "line": 391,
           "text": "M0b: Sandbox '$SANDBOX_NAME' not Ready (list: ${sandbox_list:0:200})",
           "polarity": "fail",
           "normalized_id": "m0b.sandbox.sandbox.name.not.ready.list.sandbox.list.0.200",
@@ -7898,7 +7898,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 395,
+          "line": 397,
           "text": "M1: Provider '${SANDBOX_NAME}-telegram-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m1.provider.sandbox.name.telegram.bridge.exists.in.gateway",
@@ -7906,7 +7906,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 397,
+          "line": 399,
           "text": "M1: Provider '${SANDBOX_NAME}-telegram-bridge' not found in gateway",
           "polarity": "fail",
           "normalized_id": "m1.provider.sandbox.name.telegram.bridge.not.found.in.gateway",
@@ -7914,7 +7914,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 402,
+          "line": 404,
           "text": "M2: Provider '${SANDBOX_NAME}-discord-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m2.provider.sandbox.name.discord.bridge.exists.in.gateway",
@@ -7922,7 +7922,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 404,
+          "line": 406,
           "text": "M2: Provider '${SANDBOX_NAME}-discord-bridge' not found in gateway",
           "polarity": "fail",
           "normalized_id": "m2.provider.sandbox.name.discord.bridge.not.found.in.gateway",
@@ -7930,7 +7930,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 411,
+          "line": 413,
           "text": "M-W1: Provider '${SANDBOX_NAME}-wechat-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m.w1.provider.sandbox.name.wechat.bridge.exists.in.gateway",
@@ -7938,7 +7938,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 413,
+          "line": 415,
           "text": "M-W1: Provider '${SANDBOX_NAME}-wechat-bridge' not found in gateway (non-interactive QR-skip path may be broken)",
           "polarity": "fail",
           "normalized_id": "m.w1.provider.sandbox.name.wechat.bridge.not.found.in.gateway.non.interactive.qr.skip.path.may.be.broken",
@@ -7946,7 +7946,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 427,
+          "line": 429,
           "text": "M3: Real Telegram token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m3.real.telegram.token.leaked.into.sandbox.env",
@@ -7954,7 +7954,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 429,
+          "line": 431,
           "text": "M3: Sandbox TELEGRAM_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m3.sandbox.telegram.bot.token.is.a.placeholder.not.the.real.token",
@@ -7962,7 +7962,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 440,
+          "line": 442,
           "text": "M4: Real Discord token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m4.real.discord.token.leaked.into.sandbox.env",
@@ -7970,7 +7970,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 442,
+          "line": 444,
           "text": "M4: Sandbox DISCORD_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m4.sandbox.discord.bot.token.is.a.placeholder.not.the.real.token",
@@ -7978,7 +7978,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 449,
+          "line": 451,
           "text": "M5: At least one messaging placeholder detected in sandbox",
           "polarity": "pass",
           "normalized_id": "m5.at.least.one.messaging.placeholder.detected.in.sandbox",
@@ -7986,7 +7986,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 474,
+          "line": 476,
           "text": "M5a: Real Telegram token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m5a.real.telegram.token.found.in.full.sandbox.environment.dump",
@@ -7994,7 +7994,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 476,
+          "line": 478,
           "text": "M5a: Real Telegram token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5a.real.telegram.token.absent.from.full.sandbox.environment",
@@ -8002,7 +8002,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 483,
+          "line": 485,
           "text": "M5b: Real Telegram token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m5b.real.telegram.token.found.in.sandbox.process.list",
@@ -8010,7 +8010,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 485,
+          "line": 487,
           "text": "M5b: Real Telegram token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m5b.real.telegram.token.absent.from.sandbox.process.list",
@@ -8018,7 +8018,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 492,
+          "line": 494,
           "text": "M5c: Real Telegram token found on sandbox filesystem: ${sandbox_fs_tg}",
           "polarity": "fail",
           "normalized_id": "m5c.real.telegram.token.found.on.sandbox.filesystem.sandbox.fs.tg",
@@ -8026,7 +8026,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 494,
+          "line": 496,
           "text": "M5c: Real Telegram token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m5c.real.telegram.token.absent.from.sandbox.filesystem",
@@ -8034,7 +8034,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 500,
+          "line": 502,
           "text": "M5d: Telegram placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5d.telegram.placeholder.confirmed.present.in.sandbox.environment",
@@ -8042,7 +8042,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 502,
+          "line": 504,
           "text": "M5d: Telegram placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m5d.telegram.placeholder.not.found.in.sandbox.environment",
@@ -8050,7 +8050,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 512,
+          "line": 514,
           "text": "M5e: Real Discord token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m5e.real.discord.token.found.in.full.sandbox.environment.dump",
@@ -8058,7 +8058,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 514,
+          "line": 516,
           "text": "M5e: Real Discord token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5e.real.discord.token.absent.from.full.sandbox.environment",
@@ -8066,7 +8066,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 521,
+          "line": 523,
           "text": "M5f: Real Discord token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m5f.real.discord.token.found.in.sandbox.process.list",
@@ -8074,7 +8074,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 523,
+          "line": 525,
           "text": "M5f: Real Discord token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m5f.real.discord.token.absent.from.sandbox.process.list",
@@ -8082,7 +8082,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 529,
+          "line": 531,
           "text": "M5g: Real Discord token found on sandbox filesystem: ${sandbox_fs_dc}",
           "polarity": "fail",
           "normalized_id": "m5g.real.discord.token.found.on.sandbox.filesystem.sandbox.fs.dc",
@@ -8090,7 +8090,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 531,
+          "line": 533,
           "text": "M5g: Real Discord token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m5g.real.discord.token.absent.from.sandbox.filesystem",
@@ -8098,7 +8098,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 537,
+          "line": 539,
           "text": "M5h: Discord placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5h.discord.placeholder.confirmed.present.in.sandbox.environment",
@@ -8106,7 +8106,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 539,
+          "line": 541,
           "text": "M5h: Discord placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m5h.discord.placeholder.not.found.in.sandbox.environment",
@@ -8114,7 +8114,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 554,
+          "line": 556,
           "text": "M-S5a: Real Slack bot token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.s5a.real.slack.bot.token.found.in.full.sandbox.environment.dump",
@@ -8122,7 +8122,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 556,
+          "line": 558,
           "text": "M-S5a: Real Slack bot token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.s5a.real.slack.bot.token.absent.from.full.sandbox.environment",
@@ -8130,7 +8130,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 563,
+          "line": 565,
           "text": "M-S5b: Real Slack bot token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.s5b.real.slack.bot.token.found.in.sandbox.process.list",
@@ -8138,7 +8138,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 565,
+          "line": 567,
           "text": "M-S5b: Real Slack bot token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.s5b.real.slack.bot.token.absent.from.sandbox.process.list",
@@ -8146,7 +8146,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 571,
+          "line": 573,
           "text": "M-S5c: Real Slack bot token found on sandbox filesystem: ${sandbox_fs_sl}",
           "polarity": "fail",
           "normalized_id": "m.s5c.real.slack.bot.token.found.on.sandbox.filesystem.sandbox.fs.sl",
@@ -8154,7 +8154,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 573,
+          "line": 575,
           "text": "M-S5c: Real Slack bot token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.s5c.real.slack.bot.token.absent.from.sandbox.filesystem",
@@ -8162,7 +8162,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 581,
+          "line": 583,
           "text": "M-S5d: Real Slack app token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.s5d.real.slack.app.token.found.in.full.sandbox.environment.dump",
@@ -8170,7 +8170,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 583,
+          "line": 585,
           "text": "M-S5d: Real Slack app token absent from sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.s5d.real.slack.app.token.absent.from.sandbox.environment",
@@ -8178,7 +8178,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 588,
+          "line": 590,
           "text": "M-S5d2: Real Slack app token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.s5d2.real.slack.app.token.found.in.sandbox.process.list",
@@ -8186,7 +8186,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 590,
+          "line": 592,
           "text": "M-S5d2: Real Slack app token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.s5d2.real.slack.app.token.absent.from.sandbox.process.list",
@@ -8194,7 +8194,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 594,
+          "line": 596,
           "text": "M-S5e: Real Slack app token found on sandbox filesystem: ${sandbox_fs_sapp}",
           "polarity": "fail",
           "normalized_id": "m.s5e.real.slack.app.token.found.on.sandbox.filesystem.sandbox.fs.sapp",
@@ -8202,7 +8202,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 596,
+          "line": 598,
           "text": "M-S5e: Real Slack app token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.s5e.real.slack.app.token.absent.from.sandbox.filesystem",
@@ -8210,7 +8210,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 607,
+          "line": 609,
           "text": "M-S5f: Real Slack bot/app token spliced into openclaw.json — apply_slack_token_override regression?",
           "polarity": "fail",
           "normalized_id": "m.s5f.real.slack.bot.app.token.spliced.into.openclaw.json.apply.slack.token.override.regression",
@@ -8218,7 +8218,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 611,
+          "line": 613,
           "text": "M-S5f: openclaw.json holds both Bolt-shape Slack placeholders (no real token on disk)",
           "polarity": "pass",
           "normalized_id": "m.s5f.openclaw.json.holds.both.bolt.shape.slack.placeholders.no.real.token.on.disk",
@@ -8226,7 +8226,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 620,
+          "line": 622,
           "text": "M-S5g: removed Slack token rewriter preload still present in NODE_OPTIONS",
           "polarity": "fail",
           "normalized_id": "m.s5g.removed.slack.token.rewriter.preload.still.present.in.node.options",
@@ -8234,7 +8234,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 622,
+          "line": 624,
           "text": "M-S5g: Slack token rewriter preload absent from NODE_OPTIONS",
           "polarity": "pass",
           "normalized_id": "m.s5g.slack.token.rewriter.preload.absent.from.node.options",
@@ -8242,7 +8242,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 638,
+          "line": 640,
           "text": "M-W3: Real WeChat token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m.w3.real.wechat.token.leaked.into.sandbox.env",
@@ -8250,7 +8250,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 640,
+          "line": 642,
           "text": "M-W3: Sandbox WECHAT_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m.w3.sandbox.wechat.bot.token.is.a.placeholder.not.the.real.token",
@@ -8258,7 +8258,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 649,
+          "line": 651,
           "text": "M-W3a: Real WeChat token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.w3a.real.wechat.token.found.in.full.sandbox.environment.dump",
@@ -8266,7 +8266,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 651,
+          "line": 653,
           "text": "M-W3a: Real WeChat token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.w3a.real.wechat.token.absent.from.full.sandbox.environment",
@@ -8274,7 +8274,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 658,
+          "line": 660,
           "text": "M-W3b: Real WeChat token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.w3b.real.wechat.token.found.in.sandbox.process.list",
@@ -8282,7 +8282,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 660,
+          "line": 662,
           "text": "M-W3b: Real WeChat token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.w3b.real.wechat.token.absent.from.sandbox.process.list",
@@ -8290,7 +8290,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 668,
+          "line": 670,
           "text": "M-W3c: Real WeChat token found on sandbox filesystem: ${sandbox_fs_wc}",
           "polarity": "fail",
           "normalized_id": "m.w3c.real.wechat.token.found.on.sandbox.filesystem.sandbox.fs.wc",
@@ -8298,7 +8298,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 670,
+          "line": 672,
           "text": "M-W3c: Real WeChat token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.w3c.real.wechat.token.absent.from.sandbox.filesystem",
@@ -8306,7 +8306,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 676,
+          "line": 678,
           "text": "M-W3d: WeChat placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.w3d.wechat.placeholder.confirmed.present.in.sandbox.environment",
@@ -8314,7 +8314,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 678,
+          "line": 680,
           "text": "M-W3d: WeChat placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m.w3d.wechat.placeholder.not.found.in.sandbox.environment",
@@ -8322,7 +8322,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 701,
+          "line": 703,
           "text": "M6: Could not read openclaw.json channels (${channel_json:0:200})",
           "polarity": "fail",
           "normalized_id": "m6.could.not.read.openclaw.json.channels.channel.json.0.200",
@@ -8330,7 +8330,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 718,
+          "line": 720,
           "text": "M6: Telegram channel botToken present in openclaw.json",
           "polarity": "pass",
           "normalized_id": "m6.telegram.channel.bottoken.present.in.openclaw.json",
@@ -8338,7 +8338,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 725,
+          "line": 727,
           "text": "M7: Telegram botToken is not the host-side token (placeholder confirmed)",
           "polarity": "pass",
           "normalized_id": "m7.telegram.bottoken.is.not.the.host.side.token.placeholder.confirmed",
@@ -8346,7 +8346,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 727,
+          "line": 729,
           "text": "M7: Telegram botToken matches host-side token — credential leaked into config!",
           "polarity": "fail",
           "normalized_id": "m7.telegram.bottoken.matches.host.side.token.credential.leaked.into.config",
@@ -8354,7 +8354,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 742,
+          "line": 744,
           "text": "M8: Discord channel token present in openclaw.json",
           "polarity": "pass",
           "normalized_id": "m8.discord.channel.token.present.in.openclaw.json",
@@ -8362,7 +8362,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 749,
+          "line": 751,
           "text": "M9: Discord token is not the host-side token (placeholder confirmed)",
           "polarity": "pass",
           "normalized_id": "m9.discord.token.is.not.the.host.side.token.placeholder.confirmed",
@@ -8370,7 +8370,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 751,
+          "line": 753,
           "text": "M9: Discord token matches host-side token — credential leaked into config!",
           "polarity": "fail",
           "normalized_id": "m9.discord.token.matches.host.side.token.credential.leaked.into.config",
@@ -8378,7 +8378,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 766,
+          "line": 768,
           "text": "M10: Telegram channel is enabled",
           "polarity": "pass",
           "normalized_id": "m10.telegram.channel.is.enabled",
@@ -8386,7 +8386,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 781,
+          "line": 783,
           "text": "M11: Discord channel is enabled",
           "polarity": "pass",
           "normalized_id": "m11.discord.channel.is.enabled",
@@ -8394,7 +8394,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 796,
+          "line": 798,
           "text": "M11b: Telegram dmPolicy is 'allowlist'",
           "polarity": "pass",
           "normalized_id": "m11b.telegram.dmpolicy.is.allowlist",
@@ -8402,7 +8402,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 798,
+          "line": 800,
           "text": "M11b: Telegram dmPolicy is '$tg_dm_policy' (expected 'allowlist')",
           "polarity": "fail",
           "normalized_id": "m11b.telegram.dmpolicy.is.tg.dm.policy.expected.allowlist",
@@ -8410,7 +8410,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 826,
+          "line": 828,
           "text": "M11c: Telegram allowFrom contains all expected user IDs: $tg_allow_from",
           "polarity": "pass",
           "normalized_id": "m11c.telegram.allowfrom.contains.all.expected.user.ids.tg.allow.from",
@@ -8418,7 +8418,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 828,
+          "line": 830,
           "text": "M11c: Telegram allowFrom ($tg_allow_from) is missing IDs: ${missing_ids[*]} (expected all of: $TELEGRAM_IDS)",
           "polarity": "fail",
           "normalized_id": "m11c.telegram.allowfrom.tg.allow.from.is.missing.ids.missing.ids.expected.all.of.telegram.ids",
@@ -8426,7 +8426,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 844,
+          "line": 846,
           "text": "M11d: Telegram groupPolicy is 'open'",
           "polarity": "pass",
           "normalized_id": "m11d.telegram.grouppolicy.is.open",
@@ -8434,7 +8434,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 846,
+          "line": 848,
           "text": "M11d: Telegram groupPolicy is '$tg_group_policy' (expected 'open')",
           "polarity": "fail",
           "normalized_id": "m11d.telegram.grouppolicy.is.tg.group.policy.expected.open",
@@ -8442,7 +8442,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 862,
+          "line": 864,
           "text": "M11e: Slack channel configured with placeholder tokens (guard needed)",
           "polarity": "pass",
           "normalized_id": "m11e.slack.channel.configured.with.placeholder.tokens.guard.needed",
@@ -8450,7 +8450,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 887,
+          "line": 889,
           "text": "M-W8: WeChat account '$WECHAT_ACCOUNT' is enabled in openclaw.json (channels.openclaw-weixin)",
           "polarity": "pass",
           "normalized_id": "m.w8.wechat.account.wechat.account.is.enabled.in.openclaw.json.channels.openclaw.weixin",
@@ -8458,7 +8458,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 903,
+          "line": 905,
           "text": "M-W9: Real WeChat token spliced into accounts/${WECHAT_ACCOUNT}.json — seed-wechat-accounts.py placeholder regression",
           "polarity": "fail",
           "normalized_id": "m.w9.real.wechat.token.spliced.into.accounts.wechat.account.json.seed.wechat.accounts.py.placeholder.regression",
@@ -8466,7 +8466,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 905,
+          "line": 907,
           "text": "M-W9: WeChat per-account credential file uses the L7-resolved placeholder",
           "polarity": "pass",
           "normalized_id": "m.w9.wechat.per.account.credential.file.uses.the.l7.resolved.placeholder",
@@ -8474,7 +8474,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 907,
+          "line": 909,
           "text": "M-W9: WeChat per-account credential file has unexpected token shape: $(echo ",
           "polarity": "fail",
           "normalized_id": "m.w9.wechat.per.account.credential.file.has.unexpected.token.shape.echo",
@@ -8482,7 +8482,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 926,
+          "line": 928,
           "text": "M-W10: WeChat accounts.json index contains '$WECHAT_ACCOUNT'",
           "polarity": "pass",
           "normalized_id": "m.w10.wechat.accounts.json.index.contains.wechat.account",
@@ -8490,7 +8490,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 928,
+          "line": 930,
           "text": "M-W10: WeChat accounts.json missing '$WECHAT_ACCOUNT' (raw: $(echo ",
           "polarity": "fail",
           "normalized_id": "m.w10.wechat.accounts.json.missing.wechat.account.raw.echo",
@@ -8498,7 +8498,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 949,
+          "line": 951,
           "text": "M12: Node.js reached api.telegram.org (${tg_reach})",
           "polarity": "pass",
           "normalized_id": "m12.node.js.reached.api.telegram.org.tg.reach",
@@ -8506,7 +8506,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 955,
+          "line": 957,
           "text": "M12: Node.js could not reach api.telegram.org (${tg_reach:0:200})",
           "polarity": "fail",
           "normalized_id": "m12.node.js.could.not.reach.api.telegram.org.tg.reach.0.200",
@@ -8514,23 +8514,167 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 970,
-          "text": "M13: Node.js reached discord.com (${dc_reach})",
+          "line": 965,
+          "text": "M13-policy: Live policy contains Discord endpoints and Node binaries",
           "polarity": "pass",
-          "normalized_id": "m13.node.js.reached.discord.com.dc.reach",
+          "normalized_id": "m13.policy.live.policy.contains.discord.endpoints.and.node.binaries",
           "mapping_status": "deferred"
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 974,
-          "text": "M13: Node.js could not reach discord.com (${dc_reach:0:200})",
+          "line": 967,
+          "text": "M13-policy: Live policy is missing expected Discord preset endpoint/binary entries",
           "polarity": "fail",
-          "normalized_id": "m13.node.js.could.not.reach.discord.com.dc.reach.0.200",
+          "normalized_id": "m13.policy.live.policy.is.missing.expected.discord.preset.endpoint.binary.entries",
           "mapping_status": "deferred"
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 981,
+          "line": 973,
+          "text": "M13-proxy: Sandbox uses the OpenShell gateway proxy",
+          "polarity": "pass",
+          "normalized_id": "m13.proxy.sandbox.uses.the.openshell.gateway.proxy",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 975,
+          "text": "M13-proxy: Sandbox proxy env does not point at OpenShell gateway: ${live_proxy_env:0:200}",
+          "polarity": "fail",
+          "normalized_id": "m13.proxy.sandbox.proxy.env.does.not.point.at.openshell.gateway.live.proxy.env.0.200",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 993,
+          "text": "M13-curl: curl is blocked by the Discord preset binary whitelist (#3477)",
+          "polarity": "pass",
+          "normalized_id": "m13.curl.curl.is.blocked.by.the.discord.preset.binary.whitelist.3477",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 995,
+          "text": "M13-curl: curl unexpectedly established a tunnel to Discord; binary whitelist may be too broad",
+          "polarity": "fail",
+          "normalized_id": "m13.curl.curl.unexpectedly.established.a.tunnel.to.discord.binary.whitelist.may.be.too.broad",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 997,
+          "text": "M13-curl: curl Discord denial had unexpected shape: ${live_dc_curl:0:300}",
+          "polarity": "fail",
+          "normalized_id": "m13.curl.curl.discord.denial.had.unexpected.shape.live.dc.curl.0.300",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1038,
+          "text": "M13: Node.js reached Discord API and CDN through the same proxy (${dc_reach//$'\\n'/ })",
+          "polarity": "pass",
+          "normalized_id": "m13.node.js.reached.discord.api.and.cdn.through.the.same.proxy.dc.reach.n",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1040,
+          "text": "M13: Node.js was denied by the proxy despite the Discord preset being applied: ${dc_reach:0:300}",
+          "polarity": "fail",
+          "normalized_id": "m13.node.js.was.denied.by.the.proxy.despite.the.discord.preset.being.applied.dc.reach.0.300",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1044,
+          "text": "M13: Node.js could not reach Discord API/CDN (${dc_reach:0:200})",
+          "polarity": "fail",
+          "normalized_id": "m13.node.js.could.not.reach.discord.api.cdn.dc.reach.0.200",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1051,
+          "text": "M13-rest-a: Hermetic fake Discord REST API started on host port ${FAKE_DISCORD_REST_PORT}",
+          "polarity": "pass",
+          "normalized_id": "m13.rest.a.hermetic.fake.discord.rest.api.started.on.host.port.fake.discord.rest.port",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1060,
+          "text": "M13-rest-b: Applied Node-only HTTPS policy for fake Discord REST API",
+          "polarity": "pass",
+          "normalized_id": "m13.rest.b.applied.node.only.https.policy.for.fake.discord.rest.api",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1062,
+          "text": "M13-rest-b: Failed to apply fake Discord REST policy: $(tail -20 /tmp/nemoclaw-fake-discord-rest-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
+          "polarity": "fail",
+          "normalized_id": "m13.rest.b.failed.to.apply.fake.discord.rest.policy.tail.20.tmp.nemoclaw.fake.discord.rest.policy.log.2.dev.null.tr.n.cut.c1.300",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1076,
+          "text": "M13-rest-c: Node reached the fake Discord REST API through OpenShell",
+          "polarity": "pass",
+          "normalized_id": "m13.rest.c.node.reached.the.fake.discord.rest.api.through.openshell",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1078,
+          "text": "M13-rest-c: Node failed to reach fake Discord REST API: ${fake_rest_node:0:300}",
+          "polarity": "fail",
+          "normalized_id": "m13.rest.c.node.failed.to.reach.fake.discord.rest.api.fake.rest.node.0.300",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1090,
+          "text": "M13-rest-d: curl was denied before reaching the fake Discord REST API",
+          "polarity": "pass",
+          "normalized_id": "m13.rest.d.curl.was.denied.before.reaching.the.fake.discord.rest.api",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1092,
+          "text": "M13-rest-d: curl unexpectedly established a tunnel to the fake Discord REST API",
+          "polarity": "fail",
+          "normalized_id": "m13.rest.d.curl.unexpectedly.established.a.tunnel.to.the.fake.discord.rest.api",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1094,
+          "text": "M13-rest-d: Fake Discord REST curl denial had unexpected shape: ${fake_rest_curl:0:300}",
+          "polarity": "fail",
+          "normalized_id": "m13.rest.d.fake.discord.rest.curl.denial.had.unexpected.shape.fake.rest.curl.0.300",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1106,
+          "text": "M13-rest-e: Fake server saw Node but no curl request",
+          "polarity": "pass",
+          "normalized_id": "m13.rest.e.fake.server.saw.node.but.no.curl.request",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1108,
+          "text": "M13-rest-e: Unexpected fake Discord REST capture counts: ${fake_rest_capture}",
+          "polarity": "fail",
+          "normalized_id": "m13.rest.e.unexpected.fake.discord.rest.capture.counts.fake.rest.capture",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1115,
           "text": "M13b: Hermetic fake Discord Gateway started on host port ${FAKE_DISCORD_GATEWAY_PORT}",
           "polarity": "pass",
           "normalized_id": "m13b.hermetic.fake.discord.gateway.started.on.host.port.fake.discord.gateway.port",
@@ -8538,7 +8682,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 983,
+          "line": 1117,
           "text": "M13b: Failed to start hermetic fake Discord Gateway",
           "polarity": "fail",
           "normalized_id": "m13b.failed.to.start.hermetic.fake.discord.gateway",
@@ -8546,7 +8690,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 988,
+          "line": 1122,
           "text": "M13c: Applied native WebSocket policy with credential rewrite for fake Discord Gateway",
           "polarity": "pass",
           "normalized_id": "m13c.applied.native.websocket.policy.with.credential.rewrite.for.fake.discord.gateway",
@@ -8554,7 +8698,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 990,
+          "line": 1124,
           "text": "M13c: Failed to apply fake Discord Gateway policy: $(tail -20 /tmp/nemoclaw-fake-discord-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m13c.failed.to.apply.fake.discord.gateway.policy.tail.20.tmp.nemoclaw.fake.discord.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8562,7 +8706,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1000,
+          "line": 1134,
           "text": "M13d: Native WebSocket upgrade reached fake Discord Gateway through OpenShell",
           "polarity": "pass",
           "normalized_id": "m13d.native.websocket.upgrade.reached.fake.discord.gateway.through.openshell",
@@ -8570,7 +8714,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1002,
+          "line": 1136,
           "text": "M13d: Native WebSocket upgrade failed: ${dc_ws_native:0:300}",
           "polarity": "fail",
           "normalized_id": "m13d.native.websocket.upgrade.failed.dc.ws.native.0.300",
@@ -8578,7 +8722,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1009,
+          "line": 1143,
           "text": "M13e: Discord HELLO, placeholder IDENTIFY, READY, and heartbeat ACK completed",
           "polarity": "pass",
           "normalized_id": "m13e.discord.hello.placeholder.identify.ready.and.heartbeat.ack.completed",
@@ -8586,7 +8730,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1011,
+          "line": 1145,
           "text": "M13e: Discord Gateway protocol proof incomplete: ${dc_ws_native:0:400}",
           "polarity": "fail",
           "normalized_id": "m13e.discord.gateway.protocol.proof.incomplete.dc.ws.native.0.400",
@@ -8594,7 +8738,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1017,
+          "line": 1151,
           "text": "M13f: Fake Gateway received host-side Discord token; sandbox-visible IDENTIFY used only the placeholder",
           "polarity": "pass",
           "normalized_id": "m13f.fake.gateway.received.host.side.discord.token.sandbox.visible.identify.used.only.the.placeholder",
@@ -8602,7 +8746,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1022,
+          "line": 1156,
           "text": "M13f: Fake Gateway did not prove placeholder-to-token rewrite at the relay boundary",
           "polarity": "fail",
           "normalized_id": "m13f.fake.gateway.did.not.prove.placeholder.to.token.rewrite.at.the.relay.boundary",
@@ -8610,7 +8754,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1038,
+          "line": 1172,
           "text": "M13g: Unregistered Discord WebSocket placeholder is rejected before upstream token exposure",
           "polarity": "pass",
           "normalized_id": "m13g.unregistered.discord.websocket.placeholder.is.rejected.before.upstream.token.exposure",
@@ -8618,7 +8762,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1040,
+          "line": 1174,
           "text": "M13g: Unregistered Discord WebSocket placeholder reached READY or leaked upstream",
           "polarity": "fail",
           "normalized_id": "m13g.unregistered.discord.websocket.placeholder.reached.ready.or.leaked.upstream",
@@ -8626,7 +8770,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1046,
+          "line": 1180,
           "text": "M14: curl to api.telegram.org blocked (binary restriction enforced)",
           "polarity": "pass",
           "normalized_id": "m14.curl.to.api.telegram.org.blocked.binary.restriction.enforced",
@@ -8634,7 +8778,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1048,
+          "line": 1182,
           "text": "M14: curl returned empty (likely blocked by policy)",
           "polarity": "pass",
           "normalized_id": "m14.curl.returned.empty.likely.blocked.by.policy",
@@ -8642,7 +8786,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1052,
+          "line": 1186,
           "text": "M14: curl not available in sandbox (defense in depth)",
           "polarity": "pass",
           "normalized_id": "m14.curl.not.available.in.sandbox.defense.in.depth",
@@ -8650,7 +8794,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1086,
+          "line": 1220,
           "text": "M15: Telegram getMe returned 200 — real token verified!",
           "polarity": "pass",
           "normalized_id": "m15.telegram.getme.returned.200.real.token.verified",
@@ -8658,7 +8802,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1091,
+          "line": 1225,
           "text": "M15: Telegram getMe returned $tg_status — L7 proxy rewrote placeholder (fake token rejected by API)",
           "polarity": "pass",
           "normalized_id": "m15.telegram.getme.returned.tg.status.l7.proxy.rewrote.placeholder.fake.token.rejected.by.api",
@@ -8666,7 +8810,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1092,
+          "line": 1226,
           "text": "M16: Full chain verified: sandbox → proxy → token rewrite → Telegram API",
           "polarity": "pass",
           "normalized_id": "m16.full.chain.verified.sandbox.proxy.token.rewrite.telegram.api",
@@ -8674,7 +8818,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1098,
+          "line": 1232,
           "text": "M15: Telegram API call failed with error: ${tg_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m15.telegram.api.call.failed.with.error.tg.api.0.200",
@@ -8682,7 +8826,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1100,
+          "line": 1234,
           "text": "M15: Unexpected Telegram response (status=$tg_status): ${tg_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m15.unexpected.telegram.response.status.tg.status.tg.api.0.200",
@@ -8690,7 +8834,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1127,
+          "line": 1261,
           "text": "M17: Discord users/@me returned 200 — real token verified!",
           "polarity": "pass",
           "normalized_id": "m17.discord.users.me.returned.200.real.token.verified",
@@ -8698,7 +8842,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1129,
+          "line": 1263,
           "text": "M17: Discord users/@me returned 401 — L7 proxy rewrote placeholder (fake token rejected by API)",
           "polarity": "pass",
           "normalized_id": "m17.discord.users.me.returned.401.l7.proxy.rewrote.placeholder.fake.token.rejected.by.api",
@@ -8706,7 +8850,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1133,
+          "line": 1267,
           "text": "M17: Discord API call failed with error: ${dc_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m17.discord.api.call.failed.with.error.dc.api.0.200",
@@ -8714,7 +8858,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1135,
+          "line": 1269,
           "text": "M17: Unexpected Discord response (status=$dc_status): ${dc_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m17.unexpected.discord.response.status.dc.status.dc.api.0.200",
@@ -8722,7 +8866,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1147,
+          "line": 1281,
           "text": "M-S14a: Hermetic fake Slack API started on host port ${FAKE_SLACK_API_PORT}",
           "polarity": "pass",
           "normalized_id": "m.s14a.hermetic.fake.slack.api.started.on.host.port.fake.slack.api.port",
@@ -8730,7 +8874,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1149,
+          "line": 1283,
           "text": "M-S14a: Failed to start hermetic fake Slack API",
           "polarity": "fail",
           "normalized_id": "m.s14a.failed.to.start.hermetic.fake.slack.api",
@@ -8738,7 +8882,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1154,
+          "line": 1288,
           "text": "M-S14b: Applied REST policy for hermetic fake Slack API",
           "polarity": "pass",
           "normalized_id": "m.s14b.applied.rest.policy.for.hermetic.fake.slack.api",
@@ -8746,7 +8890,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1156,
+          "line": 1290,
           "text": "M-S14b: Failed to apply fake Slack API policy: $(tail -20 /tmp/nemoclaw-fake-slack-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m.s14b.failed.to.apply.fake.slack.api.policy.tail.20.tmp.nemoclaw.fake.slack.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8754,7 +8898,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1207,
+          "line": 1341,
           "text": "M-S15: Slack auth.test returned ok:true — real token round-trip verified!",
           "polarity": "pass",
           "normalized_id": "m.s15.slack.auth.test.returned.ok.true.real.token.round.trip.verified",
@@ -8762,7 +8906,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1209,
+          "line": 1343,
           "text": "M-S15: Slack auth.test returned invalid_auth — full chain verified (OpenShell alias rewrite → fake Slack)",
           "polarity": "pass",
           "normalized_id": "m.s15.slack.auth.test.returned.invalid.auth.full.chain.verified.openshell.alias.rewrite.fake.slack",
@@ -8770,7 +8914,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1212,
+          "line": 1346,
           "text": "M-S15a: fake Slack saw host-side bot token in header and urlencoded body",
           "polarity": "pass",
           "normalized_id": "m.s15a.fake.slack.saw.host.side.bot.token.in.header.and.urlencoded.body",
@@ -8778,7 +8922,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1214,
+          "line": 1348,
           "text": "M-S15a: fake Slack capture did not prove bot header/body rewrite: ${sl_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s15a.fake.slack.capture.did.not.prove.bot.header.body.rewrite.sl.capture.0.300",
@@ -8786,7 +8930,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1219,
+          "line": 1353,
           "text": "M-S15: Slack API call failed with error: ${sl_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15.slack.api.call.failed.with.error.sl.api.0.200",
@@ -8794,7 +8938,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1221,
+          "line": 1355,
           "text": "M-S15: OpenShell did not resolve the Bolt-shape alias",
           "polarity": "fail",
           "normalized_id": "m.s15.openshell.did.not.resolve.the.bolt.shape.alias",
@@ -8802,7 +8946,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1223,
+          "line": 1357,
           "text": "M-S15: L7 proxy did not substitute the canonical placeholder — substitution chain broken",
           "polarity": "fail",
           "normalized_id": "m.s15.l7.proxy.did.not.substitute.the.canonical.placeholder.substitution.chain.broken",
@@ -8810,7 +8954,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1225,
+          "line": 1359,
           "text": "M-S15: Unexpected Slack response (status=$sl_status): ${sl_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15.unexpected.slack.response.status.sl.status.sl.api.0.200",
@@ -8818,7 +8962,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1246,
+          "line": 1380,
           "text": "M-S15b: L7 proxy substitutes openshell:resolve:env:SLACK_BOT_TOKEN at egress (parallels Telegram M15 / Discord M17)",
           "polarity": "pass",
           "normalized_id": "m.s15b.l7.proxy.substitutes.openshell.resolve.env.slack.bot.token.at.egress.parallels.telegram.m15.discord.m17",
@@ -8826,7 +8970,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1250,
+          "line": 1384,
           "text": "M-S15b: L7 proxy passed canonical placeholder through unchanged — substitution not happening for SLACK_BOT_TOKEN",
           "polarity": "fail",
           "normalized_id": "m.s15b.l7.proxy.passed.canonical.placeholder.through.unchanged.substitution.not.happening.for.slack.bot.token",
@@ -8834,7 +8978,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1252,
+          "line": 1386,
           "text": "M-S15b: Unexpected response (status=$sl_canon_status): ${sl_canonical:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15b.unexpected.response.status.sl.canon.status.sl.canonical.0.200",
@@ -8842,7 +8986,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1273,
+          "line": 1407,
           "text": "M-S15c: unset-var failed closed before upstream exposure",
           "polarity": "pass",
           "normalized_id": "m.s15c.unset.var.failed.closed.before.upstream.exposure",
@@ -8850,7 +8994,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1275,
+          "line": 1409,
           "text": "M-S15c: unset-var triggered connection-level failure — proxy refuses to forward unsubstituted placeholder",
           "polarity": "pass",
           "normalized_id": "m.s15c.unset.var.triggered.connection.level.failure.proxy.refuses.to.forward.unsubstituted.placeholder",
@@ -8858,7 +9002,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1277,
+          "line": 1411,
           "text": "M-S15c: unset-var returned HTTP 200 — proxy passed canonical placeholder through unchanged for unset env (substitution may be a no-op)",
           "polarity": "fail",
           "normalized_id": "m.s15c.unset.var.returned.http.200.proxy.passed.canonical.placeholder.through.unchanged.for.unset.env.substitution.may.be.a.no.op",
@@ -8866,7 +9010,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1279,
+          "line": 1413,
           "text": "M-S15c: unset-var request reached fake Slack — unresolved placeholder escaped the proxy boundary",
           "polarity": "fail",
           "normalized_id": "m.s15c.unset.var.request.reached.fake.slack.unresolved.placeholder.escaped.the.proxy.boundary",
@@ -8874,7 +9018,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1300,
+          "line": 1434,
           "text": "M-S16: apps.connections.open returned ok:true — real xapp token round-trip verified!",
           "polarity": "pass",
           "normalized_id": "m.s16.apps.connections.open.returned.ok.true.real.xapp.token.round.trip.verified",
@@ -8882,7 +9026,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1302,
+          "line": 1436,
           "text": "M-S16: apps.connections.open auth-rejected — Socket Mode HTTPS leg verified (OpenShell alias rewrite → fake Slack)",
           "polarity": "pass",
           "normalized_id": "m.s16.apps.connections.open.auth.rejected.socket.mode.https.leg.verified.openshell.alias.rewrite.fake.slack",
@@ -8890,7 +9034,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1305,
+          "line": 1439,
           "text": "M-S16a: fake Slack saw host-side app token in header and urlencoded body",
           "polarity": "pass",
           "normalized_id": "m.s16a.fake.slack.saw.host.side.app.token.in.header.and.urlencoded.body",
@@ -8898,7 +9042,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1307,
+          "line": 1441,
           "text": "M-S16a: fake Slack capture did not prove app header/body rewrite: ${sl_app_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s16a.fake.slack.capture.did.not.prove.app.header.body.rewrite.sl.app.capture.0.300",
@@ -8906,7 +9050,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1312,
+          "line": 1446,
           "text": "M-S16: OpenShell did not resolve the xapp- alias for Socket Mode path",
           "polarity": "fail",
           "normalized_id": "m.s16.openshell.did.not.resolve.the.xapp.alias.for.socket.mode.path",
@@ -8914,7 +9058,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1314,
+          "line": 1448,
           "text": "M-S16: Unexpected apps.connections.open response (status=$sl_app_status): ${sl_app_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s16.unexpected.apps.connections.open.response.status.sl.app.status.sl.app.api.0.200",
@@ -8922,7 +9066,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1338,
+          "line": 1472,
           "text": "M-S16b: unset app-token failed closed before upstream exposure",
           "polarity": "pass",
           "normalized_id": "m.s16b.unset.app.token.failed.closed.before.upstream.exposure",
@@ -8930,7 +9074,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1340,
+          "line": 1474,
           "text": "M-S16b: L7 proxy substitutes openshell:resolve:env:SLACK_APP_TOKEN at egress (unset-var control diverged)",
           "polarity": "pass",
           "normalized_id": "m.s16b.l7.proxy.substitutes.openshell.resolve.env.slack.app.token.at.egress.unset.var.control.diverged",
@@ -8938,7 +9082,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1342,
+          "line": 1476,
           "text": "M-S16b: unset app-token env returned HTTP 200 — proxy may be passing canonical placeholders through unchanged",
           "polarity": "fail",
           "normalized_id": "m.s16b.unset.app.token.env.returned.http.200.proxy.may.be.passing.canonical.placeholders.through.unchanged",
@@ -8946,7 +9090,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1344,
+          "line": 1478,
           "text": "M-S16b: unset app-token request reached fake Slack — unresolved placeholder escaped the proxy boundary",
           "polarity": "fail",
           "normalized_id": "m.s16b.unset.app.token.request.reached.fake.slack.unresolved.placeholder.escaped.the.proxy.boundary",
@@ -8954,7 +9098,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1353,
+          "line": 1487,
           "text": "M-S16b: L7 proxy passed canonical placeholder through unchanged for SLACK_APP_TOKEN",
           "polarity": "fail",
           "normalized_id": "m.s16b.l7.proxy.passed.canonical.placeholder.through.unchanged.for.slack.app.token",
@@ -8962,7 +9106,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1355,
+          "line": 1489,
           "text": "M-S16b: Unexpected response (status=$sl_app_canon_status): ${sl_app_canonical:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s16b.unexpected.response.status.sl.app.canon.status.sl.app.canonical.0.200",
@@ -8970,7 +9114,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1370,
+          "line": 1504,
           "text": "M18: Telegram getMe returned 200 with real token",
           "polarity": "pass",
           "normalized_id": "m18.telegram.getme.returned.200.with.real.token",
@@ -8978,7 +9122,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1372,
+          "line": 1506,
           "text": "M18b: Telegram response contains ok:true",
           "polarity": "pass",
           "normalized_id": "m18b.telegram.response.contains.ok.true",
@@ -8986,7 +9130,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1375,
+          "line": 1509,
           "text": "M18: Expected Telegram getMe 200 with real token, got: $tg_status",
           "polarity": "fail",
           "normalized_id": "m18.expected.telegram.getme.200.with.real.token.got.tg.status",
@@ -8994,7 +9138,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1405,
+          "line": 1539,
           "text": "M19: Telegram sendMessage succeeded",
           "polarity": "pass",
           "normalized_id": "m19.telegram.sendmessage.succeeded",
@@ -9002,7 +9146,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1407,
+          "line": 1541,
           "text": "M19: Telegram sendMessage failed: ${send_result:0:200}",
           "polarity": "fail",
           "normalized_id": "m19.telegram.sendmessage.failed.send.result.0.200",
@@ -9010,7 +9154,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1419,
+          "line": 1553,
           "text": "M20: Discord users/@me returned 200 with real token",
           "polarity": "pass",
           "normalized_id": "m20.discord.users.me.returned.200.with.real.token",
@@ -9018,7 +9162,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1421,
+          "line": 1555,
           "text": "M20: Expected Discord users/@me 200 with real token, got: $dc_status",
           "polarity": "fail",
           "normalized_id": "m20.expected.discord.users.me.200.with.real.token.got.dc.status",
@@ -9026,7 +9170,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1453,
+          "line": 1587,
           "text": "S1: Gateway is serving on port 18789 — Slack auth failure did not crash it",
           "polarity": "pass",
           "normalized_id": "s1.gateway.is.serving.on.port.18789.slack.auth.failure.did.not.crash.it",
@@ -9034,7 +9178,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1455,
+          "line": 1589,
           "text": "S1: Gateway is not serving on port 18789 (${gw_port:0:200})",
           "polarity": "fail",
           "normalized_id": "s1.gateway.is.not.serving.on.port.18789.gw.port.0.200",
@@ -9042,7 +9186,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1481,
+          "line": 1615,
           "text": "S2: Gateway log shows Slack rejection was caught by channel guard",
           "polarity": "pass",
           "normalized_id": "s2.gateway.log.shows.slack.rejection.was.caught.by.channel.guard",
@@ -9050,7 +9194,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1506,
+          "line": 1640,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' intentionally kept",
           "polarity": "pass",
           "normalized_id": "cleanup.sandbox.sandbox.name.intentionally.kept",
@@ -9058,7 +9202,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1508,
+          "line": 1642,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' still present after cleanup",
           "polarity": "fail",
           "normalized_id": "cleanup.sandbox.sandbox.name.still.present.after.cleanup",
@@ -9066,7 +9210,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1510,
+          "line": 1644,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' removed",
           "polarity": "pass",
           "normalized_id": "cleanup.sandbox.sandbox.name.removed",
@@ -16458,7 +16602,7 @@
   ],
   "totals": {
     "scripts": 52,
-    "assertions": 2024,
+    "assertions": 2042,
     "zero_assertion_scripts": 1
   }
 }

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -8546,15 +8546,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 993,
-          "text": "M13-curl: curl is blocked by the Discord preset binary whitelist (#3477)",
-          "polarity": "pass",
-          "normalized_id": "m13.curl.curl.is.blocked.by.the.discord.preset.binary.whitelist.3477",
-          "mapping_status": "deferred"
-        },
-        {
-          "script": "test/e2e/test-messaging-providers.sh",
-          "line": 995,
+          "line": 996,
           "text": "M13-curl: curl unexpectedly established a tunnel to Discord; binary whitelist may be too broad",
           "polarity": "fail",
           "normalized_id": "m13.curl.curl.unexpectedly.established.a.tunnel.to.discord.binary.whitelist.may.be.too.broad",
@@ -8562,15 +8554,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 997,
-          "text": "M13-curl: curl Discord denial had unexpected shape: ${live_dc_curl:0:300}",
-          "polarity": "fail",
-          "normalized_id": "m13.curl.curl.discord.denial.had.unexpected.shape.live.dc.curl.0.300",
-          "mapping_status": "deferred"
-        },
-        {
-          "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1038,
+          "line": 1039,
           "text": "M13: Node.js reached Discord API and CDN through the same proxy (${dc_reach//$'\\n'/ })",
           "polarity": "pass",
           "normalized_id": "m13.node.js.reached.discord.api.and.cdn.through.the.same.proxy.dc.reach.n",
@@ -8578,7 +8562,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1040,
+          "line": 1041,
           "text": "M13: Node.js was denied by the proxy despite the Discord preset being applied: ${dc_reach:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.node.js.was.denied.by.the.proxy.despite.the.discord.preset.being.applied.dc.reach.0.300",
@@ -8586,7 +8570,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1044,
+          "line": 1045,
           "text": "M13: Node.js could not reach Discord API/CDN (${dc_reach:0:200})",
           "polarity": "fail",
           "normalized_id": "m13.node.js.could.not.reach.discord.api.cdn.dc.reach.0.200",
@@ -8594,7 +8578,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1051,
+          "line": 1052,
           "text": "M13-rest-a: Hermetic fake Discord REST API started on host port ${FAKE_DISCORD_REST_PORT}",
           "polarity": "pass",
           "normalized_id": "m13.rest.a.hermetic.fake.discord.rest.api.started.on.host.port.fake.discord.rest.port",
@@ -8602,7 +8586,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1060,
+          "line": 1061,
           "text": "M13-rest-b: Applied Node-only HTTPS policy for fake Discord REST API",
           "polarity": "pass",
           "normalized_id": "m13.rest.b.applied.node.only.https.policy.for.fake.discord.rest.api",
@@ -8610,7 +8594,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1062,
+          "line": 1063,
           "text": "M13-rest-b: Failed to apply fake Discord REST policy: $(tail -20 /tmp/nemoclaw-fake-discord-rest-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m13.rest.b.failed.to.apply.fake.discord.rest.policy.tail.20.tmp.nemoclaw.fake.discord.rest.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8618,7 +8602,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1076,
+          "line": 1077,
           "text": "M13-rest-c: Node reached the fake Discord REST API through OpenShell",
           "polarity": "pass",
           "normalized_id": "m13.rest.c.node.reached.the.fake.discord.rest.api.through.openshell",
@@ -8626,7 +8610,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1078,
+          "line": 1079,
           "text": "M13-rest-c: Node failed to reach fake Discord REST API: ${fake_rest_node:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.rest.c.node.failed.to.reach.fake.discord.rest.api.fake.rest.node.0.300",
@@ -8634,7 +8618,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1090,
+          "line": 1091,
           "text": "M13-rest-d: curl was denied before reaching the fake Discord REST API",
           "polarity": "pass",
           "normalized_id": "m13.rest.d.curl.was.denied.before.reaching.the.fake.discord.rest.api",
@@ -8642,7 +8626,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1092,
+          "line": 1093,
           "text": "M13-rest-d: curl unexpectedly established a tunnel to the fake Discord REST API",
           "polarity": "fail",
           "normalized_id": "m13.rest.d.curl.unexpectedly.established.a.tunnel.to.the.fake.discord.rest.api",
@@ -8650,7 +8634,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1094,
+          "line": 1095,
           "text": "M13-rest-d: Fake Discord REST curl denial had unexpected shape: ${fake_rest_curl:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.rest.d.fake.discord.rest.curl.denial.had.unexpected.shape.fake.rest.curl.0.300",
@@ -8658,7 +8642,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1106,
+          "line": 1107,
           "text": "M13-rest-e: Fake server saw Node but no curl request",
           "polarity": "pass",
           "normalized_id": "m13.rest.e.fake.server.saw.node.but.no.curl.request",
@@ -8666,7 +8650,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1108,
+          "line": 1109,
           "text": "M13-rest-e: Unexpected fake Discord REST capture counts: ${fake_rest_capture}",
           "polarity": "fail",
           "normalized_id": "m13.rest.e.unexpected.fake.discord.rest.capture.counts.fake.rest.capture",
@@ -8674,7 +8658,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1115,
+          "line": 1116,
           "text": "M13b: Hermetic fake Discord Gateway started on host port ${FAKE_DISCORD_GATEWAY_PORT}",
           "polarity": "pass",
           "normalized_id": "m13b.hermetic.fake.discord.gateway.started.on.host.port.fake.discord.gateway.port",
@@ -8682,7 +8666,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1117,
+          "line": 1118,
           "text": "M13b: Failed to start hermetic fake Discord Gateway",
           "polarity": "fail",
           "normalized_id": "m13b.failed.to.start.hermetic.fake.discord.gateway",
@@ -8690,7 +8674,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1122,
+          "line": 1123,
           "text": "M13c: Applied native WebSocket policy with credential rewrite for fake Discord Gateway",
           "polarity": "pass",
           "normalized_id": "m13c.applied.native.websocket.policy.with.credential.rewrite.for.fake.discord.gateway",
@@ -8698,7 +8682,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1124,
+          "line": 1125,
           "text": "M13c: Failed to apply fake Discord Gateway policy: $(tail -20 /tmp/nemoclaw-fake-discord-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m13c.failed.to.apply.fake.discord.gateway.policy.tail.20.tmp.nemoclaw.fake.discord.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8706,7 +8690,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1134,
+          "line": 1135,
           "text": "M13d: Native WebSocket upgrade reached fake Discord Gateway through OpenShell",
           "polarity": "pass",
           "normalized_id": "m13d.native.websocket.upgrade.reached.fake.discord.gateway.through.openshell",
@@ -8714,7 +8698,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1136,
+          "line": 1137,
           "text": "M13d: Native WebSocket upgrade failed: ${dc_ws_native:0:300}",
           "polarity": "fail",
           "normalized_id": "m13d.native.websocket.upgrade.failed.dc.ws.native.0.300",
@@ -8722,7 +8706,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1143,
+          "line": 1144,
           "text": "M13e: Discord HELLO, placeholder IDENTIFY, READY, and heartbeat ACK completed",
           "polarity": "pass",
           "normalized_id": "m13e.discord.hello.placeholder.identify.ready.and.heartbeat.ack.completed",
@@ -8730,7 +8714,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1145,
+          "line": 1146,
           "text": "M13e: Discord Gateway protocol proof incomplete: ${dc_ws_native:0:400}",
           "polarity": "fail",
           "normalized_id": "m13e.discord.gateway.protocol.proof.incomplete.dc.ws.native.0.400",
@@ -8738,7 +8722,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1151,
+          "line": 1152,
           "text": "M13f: Fake Gateway received host-side Discord token; sandbox-visible IDENTIFY used only the placeholder",
           "polarity": "pass",
           "normalized_id": "m13f.fake.gateway.received.host.side.discord.token.sandbox.visible.identify.used.only.the.placeholder",
@@ -8746,7 +8730,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1156,
+          "line": 1157,
           "text": "M13f: Fake Gateway did not prove placeholder-to-token rewrite at the relay boundary",
           "polarity": "fail",
           "normalized_id": "m13f.fake.gateway.did.not.prove.placeholder.to.token.rewrite.at.the.relay.boundary",
@@ -8754,7 +8738,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1172,
+          "line": 1173,
           "text": "M13g: Unregistered Discord WebSocket placeholder is rejected before upstream token exposure",
           "polarity": "pass",
           "normalized_id": "m13g.unregistered.discord.websocket.placeholder.is.rejected.before.upstream.token.exposure",
@@ -8762,7 +8746,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1174,
+          "line": 1175,
           "text": "M13g: Unregistered Discord WebSocket placeholder reached READY or leaked upstream",
           "polarity": "fail",
           "normalized_id": "m13g.unregistered.discord.websocket.placeholder.reached.ready.or.leaked.upstream",
@@ -8770,7 +8754,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1180,
+          "line": 1181,
           "text": "M14: curl to api.telegram.org blocked (binary restriction enforced)",
           "polarity": "pass",
           "normalized_id": "m14.curl.to.api.telegram.org.blocked.binary.restriction.enforced",
@@ -8778,7 +8762,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1182,
+          "line": 1183,
           "text": "M14: curl returned empty (likely blocked by policy)",
           "polarity": "pass",
           "normalized_id": "m14.curl.returned.empty.likely.blocked.by.policy",
@@ -8786,7 +8770,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1186,
+          "line": 1187,
           "text": "M14: curl not available in sandbox (defense in depth)",
           "polarity": "pass",
           "normalized_id": "m14.curl.not.available.in.sandbox.defense.in.depth",
@@ -8794,7 +8778,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1220,
+          "line": 1221,
           "text": "M15: Telegram getMe returned 200 — real token verified!",
           "polarity": "pass",
           "normalized_id": "m15.telegram.getme.returned.200.real.token.verified",
@@ -8802,7 +8786,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1225,
+          "line": 1226,
           "text": "M15: Telegram getMe returned $tg_status — L7 proxy rewrote placeholder (fake token rejected by API)",
           "polarity": "pass",
           "normalized_id": "m15.telegram.getme.returned.tg.status.l7.proxy.rewrote.placeholder.fake.token.rejected.by.api",
@@ -8810,7 +8794,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1226,
+          "line": 1227,
           "text": "M16: Full chain verified: sandbox → proxy → token rewrite → Telegram API",
           "polarity": "pass",
           "normalized_id": "m16.full.chain.verified.sandbox.proxy.token.rewrite.telegram.api",
@@ -8818,7 +8802,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1232,
+          "line": 1233,
           "text": "M15: Telegram API call failed with error: ${tg_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m15.telegram.api.call.failed.with.error.tg.api.0.200",
@@ -8826,7 +8810,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1234,
+          "line": 1235,
           "text": "M15: Unexpected Telegram response (status=$tg_status): ${tg_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m15.unexpected.telegram.response.status.tg.status.tg.api.0.200",
@@ -8834,7 +8818,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1261,
+          "line": 1262,
           "text": "M17: Discord users/@me returned 200 — real token verified!",
           "polarity": "pass",
           "normalized_id": "m17.discord.users.me.returned.200.real.token.verified",
@@ -8842,7 +8826,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1263,
+          "line": 1264,
           "text": "M17: Discord users/@me returned 401 — L7 proxy rewrote placeholder (fake token rejected by API)",
           "polarity": "pass",
           "normalized_id": "m17.discord.users.me.returned.401.l7.proxy.rewrote.placeholder.fake.token.rejected.by.api",
@@ -8850,7 +8834,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1267,
+          "line": 1268,
           "text": "M17: Discord API call failed with error: ${dc_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m17.discord.api.call.failed.with.error.dc.api.0.200",
@@ -8858,7 +8842,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1269,
+          "line": 1270,
           "text": "M17: Unexpected Discord response (status=$dc_status): ${dc_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m17.unexpected.discord.response.status.dc.status.dc.api.0.200",
@@ -8866,7 +8850,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1281,
+          "line": 1282,
           "text": "M-S14a: Hermetic fake Slack API started on host port ${FAKE_SLACK_API_PORT}",
           "polarity": "pass",
           "normalized_id": "m.s14a.hermetic.fake.slack.api.started.on.host.port.fake.slack.api.port",
@@ -8874,7 +8858,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1283,
+          "line": 1284,
           "text": "M-S14a: Failed to start hermetic fake Slack API",
           "polarity": "fail",
           "normalized_id": "m.s14a.failed.to.start.hermetic.fake.slack.api",
@@ -8882,7 +8866,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1288,
+          "line": 1289,
           "text": "M-S14b: Applied REST policy for hermetic fake Slack API",
           "polarity": "pass",
           "normalized_id": "m.s14b.applied.rest.policy.for.hermetic.fake.slack.api",
@@ -8890,7 +8874,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1290,
+          "line": 1291,
           "text": "M-S14b: Failed to apply fake Slack API policy: $(tail -20 /tmp/nemoclaw-fake-slack-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m.s14b.failed.to.apply.fake.slack.api.policy.tail.20.tmp.nemoclaw.fake.slack.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8898,7 +8882,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1341,
+          "line": 1342,
           "text": "M-S15: Slack auth.test returned ok:true — real token round-trip verified!",
           "polarity": "pass",
           "normalized_id": "m.s15.slack.auth.test.returned.ok.true.real.token.round.trip.verified",
@@ -8906,7 +8890,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1343,
+          "line": 1344,
           "text": "M-S15: Slack auth.test returned invalid_auth — full chain verified (OpenShell alias rewrite → fake Slack)",
           "polarity": "pass",
           "normalized_id": "m.s15.slack.auth.test.returned.invalid.auth.full.chain.verified.openshell.alias.rewrite.fake.slack",
@@ -8914,7 +8898,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1346,
+          "line": 1347,
           "text": "M-S15a: fake Slack saw host-side bot token in header and urlencoded body",
           "polarity": "pass",
           "normalized_id": "m.s15a.fake.slack.saw.host.side.bot.token.in.header.and.urlencoded.body",
@@ -8922,7 +8906,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1348,
+          "line": 1349,
           "text": "M-S15a: fake Slack capture did not prove bot header/body rewrite: ${sl_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s15a.fake.slack.capture.did.not.prove.bot.header.body.rewrite.sl.capture.0.300",
@@ -8930,7 +8914,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1353,
+          "line": 1354,
           "text": "M-S15: Slack API call failed with error: ${sl_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15.slack.api.call.failed.with.error.sl.api.0.200",
@@ -8938,7 +8922,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1355,
+          "line": 1356,
           "text": "M-S15: OpenShell did not resolve the Bolt-shape alias",
           "polarity": "fail",
           "normalized_id": "m.s15.openshell.did.not.resolve.the.bolt.shape.alias",
@@ -8946,7 +8930,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1357,
+          "line": 1358,
           "text": "M-S15: L7 proxy did not substitute the canonical placeholder — substitution chain broken",
           "polarity": "fail",
           "normalized_id": "m.s15.l7.proxy.did.not.substitute.the.canonical.placeholder.substitution.chain.broken",
@@ -8954,7 +8938,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1359,
+          "line": 1360,
           "text": "M-S15: Unexpected Slack response (status=$sl_status): ${sl_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15.unexpected.slack.response.status.sl.status.sl.api.0.200",
@@ -8962,7 +8946,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1380,
+          "line": 1381,
           "text": "M-S15b: L7 proxy substitutes openshell:resolve:env:SLACK_BOT_TOKEN at egress (parallels Telegram M15 / Discord M17)",
           "polarity": "pass",
           "normalized_id": "m.s15b.l7.proxy.substitutes.openshell.resolve.env.slack.bot.token.at.egress.parallels.telegram.m15.discord.m17",
@@ -8970,7 +8954,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1384,
+          "line": 1385,
           "text": "M-S15b: L7 proxy passed canonical placeholder through unchanged — substitution not happening for SLACK_BOT_TOKEN",
           "polarity": "fail",
           "normalized_id": "m.s15b.l7.proxy.passed.canonical.placeholder.through.unchanged.substitution.not.happening.for.slack.bot.token",
@@ -8978,7 +8962,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1386,
+          "line": 1387,
           "text": "M-S15b: Unexpected response (status=$sl_canon_status): ${sl_canonical:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15b.unexpected.response.status.sl.canon.status.sl.canonical.0.200",
@@ -8986,7 +8970,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1407,
+          "line": 1408,
           "text": "M-S15c: unset-var failed closed before upstream exposure",
           "polarity": "pass",
           "normalized_id": "m.s15c.unset.var.failed.closed.before.upstream.exposure",
@@ -8994,7 +8978,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1409,
+          "line": 1410,
           "text": "M-S15c: unset-var triggered connection-level failure — proxy refuses to forward unsubstituted placeholder",
           "polarity": "pass",
           "normalized_id": "m.s15c.unset.var.triggered.connection.level.failure.proxy.refuses.to.forward.unsubstituted.placeholder",
@@ -9002,7 +8986,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1411,
+          "line": 1412,
           "text": "M-S15c: unset-var returned HTTP 200 — proxy passed canonical placeholder through unchanged for unset env (substitution may be a no-op)",
           "polarity": "fail",
           "normalized_id": "m.s15c.unset.var.returned.http.200.proxy.passed.canonical.placeholder.through.unchanged.for.unset.env.substitution.may.be.a.no.op",
@@ -9010,7 +8994,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1413,
+          "line": 1414,
           "text": "M-S15c: unset-var request reached fake Slack — unresolved placeholder escaped the proxy boundary",
           "polarity": "fail",
           "normalized_id": "m.s15c.unset.var.request.reached.fake.slack.unresolved.placeholder.escaped.the.proxy.boundary",
@@ -9018,7 +9002,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1434,
+          "line": 1435,
           "text": "M-S16: apps.connections.open returned ok:true — real xapp token round-trip verified!",
           "polarity": "pass",
           "normalized_id": "m.s16.apps.connections.open.returned.ok.true.real.xapp.token.round.trip.verified",
@@ -9026,7 +9010,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1436,
+          "line": 1437,
           "text": "M-S16: apps.connections.open auth-rejected — Socket Mode HTTPS leg verified (OpenShell alias rewrite → fake Slack)",
           "polarity": "pass",
           "normalized_id": "m.s16.apps.connections.open.auth.rejected.socket.mode.https.leg.verified.openshell.alias.rewrite.fake.slack",
@@ -9034,7 +9018,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1439,
+          "line": 1440,
           "text": "M-S16a: fake Slack saw host-side app token in header and urlencoded body",
           "polarity": "pass",
           "normalized_id": "m.s16a.fake.slack.saw.host.side.app.token.in.header.and.urlencoded.body",
@@ -9042,7 +9026,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1441,
+          "line": 1442,
           "text": "M-S16a: fake Slack capture did not prove app header/body rewrite: ${sl_app_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s16a.fake.slack.capture.did.not.prove.app.header.body.rewrite.sl.app.capture.0.300",
@@ -9050,7 +9034,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1446,
+          "line": 1447,
           "text": "M-S16: OpenShell did not resolve the xapp- alias for Socket Mode path",
           "polarity": "fail",
           "normalized_id": "m.s16.openshell.did.not.resolve.the.xapp.alias.for.socket.mode.path",
@@ -9058,7 +9042,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1448,
+          "line": 1449,
           "text": "M-S16: Unexpected apps.connections.open response (status=$sl_app_status): ${sl_app_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s16.unexpected.apps.connections.open.response.status.sl.app.status.sl.app.api.0.200",
@@ -9066,7 +9050,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1472,
+          "line": 1473,
           "text": "M-S16b: unset app-token failed closed before upstream exposure",
           "polarity": "pass",
           "normalized_id": "m.s16b.unset.app.token.failed.closed.before.upstream.exposure",
@@ -9074,7 +9058,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1474,
+          "line": 1475,
           "text": "M-S16b: L7 proxy substitutes openshell:resolve:env:SLACK_APP_TOKEN at egress (unset-var control diverged)",
           "polarity": "pass",
           "normalized_id": "m.s16b.l7.proxy.substitutes.openshell.resolve.env.slack.app.token.at.egress.unset.var.control.diverged",
@@ -9082,7 +9066,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1476,
+          "line": 1477,
           "text": "M-S16b: unset app-token env returned HTTP 200 — proxy may be passing canonical placeholders through unchanged",
           "polarity": "fail",
           "normalized_id": "m.s16b.unset.app.token.env.returned.http.200.proxy.may.be.passing.canonical.placeholders.through.unchanged",
@@ -9090,7 +9074,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1478,
+          "line": 1479,
           "text": "M-S16b: unset app-token request reached fake Slack — unresolved placeholder escaped the proxy boundary",
           "polarity": "fail",
           "normalized_id": "m.s16b.unset.app.token.request.reached.fake.slack.unresolved.placeholder.escaped.the.proxy.boundary",
@@ -9098,7 +9082,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1487,
+          "line": 1488,
           "text": "M-S16b: L7 proxy passed canonical placeholder through unchanged for SLACK_APP_TOKEN",
           "polarity": "fail",
           "normalized_id": "m.s16b.l7.proxy.passed.canonical.placeholder.through.unchanged.for.slack.app.token",
@@ -9106,7 +9090,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1489,
+          "line": 1490,
           "text": "M-S16b: Unexpected response (status=$sl_app_canon_status): ${sl_app_canonical:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s16b.unexpected.response.status.sl.app.canon.status.sl.app.canonical.0.200",
@@ -9114,7 +9098,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1504,
+          "line": 1505,
           "text": "M18: Telegram getMe returned 200 with real token",
           "polarity": "pass",
           "normalized_id": "m18.telegram.getme.returned.200.with.real.token",
@@ -9122,7 +9106,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1506,
+          "line": 1507,
           "text": "M18b: Telegram response contains ok:true",
           "polarity": "pass",
           "normalized_id": "m18b.telegram.response.contains.ok.true",
@@ -9130,7 +9114,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1509,
+          "line": 1510,
           "text": "M18: Expected Telegram getMe 200 with real token, got: $tg_status",
           "polarity": "fail",
           "normalized_id": "m18.expected.telegram.getme.200.with.real.token.got.tg.status",
@@ -9138,7 +9122,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1539,
+          "line": 1540,
           "text": "M19: Telegram sendMessage succeeded",
           "polarity": "pass",
           "normalized_id": "m19.telegram.sendmessage.succeeded",
@@ -9146,7 +9130,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1541,
+          "line": 1542,
           "text": "M19: Telegram sendMessage failed: ${send_result:0:200}",
           "polarity": "fail",
           "normalized_id": "m19.telegram.sendmessage.failed.send.result.0.200",
@@ -9154,7 +9138,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1553,
+          "line": 1554,
           "text": "M20: Discord users/@me returned 200 with real token",
           "polarity": "pass",
           "normalized_id": "m20.discord.users.me.returned.200.with.real.token",
@@ -9162,7 +9146,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1555,
+          "line": 1556,
           "text": "M20: Expected Discord users/@me 200 with real token, got: $dc_status",
           "polarity": "fail",
           "normalized_id": "m20.expected.discord.users.me.200.with.real.token.got.dc.status",
@@ -9170,7 +9154,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1587,
+          "line": 1588,
           "text": "S1: Gateway is serving on port 18789 — Slack auth failure did not crash it",
           "polarity": "pass",
           "normalized_id": "s1.gateway.is.serving.on.port.18789.slack.auth.failure.did.not.crash.it",
@@ -9178,7 +9162,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1589,
+          "line": 1590,
           "text": "S1: Gateway is not serving on port 18789 (${gw_port:0:200})",
           "polarity": "fail",
           "normalized_id": "s1.gateway.is.not.serving.on.port.18789.gw.port.0.200",
@@ -9186,7 +9170,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1615,
+          "line": 1616,
           "text": "S2: Gateway log shows Slack rejection was caught by channel guard",
           "polarity": "pass",
           "normalized_id": "s2.gateway.log.shows.slack.rejection.was.caught.by.channel.guard",
@@ -9194,7 +9178,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1640,
+          "line": 1641,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' intentionally kept",
           "polarity": "pass",
           "normalized_id": "cleanup.sandbox.sandbox.name.intentionally.kept",
@@ -9202,7 +9186,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1642,
+          "line": 1643,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' still present after cleanup",
           "polarity": "fail",
           "normalized_id": "cleanup.sandbox.sandbox.name.still.present.after.cleanup",
@@ -9210,7 +9194,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1644,
+          "line": 1645,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' removed",
           "polarity": "pass",
           "normalized_id": "cleanup.sandbox.sandbox.name.removed",
@@ -16602,7 +16586,7 @@
   ],
   "totals": {
     "scripts": 52,
-    "assertions": 2042,
+    "assertions": 2040,
     "zero_assertion_scripts": 1
   }
 }

--- a/test/e2e/docs/parity-map.yaml
+++ b/test/e2e/docs/parity-map.yaml
@@ -5302,16 +5302,107 @@ scripts:
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers
       secret_requirement: Telegram test credentials
-    - legacy: 'M13: Node.js reached discord.com (${dc_reach})'
+    - legacy: 'M13-policy: Live policy contains Discord endpoints and Node binaries'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-policy: Live policy is missing expected Discord preset endpoint/binary entries'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-proxy: Sandbox uses the OpenShell gateway proxy'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-proxy: Sandbox proxy env does not point at OpenShell gateway: ${live_proxy_env:0:200}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-curl: curl is blocked by the Discord preset binary whitelist (#3477)'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-curl: curl unexpectedly established a tunnel to Discord; binary whitelist may be too broad'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-curl: curl Discord denial had unexpected shape: ${live_dc_curl:0:300}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13: Node.js reached Discord API and CDN through the same proxy (${dc_reach//$''\n''/ })'
       status: deferred
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers
       secret_requirement: Discord test credentials
-    - legacy: 'M13: Node.js could not reach discord.com (${dc_reach:0:200})'
+    - legacy: 'M13: Node.js was denied by the proxy despite the Discord preset being applied: ${dc_reach:0:300}'
       status: deferred
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers
       secret_requirement: Discord test credentials
+    - legacy: 'M13: Node.js could not reach Discord API/CDN (${dc_reach:0:200})'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Discord test credentials
+    - legacy: 'M13-rest-a: Hermetic fake Discord REST API started on host port ${FAKE_DISCORD_REST_PORT}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-b: Applied Node-only HTTPS policy for fake Discord REST API'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-b: Failed to apply fake Discord REST policy: $(tail -20 /tmp/nemoclaw-fake-discord-rest-policy.log 2>/dev/null
+        | tr ''\n'' '' '' | cut -c1-300)'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-c: Node reached the fake Discord REST API through OpenShell'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-c: Node failed to reach fake Discord REST API: ${fake_rest_node:0:300}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-d: curl was denied before reaching the fake Discord REST API'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-d: curl unexpectedly established a tunnel to the fake Discord REST API'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-d: Fake Discord REST curl denial had unexpected shape: ${fake_rest_curl:0:300}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-e: Fake server saw Node but no curl request'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
+    - legacy: 'M13-rest-e: Unexpected fake Discord REST capture counts: ${fake_rest_capture}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
     - legacy: 'M13b: Hermetic fake Discord Gateway started on host port ${FAKE_DISCORD_GATEWAY_PORT}'
       status: deferred
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking

--- a/test/e2e/docs/parity-map.yaml
+++ b/test/e2e/docs/parity-map.yaml
@@ -5322,17 +5322,7 @@ scripts:
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers
       runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
-    - legacy: 'M13-curl: curl is blocked by the Discord preset binary whitelist (#3477)'
-      status: deferred
-      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
-      owner: e2e-maintainers
-      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
     - legacy: 'M13-curl: curl unexpectedly established a tunnel to Discord; binary whitelist may be too broad'
-      status: deferred
-      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
-      owner: e2e-maintainers
-      runner_requirement: sandbox runner with NemoClaw/OpenShell CLIs
-    - legacy: 'M13-curl: curl Discord denial had unexpected shape: ${live_dc_curl:0:300}'
       status: deferred
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers

--- a/test/e2e/lib/discord-rest-policy-proof.sh
+++ b/test/e2e/lib/discord-rest-policy-proof.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared hermetic Discord REST helpers for policy/binary-whitelist E2E checks.
+
+append_exit_trap_for_fake_discord_rest_api() {
+  local command="$1"
+  local existing
+  existing="$(trap -p EXIT | sed "s/^trap -- '//;s/' EXIT$//")"
+  trap ''"${existing:+$existing; }$command"'' EXIT
+}
+
+cleanup_fake_discord_rest_api() {
+  if [ -n "${FAKE_DISCORD_REST_CONTAINER:-}" ]; then
+    docker rm -f "$FAKE_DISCORD_REST_CONTAINER" >/dev/null 2>&1 || true
+  fi
+  if [ -n "${FAKE_DISCORD_REST_DIR:-}" ]; then
+    rm -rf "$FAKE_DISCORD_REST_DIR" 2>/dev/null || true
+  fi
+}
+
+start_fake_discord_rest_api() {
+  if ! command -v openssl >/dev/null 2>&1; then
+    echo "openssl is required for fake Discord REST TLS cert generation" >&2
+    return 1
+  fi
+
+  mkdir -p "$REPO/.tmp"
+  FAKE_DISCORD_REST_DIR="$(mktemp -d "$REPO/.tmp/fake-discord-rest.XXXXXX")"
+  FAKE_DISCORD_REST_PORT_FILE="$FAKE_DISCORD_REST_DIR/port"
+  FAKE_DISCORD_REST_CAPTURE_FILE="$FAKE_DISCORD_REST_DIR/capture.jsonl"
+  FAKE_DISCORD_REST_KEY_PATH="$FAKE_DISCORD_REST_DIR/key.pem"
+  FAKE_DISCORD_REST_CERT_PATH="$FAKE_DISCORD_REST_DIR/cert.pem"
+  FAKE_DISCORD_REST_CONTAINER="nemoclaw-fake-discord-rest-$$-$RANDOM"
+  FAKE_DISCORD_REST_HOST="host.docker.internal"
+  : >"$FAKE_DISCORD_REST_CAPTURE_FILE"
+
+  if ! openssl req -x509 -newkey rsa:2048 \
+    -keyout "$FAKE_DISCORD_REST_KEY_PATH" \
+    -out "$FAKE_DISCORD_REST_CERT_PATH" \
+    -days 7 \
+    -nodes \
+    -subj "/CN=host.docker.internal" \
+    -addext "subjectAltName=DNS:host.docker.internal,DNS:host.openshell.internal" \
+    >/dev/null 2>&1; then
+    echo "failed to generate fake Discord REST TLS certificate" >&2
+    return 1
+  fi
+
+  if ! docker run -d --rm \
+    --name "$FAKE_DISCORD_REST_CONTAINER" \
+    -p 0:8443 \
+    -e FAKE_DISCORD_REST_PORT=8443 \
+    -e FAKE_DISCORD_REST_KEY_PATH=/tmp/fake-discord-rest/key.pem \
+    -e FAKE_DISCORD_REST_CERT_PATH=/tmp/fake-discord-rest/cert.pem \
+    -e FAKE_DISCORD_REST_PORT_FILE=/tmp/fake-discord-rest/port \
+    -e FAKE_DISCORD_REST_CAPTURE_FILE=/tmp/fake-discord-rest/capture.jsonl \
+    -v "$FAKE_DISCORD_REST_DIR:/tmp/fake-discord-rest" \
+    -v "$REPO/test/e2e/lib:/opt/nemoclaw-e2e:ro" \
+    node:22-bookworm-slim \
+    node /opt/nemoclaw-e2e/fake-discord-rest-api.cjs \
+    >"$FAKE_DISCORD_REST_DIR/container.id" 2>"$FAKE_DISCORD_REST_DIR/server.log"; then
+    cat "$FAKE_DISCORD_REST_DIR/server.log" >&2 || true
+    return 1
+  fi
+  append_exit_trap_for_fake_discord_rest_api cleanup_fake_discord_rest_api
+
+  for _ in $(seq 1 50); do
+    if [ -s "$FAKE_DISCORD_REST_PORT_FILE" ]; then
+      local published_port
+      published_port="$(docker port "$FAKE_DISCORD_REST_CONTAINER" 8443/tcp 2>/dev/null | head -1 | sed 's/.*://')"
+      if [ -n "$published_port" ]; then
+        export FAKE_DISCORD_REST_PORT
+        FAKE_DISCORD_REST_PORT="$published_port"
+        return 0
+      fi
+    fi
+    if ! docker inspect "$FAKE_DISCORD_REST_CONTAINER" >/dev/null 2>&1; then
+      docker logs "$FAKE_DISCORD_REST_CONTAINER" >&2 || true
+      cat "$FAKE_DISCORD_REST_DIR/server.log" >&2 || true
+      return 1
+    fi
+    sleep 0.1
+  done
+  cat "$FAKE_DISCORD_REST_DIR/server.log" >&2 || true
+  return 1
+}
+
+apply_fake_discord_rest_policy() {
+  local sandbox_name="$1"
+  local port="$2"
+  local host="${FAKE_DISCORD_REST_HOST:-host.openshell.internal}"
+  local preset_file
+  preset_file="$FAKE_DISCORD_REST_DIR/policy.yaml"
+
+  cat >"$preset_file" <<EOF_POLICY
+preset:
+  name: fake-discord-rest
+  description: "Hermetic Discord-shaped HTTPS REST endpoint for binary whitelist E2E"
+
+network_policies:
+  fake_discord_rest:
+    name: fake_discord_rest
+    endpoints:
+      # L4 TLS pass-through keeps the proof focused on CONNECT-time binary
+      # authorization: Node is allowed to tunnel to the fake HTTPS REST
+      # server, while curl must be denied before any upstream request arrives.
+      - host: $host
+        port: $port
+        access: full
+        tls: skip
+        allowed_ips:
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+EOF_POLICY
+
+  NEMOCLAW_NON_INTERACTIVE=1 nemoclaw "$sandbox_name" policy-add --from-file "$preset_file" --yes >/tmp/nemoclaw-fake-discord-rest-policy.log 2>&1 || {
+    cat /tmp/nemoclaw-fake-discord-rest-policy.log >&2 || true
+    return 1
+  }
+}
+
+run_fake_discord_rest_node_request() {
+  local port="$1"
+  local path="$2"
+  local host="${FAKE_DISCORD_REST_HOST:-host.openshell.internal}"
+  sandbox_exec_stdin "FAKE_DISCORD_REST_HOST='$host' FAKE_DISCORD_REST_PORT='$port' FAKE_DISCORD_REST_PATH='$path' node - 2>&1" <<'NODE'
+const https = require("https");
+
+const options = {
+  hostname: process.env.FAKE_DISCORD_REST_HOST || "host.openshell.internal",
+  port: Number(process.env.FAKE_DISCORD_REST_PORT),
+  path: process.env.FAKE_DISCORD_REST_PATH || "/api/v10/gateway",
+  method: "GET",
+  rejectUnauthorized: false,
+  headers: { "User-Agent": "nemoclaw-e2e-node" },
+};
+
+const req = https.request(options, (res) => {
+  let body = "";
+  res.on("data", (chunk) => {
+    body += chunk;
+  });
+  res.on("end", () => {
+    console.log(`${res.statusCode} ${body.slice(0, 300)}`);
+  });
+});
+
+req.on("error", (error) => {
+  console.log(`ERROR: ${error.message}`);
+});
+req.setTimeout(30000, () => {
+  req.destroy();
+  console.log("TIMEOUT");
+});
+req.end();
+NODE
+}
+
+run_fake_discord_rest_curl_request() {
+  local port="$1"
+  local host="${FAKE_DISCORD_REST_HOST:-host.openshell.internal}"
+  sandbox_exec "set +e
+rm -f /tmp/nemoclaw-fake-discord-curl.err /tmp/nemoclaw-fake-discord-curl.body
+curl -k -v --max-time 15 https://$host:$port/api/v10/gateway \
+  -A nemoclaw-e2e-curl \
+  -o /tmp/nemoclaw-fake-discord-curl.body \
+  2>/tmp/nemoclaw-fake-discord-curl.err
+rc=\$?
+printf 'RC=%s\n' \"\$rc\"
+grep -E 'Uses proxy|CONNECT .* HTTP|HTTP/1\\.[01] 403|CONNECT tunnel failed|Connection established|policy_denied|Forbidden' /tmp/nemoclaw-fake-discord-curl.err /tmp/nemoclaw-fake-discord-curl.body 2>/dev/null || true
+" 2>/dev/null || true
+}
+
+fake_discord_rest_capture_counts() {
+  node - "$FAKE_DISCORD_REST_CAPTURE_FILE" <<'NODE'
+const fs = require("fs");
+const file = process.argv[2];
+const rows = fs.readFileSync(file, "utf8").trim().split(/\n+/).filter(Boolean).map((line) => JSON.parse(line));
+const requests = rows.filter((row) => row.event === "request");
+const node = requests.filter((row) => String(row.userAgent || "").includes("nemoclaw-e2e-node")).length;
+const curl = requests.filter((row) => String(row.userAgent || "").includes("nemoclaw-e2e-curl")).length;
+console.log(`requests=${requests.length} node=${node} curl=${curl}`);
+NODE
+}

--- a/test/e2e/lib/discord-rest-policy-proof.sh
+++ b/test/e2e/lib/discord-rest-policy-proof.sh
@@ -35,6 +35,7 @@ start_fake_discord_rest_api() {
   FAKE_DISCORD_REST_CONTAINER="nemoclaw-fake-discord-rest-$$-$RANDOM"
   FAKE_DISCORD_REST_HOST="host.docker.internal"
   : >"$FAKE_DISCORD_REST_CAPTURE_FILE"
+  append_exit_trap_for_fake_discord_rest_api cleanup_fake_discord_rest_api
 
   if ! openssl req -x509 -newkey rsa:2048 \
     -keyout "$FAKE_DISCORD_REST_KEY_PATH" \
@@ -64,7 +65,6 @@ start_fake_discord_rest_api() {
     cat "$FAKE_DISCORD_REST_DIR/server.log" >&2 || true
     return 1
   fi
-  append_exit_trap_for_fake_discord_rest_api cleanup_fake_discord_rest_api
 
   for _ in $(seq 1 50); do
     if [ -s "$FAKE_DISCORD_REST_PORT_FILE" ]; then

--- a/test/e2e/lib/fake-discord-rest-api.cjs
+++ b/test/e2e/lib/fake-discord-rest-api.cjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+"use strict";
+
+const fs = require("fs");
+const https = require("https");
+
+const host = process.env.FAKE_DISCORD_REST_HOST || "0.0.0.0";
+const port = Number(process.env.FAKE_DISCORD_REST_PORT || "0");
+const keyPath = process.env.FAKE_DISCORD_REST_KEY_PATH || "";
+const certPath = process.env.FAKE_DISCORD_REST_CERT_PATH || "";
+const portFile = process.env.FAKE_DISCORD_REST_PORT_FILE || "";
+const captureFile = process.env.FAKE_DISCORD_REST_CAPTURE_FILE || "";
+
+if (!keyPath || !certPath) {
+  console.error("FAKE_DISCORD_REST_KEY_PATH and FAKE_DISCORD_REST_CERT_PATH are required");
+  process.exit(2);
+}
+
+function record(event) {
+  if (!captureFile) return;
+  fs.appendFileSync(captureFile, `${JSON.stringify({ at: Date.now(), ...event })}\n`);
+}
+
+const server = https.createServer(
+  {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath),
+  },
+  (req, res) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString("utf8");
+      record({
+        event: "request",
+        method: req.method,
+        url: req.url,
+        userAgent: req.headers["user-agent"] || "",
+        bodyLength: body.length,
+      });
+
+      if (req.url === "/api/v10/gateway") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ url: "wss://gateway.discord.gg" }));
+        return;
+      }
+
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("fake discord cdn ok\n");
+    });
+  },
+);
+
+server.on("error", (error) => {
+  record({ event: "server_error", error: error.message });
+  console.error(error.stack || error.message);
+});
+
+server.listen(port, host, () => {
+  const address = server.address();
+  if (portFile) {
+    fs.writeFileSync(portFile, `${address.port}\n`, { mode: 0o600 });
+  }
+  record({ event: "listening", host, port: address.port });
+});
+
+for (const signal of ["SIGTERM", "SIGINT"]) {
+  process.on(signal, () => {
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 1000).unref();
+  });
+}

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -975,9 +975,10 @@ else
   fail "M13-proxy: Sandbox proxy env does not point at OpenShell gateway: ${live_proxy_env:0:200}"
 fi
 
-# Regression for #3477: curl is intentionally not in the Discord preset's
-# binary whitelist. A curl CONNECT 403 is local OpenShell policy behavior, not
-# evidence that an upstream/corporate proxy is blocking Discord.
+# Regression context for #3477: curl is intentionally not in the Discord
+# preset's binary whitelist, but a live curl CONNECT 403 is ambiguous because
+# an upstream network policy can produce the same symptom. Treat the live probe
+# as diagnostics only; M13-rest-d/e below provide the hermetic whitelist proof.
 live_dc_curl=$(sandbox_exec 'set +e
 rm -f /tmp/nemoclaw-discord-curl.err /tmp/nemoclaw-discord-curl.body
 curl -v --max-time 10 https://discord.com/ \
@@ -990,11 +991,11 @@ grep -E "Uses proxy|CONNECT discord.com:443|HTTP/1\\.[01] 403|CONNECT tunnel fai
 info "Discord curl probe: ${live_dc_curl:0:500}"
 if echo "$live_dc_curl" | grep -qiE "CONNECT tunnel failed.*403|CONNECT discord\.com:443|HTTP/1\.[01] 403|policy_denied|Forbidden" \
   && ! echo "$live_dc_curl" | grep -qiE "Connection established|200 Connection"; then
-  pass "M13-curl: curl is blocked by the Discord preset binary whitelist (#3477)"
+  info "M13-curl: ambiguous live CONNECT 403 may be upstream or local; hermetic M13-rest-d/e prove whitelist behavior; output: ${live_dc_curl:0:300}"
 elif echo "$live_dc_curl" | grep -qiE "Connection established|200 Connection"; then
   fail "M13-curl: curl unexpectedly established a tunnel to Discord; binary whitelist may be too broad"
 else
-  fail "M13-curl: curl Discord denial had unexpected shape: ${live_dc_curl:0:300}"
+  info "M13-curl: live curl probe inconclusive; hermetic M13-rest-d/e prove whitelist behavior; output: ${live_dc_curl:0:200}"
 fi
 
 dc_reach=$(sandbox_exec 'node - <<'"'"'NODE'"'"'

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -188,6 +188,8 @@ sandbox_exec() {
 
 # shellcheck source=test/e2e/lib/discord-gateway-proof.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/discord-gateway-proof.sh"
+# shellcheck source=test/e2e/lib/discord-rest-policy-proof.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/discord-rest-policy-proof.sh"
 # shellcheck source=test/e2e/lib/slack-api-proof.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/slack-api-proof.sh"
 
@@ -955,23 +957,155 @@ else
   fail "M12: Node.js could not reach api.telegram.org (${tg_reach:0:200})"
 fi
 
-# M13: Node.js can reach discord.com through the proxy
-dc_reach=$(sandbox_exec 'node -e "
-const https = require(\"https\");
-const req = https.get(\"https://discord.com/api/v10/gateway\", (res) => {
-  console.log(\"HTTP_\" + res.statusCode);
-  res.resume();
-});
-req.on(\"error\", (e) => console.log(\"ERROR: \" + e.message));
-req.setTimeout(15000, () => { req.destroy(); console.log(\"TIMEOUT\"); });
-"' 2>/dev/null || true)
-
-if echo "$dc_reach" | grep -q "HTTP_"; then
-  pass "M13: Node.js reached discord.com (${dc_reach})"
-elif echo "$dc_reach" | grep -q "TIMEOUT"; then
-  skip "M13: discord.com timed out (network may be slow)"
+# M13: Node.js can reach Discord API/CDN through the proxy
+live_discord_policy=$(openshell policy get --full "$SANDBOX_NAME" 2>/dev/null || true)
+if echo "$live_discord_policy" | grep -q "discord.com" \
+  && echo "$live_discord_policy" | grep -q "cdn.discordapp.com" \
+  && { echo "$live_discord_policy" | grep -q "/usr/local/bin/node" || echo "$live_discord_policy" | grep -q "/usr/bin/node"; }; then
+  pass "M13-policy: Live policy contains Discord endpoints and Node binaries"
 else
-  fail "M13: Node.js could not reach discord.com (${dc_reach:0:200})"
+  fail "M13-policy: Live policy is missing expected Discord preset endpoint/binary entries"
+fi
+
+live_proxy_env=$(sandbox_exec 'printf "HTTPS_PROXY=%s\nhttps_proxy=%s\nNO_PROXY=%s\nno_proxy=%s\n" "$HTTPS_PROXY" "$https_proxy" "$NO_PROXY" "$no_proxy"' 2>/dev/null || true)
+info "Sandbox proxy env: ${live_proxy_env//$'\n'/ }"
+if echo "$live_proxy_env" | grep -qE "https?_proxy=.*10\.200\.0\.1:3128|HTTPS_PROXY=.*10\.200\.0\.1:3128"; then
+  pass "M13-proxy: Sandbox uses the OpenShell gateway proxy"
+else
+  fail "M13-proxy: Sandbox proxy env does not point at OpenShell gateway: ${live_proxy_env:0:200}"
+fi
+
+# Regression for #3477: curl is intentionally not in the Discord preset's
+# binary whitelist. A curl CONNECT 403 is local OpenShell policy behavior, not
+# evidence that an upstream/corporate proxy is blocking Discord.
+live_dc_curl=$(sandbox_exec 'set +e
+rm -f /tmp/nemoclaw-discord-curl.err /tmp/nemoclaw-discord-curl.body
+curl -v --max-time 10 https://discord.com/ \
+  -o /tmp/nemoclaw-discord-curl.body \
+  2>/tmp/nemoclaw-discord-curl.err
+rc=$?
+printf "RC=%s\n" "$rc"
+grep -E "Uses proxy|CONNECT discord.com:443|HTTP/1\\.[01] 403|CONNECT tunnel failed|Connection established|policy_denied|Forbidden" /tmp/nemoclaw-discord-curl.err /tmp/nemoclaw-discord-curl.body 2>/dev/null || true
+' 2>/dev/null || true)
+info "Discord curl probe: ${live_dc_curl:0:500}"
+if echo "$live_dc_curl" | grep -qiE "CONNECT tunnel failed.*403|CONNECT discord\.com:443|HTTP/1\.[01] 403|policy_denied|Forbidden" \
+  && ! echo "$live_dc_curl" | grep -qiE "Connection established|200 Connection"; then
+  pass "M13-curl: curl is blocked by the Discord preset binary whitelist (#3477)"
+elif echo "$live_dc_curl" | grep -qiE "Connection established|200 Connection"; then
+  fail "M13-curl: curl unexpectedly established a tunnel to Discord; binary whitelist may be too broad"
+else
+  fail "M13-curl: curl Discord denial had unexpected shape: ${live_dc_curl:0:300}"
+fi
+
+dc_reach=$(sandbox_exec 'node - <<'"'"'NODE'"'"'
+const https = require("https");
+const targets = [
+  ["api", "https://discord.com/api/v10/gateway"],
+  ["cdn", "https://cdn.discordapp.com/"],
+];
+let pending = targets.length;
+let failed = false;
+
+function done() {
+  pending -= 1;
+  if (pending === 0) process.exit(failed ? 1 : 0);
+}
+
+for (const [name, url] of targets) {
+  const req = https.get(url, (res) => {
+    console.log(`${name}:HTTP_${res.statusCode}`);
+    res.resume();
+    done();
+  });
+  req.on("error", (error) => {
+    failed = true;
+    console.log(`${name}:ERROR_${error.message}`);
+    done();
+  });
+  req.setTimeout(15000, () => {
+    failed = true;
+    req.destroy();
+    console.log(`${name}:TIMEOUT`);
+    done();
+  });
+}
+NODE
+' 2>/dev/null || true)
+
+info "Discord Node probe: ${dc_reach:0:500}"
+if echo "$dc_reach" | grep -q "api:HTTP_" \
+  && echo "$dc_reach" | grep -q "cdn:HTTP_"; then
+  pass "M13: Node.js reached Discord API and CDN through the same proxy (${dc_reach//$'\n'/ })"
+elif echo "$dc_reach" | grep -qiE "CONNECT.*403|policy_denied|forbidden"; then
+  fail "M13: Node.js was denied by the proxy despite the Discord preset being applied: ${dc_reach:0:300}"
+elif echo "$dc_reach" | grep -qiE "TIMEOUT|ENETUNREACH|EHOSTUNREACH|ETIMEDOUT|ECONNRESET|socket hang up|network"; then
+  skip "M13: Live Discord unreachable from this network (${dc_reach:0:200})"
+else
+  fail "M13: Node.js could not reach Discord API/CDN (${dc_reach:0:200})"
+fi
+
+# M13-rest-a-M13-rest-e: Hermetic Discord-shaped HTTPS REST binary whitelist proof.
+fake_rest_ready=0
+if start_fake_discord_rest_api; then
+  fake_rest_ready=1
+  pass "M13-rest-a: Hermetic fake Discord REST API started on host port ${FAKE_DISCORD_REST_PORT}"
+else
+  skip "M13-rest-a: Could not start hermetic fake Discord REST API"
+fi
+
+fake_rest_policy_ready=0
+if [ "$fake_rest_ready" = "1" ]; then
+  if apply_fake_discord_rest_policy "$SANDBOX_NAME" "$FAKE_DISCORD_REST_PORT" >/tmp/nemoclaw-fake-discord-rest-policy.log 2>&1; then
+    fake_rest_policy_ready=1
+    pass "M13-rest-b: Applied Node-only HTTPS policy for fake Discord REST API"
+  else
+    fail "M13-rest-b: Failed to apply fake Discord REST policy: $(tail -20 /tmp/nemoclaw-fake-discord-rest-policy.log 2>/dev/null | tr '\n' ' ' | cut -c1-300)"
+  fi
+else
+  skip "M13-rest-b: Fake Discord REST API unavailable; skipping policy apply"
+fi
+
+fake_rest_node=""
+if [ "$fake_rest_policy_ready" = "1" ]; then
+  fake_rest_node=$(run_fake_discord_rest_node_request "$FAKE_DISCORD_REST_PORT" "/api/v10/gateway" || true)
+fi
+info "Fake Discord REST Node probe: ${fake_rest_node:0:300}"
+if [ "$fake_rest_policy_ready" != "1" ]; then
+  skip "M13-rest-c: Fake Discord REST policy unavailable; skipping Node proof"
+elif echo "$fake_rest_node" | grep -q "^200 "; then
+  pass "M13-rest-c: Node reached the fake Discord REST API through OpenShell"
+else
+  fail "M13-rest-c: Node failed to reach fake Discord REST API: ${fake_rest_node:0:300}"
+fi
+
+fake_rest_curl=""
+if [ "$fake_rest_policy_ready" = "1" ]; then
+  fake_rest_curl=$(run_fake_discord_rest_curl_request "$FAKE_DISCORD_REST_PORT" || true)
+fi
+info "Fake Discord REST curl probe: ${fake_rest_curl:0:500}"
+if [ "$fake_rest_policy_ready" != "1" ]; then
+  skip "M13-rest-d: Fake Discord REST policy unavailable; skipping curl denial proof"
+elif echo "$fake_rest_curl" | grep -qiE "CONNECT tunnel failed.*403|HTTP/1\.[01] 403|policy_denied|Forbidden" \
+  && ! echo "$fake_rest_curl" | grep -qiE "Connection established|200 Connection"; then
+  pass "M13-rest-d: curl was denied before reaching the fake Discord REST API"
+elif echo "$fake_rest_curl" | grep -qiE "Connection established|200 Connection"; then
+  fail "M13-rest-d: curl unexpectedly established a tunnel to the fake Discord REST API"
+else
+  fail "M13-rest-d: Fake Discord REST curl denial had unexpected shape: ${fake_rest_curl:0:300}"
+fi
+
+fake_rest_capture=""
+if [ "$fake_rest_policy_ready" = "1" ]; then
+  fake_rest_capture=$(fake_discord_rest_capture_counts || true)
+fi
+info "Fake Discord REST capture counts: ${fake_rest_capture}"
+if [ "$fake_rest_policy_ready" != "1" ]; then
+  skip "M13-rest-e: Fake Discord REST policy unavailable; skipping capture proof"
+elif echo "$fake_rest_capture" | grep -q "node=1" \
+  && echo "$fake_rest_capture" | grep -q "curl=0"; then
+  pass "M13-rest-e: Fake server saw Node but no curl request"
+else
+  fail "M13-rest-e: Unexpected fake Discord REST capture counts: ${fake_rest_capture}"
 fi
 
 # M13b-M13f: Hermetic Discord Gateway over OpenShell's native WebSocket L7 path.

--- a/tools/e2e-advisor/dispatch.mts
+++ b/tools/e2e-advisor/dispatch.mts
@@ -298,20 +298,6 @@ export function planAutoDispatch({
     };
   }
 
-  const maxJobs = Number.parseInt(env.E2E_ADVISOR_AUTO_DISPATCH_MAX_JOBS || "0", 10);
-  if (Number.isFinite(maxJobs) && maxJobs > 0 && jobs.length > maxJobs) {
-    return {
-      ...base,
-      reason: `advisor recommended ${jobs.length} dispatchable jobs, above E2E_ADVISOR_AUTO_DISPATCH_MAX_JOBS=${maxJobs}`,
-      prNumber: pr.number,
-      authorAssociation,
-      authorLogin,
-      allowedByAuthorAllowlist,
-      jobs,
-      ignoredJobs,
-    };
-  }
-
   const targetRef = pr.head?.sha || pr.head?.ref || "";
   const dispatchRef = env.E2E_ADVISOR_AUTO_DISPATCH_REF || pr.base?.ref || DEFAULT_DISPATCH_REF;
   const advisorDispatchId = buildAdvisorDispatchId(pr.number, env);


### PR DESCRIPTION
## Summary
Adds Discord messaging E2E coverage for the #3477 proxy/binary-whitelist distinction. The test now proves that curl is denied by the Discord preset while Node can use the same OpenShell proxy path, and adds a hermetic fake HTTPS REST proof so the behavior is reproducible without depending only on live Discord.

## Related Issue
Fixes #3477

## Changes
- Extended `test/e2e/test-messaging-providers.sh` to verify live Discord policy entries, OpenShell proxy env, curl denial, and Node API/CDN reachability.
- Added `test/e2e/lib/discord-rest-policy-proof.sh` plus a fake HTTPS Discord-shaped REST server fixture to prove Node-only CONNECT authorization hermetically.
- Refreshed E2E parity tracking files for the new legacy assertions.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end messaging provider tests (Telegram, Discord, WeChat) with broader connectivity, proxy/policy, credential leakage/sanitization checks, improved cleanup, and hermetic REST flows that distinguish Node vs curl behavior.
  * Added an E2E advisor auto-dispatch integration test validating plan composition with simultaneous jobs.
* **Chores**
  * Auto-dispatch logic: removed max-job truncation so computed jobs are dispatched without enforced capping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->