### PR TITLE
fix(sandbox): add python -> python3 symlink in base image (#1452)

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -68,7 +68,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         jq=1.7.1-6+deb13u2 \
         vim-tiny=2:9.1.1230-2 \
         openssh-sftp-server=1:10.0p1-7+deb13u4 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/python3 /usr/local/bin/python
 
 # gosu for privilege separation (gateway vs sandbox user).
 # Install from GitHub release with checksum verification instead of

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -192,12 +192,20 @@ describe("sandbox provisioning: base runtime tools", () => {
     const dockerfile = fs.readFileSync(DOCKERFILE_BASE, "utf-8");
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-apt-"));
     const lists = path.join(tmp, "apt-lists");
+    const fakePy3 = path.join(tmp, "usr-bin", "python3");
+    const fakePyLink = path.join(tmp, "usr-local-bin", "python");
     fs.mkdirSync(lists);
+    fs.mkdirSync(path.dirname(fakePy3), { recursive: true });
+    fs.mkdirSync(path.dirname(fakePyLink), { recursive: true });
+    fs.writeFileSync(fakePy3, "#!/bin/sh\n", { mode: 0o755 });
     const command = dockerRunCommandBetween(
       dockerfile,
       "RUN apt-get update",
       "# gosu for privilege separation",
-    ).replaceAll("/var/lib/apt/lists", lists);
+    )
+      .replaceAll("/var/lib/apt/lists", lists)
+      .replaceAll("/usr/local/bin/python", fakePyLink)
+      .replaceAll("/usr/bin/python3", fakePy3);
 
     try {
       const { result, calls } = runLoggedDockerShell(command, tmp, [
@@ -208,6 +216,38 @@ describe("sandbox provisioning: base runtime tools", () => {
       expect(calls).toContain("procps=2:4.0.4-9");
       expect(calls).toContain("e2fsprogs=1.47.2-3+b11");
       expect(calls).toContain("openssh-sftp-server=1:10.0p1-7+deb13u4");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("symlinks bare `python` to python3 so agent tool calls don't fail with command-not-found (#1452)", () => {
+    const dockerfile = fs.readFileSync(DOCKERFILE_BASE, "utf-8");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-pysymlink-"));
+    const lists = path.join(tmp, "apt-lists");
+    const fakePy3 = path.join(tmp, "usr-bin", "python3");
+    const fakePyLink = path.join(tmp, "usr-local-bin", "python");
+    fs.mkdirSync(lists, { recursive: true });
+    fs.mkdirSync(path.dirname(fakePy3), { recursive: true });
+    fs.mkdirSync(path.dirname(fakePyLink), { recursive: true });
+    fs.writeFileSync(fakePy3, "#!/bin/sh\necho 3.13\n", { mode: 0o755 });
+
+    const command = dockerRunCommandBetween(
+      dockerfile,
+      "RUN apt-get update",
+      "# gosu for privilege separation",
+    )
+      .replaceAll("/var/lib/apt/lists", lists)
+      .replaceAll("/usr/local/bin/python", fakePyLink)
+      .replaceAll("/usr/bin/python3", fakePy3);
+
+    try {
+      const { result } = runLoggedDockerShell(command, tmp, [
+        'apt-get() { printf "apt-get %s\\n" "$*" >> "$call_log"; }',
+      ]);
+      expect(result.status).toBe(0);
+      expect(fs.lstatSync(fakePyLink).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(fakePyLink)).toBe(fakePy3);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
Adds `ln -s /usr/bin/python3 /usr/local/bin/python` to `Dockerfile.base` so bare `python` invocations from agent tool calls resolve in the sandbox. Debian trixie ships only `python3`; without this symlink, scripts like the `csv_stats.py` repro in #1452 fail with `python: command not found`.

## Related Issue
Fixes #1452 (narrow trigger — bare `python` unavailable). The broader hallucination-after-tool-failure concern raised later in the thread is an OpenClaw runtime issue and should be filed upstream separately.

## Changes
- `Dockerfile.base`: chain `ln -s /usr/bin/python3 /usr/local/bin/python` into the existing apt-install RUN block (no new layer).
- `test/sandbox-provisioning.test.ts`: add a behavior test that executes the apt RUN block in a temp dir and asserts the symlink resolves to the fake python3 binary. Updated the existing apt-layer test to remap the new python paths into the temp dir so it still passes.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes (with `NEMOCLAW_TEST_TIMEOUT=20000` to absorb macOS Defender/Spotlight contention; default 5s budget hits flakes locally)
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Empirical end-to-end verification on Ubuntu 22.04 amd64 (Brev `n2d-standard-4`):
- Built the patched `Dockerfile.base` → `docker run nemoclaw-base-1452-test python --version` → `Python 3.13.5`
- `docker run ... ls -la /usr/local/bin/python` → `python -> /usr/bin/python3`
- `docker run ... python -c 'print("hello from bare python")'` → `hello from bare python`

On an unpatched `main` checkout, the original #1452 repro (`python --version` inside the sandbox) still surfaces `sh: 1: python: not found`.

## Related PR
[#1455](https://github.com/NVIDIA/NemoClaw/pull/1455) (by @BenediktSchackenberg) is the original fix for this issue. It has been stalled on CPR vetter approval since 2026-05-01 and is from a fork. This PR carries the same intent forward from a maintainer branch so it can land on the current `v0.0.47` cycle. Recommend closing #1455 as superseded once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added and updated regression tests for Python symlink configuration in sandbox provisioning.

* **Chores**
  * Updated Docker base image configuration for Python command setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->