### PR TITLE
fix(nightly): restore extension backup compatibility

### DIFF
--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -9,7 +9,7 @@
 //
 // Credentials are stripped from backups using shared credential-filter.ts.
 
-import { spawnSync } from "child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -21,17 +21,17 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "child_process";
 
-import * as registry from "./registry.js";
-import { loadAgent } from "../agent/defs.js";
-import type { AgentStateFile } from "../agent/defs.js";
-import { resolveOpenshell } from "../adapters/openshell/resolve.js";
 import { captureOpenshellCommand } from "../adapters/openshell/client.js";
-import { sanitizeConfigFile, isSensitiveFile } from "../security/credential-filter.js";
+import { resolveOpenshell } from "../adapters/openshell/resolve.js";
+import type { AgentStateFile } from "../agent/defs.js";
+import { loadAgent } from "../agent/defs.js";
 import { shellQuote } from "../runner.js";
+import { isSensitiveFile, sanitizeConfigFile } from "../security/credential-filter.js";
+import * as registry from "./registry.js";
 
 const HOME_DIR = path.resolve(process.env.HOME || os.homedir());
 const REBUILD_BACKUPS_DIR = path.join(HOME_DIR, ".nemoclaw", "rebuild-backups");
@@ -318,8 +318,7 @@ function auditExtractedSymlinks(dirPath: string, allowedRoots: string[]): string
           // path with a tampered target falls through to the normal
           // containment check.
           const relFromDir = path.relative(dirPath, fullPath).split(path.sep).join("/");
