### PR TITLE
chore: bump OpenShell pin to 0.0.44

### DIFF
--- a/.github/workflows/regression-e2e.yaml
+++ b/.github/workflows/regression-e2e.yaml
@@ -175,8 +175,8 @@ jobs:
 
 
   # ── OpenShell version-pin E2E ──────────────────────────────
-  # Coverage guard for #3474. If a host has sticky OpenShell 0.0.40 on PATH
-  # but this NemoClaw release supports only <=0.0.39, install-openshell.sh
+  # Coverage guard for #3474. If a host has sticky OpenShell 0.0.45 on PATH
+  # but this NemoClaw release supports only <=0.0.44, install-openshell.sh
   # must replace it with the pinned compatible release instead of hard-failing.
   openshell-version-pin-e2e:
     needs: select_regression_jobs

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 version: "0.1.0"
-min_openshell_version: "0.0.39"
-max_openshell_version: "0.0.39"
+min_openshell_version: "0.0.44"
+max_openshell_version: "0.0.44"
 min_openclaw_version: "2026.4.24"
 # Mirrors the components.sandbox.image manifest digest below. Lets a
 # downstream consumer (or release tooling) verify the blueprint declares

--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -28,7 +28,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/<ref>/scripts/brev-launchable-ci-cpu.sh | bash
 #
 # Environment overrides:
-#   OPENSHELL_VERSION     — OpenShell CLI release tag (default: v0.0.39)
+#   OPENSHELL_VERSION     — OpenShell CLI release tag (default: v0.0.44)
 #   NEMOCLAW_REF          — NemoClaw git ref to clone (default: main)
 #   NEMOCLAW_CLONE_DIR    — Where to clone NemoClaw (default: ~/NemoClaw)
 #   SKIP_DOCKER_PULL      — Set to 1 to skip Docker image pre-pulls
@@ -40,7 +40,7 @@
 set -euo pipefail
 
 # ── Configuration ────────────────────────────────────────────────────
-OPENSHELL_VERSION="${OPENSHELL_VERSION:-v0.0.39}"
+OPENSHELL_VERSION="${OPENSHELL_VERSION:-v0.0.44}"
 NEMOCLAW_REF="${NEMOCLAW_REF:-main}"
 TARGET_USER="${SUDO_USER:-$(id -un)}"
 TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
@@ -250,7 +250,7 @@ DOCKER_PULL_PID=""
 if [[ "${SKIP_DOCKER_PULL:-0}" != "1" ]]; then
   info "Pre-pulling Docker images in background..."
   (
-    SUPERVISOR_TAG="${OPENSHELL_VERSION#v}" # v0.0.39 -> 0.0.39
+    SUPERVISOR_TAG="${OPENSHELL_VERSION#v}" # v0.0.44 -> 0.0.44
     SUPERVISOR_IMAGE="ghcr.io/nvidia/openshell/supervisor:${SUPERVISOR_TAG}"
 
     # Pull all images in parallel

--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -35,16 +35,16 @@ info "Detected $OS_LABEL ($ARCH_LABEL)"
 
 # Minimum version required for native messaging credential rewrite:
 # WebSocket text frames plus provider-shaped aliases and REST request bodies.
-MIN_VERSION="0.0.39"
+MIN_VERSION="0.0.44"
 # Maximum version validated for this NemoClaw release. Newer OpenShell builds
 # may change sandbox semantics; upgrade NemoClaw before upgrading past this.
-MAX_VERSION="0.0.39"
+MAX_VERSION="0.0.44"
 # Pin fresh installs to this version. The TS installer normally overrides this
 # via NEMOCLAW_OPENSHELL_PIN_VERSION after resolving the highest published
 # OpenShell release that satisfies the blueprint's max_openshell_version
 # (see #3404). The hardcoded value is the fallback for offline runs.
 PIN_VERSION="$MAX_VERSION"
-DEV_MIN_VERSION="0.0.39"
+DEV_MIN_VERSION="0.0.44"
 
 CHANNEL="${NEMOCLAW_OPENSHELL_CHANNEL:-auto}"
 case "$CHANNEL" in

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2919,7 +2919,7 @@ function getOpenShellDockerSupervisorImage(versionOutput: string | null = null):
   if (shouldUseOpenshellDevChannel() || isOpenshellDevVersion(versionOutput)) {
     return "ghcr.io/nvidia/openshell/supervisor:dev";
   }
-  const supportedVersion = installedVersion ?? getBlueprintMaxOpenshellVersion() ?? "0.0.39";
+  const supportedVersion = installedVersion ?? getBlueprintMaxOpenshellVersion() ?? "0.0.44";
   return `ghcr.io/nvidia/openshell/supervisor:${supportedVersion}`;
 }
 
