### PR TITLE
fix(advisor): use configured PR review secret

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -132,7 +132,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.target_pr }}
           PR_REVIEW_ADVISOR_RUN_ANALYSIS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_analysis == false && '0' || '1' }}
           GH_TOKEN: ${{ github.token }}
-          PR_REVIEW_ADVISOR_API_KEY: ${{ secrets.PI_PR_REVIEW_ADVISOR_API_KEY }}
+          PR_REVIEW_ADVISOR_API_KEY: ${{ secrets.PR_REVIEW_ADVISOR_API_KEY || secrets.PI_PR_REVIEW_ADVISOR_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd "$ADVISOR_WORKDIR"

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -261,6 +261,9 @@ describe("PR review advisor", () => {
     for (const step of steps.filter((step: { uses?: string }) => step.uses)) {
       expect(step.uses).toMatch(/@[0-9a-f]{40}(?:\s*#.*)?$/);
     }
+    expect(analyzeStep.env.PR_REVIEW_ADVISOR_API_KEY).toBe(
+      "${{ secrets.PR_REVIEW_ADVISOR_API_KEY || secrets.PI_PR_REVIEW_ADVISOR_API_KEY }}",
+    );
     expect(installStep.run.includes("--ignore-scripts")).toBe(true);
     expect(analyzeStep.run.includes("$ADVISOR_DIR/tools/pr-review-advisor/analyze.mts")).toBe(true);
     expect(analyzeStep.run).toContain("trusted main checkout does not yet contain analyze.mts");

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -41,10 +41,11 @@ It complements CodeRabbit and the E2E Advisor by encoding NemoClaw maintainer re
 
 Configure this repository secret for review analysis:
 
-- `PI_PR_REVIEW_ADVISOR_API_KEY`
+- `PR_REVIEW_ADVISOR_API_KEY`
 
-The analyzer uses the fixed `openai/openai/gpt-5.5` advisor model and also accepts
-`OPENAI_API_KEY` for local runs.
+The workflow also accepts the legacy `PI_PR_REVIEW_ADVISOR_API_KEY` secret as a
+fallback. The analyzer uses the fixed `openai/openai/gpt-5.5` advisor model and
+also accepts `OPENAI_API_KEY` for local runs.
 
 If advisor credentials are unavailable, the advisor writes a low-confidence unavailable result
 instead of failing closed without artifacts.
@@ -76,7 +77,7 @@ node --experimental-strip-types tools/pr-review-advisor/analyze.mts \
 ```
 
 Set `PR_REVIEW_ADVISOR_API_KEY` or `OPENAI_API_KEY` locally, or configure the repository
-`PI_PR_REVIEW_ADVISOR_API_KEY` secret. Run `npm install` first so the Pi SDK dependency is
+`PR_REVIEW_ADVISOR_API_KEY` secret. Run `npm install` first so the Pi SDK dependency is
 available.
 
 ## Output contract


### PR DESCRIPTION
## Summary
Updates the PR Review Advisor workflow to consume the newly configured `PR_REVIEW_ADVISOR_API_KEY` repository secret, while keeping `PI_PR_REVIEW_ADVISOR_API_KEY` as a fallback for compatibility.

## Changes
- Change `.github/workflows/pr-review-advisor.yaml` to prefer `secrets.PR_REVIEW_ADVISOR_API_KEY` for advisor model credentials.
- Update `tools/pr-review-advisor/README.md` so the documented repository secret matches the workflow.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification run locally:
- [x] `npm test -- --run test/pr-review-advisor.test.ts`
- [x] `npx prek run --files .github/workflows/pr-review-advisor.yaml tools/pr-review-advisor/README.md`

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API key setup and manual run instructions for the PR Review Advisor tool, including guidance on legacy key support.

* **Improvements**
  * Workflow now accepts both current and legacy API key names for smoother migration and setup.

* **Tests**
  * End-to-end tests updated to verify the API key fallback behavior is propagated in the review job.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->