### PR TITLE
docs(network-policy): clarify Homebrew is preinstalled after #3916

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -142,7 +142,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 | Preset | What it enables | Key risk |
 |---|---|---|
 | `brave` | Brave Search API. | Agent can issue search queries. |
-| `brew` | Homebrew (Linuxbrew) package manager. The `brew` binary is preinstalled in the sandbox base image; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
+| `brew` | Homebrew (Linuxbrew) package manager. The sandbox base image includes the `brew` binary; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
 | `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |

--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -142,7 +142,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 | Preset | What it enables | Key risk |
 |---|---|---|
 | `brave` | Brave Search API. | Agent can issue search queries. |
-| `brew` | Homebrew (Linuxbrew) package manager. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
+| `brew` | Homebrew (Linuxbrew) package manager. The `brew` binary is preinstalled in the sandbox base image; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
 | `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |

--- a/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
@@ -213,8 +213,8 @@ $ nemoclaw my-assistant policy-remove huggingface --yes
 
 ### Homebrew Specifics
 
-Homebrew (Linuxbrew) is preinstalled in the sandbox base image, so applying the `brew` preset is the only step needed before installing a formula.
-The `brew` entry point is symlinked into `/usr/local/bin`, which is already on the sandbox `PATH`, so the agent can run `brew install <formula>` directly:
+The sandbox base image includes Homebrew (Linuxbrew), so applying the `brew` preset is the only step needed before installing a formula.
+A `/usr/local/bin/brew` symlink puts the entry point on the sandbox `PATH`, so the agent can run `brew install <formula>` directly:
 
 ```console
 $ nemoclaw my-assistant policy-add brew --yes

--- a/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
@@ -211,6 +211,18 @@ $ nemoclaw my-assistant policy-remove brew --yes
 $ nemoclaw my-assistant policy-remove huggingface --yes
 ```
 
+### Homebrew Specifics
+
+Homebrew (Linuxbrew) is preinstalled in the sandbox base image, so applying the `brew` preset is the only step needed before installing a formula.
+The `brew` entry point is symlinked into `/usr/local/bin`, which is already on the sandbox `PATH`, so the agent can run `brew install <formula>` directly:
+
+```console
+$ nemoclaw my-assistant policy-add brew --yes
+$ nemoclaw my-assistant exec -- brew install <formula>
+```
+
+You do not need to bootstrap Homebrew, install build dependencies, or source `brew shellenv` inside the sandbox.
+
 ## Local Inference
 
 Use `local-inference` when the sandbox needs access to host-side local inference services such as Ollama or vLLM through the OpenShell host gateway.

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -226,6 +226,18 @@ $ nemoclaw my-assistant policy-remove brew --yes
 $ nemoclaw my-assistant policy-remove huggingface --yes
 ```
 
+### Homebrew Specifics
+
+Homebrew (Linuxbrew) is preinstalled in the sandbox base image, so applying the `brew` preset is the only step needed before installing a formula.
+The `brew` entry point is symlinked into `/usr/local/bin`, which is already on the sandbox `PATH`, so the agent can run `brew install <formula>` directly:
+
+```console
+$ nemoclaw my-assistant policy-add brew --yes
+$ nemoclaw my-assistant exec -- brew install <formula>
+```
+
+You do not need to bootstrap Homebrew, install build dependencies, or source `brew shellenv` inside the sandbox.
+
 ## Local Inference
 
 Use `local-inference` when the sandbox needs access to host-side local inference services such as Ollama or vLLM through the OpenShell host gateway.

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -228,8 +228,8 @@ $ nemoclaw my-assistant policy-remove huggingface --yes
 
 ### Homebrew Specifics
 
-Homebrew (Linuxbrew) is preinstalled in the sandbox base image, so applying the `brew` preset is the only step needed before installing a formula.
-The `brew` entry point is symlinked into `/usr/local/bin`, which is already on the sandbox `PATH`, so the agent can run `brew install <formula>` directly:
+The sandbox base image includes Homebrew (Linuxbrew), so applying the `brew` preset is the only step needed before installing a formula.
+A `/usr/local/bin/brew` symlink puts the entry point on the sandbox `PATH`, so the agent can run `brew install <formula>` directly:
 
 ```console
 $ nemoclaw my-assistant policy-add brew --yes

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -159,7 +159,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 | Preset | What it enables | Key risk |
 |---|---|---|
 | `brave` | Brave Search API. | Agent can issue search queries. |
