### PR TITLE
chore: upgrade Hermes to v2026.5.16

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -213,12 +213,16 @@ RUN set -eu; \
         "$config_dir/plugins" \
         "$config_dir/cron" \
         "$config_dir/logs" \
+        "$config_dir/logs/curator" \
         "$config_dir/skins" \
         "$config_dir/plans" \
         "$config_dir/workspace" \
         "$config_dir/profiles" \
         "$config_dir/cache" \
         "$config_dir/pairing" \
+        "$config_dir/hooks" \
+        "$config_dir/image_cache" \
+        "$config_dir/audio_cache" \
         "$config_dir/platforms" \
         "$config_dir/platforms/whatsapp" \
         "$config_dir/platforms/whatsapp/session" \
@@ -257,12 +261,16 @@ RUN set -eu; \
         /sandbox/.hermes/plugins \
         /sandbox/.hermes/cron \
         /sandbox/.hermes/logs \
+        /sandbox/.hermes/logs/curator \
         /sandbox/.hermes/skins \
         /sandbox/.hermes/plans \
         /sandbox/.hermes/workspace \
         /sandbox/.hermes/profiles \
         /sandbox/.hermes/cache \
         /sandbox/.hermes/pairing \
+        /sandbox/.hermes/hooks \
+        /sandbox/.hermes/image_cache \
+        /sandbox/.hermes/audio_cache \
         /sandbox/.hermes/platforms \
         /sandbox/.hermes/platforms/whatsapp \
         /sandbox/.hermes/platforms/whatsapp/session \

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -23,9 +23,9 @@ FROM node:22-trixie-slim@sha256:2d9f5c76c8f4dd36e8f253bee5d828a83a6c09f36188f0b0
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Hermes version pinned for reproducibility.
-# Calver tag v2026.4.23 = semver 0.11.0.
-ARG HERMES_VERSION=v2026.4.23
-ARG HERMES_TARBALL_SHA256=1ee1be80a2112b7edc581770cee8858e725ba110cc423979cd7102492504bc6b
+# Calver tag v2026.5.16 = semver 0.14.0.
+ARG HERMES_VERSION=v2026.5.16
+ARG HERMES_TARBALL_SHA256=c0a554050a50ee9a62f3fa5cd288a167ba5640c42d647d100cdea084b7294143
 ARG HERMES_UV_EXTRAS="messaging web"
 ARG UV_VERSION=0.11.8
 
@@ -83,12 +83,16 @@ RUN mkdir -p /sandbox/.hermes/memories \
         /sandbox/.hermes/plugins \
         /sandbox/.hermes/cron \
         /sandbox/.hermes/logs \
+        /sandbox/.hermes/logs/curator \
         /sandbox/.hermes/skins \
         /sandbox/.hermes/plans \
         /sandbox/.hermes/workspace \
         /sandbox/.hermes/profiles \
         /sandbox/.hermes/cache \
         /sandbox/.hermes/pairing \
+        /sandbox/.hermes/hooks \
+        /sandbox/.hermes/image_cache \
+        /sandbox/.hermes/audio_cache \
         /sandbox/.hermes/platforms \
         /sandbox/.hermes/platforms/whatsapp \
         /sandbox/.hermes/platforms/whatsapp/session \
@@ -103,12 +107,16 @@ RUN mkdir -p /sandbox/.hermes/memories \
         /sandbox/.hermes/plugins \
         /sandbox/.hermes/cron \
         /sandbox/.hermes/logs \
+        /sandbox/.hermes/logs/curator \
         /sandbox/.hermes/skins \
         /sandbox/.hermes/plans \
         /sandbox/.hermes/workspace \
         /sandbox/.hermes/profiles \
         /sandbox/.hermes/cache \
         /sandbox/.hermes/pairing \
+        /sandbox/.hermes/hooks \
+        /sandbox/.hermes/image_cache \
+        /sandbox/.hermes/audio_cache \
         /sandbox/.hermes/platforms \
         /sandbox/.hermes/platforms/whatsapp \
         /sandbox/.hermes/platforms/whatsapp/session \

