### PR TITLE
docs: remove local flag from sandbox inference examples

### DIFF
--- a/docs/deployment/deploy-to-remote-gpu.mdx
+++ b/docs/deployment/deploy-to-remote-gpu.mdx
@@ -85,7 +85,7 @@ $ ssh <instance-name> 'cd ~/nemoclaw && set -a && . .env && set +a && openshell 
 Run a test agent prompt inside the remote sandbox:
 
 ```console
-$ openclaw agent --agent main --local -m "Hello from the remote sandbox" --session-id test
+$ openclaw agent --agent main -m "Hello from the remote sandbox" --session-id test
 ```
 
 ## Remote Dashboard Access

--- a/docs/monitoring/monitor-sandbox-activity.mdx
+++ b/docs/monitoring/monitor-sandbox-activity.mdx
@@ -77,7 +77,7 @@ Run a test inference request to verify that the provider is responding:
 
 ```console
 $ nemoclaw my-assistant connect
-$ openclaw agent --agent main --local -m "Test inference" --session-id debug
+$ openclaw agent --agent main -m "Test inference" --session-id debug
 ```
 
 If the request fails, check the following:


### PR DESCRIPTION
## Summary

- Remove `--local` from sandbox inference verification examples.
- Keep the examples on the gateway-managed inference route that works inside NemoClaw sandboxes.

## Related Issue

Fixes #3692.

## Changes

- Updated `docs/deployment/deploy-to-remote-gpu.mdx`.
- Updated `docs/monitoring/monitor-sandbox-activity.mdx`.

## Verification

- `npm run docs:strict`
- Verified the updated `openclaw agent --agent main ...` form inside a NemoClaw sandbox and confirmed it returns successfully without `--local`.

## Type of Change

- [ ] Bug fix
- [x] Documentation update
- [ ] New feature
- [ ] Breaking change
- [ ] Tests
- [ ] Other

Signed-off-by: Glenn-Agent <glenn_agent@163.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example commands in deployment and monitoring guides to reflect proper execution patterns for inference operations in remote sandbox environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->