### PR TITLE
ci(images): extend base image build timeout

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -44,7 +44,7 @@ jobs:
   build-and-push:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,7 +94,7 @@ jobs:
   build-and-push-hermes:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
  Extends the base image workflow timeout so multi-architecture Docker builds have more time to complete before GitHub Actions cancels them.
Fixes: https://github.com/NVIDIA/NemoClaw/issues/3855 

  ## Changes
  - Increase the `build-and-push` job timeout from 15 minutes to 45 minutes.
  - Increase the `build-and-push-hermes` job timeout from 15 minutes to 45 minutes.

  ## Type of Change

  - [x] Code change (feature, bug fix, or refactor)
  - [ ] Code change with doc updates
  - [ ] Doc only (prose changes, no code sample modifications)
  - [ ] Doc only (includes code sample changes)

  ## Verification
  - [ ] `npx prek run --all-files` passes
  - [ ] `npm test` passes
  - [ ] Tests added or updated for new or changed behavior
  - [x] No secrets, API keys, or credentials committed
  - [ ] Docs updated for user-facing behavior changes
  - [ ] `make docs` builds without warnings (doc changes only)
  - [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
  - [ ] New doc pages include SPDX header and frontmatter (new pages only)
  - [ ] 
---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout duration for Docker image build jobs to support longer build durations and reduce timeout-related failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->