### PR TITLE
feat(sandbox): bake Homebrew core into the sandbox base image (#3913)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -230,9 +230,10 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
 #
 # Image-build runs as root, so we create the prefix, chown it to the
 # sandbox user, clone Homebrew core under it as the sandbox user, and
-# symlink the brew entry point. After this, every sandbox starts with a
-# working `brew` on PATH (via /home/linuxbrew/.linuxbrew/bin) and the
-# preset's binary whitelist is honored.
+# symlink the brew entry point into the Homebrew prefix and /usr/local/bin.
+# /usr/local/bin is already on the locked sandbox PATH, so users can run
+# `brew` without adding the sandbox-writable Homebrew prefix to privileged
+# startup PATH.
 #
 # Companion change: /home/linuxbrew is added to filesystem_policy.read_write
 # in nemoclaw-blueprint/policies/openclaw-sandbox.yaml so brew can write
@@ -252,4 +253,6 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
         /home/linuxbrew/.linuxbrew/Homebrew \
     && ln -s /home/linuxbrew/.linuxbrew/Homebrew/bin/brew \
         /home/linuxbrew/.linuxbrew/bin/brew \
-    && gosu sandbox /home/linuxbrew/.linuxbrew/bin/brew --version
+    && ln -s /home/linuxbrew/.linuxbrew/Homebrew/bin/brew \
+        /usr/local/bin/brew \
+    && gosu sandbox brew --version

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -218,3 +218,38 @@ WORKDIR /
 # will still report healthy.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
     CMD node -e "process.exit(0)"
+
+# Bake Homebrew core (Linuxbrew) into the sandbox base image (#3913).
+#
+# Without this, applying the `brew` policy preset and trying to install
+# Homebrew at runtime fails: /home/linuxbrew is not in the sandbox
+# filesystem write paths, AND the install script's first step is `sudo`
+# to create + chown /home/linuxbrew/.linuxbrew, which the unprivileged
+# sandbox user cannot grant. The preset's binary whitelist for
+# /home/linuxbrew/.linuxbrew/bin/* is then dead code.
+#
+# Image-build runs as root, so we create the prefix, chown it to the
+# sandbox user, clone Homebrew core under it as the sandbox user, and
+# symlink the brew entry point. After this, every sandbox starts with a
+# working `brew` on PATH (via /home/linuxbrew/.linuxbrew/bin) and the
+# preset's binary whitelist is honored.
+#
+# Companion change: /home/linuxbrew is added to filesystem_policy.read_write
+# in nemoclaw-blueprint/policies/openclaw-sandbox.yaml so brew can write
+# formulae under the prefix at runtime.
+#
+# Cost: ~80 to 150 MB (Homebrew core only; formulae download on demand).
+#
+# HOMEBREW_VERSION pins the exact upstream Homebrew tag we ship, so the
+# base image layer is reproducible across rebuilds. Bump on demand; the
+# base-image workflow re-runs on push to main. Latest stable tags are
+# at https://github.com/Homebrew/brew/releases.
+ARG HOMEBREW_VERSION=5.1.12
+RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
+    && chown -R sandbox:sandbox /home/linuxbrew \
+    && gosu sandbox git clone --depth=1 --branch="${HOMEBREW_VERSION}" \
+        https://github.com/Homebrew/brew.git \
+        /home/linuxbrew/.linuxbrew/Homebrew \
+    && ln -s /home/linuxbrew/.linuxbrew/Homebrew/bin/brew \
+        /home/linuxbrew/.linuxbrew/bin/brew \
+    && gosu sandbox /home/linuxbrew/.linuxbrew/bin/brew --version

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -35,6 +35,11 @@ filesystem_policy:
     - /sandbox/.nemoclaw            # Plugin state and config (state.ts, config.ts).
                                     # Blueprints are root-owned; sticky bit (1755)
                                     # on parent prevents rename/delete (#1607).
+    - /home/linuxbrew               # Homebrew prefix. The brew core is baked into
+                                    # the sandbox base image at /home/linuxbrew/
+                                    # .linuxbrew (#3913); runtime writes here let
+                                    # `brew install <formula>` extract bottles
+                                    # and manage Cellar/opt symlinks.
 
 # TODO: evaluate landlock enforce mode — currently best_effort because
 # enforce can break things in unpredictable ways. Needs thorough testing

--- a/nemoclaw-blueprint/policies/presets/brew.yaml
+++ b/nemoclaw-blueprint/policies/presets/brew.yaml
@@ -36,6 +36,7 @@ network_policies:
     binaries:
       - { path: /usr/bin/curl }
       - { path: /usr/bin/git }
+      - { path: /usr/local/bin/brew }
       - { path: /home/linuxbrew/.linuxbrew/bin/brew }
       - { path: /home/linuxbrew/.linuxbrew/bin/* }
       - { path: /home/linuxbrew/.linuxbrew/Homebrew/bin/* }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1255,6 +1255,25 @@ exit 1
       expect(parsed.filesystem_policy.read_write).toContain("/home/linuxbrew");
     });
 
+    it("brew preset whitelists the PATH shim and Homebrew-managed entrypoints (#3913)", () => {
+      const content = requirePresetContent(policies.loadPreset("brew"));
+      const parsed = YAML.parse(content);
+      const brewPolicy = parsed.network_policies?.brew as
+        | { binaries?: Array<{ path?: string }> }
+        | undefined;
+      const binaries = (brewPolicy?.binaries ?? []).map((binary) => binary.path).sort();
+      expect(binaries).toEqual(
+        [
+          "/home/linuxbrew/.linuxbrew/Homebrew/bin/*",
+          "/home/linuxbrew/.linuxbrew/bin/*",
+          "/home/linuxbrew/.linuxbrew/bin/brew",
+          "/usr/bin/curl",
+          "/usr/bin/git",
+          "/usr/local/bin/brew",
+        ].sort(),
+      );
+    });
+
     it("telegram REST preset relies on automatic TLS handling", () => {
       const content = requirePresetContent(policies.loadPreset("telegram"));
       expect(content).toBeTruthy();

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1240,6 +1240,21 @@ exit 1
       }
     });
 
+    it("baseline filesystem_policy.read_write grants the Homebrew prefix (#3913)", () => {
+      // Companion to the Dockerfile.base step that bakes Homebrew core
+      // into the sandbox image. Without /home/linuxbrew in read_write,
+      // `brew install <formula>` cannot extract bottles or manage the
+      // Cellar/opt symlinks at runtime, and the brew preset's binary
+      // whitelist becomes dead code.
+      const parsed = YAML.parse(
+        fs.readFileSync(
+          path.join(REPO_ROOT, "nemoclaw-blueprint/policies/openclaw-sandbox.yaml"),
+          "utf-8",
+        ),
+      );
+      expect(parsed.filesystem_policy.read_write).toContain("/home/linuxbrew");
+    });
+
     it("telegram REST preset relies on automatic TLS handling", () => {
       const content = requirePresetContent(policies.loadPreset("telegram"));
       expect(content).toBeTruthy();


### PR DESCRIPTION
## Summary

Closes #3913. Bakes Homebrew core into the sandbox base image so the `brew` policy preset actually works end-to-end. Without this, applying the preset and running `brew install <formula>` inside the sandbox fails with `Insufficient permissions to install Homebrew to "/home/linuxbrew/.linuxbrew"` because the sandbox lacks filesystem write to `/home/linuxbrew/` AND runs as an unprivileged user with no sudo.

## Problem

Two filesystem constraints block runtime Homebrew installation today:

1. `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` lists only `[/tmp, /dev/null, /sandbox/.openclaw, /sandbox/.nemoclaw]` plus the workdir under `filesystem_policy.read_write`. Landlock denies writes to `/home/linuxbrew/`.
2. `Dockerfile.base` runs the sandbox as `useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox` (no sudo). Homebrew's install script's first step is `sudo` to create + chown `/home/linuxbrew/.linuxbrew`, which the sandbox cannot grant.

Result: the `brew` preset's binary whitelist for `/home/linuxbrew/.linuxbrew/bin/*` is dead code. Two QA reports already documented the symptom: [#1767](https://github.com/NVIDIA/NemoClaw/issues/1767) (filed 2026-04-10) and [#3757](https://github.com/NVIDIA/NemoClaw/issues/3757) (filed 2026-05-18). [#3846](https://github.com/NVIDIA/NemoClaw/pull/3846) was an interim docs-only attempt that we closed in favor of this PR; documenting a bootstrap that cannot actually succeed in the default sandbox would have set wrong expectations.

## Approach

Follow the [#3682](https://github.com/NVIDIA/NemoClaw/pull/3682) precedent (WeChat plugin baked into the base image in v0.0.46): provision the tool at image-build time, when the build runs as root and can create + chown the prefix.

- `Dockerfile.base`: after the existing WeChat plugin install block, add a step that creates `/home/linuxbrew/.linuxbrew/bin`, chowns to `sandbox:sandbox`, clones Homebrew core as the sandbox user via `gosu` at the pinned `ARG HOMEBREW_VERSION=5.1.12` tag, symlinks the `brew` entry point, and asserts `brew --version` succeeds. The `ARG` keeps the base-image layer reproducible across rebuilds and can be bumped by editing the default or passing `--build-arg`.
- `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`: add `/home/linuxbrew` to `filesystem_policy.read_write` so runtime `brew install <formula>` can extract bottles and manage Cellar/opt symlinks.
- `test/policies.test.ts`: behavior-style assertion that the baseline `read_write` list includes the Homebrew prefix. Trips CI if a future change drops the entry.

## Cost

Approximately 80 to 150 MB on the base image (Homebrew core only; formulae download on demand). Acceptable relative to the existing ~2.4 GB sandbox image and consistent with the trade-off the project already accepted for the WeChat plugin baking.

## Follow-up docs PR planned

Once this merges and the base image rebuilds, a small docs PR will land covering the new flow on the matching MDX pages: apply the `brew` preset, run `brew install <formula>`. The previous attempt at documenting a runtime bootstrap (closed [#3846](https://github.com/NVIDIA/NemoClaw/pull/3846)) becomes obsolete and the new docs will reflect that `brew` is included by default.

## Out of scope

- **`agents/hermes/Dockerfile.base`** — Hermes does not currently get the WeChat plugin baking either; same scoping rationale. Can extend in a follow-up if maintainers want Homebrew under Hermes.
- **System `PATH`** — users can run `brew` via the full path `/home/linuxbrew/.linuxbrew/bin/brew` or via `eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`. A separate PR could add the prefix to `/etc/bash.bashrc` if a cleaner default UX is wanted.
- **Option B (drop the brew preset entirely)** — discussed in [#3913](https://github.com/NVIDIA/NemoClaw/issues/3913); rejected because removing a Balanced-tier preset is a user-visible regression.

## Test plan

- [x] `prek run --files` clean on all changed files
- [x] New `test/policies.test.ts` assertion passes (`Homebrew prefix` test)
- [x] Behavior-style test (parses YAML and checks the structured `read_write` array); satisfies the source-shape budget
- [x] Verified the pinned `HOMEBREW_VERSION=5.1.12` tag exists upstream (`gh api repos/Homebrew/brew/releases` + direct `https://github.com/Homebrew/brew/releases/tag/5.1.12` returns 200)
- [ ] **CI to verify:** sandbox base image rebuilds successfully with the new step
- [ ] **CI to verify:** `brew --version` runs inside a freshly-created sandbox (covered by the build-time `gosu sandbox /home/linuxbrew/.linuxbrew/bin/brew --version` assertion in `Dockerfile.base`)
- [ ] **Manual smoke after base-image publish:** `nemoclaw onboard` -> `<name> policy-add brew --yes` -> `<name> connect` -> `brew install hello` -> succeeds

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homebrew package manager is now pre-installed and available in the sandbox environment, enabling users to install and manage software packages using standard Homebrew commands.

* **Tests**
  * Added validation tests for Homebrew policy configuration and binary permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->