### PR TITLE
fix(onboard): detect Windows-host Ollama via process probe

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6097,7 +6097,24 @@ async function setupNim(
       ],
       { ignoreError: true },
     ).trim();
-    hasWindowsOllama = winOllamaPath.length > 0;
+    if (winOllamaPath.length > 0) {
+      hasWindowsOllama = true;
+    } else {
+      // `Get-Command` only sees ollama.exe when it is on the calling
+      // user's PATH. Service-style installs (and any installer that does
+      // not update the user PATH) leave the binary discoverable only via
+      // the running process — see #3949. Treat a live Windows-host
+      // ollama process as proof of installation.
+      const winOllamaPid = runCapture(
+        [
+          "powershell.exe",
+          "-Command",
+          "Get-Process ollama -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Id",
+        ],
+        { ignoreError: true },
+      ).trim();
+      hasWindowsOllama = winOllamaPid.length > 0;
+    }
   }
 
   let winOllamaLoopbackOnly = false;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -99,6 +99,9 @@ const {
   stopModelRouterProcess,
   stopTrackedModelRouterForAgentChange,
 }: typeof import("./onboard/model-router-process") = require("./onboard/model-router-process");
+const {
+  detectWindowsHostOllama,
+}: typeof import("./onboard/windows-host-ollama") = require("./onboard/windows-host-ollama");
 const crypto = require("node:crypto");
 const fs = require("fs");
 const os = require("os");
@@ -6086,60 +6089,15 @@ async function setupNim(
     docker.dockerCapture(["images", "-q", vllmProfile.image], { ignoreError: true }).trim()
   );
   // Probed even when WSL has its own Ollama: users may prefer the Windows
-  // instance for GPU access and a unified model cache.
-  let hasWindowsOllama = false;
-  if (isWsl()) {
-    const winOllamaPath = runCapture(
-      [
-        "powershell.exe",
-        "-Command",
-        "Get-Command ollama.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source",
-      ],
-      { ignoreError: true },
-    ).trim();
-    if (winOllamaPath.length > 0) {
-      hasWindowsOllama = true;
-    } else {
-      // `Get-Command` only sees ollama.exe when it is on the calling
-      // user's PATH. Service-style installs (and any installer that does
-      // not update the user PATH) leave the binary discoverable only via
-      // the running process — see #3949. Treat a live Windows-host
-      // ollama process as proof of installation.
-      const winOllamaPid = runCapture(
-        [
-          "powershell.exe",
-          "-Command",
-          "Get-Process ollama -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Id",
-        ],
-        { ignoreError: true },
-      ).trim();
-      hasWindowsOllama = winOllamaPid.length > 0;
-    }
-  }
-
-  let winOllamaLoopbackOnly = false;
-  if (isWsl() && hasWindowsOllama) {
-    const winPid = runCapture(
-      [
-        "powershell.exe",
-        "-Command",
-        "Get-Process ollama -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Id",
-      ],
-      { ignoreError: true },
-    ).trim();
-    if (winPid) {
-      const listenAddrs = runCapture(
-        [
-          "powershell.exe",
-          "-Command",
-          "Get-NetTCPConnection -LocalPort 11434 -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty LocalAddress",
-        ],
-        { ignoreError: true },
-      );
-      winOllamaLoopbackOnly =
-        /127\.0\.0\.1/.test(listenAddrs) && !/0\.0\.0\.0|^::\s*$/m.test(listenAddrs);
-    }
-  }
+  // instance for GPU access and a unified model cache. See
+  // src/lib/onboard/windows-host-ollama.ts for the probe semantics, in
+  // particular the Get-Process fallback for service-style installs
+  // (#3949) and the strict path-recovery requirement before flagging
+  // the install as restartable.
+  const winOllamaState = detectWindowsHostOllama();
+  const hasWindowsOllama = winOllamaState.installed;
+  const winOllamaInstalledPath = winOllamaState.installedPath;
+  const winOllamaLoopbackOnly = winOllamaState.loopbackOnly;
 
   // Independent of findReachableOllamaHost: when WSL Ollama wins the cache
   // on 127.0.0.1, Windows-host may also be running on 0.0.0.0 and we want