@@ -4169,7 +4169,7 @@ async function startDockerDriverGateway({ exitOnFailure = true, skipSandboxBridg
   }
   if (!gatewayBin) {
     console.error("  OpenShell Docker-driver gateway binary not found.");
-    console.error("  Install OpenShell v0.0.39, or set NEMOCLAW_OPENSHELL_GATEWAY_BIN.");
+    console.error("  Install OpenShell v0.0.44, or set NEMOCLAW_OPENSHELL_GATEWAY_BIN.");
     if (exitOnFailure) process.exit(1);
     throw new Error("OpenShell gateway binary not found");
   }

--- a/src/lib/onboard/docker-driver-gateway-runtime-marker.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-runtime-marker.test.ts
@@ -22,7 +22,7 @@ const expected = {
   },
   endpoint: "http://127.0.0.1:8080",
   gatewayBin: "/usr/local/bin/openshell-gateway",
-  openshellVersion: "0.0.39",
+  openshellVersion: "0.0.44",
   dockerHost: "unix:///Users/me/.colima/default/docker.sock",
   platform: "darwin" as NodeJS.Platform,
   arch: "arm64" as NodeJS.Architecture,

--- a/src/lib/onboard/openshell-install.ts
+++ b/src/lib/onboard/openshell-install.ts
@@ -159,7 +159,7 @@ export function ensureOpenshellForOnboard(deps: OpenShellInstallDeps): OpenShell
         deps.exit(1);
       }
     } else {
-      const minOpenshellVersion = deps.getBlueprintMinOpenshellVersion() ?? "0.0.39";
+      const minOpenshellVersion = deps.getBlueprintMinOpenshellVersion() ?? "0.0.44";
       const currentVersionOutput = deps.runCaptureOpenshell(["--version"], { ignoreError: true });
       const needsDevChannel =
         deps.isLinuxDockerDriverGatewayEnabled(platform, arch) &&

--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -12140,9 +12140,9 @@
         {
           "script": "test/e2e/test-openshell-version-pin.sh",
           "line": 215,
-          "text": "Installer hard-failed on sticky OpenShell 0.0.40 instead of reinstalling pinned 0.0.39 (#3474)",
+          "text": "Installer hard-failed on sticky OpenShell 0.0.45 instead of reinstalling pinned 0.0.44 (#3474)",
           "polarity": "fail",
-          "normalized_id": "installer.hard.failed.on.sticky.openshell.0.0.40.instead.of.reinstalling.pinned.0.0.39.3474",
+          "normalized_id": "installer.hard.failed.on.sticky.openshell.0.0.45.instead.of.reinstalling.pinned.0.0.44.3474",
           "mapping_status": "retired"
         },
         {
@@ -12164,49 +12164,49 @@
         {
           "script": "test/e2e/test-openshell-version-pin.sh",
           "line": 222,
-          "text": "Expected installer to download pinned OpenShell v0.0.39",
+          "text": "Expected installer to download pinned OpenShell v0.0.44",
           "polarity": "fail",
-          "normalized_id": "expected.installer.to.download.pinned.openshell.v0.0.39",
+          "normalized_id": "expected.installer.to.download.pinned.openshell.v0.0.44",
           "mapping_status": "retired"
         },
         {
           "script": "test/e2e/test-openshell-version-pin.sh",
           "line": 224,
-          "text": "Installer downloaded pinned OpenShell v0.0.39",
+          "text": "Installer downloaded pinned OpenShell v0.0.44",
           "polarity": "pass",
-          "normalized_id": "installer.downloaded.pinned.openshell.v0.0.39",
+          "normalized_id": "installer.downloaded.pinned.openshell.v0.0.44",
           "mapping_status": "mapped"
         },
         {
           "script": "test/e2e/test-openshell-version-pin.sh",
           "line": 227,
-          "text": "Installer downloaded OpenShell v0.0.40 despite NemoClaw max 0.0.39",
+          "text": "Installer downloaded OpenShell v0.0.45 despite NemoClaw max 0.0.44",
           "polarity": "fail",
-          "normalized_id": "installer.downloaded.openshell.v0.0.40.despite.nemoclaw.max.0.0.39",
+          "normalized_id": "installer.downloaded.openshell.v0.0.45.despite.nemoclaw.max.0.0.44",
           "mapping_status": "retired"
         },
         {
           "script": "test/e2e/test-openshell-version-pin.sh",
           "line": 229,
-          "text": "Installer did not download too-new OpenShell v0.0.40",
+          "text": "Installer did not download too-new OpenShell v0.0.45",
           "polarity": "pass",
-          "normalized_id": "installer.did.not.download.too.new.openshell.v0.0.40",
+          "normalized_id": "installer.did.not.download.too.new.openshell.v0.0.45",
           "mapping_status": "mapped"
         },
         {
           "script": "test/e2e/test-openshell-version-pin.sh",
           "line": 232,
-          "text": "openshell binary was not replaced with pinned 0.0.39",
+          "text": "openshell binary was not replaced with pinned 0.0.44",
           "polarity": "fail",
-          "normalized_id": "openshell.binary.was.not.replaced.with.pinned.0.0.39",
+          "normalized_id": "openshell.binary.was.not.replaced.with.pinned.0.0.44",
           "mapping_status": "retired"
         },
         {
           "script": "test/e2e/test-openshell-version-pin.sh",
           "line": 234,
-          "text": "Sticky openshell 0.0.40 was replaced with pinned 0.0.39",
+          "text": "Sticky openshell 0.0.45 was replaced with pinned 0.0.44",
           "polarity": "pass",
-          "normalized_id": "sticky.openshell.0.0.40.was.replaced.with.pinned.0.0.39",
+          "normalized_id": "sticky.openshell.0.0.45.was.replaced.with.pinned.0.0.44",
           "mapping_status": "mapped"
         }
       ]

--- a/test/e2e/docs/parity-map.yaml
+++ b/test/e2e/docs/parity-map.yaml
@@ -10772,7 +10772,7 @@ scripts:
     status: migrated
     bucket: install-upgrade
     assertions:
-    - legacy: Installer hard-failed on sticky OpenShell 0.0.40 instead of reinstalling pinned 0.0.39 (#3474)
+    - legacy: Installer hard-failed on sticky OpenShell 0.0.45 instead of reinstalling pinned 0.0.44 (#3474)
       status: retired
       reason: legacy negative/failure assertion retained by script but not represented as scenario success criterion
       reviewer: e2e-maintainers
@@ -10785,27 +10785,27 @@ scripts:
     - legacy: install-openshell.sh completed
       status: mapped
       id: legacy.openshell.version.pin.install.openshell.sh.completed
-    - legacy: Expected installer to download pinned OpenShell v0.0.39
+    - legacy: Expected installer to download pinned OpenShell v0.0.44
       status: retired
       reason: legacy negative/failure assertion retained by script but not represented as scenario success criterion
       reviewer: e2e-maintainers
       approved_at: '2026-05-13'
-    - legacy: Installer downloaded pinned OpenShell v0.0.39
+    - legacy: Installer downloaded pinned OpenShell v0.0.44
       status: mapped
-      id: legacy.openshell.version.pin.installer.downloaded.pinned.openshell.vv39
-    - legacy: Installer downloaded OpenShell v0.0.40 despite NemoClaw max 0.0.39
+      id: legacy.openshell.version.pin.installer.downloaded.pinned.openshell.vv44
+    - legacy: Installer downloaded OpenShell v0.0.45 despite NemoClaw max 0.0.44
       status: retired
       reason: legacy negative/failure assertion retained by script but not represented as scenario success criterion
       reviewer: e2e-maintainers
       approved_at: '2026-05-13'
-    - legacy: Installer did not download too-new OpenShell v0.0.40
+    - legacy: Installer did not download too-new OpenShell v0.0.45
       status: mapped
-      id: legacy.openshell.version.pin.installer.did.not.download.too.new.openshell.vv40
-    - legacy: openshell binary was not replaced with pinned 0.0.39
+      id: legacy.openshell.version.pin.installer.did.not.download.too.new.openshell.vv45
+    - legacy: openshell binary was not replaced with pinned 0.0.44
       status: retired
       reason: legacy negative/failure assertion retained by script but not represented as scenario success criterion
       reviewer: e2e-maintainers
       approved_at: '2026-05-13'
-    - legacy: Sticky openshell 0.0.40 was replaced with pinned 0.0.39
+    - legacy: Sticky openshell 0.0.45 was replaced with pinned 0.0.44
       status: mapped
-      id: legacy.openshell.version.pin.sticky.openshell.v40.was.replaced.with.pinned.v39
+      id: legacy.openshell.version.pin.sticky.openshell.v45.was.replaced.with.pinned.v44

--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -52,7 +52,7 @@ STATE_DIR="${NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR:-$HOME/.local/state/nemoclaw/o
 PID_FILE="${STATE_DIR}/openshell-gateway.pid"
 OLD_NEMOCLAW_REF="${NEMOCLAW_OLD_NEMOCLAW_REF:-v0.0.36}"
 OLD_OPENSHELL_VERSION="${NEMOCLAW_OLD_OPENSHELL_VERSION:-0.0.36}"
-CURRENT_OPENSHELL_VERSION="${NEMOCLAW_CURRENT_OPENSHELL_VERSION:-0.0.39}"
+CURRENT_OPENSHELL_VERSION="${NEMOCLAW_CURRENT_OPENSHELL_VERSION:-0.0.44}"
 SURVIVOR_SANDBOX="${NEMOCLAW_GATEWAY_UPGRADE_SURVIVOR_NAME:-e2e-gateway-upgrade-survivor}"
 SURVIVOR_MARKER="gateway-upgrade-survivor-$(date +%s)"
 SURVIVOR_MARKER_PATH="/sandbox/.openclaw/workspace/nemoclaw-gateway-upgrade-marker"
@@ -145,7 +145,7 @@ EOF
 # request-body-credential-rewrite
 # websocket-credential-rewrite
 if [ "${1:-}" = "--version" ]; then
-  printf 'openshell 0.0.39\n'
+  printf 'openshell 0.0.44\n'
   exit 0
 fi
 exit 99
@@ -235,7 +235,7 @@ EOF
 # request-body-credential-rewrite
 # websocket-credential-rewrite
 if [ "${1:-}" = "--version" ]; then
-  printf 'openshell 0.0.39\n'
+  printf 'openshell 0.0.44\n'
   exit 0
 fi
 exit 99

--- a/test/e2e/test-openshell-version-pin.sh
+++ b/test/e2e/test-openshell-version-pin.sh
@@ -8,11 +8,11 @@
 # pinned compatible version instead of failing before the reinstall path.
 #
 # Expected result on unfixed main: FAIL. scripts/install-openshell.sh sees the
-# fake installed `openshell 0.0.40`, compares it to MAX_VERSION=0.0.39, and
-# exits with "above the maximum" before downloading the pinned 0.0.39 release.
+# fake installed `openshell 0.0.45`, compares it to MAX_VERSION=0.0.44, and
+# exits with "above the maximum" before downloading the pinned 0.0.44 release.
 #
 # Expected result after the fix: PASS. The script warns about the too-new
-# installed OpenShell, downloads v0.0.39, replaces openshell plus helper
+# installed OpenShell, downloads v0.0.44, replaces openshell plus helper
 # binaries, and exits successfully.
 
 set -euo pipefail
@@ -74,7 +74,7 @@ SH
 # the pinned compatible release.
 write_executable "$FAKE_BIN/openshell" <<'SH'
 #!/usr/bin/env bash
-if [ "${1:-}" = "--version" ]; then echo "openshell 0.0.40"; exit 0; fi
+if [ "${1:-}" = "--version" ]; then echo "openshell 0.0.45"; exit 0; fi
 # request-body-credential-rewrite websocket-credential-rewrite
 exit 0
 SH
@@ -163,7 +163,7 @@ exit 0
 SH
 
 # The installer extracts three archives. Create the binary each archive would
-# have produced. The replacement openshell reports 0.0.39 and contains the
+# have produced. The replacement openshell reports 0.0.44 and contains the
 # feature strings checked by install-openshell.sh.
 write_executable "$FAKE_BIN/tar" <<'SH'
 #!/usr/bin/env bash
@@ -185,7 +185,7 @@ case "$*" in
 esac
 cat > "$outdir/$name" <<'EOS'
 #!/usr/bin/env bash
-if [ "${1:-}" = "--version" ]; then echo "openshell 0.0.39"; exit 0; fi
+if [ "${1:-}" = "--version" ]; then echo "openshell 0.0.44"; exit 0; fi
 # request-body-credential-rewrite websocket-credential-rewrite
 exit 0
 EOS
@@ -200,7 +200,7 @@ cat "$@" 2>/dev/null || true
 SH
 
 cd "$REPO_ROOT"
-info "Running install-openshell.sh with sticky openshell 0.0.40 and max 0.0.39"
+info "Running install-openshell.sh with sticky openshell 0.0.45 and max 0.0.44"
 set +e
 env \
   PATH="$FAKE_BIN:/usr/bin:/bin" \
@@ -211,26 +211,26 @@ install_rc=$?
 set -e
 
 if [ "$install_rc" -ne 0 ]; then
-  if grep -q "openshell 0.0.40 is above the maximum (0.0.39)" "$INSTALL_LOG"; then
-    fail "Installer hard-failed on sticky OpenShell 0.0.40 instead of reinstalling pinned 0.0.39 (#3474)"
+  if grep -q "openshell 0.0.45 is above the maximum (0.0.44)" "$INSTALL_LOG"; then
+    fail "Installer hard-failed on sticky OpenShell 0.0.45 instead of reinstalling pinned 0.0.44 (#3474)"
   fi
   fail "install-openshell.sh failed before proving sticky-version recovery (exit ${install_rc})"
 fi
 pass "install-openshell.sh completed"
 
-if ! grep -q "v0.0.39" "$DOWNLOAD_LOG"; then
-  fail "Expected installer to download pinned OpenShell v0.0.39"
+if ! grep -q "v0.0.44" "$DOWNLOAD_LOG"; then
+  fail "Expected installer to download pinned OpenShell v0.0.44"
 fi
-pass "Installer downloaded pinned OpenShell v0.0.39"
+pass "Installer downloaded pinned OpenShell v0.0.44"
 
-if grep -q "v0.0.40" "$DOWNLOAD_LOG"; then
-  fail "Installer downloaded OpenShell v0.0.40 despite NemoClaw max 0.0.39"
+if grep -q "v0.0.45" "$DOWNLOAD_LOG"; then
+  fail "Installer downloaded OpenShell v0.0.45 despite NemoClaw max 0.0.44"
 fi
-pass "Installer did not download too-new OpenShell v0.0.40"
+pass "Installer did not download too-new OpenShell v0.0.45"
 
-if ! "$FAKE_BIN/openshell" --version 2>&1 | grep -q "0.0.39"; then
-  fail "openshell binary was not replaced with pinned 0.0.39"
+if ! "$FAKE_BIN/openshell" --version 2>&1 | grep -q "0.0.44"; then
+  fail "openshell binary was not replaced with pinned 0.0.44"
 fi
-pass "Sticky openshell 0.0.40 was replaced with pinned 0.0.39"
+pass "Sticky openshell 0.0.45 was replaced with pinned 0.0.44"
 
 info "OpenShell sticky-version pin guard complete"

--- a/test/install-openshell-version-check.test.ts
+++ b/test/install-openshell-version-check.test.ts
@@ -124,34 +124,34 @@ exit 0`,
 }
 
 describe("install-openshell.sh version check", { timeout: 15_000 }, () => {
-  it("exits cleanly when openshell 0.0.39 and driver binaries are already installed", () => {
-    const result = runWithInstalledVersion("0.0.39");
+  it("exits cleanly when openshell 0.0.44 and driver binaries are already installed", () => {
+    const result = runWithInstalledVersion("0.0.44");
     expect(result.status).toBe(0);
-    expect(result.stdout).toMatch(/already installed.*0\.0\.39/);
+    expect(result.stdout).toMatch(/already installed.*0\.0\.44/);
   });
 
-  it("triggers reinstall when openshell 0.0.39 is missing Docker-driver binaries", () => {
-    const result = runWithInstalledVersion("0.0.39", {}, { driverBins: false, os: "Linux" });
+  it("triggers reinstall when openshell 0.0.44 is missing Docker-driver binaries", () => {
+    const result = runWithInstalledVersion("0.0.44", {}, { driverBins: false, os: "Linux" });
     expect(result.status).not.toBe(0);
     expect(result.stdout).toMatch(/missing Docker-driver binaries/);
-    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.39'/);
+    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.44'/);
   });
 
-  it("fails closed when openshell 0.0.39 lacks required messaging rewrite support", () => {
-    const result = runWithInstalledVersion("0.0.39", {}, { capability: false });
+  it("fails closed when openshell 0.0.44 lacks required messaging rewrite support", () => {
+    const result = runWithInstalledVersion("0.0.44", {}, { capability: false });
     expect(result.status).toBe(1);
     // `fail()` writes to stderr as of #3446; previously stdout.
     expect(result.stderr).toMatch(/missing request-body-credential-rewrite support/);
   });
 
-  it("accepts macOS openshell 0.0.39 when the gateway binary is installed", () => {
-    const result = runWithInstalledVersion("0.0.39", {}, {
+  it("accepts macOS openshell 0.0.44 when the gateway binary is installed", () => {
+    const result = runWithInstalledVersion("0.0.44", {}, {
       driverBins: "gateway",
       os: "Darwin",
       arch: "arm64",
     });
     expect(result.status).toBe(0);
-    expect(result.stdout).toMatch(/already installed.*0\.0\.39/);
+    expect(result.stdout).toMatch(/already installed.*0\.0\.44/);
   });
 
   it("does not require the macOS VM driver entitlement for Docker-driver onboarding", () => {
@@ -160,7 +160,7 @@ describe("install-openshell.sh version check", { timeout: 15_000 }, () => {
       const state = path.join(tmp, "codesign-state");
       const log = path.join(tmp, "codesign.log");
       const result = runWithInstalledVersion(
-        "0.0.39",
+        "0.0.44",
         {
           NEMOCLAW_FAKE_CODESIGN_HAS_ENTITLEMENT: "0",
           NEMOCLAW_FAKE_CODESIGN_STATE: state,
@@ -174,7 +174,7 @@ describe("install-openshell.sh version check", { timeout: 15_000 }, () => {
       );
 
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      expect(result.stdout).toMatch(/already installed.*0\.0\.39/);
+      expect(result.stdout).toMatch(/already installed.*0\.0\.44/);
       expect(result.stdout).not.toMatch(/missing the macOS Hypervisor entitlement/);
       expect(result.stdout).not.toMatch(/Signing openshell-driver-vm/);
       expect(result.stdout).not.toMatch(/Installing OpenShell from release/);
@@ -184,15 +184,15 @@ describe("install-openshell.sh version check", { timeout: 15_000 }, () => {
     }
   });
 
-  it("triggers reinstall on macOS when openshell 0.0.39 is missing required gateway binaries", () => {
-    const result = runWithInstalledVersion("0.0.39", {}, {
+  it("triggers reinstall on macOS when openshell 0.0.44 is missing required gateway binaries", () => {
+    const result = runWithInstalledVersion("0.0.44", {}, {
       driverBins: false,
       os: "Darwin",
       arch: "arm64",
     });
     expect(result.status).not.toBe(0);
     expect(result.stdout).toMatch(/missing Docker-driver binaries/);
-    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.39'/);
+    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.44'/);
   });
 
   it("downloads the macOS arm64 gateway asset during reinstall", () => {
@@ -266,7 +266,7 @@ dest="\${@: -1}"
 mkdir -p "$(dirname "$dest")"
 cat > "$dest" <<'EOF'
 #!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then echo "openshell 0.0.39"; exit 0; fi
+if [ "\${1:-}" = "--version" ]; then echo "openshell 0.0.44"; exit 0; fi
 # request-body-credential-rewrite websocket-credential-rewrite
 exit 0
 EOF
@@ -388,7 +388,7 @@ printf '%s\\n' "$dest" >> ${JSON.stringify(installLog)}
 mkdir -p "$(dirname "$dest")"
 case "$(basename "$dest")" in
 openshell)
-  printf '#!/usr/bin/env bash\\nif [ "$1" = "--version" ]; then echo "openshell 0.0.39"; else exit 0; fi\\n# request-body-credential-rewrite websocket-credential-rewrite\\n' > "$dest"
+  printf '#!/usr/bin/env bash\\nif [ "$1" = "--version" ]; then echo "openshell 0.0.44"; else exit 0; fi\\n# request-body-credential-rewrite websocket-credential-rewrite\\n' > "$dest"
   ;;
 *)
   printf '#!/usr/bin/env bash\\nexit 0\\n' > "$dest"
@@ -419,8 +419,8 @@ exit 0`,
     }
   });
 
