### PR TITLE
fix(slack): allowlisted users for channel mentions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -282,8 +282,9 @@ ARG NEMOCLAW_INFERENCE_COMPAT_B64=e30=
 # so the L7 proxy can rewrite them at egress. Default: empty list.
 ARG NEMOCLAW_MESSAGING_CHANNELS_B64=W10=
 # Base64-encoded JSON map of channel→allowed sender IDs for DM allowlisting
-# (e.g. {"telegram":["123456789"]}). Channels with IDs get dmPolicy=allowlist;
-# channels without IDs keep the OpenClaw default (pairing). Default: empty map.
+# (e.g. {"telegram":["123456789"]}). Channels with IDs get dmPolicy=allowlist.
+# Slack also uses those IDs for channel @mention allowlisting. Channels without
+# IDs keep the OpenClaw default (pairing). Default: empty map.
 ARG NEMOCLAW_MESSAGING_ALLOWED_IDS_B64=e30=
 # Base64-encoded JSON map of Discord guild configs keyed by server ID
 # (e.g. {"1234567890":{"requireMention":true,"users":["555"]}}).

--- a/docs/manage-sandboxes/messaging-channels.md
+++ b/docs/manage-sandboxes/messaging-channels.md
@@ -46,7 +46,7 @@ For details, refer to [Commands](../reference/commands.md).
 |---------|-----------------|-------------------|
 | Telegram | `TELEGRAM_BOT_TOKEN` | `TELEGRAM_ALLOWED_IDS` for DM allowlisting, `TELEGRAM_REQUIRE_MENTION` for group-chat replies |
 | Discord | `DISCORD_BOT_TOKEN` | `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `DISCORD_REQUIRE_MENTION` |
-| Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | None |
+| Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | `SLACK_ALLOWED_USERS` for DM and channel `@mention` user allowlisting |
 
 Telegram uses a bot token from [BotFather](https://t.me/BotFather).
 Open Telegram, send `/newbot` to [@BotFather](https://t.me/BotFather), follow the prompts, and copy the token.

--- a/docs/manage-sandboxes/messaging-channels.md
+++ b/docs/manage-sandboxes/messaging-channels.md
@@ -63,6 +63,8 @@ Set `DISCORD_USER_ID` to restrict access to one user; otherwise, any member of t
 
 Slack uses Socket Mode and requires two tokens.
 Use `SLACK_BOT_TOKEN` for the bot user OAuth token (`xoxb-...`) and `SLACK_APP_TOKEN` for the app-level Socket Mode token (`xapp-...`).
+Set `SLACK_ALLOWED_USERS` to comma-separated Slack member IDs to authorize those users for DMs and for channel `@mention` events in channels where the Slack app is present.
+Channel messages still require an explicit bot mention.
 
 ## Enable Channels During Onboarding
 
@@ -80,6 +82,7 @@ $ export DISCORD_BOT_TOKEN=<your-discord-bot-token>
 $ export DISCORD_SERVER_ID=<your-discord-server-id>
 $ export SLACK_BOT_TOKEN=<your-slack-bot-token>
 $ export SLACK_APP_TOKEN=<your-slack-app-token>
+$ export SLACK_ALLOWED_USERS=<your-slack-member-id>
 ```
 
 Then run onboarding:

--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -27,7 +27,8 @@ Environment variables:
                                         disable). Empty/unset preserves the OpenClaw default.
     NEMOCLAW_INFERENCE_COMPAT_B64       Base64-encoded inference compat JSON
     NEMOCLAW_MESSAGING_CHANNELS_B64     Base64-encoded channel list
-    NEMOCLAW_MESSAGING_ALLOWED_IDS_B64  Base64-encoded allowed IDs map
+    NEMOCLAW_MESSAGING_ALLOWED_IDS_B64  Base64-encoded allowed IDs map (Slack IDs cover
+                                        DMs and channel @mentions)
     NEMOCLAW_DISCORD_GUILDS_B64         Base64-encoded Discord guild config
     NEMOCLAW_TELEGRAM_CONFIG_B64        Base64-encoded Telegram config (e.g. {"requireMention": true})
     NEMOCLAW_WECHAT_CONFIG_B64          Base64-encoded WeChat config (e.g. {"accountId": "...", "baseUrl": "...", "userId": "..."})
@@ -509,6 +510,15 @@ def build_config(env: dict | None = None) -> dict:
         if ch in _allowed_ids and _allowed_ids[ch]:
             account["dmPolicy"] = "allowlist"
             account["allowFrom"] = _allowed_ids[ch]
+            if ch == "slack":
+                account["groupPolicy"] = "allowlist"
+                account["channels"] = {
+                    "*": {
+                        "enabled": True,
+                        "requireMention": True,
+                        "users": _allowed_ids[ch],
+                    }
+                }
         _ch_cfg[ch] = {"accounts": {"default": account}}
 
     # WeChat (openclaw-weixin) is NOT added to channels.* here — writing

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -7436,7 +7436,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 240,
+          "line": 248,
           "text": "Pre-cleanup complete",
           "polarity": "pass",
           "normalized_id": "pre.cleanup.complete",
@@ -7444,7 +7444,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 320,
+          "line": 328,
           "text": "Failed to append Slack policy to base sandbox policy",
           "polarity": "fail",
           "normalized_id": "failed.to.append.slack.policy.to.base.sandbox.policy",
@@ -7452,7 +7452,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 323,
+          "line": 331,
           "text": "Slack network policy pre-merged into base policy",
           "polarity": "pass",
           "normalized_id": "slack.network.policy.pre.merged.into.base.policy",
@@ -7460,7 +7460,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 328,
+          "line": 336,
           "text": "Cannot pre-merge Slack policy: missing base policy or preset file",
           "polarity": "fail",
           "normalized_id": "cannot.pre.merge.slack.policy.missing.base.policy.or.preset.file",
@@ -7468,7 +7468,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 369,
+          "line": 377,
           "text": "M0: install.sh completed (exit 0)",
           "polarity": "pass",
           "normalized_id": "m0.install.sh.completed.exit.0",
@@ -7476,7 +7476,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 371,
+          "line": 379,
           "text": "M0: install.sh failed (exit $install_exit)",
           "polarity": "fail",
           "normalized_id": "m0.install.sh.failed.exit.install.exit",
@@ -7484,7 +7484,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 379,
+          "line": 387,
           "text": "openshell not found on PATH after install",
           "polarity": "fail",
           "normalized_id": "openshell.not.found.on.path.after.install",
@@ -7492,7 +7492,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 382,
+          "line": 390,
           "text": "openshell installed ($(openshell --version 2>&1 || echo unknown))",
           "polarity": "pass",
           "normalized_id": "openshell.installed.openshell.version.2.1.echo.unknown",
@@ -7500,7 +7500,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 385,
+          "line": 393,
           "text": "nemoclaw not found on PATH after install",
           "polarity": "fail",
           "normalized_id": "nemoclaw.not.found.on.path.after.install",
@@ -7508,7 +7508,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 388,
+          "line": 396,
           "text": "nemoclaw installed at $(command -v nemoclaw)",
           "polarity": "pass",
           "normalized_id": "nemoclaw.installed.at.command.v.nemoclaw",
@@ -7516,7 +7516,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 393,
+          "line": 401,
           "text": "M0b: Sandbox '$SANDBOX_NAME' is Ready",
           "polarity": "pass",
           "normalized_id": "m0b.sandbox.sandbox.name.is.ready",
@@ -7524,7 +7524,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 395,
+          "line": 403,
           "text": "M0b: Sandbox '$SANDBOX_NAME' not Ready (list: ${sandbox_list:0:200})",
           "polarity": "fail",
           "normalized_id": "m0b.sandbox.sandbox.name.not.ready.list.sandbox.list.0.200",
@@ -7532,7 +7532,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 401,
+          "line": 409,
           "text": "M1: Provider '${SANDBOX_NAME}-telegram-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m1.provider.sandbox.name.telegram.bridge.exists.in.gateway",
@@ -7540,7 +7540,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 403,
+          "line": 411,
           "text": "M1: Provider '${SANDBOX_NAME}-telegram-bridge' not found in gateway",
           "polarity": "fail",
           "normalized_id": "m1.provider.sandbox.name.telegram.bridge.not.found.in.gateway",
@@ -7548,7 +7548,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 408,
+          "line": 416,
           "text": "M2: Provider '${SANDBOX_NAME}-discord-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m2.provider.sandbox.name.discord.bridge.exists.in.gateway",
@@ -7556,7 +7556,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 410,
+          "line": 418,
           "text": "M2: Provider '${SANDBOX_NAME}-discord-bridge' not found in gateway",
           "polarity": "fail",
           "normalized_id": "m2.provider.sandbox.name.discord.bridge.not.found.in.gateway",
@@ -7564,7 +7564,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 417,
+          "line": 425,
           "text": "M-W1: Provider '${SANDBOX_NAME}-wechat-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m.w1.provider.sandbox.name.wechat.bridge.exists.in.gateway",
@@ -7572,7 +7572,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 419,
+          "line": 427,
           "text": "M-W1: Provider '${SANDBOX_NAME}-wechat-bridge' not found in gateway (non-interactive QR-skip path may be broken)",
           "polarity": "fail",
           "normalized_id": "m.w1.provider.sandbox.name.wechat.bridge.not.found.in.gateway.non.interactive.qr.skip.path.may.be.broken",
@@ -7580,7 +7580,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 433,
+          "line": 441,
           "text": "M3: Real Telegram token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m3.real.telegram.token.leaked.into.sandbox.env",
@@ -7588,7 +7588,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 435,
+          "line": 443,
           "text": "M3: Sandbox TELEGRAM_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m3.sandbox.telegram.bot.token.is.a.placeholder.not.the.real.token",
@@ -7596,7 +7596,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 446,
+          "line": 454,
           "text": "M4: Real Discord token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m4.real.discord.token.leaked.into.sandbox.env",
@@ -7604,7 +7604,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 448,
+          "line": 456,
           "text": "M4: Sandbox DISCORD_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m4.sandbox.discord.bot.token.is.a.placeholder.not.the.real.token",
@@ -7612,7 +7612,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 455,
+          "line": 463,
           "text": "M5: At least one messaging placeholder detected in sandbox",
           "polarity": "pass",
           "normalized_id": "m5.at.least.one.messaging.placeholder.detected.in.sandbox",
@@ -7620,7 +7620,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 480,
+          "line": 488,
           "text": "M5a: Real Telegram token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m5a.real.telegram.token.found.in.full.sandbox.environment.dump",
@@ -7628,7 +7628,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 482,
+          "line": 490,
           "text": "M5a: Real Telegram token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5a.real.telegram.token.absent.from.full.sandbox.environment",
@@ -7636,7 +7636,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 489,
+          "line": 497,
           "text": "M5b: Real Telegram token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m5b.real.telegram.token.found.in.sandbox.process.list",
@@ -7644,7 +7644,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 491,
+          "line": 499,
           "text": "M5b: Real Telegram token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m5b.real.telegram.token.absent.from.sandbox.process.list",
@@ -7652,7 +7652,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 498,
+          "line": 506,
           "text": "M5c: Real Telegram token found on sandbox filesystem: ${sandbox_fs_tg}",
           "polarity": "fail",
           "normalized_id": "m5c.real.telegram.token.found.on.sandbox.filesystem.sandbox.fs.tg",
@@ -7660,7 +7660,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 500,
+          "line": 508,
           "text": "M5c: Real Telegram token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m5c.real.telegram.token.absent.from.sandbox.filesystem",
@@ -7668,7 +7668,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 506,
+          "line": 514,
           "text": "M5d: Telegram placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5d.telegram.placeholder.confirmed.present.in.sandbox.environment",
@@ -7676,7 +7676,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 508,
+          "line": 516,
           "text": "M5d: Telegram placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m5d.telegram.placeholder.not.found.in.sandbox.environment",
@@ -7684,7 +7684,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 518,
+          "line": 526,
           "text": "M5e: Real Discord token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m5e.real.discord.token.found.in.full.sandbox.environment.dump",
@@ -7692,7 +7692,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 520,
+          "line": 528,
           "text": "M5e: Real Discord token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5e.real.discord.token.absent.from.full.sandbox.environment",
@@ -7700,7 +7700,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 527,
+          "line": 535,
           "text": "M5f: Real Discord token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m5f.real.discord.token.found.in.sandbox.process.list",
@@ -7708,7 +7708,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 529,
+          "line": 537,
           "text": "M5f: Real Discord token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m5f.real.discord.token.absent.from.sandbox.process.list",
@@ -7716,7 +7716,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 535,
+          "line": 543,
           "text": "M5g: Real Discord token found on sandbox filesystem: ${sandbox_fs_dc}",
           "polarity": "fail",
           "normalized_id": "m5g.real.discord.token.found.on.sandbox.filesystem.sandbox.fs.dc",
@@ -7724,7 +7724,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 537,
+          "line": 545,
           "text": "M5g: Real Discord token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m5g.real.discord.token.absent.from.sandbox.filesystem",
@@ -7732,7 +7732,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 543,
+          "line": 551,
           "text": "M5h: Discord placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5h.discord.placeholder.confirmed.present.in.sandbox.environment",
@@ -7740,7 +7740,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 545,
+          "line": 553,
           "text": "M5h: Discord placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m5h.discord.placeholder.not.found.in.sandbox.environment",
@@ -7748,7 +7748,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 560,
+          "line": 568,
           "text": "M-S5a: Real Slack bot token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.s5a.real.slack.bot.token.found.in.full.sandbox.environment.dump",
@@ -7756,7 +7756,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 562,
+          "line": 570,
           "text": "M-S5a: Real Slack bot token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.s5a.real.slack.bot.token.absent.from.full.sandbox.environment",
@@ -7764,7 +7764,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 569,
+          "line": 577,
           "text": "M-S5b: Real Slack bot token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.s5b.real.slack.bot.token.found.in.sandbox.process.list",
@@ -7772,7 +7772,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 571,
+          "line": 579,
           "text": "M-S5b: Real Slack bot token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.s5b.real.slack.bot.token.absent.from.sandbox.process.list",
@@ -7780,7 +7780,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 577,
+          "line": 585,
           "text": "M-S5c: Real Slack bot token found on sandbox filesystem: ${sandbox_fs_sl}",
           "polarity": "fail",
           "normalized_id": "m.s5c.real.slack.bot.token.found.on.sandbox.filesystem.sandbox.fs.sl",
@@ -7788,7 +7788,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 579,
+          "line": 587,
           "text": "M-S5c: Real Slack bot token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.s5c.real.slack.bot.token.absent.from.sandbox.filesystem",
@@ -7796,7 +7796,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 587,
+          "line": 595,
           "text": "M-S5d: Real Slack app token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.s5d.real.slack.app.token.found.in.full.sandbox.environment.dump",
@@ -7804,7 +7804,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 589,
+          "line": 597,
           "text": "M-S5d: Real Slack app token absent from sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.s5d.real.slack.app.token.absent.from.sandbox.environment",
@@ -7812,7 +7812,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 594,
+          "line": 602,
           "text": "M-S5d2: Real Slack app token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.s5d2.real.slack.app.token.found.in.sandbox.process.list",
@@ -7820,7 +7820,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 596,
+          "line": 604,
           "text": "M-S5d2: Real Slack app token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.s5d2.real.slack.app.token.absent.from.sandbox.process.list",
@@ -7828,7 +7828,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 600,
+          "line": 608,
           "text": "M-S5e: Real Slack app token found on sandbox filesystem: ${sandbox_fs_sapp}",
           "polarity": "fail",
           "normalized_id": "m.s5e.real.slack.app.token.found.on.sandbox.filesystem.sandbox.fs.sapp",
@@ -7836,7 +7836,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 602,
+          "line": 610,
           "text": "M-S5e: Real Slack app token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.s5e.real.slack.app.token.absent.from.sandbox.filesystem",
@@ -7844,7 +7844,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 613,
+          "line": 621,
           "text": "M-S5f: Real Slack bot/app token spliced into openclaw.json — apply_slack_token_override regression?",
           "polarity": "fail",
           "normalized_id": "m.s5f.real.slack.bot.app.token.spliced.into.openclaw.json.apply.slack.token.override.regression",
@@ -7852,7 +7852,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 617,
+          "line": 625,
           "text": "M-S5f: openclaw.json holds both Bolt-shape Slack placeholders (no real token on disk)",
           "polarity": "pass",
           "normalized_id": "m.s5f.openclaw.json.holds.both.bolt.shape.slack.placeholders.no.real.token.on.disk",
@@ -7860,7 +7860,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 626,
+          "line": 634,
           "text": "M-S5g: removed Slack token rewriter preload still present in NODE_OPTIONS",
           "polarity": "fail",
           "normalized_id": "m.s5g.removed.slack.token.rewriter.preload.still.present.in.node.options",
@@ -7868,7 +7868,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 628,
+          "line": 636,
           "text": "M-S5g: Slack token rewriter preload absent from NODE_OPTIONS",
           "polarity": "pass",
           "normalized_id": "m.s5g.slack.token.rewriter.preload.absent.from.node.options",
@@ -7876,7 +7876,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 644,
+          "line": 652,
           "text": "M-W3: Real WeChat token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m.w3.real.wechat.token.leaked.into.sandbox.env",
@@ -7884,7 +7884,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 646,
+          "line": 654,
           "text": "M-W3: Sandbox WECHAT_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m.w3.sandbox.wechat.bot.token.is.a.placeholder.not.the.real.token",
@@ -7892,7 +7892,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 655,
+          "line": 663,
           "text": "M-W3a: Real WeChat token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.w3a.real.wechat.token.found.in.full.sandbox.environment.dump",
@@ -7900,7 +7900,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 657,
+          "line": 665,
           "text": "M-W3a: Real WeChat token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.w3a.real.wechat.token.absent.from.full.sandbox.environment",
@@ -7908,7 +7908,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 664,
+          "line": 672,
           "text": "M-W3b: Real WeChat token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.w3b.real.wechat.token.found.in.sandbox.process.list",