--- a/agents/hermes/config/hermes-config.ts
+++ b/agents/hermes/config/hermes-config.ts
@@ -29,7 +29,7 @@ const API_SERVER_TOOLSETS = [
 export function buildHermesConfig(settings: HermesBuildSettings): Record<string, unknown> {
   const apiServerToolsets = [...API_SERVER_TOOLSETS];
   const config: Record<string, unknown> = {
-    _config_version: 12,
+    _config_version: 23,
     model: {
       default: settings.model,
       provider: "custom",
@@ -62,7 +62,7 @@ export function buildHermesConfig(settings: HermesBuildSettings): Record<string,
     },
   };
 
-  // Hermes v2026.4.23 reads Discord behavior from top-level `discord:`.
+  // Hermes v2026.5.16 reads Discord behavior from top-level `discord:`.
   // Bot tokens and user allowlists stay in .env so config.yaml never carries
   // real secrets or credential placeholders under platforms.discord.
   if (settings.messaging.enabledChannels.has("discord")) {

--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -60,7 +60,9 @@ state_dirs:
   - skills
   - plugins
   # Hermes v0.14 discovers user-installed gateway event hooks from
-  # ~/.hermes/hooks. Preserve them across rebuilds.
+  # ~/.hermes/hooks. Preserve them across rebuilds. Runtime media
+  # caches such as image_cache/ and audio_cache/ are intentionally
+  # omitted: the image pre-creates them, but rebuilds may discard them.
   - hooks
   - cron
   - logs

--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -16,7 +16,7 @@ homepage: "https://github.com/NousResearch/hermes-agent"
 install_method: curl  # curl install.sh | bash
 binary_path: /usr/local/bin/hermes
 version_command: "hermes --version"
-expected_version: "2026.4.23"
+expected_version: "2026.5.16"
 gateway_command: "hermes gateway run"
 
 # ── Health probe ────────────────────────────────────────────────
@@ -59,6 +59,9 @@ state_dirs:
   - sessions
   - skills
   - plugins
+  # Hermes v0.14 discovers user-installed gateway event hooks from
+  # ~/.hermes/hooks. Preserve them across rebuilds.
+  - hooks
   - cron
   - logs
   - skins

--- a/test/e2e/test-rebuild-hermes.sh
+++ b/test/e2e/test-rebuild-hermes.sh
@@ -39,7 +39,9 @@ OLD_HERMES_REGISTRY_VERSION="${OLD_HERMES_VERSION#v}"
 OLD_HERMES_TARBALL_SHA256="5e4529b8cb6e4821eb916b81517e48125109b1764d6d1e68a204a9f0ddf2d98c"
 STALE_BASE_REBUILD="${NEMOCLAW_HERMES_STALE_BASE_REBUILD_E2E:-0}"
 MARKER_FILE="/sandbox/.hermes/memories/rebuild-marker.txt"
+HOOK_MARKER_FILE="/sandbox/.hermes/hooks/rebuild-hook-marker.txt"
 MARKER_CONTENT="REBUILD_HM_E2E_$(date +%s)"
+HOOK_MARKER_CONTENT="REBUILD_HM_HOOK_E2E_$(date +%s)"
 DISCORD_PLACEHOLDER="openshell:resolve:env:DISCORD_BOT_TOKEN"
 DISCORD_FAKE_TOKEN="test-fake-discord-token-rebuild-e2e"
 REGISTRY_FILE="$HOME/.nemoclaw/sandboxes.json"
@@ -227,11 +229,13 @@ pass "Old Hermes sandbox created"
 info "Phase 4: Writing markers and registering sandbox..."
 
 openshell sandbox exec --name "${SANDBOX_NAME}" -- \
-  sh -c "mkdir -p /sandbox/.hermes/memories && echo '${MARKER_CONTENT}' > ${MARKER_FILE}" \
-  || fail "Failed to write marker file"
+  sh -c "mkdir -p /sandbox/.hermes/memories /sandbox/.hermes/hooks && echo '${MARKER_CONTENT}' > ${MARKER_FILE} && echo '${HOOK_MARKER_CONTENT}' > ${HOOK_MARKER_FILE}" \
+  || fail "Failed to write marker files"
 
 VERIFY=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- cat "${MARKER_FILE}" 2>/dev/null || true)
 [ "$VERIFY" = "${MARKER_CONTENT}" ] || fail "Marker verification failed"
+HOOK_VERIFY=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- cat "${HOOK_MARKER_FILE}" 2>/dev/null || true)
+[ "$HOOK_VERIFY" = "${HOOK_MARKER_CONTENT}" ] || fail "Hook marker verification failed"
 PRE_REBUILD_ENV=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- cat /sandbox/.hermes/.env 2>/dev/null || true)
 echo "$PRE_REBUILD_ENV" | grep -Fq "DISCORD_BOT_TOKEN=${DISCORD_PLACEHOLDER}" \
   || fail "Pre-rebuild Hermes .env missing Discord placeholder"
