### PR TITLE
fix(inference): enable streamed usage accounting for Ollama-local (#2747)

### DIFF
--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -423,6 +423,24 @@ def build_config(env: dict | None = None) -> dict:
             setup, inference_compat, openclaw_plugins, openclaw_plugin_ids
         )
 
+    # Ollama's OpenAI-compatible /v1/chat/completions stream omits the
+    # `usage` chunk by default; OpenAI clients have to send
+    # `stream_options.include_usage: true` to receive it. OpenClaw gates
+    # that request flag on `model.compat.supportsUsageInStreaming`
+    # (src/agents/openai-transport-stream.ts) and its Ollama extension
+    # only opts in when its own detector recognises the endpoint as
+    # Ollama. NemoClaw routes ollama-local traffic via the standardised
+    # `https://inference.local/v1` URL through the OpenShell gateway, so
+    # the upstream detector misses it and the TUI token counter stays
+    # `?` indefinitely (#2747). Set the flag here so the request is sent
+    # with `stream_options.include_usage: true` regardless of how
+    # OpenClaw resolves the provider id. Mirrors the LM Studio extension
+    # workaround (`withLmstudioUsageCompat` in
+    # extensions/lmstudio/src/stream.ts). Keep the set of provider keys
+    # in sync with `_bundled_provider_plugins["ollama"]` below.
+    if provider_key in {"ollama", "ollama-local"}:
+        inference_compat.setdefault("supportsUsageInStreaming", True)
+
     msg_channels = json.loads(
         base64.b64decode(
             env.get("NEMOCLAW_MESSAGING_CHANNELS_B64", "W10=") or "W10="

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -414,6 +414,70 @@ describe("generate-openclaw-config.py: config generation", () => {
     });
   });
 