@@ -7916,7 +7916,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 666,
+          "line": 674,
           "text": "M-W3b: Real WeChat token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.w3b.real.wechat.token.absent.from.sandbox.process.list",
@@ -7924,7 +7924,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 674,
+          "line": 682,
           "text": "M-W3c: Real WeChat token found on sandbox filesystem: ${sandbox_fs_wc}",
           "polarity": "fail",
           "normalized_id": "m.w3c.real.wechat.token.found.on.sandbox.filesystem.sandbox.fs.wc",
@@ -7932,7 +7932,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 676,
+          "line": 684,
           "text": "M-W3c: Real WeChat token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.w3c.real.wechat.token.absent.from.sandbox.filesystem",
@@ -7940,7 +7940,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 682,
+          "line": 690,
           "text": "M-W3d: WeChat placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.w3d.wechat.placeholder.confirmed.present.in.sandbox.environment",
@@ -7948,7 +7948,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 684,
+          "line": 692,
           "text": "M-W3d: WeChat placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m.w3d.wechat.placeholder.not.found.in.sandbox.environment",
@@ -7956,7 +7956,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 707,
+          "line": 715,
           "text": "M6: Could not read openclaw.json channels (${channel_json:0:200})",
           "polarity": "fail",
           "normalized_id": "m6.could.not.read.openclaw.json.channels.channel.json.0.200",
@@ -7964,7 +7964,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 724,
+          "line": 732,
           "text": "M6: Telegram channel botToken present in openclaw.json",
           "polarity": "pass",
           "normalized_id": "m6.telegram.channel.bottoken.present.in.openclaw.json",
@@ -7972,7 +7972,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 731,
+          "line": 739,
           "text": "M7: Telegram botToken is not the host-side token (placeholder confirmed)",
           "polarity": "pass",
           "normalized_id": "m7.telegram.bottoken.is.not.the.host.side.token.placeholder.confirmed",
@@ -7980,7 +7980,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 733,
+          "line": 741,
           "text": "M7: Telegram botToken matches host-side token — credential leaked into config!",
           "polarity": "fail",
           "normalized_id": "m7.telegram.bottoken.matches.host.side.token.credential.leaked.into.config",
@@ -7988,7 +7988,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 748,
+          "line": 756,
           "text": "M8: Discord channel token present in openclaw.json",
           "polarity": "pass",
           "normalized_id": "m8.discord.channel.token.present.in.openclaw.json",
@@ -7996,7 +7996,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 755,
+          "line": 763,
           "text": "M9: Discord token is not the host-side token (placeholder confirmed)",
           "polarity": "pass",
           "normalized_id": "m9.discord.token.is.not.the.host.side.token.placeholder.confirmed",
@@ -8004,7 +8004,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 757,
+          "line": 765,
           "text": "M9: Discord token matches host-side token — credential leaked into config!",
           "polarity": "fail",
           "normalized_id": "m9.discord.token.matches.host.side.token.credential.leaked.into.config",
@@ -8012,7 +8012,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 772,
+          "line": 780,
           "text": "M10: Telegram channel is enabled",
           "polarity": "pass",
           "normalized_id": "m10.telegram.channel.is.enabled",
@@ -8020,7 +8020,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 787,
+          "line": 795,
           "text": "M11: Discord channel is enabled",
           "polarity": "pass",
           "normalized_id": "m11.discord.channel.is.enabled",
@@ -8028,7 +8028,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 802,
+          "line": 810,
           "text": "M11b: Telegram dmPolicy is 'allowlist'",
           "polarity": "pass",
           "normalized_id": "m11b.telegram.dmpolicy.is.allowlist",
@@ -8036,7 +8036,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 804,
+          "line": 812,
           "text": "M11b: Telegram dmPolicy is '$tg_dm_policy' (expected 'allowlist')",
           "polarity": "fail",
           "normalized_id": "m11b.telegram.dmpolicy.is.tg.dm.policy.expected.allowlist",
@@ -8044,7 +8044,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 832,
+          "line": 840,
           "text": "M11c: Telegram allowFrom contains all expected user IDs: $tg_allow_from",
           "polarity": "pass",
           "normalized_id": "m11c.telegram.allowfrom.contains.all.expected.user.ids.tg.allow.from",
@@ -8052,7 +8052,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 834,
+          "line": 842,
           "text": "M11c: Telegram allowFrom ($tg_allow_from) is missing IDs: ${missing_ids[*]} (expected all of: $TELEGRAM_IDS)",
           "polarity": "fail",
           "normalized_id": "m11c.telegram.allowfrom.tg.allow.from.is.missing.ids.missing.ids.expected.all.of.telegram.ids",
@@ -8060,7 +8060,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 850,
+          "line": 858,
           "text": "M11d: Telegram groupPolicy is 'open'",
           "polarity": "pass",
           "normalized_id": "m11d.telegram.grouppolicy.is.open",
@@ -8068,7 +8068,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 852,
+          "line": 860,
           "text": "M11d: Telegram groupPolicy is '$tg_group_policy' (expected 'open')",
           "polarity": "fail",
           "normalized_id": "m11d.telegram.grouppolicy.is.tg.group.policy.expected.open",
@@ -8076,7 +8076,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 868,
+          "line": 876,
           "text": "M11e: Slack channel configured with placeholder tokens (guard needed)",
           "polarity": "pass",
           "normalized_id": "m11e.slack.channel.configured.with.placeholder.tokens.guard.needed",
@@ -8084,7 +8084,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 880,
+          "line": 888,
           "text": "M11f: Slack dmPolicy is 'allowlist'",
           "polarity": "pass",
           "normalized_id": "m11f.slack.dmpolicy.is.allowlist",
@@ -8092,7 +8092,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 882,
+          "line": 890,
           "text": "M11f: Slack dmPolicy is '$sl_dm_policy' (expected 'allowlist')",
           "polarity": "fail",
           "normalized_id": "m11f.slack.dmpolicy.is.sl.dm.policy.expected.allowlist",
@@ -8100,7 +8100,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 894,
+          "line": 902,
           "text": "M11g: Slack groupPolicy is 'allowlist'",
           "polarity": "pass",
           "normalized_id": "m11g.slack.grouppolicy.is.allowlist",
@@ -8108,7 +8108,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 896,
+          "line": 904,
           "text": "M11g: Slack groupPolicy is '$sl_group_policy' (expected 'allowlist')",
           "polarity": "fail",
           "normalized_id": "m11g.slack.grouppolicy.is.sl.group.policy.expected.allowlist",
@@ -8116,7 +8116,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 914,
+          "line": 928,
           "text": "M11h: Slack wildcard channel config is not enabled",
           "polarity": "fail",
           "normalized_id": "m11h.slack.wildcard.channel.config.is.not.enabled",
@@ -8124,7 +8124,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 916,
+          "line": 930,
           "text": "M11h: Slack wildcard channel config does not require mention",
           "polarity": "fail",
           "normalized_id": "m11h.slack.wildcard.channel.config.does.not.require.mention",
