### PR TITLE
Revert "ci(images): extend base image build timeout (#3881)"

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -44,7 +44,7 @@ jobs:
   build-and-push:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,7 +94,7 @@ jobs:
   build-and-push-hermes:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,10 +219,13 @@ RUN set -eu; \
     # \
     # Removal criteria: drop when openclaw fixes the underlying connect \
     # latency, or exposes the timeout as an unbounded env override. \
-    hto_files="$(grep -RIlE --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4' "$OC_DIST")"; \
-    test -n "$hto_files" || { echo "ERROR: handshake-timeout constant not found" >&2; exit 1; }; \
-    printf '%s\n' "$hto_files" | xargs sed -i -E 's|DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4|DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 6e4|g'; \
-    if grep -REq --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4' "$OC_DIST"; then echo "ERROR: Patch 5 left a 1e4 constant" >&2; exit 1; fi
+    hto_files="$(grep -RIlE --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4' "$OC_DIST" || true)"; \
+    if [ -n "$hto_files" ]; then \
+        printf '%s\n' "$hto_files" | xargs sed -i -E 's|DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4|DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 6e4|g'; \
+        if grep -REq --include='*.js' 'DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 1e4' "$OC_DIST"; then echo "ERROR: Patch 5 left a 1e4 constant" >&2; exit 1; fi; \
+    else \
+        echo "INFO: handshake-timeout constant not found; OpenClaw no longer needs Patch 5"; \
+    fi
 
 # Patch OpenClaw's pinned 2026.4.24 compiled selection runtime to expose a
 # compact searchable tool catalog to the model while preserving the full


### PR DESCRIPTION
## Summary
- Reverts PR #3881 (`ci(images): extend base image build timeout`)
- Restores `.github/workflows/base-image.yaml` timeout values to the pre-#3881 state

## Verification
- `git revert --signoff --no-edit 3a473cf06afc9baa88cc8c13195f8fc38784d8ae`
- `git diff --check HEAD^ HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced CI build timeout limits for base-image builds to speed up workflow throughput.
  * Made image build patching more resilient: if certain optional build-time values are absent, the build logs and continues instead of failing.
  
---

**Note:** No user-facing changes; updates are limited to build and infrastructure processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->