+  // #2747: Ollama's OpenAI-compatible streaming API omits the usage chunk
+  // unless `stream_options.include_usage` is set on the request. OpenClaw
+  // gates that on `model.compat.supportsUsageInStreaming`. NemoClaw routes
+  // ollama-local through the standardised `inference.local` URL, which
+  // OpenClaw's own Ollama detector does not recognise — so we force the
+  // flag here. Cloud providers and other local backends must not be
+  // affected.
+  it("enables supportsUsageInStreaming for Ollama provider keys (#2747)", () => {
+    for (const providerKey of ["ollama", "ollama-local"]) {
+      const config = runConfigScript({
+        NEMOCLAW_MODEL: "qwen2.5:7b",
+        NEMOCLAW_PROVIDER_KEY: providerKey,
+        NEMOCLAW_PRIMARY_MODEL_REF: "qwen2.5:7b",
+        NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+        NEMOCLAW_INFERENCE_API: "openai-completions",
+      });
+      const model = config.models.providers[providerKey].models[0];
+      expect(model.compat?.supportsUsageInStreaming).toBe(true);
+    }
+  });
+
+  it("does not enable supportsUsageInStreaming for non-Ollama providers (#2747)", () => {
+    const cases = [
+      { NEMOCLAW_PROVIDER_KEY: "openai", NEMOCLAW_INFERENCE_BASE_URL: "https://api.openai.com/v1" },
+      {
+        NEMOCLAW_PROVIDER_KEY: "anthropic",
+        NEMOCLAW_INFERENCE_BASE_URL: "https://api.anthropic.com",
+      },
+      { NEMOCLAW_PROVIDER_KEY: "vllm", NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1" },
+      {
+        NEMOCLAW_PROVIDER_KEY: "nim-local",
+        NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+      },
+    ];
+
+    for (const envCase of cases) {
+      const config = runConfigScript({
+        NEMOCLAW_MODEL: "test-model",
+        NEMOCLAW_PRIMARY_MODEL_REF: "test-ref",
+        NEMOCLAW_INFERENCE_API: "openai-completions",
+        ...envCase,
+      });
+      const model = config.models.providers[envCase.NEMOCLAW_PROVIDER_KEY].models[0];
+      expect(model.compat?.supportsUsageInStreaming).toBeUndefined();
+    }
+  });
+
+  // If a future model-specific-setup manifest declares
+  // supportsUsageInStreaming explicitly, that decision should win over our
+  // ollama-keyed default — including when a manifest opts the flag *off*.
+  it("respects existing supportsUsageInStreaming from inference compat (#2747)", () => {
+    const config = runConfigScript({
+      NEMOCLAW_MODEL: "qwen2.5:7b",
+      NEMOCLAW_PROVIDER_KEY: "ollama",
+      NEMOCLAW_PRIMARY_MODEL_REF: "qwen2.5:7b",
+      NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+      NEMOCLAW_INFERENCE_API: "openai-completions",
+      NEMOCLAW_INFERENCE_COMPAT_B64: Buffer.from(
+        JSON.stringify({ supportsUsageInStreaming: false }),
+      ).toString("base64"),
+    });
+    expect(config.models.providers.ollama.models[0].compat.supportsUsageInStreaming).toBe(false);
+  });
+
   it("does not activate the OpenClaw Kimi setup for non-matching routes", () => {
     const cases = [
       { NEMOCLAW_MODEL: "deepseek-ai/DeepSeek-V4-Flash" },


### PR DESCRIPTION
## Summary
- `model.compat.supportsUsageInStreaming` is now set when the build's `NEMOCLAW_PROVIDER_KEY` is `ollama` or `ollama-local`, so OpenClaw sends `stream_options.include_usage: true` and the TUI token counter updates after each turn instead of staying `?`.
- Existing explicit `supportsUsageInStreaming` values in the incoming inference compat blob take precedence, leaving room for a future model-specific-setup manifest to opt models out.
- Regression test added in `test/generate-openclaw-config.test.ts`.

## Root cause

OpenClaw's Ollama extension already enables streamed usage accounting *if* its detector (`isOllamaCompatProvider` in `extensions/ollama/src/stream.ts` upstream) recognises the endpoint. The detector requires one of: `model.provider === "ollama"` (exact match after normalization), or `baseUrl` pointing at `localhost:11434`, or a provider id that *contains* `ollama` reaching port `11434` on a `/v1` path.

NemoClaw routes ollama-local traffic via the standardised `https://inference.local/v1` URL through the OpenShell gateway. The base URL is loopback-equivalent inside the sandbox but the hostname is `inference.local` and the port is `443`, so none of the detector's positive paths match. Without that opt-in, OpenClaw omits `stream_options.include_usage`, Ollama's `/v1/chat/completions` stream omits the trailing `usage` chunk, OpenClaw's `parseTransportChunkUsage` never runs, and `model.compat.supportsUsageInStreaming` stays `false`. End result: the TUI's `tokens X/Y` field never moves off `?`.

Setting `supportsUsageInStreaming: true` directly in the compat block bypasses the detector entirely and forces the request to ask for the usage chunk. This mirrors the LM Studio extension's `withLmstudioUsageCompat` workaround (`extensions/lmstudio/src/stream.ts` upstream), which addresses the same class of bug for LM Studio's OpenAI-compatible streaming.

## Test plan

- `npx vitest run test/generate-openclaw-config.test.ts -t "supportsUsageInStreaming"` — 3 new cases pass:
  - flag set for `ollama` and `ollama-local` provider keys
  - flag absent for `openai`, `anthropic`, `vllm`, `nim-local`
  - explicit `supportsUsageInStreaming: false` in the incoming compat blob is preserved
- `npx vitest run test/generate-openclaw-config.test.ts` — 70/70 pass, no regressions

Fixes #2747.

Signed-off-by: Shawn Xie <shaxie@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw streaming usage support is now automatically enabled when using Ollama and Ollama-local providers, delivering enhanced streaming performance and reliability.

* **Tests**
  * Added comprehensive tests validating that streaming usage support is properly enabled for Ollama providers, remains unaffected for non-Ollama providers, and respects explicit configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->