@@ -8132,23 +8132,39 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 929,
-          "text": "M11h: Slack wildcard channel @mention allowlist contains expected users: $sl_channel_users",
-          "polarity": "pass",
-          "normalized_id": "m11h.slack.wildcard.channel.mention.allowlist.contains.expected.users.sl.channel.users",
-          "mapping_status": "deferred"
-        },
-        {
-          "script": "test/e2e/test-messaging-providers.sh",
-          "line": 931,
-          "text": "M11h: Slack wildcard channel users ($sl_channel_users) missing IDs: ${missing_slack_ids[*]}",
+          "line": 932,
+          "text": "M11h: Slack wildcard channel users is not a list",
           "polarity": "fail",
-          "normalized_id": "m11h.slack.wildcard.channel.users.sl.channel.users.missing.ids.missing.slack.ids",
+          "normalized_id": "m11h.slack.wildcard.channel.users.is.not.a.list",
           "mapping_status": "deferred"
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 960,
+          "line": 934,
+          "text": "M11h: Slack wildcard channel users is empty",
+          "polarity": "fail",
+          "normalized_id": "m11h.slack.wildcard.channel.users.is.empty",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 949,
+          "text": "M11h: Slack wildcard channel @mention allowlist contains expected user count (${expected_slack_id_count})",
+          "polarity": "pass",
+          "normalized_id": "m11h.slack.wildcard.channel.mention.allowlist.contains.expected.user.count.expected.slack.id.count",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 951,
+          "text": "M11h: Slack wildcard channel users missing ${#missing_slack_ids[@]} expected ID(s)",
+          "polarity": "fail",
+          "normalized_id": "m11h.slack.wildcard.channel.users.missing.missing.slack.ids.expected.id.s",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 980,
           "text": "M-W8: WeChat account '$WECHAT_ACCOUNT' is enabled in openclaw.json (channels.openclaw-weixin)",
           "polarity": "pass",
           "normalized_id": "m.w8.wechat.account.wechat.account.is.enabled.in.openclaw.json.channels.openclaw.weixin",
@@ -8156,7 +8172,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 976,
+          "line": 996,
           "text": "M-W9: Real WeChat token spliced into accounts/${WECHAT_ACCOUNT}.json — seed-wechat-accounts.py placeholder regression",
           "polarity": "fail",
           "normalized_id": "m.w9.real.wechat.token.spliced.into.accounts.wechat.account.json.seed.wechat.accounts.py.placeholder.regression",
@@ -8164,7 +8180,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 978,
+          "line": 998,
           "text": "M-W9: WeChat per-account credential file uses the L7-resolved placeholder",
           "polarity": "pass",
           "normalized_id": "m.w9.wechat.per.account.credential.file.uses.the.l7.resolved.placeholder",
@@ -8172,7 +8188,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 980,
+          "line": 1000,
           "text": "M-W9: WeChat per-account credential file has unexpected token shape: $(echo ",
           "polarity": "fail",
           "normalized_id": "m.w9.wechat.per.account.credential.file.has.unexpected.token.shape.echo",
@@ -8180,7 +8196,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 999,
+          "line": 1019,
           "text": "M-W10: WeChat accounts.json index contains '$WECHAT_ACCOUNT'",
           "polarity": "pass",
           "normalized_id": "m.w10.wechat.accounts.json.index.contains.wechat.account",
@@ -8188,7 +8204,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1001,
+          "line": 1021,
           "text": "M-W10: WeChat accounts.json missing '$WECHAT_ACCOUNT' (raw: $(echo ",
           "polarity": "fail",
           "normalized_id": "m.w10.wechat.accounts.json.missing.wechat.account.raw.echo",
@@ -8196,7 +8212,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1022,
+          "line": 1042,
           "text": "M12: Node.js reached api.telegram.org (${tg_reach})",
           "polarity": "pass",
           "normalized_id": "m12.node.js.reached.api.telegram.org.tg.reach",
@@ -8204,7 +8220,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1028,
+          "line": 1048,
           "text": "M12: Node.js could not reach api.telegram.org (${tg_reach:0:200})",
           "polarity": "fail",
           "normalized_id": "m12.node.js.could.not.reach.api.telegram.org.tg.reach.0.200",
@@ -8212,7 +8228,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1036,
+          "line": 1056,
           "text": "M13-policy: Live policy contains Discord endpoints and Node binaries",
           "polarity": "pass",
           "normalized_id": "m13.policy.live.policy.contains.discord.endpoints.and.node.binaries",
@@ -8220,7 +8236,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1038,
+          "line": 1058,
           "text": "M13-policy: Live policy is missing expected Discord preset endpoint/binary entries",
           "polarity": "fail",
           "normalized_id": "m13.policy.live.policy.is.missing.expected.discord.preset.endpoint.binary.entries",
@@ -8228,7 +8244,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1044,
+          "line": 1064,
           "text": "M13-proxy: Sandbox uses the OpenShell gateway proxy",
           "polarity": "pass",
           "normalized_id": "m13.proxy.sandbox.uses.the.openshell.gateway.proxy",
@@ -8236,7 +8252,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1046,
+          "line": 1066,
           "text": "M13-proxy: Sandbox proxy env does not point at OpenShell gateway: ${live_proxy_env:0:200}",
           "polarity": "fail",
           "normalized_id": "m13.proxy.sandbox.proxy.env.does.not.point.at.openshell.gateway.live.proxy.env.0.200",
@@ -8244,7 +8260,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1067,
+          "line": 1087,
           "text": "M13-curl: curl unexpectedly established a tunnel to Discord; binary whitelist may be too broad",
           "polarity": "fail",
           "normalized_id": "m13.curl.curl.unexpectedly.established.a.tunnel.to.discord.binary.whitelist.may.be.too.broad",
@@ -8252,7 +8268,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1110,
+          "line": 1130,
           "text": "M13: Node.js reached Discord API and CDN through the same proxy (${dc_reach//$'\\n'/ })",
           "polarity": "pass",
           "normalized_id": "m13.node.js.reached.discord.api.and.cdn.through.the.same.proxy.dc.reach.n",
@@ -8260,7 +8276,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1112,
+          "line": 1132,
           "text": "M13: Node.js was denied by the proxy despite the Discord preset being applied: ${dc_reach:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.node.js.was.denied.by.the.proxy.despite.the.discord.preset.being.applied.dc.reach.0.300",
@@ -8268,7 +8284,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1116,
+          "line": 1136,
           "text": "M13: Node.js could not reach Discord API/CDN (${dc_reach:0:200})",
           "polarity": "fail",
           "normalized_id": "m13.node.js.could.not.reach.discord.api.cdn.dc.reach.0.200",
@@ -8276,7 +8292,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1123,
+          "line": 1143,
           "text": "M13-rest-a: Hermetic fake Discord REST API started on host port ${FAKE_DISCORD_REST_PORT}",
           "polarity": "pass",
           "normalized_id": "m13.rest.a.hermetic.fake.discord.rest.api.started.on.host.port.fake.discord.rest.port",
@@ -8284,7 +8300,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1132,
+          "line": 1152,
           "text": "M13-rest-b: Applied Node-only HTTPS policy for fake Discord REST API",
           "polarity": "pass",
           "normalized_id": "m13.rest.b.applied.node.only.https.policy.for.fake.discord.rest.api",
@@ -8292,7 +8308,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1134,
+          "line": 1154,
           "text": "M13-rest-b: Failed to apply fake Discord REST policy: $(tail -20 /tmp/nemoclaw-fake-discord-rest-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m13.rest.b.failed.to.apply.fake.discord.rest.policy.tail.20.tmp.nemoclaw.fake.discord.rest.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8300,7 +8316,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1148,
+          "line": 1168,
           "text": "M13-rest-c: Node reached the fake Discord REST API through OpenShell",
           "polarity": "pass",
           "normalized_id": "m13.rest.c.node.reached.the.fake.discord.rest.api.through.openshell",
@@ -8308,7 +8324,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1150,
+          "line": 1170,
           "text": "M13-rest-c: Node failed to reach fake Discord REST API: ${fake_rest_node:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.rest.c.node.failed.to.reach.fake.discord.rest.api.fake.rest.node.0.300",
@@ -8316,7 +8332,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1162,
+          "line": 1182,
           "text": "M13-rest-d: curl was denied before reaching the fake Discord REST API",
           "polarity": "pass",
           "normalized_id": "m13.rest.d.curl.was.denied.before.reaching.the.fake.discord.rest.api",
@@ -8324,7 +8340,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1164,
+          "line": 1184,
           "text": "M13-rest-d: curl unexpectedly established a tunnel to the fake Discord REST API",
           "polarity": "fail",
           "normalized_id": "m13.rest.d.curl.unexpectedly.established.a.tunnel.to.the.fake.discord.rest.api",
@@ -8332,7 +8348,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1166,
+          "line": 1186,
           "text": "M13-rest-d: Fake Discord REST curl denial had unexpected shape: ${fake_rest_curl:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.rest.d.fake.discord.rest.curl.denial.had.unexpected.shape.fake.rest.curl.0.300",
@@ -8340,7 +8356,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1178,
+          "line": 1198,
           "text": "M13-rest-e: Fake server saw Node but no curl request",
           "polarity": "pass",
           "normalized_id": "m13.rest.e.fake.server.saw.node.but.no.curl.request",
@@ -8348,7 +8364,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1180,
+          "line": 1200,
           "text": "M13-rest-e: Unexpected fake Discord REST capture counts: ${fake_rest_capture}",
           "polarity": "fail",
           "normalized_id": "m13.rest.e.unexpected.fake.discord.rest.capture.counts.fake.rest.capture",
@@ -8356,7 +8372,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1187,
+          "line": 1207,
           "text": "M13b: Hermetic fake Discord Gateway started on host port ${FAKE_DISCORD_GATEWAY_PORT}",
           "polarity": "pass",
           "normalized_id": "m13b.hermetic.fake.discord.gateway.started.on.host.port.fake.discord.gateway.port",
@@ -8364,7 +8380,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1189,
+          "line": 1209,
           "text": "M13b: Failed to start hermetic fake Discord Gateway",
           "polarity": "fail",
           "normalized_id": "m13b.failed.to.start.hermetic.fake.discord.gateway",
@@ -8372,7 +8388,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1194,
+          "line": 1214,
           "text": "M13c: Applied native WebSocket policy with credential rewrite for fake Discord Gateway",
           "polarity": "pass",
           "normalized_id": "m13c.applied.native.websocket.policy.with.credential.rewrite.for.fake.discord.gateway",
@@ -8380,7 +8396,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1196,
+          "line": 1216,
           "text": "M13c: Failed to apply fake Discord Gateway policy: $(tail -20 /tmp/nemoclaw-fake-discord-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m13c.failed.to.apply.fake.discord.gateway.policy.tail.20.tmp.nemoclaw.fake.discord.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8388,7 +8404,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1206,
+          "line": 1226,
           "text": "M13d: Native WebSocket upgrade reached fake Discord Gateway through OpenShell",
           "polarity": "pass",
           "normalized_id": "m13d.native.websocket.upgrade.reached.fake.discord.gateway.through.openshell",
@@ -8396,7 +8412,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1208,
+          "line": 1228,
           "text": "M13d: Native WebSocket upgrade failed: ${dc_ws_native:0:300}",
           "polarity": "fail",
           "normalized_id": "m13d.native.websocket.upgrade.failed.dc.ws.native.0.300",
@@ -8404,7 +8420,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1215,
+          "line": 1235,
           "text": "M13e: Discord HELLO, placeholder IDENTIFY, READY, and heartbeat ACK completed",
           "polarity": "pass",
           "normalized_id": "m13e.discord.hello.placeholder.identify.ready.and.heartbeat.ack.completed",
@@ -8412,7 +8428,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1217,
+          "line": 1237,
           "text": "M13e: Discord Gateway protocol proof incomplete: ${dc_ws_native:0:400}",
           "polarity": "fail",
           "normalized_id": "m13e.discord.gateway.protocol.proof.incomplete.dc.ws.native.0.400",
@@ -8420,7 +8436,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1223,
+          "line": 1243,
           "text": "M13f: Fake Gateway received host-side Discord token; sandbox-visible IDENTIFY used only the placeholder",
           "polarity": "pass",
           "normalized_id": "m13f.fake.gateway.received.host.side.discord.token.sandbox.visible.identify.used.only.the.placeholder",
@@ -8428,7 +8444,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1228,
+          "line": 1248,
           "text": "M13f: Fake Gateway did not prove placeholder-to-token rewrite at the relay boundary",
           "polarity": "fail",
           "normalized_id": "m13f.fake.gateway.did.not.prove.placeholder.to.token.rewrite.at.the.relay.boundary",
@@ -8436,7 +8452,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1244,
+          "line": 1264,
           "text": "M13g: Unregistered Discord WebSocket placeholder is rejected before upstream token exposure",
           "polarity": "pass",
           "normalized_id": "m13g.unregistered.discord.websocket.placeholder.is.rejected.before.upstream.token.exposure",
@@ -8444,7 +8460,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1246,
+          "line": 1266,
           "text": "M13g: Unregistered Discord WebSocket placeholder reached READY or leaked upstream",
           "polarity": "fail",
           "normalized_id": "m13g.unregistered.discord.websocket.placeholder.reached.ready.or.leaked.upstream",
@@ -8452,7 +8468,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1252,
+          "line": 1272,
           "text": "M14: curl to api.telegram.org blocked (binary restriction enforced)",
           "polarity": "pass",
           "normalized_id": "m14.curl.to.api.telegram.org.blocked.binary.restriction.enforced",
@@ -8460,7 +8476,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1254,
+          "line": 1274,
           "text": "M14: curl returned empty (likely blocked by policy)",
           "polarity": "pass",
           "normalized_id": "m14.curl.returned.empty.likely.blocked.by.policy",
@@ -8468,7 +8484,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1258,
+          "line": 1278,
           "text": "M14: curl not available in sandbox (defense in depth)",
           "polarity": "pass",
           "normalized_id": "m14.curl.not.available.in.sandbox.defense.in.depth",
@@ -8476,7 +8492,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1292,
+          "line": 1312,
           "text": "M15: Telegram getMe returned 200 — real token verified!",
           "polarity": "pass",
           "normalized_id": "m15.telegram.getme.returned.200.real.token.verified",
@@ -8484,7 +8500,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1297,
+          "line": 1317,
           "text": "M15: Telegram getMe returned $tg_status — L7 proxy rewrote placeholder (fake token rejected by API)",
           "polarity": "pass",
           "normalized_id": "m15.telegram.getme.returned.tg.status.l7.proxy.rewrote.placeholder.fake.token.rejected.by.api",
@@ -8492,7 +8508,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1298,
+          "line": 1318,
           "text": "M16: Full chain verified: sandbox → proxy → token rewrite → Telegram API",
           "polarity": "pass",
           "normalized_id": "m16.full.chain.verified.sandbox.proxy.token.rewrite.telegram.api",
@@ -8500,7 +8516,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1304,
+          "line": 1324,
           "text": "M15: Telegram API call failed with error: ${tg_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m15.telegram.api.call.failed.with.error.tg.api.0.200",
@@ -8508,7 +8524,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1306,
+          "line": 1326,
           "text": "M15: Unexpected Telegram response (status=$tg_status): ${tg_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m15.unexpected.telegram.response.status.tg.status.tg.api.0.200",
@@ -8516,7 +8532,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1333,
+          "line": 1353,
           "text": "M17: Discord users/@me returned 200 — real token verified!",
           "polarity": "pass",
           "normalized_id": "m17.discord.users.me.returned.200.real.token.verified",
@@ -8524,7 +8540,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1335,
+          "line": 1355,
           "text": "M17: Discord users/@me returned 401 — L7 proxy rewrote placeholder (fake token rejected by API)",
           "polarity": "pass",
           "normalized_id": "m17.discord.users.me.returned.401.l7.proxy.rewrote.placeholder.fake.token.rejected.by.api",
@@ -8532,7 +8548,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1339,
+          "line": 1359,
           "text": "M17: Discord API call failed with error: ${dc_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m17.discord.api.call.failed.with.error.dc.api.0.200",
@@ -8540,7 +8556,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1341,
+          "line": 1361,
           "text": "M17: Unexpected Discord response (status=$dc_status): ${dc_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m17.unexpected.discord.response.status.dc.status.dc.api.0.200",
@@ -8548,7 +8564,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1353,
+          "line": 1373,
           "text": "M-S14a: Hermetic fake Slack API started on host port ${FAKE_SLACK_API_PORT}",
           "polarity": "pass",
           "normalized_id": "m.s14a.hermetic.fake.slack.api.started.on.host.port.fake.slack.api.port",
@@ -8556,7 +8572,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1355,
+          "line": 1375,
           "text": "M-S14a: Failed to start hermetic fake Slack API",
           "polarity": "fail",
           "normalized_id": "m.s14a.failed.to.start.hermetic.fake.slack.api",
@@ -8564,7 +8580,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1360,
+          "line": 1380,
           "text": "M-S14b: Applied REST policy for hermetic fake Slack API",
           "polarity": "pass",
           "normalized_id": "m.s14b.applied.rest.policy.for.hermetic.fake.slack.api",
@@ -8572,7 +8588,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1362,
+          "line": 1382,
           "text": "M-S14b: Failed to apply fake Slack API policy: $(tail -20 /tmp/nemoclaw-fake-slack-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m.s14b.failed.to.apply.fake.slack.api.policy.tail.20.tmp.nemoclaw.fake.slack.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8580,7 +8596,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1444,
+          "line": 1464,
           "text": "M-S15: Slack auth.test returned ok:true — real token round-trip verified!",
           "polarity": "pass",
           "normalized_id": "m.s15.slack.auth.test.returned.ok.true.real.token.round.trip.verified",
@@ -8588,7 +8604,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1446,
+          "line": 1466,
           "text": "M-S15: Slack auth.test returned invalid_auth — full chain verified (OpenShell alias rewrite → fake Slack)",
           "polarity": "pass",
           "normalized_id": "m.s15.slack.auth.test.returned.invalid.auth.full.chain.verified.openshell.alias.rewrite.fake.slack",
@@ -8596,7 +8612,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1449,
+          "line": 1469,
           "text": "M-S15a: fake Slack saw host-side bot token in header and urlencoded body",
           "polarity": "pass",
           "normalized_id": "m.s15a.fake.slack.saw.host.side.bot.token.in.header.and.urlencoded.body",
@@ -8604,7 +8620,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1451,
+          "line": 1471,
           "text": "M-S15a: fake Slack capture did not prove bot header/body rewrite: ${sl_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s15a.fake.slack.capture.did.not.prove.bot.header.body.rewrite.sl.capture.0.300",
@@ -8612,7 +8628,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1456,
+          "line": 1476,
           "text": "M-S15: Slack API call failed with error: ${sl_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15.slack.api.call.failed.with.error.sl.api.0.200",
@@ -8620,7 +8636,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1458,
+          "line": 1478,
           "text": "M-S15: OpenShell did not resolve the Bolt-shape alias",
           "polarity": "fail",
           "normalized_id": "m.s15.openshell.did.not.resolve.the.bolt.shape.alias",
@@ -8628,7 +8644,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1460,
+          "line": 1480,
           "text": "M-S15: L7 proxy did not substitute the canonical placeholder — substitution chain broken",
           "polarity": "fail",
           "normalized_id": "m.s15.l7.proxy.did.not.substitute.the.canonical.placeholder.substitution.chain.broken",
@@ -8636,7 +8652,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1462,
+          "line": 1482,
           "text": "M-S15: Unexpected Slack response (status=$sl_status): ${sl_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15.unexpected.slack.response.status.sl.status.sl.api.0.200",
@@ -8644,7 +8660,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1483,
+          "line": 1503,
           "text": "M-S15b: L7 proxy substitutes openshell:resolve:env:SLACK_BOT_TOKEN at egress (parallels Telegram M15 / Discord M17)",
           "polarity": "pass",
           "normalized_id": "m.s15b.l7.proxy.substitutes.openshell.resolve.env.slack.bot.token.at.egress.parallels.telegram.m15.discord.m17",
@@ -8652,7 +8668,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1487,
+          "line": 1507,
           "text": "M-S15b: L7 proxy passed canonical placeholder through unchanged — substitution not happening for SLACK_BOT_TOKEN",
           "polarity": "fail",
           "normalized_id": "m.s15b.l7.proxy.passed.canonical.placeholder.through.unchanged.substitution.not.happening.for.slack.bot.token",
@@ -8660,7 +8676,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1489,
+          "line": 1509,
           "text": "M-S15b: Unexpected response (status=$sl_canon_status): ${sl_canonical:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15b.unexpected.response.status.sl.canon.status.sl.canonical.0.200",
@@ -8668,7 +8684,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1510,
+          "line": 1530,
           "text": "M-S15c: unset-var failed closed before upstream exposure",
           "polarity": "pass",
           "normalized_id": "m.s15c.unset.var.failed.closed.before.upstream.exposure",
@@ -8676,7 +8692,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1512,
+          "line": 1532,
           "text": "M-S15c: unset-var triggered connection-level failure — proxy refuses to forward unsubstituted placeholder",
           "polarity": "pass",
           "normalized_id": "m.s15c.unset.var.triggered.connection.level.failure.proxy.refuses.to.forward.unsubstituted.placeholder",
@@ -8684,7 +8700,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1514,
+          "line": 1534,
           "text": "M-S15c: unset-var returned HTTP 200 — proxy passed canonical placeholder through unchanged for unset env (substitution may be a no-op)",
           "polarity": "fail",
           "normalized_id": "m.s15c.unset.var.returned.http.200.proxy.passed.canonical.placeholder.through.unchanged.for.unset.env.substitution.may.be.a.no.op",
@@ -8692,7 +8708,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1516,
+          "line": 1536,
           "text": "M-S15c: unset-var request reached fake Slack — unresolved placeholder escaped the proxy boundary",
           "polarity": "fail",
           "normalized_id": "m.s15c.unset.var.request.reached.fake.slack.unresolved.placeholder.escaped.the.proxy.boundary",
@@ -8700,7 +8716,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1537,
+          "line": 1557,
           "text": "M-S16: apps.connections.open returned ok:true — real xapp token round-trip verified!",
           "polarity": "pass",
           "normalized_id": "m.s16.apps.connections.open.returned.ok.true.real.xapp.token.round.trip.verified",
@@ -8708,7 +8724,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1539,
+          "line": 1559,
           "text": "M-S16: apps.connections.open auth-rejected — Socket Mode HTTPS leg verified (OpenShell alias rewrite → fake Slack)",
           "polarity": "pass",
           "normalized_id": "m.s16.apps.connections.open.auth.rejected.socket.mode.https.leg.verified.openshell.alias.rewrite.fake.slack",
@@ -8716,7 +8732,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1542,
+          "line": 1562,
           "text": "M-S16a: fake Slack saw host-side app token in header and urlencoded body",
           "polarity": "pass",
           "normalized_id": "m.s16a.fake.slack.saw.host.side.app.token.in.header.and.urlencoded.body",
@@ -8724,7 +8740,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1544,
+          "line": 1564,
           "text": "M-S16a: fake Slack capture did not prove app header/body rewrite: ${sl_app_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s16a.fake.slack.capture.did.not.prove.app.header.body.rewrite.sl.app.capture.0.300",
@@ -8732,7 +8748,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1549,
+          "line": 1569,
           "text": "M-S16: OpenShell did not resolve the xapp- alias for Socket Mode path",
           "polarity": "fail",
           "normalized_id": "m.s16.openshell.did.not.resolve.the.xapp.alias.for.socket.mode.path",
@@ -8740,7 +8756,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1551,
+          "line": 1571,
           "text": "M-S16: Unexpected apps.connections.open response (status=$sl_app_status): ${sl_app_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s16.unexpected.apps.connections.open.response.status.sl.app.status.sl.app.api.0.200",
@@ -8748,7 +8764,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1575,
+          "line": 1595,
           "text": "M-S16b: unset app-token failed closed before upstream exposure",
           "polarity": "pass",
           "normalized_id": "m.s16b.unset.app.token.failed.closed.before.upstream.exposure",
@@ -8756,7 +8772,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1577,
+          "line": 1597,
           "text": "M-S16b: L7 proxy substitutes openshell:resolve:env:SLACK_APP_TOKEN at egress (unset-var control diverged)",
           "polarity": "pass",
           "normalized_id": "m.s16b.l7.proxy.substitutes.openshell.resolve.env.slack.app.token.at.egress.unset.var.control.diverged",
@@ -8764,7 +8780,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1579,
+          "line": 1599,
           "text": "M-S16b: unset app-token env returned HTTP 200 — proxy may be passing canonical placeholders through unchanged",
           "polarity": "fail",
           "normalized_id": "m.s16b.unset.app.token.env.returned.http.200.proxy.may.be.passing.canonical.placeholders.through.unchanged",
@@ -8772,7 +8788,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1581,
+          "line": 1601,
           "text": "M-S16b: unset app-token request reached fake Slack — unresolved placeholder escaped the proxy boundary",
           "polarity": "fail",
           "normalized_id": "m.s16b.unset.app.token.request.reached.fake.slack.unresolved.placeholder.escaped.the.proxy.boundary",
@@ -8780,7 +8796,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1590,
+          "line": 1610,
           "text": "M-S16b: L7 proxy passed canonical placeholder through unchanged for SLACK_APP_TOKEN",
           "polarity": "fail",
           "normalized_id": "m.s16b.l7.proxy.passed.canonical.placeholder.through.unchanged.for.slack.app.token",
@@ -8788,7 +8804,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1592,
+          "line": 1612,
           "text": "M-S16b: Unexpected response (status=$sl_app_canon_status): ${sl_app_canonical:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s16b.unexpected.response.status.sl.app.canon.status.sl.app.canonical.0.200",
@@ -8796,7 +8812,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1611,
+          "line": 1631,
           "text": "M-S17: Slack channel @mention allowlist accepts configured user and denies another user",
           "polarity": "pass",
           "normalized_id": "m.s17.slack.channel.mention.allowlist.accepts.configured.user.and.denies.another.user",
@@ -8804,7 +8820,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1614,
+          "line": 1634,
           "text": "M-S17a: fake Slack saw host-side bot token for channel reply",
           "polarity": "pass",
           "normalized_id": "m.s17a.fake.slack.saw.host.side.bot.token.for.channel.reply",
@@ -8812,7 +8828,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1616,
+          "line": 1636,
           "text": "M-S17a: fake Slack capture did not prove channel reply token rewrite: ${sl_post_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s17a.fake.slack.capture.did.not.prove.channel.reply.token.rewrite.sl.post.capture.0.300",
@@ -8820,7 +8836,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1620,
+          "line": 1640,
           "text": "M-S17b: fake Slack captured non-secret channel/text metadata for channel reply",
           "polarity": "pass",
           "normalized_id": "m.s17b.fake.slack.captured.non.secret.channel.text.metadata.for.channel.reply",
@@ -8828,7 +8844,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1622,
+          "line": 1642,
           "text": "M-S17b: fake Slack did not capture expected channel reply metadata: ${sl_message_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s17b.fake.slack.did.not.capture.expected.channel.reply.metadata.sl.message.capture.0.300",
@@ -8836,7 +8852,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1629,
+          "line": 1649,
           "text": "M-S17: Slack channel @mention proof failed: ${sl_channel_proof:0:500}",
           "polarity": "fail",
           "normalized_id": "m.s17.slack.channel.mention.proof.failed.sl.channel.proof.0.500",
@@ -8844,7 +8860,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1644,
+          "line": 1664,
           "text": "M18: Telegram getMe returned 200 with real token",
           "polarity": "pass",
           "normalized_id": "m18.telegram.getme.returned.200.with.real.token",
@@ -8852,7 +8868,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1646,
+          "line": 1666,
           "text": "M18b: Telegram response contains ok:true",
           "polarity": "pass",
           "normalized_id": "m18b.telegram.response.contains.ok.true",
@@ -8860,7 +8876,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1649,
+          "line": 1669,
           "text": "M18: Expected Telegram getMe 200 with real token, got: $tg_status",
           "polarity": "fail",
           "normalized_id": "m18.expected.telegram.getme.200.with.real.token.got.tg.status",
@@ -8868,7 +8884,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1679,
+          "line": 1699,
           "text": "M19: Telegram sendMessage succeeded",
           "polarity": "pass",
           "normalized_id": "m19.telegram.sendmessage.succeeded",
@@ -8876,7 +8892,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1681,
+          "line": 1701,
           "text": "M19: Telegram sendMessage failed: ${send_result:0:200}",
           "polarity": "fail",
           "normalized_id": "m19.telegram.sendmessage.failed.send.result.0.200",
@@ -8884,7 +8900,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1693,
+          "line": 1713,
           "text": "M20: Discord users/@me returned 200 with real token",
           "polarity": "pass",
           "normalized_id": "m20.discord.users.me.returned.200.with.real.token",
@@ -8892,7 +8908,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1695,
+          "line": 1715,
           "text": "M20: Expected Discord users/@me 200 with real token, got: $dc_status",
           "polarity": "fail",
           "normalized_id": "m20.expected.discord.users.me.200.with.real.token.got.dc.status",
@@ -8900,7 +8916,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1727,
+          "line": 1747,
           "text": "S1: Gateway is serving on port 18789 — Slack auth failure did not crash it",
           "polarity": "pass",
           "normalized_id": "s1.gateway.is.serving.on.port.18789.slack.auth.failure.did.not.crash.it",
@@ -8908,7 +8924,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1729,
+          "line": 1749,
           "text": "S1: Gateway is not serving on port 18789 (${gw_port:0:200})",
           "polarity": "fail",
           "normalized_id": "s1.gateway.is.not.serving.on.port.18789.gw.port.0.200",
@@ -8916,7 +8932,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1755,
+          "line": 1775,
           "text": "S2: Gateway log shows Slack rejection was caught by channel guard",
           "polarity": "pass",
           "normalized_id": "s2.gateway.log.shows.slack.rejection.was.caught.by.channel.guard",
@@ -8924,7 +8940,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1780,
+          "line": 1800,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' intentionally kept",
           "polarity": "pass",
           "normalized_id": "cleanup.sandbox.sandbox.name.intentionally.kept",
@@ -8932,7 +8948,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1782,
+          "line": 1802,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' still present after cleanup",
           "polarity": "fail",
           "normalized_id": "cleanup.sandbox.sandbox.name.still.present.after.cleanup",
@@ -8940,7 +8956,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1784,
+          "line": 1804,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' removed",
           "polarity": "pass",
           "normalized_id": "cleanup.sandbox.sandbox.name.removed",
@@ -16332,7 +16348,7 @@
   ],
   "totals": {
     "scripts": 52,
-    "assertions": 2008,
+    "assertions": 2010,
     "zero_assertion_scripts": 2
   }
 }

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -7404,7 +7404,7 @@
       "assertions": [
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 202,
+          "line": 205,
           "text": "NVIDIA_API_KEY not set",
           "polarity": "fail",
           "normalized_id": "nvidia.api.key.not.set",
@@ -7412,7 +7412,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 205,
+          "line": 208,
           "text": "NVIDIA_API_KEY is set",
           "polarity": "pass",
           "normalized_id": "nvidia.api.key.is.set",
@@ -7420,7 +7420,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 208,
+          "line": 211,
           "text": "Docker is not running",
           "polarity": "fail",
           "normalized_id": "docker.is.not.running",
@@ -7428,7 +7428,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 211,
+          "line": 214,
           "text": "Docker is running",
           "polarity": "pass",
           "normalized_id": "docker.is.running",
@@ -7436,7 +7436,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 236,
+          "line": 240,
           "text": "Pre-cleanup complete",
           "polarity": "pass",
           "normalized_id": "pre.cleanup.complete",
@@ -7444,7 +7444,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 316,
+          "line": 320,
           "text": "Failed to append Slack policy to base sandbox policy",
           "polarity": "fail",
           "normalized_id": "failed.to.append.slack.policy.to.base.sandbox.policy",
@@ -7452,7 +7452,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 319,
+          "line": 323,
           "text": "Slack network policy pre-merged into base policy",
           "polarity": "pass",
           "normalized_id": "slack.network.policy.pre.merged.into.base.policy",
@@ -7460,7 +7460,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 324,
+          "line": 328,
           "text": "Cannot pre-merge Slack policy: missing base policy or preset file",
           "polarity": "fail",
           "normalized_id": "cannot.pre.merge.slack.policy.missing.base.policy.or.preset.file",
@@ -7468,7 +7468,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 365,
+          "line": 369,
           "text": "M0: install.sh completed (exit 0)",
           "polarity": "pass",
           "normalized_id": "m0.install.sh.completed.exit.0",
@@ -7476,7 +7476,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 367,
+          "line": 371,
           "text": "M0: install.sh failed (exit $install_exit)",
           "polarity": "fail",
           "normalized_id": "m0.install.sh.failed.exit.install.exit",
@@ -7484,7 +7484,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 375,
+          "line": 379,
           "text": "openshell not found on PATH after install",
           "polarity": "fail",
           "normalized_id": "openshell.not.found.on.path.after.install",
@@ -7492,7 +7492,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 378,
+          "line": 382,
           "text": "openshell installed ($(openshell --version 2>&1 || echo unknown))",
           "polarity": "pass",
           "normalized_id": "openshell.installed.openshell.version.2.1.echo.unknown",
@@ -7500,7 +7500,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 381,
+          "line": 385,
           "text": "nemoclaw not found on PATH after install",
           "polarity": "fail",
           "normalized_id": "nemoclaw.not.found.on.path.after.install",
@@ -7508,7 +7508,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 384,
+          "line": 388,
           "text": "nemoclaw installed at $(command -v nemoclaw)",
           "polarity": "pass",
           "normalized_id": "nemoclaw.installed.at.command.v.nemoclaw",
@@ -7516,7 +7516,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 389,
+          "line": 393,
           "text": "M0b: Sandbox '$SANDBOX_NAME' is Ready",
           "polarity": "pass",
           "normalized_id": "m0b.sandbox.sandbox.name.is.ready",
@@ -7524,7 +7524,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 391,
+          "line": 395,
           "text": "M0b: Sandbox '$SANDBOX_NAME' not Ready (list: ${sandbox_list:0:200})",
           "polarity": "fail",
           "normalized_id": "m0b.sandbox.sandbox.name.not.ready.list.sandbox.list.0.200",
@@ -7532,7 +7532,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 397,
+          "line": 401,
           "text": "M1: Provider '${SANDBOX_NAME}-telegram-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m1.provider.sandbox.name.telegram.bridge.exists.in.gateway",
@@ -7540,7 +7540,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 399,
+          "line": 403,
           "text": "M1: Provider '${SANDBOX_NAME}-telegram-bridge' not found in gateway",
           "polarity": "fail",
           "normalized_id": "m1.provider.sandbox.name.telegram.bridge.not.found.in.gateway",
@@ -7548,7 +7548,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 404,
+          "line": 408,
           "text": "M2: Provider '${SANDBOX_NAME}-discord-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m2.provider.sandbox.name.discord.bridge.exists.in.gateway",
@@ -7556,7 +7556,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 406,
+          "line": 410,
           "text": "M2: Provider '${SANDBOX_NAME}-discord-bridge' not found in gateway",
           "polarity": "fail",
           "normalized_id": "m2.provider.sandbox.name.discord.bridge.not.found.in.gateway",
@@ -7564,7 +7564,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 413,
+          "line": 417,
           "text": "M-W1: Provider '${SANDBOX_NAME}-wechat-bridge' exists in gateway",
           "polarity": "pass",
           "normalized_id": "m.w1.provider.sandbox.name.wechat.bridge.exists.in.gateway",
@@ -7572,7 +7572,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 415,
+          "line": 419,
           "text": "M-W1: Provider '${SANDBOX_NAME}-wechat-bridge' not found in gateway (non-interactive QR-skip path may be broken)",
           "polarity": "fail",
           "normalized_id": "m.w1.provider.sandbox.name.wechat.bridge.not.found.in.gateway.non.interactive.qr.skip.path.may.be.broken",
@@ -7580,7 +7580,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 429,
+          "line": 433,
           "text": "M3: Real Telegram token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m3.real.telegram.token.leaked.into.sandbox.env",
@@ -7588,7 +7588,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 431,
+          "line": 435,
           "text": "M3: Sandbox TELEGRAM_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m3.sandbox.telegram.bot.token.is.a.placeholder.not.the.real.token",
@@ -7596,7 +7596,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 442,
+          "line": 446,
           "text": "M4: Real Discord token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m4.real.discord.token.leaked.into.sandbox.env",
@@ -7604,7 +7604,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 444,
+          "line": 448,
           "text": "M4: Sandbox DISCORD_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m4.sandbox.discord.bot.token.is.a.placeholder.not.the.real.token",
@@ -7612,7 +7612,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 451,
+          "line": 455,
           "text": "M5: At least one messaging placeholder detected in sandbox",
           "polarity": "pass",
           "normalized_id": "m5.at.least.one.messaging.placeholder.detected.in.sandbox",
@@ -7620,7 +7620,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 476,
+          "line": 480,
           "text": "M5a: Real Telegram token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m5a.real.telegram.token.found.in.full.sandbox.environment.dump",
@@ -7628,7 +7628,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 478,
+          "line": 482,
           "text": "M5a: Real Telegram token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5a.real.telegram.token.absent.from.full.sandbox.environment",
@@ -7636,7 +7636,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 485,
+          "line": 489,
           "text": "M5b: Real Telegram token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m5b.real.telegram.token.found.in.sandbox.process.list",
@@ -7644,7 +7644,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 487,
+          "line": 491,
           "text": "M5b: Real Telegram token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m5b.real.telegram.token.absent.from.sandbox.process.list",
@@ -7652,7 +7652,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 494,
+          "line": 498,
           "text": "M5c: Real Telegram token found on sandbox filesystem: ${sandbox_fs_tg}",
           "polarity": "fail",
           "normalized_id": "m5c.real.telegram.token.found.on.sandbox.filesystem.sandbox.fs.tg",
@@ -7660,7 +7660,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 496,
+          "line": 500,
           "text": "M5c: Real Telegram token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m5c.real.telegram.token.absent.from.sandbox.filesystem",
@@ -7668,7 +7668,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 502,
+          "line": 506,
           "text": "M5d: Telegram placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5d.telegram.placeholder.confirmed.present.in.sandbox.environment",
@@ -7676,7 +7676,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 504,
+          "line": 508,
           "text": "M5d: Telegram placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m5d.telegram.placeholder.not.found.in.sandbox.environment",
@@ -7684,7 +7684,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 514,
+          "line": 518,
           "text": "M5e: Real Discord token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m5e.real.discord.token.found.in.full.sandbox.environment.dump",
@@ -7692,7 +7692,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 516,
+          "line": 520,
           "text": "M5e: Real Discord token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5e.real.discord.token.absent.from.full.sandbox.environment",
@@ -7700,7 +7700,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 523,
+          "line": 527,
           "text": "M5f: Real Discord token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m5f.real.discord.token.found.in.sandbox.process.list",
@@ -7708,7 +7708,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 525,
+          "line": 529,
           "text": "M5f: Real Discord token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m5f.real.discord.token.absent.from.sandbox.process.list",
@@ -7716,7 +7716,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 531,
+          "line": 535,
           "text": "M5g: Real Discord token found on sandbox filesystem: ${sandbox_fs_dc}",
           "polarity": "fail",
           "normalized_id": "m5g.real.discord.token.found.on.sandbox.filesystem.sandbox.fs.dc",
@@ -7724,7 +7724,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 533,
+          "line": 537,
           "text": "M5g: Real Discord token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m5g.real.discord.token.absent.from.sandbox.filesystem",
@@ -7732,7 +7732,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 539,
+          "line": 543,
           "text": "M5h: Discord placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m5h.discord.placeholder.confirmed.present.in.sandbox.environment",
@@ -7740,7 +7740,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 541,
+          "line": 545,
           "text": "M5h: Discord placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m5h.discord.placeholder.not.found.in.sandbox.environment",
@@ -7748,7 +7748,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 556,
+          "line": 560,
           "text": "M-S5a: Real Slack bot token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.s5a.real.slack.bot.token.found.in.full.sandbox.environment.dump",
@@ -7756,7 +7756,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 558,
+          "line": 562,
           "text": "M-S5a: Real Slack bot token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.s5a.real.slack.bot.token.absent.from.full.sandbox.environment",
@@ -7764,7 +7764,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 565,
+          "line": 569,
           "text": "M-S5b: Real Slack bot token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.s5b.real.slack.bot.token.found.in.sandbox.process.list",
@@ -7772,7 +7772,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 567,
+          "line": 571,
           "text": "M-S5b: Real Slack bot token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.s5b.real.slack.bot.token.absent.from.sandbox.process.list",
@@ -7780,7 +7780,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 573,
+          "line": 577,
           "text": "M-S5c: Real Slack bot token found on sandbox filesystem: ${sandbox_fs_sl}",
           "polarity": "fail",
           "normalized_id": "m.s5c.real.slack.bot.token.found.on.sandbox.filesystem.sandbox.fs.sl",
@@ -7788,7 +7788,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 575,
+          "line": 579,
           "text": "M-S5c: Real Slack bot token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.s5c.real.slack.bot.token.absent.from.sandbox.filesystem",
@@ -7796,7 +7796,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 583,
+          "line": 587,
           "text": "M-S5d: Real Slack app token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.s5d.real.slack.app.token.found.in.full.sandbox.environment.dump",
@@ -7804,7 +7804,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 585,
+          "line": 589,
           "text": "M-S5d: Real Slack app token absent from sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.s5d.real.slack.app.token.absent.from.sandbox.environment",
@@ -7812,7 +7812,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 590,
+          "line": 594,
           "text": "M-S5d2: Real Slack app token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.s5d2.real.slack.app.token.found.in.sandbox.process.list",
@@ -7820,7 +7820,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 592,
+          "line": 596,
           "text": "M-S5d2: Real Slack app token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.s5d2.real.slack.app.token.absent.from.sandbox.process.list",
@@ -7828,7 +7828,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 596,
+          "line": 600,
           "text": "M-S5e: Real Slack app token found on sandbox filesystem: ${sandbox_fs_sapp}",
           "polarity": "fail",
           "normalized_id": "m.s5e.real.slack.app.token.found.on.sandbox.filesystem.sandbox.fs.sapp",
@@ -7836,7 +7836,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 598,
+          "line": 602,
           "text": "M-S5e: Real Slack app token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.s5e.real.slack.app.token.absent.from.sandbox.filesystem",
@@ -7844,7 +7844,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 609,
+          "line": 613,
           "text": "M-S5f: Real Slack bot/app token spliced into openclaw.json — apply_slack_token_override regression?",
           "polarity": "fail",
           "normalized_id": "m.s5f.real.slack.bot.app.token.spliced.into.openclaw.json.apply.slack.token.override.regression",
@@ -7852,7 +7852,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 613,
+          "line": 617,
           "text": "M-S5f: openclaw.json holds both Bolt-shape Slack placeholders (no real token on disk)",
           "polarity": "pass",
           "normalized_id": "m.s5f.openclaw.json.holds.both.bolt.shape.slack.placeholders.no.real.token.on.disk",
@@ -7860,7 +7860,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 622,
+          "line": 626,
           "text": "M-S5g: removed Slack token rewriter preload still present in NODE_OPTIONS",
           "polarity": "fail",
           "normalized_id": "m.s5g.removed.slack.token.rewriter.preload.still.present.in.node.options",
@@ -7868,7 +7868,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 624,
+          "line": 628,
           "text": "M-S5g: Slack token rewriter preload absent from NODE_OPTIONS",
           "polarity": "pass",
           "normalized_id": "m.s5g.slack.token.rewriter.preload.absent.from.node.options",
@@ -7876,7 +7876,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 640,
+          "line": 644,
           "text": "M-W3: Real WeChat token leaked into sandbox env",
           "polarity": "fail",
           "normalized_id": "m.w3.real.wechat.token.leaked.into.sandbox.env",
@@ -7884,7 +7884,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 642,
+          "line": 646,
           "text": "M-W3: Sandbox WECHAT_BOT_TOKEN is a placeholder (not the real token)",
           "polarity": "pass",
           "normalized_id": "m.w3.sandbox.wechat.bot.token.is.a.placeholder.not.the.real.token",
@@ -7892,7 +7892,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 651,
+          "line": 655,
           "text": "M-W3a: Real WeChat token found in full sandbox environment dump",
           "polarity": "fail",
           "normalized_id": "m.w3a.real.wechat.token.found.in.full.sandbox.environment.dump",
@@ -7900,7 +7900,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 653,
+          "line": 657,
           "text": "M-W3a: Real WeChat token absent from full sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.w3a.real.wechat.token.absent.from.full.sandbox.environment",
@@ -7908,7 +7908,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 660,
+          "line": 664,
           "text": "M-W3b: Real WeChat token found in sandbox process list",
           "polarity": "fail",
           "normalized_id": "m.w3b.real.wechat.token.found.in.sandbox.process.list",
@@ -7916,7 +7916,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 662,
+          "line": 666,
           "text": "M-W3b: Real WeChat token absent from sandbox process list",
           "polarity": "pass",
           "normalized_id": "m.w3b.real.wechat.token.absent.from.sandbox.process.list",
@@ -7924,7 +7924,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 670,
+          "line": 674,
           "text": "M-W3c: Real WeChat token found on sandbox filesystem: ${sandbox_fs_wc}",
           "polarity": "fail",
           "normalized_id": "m.w3c.real.wechat.token.found.on.sandbox.filesystem.sandbox.fs.wc",
@@ -7932,7 +7932,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 672,
+          "line": 676,
           "text": "M-W3c: Real WeChat token absent from sandbox filesystem",
           "polarity": "pass",
           "normalized_id": "m.w3c.real.wechat.token.absent.from.sandbox.filesystem",
@@ -7940,7 +7940,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 678,
+          "line": 682,
           "text": "M-W3d: WeChat placeholder confirmed present in sandbox environment",
           "polarity": "pass",
           "normalized_id": "m.w3d.wechat.placeholder.confirmed.present.in.sandbox.environment",
@@ -7948,7 +7948,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 680,
+          "line": 684,
           "text": "M-W3d: WeChat placeholder not found in sandbox environment",
           "polarity": "fail",
           "normalized_id": "m.w3d.wechat.placeholder.not.found.in.sandbox.environment",
@@ -7956,7 +7956,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 703,
+          "line": 707,
           "text": "M6: Could not read openclaw.json channels (${channel_json:0:200})",
           "polarity": "fail",
           "normalized_id": "m6.could.not.read.openclaw.json.channels.channel.json.0.200",
@@ -7964,7 +7964,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 720,
+          "line": 724,
           "text": "M6: Telegram channel botToken present in openclaw.json",
           "polarity": "pass",
           "normalized_id": "m6.telegram.channel.bottoken.present.in.openclaw.json",
@@ -7972,7 +7972,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 727,
+          "line": 731,
           "text": "M7: Telegram botToken is not the host-side token (placeholder confirmed)",
           "polarity": "pass",
           "normalized_id": "m7.telegram.bottoken.is.not.the.host.side.token.placeholder.confirmed",
@@ -7980,7 +7980,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 729,
+          "line": 733,
           "text": "M7: Telegram botToken matches host-side token — credential leaked into config!",
           "polarity": "fail",
           "normalized_id": "m7.telegram.bottoken.matches.host.side.token.credential.leaked.into.config",
@@ -7988,7 +7988,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 744,
+          "line": 748,
           "text": "M8: Discord channel token present in openclaw.json",
           "polarity": "pass",
           "normalized_id": "m8.discord.channel.token.present.in.openclaw.json",
@@ -7996,7 +7996,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 751,
+          "line": 755,
           "text": "M9: Discord token is not the host-side token (placeholder confirmed)",
           "polarity": "pass",
           "normalized_id": "m9.discord.token.is.not.the.host.side.token.placeholder.confirmed",
@@ -8004,7 +8004,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 753,
+          "line": 757,
           "text": "M9: Discord token matches host-side token — credential leaked into config!",
           "polarity": "fail",
           "normalized_id": "m9.discord.token.matches.host.side.token.credential.leaked.into.config",
@@ -8012,7 +8012,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 768,
+          "line": 772,
           "text": "M10: Telegram channel is enabled",
           "polarity": "pass",
           "normalized_id": "m10.telegram.channel.is.enabled",
@@ -8020,7 +8020,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 783,
+          "line": 787,
           "text": "M11: Discord channel is enabled",
           "polarity": "pass",
           "normalized_id": "m11.discord.channel.is.enabled",
@@ -8028,7 +8028,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 798,
+          "line": 802,
           "text": "M11b: Telegram dmPolicy is 'allowlist'",
           "polarity": "pass",
           "normalized_id": "m11b.telegram.dmpolicy.is.allowlist",
@@ -8036,7 +8036,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 800,
+          "line": 804,
           "text": "M11b: Telegram dmPolicy is '$tg_dm_policy' (expected 'allowlist')",
           "polarity": "fail",
           "normalized_id": "m11b.telegram.dmpolicy.is.tg.dm.policy.expected.allowlist",
@@ -8044,7 +8044,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 828,
+          "line": 832,
           "text": "M11c: Telegram allowFrom contains all expected user IDs: $tg_allow_from",
           "polarity": "pass",
           "normalized_id": "m11c.telegram.allowfrom.contains.all.expected.user.ids.tg.allow.from",
@@ -8052,7 +8052,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 830,
+          "line": 834,
           "text": "M11c: Telegram allowFrom ($tg_allow_from) is missing IDs: ${missing_ids[*]} (expected all of: $TELEGRAM_IDS)",
           "polarity": "fail",
           "normalized_id": "m11c.telegram.allowfrom.tg.allow.from.is.missing.ids.missing.ids.expected.all.of.telegram.ids",
@@ -8060,7 +8060,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 846,
+          "line": 850,
           "text": "M11d: Telegram groupPolicy is 'open'",
           "polarity": "pass",
           "normalized_id": "m11d.telegram.grouppolicy.is.open",
@@ -8068,7 +8068,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 848,
+          "line": 852,
           "text": "M11d: Telegram groupPolicy is '$tg_group_policy' (expected 'open')",
           "polarity": "fail",
           "normalized_id": "m11d.telegram.grouppolicy.is.tg.group.policy.expected.open",
@@ -8076,7 +8076,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 864,
+          "line": 868,
           "text": "M11e: Slack channel configured with placeholder tokens (guard needed)",
           "polarity": "pass",
           "normalized_id": "m11e.slack.channel.configured.with.placeholder.tokens.guard.needed",
@@ -8084,7 +8084,71 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 889,
+          "line": 880,
+          "text": "M11f: Slack dmPolicy is 'allowlist'",
+          "polarity": "pass",
+          "normalized_id": "m11f.slack.dmpolicy.is.allowlist",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 882,
+          "text": "M11f: Slack dmPolicy is '$sl_dm_policy' (expected 'allowlist')",
+          "polarity": "fail",
+          "normalized_id": "m11f.slack.dmpolicy.is.sl.dm.policy.expected.allowlist",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 894,
+          "text": "M11g: Slack groupPolicy is 'allowlist'",
+          "polarity": "pass",
+          "normalized_id": "m11g.slack.grouppolicy.is.allowlist",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 896,
+          "text": "M11g: Slack groupPolicy is '$sl_group_policy' (expected 'allowlist')",
+          "polarity": "fail",
+          "normalized_id": "m11g.slack.grouppolicy.is.sl.group.policy.expected.allowlist",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 914,
+          "text": "M11h: Slack wildcard channel config is not enabled",
+          "polarity": "fail",
+          "normalized_id": "m11h.slack.wildcard.channel.config.is.not.enabled",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 916,
+          "text": "M11h: Slack wildcard channel config does not require mention",
+          "polarity": "fail",
+          "normalized_id": "m11h.slack.wildcard.channel.config.does.not.require.mention",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 929,
+          "text": "M11h: Slack wildcard channel @mention allowlist contains expected users: $sl_channel_users",
+          "polarity": "pass",
+          "normalized_id": "m11h.slack.wildcard.channel.mention.allowlist.contains.expected.users.sl.channel.users",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 931,
+          "text": "M11h: Slack wildcard channel users ($sl_channel_users) missing IDs: ${missing_slack_ids[*]}",
+          "polarity": "fail",
+          "normalized_id": "m11h.slack.wildcard.channel.users.sl.channel.users.missing.ids.missing.slack.ids",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 960,
           "text": "M-W8: WeChat account '$WECHAT_ACCOUNT' is enabled in openclaw.json (channels.openclaw-weixin)",
           "polarity": "pass",
           "normalized_id": "m.w8.wechat.account.wechat.account.is.enabled.in.openclaw.json.channels.openclaw.weixin",
@@ -8092,7 +8156,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 905,
+          "line": 976,
           "text": "M-W9: Real WeChat token spliced into accounts/${WECHAT_ACCOUNT}.json — seed-wechat-accounts.py placeholder regression",
           "polarity": "fail",
           "normalized_id": "m.w9.real.wechat.token.spliced.into.accounts.wechat.account.json.seed.wechat.accounts.py.placeholder.regression",
@@ -8100,7 +8164,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 907,
+          "line": 978,
           "text": "M-W9: WeChat per-account credential file uses the L7-resolved placeholder",
           "polarity": "pass",
           "normalized_id": "m.w9.wechat.per.account.credential.file.uses.the.l7.resolved.placeholder",
@@ -8108,7 +8172,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 909,
+          "line": 980,
           "text": "M-W9: WeChat per-account credential file has unexpected token shape: $(echo ",
           "polarity": "fail",
           "normalized_id": "m.w9.wechat.per.account.credential.file.has.unexpected.token.shape.echo",
@@ -8116,7 +8180,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 928,
+          "line": 999,
           "text": "M-W10: WeChat accounts.json index contains '$WECHAT_ACCOUNT'",
           "polarity": "pass",
           "normalized_id": "m.w10.wechat.accounts.json.index.contains.wechat.account",
@@ -8124,7 +8188,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 930,
+          "line": 1001,
           "text": "M-W10: WeChat accounts.json missing '$WECHAT_ACCOUNT' (raw: $(echo ",
           "polarity": "fail",
           "normalized_id": "m.w10.wechat.accounts.json.missing.wechat.account.raw.echo",
@@ -8132,7 +8196,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 951,
+          "line": 1022,
           "text": "M12: Node.js reached api.telegram.org (${tg_reach})",
           "polarity": "pass",
           "normalized_id": "m12.node.js.reached.api.telegram.org.tg.reach",
@@ -8140,7 +8204,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 957,
+          "line": 1028,
           "text": "M12: Node.js could not reach api.telegram.org (${tg_reach:0:200})",
           "polarity": "fail",
           "normalized_id": "m12.node.js.could.not.reach.api.telegram.org.tg.reach.0.200",
@@ -8148,7 +8212,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 965,
+          "line": 1036,
           "text": "M13-policy: Live policy contains Discord endpoints and Node binaries",
           "polarity": "pass",
           "normalized_id": "m13.policy.live.policy.contains.discord.endpoints.and.node.binaries",
@@ -8156,7 +8220,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 967,
+          "line": 1038,
           "text": "M13-policy: Live policy is missing expected Discord preset endpoint/binary entries",
           "polarity": "fail",
           "normalized_id": "m13.policy.live.policy.is.missing.expected.discord.preset.endpoint.binary.entries",
@@ -8164,7 +8228,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 973,
+          "line": 1044,
           "text": "M13-proxy: Sandbox uses the OpenShell gateway proxy",
           "polarity": "pass",
           "normalized_id": "m13.proxy.sandbox.uses.the.openshell.gateway.proxy",
@@ -8172,7 +8236,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 975,
+          "line": 1046,
           "text": "M13-proxy: Sandbox proxy env does not point at OpenShell gateway: ${live_proxy_env:0:200}",
           "polarity": "fail",
           "normalized_id": "m13.proxy.sandbox.proxy.env.does.not.point.at.openshell.gateway.live.proxy.env.0.200",
@@ -8180,7 +8244,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 996,
+          "line": 1067,
           "text": "M13-curl: curl unexpectedly established a tunnel to Discord; binary whitelist may be too broad",
           "polarity": "fail",
           "normalized_id": "m13.curl.curl.unexpectedly.established.a.tunnel.to.discord.binary.whitelist.may.be.too.broad",
@@ -8188,7 +8252,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1039,
+          "line": 1110,
           "text": "M13: Node.js reached Discord API and CDN through the same proxy (${dc_reach//$'\\n'/ })",
           "polarity": "pass",
           "normalized_id": "m13.node.js.reached.discord.api.and.cdn.through.the.same.proxy.dc.reach.n",
@@ -8196,7 +8260,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1041,
+          "line": 1112,
           "text": "M13: Node.js was denied by the proxy despite the Discord preset being applied: ${dc_reach:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.node.js.was.denied.by.the.proxy.despite.the.discord.preset.being.applied.dc.reach.0.300",
@@ -8204,7 +8268,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1045,
+          "line": 1116,
           "text": "M13: Node.js could not reach Discord API/CDN (${dc_reach:0:200})",
           "polarity": "fail",
           "normalized_id": "m13.node.js.could.not.reach.discord.api.cdn.dc.reach.0.200",
@@ -8212,7 +8276,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1052,
+          "line": 1123,
           "text": "M13-rest-a: Hermetic fake Discord REST API started on host port ${FAKE_DISCORD_REST_PORT}",
           "polarity": "pass",
           "normalized_id": "m13.rest.a.hermetic.fake.discord.rest.api.started.on.host.port.fake.discord.rest.port",
@@ -8220,7 +8284,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1061,
+          "line": 1132,
           "text": "M13-rest-b: Applied Node-only HTTPS policy for fake Discord REST API",
           "polarity": "pass",
           "normalized_id": "m13.rest.b.applied.node.only.https.policy.for.fake.discord.rest.api",
@@ -8228,7 +8292,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1063,
+          "line": 1134,
           "text": "M13-rest-b: Failed to apply fake Discord REST policy: $(tail -20 /tmp/nemoclaw-fake-discord-rest-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m13.rest.b.failed.to.apply.fake.discord.rest.policy.tail.20.tmp.nemoclaw.fake.discord.rest.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8236,7 +8300,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1077,
+          "line": 1148,
           "text": "M13-rest-c: Node reached the fake Discord REST API through OpenShell",
           "polarity": "pass",
           "normalized_id": "m13.rest.c.node.reached.the.fake.discord.rest.api.through.openshell",
@@ -8244,7 +8308,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1079,
+          "line": 1150,
           "text": "M13-rest-c: Node failed to reach fake Discord REST API: ${fake_rest_node:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.rest.c.node.failed.to.reach.fake.discord.rest.api.fake.rest.node.0.300",
@@ -8252,7 +8316,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1091,
+          "line": 1162,
           "text": "M13-rest-d: curl was denied before reaching the fake Discord REST API",
           "polarity": "pass",
           "normalized_id": "m13.rest.d.curl.was.denied.before.reaching.the.fake.discord.rest.api",
@@ -8260,7 +8324,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1093,
+          "line": 1164,
           "text": "M13-rest-d: curl unexpectedly established a tunnel to the fake Discord REST API",
           "polarity": "fail",
           "normalized_id": "m13.rest.d.curl.unexpectedly.established.a.tunnel.to.the.fake.discord.rest.api",
@@ -8268,7 +8332,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1095,
+          "line": 1166,
           "text": "M13-rest-d: Fake Discord REST curl denial had unexpected shape: ${fake_rest_curl:0:300}",
           "polarity": "fail",
           "normalized_id": "m13.rest.d.fake.discord.rest.curl.denial.had.unexpected.shape.fake.rest.curl.0.300",
@@ -8276,7 +8340,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1107,
+          "line": 1178,
           "text": "M13-rest-e: Fake server saw Node but no curl request",
           "polarity": "pass",
           "normalized_id": "m13.rest.e.fake.server.saw.node.but.no.curl.request",
@@ -8284,7 +8348,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1109,
+          "line": 1180,
           "text": "M13-rest-e: Unexpected fake Discord REST capture counts: ${fake_rest_capture}",
           "polarity": "fail",
           "normalized_id": "m13.rest.e.unexpected.fake.discord.rest.capture.counts.fake.rest.capture",
@@ -8292,7 +8356,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1116,
+          "line": 1187,
           "text": "M13b: Hermetic fake Discord Gateway started on host port ${FAKE_DISCORD_GATEWAY_PORT}",
           "polarity": "pass",
           "normalized_id": "m13b.hermetic.fake.discord.gateway.started.on.host.port.fake.discord.gateway.port",
@@ -8300,7 +8364,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1118,
+          "line": 1189,
           "text": "M13b: Failed to start hermetic fake Discord Gateway",
           "polarity": "fail",
           "normalized_id": "m13b.failed.to.start.hermetic.fake.discord.gateway",
@@ -8308,7 +8372,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1123,
+          "line": 1194,
           "text": "M13c: Applied native WebSocket policy with credential rewrite for fake Discord Gateway",
           "polarity": "pass",
           "normalized_id": "m13c.applied.native.websocket.policy.with.credential.rewrite.for.fake.discord.gateway",
@@ -8316,7 +8380,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1125,
+          "line": 1196,
           "text": "M13c: Failed to apply fake Discord Gateway policy: $(tail -20 /tmp/nemoclaw-fake-discord-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m13c.failed.to.apply.fake.discord.gateway.policy.tail.20.tmp.nemoclaw.fake.discord.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8324,7 +8388,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1135,
+          "line": 1206,
           "text": "M13d: Native WebSocket upgrade reached fake Discord Gateway through OpenShell",
           "polarity": "pass",
           "normalized_id": "m13d.native.websocket.upgrade.reached.fake.discord.gateway.through.openshell",
@@ -8332,7 +8396,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1137,
+          "line": 1208,
           "text": "M13d: Native WebSocket upgrade failed: ${dc_ws_native:0:300}",
           "polarity": "fail",
           "normalized_id": "m13d.native.websocket.upgrade.failed.dc.ws.native.0.300",
@@ -8340,7 +8404,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1144,
+          "line": 1215,
           "text": "M13e: Discord HELLO, placeholder IDENTIFY, READY, and heartbeat ACK completed",
           "polarity": "pass",
           "normalized_id": "m13e.discord.hello.placeholder.identify.ready.and.heartbeat.ack.completed",
@@ -8348,7 +8412,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1146,
+          "line": 1217,
           "text": "M13e: Discord Gateway protocol proof incomplete: ${dc_ws_native:0:400}",
           "polarity": "fail",
           "normalized_id": "m13e.discord.gateway.protocol.proof.incomplete.dc.ws.native.0.400",
@@ -8356,7 +8420,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1152,
+          "line": 1223,
           "text": "M13f: Fake Gateway received host-side Discord token; sandbox-visible IDENTIFY used only the placeholder",
           "polarity": "pass",
           "normalized_id": "m13f.fake.gateway.received.host.side.discord.token.sandbox.visible.identify.used.only.the.placeholder",
@@ -8364,7 +8428,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1157,
+          "line": 1228,
           "text": "M13f: Fake Gateway did not prove placeholder-to-token rewrite at the relay boundary",
           "polarity": "fail",
           "normalized_id": "m13f.fake.gateway.did.not.prove.placeholder.to.token.rewrite.at.the.relay.boundary",
@@ -8372,7 +8436,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1173,
+          "line": 1244,
           "text": "M13g: Unregistered Discord WebSocket placeholder is rejected before upstream token exposure",
           "polarity": "pass",
           "normalized_id": "m13g.unregistered.discord.websocket.placeholder.is.rejected.before.upstream.token.exposure",
@@ -8380,7 +8444,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1175,
+          "line": 1246,
           "text": "M13g: Unregistered Discord WebSocket placeholder reached READY or leaked upstream",
           "polarity": "fail",
           "normalized_id": "m13g.unregistered.discord.websocket.placeholder.reached.ready.or.leaked.upstream",
@@ -8388,7 +8452,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1181,
+          "line": 1252,
           "text": "M14: curl to api.telegram.org blocked (binary restriction enforced)",
           "polarity": "pass",
           "normalized_id": "m14.curl.to.api.telegram.org.blocked.binary.restriction.enforced",
@@ -8396,7 +8460,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1183,
+          "line": 1254,
           "text": "M14: curl returned empty (likely blocked by policy)",
           "polarity": "pass",
           "normalized_id": "m14.curl.returned.empty.likely.blocked.by.policy",
@@ -8404,7 +8468,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1187,
+          "line": 1258,
           "text": "M14: curl not available in sandbox (defense in depth)",
           "polarity": "pass",
           "normalized_id": "m14.curl.not.available.in.sandbox.defense.in.depth",
@@ -8412,7 +8476,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1221,
+          "line": 1292,
           "text": "M15: Telegram getMe returned 200 — real token verified!",
           "polarity": "pass",
           "normalized_id": "m15.telegram.getme.returned.200.real.token.verified",
@@ -8420,7 +8484,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1226,
+          "line": 1297,
           "text": "M15: Telegram getMe returned $tg_status — L7 proxy rewrote placeholder (fake token rejected by API)",
           "polarity": "pass",
           "normalized_id": "m15.telegram.getme.returned.tg.status.l7.proxy.rewrote.placeholder.fake.token.rejected.by.api",
@@ -8428,7 +8492,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1227,
+          "line": 1298,
           "text": "M16: Full chain verified: sandbox → proxy → token rewrite → Telegram API",
           "polarity": "pass",
           "normalized_id": "m16.full.chain.verified.sandbox.proxy.token.rewrite.telegram.api",
@@ -8436,7 +8500,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1233,
+          "line": 1304,
           "text": "M15: Telegram API call failed with error: ${tg_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m15.telegram.api.call.failed.with.error.tg.api.0.200",
@@ -8444,7 +8508,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1235,
+          "line": 1306,
           "text": "M15: Unexpected Telegram response (status=$tg_status): ${tg_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m15.unexpected.telegram.response.status.tg.status.tg.api.0.200",
@@ -8452,7 +8516,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1262,
+          "line": 1333,
           "text": "M17: Discord users/@me returned 200 — real token verified!",
           "polarity": "pass",
           "normalized_id": "m17.discord.users.me.returned.200.real.token.verified",
@@ -8460,7 +8524,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1264,
+          "line": 1335,
           "text": "M17: Discord users/@me returned 401 — L7 proxy rewrote placeholder (fake token rejected by API)",
           "polarity": "pass",
           "normalized_id": "m17.discord.users.me.returned.401.l7.proxy.rewrote.placeholder.fake.token.rejected.by.api",
@@ -8468,7 +8532,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1268,
+          "line": 1339,
           "text": "M17: Discord API call failed with error: ${dc_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m17.discord.api.call.failed.with.error.dc.api.0.200",
@@ -8476,7 +8540,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1270,
+          "line": 1341,
           "text": "M17: Unexpected Discord response (status=$dc_status): ${dc_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m17.unexpected.discord.response.status.dc.status.dc.api.0.200",
@@ -8484,7 +8548,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1282,
+          "line": 1353,
           "text": "M-S14a: Hermetic fake Slack API started on host port ${FAKE_SLACK_API_PORT}",
           "polarity": "pass",
           "normalized_id": "m.s14a.hermetic.fake.slack.api.started.on.host.port.fake.slack.api.port",
@@ -8492,7 +8556,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1284,
+          "line": 1355,
           "text": "M-S14a: Failed to start hermetic fake Slack API",
           "polarity": "fail",
           "normalized_id": "m.s14a.failed.to.start.hermetic.fake.slack.api",
@@ -8500,7 +8564,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1289,
+          "line": 1360,
           "text": "M-S14b: Applied REST policy for hermetic fake Slack API",
           "polarity": "pass",
           "normalized_id": "m.s14b.applied.rest.policy.for.hermetic.fake.slack.api",
@@ -8508,7 +8572,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1291,
+          "line": 1362,
           "text": "M-S14b: Failed to apply fake Slack API policy: $(tail -20 /tmp/nemoclaw-fake-slack-policy.log 2>/dev/null | tr '\\n' ' ' | cut -c1-300)",
           "polarity": "fail",
           "normalized_id": "m.s14b.failed.to.apply.fake.slack.api.policy.tail.20.tmp.nemoclaw.fake.slack.policy.log.2.dev.null.tr.n.cut.c1.300",
@@ -8516,7 +8580,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1342,
+          "line": 1444,
           "text": "M-S15: Slack auth.test returned ok:true — real token round-trip verified!",
           "polarity": "pass",
           "normalized_id": "m.s15.slack.auth.test.returned.ok.true.real.token.round.trip.verified",
@@ -8524,7 +8588,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1344,
+          "line": 1446,
           "text": "M-S15: Slack auth.test returned invalid_auth — full chain verified (OpenShell alias rewrite → fake Slack)",
           "polarity": "pass",
           "normalized_id": "m.s15.slack.auth.test.returned.invalid.auth.full.chain.verified.openshell.alias.rewrite.fake.slack",
@@ -8532,7 +8596,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1347,
+          "line": 1449,
           "text": "M-S15a: fake Slack saw host-side bot token in header and urlencoded body",
           "polarity": "pass",
           "normalized_id": "m.s15a.fake.slack.saw.host.side.bot.token.in.header.and.urlencoded.body",
@@ -8540,7 +8604,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1349,
+          "line": 1451,
           "text": "M-S15a: fake Slack capture did not prove bot header/body rewrite: ${sl_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s15a.fake.slack.capture.did.not.prove.bot.header.body.rewrite.sl.capture.0.300",
@@ -8548,7 +8612,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1354,
+          "line": 1456,
           "text": "M-S15: Slack API call failed with error: ${sl_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15.slack.api.call.failed.with.error.sl.api.0.200",
@@ -8556,7 +8620,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1356,
+          "line": 1458,
           "text": "M-S15: OpenShell did not resolve the Bolt-shape alias",
           "polarity": "fail",
           "normalized_id": "m.s15.openshell.did.not.resolve.the.bolt.shape.alias",
@@ -8564,7 +8628,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1358,
+          "line": 1460,
           "text": "M-S15: L7 proxy did not substitute the canonical placeholder — substitution chain broken",
           "polarity": "fail",
           "normalized_id": "m.s15.l7.proxy.did.not.substitute.the.canonical.placeholder.substitution.chain.broken",
@@ -8572,7 +8636,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1360,
+          "line": 1462,
           "text": "M-S15: Unexpected Slack response (status=$sl_status): ${sl_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15.unexpected.slack.response.status.sl.status.sl.api.0.200",
@@ -8580,7 +8644,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1381,
+          "line": 1483,
           "text": "M-S15b: L7 proxy substitutes openshell:resolve:env:SLACK_BOT_TOKEN at egress (parallels Telegram M15 / Discord M17)",
           "polarity": "pass",
           "normalized_id": "m.s15b.l7.proxy.substitutes.openshell.resolve.env.slack.bot.token.at.egress.parallels.telegram.m15.discord.m17",
@@ -8588,7 +8652,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1385,
+          "line": 1487,
           "text": "M-S15b: L7 proxy passed canonical placeholder through unchanged — substitution not happening for SLACK_BOT_TOKEN",
           "polarity": "fail",
           "normalized_id": "m.s15b.l7.proxy.passed.canonical.placeholder.through.unchanged.substitution.not.happening.for.slack.bot.token",
@@ -8596,7 +8660,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1387,
+          "line": 1489,
           "text": "M-S15b: Unexpected response (status=$sl_canon_status): ${sl_canonical:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s15b.unexpected.response.status.sl.canon.status.sl.canonical.0.200",
@@ -8604,7 +8668,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1408,
+          "line": 1510,
           "text": "M-S15c: unset-var failed closed before upstream exposure",
           "polarity": "pass",
           "normalized_id": "m.s15c.unset.var.failed.closed.before.upstream.exposure",
@@ -8612,7 +8676,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1410,
+          "line": 1512,
           "text": "M-S15c: unset-var triggered connection-level failure — proxy refuses to forward unsubstituted placeholder",
           "polarity": "pass",
           "normalized_id": "m.s15c.unset.var.triggered.connection.level.failure.proxy.refuses.to.forward.unsubstituted.placeholder",
@@ -8620,7 +8684,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1412,
+          "line": 1514,
           "text": "M-S15c: unset-var returned HTTP 200 — proxy passed canonical placeholder through unchanged for unset env (substitution may be a no-op)",
           "polarity": "fail",
           "normalized_id": "m.s15c.unset.var.returned.http.200.proxy.passed.canonical.placeholder.through.unchanged.for.unset.env.substitution.may.be.a.no.op",
@@ -8628,7 +8692,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1414,
+          "line": 1516,
           "text": "M-S15c: unset-var request reached fake Slack — unresolved placeholder escaped the proxy boundary",
           "polarity": "fail",
           "normalized_id": "m.s15c.unset.var.request.reached.fake.slack.unresolved.placeholder.escaped.the.proxy.boundary",
@@ -8636,7 +8700,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1435,
+          "line": 1537,
           "text": "M-S16: apps.connections.open returned ok:true — real xapp token round-trip verified!",
           "polarity": "pass",
           "normalized_id": "m.s16.apps.connections.open.returned.ok.true.real.xapp.token.round.trip.verified",
@@ -8644,7 +8708,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1437,
+          "line": 1539,
           "text": "M-S16: apps.connections.open auth-rejected — Socket Mode HTTPS leg verified (OpenShell alias rewrite → fake Slack)",
           "polarity": "pass",
           "normalized_id": "m.s16.apps.connections.open.auth.rejected.socket.mode.https.leg.verified.openshell.alias.rewrite.fake.slack",
@@ -8652,7 +8716,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1440,
+          "line": 1542,
           "text": "M-S16a: fake Slack saw host-side app token in header and urlencoded body",
           "polarity": "pass",
           "normalized_id": "m.s16a.fake.slack.saw.host.side.app.token.in.header.and.urlencoded.body",
@@ -8660,7 +8724,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1442,
+          "line": 1544,
           "text": "M-S16a: fake Slack capture did not prove app header/body rewrite: ${sl_app_capture:0:300}",
           "polarity": "fail",
           "normalized_id": "m.s16a.fake.slack.capture.did.not.prove.app.header.body.rewrite.sl.app.capture.0.300",
@@ -8668,7 +8732,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1447,
+          "line": 1549,
           "text": "M-S16: OpenShell did not resolve the xapp- alias for Socket Mode path",
           "polarity": "fail",
           "normalized_id": "m.s16.openshell.did.not.resolve.the.xapp.alias.for.socket.mode.path",
@@ -8676,7 +8740,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1449,
+          "line": 1551,
           "text": "M-S16: Unexpected apps.connections.open response (status=$sl_app_status): ${sl_app_api:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s16.unexpected.apps.connections.open.response.status.sl.app.status.sl.app.api.0.200",
@@ -8684,7 +8748,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1473,
+          "line": 1575,
           "text": "M-S16b: unset app-token failed closed before upstream exposure",
           "polarity": "pass",
           "normalized_id": "m.s16b.unset.app.token.failed.closed.before.upstream.exposure",
@@ -8692,7 +8756,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1475,
+          "line": 1577,
           "text": "M-S16b: L7 proxy substitutes openshell:resolve:env:SLACK_APP_TOKEN at egress (unset-var control diverged)",
           "polarity": "pass",
           "normalized_id": "m.s16b.l7.proxy.substitutes.openshell.resolve.env.slack.app.token.at.egress.unset.var.control.diverged",
@@ -8700,7 +8764,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1477,
+          "line": 1579,
           "text": "M-S16b: unset app-token env returned HTTP 200 — proxy may be passing canonical placeholders through unchanged",
           "polarity": "fail",
           "normalized_id": "m.s16b.unset.app.token.env.returned.http.200.proxy.may.be.passing.canonical.placeholders.through.unchanged",
@@ -8708,7 +8772,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1479,
+          "line": 1581,
           "text": "M-S16b: unset app-token request reached fake Slack — unresolved placeholder escaped the proxy boundary",
           "polarity": "fail",
           "normalized_id": "m.s16b.unset.app.token.request.reached.fake.slack.unresolved.placeholder.escaped.the.proxy.boundary",
@@ -8716,7 +8780,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1488,
+          "line": 1590,
           "text": "M-S16b: L7 proxy passed canonical placeholder through unchanged for SLACK_APP_TOKEN",
           "polarity": "fail",
           "normalized_id": "m.s16b.l7.proxy.passed.canonical.placeholder.through.unchanged.for.slack.app.token",
@@ -8724,7 +8788,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1490,
+          "line": 1592,
           "text": "M-S16b: Unexpected response (status=$sl_app_canon_status): ${sl_app_canonical:0:200}",
           "polarity": "fail",
           "normalized_id": "m.s16b.unexpected.response.status.sl.app.canon.status.sl.app.canonical.0.200",
@@ -8732,7 +8796,55 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1505,
+          "line": 1611,
+          "text": "M-S17: Slack channel @mention allowlist accepts configured user and denies another user",
+          "polarity": "pass",
+          "normalized_id": "m.s17.slack.channel.mention.allowlist.accepts.configured.user.and.denies.another.user",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1614,
+          "text": "M-S17a: fake Slack saw host-side bot token for channel reply",
+          "polarity": "pass",
+          "normalized_id": "m.s17a.fake.slack.saw.host.side.bot.token.for.channel.reply",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1616,
+          "text": "M-S17a: fake Slack capture did not prove channel reply token rewrite: ${sl_post_capture:0:300}",
+          "polarity": "fail",
+          "normalized_id": "m.s17a.fake.slack.capture.did.not.prove.channel.reply.token.rewrite.sl.post.capture.0.300",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1620,
+          "text": "M-S17b: fake Slack captured non-secret channel/text metadata for channel reply",
+          "polarity": "pass",
+          "normalized_id": "m.s17b.fake.slack.captured.non.secret.channel.text.metadata.for.channel.reply",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1622,
+          "text": "M-S17b: fake Slack did not capture expected channel reply metadata: ${sl_message_capture:0:300}",
+          "polarity": "fail",
+          "normalized_id": "m.s17b.fake.slack.did.not.capture.expected.channel.reply.metadata.sl.message.capture.0.300",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1629,
+          "text": "M-S17: Slack channel @mention proof failed: ${sl_channel_proof:0:500}",
+          "polarity": "fail",
+          "normalized_id": "m.s17.slack.channel.mention.proof.failed.sl.channel.proof.0.500",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1644,
           "text": "M18: Telegram getMe returned 200 with real token",
           "polarity": "pass",
           "normalized_id": "m18.telegram.getme.returned.200.with.real.token",
@@ -8740,7 +8852,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1507,
+          "line": 1646,
           "text": "M18b: Telegram response contains ok:true",
           "polarity": "pass",
           "normalized_id": "m18b.telegram.response.contains.ok.true",
@@ -8748,7 +8860,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1510,
+          "line": 1649,
           "text": "M18: Expected Telegram getMe 200 with real token, got: $tg_status",
           "polarity": "fail",
           "normalized_id": "m18.expected.telegram.getme.200.with.real.token.got.tg.status",
@@ -8756,7 +8868,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1540,
+          "line": 1679,
           "text": "M19: Telegram sendMessage succeeded",
           "polarity": "pass",
           "normalized_id": "m19.telegram.sendmessage.succeeded",
@@ -8764,7 +8876,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1542,
+          "line": 1681,
           "text": "M19: Telegram sendMessage failed: ${send_result:0:200}",
           "polarity": "fail",
           "normalized_id": "m19.telegram.sendmessage.failed.send.result.0.200",
@@ -8772,7 +8884,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1554,
+          "line": 1693,
           "text": "M20: Discord users/@me returned 200 with real token",
           "polarity": "pass",
           "normalized_id": "m20.discord.users.me.returned.200.with.real.token",
@@ -8780,7 +8892,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1556,
+          "line": 1695,
           "text": "M20: Expected Discord users/@me 200 with real token, got: $dc_status",
           "polarity": "fail",
           "normalized_id": "m20.expected.discord.users.me.200.with.real.token.got.dc.status",
@@ -8788,7 +8900,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1588,
+          "line": 1727,
           "text": "S1: Gateway is serving on port 18789 — Slack auth failure did not crash it",
           "polarity": "pass",
           "normalized_id": "s1.gateway.is.serving.on.port.18789.slack.auth.failure.did.not.crash.it",
@@ -8796,7 +8908,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1590,
+          "line": 1729,
           "text": "S1: Gateway is not serving on port 18789 (${gw_port:0:200})",
           "polarity": "fail",
           "normalized_id": "s1.gateway.is.not.serving.on.port.18789.gw.port.0.200",
@@ -8804,7 +8916,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1616,
+          "line": 1755,
           "text": "S2: Gateway log shows Slack rejection was caught by channel guard",
           "polarity": "pass",
           "normalized_id": "s2.gateway.log.shows.slack.rejection.was.caught.by.channel.guard",
@@ -8812,7 +8924,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1641,
+          "line": 1780,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' intentionally kept",
           "polarity": "pass",
           "normalized_id": "cleanup.sandbox.sandbox.name.intentionally.kept",
@@ -8820,7 +8932,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1643,
+          "line": 1782,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' still present after cleanup",
           "polarity": "fail",
           "normalized_id": "cleanup.sandbox.sandbox.name.still.present.after.cleanup",
@@ -8828,7 +8940,7 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1645,
+          "line": 1784,
           "text": "Cleanup: Sandbox '$SANDBOX_NAME' removed",
           "polarity": "pass",
           "normalized_id": "cleanup.sandbox.sandbox.name.removed",
@@ -16220,7 +16332,7 @@
   ],
   "totals": {
     "scripts": 52,
-    "assertions": 1994,
+    "assertions": 2008,
     "zero_assertion_scripts": 2
   }
 }

