### PR TITLE
fix(onboard): recover GPU gateway reuse

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -278,10 +278,11 @@ repos:
       - id: test-cli
         name: Test (CLI)
         entry: >-
-          bash -c 'node -e "require(\"node:fs\").rmSync(\"dist\", { recursive: true, force: true })" && npm run build:cli && npx tsx scripts/check-dist-sourcemaps.ts dist && npx vitest run --project cli --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.include="dist/lib/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
+          bash -c 'rm -rf dist && npm run build:cli && npx tsx scripts/check-dist-sourcemaps.ts dist && NEMOCLAW_TEST_TIMEOUT=20000 npx vitest run --project cli --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.include="dist/lib/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
         language: system
         pass_filenames: false
         files: ^(bin/|src/|test/)
+        require_serial: true
         priority: 20
 
       - id: test-plugin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -278,7 +278,7 @@ repos:
       - id: test-cli
         name: Test (CLI)
         entry: >-
-          bash -c 'rm -rf dist && npm run build:cli && npx tsx scripts/check-dist-sourcemaps.ts dist && NEMOCLAW_TEST_TIMEOUT=20000 npx vitest run --project cli --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.include="dist/lib/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
+          bash -c 'rm -rf dist && npm run build:cli && npx tsx scripts/check-dist-sourcemaps.ts dist && npx vitest run --project cli --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include="bin/**/*.js" --coverage.include="dist/lib/**/*.js" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts" && npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"'
         language: system
         pass_filenames: false
         files: ^(bin/|src/|test/)

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -68,7 +68,12 @@ const {
   getSelectionDrift,
 }: typeof import("./onboard/selection-drift") = require("./onboard/selection-drift");
 const { isLinuxDockerDriverGatewayEnabled }: typeof import("./onboard/docker-driver-platform") = require("./onboard/docker-driver-platform");
-const { shouldInspectLegacyGatewayGpuPassthrough }: typeof import("./onboard/gateway-gpu-passthrough") = require("./onboard/gateway-gpu-passthrough");
+const {
+  canRestartCpuOnlyGatewayForGpuIntent,
+  decideGatewayGpuReuseForGpuIntent,
+  inspectLegacyGatewayGpuPassthroughResult,
+  shouldInspectLegacyGatewayGpuPassthrough,
+}: typeof import("./onboard/gateway-gpu-passthrough") = require("./onboard/gateway-gpu-passthrough");
 const {
   syncPresetSelection,
 }: typeof import("./onboard/policy-preset-sync") = require("./onboard/policy-preset-sync");
@@ -2742,6 +2747,37 @@ async function refreshDockerDriverGatewayReuseState(
   return "stale";
 }
 
