### PR TITLE
fix(openclaw): queue webchat sends in pinned bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
 COPY nemoclaw/package.json nemoclaw/package-lock.json /opt/nemoclaw/
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
+COPY scripts/patch-openclaw-chat-send-queue.py /opt/nemoclaw/scripts/patch-openclaw-chat-send-queue.py
 RUN chmod -R a+rX /opt/nemoclaw-blueprint/
 
 # Install runtime dependencies only (no devDependencies, no build step)
@@ -221,6 +222,19 @@ RUN set -eu; \
     test -n "$hto_files" || { echo "ERROR: handshake-timeout constant not found" >&2; exit 1; }; \
     printf '%s\n' "$hto_files" | xargs sed -i -E 's|DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4|DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 6e4|g'; \
     if grep -REq --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4' "$OC_DIST"; then echo "ERROR: Patch 5 left a 1e4 constant" >&2; exit 1; fi
+
+# Patch OpenClaw WebChat/TUI rapid-send correlation (#2603).
+#
+# Pinned OpenClaw 2026.4.24 can process overlapping chat.send turns for the
+# same session. That lets later user turns enter the transcript before the
+# active turn finishes, producing empty finals, mismatched runIds, and duplicate
+# user turns in chat.history. Queue the transcript update + dispatch section per
+# session while preserving each client idempotency key/runId.
+#
+# Removal criteria: drop this once the pinned OpenClaw version includes a
+# server-side chat.send/session-history correlation fix for #2603.
+# hadolint ignore=DL3059
+RUN python3 /opt/nemoclaw/scripts/patch-openclaw-chat-send-queue.py /usr/local/lib/node_modules/openclaw/dist
 
 # Set up blueprint for local resolution.
 # Blueprints are immutable at runtime; DAC protection (root ownership) is applied