@@ -311,12 +315,19 @@ pass "Rebuild completed"
 # ── Phase 7: Verify ─────────────────────────────────────────────────
 info "Phase 7: Verifying results..."
 
-# Marker file survived
+# Marker files survived
 RESTORED=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- cat "${MARKER_FILE}" 2>/dev/null || true)
 if [ "$RESTORED" = "${MARKER_CONTENT}" ]; then
   pass "Marker file survived rebuild"
 else
   fail "Marker file lost: got '${RESTORED}', expected '${MARKER_CONTENT}'"
+fi
+
+HOOK_RESTORED=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- cat "${HOOK_MARKER_FILE}" 2>/dev/null || true)
+if [ "$HOOK_RESTORED" = "${HOOK_MARKER_CONTENT}" ]; then
+  pass "Hermes hooks marker survived rebuild"
+else
+  fail "Hermes hooks marker lost: got '${HOOK_RESTORED}', expected '${HOOK_MARKER_CONTENT}'"
 fi
 
 # Actual Hermes binary version updated

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -101,6 +101,7 @@ describe("agents/hermes/generate-config.ts", () => {
   it("generates API server config without messaging platform token blocks", () => {
     const { config, envFile } = runConfigScript();
 
+    expect(config._config_version).toBe(23);
     expect(config.model).toMatchObject({
       default: "test-model",
       provider: "custom",

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -495,7 +495,9 @@ describe("Hermes sandbox provisioning", () => {
           "audio_cache",
           "platforms",
         ]) {
-          expect((fs.statSync(path.join(hermesDir, dir)).mode & 0o777).toString(8)).toBe("770");
+          const dirPath = path.join(hermesDir, dir);
+          expect((fs.statSync(dirPath).mode & 0o777).toString(8)).toBe("770");
+          expect(run.calls).toContain(`chown -R sandbox:sandbox ${dirPath}`);
         }
         expect((fs.statSync(path.join(hermesDir, "platforms")).mode & 0o7777).toString(8)).toBe(
           "2770",

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -486,7 +486,15 @@ describe("Hermes sandbox provisioning", () => {
         expect(run.result.status).toBe(0);
         const hermesDir = path.join(run.sandboxRoot, ".hermes");
         expect((fs.statSync(hermesDir).mode & 0o777).toString(8)).toBe("750");
-        for (const dir of ["logs", "cache", "platforms"]) {
+        for (const dir of [
+          "logs",
+          "logs/curator",
+          "cache",
+          "hooks",
+          "image_cache",
+          "audio_cache",
+          "platforms",
+        ]) {
           expect((fs.statSync(path.join(hermesDir, dir)).mode & 0o777).toString(8)).toBe("770");
         }
         expect((fs.statSync(path.join(hermesDir, "platforms")).mode & 0o7777).toString(8)).toBe(


### PR DESCRIPTION
## Summary
- upgrade Hermes Agent from v2026.4.23 / semver 0.11.0 to v2026.5.16 / semver 0.14.0
- update the pinned upstream tarball SHA-256 and Hermes manifest expected version
- bump the generated Hermes config schema version to 23
- precreate new upstream HERMES_HOME directories: logs/curator, hooks, image_cache, and audio_cache
- preserve user-installed Hermes hooks across rebuilds via manifest state_dirs

## Validation
- git diff --check
- npm ci --ignore-scripts
- npx vitest run test/*hermes*.test.ts test/nemohermes-alias.test.ts test/rebuild-credential-preflight.test.ts test/rebuild-credential-hydration.test.ts test/sandbox-provisioning.test.ts
- npm run validate:configs
- npm run source-shape:check
- npm run typecheck:cli
- npx vitest run src/lib/agent/defs.test.ts src/lib/agent/base-image.test.ts src/lib/sandbox/version.test.ts test/validate-config-schemas.test.ts
- npm run build:cli
- uv sync --frozen --no-dev --extra messaging --extra web --no-cache (in unpacked upstream Hermes v2026.5.16 source)
- npm ci --prefer-offline --no-audit --no-fund --ignore-scripts (in unpacked upstream Hermes v2026.5.16 source)
- .venv/bin/hermes --version (reported Hermes Agent v0.14.0 / 2026.5.16)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Hermes Agent to v2026.5.16 and bumped generated config version.

* **New Features**
  * Added persistent gateway hooks directory and new runtime cache directories for image, audio, and curator logs.
  * Ensured these runtime directories receive correct writable permissions for the sandbox.

* **Tests**
  * Expanded unit and E2E tests to verify config version, directory permissions, and hooks persistence across rebuilds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->