### PR TITLE
fix(ci): clarify selective E2E scorecards

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -2332,6 +2332,17 @@ jobs:
             // ── Gather results from the current run's needs context ─
             const needs = ${{ toJSON(needs) }};
             const today = formatDate(new Date());
+            const isDispatch = context.eventName === 'workflow_dispatch';
+            const requestedJobsRaw = isDispatch ? '${{ inputs.jobs }}'.trim() : '';
+            const requestedJobs = requestedJobsRaw
+              ? requestedJobsRaw.split(',').map((name) => name.trim()).filter(Boolean)
+              : [];
+            const isSelectiveDispatch = isDispatch && requestedJobs.length > 0;
+            const runMode = isSelectiveDispatch
+              ? 'Selective dispatch'
+              : isDispatch
+                ? 'Manual full run'
+                : 'Scheduled full nightly';
 
             const entries = Object.entries(needs).filter(([name]) => !EXCLUDED_JOBS.has(name));
             let success = 0;
@@ -2358,45 +2369,49 @@ jobs:
 
             // ── Fetch prior-day run for trend comparison ────────────
             let trendLine = '';
-            try {
-              const WORKFLOW_FILE = 'nightly-e2e.yaml';
-              const now = new Date();
-              const since48h = new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString();
-              const since24h = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+            if (isSelectiveDispatch) {
+              trendLine = 'Trend: ⊘ Not shown for selective dispatches';
+            } else {
+              try {
+                const WORKFLOW_FILE = 'nightly-e2e.yaml';
+                const now = new Date();
+                const since48h = new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString();
+                const since24h = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
 
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: WORKFLOW_FILE,
-                created: `>=${since48h}`,
-                per_page: 50,
-              });
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: WORKFLOW_FILE,
+                  created: `>=${since48h}`,
+                  per_page: 50,
+                });
 
-              // Find completed scheduled runs from 24–48h ago
-              const priorRuns = data.workflow_runs.filter(r =>
-                r.status === 'completed' &&
-                r.event === 'schedule' &&
-                new Date(r.created_at) < new Date(since24h)
-              );
+                // Find completed scheduled runs from 24–48h ago
+                const priorRuns = data.workflow_runs.filter(r =>
+                  r.status === 'completed' &&
+                  r.event === 'schedule' &&
+                  new Date(r.created_at) < new Date(since24h)
+                );
 
-              if (priorRuns.length > 0) {
-                // Check the most recent prior run
-                const priorRun = priorRuns[0];
-                const priorPerfect = priorRun.conclusion === 'success';
-                if (perfect && priorPerfect) {
-                  trendLine = 'Trend: ➡️ Stable (perfect both days)';
-                } else if (perfect && !priorPerfect) {
-                  trendLine = 'Trend: ↗️ Improving (yesterday had failures → today perfect)';
-                } else if (!perfect && priorPerfect) {
-                  trendLine = 'Trend: ↘️ Degrading (yesterday perfect → today has failures)';
+                if (priorRuns.length > 0) {
+                  // Check the most recent prior run
+                  const priorRun = priorRuns[0];
+                  const priorPerfect = priorRun.conclusion === 'success';
+                  if (perfect && priorPerfect) {
+                    trendLine = 'Trend: ➡️ Stable (perfect both days)';
+                  } else if (perfect && !priorPerfect) {
+                    trendLine = 'Trend: ↗️ Improving (yesterday had failures → today perfect)';
+                  } else if (!perfect && priorPerfect) {
+                    trendLine = 'Trend: ↘️ Degrading (yesterday perfect → today has failures)';
+                  } else {
+                    trendLine = 'Trend: ➡️ Stable (failures both days)';
+                  }
                 } else {
-                  trendLine = 'Trend: ➡️ Stable (failures both days)';
+                  trendLine = 'Trend: ⊘ No prior-day data for comparison';
                 }
-              } else {
-                trendLine = 'Trend: ⊘ No prior-day data for comparison';
+              } catch (e) {
+                trendLine = `Trend: ⊘ Could not fetch prior-day data (${e.message})`;
               }
-            } catch (e) {
-              trendLine = `Trend: ⊘ Could not fetch prior-day data (${e.message})`;
             }
 
             // ── Build scorecard ─────────────────────────────────────
@@ -2404,12 +2419,20 @@ jobs:
             const lines = [
               `## 🌅 NemoClaw Nightly Scorecard — ${today}`,
               '',
+              `**Run mode:** ${runMode}`,
+            ];
+
+            if (isSelectiveDispatch) {
+              lines.push(`**Requested jobs:** ${requestedJobs.map((name) => `\`${name}\``).join(', ')}`);
+            }
+
+            lines.push(
               `**Jobs run:** ${ran} of ${total}`,
               `  ✅ ${success} passed`,
               `  ❌ ${failure} failed`,
               `  ⊘  ${cancelled} cancelled`,
               `  ⏭️  ${skipped} skipped`,
-            ];
+            );
 
             if (failedJobs.length > 0) {
               lines.push('');


### PR DESCRIPTION
## Summary
- label nightly scorecards as scheduled full nightly, manual full run, or selective dispatch
- include requested job names for selective E2E advisor/manual dispatches
- suppress prior-day trend wording for selective dispatches where it is misleading

## Validation
- git diff --check
- npm test -- test/validate-e2e-coverage.test.ts *(fails locally: vitest not installed after pnpm attempted install and hit ERR_PNPM_IGNORED_BUILDS)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Nightly E2E reporting enhanced: scorecards now show run mode, include requested-jobs for selective dispatch, and adjust trend reporting for selective/manual vs scheduled runs.

* **Chores**
  * Streamlined guidance for maintaining E2E coverage and updating aggregate reporting lists.

* **Tests**
  * Validation tests refocused to check selective-dispatch guards and that aggregate reporting jobs depend on all nightly E2E jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->