### PR TITLE
ci: move broad Vitest ownership to Linux PR job

### DIFF
--- a/.github/workflows/macos-e2e.yaml
+++ b/.github/workflows/macos-e2e.yaml
@@ -70,9 +70,6 @@ jobs:
           npm ci --ignore-scripts
           npm run build
 
-      - name: Run vitest suite
-        run: npx vitest run --testTimeout 60000
-
       - name: Detect Docker availability
         id: docker
         run: |
@@ -100,7 +97,7 @@ jobs:
         if: steps.docker.outputs.docker_ok != 'true'
         run: |
           echo 'Skipping macOS full E2E because Docker is unavailable on this runner.'
-          echo 'The workflow still validated the NemoClaw build and vitest suite on macOS (Apple Silicon).'
+          echo 'The workflow still validated the NemoClaw build on macOS (Apple Silicon).'
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/platform-vitest-main.yaml
+++ b/.github/workflows/platform-vitest-main.yaml
@@ -1,40 +1,70 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: E2E / WSL
+name: CI / Platform Vitest Main Watch
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "bin/**"
-      - "nemoclaw/**"
-      - "scripts/**"
-      - "test/**"
-      - ".github/workflows/wsl-e2e.yaml"
-      - "package.json"
-      - "vitest.config.ts"
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/workflows/docs-preview-*.yaml"
+      - "ISSUE_TEMPLATE/**"
+      - ".github/ISSUE_TEMPLATE/**"
 
 permissions:
   contents: read
 
 concurrency:
-  group: wsl-e2e-${{ github.ref }}
+  group: platform-vitest-main-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  wsl-e2e:
+  macos-vitest:
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Show environment
+        run: |
+          set -euo pipefail
+          echo "Runner: $(uname -a)"
+          echo "Arch:   $(uname -m)"
+          sw_vers
+          node --version
+          npm --version
+
+      - name: Install dependencies
+        run: |
+          npm ci --ignore-scripts
+          cd nemoclaw
+          npm ci --ignore-scripts
+
+      - name: Build CLI and plugin
+        run: |
+          npm run build:cli
+          cd nemoclaw
+          npm run build
+
+      - name: Run full Vitest suite on macOS
+        run: npx vitest run --testTimeout 60000
+
+  wsl-vitest:
     runs-on: windows-latest
-    timeout-minutes: 90
+    timeout-minutes: 45
     env:
       WSL_DISTRO: Ubuntu
-      NEMOCLAW_NON_INTERACTIVE: "1"
-      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
-      NEMOCLAW_RECREATE_SANDBOX: "1"
-      NEMOCLAW_SANDBOX_NAME: "e2e-wsl"
     steps:
       - name: Force LF line endings for checkout
         shell: powershell
