### PR TITLE
fix(doctor): handle docker-driver gateway mode (resolver + skip k3s port check)

### DIFF
--- a/src/lib/actions/sandbox/doctor.test.ts
+++ b/src/lib/actions/sandbox/doctor.test.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import type {
+  SpawnSyncOptions,
+  SpawnSyncReturns,
+} from "node:child_process";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Import from dist/ rather than ./doctor: doctor.ts's transitive deps use bare
+// CJS require("./relative") for sibling modules, which Node's CJS loader
+// resolves fine against compiled .js but vitest cannot resolve to .ts on the
+// fly. The same dist-import pattern is used by
+// src/lib/actions/sandbox/status.test.ts.
+import { dockerInspectGateway } from "../../../../dist/lib/actions/sandbox/doctor";
+
+// Grab the *CJS-cached* node:child_process the compiled doctor.js will see.
+// `import * as childProcess from "node:child_process"` returns a frozen ESM
+// namespace whose properties cannot be redefined, so vi.spyOn fails. The
+// require() path gives the mutable module object that the compiled dist
+// module reads at each call.
+const childProcessCjs = createRequire(import.meta.url)("node:child_process") as {
+  spawnSync: typeof import("node:child_process").spawnSync;
+};
+
+// The `docker inspect` format string the doctor uses is:
+//   {{.State.Running}}\t{{Health}}\t{{.Config.Image}}
+const HEALTHY_INSPECT_STDOUT = "true\thealthy\topenshell/sandbox-from:1779075943";
+// `docker port <container> 30051/tcp` returns the host-side mapping.
+// The doctor accepts the mapping iff it contains `:${GATEWAY_PORT}` (default 8080).
+const HOST_PORT_MAPPING_STDOUT = "0.0.0.0:8080\n";
+
+type SpawnReply = SpawnSyncReturns<string>;
+
+function spawnReply(stdout: string, status = 0): SpawnReply {
+  return {
+    status,
+    stdout,
+    stderr: "",
+    pid: 1,
+    output: [null, stdout, ""],
+    signal: null,
+  };
+}
+
+describe("dockerInspectGateway", () => {
+  const originalSpawnSync = childProcessCjs.spawnSync;
+  let spawnSyncMock: ReturnType<typeof vi.fn<(...args: unknown[]) => SpawnReply>>;
+
+  beforeEach(() => {
+    spawnSyncMock = vi.fn<(...args: unknown[]) => SpawnReply>();
+    childProcessCjs.spawnSync = spawnSyncMock as unknown as typeof originalSpawnSync;
+  });
+
+  afterEach(() => {
+    childProcessCjs.spawnSync = originalSpawnSync;
+  });
+
+  it("skips the port-mapping check when skipPortCheck=true (docker-driver mode)", () => {
+    // Only one spawnSync call is expected (the inspect probe). A second call
+    // would be the regression this test guards against.
+    spawnSyncMock.mockReturnValueOnce(spawnReply(HEALTHY_INSPECT_STDOUT));
+
+    const checks = dockerInspectGateway("openshell-jarvis-abc123", true);
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const firstCall = spawnSyncMock.mock.calls[0] as [
+      string,
+      string[],
+      SpawnSyncOptions,
+    ];
+    expect(firstCall[0]).toBe("docker");
+    expect(firstCall[1][0]).toBe("inspect");
+    expect(firstCall[1]).toContain("openshell-jarvis-abc123");
+
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({
+      group: "Gateway",
+      label: "Docker container",
+      status: "ok",
+    });
+    expect(checks.find((c: { label: string }) => c.label === "Port mapping")).toBeUndefined();
+  });
+
+  it("runs the port-mapping check when skipPortCheck defaults to false (legacy K3s mode)", () => {
+    // Two calls expected: inspect, then port. Both succeed.
+    spawnSyncMock
+      .mockReturnValueOnce(spawnReply(HEALTHY_INSPECT_STDOUT))
+      .mockReturnValueOnce(spawnReply(HOST_PORT_MAPPING_STDOUT));
+
+    const checks = dockerInspectGateway("openshell-cluster-nemoclaw");
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+    const calls = spawnSyncMock.mock.calls as Array<
+      [string, string[], SpawnSyncOptions]
+    >;
+    expect(calls[0][1][0]).toBe("inspect");
+    expect(calls[1][1][0]).toBe("port");
+    expect(calls[1][1]).toContain("30051/tcp");
+
+    expect(checks).toHaveLength(2);
+    expect(checks[0]).toMatchObject({
+      group: "Gateway",
+      label: "Docker container",
+      status: "ok",
+    });
+    expect(checks[1]).toMatchObject({
+      group: "Gateway",
+      label: "Port mapping",
+      status: "ok",
+    });
+  });
+});

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -184,7 +184,8 @@ function renderDoctorReport(report: DoctorReport, asJson: boolean): number {
   return doctorReportExitCode(report);
 }
 