-| `brew` | Homebrew (Linuxbrew) package manager. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
+| `brew` | Homebrew (Linuxbrew) package manager. The `brew` binary is preinstalled in the sandbox base image; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
 | `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -159,7 +159,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 | Preset | What it enables | Key risk |
 |---|---|---|
 | `brave` | Brave Search API. | Agent can issue search queries. |
-| `brew` | Homebrew (Linuxbrew) package manager. The `brew` binary is preinstalled in the sandbox base image; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
+| `brew` | Homebrew (Linuxbrew) package manager. The sandbox base image includes the `brew` binary; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
 | `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |

--- a/nemoclaw-blueprint/policies/presets/brew.yaml
+++ b/nemoclaw-blueprint/policies/presets/brew.yaml
@@ -3,7 +3,10 @@
 
 preset:
   name: brew
-  description: "Homebrew (Linuxbrew) package manager access"
+  # The brew binary is preinstalled in the sandbox base image (#3913), so this
+  # preset only needs to grant the network egress used by `brew install` to
+  # fetch formulae and bottles.
+  description: "Homebrew (Linuxbrew) package manager access (brew binary preinstalled in base image)"
 
 network_policies:
   brew:


### PR DESCRIPTION
## Summary

Updates the network-policy docs and the brew preset description so users know that the brew binary already ships in the sandbox base image after #3916, and the brew preset is the only step needed before installing a formula.

## Problem

Before #3916 landed, the brew preset only granted network egress and assumed Homebrew was already on PATH. Several pages still describe brew as a generic package-manager preset without mentioning that the binary is now baked into the image, so a new user following the integration policy examples can be left looking for a separate bootstrap step that no longer applies. This PR brings those pages and the preset description in line with the post-#3916 flow.

## Changes

- docs/network-policy/integration-policy-examples.mdx: add a short "Homebrew Specifics" subsection under Package and Model Tooling that explains the post-#3916 flow with a concrete policy-add brew + exec -- brew install example, and notes that no separate Homebrew bootstrap, build dependency install, or `brew shellenv` step is required.
- docs/security/best-practices.mdx: expand the brew preset row in the policy preset table to note that the binary is preinstalled and the preset only opens network egress to GitHub and the Homebrew formulae index.
- nemoclaw-blueprint/policies/presets/brew.yaml: clarify in the preset description and a YAML comment that the brew binary is preinstalled (referencing #3913).
- .agents/skills/nemoclaw-user-{configure-security,manage-policy}/references/*.md: regenerated via the canonical docs-to-skills invocation so the agent skill mirrors stay in sync with the source pages.

## Test plan

- python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx: skill regen runs to completion and only touches the two expected reference mirrors.
- Pre-commit + pre-push hooks (markdownlint-cli2, Verify docs-to-skills output, Test (skills YAML), Source-shape test budget, TypeScript (CLI), gitleaks, NEMOCLAW_* env-var doc gate, etc.) all pass on the docs-only diff.

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded security best-practices entry for the Homebrew preset to explain what the preset enables and the risk of installing arbitrary packages.
  * Added a “Homebrew Specifics” integration guide with usage examples showing how to apply the preset and run brew installs in the sandbox.
  * Clarified that Homebrew is preinstalled in the sandbox base image and that the preset grants outbound access to fetch formulae/bottles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->