### PR TITLE
feat(plugin): request network access through policy local

### DIFF
--- a/docs/reference/nemoclaw-openshell-integration.md
+++ b/docs/reference/nemoclaw-openshell-integration.md
@@ -1,0 +1,72 @@
+# NemoClaw OpenShell Integration
+
+```mermaid
+flowchart LR
+  user["User"] --> agent["Agent runtime"]
+  agent --> adapter["NemoClaw agent adapter"]
+
+  subgraph adapters["Current adapters"]
+    openclaw["OpenClaw plugin"]
+    hermes["Hermes plugin"]
+  end
+
+  subgraph plugin_tools["NemoClaw access tools"]
+    list["list_resource_access_presets"]
+    request["request_resource_access"]
+    check["check_resource_access"]
+  end
+
+  adapter --> adapters
+  adapters --> plugin_tools
+  onboard["nemoclaw onboard"] --> profile_import["Import NemoClaw provider profiles"]
+  profile_import --> profiles["OpenShell provider profiles"]
+  list --> profiles
+  profiles --> presets["Provider-backed access presets"]
+  presets --> request
+
+  request --> policy_local["policy.local HTTP API"]
+  check --> policy_local
+
+  subgraph sandbox["OpenShell sandbox"]
+    policy_local
+    proxy["Sandbox HTTP proxy"]
+    policy_runtime["Sandbox policy runtime"]
+  end
+
+  policy_local --> proposals["OpenShell policy proposals"]
+  proposals --> review["Operator review"]
+  review --> approve["Approve or reject"]
+  approve --> merge["Policy merge and reload"]
+  merge --> policy_runtime
+  policy_runtime --> check
+
+  agent --> workload["Requested agent work"]
+  workload --> proxy
+  proxy --> policy_runtime
+  policy_runtime --> external["Approved external resources"]
+```
+
+## Flow
+
+1. The agent asks NemoClaw for allowed resource presets with `list_resource_access_presets`.
+2. During onboarding, NemoClaw imports its provider profiles into OpenShell for package registries, messaging platforms, Brave Search, Jira, Hugging Face, and local inference.
+3. NemoClaw builds the agent-visible preset list from OpenShell provider profiles, with built-in presets as fallback coverage for older OpenShell versions.
+4. The agent calls `request_resource_access` with a preset, access mode, reason, and optional wait timeout.
+5. NemoClaw submits a least-privilege proposal to `policy.local`.
+6. OpenShell surfaces the proposal for operator review.
+7. After approval, OpenShell merges and reloads the sandbox policy.
+8. The agent calls `check_resource_access`; NemoClaw reports `applied` only after OpenShell reports the policy reload is complete.
+
+## Agent Tools
+
+- `list_resource_access_presets`: discovers provider-backed preset ids.
+- `request_resource_access`: submits a network access proposal through OpenShell.
+- `check_resource_access`: polls an existing proposal until it is pending, denied, failed, or applied.
+
+## Adapter Contract
+
+Each agent adapter exposes the same tool names and response shape through the harness-native mechanism. OpenClaw uses its plugin API. Hermes uses its Python plugin API. Additional harnesses can implement the same contract without changing the OpenShell policy proposal flow.
+
+## Provider Profiles
+
+NemoClaw imports OpenShell provider profiles for its policy presets during onboarding. Existing OpenShell profiles are left untouched, and already-imported NemoClaw profiles are skipped so repeated onboarding remains idempotent. If the OpenShell gateway does not support provider-profile import, NemoClaw continues with local fallback presets.

--- a/nemoclaw-blueprint/provider-profiles/brave.yaml
+++ b/nemoclaw-blueprint/provider-profiles/brave.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: brave
+display_name: Brave Search
+description: Brave Search API access
+category: knowledge
+endpoints:
+  - host: api.search.brave.com
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+binaries:
+  - /usr/local/bin/node
+  - /usr/bin/node
+  - /usr/bin/curl

--- a/nemoclaw-blueprint/provider-profiles/brew.yaml
+++ b/nemoclaw-blueprint/provider-profiles/brew.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: brew
+display_name: Homebrew
+description: Homebrew (Linuxbrew) package manager access
+category: data
+endpoints:
+  - host: formulae.brew.sh
+    port: 443
+    access: full
+    tls: skip
+  - host: github.com
+    port: 443
+    access: full
+    tls: skip
+  - host: ghcr.io
+    port: 443
+    access: full
+    tls: skip
+  - host: pkg-containers.githubusercontent.com
+    port: 443
+    access: full
+    tls: skip
+  - host: objects.githubusercontent.com
+    port: 443
+    access: full
+    tls: skip
+  - host: raw.githubusercontent.com
+    port: 443
+    access: full
+    tls: skip
+binaries:
+  - /usr/bin/curl
+  - /usr/bin/git
+  - /home/linuxbrew/.linuxbrew/bin/brew
+  - /home/linuxbrew/.linuxbrew/bin/*
+  - /home/linuxbrew/.linuxbrew/Homebrew/bin/*

--- a/nemoclaw-blueprint/provider-profiles/discord.yaml
+++ b/nemoclaw-blueprint/provider-profiles/discord.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: discord
+display_name: Discord
+description: Discord API, gateway, and CDN access
+category: messaging
+endpoints:
+  - host: discord.com
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+      - allow: { method: PUT, path: "/**" }
+      - allow: { method: PATCH, path: "/**" }
+      - allow: { method: DELETE, path: "/api/v*/channels/*/messages/*" }
+      - allow: { method: DELETE, path: "/api/v*/channels/*/messages/*/reactions/*/*" }
+  - host: gateway.discord.gg
+    port: 443
+    protocol: websocket
+    enforcement: enforce
+    websocket_credential_rewrite: true
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: WEBSOCKET_TEXT, path: "/**" }
+  - host: cdn.discordapp.com
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+  - host: media.discordapp.net
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+binaries:
+  - /usr/local/bin/node
+  - /usr/bin/node

--- a/nemoclaw-blueprint/provider-profiles/huggingface.yaml
+++ b/nemoclaw-blueprint/provider-profiles/huggingface.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: huggingface
+display_name: Hugging Face
+description: Hugging Face Hub, LFS, and Inference API access
+category: knowledge
+endpoints:
+  - host: huggingface.co
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+  - host: cdn-lfs.huggingface.co
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+  - host: router.huggingface.co
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+binaries:
+  - /usr/local/bin/python3
+  - /usr/local/bin/node

--- a/nemoclaw-blueprint/provider-profiles/jira.yaml
+++ b/nemoclaw-blueprint/provider-profiles/jira.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: jira
+display_name: Jira
+description: Jira and Atlassian Cloud access
+category: data
+endpoints:
+  - host: "*.atlassian.net"
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+  - host: auth.atlassian.com
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+  - host: api.atlassian.com
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+binaries:
+  - /usr/local/bin/node

--- a/nemoclaw-blueprint/provider-profiles/local-inference.yaml
+++ b/nemoclaw-blueprint/provider-profiles/local-inference.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: local-inference
+display_name: Local Inference
+description: Local inference access (Ollama, vLLM) via host gateway
+category: inference
+endpoints:
+  - host: host.openshell.internal
+    port: 11434
+    protocol: rest
+    enforcement: enforce
+    allowed_ips:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+  - host: host.openshell.internal
+    port: 11435
+    protocol: rest
+    enforcement: enforce
+    allowed_ips:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+  - host: host.openshell.internal
+    port: 8000
+    protocol: rest
+    enforcement: enforce
+    allowed_ips:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+binaries:
+  - /usr/local/bin/openclaw
+  - /usr/local/bin/node
+  - /usr/bin/node
+  - /usr/bin/curl
+  - /usr/bin/python3

--- a/nemoclaw-blueprint/provider-profiles/npm.yaml
+++ b/nemoclaw-blueprint/provider-profiles/npm.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: npm
+display_name: npm
+description: npm and Yarn registry access
+category: data
+endpoints:
+  - host: registry.npmjs.org
+    port: 443
+    access: full
+    tls: skip
+  - host: registry.yarnpkg.com
+    port: 443
+    access: full
+    tls: skip
+binaries:
+  - /usr/local/bin/npm*
+  - /usr/local/bin/npx*
+  - /usr/local/bin/node*
+  - /usr/local/bin/yarn*
+  - /usr/bin/npm*
+  - /usr/bin/node*

--- a/nemoclaw-blueprint/provider-profiles/pypi.yaml
+++ b/nemoclaw-blueprint/provider-profiles/pypi.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: pypi
+display_name: PyPI
+description: Python Package Index (PyPI) access
+category: data
+endpoints:
+  - host: pypi.org
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: HEAD, path: "/**" }
+  - host: files.pythonhosted.org
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: HEAD, path: "/**" }
+binaries:
+  - /usr/bin/python3*
+  - /usr/bin/pip*
+  - /usr/local/bin/python3*
+  - /usr/local/bin/pip*
+  - /sandbox/.venv/bin/python*
+  - /sandbox/.venv/bin/pip*
+  - /sandbox/.uv/python/**/python*
+  - /sandbox/.local/bin/pip*

--- a/nemoclaw-blueprint/provider-profiles/slack.yaml
+++ b/nemoclaw-blueprint/provider-profiles/slack.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: slack
+display_name: Slack
+description: Slack API, Socket Mode, and webhooks access
+category: messaging
+endpoints:
+  - host: slack.com
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    request_body_credential_rewrite: true
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+  - host: api.slack.com
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    request_body_credential_rewrite: true
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+  - host: hooks.slack.com
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    request_body_credential_rewrite: true
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: POST, path: "/**" }
+  - host: wss-primary.slack.com
+    port: 443
+    protocol: websocket
+    enforcement: enforce
+    websocket_credential_rewrite: true
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: WEBSOCKET_TEXT, path: "/**" }
+  - host: wss-backup.slack.com
+    port: 443
+    protocol: websocket
+    enforcement: enforce
+    websocket_credential_rewrite: true
+    rules:
+      - allow: { method: GET, path: "/**" }
+      - allow: { method: WEBSOCKET_TEXT, path: "/**" }
+binaries:
+  - /usr/local/bin/node
+  - /usr/bin/node

--- a/nemoclaw-blueprint/provider-profiles/telegram.yaml
+++ b/nemoclaw-blueprint/provider-profiles/telegram.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: telegram
+display_name: Telegram
+description: Telegram Bot API access
+category: messaging
+endpoints:
+  - host: api.telegram.org
+    port: 443
+    protocol: rest
+    enforcement: enforce
+    rules:
+      - allow: { method: GET, path: "/bot*/**" }
+      - allow: { method: POST, path: "/bot*/**" }
+      - allow: { method: GET, path: "/file/bot*/**" }
+binaries:
+  - /usr/local/bin/node
+  - /usr/bin/node

