### PR TITLE
fix(inference): apply model-specific compat during inference set for z-ai/glm-5.1

### DIFF
--- a/nemoclaw-blueprint/model-specific-setup/openclaw/glm-5.1-managed-inference.json
+++ b/nemoclaw-blueprint/model-specific-setup/openclaw/glm-5.1-managed-inference.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../schema.json",
+  "id": "glm-5.1-managed-inference",
+  "agent": "openclaw",
+  "description": "Preserves OpenClaw request compatibility for z-ai/glm-5.1 through NemoClaw managed inference.local chat completions. GLM-5.1 requires max_tokens (not max_completion_tokens) and string content (not content-part arrays).",
+  "match": {
+    "modelIds": ["z-ai/glm-5.1"],
+    "providerKey": "inference",
+    "inferenceApi": "openai-completions",
+    "baseUrl": "https://inference.local/v1"
+  },
+  "effects": {
+    "openclawCompat": {
+      "requiresStringContent": true,
+      "maxTokensField": "max_tokens"
+    }
+  }
+}

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -9,6 +9,7 @@ import {
   getSandboxInferenceConfig,
   type SandboxInferenceConfig,
 } from "../inference/config";
+import { loadOpenClawModelCompat } from "../inference/model-specific-setup";
 import type { ConfigObject, ConfigValue } from "../security/credential-filter";
 import { isConfigObject, isConfigValue } from "../security/credential-filter";
 import {
@@ -237,6 +238,27 @@ function buildProviderConfig(
   };
 }
 
+function applyModelCompatToConfig(
+  config: ConfigObject,
+  providerKey: string,
+  modelCompat: Record<string, unknown>,
+): void {
+  const models = config.models;
+  if (!isConfigObject(models)) return;
+  const providers = models.providers;
+  if (!isConfigObject(providers)) return;
+  const prov = providers[providerKey];
+  if (!isConfigObject(prov)) return;
+  const modelsList = prov.models;
+  if (!Array.isArray(modelsList) || modelsList.length === 0) return;
+  const firstModel = modelsList[0];
+  if (!isConfigObject(firstModel)) return;
+  const existingCompat = isConfigObject(firstModel.compat)
+    ? { ...firstModel.compat }
+    : {};
+  firstModel.compat = { ...existingCompat, ...asConfigObject(modelCompat as Record<string, unknown>) };
+}
+
 export function patchOpenClawInferenceConfig(
   config: ConfigObject,
   provider: string,
@@ -369,6 +391,21 @@ export async function runInferenceSet(
     agentName === "hermes"
       ? patchHermesInferenceConfig(config, provider, model)
       : patchOpenClawInferenceConfig(config, provider, model, getPreferredInferenceApi(config));
+
+  // Apply model-specific compat from the blueprint registry so runtime
+  // switches receive the same flags that generate-openclaw-config.py
+  // applies at build time (e.g. maxTokensField for z-ai/glm-5.1).
+  if (agentName === "openclaw") {
+    const modelCompat = loadOpenClawModelCompat({
+      model,
+      providerKey: patched.route.providerKey,
+      inferenceApi: patched.route.inferenceApi,
+      baseUrl: patched.route.inferenceBaseUrl,
+    });
+    if (modelCompat) {
+      applyModelCompatToConfig(config, patched.route.providerKey, modelCompat);
+    }
+  }
 
   deps.log(
     agentName === "hermes"

--- a/src/lib/inference/model-specific-setup.ts
+++ b/src/lib/inference/model-specific-setup.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reads model-specific setup manifests from the NemoClaw blueprint
+ * registry and returns matching OpenClaw compatibility effects.
+ *
+ * Build-time: generate-openclaw-config.py applies these during image
+ * build. Runtime: inference-set.ts calls loadOpenClawModelCompat() when
+ * switching models so the patched openclaw.json receives the same compat
+ * flags that a fresh build would.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface ModelSpecificCompat {
+  [key: string]: unknown;
+}
+
+interface ManifestMatch {
+  modelIds?: string[];
+  providerKey?: string;
+  inferenceApi?: string;
+  baseUrl?: string;
+}
+
+interface ManifestEffects {
+  openclawCompat?: ModelSpecificCompat;
+}
+
+interface Manifest {
+  id: string;
+  agent: string;
+  match: ManifestMatch;
+  effects: ManifestEffects;
+}
+
+export interface ModelSetupMatchContext {
+  model: string;
+  providerKey: string;
+  inferenceApi: string;
+  baseUrl: string;
+}
+
+function registrySearchPaths(): string[] {
+  const paths: string[] = [];
+
+  const envDir = process.env.NEMOCLAW_MODEL_SPECIFIC_SETUP_DIR;
+  if (envDir) paths.push(envDir);
+
+  // Compiled location: dist/lib/inference/model-specific-setup.js
+  // Repo root is 3 levels up → nemoclaw-blueprint/model-specific-setup
+  const fromModule = path.resolve(__dirname, "..", "..", "..", "nemoclaw-blueprint", "model-specific-setup");
+  paths.push(fromModule);
+
+  paths.push(path.resolve(process.cwd(), "nemoclaw-blueprint", "model-specific-setup"));
+
+  return paths;
+}
+
+function findRegistryRoot(): string | null {
+  for (const candidate of registrySearchPaths()) {
+    try {
+      if (fs.statSync(candidate).isDirectory()) return candidate;
+    } catch {
+      // not found, try next
+    }
+  }
+  return null;
+}
+
+function matchesContext(manifest: Manifest, context: ModelSetupMatchContext): boolean {
+  const { match } = manifest;
+
+  if (match.modelIds) {
+    const normalizedModel = context.model.trim().toLowerCase();
+    if (!match.modelIds.some((id) => id.trim().toLowerCase() === normalizedModel)) return false;
+  }
+
+  if (match.providerKey && context.providerKey !== match.providerKey) return false;
+  if (match.inferenceApi && context.inferenceApi !== match.inferenceApi) return false;
+  if (match.baseUrl && context.baseUrl.replace(/\/+$/, "") !== match.baseUrl.replace(/\/+$/, "")) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Load OpenClaw model-specific compatibility flags for a given
+ * model/provider/api/baseUrl context.
+ *
+ * Returns merged openclawCompat from all matching manifests, or null
+ * if no manifests match (or the registry is not found on disk).
+ */
+export function loadOpenClawModelCompat(
+  context: ModelSetupMatchContext,
+): ModelSpecificCompat | null {
+  const root = findRegistryRoot();
+  if (!root) return null;
+
+  const openclawDir = path.join(root, "openclaw");
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(openclawDir).sort();
+  } catch {
+    return null;
+  }
+
+  const merged: ModelSpecificCompat = {};
+  let found = false;
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".json") || entry === "schema.json") continue;
+    const filePath = path.join(openclawDir, entry);
+    try {
+      const raw = fs.readFileSync(filePath, "utf-8");
+      const manifest: Manifest = JSON.parse(raw);
+      if (manifest.agent !== "openclaw") continue;
+      if (!matchesContext(manifest, context)) continue;
+
+      const compat = manifest.effects?.openclawCompat;
+      if (compat && typeof compat === "object") {
+        Object.assign(merged, compat);
+        found = true;
+      }
+    } catch {
+      // Skip manifests that cannot be read or parsed
+    }
+  }
+
+  return found ? merged : null;
+}