--- a/scripts/patch-openclaw-chat-send-queue.py
+++ b/scripts/patch-openclaw-chat-send-queue.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Patch pinned OpenClaw chat.send to serialize WebChat/TUI turns per session.
+
+This is intentionally shape-checked against OpenClaw 2026.4.24's compiled dist.
+It should fail closed when the bundled OpenClaw implementation changes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+HELPER = """\
+const nemoclawChatSendQueues = globalThis.__nemoclawChatSendQueues ??= new Map();
+function nemoclawQueueChatSend(sessionKey, runId, work) {
+\tconst queueKey = typeof sessionKey === "string" && sessionKey.trim() ? sessionKey.trim() : runId;
+\tconst previous = nemoclawChatSendQueues.get(queueKey) ?? Promise.resolve();
+\tconst next = previous.catch(() => {}).then(work).finally(() => {
+\t\tif (nemoclawChatSendQueues.get(queueKey) === next) nemoclawChatSendQueues.delete(queueKey);
+\t});
+\tnemoclawChatSendQueues.set(queueKey, next);
+\treturn next;
+}
+function nemoclawDedupeChatHistoryMessages(messages) {
+\tconst seen = new Set();
+\tconst deduped = [];
+\tfor (const message of messages) {
+\t\tconst role = message && typeof message === "object" ? message.role : void 0;
+\t\tconst timestamp = message && typeof message === "object" ? message.timestamp : void 0;
+\t\tconst text = extractChatHistoryBlockText(message);
+\t\tif ((role === "user" || role === "assistant") && (typeof timestamp === "number" || typeof timestamp === "string") && typeof text === "string" && text.trim()) {
+\t\t\tconst key = `${role}\\0${timestamp}\\0${text.trim()}`;
+\t\t\tif (seen.has(key)) continue;
+\t\t\tseen.add(key);
+\t\t}
+\t\tdeduped.push(message);
+\t}
+\treturn deduped;
+}
+"""
+
+
+def _replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f"{label}: expected exactly one match, found {count}")
+    return text.replace(old, new, 1)
+
+
+def _patch_chat_bundle(path: Path) -> bool:
+    text = path.read_text(encoding="utf-8")
+    if "nemoclawQueueChatSend" in text:
+        return True
+    if '"chat.send": async ({ params, respond, context, client }) => {' not in text:
+        return False
+    if "dispatchInboundMessage({" not in text:
+        return False
+
+    text = _replace_once(
+        text,
+        "const chatHandlers = {",
+        f"{HELPER}const chatHandlers = {{",
+        f"{path}: helper insertion",
+    )
+    text = _replace_once(
+        text,
+        "\t\tconst normalized = augmentChatHistoryWithCanvasBlocks(sanitizeChatHistoryMessages(stripEnvelopeFromMessages(rawMessages.length > max ? rawMessages.slice(-max) : rawMessages), effectiveMaxChars));",
+        "\t\tconst normalized = nemoclawDedupeChatHistoryMessages(augmentChatHistoryWithCanvasBlocks(sanitizeChatHistoryMessages(stripEnvelopeFromMessages(rawMessages.length > max ? rawMessages.slice(-max) : rawMessages), effectiveMaxChars)));",
+        f"{path}: chat.history duplicate display turn filter",
+    )
+    text = _replace_once(
+        text,
+        "\t\t\tconst deliveredReplies = [];\n"
+        "\t\t\tlet appendedWebchatAgentMedia = false;\n"
+        "\t\t\tlet userTranscriptUpdatePromise = null;",
+        "\t\t\tconst deliveredReplies = [];\n"
+        "\t\t\tlet appendedWebchatAgentMedia = false;\n"
+        "\t\t\tlet agentRunStarted = false;\n"
+        "\t\t\tlet userTranscriptUpdatePromise = null;",
+        f"{path}: agentRunStarted hoist",
+    )
+    text = _replace_once(
+        text,
+        "\t\t\temitUserTranscriptUpdate().catch((transcriptErr) => {\n"
+        "\t\t\t\tcontext.logGateway.warn(`webchat eager user transcript update failed: ${formatForLog(transcriptErr)}`);\n"
+        "\t\t\t});\n"
+        "\t\t\tlet agentRunStarted = false;\n"
+        "\t\t\tdispatchInboundMessage({",
+        "\t\t\tnemoclawQueueChatSend(sessionKey, clientRunId, () => {\n"
+        "\t\t\t\tif (trimmedMessage && !trimmedMessage.startsWith(\"/\")) agentRunStarted = true;\n"
+        "\t\t\t\treturn dispatchInboundMessage({",
+        f"{path}: queue dispatch opening",
+    )
+    text = _replace_once(
+        text,
+        "\t\t\t\t\tonAgentRunStart: (runId) => {\n"
+        "\t\t\t\t\t\tagentRunStarted = true;\n"
+        "\t\t\t\t\t\temitUserTranscriptUpdate();",
+        "\t\t\t\t\tonAgentRunStart: (runId) => {\n"
+        "\t\t\t\t\t\tagentRunStarted = true;",
+        f"{path}: remove eager agent-start transcript append",
+    )
+    text = _replace_once(
+        text,
+        "\t\t\t\t} else emitUserTranscriptUpdate();\n"
+        "\t\t\t\tsetGatewayDedupeEntry({",
+        "\t\t\t\t}\n"
+        "\t\t\t\tsetGatewayDedupeEntry({",
+        f"{path}: remove post-agent transcript append",
+    )
+    text = _replace_once(
+        text,
+        "\t\t\t\tif (!agentRunStarted) {\n"
+        "\t\t\t\t\tawait emitUserTranscriptUpdate();",
+        "\t\t\t\tif (!agentRunStarted && (!trimmedMessage || trimmedMessage.startsWith(\"/\"))) {\n"
+        "\t\t\t\t\tawait emitUserTranscriptUpdate();",
+        f"{path}: skip fallback transcript append for normal chat text",
+    )
+    text = _replace_once(
+        text,
+        "\t\t\t}).finally(() => {\n"
+        "\t\t\t\tactiveRunAbort.cleanup();\n"
+        "\t\t\t\tcontext.removeChatRun(clientRunId, clientRunId, sessionKey);\n"
+        "\t\t\t});\n"
+        "\t\t} catch (err) {",
+        "\t\t\t}).finally(() => {\n"
+        "\t\t\t\tactiveRunAbort.cleanup();\n"
+        "\t\t\t\tcontext.removeChatRun(clientRunId, clientRunId, sessionKey);\n"
+        "\t\t\t});\n"
+        "\t\t\t});\n"
+        "\t\t} catch (err) {",
+        f"{path}: queue dispatch closing",
+    )
+    path.write_text(text, encoding="utf-8")
+    return True
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: patch-openclaw-chat-send-queue.py OPENCLAW_DIST", file=sys.stderr)
+        return 2
+    dist = Path(argv[1])
+    if not dist.is_dir():
+        print(f"ERROR: OpenClaw dist directory not found: {dist}", file=sys.stderr)
+        return 1
+    try:
+        patched = [path for path in sorted(dist.glob("chat-*.js")) if _patch_chat_bundle(path)]
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if len(patched) != 1:
+        print(f"ERROR: expected exactly one OpenClaw chat bundle to patch, patched {len(patched)}", file=sys.stderr)
+        for path in patched:
+            print(f"  patched: {path}", file=sys.stderr)
+        return 1
+    print(f"INFO: patched OpenClaw chat.send session queue in {patched[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -8,6 +8,12 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const DOCKERFILE = path.join(import.meta.dirname, "..", "Dockerfile");
+const CHAT_SEND_PATCHER = path.join(
+  import.meta.dirname,
+  "..",
+  "scripts",
+  "patch-openclaw-chat-send-queue.py",
+);
 
 function dockerRunCommandBetween(startMarker: string, endMarker: string): string {
   const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
@@ -137,6 +143,104 @@ if (globalThis.proxyChecks.length !== 0) throw new Error('sandbox proxy validati
       );
       expect(verify.status).toBe(0);
       expect(verify.stderr).toBe("");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("patches pinned OpenClaw chat.send to queue transcript dispatch per session", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-chat-send-queue-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist, { recursive: true });
+    const modulePath = path.join(dist, "chat-test.js");
+    fs.writeFileSync(
+      modulePath,
+      [
+        "function dispatchInboundMessage() { return Promise.resolve(); }",
+        "function augmentChatHistoryWithCanvasBlocks(messages) { return messages; }",
+        "function sanitizeChatHistoryMessages(messages) { return messages; }",
+        "function stripEnvelopeFromMessages(messages) { return messages; }",
+        "function extractChatHistoryBlockText(message) { return message?.content?.[0]?.text; }",
+        "function formatForLog(value) { return String(value); }",
+        "const activeRunAbort = { cleanup() {} };",
+        "const clientRunId = 'run-1';",
+        "const sessionKey = 'session-1';",
+        "const rawMessages = [];",
+        "const max = 200;",
+        "const effectiveMaxChars = 8000;",
+        "    const normalized = augmentChatHistoryWithCanvasBlocks(sanitizeChatHistoryMessages(stripEnvelopeFromMessages(rawMessages.length > max ? rawMessages.slice(-max) : rawMessages), effectiveMaxChars));",
+        "const chatHandlers = {",
+        '  "chat.send": async ({ params, respond, context, client }) => {',
+        "    try {",
+        "      const deliveredReplies = [];",
+        "      let appendedWebchatAgentMedia = false;",
+        "      let userTranscriptUpdatePromise = null;",
+        '      const trimmedMessage = "hello";',
+        "      const emitUserTranscriptUpdate = async () => {};",
+        "      const appendWebchatAgentMediaTranscriptIfNeeded = async () => {",
+        "        if (!agentRunStarted || appendedWebchatAgentMedia || deliveredReplies.length < 0) return;",
+        "      };",
+        "      emitUserTranscriptUpdate().catch((transcriptErr) => {",
+        "        context.logGateway.warn(`webchat eager user transcript update failed: ${formatForLog(transcriptErr)}`);",
+        "      });",
+        "      let agentRunStarted = false;",
+        "      dispatchInboundMessage({",
+        "        replyOptions: {",
+        "          onAgentRunStart: (runId) => {",
+        "            agentRunStarted = true;",
+        "            emitUserTranscriptUpdate();",
+        "            void runId;",
+        "          }",
+        "        }",
+        "      }).then(async () => {",
+        "        if (!agentRunStarted) {",
+        "          await emitUserTranscriptUpdate();",
+        "          await appendWebchatAgentMediaTranscriptIfNeeded({});",
+        "        } else emitUserTranscriptUpdate();",
+        "        setGatewayDedupeEntry({});",
+        "      }).catch((err) => {",
+        "        emitUserTranscriptUpdate().catch((transcriptErr) => {",
+        "          context.logGateway.warn(`webchat user transcript update failed after error: ${formatForLog(transcriptErr)}`);",
+        "        });",
+        "      }).finally(() => {",
+        "        activeRunAbort.cleanup();",
+        "        context.removeChatRun(clientRunId, clientRunId, sessionKey);",
+        "      });",
+        "    } catch (err) {",
+        "      context.chatAbortControllers.delete(clientRunId);",
+        "    }",
+        "  }",
+        "};",
+        "void chatHandlers;",
+        "",
+      ].join("\n").replaceAll("  ", "\t"),
+    );
+
+    try {
+      const patch = spawnSync("python3", [CHAT_SEND_PATCHER, dist], {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      const patched = fs.readFileSync(modulePath, "utf-8");
+      expect(patched).toContain("function nemoclawQueueChatSend(sessionKey, runId, work)");
+      expect(patched).toContain("function nemoclawDedupeChatHistoryMessages(messages)");
+      expect(patched).toContain("const normalized = nemoclawDedupeChatHistoryMessages(");
+      expect(patched).toContain("let agentRunStarted = false;\n\t\t\tlet userTranscriptUpdatePromise");
+      expect(patched).toContain("nemoclawQueueChatSend(sessionKey, clientRunId, () => {");
+      expect(patched).toContain('if (trimmedMessage && !trimmedMessage.startsWith("/")) agentRunStarted = true;');
+      expect(patched).toContain("return dispatchInboundMessage({");
+      expect(patched).toContain(
+        'if (!agentRunStarted && (!trimmedMessage || trimmedMessage.startsWith("/"))) {',
+      );
+      expect(patched).not.toContain("webchat eager user transcript update failed");
+      expect(patched).not.toContain("agentRunStarted = true; emitUserTranscriptUpdate();");
+      expect(patched).not.toContain("} else emitUserTranscriptUpdate();");
+      const check = spawnSync(process.execPath, ["--check", modulePath], {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      expect(check.status, check.stderr).toBe(0);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- keeps OpenClaw pinned at 2026.4.24; no version bump
- adds a shape-checked build-time patch for the pinned OpenClaw chat bundle to serialize `chat.send` dispatch per `sessionKey`
- preserves client `runId`/idempotency keys, removes eager duplicate transcript emits, and de-dupes duplicate `chat.history` display turns by role/timestamp/text

## Validation
- `npx vitest run test/fetch-guard-patch-regression.test.ts`
- Docker image build with `nemoclaw-issue2603-hotfix:queue`; build log confirms `OpenClaw 2026.4.24 is current` and patch application to `chat-DznnoAn8.js`
- Local gateway e2e in the built image with three rapid `chat.send` calls, slow first reply, mock OpenAI-compatible backend:
  - `emptyFinalsForSubmittedRuns: []`
  - `uncorrelatedReplies: []`
  - `duplicateUserTurns: []`
- fail-closed check against OpenClaw 2026.5.12 bundle shape returned the expected patch-shape error

## Notes
- The broad local `test-cli` pre-commit/pre-push hook failed on unrelated local environment/suite issues (`nemoclaw/node_modules/json5` missing, `nemoclaw/dist/blueprint/private-networks.js` missing, several 5s timeouts, and later `rm: dist: Directory not empty`). The targeted regression guard, clean Docker build, and built-image e2e passed.

Fixes #2603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented patches to enhance chat operation handling, including improved message sequencing, deduplication, and transcript management for better session correlation.

* **Tests**
  * Added comprehensive regression test suite that validates the patching mechanism, verifies type-safety checks, and ensures all expected behavioral modifications are correctly applied in the build pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->