### PR TITLE
fix(openclaw): reapply WeChat channel seed after config mutations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -392,11 +392,14 @@ ENV NPM_CONFIG_OFFLINE=true \
     NPM_CONFIG_FUND=false
 
 # Install NemoClaw plugin into OpenClaw (local /opt/nemoclaw, no network).
+# Re-apply WeChat account seeding after OpenClaw doctor/plugin-install touches
+# openclaw.json; the seed script no-ops unless WeChat is actively configured.
 # Prune non-runtime metadata from staged bundled plugin dependencies before
 # this layer is committed; deleting it in a later layer would not reduce the
 # OCI image imported by k3s.
 # hadolint ignore=DL3059,DL4006
 RUN (openclaw plugins install /opt/nemoclaw > /dev/null 2>&1 || true) \
+    && python3 /usr/local/lib/nemoclaw/seed-wechat-accounts.py \
     && if [ -d /sandbox/.openclaw/plugin-runtime-deps ]; then \
         find /sandbox/.openclaw/plugin-runtime-deps -type f \( \
             -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o \

--- a/scripts/seed-wechat-accounts.py
+++ b/scripts/seed-wechat-accounts.py
@@ -19,8 +19,9 @@
 # is registered. Without channels.openclaw-weixin.accounts.<id>.enabled=true
 # in openclaw.json, the plugin's auth/accounts.ts considers the account
 # disabled and the bridge won't start, even if the per-account state files
-# above exist. generate-openclaw-config.py invokes this only after
-# plugins.installs.openclaw-weixin has been preserved from the base image.
+# above exist. The patch also restores the openclaw-weixin plugin registry
+# entry because later OpenClaw config rewrites can drop it while leaving the
+# pre-installed extension files in place.
 #
 # State dir resolution mirrors the upstream's resolveStateDir():
 #   $OPENCLAW_STATE_DIR || $CLAWDBOT_STATE_DIR || ~/.openclaw
@@ -53,6 +54,12 @@ import pathlib
 import sys
 
 
+WECHAT_PLUGIN_ID = "openclaw-weixin"
+WECHAT_PLUGIN_SPEC = "@tencent-weixin/openclaw-weixin@2.4.2"
+WECHAT_PLUGIN_INSTALL = {
+    "source": "npm",
+    "spec": WECHAT_PLUGIN_SPEC,
+}
 WECHAT_TOKEN_PLACEHOLDER = "openshell:resolve:env:WECHAT_BOT_TOKEN"
 
 
@@ -140,6 +147,31 @@ def _patch_openclaw_config(account_id: str) -> None:
             file=sys.stderr,
         )
         return
+
+    plugins = cfg.setdefault("plugins", {})
+    if not isinstance(plugins, dict):
+        plugins = {}
+        cfg["plugins"] = plugins
+    installs = plugins.setdefault("installs", {})
+    if not isinstance(installs, dict):
+        installs = {}
+        plugins["installs"] = installs
+    wechat_install = installs.get(WECHAT_PLUGIN_ID)
+    if (
+        not isinstance(wechat_install, dict)
+        or wechat_install.get("source") != WECHAT_PLUGIN_INSTALL["source"]
+        or not wechat_install.get("spec")
+    ):
+        installs[WECHAT_PLUGIN_ID] = dict(WECHAT_PLUGIN_INSTALL)
+    entries = plugins.setdefault("entries", {})
+    if not isinstance(entries, dict):
+        entries = {}
+        plugins["entries"] = entries
+    wechat_entry = entries.setdefault(WECHAT_PLUGIN_ID, {})
+    if not isinstance(wechat_entry, dict):
+        wechat_entry = {}
+        entries[WECHAT_PLUGIN_ID] = wechat_entry
+    wechat_entry["enabled"] = True
 
     channels = cfg.setdefault("channels", {})
     weixin = channels.setdefault("openclaw-weixin", {})


### PR DESCRIPTION
## Summary

- Re-run `seed-wechat-accounts.py` after `openclaw doctor --fix` and `openclaw plugins install /opt/nemoclaw` have rewritten `openclaw.json` in the Dockerfile.
- Enhance the seed script to restore `plugins.installs.openclaw-weixin` and `plugins.entries.openclaw-weixin.enabled` before writing `channels.openclaw-weixin`, so the gateway recognizes the upstream channel id.
- No-op when WeChat is not configured for the current build.

## Root cause

The Dockerfile executes `generate-openclaw-config.py` (which calls `seed-wechat-accounts.py` to register `channels.openclaw-weixin`), then runs `openclaw doctor --fix` and `openclaw plugins install /opt/nemoclaw`. Both of those OpenClaw CLI commands rewrite `openclaw.json` and drop the `channels.openclaw-weixin` block that the seed script just added.

The final image's `openclaw.json` therefore lists only `['defaults', 'discord', 'slack', 'telegram', 'whatsapp']` — no `openclaw-weixin` — and the WeChat bridge never starts.

Nightly evidence: https://github.com/NVIDIA/NemoClaw/actions/runs/26133440454/job/76863300166

## Validation

The equivalent fix was independently landed on `main` as PR #3839 (commit ce03b01). The `GITHUB_TOKEN` lacks `workflow` scope so a `-custom-e2e` validation branch could not be pushed; however the next scheduled nightly on `main` (which includes ce03b01) will validate the fix end-to-end.

- Equivalent fix on main: [`ce03b01`](https://github.com/NVIDIA/NemoClaw/commit/ce03b013f10ffed72d194e99661d54ff4ff83436) (PR #3839)
- Original failing run: [26133440454](https://github.com/NVIDIA/NemoClaw/actions/runs/26133440454) on `2dc09427`
- Targeted job: `channels-stop-start-e2e` (#76863300166)

## Files changed

| File | Change |
|---|---|
| `Dockerfile` | Add late `seed-wechat-accounts.py` call after `openclaw plugins install` |
| `scripts/seed-wechat-accounts.py` | Restore `plugins.installs` and `plugins.entries` for openclaw-weixin before writing channel block |

Signed-off-by: Hung Le <hple@nvidia.com>

Fixes #3844