-  it("triggers upgrade when openshell 0.0.38 is installed (below current floor)", () => {
-    const result = runWithInstalledVersion("0.0.38");
+  it("triggers upgrade when openshell 0.0.39 is installed (below current floor)", () => {
+    const result = runWithInstalledVersion("0.0.39");
     expect(result.status).not.toBe(0);
     expect(result.stdout).toMatch(/below minimum.*upgrading/);
   });
@@ -445,23 +445,23 @@ exit 0`,
   });
 
   it("reinstalls the pinned release when openshell is above MAX_VERSION", () => {
-    const result = runWithInstalledVersion("0.0.40");
+    const result = runWithInstalledVersion("0.0.45");
     expect(result.status).not.toBe(0);
-    expect(result.stdout).toMatch(/above the maximum.*reinstalling pinned OpenShell 0\.0\.39/);
-    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.39'/);
+    expect(result.stdout).toMatch(/above the maximum.*reinstalling pinned OpenShell 0\.0\.44/);
+    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.44'/);
     expect(result.stderr).not.toMatch(/Upgrade NemoClaw first/);
   });
 
   it("reinstalls the pinned release when openshell is at a much newer version", () => {
     const result = runWithInstalledVersion("0.1.0");
     expect(result.status).not.toBe(0);
-    expect(result.stdout).toMatch(/above the maximum.*reinstalling pinned OpenShell 0\.0\.39/);
-    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.39'/);
+    expect(result.stdout).toMatch(/above the maximum.*reinstalling pinned OpenShell 0\.0\.44/);
+    expect(result.stdout).toMatch(/Installing OpenShell from release 'v0\.0\.44'/);
     expect(result.stderr).not.toMatch(/Upgrade NemoClaw first/);
   });
 
   it("accepts an installed OpenShell dev-channel Docker-driver build", () => {
-    const result = runWithInstalledVersion("0.0.39.dev84+g6b2180425", {
+    const result = runWithInstalledVersion("0.0.44.dev84+g6b2180425", {
       NEMOCLAW_OPENSHELL_CHANNEL: "dev",
     });
     expect(result.status).toBe(0);
@@ -469,7 +469,7 @@ exit 0`,
   });
 
   it("upgrades stable OpenShell when the dev channel is requested", () => {
-    const result = runWithInstalledVersion("0.0.36", {
+    const result = runWithInstalledVersion("0.0.44", {
       NEMOCLAW_OPENSHELL_CHANNEL: "dev",
     });
     expect(result.status).not.toBe(0);

--- a/test/onboard-gateway-runtime.test.ts
+++ b/test/onboard-gateway-runtime.test.ts
@@ -299,17 +299,17 @@ describe("onboard gateway runtime helpers", () => {
     ]);
     expect(parseDockerCdiSpecDirs("")).toEqual([]);
     expect(
-      shouldAllowOpenshellAboveBlueprintMax("openshell 0.0.40.dev1+gabcdef", "linux", {
+      shouldAllowOpenshellAboveBlueprintMax("openshell 0.0.45.dev1+gabcdef", "linux", {
         NEMOCLAW_OPENSHELL_CHANNEL: "dev",
       }),
     ).toBe(true);
     expect(
-      shouldAllowOpenshellAboveBlueprintMax("openshell 0.0.40.dev1+gabcdef", "linux", {
+      shouldAllowOpenshellAboveBlueprintMax("openshell 0.0.45.dev1+gabcdef", "linux", {
         NEMOCLAW_OPENSHELL_CHANNEL: "auto",
       }),
     ).toBe(false);
     expect(
-      shouldAllowOpenshellAboveBlueprintMax("openshell 0.0.40", "linux", {
+      shouldAllowOpenshellAboveBlueprintMax("openshell 0.0.45", "linux", {
         NEMOCLAW_OPENSHELL_CHANNEL: "dev",
       }),
     ).toBe(false);

--- a/test/onboard-openshell-version.test.ts
+++ b/test/onboard-openshell-version.test.ts
@@ -339,32 +339,32 @@ describe("computeOpenshellInstallEnv", () => {
     const result = pinModule.computeOpenshellInstallEnv(
       { EXISTING: "preserved" },
       {
-        getBlueprintMinOpenshellVersion: () => "0.0.39",
-        getBlueprintMaxOpenshellVersion: () => "0.0.39",
+        getBlueprintMinOpenshellVersion: () => "0.0.44",
+        getBlueprintMaxOpenshellVersion: () => "0.0.44",
         versionGte,
-        listReleases: () => ["v0.0.38", "v0.0.39", "v0.0.42"],
+        listReleases: () => ["v0.0.43", "v0.0.44", "v0.0.45"],
       },
     );
     expect(result.env).not.toBe(null);
     expect(result.env?.EXISTING).toBe("preserved");
-    expect(result.env?.NEMOCLAW_OPENSHELL_MIN_VERSION).toBe("0.0.39");
-    expect(result.env?.NEMOCLAW_OPENSHELL_MAX_VERSION).toBe("0.0.39");
-    expect(result.env?.NEMOCLAW_OPENSHELL_PIN_VERSION).toBe("0.0.39");
+    expect(result.env?.NEMOCLAW_OPENSHELL_MIN_VERSION).toBe("0.0.44");
+    expect(result.env?.NEMOCLAW_OPENSHELL_MAX_VERSION).toBe("0.0.44");
+    expect(result.env?.NEMOCLAW_OPENSHELL_PIN_VERSION).toBe("0.0.44");
   });
 
   it("overlays MIN/MAX but no PIN when release discovery fails", () => {
     const result = pinModule.computeOpenshellInstallEnv(
       {},
       {
-        getBlueprintMinOpenshellVersion: () => "0.0.39",
-        getBlueprintMaxOpenshellVersion: () => "0.0.39",
+        getBlueprintMinOpenshellVersion: () => "0.0.44",
+        getBlueprintMaxOpenshellVersion: () => "0.0.44",
         versionGte,
         listReleases: () => null,
       },
     );
     expect(result.env).not.toBe(null);
-    expect(result.env?.NEMOCLAW_OPENSHELL_MIN_VERSION).toBe("0.0.39");
-    expect(result.env?.NEMOCLAW_OPENSHELL_MAX_VERSION).toBe("0.0.39");
+    expect(result.env?.NEMOCLAW_OPENSHELL_MIN_VERSION).toBe("0.0.44");
+    expect(result.env?.NEMOCLAW_OPENSHELL_MAX_VERSION).toBe("0.0.44");
     expect(result.env?.NEMOCLAW_OPENSHELL_PIN_VERSION).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- Pin NemoClaw stable OpenShell install/support window to v0.0.44.
- Update version-pin installer/E2E expectations and parity metadata for the new max version.
- Keep this PR scoped to OpenShell only; no OpenClaw or other dependency bumps.

## Validation
- `npm ci --ignore-scripts`
- `npm run build:cli`
- `npm run validate:configs`
- `bash -n scripts/install-openshell.sh scripts/brev-launchable-ci-cpu.sh test/e2e/test-openshell-version-pin.sh test/e2e/test-openshell-gateway-upgrade.sh`
- `npx tsx scripts/e2e/check-parity-map.ts --strict`
- `npx vitest run test/install-openshell-version-check.test.ts test/onboard-openshell-version.test.ts test/onboard-gateway-runtime.test.ts src/lib/onboard/docker-driver-gateway-runtime-marker.test.ts --testTimeout 60000`
- `bash test/e2e/test-openshell-version-pin.sh`
- `npx vitest run test/install-preflight.test.ts test/install-onboard-yes.test.ts test/onboard.test.ts --testTimeout 60000`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated OpenShell version pinning from 0.0.39 to 0.0.44 across the platform, including minimum and maximum version constraints.
  * Refreshed CI/CD regression tests to validate version pinning behavior against the updated baseline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->