### PR TITLE
fix(e2e): allow Brev GPU bridge gateway traffic

### DIFF
--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -88,7 +88,7 @@ const BREV_SSH_READY_TIMEOUT_MS =
       ? 1800
       : 900) * 1000;
 const OPENSHELL_GATEWAY_PORT = 8080;
-const DOCKER_BRIDGE_CIDR = "172.16.0.0/12";
+const DOCKER_DEFAULT_BRIDGE_POOL_CIDR = "172.16.0.0/12";
 
 function requireInstanceName(): string {
   if (!INSTANCE_NAME) {
@@ -740,10 +740,12 @@ function gpuDockerRuntimeSetupCommands(): string[] {
     `sudo nvidia-ctk runtime configure --runtime=docker`,
     `sudo systemctl restart docker`,
     `sudo chmod 666 /var/run/docker.sock`,
-    // Brev GPU images can run UFW with Docker bridge traffic denied (#3959). The
-    // OpenShell Docker-driver gateway listens on the host, while sandboxes
-    // reach it through host.openshell.internal on a Docker bridge gateway IP.
-    `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_BRIDGE_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp >/dev/null || true; fi`,
+    // Brev GPU branch-validation VMs are single-use CI hosts. The
+    // openshell-docker network is created later by gateway startup, so this
+    // setup cannot know the exact future bridge subnet. Allow Docker's default
+    // local bridge pool to the gateway port only; product-side reachability
+    // checks still fail closed if the sandbox route is actually broken (#3959).
+    `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW Docker bridge allow rule" >&2; fi`,
     `docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi`,
   ];
 }
@@ -1055,9 +1057,9 @@ describe("Brev GPU runtime setup", () => {
     const setup = gpuDockerRuntimeSetupCommands().join("\n");
 
     expect(setup).toContain(
-      `ufw allow from ${DOCKER_BRIDGE_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp`,
+      `ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp`,
     );
-    expect(setup).toContain("|| true");
+    expect(setup).toContain("warning: could not add UFW Docker bridge allow rule");
   });
 });
 

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -87,6 +87,8 @@ const BREV_SSH_READY_TIMEOUT_MS =
     : GPU_TEST_SUITE
       ? 1800
       : 900) * 1000;
+const OPENSHELL_GATEWAY_PORT = 8080;
+const DOCKER_BRIDGE_CIDR = "172.16.0.0/12";
 
 function requireInstanceName(): string {
   if (!INSTANCE_NAME) {
@@ -724,26 +726,31 @@ function createBrevInstance(elapsed: () => string): void {
  * GPU Brev instances provide the host driver, but Docker may still need the
  * NVIDIA container runtime configured before sandbox containers can use GPUs.
  */
+function gpuDockerRuntimeSetupCommands(): string[] {
+  return [
+    `set -euo pipefail`,
+    `nvidia-smi`,
+    `sudo apt-get update -qq`,
+    `sudo apt-get install -y -qq ca-certificates curl gnupg >/dev/null`,
+    `sudo rm -f /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`,
+    `curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`,
+    `curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list >/dev/null`,
+    `sudo apt-get update -qq`,
+    `sudo apt-get install -y -qq nvidia-container-toolkit >/dev/null`,
+    `sudo nvidia-ctk runtime configure --runtime=docker`,
+    `sudo systemctl restart docker`,
+    `sudo chmod 666 /var/run/docker.sock`,
+    // Brev GPU images can run UFW with Docker bridge traffic denied (#3959). The
+    // OpenShell Docker-driver gateway listens on the host, while sandboxes
+    // reach it through host.openshell.internal on a Docker bridge gateway IP.
+    `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_BRIDGE_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp >/dev/null || true; fi`,
+    `docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi`,
+  ];
+}
+
 function prepareGpuDockerRuntime(elapsed: () => string): void {
   console.log(`[${elapsed()}] Preparing NVIDIA Docker runtime on Brev GPU instance...`);
-  ssh(
-    [
-      `set -euo pipefail`,
-      `nvidia-smi`,
-      `sudo apt-get update -qq`,
-      `sudo apt-get install -y -qq ca-certificates curl gnupg >/dev/null`,
-      `sudo rm -f /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`,
-      `curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`,
-      `curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list >/dev/null`,
-      `sudo apt-get update -qq`,
-      `sudo apt-get install -y -qq nvidia-container-toolkit >/dev/null`,
-      `sudo nvidia-ctk runtime configure --runtime=docker`,
-      `sudo systemctl restart docker`,
-      `sudo chmod 666 /var/run/docker.sock`,
-      `docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi`,
-    ].join(" && "),
-    { timeout: 900_000, stream: true },
-  );
+  ssh(gpuDockerRuntimeSetupCommands().join(" && "), { timeout: 900_000, stream: true });
   console.log(`[${elapsed()}] NVIDIA Docker runtime ready`);
 }
 
@@ -1040,6 +1047,17 @@ describe("Brev deploy input validation", () => {
     expect(output).not.toContain("Waiting for Brev instance readiness");
     expect(output).not.toContain("Waiting for SSH");
     expect(output).not.toContain("bash scripts/install.sh");
+  });
+});
+
+describe("Brev GPU runtime setup", () => {
+  it("allows Docker bridge traffic to reach the OpenShell gateway port", () => {
+    const setup = gpuDockerRuntimeSetupCommands().join("\n");
+
+    expect(setup).toContain(
+      `ufw allow from ${DOCKER_BRIDGE_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp`,
+    );
+    expect(setup).toContain("|| true");
   });
 });
 

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -88,6 +88,7 @@ const BREV_SSH_READY_TIMEOUT_MS =
       ? 1800
       : 900) * 1000;
 const OPENSHELL_GATEWAY_PORT = 8080;
