### PR TITLE
refactor(cli): add onboard FSM transition types

### DIFF
--- a/src/lib/onboard/machine/transitions.test.ts
+++ b/src/lib/onboard/machine/transitions.test.ts
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ONBOARD_MACHINE_EVENT_TYPES,
+  ONBOARD_MACHINE_STATES,
+  ONBOARD_NON_TERMINAL_MACHINE_STATES,
+} from "./types";
+import {
+  assertValidOnboardMachineTransition,
+  canTransitionOnboardMachineState,
+  getNextOnboardMachineStates,
+  getOnboardMachineTransition,
+  InvalidOnboardMachineTransitionError,
+  isOnboardMachineState,
+  isTerminalOnboardMachineState,
+  ONBOARD_MACHINE_DIRECT_TRANSITIONS,
+  ONBOARD_MACHINE_NEXT_STATES,
+  ONBOARD_MACHINE_TRANSITIONS,
+} from "./transitions";
+
+const canonicalDirectTransitions = [
+  ["init", "preflight", "advance"],
+  ["preflight", "gateway", "advance"],
+  ["gateway", "provider_selection", "advance"],
+  ["provider_selection", "inference", "advance"],
+  ["inference", "provider_selection", "retry"],
+  ["inference", "sandbox", "advance"],
+  ["sandbox", "openclaw", "branch"],
+  ["sandbox", "agent_setup", "branch"],
+  ["openclaw", "policies", "advance"],
+  ["agent_setup", "policies", "advance"],
+  ["policies", "finalizing", "advance"],
+  ["finalizing", "post_verify", "advance"],
+  ["post_verify", "complete", "advance"],
+] as const;
+
+describe("onboard machine vocabulary", () => {
+  it("defines the initial coarse state vocabulary from issue #3802", () => {
+    expect(ONBOARD_MACHINE_STATES).toEqual([
+      "init",
+      "preflight",
+      "gateway",
+      "provider_selection",
+      "inference",
+      "sandbox",
+      "agent_setup",
+      "openclaw",
+      "policies",
+      "finalizing",
+      "post_verify",
+      "complete",
+      "failed",
+    ]);
+  });
+
+  it("defines the initial observe-only event vocabulary from issue #3802", () => {
+    expect(ONBOARD_MACHINE_EVENT_TYPES).toEqual([
+      "onboard.started",
+      "onboard.resumed",
+      "onboard.completed",
+      "onboard.failed",
+      "state.entered",
+      "state.exited",
+      "state.skipped",
+      "state.completed",
+      "state.failed",
+      "state.repair.started",
+      "state.repair.completed",
+      "state.repair.failed",
+      "context.updated",
+      "resume.conflict",
+      "hook.started",
+      "hook.completed",
+      "hook.failed",
+    ]);
+  });
+
+  it("recognizes valid machine state names", () => {
+    expect(isOnboardMachineState("preflight")).toBe(true);
+    expect(isOnboardMachineState("messaging")).toBe(false);
+    expect(isOnboardMachineState(null)).toBe(false);
+  });
+});
+
+describe("onboard machine transitions", () => {
+  it("encodes the canonical direct transition graph", () => {
+    expect(ONBOARD_MACHINE_DIRECT_TRANSITIONS).toEqual(
+      canonicalDirectTransitions.map(([from, to, kind]) => ({ from, to, kind })),
+    );
+  });
+
+  it("allows every non-terminal state to fail", () => {
+    for (const state of ONBOARD_NON_TERMINAL_MACHINE_STATES) {
+      expect(canTransitionOnboardMachineState(state, "failed")).toBe(true);
+      expect(getOnboardMachineTransition(state, "failed")?.kind).toBe("failure");
+    }
+  });
+
+  it("keeps terminal states terminal", () => {
+    expect(isTerminalOnboardMachineState("complete")).toBe(true);
+    expect(isTerminalOnboardMachineState("failed")).toBe(true);
+    expect(getNextOnboardMachineStates("complete")).toEqual([]);
+    expect(getNextOnboardMachineStates("failed")).toEqual([]);
+    expect(canTransitionOnboardMachineState("complete", "failed")).toBe(false);
+    expect(canTransitionOnboardMachineState("failed", "init")).toBe(false);
+  });
+
+  it("exposes next states in deterministic order", () => {
+    expect(ONBOARD_MACHINE_NEXT_STATES).toEqual({
+      init: ["preflight", "failed"],
+      preflight: ["gateway", "failed"],
+      gateway: ["provider_selection", "failed"],
+      provider_selection: ["inference", "failed"],
+      inference: ["provider_selection", "sandbox", "failed"],
+      sandbox: ["openclaw", "agent_setup", "failed"],
+      agent_setup: ["policies", "failed"],
+      openclaw: ["policies", "failed"],
+      policies: ["finalizing", "failed"],
+      finalizing: ["post_verify", "failed"],
+      post_verify: ["complete", "failed"],
+      complete: [],
+      failed: [],
+    });
+  });
+
+  it("classifies retry and branch transitions", () => {
+    expect(assertValidOnboardMachineTransition("inference", "provider_selection")).toMatchObject({
+      kind: "retry",
+    });
+    expect(assertValidOnboardMachineTransition("sandbox", "openclaw")).toMatchObject({
+      kind: "branch",
+    });
+    expect(assertValidOnboardMachineTransition("sandbox", "agent_setup")).toMatchObject({
+      kind: "branch",
+    });
+  });
+
+  it("rejects transitions outside the graph", () => {
+    expect(() => assertValidOnboardMachineTransition("init", "sandbox")).toThrow(
+      InvalidOnboardMachineTransitionError,
+    );
+    expect(() => assertValidOnboardMachineTransition("complete", "failed")).toThrow(
+      "complete -> failed",
+    );
+  });
+
+  it("keeps the next-state map aligned with the transition list", () => {
+    for (const state of ONBOARD_MACHINE_STATES) {
+      expect(
+        ONBOARD_MACHINE_TRANSITIONS.filter((transition) => transition.from === state).map(
+          (transition) => transition.to,
+        ),
+      ).toEqual(getNextOnboardMachineStates(state));
+    }
+  });
+
+  it("does not contain duplicate transition edges", () => {
+    const edges = ONBOARD_MACHINE_TRANSITIONS.map(({ from, to }) => `${from}->${to}`);
+    expect(new Set(edges).size).toBe(edges.length);
+  });
+});

