### PR TITLE
fix(e2e): mirror skill fixture to passwd-based home directory

### DIFF
--- a/test/e2e/e2e-cloud-experimental/features/skill/add-sandbox-skill.sh
+++ b/test/e2e/e2e-cloud-experimental/features/skill/add-sandbox-skill.sh
@@ -123,13 +123,29 @@ temp_file="$3"
 mkdir -p "$skill_dir"
 cp "$temp_file" "$skill_file"
 
-# Mirror into $HOME/.openclaw/skills so OpenClaw tools resolve the same SKILL.md (see agent ENOENT on /home/sandbox/.openclaw/skills/...).
+# Mirror into $HOME/.openclaw/skills so OpenClaw tools resolve the same
+# SKILL.md.  OpenShell sets $HOME to the sandbox working directory
+# (/sandbox), but the `sandbox` user's passwd entry points to
+# /home/sandbox — the openclaw agent's managed-skills loader resolves via
+# os.homedir() (getpwnam), not $HOME.  Mirror to both so the skill is
+# reachable regardless of which path the consumer uses.
 skill_id="$(basename "$skill_dir")"
 home_root="${HOME:-/home/sandbox}"
 home_skill_dir="${home_root}/.openclaw/skills/${skill_id}"
 home_skill_file="${home_skill_dir}/SKILL.md"
 mkdir -p "$home_skill_dir"
 cp "$temp_file" "$home_skill_file"
+
+# If the passwd home differs from $HOME, mirror there too so tools that
+# resolve the home directory via getpwnam (e.g. Node os.homedir()) find
+# the skill.  This covers the OpenShell case where $HOME=/sandbox but
+# getent reports /home/sandbox.
+passwd_home="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f6 || true)"
+if [ -n "$passwd_home" ] && [ "$passwd_home" != "$home_root" ]; then
+  alt_skill_dir="${passwd_home}/.openclaw/skills/${skill_id}"
+  mkdir -p "$alt_skill_dir"
+  cp "$temp_file" "${alt_skill_dir}/SKILL.md"
+fi
 
 rm -f "$temp_file"
 


### PR DESCRIPTION
## Summary

The `add-sandbox-skill.sh` helper mirrors injected skill files into `$HOME/.openclaw/skills/`, but inside an OpenShell SSH session `$HOME` resolves to `/sandbox` (the sandbox working directory) rather than `/home/sandbox` (the `sandbox` user's passwd entry). The OpenClaw agent's managed-skills loader resolves the skills directory via `os.homedir()` / `getpwnam`, which returns `/home/sandbox`, causing `[tools] read failed: ENOENT` on every agent turn.

This PR adds a secondary mirror into the passwd-reported home directory (queried via `getent passwd`) when it differs from `$HOME`, so the skill `SKILL.md` is reachable regardless of which path resolution the consumer uses.

## Related Issue

Fixes #3958

## Changes

- `test/e2e/e2e-cloud-experimental/features/skill/add-sandbox-skill.sh`: After mirroring to `$HOME/.openclaw/skills/<id>/`, query the passwd-based home via `getent passwd` and mirror there too when it differs from `$HOME`.

## Validation

The `-custom-e2e` validation branch could not be pushed because the automation token lacks the `workflow` scope (required by GitHub to push `.github/workflows/` files). Manual validation: re-run `skill-agent-e2e` on this branch via `gh workflow run nightly-e2e.yaml --repo NVIDIA/NemoClaw --ref fix/nightly-e2e-skill-agent-home-path-f19061e -f jobs=skill-agent-e2e`.

- Original failing run: [26197765497](https://github.com/NVIDIA/NemoClaw/actions/runs/26197765497) on `f19061ec9b79d019afdb274786ff0211182dc8df`
- Targeted job: `skill-agent-e2e (#77080825135)`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>