--- a/test/e2e/docs/parity-map.yaml
+++ b/test/e2e/docs/parity-map.yaml
@@ -5093,12 +5093,22 @@ scripts:
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers
       secret_requirement: Slack test credentials
-    - legacy: 'M11h: Slack wildcard channel @mention allowlist contains expected users: $sl_channel_users'
+    - legacy: 'M11h: Slack wildcard channel users is not a list'
       status: deferred
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers
       secret_requirement: Slack test credentials
-    - legacy: 'M11h: Slack wildcard channel users ($sl_channel_users) missing IDs: ${missing_slack_ids[*]}'
+    - legacy: 'M11h: Slack wildcard channel users is empty'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11h: Slack wildcard channel @mention allowlist contains expected user count (${expected_slack_id_count})'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11h: Slack wildcard channel users missing ${#missing_slack_ids[@]} expected ID(s)'
       status: deferred
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
       owner: e2e-maintainers

--- a/test/e2e/docs/parity-map.yaml
+++ b/test/e2e/docs/parity-map.yaml
@@ -5063,6 +5063,46 @@ scripts:
       reason: legacy assertion is obsolete or negative cleanup behavior after scenario migration
       reviewer: e2e-maintainers
       approved_at: '2026-05-13'
+    - legacy: 'M11f: Slack dmPolicy is ''allowlist'''
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11f: Slack dmPolicy is ''$sl_dm_policy'' (expected ''allowlist'')'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11g: Slack groupPolicy is ''allowlist'''
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11g: Slack groupPolicy is ''$sl_group_policy'' (expected ''allowlist'')'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11h: Slack wildcard channel config is not enabled'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11h: Slack wildcard channel config does not require mention'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11h: Slack wildcard channel @mention allowlist contains expected users: $sl_channel_users'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M11h: Slack wildcard channel users ($sl_channel_users) missing IDs: ${missing_slack_ids[*]}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
     - legacy: 'M12: Node.js reached api.telegram.org (${tg_reach})'
       status: deferred
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
@@ -5445,6 +5485,36 @@ scripts:
       reason: legacy assertion is obsolete or negative cleanup behavior after scenario migration
       reviewer: e2e-maintainers
       approved_at: '2026-05-13'
