### PR TITLE
fix(cli): align shields status and logs tail UX

### DIFF
--- a/docs/reference/cli-selection-guide.mdx
+++ b/docs/reference/cli-selection-guide.mdx
@@ -98,7 +98,7 @@ Use `openshell` when the docs explicitly call for a live OpenShell gateway opera
   ```console
   $ openshell sandbox list
   $ openshell sandbox get <sandbox-name>
-  $ openshell logs <sandbox-name> --tail
+  $ openshell logs <sandbox-name> -n 200 --tail
   ```
 
 - Run one-off commands or move files without starting a NemoClaw chat session:
@@ -152,6 +152,7 @@ Use `nemoclaw <name> status` and `nemoclaw <name> logs` first.
 They combine NemoClaw registry data, OpenShell state, OpenClaw process health, inference health, policy details, and messaging-channel warnings.
 
 Use `openshell sandbox list`, `openshell sandbox get`, or `openshell logs` when debugging lower-level OpenShell behavior.
+When using `openshell logs` directly, `--tail` follows live output and `-n <lines>` controls the line count; NemoClaw's `logs --tail <lines>` is the line-count form, and `logs --follow` opts into streaming.
 
 ### Approve Blocked Network Requests
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -427,6 +427,7 @@ Use `--tail <lines>` or `-n <lines>` to limit the number of returned lines.
 Use `--since <duration>` to show recent logs only, such as `5m`, `1h`, or `30s`.
 The command reads both OpenClaw gateway output and OpenShell audit events, so policy denials appear alongside the gateway log stream.
 If one log source is unavailable, NemoClaw prints a warning and keeps reading the remaining source.
+NemoClaw's `--tail <lines>` flag is a line-count flag; the lower-level `openshell logs --tail` flag means follow live output, so use `openshell logs <sandbox> -n <lines>` when running OpenShell directly for a fixed line count.
 
 ```console
 $ nemoclaw my-assistant logs [--follow] [--tail <lines>|-n <lines>] [--since <duration>]

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -611,15 +611,25 @@ export async function runSandboxDoctor(
       });
     }
 
-    const shieldsDown = shields.isShieldsDown(sandboxName, true);
+    const shieldsPosture = shields.getShieldsPosture(sandboxName, true);
+    const shieldsStatus: DoctorStatus =
+      shieldsPosture.mode === "locked"
+        ? "ok"
+        : shieldsPosture.mode === "temporarily_unlocked" || shieldsPosture.mode === "error"
+          ? "warn"
+          : "info";
+    const shieldsHint =
+      shieldsPosture.mode === "mutable_default"
+        ? `run \`${CLI_NAME} ${sandboxName} shields up\` to opt into lockdown`
+        : shieldsPosture.mode === "locked"
+          ? undefined
+          : `run \`${CLI_NAME} ${sandboxName} shields status\` for details`;
     checks.push({
       group: "Sandbox",
       label: "Shields",
-      status: shieldsDown ? "warn" : "ok",
-      detail: shieldsDown ? "down" : "up",
-      hint: shieldsDown
-        ? `run \`${CLI_NAME} ${sandboxName} shields status\` for details`
-        : undefined,
+      status: shieldsStatus,
+      detail: shieldsPosture.detail,
+      hint: shieldsHint,
     });
     checks.push(messagingDoctorCheck(sandboxName, sb));
   }

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -219,8 +219,13 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
       /* non-fatal */
     }
 