-function dockerInspectGateway(containerName: string, skipPortCheck: boolean = false): DoctorCheck[] {
+/** @internal — exported for unit tests; sole production consumer is runSandboxDoctor in this file. */
+export function dockerInspectGateway(containerName: string, skipPortCheck: boolean = false): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
   const inspect = captureHostCommand(
     "docker",

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -184,7 +184,7 @@ function renderDoctorReport(report: DoctorReport, asJson: boolean): number {
   return doctorReportExitCode(report);
 }
 
-function dockerInspectGateway(containerName: string): DoctorCheck[] {
+function dockerInspectGateway(containerName: string, skipPortCheck: boolean = false): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
   const inspect = captureHostCommand(
     "docker",
@@ -220,6 +220,8 @@ function dockerInspectGateway(containerName: string): DoctorCheck[] {
     hint: running ? undefined : "restart the gateway with `openshell gateway start --name nemoclaw`",
   });
 
+  // docker-driver mode: gateway runs on host, no port mapping on container
+  if (skipPortCheck) return checks;
   const port = captureHostCommand("docker", ["port", containerName, "30051/tcp"], 5000);
   if (port.status === 0 && port.stdout.trim()) {
     const mapping = oneLine(port.stdout);
@@ -463,7 +465,8 @@ export async function runSandboxDoctor(
     hint: openshellBin ? undefined : "install OpenShell before using sandbox commands",
   });
 
-  checks.push(...dockerInspectGateway(`openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`));
+  const _dockerDriverContainer = shields.resolveDockerDriverSandboxContainer(sandboxName);
+  checks.push(...dockerInspectGateway(_dockerDriverContainer || `openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`, !!_dockerDriverContainer));
 
   let openshellConnected = false;
   if (openshellBin) {

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -1268,6 +1268,7 @@ export {
   parseDuration,
   lockAgentConfig,
   unlockAgentConfig,
+  resolveDockerDriverSandboxContainer,
   MAX_TIMEOUT_SECONDS,
   DEFAULT_TIMEOUT_SECONDS,
 };


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Summary</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">nemoclaw &lt;sandbox&gt; doctor</code> reports two false failures in docker-driver gateway mode (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshellDriver === "docker"</code>):</p>
<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong>Gateway &gt; Docker container: fail</strong> — <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dockerInspectGateway</code> looks for a hard-coded container name <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshell-cluster-${NEMOCLAW_GATEWAY_NAME}</code> that only exists in kubernetes-driver mode.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong>Gateway &gt; Port mapping: fail</strong> — once the inspect succeeds, this check looks for <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">30051/tcp</code> published on the host port. In docker-driver mode the gateway is a HOST process (not inside the sandbox container), so no container port mapping exists.</li>
</ol>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Both failures are diagnostic-only — the gateway itself works correctly in docker-driver mode, and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">OpenShell status: connected</code> reports <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ok</code> alongside the failed container check. The user is told the system is broken when it isn't.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Root cause</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dockerInspectGateway</code> in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/lib/actions/sandbox/doctor.ts</code> was written for the legacy k3s-style cluster gateway architecture:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2">The gateway runs <strong>inside</strong> a Docker container named <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshell-cluster-&lt;gateway-name&gt;</code>.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">That container exposes gRPC on port <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">:30051</code>.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">The host publishes that port at <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">NEMOCLAW_GATEWAY_PORT</code>.</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">In docker-driver mode (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshellDriver === "docker"</code>), the architecture is different:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2">Each sandbox has its own container named <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshell-${sandbox-name}-${uuid}</code>.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">The gateway runs as a <strong>host process</strong> (not inside any container).</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">The sandbox container talks to the host gateway via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">host.openshell.internal</code>.</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/lib/shields/index.ts</code> already has a <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">resolveDockerDriverSandboxContainer(sandboxName)</code> helper that handles this correctly — it returns <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">null</code> unless <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshellDriver === "docker"</code>, otherwise enumerates containers via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">docker ps</code> and matches the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshell-${sandbox-name}-</code> prefix. It's used internally for <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">kubectlExecArgv</code> vs. docker-driver routing in shields code. But it wasn't exported, so <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">doctor.ts</code> couldn't use it.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Fix</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Two surgical changes (2 files, ~7 insertions, 2 deletions):</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/lib/shields/index.ts</code></strong> — add <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">resolveDockerDriverSandboxContainer</code> to the named-export block at line ~1260. No function body changes; just exposing the existing implementation.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/lib/actions/sandbox/doctor.ts</code></strong>:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dockerInspectGateway(containerName: string)</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dockerInspectGateway(containerName: string, skipPortCheck: boolean = false)</code>. The new optional flag defaults to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">false</code>, preserving all existing callers' behavior.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Inside the function, add <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">if (skipPortCheck) return checks;</code> before the port-mapping block. When set, the function emits the "Docker container" check and returns, skipping the k3s-only port check.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">The single caller (line 448) computes the resolver result and passes the resolved name (or legacy fallback) plus the skip flag:</li>
</ul>
<div role="group" aria-label="ts code" tabindex="0" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  isolate
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md backdrop-blur-md _fill_10ocf_9 _ghost_10ocf_96" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3A1.5 1.5 0 0 1 14 4.5V6h1.5A1.5 1.5 0 0 1 17 7.5v8a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 6 15.5V14H4.5A1.5 1.5 0 0 1 3 12.5v-8A1.5 1.5 0 0 1 4.5 3zm1.5 9.5a1.5 1.5 0 0 1-1.5 1.5H7v1.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5H14zM4.5 4a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.188 5.11a.5.5 0 0 1 .752.626l-.056.084-7.5 9a.5.5 0 0 1-.738.033l-3.5-3.5-.064-.078a.501.501 0 0 1 .693-.693l.078.064 3.113 3.113 7.15-8.58z"></path></svg></div></div></div></button></div></div><div class="text-text-500 font-small p-3.5 pb-0">ts</div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code class="language-ts" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre;"><span><span class="token token" style="color: rgb(204, 123, 244);">const</span><span> _dockerDriverContainer </span><span class="token token" style="color: rgb(234, 236, 240);">=</span><span> shields</span><span class="token token" style="color: rgb(211, 215, 222);">.</span><span class="token token property-access" style="color: rgb(112, 184, 255);">resolveDockerDriverSandboxContainer</span><span class="token token" style="color: rgb(211, 215, 222);">(</span><span>sandboxName</span><span class="token token" style="color: rgb(211, 215, 222);">)</span><span class="token token" style="color: rgb(211, 215, 222);">;</span><span>
</span></span><span><span>checks</span><span class="token token" style="color: rgb(211, 215, 222);">.</span><span class="token token property-access" style="color: rgb(112, 184, 255);">push</span><span class="token token" style="color: rgb(211, 215, 222);">(</span><span class="token token spread" style="color: rgb(234, 236, 240);">...</span><span class="token token property-access" style="color: rgb(112, 184, 255);">dockerInspectGateway</span><span class="token token" style="color: rgb(211, 215, 222);">(</span><span>
</span></span><span><span>  _dockerDriverContainer </span><span class="token token" style="color: rgb(234, 236, 240);">||</span><span> </span><span class="token token template-punctuation" style="color: rgb(155, 233, 99);">`</span><span class="token token" style="color: rgb(155, 233, 99);">openshell-cluster-</span><span class="token token interpolation interpolation-punctuation" style="color: rgb(211, 215, 222);">${</span><span class="token token interpolation" style="color: rgb(94, 237, 237);">NEMOCLAW_GATEWAY_NAME</span><span class="token token interpolation interpolation-punctuation" style="color: rgb(211, 215, 222);">}</span><span class="token token template-punctuation" style="color: rgb(155, 233, 99);">`</span><span class="token token" style="color: rgb(211, 215, 222);">,</span><span>
</span></span><span><span>  </span><span class="token token" style="color: rgb(234, 236, 240);">!</span><span class="token token" style="color: rgb(234, 236, 240);">!</span><span>_dockerDriverContainer
</span></span><span><span></span><span class="token token" style="color: rgb(211, 215, 222);">)</span><span class="token token" style="color: rgb(211, 215, 222);">)</span><span class="token token" style="color: rgb(211, 215, 222);">;</span></span></code></pre></div></div>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dockerInspectGateway</code> is now <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">export</code>ed (annotated <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">/** @internal — exported for unit tests; sole production consumer is runSandboxDoctor in this file. */</code>) so the new test file can import it directly.</li>
</ul>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Tests</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Added <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/lib/actions/sandbox/doctor.test.ts</code> with two unit tests covering both branches of <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dockerInspectGateway</code>:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">skipPortCheck=true</code> (docker-driver path) — asserts only one host command issued (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">docker inspect</code>), no port probe; result contains the "Docker container" check, no "Port mapping" check.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">skipPortCheck=false</code> (default, K3s path) — asserts both inspect + port probes run as before; result contains both checks, port mapping reports <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ok</code> when host mapping contains <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">:GATEWAY_PORT</code>.</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Verified locally on Ubuntu 24.04 aarch64 (DGX Spark) with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">npx vitest run src/lib/actions/sandbox/</code> — 37/37 tests pass across 7 files in 4ms.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Note for reviewers about the test import path</strong>: the test imports <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dockerInspectGateway</code> from <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">../../../../dist/lib/actions/sandbox/doctor</code> (compiled output) rather than <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">./doctor</code> (source). This follows the existing precedent in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/lib/actions/sandbox/status.test.ts</code>. The reason: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">doctor.ts</code>'s transitive deps use bare CJS <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">require("./relative")</code> for sibling modules, which vitest cannot resolve to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">.ts</code> on the fly without first running <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">npm run build:cli</code>. A long-term refactor converting these <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">require()</code> calls to ES imports would unblock direct <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">.ts</code> testing project-wide — happy to do that in a follow-up PR if desired.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Two other diligence notes from the test work:</p>
<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">npm install --ignore-scripts</code> is required to get vitest installed</strong> because the package's <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">prepare</code> script runs <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">npm install --omit=dev</code> after the build, which would strip vitest right after installing it. The <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">--ignore-scripts</code> flag avoids that. Worth a contributor-docs note.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong>Mocking <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">child_process.spawnSync</code> for dist/-imported code</strong> required the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">createRequire(import.meta.url)("node:child_process")</code> pattern. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">vi.spyOn</code> against the ESM namespace fails with "Cannot redefine property: spawnSync" (the namespace is frozen). The CJS-cached module is mutable. Documented inline in the test for future contributors.</li>
</ol>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Driver-mode matrix (verified behavior)</h2>
<div class="overflow-x-auto w-full px-2 mb-6">
openshellDriver | Container check | Port check
-- | -- | --
"docker" | inspects real sandbox container, reports running/health/image | skipped (gateway is on host, not in container)
"kubernetes" | inspects openshell-cluster-<gateway> (unchanged) | runs as before (looks for 30051/tcp)
"vm" (macOS) | resolver returns null, legacy fallback, inspect fails as before | runs as before, fails as before
null / undefined / registry throws | resolver's try/catch returns null, legacy fallback | runs as before

</div>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">All non-docker modes preserve current behavior exactly. Docker-driver mode now gets accurate diagnostics.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Reproduction (before this PR)</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">On Ubuntu 24.04 aarch64 (DGX Spark) with NemoClaw <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">2026.4.24</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshellDriver === "docker"</code>, real sandbox container <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshell-jarvis-19f22332-…</code>:</p>
<div role="group" aria-label="Code" tabindex="0" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  isolate
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md backdrop-blur-md _fill_10ocf_9 _ghost_10ocf_96" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3A1.5 1.5 0 0 1 14 4.5V6h1.5A1.5 1.5 0 0 1 17 7.5v8a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 6 15.5V14H4.5A1.5 1.5 0 0 1 3 12.5v-8A1.5 1.5 0 0 1 4.5 3zm1.5 9.5a1.5 1.5 0 0 1-1.5 1.5H7v1.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5H14zM4.5 4a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.188 5.11a.5.5 0 0 1 .752.626l-.056.084-7.5 9a.5.5 0 0 1-.738.033l-3.5-3.5-.064-.078a.501.501 0 0 1 .693-.693l.078.064 3.113 3.113 7.15-8.58z"></path></svg></div></div></div></button></div></div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre-wrap;"><span><span>$ nemoclaw &lt;sandbox&gt; doctor
</span></span><span>…
</span><span>Gateway:
</span><span>  [fail] Docker container: openshell-cluster-nemoclaw not found or not inspectable
</span><span>       hint: run `docker ps --filter name=openshell-cluster-nemoclaw`
</span><span>  [ok] OpenShell status: connected to nemoclaw
</span><span>Summary: attention needed (1 failed, 1 warning(s))</span></code></pre></div></div>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">After this PR:</p>
<div role="group" aria-label="Code" tabindex="0" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  isolate
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md backdrop-blur-md _fill_10ocf_9 _ghost_10ocf_96" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3A1.5 1.5 0 0 1 14 4.5V6h1.5A1.5 1.5 0 0 1 17 7.5v8a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 6 15.5V14H4.5A1.5 1.5 0 0 1 3 12.5v-8A1.5 1.5 0 0 1 4.5 3zm1.5 9.5a1.5 1.5 0 0 1-1.5 1.5H7v1.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5H14zM4.5 4a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.188 5.11a.5.5 0 0 1 .752.626l-.056.084-7.5 9a.5.5 0 0 1-.738.033l-3.5-3.5-.064-.078a.501.501 0 0 1 .693-.693l.078.064 3.113 3.113 7.15-8.58z"></path></svg></div></div></div></button></div></div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre-wrap;"><span><span>$ nemoclaw &lt;sandbox&gt; doctor
</span></span><span>…
</span><span>Gateway:
</span><span>  [ok] Docker container: openshell-jarvis-19f22332-… running (none; openshell/sandbox-from:1779075943)
</span><span>  [ok] OpenShell status: connected to nemoclaw
</span><span>Summary: healthy with 1 warning(s)</span></code></pre></div></div>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">The remaining warning is <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Shields: down</code>, an environmental finding unrelated to this PR.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Also verified end-to-end post-patch in the same environment:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2">Gateway gRPC/MCP traffic still works (sandbox → host MCP server → Gmail / iCloud Calendar APIs; confirmed via real bilingual tool-call exchange).</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">nemoclaw &lt;sandbox&gt; status</code> output unchanged.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Local automated audit suite (independent of doctor) remains green.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">No shields-related regressions.</li>
</ul>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Blast radius / risk</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Minimal:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">shields/index.ts</code></strong> change is purely additive (one new line in the named-export block; no function body changes). Cannot affect any existing call paths.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">doctor.ts</code></strong> change adds an optional parameter (default preserves all existing callers' behavior) and a single early-return guard. The only call site that passes the new flag is the one updated. The function is annotated <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@internal — exported for unit tests</code> so the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">export</code> keyword shouldn't be relied on by external consumers.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">No new dependencies, no signature changes to publicly-exported functions, no shared-state changes.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Tests are additive (new file, new export). Existing tests untouched.</li>
</ul>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Related findings (not in this PR)</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">While auditing, I also noticed <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">stopSandboxChannelsViaKubectl</code> in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/lib/tunnel/services.ts:439</code> uses the same hard-coded <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">GATEWAY_CLUSTER_CONTAINER</code> constant. <strong>However, this is safe and doesn't need a patch</strong> — it's wrapped in a try-then-fallback pattern: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">stopSandboxChannels</code> (line ~369) tries the kubectl-via-cluster-container path first, checks the result via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">reportStopResult</code>, and falls through to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshell sandbox exec</code> with the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">GATEWAY_STOP_SCRIPT</code> if the kubectl call fails or returns false. In docker-driver mode, the kubectl call fails gracefully (container doesn't exist), and the fallback runs the verified bash script inside the actual sandbox to stop the gateway. The doctor's failure was the anomaly precisely because doctor had no equivalent fallback; the gateway-stop architecture already self-protects. If a maintainer would prefer this PR also include a defensive guard inside <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">stopSandboxChannelsViaKubectl</code> itself (return <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">null</code> early when <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openshellDriver !== "kubernetes"</code>), I'm happy to add it — let me know.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Also: I observed that OpenClaw's MCP runtime adapter (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openclaw/openclaw</code> repo, separate from this) silently drops the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">headers</code> field on remote MCP server configs when the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">transport</code> field is not set explicitly (even though <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sse</code> is the documented default). This is the SSE analogue of openclaw/openclaw#65590 (streamable-http). Will file a separate issue against <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">openclaw/openclaw</code> referencing #65590 — wrong repo for this PR.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Local commit history on this branch</h2>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">6c9201062</code> — fix(doctor): handle docker-driver gateway mode (resolver + skip k3s port check)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">870844ef5</code> — test(doctor): cover docker-driver skipPortCheck branch of dockerInspectGateway</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">2 commits, 2 files net, ~123 insertions / 2 deletions. Ready to squash-merge if you prefer a single-commit history.</p><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for Docker gateway inspection diagnostics.
  
* **Refactor**
  * Improved sandbox diagnostics to better handle docker-driver containers by optimizing Docker port-mapping checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->