### PR TITLE
chore: upgrade OpenClaw to 2026.5.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,25 +202,25 @@ RUN set -eu; \
     sed -i 's/const baseLstat = await fs\.lstat(params\.installBaseDir)/const baseLstat = await fs.stat(params.installBaseDir)/' "$ipd_file"; \
     sed -i 's/baseLstat\.isSymbolicLink()/false \/* nemoclaw: symlink check disabled, realpath guards containment *\//' "$ipd_file"; \
     if grep -q 'fs\.lstat(params\.installBaseDir)' "$ipd_file"; then echo "ERROR: Patch 3b (install-package-dir) left lstat in assertInstallBaseStable" >&2; exit 1; fi; \
-    # --- Patch 5: bump default WS handshake timeout 10s -> 60s (#2484) --- \
-    # OpenClaw's WS connect handshake has a hard-coded 10s timeout on both \
+    # --- Patch 5: bump default WS handshake timeout to 60s (#2484) --- \
+    # OpenClaw's WS connect handshake has a short default timeout on both \
     # client and server. Server-side connect-handler processing can exceed \
-    # 10s under load (multiple concurrent connects on slow CI infra), \
+    # that under load (multiple concurrent connects on slow CI infra), \
     # causing `openclaw agent --json` to fail with "gateway timeout after \
-    # 10000ms" and TC-SBX-02 to hit its 90s SSH timeout. \
+    # <timeout>ms" and TC-SBX-02 to hit its 90s SSH timeout. \
     # \
-    # Both env vars (OPENCLAW_HANDSHAKE_TIMEOUT_MS, \
-    # OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS) are clamped at the same \
-    # DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS constant, so we patch the \
-    # constant itself.  Affects both client.js (used by openclaw CLI) and \
-    # server.impl.js (gateway side). \
+    # OpenClaw now lets env/config raise portions of this path, but NemoClaw \
+    # cannot rely on every caller setting those knobs, so patch the default \
+    # constant itself. Affects both client.js (used by openclaw CLI) and \
+    # server.impl.js (gateway side). 2026.5.18 uses 15e3; older builds used \
+    # 1e4. \
     # \
     # Removal criteria: drop when openclaw fixes the underlying connect \
     # latency, or exposes the timeout as an unbounded env override. \
-    hto_files="$(grep -RIlE --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4' "$OC_DIST")"; \
+    hto_files="$(grep -RIlE --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = (1e4|15e3)' "$OC_DIST")"; \
     test -n "$hto_files" || { echo "ERROR: handshake-timeout constant not found" >&2; exit 1; }; \
-    printf '%s\n' "$hto_files" | xargs sed -i -E 's|DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4|DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 6e4|g'; \
-    if grep -REq --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4' "$OC_DIST"; then echo "ERROR: Patch 5 left a 1e4 constant" >&2; exit 1; fi
+    printf '%s\n' "$hto_files" | xargs sed -i -E 's#DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = (1e4|15e3)#DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 6e4#g'; \
+    if grep -REq --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = (1e4|15e3)' "$OC_DIST"; then echo "ERROR: Patch 5 left a short handshake constant" >&2; exit 1; fi
 
 # Set up blueprint for local resolution.
 # Blueprints are immutable at runtime; DAC protection (root ownership) is applied

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -177,7 +177,7 @@ RUN printf '%s\n' \
 # OpenClaw version: change the OPENCLAW_VERSION ARG default so CI rebuilds
 # the base image on push to main, or use workflow_dispatch on base-image.yaml
 # with the openclaw_version input for a one-off build without editing this file.
-ARG OPENCLAW_VERSION=2026.4.24
+ARG OPENCLAW_VERSION=2026.5.18
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/agents/openclaw/manifest.yaml
+++ b/agents/openclaw/manifest.yaml
@@ -19,7 +19,7 @@ homepage: "https://openclaw.ai"
 install_method: npm  # npm install -g openclaw@<version>
 binary_path: /usr/local/bin/openclaw
 version_command: "openclaw --version"
-expected_version: "2026.4.24"
+expected_version: "2026.5.18"
 gateway_command: "openclaw gateway run"
 
 # ── Health probe ────────────────────────────────────────────────

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -416,7 +416,7 @@ Existing sandboxes do not auto-upgrade when a newer NemoClaw release ships a new
 ```console
 $ nemoclaw my-assistant status
 ...
-    Agent:    OpenClaw v2026.4.24
+    Agent:    OpenClaw v2026.5.18
 ...
 ```
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -383,7 +383,7 @@ Existing sandboxes do not auto-upgrade when a newer NemoClaw release ships a new
 ```console
 $ nemoclaw my-assistant status
 ...
-    Agent:    OpenClaw v2026.4.24
+    Agent:    OpenClaw v2026.5.18
 ...
 ```
 

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -4,7 +4,7 @@
 version: "0.1.0"
 min_openshell_version: "0.0.39"
 max_openshell_version: "0.0.39"
-min_openclaw_version: "2026.4.24"
+min_openclaw_version: "2026.5.18"
 # Mirrors the components.sandbox.image manifest digest below. Lets a
 # downstream consumer (or release tooling) verify the blueprint declares
 # a specific sandbox image without parsing the components tree, and