@@ -7079,7 +7037,16 @@ async function setupNim(
           }
           console.log(`  ✓ Using Ollama on host.docker.internal:${OLLAMA_PORT}`);
         } else {
-          if (!setupWindowsOllamaWith0000Binding({ announceStop: isRestart })) {
+          // Pass the verified executable path so windows.ts can target
+          // it directly instead of falling back to the calling shell's
+          // Windows PATH — which is the broken case for service-style
+          // installs that #3949 surfaces.
+          if (
+            !setupWindowsOllamaWith0000Binding({
+              announceStop: isRestart,
+              installedPath: winOllamaInstalledPath || undefined,
+            })
+          ) {
             printWindowsOllamaTimeoutDiagnostics();
             if (isNonInteractive()) process.exit(1);
             continue selectionLoop;

--- a/src/lib/onboard/windows-host-ollama.ts
+++ b/src/lib/onboard/windows-host-ollama.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isWsl } from "../platform";
+import { runCapture } from "../runner";
+
+export interface WindowsHostOllamaState {
+  // True when an ollama install is observable on the Windows host (either
+  // on the user PATH, or as a running process whose executable path we
+  // can recover).
+  installed: boolean;
+  // Absolute Windows path to ollama.exe. Empty when we could not recover
+  // it — in that case we deliberately leave `installed` false so the
+  // restart path does not kill a daemon we cannot relaunch.
+  installedPath: string;
+  // True when the running daemon is listening on 127.0.0.1 only and not
+  // on 0.0.0.0 / ::. Drives the "Restart Ollama on Windows host with
+  // 0.0.0.0 binding" menu variant (#3949).
+  loopbackOnly: boolean;
+}
+
+const POWERSHELL = "powershell.exe";
+
+const GET_COMMAND_OLLAMA =
+  "Get-Command ollama.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source";
+
+const GET_PROCESS_OLLAMA_PATH =
+  "Get-Process ollama -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Path";
+
+const GET_PROCESS_OLLAMA_ID =
+  "Get-Process ollama -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Id";
+
+const GET_NETTCP_OLLAMA_LISTEN =
+  "Get-NetTCPConnection -LocalPort 11434 -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty LocalAddress";
+
+function powershell(script: string): string {
+  return runCapture([POWERSHELL, "-Command", script], { ignoreError: true }).trim();
+}
+
+function probeInstalledPath(): string {
+  const onPath = powershell(GET_COMMAND_OLLAMA);
+  if (onPath.length > 0) return onPath;
+  // PATH miss: service-style installs and any installer that does not
+  // update the calling user's PATH leave ollama.exe invisible to
+  // Get-Command even when the daemon is running. Recover the path from
+  // the live process so the restart launcher in windows.ts can target
+  // the verified executable instead of falling back to a broken PATH
+  // lookup (#3949).
+  return powershell(GET_PROCESS_OLLAMA_PATH);
+}
+
+function probeLoopbackOnly(): boolean {
+  const pid = powershell(GET_PROCESS_OLLAMA_ID);
+  if (!pid) return false;
+  const listenAddrs = runCapture([POWERSHELL, "-Command", GET_NETTCP_OLLAMA_LISTEN], {
+    ignoreError: true,
+  });
+  return /127\.0\.0\.1/.test(listenAddrs) && !/0\.0\.0\.0|^::\s*$/m.test(listenAddrs);
+}
+
+export function detectWindowsHostOllama(): WindowsHostOllamaState {
+  if (!isWsl()) {
+    return { installed: false, installedPath: "", loopbackOnly: false };
+  }
+  const installedPath = probeInstalledPath();
+  const installed = installedPath.length > 0;
+  const loopbackOnly = installed ? probeLoopbackOnly() : false;
+  return { installed, installedPath, loopbackOnly };
+}

--- a/src/lib/onboard/windows-host-ollama.ts
+++ b/src/lib/onboard/windows-host-ollama.ts
@@ -30,6 +30,13 @@ const GET_PROCESS_OLLAMA_PATH =
 const GET_PROCESS_OLLAMA_ID =
   "Get-Process ollama -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Id";
 
+const GET_KNOWN_OLLAMA_INSTALL_PATH =
+  "$candidates = @(); " +
+  "if ($env:LOCALAPPDATA) { $candidates += (Join-Path $env:LOCALAPPDATA 'Programs\\Ollama\\ollama.exe') }; " +
+  "if ($env:ProgramFiles) { $candidates += (Join-Path $env:ProgramFiles 'Ollama\\ollama.exe') }; " +
+  "if (${env:ProgramFiles(x86)}) { $candidates += (Join-Path ${env:ProgramFiles(x86)} 'Ollama\\ollama.exe') }; " +
+  "$candidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1";
+
 const GET_NETTCP_OLLAMA_LISTEN =
   "Get-NetTCPConnection -LocalPort 11434 -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty LocalAddress";
 
@@ -46,7 +53,15 @@ function probeInstalledPath(): string {
   // the live process so the restart launcher in windows.ts can target
   // the verified executable instead of falling back to a broken PATH
   // lookup (#3949).
-  return powershell(GET_PROCESS_OLLAMA_PATH);
+  const processPath = powershell(GET_PROCESS_OLLAMA_PATH);
+  if (processPath.length > 0) return processPath;
+  // Some WSL-launched PowerShell sessions can see the Windows ollama PID
+  // but cannot read the Path property. Only after observing the live
+  // daemon, fall back to fixed installer locations so the restart path
+  // still has an explicit executable to launch.
+  const pid = powershell(GET_PROCESS_OLLAMA_ID);
+  if (!pid) return "";
+  return powershell(GET_KNOWN_OLLAMA_INSTALL_PATH);
 }
 
 function probeLoopbackOnly(): boolean {

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -5402,7 +5402,22 @@ const { setupNim } = require(${onboardPath});
     assert.equal(payload.result.provider, "ollama-local");
     assert.equal(payload.result.model, "qwen3:8b");
     assert.equal(payload.installCalls.length, 0);
-    assert.deepEqual(payload.setupCalls, [{ announceStop: false }]);
+    // The restart/start path now forwards the verified executable path
+    // recovered from Get-Command so windows.ts can launch the binary
+    // directly instead of relying on the calling shell's Windows PATH
+    // (#3949).
+    assert.deepEqual(payload.setupCalls, [
+      {
+        announceStop: false,
+        // The mock injects `\\\\` per separator (raw template → 4 source
+        // backslashes per separator → 2 backslashes in the subprocess
+        // JS string). The deepEqual right-hand side is a regular TS
+        // string, so 4 backslashes per separator here equals 2 in the
+        // compiled string, matching what the subprocess captured.
+        installedPath:
+          "C:\\\\Users\\\\tester\\\\AppData\\\\Local\\\\Programs\\\\Ollama\\\\ollama.exe",
+      },
+    ]);
     assert.ok(
       payload.lines.some((line: string) =>
         line.includes("Using Ollama on host.docker.internal:11434"),
@@ -5456,6 +5471,7 @@ const platform = require(${platformPath});
 platform.isWsl = () => true;
 
 const setupCalls = [];
+const installedPath = "C:/Program Files/Ollama/ollama.exe";
 credentials.prompt = async () => "";
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
@@ -5463,9 +5479,13 @@ runner.runCapture = (command) => {
   if (cmd.includes("command -v ollama")) return "";
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
   // The fix: Get-Command misses ollama.exe (service install, not on user
-  // PATH), but Get-Process finds the running daemon. Repro for #3949.
+  // PATH), but Get-Process recovers both the live PID and the verified
+  // executable path. Repro for #3949.
   if (cmd.includes("powershell.exe") && cmd.includes("Get-Command ollama.exe")) return "";
-  if (cmd.includes("powershell.exe") && cmd.includes("Get-Process ollama")) return "7652";
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-Process ollama") && cmd.includes("Path"))
+    return installedPath;
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-Process ollama") && cmd.includes("Id"))
+    return "7652";
   if (cmd.includes("powershell.exe") && cmd.includes("Get-NetTCPConnection")) return "127.0.0.1";
   if (cmd.includes("api/tags")) {
     if (setupCalls.length === 0) return "";
@@ -5534,9 +5554,17 @@ const { setupNim } = require(${onboardPath});
 
     assert.equal(payload.result.provider, "ollama-local");
     // hasWindowsOllama detected via Get-Process → winOllamaLoopbackOnly
-    // observed from 127.0.0.1 listen → restart-with-0.0.0.0 path taken,
-    // not the bogus install path (which was the pre-fix behaviour).
-    assert.equal(payload.setupCalls.length, 1);
+    // observed from 127.0.0.1 listen → restart path taken with
+    // announceStop:true and the recovered executable path threaded
+    // through so windows.ts can target the verified binary instead of
+    // the broken PATH fallback. Pre-fix behaviour was the bogus install
+    // path with no setup call at all.
+    assert.deepEqual(payload.setupCalls, [
+      {
+        announceStop: true,
+        installedPath: "C:/Program Files/Ollama/ollama.exe",
+      },
+    ]);
   });
 
   it("does not satisfy start-windows-ollama with WSL-local Ollama", () => {

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -5410,6 +5410,135 @@ const { setupNim } = require(${onboardPath});
     );
   });
 
+  it("detects Windows-host Ollama via running process when not on the user PATH (#3949)", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-windows-ollama-process-fallback-"),
+    );
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "windows-ollama-process-fallback-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials", "store.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const platformPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "platform.js"));
+    const localPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "inference", "local.js"));
+    const windowsPath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "inference", "ollama", "windows.js"),
+    );
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+body='${OLLAMA_CHAT_COMPLETIONS_TOOL_CALL_RESPONSE}'
+status="200"
+outfile=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) outfile="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$outfile" ]; then
+  printf '%s' "$body" > "$outfile"
+  printf '%s' "$status"
+else
+  printf '%s' "$body"
+fi
+`,
+      { mode: 0o755 },
+    );
+
+    const script = String.raw`
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+const platform = require(${platformPath});
+platform.isWsl = () => true;
+
+const setupCalls = [];
+credentials.prompt = async () => "";
+credentials.ensureApiKey = async () => {};
+runner.runCapture = (command) => {
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "";
+  if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
+  // The fix: Get-Command misses ollama.exe (service install, not on user
+  // PATH), but Get-Process finds the running daemon. Repro for #3949.
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-Command ollama.exe")) return "";
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-Process ollama")) return "7652";
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-NetTCPConnection")) return "127.0.0.1";
+  if (cmd.includes("api/tags")) {
+    if (setupCalls.length === 0) return "";
+    return JSON.stringify({ models: [{ name: "qwen3:8b" }] });
+  }
+  if (cmd.includes("api/show")) return JSON.stringify({ capabilities: ["completion", "tools"] });
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  return "";
+};
+runner.run = () => ({ status: 0 });
+runner.runShell = () => ({ status: 0 });
+
+const local = require(${localPath});
+local.resetOllamaHostCache();
+
+const windows = require(${windowsPath});
+windows.installOllamaOnWindowsHost = async () => {
+  throw new Error("installOllamaOnWindowsHost called: hasWindowsOllama not detected");
+};
+windows.setupWindowsOllamaWith0000Binding = (opts) => {
+  setupCalls.push(opts || {});
+  local.setResolvedOllamaHost(local.OLLAMA_HOST_DOCKER_INTERNAL);
+  return true;
+};
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  const originalLog = console.log;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim("windows-process-fallback-test", null);
+    originalLog(JSON.stringify({ result, setupCalls, lines }));
+  } finally {
+    console.log = originalLog;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_PROVIDER: "start-windows-ollama",
+        NEMOCLAW_MODEL: "qwen3:8b",
+        NEMOCLAW_YES: "1",
+      },
+    });
+
+    assert.equal(
+      result.status,
+      0,
+      `Process failed:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+    assert.notEqual(result.stdout.trim(), "", result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+
+    assert.equal(payload.result.provider, "ollama-local");
+    // hasWindowsOllama detected via Get-Process → winOllamaLoopbackOnly
+    // observed from 127.0.0.1 listen → restart-with-0.0.0.0 path taken,
+    // not the bogus install path (which was the pre-fix behaviour).
+    assert.equal(payload.setupCalls.length, 1);
+  });
+
   it("does not satisfy start-windows-ollama with WSL-local Ollama", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -5567,6 +5567,141 @@ const { setupNim } = require(${onboardPath});
     ]);
   });
 
+  it("uses a known Windows install path when a running Ollama process has no readable path", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-windows-ollama-static-path-fallback-"),
+    );
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "windows-ollama-static-path-fallback-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials", "store.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const platformPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "platform.js"));
+    const localPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "inference", "local.js"));
+    const windowsPath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "inference", "ollama", "windows.js"),
+    );
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+body='${OLLAMA_CHAT_COMPLETIONS_TOOL_CALL_RESPONSE}'
+status="200"
+outfile=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) outfile="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$outfile" ]; then
+  printf '%s' "$body" > "$outfile"
+  printf '%s' "$status"
+else
+  printf '%s' "$body"
+fi
+`,
+      { mode: 0o755 },
+    );
+
+    const script = String.raw`
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+const platform = require(${platformPath});
+platform.isWsl = () => true;
+
+const setupCalls = [];
+const installedPath = "C:/Users/tester/AppData/Local/Programs/Ollama/ollama.exe";
+credentials.prompt = async () => "";
+credentials.ensureApiKey = async () => {};
+runner.runCapture = (command) => {
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "";
+  if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-Command ollama.exe")) return "";
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-Process ollama") && cmd.includes("Path"))
+    return "";
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-Process ollama") && cmd.includes("Id"))
+    return "7652";
+  if (cmd.includes("powershell.exe") && cmd.includes("Test-Path -LiteralPath"))
+    return installedPath;
+  if (cmd.includes("powershell.exe") && cmd.includes("Get-NetTCPConnection")) return "127.0.0.1";
+  if (cmd.includes("api/tags")) {
+    if (setupCalls.length === 0) return "";
+    return JSON.stringify({ models: [{ name: "qwen3:8b" }] });
+  }
+  if (cmd.includes("api/show")) return JSON.stringify({ capabilities: ["completion", "tools"] });
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  return "";
+};
+runner.run = () => ({ status: 0 });
+runner.runShell = () => ({ status: 0 });
+
+const local = require(${localPath});
+local.resetOllamaHostCache();
+
+const windows = require(${windowsPath});
+windows.installOllamaOnWindowsHost = async () => {
+  throw new Error("installOllamaOnWindowsHost called: hasWindowsOllama not detected");
+};
+windows.setupWindowsOllamaWith0000Binding = (opts) => {
+  setupCalls.push(opts || {});
+  local.setResolvedOllamaHost(local.OLLAMA_HOST_DOCKER_INTERNAL);
+  return true;
+};
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  const originalLog = console.log;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim("windows-static-path-fallback-test", null);
+    originalLog(JSON.stringify({ result, setupCalls, lines }));
+  } finally {
+    console.log = originalLog;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_PROVIDER: "start-windows-ollama",
+        NEMOCLAW_MODEL: "qwen3:8b",
+        NEMOCLAW_YES: "1",
+      },
+    });
+
+    assert.equal(
+      result.status,
+      0,
+      `Process failed:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+    assert.notEqual(result.stdout.trim(), "", result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+
+    assert.equal(payload.result.provider, "ollama-local");
+    assert.deepEqual(payload.setupCalls, [
+      {
+        announceStop: true,
+        installedPath: "C:/Users/tester/AppData/Local/Programs/Ollama/ollama.exe",
+      },
+    ]);
+  });
+
   it("does not satisfy start-windows-ollama with WSL-local Ollama", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(


### PR DESCRIPTION
## Summary

On WSL2, `hasWindowsOllama` was determined solely by running `powershell.exe Get-Command ollama.exe`, which only returns a path when `ollama.exe` is on the calling user's PATH. Service-style installs (and any installer that does not update the user PATH) leave the binary undiscoverable by `Get-Command` even while the Windows-host Ollama daemon is running on `127.0.0.1:11434`.

In that state, the inference menu offered "Install Ollama on Windows host (recommended)" instead of the "Restart Ollama on Windows host with 0.0.0.0 binding" variant that the bug report and the WSL2 Ollama test expect.

Fall back to a `Get-Process ollama` probe when `Get-Command` returns empty: a live ollama process is sufficient proof of installation. The existing `winOllamaLoopbackOnly` block already uses `Get-Process` for the PID and `Get-NetTCPConnection` for the listen address, so once `hasWindowsOllama` is true the loopback-only menu variant fires correctly.

## Related Issue

Fixes #3949

## Changes

- [src/lib/onboard.ts:6090](src/lib/onboard.ts#L6090): when `Get-Command ollama.exe` returns empty, fall back to `Get-Process ollama` and treat a live PID as proof of installation. Bracketed by `if (isWsl())` as before.
- [test/onboard-selection.test.ts](test/onboard-selection.test.ts): new regression test "detects Windows-host Ollama via running process when not on the user PATH (#3949)" — sets up the bug's exact probe state (Get-Command empty, Get-Process returns a PID, NetTCPConnection on 127.0.0.1, host.docker.internal unreachable) and asserts `NEMOCLAW_PROVIDER=start-windows-ollama` is satisfied and `setupWindowsOllamaWith0000Binding` is invoked exactly once.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows onboarding: detects Ollama on the host even when not on PATH (falls back to a running process) and uses the discovered executable path to drive start/restart behavior.
  * UI now offers "Start Windows Ollama" and correctly distinguishes loopback-only restarts versus fresh starts.

* **Tests**
  * Added tests covering the detection fallback and the Windows start flow, including cases that recover the executable path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->