### PR TITLE
fix(onboard): clear tirith install-failed marker at startup for runtime retry

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -579,6 +579,22 @@ migrate_legacy_layout "/sandbox/.hermes" "/sandbox/.hermes-data" "hermes" || exi
 
 echo 'Setting up NemoClaw (Hermes)...' >&2
 
+# ── Tirith build-time failure recovery ────────────────────────
+# The Hermes base image downloads tirith during `docker build`. When the
+# download fails (e.g. no proxy env in build context), a marker file is
+# written and the build proceeds silently. Hermes's own ensure_installed()
+# checks this marker and skips retry, so the gateway starts without tirith
+# and the onboard health-check times out (#3793).
+#
+# Fix: clear the marker before launching the gateway so ensure_installed()
+# retries the download at runtime (where the network is reachable via the
+# OpenShell proxy). The runtime fallback is proven to work — see #3793.
+TIRITH_MARKER="${HERMES_DIR}/.tirith-install-failed"
+if [ -f "$TIRITH_MARKER" ]; then
+  echo "[startup] tirith build-time install failed (reason: $(cat "$TIRITH_MARKER" 2>/dev/null || echo unknown)), clearing marker for runtime retry..." >&2
+  rm -f "$TIRITH_MARKER"
+fi
+
 # ── Non-root fallback ──────────────────────────────────────────
 if [ "$(id -u)" -ne 0 ]; then
   echo "[gateway] Running as non-root (uid=$(id -u)) — privilege separation disabled" >&2

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -592,7 +592,10 @@ echo 'Setting up NemoClaw (Hermes)...' >&2
 TIRITH_MARKER="${HERMES_DIR}/.tirith-install-failed"
 if [ -f "$TIRITH_MARKER" ]; then
   echo "[startup] tirith build-time install failed (reason: $(cat "$TIRITH_MARKER" 2>/dev/null || echo unknown)), clearing marker for runtime retry..." >&2
-  rm -f "$TIRITH_MARKER"
+  rm -f "$TIRITH_MARKER" 2>/dev/null
+  if [ -f "$TIRITH_MARKER" ]; then
+    echo "[startup] Warning: failed to remove tirith marker at $TIRITH_MARKER — runtime retry may be blocked" >&2
+  fi
 fi
 
 # ── Non-root fallback ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

When tirith download fails during `docker build` (e.g. missing proxy env in build context), Hermes writes a `.tirith-install-failed` marker to `$HERMES_HOME`. At runtime, Hermes's `ensure_installed()` checks this marker and **skips retry**, so the gateway starts without tirith and the onboard Step [7/8] health-check times out after 90s.

## Root Cause

The sandbox network is reachable at runtime (via OpenShell proxy), but the build-time download context may lack proxy configuration. The marker persists across the build → runtime boundary, blocking the retry that would otherwise succeed.

Proven by the recovery flow: `nemoclaw <name> connect` triggers `tools.tirith_security`'s runtime fallback, which successfully downloads tirith — confirming the network works at runtime.

## Fix

Clear the `.tirith-install-failed` marker in `agents/hermes/start.sh` before launching `hermes gateway run`. This lets Hermes's existing `ensure_installed()` runtime download path retry the install automatically. Cost: ~2 seconds when the marker exists, zero cost otherwise.

The fix is placed before the non-root/root branching point so it applies regardless of privilege separation mode.

## Testing

- `bash -n agents/hermes/start.sh` — syntax validation passes
- Logic is minimal (file existence check + remove), leveraging Hermes's existing download retry mechanism
- The runtime download path is already proven to work (see issue #3793 recovery flow logs)

Fixes #3793

Signed-off-by: kagura-agent <kagura-agent@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added startup recovery for incomplete build-time installations: the service now detects prior install failures on boot, logs available failure details, attempts to clean up leftover markers, and emits warnings if cleanup fails so the gateway can retry installation at runtime. This improves resilience and reduces need for manual intervention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->