### PR TITLE
fix(share): target sandbox with -n in remote-path probe

### DIFF
--- a/src/lib/share-command-deps.ts
+++ b/src/lib/share-command-deps.ts
@@ -12,7 +12,7 @@ export interface ShareCommandDeps {
   ensureLive: (sandboxName: string) => Promise<void>;
   /**
    * Check whether `remotePath` exists inside the sandbox via
-   * `openshell sandbox exec <name> -- test -e <remotePath>`. Returns true when
+   * `openshell sandbox exec -n <name> -- test -e <remotePath>`. Returns true when
    * the path exists; false when it is missing, when the sandbox is unreachable,
    * or when the exec itself fails. Used by `share mount` as a pre-flight
    * before invoking `sshfs`, which exits non-zero with empty stderr on a

--- a/src/lib/share-command-deps.ts
+++ b/src/lib/share-command-deps.ts
@@ -49,7 +49,7 @@ export function buildShareCommandDeps(): ShareCommandDeps {
     },
     checkSandboxPathExists: (sandboxName: string, remotePath: string) => {
       const result = captureOpenshell(
-        ["sandbox", "exec", sandboxName, "--", "test", "-e", remotePath],
+        ["sandbox", "exec", "-n", sandboxName, "--", "test", "-e", remotePath],
         { ignoreError: true, timeout: OPENSHELL_PROBE_TIMEOUT_MS },
       );
       return result.status === 0;

--- a/test/e2e/validation_suites/lib/rebuild_upgrade.sh
+++ b/test/e2e/validation_suites/lib/rebuild_upgrade.sh
@@ -38,7 +38,7 @@ rebuild_upgrade_assert_sandbox_reachable() {
   fi
   local sandbox
   sandbox="$(_rebuild_upgrade_ctx E2E_SANDBOX_NAME)"
-  if _rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec "${sandbox}" -- true; then
+  if _rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec -n "${sandbox}" -- true; then
     e2e_pass "suite.upgrade.survivor_agent_reachable"
   else
     e2e_fail "suite.upgrade.survivor_agent_reachable"
@@ -55,7 +55,7 @@ rebuild_upgrade_assert_marker_preserved() {
   sandbox="$(_rebuild_upgrade_ctx E2E_SANDBOX_NAME)"
   marker_path="${E2E_REBUILD_MARKER_PATH:-/workspace/.nemoclaw-rebuild-marker}"
   expected="${E2E_REBUILD_MARKER_EXPECTED:-${E2E_STATE_MARKER_EXPECTED:-}}"
-  actual="$(_rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec "${sandbox}" -- cat "${marker_path}" 2>/dev/null || true)"
+  actual="$(_rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec -n "${sandbox}" -- cat "${marker_path}" 2>/dev/null || true)"
   if [[ -n "${actual}" && (-z "${expected}" || "${actual}" == "${expected}") ]]; then
     e2e_pass "suite.rebuild.workspace_state_preserved"
   else
@@ -74,7 +74,7 @@ rebuild_upgrade_assert_agent_version_upgraded() {
   old="${E2E_OLD_AGENT_VERSION:-}"
   expected="${E2E_EXPECTED_AGENT_VERSION:-}"
   cmd="${E2E_AGENT_VERSION_COMMAND:-openclaw --version}"
-  actual="$(_rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec "${sandbox}" -- bash -lc "${cmd}" 2>/dev/null || true)"
+  actual="$(_rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec -n "${sandbox}" -- bash -lc "${cmd}" 2>/dev/null || true)"
   if [[ -n "${actual}" && (-z "${old}" || "${actual}" != *"${old}"*) && (-z "${expected}" || "${actual}" == *"${expected}"*) ]]; then
     e2e_pass "suite.rebuild.agent_version_upgraded"
   else
@@ -91,7 +91,7 @@ rebuild_upgrade_assert_inference_works() {
   local sandbox cmd output
   sandbox="$(_rebuild_upgrade_ctx E2E_SANDBOX_NAME)"
   cmd="${E2E_INFERENCE_CHECK_COMMAND:-curl -fsS http://inference.local/v1/models}"
-  output="$(_rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec "${sandbox}" -- bash -lc "${cmd}" 2>/dev/null || true)"
+  output="$(_rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec -n "${sandbox}" -- bash -lc "${cmd}" 2>/dev/null || true)"
   if [[ -n "${output}" ]]; then
     e2e_pass "suite.rebuild.inference_still_works"
   else
@@ -129,7 +129,7 @@ rebuild_upgrade_assert_hermes_config_preserved() {
   fi
   local sandbox output
   sandbox="$(_rebuild_upgrade_ctx E2E_SANDBOX_NAME)"
-  output="$(_rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec "${sandbox}" -- bash -lc "grep -R 'platforms.discord\|DISCORD' ~/.hermes . 2>/dev/null" || true)"
+  output="$(_rebuild_upgrade_run REBUILD_UPGRADE_SANDBOX_CMD openshell sandbox exec -n "${sandbox}" -- bash -lc "grep -R 'platforms.discord\|DISCORD' ~/.hermes . 2>/dev/null" || true)"
   if [[ "${output}" == *"discord"* || "${output}" == *"DISCORD"* ]]; then
     e2e_pass "suite.rebuild.hermes_config_preserved"
   else

--- a/test/e2e/validation_suites/lib/sandbox_lifecycle.sh
+++ b/test/e2e/validation_suites/lib/sandbox_lifecycle.sh
@@ -105,7 +105,7 @@ sandbox_lifecycle_assert_logs_available() {
 
 sandbox_lifecycle_assert_openshell_exec_ok() {
   local id="validation.sandbox_operations.openshell_exec_ok"
-  sandbox_lifecycle_run_with_timeout 20 openshell sandbox exec "${E2E_SANDBOX_NAME}" -- sh -lc 'echo lifecycle-ok' >/dev/null || {
+  sandbox_lifecycle_run_with_timeout 20 openshell sandbox exec -n "${E2E_SANDBOX_NAME}" -- sh -lc 'echo lifecycle-ok' >/dev/null || {
     sandbox_lifecycle_fail "${id}" "openshell exec failed"
     return 1
   }
@@ -139,7 +139,7 @@ sandbox_lifecycle_assert_gateway_recovers_after_probe() {
 }
 
 sandbox_lifecycle_assert_snapshot_create_list_restore_marker() {
-  sandbox_lifecycle_run_with_timeout 30 openshell sandbox exec "${E2E_SANDBOX_NAME}" -- sh -lc 'echo lifecycle-marker-before-snapshot > /tmp/nemoclaw-lifecycle-marker' >/dev/null || {
+  sandbox_lifecycle_run_with_timeout 30 openshell sandbox exec -n "${E2E_SANDBOX_NAME}" -- sh -lc 'echo lifecycle-marker-before-snapshot > /tmp/nemoclaw-lifecycle-marker' >/dev/null || {
     sandbox_lifecycle_fail validation.sandbox_snapshot.marker_written "failed to write marker"
     return 1
   }
@@ -149,7 +149,7 @@ sandbox_lifecycle_assert_snapshot_create_list_restore_marker() {
     return 1
   }
   sandbox_lifecycle_pass validation.sandbox_snapshot.create_succeeds "snapshot create succeeded"
-  sandbox_lifecycle_run_with_timeout 30 openshell sandbox exec "${E2E_SANDBOX_NAME}" -- sh -lc 'echo lifecycle-marker-after-snapshot > /tmp/nemoclaw-lifecycle-marker' >/dev/null || {
+  sandbox_lifecycle_run_with_timeout 30 openshell sandbox exec -n "${E2E_SANDBOX_NAME}" -- sh -lc 'echo lifecycle-marker-after-snapshot > /tmp/nemoclaw-lifecycle-marker' >/dev/null || {
     sandbox_lifecycle_fail validation.sandbox_snapshot.restore_rolls_back_marker "failed to mutate marker"
     return 1
   }
@@ -162,7 +162,7 @@ sandbox_lifecycle_assert_snapshot_create_list_restore_marker() {
     sandbox_lifecycle_fail validation.sandbox_snapshot.restore_rolls_back_marker "snapshot restore failed"
     return 1
   }
-  sandbox_lifecycle_run_with_timeout 30 openshell sandbox exec "${E2E_SANDBOX_NAME}" -- sh -lc 'test -f /tmp/nemoclaw-lifecycle-marker && grep -Fxq lifecycle-marker-before-snapshot /tmp/nemoclaw-lifecycle-marker' >/dev/null || {
+  sandbox_lifecycle_run_with_timeout 30 openshell sandbox exec -n "${E2E_SANDBOX_NAME}" -- sh -lc 'test -f /tmp/nemoclaw-lifecycle-marker && grep -Fxq lifecycle-marker-before-snapshot /tmp/nemoclaw-lifecycle-marker' >/dev/null || {
     sandbox_lifecycle_fail validation.sandbox_snapshot.restore_rolls_back_marker "marker did not roll back"
     return 1
   }

--- a/test/share-command-deps-probe-argv.test.ts
+++ b/test/share-command-deps-probe-argv.test.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const requireCache: Record<string, unknown> = require.cache as any;
+
+// Regression: `nemoclaw share mount` was passing the sandbox name as a bare
+// positional to `openshell sandbox exec`, so OpenShell treated it as the
+// command to run and the probe always returned a non-zero exit code even
+// when `/sandbox` existed. Every other `openshell sandbox exec` call site
+// in the repo selects the target sandbox with `-n` (or `--name`).
+// See #3889 and #3954.
+describe("buildShareCommandDeps().checkSandboxPathExists probe argv", () => {
+  afterEach(() => {
+    const openshellRuntimePath = require.resolve("../dist/lib/adapters/openshell/runtime");
+    const shareDepsPath = require.resolve("../dist/lib/share-command-deps");
+    delete require.cache[openshellRuntimePath];
+    delete require.cache[shareDepsPath];
+  });
+
+  it("targets the sandbox with `-n <name>` so it is not parsed as the command", () => {
+    const openshellRuntimePath = require.resolve("../dist/lib/adapters/openshell/runtime");
+    const shareDepsPath = require.resolve("../dist/lib/share-command-deps");
+
+    let recordedArgs: readonly string[] | undefined;
+    requireCache[openshellRuntimePath] = {
+      id: openshellRuntimePath,
+      filename: openshellRuntimePath,
+      loaded: true,
+      exports: {
+        captureOpenshell: (args: readonly string[]) => {
+          recordedArgs = args;
+          return { status: 0, output: "" };
+        },
+      },
+    } as any;
+    delete require.cache[shareDepsPath];
+
+    const { buildShareCommandDeps } = require("../dist/lib/share-command-deps");
+    const deps = buildShareCommandDeps();
+    const exists = deps.checkSandboxPathExists("prachi-sbox", "/sandbox");
+
+    expect(exists).toBe(true);
+    expect(recordedArgs).toEqual([
+      "sandbox",
+      "exec",
+      "-n",
+      "prachi-sbox",
+      "--",
+      "test",
+      "-e",
+      "/sandbox",
+    ]);
+  });
+
+  it("reports the path as missing when the probe exits non-zero", () => {
+    const openshellRuntimePath = require.resolve("../dist/lib/adapters/openshell/runtime");
+    const shareDepsPath = require.resolve("../dist/lib/share-command-deps");
+
+    requireCache[openshellRuntimePath] = {
+      id: openshellRuntimePath,
+      filename: openshellRuntimePath,
+      loaded: true,
+      exports: {
+        captureOpenshell: () => ({ status: 1, output: "" }),
+      },
+    } as any;
+    delete require.cache[shareDepsPath];
+
+    const { buildShareCommandDeps } = require("../dist/lib/share-command-deps");
+    const deps = buildShareCommandDeps();
+    expect(deps.checkSandboxPathExists("alpha", "/sandbox/missing")).toBe(false);
+  });
+});

--- a/test/share-command-deps-probe-argv.test.ts
+++ b/test/share-command-deps-probe-argv.test.ts
@@ -10,8 +10,8 @@ const requireCache: Record<string, unknown> = require.cache as any;
 // Regression: `nemoclaw share mount` was passing the sandbox name as a bare
 // positional to `openshell sandbox exec`, so OpenShell treated it as the
 // command to run and the probe always returned a non-zero exit code even
-// when `/sandbox` existed. Every other `openshell sandbox exec` call site
-// in the repo selects the target sandbox with `-n` (or `--name`).
+// when `/sandbox` existed. The convention in this repo is to select the
+// target sandbox with `-n` (or `--name`).
 // See #3889 and #3954.
 describe("buildShareCommandDeps().checkSandboxPathExists probe argv", () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary

`nemoclaw <name> share mount` was refusing to mount the default `/sandbox` remote path because the pre-flight probe was passing the sandbox name as a bare positional to `openshell sandbox exec`, which parsed it as the command to run. The probe therefore returned a non-zero exit code even when `/sandbox` existed and was readable.

The same bare-positional pattern was also present in two E2E helper libraries — fix them at the same time so the rebuild-upgrade and sandbox-lifecycle validation suites stop relying on the broken form.

## Related Issue

Fixes #3889
Closes #3954

## Changes

- [src/lib/share-command-deps.ts:52](src/lib/share-command-deps.ts#L52): add `-n` before `sandboxName` in the `openshell sandbox exec ... -- test -e <remotePath>` argv; update the doc comment on the dep interface to reflect the corrected form.
- [test/e2e/validation_suites/lib/sandbox_lifecycle.sh](test/e2e/validation_suites/lib/sandbox_lifecycle.sh): add `-n` to all 4 `openshell sandbox exec` call sites (lines 108, 142, 152, 165).
- [test/e2e/validation_suites/lib/rebuild_upgrade.sh](test/e2e/validation_suites/lib/rebuild_upgrade.sh): add `-n` to all 5 `openshell sandbox exec` call sites (lines 41, 58, 77, 94, 132).
- [test/share-command-deps-probe-argv.test.ts](test/share-command-deps-probe-argv.test.ts): new regression test that intercepts `captureOpenshell` and asserts the exact probe argv shape, so this never regresses again.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox path existence checks so file presence is detected reliably within sandboxes.

* **Tests**
  * Added regression tests for sandbox probe behavior and updated end-to-end validation scripts for sandbox exec and lifecycle checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->