@@ -50,7 +80,7 @@ jobs:
           $drive = $winPath.Substring(0,1).ToLower()
           $rest = $winPath.Substring(2).Replace('\','/')
           $wslCheckoutPath = "/mnt/$drive$rest"
-          $wslWorkdir = "/tmp/nemoclaw-wsl-workdir/${env:GITHUB_RUN_ID}-${env:GITHUB_RUN_ATTEMPT}"
+          $wslWorkdir = "/tmp/nemoclaw-wsl-vitest/${env:GITHUB_RUN_ID}-${env:GITHUB_RUN_ATTEMPT}"
           "WSL_CHECKOUT_DIR=$wslCheckoutPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "WSL_WORKDIR=$wslWorkdir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "WSL_CHECKOUT_DIR=$wslCheckoutPath"
@@ -60,7 +90,6 @@ jobs:
         shell: powershell
         run: |
           wsl --list --verbose 2>&1 | Out-Default
-          # Native commands do not throw in PowerShell; check LASTEXITCODE.
           $null = wsl -d $env:WSL_DISTRO -- echo ok 2>&1
           if ($LASTEXITCODE -ne 0) {
             $maxAttempts = 3
@@ -70,51 +99,33 @@ jobs:
               wsl --install -d $env:WSL_DISTRO --no-launch --web-download
               $installExitCode = $LASTEXITCODE
               if ($installExitCode -eq 0) {
-                # The first launch initialises the distro with the default root user.
                 wsl -d $env:WSL_DISTRO -- bash -c 'echo distro initialised'
-                $launchExitCode = $LASTEXITCODE
-                if ($launchExitCode -eq 0) {
+                if ($LASTEXITCODE -eq 0) {
                   $installed = $true
                   break
                 }
-                Write-Warning "distro first-launch failed with exit code $launchExitCode"
-              } else {
-                Write-Warning "wsl --install failed with exit code $installExitCode"
               }
 
-              # Some WSL installs return a non-zero code after registering a usable distro.
               $null = wsl -d $env:WSL_DISTRO -- echo ok 2>&1
               if ($LASTEXITCODE -eq 0) {
-                Write-Host 'Ubuntu became available after the install command returned non-zero'
                 $installed = $true
                 break
               }
 
               if ($attempt -lt $maxAttempts) {
-                Write-Host 'Cleaning up any partial WSL registration before retrying'
                 $null = wsl --unregister $env:WSL_DISTRO 2>&1
-                $delaySeconds = [Math]::Min(60, 20 * $attempt)
-                Write-Host "Retrying WSL install in $delaySeconds seconds..."
-                Start-Sleep -Seconds $delaySeconds
+                Start-Sleep -Seconds ([Math]::Min(60, 20 * $attempt))
               }
             }
 
             if (-not $installed) {
               throw ("failed to install and initialize $env:WSL_DISTRO after $maxAttempts attempts")
             }
-          } else {
-            Write-Host 'Ubuntu already available'
           }
           wsl --set-default $env:WSL_DISTRO
           if ($LASTEXITCODE -ne 0) {
             throw ('wsl --set-default failed with exit code ' + $LASTEXITCODE)
           }
-
-      - name: Verify WSL
-        shell: powershell
-        run: |
-          wsl -d $env:WSL_DISTRO -- bash -lc "uname -a"
-          wsl -d $env:WSL_DISTRO -- bash -lc "cat /etc/os-release"
 
       - name: Install Ubuntu dependencies
         shell: powershell
@@ -157,14 +168,6 @@ jobs:
           $workdirParent = $workdir.Substring(0, $workdir.LastIndexOf('/'))
           $script = @"
           set -euo pipefail
-          echo 'Syncing checkout from $checkout to $workdir'
-          if [ ! -d '$checkout/.git' ]; then
-            echo 'Expected a Git checkout at $checkout' >&2
-            exit 1
-          fi
-          # Keep npm and test I/O on WSL's ext4 VHD. Running directly from
-          # /mnt/<drive> (DrvFS) is slower and has Windows-style permission
-          # semantics that hide Linux permission regressions.
           rm -rf '$workdir'
           mkdir -p '$workdirParent'
           rsync -a --no-owner --no-group --delete \
@@ -175,24 +178,22 @@ jobs:
           git config --global --add safe.directory '$workdir'
           git -C '$workdir' reset --hard HEAD
           git -C '$workdir' clean -ffdx
-          git -C '$workdir' status --short
-          echo 'WSL ext4 workspace ready at $workdir'
           "@
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
           wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
 
-      - name: Install project dependencies and build plugin
+      - name: Install dependencies and build in WSL
         shell: powershell
         run: |
           $script = @"
           set -euo pipefail
           cd '$env:WSL_WORKDIR'
-          npm install --ignore-scripts
+          npm ci --ignore-scripts
           npm run build:cli
           cd nemoclaw
-          npm install --ignore-scripts
+          npm ci --ignore-scripts
           npm run build
           "@
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
@@ -200,64 +201,17 @@ jobs:
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
           wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
 
-      - name: Detect Docker availability in WSL
-        id: docker
+      - name: Run full Vitest suite in WSL
         shell: powershell
-        run: |
-          $script = @'
-          if docker info >/dev/null 2>&1; then
-            echo DOCKER_OK=1
-          else
-            echo DOCKER_OK=0
-          fi
-          '@
-          $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
-          [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
-          $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
-          $result = wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
-          if ($result -match 'DOCKER_OK=1') {
-            'docker_ok=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host 'Docker is available in WSL'
-          } else {
-            'docker_ok=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host 'Docker is not available in WSL; full E2E will be skipped'
-          }
-
-      - name: Run WSL full E2E
-        if: steps.docker.outputs.docker_ok == 'true'
-        shell: powershell
-        env:
-          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           $script = @"
           set -euo pipefail
           cd '$env:WSL_WORKDIR'
-          export NVIDIA_API_KEY='$env:NVIDIA_API_KEY'
-          export GITHUB_TOKEN='$env:GITHUB_TOKEN'
-          export NEMOCLAW_NON_INTERACTIVE='$env:NEMOCLAW_NON_INTERACTIVE'
-          export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE='$env:NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE'
-          export NEMOCLAW_RECREATE_SANDBOX='$env:NEMOCLAW_RECREATE_SANDBOX'
-          export NEMOCLAW_SANDBOX_NAME='$env:NEMOCLAW_SANDBOX_NAME'
-          bash test/e2e/test-full-e2e.sh
+          export NEMOCLAW_EXEC_TIMEOUT=60000
+          export NEMOCLAW_TEST_TIMEOUT=60000
+          npx vitest run --testTimeout 60000
           "@
           $tmp = "$env:RUNNER_TEMP\wsl-step.sh"
           [IO.File]::WriteAllText($tmp, ($script -replace "`r",""), (New-Object System.Text.UTF8Encoding $false))
           $wslTmp = wsl -d $env:WSL_DISTRO -- wslpath -u ($tmp -replace '\\','/')
           wsl -d $env:WSL_DISTRO -- bash -l $wslTmp
-
-      - name: Explain skipped full E2E
-        if: steps.docker.outputs.docker_ok != 'true'
-        shell: powershell
-        run: |
-          Write-Host 'Skipping WSL full E2E because Docker is unavailable on this runner.'
-          Write-Host 'The workflow still validated the NemoClaw build flow inside Ubuntu WSL.'
-
-      - name: Upload install log on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: wsl-e2e-install-log
-          path: |
-            C:\Users\runneradmin\AppData\Local\Temp\nemoclaw-e2e-install.log
-          if-no-files-found: ignore

--- a/.github/workflows/pr-self-hosted.yaml
+++ b/.github/workflows/pr-self-hosted.yaml
@@ -36,6 +36,34 @@ jobs:
       - id: get-pr-info
         uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
 
+  unit-vitest-linux:
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          npm ci --ignore-scripts
+          cd nemoclaw
+          npm ci --ignore-scripts
+
+      - name: Build CLI and plugin
+        run: |
+          npm run build:cli
+          cd nemoclaw
+          npm run build
+
+      - name: Run full Vitest suite
+        run: npx vitest run --testTimeout 60000
+
   build-sandbox-images:
     runs-on: linux-amd64-cpu4
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- move broad `npx vitest run --testTimeout 60000` out of the macOS and WSL PR E2E workflows
- add an explicit `unit-vitest-linux` job on `linux-amd64-cpu4` in the self-hosted PR flow
- add a separate main-branch watch workflow that continues running the full Vitest suite on macOS and WSL after merge, plus manual dispatch

## Why
The macOS/WSL workflows are named E2E, but Docker-backed E2E is usually skipped there, so their dominant behavior has been platform setup plus the full Vitest suite. That makes generic unit/integration failures appear as platform/E2E failures.

Recent PR history showed no paired cases where macOS failed while WSL succeeded, or WSL failed while macOS succeeded. The only asymmetric cases found were macOS failures where WSL was cancelled, which does not prove platform-specific test divergence.

A benchmark PR showed the full Vitest suite is fastest on the NVIDIA CPU runner:

| Runner | Full Vitest step |
| --- | ---: |
| `linux-amd64-cpu4` | 2m24.793s |
| `ubuntu-latest` | 2m59.391s |
| macOS PR workflow | ~4m41s |
| WSL PR workflow | ~5m19s-5m21s |

This keeps broad Vitest coverage on every trusted PR while reducing duplicate platform execution and preserving macOS/WSL signal on main while we watch for platform-only failures.

## Test plan
- Validated workflow YAML parses locally.
- CI on this PR should run the new Linux Vitest job in the self-hosted PR flow once mirrored.
- After merge, `CI / Platform Vitest Main Watch` will continue monitoring full Vitest on macOS and WSL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Reorganized CI/CD test workflows to separate unit tests from E2E tests.
* Added dedicated test workflows for macOS and WSL platforms.
* Simplified E2E workflow configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->