+    - legacy: 'M-S17: Slack channel @mention allowlist accepts configured user and denies another user'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M-S17a: fake Slack saw host-side bot token for channel reply'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M-S17a: fake Slack capture did not prove channel reply token rewrite: ${sl_post_capture:0:300}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M-S17b: fake Slack captured non-secret channel/text metadata for channel reply'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M-S17b: fake Slack did not capture expected channel reply metadata: ${sl_message_capture:0:300}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
+    - legacy: 'M-S17: Slack channel @mention proof failed: ${sl_channel_proof:0:500}'
+      status: deferred
+      reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking
+      owner: e2e-maintainers
+      secret_requirement: Slack test credentials
     - legacy: 'M18: Telegram getMe returned 200 with real token'
       status: deferred
       reason: live legacy behavior requires non-deterministic infrastructure; retained for bucket parity tracking

--- a/test/e2e/lib/fake-slack-api.cjs
+++ b/test/e2e/lib/fake-slack-api.cjs
@@ -102,7 +102,7 @@ const server = http.createServer((req, res) => {
     });
 
     if (pathname === "/api/chat.postMessage") {
-      res.writeHead(authAccepted ? 200 : 401, {
+      res.writeHead(200, {
         "content-type": "application/json",
       });
       res.end(

--- a/test/e2e/lib/fake-slack-api.cjs
+++ b/test/e2e/lib/fake-slack-api.cjs
@@ -65,7 +65,11 @@ const server = http.createServer((req, res) => {
     const authorization = req.headers.authorization || "";
     const expectedToken = expectedTokenForPath(pathname);
     const expectedAuthorization = `Bearer ${expectedToken}`;
-    const bodyToken = new URLSearchParams(body).get("token") || "";
+    const bodyParams = new URLSearchParams(body);
+    const bodyToken = bodyParams.get("token") || "";
+    const channel = bodyParams.get("channel") || "";
+    const text = bodyParams.get("text") || "";
+    const threadTs = bodyParams.get("thread_ts") || "";
     const tokenMatchesExpected = authorization === expectedAuthorization;
     const bodyMatchesExpected = bodyToken === expectedToken;
     const authAccepted = tokenMatchesExpected && bodyMatchesExpected;
@@ -87,7 +91,44 @@ const server = http.createServer((req, res) => {
       bodyTokenPresent: Boolean(bodyToken),
       authorizationRedacted: true,
       bodyRedacted: true,
+      ...(pathname === "/api/chat.postMessage"
+        ? {
+            channel,
+            text,
+            textLength: text.length,
+            threadTs,
+          }
+        : {}),
     });
+
+    if (pathname === "/api/chat.postMessage") {
+      res.writeHead(authAccepted ? 200 : 401, {
+        "content-type": "application/json",
+      });
+      res.end(
+        JSON.stringify(
+          authAccepted
+            ? {
+                ok: true,
+                channel,
+                ts: "1710000000.000200",
+                message: {
+                  type: "message",
+                  channel,
+                  text,
+                  ts: "1710000000.000200",
+                  ...(threadTs ? { thread_ts: threadTs } : {}),
+                },
+              }
+            : {
+                ok: false,
+                error: "bad_auth",
+                endpoint: pathname,
+              },
+        ),
+      );
+      return;
+    }
 
     res.writeHead(authAccepted ? 200 : 401, {
       "content-type": "application/json",

--- a/test/e2e/lib/slack-api-proof.sh
+++ b/test/e2e/lib/slack-api-proof.sh
@@ -251,8 +251,12 @@ function createOpenClawSlackProofRoot(openclawRoot) {
 }
 
 function resolveSlackTestApiImport(testApiSource, exportName) {
-  const pattern = new RegExp(`import \\\\{[^}]*\\\\bas\\\\s+${exportName}\\\\b[^}]*\\\\}\\\\s+from\\\\s+["']([^"']+)["']`);
-  const match = testApiSource.match(pattern);
+  const escapedExportName = exportName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const patterns = [
+    new RegExp(`import\\s+\\{[^}]*\\bas\\s+${escapedExportName}\\b[^}]*\\}\\s+from\\s+["']([^"']+)["']`),
+    new RegExp(`import\\s+\\{[^}]*\\b${escapedExportName}\\b[^}]*\\}\\s+from\\s+["']([^"']+)["']`),
+  ];
+  const match = patterns.map((pattern) => testApiSource.match(pattern)).find(Boolean);
   if (!match) fail(`OpenClaw Slack test API does not expose ${exportName}`);
   return match[1];
 }

--- a/test/e2e/lib/slack-api-proof.sh
+++ b/test/e2e/lib/slack-api-proof.sh
@@ -138,3 +138,327 @@ req.write(data);
 req.end();
 NODE
 }
+
+run_fake_slack_channel_mention_proof() {
+  local port="$1"
+  local allowed_user="$2"
+  local denied_user="$3"
+  local host="${FAKE_SLACK_API_HOST:-host.openshell.internal}"
+  sandbox_exec_stdin "FAKE_SLACK_API_HOST='$host' FAKE_SLACK_API_PORT='$port' SLACK_ALLOWED_USER='$allowed_user' SLACK_DENIED_USER='$denied_user' node --preserve-symlinks --input-type=module - 2>&1" <<'NODE'
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function resolveOpenClawRoot() {
+  const candidates = [];
+  if (process.env.OPENCLAW_PACKAGE_ROOT) candidates.push(process.env.OPENCLAW_PACKAGE_ROOT);
+  try {
+    const globalRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
+    if (globalRoot) candidates.push(path.join(globalRoot, "openclaw"));
+  } catch {}
+  candidates.push("/usr/local/lib/node_modules/openclaw");
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(path.join(candidate, "dist/extensions/slack/test-api.js"))) {
+      return candidate;
+    }
+  }
+  fail(`OpenClaw Slack test API not found in: ${candidates.join(", ")}`);
+}
+
+function createOpenClawSlackProofRoot(openclawRoot) {
+  const proofWorkspace = fs.mkdtempSync("/tmp/openclaw-slack-proof-");
+  const proofRoot = path.join(proofWorkspace, "node_modules/openclaw");
+  fs.mkdirSync(proofRoot, { recursive: true });
+  fs.copyFileSync(path.join(openclawRoot, "package.json"), path.join(proofRoot, "package.json"));
+  fs.symlinkSync(path.join(openclawRoot, "dist"), path.join(proofRoot, "dist"), "dir");
+
+  const nodeModulesRoot = path.join(proofRoot, "node_modules");
+  fs.mkdirSync(nodeModulesRoot, { recursive: true });
+
+  const linkNodeModules = (sourceNodeModules) => {
+    if (!fs.existsSync(sourceNodeModules)) return;
+    for (const entry of fs.readdirSync(sourceNodeModules)) {
+      if (entry === "openclaw") continue;
+      const sourceEntry = path.join(sourceNodeModules, entry);
+      const destEntry = path.join(nodeModulesRoot, entry);
+      if (entry.startsWith("@") && fs.statSync(sourceEntry).isDirectory()) {
+        fs.mkdirSync(destEntry, { recursive: true });
+        for (const scopedEntry of fs.readdirSync(sourceEntry)) {
+          const sourceScopedEntry = path.join(sourceEntry, scopedEntry);
+          const destScopedEntry = path.join(destEntry, scopedEntry);
+          if (!fs.existsSync(destScopedEntry)) {
+            fs.symlinkSync(sourceScopedEntry, destScopedEntry, "dir");
+          }
+        }
+      } else if (!fs.existsSync(destEntry)) {
+        fs.symlinkSync(sourceEntry, destEntry, "dir");
+      }
+    }
+  };
+  linkNodeModules(path.join(openclawRoot, "node_modules"));
+  linkNodeModules(path.dirname(openclawRoot));
+
+  const slackWebApiRoot = path.join(proofRoot, "node_modules/@slack/web-api");
+  if (!fs.existsSync(slackWebApiRoot)) {
+    fs.mkdirSync(slackWebApiRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(slackWebApiRoot, "package.json"),
+      JSON.stringify({ type: "module", exports: "./index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(slackWebApiRoot, "index.js"),
+      `export class WebClient {
+  constructor(token, options = {}) {
+    this.token = token;
+    this.options = options;
+    this.chat = {
+      postMessage: async () => {
+        throw new Error("stub @slack/web-api WebClient is not used by the NemoClaw E2E proof");
+      },
+    };
+  }
+}
+`,
+    );
+  }
+
+  const proxyAgentRoot = path.join(proofRoot, "node_modules/https-proxy-agent");
+  if (!fs.existsSync(proxyAgentRoot)) {
+    fs.mkdirSync(proxyAgentRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(proxyAgentRoot, "package.json"),
+      JSON.stringify({ type: "module", exports: "./index.js" }),
+    );
+    fs.writeFileSync(
+      path.join(proxyAgentRoot, "index.js"),
+      `export class HttpsProxyAgent {
+  constructor(url) {
+    this.url = url;
+  }
+}
+`,
+    );
+  }
+
+  return proofRoot;
+}
+
+function resolveSlackTestApiImport(testApiSource, exportName) {
+  const pattern = new RegExp(`import \\\\{[^}]*\\\\bas\\\\s+${exportName}\\\\b[^}]*\\\\}\\\\s+from\\\\s+["']([^"']+)["']`);
+  const match = testApiSource.match(pattern);
+  if (!match) fail(`OpenClaw Slack test API does not expose ${exportName}`);
+  return match[1];
+}
+
+async function importOpenClawSlackProofApi(openclawRoot) {
+  const proofRoot = createOpenClawSlackProofRoot(openclawRoot);
+  const slackDir = path.join(proofRoot, "dist/extensions/slack");
+  const testApiSource = fs.readFileSync(path.join(slackDir, "test-api.js"), "utf8");
+  const helperPath = resolveSlackTestApiImport(testApiSource, "createInboundSlackTestContext");
+  const preparePath = resolveSlackTestApiImport(testApiSource, "prepareSlackMessage");
+  const sendPath = resolveSlackTestApiImport(testApiSource, "sendMessageSlack");
+  const [helperModule, prepareModule, sendModule] = await Promise.all([
+    import(pathToFileURL(path.join(slackDir, helperPath)).href),
+    import(pathToFileURL(path.join(slackDir, preparePath)).href),
+    import(pathToFileURL(path.join(slackDir, sendPath)).href),
+  ]);
+  return {
+    createInboundSlackTestContext: helperModule.createInboundSlackTestContext ?? helperModule.t,
+    prepareSlackMessage: prepareModule.prepareSlackMessage ?? prepareModule.t,
+    sendMessageSlack: sendModule.sendMessageSlack ?? sendModule.t,
+  };
+}
+
+function postForm(pathname, fields, authorization) {
+  const body = new URLSearchParams(fields).toString();
+  const options = {
+    hostname: process.env.FAKE_SLACK_API_HOST || "host.openshell.internal",
+    port: Number(process.env.FAKE_SLACK_API_PORT),
+    path: pathname,
+    method: "POST",
+    headers: {
+      Authorization: authorization,
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Content-Length": Buffer.byteLength(body),
+    },
+  };
+  return new Promise((resolve, reject) => {
+    const req = http.request(options, (res) => {
+      let responseBody = "";
+      res.on("data", (chunk) => {
+        responseBody += chunk;
+      });
+      res.on("end", () => {
+        let parsed = {};
+        try {
+          parsed = responseBody ? JSON.parse(responseBody) : {};
+        } catch (error) {
+          reject(new Error(`invalid JSON from fake Slack: ${error.message}: ${responseBody}`));
+          return;
+        }
+        resolve({ statusCode: res.statusCode, body: parsed });
+      });
+    });
+    req.on("error", reject);
+    req.setTimeout(30000, () => {
+      req.destroy(new Error("fake Slack postMessage timed out"));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+const cfg = JSON.parse(fs.readFileSync("/sandbox/.openclaw/openclaw.json", "utf8"));
+const slackAccount = cfg.channels?.slack?.accounts?.default;
+if (!slackAccount) fail("missing channels.slack.accounts.default");
+if (slackAccount.dmPolicy !== "allowlist") fail(`unexpected Slack dmPolicy: ${slackAccount.dmPolicy}`);
+if (slackAccount.groupPolicy !== "allowlist") {
+  fail(`unexpected Slack groupPolicy: ${slackAccount.groupPolicy}`);
+}
+const wildcard = slackAccount.channels?.["*"];
+if (!wildcard?.enabled || wildcard.requireMention !== true) {
+  fail(`missing enabled requireMention wildcard Slack channel config: ${JSON.stringify(wildcard)}`);
+}
+const allowedUser = process.env.SLACK_ALLOWED_USER || "U0AR85ATALW";
+const deniedUser = process.env.SLACK_DENIED_USER || "U999DENIED";
+if (!Array.isArray(wildcard.users) || !wildcard.users.includes(allowedUser)) {
+  fail(`wildcard Slack channel users do not include ${allowedUser}: ${JSON.stringify(wildcard.users)}`);
+}
+
+const openclawRoot = resolveOpenClawRoot();
+const slackApi = await importOpenClawSlackProofApi(openclawRoot);
+const { createInboundSlackTestContext, prepareSlackMessage, sendMessageSlack } = slackApi;
+
+const channelId = "C0E2ESLACK";
+const appClient = {
+  assistant: {
+    threads: {
+      setStatus: async () => ({ ok: true }),
+    },
+  },
+  conversations: {
+    info: async () => ({
+      ok: true,
+      channel: {
+        id: channelId,
+        name: "nemoclaw-test",
+        is_channel: true,
+      },
+    }),
+    open: async ({ users }) => ({
+      ok: true,
+      channel: { id: `D${users}` },
+    }),
+  },
+  reactions: {
+    add: async () => ({ ok: true }),
+    remove: async () => ({ ok: true }),
+  },
+  users: {
+    info: async ({ user }) => ({
+      ok: true,
+      user: {
+        id: user,
+        name: user,
+        profile: { display_name: user, real_name: user },
+      },
+    }),
+  },
+};
+
+const ctx = createInboundSlackTestContext({
+  cfg,
+  appClient,
+  channelsConfig: slackAccount.channels,
+  defaultRequireMention: slackAccount.requireMention ?? true,
+});
+ctx.botToken = slackAccount.botToken;
+ctx.botUserId = "B1";
+ctx.botId = "B1";
+ctx.teamId = "T1";
+ctx.apiAppId = "A1";
+
+const account = {
+  accountId: "default",
+  botToken: slackAccount.botToken,
+  appToken: slackAccount.appToken,
+  config: slackAccount,
+};
+const baseMessage = {
+  channel: channelId,
+  channel_type: "channel",
+  team: "T1",
+  text: "<@B1> channel mention proof",
+};
+
+const allowedPrepared = await prepareSlackMessage({
+  ctx,
+  account,
+  message: { ...baseMessage, user: allowedUser, ts: "1710000000.000100" },
+  opts: { source: "app_mention", wasMentioned: true },
+});
+if (!allowedPrepared) fail("allowed Slack app_mention did not prepare");
+if (allowedPrepared.replyTarget !== `channel:${channelId}`) {
+  fail(`unexpected allowed replyTarget: ${allowedPrepared.replyTarget}`);
+}
+
+const deniedPrepared = await prepareSlackMessage({
+  ctx,
+  account,
+  message: { ...baseMessage, user: deniedUser, ts: "1710000000.000101" },
+  opts: { source: "app_mention", wasMentioned: true },
+});
+if (deniedPrepared !== null) fail("denied Slack app_mention unexpectedly prepared");
+
+const proofText = "NemoClaw Slack channel mention proof";
+const token = slackAccount.botToken;
+const fakeClient = {
+  chat: {
+    postMessage: async (payload) => {
+      const response = await postForm(
+        "/api/chat.postMessage",
+        {
+          token,
+          channel: payload.channel || "",
+          text: payload.text || "",
+          ...(payload.thread_ts ? { thread_ts: payload.thread_ts } : {}),
+          ...(payload.blocks ? { blocks: JSON.stringify(payload.blocks) } : {}),
+        },
+        `Bearer ${token}`,
+      );
+      if (response.statusCode !== 200 || response.body?.ok !== true) {
+        throw new Error(`fake Slack chat.postMessage failed: ${response.statusCode} ${JSON.stringify(response.body)}`);
+      }
+      return response.body;
+    },
+  },
+};
+
+const sendResult = await sendMessageSlack(allowedPrepared.replyTarget, proofText, {
+  cfg,
+  token,
+  client: fakeClient,
+  accountId: "default",
+});
+if (sendResult.channelId !== channelId) {
+  fail(`sendMessageSlack returned unexpected channelId: ${sendResult.channelId}`);
+}
+
+console.log(
+  JSON.stringify({
+    ok: true,
+    allowedReplyTarget: allowedPrepared.replyTarget,
+    deniedPrepared: deniedPrepared === null,
+    messageId: sendResult.messageId,
+    channelId: sendResult.channelId,
+  }),
+);
+NODE
+}

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -124,7 +124,7 @@ DISCORD_TOKEN="${DISCORD_BOT_TOKEN:-test-fake-discord-token-e2e}"
 SLACK_TOKEN="${SLACK_BOT_TOKEN:-xoxb-fake-slack-token-e2e}"
 SLACK_APP="${SLACK_APP_TOKEN:-xapp-fake-slack-app-token-e2e}"
 TELEGRAM_IDS="${TELEGRAM_ALLOWED_IDS:-123456789,987654321}"
-SLACK_IDS="${SLACK_ALLOWED_USERS:-U0AR85ATALW,U09E2ESLACK}"
+SLACK_IDS="${SLACK_ALLOWED_USERS-U0AR85ATALW,U09E2ESLACK}"
 # WeChat: pre-seeding WECHAT_BOT_TOKEN + the per-account metadata env vars lets
 # the non-interactive onboard path (src/lib/onboard.ts:8433) treat wechat as
 # "already configured" and skip the host-qr handler entirely. Fake values are
@@ -217,7 +217,15 @@ info "Telegram token: ${TELEGRAM_TOKEN:0:10}... (${#TELEGRAM_TOKEN} chars)"
 info "Discord token: ${DISCORD_TOKEN:0:10}... (${#DISCORD_TOKEN} chars)"
 info "Slack bot token: configured (${#SLACK_TOKEN} chars)"
 info "Slack app token: configured (${#SLACK_APP} chars)"
-info "Slack allowed users: $SLACK_IDS"
+slack_allowed_user_count=0
+if [ -n "$SLACK_IDS" ]; then
+  IFS=',' read -ra _slack_allowed_ids <<<"$SLACK_IDS"
+  for _sid in "${_slack_allowed_ids[@]}"; do
+    _sid="${_sid//[[:space:]]/}"
+    [ -n "$_sid" ] && ((slack_allowed_user_count++))
+  done
+fi
+info "Slack allowed users configured: ${slack_allowed_user_count} ID(s)"
 info "WeChat token: configured (${#WECHAT_TOKEN} chars), account=${WECHAT_ACCOUNT}"
 info "Sandbox name: $SANDBOX_NAME"
 
@@ -908,27 +916,39 @@ if wildcard.get('enabled') is not True:
 elif wildcard.get('requireMention') is not True:
     print('BAD_REQUIRE_MENTION')
 else:
-    print(','.join(str(i) for i in wildcard.get('users', [])))
+    users = wildcard.get('users', [])
+    if not isinstance(users, list):
+        print('BAD_USERS_TYPE')
+    elif len(users) == 0:
+        print('EMPTY_USERS')
+    else:
+        print(','.join(str(i) for i in users))
 " 2>/dev/null || true)
     if [ "$sl_channel_users" = "BAD_ENABLED" ]; then
       fail "M11h: Slack wildcard channel config is not enabled"
     elif [ "$sl_channel_users" = "BAD_REQUIRE_MENTION" ]; then
       fail "M11h: Slack wildcard channel config does not require mention"
+    elif [ "$sl_channel_users" = "BAD_USERS_TYPE" ]; then
+      fail "M11h: Slack wildcard channel users is not a list"
+    elif [ "$sl_channel_users" = "EMPTY_USERS" ]; then
+      fail "M11h: Slack wildcard channel users is empty"
     elif [ -n "$sl_channel_users" ]; then
       IFS=',' read -ra expected_slack_ids <<<"$SLACK_IDS"
       missing_slack_ids=()
+      expected_slack_id_count=0
       sl_channel_users_csv=",${sl_channel_users//[[:space:]]/},"
       for sid in "${expected_slack_ids[@]}"; do
         sid="${sid//[[:space:]]/}"
         [ -z "$sid" ] && continue
+        ((expected_slack_id_count++))
         if [[ "$sl_channel_users_csv" != *",$sid,"* ]]; then
           missing_slack_ids+=("$sid")
         fi
       done
       if [ ${#missing_slack_ids[@]} -eq 0 ]; then
-        pass "M11h: Slack wildcard channel @mention allowlist contains expected users: $sl_channel_users"
+        pass "M11h: Slack wildcard channel @mention allowlist contains expected user count (${expected_slack_id_count})"
       else
-        fail "M11h: Slack wildcard channel users ($sl_channel_users) missing IDs: ${missing_slack_ids[*]}"
+        fail "M11h: Slack wildcard channel users missing ${#missing_slack_ids[@]} expected ID(s)"
       fi
     else
       skip "M11h: Slack wildcard channel users not set"

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -44,6 +44,7 @@
 #   DISCORD_BOT_TOKEN_REAL                 — optional: enables Phase 6 real round-trip
 #   SLACK_BOT_TOKEN                        — defaults to fake token (xoxb-fake-...)
 #   SLACK_APP_TOKEN                        — defaults to fake token (xapp-fake-...)
+#   SLACK_ALLOWED_USERS                    — comma-separated Slack user IDs for DM and channel @mention allowlisting
 #   SLACK_BOT_TOKEN_REVOKED                — optional: revoked xoxb- token to test auth pre-validation (#2340)
 #   SLACK_APP_TOKEN_REVOKED                — optional: paired xapp- token for the revoked bot token
 #   WECHAT_BOT_TOKEN                       — defaults to fake token; presence skips host-side QR login
@@ -123,6 +124,7 @@ DISCORD_TOKEN="${DISCORD_BOT_TOKEN:-test-fake-discord-token-e2e}"
 SLACK_TOKEN="${SLACK_BOT_TOKEN:-xoxb-fake-slack-token-e2e}"
 SLACK_APP="${SLACK_APP_TOKEN:-xapp-fake-slack-app-token-e2e}"
 TELEGRAM_IDS="${TELEGRAM_ALLOWED_IDS:-123456789,987654321}"
+SLACK_IDS="${SLACK_ALLOWED_USERS:-U0AR85ATALW,U09E2ESLACK}"
 # WeChat: pre-seeding WECHAT_BOT_TOKEN + the per-account metadata env vars lets
 # the non-interactive onboard path (src/lib/onboard.ts:8433) treat wechat as
 # "already configured" and skip the host-qr handler entirely. Fake values are
@@ -138,6 +140,7 @@ export DISCORD_BOT_TOKEN="$DISCORD_TOKEN"
 export SLACK_BOT_TOKEN="$SLACK_TOKEN"
 export SLACK_APP_TOKEN="$SLACK_APP"
 export TELEGRAM_ALLOWED_IDS="$TELEGRAM_IDS"
+export SLACK_ALLOWED_USERS="$SLACK_IDS"
 export WECHAT_BOT_TOKEN="$WECHAT_TOKEN"
 export WECHAT_ACCOUNT_ID="$WECHAT_ACCOUNT"
 export WECHAT_BASE_URL="$WECHAT_BASE"
@@ -214,6 +217,7 @@ info "Telegram token: ${TELEGRAM_TOKEN:0:10}... (${#TELEGRAM_TOKEN} chars)"
 info "Discord token: ${DISCORD_TOKEN:0:10}... (${#DISCORD_TOKEN} chars)"
 info "Slack bot token: configured (${#SLACK_TOKEN} chars)"
 info "Slack app token: configured (${#SLACK_APP} chars)"
+info "Slack allowed users: $SLACK_IDS"
 info "WeChat token: configured (${#WECHAT_TOKEN} chars), account=${WECHAT_ACCOUNT}"
 info "Sandbox name: $SANDBOX_NAME"
 
@@ -863,6 +867,73 @@ print('yes' if 'slack' in d else 'no')
   if [ "$slack_configured" = "yes" ]; then
     pass "M11e: Slack channel configured with placeholder tokens (guard needed)"
 
+    # M11f/M11g/M11h: SLACK_ALLOWED_USERS should authorize both DMs and
+    # channel @mentions from the same users. Config lives on the Slack account
+    # because OpenClaw supports multi-account Slack channel policy.
+    sl_dm_policy=$(echo "$channel_json" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+account = d.get('slack', {}).get('accounts', {}).get('default', {})
+print(account.get('dmPolicy', ''))
+" 2>/dev/null || true)
+    if [ "$sl_dm_policy" = "allowlist" ]; then
+      pass "M11f: Slack dmPolicy is 'allowlist'"
+    elif [ -n "$sl_dm_policy" ]; then
+      fail "M11f: Slack dmPolicy is '$sl_dm_policy' (expected 'allowlist')"
+    else
+      skip "M11f: Slack dmPolicy not set"
+    fi
+
+    sl_group_policy=$(echo "$channel_json" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+account = d.get('slack', {}).get('accounts', {}).get('default', {})
+print(account.get('groupPolicy', ''))
+" 2>/dev/null || true)
+    if [ "$sl_group_policy" = "allowlist" ]; then
+      pass "M11g: Slack groupPolicy is 'allowlist'"
+    elif [ -n "$sl_group_policy" ]; then
+      fail "M11g: Slack groupPolicy is '$sl_group_policy' (expected 'allowlist')"
+    else
+      skip "M11g: Slack groupPolicy not set"
+    fi
+
+    sl_channel_users=$(echo "$channel_json" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+account = d.get('slack', {}).get('accounts', {}).get('default', {})
+wildcard = account.get('channels', {}).get('*', {})
+if wildcard.get('enabled') is not True:
+    print('BAD_ENABLED')
+elif wildcard.get('requireMention') is not True:
+    print('BAD_REQUIRE_MENTION')
+else:
+    print(','.join(str(i) for i in wildcard.get('users', [])))
+" 2>/dev/null || true)
+    if [ "$sl_channel_users" = "BAD_ENABLED" ]; then
+      fail "M11h: Slack wildcard channel config is not enabled"
+    elif [ "$sl_channel_users" = "BAD_REQUIRE_MENTION" ]; then
+      fail "M11h: Slack wildcard channel config does not require mention"
+    elif [ -n "$sl_channel_users" ]; then
+      IFS=',' read -ra expected_slack_ids <<<"$SLACK_IDS"
+      missing_slack_ids=()
+      sl_channel_users_csv=",${sl_channel_users//[[:space:]]/},"
+      for sid in "${expected_slack_ids[@]}"; do
+        sid="${sid//[[:space:]]/}"
+        [ -z "$sid" ] && continue
+        if [[ "$sl_channel_users_csv" != *",$sid,"* ]]; then
+          missing_slack_ids+=("$sid")
+        fi
+      done
+      if [ ${#missing_slack_ids[@]} -eq 0 ]; then
+        pass "M11h: Slack wildcard channel @mention allowlist contains expected users: $sl_channel_users"
+      else
+        fail "M11h: Slack wildcard channel users ($sl_channel_users) missing IDs: ${missing_slack_ids[*]}"
+      fi
+    else
+      skip "M11h: Slack wildcard channel users not set"
+    fi
+
     # Diagnostics: check if the guard was installed and what NODE_OPTIONS looks like
     info "Checking guard installation diagnostics:"
     guard_exists=$(openshell sandbox exec --name "$SANDBOX_NAME" -- ls -la /tmp/nemoclaw-slack-channel-guard.js 2>/dev/null || echo "EXEC_FAILED")
@@ -1329,6 +1400,37 @@ console.log("OK");
 NODE
 }
 
+check_fake_slack_capture_message() {
+  local path="$1"
+  local expected_channel="$2"
+  local expected_text="$3"
+  node - "$FAKE_SLACK_API_CAPTURE_FILE" "$path" "$expected_channel" "$expected_text" <<'NODE'
+const fs = require("fs");
+const [file, path, expectedChannel, expectedText] = process.argv.slice(2);
+const rows = fs
+  .readFileSync(file, "utf8")
+  .trim()
+  .split(/\n+/)
+  .filter(Boolean)
+  .map((line) => JSON.parse(line))
+  .filter((row) => row.event === "request" && row.path === path);
+const last = rows.at(-1);
+if (!last) {
+  console.log(`NO_REQUEST ${path}`);
+  process.exit(2);
+}
+if (last.channel !== expectedChannel) {
+  console.log(`BAD_CHANNEL ${last.channel}`);
+  process.exit(3);
+}
+if (last.text !== expectedText) {
+  console.log(`BAD_TEXT ${last.text}`);
+  process.exit(4);
+}
+console.log("OK");
+NODE
+}
+
 info "Calling fake Slack /api/auth.test from inside sandbox with Bolt-shape placeholder..."
 sl_api=""
 if [ "$fake_slack_ready" = "1" ]; then
@@ -1488,6 +1590,43 @@ elif echo "$sl_app_canonical" | grep -qF 'openshell:resolve:env:'; then
   fail "M-S16b: L7 proxy passed canonical placeholder through unchanged for SLACK_APP_TOKEN"
 else
   fail "M-S16b: Unexpected response (status=$sl_app_canon_status): ${sl_app_canonical:0:200}"
+fi
+
+# M-S17: Slack channel @mention allowlist proof (#3729). This runs inside the
+# sandbox, imports OpenClaw's installed Slack test API, and verifies:
+#   - the configured Slack user can prepare a channel app_mention
+#   - another user is denied by channels.*.users
+#   - sendMessageSlack posts back to the channel through the hermetic fake API
+info "Running Slack channel @mention allowlist proof through installed OpenClaw..."
+sl_channel_proof=""
+sl_allowed_user="${SLACK_IDS%%,*}"
+sl_allowed_user="${sl_allowed_user//[[:space:]]/}"
+if [ "$fake_slack_ready" = "1" ] && [ -n "$sl_allowed_user" ]; then
+  sl_channel_proof=$(run_fake_slack_channel_mention_proof "$FAKE_SLACK_API_PORT" "$sl_allowed_user" "U999DENIED" || true)
+fi
+
+info "Slack channel @mention proof response: ${sl_channel_proof:0:500}"
+if echo "$sl_channel_proof" | grep -q '"ok":true' \
+  && echo "$sl_channel_proof" | grep -q '"deniedPrepared":true'; then
+  pass "M-S17: Slack channel @mention allowlist accepts configured user and denies another user"
+  sl_post_capture=$(check_fake_slack_capture_token "/api/chat.postMessage" "$SLACK_TOKEN" || true)
+  if [ "$sl_post_capture" = "OK" ]; then
+    pass "M-S17a: fake Slack saw host-side bot token for channel reply"
+  else
+    fail "M-S17a: fake Slack capture did not prove channel reply token rewrite: ${sl_post_capture:0:300}"
+  fi
+  sl_message_capture=$(check_fake_slack_capture_message "/api/chat.postMessage" "C0E2ESLACK" "NemoClaw Slack channel mention proof" || true)
+  if [ "$sl_message_capture" = "OK" ]; then
+    pass "M-S17b: fake Slack captured non-secret channel/text metadata for channel reply"
+  else
+    fail "M-S17b: fake Slack did not capture expected channel reply metadata: ${sl_message_capture:0:300}"
+  fi
+elif [ "$fake_slack_ready" != "1" ]; then
+  skip "M-S17: fake Slack API was not ready"
+elif [ -z "$sl_allowed_user" ]; then
+  skip "M-S17: SLACK_ALLOWED_USERS is empty"
+else
+  fail "M-S17: Slack channel @mention proof failed: ${sl_channel_proof:0:500}"
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -289,6 +289,28 @@ describe("generate-openclaw-config.py: config generation", () => {
     expect(slack.appToken).toMatch(/^xapp-[A-Za-z0-9_-]+$/);
   });
 
+  it("uses Slack allowed IDs for DMs and channel mention allowlisting (#3729)", () => {
+    const allowedUsers = ["U01ABC2DEF3", "U04GHI5JKL6"];
+    const channels = Buffer.from(JSON.stringify(["slack"])).toString("base64");
+    const allowedIds = Buffer.from(JSON.stringify({ slack: allowedUsers })).toString("base64");
+    const config = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+      NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: allowedIds,
+    });
+    const slack = config.channels.slack.accounts.default;
+
+    expect(slack.dmPolicy).toBe("allowlist");
+    expect(slack.allowFrom).toEqual(allowedUsers);
+    expect(slack.groupPolicy).toBe("allowlist");
+    expect(slack.channels).toEqual({
+      "*": {
+        enabled: true,
+        requireMention: true,
+        users: allowedUsers,
+      },
+    });
+  });
+
   it("enables web search when env is '1'", () => {
     const config = runConfigScript({ NEMOCLAW_WEB_SEARCH_ENABLED: "1" });
     expect(config.tools?.web?.search?.enabled).toBe(true);


### PR DESCRIPTION
## Summary
- reuse Slack allowed IDs for both DM allowlisting and wildcard channel `@mention` gating
- document that `SLACK_ALLOWED_USERS` covers Slack DMs and channel mentions where the app is present
- extend messaging-provider E2E coverage with fake Slack `chat.postMessage` capture and allowed/denied channel mention proof

Fixes #3729.

## Validation
- `npm test -- test/generate-openclaw-config.test.ts test/e2e/scenario-framework-tests/e2e-coverage-report.test.ts`
- `npm test -- test/e2e/scenario-framework-tests/e2e-convention-lint.test.ts`
- `npm test -- test/cli.test.ts test/nemoclaw-start.test.ts src/lib/status-command-deps.test.ts`
- `npm run build:cli`
- `npm run typecheck:cli`
- `bash -n test/e2e/test-messaging-providers.sh test/e2e/lib/slack-api-proof.sh`
- `node --check test/e2e/lib/fake-slack-api.cjs`
- `python3 -m py_compile scripts/generate-openclaw-config.py`
- `npx tsx scripts/e2e/check-parity-map.ts --strict`
- commit and push hooks passed

## Runtime E2E
- `test/e2e/test-messaging-providers.sh` built the sandbox image with the updated Slack config and the generated image contains `dmPolicy: allowlist`, `allowFrom`, `groupPolicy: allowlist`, and wildcard channel `requireMention` plus `users` for the configured Slack IDs.
- The run did not complete sandbox startup on this host: OpenShell returned `exec: "/opt/openshell/bin/openshell-sandbox": is a directory: permission denied` after image build, before the in-sandbox Slack proof could execute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack allowlist support: restrict direct messages and channel `@mention` events to configured Slack user IDs; wildcard channel mention policy now enforces require-mention behavior.

* **Documentation**
  * Messaging docs updated with new Slack allowed-users setting and environment variable example.

* **Tests**
  * Expanded end-to-end and unit tests to validate Slack allowlist behavior, mention handling, and message-capture proofs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->