+function isConfirmedDockerDriverGatewayForGpuReuse(gatewayReuseState: GatewayReuseState): boolean {
+  if (!isLinuxDockerDriverGatewayEnabled() || gatewayReuseState !== "healthy") return false;
+  return isDockerDriverGatewayProcessAlive();
+}
+
+function readRegisteredSandboxNamesForGatewayGpuReuse(): string[] | null {
+  try {
+    return registry
+      .listSandboxes()
+      .sandboxes.map((s) => s.name)
+      .filter((name) => typeof name === "string" && name.trim().length > 0);
+  } catch {
+    return null;
+  }
+}
+
+function reportUnreadableSandboxRegistryForGpuGatewayReuse(): never {
+  console.error("  Existing gateway was started without GPU passthrough.");
+  console.error(
+    "  Could not read the local sandbox registry, so automatic gateway cleanup would be unsafe.",
+  );
+  console.error(
+    "  Fix the registry read error and rerun, or manually verify no sandboxes depend on the gateway before running:",
+  );
+  console.error(`    openshell gateway remove ${GATEWAY_NAME}`);
+  console.error("    # For OpenShell releases that still expose lifecycle commands:");
+  console.error(`    openshell gateway destroy -g ${GATEWAY_NAME}`);
+  console.error("    nemoclaw onboard --gpu");
+  process.exit(1);
+}
+
 function destroyGateway(): boolean {
   return destroyGatewayWithVolumeCleanup({
     clearRegistry: registry.clearAll,
@@ -2749,6 +2785,19 @@ function destroyGateway(): boolean {
     gatewayName: GATEWAY_NAME,
     hasLifecycleCommands: () => gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
     isDockerDriverGatewayEnabled: isLinuxDockerDriverGatewayEnabled,
+    removeDockerDriverGatewayRegistration,
+    runOpenshell,
+    stopDockerDriverGatewayProcess,
+  });
+}
+
+function destroyGatewayRuntimeForGpuReuse(): boolean {
+  return destroyGatewayWithVolumeCleanup({
+    clearRegistry: () => undefined,
+    dockerRemoveVolumesByPrefix,
+    gatewayName: GATEWAY_NAME,
+    hasLifecycleCommands: () => gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
+    isDockerDriverGatewayEnabled: () => false,
     removeDockerDriverGatewayRegistration,
     runOpenshell,
     stopDockerDriverGatewayProcess,
@@ -9681,27 +9730,82 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       }
     }
 
-    const canReuseHealthyGateway = gatewayReuseState === "healthy";
+    const confirmedDockerDriverGateway = isConfirmedDockerDriverGatewayForGpuReuse(gatewayReuseState);
 
-    // Verify legacy reusable gateway GPU passthrough; Docker-driver gateways use live CLI health.
+    // Verify legacy reusable gateway GPU passthrough; confirmed Docker-driver
+    // gateways use live CLI health.
     if (shouldInspectLegacyGatewayGpuPassthrough(
       gatewayReuseState,
       gpuPassthrough,
-      isLinuxDockerDriverGatewayEnabled(),
-      gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
+      confirmedDockerDriverGateway,
     )) {
       const container = `openshell-cluster-${GATEWAY_NAME}`;
       const gpuCheck = docker.dockerInspect(
         ["--type", "container", "--format", "{{json .HostConfig.DeviceRequests}}", container],
         { ignoreError: true, suppressOutput: true },
       );
-      const gpuOutput = String(gpuCheck.stdout || "").trim();
-      const gatewayHasGpu = gpuCheck.status === 0 && gpuOutput !== "null" && gpuOutput !== "[]";
-      if (!gatewayHasGpu) {
-        reportGpuPassthroughRecovery(console.error);
+      const legacyGatewayGpuInspection = inspectLegacyGatewayGpuPassthroughResult(
+        gpuCheck.status,
+        gpuCheck.stdout,
+        gpuCheck.stderr,
+      );
+
+      if (legacyGatewayGpuInspection === "unknown") {
+        console.error("  Existing gateway GPU passthrough could not be verified.");
+        console.error(
+          "  Refusing automatic gateway cleanup without a clear Docker signal; restart Docker and rerun onboard.",
+        );
+        process.exit(1);
+      }
+
+      const registeredSandboxNames =
+        legacyGatewayGpuInspection === "cpu-only"
+          ? readRegisteredSandboxNamesForGatewayGpuReuse()
+          : [];
+      if (registeredSandboxNames === null) {
+        reportUnreadableSandboxRegistryForGpuGatewayReuse();
+      }
+      const cpuOnlyGatewayRestartSafe = canRestartCpuOnlyGatewayForGpuIntent(
+        registeredSandboxNames,
+        recordedSandboxName || requestedSandboxName,
+        isRecreateSandbox(),
+      );
+
+      const gatewayGpuReuseDecision = decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState,
+        gpuPassthrough,
+        confirmedDockerDriverGateway,
+        legacyGatewayGpuInspection,
+        cpuOnlyGatewayRestartSafe,
+      });
+
+      if (gatewayGpuReuseDecision === "restart-gateway") {
+        console.log(
+          "  Existing gateway was started without GPU passthrough; recreating it for GPU onboarding...",
+        );
+        stopAllDashboardForwards();
+        if (isLinuxDockerDriverGatewayEnabled()) {
+          retireLegacyGatewayForDockerDriverUpgrade();
+          gatewayReuseState = "missing";
+          console.log("  ✓ Previous CPU-only gateway cleaned up");
+        } else {
+          gatewayReuseState = destroyGatewayForReuse(
+            destroyGatewayRuntimeForGpuReuse,
+            "  ✓ Previous CPU-only gateway cleaned up",
+            "  ! Previous CPU-only gateway cleanup failed; leaving registry state intact.",
+          );
+        }
+        if (gatewayReuseState !== "missing") {
+          reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames);
+          process.exit(1);
+        }
+      } else if (gatewayGpuReuseDecision === "abort-with-recovery") {
+        reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames);
         process.exit(1);
       }
     }
+
+    const canReuseHealthyGateway = gatewayReuseState === "healthy";
 
     const resumeGateway =
       resume && session?.steps?.gateway?.status === "complete" && canReuseHealthyGateway;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -9693,7 +9693,9 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       currentSandboxName: recordedSandboxName || requestedSandboxName,
       recreateSandbox: isRecreateSandbox(),
       confirmedDockerDriverGateway:
