### PR TITLE
fix(installer): clarify express, CDI, and Ollama install prompts

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -53,7 +53,7 @@ $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 On DGX Spark, DGX Station, and Windows WSL, an interactive installer offers express install after you accept the third-party software notice.
 Express install switches onboarding to non-interactive mode, allows `sudo` password prompts for required host changes, and selects the managed local inference path for that platform.
-It applies sandbox policy in `suggested` mode with the `balanced` tier by default, unless `NEMOCLAW_POLICY_TIER` is set: the base sandbox policy plus supported package, model, web-search, and local-inference presets.
+Unless `NEMOCLAW_POLICY_TIER` is set, it applies sandbox policy in `suggested` mode with the `balanced` tier by default, using the base sandbox policy plus supported package, model, web-search, and local-inference presets.
 On WSL, express install selects the Windows-host Ollama setup path.
 Set `NEMOCLAW_NO_EXPRESS=1` to skip the express prompt, or set `NEMOCLAW_PROVIDER` before launching the installer when you want to choose a provider yourself.
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -52,7 +52,8 @@ $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
 On DGX Spark, DGX Station, and Windows WSL, an interactive installer offers express install after you accept the third-party software notice.
-Express install switches onboarding to non-interactive mode, allows `sudo` password prompts for required host changes, applies the suggested security policy, and selects the managed local inference path for that platform.
+Express install switches onboarding to non-interactive mode, allows `sudo` password prompts for required host changes, and selects the managed local inference path for that platform.
+It applies sandbox policy in `suggested` mode with the `balanced` tier by default, unless `NEMOCLAW_POLICY_TIER` is set: the base sandbox policy plus supported package, model, web-search, and local-inference presets.
 On WSL, express install selects the Windows-host Ollama setup path.
 Set `NEMOCLAW_NO_EXPRESS=1` to skip the express prompt, or set `NEMOCLAW_PROVIDER` before launching the installer when you want to choose a provider yourself.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1843,9 +1843,15 @@ repair_installer_nvidia_cdi_spec() {
 
   local sudo_cmd=()
   info "Generating missing NVIDIA CDI device spec at ${spec_path}."
+  info "NVIDIA GPU passthrough uses CDI specs so Docker/OpenShell can request nvidia.com/gpu devices."
+  info "Docker is configured for CDI, but the nvidia.com/gpu spec is missing."
+  info "Without it, OpenShell gateway startup would fail before the sandbox can use the GPU."
+  info "NemoClaw will first enable NVIDIA's CDI refresh service."
+  info "If that service does not generate the spec, NemoClaw will run nvidia-ctk cdi generate directly."
   if [[ "$(id -u)" -ne 0 ]]; then
     sudo_cmd=(sudo)
-    info "This host is missing NVIDIA CDI device specs. The next steps use sudo to repair them."
+    info "You may be asked for your password to authorize these host-level admin changes."
+    info "NemoClaw does not store your password."
     if ! sudo -v; then
       warn "Could not obtain sudo credentials for NVIDIA CDI device spec generation."
       return 0
@@ -2212,6 +2218,50 @@ detect_express_platform() {
 # non-interactive + provider/model env vars when accepted. Skipped when
 # the user already passed --non-interactive, set NEMOCLAW_PROVIDER, or has
 # no TTY.
+describe_express_install() {
+  local platform="$1"
+  local inference_summary=""
+  local tier="${NEMOCLAW_POLICY_TIER:-balanced}"
+  local policy_summary=""
+
+  case "$platform" in
+    "DGX Spark")
+      inference_summary="managed local Ollama with model qwen3.6:35b"
+      ;;
+    "DGX Station")
+      inference_summary="managed local vLLM"
+      ;;
+    "Windows WSL")
+      inference_summary="Windows-host Ollama through host.docker.internal"
+      ;;
+    *)
+      inference_summary="managed local inference"
+      ;;
+  esac
+
+  case "$tier" in
+    balanced)
+      policy_summary="base sandbox policy plus npm, pypi, huggingface, brew, brave when supported"
+      policy_summary="${policy_summary}, and local-inference access when needed"
+      ;;
+    restricted)
+      policy_summary="base sandbox policy, plus local-inference access when needed"
+      ;;
+    open)
+      policy_summary="base sandbox policy plus broad third-party presets"
+      policy_summary="${policy_summary}, and local-inference access when needed"
+      ;;
+    *)
+      policy_summary="base sandbox policy plus tier presets supported by the active agent"
+      policy_summary="${policy_summary}, and local-inference access when needed"
+      ;;
+  esac
+
+  printf "  Express install will configure %s.\n" "$inference_summary"
+  printf "  It runs onboarding non-interactively, but still prompts for sudo when host setup needs it.\n"
+  printf "  Sandbox policy: suggested mode, tier '%s'. This uses the %s.\n" "$tier" "$policy_summary"
+}
+
 maybe_offer_express_install() {
   local platform
   platform="$(detect_express_platform)"
@@ -2236,14 +2286,16 @@ maybe_offer_express_install() {
   local reply=""
   if [ -t 0 ]; then
     info "Detected ${platform}."
-    printf "  Run express install (auto-configures inference and applies suggested security policy)? [Y/n]: "
+    describe_express_install "$platform"
+    printf "  Run express install with these settings? [Y/n]: "
     if ! IFS= read -r reply; then
       info "Skipping express install (unable to read from TTY)."
       return 0
     fi
   elif { exec 3</dev/tty; } 2>/dev/null; then
     info "Detected ${platform}."
-    printf "  Run express install (auto-configures inference and applies suggested security policy)? [Y/n]: "
+    describe_express_install "$platform"
+    printf "  Run express install with these settings? [Y/n]: "
     if ! IFS= read -r reply <&3; then
       exec 3<&-
       info "Skipping express install (unable to read from TTY)."
@@ -2328,6 +2380,8 @@ main() {
   export NEMOCLAW_NON_INTERACTIVE="${NON_INTERACTIVE}"
   export NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE="${ACCEPT_THIRD_PARTY_SOFTWARE}"
 
+  print_banner
+
   # Fail-fast license-acceptance check (#2671). Headless curl|bash still exits
   # before phase 1 so it cannot leave a half-install behind. Piped installs from
   # a real terminal are different: stdin is the script pipe, but /dev/tty can
@@ -2336,15 +2390,14 @@ main() {
 
   ensure_docker
 
-  # Offer express install on supported platforms (DGX Spark / Station). Runs
-  # AFTER the third-party notice so the user has explicitly accepted the
+  # Offer express install on supported platforms (DGX Spark / Station / WSL).
+  # Runs AFTER the third-party notice so the user has explicitly accepted the
   # license before opting into the unattended path. Express only sets the
   # provider/model/policy + non-interactive vars; license acceptance is
   # already recorded by preflight above.
   maybe_offer_express_install
 
   _INSTALL_START=$SECONDS
-  print_banner
   bash "${SCRIPT_DIR}/setup-jetson.sh"
 
   step 1 "Node.js"

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -53,7 +53,9 @@ else
   : >"$_START_LOG"
   chmod 600 "$_START_LOG" 2>/dev/null || true
 fi
-exec > >(tee -a "$_START_LOG") 2> >(tee -a "$_START_LOG" >&2)
+exec 3>&1
+exec 4>&2
+exec > >(tee -a "$_START_LOG" >&3) 2> >(tee -a "$_START_LOG" >&4)
 
 # ── Source shared sandbox initialisation library ─────────────────
 # Single source of truth for security-sensitive primitives shared with
@@ -189,6 +191,18 @@ print(port)
 PYPORT
 }
 
+emit_startup_error() {
+  local message="$1"
+  if [ -n "${_START_LOG:-}" ]; then
+    printf '%s\n' "$message" >>"$_START_LOG" 2>/dev/null || true
+  fi
+  if { true >&4; } 2>/dev/null; then
+    printf '%s\n' "$message" >&4
+  else
+    printf '%s\n' "$message" >&2
+  fi
+}
+
 # Validate NEMOCLAW_DASHBOARD_PORT if set (same behavior as ports.js: fail fast).
 _DASHBOARD_PORT_RAW="${NEMOCLAW_DASHBOARD_PORT:-}"
 if [ -z "$_DASHBOARD_PORT_RAW" ]; then
@@ -209,7 +223,7 @@ else
     _DASHBOARD_PORT_VALID=0
   fi
   if [ "$_DASHBOARD_PORT_VALID" -ne 1 ]; then
-    echo "[SECURITY] Invalid NEMOCLAW_DASHBOARD_PORT='${NEMOCLAW_DASHBOARD_PORT}' — must be an integer between 1024 and 65535" >&2
+    emit_startup_error "[SECURITY] Invalid NEMOCLAW_DASHBOARD_PORT='${NEMOCLAW_DASHBOARD_PORT}' — must be an integer between 1024 and 65535"
     exit 1
   fi
 fi

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -7159,9 +7159,9 @@ async function setupNim(
           ensureOllamaLinuxExtractionDependencies();
           console.log(
             "  The Ollama installer creates a system user, a systemd service, and writes to /usr/local. " +
-              "It uses sudo for those steps; you may be prompted for your password.",
+              "It uses sudo, may ask for your password, and can take a few minutes; installer output will stream below.",
           );
-          runShell("set -o pipefail; curl -fsSL https://ollama.com/install.sh | sh");
+          runShell("set -o pipefail; curl -fsSL https://ollama.com/install.sh | sh", { stdio: "inherit" });
           // Give the just-started ollama.service a moment to bind port
           // 11434 before we probe or apply the systemd drop-in override.
           sleep(2);

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -1180,6 +1180,13 @@ exit 99
     });
 
     expect(result.status, output).toBe(0);
+    expect(output).toMatch(
+      /NVIDIA GPU passthrough uses CDI specs so Docker\/OpenShell can request nvidia\.com\/gpu devices/,
+    );
+    expect(output).toMatch(/Docker is configured for CDI, but the nvidia\.com\/gpu spec is missing/);
+    expect(output).toMatch(
+      /You may be asked for your password to authorize these host-level admin changes/,
+    );
     expect(output).toMatch(/Trying NVIDIA CDI refresh service \(auto-generates GPU CDI specs\)/);
     expect(output).toMatch(/Enabled NVIDIA CDI refresh service/);
     expect(output).not.toMatch(/falling back to direct generation/);
@@ -1204,6 +1211,8 @@ exit 1
 
     expect(result.status, output).toBe(0);
     expect(output).toMatch(/Generating missing NVIDIA CDI device spec/);
+    expect(output).toMatch(/NemoClaw will first enable NVIDIA's CDI refresh service/);
+    expect(output).toMatch(/NemoClaw does not store your password/);
     expect(output).toMatch(/Generated NVIDIA CDI device spec/);
     expect(output).toMatch(/Trying NVIDIA CDI refresh service \(auto-generates GPU CDI specs\)/);
     expect(output).toMatch(/falling back to direct generation/);
@@ -3192,6 +3201,10 @@ sys.exit(exit_code)
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status, output).toBe(0);
     expect(output).toMatch(/Detected DGX Spark/);
+    expect(output).toMatch(
+      /Express install will configure managed local Ollama with model qwen3\.6:35b/,
+    );
+    expect(output).toMatch(/Sandbox policy: suggested mode, tier 'balanced'/);
     expect(output).toMatch(/Run express install/);
     expect(output).toMatch(/Using express install for DGX Spark/);
     expect(output).toMatch(
@@ -3230,6 +3243,10 @@ detect_express_platform
     const output = `${result.stdout}${result.stderr}`;
     expect(result.status, output).toBe(0);
     expect(output).toMatch(/Detected Windows WSL/);
+    expect(output).toMatch(
+      /Express install will configure Windows-host Ollama through host\.docker\.internal/,
+    );
+    expect(output).toMatch(/Sandbox policy: suggested mode, tier 'balanced'/);
     expect(output).toMatch(/Run express install/);
     expect(output).toMatch(/Using express install for Windows WSL/);
     expect(output).toMatch(

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -4734,9 +4734,9 @@ runner.run = (command, opts) => {
   runCommands.push(rendered);
   events.push({ type: "command", value: rendered });
 };
-runner.runShell = (command, opts) => {
+runner.runShell = (command, opts = {}) => {
   runCommands.push(command);
-  events.push({ type: "command", value: command });
+  events.push({ type: "command", value: command, stdio: opts.stdio || null });
 };
 registry.updateSandbox = (_name, update) => updates.push(update);
 
@@ -4820,6 +4820,14 @@ const { setupNim } = require(${onboardPath});
       (event: { type: string; value: string }) =>
         event.type === "command" && event.value.includes("ollama.com/install.sh"),
     );
+    const installerProgressEventIndex = payload.events.findIndex(
+      (event: { type: string; value: string }) =>
+        event.type === "log" && event.value.includes("installer output will stream below"),
+    );
+    const installerCommandEvent = payload.events.find(
+      (event: { type: string; value: string }) =>
+        event.type === "command" && event.value.includes("ollama.com/install.sh"),
+    );
     assert.ok(
       zstdWarningEventIndex >= 0 && zstdWarningEventIndex < zstdCommandEventIndex,
       "Should explain the zstd sudo install before running apt-get",
@@ -4827,6 +4835,15 @@ const { setupNim } = require(${onboardPath});
     assert.ok(
       installerWarningEventIndex >= 0 && installerWarningEventIndex < installerCommandEventIndex,
       "Should explain the Ollama installer sudo usage before running it",
+    );
+    assert.ok(
+      installerProgressEventIndex >= 0 && installerProgressEventIndex < installerCommandEventIndex,
+      "Should warn that the Ollama installer can take a few minutes before running it",
+    );
+    assert.equal(
+      installerCommandEvent?.stdio,
+      "inherit",
+      "Should stream Ollama installer output live",
     );
     assert.ok(
       payload.runCommands.some((cmd: string) => cmd.includes("ollama.com/install.sh")),
@@ -4990,6 +5007,7 @@ child_process.spawnSync = (cmd, args, opts) => {
 let promptCalls = 0;
 const updates = [];
 const runCommands = [];
+const runShellCalls = [];
 
 credentials.prompt = async () => {
   promptCalls += 1;
@@ -5009,8 +5027,9 @@ runner.runCapture = (command) => {
 runner.run = (command) => {
   runCommands.push(typeof command === "string" ? command : command.join(" "));
 };
-runner.runShell = (command) => {
+runner.runShell = (command, opts = {}) => {
   runCommands.push(command);
+  runShellCalls.push({ command, stdio: opts.stdio || null });
 };
 registry.updateSandbox = (_name, update) => updates.push(update);
 
@@ -5025,7 +5044,7 @@ const { setupNim } = require(${onboardPath});
   console.log = (...args) => lines.push(args.join(" "));
   try {
     const result = await setupNim("noninteractive-install-test", null);
-    originalLog(JSON.stringify({ result, promptCalls, updates, lines, runCommands }));
+    originalLog(JSON.stringify({ result, promptCalls, updates, lines, runCommands, runShellCalls }));
   } finally {
     console.log = originalLog;
   }
@@ -5072,6 +5091,14 @@ const { setupNim } = require(${onboardPath});
     assert.ok(
       payload.runCommands.some((cmd: string) => cmd.includes("ollama.com/install.sh")),
       "Should use the Ollama installer when requested non-interactively on a fresh host",
+    );
+    const ollamaInstallShellCall = payload.runShellCalls.find((call: { command: string }) =>
+      call.command.includes("ollama.com/install.sh"),
+    );
+    assert.equal(
+      ollamaInstallShellCall?.stdio,
+      "inherit",
+      "non-interactive Ollama install should stream installer output live",
     );
     assert.ok(
       payload.runCommands.some((cmd: string) =>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Clarifies installer and onboarding terminal output for Express install, NVIDIA CDI repair, and Linux Ollama installation. The installer now explains selected inference and policy settings, why host repair may ask for sudo, and streams Ollama installer progress during long-running setup.

## Changes
- Move the installer banner before early interactive prompts so resumed installs feel anchored.
- Expand Express install text to explain selected local inference and sandbox policy behavior.
- Add NVIDIA CDI repair context before sudo prompts.
- Stream Linux Ollama installer output and clarify that the step may take a few minutes.
- Update focused tests for Express install, CDI repair messaging, and Ollama install streaming.
- Update quickstart docs for Express install policy behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Express install guidance: non-interactive mode, sudo password prompt behavior, and default sandbox policy/tier details.

* **Improvements**
  * Show live installer output during Linux Ollama install.
  * Expanded express-install summary to surface selected inference setup and sandbox policy.
  * Enhanced CDI/repair messaging with clearer guidance on host-level authorization and password handling.
  * Improved startup error reporting and log capture for the entrypoint.

* **Tests**
  * Updated tests to assert new messaging, prompts, and live-install behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->