-          const expectedTarget = AUDIT_SYMLINK_WHITELIST.get(relFromDir);
-          if (expectedTarget !== undefined && expectedTarget === linkTarget) {
+          if (isAllowedStateSymlink(relFromDir, linkTarget)) {
             continue;
           }
 
@@ -565,17 +564,12 @@ function sanitizeBackupDirectory(dirPath: string): void {
 
 const _verbose = () => process.env.NEMOCLAW_REBUILD_VERBOSE === "1";
 
-// Symlinks baked into the base image at build time (Dockerfile.base) by
-// `openclaw plugins install`. npm creates these as part of its standard
-// install layout — peer-dependency links and .bin shortcuts — and the
-// pre-backup audit would otherwise treat them as agent-planted exfil
-// attempts. Source paths are relative to the agent state-dir root (e.g.
-// for OpenClaw, /sandbox/.openclaw); targets are matched exactly against
-// the value of `readlink(source)`. Source-only matching is unsafe: a
-// compromised agent could repoint one of these to /etc/passwd and the
-// audit would still let it through. Keep in lockstep with
-// WECHAT_PLUGIN_VERSION in Dockerfile.base — bump together if the plugin
-// install layout changes.
+// Exact symlinks baked into the base image at build time (Dockerfile.base) by
+// `openclaw plugins install`. Source paths are relative to the agent state-dir
+// root (e.g. for OpenClaw, /sandbox/.openclaw); targets are matched exactly
+// against the value of `readlink(source)`. Source-only matching is unsafe: a
+// compromised agent could repoint one of these to /etc/passwd and the audit
+// would still let it through.
 const AUDIT_SYMLINK_WHITELIST: ReadonlyMap<string, string> = new Map([
   [
     "extensions/openclaw-weixin/node_modules/.bin/qrcode-terminal",
@@ -586,6 +580,33 @@ const AUDIT_SYMLINK_WHITELIST: ReadonlyMap<string, string> = new Map([
     "/usr/local/lib/node_modules/openclaw",
   ],
 ]);
+
+const EXTENSION_NPM_BIN_RE = /^extensions\/[^/]+\/node_modules\/\.bin\/[^/]+$/;
+
+function isAllowedExtensionNpmBinSymlink(relPath: string, linkTarget: string): boolean {
+  const normalizedRelPath = relPath.split(path.sep).join("/");
+  if (!EXTENSION_NPM_BIN_RE.test(normalizedRelPath)) return false;
+  if (linkTarget.length === 0 || path.posix.isAbsolute(linkTarget)) return false;
+
+  const binDir = path.posix.dirname(normalizedRelPath);
+  const nodeModulesDir = path.posix.dirname(binDir);
+  const resolvedTarget = path.posix.normalize(path.posix.join(binDir, linkTarget));
+  const targetWithinNodeModules = path.posix.relative(nodeModulesDir, resolvedTarget);
+
+  return (
+    targetWithinNodeModules.length > 0 &&
+    !targetWithinNodeModules.startsWith("../") &&
+    !path.posix.isAbsolute(targetWithinNodeModules) &&
+    !targetWithinNodeModules.startsWith(".bin/")
+  );
+}
+
+function isAllowedStateSymlink(relPath: string, linkTarget: string): boolean {
+  const exactTarget = AUDIT_SYMLINK_WHITELIST.get(relPath.split(path.sep).join("/"));
+  if (exactTarget !== undefined) return exactTarget === linkTarget;
+  return isAllowedExtensionNpmBinSymlink(relPath, linkTarget);
+}
+
 function _log(msg: string): void {
   if (_verbose()) console.error(`  [sandbox-state ${new Date().toISOString()}] ${msg}`);
 }
@@ -1059,9 +1080,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
             const relPath = absPath.startsWith(dirPrefix)
               ? absPath.slice(dirPrefix.length)
               : absPath;
-            const expectedTarget =
-              type === "l" ? AUDIT_SYMLINK_WHITELIST.get(relPath) : undefined;
-            if (expectedTarget !== undefined && expectedTarget === linkTarget) {
+            if (type === "l" && isAllowedStateSymlink(relPath, linkTarget)) {
               whitelisted.push(entry);
             } else {
               violations.push(entry);

--- a/test/e2e/test-credential-sanitization.sh
+++ b/test/e2e/test-credential-sanitization.sh
@@ -423,11 +423,17 @@ fi
 info "C7: Checking for secret patterns in sandbox config..."
 
 # Search for real API key patterns (not our test fakes).
-# Exclude policy preset files and vendored plugin dependencies; dependency
-# package names can contain strings like ghp_ or npm_ without storing secrets.
-c7_nvapi=$(sandbox_exec "grep -r 'nvapi-' /sandbox/.openclaw/ /sandbox/.nemoclaw/ 2>/dev/null | grep -v 'STRIPPED' | grep -v '/policies/' | grep -v '/plugin-runtime-deps/' | head -5" || true)
-c7_ghp=$(sandbox_exec "grep -r 'ghp_' /sandbox/.openclaw/ /sandbox/.nemoclaw/ 2>/dev/null | grep -v 'STRIPPED' | grep -v '/policies/' | grep -v '/plugin-runtime-deps/' | head -5" || true)
-c7_npm=$(sandbox_exec "grep -r 'npm_' /sandbox/.openclaw/ /sandbox/.nemoclaw/ 2>/dev/null | grep -v 'STRIPPED' | grep -v '/policies/' | grep -v '/plugin-runtime-deps/' | head -5" || true)
+# Exclude policy preset files and installed extension code/dependencies; package
+# sources can contain detector strings like nvapi-, ghp_, or npm_ without storing
+# user secrets.
+c7_scan_pattern() {
+  local pattern="$1"
+  sandbox_exec "grep -r '$pattern' /sandbox/.openclaw/ /sandbox/.nemoclaw/ 2>/dev/null | grep -v 'STRIPPED' | grep -v '/policies/' | grep -v '/plugin-runtime-deps/' | grep -Ev '/extensions/[^/]+/(dist|node_modules)/' | head -5" || true
+}
+
+c7_nvapi=$(c7_scan_pattern "nvapi-")
+c7_ghp=$(c7_scan_pattern "ghp_")
+c7_npm=$(c7_scan_pattern "npm_")
 
 if [ "$c7_nvapi" = "__PROBE_FAILED__" ] || [ "$c7_ghp" = "__PROBE_FAILED__" ] || [ "$c7_npm" = "__PROBE_FAILED__" ]; then
   fail "C7: Sandbox probe failed — SSH did not execute; cannot verify secret absence"

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -639,6 +639,121 @@ process.exit(0);
     }
   });
 
+  it("accepts extension npm .bin symlinks that resolve inside node_modules", () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-audit-npm-bin-"));
+    const oldPath = process.env.PATH;
+    const oldOpenshell = process.env.NEMOCLAW_OPENSHELL_BIN;
+    try {
+      const binDir = path.join(fixture, "bin");
+      const openclawDir = path.join(fixture, "sandbox-root", ".openclaw");
+      const existingDirs = ["extensions"];
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(path.join(openclawDir, "extensions"), { recursive: true });
+
+      const auditLines = [
+        "l\t/sandbox/.openclaw/extensions/nemoclaw/node_modules/.bin/json5\t../json5/lib/cli.js",
+        "l\t/sandbox/.openclaw/extensions/nemoclaw/node_modules/.bin/yaml\t../yaml/bin.mjs",
+        "l\t/sandbox/.openclaw/extensions/nemoclaw/node_modules/.bin/node-which\t../which/bin/node-which",
+      ].join("\n");
+
+      const openshell = writeFakeOpenshell(binDir);
+      writeExecutable(
+        path.join(binDir, "ssh"),
+        `#!/usr/bin/env node
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
+const cmd = process.argv[process.argv.length - 1] || "";
+const existingDirs = ${JSON.stringify(existingDirs)};
+const openclawDir = ${JSON.stringify(openclawDir)};
+if (cmd.includes("[ -d ")) {
+  process.stdout.write(existingDirs.join("\\n") + "\\n");
+  process.exit(0);
+}
+if (cmd.includes("find ")) {
+  process.stdout.write(${JSON.stringify(auditLines)} + "\\n");
+  process.exit(0);
+}
+if (cmd.includes("tar -cf -")) {
+  const r = spawnSync("tar", ["-cf", "-", "-C", openclawDir, ...existingDirs], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (r.stdout) fs.writeSync(1, r.stdout);
+  process.exit(r.status || 0);
+}
+process.exit(0);
+`,
+      );
+
+      writeOpenClawRegistry("alpha");
+      process.env.NEMOCLAW_OPENSHELL_BIN = openshell;
+      process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
+
+      const backup = sandboxState.backupSandboxState("alpha");
+      expect(backup.success).toBe(true);
+      expect(backup.error).toBeUndefined();
+    } finally {
+      if (oldOpenshell === undefined) {
+        delete process.env.NEMOCLAW_OPENSHELL_BIN;
+      } else {
+        process.env.NEMOCLAW_OPENSHELL_BIN = oldOpenshell;
+      }
+      process.env.PATH = oldPath;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects extension npm .bin symlinks that escape node_modules", () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-audit-npm-bin-escape-"));
+    const oldPath = process.env.PATH;
+    const oldOpenshell = process.env.NEMOCLAW_OPENSHELL_BIN;
+    try {
+      const binDir = path.join(fixture, "bin");
+      const openclawDir = path.join(fixture, "sandbox-root", ".openclaw");
+      const existingDirs = ["extensions"];
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(path.join(openclawDir, "extensions"), { recursive: true });
+
+      const auditLines = [
+        "l\t/sandbox/.openclaw/extensions/nemoclaw/node_modules/.bin/leak\t../../../../openclaw.json",
+      ].join("\n");
+
+      const openshell = writeFakeOpenshell(binDir);
+      writeExecutable(
+        path.join(binDir, "ssh"),
+        `#!/usr/bin/env node
+const cmd = process.argv[process.argv.length - 1] || "";
+const existingDirs = ${JSON.stringify(existingDirs)};
+if (cmd.includes("[ -d ")) {
+  process.stdout.write(existingDirs.join("\\n") + "\\n");
+  process.exit(0);
+}
+if (cmd.includes("find ")) {
+  process.stdout.write(${JSON.stringify(auditLines)} + "\\n");
+  process.exit(0);
+}
+process.exit(0);
+`,
+      );
+
+      writeOpenClawRegistry("alpha");
+      process.env.NEMOCLAW_OPENSHELL_BIN = openshell;
+      process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
+
+      const backup = sandboxState.backupSandboxState("alpha");
+      expect(backup.success).toBe(false);
+      expect(backup.error).toMatch(/node_modules\/\.bin\/leak/);
+      expect(backup.error).toMatch(/openclaw\.json/);
+    } finally {
+      if (oldOpenshell === undefined) {
+        delete process.env.NEMOCLAW_OPENSHELL_BIN;
+      } else {
+        process.env.NEMOCLAW_OPENSHELL_BIN = oldOpenshell;
+      }
+      process.env.PATH = oldPath;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
   it("still rejects non-whitelisted symlinks alongside whitelisted ones", () => {
     const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-audit-mixed-"));
     const oldPath = process.env.PATH;


### PR DESCRIPTION
## Summary

This fixes the new main nightly failures on `main-manual-6b8bb5e` after PR #3777 began installing/enabling the bundled NemoClaw OpenClaw extension during image build.

- Allow npm-generated extension `.bin` symlinks during the sandbox pre-backup audit only when they live under `extensions/<id>/node_modules/.bin` and resolve back inside that same extension `node_modules` tree.
- Preserve the existing exact-match allowlist for absolute baked-in plugin symlinks and keep rejecting `.bin` links that escape toward config/state files.
- Keep credential C7 scanning focused on sandbox config/state by excluding installed extension code/dependencies, which can legitimately contain detector strings such as `nvapi-`, `ghp_`, and `npm_` in source.

## Nightly Evidence

Failed run: https://github.com/NVIDIA/NemoClaw/actions/runs/26134407888 on `6b8bb5eb0e5d7b665276a23e43422f11d3e1bf08`.

Failures addressed:

- `snapshot-commands-e2e`: `Pre-backup audit rejected` npm `.bin` symlinks under `/sandbox/.openclaw/extensions/nemoclaw/node_modules/.bin`.
- `messaging-providers-e2e`: rebuild aborted because state backup failed after adding WhatsApp.
- `channels-stop-start-e2e`: rebuild aborted because state backup failed after adding tokenless WhatsApp.
- `credential-sanitization-e2e`: C7 matched `extensions/nemoclaw/dist/security/secret-scanner.js`, i.e. the scanner's own detector strings, not leaked credentials.

## Validation

- `npm run build:cli`
- `npm test -- --run test/snapshot.test.ts test/security-sandbox-tar-traversal.test.ts`
- `bash -n test/e2e/test-credential-sanitization.sh && shellcheck test/e2e/test-credential-sanitization.sh`
- `npx @biomejs/biome check src/lib/state/sandbox.ts test/snapshot.test.ts`
- `npm run typecheck:cli`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced symlink validation during sandbox backup operations to prevent escape attempts and strengthen protection of extension dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->