--- a/nemoclaw/package.json
+++ b/nemoclaw/package.json
@@ -11,11 +11,11 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.5.10-beta.1",
-      "minGatewayVersion": "2026.5.10-beta.1"
+      "pluginApi": ">=2026.5.18",
+      "minGatewayVersion": "2026.5.18"
     },
     "build": {
-      "openclawVersion": "2026.5.10-beta.1"
+      "openclawVersion": "2026.5.18"
     }
   },
   "scripts": {

--- a/nemoclaw/src/package-metadata.test.ts
+++ b/nemoclaw/src/package-metadata.test.ts
@@ -20,8 +20,8 @@ const packageJson = JSON.parse(
 
 describe("OpenClaw package metadata", () => {
   it("declares the required external plugin compatibility fields", () => {
-    expect(packageJson.openclaw?.compat?.pluginApi).toBe(">=2026.5.10-beta.1");
-    expect(packageJson.openclaw?.compat?.minGatewayVersion).toBe("2026.5.10-beta.1");
-    expect(packageJson.openclaw?.build?.openclawVersion).toBe("2026.5.10-beta.1");
+    expect(packageJson.openclaw?.compat?.pluginApi).toBe(">=2026.5.18");
+    expect(packageJson.openclaw?.compat?.minGatewayVersion).toBe("2026.5.18");
+    expect(packageJson.openclaw?.build?.openclawVersion).toBe("2026.5.18");
   });
 });

--- a/src/lib/sandbox/version.test.ts
+++ b/src/lib/sandbox/version.test.ts
@@ -36,7 +36,7 @@ vi.mock("../agent/defs.js", () => ({
     name,
     displayName: name === "openclaw" ? "OpenClaw" : "Hermes Agent",
     versionCommand: name === "openclaw" ? "openclaw --version" : "hermes --version",
-    expectedVersion: name === "openclaw" ? "2026.4.24" : "2026.4.24",
+    expectedVersion: name === "openclaw" ? "2026.5.18" : "2026.4.24",
     stateDirs: [],
     configPaths: { dir: "/sandbox/.openclaw" },
   })),
@@ -77,12 +77,12 @@ describe("checkAgentVersion", () => {
     registry.registerSandbox({
       name: "test-sb",
       agent: null,
-      agentVersion: "2026.4.24",
+      agentVersion: "2026.5.18",
     });
 
     const result = checkAgentVersion("test-sb");
     expect(result.detectionMethod).toBe("registry");
-    expect(result.sandboxVersion).toBe("2026.4.24");
+    expect(result.sandboxVersion).toBe("2026.5.18");
     expect(result.isStale).toBe(false);
   });
 
@@ -103,7 +103,7 @@ describe("checkAgentVersion", () => {
     registry.registerSandbox({
       name: "test-sb",
       agent: null,
-      agentVersion: "2026.4.24",
+      agentVersion: "2026.5.18",
     });
 
     const result = checkAgentVersion("test-sb");
@@ -120,7 +120,7 @@ describe("checkAgentVersion", () => {
 
     vi.mocked(spawnSync).mockReturnValue({
       status: 0,
-      stdout: "OpenClaw 2026.4.24 (abc123)\n",
+      stdout: "OpenClaw 2026.5.18 (abc123)\n",
       stderr: "",
       pid: 1234,
       output: [],
@@ -129,7 +129,7 @@ describe("checkAgentVersion", () => {
 
     const result = checkAgentVersion("test-sb");
     expect(result.detectionMethod).toBe("ssh-exec");
-    expect(result.sandboxVersion).toBe("2026.4.24");
+    expect(result.sandboxVersion).toBe("2026.5.18");
     expect(result.isStale).toBe(false);
     expect(captureOpenshellCommand).toHaveBeenCalledWith(
       "/usr/local/bin/openshell",
@@ -139,7 +139,7 @@ describe("checkAgentVersion", () => {
 
     // Should have cached the version in registry
     const updated = registry.getSandbox("test-sb");
-    expect(updated?.agentVersion).toBe("2026.4.24");
+    expect(updated?.agentVersion).toBe("2026.5.18");
   });
 
   it("returns unavailable when SSH config fails", () => {
@@ -183,7 +183,7 @@ describe("checkAgentVersion", () => {
 
     vi.mocked(spawnSync).mockReturnValue({
       status: 0,
-      stdout: "OpenClaw 2026.4.24 (abc123)\n",
+      stdout: "OpenClaw 2026.5.18 (abc123)\n",
       stderr: "",
       pid: 1234,
       output: [],
@@ -192,7 +192,7 @@ describe("checkAgentVersion", () => {
 
     const result = checkAgentVersion("test-sb", { forceProbe: true });
     expect(result.detectionMethod).toBe("ssh-exec");
-    expect(result.sandboxVersion).toBe("2026.4.24");
+    expect(result.sandboxVersion).toBe("2026.5.18");
   });
 });
 
@@ -219,14 +219,14 @@ describe("formatStalenessWarning", () => {
   it("includes sandbox name, versions, and rebuild hint", () => {
     const lines = formatStalenessWarning("my-sb", {
       sandboxVersion: "2026.3.11",
-      expectedVersion: "2026.4.24",
+      expectedVersion: "2026.5.18",
       isStale: true,
       detectionMethod: "registry",
     });
     const joined = lines.join("\n");
     expect(joined).toContain("my-sb");
     expect(joined).toContain("2026.3.11");
-    expect(joined).toContain("2026.4.24");
+    expect(joined).toContain("2026.5.18");
     expect(joined).toContain("rebuild");
   });
 });

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -32,6 +32,23 @@ function dockerRunCommandBetween(startMarker: string, endMarker: string): string
   return command;
 }
 
+function dockerShellSegmentBetween(startMarker: string, endMarker: string): string {
+  const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
+  const start = dockerfile.indexOf(startMarker);
+  const end = dockerfile.indexOf(endMarker, start);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(`Expected Dockerfile segment between ${startMarker} and ${endMarker}`);
+  }
+  return dockerfile
+    .slice(start, end)
+    .trim()
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n")
+    .replace(/\\\n/g, " ")
+    .replace(/\\\s*$/, "");
+}
+
 function runOpenClawUpgradeBlock(currentVersion: string) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-upgrade-"));
   const blueprint = path.join(tmp, "blueprint.yaml");
@@ -137,6 +154,67 @@ if (globalThis.proxyChecks.length !== 0) throw new Error('sandbox proxy validati
       );
       expect(verify.status).toBe(0);
       expect(verify.stderr).toBe("");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("patches the OpenClaw 2026.5.x handshake timeout constant shape", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-handshake-timeout-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist, { recursive: true });
+    const modulePath = path.join(dist, "handshake-timeouts-test.js");
+    fs.writeFileSync(
+      modulePath,
+      [
+        "const DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 15e3;",
+        "const MAX_CONNECT_CHALLENGE_TIMEOUT_MS = DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;",
+        "export { DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS };",
+        "",
+      ].join("\n"),
+    );
+
+    const command = dockerShellSegmentBetween(
+      "# --- Patch 5: bump default WS handshake timeout",
+      "# Set up blueprint for local resolution.",
+    );
+    const fakeBin = path.join(tmp, "bin");
+    fs.mkdirSync(fakeBin);
+    const sedWrapper = path.join(fakeBin, "sed");
+    fs.writeFileSync(
+      sedWrapper,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'if [ "${1:-}" = "-i" ] && [ "${2:-}" = "-E" ]; then',
+        "  expr=$3",
+        "  shift 3",
+        '  for file in "$@"; do perl -0pi -e "$expr" "$file"; done',
+        "  exit 0",
+        "fi",
+        'exec /usr/bin/sed "$@"',
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const scriptPath = path.join(tmp, "patch.sh");
+    fs.writeFileSync(
+      scriptPath,
+      ["#!/usr/bin/env bash", "set -euo pipefail", `OC_DIST=${JSON.stringify(dist)}`, command].join(
+        "\n",
+      ),
+      { mode: 0o700 },
+    );
+
+    try {
+      const patch = spawnSync("bash", [scriptPath], {
+        encoding: "utf-8",
+        env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH || ""}` },
+        timeout: 5000,
+      });
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      const patched = fs.readFileSync(modulePath, "utf-8");
+      expect(patched).toContain("DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 6e4");
+      expect(patched).not.toContain("DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 15e3");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Bump the NemoClaw OpenClaw pin and compatibility metadata to stable `2026.5.18`.
- Keep the upgrade OpenClaw-only: base image ARG, blueprint minimum, agent manifest expected version, plugin metadata/tests, and docs example.
- Update the Dockerfile OpenClaw dist patch guard for the 2026.5.x handshake-timeout constant shape and add a regression test.

## Local validation
- `npm ci --ignore-scripts` passed.
- `npm run build:cli` passed.
- `npm run validate:configs` passed: 22 config files valid.
- `npx vitest run --project plugin nemoclaw/src/package-metadata.test.ts` passed: 1 test.
- `npx vitest run --project cli src/lib/sandbox/version.test.ts src/lib/sandbox-base-image.test.ts test/fetch-guard-patch-regression.test.ts test/validate-blueprint.test.ts` passed: 83 tests.
- `npm run source-shape:check` passed: no source-shape tests detected.
- `npm run checks` passed.
- `git diff --check` passed.

## Notes
- `npm view openclaw@2026.5.18 version` returned `2026.5.18`.
- I inspected the 2026.5.18 package dist and confirmed the guarded fetch symbols still exist; the handshake default constant moved to `15e3`, which required the Dockerfile regex update.
- Full `E2E / Nightly` workflow dispatch will follow this PR creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenClaw version from 2026.4.24 to 2026.5.18 across build configuration, manifests, and dependencies.
  * Improved WebSocket pre-auth handshake timeout patch to handle multiple upstream timeout defaults.

* **Documentation**
  * Updated documentation to reflect OpenClaw v2026.5.18.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->