### PR TITLE
ci(images): extend base image build timeout

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -44,7 +44,7 @@ jobs:
   build-and-push:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,7 +94,7 @@ jobs:
   build-and-push-hermes:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
  Extends the base image workflow timeout so multi-architecture Docker builds have more time to complete before GitHub Actions cancels them.

  ## Changes
  - Increase `build-and-push` timeout from 15 minutes to 45 minutes.
  - Increase `build-and-push-hermes` timeout from 15 minutes to 45 minutes.

  ## Type of Change
  - [ ] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates
  - [ ] Doc only (prose changes, no code sample modifications)
  - [ ] Doc only (includes code sample changes)

  ## Verification
  - [ ] `npx prek run --all-files` passes
  - [ ] `npm test` passes
  - [ ] Tests added or updated for new or changed behavior
  - [x] No secrets, API keys, or credentials committed
  - [ ] Docs updated for user-facing behavior changes
  - [ ] `make docs` builds without warnings (doc changes only)
  - [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
  - [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Your Name <your-email@example.com>
