### PR TITLE
fix(hermes): avoid rc rewrites after capability drop

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -353,12 +353,14 @@ reviews:
         - `hermes-discord-e2e` — Hermes Discord config schema + placeholder
           isolation
         - `hermes-slack-e2e` — Hermes Slack policy + Python placeholder egress
+        - `hermes-onboard-security-posture-e2e` — Hermes onboard under a
+          non-root host security posture
         - `rebuild-hermes-e2e` — Hermes upgrade path
         - `rebuild-hermes-stale-base-e2e` — Hermes rebuild with stale cached base image
 
         To run selectively:
         ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=hermes-e2e,hermes-inference-switch-e2e,hermes-discord-e2e,hermes-slack-e2e,rebuild-hermes-e2e,rebuild-hermes-stale-base-e2e
+        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=hermes-e2e,hermes-inference-switch-e2e,hermes-discord-e2e,hermes-slack-e2e,hermes-onboard-security-posture-e2e,rebuild-hermes-e2e,rebuild-hermes-stale-base-e2e
         ```
 
     - path: "test/e2e/test-hermes-slack-e2e.sh"
@@ -446,6 +448,56 @@ reviews:
         To run selectively:
         ```
         gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=issue-2478-crash-loop-recovery-e2e
+        ```
+
+    - path: "test/e2e/lib/security-posture-assertions.sh"
+      instructions: &e2e-security-posture |
+        This helper asserts the Linux Docker-driver posture that protects
+        static rc-file shims and runtime proxy-env configure guards under
+        a non-root host user. Changes here affect both full onboard
+        security posture lanes.
+
+        **E2E test recommendation:**
+        - `openclaw-onboard-security-posture-e2e` — OpenClaw onboard under a
+          non-root host security posture
+        - `hermes-onboard-security-posture-e2e` — Hermes onboard under a
+          non-root host security posture
+
+        To run selectively:
+        ```
+        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=openclaw-onboard-security-posture-e2e,hermes-onboard-security-posture-e2e
+        ```
+
+    - path: "test/e2e/test-full-e2e.sh"
+      instructions: |
+        This script drives the full OpenClaw onboard path. Changes can
+        alter the install, sandbox creation, health, inference, and
+        security posture assertions used by the OpenClaw nightly lanes.
+
+        **E2E test recommendation:**
+        - `cloud-e2e` — full onboard + cloud inference
+        - `openclaw-onboard-security-posture-e2e` — OpenClaw onboard under a
+          non-root host security posture
+
+        To run selectively:
+        ```
+        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=cloud-e2e,openclaw-onboard-security-posture-e2e
+        ```
+
+    - path: "test/e2e/test-hermes-e2e.sh"
+      instructions: |
+        This script drives the full Hermes onboard path. Changes can alter
+        install, sandbox creation, health, inference, and security posture
+        assertions used by the Hermes nightly lanes.
+
+        **E2E test recommendation:**
+        - `hermes-e2e` — Hermes onboard + health probe + live inference
+        - `hermes-onboard-security-posture-e2e` — Hermes onboard under a
+          non-root host security posture
+
+        To run selectively:
+        ```
+        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=hermes-e2e,hermes-onboard-security-posture-e2e
         ```
 
     # ── Split cloud-experimental tests (#2644) ──────────────────

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -30,6 +30,12 @@
 #                            agent state, and the same agent type running.
 #   hermes-e2e               Hermes Agent E2E — install → onboard --agent hermes → health
 #                            probe → live inference. Validates the multi-agent architecture.
+#   openclaw-onboard-security-posture-e2e
+#                            Full OpenClaw onboard on a non-root host user with
+#                            post-drop capability and trusted rc-file assertions.
+#   hermes-onboard-security-posture-e2e
+#                            Full Hermes onboard on a non-root host user with
+#                            post-drop capability and trusted rc-file assertions.
 #   hermes-inference-switch-e2e
 #                            Switches a running Hermes sandbox with `nemohermes inference set`
 #                            and verifies route, config.yaml, hashes, and live requests.
@@ -79,6 +85,8 @@ on:
           token-rotation-e2e, sandbox-survival-e2e,
           openshell-gateway-upgrade-e2e,
           issue-2478-crash-loop-recovery-e2e, hermes-e2e,
+          openclaw-onboard-security-posture-e2e,
+          hermes-onboard-security-posture-e2e,
           hermes-inference-switch-e2e, hermes-discord-e2e,
           hermes-slack-e2e, sandbox-operations-e2e, inference-routing-e2e,
           openclaw-inference-switch-e2e,
@@ -778,6 +786,84 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hermes-e2e-install-log
+          path: /tmp/nemoclaw-e2e-hermes-install.log
+          if-no-files-found: ignore
+
+  # ── OpenClaw onboard security posture E2E ───────────────────────
+  # Full OpenClaw install/onboard/inference path, then asserts the Linux
+  # Docker-driver security posture that #3891 needed: non-root host user,
+  # post-drop PID 1 bounding caps without CAP_DAC_OVERRIDE, static root-owned
+  # rc shims, and dynamic configure guards only in /tmp/nemoclaw-proxy-env.sh.
+  openclaw-onboard-security-posture-e2e:
+    if: >-
+      github.repository == 'NVIDIA/NemoClaw' &&
+      (github.event_name != 'workflow_dispatch' ||
+       inputs.jobs == '' ||
+       contains(format(',{0},', inputs.jobs), ',openclaw-onboard-security-posture-e2e,'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.target_ref || github.ref }}
+
+      - name: Run OpenClaw onboard security posture E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-openclaw-security-posture"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          NEMOCLAW_E2E_SECURITY_POSTURE: "1"
+          NEMOCLAW_E2E_EXPECT_NON_ROOT_HOST: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-full-e2e.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: openclaw-onboard-security-posture-install-log
+          path: /tmp/nemoclaw-e2e-install.log
+          if-no-files-found: ignore
+
+  # ── Hermes onboard security posture E2E ─────────────────────────
+  # Full Hermes install/onboard/health/inference path with the same posture
+  # assertions as OpenClaw. This specifically catches the #3891 class where
+  # startup rewrites /sandbox rc files after CAP_DAC_OVERRIDE is gone.
+  hermes-onboard-security-posture-e2e:
+    if: >-
+      github.repository == 'NVIDIA/NemoClaw' &&
+      (github.event_name != 'workflow_dispatch' ||
+       inputs.jobs == '' ||
+       contains(format(',{0},', inputs.jobs), ',hermes-onboard-security-posture-e2e,'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.target_ref || github.ref }}
+
+      - name: Run Hermes onboard security posture E2E test
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          NEMOCLAW_NON_INTERACTIVE: "1"
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+          NEMOCLAW_SANDBOX_NAME: "e2e-hermes-security-posture"
+          NEMOCLAW_RECREATE_SANDBOX: "1"
+          NEMOCLAW_AGENT: "hermes"
+          NEMOCLAW_E2E_SECURITY_POSTURE: "1"
+          NEMOCLAW_E2E_EXPECT_NON_ROOT_HOST: "1"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash test/e2e/test-hermes-e2e.sh
+
+      - name: Upload install log on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: hermes-onboard-security-posture-install-log
           path: /tmp/nemoclaw-e2e-hermes-install.log
           if-no-files-found: ignore
 
@@ -2204,6 +2290,8 @@ jobs:
         sandbox-survival-e2e,
         issue-2478-crash-loop-recovery-e2e,
         hermes-e2e,
+        openclaw-onboard-security-posture-e2e,
+        hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,
         hermes-discord-e2e,
         hermes-slack-e2e,
@@ -2300,6 +2388,8 @@ jobs:
         sandbox-survival-e2e,
         issue-2478-crash-loop-recovery-e2e,
         hermes-e2e,
+        openclaw-onboard-security-posture-e2e,
+        hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,
         hermes-discord-e2e,
         hermes-slack-e2e,
@@ -2453,6 +2543,8 @@ jobs:
         sandbox-survival-e2e,
         issue-2478-crash-loop-recovery-e2e,
         hermes-e2e,
+        openclaw-onboard-security-posture-e2e,
+        hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,
         hermes-discord-e2e,
         hermes-slack-e2e,

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -31,11 +31,11 @@
 #   hermes-e2e               Hermes Agent E2E — install → onboard --agent hermes → health
 #                            probe → live inference. Validates the multi-agent architecture.
 #   openclaw-onboard-security-posture-e2e
-#                            Full OpenClaw onboard on a non-root host user with
-#                            post-drop capability and trusted rc-file assertions.
+#                            Full OpenClaw onboard on a non-root host/entrypoint
+#                            with trusted rc-file and runtime guard assertions.
 #   hermes-onboard-security-posture-e2e
-#                            Full Hermes onboard on a non-root host user with
-#                            post-drop capability and trusted rc-file assertions.
+#                            Full Hermes onboard on a non-root host/entrypoint
+#                            with trusted rc-file and runtime guard assertions.
 #   hermes-inference-switch-e2e
 #                            Switches a running Hermes sandbox with `nemohermes inference set`
 #                            and verifies route, config.yaml, hashes, and live requests.
@@ -792,8 +792,8 @@ jobs:
   # ── OpenClaw onboard security posture E2E ───────────────────────
   # Full OpenClaw install/onboard/inference path, then asserts the Linux
   # Docker-driver security posture that #3891 needed: non-root host user,
-  # post-drop PID 1 bounding caps without CAP_DAC_OVERRIDE, static root-owned
-  # rc shims, and dynamic configure guards only in /tmp/nemoclaw-proxy-env.sh.
+  # non-root sandbox entrypoint, static root-owned rc shims, and dynamic
+  # configure guards only in /tmp/nemoclaw-proxy-env.sh.
   openclaw-onboard-security-posture-e2e:
     if: >-
       github.repository == 'NVIDIA/NemoClaw' &&
@@ -817,6 +817,7 @@ jobs:
           NEMOCLAW_RECREATE_SANDBOX: "1"
           NEMOCLAW_E2E_SECURITY_POSTURE: "1"
           NEMOCLAW_E2E_EXPECT_NON_ROOT_HOST: "1"
+          NEMOCLAW_E2E_EXPECT_NON_ROOT_ENTRYPOINT: "1"
           GITHUB_TOKEN: ${{ github.token }}
         run: bash test/e2e/test-full-e2e.sh
 
@@ -831,7 +832,7 @@ jobs:
   # ── Hermes onboard security posture E2E ─────────────────────────
   # Full Hermes install/onboard/health/inference path with the same posture
   # assertions as OpenClaw. This specifically catches the #3891 class where
-  # startup rewrites /sandbox rc files after CAP_DAC_OVERRIDE is gone.
+  # startup rewrites /sandbox rc files from a non-root sandbox entrypoint.
   hermes-onboard-security-posture-e2e:
     if: >-
       github.repository == 'NVIDIA/NemoClaw' &&
@@ -856,6 +857,7 @@ jobs:
           NEMOCLAW_AGENT: "hermes"
           NEMOCLAW_E2E_SECURITY_POSTURE: "1"
           NEMOCLAW_E2E_EXPECT_NON_ROOT_HOST: "1"
+          NEMOCLAW_E2E_EXPECT_NON_ROOT_ENTRYPOINT: "1"
           GITHUB_TOKEN: ${{ github.token }}
         run: bash test/e2e/test-hermes-e2e.sh
 

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -31,10 +31,10 @@
 #   hermes-e2e               Hermes Agent E2E — install → onboard --agent hermes → health
 #                            probe → live inference. Validates the multi-agent architecture.
 #   openclaw-onboard-security-posture-e2e
-#                            Full OpenClaw onboard on a non-root host/entrypoint
+#                            Full OpenClaw onboard on a non-root host user
 #                            with trusted rc-file and runtime guard assertions.
 #   hermes-onboard-security-posture-e2e
-#                            Full Hermes onboard on a non-root host/entrypoint
+#                            Full Hermes onboard on a non-root host user
 #                            with trusted rc-file and runtime guard assertions.
 #   hermes-inference-switch-e2e
 #                            Switches a running Hermes sandbox with `nemohermes inference set`
@@ -792,8 +792,8 @@ jobs:
   # ── OpenClaw onboard security posture E2E ───────────────────────
   # Full OpenClaw install/onboard/inference path, then asserts the Linux
   # Docker-driver security posture that #3891 needed: non-root host user,
-  # non-root sandbox entrypoint, static root-owned rc shims, and dynamic
-  # configure guards only in /tmp/nemoclaw-proxy-env.sh.
+  # static root-owned rc shims, and dynamic configure guards only in
+  # /tmp/nemoclaw-proxy-env.sh.
   openclaw-onboard-security-posture-e2e:
     if: >-
       github.repository == 'NVIDIA/NemoClaw' &&
@@ -817,7 +817,6 @@ jobs:
           NEMOCLAW_RECREATE_SANDBOX: "1"
           NEMOCLAW_E2E_SECURITY_POSTURE: "1"
           NEMOCLAW_E2E_EXPECT_NON_ROOT_HOST: "1"
-          NEMOCLAW_E2E_EXPECT_NON_ROOT_ENTRYPOINT: "1"
           GITHUB_TOKEN: ${{ github.token }}
         run: bash test/e2e/test-full-e2e.sh
 
@@ -832,7 +831,7 @@ jobs:
   # ── Hermes onboard security posture E2E ─────────────────────────
   # Full Hermes install/onboard/health/inference path with the same posture
   # assertions as OpenClaw. This specifically catches the #3891 class where
-  # startup rewrites /sandbox rc files from a non-root sandbox entrypoint.
+  # startup rewrites /sandbox rc files under a non-root-host OpenShell posture.
   hermes-onboard-security-posture-e2e:
     if: >-
       github.repository == 'NVIDIA/NemoClaw' &&
@@ -857,7 +856,6 @@ jobs:
           NEMOCLAW_AGENT: "hermes"
           NEMOCLAW_E2E_SECURITY_POSTURE: "1"
           NEMOCLAW_E2E_EXPECT_NON_ROOT_HOST: "1"
-          NEMOCLAW_E2E_EXPECT_NON_ROOT_ENTRYPOINT: "1"
           GITHUB_TOKEN: ${{ github.token }}
         run: bash test/e2e/test-hermes-e2e.sh
 

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -807,6 +807,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.target_ref || github.ref }}
+          persist-credentials: false
 
       - name: Run OpenClaw onboard security posture E2E test
         env:
@@ -845,6 +846,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.target_ref || github.ref }}
+          persist-credentials: false
 
       - name: Run Hermes onboard security posture E2E test
         env:

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -125,8 +125,9 @@ RUN mkdir -p /sandbox/.hermes/memories \
 
 # Pre-create shell init files for the sandbox user.
 # The Hermes entrypoint writes proxy vars and
-# HERMES_HOME to /tmp/nemoclaw-proxy-env.sh (root-owned, mode 444); these rc
-# files source it on every interactive `openshell sandbox connect` session.
+# HERMES_HOME to /tmp/nemoclaw-proxy-env.sh (mode 444, root-owned when the
+# entrypoint runs as root); these rc files source it on every interactive
+# `openshell sandbox connect` session.
 # Ref: #2376.
 # hadolint ignore=SC2016,SC2028
 RUN printf '%s\n' \

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -227,9 +227,9 @@ else
 fi
 
 # SECURITY FIX: Write proxy config to a standalone file via
-# emit_sandbox_sourced_file() (root:root 444) instead of appending
-# inline to .bashrc/.profile. The old approach left .bashrc writable
-# by the sandbox user — same vulnerability class as #2181.
+# emit_sandbox_sourced_file() (444, root-owned when running as root) instead of
+# appending inline to .bashrc/.profile. The old approach rewrote files under
+# /sandbox during startup, which fails in non-root entrypoint postures.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/2277
 _PROXY_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
 write_runtime_shell_env() {

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -124,97 +124,6 @@ HERMES_HASH_FILE="/etc/nemoclaw/hermes.config-hash"
 
 # verify_config_integrity is provided by sandbox-init.sh (parameterized).
 
-rewrite_rc_marker_block() {
-  local rc_file="$1"
-  local marker_begin="$2"
-  local marker_end="$3"
-  local snippet="${4:-}"
-  local dir base tmp
-
-  [ -e "$rc_file" ] || return 0
-  if [ -L "$rc_file" ] || [ ! -f "$rc_file" ]; then
-    echo "[SECURITY] refusing unsafe rc file: $rc_file" >&2
-    return 1
-  fi
-
-  dir="$(dirname "$rc_file")"
-  base="$(basename "$rc_file")"
-  tmp="$(mktemp "${dir}/.${base}.tmp.XXXXXX")" || return 1
-
-  awk -v b="$marker_begin" -v e="$marker_end" \
-    '$0==b{s=1;next} $0==e{s=0;next} !s' "$rc_file" >"$tmp" 2>/dev/null || {
-    rm -f "$tmp"
-    return 1
-  }
-
-  if [ -n "$snippet" ]; then
-    printf '%s\n' "$snippet" >>"$tmp" || {
-      rm -f "$tmp"
-      return 1
-    }
-  fi
-
-  if [ "$(id -u)" -eq 0 ] && ! chown root:root "$tmp"; then
-    rm -f "$tmp"
-    return 1
-  fi
-  chmod 644 "$tmp" 2>/dev/null || true
-
-  if [ -L "$rc_file" ]; then
-    echo "[SECURITY] refusing symlinked rc file during replace: $rc_file" >&2
-    rm -f "$tmp"
-    return 1
-  fi
-  mv -f "$tmp" "$rc_file" 2>/dev/null || {
-    rm -f "$tmp"
-    return 1
-  }
-}
-
-rewrite_rc_marker_block_or_fail_in_root() {
-  local rc_file="$1"
-  if rewrite_rc_marker_block "$@"; then
-    return 0
-  fi
-  if [ "$(id -u)" -eq 0 ]; then
-    return 1
-  fi
-  echo "[setup] could not update rc file ${rc_file}; continuing in non-root mode" >&2
-  return 0
-}
-
-install_configure_guard() {
-  local marker_begin="# nemoclaw-configure-guard begin"
-  local marker_end="# nemoclaw-configure-guard end"
-  local snippet
-  read -r -d '' snippet <<'GUARD' || true
-# nemoclaw-configure-guard begin
-hermes() {
-  case "$1" in
-    setup|doctor)
-      echo "Error: 'hermes $1' cannot modify config inside the sandbox." >&2
-      echo "NemoClaw manages sandbox config from the host for integrity checks." >&2
-      echo "" >&2
-      echo "To change your configuration, exit the sandbox and run:" >&2
-      echo "  nemoclaw onboard --resume" >&2
-      return 1
-      ;;
-  esac
-  command hermes "$@"
-}
-# nemoclaw-configure-guard end
-GUARD
-
-  for rc_file in "${_SANDBOX_HOME}/.bashrc" "${_SANDBOX_HOME}/.profile"; do
-    [ -f "$rc_file" ] || continue
-    rewrite_rc_marker_block_or_fail_in_root "$rc_file" "$marker_begin" "$marker_end" "$snippet"
-  done
-  # SECURITY FIX: Lock .bashrc/.profile after all mutations are complete.
-  # This was missing in Hermes (unlike OpenClaw which had it via #2125),
-  # leaving rc files writable by the sandbox user. Ref: #2277
-  lock_rc_files "$_SANDBOX_HOME"
-}
-
 # configure_messaging_channels is provided by sandbox-init.sh (shared).
 
 print_dashboard_urls() {
@@ -308,8 +217,8 @@ if [ -n "${SSL_CERT_FILE:-}" ] && [ -f "${SSL_CERT_FILE}" ]; then
   export GIT_SSL_CAINFO="${GIT_SSL_CAINFO:-$SSL_CERT_FILE}"
 fi
 
-# Resolve sandbox home dir early — used by proxy-env writing and
-# install_configure_guard before the non-root/root branch below.
+# Resolve sandbox home dir early — used by proxy-env writing before the
+# non-root/root branch below.
 if [ "$(id -u)" -eq 0 ]; then
   _SANDBOX_HOME=$(getent passwd sandbox 2>/dev/null | cut -d: -f6)
   _SANDBOX_HOME="${_SANDBOX_HOME:-/sandbox}"
@@ -323,8 +232,9 @@ fi
 # by the sandbox user — same vulnerability class as #2181.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/2277
 _PROXY_ENV_FILE="/tmp/nemoclaw-proxy-env.sh"
-{
-  cat <<PROXYEOF
+write_runtime_shell_env() {
+  {
+    cat <<PROXYEOF
 # Proxy configuration (overrides narrow OpenShell defaults on connect)
 export HTTP_PROXY="$_PROXY_URL"
 export HTTPS_PROXY="$_PROXY_URL"
@@ -334,13 +244,37 @@ export https_proxy="$_PROXY_URL"
 export no_proxy="$_NO_PROXY_VAL"
 export HERMES_HOME="${HERMES_DIR}"
 PROXYEOF
-  for _ca_env_name in SSL_CERT_FILE CURL_CA_BUNDLE REQUESTS_CA_BUNDLE GIT_SSL_CAINFO; do
-    _ca_env_value="${!_ca_env_name:-}"
-    if [ -n "$_ca_env_value" ]; then
-      printf 'export %s=%q\n' "$_ca_env_name" "$_ca_env_value"
-    fi
-  done
-} | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"
+    for _ca_env_name in SSL_CERT_FILE CURL_CA_BUNDLE REQUESTS_CA_BUNDLE GIT_SSL_CAINFO; do
+      _ca_env_value="${!_ca_env_name:-}"
+      if [ -n "$_ca_env_value" ]; then
+        printf 'export %s=%q\n' "$_ca_env_name" "$_ca_env_value"
+      fi
+    done
+    cat <<'GUARDENVEOF'
+# nemoclaw-configure-guard begin
+hermes() {
+  case "$1" in
+    setup|doctor)
+      echo "Error: 'hermes $1' cannot modify config inside the sandbox." >&2
+      echo "NemoClaw manages sandbox config from the host for integrity checks." >&2
+      echo "" >&2
+      echo "To change your configuration, exit the sandbox and run:" >&2
+      echo "  nemoclaw onboard --resume" >&2
+      return 1
+      ;;
+  esac
+  command hermes "$@"
+}
+# nemoclaw-configure-guard end
+GUARDENVEOF
+  } | emit_sandbox_sourced_file "$_PROXY_ENV_FILE"
+}
+
+write_runtime_shell_env
+# SECURITY FIX: Lock .bashrc/.profile after all static shims are in place.
+# Hermes connect sessions source the dynamic guard from /tmp/nemoclaw-proxy-env.sh
+# so startup never needs to rewrite files directly under /sandbox after caps drop.
+lock_rc_files "$_SANDBOX_HOME"
 
 # ── Legacy layout migration ──────────────────────────────────────
 path_has_immutable_bit() {
@@ -617,7 +551,6 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
   fi
   refresh_hermes_provider_placeholders
-  install_configure_guard
   configure_messaging_channels
 
   if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
@@ -660,7 +593,6 @@ fi
 export HERMES_HOME="${HERMES_DIR}"
 verify_config_integrity "${HERMES_DIR}" "${HERMES_HASH_FILE}"
 refresh_hermes_provider_placeholders
-install_configure_guard
 configure_messaging_channels
 
 if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -38,6 +38,7 @@
  *   BREV_GPU_NAME          — GPU name filter when BREV_GPU_TYPE is unset (default: any GPU)
  *   BREV_GPU_MIN_VRAM      — Minimum total VRAM GB when BREV_GPU_TYPE is unset (default: 20)
  *   BREV_CREATE_TIMEOUT_SECONDS — Brev create timeout, seconds (default: 1200 for GPU)
+ *   BREV_SSH_READY_TIMEOUT_SECONDS — SSH readiness timeout, seconds (default: 900 CPU, 1800 GPU)
  *   TELEGRAM_BOT_TOKEN       — Telegram bot token for messaging-providers test (fake OK)
  *   DISCORD_BOT_TOKEN        — Discord bot token for messaging-providers test (fake OK)
  *   SLACK_BOT_TOKEN          — Slack bot token for messaging-providers test (fake OK)
@@ -76,6 +77,16 @@ const BREV_CREATE_TIMEOUT_MS =
     : GPU_TEST_SUITE
       ? 1200
       : 180) * 1000;
+const BREV_SSH_READY_TIMEOUT_SECONDS = parseInt(
+  process.env.BREV_SSH_READY_TIMEOUT_SECONDS || (GPU_TEST_SUITE ? "1800" : "900"),
+  10,
+);
+const BREV_SSH_READY_TIMEOUT_MS =
+  (Number.isFinite(BREV_SSH_READY_TIMEOUT_SECONDS) && BREV_SSH_READY_TIMEOUT_SECONDS > 0
+    ? BREV_SSH_READY_TIMEOUT_SECONDS
+    : GPU_TEST_SUITE
+      ? 1800
+      : 900) * 1000;
 
 function requireInstanceName(): string {
   if (!INSTANCE_NAME) {
@@ -101,6 +112,7 @@ let instanceCreated = false;
 
 const STREAM_STDIO: StdioOptions = ["inherit", "inherit", "inherit"];
 const CAPTURE_STDIO: StdioOptions = ["pipe", "pipe", "pipe"];
+const CAPTURE_OUTPUT_STDIO: StdioOptions = ["ignore", "pipe", "inherit"];
 const PIPE_INPUT_STDIO: StdioOptions = ["pipe", "inherit", "inherit"];
 
 // --- low-level helpers ------------------------------------------------------
@@ -113,14 +125,58 @@ function brev(...args: string[]): string {
   }).trim();
 }
 
-function listBrevInstances(): Array<{ name: string; status?: string }> {
+type BrevInstance = { name: string; status?: string };
+
+function normalizeBrevInstance(raw: unknown): BrevInstance | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+  const name = record.name ?? record.workspaceName ?? record.instanceName ?? record.Name;
+  if (typeof name !== "string" || !name.trim()) return null;
+  const status = record.status ?? record.state ?? record.lifecycleStatus ?? record.Status;
+  return {
+    name: name.trim(),
+    status: typeof status === "string" ? status.trim().toUpperCase() : undefined,
+  };
+}
+
+function parseBrevListOutput(output: string): BrevInstance[] {
+  const instances: BrevInstance[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const fields = trimmed.split(/\s+/);
+    const [name] = fields;
+    if (!name || /^(NAME|TYPE|Usage:|Error:|no)$/i.test(name)) continue;
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name)) continue;
+    const status = fields.find((field) =>
+      /^(CREATING|DELETING|FAILED|OFF|ON|READY|RUNNING|STARTING|STOPPED|STOPPING)$/i.test(field),
+    );
+    instances.push({
+      name,
+      status: status?.toUpperCase(),
+    });
+  }
+  return instances;
+}
+
+function listBrevInstances(): BrevInstance[] {
   try {
     const parsed = JSON.parse(brev("ls", "--json"));
-    if (Array.isArray(parsed)) return parsed;
-    if (Array.isArray(parsed?.workspaces)) return parsed.workspaces;
-    return [];
+    const rawInstances = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.workspaces)
+        ? parsed.workspaces
+        : [];
+    return rawInstances.flatMap((instance) => {
+      const normalized = normalizeBrevInstance(instance);
+      return normalized ? [normalized] : [];
+    });
   } catch {
-    return [];
+    try {
+      return parseBrevListOutput(brev("ls"));
+    } catch {
+      return [];
+    }
   }
 }
 
@@ -141,8 +197,10 @@ function deleteBrevInstance(instanceName: string): boolean {
     return true;
   }
 
+  let deleteRequested = false;
   try {
     brev("delete", instanceName);
+    deleteRequested = true;
   } catch {
     // Best-effort delete
   }
@@ -153,7 +211,7 @@ function deleteBrevInstance(instanceName: string): boolean {
     return true;
   }
 
-  return false;
+  return deleteRequested;
 }
 
 function waitForBrevInstanceRemoved(
@@ -236,11 +294,13 @@ function sshEnv(
   return ssh(`${envPrefix} && ${cmd}`, { timeout, stream });
 }
 
-function waitForSsh(maxAttempts = GPU_TEST_SUITE ? 180 : 40, intervalMs = 5_000): void {
+function waitForSsh(maxWaitMs = BREV_SSH_READY_TIMEOUT_MS, intervalMs = 5_000): void {
+  const deadline = Date.now() + maxWaitMs;
+  let attempts = 0;
   let dnsFailures = 0;
   let lastError = "";
-  const maxDnsFailures = GPU_TEST_SUITE ? 60 : 15;
-  for (let i = 1; i <= maxAttempts; i++) {
+  while (Date.now() < deadline) {
+    attempts += 1;
     try {
       ssh("echo ok", { timeout: 10_000 });
       return;
@@ -251,18 +311,10 @@ function waitForSsh(maxAttempts = GPU_TEST_SUITE ? 180 : 40, intervalMs = 5_000)
       } else {
         dnsFailures = 0;
       }
-      if (dnsFailures >= maxDnsFailures) {
-        throw new Error(
-          `SSH alias did not resolve after ${dnsFailures} consecutive attempts. Last SSH error: ${lastError}`,
-        );
-      }
-      if (i === maxAttempts) {
-        throw new Error(
-          `SSH not ready after ${maxAttempts} attempts (~${Math.round((maxAttempts * (intervalMs + 10_000)) / 60_000)} min). Last SSH error: ${lastError}`,
-        );
-      }
-      console.log(`  SSH attempt ${i}/${maxAttempts} failed, retrying in ${intervalMs / 1000}s...`);
-      if (i % 5 === 0) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) break;
+      console.log(`  SSH attempt ${attempts} failed, retrying in ${intervalMs / 1000}s...`);
+      if (attempts % 5 === 0) {
         console.log(`  Refreshing brev SSH config...`);
         try {
           brev("refresh");
@@ -270,9 +322,14 @@ function waitForSsh(maxAttempts = GPU_TEST_SUITE ? 180 : 40, intervalMs = 5_000)
           /* ignore */
         }
       }
-      execSync(`sleep ${intervalMs / 1000}`);
+      execSync(`sleep ${Math.max(1, Math.ceil(Math.min(intervalMs, remainingMs) / 1000))}`);
     }
   }
+  throw new Error(
+    `SSH not ready after ${Math.round(maxWaitMs / 60_000)} min ` +
+      `(${attempts} attempts, ${dnsFailures} hostname-resolution failures). ` +
+      `Last SSH error: ${lastError}`,
+  );
 }
 
 /**
@@ -580,7 +637,7 @@ function createBrevInstance(elapsed: () => string): void {
           gpuCandidates = execFileSync("brev", gpuSearchArgs, {
             encoding: "utf-8",
             timeout: 120_000,
-            stdio: ["ignore", "pipe", "inherit"],
+            stdio: CAPTURE_OUTPUT_STDIO,
           });
         } catch (searchErr) {
           throw new Error(
@@ -618,7 +675,7 @@ function createBrevInstance(elapsed: () => string): void {
           "--sort",
           "price",
         ],
-        { encoding: "utf-8", timeout: 120_000, stdio: PIPE_INPUT_STDIO },
+        { encoding: "utf-8", timeout: 120_000, stdio: CAPTURE_OUTPUT_STDIO },
       );
       execFileSync(
         "brev",

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -167,7 +167,7 @@ function listBrevInstances(): BrevInstance[] {
       : Array.isArray(parsed?.workspaces)
         ? parsed.workspaces
         : [];
-    return rawInstances.flatMap((instance) => {
+    return rawInstances.flatMap((instance: unknown) => {
       const normalized = normalizeBrevInstance(instance);
       return normalized ? [normalized] : [];
     });

--- a/test/e2e/lib/security-posture-assertions.sh
+++ b/test/e2e/lib/security-posture-assertions.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared assertions for full onboard tests that need to prove the Linux
+# Docker-driver security posture that caught the Hermes rc-file startup bug.
+# The caller provides the e2e `section`, `info`, `pass`, and `fail` functions.
+
+security_posture_sandbox_exec() {
+  local sandbox_name="$1"
+  local remote_cmd="$2"
+  openshell sandbox exec --name "$sandbox_name" -- sh -lc "$remote_cmd" 2>&1
+}
+
+security_posture_cap_absent() {
+  local cap_hex="$1"
+  local bit="$2"
+  local cap_name="$3"
+  local context="$4"
+  local cap_val
+
+  cap_val=$((16#$cap_hex))
+  if [ $(((cap_val >> bit) & 1)) -eq 0 ]; then
+    pass "${context}: ${cap_name} absent from CapBnd (0x${cap_hex})"
+  else
+    fail "${context}: ${cap_name} still present in CapBnd (0x${cap_hex})"
+  fi
+}
+
+security_posture_assert_host_user() {
+  if [ "${NEMOCLAW_E2E_EXPECT_NON_ROOT_HOST:-}" != "1" ]; then
+    return 0
+  fi
+
+  local uid gid
+  uid="$(id -u)"
+  gid="$(id -g)"
+  if [ "$uid" -eq 0 ]; then
+    fail "Host test process is running as root; expected a non-root host user"
+  else
+    pass "Host test process is non-root (uid=${uid}, gid=${gid})"
+  fi
+}
+
+security_posture_assert_entrypoint_caps() {
+  local sandbox_name="$1"
+  local out cap_bnd no_new_privs
+
+  out="$(security_posture_sandbox_exec "$sandbox_name" 'grep -E "^(CapBnd|NoNewPrivs):" /proc/1/status 2>/dev/null || true')" || true
+  info "PID 1 status: ${out//$'\n'/; }"
+  cap_bnd="$(printf '%s\n' "$out" | awk '/^CapBnd:/ { print $2; exit }')"
+  no_new_privs="$(printf '%s\n' "$out" | awk '/^NoNewPrivs:/ { print $2; exit }')"
+
+  if [ -z "$cap_bnd" ]; then
+    fail "Could not capture PID 1 CapBnd from sandbox ${sandbox_name}: ${out:0:300}"
+    return 0
+  fi
+
+  security_posture_cap_absent "$cap_bnd" 21 CAP_SYS_ADMIN "Entrypoint PID 1"
+  security_posture_cap_absent "$cap_bnd" 19 CAP_SYS_PTRACE "Entrypoint PID 1"
+  security_posture_cap_absent "$cap_bnd" 13 CAP_NET_RAW "Entrypoint PID 1"
+  security_posture_cap_absent "$cap_bnd" 10 CAP_NET_BIND_SERVICE "Entrypoint PID 1"
+  security_posture_cap_absent "$cap_bnd" 1 CAP_DAC_OVERRIDE "Entrypoint PID 1"
+
+  if [ "${NEMOCLAW_E2E_EXPECT_NO_NEW_PRIVS:-}" = "1" ]; then
+    if [ "$no_new_privs" = "1" ]; then
+      pass "Entrypoint PID 1 has NoNewPrivs=1"
+    else
+      fail "Entrypoint PID 1 expected NoNewPrivs=1, got '${no_new_privs:-<missing>}'"
+    fi
+  elif [ -n "$no_new_privs" ]; then
+    info "Entrypoint PID 1 NoNewPrivs=${no_new_privs}"
+  fi
+}
+
+security_posture_assert_rc_files() {
+  local sandbox_name="$1"
+  local out rc
+
+  rc=0
+  out="$(security_posture_sandbox_exec "$sandbox_name" 'bad=0; for f in /sandbox/.bashrc /sandbox/.profile; do if [ ! -f "$f" ]; then echo "MISSING $f"; bad=1; continue; fi; if [ -L "$f" ]; then echo "SYMLINK $f"; bad=1; fi; meta=$(stat -c "%a %U:%G" "$f" 2>/dev/null || true); echo "META $f $meta"; set -- $meta; mode="${1:-}"; owner="${2:-}"; if [ "$mode" != "444" ]; then echo "BAD_MODE $f $mode"; bad=1; fi; if [ "$owner" != "root:root" ]; then echo "BAD_OWNER $f $owner"; bad=1; fi; if grep -Eq "nemoclaw-configure-guard|^(openclaw|hermes)\(\)" "$f" 2>/dev/null; then echo "INLINE_GUARD $f"; bad=1; fi; done; exit "$bad"')" || rc=$?
+  info "rc-file metadata: ${out//$'\n'/; }"
+  if [ "$rc" -eq 0 ]; then
+    pass "Sandbox rc files are static root-owned 444 shims without inline configure guards"
+  else
+    fail "Sandbox rc files are not locked/static as expected: ${out:0:500}"
+  fi
+}
+
+security_posture_assert_proxy_env() {
+  local sandbox_name="$1"
+  local agent_name="$2"
+  local function_name guard_arg out rc
+
+  case "$agent_name" in
+    hermes)
+      function_name="hermes"
+      guard_arg="setup"
+      ;;
+    *)
+      function_name="openclaw"
+      guard_arg="configure"
+      ;;
+  esac
+
+  rc=0
+  out="$(security_posture_sandbox_exec "$sandbox_name" "f=/tmp/nemoclaw-proxy-env.sh; bad=0; if [ ! -f \"\$f\" ]; then echo MISSING_PROXY_ENV; exit 1; fi; if [ -L \"\$f\" ]; then echo SYMLINK_PROXY_ENV; bad=1; fi; meta=\$(stat -c \"%a %U:%G\" \"\$f\" 2>/dev/null || true); echo \"META \$f \$meta\"; set -- \$meta; mode=\"\${1:-}\"; owner=\"\${2:-}\"; if [ \"\$mode\" != \"444\" ]; then echo \"BAD_PROXY_ENV_MODE \$mode\"; bad=1; fi; if [ \"\$owner\" != \"root:root\" ]; then echo \"BAD_PROXY_ENV_OWNER \$owner\"; bad=1; fi; grep -Fq '# nemoclaw-configure-guard begin' \"\$f\" || { echo MISSING_GUARD_BEGIN; bad=1; }; grep -Fq '${function_name}() {' \"\$f\" || { echo MISSING_AGENT_GUARD_FUNCTION; bad=1; }; grep -Fq '# nemoclaw-configure-guard end' \"\$f\" || { echo MISSING_GUARD_END; bad=1; }; exit \"\$bad\"")" || rc=$?
+  info "runtime proxy-env metadata: ${out//$'\n'/; }"
+  if [ "$rc" -eq 0 ]; then
+    pass "Runtime proxy env is root-owned 444 and carries the ${function_name} configure guard"
+  else
+    fail "Runtime proxy env is not locked or missing guard content: ${out:0:500}"
+  fi
+
+  rc=0
+  out="$(security_posture_sandbox_exec "$sandbox_name" ". /tmp/nemoclaw-proxy-env.sh || { echo SOURCE_FAILED; exit 1; }; if ${function_name} ${guard_arg} >/tmp/nemoclaw-security-guard-probe.out 2>&1; then echo GUARD_DID_NOT_BLOCK; cat /tmp/nemoclaw-security-guard-probe.out; exit 1; fi; cat /tmp/nemoclaw-security-guard-probe.out; grep -q 'cannot modify config inside the sandbox' /tmp/nemoclaw-security-guard-probe.out || { echo GUARD_MESSAGE_MISSING; exit 1; }")" || rc=$?
+  info "configure guard probe: ${out//$'\n'/; }"
+  if [ "$rc" -eq 0 ]; then
+    pass "${function_name} ${guard_arg} is blocked by the runtime guard after sourcing proxy-env"
+  else
+    fail "Runtime configure guard did not behave as expected: ${out:0:500}"
+  fi
+}
+
+security_posture_assert_start_log() {
+  local sandbox_name="$1"
+  local agent_name="$2"
+  local out rc launch_pattern
+
+  case "$agent_name" in
+    hermes) launch_pattern='hermes gateway launched' ;;
+    *) launch_pattern='openclaw gateway launched' ;;
+  esac
+
+  rc=0
+  out="$(security_posture_sandbox_exec "$sandbox_name" "log=/tmp/nemoclaw-start.log; bad=0; [ -f \"\$log\" ] || { echo MISSING_START_LOG; exit 1; }; if ! grep -qi '${launch_pattern}' \"\$log\"; then echo MISSING_GATEWAY_LAUNCH_MARKER; bad=1; fi; if grep -E 'mktemp:.*(/sandbox/\\.\\.(bashrc|profile)\\.tmp|/sandbox/\\.nemoclaw.*tmp)|Permission denied.*(/sandbox/\\.bashrc|/sandbox/\\.profile)' \"\$log\"; then echo START_LOG_HAS_RC_WRITE_FAILURE; bad=1; fi; tail -n 20 \"\$log\"; exit \"\$bad\"")" || rc=$?
+  info "start log probe: ${out//$'\n'/; }"
+  if [ "$rc" -eq 0 ]; then
+    pass "Startup log has no rc-file mktemp/permission failure"
+  else
+    fail "Startup log shows the rc-file write failure class: ${out:0:500}"
+  fi
+}
+
+security_posture_assertions_run() {
+  local sandbox_name="$1"
+  local agent_name="${2:-openclaw}"
+
+  section "Security posture regression checks"
+  security_posture_assert_host_user
+  security_posture_assert_entrypoint_caps "$sandbox_name"
+  security_posture_assert_rc_files "$sandbox_name"
+  security_posture_assert_proxy_env "$sandbox_name" "$agent_name"
+  security_posture_assert_start_log "$sandbox_name" "$agent_name"
+}

--- a/test/e2e/lib/security-posture-assertions.sh
+++ b/test/e2e/lib/security-posture-assertions.sh
@@ -42,25 +42,75 @@ security_posture_assert_host_user() {
   fi
 }
 
-security_posture_assert_entrypoint_caps() {
-  local sandbox_name="$1"
-  local out cap_bnd no_new_privs
+security_posture_dangerous_caps_present() {
+  local cap_hex="$1"
+  local val entry bit name present_caps=""
 
-  out="$(security_posture_sandbox_exec "$sandbox_name" 'grep -E "^(CapBnd|NoNewPrivs):" /proc/1/status 2>/dev/null || true')" || true
+  val=$((16#$cap_hex))
+  for entry in \
+    "21:CAP_SYS_ADMIN" \
+    "19:CAP_SYS_PTRACE" \
+    "13:CAP_NET_RAW" \
+    "10:CAP_NET_BIND_SERVICE" \
+    "1:CAP_DAC_OVERRIDE"; do
+    bit="${entry%%:*}"
+    name="${entry#*:}"
+    if [ $(((val >> bit) & 1)) -ne 0 ]; then
+      present_caps="${present_caps:+$present_caps,}$name"
+    fi
+  done
+  printf '%s\n' "$present_caps"
+}
+
+security_posture_assert_entrypoint_process() {
+  local sandbox_name="$1"
+  local out cap_bnd cap_eff no_new_privs entry_uid present_caps
+
+  out="$(security_posture_sandbox_exec "$sandbox_name" 'grep -E "^(Uid|Gid|CapBnd|CapEff|NoNewPrivs):" /proc/1/status 2>/dev/null || true')" || true
   info "PID 1 status: ${out//$'\n'/; }"
+  entry_uid="$(printf '%s\n' "$out" | awk '/^Uid:/ { print $2; exit }')"
   cap_bnd="$(printf '%s\n' "$out" | awk '/^CapBnd:/ { print $2; exit }')"
+  cap_eff="$(printf '%s\n' "$out" | awk '/^CapEff:/ { print $2; exit }')"
   no_new_privs="$(printf '%s\n' "$out" | awk '/^NoNewPrivs:/ { print $2; exit }')"
+
+  if [ "${NEMOCLAW_E2E_EXPECT_NON_ROOT_ENTRYPOINT:-}" = "1" ]; then
+    if [ -n "$entry_uid" ] && [ "$entry_uid" != "0" ]; then
+      pass "Entrypoint PID 1 is non-root inside the sandbox (uid=${entry_uid})"
+    else
+      fail "Entrypoint PID 1 expected non-root uid, got '${entry_uid:-<missing>}'"
+    fi
+  elif [ -n "$entry_uid" ]; then
+    info "Entrypoint PID 1 uid=${entry_uid}"
+  fi
 
   if [ -z "$cap_bnd" ]; then
     fail "Could not capture PID 1 CapBnd from sandbox ${sandbox_name}: ${out:0:300}"
     return 0
   fi
 
-  security_posture_cap_absent "$cap_bnd" 21 CAP_SYS_ADMIN "Entrypoint PID 1"
-  security_posture_cap_absent "$cap_bnd" 19 CAP_SYS_PTRACE "Entrypoint PID 1"
-  security_posture_cap_absent "$cap_bnd" 13 CAP_NET_RAW "Entrypoint PID 1"
-  security_posture_cap_absent "$cap_bnd" 10 CAP_NET_BIND_SERVICE "Entrypoint PID 1"
-  security_posture_cap_absent "$cap_bnd" 1 CAP_DAC_OVERRIDE "Entrypoint PID 1"
+  if [ "${NEMOCLAW_E2E_EXPECT_DROPPED_BOUNDS:-}" = "1" ]; then
+    security_posture_cap_absent "$cap_bnd" 21 CAP_SYS_ADMIN "Entrypoint PID 1"
+    security_posture_cap_absent "$cap_bnd" 19 CAP_SYS_PTRACE "Entrypoint PID 1"
+    security_posture_cap_absent "$cap_bnd" 13 CAP_NET_RAW "Entrypoint PID 1"
+    security_posture_cap_absent "$cap_bnd" 10 CAP_NET_BIND_SERVICE "Entrypoint PID 1"
+    security_posture_cap_absent "$cap_bnd" 1 CAP_DAC_OVERRIDE "Entrypoint PID 1"
+  else
+    present_caps="$(security_posture_dangerous_caps_present "$cap_bnd")"
+    if [ -n "$present_caps" ]; then
+      info "Entrypoint PID 1 residual CapBnd dangerous caps: ${present_caps}"
+    else
+      pass "Entrypoint PID 1 dangerous caps are absent from CapBnd"
+    fi
+  fi
+
+  if [ -n "$cap_eff" ]; then
+    present_caps="$(security_posture_dangerous_caps_present "$cap_eff")"
+    if [ -n "$present_caps" ]; then
+      info "Entrypoint PID 1 residual CapEff dangerous caps: ${present_caps}"
+    else
+      pass "Entrypoint PID 1 dangerous caps are absent from CapEff"
+    fi
+  fi
 
   if [ "${NEMOCLAW_E2E_EXPECT_NO_NEW_PRIVS:-}" = "1" ]; then
     if [ "$no_new_privs" = "1" ]; then
@@ -104,10 +154,10 @@ security_posture_assert_proxy_env() {
   esac
 
   rc=0
-  out="$(security_posture_sandbox_exec "$sandbox_name" "f=/tmp/nemoclaw-proxy-env.sh; bad=0; if [ ! -f \"\$f\" ]; then echo MISSING_PROXY_ENV; exit 1; fi; if [ -L \"\$f\" ]; then echo SYMLINK_PROXY_ENV; bad=1; fi; meta=\$(stat -c \"%a %U:%G\" \"\$f\" 2>/dev/null || true); echo \"META \$f \$meta\"; set -- \$meta; mode=\"\${1:-}\"; owner=\"\${2:-}\"; if [ \"\$mode\" != \"444\" ]; then echo \"BAD_PROXY_ENV_MODE \$mode\"; bad=1; fi; if [ \"\$owner\" != \"root:root\" ]; then echo \"BAD_PROXY_ENV_OWNER \$owner\"; bad=1; fi; grep -Fq '# nemoclaw-configure-guard begin' \"\$f\" || { echo MISSING_GUARD_BEGIN; bad=1; }; grep -Fq '${function_name}() {' \"\$f\" || { echo MISSING_AGENT_GUARD_FUNCTION; bad=1; }; grep -Fq '# nemoclaw-configure-guard end' \"\$f\" || { echo MISSING_GUARD_END; bad=1; }; exit \"\$bad\"")" || rc=$?
+  out="$(security_posture_sandbox_exec "$sandbox_name" "f=/tmp/nemoclaw-proxy-env.sh; bad=0; if [ ! -f \"\$f\" ]; then echo MISSING_PROXY_ENV; exit 1; fi; if [ -L \"\$f\" ]; then echo SYMLINK_PROXY_ENV; bad=1; fi; meta=\$(stat -c \"%a %U:%G\" \"\$f\" 2>/dev/null || true); echo \"META \$f \$meta\"; set -- \$meta; mode=\"\${1:-}\"; owner=\"\${2:-}\"; current_owner=\"\$(id -un):\$(id -gn)\"; if [ \"\$mode\" != \"444\" ]; then echo \"BAD_PROXY_ENV_MODE \$mode\"; bad=1; fi; case \"\$owner\" in root:root) ;; \"\$current_owner\") echo \"NON_ROOT_PROXY_ENV_OWNER \$owner\" ;; *) echo \"BAD_PROXY_ENV_OWNER \$owner\"; bad=1 ;; esac; grep -Fq '# nemoclaw-configure-guard begin' \"\$f\" || { echo MISSING_GUARD_BEGIN; bad=1; }; grep -Fq '${function_name}() {' \"\$f\" || { echo MISSING_AGENT_GUARD_FUNCTION; bad=1; }; grep -Fq '# nemoclaw-configure-guard end' \"\$f\" || { echo MISSING_GUARD_END; bad=1; }; exit \"\$bad\"")" || rc=$?
   info "runtime proxy-env metadata: ${out//$'\n'/; }"
   if [ "$rc" -eq 0 ]; then
-    pass "Runtime proxy env is root-owned 444 and carries the ${function_name} configure guard"
+    pass "Runtime proxy env is mode 444 and carries the ${function_name} configure guard"
   else
     fail "Runtime proxy env is not locked or missing guard content: ${out:0:500}"
   fi
@@ -148,7 +198,7 @@ security_posture_assertions_run() {
 
   section "Security posture regression checks"
   security_posture_assert_host_user
-  security_posture_assert_entrypoint_caps "$sandbox_name"
+  security_posture_assert_entrypoint_process "$sandbox_name"
   security_posture_assert_rc_files "$sandbox_name"
   security_posture_assert_proxy_env "$sandbox_name" "$agent_name"
   security_posture_assert_start_log "$sandbox_name" "$agent_name"

--- a/test/e2e/lib/security-posture-assertions.sh
+++ b/test/e2e/lib/security-posture-assertions.sh
@@ -141,7 +141,7 @@ security_posture_assert_rc_files() {
 security_posture_assert_proxy_env() {
   local sandbox_name="$1"
   local agent_name="$2"
-  local function_name guard_arg out rc
+  local function_name guard_arg out rc allow_non_root_owner
 
   case "$agent_name" in
     hermes)
@@ -154,11 +154,19 @@ security_posture_assert_proxy_env() {
       ;;
   esac
 
+  allow_non_root_owner=0
+  if [ "${NEMOCLAW_E2E_EXPECT_NON_ROOT_HOST:-}" = "1" ]; then
+    # OpenShell's non-root host posture creates the runtime proxy-env file
+    # after dropping to the sandbox user. Keep root ownership required in
+    # normal lanes, but accept current-user ownership for that explicit lane.
+    allow_non_root_owner=1
+  fi
+
   rc=0
-  out="$(security_posture_sandbox_exec "$sandbox_name" "f=/tmp/nemoclaw-proxy-env.sh; bad=0; if [ ! -f \"\$f\" ]; then echo MISSING_PROXY_ENV; exit 1; fi; if [ -L \"\$f\" ]; then echo SYMLINK_PROXY_ENV; bad=1; fi; meta=\$(stat -c \"%a %U:%G\" \"\$f\" 2>/dev/null || true); echo \"META \$f \$meta\"; set -- \$meta; mode=\"\${1:-}\"; owner=\"\${2:-}\"; current_owner=\"\$(id -un):\$(id -gn)\"; if [ \"\$mode\" != \"444\" ]; then echo \"BAD_PROXY_ENV_MODE \$mode\"; bad=1; fi; case \"\$owner\" in root:root) ;; \"\$current_owner\") echo \"NON_ROOT_PROXY_ENV_OWNER \$owner\" ;; *) echo \"BAD_PROXY_ENV_OWNER \$owner\"; bad=1 ;; esac; grep -Fq '# nemoclaw-configure-guard begin' \"\$f\" || { echo MISSING_GUARD_BEGIN; bad=1; }; grep -Fq '${function_name}() {' \"\$f\" || { echo MISSING_AGENT_GUARD_FUNCTION; bad=1; }; grep -Fq '# nemoclaw-configure-guard end' \"\$f\" || { echo MISSING_GUARD_END; bad=1; }; exit \"\$bad\"")" || rc=$?
+  out="$(security_posture_sandbox_exec "$sandbox_name" "f=/tmp/nemoclaw-proxy-env.sh; allow_non_root_owner=${allow_non_root_owner}; bad=0; if [ ! -f \"\$f\" ]; then echo MISSING_PROXY_ENV; exit 1; fi; if [ -L \"\$f\" ]; then echo SYMLINK_PROXY_ENV; bad=1; fi; meta=\$(stat -c \"%a %U:%G\" \"\$f\" 2>/dev/null || true); echo \"META \$f \$meta\"; set -- \$meta; mode=\"\${1:-}\"; owner=\"\${2:-}\"; current_owner=\"\$(id -un):\$(id -gn)\"; if [ \"\$mode\" != \"444\" ]; then echo \"BAD_PROXY_ENV_MODE \$mode\"; bad=1; fi; case \"\$owner\" in root:root) ;; \"\$current_owner\") if [ \"\$allow_non_root_owner\" = \"1\" ]; then echo \"NON_ROOT_PROXY_ENV_OWNER \$owner\"; else echo \"BAD_PROXY_ENV_OWNER \$owner\"; bad=1; fi ;; *) echo \"BAD_PROXY_ENV_OWNER \$owner\"; bad=1 ;; esac; grep -Fq '# nemoclaw-configure-guard begin' \"\$f\" || { echo MISSING_GUARD_BEGIN; bad=1; }; grep -Fq '${function_name}() {' \"\$f\" || { echo MISSING_AGENT_GUARD_FUNCTION; bad=1; }; grep -Fq '# nemoclaw-configure-guard end' \"\$f\" || { echo MISSING_GUARD_END; bad=1; }; exit \"\$bad\"")" || rc=$?
   info "runtime proxy-env metadata: ${out//$'\n'/; }"
   if [ "$rc" -eq 0 ]; then
-    pass "Runtime proxy env is mode 444 and carries the ${function_name} configure guard"
+    pass "Runtime proxy env is mode 444 with an accepted owner and carries the ${function_name} configure guard"
   else
     fail "Runtime proxy env is not locked or missing guard content: ${out:0:500}"
   fi

--- a/test/e2e/lib/security-posture-assertions.sh
+++ b/test/e2e/lib/security-posture-assertions.sh
@@ -128,6 +128,7 @@ security_posture_assert_rc_files() {
   local out rc
 
   rc=0
+  # shellcheck disable=SC2016 # Remote shell snippet; expansion must happen inside the sandbox.
   out="$(security_posture_sandbox_exec "$sandbox_name" 'bad=0; for f in /sandbox/.bashrc /sandbox/.profile; do if [ ! -f "$f" ]; then echo "MISSING $f"; bad=1; continue; fi; if [ -L "$f" ]; then echo "SYMLINK $f"; bad=1; fi; meta=$(stat -c "%a %U:%G" "$f" 2>/dev/null || true); echo "META $f $meta"; set -- $meta; mode="${1:-}"; owner="${2:-}"; if [ "$mode" != "444" ]; then echo "BAD_MODE $f $mode"; bad=1; fi; if [ "$owner" != "root:root" ]; then echo "BAD_OWNER $f $owner"; bad=1; fi; if grep -Eq "nemoclaw-configure-guard|^(openclaw|hermes)\(\)" "$f" 2>/dev/null; then echo "INLINE_GUARD $f"; bad=1; fi; done; exit "$bad"')" || rc=$?
   info "rc-file metadata: ${out//$'\n'/; }"
   if [ "$rc" -eq 0 ]; then

--- a/test/e2e/test-full-e2e.sh
+++ b/test/e2e/test-full-e2e.sh
@@ -435,6 +435,15 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════
+# Optional Phase 5b: Security posture regression checks
+# ══════════════════════════════════════════════════════════════════
+if [ "${NEMOCLAW_E2E_SECURITY_POSTURE:-}" = "1" ]; then
+  # shellcheck source=test/e2e/lib/security-posture-assertions.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/lib/security-posture-assertions.sh"
+  security_posture_assertions_run "$SANDBOX_NAME" "openclaw"
+fi
+
+# ══════════════════════════════════════════════════════════════════
 # Phase 6: Cleanup
 # ══════════════════════════════════════════════════════════════════
 section "Phase 6: Cleanup"

--- a/test/e2e/test-hermes-e2e.sh
+++ b/test/e2e/test-hermes-e2e.sh
@@ -553,6 +553,15 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════
+# Optional Phase 7b: Security posture regression checks
+# ══════════════════════════════════════════════════════════════════
+if [ "${NEMOCLAW_E2E_SECURITY_POSTURE:-}" = "1" ]; then
+  # shellcheck source=test/e2e/lib/security-posture-assertions.sh
+  . "$(dirname "${BASH_SOURCE[0]}")/lib/security-posture-assertions.sh"
+  security_posture_assertions_run "$SANDBOX_NAME" "hermes"
+fi
+
+# ══════════════════════════════════════════════════════════════════
 # Phase 8: Cleanup
 # ══════════════════════════════════════════════════════════════════
 section "Phase 8: Cleanup"

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -152,7 +152,8 @@ describe("agents/hermes/start.sh runtime shell env", () => {
     expect(run.result.status).toBe(0);
     expect(run.envFileMode).toBe("444");
     expect(run.envFileContent).toContain(`export HERMES_HOME="${run.hermesHome}"`);
-    expect(run.envFileContent).toContain(`export SSL_CERT_FILE=${run.caFile.replace(/ /g, "\\ ")}`);
+    expect(run.envFileContent).toContain("export SSL_CERT_FILE=");
+    expect(run.envFileContent).toContain("/proxy\\ ca.pem");
     expect(run.envFileContent).toContain("# nemoclaw-configure-guard begin");
     expect(run.envFileContent).toContain("hermes() {");
     expect(run.envFileContent).toContain("# nemoclaw-configure-guard end");

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -148,11 +148,12 @@ function runRuntimeShellEnvBootstrap() {
 describe("agents/hermes/start.sh runtime shell env", () => {
   it("puts the Hermes configure guard in the sourced proxy env file", () => {
     const run = runRuntimeShellEnvBootstrap();
+    const escapedCaFile = run.caFile.replace(/ /g, "\\ ");
 
     expect(run.result.status).toBe(0);
     expect(run.envFileMode).toBe("444");
     expect(run.envFileContent).toContain(`export HERMES_HOME="${run.hermesHome}"`);
-    expect(run.envFileContent).toMatch(/^export SSL_CERT_FILE=.*\/proxy\\ ca\.pem$/m);
+    expect(run.envFileContent).toContain(`export SSL_CERT_FILE=${escapedCaFile}`);
     expect(run.envFileContent).toContain("# nemoclaw-configure-guard begin");
     expect(run.envFileContent).toContain("hermes() {");
     expect(run.envFileContent).toContain("# nemoclaw-configure-guard end");

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -152,8 +152,7 @@ describe("agents/hermes/start.sh runtime shell env", () => {
     expect(run.result.status).toBe(0);
     expect(run.envFileMode).toBe("444");
     expect(run.envFileContent).toContain(`export HERMES_HOME="${run.hermesHome}"`);
-    expect(run.envFileContent).toContain("export SSL_CERT_FILE=");
-    expect(run.envFileContent).toContain("/proxy\\ ca.pem");
+    expect(run.envFileContent).toMatch(/^export SSL_CERT_FILE=.*\/proxy\\ ca\.pem$/m);
     expect(run.envFileContent).toContain("# nemoclaw-configure-guard begin");
     expect(run.envFileContent).toContain("hermes() {");
     expect(run.envFileContent).toContain("# nemoclaw-configure-guard end");

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -13,6 +13,18 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+function bashPrintfQ(value: string): string {
+  const result = spawnSync("bash", ["-c", "printf '%q' \"$1\"", "bash-printf-q", value], {
+    encoding: "utf-8",
+    timeout: 5000,
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(`bash printf %q failed: ${result.stderr}`);
+  }
+  return result.stdout;
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -148,7 +160,7 @@ function runRuntimeShellEnvBootstrap() {
 describe("agents/hermes/start.sh runtime shell env", () => {
   it("puts the Hermes configure guard in the sourced proxy env file", () => {
     const run = runRuntimeShellEnvBootstrap();
-    const escapedCaFile = run.caFile.replace(/ /g, "\\ ");
+    const escapedCaFile = bashPrintfQ(run.caFile);
 
     expect(run.result.status).toBe(0);
     expect(run.envFileMode).toBe("444");

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -26,6 +26,15 @@ function extractShellFunctionFromSource(src: string, name: string): string {
   return `${name}() {${match[1]}\n}`;
 }
 
+function extractRuntimeShellEnvBlock(src: string): string {
+  const start = src.indexOf("write_runtime_shell_env() {");
+  const end = src.indexOf("\nwrite_runtime_shell_env\n", start);
+  if (start < 0 || end < 0) {
+    throw new Error("Expected write_runtime_shell_env block in agents/hermes/start.sh");
+  }
+  return src.slice(start, end).trimEnd();
+}
+
 function runTirithMarkerBootstrap(opts: {
   markerReason?: string;
   symlinkMarker?: boolean;
@@ -74,6 +83,96 @@ function runTirithMarkerBootstrap(opts: {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 }
+
+function runRuntimeShellEnvBootstrap() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-runtime-env-"));
+  const envFile = path.join(tmpDir, "nemoclaw-proxy-env.sh");
+  const caFile = path.join(tmpDir, "proxy ca.pem");
+  const hermesHome = path.join(tmpDir, ".hermes");
+  const scriptPath = path.join(tmpDir, "run.sh");
+
+  fs.mkdirSync(hermesHome, { recursive: true });
+  fs.writeFileSync(caFile, "ca");
+
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+  fs.writeFileSync(
+    scriptPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'emit_sandbox_sourced_file() { cat >"$1"; chmod 444 "$1"; }',
+      `_PROXY_ENV_FILE=${shellQuote(envFile)}`,
+      `_PROXY_URL=${shellQuote("http://10.200.0.1:3128")}`,
+      `_NO_PROXY_VAL=${shellQuote("localhost,127.0.0.1,::1,10.200.0.1")}`,
+      `HERMES_DIR=${shellQuote(hermesHome)}`,
+      `SSL_CERT_FILE=${shellQuote(caFile)}`,
+      "CURL_CA_BUNDLE=",
+      "REQUESTS_CA_BUNDLE=",
+      "GIT_SSL_CAINFO=",
+      extractRuntimeShellEnvBlock(src),
+      "write_runtime_shell_env",
+    ].join("\n"),
+    { mode: 0o700 },
+  );
+
+  try {
+    const result = spawnSync("bash", [scriptPath], {
+      encoding: "utf-8",
+      timeout: 5000,
+      env: process.env,
+    });
+    const envFileContent = fs.existsSync(envFile) ? fs.readFileSync(envFile, "utf-8") : "";
+    const envFileMode = fs.existsSync(envFile)
+      ? (fs.statSync(envFile).mode & 0o777).toString(8)
+      : "";
+    const guardResult = spawnSync("bash", ["-c", `. ${shellQuote(envFile)}; hermes setup`], {
+      encoding: "utf-8",
+      timeout: 5000,
+      env: { ...process.env, PATH: "/usr/bin:/bin" },
+    });
+
+    return {
+      src,
+      result,
+      envFileContent,
+      envFileMode,
+      guardResult,
+      hermesHome,
+      caFile,
+    };
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe("agents/hermes/start.sh runtime shell env", () => {
+  it("puts the Hermes configure guard in the sourced proxy env file", () => {
+    const run = runRuntimeShellEnvBootstrap();
+
+    expect(run.result.status).toBe(0);
+    expect(run.envFileMode).toBe("444");
+    expect(run.envFileContent).toContain(`export HERMES_HOME="${run.hermesHome}"`);
+    expect(run.envFileContent).toContain(`export SSL_CERT_FILE=${run.caFile.replace(/ /g, "\\ ")}`);
+    expect(run.envFileContent).toContain("# nemoclaw-configure-guard begin");
+    expect(run.envFileContent).toContain("hermes() {");
+    expect(run.envFileContent).toContain("# nemoclaw-configure-guard end");
+    expect(run.envFileContent).not.toContain(".bashrc");
+    expect(run.envFileContent).not.toContain(".profile");
+
+    expect(run.guardResult.status).toBe(1);
+    expect(run.guardResult.stderr).toContain(
+      "Error: 'hermes setup' cannot modify config inside the sandbox.",
+    );
+  });
+
+  it("does not keep the old post-capability-drop rc rewrite path", () => {
+    const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+    expect(src).not.toContain("rewrite_rc_marker_block");
+    expect(src).not.toContain("install_configure_guard");
+    expect(src).toContain("write_runtime_shell_env");
+  });
+});
 
 describe("agents/hermes/start.sh Tirith marker bootstrap", () => {
   it("removes a retryable download_failed marker so Hermes runtime fallback can retry", () => {

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -165,13 +165,6 @@ describe("agents/hermes/start.sh runtime shell env", () => {
     );
   });
 
-  it("does not keep the old post-capability-drop rc rewrite path", () => {
-    const src = fs.readFileSync(START_SCRIPT, "utf-8");
-
-    expect(src).not.toContain("rewrite_rc_marker_block");
-    expect(src).not.toContain("install_configure_guard");
-    expect(src).toContain("write_runtime_shell_env");
-  });
 });
 
 describe("agents/hermes/start.sh Tirith marker bootstrap", () => {

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -870,6 +870,20 @@ describe("regression guards", () => {
       expect(src).not.toContain('brev("login", "--token"');
     });
 
+    it("brev e2e suite captures CPU candidates before piping them into create", () => {
+      const src = fs.readFileSync(
+        path.join(import.meta.dirname, "..", "test", "e2e", "brev-e2e.test.ts"),
+        "utf-8",
+      );
+      expect(src).toContain(
+        'const CAPTURE_OUTPUT_STDIO: StdioOptions = ["ignore", "pipe", "inherit"]',
+      );
+      expect(src).toMatch(
+        /const cpuCandidates = execFileSync\([\s\S]*"search",[\s\S]*"cpu",[\s\S]*stdio: CAPTURE_OUTPUT_STDIO/,
+      );
+      expect(src).toMatch(/input: cpuCandidates,[\s\S]*stdio: PIPE_INPUT_STDIO/);
+    });
+
     it("brev e2e suite no longer contains the old brev-setup compatibility path", () => {
       const src = fs.readFileSync(
         path.join(import.meta.dirname, "..", "test", "e2e", "brev-e2e.test.ts"),


### PR DESCRIPTION
## Summary
- Move Hermes runtime shell configuration and configure guard into `/tmp/nemoclaw-proxy-env.sh` instead of rewriting `/sandbox/.bashrc` and `/sandbox/.profile` after `drop_capabilities`.
- Keep Hermes rc files as static root-owned shims and lock them before startup continues.
- Add two dedicated nightly E2E lanes for full OpenClaw and Hermes onboard flows with non-root host/security-posture assertions.

## Issues
- Addresses #3891
- Addresses #3764

## Validation
- `bash -n agents/hermes/start.sh test/e2e/lib/security-posture-assertions.sh test/e2e/test-full-e2e.sh test/e2e/test-hermes-e2e.sh`
- `npm test -- test/validate-e2e-coverage.test.ts test/e2e-advisor-dispatch.test.ts`
- `npm test -- test/hermes-start.test.ts test/sandbox-init.test.ts`
- `npm run typecheck:cli`
- `git diff --check HEAD~1 HEAD`

## Nightly proof plan
Dispatch only the new proof lanes from this PR branch:
- `openclaw-onboard-security-posture-e2e`
- `hermes-onboard-security-posture-e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added nightly E2E jobs for two agents to run security-posture checks; included in manual dispatch, failure notifications, and nightly reporting.
  * Enhanced E2E suites with optional security-posture regression phases, reusable sandbox assertion helpers, and unit tests validating proxy-env generation and guard behavior.
  * Improved SSH readiness, instance handling, and output-capture resilience.

* **Chores**
  * Centralized runtime shell environment generation and simplified sandbox guard handling.

* **Documentation**
  * Clarified sandbox RC-file behavior in container image comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->