### PR TITLE
fix(e2e): treat ERR_PROXY_TUNNEL as proxy wiring success in M12 test

### DIFF
--- a/test/e2e/docs/parity-inventory.generated.json
+++ b/test/e2e/docs/parity-inventory.generated.json
@@ -8849,7 +8849,15 @@
         },
         {
           "script": "test/e2e/test-messaging-providers.sh",
-          "line": 1264,
+          "line": 1263,
+          "text": "M12: Node.js routed through proxy (proxy policy blocked destination: ${tg_reach:0:160})",
+          "polarity": "pass",
+          "normalized_id": "m12.node.js.routed.through.proxy.policy.blocked.destination",
+          "mapping_status": "deferred"
+        },
+        {
+          "script": "test/e2e/test-messaging-providers.sh",
+          "line": 1270,
           "text": "M12: Node.js could not reach api.telegram.org (${tg_reach:0:200})",
           "polarity": "fail",
           "normalized_id": "m12.node.js.could.not.reach.api.telegram.org.tg.reach.0.200",

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -1282,6 +1282,11 @@ if echo "$tg_reach" | grep -q "HTTP_"; then
   pass "M12: Node.js reached api.telegram.org (${tg_reach})"
 elif echo "$tg_reach" | grep -q "TIMEOUT"; then
   skip "M12: api.telegram.org timed out (network may be slow)"
+elif echo "$tg_reach" | grep -qiE "ERROR:.*(ERR_PROXY_TUNNEL|PROXY_CONNECTION_LOST)"; then
+  # ERR_PROXY_TUNNEL means Node routed through the proxy and the proxy issued
+  # a non-2xx CONNECT response (e.g. 403 Forbidden).  This proves proxy *wiring*
+  # is correct — the failure is upstream proxy policy, not NemoClaw configuration.
+  pass "M12: Node.js routed through proxy (proxy policy blocked destination: ${tg_reach:0:160})"
 elif echo "$tg_reach" | grep -qiE "ERROR:.*(ECONNRESET|reset|socket hang up|ENETUNREACH|EHOSTUNREACH|ETIMEDOUT)"; then
   skip "M12: api.telegram.org unreachable from this network (${tg_reach:0:160})"
 else


### PR DESCRIPTION
## Summary

The M12 reachability test in `test-messaging-providers.sh` conflates proxy *wiring* validation with upstream proxy *policy*. When the configured proxy correctly forwards the CONNECT request but returns HTTP 403 (policy deny), Node.js emits `ERR_PROXY_TUNNEL`. This proves proxy wiring is correct — traffic was routed through the proxy — but the test fell through to the `fail` branch because it only recognized:
- `HTTP_*` → pass
- `TIMEOUT` → skip
- `ECONNRESET|ENETUNREACH|...` → skip
- everything else → **fail**

`ERR_PROXY_TUNNEL` didn't match any of the skip patterns, so it was treated as a failure even though NemoClaw's proxy integration is functioning correctly.

## Changes

- **`test/e2e/test-messaging-providers.sh`**: Add a new `elif` branch before the network-error skip that recognizes `ERR_PROXY_TUNNEL` and `PROXY_CONNECTION_LOST` as **pass** outcomes, since they prove Node.js honored the `HTTPS_PROXY` env var and routed through the configured proxy endpoint.
- **`test/e2e/docs/parity-map.yaml`**: Add the new pass verdict to the M12 parity entries.
- **`test/e2e/docs/parity-inventory.generated.json`**: Add the new pass entry with updated line references.

## How it works

```
Before:  ERR_PROXY_TUNNEL → (no match) → fail ❌
After:   ERR_PROXY_TUNNEL → pass ✅ (proxy wiring confirmed, policy blocked destination)
```

The fix distinguishes:
1. **Proxy wiring broken** → traffic bypasses proxy, direct connection fails (`ECONNREFUSED` to destination) → still fails as expected
2. **Proxy wiring works, proxy allows destination** → `HTTP_200`/`HTTP_301` → pass (unchanged)
3. **Proxy wiring works, proxy blocks destination** → `ERR_PROXY_TUNNEL` → **now passes** (was: fail)

Closes #3836

Signed-off-by: kagura-agent <kagura-agent@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced network reachability tests for messaging providers with improved proxy scenario handling and updated test assertions to reflect expected outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->