### PR TITLE
fix(onboard): make step 3 banner provider-agnostic

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6054,7 +6054,7 @@ async function setupNim(
   preferredInferenceApi: string | null;
   nimContainer: string | null;
 }> {
-  step(3, 8, "Configuring inference (NIM)");
+  step(3, 8, "Configuring inference provider");
 
   let model: string | null = null;
   let provider: string = REMOTE_PROVIDER_CONFIG.build.providerName;
@@ -8983,7 +8983,7 @@ function startRecordedStep(
 const ONBOARD_STEP_INDEX: Record<string, { number: number; title: string }> = {
   preflight: { number: 1, title: "Preflight checks" },
   gateway: { number: 2, title: "Starting OpenShell gateway" },
-  provider_selection: { number: 3, title: "Configuring inference (NIM)" },
+  provider_selection: { number: 3, title: "Configuring inference provider" },
   inference: { number: 4, title: "Setting up inference provider" },
   messaging: { number: 5, title: "Messaging channels" },
   sandbox: { number: 6, title: "Creating sandbox" },

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -227,6 +227,18 @@ const { setupNim } = require(${onboardPath});
     assert.ok(
       payload.lines.some((line: string) => line.includes("Chat Completions API available")),
     );
+    // #3951: step 3 banner must be provider-agnostic — selecting a non-NIM
+    // provider (here, NVIDIA Endpoints) must not be labeled "(NIM)".
+    assert.ok(
+      payload.lines.some((line: string) =>
+        /\[3\/8\] Configuring inference provider\b/.test(line),
+      ),
+      "expected provider-agnostic [3/8] banner",
+    );
+    assert.ok(
+      !payload.lines.some((line: string) => line.includes("Configuring inference (NIM)")),
+      'step 3 banner must not be labeled "Configuring inference (NIM)" for non-NIM providers',
+    );
   });
 
   it("offers detected running vLLM without requiring a rerun", () => {


### PR DESCRIPTION
## Summary

The step 3 onboard banner printed `Configuring inference (NIM)` before the user picked a provider, so the `(NIM)` qualifier appeared for OpenAI, Anthropic, Gemini, Ollama, and every other non-NIM selection. Switch the label to `Configuring inference provider`, matching the wording already used by the blueprint runner ([`nemoclaw/src/blueprint/runner.ts:736`](https://github.com/NVIDIA/NemoClaw/blob/main/nemoclaw/src/blueprint/runner.ts#L736)) and the e2e harness.

## Related Issue

Closes #3951

## Changes

- `src/lib/onboard.ts`: rename the step 3 banner inside `setupNim()` from `Configuring inference (NIM)` to `Configuring inference provider`.
- `src/lib/onboard.ts`: update `ONBOARD_STEP_INDEX.provider_selection.title` so the resume / reuse banner stays consistent with the live banner.
- `test/onboard-selection.test.ts`: add two regression assertions on the captured stdout of `setupNim()` — the new banner must appear and `(NIM)` must not, when a non-NIM provider is selected.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes <!-- local prek env is Python 3.8 (prek wants >= 3.9); relying on CI -->
- [x] Targeted vitest project run: `vitest run --project cli test/onboard-selection.test.ts test/onboard.test.ts test/onboard-resume-provider-recovery.test.ts` — 125 tests, all pass
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes <!-- string is operator-facing only; no docs reference the old label -->

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "Configuring inference provider" onboarding step label to use provider-agnostic terminology.

* **Tests**
  * Added test assertions to verify the inference provider selection step uses provider-agnostic labeling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->