### PR TITLE
docs: clarify Discord preset validation

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -813,6 +813,54 @@ In that case:
 - inspect gateway logs and blocked requests with `openshell term`
 - treat the failure as a native Discord gateway problem, not as a bridge startup problem
 
+### Discord preset validation behind a proxy
+
+The built-in Discord policy preset intentionally allows the Node binaries used by the messaging runtime and does not allow `curl`.
+As a result, `curl -s https://discord.com` failing, hanging, or printing no output is not proof that the Discord preset is broken.
+
+Behind the OpenShell proxy, direct DNS-only checks can also be the wrong signal.
+For example, `dns.resolve("gateway.discord.gg")` can fail even when HTTPS requests routed through the proxy are healthy.
+
+Use Node HTTPS as the manual REST probe:
+
+```console
+$ node - <<'NODE'
+const https = require("node:https");
+
+https
+  .get("https://discord.com/api/v10/gateway", (res) => {
+    console.log(`${res.statusCode} ${res.statusMessage || ""}`.trim());
+    res.resume();
+  })
+  .on("error", (err) => {
+    console.error(err.message);
+    process.exitCode = 1;
+  });
+NODE
+```
+
+To check Discord CDN egress, use the same Node HTTPS path:
+
+```console
+$ node - <<'NODE'
+const https = require("node:https");
+
+https
+  .get("https://cdn.discordapp.com/", (res) => {
+    console.log(`${res.statusCode} ${res.statusMessage || ""}`.trim());
+    res.resume();
+  })
+  .on("error", (err) => {
+    console.error(err.message);
+    process.exitCode = 1;
+  });
+NODE
+```
+
+Any HTTP status from these probes means the Node process reached the endpoint; the exact status can vary by unauthenticated path.
+If the Node REST probe works but the Discord channel is still unhealthy, investigate the native gateway path instead of widening the preset.
+Check the gateway logs and blocked-request output with `openshell term`, and look for `gateway.discord.gg` connection or WebSocket upgrade failures.
+
 ### Messaging bridge appears running but no messages arrive
 
 Bot tokens for Telegram (`getUpdates`), Discord (gateway), and Slack (Socket Mode) only allow one active consumer per token. If two NemoClaw sandboxes are configured with the same bot token, each one kicks the other off its polling connection and neither delivers messages. `nemoclaw status` still reports the bridge as running because the gateway process itself is alive.

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -117,13 +117,26 @@ const MESSAGING_PRESET_LABELS: Record<string, string> = {
 function getMessagingPresetWarning(presetName: string): string | null {
   const label = MESSAGING_PRESET_LABELS[presetName];
   if (!label) return null;
-  return [
+  const lines = [
     `Note: the '${presetName}' preset only opens network egress to the ${label} API.`,
     `To actually enable ${label} messaging, re-run 'nemoclaw onboard' and select ${label}`,
     "in the messaging channels step. Channel setup, pairing, and runtime",
     "configuration are wired up at onboard time and are not added by applying",
     "this preset alone.",
-  ].join("\n  ");
+  ];
+
+  if (presetName === "discord") {
+    lines.push(
+      "For Discord preset validation, do not use curl as the success signal:",
+      "curl is not in the preset binary allowlist, so curl probes can fail even",
+      "when the policy is working. Use Node HTTPS against",
+      "https://discord.com/api/v10/gateway or validate the configured",
+      'messaging bridge/gateway path. DNS-only checks such as dns.resolve("gateway.discord.gg")',
+      "can also be inconclusive behind a proxy.",
+    );
+  }
+
+  return lines.join("\n  ");
 }
 
 function setupPolicyPresetSupported(

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -69,6 +69,7 @@ registry.listSandboxes = () => ({ sandboxes: [{ name: "test-sandbox" }] });
 policies.listPresets = () => [
   { name: "npm", description: "npm and Yarn registry access" },
   { name: "pypi", description: "Python Package Index (PyPI) access" },
+  { name: "discord", description: "Discord API, gateway, and CDN access" },
 ];
 policies.getAppliedPresets = () => [];
 policies.applyPreset = (sandboxName, presetName) => {
@@ -434,6 +435,16 @@ describe("policies", () => {
       expect(policies.getMessagingPresetWarning("discord")).toContain("Discord");
       expect(policies.getMessagingPresetWarning("slack")).toContain("Slack");
       expect(policies.getMessagingPresetWarning("wechat")).toContain("WeChat");
+    });
+
+    it("adds Discord validation guidance for Node probes instead of curl or DNS-only checks", () => {
+      const warning = policies.getMessagingPresetWarning("discord");
+
+      expect(warning).toContain("curl");
+      expect(warning).toContain("preset binary allowlist");
+      expect(warning).toContain("Node HTTPS");
+      expect(warning).toContain("https://discord.com/api/v10/gateway");
+      expect(warning).toContain('dns.resolve("gateway.discord.gg")');
     });
 
     it("returns null for non-messaging presets", () => {
@@ -1599,6 +1610,40 @@ selectForRemoval(items, options)
         /Note: the 'wechat' preset only opens network egress to the WeChat API\./,
       );
       expect(result.stdout).toMatch(/re-run 'nemoclaw onboard' and select WeChat/);
+    });
+
+    it("prints Discord validation guidance from the interactive preset flow", () => {
+      const result = runPolicyAdd("y", [], {}, "discord");
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(
+        /curl is not in the preset binary allowlist, so curl probes can fail/,
+      );
+      expect(result.stdout).toMatch(/https:\/\/discord\.com\/api\/v10\/gateway/);
+      expect(result.stdout).toMatch(/dns\.resolve\("gateway\.discord\.gg"\)/);
+      const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim()) as PolicyCall[];
+      expect(calls).toContainEqual({
+        type: "apply",
+        sandboxName: "test-sandbox",
+        presetName: "discord",
+      });
+    });
+
+    it("prints Discord validation guidance when the preset name is provided", () => {
+      const result = runPolicyAdd("n", ["discord", "--yes"]);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(
+        /curl is not in the preset binary allowlist, so curl probes can fail/,
+      );
+      expect(result.stdout).toMatch(/Node HTTPS/);
+      const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim()) as PolicyCall[];
+      expect(calls.some((call: PolicyCall) => call.type === "prompt")).toBeFalsy();
+      expect(calls).toContainEqual({
+        type: "apply",
+        sandboxName: "test-sandbox",
+        presetName: "discord",
+      });
     });
 
     it("does not warn about messaging when a non-messaging preset is selected", () => {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1619,7 +1619,7 @@ selectForRemoval(items, options)
       expect(result.stdout).toMatch(
         /curl is not in the preset binary allowlist, so curl probes can fail/,
       );
-      expect(result.stdout).toMatch(/https:\/\/discord\.com\/api\/v10\/gateway/);
+      expect(result.stdout).toContain("https://discord.com/api/v10/gateway");
       expect(result.stdout).toMatch(/dns\.resolve\("gateway\.discord\.gg"\)/);
       const calls = JSON.parse(result.stdout.split("__CALLS__")[1].trim()) as PolicyCall[];
       expect(calls).toContainEqual({


### PR DESCRIPTION
## Summary
- add Discord-specific policy-add guidance that curl is not a valid success signal because it is outside the preset binary allowlist
- document Node HTTPS probes for Discord REST/CDN validation behind proxy and call out DNS-only checks as inconclusive
- cover the direct warning helper plus interactive and named policy-add discord flows

## Reopen Context
Issue #3477 was closed by #3663, then reopened from a v0.0.44 QA repro that still used curl and dns.resolve as validation signals. That same repro showed Node HTTPS to https://discord.com/api/v10/gateway returning 200, which is the signal this PR now documents and surfaces in policy-add.

## Related Issue
Fixes #3477

## Verification
- [x] npm run build:cli
- [x] npm test -- test/policies.test.ts
- [x] npm test -- test/validate-blueprint.test.ts
- [x] make docs

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Added troubleshooting guidance for Discord preset validation behind proxies: explains why curl probes can mislead, clarifies the built-in preset’s behavior, warns about DNS-only checks, and provides Node HTTPS one-liners to verify Discord API/CDN egress and next investigative steps.

## Tests
- Extended coverage to assert Discord preset validation warnings and to verify interactive and non-interactive policy-add flows print the new guidance and proceed with apply as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->