### PR TITLE
test(e2e): clear Hermes rebuild dashboard forward

### DIFF
--- a/test/e2e/test-rebuild-hermes.sh
+++ b/test/e2e/test-rebuild-hermes.sh
@@ -142,6 +142,11 @@ pass "NemoClaw installed"
 # Delete the sandbox that install.sh created — we'll make our own old one.
 # Use openshell directly to preserve the 'nemoclaw' gateway for the rebuild.
 openshell sandbox delete "${SANDBOX_NAME}" 2>/dev/null || true
+# Raw OpenShell deletion can leave the prior Hermes API/dashboard forward
+# bound for a short window. The rebuild create path intentionally rolls back if
+# the baked dashboard port is host-bound after image build, so make this phase
+# cleanup synchronous before creating the old fixture sandbox.
+openshell forward stop 8642 >/dev/null 2>&1 || true
 diag "Deleted Phase 1 sandbox, gateway preserved: $(docker ps --filter name=openshell --format '{{.Names}} {{.Status}}' 2>/dev/null)"
 
 # ── Phase 2: Build old Hermes base image ───────────────────────────


### PR DESCRIPTION
## Summary
- stop the prior Hermes dashboard/API forward after the Phase 1 sandbox delete in the Hermes rebuild E2E
- prevents the rebuild recreate path from tripping over a stale host-bound 8642 forward during image build

## Verification
- bash -n test/e2e/test-rebuild-hermes.sh
- git diff --check

Follow-up to main nightly https://github.com/NVIDIA/NemoClaw/actions/runs/26194332461 where rebuild-hermes-e2e failed on the stale dashboard forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Hermes rebuild end-to-end test to improve the sandbox recreation sequence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->