-        isLinuxDockerDriverGatewayEnabled() && gatewayReuseState === "healthy",
+        isLinuxDockerDriverGatewayEnabled() &&
+        gatewayReuseState === "healthy" &&
+        !gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
       stopDashboardForwards: stopAllDashboardForwards,
       retireLegacyGatewayForDockerDriverUpgrade,
       destroyGatewayRuntimeForGpuReuse: () => destroyGateway(() => undefined, () => false),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -69,10 +69,7 @@ const {
 }: typeof import("./onboard/selection-drift") = require("./onboard/selection-drift");
 const { isLinuxDockerDriverGatewayEnabled }: typeof import("./onboard/docker-driver-platform") = require("./onboard/docker-driver-platform");
 const {
-  canRestartCpuOnlyGatewayForGpuIntent,
-  decideGatewayGpuReuseForGpuIntent,
-  inspectLegacyGatewayGpuPassthroughResult,
-  shouldInspectLegacyGatewayGpuPassthrough,
+  reconcileGatewayGpuReuseForGpuIntent,
 }: typeof import("./onboard/gateway-gpu-passthrough") = require("./onboard/gateway-gpu-passthrough");
 const {
   syncPresetSelection,
@@ -2747,57 +2744,16 @@ async function refreshDockerDriverGatewayReuseState(
   return "stale";
 }
 
-function isConfirmedDockerDriverGatewayForGpuReuse(gatewayReuseState: GatewayReuseState): boolean {
-  if (!isLinuxDockerDriverGatewayEnabled() || gatewayReuseState !== "healthy") return false;
-  return isDockerDriverGatewayProcessAlive();
-}
-
-function readRegisteredSandboxNamesForGatewayGpuReuse(): string[] | null {
-  try {
-    return registry
-      .listSandboxes()
-      .sandboxes.map((s) => s.name)
-      .filter((name) => typeof name === "string" && name.trim().length > 0);
-  } catch {
-    return null;
-  }
-}
-
-function reportUnreadableSandboxRegistryForGpuGatewayReuse(): never {
-  console.error("  Existing gateway was started without GPU passthrough.");
-  console.error(
-    "  Could not read the local sandbox registry, so automatic gateway cleanup would be unsafe.",
-  );
-  console.error(
-    "  Fix the registry read error and rerun, or manually verify no sandboxes depend on the gateway before running:",
-  );
-  console.error(`    openshell gateway remove ${GATEWAY_NAME}`);
-  console.error("    # For OpenShell releases that still expose lifecycle commands:");
-  console.error(`    openshell gateway destroy -g ${GATEWAY_NAME}`);
-  console.error("    nemoclaw onboard --gpu");
-  process.exit(1);
-}
-
-function destroyGateway(): boolean {
+function destroyGateway(
+  clearRegistry: () => void = registry.clearAll,
+  isDockerDriverGatewayEnabledForDestroy: () => boolean = isLinuxDockerDriverGatewayEnabled,
+): boolean {
   return destroyGatewayWithVolumeCleanup({
-    clearRegistry: registry.clearAll,
+    clearRegistry,
     dockerRemoveVolumesByPrefix,
     gatewayName: GATEWAY_NAME,
     hasLifecycleCommands: () => gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
-    isDockerDriverGatewayEnabled: isLinuxDockerDriverGatewayEnabled,
-    removeDockerDriverGatewayRegistration,
-    runOpenshell,
-    stopDockerDriverGatewayProcess,
-  });
-}
-
-function destroyGatewayRuntimeForGpuReuse(): boolean {
-  return destroyGatewayWithVolumeCleanup({
-    clearRegistry: () => undefined,
-    dockerRemoveVolumesByPrefix,
-    gatewayName: GATEWAY_NAME,
-    hasLifecycleCommands: () => gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
-    isDockerDriverGatewayEnabled: () => false,
+    isDockerDriverGatewayEnabled: isDockerDriverGatewayEnabledForDestroy,
     removeDockerDriverGatewayRegistration,
     runOpenshell,
     stopDockerDriverGatewayProcess,
@@ -9730,80 +9686,18 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       }
     }
 
-    const confirmedDockerDriverGateway = isConfirmedDockerDriverGatewayForGpuReuse(gatewayReuseState);
-
-    // Verify legacy reusable gateway GPU passthrough; confirmed Docker-driver
-    // gateways use live CLI health.
-    if (shouldInspectLegacyGatewayGpuPassthrough(
+    gatewayReuseState = reconcileGatewayGpuReuseForGpuIntent({
       gatewayReuseState,
       gpuPassthrough,
-      confirmedDockerDriverGateway,
-    )) {
-      const container = `openshell-cluster-${GATEWAY_NAME}`;
-      const gpuCheck = docker.dockerInspect(
-        ["--type", "container", "--format", "{{json .HostConfig.DeviceRequests}}", container],
-        { ignoreError: true, suppressOutput: true },
-      );
-      const legacyGatewayGpuInspection = inspectLegacyGatewayGpuPassthroughResult(
-        gpuCheck.status,
-        gpuCheck.stdout,
-        gpuCheck.stderr,
-      );
-
-      if (legacyGatewayGpuInspection === "unknown") {
-        console.error("  Existing gateway GPU passthrough could not be verified.");
-        console.error(
-          "  Refusing automatic gateway cleanup without a clear Docker signal; restart Docker and rerun onboard.",
-        );
-        process.exit(1);
-      }
-
-      const registeredSandboxNames =
-        legacyGatewayGpuInspection === "cpu-only"
-          ? readRegisteredSandboxNamesForGatewayGpuReuse()
-          : [];
-      if (registeredSandboxNames === null) {
-        reportUnreadableSandboxRegistryForGpuGatewayReuse();
-      }
-      const cpuOnlyGatewayRestartSafe = canRestartCpuOnlyGatewayForGpuIntent(
-        registeredSandboxNames,
-        recordedSandboxName || requestedSandboxName,
-        isRecreateSandbox(),
-      );
-
-      const gatewayGpuReuseDecision = decideGatewayGpuReuseForGpuIntent({
-        gatewayReuseState,
-        gpuPassthrough,
-        confirmedDockerDriverGateway,
-        legacyGatewayGpuInspection,
-        cpuOnlyGatewayRestartSafe,
-      });
-
-      if (gatewayGpuReuseDecision === "restart-gateway") {
-        console.log(
-          "  Existing gateway was started without GPU passthrough; recreating it for GPU onboarding...",
-        );
-        stopAllDashboardForwards();
-        if (isLinuxDockerDriverGatewayEnabled()) {
-          retireLegacyGatewayForDockerDriverUpgrade();
-          gatewayReuseState = "missing";
-          console.log("  ✓ Previous CPU-only gateway cleaned up");
-        } else {
-          gatewayReuseState = destroyGatewayForReuse(
-            destroyGatewayRuntimeForGpuReuse,
-            "  ✓ Previous CPU-only gateway cleaned up",
-            "  ! Previous CPU-only gateway cleanup failed; leaving registry state intact.",
-          );
-        }
-        if (gatewayReuseState !== "missing") {
-          reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames);
-          process.exit(1);
-        }
-      } else if (gatewayGpuReuseDecision === "abort-with-recovery") {
-        reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames);
-        process.exit(1);
-      }
-    }
+      gatewayName: GATEWAY_NAME,
+      currentSandboxName: recordedSandboxName || requestedSandboxName,
+      recreateSandbox: isRecreateSandbox(),
+      confirmedDockerDriverGateway:
+        isLinuxDockerDriverGatewayEnabled() && gatewayReuseState === "healthy",
+      stopDashboardForwards: stopAllDashboardForwards,
+      retireLegacyGatewayForDockerDriverUpgrade,
+      destroyGatewayRuntimeForGpuReuse: () => destroyGateway(() => undefined, () => false),
+    });
 
     const canReuseHealthyGateway = gatewayReuseState === "healthy";
 

--- a/src/lib/onboard/gateway-gpu-passthrough.test.ts
+++ b/src/lib/onboard/gateway-gpu-passthrough.test.ts
@@ -3,18 +3,135 @@
 
 import { describe, expect, it } from "vitest";
 
-import { shouldInspectLegacyGatewayGpuPassthrough } from "./gateway-gpu-passthrough";
+import {
+  canRestartCpuOnlyGatewayForGpuIntent,
+  decideGatewayGpuReuseForGpuIntent,
+  inspectLegacyGatewayGpuPassthroughResult,
+  shouldInspectLegacyGatewayGpuPassthrough,
+} from "./gateway-gpu-passthrough";
 import type { GatewayReuseState } from "../state/gateway";
 
 describe("gateway GPU passthrough inspection", () => {
-  it("only inspects reusable legacy gateway containers", () => {
-    const healthy: GatewayReuseState = "healthy";
-    const missing: GatewayReuseState = "missing";
+  const healthy: GatewayReuseState = "healthy";
+  const missing: GatewayReuseState = "missing";
 
-    expect(shouldInspectLegacyGatewayGpuPassthrough(healthy, true, false, true)).toBe(true);
-    expect(shouldInspectLegacyGatewayGpuPassthrough(healthy, true, false, false)).toBe(false);
-    expect(shouldInspectLegacyGatewayGpuPassthrough(healthy, true, true, true)).toBe(false);
-    expect(shouldInspectLegacyGatewayGpuPassthrough(missing, true, false, true)).toBe(false);
-    expect(shouldInspectLegacyGatewayGpuPassthrough(healthy, false, false, true)).toBe(false);
+  it("only inspects reusable legacy gateway containers", () => {
+    expect(shouldInspectLegacyGatewayGpuPassthrough(healthy, true, false)).toBe(true);
+    expect(shouldInspectLegacyGatewayGpuPassthrough(healthy, true, true)).toBe(false);
+    expect(shouldInspectLegacyGatewayGpuPassthrough(missing, true, false)).toBe(false);
+    expect(shouldInspectLegacyGatewayGpuPassthrough(healthy, false, false)).toBe(false);
+  });
+
+  it("parses legacy Docker DeviceRequests inspection conservatively", () => {
+    expect(inspectLegacyGatewayGpuPassthroughResult(0, "null\n")).toBe("cpu-only");
+    expect(inspectLegacyGatewayGpuPassthroughResult(0, "[]")).toBe("cpu-only");
+    expect(inspectLegacyGatewayGpuPassthroughResult(0, '[{"Driver":"nvidia"}]')).toBe(
+      "gpu-enabled",
+    );
+    expect(inspectLegacyGatewayGpuPassthroughResult(1, "", "No such object: x")).toBe(
+      "not-found",
+    );
+    expect(inspectLegacyGatewayGpuPassthroughResult(1, "")).toBe("unknown");
+    expect(inspectLegacyGatewayGpuPassthroughResult(0, "")).toBe("unknown");
+  });
+
+  it("reuses when GPU is not requested or the gateway is already Docker-driver/current", () => {
+    expect(
+      decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState: healthy,
+        gpuPassthrough: false,
+        confirmedDockerDriverGateway: false,
+        legacyGatewayGpuInspection: "cpu-only",
+        cpuOnlyGatewayRestartSafe: true,
+      }),
+    ).toBe("reuse");
+
+    expect(
+      decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState: healthy,
+        gpuPassthrough: true,
+        confirmedDockerDriverGateway: true,
+        legacyGatewayGpuInspection: "cpu-only",
+        cpuOnlyGatewayRestartSafe: true,
+      }),
+    ).toBe("reuse");
+  });
+
+  it("reuses legacy gateways that already expose GPU passthrough", () => {
+    expect(
+      decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState: healthy,
+        gpuPassthrough: true,
+        confirmedDockerDriverGateway: false,
+        legacyGatewayGpuInspection: "gpu-enabled",
+        cpuOnlyGatewayRestartSafe: false,
+      }),
+    ).toBe("reuse");
+
+    expect(
+      decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState: healthy,
+        gpuPassthrough: true,
+        confirmedDockerDriverGateway: false,
+        legacyGatewayGpuInspection: "not-found",
+        cpuOnlyGatewayRestartSafe: true,
+      }),
+    ).toBe("reuse");
+  });
+
+  it("restarts CPU-only legacy gateways only when the caller has proved it is safe", () => {
+    expect(
+      decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState: healthy,
+        gpuPassthrough: true,
+        confirmedDockerDriverGateway: false,
+        legacyGatewayGpuInspection: "cpu-only",
+        cpuOnlyGatewayRestartSafe: true,
+      }),
+    ).toBe("restart-gateway");
+
+    expect(
+      decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState: healthy,
+        gpuPassthrough: true,
+        confirmedDockerDriverGateway: false,
+        legacyGatewayGpuInspection: "cpu-only",
+        cpuOnlyGatewayRestartSafe: false,
+      }),
+    ).toBe("abort-with-recovery");
+  });
+
+  it("keeps unknown legacy gateway GPU state non-destructive", () => {
+    expect(
+      decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState: healthy,
+        gpuPassthrough: true,
+        confirmedDockerDriverGateway: false,
+        legacyGatewayGpuInspection: "unknown",
+        cpuOnlyGatewayRestartSafe: true,
+      }),
+    ).toBe("abort-with-recovery");
+
+    expect(
+      decideGatewayGpuReuseForGpuIntent({
+        gatewayReuseState: healthy,
+        gpuPassthrough: true,
+        confirmedDockerDriverGateway: false,
+        legacyGatewayGpuInspection: "cpu-only",
+        cpuOnlyGatewayRestartSafe: false,
+      }),
+    ).toBe("abort-with-recovery");
+  });
+
+  it("allows CPU-only gateway restart for empty registry or the one sandbox being recreated", () => {
+    expect(canRestartCpuOnlyGatewayForGpuIntent([], null, false)).toBe(true);
+    expect(canRestartCpuOnlyGatewayForGpuIntent(["my-assistant"], "my-assistant", true)).toBe(
+      true,
+    );
+    expect(canRestartCpuOnlyGatewayForGpuIntent(["my-assistant"], "my-assistant", false)).toBe(
+      false,
+    );
+    expect(canRestartCpuOnlyGatewayForGpuIntent(["alpha"], "beta", true)).toBe(false);
+    expect(canRestartCpuOnlyGatewayForGpuIntent(["alpha", "beta"], "alpha", true)).toBe(false);
   });
 });