--- a/src/lib/onboard/machine/transitions.ts
+++ b/src/lib/onboard/machine/transitions.ts
@@ -8,22 +8,6 @@ import {
   ONBOARD_TERMINAL_MACHINE_STATES,
 } from "./types";
 
-export const ONBOARD_MACHINE_NEXT_STATES = {
-  init: ["preflight", "failed"],
-  preflight: ["gateway", "failed"],
-  gateway: ["provider_selection", "failed"],
-  provider_selection: ["inference", "failed"],
-  inference: ["provider_selection", "sandbox", "failed"],
-  sandbox: ["openclaw", "agent_setup", "failed"],
-  agent_setup: ["policies", "failed"],
-  openclaw: ["policies", "failed"],
-  policies: ["finalizing", "failed"],
-  finalizing: ["post_verify", "failed"],
-  post_verify: ["complete", "failed"],
-  complete: [],
-  failed: [],
-} as const satisfies Readonly<Record<OnboardMachineState, readonly OnboardMachineState[]>>;
-
 export const ONBOARD_MACHINE_DIRECT_TRANSITIONS = [
   { from: "init", to: "preflight", kind: "advance" },
   { from: "preflight", to: "gateway", kind: "advance" },
@@ -48,6 +32,18 @@ export const ONBOARD_MACHINE_TRANSITIONS = [
   ...ONBOARD_MACHINE_DIRECT_TRANSITIONS,
   ...ONBOARD_MACHINE_FAILURE_TRANSITIONS,
 ] as const satisfies readonly OnboardMachineTransition[];
+
+export const ONBOARD_MACHINE_NEXT_STATES: Readonly<
+  Record<OnboardMachineState, readonly OnboardMachineState[]>
+> = ONBOARD_MACHINE_STATES.reduce(
+  (nextStates, state) => ({
+    ...nextStates,
+    [state]: ONBOARD_MACHINE_TRANSITIONS.filter((transition) => transition.from === state).map(
+      (transition) => transition.to,
+    ),
+  }),
+  {} as Record<OnboardMachineState, readonly OnboardMachineState[]>,
+);
 
 export class InvalidOnboardMachineTransitionError extends Error {
   readonly from: OnboardMachineState;

--- a/src/lib/onboard/machine/transitions.ts
+++ b/src/lib/onboard/machine/transitions.ts
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OnboardMachineState, OnboardMachineTransition } from "./types";
+import {
+  ONBOARD_MACHINE_STATES,
+  ONBOARD_NON_TERMINAL_MACHINE_STATES,
+  ONBOARD_TERMINAL_MACHINE_STATES,
+} from "./types";
+
+export const ONBOARD_MACHINE_NEXT_STATES = {
+  init: ["preflight", "failed"],
+  preflight: ["gateway", "failed"],
+  gateway: ["provider_selection", "failed"],
+  provider_selection: ["inference", "failed"],
+  inference: ["provider_selection", "sandbox", "failed"],
+  sandbox: ["openclaw", "agent_setup", "failed"],
+  agent_setup: ["policies", "failed"],
+  openclaw: ["policies", "failed"],
+  policies: ["finalizing", "failed"],
+  finalizing: ["post_verify", "failed"],
+  post_verify: ["complete", "failed"],
+  complete: [],
+  failed: [],
+} as const satisfies Readonly<Record<OnboardMachineState, readonly OnboardMachineState[]>>;
+
+export const ONBOARD_MACHINE_DIRECT_TRANSITIONS = [
+  { from: "init", to: "preflight", kind: "advance" },
+  { from: "preflight", to: "gateway", kind: "advance" },
+  { from: "gateway", to: "provider_selection", kind: "advance" },
+  { from: "provider_selection", to: "inference", kind: "advance" },
+  { from: "inference", to: "provider_selection", kind: "retry" },
+  { from: "inference", to: "sandbox", kind: "advance" },
+  { from: "sandbox", to: "openclaw", kind: "branch" },
+  { from: "sandbox", to: "agent_setup", kind: "branch" },
+  { from: "openclaw", to: "policies", kind: "advance" },
+  { from: "agent_setup", to: "policies", kind: "advance" },
+  { from: "policies", to: "finalizing", kind: "advance" },
+  { from: "finalizing", to: "post_verify", kind: "advance" },
+  { from: "post_verify", to: "complete", kind: "advance" },
+] as const satisfies readonly OnboardMachineTransition[];
+
+export const ONBOARD_MACHINE_FAILURE_TRANSITIONS = ONBOARD_NON_TERMINAL_MACHINE_STATES.map(
+  (from) => ({ from, to: "failed" as const, kind: "failure" as const }),
+) satisfies readonly OnboardMachineTransition[];
+
+export const ONBOARD_MACHINE_TRANSITIONS = [
+  ...ONBOARD_MACHINE_DIRECT_TRANSITIONS,
+  ...ONBOARD_MACHINE_FAILURE_TRANSITIONS,
+] as const satisfies readonly OnboardMachineTransition[];
+
+export class InvalidOnboardMachineTransitionError extends Error {
+  readonly from: OnboardMachineState;
+  readonly to: OnboardMachineState;
+
+  constructor(from: OnboardMachineState, to: OnboardMachineState) {
+    super(`Invalid onboarding machine transition: ${from} -> ${to}`);
+    this.name = "InvalidOnboardMachineTransitionError";
+    this.from = from;
+    this.to = to;
+  }
+}
+
+export function isOnboardMachineState(value: unknown): value is OnboardMachineState {
+  return typeof value === "string" && ONBOARD_MACHINE_STATES.includes(value as OnboardMachineState);
+}
+
+export function isTerminalOnboardMachineState(
+  state: OnboardMachineState,
+): state is "complete" | "failed" {
+  return ONBOARD_TERMINAL_MACHINE_STATES.includes(state as "complete" | "failed");
+}
+
+export function getNextOnboardMachineStates(
+  from: OnboardMachineState,
+): readonly OnboardMachineState[] {
+  return ONBOARD_MACHINE_NEXT_STATES[from];
+}
+
+export function canTransitionOnboardMachineState(
+  from: OnboardMachineState,
+  to: OnboardMachineState,
+): boolean {
+  return getNextOnboardMachineStates(from).includes(to);
+}
+
+export function getOnboardMachineTransition(
+  from: OnboardMachineState,
+  to: OnboardMachineState,
+): OnboardMachineTransition | null {
+  return (
+    ONBOARD_MACHINE_TRANSITIONS.find(
+      (transition) => transition.from === from && transition.to === to,
+    ) ?? null
+  );
+}
+
+export function assertValidOnboardMachineTransition(
+  from: OnboardMachineState,
+  to: OnboardMachineState,
+): OnboardMachineTransition {
+  const transition = getOnboardMachineTransition(from, to);
+  if (!transition) {
+    throw new InvalidOnboardMachineTransitionError(from, to);
+  }
+  return transition;
+}

--- a/src/lib/onboard/machine/types.ts
+++ b/src/lib/onboard/machine/types.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Coarse onboarding finite-state-machine vocabulary.
+ *
+ * These types intentionally model only major step boundaries. Mid-operation
+ * resume inside gateway startup, sandbox creation, credential upserts, model
+ * probes, or policy application is out of scope for the initial FSM shell.
+ */
+
+export const ONBOARD_MACHINE_STATES = [
+  "init",
+  "preflight",
+  "gateway",
+  "provider_selection",
+  "inference",
+  "sandbox",
+  "agent_setup",
+  "openclaw",
+  "policies",
+  "finalizing",
+  "post_verify",
+  "complete",
+  "failed",
+] as const;
+
+export type OnboardMachineState = (typeof ONBOARD_MACHINE_STATES)[number];
+
+export const ONBOARD_TERMINAL_MACHINE_STATES = ["complete", "failed"] as const;
+
+export type OnboardTerminalMachineState =
+  (typeof ONBOARD_TERMINAL_MACHINE_STATES)[number];
+
+export type OnboardNonTerminalMachineState = Exclude<
+  OnboardMachineState,
+  OnboardTerminalMachineState
+>;
+
+export const ONBOARD_NON_TERMINAL_MACHINE_STATES: readonly OnboardNonTerminalMachineState[] =
+  ONBOARD_MACHINE_STATES.filter(
+    (state): state is OnboardNonTerminalMachineState =>
+      !ONBOARD_TERMINAL_MACHINE_STATES.includes(state as OnboardTerminalMachineState),
+  );
+
+export const ONBOARD_MACHINE_EVENT_TYPES = [
+  "onboard.started",
+  "onboard.resumed",
+  "onboard.completed",
+  "onboard.failed",
+  "state.entered",
+  "state.exited",
+  "state.skipped",
+  "state.completed",
+  "state.failed",
+  "state.repair.started",
+  "state.repair.completed",
+  "state.repair.failed",
+  "context.updated",
+  "resume.conflict",
+  "hook.started",
+  "hook.completed",
+  "hook.failed",
+] as const;
+
+export type OnboardMachineEventType = (typeof ONBOARD_MACHINE_EVENT_TYPES)[number];
+
+export type OnboardMachineTransitionKind =
+  | "advance"
+  | "retry"
+  | "branch"
+  | "failure";
+
+export interface OnboardMachineTransition {
+  from: OnboardMachineState;
+  to: OnboardMachineState;
+  kind: OnboardMachineTransitionKind;
+}
+
+/**
+ * Stable, redacted context keys that machine events may expose.
+ *
+ * Do not add raw secrets or unredacted URLs here. Runtime-derived topology
+ * decisions such as Docker/WSL reachability, Ollama proxy necessity, or live
+ * gateway health should be recomputed during execution rather than stored as
+ * durable FSM context.
+ */
+export interface OnboardMachineContext {
+  agent?: string | null;
+  sandboxName?: string | null;
+  provider?: string | null;
+  model?: string | null;
+  endpointUrl?: string | null;
+  credentialEnv?: string | null;
+  preferredInferenceApi?: string | null;
+  hermesAuthMethod?: "oauth" | "api_key" | null;
+  hermesToolGateways?: string[] | null;
+  policyPresets?: string[] | null;
+  messagingChannels?: string[] | null;
+  gpuPassthrough?: boolean;
+}

--- a/src/lib/onboard/machine/types.ts
+++ b/src/lib/onboard/machine/types.ts
@@ -90,7 +90,7 @@ export interface OnboardMachineContext {
   sandboxName?: string | null;
   provider?: string | null;
   model?: string | null;
-  endpointUrl?: string | null;
+  endpointOrigin?: string | null;
   credentialEnv?: string | null;
   preferredInferenceApi?: string | null;
   hermesAuthMethod?: "oauth" | "api_key" | null;


### PR DESCRIPTION
## Summary
Add the first observable onboarding FSM shell primitives: coarse machine state names, event vocabulary, transition metadata, and validation helpers. This is the no-behavior-change foundation for the #3802 onboarding FSM workstream.

## Related Issue
Refs #3802

## Changes
- Added `src/lib/onboard/machine/types.ts` with onboarding machine states, event types, transition/context types, and terminal-state vocabulary.
- Added `src/lib/onboard/machine/transitions.ts` with the canonical transition graph, failure transitions from non-terminal states, lookup helpers, and invalid-transition errors.
- Added `src/lib/onboard/machine/transitions.test.ts` covering vocabulary, transition ordering, retry/branch/failure classification, terminal states, and duplicate edge protection.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved onboarding flow with explicit transition rules, deterministic next-state ordering, and runtime validation to prevent invalid moves.

* **Bug Fixes**
  * Terminal states are enforced and failure transitions are consistently handled to avoid unexpected progression.

* **Tests**
  * Added comprehensive tests validating onboarding transition invariants and error handling.

* **Chores**
  * Added type-safe definitions and utilities to support onboarding state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->