### PR DESCRIPTION
## Summary

`nemoclaw inference set` clears model compat flags (`delete firstExistingModel.compat`)
but never consults the `nemoclaw-blueprint/model-specific-setup/` registry to re-apply
them for the target model. When switching to `z-ai/glm-5.1`, the agent turn hangs
because OpenClaw sends `max_completion_tokens` — a parameter the NVIDIA-proxied GLM
endpoint does not support — instead of `max_tokens`.

### Changes

- **New:** `nemoclaw-blueprint/model-specific-setup/openclaw/glm-5.1-managed-inference.json`
  — declares `maxTokensField: "max_tokens"` and `requiresStringContent: true` for
  `z-ai/glm-5.1` through managed `inference.local`, matching the pattern established
  by the existing `kimi-k2.6-managed-inference.json` manifest.

- **New:** `src/lib/inference/model-specific-setup.ts` — reads model-specific setup
  manifests from the blueprint registry on disk and returns matching OpenClaw compat
  effects. Mirrors the Python registry logic in `generate-openclaw-config.py`.

- **Modified:** `src/lib/actions/inference-set.ts` — after patching `openclaw.json`,
  calls `loadOpenClawModelCompat()` to apply model-specific compat from matching
  manifests. This ensures runtime switches receive the same compat flags that
  `generate-openclaw-config.py` applies at build time.

### Root cause

The `openclaw-inference-switch-e2e` nightly job switches a running OpenClaw sandbox
from `nvidia/nemotron-3-super-120b-a12b` to `nvidia-prod / z-ai/glm-5.1`. The
inference.local PONG test passes (direct curl with `max_tokens`), but the
`openclaw agent` turn times out after 120 s with empty output (exit 124) because
OpenClaw's transport layer sends `max_completion_tokens` by default for models
without a `maxTokensField` compat override.

### Evidence

| Signal | Result |
|--------|--------|
| `check_sandbox_inference` (PONG via curl with `max_tokens: 100`) | ✅ PASS |
| `check_openclaw_agent_turn` (openclaw agent through gateway) | ❌ exit 124, empty reply |
| Kimi K2.6 manifest with identical compat flags | exists and passing |
| `inference-set.ts` reads model-specific registry | ❌ missing |

## Validation

A focused `custom-e2e.yaml` validation workflow was prepared but could not be pushed
because the available token lacks the `workflow` scope required to create workflow
files. The fix can be validated by re-running `openclaw-inference-switch-e2e` on this
branch:

```
gh workflow run nightly-e2e.yaml --repo NVIDIA/NemoClaw \
  --ref fix/nightly-e2e-glm-compat-inference-set-5a03166 \
  -f jobs=openclaw-inference-switch-e2e
```

- Original failing run: [26068303685](https://github.com/NVIDIA/NemoClaw/actions/runs/26068303685) on `5a03166`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

Signed-off-by: Hung Le <hple@nvidia.com>

Fixes #3779