### PR TITLE
fix(policy): preserve Homebrew in permissive OpenClaw policies

### DIFF
--- a/agents/openclaw/policy-permissive.yaml
+++ b/agents/openclaw/policy-permissive.yaml
@@ -25,6 +25,7 @@ filesystem_policy:
     - /dev/null
     - /sandbox/.openclaw
     - /sandbox/.nemoclaw
+    - /home/linuxbrew
 
 landlock:
   compatibility: best_effort

--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -14,7 +14,7 @@ version: 1
 
 filesystem_policy:
   # Filesystem section mirrors the default policy (openclaw-sandbox.yaml).
-  # OpenShell rejects include_workdir changes and read_only path removals on
+  # OpenShell rejects include_workdir changes and filesystem path removals on
   # live sandboxes.
   include_workdir: true
   read_only:
@@ -30,6 +30,7 @@ filesystem_policy:
     - /dev/null
     - /sandbox/.openclaw
     - /sandbox/.nemoclaw
+    - /home/linuxbrew
 
 landlock:
   compatibility: best_effort

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1266,6 +1266,29 @@ exit 1
       expect(parsed.filesystem_policy.read_write).toContain("/home/linuxbrew");
     });
 
+    it("OpenClaw permissive policies preserve baseline read_write paths (#3916)", () => {
+      const baseline = YAML.parse(
+        fs.readFileSync(
+          path.join(REPO_ROOT, "nemoclaw-blueprint/policies/openclaw-sandbox.yaml"),
+          "utf-8",
+        ),
+      ) as { filesystem_policy?: { read_write?: string[] } };
+      const baselineReadWrite = baseline.filesystem_policy?.read_write ?? [];
+      const permissivePolicyPaths = [
+        "nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
+        "agents/openclaw/policy-permissive.yaml",
+      ];
+
+      for (const relativePath of permissivePolicyPaths) {
+        const parsed = YAML.parse(
+          fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8"),
+        ) as { filesystem_policy?: { read_write?: string[] } };
+        expect(parsed.filesystem_policy?.read_write, relativePath).toEqual(
+          expect.arrayContaining(baselineReadWrite),
+        );
+      }
+    });
+
     it("brew preset whitelists the PATH shim and Homebrew-managed entrypoints (#3913)", () => {
       const content = requirePresetContent(policies.loadPreset("brew"));
       const parsed = YAML.parse(content);


### PR DESCRIPTION
## Summary

- Preserve `/home/linuxbrew` in the global OpenClaw permissive policy used directly by `network-policy-e2e` TC-NET-06.
- Preserve `/home/linuxbrew` in the agent-specific OpenClaw permissive policy used by `nemoclaw <sandbox> shields down`.
- Add regression coverage that both OpenClaw permissive policy files retain every baseline `filesystem_policy.read_write` path.

## Failure

Pinned nightly: https://github.com/NVIDIA/NemoClaw/actions/runs/26197248467 at `413503870a01f0e2ed27c8d9e067a7003af66cb2` after PR #3916.

- `shields-config-e2e`: https://github.com/NVIDIA/NemoClaw/actions/runs/26197248467/job/77079286013
- `network-policy-e2e`: https://github.com/NVIDIA/NemoClaw/actions/runs/26197248467/job/77079286006

Both failed while applying a permissive policy because OpenShell rejected the live removal of the PR #3916 Homebrew writable path: `filesystem read_write path '/home/linuxbrew' cannot be removed on a live sandbox`.

## Verification

- `git diff --check`
- `npm test -- test/policies.test.ts`
- `npm run validate:configs`
- `npm run typecheck`

No focused E2E was dispatched from this branch; the change is a static policy alignment plus targeted regression coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled write access to the Homebrew installation directory within sandbox environments, improving compatibility with package management operations.

* **Tests**
  * Added validation tests to ensure baseline filesystem access policies are preserved across permissive sandbox configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->