### PR TITLE
ci(e2e): isolate onboard negative nightly

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1792,15 +1792,7 @@ jobs:
           export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
           [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
           [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && export PATH="$HOME/.local/bin:$PATH"
-          npm ci --ignore-scripts
-          log_file="/tmp/nemoclaw-e2e-onboard-negative-paths.log"
-          : >"${log_file}"
-          for scenario in \
-            ubuntu-repo-cloud-openclaw-custom-policies \
-            ubuntu-invalid-nvidia-key-negative \
-            ubuntu-gateway-port-conflict-negative; do
-            bash test/e2e/runtime/run-scenario.sh "$scenario" 2>&1 | tee -a "${log_file}"
-          done
+          bash test/e2e/test-onboard-negative-paths.sh
       - name: Upload test log on failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Summary
- Run `test/e2e/test-onboard-negative-paths.sh` directly from `onboard-negative-paths-e2e`
- Remove the scenario-runner loop from the legacy nightly job so scenario-suite changes do not affect it
- Keep the existing `/tmp/nemoclaw-e2e-onboard-negative-paths.log` artifact path, which the standalone script already writes

## Test plan
- `git diff --check`

## Context
Nightly run 26185198123 failed because the legacy nightly job was invoking `test/e2e/runtime/run-scenario.sh` and inherited newly-added scenario-suite `baseline-onboarding` coverage. The intended coverage from PR #3791 was the standalone onboard negative-path script, so this restores isolation between nightly E2E and scenario E2E.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the nightly end-to-end testing workflow by consolidating test execution steps for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->