### PR TITLE
fix(cli): explain restricted dmesg in debug output

### DIFF
--- a/src/lib/diagnostics/debug.test.ts
+++ b/src/lib/diagnostics/debug.test.ts
@@ -6,7 +6,12 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 // Import from compiled dist/ so coverage is attributed correctly.
-import { createTarball, getDebugCompletionMessages, redact } from "../../../dist/lib/diagnostics/debug";
+import {
+  createTarball,
+  getDebugCompletionMessages,
+  isDmesgPermissionDeniedOutput,
+  redact,
+} from "../../../dist/lib/diagnostics/debug";
 
 describe("redact", () => {
   it("redacts NVIDIA_API_KEY=value patterns", () => {
@@ -100,5 +105,19 @@ describe("getDebugCompletionMessages", () => {
 
   it("omits the redundant --output hint when a tarball was already written", () => {
     expect(getDebugCompletionMessages("/tmp/nemoclaw-debug.tar.gz")).toEqual([]);
+  });
+});
+
+describe("isDmesgPermissionDeniedOutput", () => {
+  it("recognizes restricted dmesg stderr", () => {
+    expect(
+      isDmesgPermissionDeniedOutput(
+        "dmesg: read kernel buffer failed: Operation not permitted",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat unrelated permission errors as dmesg restrictions", () => {
+    expect(isDmesgPermissionDeniedOutput("docker: Permission denied")).toBe(false);
   });
 });

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
@@ -63,6 +63,7 @@ export { redact };
 
 const isMacOS = platform() === "darwin";
 const TIMEOUT_MS = 30_000;
+const DMESG_RESTRICT_PATH = "/proc/sys/kernel/dmesg_restrict";
 
 function commandExists(cmd: string): boolean {
   try {
@@ -118,6 +119,80 @@ function collectShell(collectDir: string, label: string, shellCmd: string): void
   const raw = (result.stdout ?? "") + "\n" + (result.stderr ?? "");
   const redacted = redact(raw);
   writeFileSync(outfile, redacted);
+  console.log(redacted.trimEnd());
+
+  if (result.status !== 0) {
+    console.log("  (command exited with non-zero status)");
+  }
+}
+
+function writeCollectedMessage(collectDir: string, label: string, message: string): void {
+  const filename = label.replace(/[ /]/g, (c) => (c === " " ? "_" : "-"));
+  const outfile = join(collectDir, `${filename}.txt`);
+  writeFileSync(outfile, message + "\n");
+  console.log(message);
+}
+
+function isRootUser(): boolean {
+  return typeof process.getuid === "function" && process.getuid() === 0;
+}
+
+function isDmesgRestrictedForCurrentUser(): boolean {
+  if (isRootUser()) return false;
+
+  try {
+    return readFileSync(DMESG_RESTRICT_PATH, "utf-8").trim() === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function isDmesgPermissionDeniedOutput(output: string): boolean {
+  if (!/\b(operation not permitted|permission denied)\b/i.test(output)) {
+    return false;
+  }
+  return /\b(dmesg|kernel buffer|kernel logs?)\b/i.test(output);
+}
+
+function dmesgRestrictedMessage(reason: string): string {
+  return `  (kernel messages skipped: dmesg access is restricted for this user; ${reason})`;
+}
+
+function collectDmesg(collectDir: string): void {
+  if (!commandExists("dmesg")) {
+    writeCollectedMessage(collectDir, "dmesg", "  (dmesg not found, skipping)");
+    return;
+  }
+
+  if (isDmesgRestrictedForCurrentUser()) {
+    writeCollectedMessage(
+      collectDir,
+      "dmesg",
+      dmesgRestrictedMessage(
+        `${DMESG_RESTRICT_PATH}=1 prevents non-root users from reading kernel logs`,
+      ),
+    );
+    return;
+  }
+
+  const result = spawnSync("sh", ["-c", "dmesg | tail -100"], {
+    timeout: TIMEOUT_MS,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+
+  const raw = (result.stdout ?? "") + "\n" + (result.stderr ?? "");
+  if (isDmesgPermissionDeniedOutput(raw)) {
+    writeCollectedMessage(
+      collectDir,
+      "dmesg",
+      dmesgRestrictedMessage("the dmesg command denied access to kernel logs"),
+    );
+    return;
+  }
+
+  const redacted = redact(raw);
+  writeFileSync(join(collectDir, "dmesg.txt"), redacted);
   console.log(redacted.trimEnd());
 
   if (result.status !== 0) {
@@ -424,7 +499,7 @@ function collectKernelMessages(collectDir: string): void {
       'log show --last 5m --predicate "eventType == logEvent" --style compact 2>/dev/null | tail -100',
     );
   } else {
-    collectShell(collectDir, "dmesg", "dmesg | tail -100");
+    collectDmesg(collectDir);
   }
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -282,6 +282,7 @@ function createCloudflaredServiceDir(prefix: string): { sandboxName: string; ser
 function createDebugCommandTestEnv(prefix: string): Record<string, string> {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   const localBin = path.join(home, "bin");
+  const sandboxName = `${prefix}${process.pid.toString(36)}-${Date.now().toString(36)}`;
   fs.mkdirSync(localBin, { recursive: true });
   fs.writeFileSync(
     path.join(localBin, "openshell"),
@@ -299,8 +300,15 @@ function createDebugCommandTestEnv(prefix: string): Record<string, string> {
   fs.writeFileSync(path.join(localBin, "docker"), ["#!/bin/sh", "exit 0"].join("\n"), {
     mode: 0o755,
   });
+  fs.writeFileSync(
+    path.join(localBin, "dmesg"),
+    ["#!/bin/sh", "echo 'nemoclaw test kernel message'", "exit 0"].join("\n"),
+    { mode: 0o755 },
+  );
   return {
     HOME: home,
+    NEMOCLAW_HOME: path.join(home, ".nemoclaw"),
+    NEMOCLAW_SANDBOX: sandboxName,
     PATH: `${localBin}:${process.env.PATH || ""}`,
   };
 }
@@ -1401,6 +1409,33 @@ describe("CLI dispatch", () => {
     expect(r.out.includes("Onboard Session")).toBeTruthy();
     expect(r.out.includes("Done")).toBeTruthy();
   });
+
+  it(
+    "debug --quick explains restricted dmesg instead of printing raw stderr",
+    testTimeoutOptions(30_000),
+    () => {
+      const env = createDebugCommandTestEnv("nemoclaw-cli-debug-dmesg-");
+      const localBin = env.PATH?.split(path.delimiter)[0];
+      if (!localBin) throw new Error("Expected debug test PATH to include a fake bin dir");
+      fs.writeFileSync(
+        path.join(localBin, "dmesg"),
+        [
+          "#!/bin/sh",
+          "echo 'dmesg: read kernel buffer failed: Operation not permitted' >&2",
+          "exit 1",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const r = runWithEnv("debug --quick", env, 30000);
+
+      expect(r.code).toBe(0);
+      expect(r.out).toContain("Kernel Messages");
+      expect(r.out).toContain("kernel messages skipped");
+      expect(r.out).toContain("dmesg access is restricted");
+      expect(r.out).not.toContain("dmesg: read kernel buffer failed: Operation not permitted");
+    },
+  );
 
   it("debug exits 1 on unknown option", () => {
     const r = run("debug --quik");


### PR DESCRIPTION
## Summary
`nemoclaw debug --quick` now reports restricted kernel log access as a contextual skipped kernel-message section instead of surfacing raw `dmesg` permission stderr.

## Related Issue
Fixes #3700

## Changes
- Adds dmesg-specific diagnostics handling for restricted kernel-log access and missing `dmesg` binaries.
- Detects common dmesg permission-denied output and `/proc/sys/kernel/dmesg_restrict=1` for non-root users.
- Adds focused diagnostics and CLI regression coverage for restricted dmesg output.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Focused verification run locally with Node v22.16.0:
- `npm run build:cli`
- `npx vitest run --project cli src/lib/diagnostics/debug.test.ts test/cli.test.ts -t "isDmesgPermissionDeniedOutput|debug --quick"`
- `npx vitest run --project cli src/lib/diagnostics/debug.test.ts`
- isolated `node bin/nemoclaw.js debug --quick` with fake `dmesg` under `/tmp/nemoclaw-fix-3700-home`
- `npm run typecheck:cli`
- `npm run checks`
- `npx biome lint --write --no-errors-on-unmatched src/lib/diagnostics/debug.ts src/lib/diagnostics/debug.test.ts test/cli.test.ts`
- `git diff --check`
- `codex review -c sandbox_mode="danger-full-access" --uncommitted`

Broader `npx vitest run --project cli src/lib/diagnostics/debug.test.ts test/cli.test.ts` was stopped after the diagnostics file passed and `test/cli.test.ts` made no progress for more than three minutes in unrelated later CLI dispatch tests.

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of restricted kernel message access on Linux. The debug command now displays a clear message explaining permission restrictions instead of showing raw error output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->