### PR TITLE
docs(commands): document nemoclaw internal:* command family

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1125,21 +1125,21 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 
 ## Internal Commands
 
-NemoClaw registers a small family of `nemoclaw internal <topic> <action>` commands that the installer, uninstaller, and a few wrapper scripts (`uninstall.sh`, `scripts/npm-link-or-shim.sh`, `scripts/fix-coredns.sh`, `scripts/setup-dns-proxy.sh`) invoke under the hood.
+NemoClaw registers a small family of `nemoclaw internal <topic> <action>` commands that wrapper scripts (`uninstall.sh`, `scripts/npm-link-or-shim.sh`, `scripts/fix-coredns.sh`, `scripts/setup-dns-proxy.sh`) invoke under the hood, plus a few internal planning and inspection helpers that mirror logic used elsewhere in the CLI.
 They are intentionally omitted from `nemoclaw --help` via `static hidden = true` and are not part of the supported public CLI surface.
 Their flags, output, and exit codes may change without notice between releases.
-Operators should not invoke them directly; use the user-facing commands or wrapper scripts above instead.
+You should not invoke these directly; use the user-facing commands or wrapper scripts above instead.
 
 | Command | Caller | Purpose |
 |---|---|---|
 | `nemoclaw internal dev npm-link-or-shim` | `scripts/npm-link-or-shim.sh` | Run `npm link`, falling back to a user-local NemoClaw development shim. |
 | `nemoclaw internal dns fix-coredns` | `scripts/fix-coredns.sh` | Patch CoreDNS to use a non-loopback upstream resolver. |
 | `nemoclaw internal dns setup-proxy` | `scripts/setup-dns-proxy.sh` | Configure the DNS forwarder bridge inside a sandbox pod. |
-| `nemoclaw internal installer plan` | `install.sh` planning step | Build a deterministic installer plan from environment and probe inputs without applying it. |
-| `nemoclaw internal installer resolve-release-tag` | `install.sh` planning step | Resolve the installer ref using the same precedence as `install.sh`. |
-| `nemoclaw internal installer normalize-env` | `install.sh` planning step | Normalize installer ref and provider environment values without applying any installation changes. |
-| `nemoclaw internal uninstall plan` | `uninstall.sh` planning step | Build a deterministic uninstall plan without applying it. |
-| `nemoclaw internal uninstall classify-shim` | `uninstall.sh` planning step | Classify whether a NemoClaw shim path is safe to remove. |
+| `nemoclaw internal installer plan` | Internal planning helper | Build a deterministic installer plan from environment and probe inputs without applying it. Not currently invoked by `install.sh` (which has its own Bash equivalents); exposed for external tooling and inspection. |
+| `nemoclaw internal installer resolve-release-tag` | Internal planning helper | Resolve the installer ref using the same precedence as `install.sh`. Not currently invoked by `install.sh`; exposed for external tooling and inspection. |
+| `nemoclaw internal installer normalize-env` | Internal planning helper | Normalize installer ref and provider environment values without applying any installation changes. Not currently invoked by `install.sh`; exposed for external tooling and inspection. |
+| `nemoclaw internal uninstall plan` | Internal inspection helper | Build a deterministic uninstall plan without applying it. The runtime path (`uninstall.sh` → `internal uninstall run-plan`) calls the underlying plan logic directly, not via this command. |
+| `nemoclaw internal uninstall classify-shim` | Internal inspection helper | Classify whether a NemoClaw shim path is safe to remove. Called as a library function by `internal uninstall run-plan`, not via this command. |
 | `nemoclaw internal uninstall run-plan` | `uninstall.sh` | Execute the host-side uninstall plan. |
 
 ## Environment Variables

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1123,6 +1123,25 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 | **Robustness** | Requires the npm package to be discoverable so the CLI can find the local script. | Works even if the `nemoclaw` CLI is missing, broken, or partially uninstalled. |
 | **Recommended for** | Routine uninstalls. | Recovery when the CLI is unavailable. |
 
+## Internal Commands
+
+NemoClaw registers a small family of `nemoclaw internal <topic> <action>` commands that the installer, uninstaller, and a few wrapper scripts (`uninstall.sh`, `scripts/npm-link-or-shim.sh`, `scripts/fix-coredns.sh`, `scripts/setup-dns-proxy.sh`) invoke under the hood.
+They are intentionally omitted from `nemoclaw --help` via `static hidden = true` and are not part of the supported public CLI surface.
+Their flags, output, and exit codes may change without notice between releases.
+Operators should not invoke them directly; use the user-facing commands or wrapper scripts above instead.
+
+| Command | Caller | Purpose |
+|---|---|---|
+| `nemoclaw internal dev npm-link-or-shim` | `scripts/npm-link-or-shim.sh` | Run `npm link`, falling back to a user-local NemoClaw development shim. |
+| `nemoclaw internal dns fix-coredns` | `scripts/fix-coredns.sh` | Patch CoreDNS to use a non-loopback upstream resolver. |
+| `nemoclaw internal dns setup-proxy` | `scripts/setup-dns-proxy.sh` | Configure the DNS forwarder bridge inside a sandbox pod. |
+| `nemoclaw internal installer plan` | `install.sh` planning step | Build a deterministic installer plan from environment and probe inputs without applying it. |
+| `nemoclaw internal installer resolve-release-tag` | `install.sh` planning step | Resolve the installer ref using the same precedence as `install.sh`. |
+| `nemoclaw internal installer normalize-env` | `install.sh` planning step | Normalize installer ref and provider environment values without applying any installation changes. |
+| `nemoclaw internal uninstall plan` | `uninstall.sh` planning step | Build a deterministic uninstall plan without applying it. |
+| `nemoclaw internal uninstall classify-shim` | `uninstall.sh` planning step | Classify whether a NemoClaw shim path is safe to remove. |
+| `nemoclaw internal uninstall run-plan` | `uninstall.sh` | Execute the host-side uninstall plan. |
+
 ## Environment Variables
 
 NemoClaw reads the following environment variables to configure service ports, onboarding behavior, and lifecycle defaults.


### PR DESCRIPTION
## Summary

Adds an "Internal Commands" section to docs/reference/commands.mdx listing the nine `nemoclaw internal <topic> <action>` commands. The commands are already registered as hidden in oclif (`static hidden = true`, added in #3074/#3075/#3083/#3090/#3108 on 2026-05-06), so they are absent from `nemoclaw --help`, but they had no documented description anywhere — operators who became aware of them through other paths had no canonical reference.

## Related Issue

Fixes #3782
Closes #3938

## Changes

- [docs/reference/commands.mdx](docs/reference/commands.mdx): new "Internal Commands" section between `nemoclaw uninstall` and "Environment Variables". Lists each of the nine commands, the wrapper script that calls it, and a one-line purpose. Header explicitly states the family is not part of the supported public CLI surface and that flags/output/exit codes may change without notice.

Note: the orthogonal "`_commandIDs` leak via oclif validation stack trace" symptom called out in #3782 is not addressed here — that is the separate UX bug the original report flagged as out of scope for the hide/document fix.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section documenting internal CLI commands and their usage contexts.
  * Clarifies these commands are omitted from standard help, are not part of the supported public CLI surface, and may change between releases.
  * Includes a mapping of internal commands to the installer/uninstaller and other internal tooling contexts for reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->