--- a/src/lib/onboard/gateway-gpu-passthrough.test.ts
+++ b/src/lib/onboard/gateway-gpu-passthrough.test.ts
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../adapters/docker", () => ({
+  dockerInspect: vi.fn(),
+}));
 
 import {
   canRestartCpuOnlyGatewayForGpuIntent,

--- a/src/lib/onboard/gateway-gpu-passthrough.ts
+++ b/src/lib/onboard/gateway-gpu-passthrough.ts
@@ -2,10 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { GatewayReuseState } from "../state/gateway";
+import * as registry from "../state/registry";
+import * as docker from "../adapters/docker";
+import { destroyGatewayForReuse } from "./gateway-cleanup";
+import { reportGpuPassthroughRecovery } from "./gpu-recovery";
+import { isLinuxDockerDriverGatewayEnabled } from "./docker-driver-platform";
 
 export type LegacyGatewayGpuInspection = "gpu-enabled" | "cpu-only" | "not-found" | "unknown";
 
 export type GatewayGpuReuseDecision = "reuse" | "restart-gateway" | "abort-with-recovery";
+
+type GatewayGpuDeviceRequestInspection = {
+  status: number | null | undefined;
+  stdout?: unknown;
+  stderr?: unknown;
+};
+
+export type GatewayGpuReuseReconcileOptions = {
+  gatewayReuseState: GatewayReuseState;
+  gpuPassthrough: boolean;
+  gatewayName: string;
+  currentSandboxName: string | null;
+  recreateSandbox: boolean;
+  confirmedDockerDriverGateway: boolean;
+  stopDashboardForwards: () => void;
+  retireLegacyGatewayForDockerDriverUpgrade: () => void;
+  destroyGatewayRuntimeForGpuReuse: () => boolean;
+};
 
 // Docker-driver/package-managed gateways do not expose reusable GPU state
 // through the legacy openshell-cluster-* container's DeviceRequests field.
@@ -67,4 +90,119 @@ export function canRestartCpuOnlyGatewayForGpuIntent(
     names.length === 1 &&
     names[0] === currentSandboxName
   );
+}
+
+function readRegisteredSandboxNamesForGatewayGpuReuse(): string[] | null {
+  try {
+    return registry
+      .listSandboxes()
+      .sandboxes.map((s) => s.name)
+      .filter((name) => typeof name === "string" && name.trim().length > 0);
+  } catch {
+    return null;
+  }
+}
+
+function reportUnreadableSandboxRegistryForGpuGatewayReuse(
+  error: (line: string) => void,
+  exit: (code: number) => never,
+  gatewayName: string,
+): never {
+  error("  Existing gateway was started without GPU passthrough.");
+  error("  Could not read the local sandbox registry, so automatic gateway cleanup would be unsafe.");
+  error(
+    "  Fix the registry read error and rerun, or manually verify no sandboxes depend on the gateway before running:",
+  );
+  error(`    openshell gateway remove ${gatewayName}`);
+  error("    # For OpenShell releases that still expose lifecycle commands:");
+  error(`    openshell gateway destroy -g ${gatewayName}`);
+  error("    nemoclaw onboard --gpu");
+  exit(1);
+}
+
+function inspectLegacyGatewayDeviceRequests(containerName: string): GatewayGpuDeviceRequestInspection {
+  return docker.dockerInspect(
+    ["--type", "container", "--format", "{{json .HostConfig.DeviceRequests}}", containerName],
+    { ignoreError: true, suppressOutput: true },
+  );
+}
+
+export function reconcileGatewayGpuReuseForGpuIntent({
+  gatewayReuseState,
+  gpuPassthrough,
+  gatewayName,
+  currentSandboxName,
+  recreateSandbox,
+  confirmedDockerDriverGateway,
+  stopDashboardForwards,
+  retireLegacyGatewayForDockerDriverUpgrade,
+  destroyGatewayRuntimeForGpuReuse,
+}: GatewayGpuReuseReconcileOptions): GatewayReuseState {
+  if (!shouldInspectLegacyGatewayGpuPassthrough(
+    gatewayReuseState,
+    gpuPassthrough,
+    confirmedDockerDriverGateway,
+  )) {
+    return gatewayReuseState;
+  }
+
+  const container = `openshell-cluster-${gatewayName}`;
+  const gpuCheck = inspectLegacyGatewayDeviceRequests(container);
+  const legacyGatewayGpuInspection = inspectLegacyGatewayGpuPassthroughResult(
+    gpuCheck.status,
+    gpuCheck.stdout,
+    gpuCheck.stderr,
+  );
+
+  if (legacyGatewayGpuInspection === "unknown") {
+    console.error("  Existing gateway GPU passthrough could not be verified.");
+    console.error(
+      "  Refusing automatic gateway cleanup without a clear Docker signal; restart Docker and rerun onboard.",
+    );
+    process.exit(1);
+  }
+
+  const registeredSandboxNames =
+    legacyGatewayGpuInspection === "cpu-only"
+      ? readRegisteredSandboxNamesForGatewayGpuReuse()
+      : [];
+  if (registeredSandboxNames === null) {
+    reportUnreadableSandboxRegistryForGpuGatewayReuse(console.error, process.exit, gatewayName);
+  }
+
+  const gatewayGpuReuseDecision = decideGatewayGpuReuseForGpuIntent({
+    gatewayReuseState,
+    gpuPassthrough,
+    confirmedDockerDriverGateway,
+    legacyGatewayGpuInspection,
+    cpuOnlyGatewayRestartSafe: canRestartCpuOnlyGatewayForGpuIntent(
+      registeredSandboxNames,
+      currentSandboxName,
+      recreateSandbox,
+    ),
+  });
+
+  if (gatewayGpuReuseDecision === "restart-gateway") {
+    console.log("  Existing gateway was started without GPU passthrough; recreating it for GPU onboarding...");
+    stopDashboardForwards();
+    if (isLinuxDockerDriverGatewayEnabled()) {
+      retireLegacyGatewayForDockerDriverUpgrade();
+      gatewayReuseState = "missing";
+      console.log("  ✓ Previous CPU-only gateway cleaned up");
+    } else {
+      gatewayReuseState = destroyGatewayForReuse(
+        destroyGatewayRuntimeForGpuReuse,
+        "  ✓ Previous CPU-only gateway cleaned up",
+        "  ! Previous CPU-only gateway cleanup failed; leaving registry state intact.",
+      );
+    }
+    if (gatewayReuseState !== "missing") {
+      reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames);
+      process.exit(1);
+    }
+  } else if (gatewayGpuReuseDecision === "abort-with-recovery") {
+    reportGpuPassthroughRecovery(console.error, () => registeredSandboxNames);
+    process.exit(1);
+  }
+  return gatewayReuseState;
 }

