### PR TITLE
ci: benchmark full Vitest runner speed

### DIFF
--- a/.github/workflows/pr-self-hosted.yaml
+++ b/.github/workflows/pr-self-hosted.yaml
@@ -36,6 +36,34 @@ jobs:
       - id: get-pr-info
         uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
 
+  benchmark-vitest-linux-amd64-cpu4:
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          npm ci --ignore-scripts
+          cd nemoclaw
+          npm ci --ignore-scripts
+
+      - name: Build CLI and plugin
+        run: |
+          npm run build:cli
+          cd nemoclaw
+          npm run build
+
+      - name: Benchmark full Vitest suite on linux-amd64-cpu4
+        run: time npx vitest run --testTimeout 60000
+
   build-sandbox-images:
     runs-on: linux-amd64-cpu4
     timeout-minutes: 15

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,6 +51,36 @@ jobs:
       - name: Verify platform matrix is in sync
         run: python3 scripts/generate-platform-docs.py --check
 
+  benchmark-vitest-ubuntu:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          npm ci --ignore-scripts
+          cd nemoclaw
+          npm ci --ignore-scripts
+
+      - name: Build CLI and plugin
+        run: |
+          npm run build:cli
+          cd nemoclaw
+          npm run build
+
+      - name: Benchmark full Vitest suite on ubuntu-latest
+        run: time npx vitest run --testTimeout 60000
+
   test-e2e-ollama-proxy:
     needs: [checks, changes]
     if: needs.changes.outputs.code == 'true'


### PR DESCRIPTION
## Summary
- add a GitHub-hosted `ubuntu-latest` full Vitest benchmark job to PR CI
- add a self-hosted `linux-amd64-cpu4` full Vitest benchmark job to self-hosted PR CI
- keep both jobs intentionally equivalent: checkout, Node 22, npm ci for root/plugin, build CLI/plugin, then `time npx vitest run --testTimeout 60000`

## Why
We want data before moving broad Vitest ownership out of macOS/WSL E2E workflows. This draft PR lets us compare wall-clock time and job logs between GitHub-hosted Linux and NVIDIA CPU runners.

## Test plan
- CI benchmark jobs are the test.
- Compare elapsed times in the final Vitest step and total job duration.