-    if (shields.isShieldsDown(sandboxName, true)) {
-      console.log("    Permissions: shields down (check `shields status` for details)");
+    const shieldsPosture = shields.getShieldsPosture(sandboxName, true);
+    if (shieldsPosture.mode !== "locked") {
+      const detail =
+        shieldsPosture.mode === "mutable_default"
+          ? shieldsPosture.detail
+          : `${shieldsPosture.detail} (check \`shields status\` for details)`;
+      console.log(`    Permissions: ${detail}`);
     }
 
     // Agent version check

--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -327,6 +327,58 @@ describe("shields — unit logic", () => {
       expect(deriveShieldsMode({ shieldsDown: false }, true)).toBe("locked");
       expect(deriveShieldsMode({}, true)).toBe("mutable_default");
     });
+
+    it("getShieldsPosture exposes canonical status wording for callers", async () => {
+      const distModulePath = path.join(
+        process.cwd(),
+        "dist",
+        "lib",
+        "shields",
+        "index.js",
+      );
+      const { getShieldsPosture } = await import(distModulePath);
+      const stateDir = path.join(tmpDir, ".nemoclaw", "state");
+      fs.mkdirSync(stateDir, { recursive: true });
+
+      expect(getShieldsPosture("openclaw", false)).toEqual(
+        expect.objectContaining({
+          mode: "mutable_default",
+          detail: "not configured (default mutable state)",
+          statusText: "NOT CONFIGURED (default mutable state)",
+        }),
+      );
+
+      fs.writeFileSync(
+        path.join(stateDir, "shields-openclaw.json"),
+        JSON.stringify({ shieldsDown: false, updatedAt: "2026-05-20T00:00:00Z" }),
+        { mode: 0o600 },
+      );
+      expect(getShieldsPosture("openclaw", false)).toEqual(
+        expect.objectContaining({
+          mode: "locked",
+          detail: "up (lockdown active)",
+          statusText: "UP (lockdown active)",
+        }),
+      );
+
+      fs.writeFileSync(
+        path.join(stateDir, "shields-openclaw.json"),
+        JSON.stringify({
+          shieldsDown: true,
+          shieldsDownAt: "2026-05-20T00:00:00Z",
+          shieldsDownTimeout: 300,
+          updatedAt: "2026-05-20T00:00:00Z",
+        }),
+        { mode: 0o600 },
+      );
+      expect(getShieldsPosture("openclaw", false)).toEqual(
+        expect.objectContaining({
+          mode: "temporarily_unlocked",
+          detail: "down (temporarily unlocked)",
+          statusText: "DOWN (temporarily unlocked)",
+        }),
+      );
+    });
   });
 
   describe("NC-3112: status self-heals stale expired auto-restore markers", () => {

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -143,6 +143,7 @@ function stateFilePath(sandboxName: string): string {
 //   "locked"          — shields up has been run and verified
 //   "temporarily_unlocked" — shields down after a prior shields up
 type ShieldsMode = "mutable_default" | "locked" | "temporarily_unlocked";
+type ShieldsPostureMode = ShieldsMode | "error";
 
 interface ShieldsState {
   shieldsDown?: boolean;
@@ -152,6 +153,21 @@ interface ShieldsState {
   shieldsDownPolicy?: string | null;
   shieldsPolicySnapshotPath?: string | null;
   updatedAt?: string;
+}
+
+type LoadedShieldsState = ShieldsState & {
+  _hasStateFile: boolean;
+  _isCorrupt?: boolean;
+  _corruptError?: string;
+};
+
+interface ShieldsPosture {
+  mode: ShieldsPostureMode;
+  detail: string;
+  statusText: string;
+  locked: boolean;
+  mutable: boolean;
+  state: LoadedShieldsState;
 }
 
 /**
@@ -173,11 +189,44 @@ function deriveShieldsMode(
   return "mutable_default";
 }
 
-function loadShieldsState(sandboxName: string): ShieldsState & {
-  _hasStateFile: boolean;
-  _isCorrupt?: boolean;
-  _corruptError?: string;
-} {
+function describeShieldsMode(mode: ShieldsPostureMode): Omit<ShieldsPosture, "state"> {
+  switch (mode) {
+    case "mutable_default":
+      return {
+        mode,
+        detail: "not configured (default mutable state)",
+        statusText: "NOT CONFIGURED (default mutable state)",
+        locked: false,
+        mutable: true,
+      };
+    case "locked":
+      return {
+        mode,
+        detail: "up (lockdown active)",
+        statusText: "UP (lockdown active)",
+        locked: true,
+        mutable: false,
+      };
+    case "temporarily_unlocked":
+      return {
+        mode,
+        detail: "down (temporarily unlocked)",
+        statusText: "DOWN (temporarily unlocked)",
+        locked: false,
+        mutable: true,
+      };
+    case "error":
+      return {
+        mode,
+        detail: "error (state file is corrupt)",
+        statusText: "ERROR (state file is corrupt)",
+        locked: false,
+        mutable: true,
+      };
+  }
+}
+
+function loadShieldsState(sandboxName: string): LoadedShieldsState {
   const filePath = stateFilePath(sandboxName);
   if (!fs.existsSync(filePath)) return { _hasStateFile: false };
   try {
@@ -199,6 +248,17 @@ function loadShieldsState(sandboxName: string): ShieldsState & {
       _corruptError: message,
     };
   }
+}
+
+function getShieldsPosture(
+  sandboxName: string,
+  allowInlineRecovery = false,
+): ShieldsPosture {
+  const state = recoverExpiredAutoRestoreGate(sandboxName, allowInlineRecovery);
+  const mode = state._isCorrupt
+    ? "error"
+    : deriveShieldsMode(state, state._hasStateFile);
+  return { ...describeShieldsMode(mode), state };
 }
 
 function saveShieldsState(
@@ -821,11 +881,7 @@ function recoverExpiredAutoRestoreInline(
 function recoverExpiredAutoRestoreGate(
   sandboxName: string,
   allowInlineRecovery = true,
-): ShieldsState & {
-  _hasStateFile: boolean;
-  _isCorrupt?: boolean;
-  _corruptError?: string;
-} {
+): LoadedShieldsState {
   const state = loadShieldsState(sandboxName);
   if (!allowInlineRecovery) return state;
   if (
@@ -1179,7 +1235,8 @@ function shieldsUp(sandboxName: string): void {
 function shieldsStatus(sandboxName: string, allowInlineRecovery = true): void {
   validateName(sandboxName, "sandbox name");
 
-  const state = recoverExpiredAutoRestoreGate(sandboxName, allowInlineRecovery);
+  const posture = getShieldsPosture(sandboxName, allowInlineRecovery);
+  const { state } = posture;
   if (state._isCorrupt) {
     console.error("  Shields: ERROR (state file is corrupt)");
     console.error(
@@ -1190,19 +1247,18 @@ function shieldsStatus(sandboxName: string, allowInlineRecovery = true): void {
     );
     process.exit(1);
   }
-  const mode = deriveShieldsMode(state, state._hasStateFile);
 
-  switch (mode) {
+  switch (posture.mode) {
     case "mutable_default":
       // NC-2227-02: Fresh sandbox with no shields history — do NOT claim locked
-      console.log("  Shields: NOT CONFIGURED (default mutable state)");
+      console.log(`  Shields: ${posture.statusText}`);
       console.log(
         "  Config is mutable. Run `nemoclaw <sandbox> shields up` to opt into lockdown.",
       );
       return;
 
     case "locked":
-      console.log("  Shields: UP (lockdown active)");
+      console.log(`  Shields: ${posture.statusText}`);
       console.log(
         `  Policy:  restrictive${state.shieldsPolicySnapshotPath ? " (snapshot preserved)" : ""}`,
       );
@@ -1223,7 +1279,7 @@ function shieldsStatus(sandboxName: string, allowInlineRecovery = true): void {
           ? Math.max(0, state.shieldsDownTimeout - elapsed)
           : null;
 
-      console.log("  Shields: DOWN (temporarily unlocked)");
+      console.log(`  Shields: ${posture.statusText}`);
       console.log(`  Since:   ${state.shieldsDownAt ?? "unknown"}`);
       if (remaining !== null) {
         const mins = Math.floor(remaining / 60);
@@ -1242,10 +1298,10 @@ function shieldsStatus(sandboxName: string, allowInlineRecovery = true): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true if shields are currently down (temporarily unlocked).
- * NC-2227-02: Fresh sandboxes (no state file, mutable_default) return
- * true since the config IS mutable. Only returns false when shields
- * have been explicitly locked via `shields up`.
+ * Legacy mutability predicate. Fresh sandboxes and temporarily unlocked
+ * sandboxes both return true because their config is mutable; user-facing
+ * callers should use getShieldsPosture() so fresh state is labeled as
+ * "not configured" instead of "down".
  */
 function isShieldsDown(sandboxName: string, allowInlineRecovery = false): boolean {
   const state = recoverExpiredAutoRestoreGate(sandboxName, allowInlineRecovery);
@@ -1263,6 +1319,7 @@ export {
   shieldsUp,
   shieldsStatus,
   isShieldsDown,
+  getShieldsPosture,
   killTimer,
   deriveShieldsMode,
   parseDuration,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1503,6 +1503,35 @@ describe("CLI dispatch", () => {
     );
   });
 
+  it(
+    "doctor reports fresh shields state as not configured instead of down",
+    testTimeoutOptions(30_000),
+    () => {
+      const setup = createDoctorTestSetup("nemoclaw-cli-doctor-shields-default-", [
+        'case "$*" in',
+        '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
+        '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+        '  "sandbox list") printf "NAME STATUS\\nalpha Ready\\n"; exit 0 ;;',
+        '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
+        "esac",
+      ]);
+
+      const r = setup.runDoctor("alpha doctor --json");
+
+      const report = JSON.parse(r.out) as {
+        checks: Array<{ label: string; status: string; detail: string; hint?: string }>;
+      };
+      const shields = report.checks.find((check) => check.label === "Shields");
+      expect(shields).toEqual(
+        expect.objectContaining({
+          status: "info",
+          detail: "not configured (default mutable state)",
+        }),
+      );
+      expect(shields?.detail).not.toBe("down");
+    },
+  );
+
   it("doctor does not query sandbox state from a different active gateway", () => {
     const setup = createDoctorTestSetup("nemoclaw-cli-doctor-wrong-gateway-", [
       'case "$*" in',
@@ -2122,6 +2151,17 @@ describe("CLI dispatch", () => {
       "sandbox exec -n alpha -- tail -n 25 /tmp/gateway.log",
       "logs alpha -n 25 --source all",
     ]);
+  });
+
+  it("passes --follow --tail line count to both streaming log sources", () => {
+    const setup = createLogsTestSetup("nemoclaw-cli-logs-follow-tail-");
+    const r = setup.runLogs("alpha logs --follow --tail 50");
+
+    const calls = setup.readCalls();
+    expect(r.code).toBe(0);
+    expect(calls).toContain("settings set alpha --key ocsf_json_enabled --value true");
+    expect(calls).toContain("sandbox exec -n alpha -- tail -n 50 -f /tmp/gateway.log");
+    expect(calls).toContain("logs alpha -n 50 --source all --tail");
   });
 
   it("passes --since to OpenShell logs without an unfiltered gateway tail", () => {
@@ -4746,6 +4786,53 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("Start Ollama and retry");
     expect(r.out).toContain("http://127.0.0.1:11434/api/tags");
   });
+
+  it(
+    "status reports fresh shields state as not configured instead of down",
+    testTimeoutOptions(30_000),
+    () => {
+      const home = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-cli-status-shields-default-"),
+      );
+      const localBin = path.join(home, "bin");
+      fs.mkdirSync(localBin, { recursive: true });
+      writeSandboxRegistry(home);
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/usr/bin/env bash",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "alpha" ]; then',
+          "  echo 'Error: sandbox not found' >&2",
+          "  exit 1",
+          "fi",
+          'if [ "$1" = "status" ]; then',
+          "  echo 'Server Status'",
+          "  echo",
+          "  echo '  Gateway: nemoclaw'",
+          "  echo '  Status: Connected'",
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "gateway" ] && [ "$2" = "info" ] && [ "$3" = "-g" ] && [ "$4" = "nemoclaw" ]; then',
+          "  echo 'Gateway Info'",
+          "  echo",
+          "  echo '  Gateway: nemoclaw'",
+          "  exit 0",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const r = runWithEnv("alpha status 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+
+      expect(r.code).toBe(1);
+      expect(r.out).toContain("Permissions: not configured (default mutable state)");
+      expect(r.out).not.toContain("Permissions: shields down");
+    },
+  );
 
   it("prints healthy inference only after the sandbox and gateway are verified", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-status-healthy-"));


### PR DESCRIPTION
## Summary
Aligns status and doctor shields wording with the canonical shields state so fresh mutable sandboxes report as not configured instead of down. Clarifies NemoClaw versus OpenShell log tail semantics and locks the combined `logs --follow --tail <lines>` argv behavior with tests.

## Related Issue
Fixes #3702

## Changes
- Added `getShieldsPosture()` for canonical shields state labels and reused it in `status`, `doctor`, and `shields status`.
- Added focused CLI regressions for fresh shields status/doctor output and `logs --follow --tail <lines>` routing.
- Updated command docs to distinguish NemoClaw `--tail <lines>` from OpenShell `--tail` follow behavior.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Focused verification run locally:
- `npm run build:cli`
- `npx vitest run src/lib/domain/sandbox/logs.test.ts src/lib/shields/index.test.ts test/cli.test.ts -t "sandbox logs helpers|shields — unit logic|doctor reports fresh shields state|status reports fresh shields state|passes --tail line count|passes -n line count|passes --follow --tail line count|maps --follow to OpenShell live log streaming|passes plain logs through without the tail flag"`
- Isolated real CLI probe under `HOME=/tmp/nemoclaw-fix-3702-home` / `NEMOCLAW_HOME=/tmp/nemoclaw-fix-3702-home/.nemoclaw`, including `timeout 30s node bin/nemoclaw.js fix3702-alpha logs --follow --tail 7`
- `npm run typecheck:cli`
- `cd nemoclaw && npm run build`
- `make docs` (Fern reported 0 errors and 2 hidden warnings)
- `codex review -c sandbox_mode="danger-full-access" --uncommitted`

`npx prek run --all-files` was attempted. Static/docs/plugin stages passed, but the full CLI coverage hook failed after about 13.5 minutes in unrelated broad-suite paths: multiple existing `test/cli.test.ts` timeouts, `test/fetch-guard-patch-regression.test.ts`, and `test/sandbox-connect-inference.test.ts`. Scoped regressions and typecheck/build/docs checks above passed after that.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified `openshell logs` command flag semantics and usage in CLI guides with explicit examples and NemoClaw comparison.

* **Bug Fixes**
  * Improved shields/permissions status reporting with richer, posture-aware status information.
  * Enhanced sandbox doctor checks and status display with clearer shield and permission state messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->