--- a/src/lib/onboard/gateway-gpu-passthrough.ts
+++ b/src/lib/onboard/gateway-gpu-passthrough.ts
@@ -3,18 +3,68 @@
 
 import type { GatewayReuseState } from "../state/gateway";
 
+export type LegacyGatewayGpuInspection = "gpu-enabled" | "cpu-only" | "not-found" | "unknown";
+
+export type GatewayGpuReuseDecision = "reuse" | "restart-gateway" | "abort-with-recovery";
+
 // Docker-driver/package-managed gateways do not expose reusable GPU state
 // through the legacy openshell-cluster-* container's DeviceRequests field.
 export function shouldInspectLegacyGatewayGpuPassthrough(
   gatewayReuseState: GatewayReuseState,
   gpuPassthrough: boolean,
-  dockerDriverGatewayEnabled: boolean,
-  gatewayLifecycleCommandsSupported: boolean,
+  confirmedDockerDriverGateway: boolean,
 ): boolean {
+  return gatewayReuseState === "healthy" && gpuPassthrough && !confirmedDockerDriverGateway;
+}
+
+export function inspectLegacyGatewayGpuPassthroughResult(
+  status: number | null | undefined,
+  stdout: unknown,
+  stderr: unknown = "",
+): LegacyGatewayGpuInspection {
+  if (status !== 0) {
+    const error = String(stderr ?? "");
+    return /\bNo such (object|container)\b|not found/i.test(error) ? "not-found" : "unknown";
+  }
+  const output = String(stdout ?? "").trim();
+  if (output === "null" || output === "[]") return "cpu-only";
+  if (!output) return "unknown";
+  return "gpu-enabled";
+}
+
+export function decideGatewayGpuReuseForGpuIntent({
+  gatewayReuseState,
+  gpuPassthrough,
+  confirmedDockerDriverGateway,
+  legacyGatewayGpuInspection,
+  cpuOnlyGatewayRestartSafe,
+}: {
+  gatewayReuseState: GatewayReuseState;
+  gpuPassthrough: boolean;
+  confirmedDockerDriverGateway: boolean;
+  legacyGatewayGpuInspection: LegacyGatewayGpuInspection;
+  cpuOnlyGatewayRestartSafe: boolean;
+}): GatewayGpuReuseDecision {
+  if (gatewayReuseState !== "healthy" || !gpuPassthrough) return "reuse";
+  if (confirmedDockerDriverGateway) return "reuse";
+  if (legacyGatewayGpuInspection === "gpu-enabled" || legacyGatewayGpuInspection === "not-found") {
+    return "reuse";
+  }
+  if (legacyGatewayGpuInspection !== "cpu-only") return "abort-with-recovery";
+  return cpuOnlyGatewayRestartSafe ? "restart-gateway" : "abort-with-recovery";
+}
+
+export function canRestartCpuOnlyGatewayForGpuIntent(
+  registeredSandboxNames: readonly string[],
+  currentSandboxName: string | null,
+  recreateSandbox: boolean,
+): boolean {
+  const names = registeredSandboxNames.map((name) => name.trim()).filter(Boolean);
+  if (names.length === 0) return true;
   return (
-    gatewayReuseState === "healthy" &&
-    gpuPassthrough &&
-    !dockerDriverGatewayEnabled &&
-    gatewayLifecycleCommandsSupported
+    recreateSandbox &&
+    currentSandboxName !== null &&
+    names.length === 1 &&
+    names[0] === currentSandboxName
   );
 }