+const OLLAMA_AUTH_PROXY_PORT = 11435;
 const DOCKER_DEFAULT_BRIDGE_POOL_CIDR = "172.16.0.0/12";
 
 function requireInstanceName(): string {
@@ -743,9 +744,11 @@ function gpuDockerRuntimeSetupCommands(): string[] {
     // Brev GPU branch-validation VMs are single-use CI hosts. The
     // openshell-docker network is created later by gateway startup, so this
     // setup cannot know the exact future bridge subnet. Allow Docker's default
-    // local bridge pool to the gateway port only; product-side reachability
-    // checks still fail closed if the sandbox route is actually broken (#3959).
-    `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW Docker bridge allow rule" >&2; fi`,
+    // local bridge pool to the OpenShell host-service ports needed by the GPU
+    // path; product-side reachability checks still fail closed if the sandbox
+    // route is actually broken (#3959).
+    `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW OpenShell gateway allow rule" >&2; fi`,
+    `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OLLAMA_AUTH_PROXY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW Ollama auth proxy allow rule" >&2; fi`,
     `docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi`,
   ];
 }
@@ -1053,11 +1056,14 @@ describe("Brev deploy input validation", () => {
 });
 
 describe("Brev GPU runtime setup", () => {
-  it("allows Docker bridge traffic to reach the OpenShell gateway port", () => {
+  it("allows Docker bridge traffic to reach OpenShell host-service ports", () => {
     const setup = gpuDockerRuntimeSetupCommands().join("\n");
 
     expect(setup).toContain(
-      `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW Docker bridge allow rule" >&2; fi`,
+      `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW OpenShell gateway allow rule" >&2; fi`,
+    );
+    expect(setup).toContain(
+      `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OLLAMA_AUTH_PROXY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW Ollama auth proxy allow rule" >&2; fi`,
     );
   });
 });

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -1057,9 +1057,8 @@ describe("Brev GPU runtime setup", () => {
     const setup = gpuDockerRuntimeSetupCommands().join("\n");
 
     expect(setup).toContain(
-      `ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp`,
+      `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OPENSHELL_GATEWAY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW Docker bridge allow rule" >&2; fi`,
     );
-    expect(setup).toContain("warning: could not add UFW Docker bridge allow rule");
   });
 });
 

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -52,6 +52,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync, execFileSync, spawnSync, type StdioOptions } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 // Instance configuration
@@ -1064,6 +1065,18 @@ describe("Brev GPU runtime setup", () => {
     );
     expect(setup).toContain(
       `if command -v ufw >/dev/null 2>&1; then sudo ufw allow from ${DOCKER_DEFAULT_BRIDGE_POOL_CIDR} to any port ${OLLAMA_AUTH_PROXY_PORT} proto tcp >/dev/null || echo "warning: could not add UFW Ollama auth proxy allow rule" >&2; fi`,
+    );
+  });
+
+  it("runs Docker GPU sandbox inference proof with the OpenShell proxy env", () => {
+    const script = fs.readFileSync(path.join(REPO_DIR, "test/e2e/test-gpu-e2e.sh"), "utf-8");
+
+    expect(script).toContain('[[ "$SANDBOX_INFERENCE_URL" == https://inference.local/* ]]');
+    expect(script).toContain('SANDBOX_INFERENCE_DOCKER_EXEC_ENV=(');
+    expect(script).toContain('--env "HTTPS_PROXY=${INFERENCE_PROXY_URL}"');
+    expect(script).toContain('INFERENCE_NO_PROXY="localhost,127.0.0.1,::1,${INFERENCE_PROXY_HOST}"');
+    expect(script).toContain(
+      'docker exec "${SANDBOX_INFERENCE_DOCKER_EXEC_ENV[@]}" "$sandbox_container_id"',
     );
   });
 });

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -1075,6 +1075,7 @@ describe("Brev GPU runtime setup", () => {
     expect(script).toContain('SANDBOX_INFERENCE_DOCKER_EXEC_ENV=(');
     expect(script).toContain('--env "HTTPS_PROXY=${INFERENCE_PROXY_URL}"');
     expect(script).toContain('INFERENCE_NO_PROXY="localhost,127.0.0.1,::1,${INFERENCE_PROXY_HOST}"');
+    expect(script).toContain("curl -skS --max-time 90");
     expect(script).toContain(
       'docker exec "${SANDBOX_INFERENCE_DOCKER_EXEC_ENV[@]}" "$sandbox_container_id"',
     );

--- a/test/e2e/test-gpu-e2e.sh
+++ b/test/e2e/test-gpu-e2e.sh
@@ -514,8 +514,8 @@ fi
 # OpenClaw to avoid OpenShell's inference.local TCP relay path.
 SANDBOX_INFERENCE_URL="https://inference.local/v1/chat/completions"
 SANDBOX_INFERENCE_EXEC="openshell"
-if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG" ||
-  grep -Fq "Docker-driver GPU patch active" "$INSTALL_LOG"; then
+if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG" \
+  || grep -Fq "Docker-driver GPU patch active" "$INSTALL_LOG"; then
   OLLAMA_HOST_PORT="${NEMOCLAW_OLLAMA_PORT:-11434}"
   SANDBOX_INFERENCE_URL="http://127.0.0.1:${OLLAMA_HOST_PORT}/v1/chat/completions"
   SANDBOX_INFERENCE_EXEC="docker"

--- a/test/e2e/test-gpu-e2e.sh
+++ b/test/e2e/test-gpu-e2e.sh
@@ -532,31 +532,56 @@ sandbox_curl_cmd=$(printf "curl -sS --max-time 90 %q -H %q -d %q" \
   "$SANDBOX_INFERENCE_URL" \
   "Content-Type: application/json" \
   "$sandbox_payload")
-if [ "$SANDBOX_INFERENCE_EXEC" = "docker" ]; then
-  sandbox_container_id=$(docker ps --quiet \
-    --filter "label=openshell.ai/managed-by=openshell" \
-    --filter "label=openshell.ai/sandbox-name=${SANDBOX_NAME}" \
-    | head -n 1)
-  if [ -n "$sandbox_container_id" ]; then
-    info "[LOCAL] Using docker exec for Docker GPU sandbox inference proof (${sandbox_container_id:0:12})..."
-    sandbox_response=$($TIMEOUT_CMD docker exec "$sandbox_container_id" sh -lc "$sandbox_curl_cmd" 2>&1) || true
+
+run_sandbox_inference_probe() {
+  sandbox_probe_failure=""
+  sandbox_response=""
+  if [ "$SANDBOX_INFERENCE_EXEC" = "docker" ]; then
+    sandbox_container_id=$(docker ps --quiet \
+      --filter "label=openshell.ai/managed-by=openshell" \
+      --filter "label=openshell.ai/sandbox-name=${SANDBOX_NAME}" \
+      | head -n 1)
+    if [ -n "$sandbox_container_id" ]; then
+      info "[LOCAL] Using docker exec for Docker GPU sandbox inference proof (${sandbox_container_id:0:12})..."
+      sandbox_response=$($TIMEOUT_CMD docker exec "$sandbox_container_id" sh -lc "$sandbox_curl_cmd" 2>&1) || true
+    else
+      sandbox_probe_failure="OpenShell-managed Docker container not found for ${SANDBOX_NAME}"
+    fi
   else
-    sandbox_probe_failure="OpenShell-managed Docker container not found for ${SANDBOX_NAME}"
+    sandbox_response=$($TIMEOUT_CMD openshell sandbox exec -n "$SANDBOX_NAME" -- sh -lc "$sandbox_curl_cmd" 2>&1) || true
   fi
-else
-  sandbox_response=$($TIMEOUT_CMD openshell sandbox exec -n "$SANDBOX_NAME" -- sh -lc "$sandbox_curl_cmd" 2>&1) || true
-fi
+}
+
+pong_ok=false
+sandbox_content=""
+for sandbox_attempt in 1 2 3; do
+  run_sandbox_inference_probe
+  if [ -n "$sandbox_probe_failure" ]; then
+    break
+  fi
+  if [ -n "$sandbox_response" ]; then
+    sandbox_content=$(echo "$sandbox_response" | parse_chat_content 2>/dev/null) || true
+    if echo "$sandbox_content" | grep -qi "PONG"; then
+      pong_ok=true
+      break
+    fi
+    info "Sandbox inference attempt ${sandbox_attempt}/3: got '${sandbox_content:0:80}'"
+    info "Sandbox inference raw response (first 400 chars): ${sandbox_response:0:400}"
+  else
+    info "Sandbox inference attempt ${sandbox_attempt}/3: empty response"
+  fi
+  [ "$sandbox_attempt" -lt 3 ] || break
+  sleep 5
+done
 
 if [ -n "$sandbox_probe_failure" ]; then
   fail "[LOCAL] Sandbox inference: ${sandbox_probe_failure}"
+elif $pong_ok; then
+  pass "[LOCAL] Sandbox inference: Ollama responded through sandbox"
+  info "Full path proven: sandbox → ${SANDBOX_INFERENCE_URL} → Ollama GPU (:11434)"
 elif [ -n "$sandbox_response" ]; then
-  sandbox_content=$(echo "$sandbox_response" | parse_chat_content 2>/dev/null) || true
-  if echo "$sandbox_content" | grep -qi "PONG"; then
-    pass "[LOCAL] Sandbox inference: Ollama responded through sandbox"
-    info "Full path proven: sandbox → ${SANDBOX_INFERENCE_URL} → Ollama GPU (:11434)"
-  else
-    fail "[LOCAL] Sandbox inference: expected PONG, got: ${sandbox_content:0:200}"
-  fi
+  fail "[LOCAL] Sandbox inference: expected PONG after 3 attempts, got: ${sandbox_content:0:200}"
+  info "Sandbox inference final raw response (first 800 chars): ${sandbox_response:0:800}"
 else
   fail "[LOCAL] Sandbox inference: no response from ${SANDBOX_INFERENCE_URL} inside sandbox"
 fi

--- a/test/e2e/test-gpu-e2e.sh
+++ b/test/e2e/test-gpu-e2e.sh
@@ -508,16 +508,18 @@ else
   fail "[LOCAL] Direct Ollama: empty response"
 fi
 
-# 5b: Inference through sandbox → provider route → Ollama. The Docker GPU
-# patch uses host networking so the sandbox can reconnect to OpenShell after
-# recreation; in that mode NemoClaw bakes a direct loopback Ollama URL into
-# OpenClaw to avoid OpenShell's inference.local TCP relay path.
+# 5b: Inference through sandbox → provider route → Ollama. When the Docker GPU
+# patch preserves the original sandbox network, inference still goes through
+# inference.local; use docker exec only to avoid depending on OpenShell exec
+# after the container is recreated. Host-network GPU patch runs are the only
+# mode where OpenClaw is configured with a direct loopback Ollama URL.
 SANDBOX_INFERENCE_URL="https://inference.local/v1/chat/completions"
 SANDBOX_INFERENCE_EXEC="openshell"
-if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG" \
-  || grep -Fq "Docker-driver GPU patch active" "$INSTALL_LOG"; then
+if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG"; then
   OLLAMA_HOST_PORT="${NEMOCLAW_OLLAMA_PORT:-11434}"
   SANDBOX_INFERENCE_URL="http://127.0.0.1:${OLLAMA_HOST_PORT}/v1/chat/completions"
+  SANDBOX_INFERENCE_EXEC="docker"
+elif grep -Fq "Docker-driver GPU patch active" "$INSTALL_LOG"; then
   SANDBOX_INFERENCE_EXEC="docker"
 fi
 info "[LOCAL] Sandbox inference test → ${SANDBOX_INFERENCE_URL} → Ollama on GPU..."
@@ -526,7 +528,7 @@ sandbox_response=""
 TIMEOUT_CMD=""
 command -v timeout >/dev/null 2>&1 && TIMEOUT_CMD="timeout 120"
 sandbox_payload=$(python3 -c 'import json, sys; print(json.dumps({"model": sys.argv[1], "messages": [{"role": "user", "content": "Reply with exactly one word: PONG"}], "max_tokens": 200}))' "$CONFIGURED_MODEL")
-sandbox_curl_cmd=$(printf "curl -s --max-time 90 %q -H %q -d %q" \
+sandbox_curl_cmd=$(printf "curl -sS --max-time 90 %q -H %q -d %q" \
   "$SANDBOX_INFERENCE_URL" \
   "Content-Type: application/json" \
   "$sandbox_payload")

--- a/test/e2e/test-gpu-e2e.sh
+++ b/test/e2e/test-gpu-e2e.sh
@@ -544,7 +544,7 @@ sandbox_response=""
 TIMEOUT_CMD=""
 command -v timeout >/dev/null 2>&1 && TIMEOUT_CMD="timeout 120"
 sandbox_payload=$(python3 -c 'import json, sys; print(json.dumps({"model": sys.argv[1], "messages": [{"role": "user", "content": "Reply with exactly one word: PONG"}], "max_tokens": 200}))' "$CONFIGURED_MODEL")
-sandbox_curl_cmd=$(printf "curl -sS --max-time 90 %q -H %q -d %q" \
+sandbox_curl_cmd=$(printf "curl -skS --max-time 90 %q -H %q -d %q" \
   "$SANDBOX_INFERENCE_URL" \
   "Content-Type: application/json" \
   "$sandbox_payload")

--- a/test/e2e/test-gpu-e2e.sh
+++ b/test/e2e/test-gpu-e2e.sh
@@ -514,7 +514,8 @@ fi
 # OpenClaw to avoid OpenShell's inference.local TCP relay path.
 SANDBOX_INFERENCE_URL="https://inference.local/v1/chat/completions"
 SANDBOX_INFERENCE_EXEC="openshell"
-if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG"; then
+if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG" ||
+  grep -Fq "Docker-driver GPU patch active" "$INSTALL_LOG"; then
   OLLAMA_HOST_PORT="${NEMOCLAW_OLLAMA_PORT:-11434}"
   SANDBOX_INFERENCE_URL="http://127.0.0.1:${OLLAMA_HOST_PORT}/v1/chat/completions"
   SANDBOX_INFERENCE_EXEC="docker"

--- a/test/e2e/test-gpu-e2e.sh
+++ b/test/e2e/test-gpu-e2e.sh
@@ -515,12 +515,28 @@ fi
 # mode where OpenClaw is configured with a direct loopback Ollama URL.
 SANDBOX_INFERENCE_URL="https://inference.local/v1/chat/completions"
 SANDBOX_INFERENCE_EXEC="openshell"
+SANDBOX_INFERENCE_DOCKER_EXEC_ENV=()
 if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG"; then
   OLLAMA_HOST_PORT="${NEMOCLAW_OLLAMA_PORT:-11434}"
   SANDBOX_INFERENCE_URL="http://127.0.0.1:${OLLAMA_HOST_PORT}/v1/chat/completions"
   SANDBOX_INFERENCE_EXEC="docker"
 elif grep -Fq "Docker-driver GPU patch active" "$INSTALL_LOG"; then
   SANDBOX_INFERENCE_EXEC="docker"
+fi
+if [ "$SANDBOX_INFERENCE_EXEC" = "docker" ] && [[ "$SANDBOX_INFERENCE_URL" == https://inference.local/* ]]; then
+  INFERENCE_PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
+  INFERENCE_PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
+  INFERENCE_PROXY_URL="http://${INFERENCE_PROXY_HOST}:${INFERENCE_PROXY_PORT}"
+  INFERENCE_NO_PROXY="localhost,127.0.0.1,::1,${INFERENCE_PROXY_HOST}"
+  SANDBOX_INFERENCE_DOCKER_EXEC_ENV=(
+    --env "HTTP_PROXY=${INFERENCE_PROXY_URL}"
+    --env "HTTPS_PROXY=${INFERENCE_PROXY_URL}"
+    --env "NO_PROXY=${INFERENCE_NO_PROXY}"
+    --env "http_proxy=${INFERENCE_PROXY_URL}"
+    --env "https_proxy=${INFERENCE_PROXY_URL}"
+    --env "no_proxy=${INFERENCE_NO_PROXY}"
+  )
+  info "[LOCAL] Docker GPU inference proof will use OpenShell proxy ${INFERENCE_PROXY_URL}"
 fi
 info "[LOCAL] Sandbox inference test → ${SANDBOX_INFERENCE_URL} → Ollama on GPU..."
 sandbox_probe_failure=""
@@ -543,7 +559,7 @@ run_sandbox_inference_probe() {
       | head -n 1)
     if [ -n "$sandbox_container_id" ]; then
       info "[LOCAL] Using docker exec for Docker GPU sandbox inference proof (${sandbox_container_id:0:12})..."
-      sandbox_response=$($TIMEOUT_CMD docker exec "$sandbox_container_id" sh -lc "$sandbox_curl_cmd" 2>&1) || true
+      sandbox_response=$($TIMEOUT_CMD docker exec "${SANDBOX_INFERENCE_DOCKER_EXEC_ENV[@]}" "$sandbox_container_id" sh -lc "$sandbox_curl_cmd" 2>&1) || true
     else
       sandbox_probe_failure="OpenShell-managed Docker container not found for ${SANDBOX_NAME}"
     fi


### PR DESCRIPTION
## Summary

- prepare Brev GPU branch-validation VMs to allow Docker bridge traffic to the OpenShell gateway port
- extract the remote GPU runtime setup command list so the firewall rule is covered by a focused test
- keep the product-side sandbox bridge reachability check fatal for real failures; this only adjusts the Brev GPU CI host setup

Refs #3959.

## Testing

- `npx vitest run test/e2e/brev-e2e.test.ts -t "Brev GPU runtime setup|Brev deploy input validation"`
- `git diff --check`

## Follow-up

- Live Brev GPU branch validation should be run on this PR to confirm it gets past `[2/8] Starting OpenShell gateway` and reaches sandbox GPU proof/inference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end GPU test that verifies the runtime setup and sandbox inference probing with retries and proxy behavior.

* **Bug Fixes / Reliability**
  * Improved GPU Docker runtime provisioning to allow network access from the Docker bridge to gateway/auth-proxy ports with tolerant fallback if firewall rules can’t be added.
  * Updated sandbox inference flow to prefer a direct local inference URL for an additional GPU install marker and to configure proxy settings when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->