### PR TITLE
fix(ci): paginate nightly scorecard trend lookup

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -2550,20 +2550,27 @@ jobs:
                 const since48h = new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString();
                 const since24h = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
 
-                const { data } = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: WORKFLOW_FILE,
-                  created: `>=${since48h}`,
-                  per_page: 50,
-                });
+                const priorRuns = [];
+                for (let page = 1; page <= 10 && priorRuns.length === 0; page++) {
+                  const { data } = await github.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: WORKFLOW_FILE,
+                    created: `>=${since48h}`,
+                    per_page: 100,
+                    page,
+                  });
 
-                // Find completed scheduled runs from 24–48h ago
-                const priorRuns = data.workflow_runs.filter(r =>
-                  r.status === 'completed' &&
-                  r.event === 'schedule' &&
-                  new Date(r.created_at) < new Date(since24h)
-                );
+                  priorRuns.push(
+                    ...data.workflow_runs.filter(r =>
+                      r.status === 'completed' &&
+                      r.event === 'schedule' &&
+                      new Date(r.created_at) < new Date(since24h)
+                    )
+                  );
+
+                  if (data.workflow_runs.length < 100) break;
+                }
 
                 if (priorRuns.length > 0) {
                   // Check the most recent prior run

--- a/test/nightly-scorecard.test.ts
+++ b/test/nightly-scorecard.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+type WorkflowRun = {
+  status: string;
+  event: string;
+  created_at: string;
+  conclusion: string | null;
+};
+
+function findPriorScheduledRunFromFirstPage(
+  runs: WorkflowRun[],
+  since24h: string,
+): WorkflowRun | undefined {
+  return runs.filter(
+    (run) =>
+      run.status === "completed" &&
+      run.event === "schedule" &&
+      new Date(run.created_at) < new Date(since24h),
+  )[0];
+}
+
+describe("nightly scorecard prior-day trend lookup", () => {
+  it("finds the prior scheduled run even when selective dispatches fill the first API page", () => {
+    const since24h = "2026-05-19T01:02:21.000Z";
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      status: "completed",
+      event: index === 20 ? "schedule" : "workflow_dispatch",
+      created_at:
+        index === 20
+          ? "2026-05-20T00:21:09Z"
+          : `2026-05-20T${String(23 - Math.floor(index / 5)).padStart(2, "0")}:00:00Z`,
+      conclusion: index % 3 === 0 ? "failure" : "success",
+    }));
+    const secondPage = [
+      {
+        status: "completed",
+        event: "schedule",
+        created_at: "2026-05-19T00:20:30Z",
+        conclusion: "failure",
+      },
+    ];
+
+    const currentImplementationResult = findPriorScheduledRunFromFirstPage(
+      firstPage,
+      since24h,
+    );
+
+    expect(currentImplementationResult?.created_at).toBe(secondPage[0].created_at);
+  });
+});

--- a/test/nightly-scorecard.test.ts
+++ b/test/nightly-scorecard.test.ts
@@ -10,16 +10,22 @@ type WorkflowRun = {
   conclusion: string | null;
 };
 
-function findPriorScheduledRunFromFirstPage(
-  runs: WorkflowRun[],
+function findPriorScheduledRunFromPages(
+  pages: WorkflowRun[][],
   since24h: string,
 ): WorkflowRun | undefined {
-  return runs.filter(
-    (run) =>
-      run.status === "completed" &&
-      run.event === "schedule" &&
-      new Date(run.created_at) < new Date(since24h),
-  )[0];
+  const priorRuns: WorkflowRun[] = [];
+  for (let page = 0; page < pages.length && priorRuns.length === 0; page++) {
+    priorRuns.push(
+      ...pages[page].filter(
+        (run) =>
+          run.status === "completed" &&
+          run.event === "schedule" &&
+          new Date(run.created_at) < new Date(since24h),
+      ),
+    );
+  }
+  return priorRuns[0];
 }
 
 describe("nightly scorecard prior-day trend lookup", () => {
@@ -43,11 +49,11 @@ describe("nightly scorecard prior-day trend lookup", () => {
       },
     ];
 
-    const currentImplementationResult = findPriorScheduledRunFromFirstPage(
-      firstPage,
+    const result = findPriorScheduledRunFromPages(
+      [firstPage, secondPage],
       since24h,
     );
 
-    expect(currentImplementationResult?.created_at).toBe(secondPage[0].created_at);
+    expect(result?.created_at).toBe(secondPage[0].created_at);
   });
 });


### PR DESCRIPTION
## Summary
- add a regression test for scorecard trend lookup when selective dispatch volume fills the first workflow-runs API page
- paginate the prior scheduled-run lookup in the nightly scorecard
- keep the lookup bounded while allowing the previous scheduled run to be found beyond page one

## Validation
- npm test -- test/nightly-scorecard.test.ts test/validate-e2e-coverage.test.ts test/e2e-advisor-dispatch.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for detecting prior scheduled workflow runs with filtering and pagination.

* **Chores**
  * Improved nightly test workflow to use optimized pagination when fetching prior workflow runs for trend comparison.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->