--- a/nemoclaw/src/access-client.test.ts
+++ b/nemoclaw/src/access-client.test.ts
@@ -1,11 +1,45 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { createAccessRequest, listAccessPresets } from "./access-client.js";
+import {
+  clearAccessPresetCache,
+  createAccessRequest,
+  getAccessRequest,
+  listAccessPresets,
+} from "./access-client.js";
+
+function withServer(
+  handler: http.RequestListener,
+  fn: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(handler);
+    server.listen(0, "127.0.0.1", async () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("test server did not bind to a TCP port"));
+        return;
+      }
+      try {
+        await fn(`http://127.0.0.1:${address.port}`);
+        server.close((err) => (err ? reject(err) : resolve()));
+      } catch (err) {
+        server.close(() => reject(err));
+      }
+    });
+  });
+}
 
 describe("access client", () => {
+  afterEach(() => {
+    delete process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON;
+    clearAccessPresetCache();
+  });
+
   it("rejects non-HTTP policy.local URLs", () => {
     expect(() =>
       createAccessRequest(
@@ -32,5 +66,132 @@ describe("access client", () => {
         expect.objectContaining({ name: "outlook", provider_profile: "outlook" }),
       ]),
     });
+  });
+
+  it("adds dynamic OpenShell provider profiles to the access preset list", async () => {
+    process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON = JSON.stringify({
+      profiles: [
+        {
+          id: "gitlab",
+          display_name: "GitLab",
+          description: "GitLab API and Git operations",
+          endpoints: [{ host: "gitlab.com", port: 443, protocol: "rest" }],
+          binaries: ["/usr/bin/git"],
+        },
+        {
+          id: "empty-provider",
+          display_name: "Empty",
+          endpoints: [],
+        },
+      ],
+    });
+
+    await expect(listAccessPresets()).resolves.toMatchObject({
+      presets: expect.arrayContaining([
+        expect.objectContaining({
+          name: "gitlab",
+          description: "GitLab API and Git operations",
+          provider_profile: "gitlab",
+        }),
+      ]),
+    });
+    const response = await listAccessPresets();
+    expect(response.presets.some((preset) => preset.name === "empty-provider")).toBe(false);
+  });
+
+  it("submits provider-profile-backed proposals", async () => {
+    process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON = JSON.stringify([
+      {
+        id: "gitlab",
+        description: "GitLab access",
+        endpoints: [
+          {
+            host: "gitlab.com",
+            port: 443,
+            protocol: "rest",
+            enforcement: "enforce",
+          },
+        ],
+        binaries: ["/usr/bin/git"],
+      },
+    ]);
+
+    let captured = "";
+    await withServer(
+      (req, res) => {
+        req.setEncoding("utf8");
+        req.on("data", (chunk) => {
+          captured += chunk;
+        });
+        req.on("end", () => {
+          res.writeHead(202, { "content-type": "application/json" });
+          res.end(JSON.stringify({ accepted_chunk_ids: ["chunk_gitlab"] }));
+        });
+      },
+      async (baseUrl) => {
+        await expect(
+          createAccessRequest(
+            {
+              version: "nemoclaw.access.v1",
+              user_intent: "Inspect merge requests",
+              llm_proposal: {
+                resource_type: "network",
+                preset: "gitlab",
+                access: "read",
+                duration: "session",
+                reason: "Need GitLab API metadata.",
+              },
+            },
+            { policyLocalUrl: baseUrl },
+          ),
+        ).resolves.toMatchObject({ request_id: "chunk_gitlab", status: "pending_approval" });
+      },
+    );
+
+    const body = JSON.parse(captured);
+    expect(body.operations[0].addRule.ruleName).toBe("gitlab");
+    expect(body.operations[0].addRule.rule).toMatchObject({
+      name: "gitlab",
+      endpoints: [
+        {
+          host: "gitlab.com",
+          port: 443,
+          protocol: "rest",
+          enforcement: "enforce",
+        },
+      ],
+      binaries: [{ path: "/usr/bin/git" }],
+    });
+    expect(body.operations[0].addRule.rule.endpoints[0].rules).toEqual([
+      { allow: { method: "GET", path: "/**" } },
+      { allow: { method: "HEAD", path: "/**" } },
+    ]);
+  });
+
+  it("does not report approved requests as applied until policy reloads", async () => {
+    await withServer(
+      (_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            chunk_id: "chunk_wait",
+            status: "approved",
+            policy_reloaded: false,
+          }),
+        );
+      },
+      async (baseUrl) => {
+        await expect(getAccessRequest("chunk_wait", { policyLocalUrl: baseUrl })).resolves.toEqual({
+          request_id: "chunk_wait",
+          status: "pending_approval",
+          message: undefined,
+          canonical_request: {
+            chunk_id: "chunk_wait",
+            status: "approved",
+            policy_reloaded: false,
+          },
+        });
+      },
+    );
   });
 });

--- a/nemoclaw/src/access-client.test.ts
+++ b/nemoclaw/src/access-client.test.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { createAccessRequest, listAccessPresets } from "./access-client.js";
+
+describe("access client", () => {
+  it("rejects non-HTTP policy.local URLs", () => {
+    expect(() =>
+      createAccessRequest(
+        {
+          version: "nemoclaw.access.v1",
+          user_intent: "Need GitHub",
+          llm_proposal: {
+            resource_type: "network",
+            preset: "github",
+            access: "read",
+            duration: "session",
+            reason: "Inspect a repository.",
+          },
+        },
+        { policyLocalUrl: "https://policy.local" },
+      ),
+    ).toThrow(/must use HTTP inside the sandbox/);
+  });
+
+  it("lists OpenShell-backed provider presets", async () => {
+    await expect(listAccessPresets()).resolves.toMatchObject({
+      presets: expect.arrayContaining([
+        expect.objectContaining({ name: "github", provider_profile: "github" }),
+        expect.objectContaining({ name: "outlook", provider_profile: "outlook" }),
+      ]),
+    });
+  });
+});

