### PR TITLE
fix: nemoclaw plugin installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -405,7 +405,7 @@ ENV NPM_CONFIG_OFFLINE=true \
 # this layer is committed; deleting it in a later layer would not reduce the
 # OCI image imported by k3s.
 # hadolint ignore=DL3059,DL4006
-RUN (openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true) \
+RUN openclaw plugins install /opt/nemoclaw --dangerously-force-unsafe-install > /tmp/nemoclaw-plugin-install.log 2>&1 \
     && if [ -d /sandbox/.openclaw/plugin-runtime-deps ]; then \
         find /sandbox/.openclaw/plugin-runtime-deps -type f \( \
             -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o \

--- a/test/e2e-test.sh
+++ b/test/e2e-test.sh
@@ -31,15 +31,10 @@ fi
 # -------------------------------------------------------
 info "2. Verify plugin can be installed"
 # -------------------------------------------------------
-if openclaw plugins install /opt/nemoclaw 2>&1; then
+if openclaw plugins install /opt/nemoclaw --dangerously-force-unsafe-install 2>&1; then
   pass "Plugin installed"
 else
-  # If plugins install isn't available, verify the built artifacts exist
-  if [ -f /opt/nemoclaw/dist/index.js ]; then
-    pass "Plugin built successfully (dist/index.js exists)"
-  else
-    fail "Plugin build artifacts missing"
-  fi
+  fail "Plugin install failed"
 fi
 
 # -------------------------------------------------------

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -601,3 +601,57 @@ describe("sandbox operations E2E harness", () => {
     expect(src).toContain("nemoclaw onboard --resume --non-interactive");
   });
 });
+
+describe("sandbox provisioning: NemoClaw plugin install (#2021)", () => {
+  it("fails the image build if the NemoClaw plugin cannot be installed", () => {
+    const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-plugin-install-fail-"));
+    const localBin = path.join(tmp, "bin");
+    const sandboxRoot = path.join(tmp, "sandbox");
+    const callLog = path.join(tmp, "openclaw.log");
+    const pluginLog = path.join(tmp, "plugin-install.log");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.mkdirSync(sandboxRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(localBin, "openclaw"),
+      [
+        "#!/bin/sh",
+        `printf '%s\n' "$*" > ${JSON.stringify(callLog)}`,
+        "echo plugin install failed >&2",
+        "exit 42",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const command = dockerRunCommandBetween(
+      dockerfile,
+      "# Install NemoClaw plugin into OpenClaw",
+      "# SECURITY: Clear any gateway auth token",
+    )
+      .replaceAll("/tmp/nemoclaw-plugin-install.log", pluginLog)
+      .replaceAll("/sandbox", sandboxRoot);
+
+    try {
+      const result = spawnSync("bash", ["-c", command], {
+        encoding: "utf-8",
+        env: { ...process.env, PATH: `${localBin}:${process.env.PATH ?? ""}` },
+        timeout: 5000,
+      });
+
+      expect(result.status).toBe(42);
+      expect(fs.readFileSync(callLog, "utf-8")).toBe(
+        "plugins install /opt/nemoclaw --dangerously-force-unsafe-install\n",
+      );
+      expect(fs.readFileSync(pluginLog, "utf-8")).toContain("plugin install failed");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the e2e plugin install check strict", () => {
+    const e2e = fs.readFileSync(path.join(ROOT, "test", "e2e-test.sh"), "utf-8");
+    expect(e2e).toContain("openclaw plugins install /opt/nemoclaw --dangerously-force-unsafe-install");
+    expect(e2e).toContain('fail "Plugin install failed"');
+    expect(e2e).not.toContain("Plugin built successfully (dist/index.js exists)");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR fixes NemoClaw sandbox plugin installation by passing `--dangerously-force-unsafe-install` when installing the bundled `/nemoclaw` OpenClaw plugin.

OpenClaw's security scanner blocks the plugin because it uses `child_process`, so the sandbox image must explicitly allow this install and fail the Docker build if the plugin is not installed successfully.

## Related Issue

Fixes #2021

## Changes

- Require `openclaw plugins install /opt/nemoclaw --dangerously-force-unsafe-install` to succeed during the sandbox image build, so the known `child_process` scanner finding is explicit instead of silently blocking the bundled plugin.
- Tighten the e2e smoke test so plugin install failures fail the test instead of passing when `dist/index.js` exists.
- Add sandbox provisioning regression coverage to guard against reintroducing fail-open plugin install behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Test

<img width="2184" height="602" alt="CleanShot 2026-05-18 at 22 43 35@2x" src="https://github.com/user-attachments/assets/35b64ef9-1607-48c1-8917-b673a903304f" />


<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: se7en-agent <se7en.agent.ai@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to enforce strict plugin installation behavior and assert failures are surfaced.
  * Updated E2E verification to require explicit install failure handling (no silent success fallback).

* **Chores**
  * Build now fails when plugin installation errors occur.
  * Plugin installation output is preserved for visibility instead of being discarded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->