### PR TITLE
test: stabilize installer Docker bootstrap tests on WSL

### DIFF
--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -2854,6 +2854,11 @@ printf 'Linux\\n'
         "-c",
         `
 source "$INSTALLER_UNDER_TEST" >/dev/null
+# These tests validate the Linux Docker bootstrap branches. On a real WSL
+# runner the installer intentionally skips that bootstrap, so force the helper
+# under test to behave as a non-WSL Linux host while keeping uname/id/docker
+# stubbed through PATH.
+is_wsl_host() { return 1; }
 info() { printf 'INFO: %s\\n' "$*" >&2; }
 warn() { printf 'WARN: %s\\n' "$*" >&2; }
 error() { printf 'ERROR: %s\\n' "$*" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- force the installer Docker bootstrap unit-test helper to exercise the non-WSL Linux path
- keep the real installer behavior unchanged: WSL hosts still skip Linux Docker bootstrap

## Why
PR #3824 broadened WSL detection from WSL env vars to `/proc` probes via `is_wsl_host`. That is correct for runtime behavior, but these unit tests are specifically validating Linux Docker bootstrap branches with stubbed `docker`, `id`, `sudo`, and `systemctl`. On the real WSL main-watch runner, `/proc` identifies WSL, so `ensure_docker` returns before touching the stubs and the tests fail with empty output.

This overrides `is_wsl_host` inside that sourced-test harness only, so the tests keep validating the intended Linux branches on every host.

## Test plan
- `npm ci --ignore-scripts`
- `npx vitest run test/install-preflight.test.ts --testNamePattern "installer Docker bootstrap" --testTimeout 60000`

Fixes the WSL-only failures in `CI / Platform Vitest Main Watch` after #3824.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced testing for Linux Docker bootstrap procedures to ensure comprehensive coverage of installation scenarios across different system configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->