--- a/nemoclaw/src/access-client.ts
+++ b/nemoclaw/src/access-client.ts
@@ -1,0 +1,465 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import http from "node:http";
+
+export type AccessStatus = "pending_approval" | "applied" | "denied" | "failed";
+
+export type AccessCanonicalRequest = {
+  [key: string]: unknown;
+};
+
+export interface AccessRequestResponse {
+  request_id: string;
+  status: AccessStatus;
+  message?: string;
+  canonical_request?: AccessCanonicalRequest;
+}
+
+export interface AccessPresetInfo {
+  name: string;
+  description: string;
+  provider_profile?: string;
+}
+
+export interface AccessPresetsResponse {
+  presets: AccessPresetInfo[];
+}
+
+export interface CreateAccessRequestBody {
+  version: "nemoclaw.access.v1";
+  task_id?: string;
+  user_intent: string;
+  llm_proposal: {
+    resource_type: "network";
+    preset: string;
+    access: "read" | "read_write";
+    duration: "session" | "persistent";
+    reason: string;
+  };
+}
+
+export interface AccessClientOptions {
+  policyLocalUrl?: string;
+  timeoutMs?: number;
+}
+
+type L7Rule = {
+  allow: {
+    method: string;
+    path: string;
+  };
+};
+
+type NetworkEndpoint = {
+  host: string;
+  port: number;
+  protocol?: string;
+  enforcement?: string;
+  access?: string;
+  tls?: string;
+  rules?: L7Rule[];
+};
+
+type NetworkRule = {
+  name: string;
+  endpoints: NetworkEndpoint[];
+  binaries: Array<{ path: string }>;
+};
+
+type AccessPreset = AccessPresetInfo & {
+  rule: NetworkRule;
+};
+
+const NODE_BINARIES = [{ path: "/usr/local/bin/node" }, { path: "/usr/bin/node" }];
+const READ_METHODS = ["GET", "HEAD"];
+const READ_WRITE_METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"];
+
+const PRESETS: AccessPreset[] = [
+  {
+    name: "github",
+    description: "GitHub.com and GitHub API access (git)",
+    provider_profile: "github",
+    rule: {
+      name: "github",
+      endpoints: [
+        { host: "github.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "api.github.com", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: [{ path: "/usr/bin/git" }],
+    },
+  },
+  {
+    name: "outlook",
+    description: "Microsoft Outlook and Graph API access",
+    provider_profile: "outlook",
+    rule: {
+      name: "outlook_graph",
+      endpoints: [
+        { host: "graph.microsoft.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "login.microsoftonline.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "outlook.office365.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "outlook.office.com", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: [{ path: "/usr/local/bin/node" }],
+    },
+  },
+  {
+    name: "pypi",
+    description: "Python Package Index (PyPI) access",
+    rule: {
+      name: "pypi",
+      endpoints: [
+        { host: "pypi.org", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "files.pythonhosted.org", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: [
+        { path: "/usr/bin/python3*" },
+        { path: "/usr/bin/pip*" },
+        { path: "/usr/local/bin/python3*" },
+        { path: "/usr/local/bin/pip*" },
+        { path: "/sandbox/.venv/bin/python*" },
+        { path: "/sandbox/.venv/bin/pip*" },
+      ],
+    },
+  },
+  {
+    name: "npm",
+    description: "npm and Yarn registry access",
+    rule: {
+      name: "npm_yarn",
+      endpoints: [
+        { host: "registry.npmjs.org", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "registry.yarnpkg.com", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: [
+        { path: "/usr/local/bin/npm*" },
+        { path: "/usr/local/bin/npx*" },
+        { path: "/usr/local/bin/node*" },
+        { path: "/usr/local/bin/yarn*" },
+        { path: "/usr/bin/npm*" },
+        { path: "/usr/bin/node*" },
+      ],
+    },
+  },
+  {
+    name: "brave",
+    description: "Brave Search API access",
+    rule: {
+      name: "brave",
+      endpoints: [
+        { host: "api.search.brave.com", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: [...NODE_BINARIES, { path: "/usr/bin/curl" }],
+    },
+  },
+  {
+    name: "local-inference",
+    description: "Local inference access via host gateway",
+    rule: {
+      name: "local_inference",
+      endpoints: [
+        { host: "host.openshell.internal", port: 11434, protocol: "rest", enforcement: "enforce" },
+        { host: "host.openshell.internal", port: 11435, protocol: "rest", enforcement: "enforce" },
+        { host: "host.openshell.internal", port: 8000, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: [
+        { path: "/usr/local/bin/openclaw" },
+        { path: "/usr/local/bin/claude" },
+        { path: "/usr/local/bin/node" },
+        { path: "/usr/bin/node" },
+        { path: "/usr/bin/curl" },
+        { path: "/usr/bin/python3" },
+      ],
+    },
+  },
+  {
+    name: "jira",
+    description: "Jira and Atlassian Cloud access",
+    rule: {
+      name: "atlassian",
+      endpoints: [
+        { host: "*.atlassian.net", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "auth.atlassian.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "api.atlassian.com", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: [{ path: "/usr/local/bin/node" }],
+    },
+  },
+  {
+    name: "slack",
+    description: "Slack API, Socket Mode, and webhooks access",
+    rule: {
+      name: "slack",
+      endpoints: [
+        { host: "slack.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "api.slack.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "hooks.slack.com", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: NODE_BINARIES,
+    },
+  },
+  {
+    name: "discord",
+    description: "Discord API, gateway, and CDN access",
+    rule: {
+      name: "discord",
+      endpoints: [
+        { host: "discord.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "cdn.discordapp.com", port: 443, protocol: "rest", enforcement: "enforce" },
+        { host: "media.discordapp.net", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: NODE_BINARIES,
+    },
+  },
+  {
+    name: "telegram",
+    description: "Telegram Bot API access",
+    rule: {
+      name: "telegram_bot",
+      endpoints: [
+        { host: "api.telegram.org", port: 443, protocol: "rest", enforcement: "enforce" },
+      ],
+      binaries: NODE_BINARIES,
+    },
+  },
+];
+
+function normalizePresetName(resource: string): string {
+  const normalized = resource.trim().toLowerCase();
+  const host = (() => {
+    if (!normalized.includes("://")) {
+      return normalized;
+    }
+    try {
+      return new URL(normalized).hostname.toLowerCase();
+    } catch {
+      return normalized;
+    }
+  })();
+  if (host === "github.com" || host === "api.github.com") {
+    return "github";
+  }
+  return host;
+}
+
+function rulesForAccess(access: "read" | "read_write"): L7Rule[] {
+  const methods = access === "read_write" ? READ_WRITE_METHODS : READ_METHODS;
+  return methods.map((method) => ({ allow: { method, path: "/**" } }));
+}
+
+function ruleForRequest(body: CreateAccessRequestBody): NetworkRule {
+  const presetName = normalizePresetName(body.llm_proposal.preset);
+  const preset = PRESETS.find((candidate) => candidate.name === presetName);
+  if (!preset) {
+    throw new Error(`Unknown access preset '${body.llm_proposal.preset}'.`);
+  }
+  return {
+    ...preset.rule,
+    endpoints: preset.rule.endpoints.map((endpoint) => {
+      if (endpoint.access === "full" || endpoint.tls === "skip") {
+        return { ...endpoint };
+      }
+      return {
+        ...endpoint,
+        access: undefined,
+        rules: endpoint.rules ?? rulesForAccess(body.llm_proposal.access),
+      };
+    }),
+    binaries: preset.rule.binaries.map((binary) => ({ ...binary })),
+  };
+}
+
+function policyLocalUrl(options: AccessClientOptions = {}): URL {
+  return new URL(
+    options.policyLocalUrl ?? process.env.OPENSHELL_POLICY_LOCAL_URL ?? "http://policy.local",
+  );
+}
+
+function proxyUrl(): URL | null {
+  const raw = process.env.HTTP_PROXY ?? process.env.http_proxy;
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "http:" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> {
+  const parsed: unknown = raw.length > 0 ? JSON.parse(raw) : {};
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("OpenShell policy.local returned a non-object response");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function mapChunkStatus(status: unknown): AccessStatus {
+  if (status === "approved") return "applied";
+  if (status === "rejected") return "denied";
+  if (status === "pending") return "pending_approval";
+  return "failed";
+}
+
+function requestJson<T>(
+  method: "GET" | "POST",
+  requestPath: string,
+  body: Record<string, unknown> | undefined,
+  options: AccessClientOptions,
+  parseResponse: (raw: string) => T,
+): Promise<T> {
+  const base = policyLocalUrl(options);
+  if (base.protocol !== "http:") {
+    throw new Error("OpenShell policy.local URL must use HTTP inside the sandbox.");
+  }
+
+  const payload = body === undefined ? undefined : JSON.stringify(body);
+  const headers: Record<string, string | number> = {
+    Accept: "application/json",
+    Host: base.host,
+  };
+  if (payload !== undefined) {
+    headers["Content-Type"] = "application/json";
+    headers["Content-Length"] = Buffer.byteLength(payload);
+  }
+
+  return new Promise((resolve, reject) => {
+    const proxy = base.hostname === "policy.local" ? proxyUrl() : null;
+    const req = http.request(
+      {
+        method,
+        protocol: proxy?.protocol ?? base.protocol,
+        hostname: proxy?.hostname ?? base.hostname,
+        port:
+          proxy?.port !== undefined && proxy.port !== ""
+            ? Number(proxy.port)
+            : base.port === ""
+              ? undefined
+              : Number(base.port),
+        path:
+          proxy === null
+            ? `${base.pathname.replace(/\/$/, "")}${requestPath}`
+            : `${base.origin}${base.pathname.replace(/\/$/, "")}${requestPath}`,
+        headers,
+        timeout: options.timeoutMs ?? 310_000,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf-8");
+          if (res.statusCode === undefined || res.statusCode < 200 || res.statusCode >= 300) {
+            reject(
+              new Error(
+                `OpenShell policy.local ${method} ${requestPath} failed with HTTP ${res.statusCode ?? "unknown"}: ${raw}`,
+              ),
+            );
+            return;
+          }
+          try {
+            resolve(parseResponse(raw));
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+
+    req.on("timeout", () => {
+      req.destroy(new Error(`OpenShell policy.local ${method} ${requestPath} timed out`));
+    });
+    req.on("error", reject);
+    if (payload !== undefined) req.write(payload);
+    req.end();
+  });
+}
+
+function proposalBody(body: CreateAccessRequestBody): Record<string, unknown> {
+  const rule = ruleForRequest(body);
+  return {
+    intent_summary: [body.user_intent, body.llm_proposal.reason].filter(Boolean).join(" "),
+    operations: [{ addRule: { ruleName: rule.name, rule } }],
+  };
+}
+
+function parseCreateResponse(raw: string): AccessRequestResponse {
+  const parsed = parseJsonObject(raw);
+  const accepted = Array.isArray(parsed.accepted_chunk_ids) ? parsed.accepted_chunk_ids : [];
+  const requestId = accepted.find((id): id is string => typeof id === "string" && id.length > 0);
+  if (!requestId) {
+    return {
+      request_id: "",
+      status: "failed",
+      message: `OpenShell rejected the proposal: ${JSON.stringify(parsed.rejection_reasons ?? [])}`,
+    };
+  }
+  return {
+    request_id: requestId,
+    status: "pending_approval",
+    message: "Proposal submitted to OpenShell; waiting for operator approval.",
+  };
+}
+
+function parseStateResponse(raw: string): AccessRequestResponse {
+  const parsed = parseJsonObject(raw);
+  const requestId = typeof parsed.chunk_id === "string" ? parsed.chunk_id : "";
+  return {
+    request_id: requestId,
+    status: mapChunkStatus(parsed.status),
+    message:
+      typeof parsed.rejection_reason === "string" && parsed.rejection_reason
+        ? parsed.rejection_reason
+        : typeof parsed.validation_result === "string" && parsed.validation_result
+          ? parsed.validation_result
+          : undefined,
+    canonical_request: parsed,
+  };
+}
+
+export function createAccessRequest(
+  body: CreateAccessRequestBody,
+  options: AccessClientOptions = {},
+): Promise<AccessRequestResponse> {
+  return requestJson("POST", "/v1/proposals", proposalBody(body), options, parseCreateResponse);
+}
+
+export function getAccessRequest(
+  requestId: string,
+  options: AccessClientOptions = {},
+): Promise<AccessRequestResponse> {
+  return requestJson(
+    "GET",
+    `/v1/proposals/${encodeURIComponent(requestId)}`,
+    undefined,
+    options,
+    parseStateResponse,
+  );
+}
+
+export function waitAccessRequest(
+  requestId: string,
+  timeoutMs: number,
+  options: AccessClientOptions = {},
+): Promise<AccessRequestResponse> {
+  const seconds = Math.max(1, Math.min(300, Math.ceil(timeoutMs / 1000)));
+  return requestJson(
+    "GET",
+    `/v1/proposals/${encodeURIComponent(requestId)}/wait?timeout=${seconds}`,
+    undefined,
+    { ...options, timeoutMs: Math.max(options.timeoutMs ?? 0, (seconds + 10) * 1000) },
+    parseStateResponse,
+  );
+}
+
+export function listAccessPresets(
+  _options: AccessClientOptions = {},
+): Promise<AccessPresetsResponse> {
+  return Promise.resolve({
+    presets: PRESETS.map(({ name, description, provider_profile }) => ({
+      name,
+      description,
+      ...(provider_profile ? { provider_profile } : {}),
+    })),
+  });
+}

--- a/nemoclaw/src/access-client.ts
+++ b/nemoclaw/src/access-client.ts
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { execFileSync } from "node:child_process";
 import http from "node:http";
+import net from "node:net";
 
 export type AccessStatus = "pending_approval" | "applied" | "denied" | "failed";
 
@@ -71,9 +73,40 @@ type AccessPreset = AccessPresetInfo & {
   rule: NetworkRule;
 };
 
+type ProviderProfileEndpoint = {
+  host?: unknown;
+  port?: unknown;
+  protocol?: unknown;
+  tls?: unknown;
+  access?: unknown;
+  enforcement?: unknown;
+  rules?: unknown;
+  allowed_ips?: unknown;
+  ports?: unknown;
+  deny_rules?: unknown;
+  allow_encoded_slash?: unknown;
+  websocket_credential_rewrite?: unknown;
+  request_body_credential_rewrite?: unknown;
+  persisted_queries?: unknown;
+  graphql_persisted_queries?: unknown;
+  graphql_max_body_bytes?: unknown;
+  path?: unknown;
+};
+
+type ProviderProfile = {
+  id: string;
+  display_name?: string;
+  description?: string;
+  endpoints?: ProviderProfileEndpoint[];
+  binaries?: Array<string | { path?: unknown }>;
+};
+
 const NODE_BINARIES = [{ path: "/usr/local/bin/node" }, { path: "/usr/bin/node" }];
 const READ_METHODS = ["GET", "HEAD"];
 const READ_WRITE_METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"];
+const PROVIDER_PROFILE_CACHE_MS = 30_000;
+
+let cachedProviderPresets: { loadedAt: number; presets: AccessPreset[] } | null = null;
 
 const PRESETS: AccessPreset[] = [
   {
@@ -225,6 +258,155 @@ const PRESETS: AccessPreset[] = [
   },
 ];
 
+function openshellBinary(): string {
+  return process.env.NEMOCLAW_OPENSHELL_BIN || "openshell";
+}
+
+function parseProviderProfilesJson(raw: string): ProviderProfile[] {
+  if (!raw.trim()) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const candidates = Array.isArray(parsed)
+    ? parsed
+    : parsed &&
+        typeof parsed === "object" &&
+        Array.isArray((parsed as { profiles?: unknown }).profiles)
+      ? (parsed as { profiles: unknown[] }).profiles
+      : [];
+
+  return candidates
+    .filter((value): value is Record<string, unknown> => {
+      return typeof value === "object" && value !== null && typeof value.id === "string";
+    })
+    .map((profile) => ({
+      id: String(profile.id),
+      display_name: typeof profile.display_name === "string" ? profile.display_name : undefined,
+      description: typeof profile.description === "string" ? profile.description : undefined,
+      endpoints: Array.isArray(profile.endpoints)
+        ? (profile.endpoints as ProviderProfileEndpoint[])
+        : [],
+      binaries: Array.isArray(profile.binaries)
+        ? (profile.binaries as Array<string | { path?: unknown }>)
+        : [],
+    }));
+}
+
+function providerBinaryPath(binary: string | { path?: unknown }): string | null {
+  if (typeof binary === "string") return binary;
+  if (binary && typeof binary.path === "string") return binary.path;
+  return null;
+}
+
+function cleanProviderEndpoint(endpoint: ProviderProfileEndpoint): NetworkEndpoint | null {
+  if (typeof endpoint.host !== "string" || Number(endpoint.port) <= 0) return null;
+  const output: NetworkEndpoint = {
+    host: endpoint.host,
+    port: Number(endpoint.port),
+  };
+  for (const key of [
+    "protocol",
+    "tls",
+    "access",
+    "enforcement",
+    "rules",
+    "allowed_ips",
+    "ports",
+    "deny_rules",
+    "allow_encoded_slash",
+    "websocket_credential_rewrite",
+    "request_body_credential_rewrite",
+    "persisted_queries",
+    "graphql_persisted_queries",
+    "graphql_max_body_bytes",
+    "path",
+  ] as const) {
+    const value = endpoint[key];
+    if (
+      value !== undefined &&
+      value !== null &&
+      value !== "" &&
+      !(Array.isArray(value) && value.length === 0)
+    ) {
+      (output as Record<string, unknown>)[key] = value;
+    }
+  }
+  return output;
+}
+
+function providerProfileToPreset(profile: ProviderProfile): AccessPreset | null {
+  const endpoints = (profile.endpoints || [])
+    .map(cleanProviderEndpoint)
+    .filter((endpoint): endpoint is NetworkEndpoint => endpoint !== null);
+  if (endpoints.length === 0) return null;
+
+  const binaries = (profile.binaries || [])
+    .map(providerBinaryPath)
+    .filter((binary): binary is string => Boolean(binary))
+    .map((path) => ({ path }));
+
+  const ruleName = profile.id.replace(/-/g, "_");
+  return {
+    name: profile.id,
+    description: profile.description || profile.display_name || `${profile.id} provider profile`,
+    provider_profile: profile.id,
+    rule: {
+      name: ruleName,
+      endpoints,
+      binaries,
+    },
+  };
+}
+
+function readProviderProfilesFromOpenShell(): ProviderProfile[] {
+  if (process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON) {
+    return parseProviderProfilesJson(process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON);
+  }
+  try {
+    const raw = execFileSync(openshellBinary(), ["provider", "list-profiles", "-o", "json"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return parseProviderProfilesJson(raw);
+  } catch {
+    return [];
+  }
+}
+
+function listProviderProfilePresets(): AccessPreset[] {
+  const now = Date.now();
+  if (cachedProviderPresets && now - cachedProviderPresets.loadedAt < PROVIDER_PROFILE_CACHE_MS) {
+    return cachedProviderPresets.presets;
+  }
+  const presets = readProviderProfilesFromOpenShell()
+    .map(providerProfileToPreset)
+    .filter((preset): preset is AccessPreset => preset !== null);
+  cachedProviderPresets = { loadedAt: now, presets };
+  return presets;
+}
+
+function allPresets(): AccessPreset[] {
+  const byName = new Map<string, AccessPreset>();
+  for (const preset of PRESETS) byName.set(preset.name, preset);
+  for (const preset of listProviderProfilePresets()) {
+    const existing = byName.get(preset.name);
+    byName.set(
+      preset.name,
+      existing ? { ...existing, provider_profile: preset.provider_profile } : preset,
+    );
+  }
+  return [...byName.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function clearAccessPresetCache(): void {
+  cachedProviderPresets = null;
+}
+
 function normalizePresetName(resource: string): string {
   const normalized = resource.trim().toLowerCase();
   const host = (() => {
@@ -250,7 +432,7 @@ function rulesForAccess(access: "read" | "read_write"): L7Rule[] {
 
 function ruleForRequest(body: CreateAccessRequestBody): NetworkRule {
   const presetName = normalizePresetName(body.llm_proposal.preset);
-  const preset = PRESETS.find((candidate) => candidate.name === presetName);
+  const preset = allPresets().find((candidate) => candidate.name === presetName);
   if (!preset) {
     throw new Error(`Unknown access preset '${body.llm_proposal.preset}'.`);
   }
@@ -295,8 +477,8 @@ function parseJsonObject(raw: string): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
-function mapChunkStatus(status: unknown): AccessStatus {
-  if (status === "approved") return "applied";
+function mapChunkStatus(status: unknown, policyReloaded: unknown): AccessStatus {
+  if (status === "approved") return policyReloaded === true ? "applied" : "pending_approval";
   if (status === "rejected") return "denied";
   if (status === "pending") return "pending_approval";
   return "failed";
@@ -324,23 +506,27 @@ function requestJson<T>(
     headers["Content-Length"] = Buffer.byteLength(payload);
   }
 
+  const proxy = base.hostname === "policy.local" ? proxyUrl() : null;
+  if (proxy) {
+    return requestJsonViaHttpProxy(
+      method,
+      base,
+      requestPath,
+      headers,
+      payload,
+      options,
+      parseResponse,
+    );
+  }
+
   return new Promise((resolve, reject) => {
-    const proxy = base.hostname === "policy.local" ? proxyUrl() : null;
     const req = http.request(
       {
         method,
-        protocol: proxy?.protocol ?? base.protocol,
-        hostname: proxy?.hostname ?? base.hostname,
-        port:
-          proxy?.port !== undefined && proxy.port !== ""
-            ? Number(proxy.port)
-            : base.port === ""
-              ? undefined
-              : Number(base.port),
-        path:
-          proxy === null
-            ? `${base.pathname.replace(/\/$/, "")}${requestPath}`
-            : `${base.origin}${base.pathname.replace(/\/$/, "")}${requestPath}`,
+        protocol: base.protocol,
+        hostname: base.hostname,
+        port: base.port === "" ? undefined : Number(base.port),
+        path: `${base.pathname.replace(/\/$/, "")}${requestPath}`,
         headers,
         timeout: options.timeoutMs ?? 310_000,
       },
@@ -375,6 +561,80 @@ function requestJson<T>(
   });
 }
 
+function requestJsonViaHttpProxy<T>(
+  method: "GET" | "POST",
+  base: URL,
+  requestPath: string,
+  headers: Record<string, string | number>,
+  payload: string | undefined,
+  options: AccessClientOptions,
+  parseResponse: (raw: string) => T,
+): Promise<T> {
+  const proxy = proxyUrl();
+  if (!proxy) {
+    return Promise.reject(new Error("HTTP proxy is not configured."));
+  }
+
+  const target = `http://policy.local:80${base.pathname.replace(/\/$/, "")}${requestPath}`;
+  const timeoutMs = options.timeoutMs ?? 310_000;
+  const proxyPort = proxy.port ? Number(proxy.port) : 80;
+  const headerLines = Object.entries(headers).map(([key, value]) => `${key}: ${value}`);
+  const requestBytes = [
+    `${method} ${target} HTTP/1.1`,
+    ...headerLines,
+    "Connection: close",
+    "",
+    payload ?? "",
+  ].join("\r\n");
+
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: proxy.hostname, port: proxyPort });
+    const chunks: Buffer[] = [];
+    const timer = setTimeout(() => {
+      socket.destroy(new Error(`OpenShell policy.local ${method} ${requestPath} timed out`));
+    }, timeoutMs);
+
+    socket.on("connect", () => {
+      socket.write(requestBytes);
+    });
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+    socket.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    socket.on("end", () => {
+      clearTimeout(timer);
+      const raw = Buffer.concat(chunks).toString("utf-8");
+      const headerEnd = raw.indexOf("\r\n\r\n");
+      if (headerEnd === -1) {
+        reject(
+          new Error(
+            `OpenShell policy.local ${method} ${requestPath} returned a malformed HTTP response`,
+          ),
+        );
+        return;
+      }
+      const header = raw.slice(0, headerEnd);
+      const body = raw.slice(headerEnd + 4);
+      const statusLine = header.split("\r\n")[0] ?? "";
+      const statusCode = Number(statusLine.split(/\s+/)[1]);
+      if (!Number.isFinite(statusCode) || statusCode < 200 || statusCode >= 300) {
+        reject(
+          new Error(
+            `OpenShell policy.local ${method} ${requestPath} failed with HTTP ${Number.isFinite(statusCode) ? statusCode : "unknown"}: ${body}`,
+          ),
+        );
+        return;
+      }
+      try {
+        resolve(parseResponse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
 function proposalBody(body: CreateAccessRequestBody): Record<string, unknown> {
   const rule = ruleForRequest(body);
   return {
@@ -406,7 +666,7 @@ function parseStateResponse(raw: string): AccessRequestResponse {
   const requestId = typeof parsed.chunk_id === "string" ? parsed.chunk_id : "";
   return {
     request_id: requestId,
-    status: mapChunkStatus(parsed.status),
+    status: mapChunkStatus(parsed.status, parsed.policy_reloaded),
     message:
       typeof parsed.rejection_reason === "string" && parsed.rejection_reason
         ? parsed.rejection_reason
@@ -456,7 +716,7 @@ export function listAccessPresets(
   _options: AccessClientOptions = {},
 ): Promise<AccessPresetsResponse> {
   return Promise.resolve({
-    presets: PRESETS.map(({ name, description, provider_profile }) => ({
+    presets: allPresets().map(({ name, description, provider_profile }) => ({
       name,
       description,
       ...(provider_profile ? { provider_profile } : {}),

--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -19,6 +19,17 @@ import {
   describeOnboardProvider,
   loadOnboardConfig,
 } from "./onboard/config.js";
+import {
+  createAccessRequest,
+  getAccessRequest,
+  listAccessPresets,
+  waitAccessRequest,
+  type AccessCanonicalRequest,
+  type AccessClientOptions,
+  type AccessRequestResponse,
+  type AccessStatus,
+  type CreateAccessRequestBody,
+} from "./access-client.js";
 import { registerRuntimeContext } from "./runtime-context.js";
 import { scanForSecrets, isMemoryPath } from "./security/secret-scanner.js";
 
@@ -99,6 +110,17 @@ export interface PluginLogger {
 }
 
 type ToolParams = { [key: string]: PluginValue };
+
+export interface PluginToolResult {
+  [key: string]: PluginValue | AccessCanonicalRequest;
+}
+
+export interface PluginToolDefinition {
+  name: string;
+  description: string;
+  parameters: PluginRecord;
+  execute: (id: string, params: ToolParams) => PluginToolResult | Promise<PluginToolResult>;
+}
 
 /** Context passed to slash-command handlers. */
 export interface PluginCommandContext {
@@ -210,6 +232,7 @@ export interface OpenClawPluginApi {
   registerCommand: (command: PluginCommandDefinition) => void;
   registerProvider: (provider: ProviderPlugin) => void;
   registerService: (service: PluginService) => void;
+  registerTool: (tool: PluginToolDefinition) => void;
   resolvePath: (input: string) => string;
   on: (
     hookName: string,
@@ -335,6 +358,119 @@ export function getPluginConfig(api: OpenClawPluginApi): NemoClawConfig {
 
 /** Tool names that can write/modify files and should be scanned for secrets. */
 const WRITE_TOOL_NAMES = new Set(["write", "edit", "apply_patch", "notebook_edit"]);
+const DEFAULT_ACCESS_WAIT_MS = 90_000;
+const MAX_ACCESS_WAIT_MS = 300_000;
+const TERMINAL_ACCESS_STATUSES = new Set<AccessStatus>(["applied", "denied", "failed"]);
+
+function readNumberProperty(
+  value: PluginValue | object | null | undefined,
+  key: string,
+): number | undefined {
+  if (!isToolParams(value)) {
+    return undefined;
+  }
+  const property = value[key];
+  return typeof property === "number" && Number.isFinite(property) ? property : undefined;
+}
+
+function readAccessMode(params: ToolParams): "read" | "read_write" {
+  return params["access"] === "read_write" ? "read_write" : "read";
+}
+
+function readDuration(params: ToolParams): "session" | "persistent" {
+  return params["duration"] === "persistent" ? "persistent" : "session";
+}
+
+function normalizeRequestedResource(resource: string): string {
+  const normalized = resource.trim().toLowerCase();
+  const normalizedHost = (() => {
+    if (!normalized.includes("://")) {
+      return normalized;
+    }
+    try {
+      return new URL(normalized).hostname.toLowerCase();
+    } catch {
+      return normalized;
+    }
+  })();
+  if (
+    normalizedHost === "github" ||
+    normalizedHost === "github.com" ||
+    normalizedHost === "api.github.com"
+  ) {
+    return "github";
+  }
+  return normalizedHost;
+}
+
+function clampWaitTimeout(value: number | undefined, fallback: number): number {
+  const timeout = value ?? fallback;
+  if (timeout <= 0) {
+    return 0;
+  }
+  return Math.min(timeout, MAX_ACCESS_WAIT_MS);
+}
+
+function toToolResult(response: AccessRequestResponse): PluginToolResult {
+  return {
+    request_id: response.request_id,
+    status: response.status,
+    message:
+      response.message ??
+      (TERMINAL_ACCESS_STATUSES.has(response.status)
+        ? "OpenShell returned a terminal access status."
+        : "Access request is still pending; call check_resource_access with the request_id to continue polling."),
+    ...(response.canonical_request ? { canonical_request: response.canonical_request } : {}),
+  };
+}
+
+async function waitForAccessStatus(
+  initial: AccessRequestResponse,
+  timeoutMs: number,
+  clientOptions: AccessClientOptions,
+): Promise<AccessRequestResponse> {
+  if (TERMINAL_ACCESS_STATUSES.has(initial.status) || timeoutMs <= 0) {
+    return initial;
+  }
+  return waitAccessRequest(initial.request_id, timeoutMs, clientOptions);
+}
+
+function accessClientOptions(): AccessClientOptions {
+  return {
+    ...(process.env.OPENSHELL_POLICY_LOCAL_URL
+      ? { policyLocalUrl: process.env.OPENSHELL_POLICY_LOCAL_URL }
+      : {}),
+  };
+}
+
+function createAccessRequestBody(params: ToolParams): CreateAccessRequestBody {
+  const userIntent = readStringProperty(params, "user_intent") ?? "";
+  const resource = normalizeRequestedResource(readStringProperty(params, "resource") ?? "");
+  const reason = readStringProperty(params, "reason") ?? "";
+  const taskId = readStringProperty(params, "task_id");
+
+  return {
+    version: "nemoclaw.access.v1",
+    ...(taskId ? { task_id: taskId } : {}),
+    user_intent: userIntent,
+    llm_proposal: {
+      resource_type: "network",
+      preset: resource,
+      access: readAccessMode(params),
+      duration: readDuration(params),
+      reason,
+    },
+  };
+}
+
+function accessToolParameters(required: string[], properties: PluginRecord): PluginRecord {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required,
+    properties,
+  };
+}
 
 export default function register(api: OpenClawPluginApi): void {
   // 1. Register /nemoclaw slash command (chat interface)
@@ -377,6 +513,110 @@ export default function register(api: OpenClawPluginApi): void {
   api.registerProvider(
     registeredProviderForConfig(onboardCfg, providerCredentialEnv, probed.model),
   );
+
+  api.registerTool({
+    name: "request_resource_access",
+    description:
+      "Request least-privilege external resource access through OpenShell. The resource field must be a preset id, not a hostname. Call list_resource_access_presets first if you are unsure which preset to request. Prefer read access unless mutation is required.",
+    parameters: accessToolParameters(["user_intent", "resource", "reason"], {
+      user_intent: {
+        type: "string",
+        description: "The user's natural-language request.",
+      },
+      resource: {
+        type: "string",
+        description:
+          "Preset id to request. Use list_resource_access_presets to discover valid preset ids. Use github for GitHub hosts such as github.com and api.github.com.",
+      },
+      access: {
+        type: "string",
+        enum: ["read", "read_write"],
+        default: "read",
+        description: "Requested access mode. Use read unless mutation is required.",
+      },
+      reason: {
+        type: "string",
+        description: "Why this access is needed for the current task.",
+      },
+      duration: {
+        type: "string",
+        enum: ["session", "persistent"],
+        default: "session",
+        description: "Requested duration. Session access is the default.",
+      },
+      task_id: {
+        type: "string",
+        description: "Optional opaque task identifier for correlation.",
+      },
+      wait_timeout_ms: {
+        type: "number",
+        minimum: 0,
+        maximum: MAX_ACCESS_WAIT_MS,
+        default: DEFAULT_ACCESS_WAIT_MS,
+        description: "How long to wait for operator approval before returning pending.",
+      },
+    }),
+    async execute(_id, params) {
+      const clientOptions = accessClientOptions();
+      const response = await createAccessRequest(createAccessRequestBody(params), clientOptions);
+      const timeoutMs = clampWaitTimeout(
+        readNumberProperty(params, "wait_timeout_ms"),
+        DEFAULT_ACCESS_WAIT_MS,
+      );
+      return toToolResult(await waitForAccessStatus(response, timeoutMs, clientOptions));
+    },
+  });
+
+  api.registerTool({
+    name: "list_resource_access_presets",
+    description:
+      "List resource-access preset ids currently accepted for OpenShell access proposals.",
+    parameters: accessToolParameters([], {}),
+    async execute() {
+      const response = await listAccessPresets(accessClientOptions());
+      return {
+        presets: response.presets.map((preset) => ({
+          name: preset.name,
+          description: preset.description,
+          ...(preset.provider_profile ? { provider_profile: preset.provider_profile } : {}),
+        })),
+      };
+    },
+  });
+
+  api.registerTool({
+    name: "check_resource_access",
+    description:
+      "Check or continue waiting for an OpenShell access proposal. This reports status only and cannot approve or modify access.",
+    parameters: accessToolParameters(["request_id"], {
+      request_id: {
+        type: "string",
+        description: "The request_id returned by request_resource_access.",
+      },
+      wait_timeout_ms: {
+        type: "number",
+        minimum: 0,
+        maximum: MAX_ACCESS_WAIT_MS,
+        default: 0,
+        description: "Optional time to wait for a terminal status before returning pending.",
+      },
+    }),
+    async execute(_id, params) {
+      const requestId = readStringProperty(params, "request_id");
+      if (!requestId) {
+        return {
+          request_id: "",
+          status: "failed",
+          message: "Missing request_id.",
+        };
+      }
+
+      const clientOptions = accessClientOptions();
+      const response = await getAccessRequest(requestId, clientOptions);
+      const timeoutMs = clampWaitTimeout(readNumberProperty(params, "wait_timeout_ms"), 0);
+      return toToolResult(await waitForAccessStatus(response, timeoutMs, clientOptions));
+    },
+  });
 
   // 3. Register before_tool_call hook to block secrets in memory writes (#1233)
   // NOTE: This relies on OpenClaw's before_tool_call plugin hook contract

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { OpenClawPluginApi } from "./index.js";
+import type { OpenClawPluginApi, PluginToolDefinition } from "./index.js";
 
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
@@ -15,12 +15,29 @@ vi.mock("./onboard/config.js", () => ({
   describeOnboardProvider: vi.fn(() => "NVIDIA Endpoint API"),
 }));
 
+vi.mock("./access-client.js", () => ({
+  createAccessRequest: vi.fn(),
+  getAccessRequest: vi.fn(),
+  listAccessPresets: vi.fn(),
+  waitAccessRequest: vi.fn(),
+}));
+
 import { execFileSync } from "node:child_process";
 import register, { getPluginConfig } from "./index.js";
 import { loadOnboardConfig } from "./onboard/config.js";
+import {
+  createAccessRequest,
+  getAccessRequest,
+  listAccessPresets,
+  waitAccessRequest,
+} from "./access-client.js";
 
 const mockedExecFileSync = vi.mocked(execFileSync);
 const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
+const mockedCreateAccessRequest = vi.mocked(createAccessRequest);
+const mockedGetAccessRequest = vi.mocked(getAccessRequest);
+const mockedListAccessPresets = vi.mocked(listAccessPresets);
+const mockedWaitAccessRequest = vi.mocked(waitAccessRequest);
 
 function createMockApi(): OpenClawPluginApi {
   return {
@@ -38,9 +55,16 @@ function createMockApi(): OpenClawPluginApi {
     registerCommand: vi.fn(),
     registerProvider: vi.fn(),
     registerService: vi.fn(),
+    registerTool: vi.fn(),
     resolvePath: vi.fn((p: string) => p),
     on: vi.fn(),
   };
+}
+
+function getRegisteredTool(api: OpenClawPluginApi, name: string): PluginToolDefinition {
+  const call = vi.mocked(api.registerTool).mock.calls.find(([tool]) => tool.name === name);
+  expect(call).toBeDefined();
+  return call![0];
 }
 
 describe("plugin registration", () => {
@@ -48,6 +72,11 @@ describe("plugin registration", () => {
     vi.clearAllMocks();
     mockedExecFileSync.mockReset();
     mockedLoadOnboardConfig.mockReturnValue(null);
+    mockedCreateAccessRequest.mockReset();
+    mockedGetAccessRequest.mockReset();
+    mockedListAccessPresets.mockReset();
+    mockedWaitAccessRequest.mockReset();
+    delete process.env.OPENSHELL_POLICY_LOCAL_URL;
   });
 
   it("registers a slash command", () => {
@@ -60,6 +89,107 @@ describe("plugin registration", () => {
     const api = createMockApi();
     register(api);
     expect(api.registerProvider).toHaveBeenCalledWith(expect.objectContaining({ id: "inference" }));
+  });
+
+  it("registers OpenShell resource access tools", () => {
+    const api = createMockApi();
+    register(api);
+    expect(api.registerTool).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "request_resource_access" }),
+    );
+    expect(api.registerTool).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "list_resource_access_presets" }),
+    );
+    expect(api.registerTool).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "check_resource_access" }),
+    );
+  });
+
+  it("list_resource_access_presets surfaces OpenShell provider profile backed presets", async () => {
+    mockedListAccessPresets.mockResolvedValue({
+      presets: [
+        { name: "github", description: "GitHub access", provider_profile: "github" },
+        { name: "outlook", description: "Outlook access", provider_profile: "outlook" },
+      ],
+    });
+
+    const api = createMockApi();
+    register(api);
+    const tool = getRegisteredTool(api, "list_resource_access_presets");
+    const result = await tool.execute("call_1", {});
+
+    expect(mockedListAccessPresets).toHaveBeenCalledWith({});
+    expect(result).toEqual({
+      presets: [
+        { name: "github", description: "GitHub access", provider_profile: "github" },
+        { name: "outlook", description: "Outlook access", provider_profile: "outlook" },
+      ],
+    });
+  });
+
+  it("request_resource_access submits an OpenShell proposal and waits for approval", async () => {
+    mockedCreateAccessRequest.mockResolvedValue({
+      request_id: "chunk_123",
+      status: "pending_approval",
+      message: "Proposal submitted.",
+    });
+    mockedWaitAccessRequest.mockResolvedValue({
+      request_id: "chunk_123",
+      status: "applied",
+      message: "Approved.",
+    });
+
+    const api = createMockApi();
+    register(api);
+    const tool = getRegisteredTool(api, "request_resource_access");
+    const result = await tool.execute("call_1", {
+      user_intent: "Inspect a repo",
+      resource: "github.com",
+      reason: "Need repository metadata.",
+    });
+
+    expect(mockedCreateAccessRequest).toHaveBeenCalledWith(
+      {
+        version: "nemoclaw.access.v1",
+        user_intent: "Inspect a repo",
+        llm_proposal: {
+          resource_type: "network",
+          preset: "github",
+          access: "read",
+          duration: "session",
+          reason: "Need repository metadata.",
+        },
+      },
+      {},
+    );
+    expect(mockedWaitAccessRequest).toHaveBeenCalledWith("chunk_123", 90_000, {});
+    expect(result).toEqual({
+      request_id: "chunk_123",
+      status: "applied",
+      message: "Approved.",
+    });
+  });
+
+  it("check_resource_access reads an existing OpenShell proposal status", async () => {
+    mockedGetAccessRequest.mockResolvedValue({
+      request_id: "chunk_123",
+      status: "denied",
+      message: "Rejected.",
+    });
+
+    const api = createMockApi();
+    register(api);
+    const tool = getRegisteredTool(api, "check_resource_access");
+    const result = await tool.execute("call_2", {
+      request_id: "chunk_123",
+    });
+
+    expect(mockedGetAccessRequest).toHaveBeenCalledWith("chunk_123", {});
+    expect(result).toEqual({
+      request_id: "chunk_123",
+      status: "denied",
+      message: "Rejected.",
+    });
   });
 
   it("continues registration when the runtime context hook is unsupported", () => {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -330,6 +330,8 @@ const openshellPinFlow: typeof import("./onboard/openshell-pin") =
   require("./onboard/openshell-pin");
 const sandboxCreateFailureDiagnostics: typeof import("./onboard/sandbox-create-failure") =
   require("./onboard/sandbox-create-failure");
+const providerProfileOnboard: typeof import("./onboard/provider-profiles") =
+  require("./onboard/provider-profiles");
 
 import type { AgentDefinition } from "./agent/defs";
 import type { CurlProbeResult } from "./adapters/http/probe";
@@ -1788,6 +1790,18 @@ function upsertMessagingProviders(tokenDefs: MessagingTokenDef[]) {
 }
 function providerExistsInGateway(name: string) {
   return onboardProviders.providerExistsInGateway(name, runOpenshell);
+}
+
+function ensureProviderProfilesAvailable(): void {
+  const result = providerProfileOnboard.ensureNemoClawProviderProfiles(runOpenshell, {
+    log: note,
+  });
+  if (result.status === "unsupported") {
+    note(`  ${result.message}`);
+  } else if (result.status === "already-present" && result.skipped.length > 0) {
+    note(`  NemoClaw provider profiles already registered: ${result.skipped.join(", ")}`);
+  }
+  policies.clearProviderProfileCache();
 }
 
 function getMessagingChannelForEnvKey(envKey: string): string | null {
@@ -9733,6 +9747,8 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       await startGateway(gpu, { gpuPassthrough });
       onboardSession.markStepComplete("gateway");
     }
+
+    ensureProviderProfilesAvailable();
 
     // #2753: prefer requestedSandboxName over an unconfirmed session name.
     // A pre-fix session may carry sandboxName even though sandbox creation

--- a/src/lib/onboard/provider-profiles.ts
+++ b/src/lib/onboard/provider-profiles.ts
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import YAML from "yaml";
+
+const ROOT = path.resolve(__dirname, "..", "..", "..");
+
+type RunOpenshell = (
+  args: string[],
+  opts?: {
+    ignoreError?: boolean;
+    stdio?: Array<"ignore" | "pipe" | "inherit">;
+    suppressOutput?: boolean;
+    timeout?: number;
+  },
+) => { status?: number | null; stdout?: string | Buffer | null; stderr?: string | Buffer | null };
+
+export type ProviderProfileImportResult =
+  | { status: "missing-directory"; imported: string[]; skipped: string[] }
+  | { status: "unsupported"; imported: string[]; skipped: string[]; message: string }
+  | { status: "already-present"; imported: string[]; skipped: string[] }
+  | { status: "imported"; imported: string[]; skipped: string[] };
+
+export const NEMOCLAW_PROVIDER_PROFILES_DIR = path.join(
+  ROOT,
+  "nemoclaw-blueprint",
+  "provider-profiles",
+);
+
+function outputText(value: string | Buffer | null | undefined): string {
+  if (typeof value === "string") return value;
+  if (Buffer.isBuffer(value)) return value.toString("utf-8");
+  return "";
+}
+
+function isUnsupportedProviderProfileCommand(result: {
+  stdout?: string | Buffer | null;
+  stderr?: string | Buffer | null;
+}): boolean {
+  const text = `${outputText(result.stderr)}\n${outputText(result.stdout)}`.toLowerCase();
+  return (
+    text.includes("unrecognized subcommand") ||
+    text.includes("unknown command") ||
+    text.includes("invalid subcommand")
+  );
+}
+
+function parseProfileIds(raw: string): Set<string> {
+  if (!raw.trim()) return new Set();
+  try {
+    const parsed = JSON.parse(raw);
+    const candidates = Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === "object" && Array.isArray(parsed.profiles)
+        ? parsed.profiles
+        : [];
+    return new Set(
+      candidates
+        .map((profile: unknown) =>
+          profile && typeof profile === "object" && typeof (profile as { id?: unknown }).id === "string"
+            ? (profile as { id: string }).id
+            : null,
+        )
+        .filter((id: string | null): id is string => Boolean(id)),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+function readProfileId(filePath: string): string | null {
+  try {
+    const parsed = YAML.parse(fs.readFileSync(filePath, "utf-8"));
+    return parsed && typeof parsed === "object" && typeof parsed.id === "string"
+      ? parsed.id
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function providerProfileFiles(dir: string): Array<{ id: string; path: string }> {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith(".yaml") || file.endsWith(".yml"))
+    .map((file) => {
+      const filePath = path.join(dir, file);
+      const id = readProfileId(filePath);
+      return id ? { id, path: filePath } : null;
+    })
+    .filter((item): item is { id: string; path: string } => item !== null)
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function ensureNemoClawProviderProfiles(
+  runOpenshell: RunOpenshell,
+  options: { profilesDir?: string; log?: (message: string) => void } = {},
+): ProviderProfileImportResult {
+  const profilesDir = options.profilesDir || NEMOCLAW_PROVIDER_PROFILES_DIR;
+  const log = options.log || (() => {});
+  const profiles = providerProfileFiles(profilesDir);
+  if (profiles.length === 0) {
+    return { status: "missing-directory", imported: [], skipped: [] };
+  }
+
+  const list = runOpenshell(["provider", "list-profiles", "-o", "json"], {
+    ignoreError: true,
+    stdio: ["ignore", "pipe", "pipe"],
+    suppressOutput: true,
+    timeout: 10_000,
+  });
+  if (list.status !== 0) {
+    return {
+      status: "unsupported",
+      imported: [],
+      skipped: [],
+      message: "OpenShell provider profiles are not available; using local preset fallbacks.",
+    };
+  }
+
+  const existing = parseProfileIds(outputText(list.stdout));
+  const missing = profiles.filter((profile) => !existing.has(profile.id));
+  const skipped = profiles
+    .filter((profile) => existing.has(profile.id))
+    .map((profile) => profile.id);
+  if (missing.length === 0) {
+    return { status: "already-present", imported: [], skipped };
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-provider-profiles-"));
+  try {
+    for (const profile of missing) {
+      fs.copyFileSync(profile.path, path.join(tempDir, path.basename(profile.path)));
+    }
+
+    const lint = runOpenshell(["provider", "profile", "lint", "--from", tempDir], {
+      ignoreError: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      suppressOutput: true,
+      timeout: 10_000,
+    });
+    if (lint.status !== 0) {
+      if (isUnsupportedProviderProfileCommand(lint)) {
+        return {
+          status: "unsupported",
+          imported: [],
+          skipped,
+          message: "OpenShell provider profile import is not available; using local preset fallbacks.",
+        };
+      }
+      const details =
+        outputText(lint.stderr) || outputText(lint.stdout) || "provider profile lint failed";
+      throw new Error(`NemoClaw provider profile lint failed: ${details.trim()}`);
+    }
+
+    const importedIds = missing.map((profile) => profile.id);
+    const imported = runOpenshell(["provider", "profile", "import", "--from", tempDir], {
+      ignoreError: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      suppressOutput: true,
+      timeout: 10_000,
+    });
+    if (imported.status !== 0) {
+      if (isUnsupportedProviderProfileCommand(imported)) {
+        return {
+          status: "unsupported",
+          imported: [],
+          skipped,
+          message: "OpenShell provider profile import is not available; using local preset fallbacks.",
+        };
+      }
+      const details =
+        outputText(imported.stderr) || outputText(imported.stdout) || "provider profile import failed";
+      throw new Error(`NemoClaw provider profile import failed: ${details.trim()}`);
+    }
+
+    log(`  Imported NemoClaw provider profiles: ${importedIds.join(", ")}`);
+    return { status: "imported", imported: importedIds, skipped };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -17,11 +17,42 @@ const { loadAgent } = require("../agent/defs");
 const PRESETS_DIR = path.join(ROOT, "nemoclaw-blueprint", "policies", "presets");
 
 const MAX_PRESET_FILE_BYTES = 10_000_000;
+const PROVIDER_PROFILE_PRESET_PREFIX = "provider:";
+let cachedProviderProfiles: ProviderProfile[] | null = null;
 
 type PresetInfo = {
   file: string;
   name: string;
   description: string;
+  provider_profile?: string;
+};
+
+type ProviderProfileEndpoint = {
+  host?: unknown;
+  port?: unknown;
+  protocol?: unknown;
+  tls?: unknown;
+  access?: unknown;
+  enforcement?: unknown;
+  rules?: unknown;
+  allowed_ips?: unknown;
+  ports?: unknown;
+  deny_rules?: unknown;
+  allow_encoded_slash?: unknown;
+  websocket_credential_rewrite?: unknown;
+  request_body_credential_rewrite?: unknown;
+  persisted_queries?: unknown;
+  graphql_persisted_queries?: unknown;
+  graphql_max_body_bytes?: unknown;
+  path?: unknown;
+};
+
+type ProviderProfile = {
+  id: string;
+  display_name?: string;
+  description?: string;
+  endpoints?: ProviderProfileEndpoint[];
+  binaries?: Array<string | { path?: unknown }>;
 };
 
 // Re-use shared JSON types under policy-domain names.
@@ -51,20 +82,22 @@ function isPolicyDocument(value: PolicyValue): value is PolicyDocument {
  * `preset:` header.
  */
 function listPresets(): PresetInfo[] {
-  if (!fs.existsSync(PRESETS_DIR)) return [];
-  return fs
-    .readdirSync(PRESETS_DIR)
-    .filter((f: string) => f.endsWith(".yaml"))
-    .map((f: string) => {
-      const content = fs.readFileSync(path.join(PRESETS_DIR, f), "utf-8");
-      const nameMatch = content.match(/^\s*name:\s*(.+)$/m);
-      const descMatch = content.match(/^\s*description:\s*"?([^"]*)"?$/m);
-      return {
-        file: f,
-        name: nameMatch ? nameMatch[1].trim() : f.replace(".yaml", ""),
-        description: descMatch ? descMatch[1].trim() : "",
-      };
-    });
+  const builtinPresets = fs.existsSync(PRESETS_DIR)
+    ? fs
+        .readdirSync(PRESETS_DIR)
+        .filter((f: string) => f.endsWith(".yaml"))
+        .map((f: string) => {
+          const content = fs.readFileSync(path.join(PRESETS_DIR, f), "utf-8");
+          const nameMatch = content.match(/^\s*name:\s*(.+)$/m);
+          const descMatch = content.match(/^\s*description:\s*"?([^"]*)"?$/m);
+          return {
+            file: f,
+            name: nameMatch ? nameMatch[1].trim() : f.replace(".yaml", ""),
+            description: descMatch ? descMatch[1].trim() : "",
+          };
+        })
+    : [];
+  return mergeProviderProfilePresets(builtinPresets, listOpenShellProviderPresets());
 }
 
 /**
@@ -72,6 +105,9 @@ function listPresets(): PresetInfo[] {
  * path traversal and returns `null` if the preset does not exist.
  */
 function loadPreset(name: string): string | null {
+  const providerPreset = loadOpenShellProviderPreset(name);
+  if (providerPreset) return providerPreset;
+
   const file = path.resolve(PRESETS_DIR, `${name}.yaml`);
   if (!file.startsWith(PRESETS_DIR + path.sep) && file !== PRESETS_DIR) {
     console.error(`  Invalid preset name: ${name}`);
@@ -82,6 +118,173 @@ function loadPreset(name: string): string | null {
     return null;
   }
   return fs.readFileSync(file, "utf-8");
+}
+
+function openshellBinary(): string {
+  return process.env.NEMOCLAW_OPENSHELL_BIN || "openshell";
+}
+
+function parseProviderProfilesJson(raw: string): ProviderProfile[] {
+  if (!raw.trim()) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const candidates = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object" && Array.isArray((parsed as { profiles?: unknown }).profiles)
+      ? (parsed as { profiles: unknown[] }).profiles
+      : [];
+
+  return candidates
+    .filter((value): value is Record<string, unknown> => {
+      return typeof value === "object" && value !== null && typeof value.id === "string";
+    })
+    .map((profile) => ({
+      id: String(profile.id),
+      display_name: typeof profile.display_name === "string" ? profile.display_name : undefined,
+      description: typeof profile.description === "string" ? profile.description : undefined,
+      endpoints: Array.isArray(profile.endpoints)
+        ? (profile.endpoints as ProviderProfileEndpoint[])
+        : [],
+      binaries: Array.isArray(profile.binaries)
+        ? (profile.binaries as Array<string | { path?: unknown }>)
+        : [],
+    }));
+}
+
+function readProviderProfilesFromOpenShell(): ProviderProfile[] {
+  if (process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON) {
+    return parseProviderProfilesJson(process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON);
+  }
+  if (cachedProviderProfiles !== null) return cachedProviderProfiles;
+
+  const raw = runCapture([openshellBinary(), "provider", "list-profiles", "-o", "json"], {
+    ignoreError: true,
+    timeout: 5_000,
+  });
+  cachedProviderProfiles = parseProviderProfilesJson(raw);
+  return cachedProviderProfiles;
+}
+
+function providerProfileHasPolicy(profile: ProviderProfile): boolean {
+  return Array.isArray(profile.endpoints) && profile.endpoints.some((endpoint) => {
+    return typeof endpoint.host === "string" && Number(endpoint.port) > 0;
+  });
+}
+
+function providerProfileToPresetInfo(profile: ProviderProfile): PresetInfo | null {
+  if (!providerProfileHasPolicy(profile)) return null;
+  return {
+    file: `${PROVIDER_PROFILE_PRESET_PREFIX}${profile.id}`,
+    name: profile.id,
+    description: profile.description || profile.display_name || `${profile.id} provider profile`,
+    provider_profile: profile.id,
+  };
+}
+
+function listOpenShellProviderPresets(): PresetInfo[] {
+  return readProviderProfilesFromOpenShell()
+    .map(providerProfileToPresetInfo)
+    .filter((preset): preset is PresetInfo => preset !== null);
+}
+
+function mergeProviderProfilePresets(
+  builtinPresets: PresetInfo[],
+  providerPresets: PresetInfo[],
+): PresetInfo[] {
+  const byName = new Map<string, PresetInfo>();
+  for (const preset of builtinPresets) byName.set(preset.name, preset);
+  for (const preset of providerPresets) {
+    const existing = byName.get(preset.name);
+    byName.set(
+      preset.name,
+      existing ? { ...existing, provider_profile: preset.provider_profile } : preset,
+    );
+  }
+  return [...byName.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function providerBinaryPath(binary: string | { path?: unknown }): string | null {
+  if (typeof binary === "string") return binary;
+  if (binary && typeof binary.path === "string") return binary.path;
+  return null;
+}
+
+function cleanProviderEndpoint(endpoint: ProviderProfileEndpoint): PolicyObject | null {
+  if (typeof endpoint.host !== "string" || Number(endpoint.port) <= 0) return null;
+  const output: PolicyObject = {
+    host: endpoint.host,
+    port: Number(endpoint.port),
+  };
+  for (const key of [
+    "protocol",
+    "tls",
+    "access",
+    "enforcement",
+    "rules",
+    "allowed_ips",
+    "ports",
+    "deny_rules",
+    "allow_encoded_slash",
+    "websocket_credential_rewrite",
+    "request_body_credential_rewrite",
+    "persisted_queries",
+    "graphql_persisted_queries",
+    "graphql_max_body_bytes",
+    "path",
+  ] as const) {
+    const value = endpoint[key];
+    if (
+      value !== undefined &&
+      value !== null &&
+      value !== "" &&
+      !(Array.isArray(value) && value.length === 0)
+    ) {
+      output[key] = value as PolicyValue;
+    }
+  }
+  return output;
+}
+
+function providerProfileToPresetContent(profile: ProviderProfile): string | null {
+  const endpoints = (profile.endpoints || [])
+    .map(cleanProviderEndpoint)
+    .filter((endpoint): endpoint is PolicyObject => endpoint !== null);
+  if (endpoints.length === 0) return null;
+
+  const binaries = (profile.binaries || [])
+    .map(providerBinaryPath)
+    .filter((binary): binary is string => Boolean(binary))
+    .map((binary) => ({ path: binary }));
+
+  const policyName = profile.id.replace(/-/g, "_");
+  return YAML.stringify({
+    preset: {
+      name: profile.id,
+      description: profile.description || profile.display_name || `${profile.id} provider profile`,
+      provider_profile: profile.id,
+    },
+    network_policies: {
+      [policyName]: {
+        name: policyName,
+        endpoints,
+        ...(binaries.length > 0 ? { binaries } : {}),
+      },
+    },
+  });
+}
+
+function loadOpenShellProviderPreset(name: string): string | null {
+  const profile = readProviderProfilesFromOpenShell().find((candidate) => candidate.id === name);
+  return profile ? providerProfileToPresetContent(profile) : null;
+}
+
+function clearProviderProfileCache(): void {
+  cachedProviderProfiles = null;
 }
 
 /**
@@ -1071,6 +1274,11 @@ export {
   PERMISSIVE_POLICY_PATH,
   listPresets,
   loadPreset,
+  listOpenShellProviderPresets,
+  loadOpenShellProviderPreset,
+  providerProfileToPresetContent,
+  parseProviderProfilesJson,
+  clearProviderProfileCache,
   getPresetEndpoints,
   getMessagingPresetWarning,
   setupPolicyPresetSupported,

--- a/test/e2e/nemoclaw-policy-local-runner.mjs
+++ b/test/e2e/nemoclaw-policy-local-runner.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import register from "/sandbox/nemoclaw/dist/index.js";
+
+const tools = new Map();
+const api = {
+  id: "nemoclaw",
+  name: "NemoClaw",
+  version: "0.1.0",
+  config: {},
+  pluginConfig: {},
+  logger: {
+    info() {},
+    warn(message) {
+      console.error(`[warn] ${message}`);
+    },
+    error(message) {
+      console.error(`[error] ${message}`);
+    },
+    debug() {},
+  },
+  registerCommand() {},
+  registerProvider() {},
+  registerService() {},
+  registerTool(tool) {
+    tools.set(tool.name, tool);
+  },
+  resolvePath(input) {
+    return input;
+  },
+  on() {},
+};
+
+function usage() {
+  console.error("usage: nemoclaw-policy-local-runner.mjs list|request|check <request_id>");
+  process.exit(2);
+}
+
+register(api);
+
+const [command, requestId] = process.argv.slice(2);
+if (!command) usage();
+
+function tool(name) {
+  const entry = tools.get(name);
+  if (!entry) throw new Error(`tool not registered: ${name}`);
+  return entry;
+}
+
+let result;
+if (command === "list") {
+  result = await tool("list_resource_access_presets").execute("call_list", {});
+} else if (command === "request") {
+  result = await tool("request_resource_access").execute("call_request", {
+    user_intent: "Verify NemoClaw plugin access request integration",
+    resource: "github",
+    access: "read",
+    duration: "session",
+    reason: "The live e2e needs a deterministic provider-backed proposal.",
+    wait_timeout_ms: 0,
+  });
+} else if (command === "check") {
+  if (!requestId) usage();
+  result = await tool("check_resource_access").execute("call_check", {
+    request_id: requestId,
+    wait_timeout_ms: 30_000,
+  });
+} else {
+  usage();
+}
+
+console.log(JSON.stringify(result));

--- a/test/e2e/test-nemoclaw-policy-local-plugin.sh
+++ b/test/e2e/test-nemoclaw-policy-local-plugin.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 /path/to/openshell/repo" >&2
+  exit 2
+fi
+
+OPEN_SHELL_ROOT="$1"
+NEMOCLAW_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OPENSHELL_BIN="${OPEN_SHELL_ROOT}/target/debug/openshell"
+SANDBOX="${SANDBOX:-nemoclaw-plugin-live-$(date +%Y%m%d-%H%M%S)}"
+TMP_DIR="$(mktemp -d)"
+UPLOAD_DIR="${TMP_DIR}/upload"
+
+cleanup() {
+  "${OPENSHELL_BIN}" sandbox delete "${SANDBOX}" >/dev/null 2>&1 || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+"${OPENSHELL_BIN}" settings set --global \
+  --key agent_policy_proposals_enabled \
+  --value true \
+  --yes
+
+mkdir -p "${UPLOAD_DIR}/nemoclaw"
+cp -R "${NEMOCLAW_ROOT}/nemoclaw/dist" "${UPLOAD_DIR}/nemoclaw/dist"
+cp "${NEMOCLAW_ROOT}/nemoclaw/package.json" "${UPLOAD_DIR}/nemoclaw/package.json"
+cp -R "${NEMOCLAW_ROOT}/nemoclaw/node_modules" "${UPLOAD_DIR}/nemoclaw/node_modules"
+cp "${NEMOCLAW_ROOT}/test/e2e/nemoclaw-policy-local-runner.mjs" "${UPLOAD_DIR}/runner.mjs"
+
+"${OPENSHELL_BIN}" sandbox delete "${SANDBOX}" >/dev/null 2>&1 || true
+"${OPENSHELL_BIN}" sandbox create \
+  --name "${SANDBOX}" \
+  --upload "${UPLOAD_DIR}:/sandbox" \
+  --no-git-ignore \
+  --keep \
+  --no-auto-providers \
+  --no-tty \
+  -- bash -lc "if [ -d /sandbox/upload ]; then cp -R /sandbox/upload/. /sandbox/; fi && node --version && test -f /sandbox/nemoclaw/dist/index.js && test -d /sandbox/nemoclaw/node_modules && test -f /sandbox/runner.mjs && echo plugin sandbox ready"
+
+"${OPENSHELL_BIN}" sandbox ssh-config "${SANDBOX}" > "${TMP_DIR}/ssh_config"
+SSH_HOST="$(awk '/^Host / { print $2; exit }' "${TMP_DIR}/ssh_config")"
+if [ -z "${SSH_HOST}" ]; then
+  echo "failed to parse sandbox ssh host" >&2
+  exit 1
+fi
+
+for _ in $(seq 1 30); do
+  if ssh -F "${TMP_DIR}/ssh_config" "${SSH_HOST}" true >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+ssh -F "${TMP_DIR}/ssh_config" "${SSH_HOST}" true
+
+LIST_JSON="$(ssh -F "${TMP_DIR}/ssh_config" "${SSH_HOST}" node /sandbox/runner.mjs list)"
+printf "LIST_JSON=%s\n" "${LIST_JSON}"
+printf "%s" "${LIST_JSON}" \
+  | jq -e '.presets[] | select(.name == "github" and .provider_profile == "github")' \
+  >/dev/null
+
+REQUEST_JSON="$(ssh -F "${TMP_DIR}/ssh_config" "${SSH_HOST}" node /sandbox/runner.mjs request)"
+printf "REQUEST_JSON=%s\n" "${REQUEST_JSON}"
+REQ_ID="$(printf "%s" "${REQUEST_JSON}" | jq -r '.request_id')"
+if [ -z "${REQ_ID}" ] || [ "${REQ_ID}" = "null" ]; then
+  echo "request_resource_access did not return a request_id" >&2
+  exit 1
+fi
+if [ "$(printf "%s" "${REQUEST_JSON}" | jq -r '.status')" != "pending_approval" ]; then
+  echo "request_resource_access did not return pending_approval" >&2
+  exit 1
+fi
+
+"${OPENSHELL_BIN}" rule approve "${SANDBOX}" --chunk-id "${REQ_ID}"
+
+CHECK_JSON="$(ssh -F "${TMP_DIR}/ssh_config" "${SSH_HOST}" node /sandbox/runner.mjs check "${REQ_ID}")"
+printf "CHECK_JSON=%s\n" "${CHECK_JSON}"
+if [ "$(printf "%s" "${CHECK_JSON}" | jq -r '.status')" != "applied" ]; then
+  echo "check_resource_access did not return applied" >&2
+  exit 1
+fi
+
+printf "NemoClaw plugin live policy.local flow passed for request_id=%s\n" "${REQ_ID}"

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -129,6 +129,11 @@ selectFromList(items, options)
 
 describe("policies", () => {
   describe("listPresets", () => {
+    afterEach(() => {
+      delete process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON;
+      policies.clearProviderProfileCache?.();
+    });
+
     it("returns all 13 presets", () => {
       const presets = policies.listPresets();
       expect(presets.length).toBe(13);
@@ -163,9 +168,48 @@ describe("policies", () => {
       ];
       expect(names).toEqual(expected);
     });
+
+    it("adds OpenShell provider profiles as provider-backed presets", () => {
+      process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON = JSON.stringify({
+        profiles: [
+          {
+            id: "gitlab",
+            display_name: "GitLab",
+            description: "GitLab API and Git operations",
+            endpoints: [{ host: "gitlab.com", port: 443, protocol: "rest", access: "read-write" }],
+            binaries: ["/usr/bin/git"],
+          },
+          {
+            id: "empty-provider",
+            display_name: "Empty",
+            endpoints: [],
+          },
+        ],
+      });
+      policies.clearProviderProfileCache?.();
+
+      const presets = policies.listPresets();
+      expect(presets).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "gitlab",
+            file: "provider:gitlab",
+            provider_profile: "gitlab",
+          }),
+        ]),
+      );
+      expect(presets.some((preset: { name: string }) => preset.name === "empty-provider")).toBe(
+        false,
+      );
+    });
   });
 
   describe("loadPreset", () => {
+    afterEach(() => {
+      delete process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON;
+      policies.clearProviderProfileCache?.();
+    });
+
     it("loads existing preset", () => {
       const content = requirePresetContent(policies.loadPreset("outlook"));
       expect(content.includes("network_policies:")).toBeTruthy();
@@ -173,6 +217,41 @@ describe("policies", () => {
 
     it("returns null for nonexistent preset", () => {
       expect(policies.loadPreset("nonexistent")).toBe(null);
+    });
+
+    it("can synthesize preset YAML from an OpenShell provider profile", () => {
+      process.env.NEMOCLAW_OPENSHELL_PROVIDER_PROFILES_JSON = JSON.stringify([
+        {
+          id: "gitlab",
+          display_name: "GitLab",
+          description: "GitLab API and Git operations",
+          endpoints: [
+            {
+              host: "gitlab.com",
+              port: 443,
+              protocol: "rest",
+              access: "read-write",
+              enforcement: "enforce",
+            },
+          ],
+          binaries: ["/usr/bin/git", { path: "/usr/local/bin/glab" }],
+        },
+      ]);
+      policies.clearProviderProfileCache?.();
+
+      const content = requirePresetContent(policies.loadPreset("gitlab"));
+      const parsed = YAML.parse(content);
+      expect(parsed.preset.provider_profile).toBe("gitlab");
+      expect(parsed.network_policies.gitlab.endpoints[0]).toMatchObject({
+        host: "gitlab.com",
+        port: 443,
+        protocol: "rest",
+        access: "read-write",
+      });
+      expect(parsed.network_policies.gitlab.binaries).toEqual([
+        { path: "/usr/bin/git" },
+        { path: "/usr/local/bin/glab" },
+      ]);
     });
 
     it("rejects path traversal attempts", () => {

--- a/test/provider-profile-onboard.test.ts
+++ b/test/provider-profile-onboard.test.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import {
+  ensureNemoClawProviderProfiles,
+  NEMOCLAW_PROVIDER_PROFILES_DIR,
+} from "../src/lib/onboard/provider-profiles";
+
+function writeProfile(dir: string, id: string): void {
+  fs.writeFileSync(
+    path.join(dir, `${id}.yaml`),
+    [
+      `id: ${id}`,
+      `display_name: ${id}`,
+      "description: fixture profile",
+      "category: other",
+      "endpoints:",
+      "  - host: example.com",
+      "    port: 443",
+      "binaries:",
+      "  - /usr/bin/curl",
+      "",
+    ].join("\n"),
+  );
+}
+
+describe("NemoClaw provider profile onboarding", () => {
+  it("ships provider profiles for NemoClaw presets not built into OpenShell", () => {
+    const ids = fs
+      .readdirSync(NEMOCLAW_PROVIDER_PROFILES_DIR)
+      .filter((file) => file.endsWith(".yaml"))
+      .map((file) => {
+        const parsed = YAML.parse(
+          fs.readFileSync(path.join(NEMOCLAW_PROVIDER_PROFILES_DIR, file), "utf-8"),
+        );
+        return parsed.id;
+      })
+      .sort();
+
+    expect(ids).toEqual([
+      "brave",
+      "brew",
+      "discord",
+      "huggingface",
+      "jira",
+      "local-inference",
+      "npm",
+      "pypi",
+      "slack",
+      "telegram",
+    ]);
+  });
+
+  it("imports only profiles missing from OpenShell", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-provider-profile-test-"));
+    const calls: string[][] = [];
+    try {
+      writeProfile(tmp, "brave");
+      writeProfile(tmp, "npm");
+      const result = ensureNemoClawProviderProfiles(
+        (args) => {
+          calls.push(args);
+          if (args.join(" ") === "provider list-profiles -o json") {
+            return {
+              status: 0,
+              stdout: JSON.stringify({ profiles: [{ id: "brave" }] }),
+              stderr: "",
+            };
+          }
+          return { status: 0, stdout: "", stderr: "" };
+        },
+        { profilesDir: tmp },
+      );
+
+      expect(result).toMatchObject({
+        status: "imported",
+        imported: ["npm"],
+        skipped: ["brave"],
+      });
+      expect(calls).toEqual([
+        ["provider", "list-profiles", "-o", "json"],
+        ["provider", "profile", "lint", "--from", expect.any(String)],
+        ["provider", "profile", "import", "--from", expect.any(String)],
+      ]);
+      const importDir = calls[2][4];
+      expect(fs.existsSync(importDir)).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("skips import when all profiles already exist", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-provider-profile-test-"));
+    const calls: string[][] = [];
+    try {
+      writeProfile(tmp, "brave");
+      const result = ensureNemoClawProviderProfiles(
+        (args) => {
+          calls.push(args);
+          return {
+            status: 0,
+            stdout: JSON.stringify({ profiles: [{ id: "brave" }] }),
+            stderr: "",
+          };
+        },
+        { profilesDir: tmp },
+      );
+
+      expect(result).toMatchObject({
+        status: "already-present",
+        imported: [],
+        skipped: ["brave"],
+      });
+      expect(calls).toEqual([["provider", "list-profiles", "-o", "json"]]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back when OpenShell does not support provider profiles", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-provider-profile-test-"));
+    try {
+      writeProfile(tmp, "brave");
+      const result = ensureNemoClawProviderProfiles(
+        () => ({
+          status: 2,
+          stdout: "",
+          stderr: "error: unrecognized subcommand 'profile'",
+        }),
+        { profilesDir: tmp },
+      );
+
+      expect(result.status).toBe("unsupported");
+      expect(result.imported).toEqual([]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds OpenClaw plugin support for requesting OpenShell policy.local network access from inside the sandbox. This gives agents a structured way to list provider-backed presets, submit least-privilege access proposals, and poll proposal status.

## Changes
- Add `nemoclaw/src/access-client.ts` for policy.local proposal creation and status polling.
- Register OpenClaw access tools in `nemoclaw/src/index.ts`.
- Add plugin tests for preset listing, proposal submission, and status mapping.
- Add live e2e helper scripts for the policy.local OpenClaw plugin flow.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Patrick Riel <priel@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated resource access request system enabling agents to request and monitor external service access through OpenShell policy management.
  * Added agent tools to list available resource presets, request resource access, and check request status.
  * Introduced provider profiles for multiple services: Slack, Jira, Discord, Hugging Face, PyPI, npm, Brave, Telegram, Homebrew, and local inference endpoints.
  * Automated provider profile onboarding during initial setup.

* **Documentation**
  * Added integration guide documenting the end-to-end resource access workflow between agents and policy systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->