### PR TITLE
fix(blueprint): fail rollback when sandbox name is missing

### DIFF
--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -1351,15 +1351,25 @@ describe("runner", () => {
       expect(store.has(`${runDir}/rolled_back`)).toBe(true);
     });
 
-    it("still writes marker when plan.json is missing", async () => {
+    it("throws when plan.json is missing", async () => {
       const runDir = `${RUNS_DIR}/nc-run-1`;
       addDir(runDir);
-      // No plan.json — should skip sandbox stop/remove but still mark rolled_back
 
-      await actionRollback("nc-run-1");
+      await expect(actionRollback("nc-run-1")).rejects.toThrow(/Cannot read rollback plan/);
 
       expect(mockExeca).not.toHaveBeenCalled();
-      expect(store.has(`${runDir}/rolled_back`)).toBe(true);
+      expect(store.has(`${runDir}/rolled_back`)).toBe(false);
+    });
+
+    it("throws when plan.json is corrupt", async () => {
+      const runDir = `${RUNS_DIR}/nc-run-1`;
+      addDir(runDir);
+      addFile(`${runDir}/plan.json`, "{");
+
+      await expect(actionRollback("nc-run-1")).rejects.toThrow(/Cannot read rollback plan/);
+
+      expect(mockExeca).not.toHaveBeenCalled();
+      expect(store.has(`${runDir}/rolled_back`)).toBe(false);
     });
 
     // ── Path traversal rejection ──────────────────────────────────
@@ -1375,18 +1385,17 @@ describe("runner", () => {
       await expect(actionRollback(rid)).rejects.toThrow(/Invalid run ID/);
     });
 
-    it("defaults sandbox_name to 'openclaw' when not in plan", async () => {
+    it("throws when rollback plan has no sandbox_name", async () => {
       const runDir = `${RUNS_DIR}/nc-run-1`;
       addDir(runDir);
       addFile(`${runDir}/plan.json`, JSON.stringify({}));
 
-      await actionRollback("nc-run-1");
-
-      expect(mockExeca).toHaveBeenCalledWith(
-        "openshell",
-        ["sandbox", "stop", "openclaw"],
-        expect.anything(),
+      await expect(actionRollback("nc-run-1")).rejects.toThrow(
+        /sandbox_name must be a non-empty string/,
       );
+
+      expect(mockExeca).not.toHaveBeenCalled();
+      expect(store.has(`${runDir}/rolled_back`)).toBe(false);
     });
   });
 

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -26,7 +26,7 @@ import { DASHBOARD_PORT } from "../lib/ports.js";
 
 type Action = "plan" | "apply" | "status" | "rollback";
 
-type RollbackPlanSource = { sandbox_name?: string };
+type RollbackPlanSource = { sandbox_name?: unknown };
 type UnknownRecord = { [key: string]: unknown };
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 type RestProtocol = "rest";
@@ -264,7 +264,11 @@ function progress(pct: number, label: string): void {
 }
 
 function readRollbackSandboxName(value: RollbackPlanSource | null): string {
-  return value && typeof value.sandbox_name === "string" ? value.sandbox_name : "openclaw";
+  if (!value || typeof value.sandbox_name !== "string" || value.sandbox_name.trim() === "") {
+    throw new Error("rollback plan sandbox_name must be a non-empty string");
+  }
+
+  return value.sandbox_name;
 }
 
 // ── Utilities ───────────────────────────────────────────────────
@@ -901,6 +905,7 @@ export async function actionRollback(rid: string): Promise<void> {
   }
 
   const planFile = join(stateDir, "plan.json");
+  let sandboxName: string;
   try {
     const planData = readFileSync(planFile, "utf-8");
     const parsedPlan: unknown = JSON.parse(planData);
@@ -908,15 +913,20 @@ export async function actionRollback(rid: string): Promise<void> {
       typeof parsedPlan === "object" && parsedPlan !== null && !Array.isArray(parsedPlan)
         ? parsedPlan
         : null;
-    const sandboxName = readRollbackSandboxName(rollbackPlan);
+    sandboxName = readRollbackSandboxName(rollbackPlan);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot read rollback plan for run ${rid}: ${detail}`);
+  }
 
+  try {
     progress(30, `Stopping sandbox ${sandboxName}`);
     await runCmd(["openshell", "sandbox", "stop", sandboxName], { reject: false });
 
     progress(60, `Removing sandbox ${sandboxName}`);
     await runCmd(["openshell", "sandbox", "remove", sandboxName], { reject: false });
   } catch {
-    // plan.json missing or corrupt — skip sandbox stop/remove
+    // Sandbox cleanup is best-effort; the rollback marker still records this run as handled.
   }
 
   progress(90, "Cleaning up run state");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR makes blueprint rollback fail closed when `plan.json` does not contain a verifiable `sandbox_name`. Previously, a partial or corrupted rollback plan could fall back to `openclaw`, which risked stopping or removing the wrong sandbox.

## Related Issue
Fixes #3783 

## Changes
- Require `sandbox_name` to be present, a string, and non-empty before rollback runs sandbox cleanup.
- Split rollback plan validation from best-effort `openshell sandbox stop/remove` cleanup so plan errors are not swallowed.
- Update rollback tests to cover missing, corrupt, and partial `plan.json` cases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Focused verification run:
- `npx vitest run --project plugin nemoclaw/src/blueprint/runner.test.ts`
- `npm --prefix nemoclaw run check`

Note: I did not mark full `npm test` as passing because the broader suite has unrelated local/environment failures outside this rollback change.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: 1PoPTRoN <vrxn.arp1traj@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rollback now requires a valid plan and an explicit, non-empty sandbox name; missing or corrupt plans cause rollback to fail with a clear error, make no subprocess calls, and will not mark as rolled back.
  * Sandbox cleanup is best-effort; cleanup failures no longer block writing the rolled-back marker or completing rollback.

* **Tests**
  * Updated tests to expect failures when plan or sandbox name is missing/corrupt and to verify no cleanup or marker is produced; added a test for missing sandbox name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->