--- a/src/lib/onboard/gpu-recovery.test.ts
+++ b/src/lib/onboard/gpu-recovery.test.ts
@@ -21,19 +21,23 @@ describe("gpuPassthroughRecoveryLines", () => {
     }
   });
 
-  it("suggests `nemoclaw uninstall` when no sandboxes are registered (null input)", () => {
+  it("suggests targeted gateway cleanup when no sandboxes are registered (null input)", () => {
     const lines = gpuPassthroughRecoveryLines(null);
     const joined = lines.join("\n");
     expect(joined).toContain("Existing gateway was started without GPU passthrough");
-    expect(joined).toContain("nemoclaw uninstall");
+    expect(joined).toContain("attempted safe gateway replacement automatically");
+    expect(joined).toContain("openshell gateway remove nemoclaw");
+    expect(joined).toContain("openshell gateway destroy -g nemoclaw");
     expect(joined).toContain("nemoclaw onboard --gpu");
+    expect(joined).not.toContain("nemoclaw uninstall");
     // Must NOT suggest the destroy form — there is nothing to destroy.
     expect(joined).not.toMatch(/nemoclaw [a-z-]+ destroy/);
   });
 
-  it("suggests `nemoclaw uninstall` when no sandboxes are registered (empty array)", () => {
+  it("suggests targeted gateway cleanup when no sandboxes are registered (empty array)", () => {
     const lines = gpuPassthroughRecoveryLines([]);
-    expect(lines.join("\n")).toContain("nemoclaw uninstall");
+    expect(lines.join("\n")).toContain("openshell gateway remove nemoclaw");
+    expect(lines.join("\n")).not.toContain("nemoclaw uninstall");
     expect(lines.join("\n")).not.toMatch(/nemoclaw [a-z-]+ destroy/);
   });
 
@@ -78,7 +82,8 @@ describe("reportGpuPassthroughRecovery", () => {
     const emit = vi.fn();
     reportGpuPassthroughRecovery(emit, () => []);
     const joined = emit.mock.calls.map((c) => c[0]).join("\n");
-    expect(joined).toContain("nemoclaw uninstall");
+    expect(joined).toContain("openshell gateway remove nemoclaw");
+    expect(joined).not.toContain("nemoclaw uninstall");
     expect(joined).not.toMatch(/<name>/);
   });
 

--- a/src/lib/onboard/gpu-recovery.ts
+++ b/src/lib/onboard/gpu-recovery.ts
@@ -20,13 +20,14 @@ import * as registry from "../state/registry";
  * branch in onboard. Caller is expected to emit each line on its own line
  * via `console.error` / `runtime.log`.
  *
- * Empty / null input means no sandboxes are registered locally; we suggest
- * `nemoclaw uninstall` because there is nothing for `nemoclaw <name>
- * destroy` to act on. A single registered sandbox gets one destroy line
- * with `--cleanup-gateway` so the gateway also goes away (otherwise destroy
- * preserves the shared gateway by default — see v0.0.39 release notes).
- * Multiple sandboxes get one destroy line each; only the last carries
- * `--cleanup-gateway` so the gateway lives until every sandbox is gone.
+ * Empty / null input means no sandboxes are registered locally; onboard has
+ * already tried the safe stale-gateway replacement path, so the manual fallback
+ * should target gateway cleanup instead of a full uninstall. A single
+ * registered sandbox gets one destroy line with `--cleanup-gateway` so the
+ * gateway also goes away (otherwise destroy preserves the shared gateway by
+ * default — see v0.0.39 release notes). Multiple sandboxes get one destroy
+ * line each; only the last carries `--cleanup-gateway` so the gateway lives
+ * until every sandbox is gone.
  */
 export function gpuPassthroughRecoveryLines(names: readonly string[] | null): string[] {
   const cleanNames = (names ?? []).map((n) => n.trim()).filter((n) => n.length > 0);
@@ -34,9 +35,12 @@ export function gpuPassthroughRecoveryLines(names: readonly string[] | null): st
   if (cleanNames.length === 0) {
     return [
       "  Existing gateway was started without GPU passthrough.",
-      "  No sandboxes are registered, so there is nothing for `nemoclaw destroy` to act on.",
-      "  Clear the stale gateway state and re-onboard with GPU enabled:",
-      "    nemoclaw uninstall && nemoclaw onboard --gpu",
+      "  No sandboxes are registered, so onboard attempted safe gateway replacement automatically.",
+      "  If the retry still fails, clear the stale gateway state and re-onboard with GPU enabled:",
+      "    openshell gateway remove nemoclaw",
+      "    # For OpenShell releases that still expose lifecycle commands:",
+      "    openshell gateway destroy -g nemoclaw",
+      "    nemoclaw onboard --gpu",
     ];
   }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1558,7 +1558,7 @@ describe("CLI dispatch", () => {
     }
   });
 
-  it("doctor accepts a live cloudflared PID", () => {
+  it("doctor accepts a live cloudflared PID", testTimeoutOptions(35_000), () => {
     const { sandboxName, serviceDir } = createCloudflaredServiceDir("doctorcloudflared-");
     const setup = createDoctorTestSetup(
       "nemoclaw-cli-doctor-cloudflared-pid-",
@@ -3444,7 +3444,7 @@ describe("CLI dispatch", () => {
     expect(fs.existsSync(sshMarkerFile)).toBe(false);
   });
 
-  it("connect --probe-only falls back to SSH when sandbox exec never starts", () => {
+  it("connect --probe-only falls back to SSH when sandbox exec never starts", testTimeoutOptions(15_000), () => {
     const home = fs.mkdtempSync(
       path.join(os.tmpdir(), "nemoclaw-cli-connect-probe-exec-fallback-"),
     );

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -579,7 +579,13 @@ describe("regression guards", () => {
 
     const defs = [];
     for (const file of files) {
-      const src = fs.readFileSync(file, "utf-8");
+      let src: string;
+      try {
+        src = fs.readFileSync(file, "utf-8");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw error;
+      }
       if (src.includes("function shellQuote")) {
         defs.push(path.relative(repoRoot, file));
       }


### PR DESCRIPTION
## Summary

Fixes #3578.

This makes GPU-enabled onboarding recover from a healthy reusable gateway that was previously started without GPU passthrough, instead of aborting with a full `nemoclaw uninstall && nemoclaw onboard --gpu` recovery path.

The recovery is intentionally conservative:

- Reuse is unchanged when GPU is not requested, when the reusable gateway is already a confirmed Docker-driver gateway, or when a legacy gateway already has Docker GPU DeviceRequests.
- A CPU-only legacy gateway is automatically retired only when no local sandboxes are registered, or when `NEMOCLAW_RECREATE_SANDBOX=1` is recreating the one registered sandbox with the same name.
- If other registered sandboxes depend on the gateway, onboarding still aborts non-destructively and prints targeted `destroy --cleanup-gateway` guidance.
- Unknown Docker/container state remains non-destructive.
- `--no-gpu` / `NEMOCLAW_SANDBOX_GPU=0` remain explicit opt-outs; this does not silently downshift GPU-selected onboarding to CPU.

I also tightened the manual recovery message so the empty-registry fallback no longer recommends full uninstall first.

## Testing for reviewers

The focused unit coverage exercises the issue decision matrix:

- GPU requested + healthy CPU-only legacy gateway + empty registry => restart/recreate path.
- GPU requested + healthy CPU-only legacy gateway + the one registered sandbox being recreated => restart/recreate path.
- GPU requested + healthy CPU-only legacy gateway + shared/different registered sandboxes => abort with targeted recovery.
- GPU not requested => reuse path unchanged.
- Confirmed Docker-driver gateway => reuse path unchanged.
- Unknown legacy Docker inspection state => non-destructive abort.
- Empty-registry recovery wording recommends targeted gateway cleanup, not full uninstall.

Local validation run:

```text
npm run build:cli
npm test -- src/lib/onboard/gateway-gpu-passthrough.test.ts src/lib/onboard/gpu-recovery.test.ts src/lib/onboard/sandbox-gpu-create.test.ts src/lib/onboard/docker-gpu-patch.test.ts
npm run typecheck
npm run source-shape:check
git diff --check
npx prek run --all-files
```

All of the above passed locally.

I did not run live GPU UAT on Ubuntu GPU, DGX Spark, or DGX Station hardware. That is still the end-to-end validation needed for the exact reporter scenario: first create a CPU/no-GPU gateway, leave the stale gateway behind, then rerun GPU-default onboarding with `NEMOCLAW_RECREATE_SANDBOX=1` and verify the new sandbox gets GPU access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU passthrough detection and reuse logic to avoid unsafe reuse and to perform safer restart or abort-with-recovery when needed
  * Updated recovery guidance for GPU passthrough issues with clearer cleanup and re-onboarding instructions

* **New Features**
  * Added explicit GPU inspection and decision flow to better handle legacy gateway GPU states and restart safety checks

* **Tests**
  * Expanded and hardened tests around GPU inspection, reuse decisions, recovery messaging, and CLI timeouts/robustness

* **Chores**
  * Hardened pre-commit test hook execution (serialized runs and cleanup before build)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->