### PR TITLE
fix(shields): union live policy into permissive before applying

### DIFF
--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -42,6 +42,10 @@ const {
 const { resolveNemoclawStateDir } = require("../state/paths");
 const { appendAuditEntry } = require("./audit");
 const { resolveAgentConfig } = require("../sandbox/config");
+const {
+  buildRuntimePermissivePolicy,
+}: typeof import("./permissive-runtime") = require("./permissive-runtime");
+const { cleanupTempDir } = require("../onboard/temp-files");
 
 const STATE_DIR = resolveNemoclawStateDir();
 
@@ -902,8 +906,19 @@ function shieldsDown(sandboxName: string, opts: ShieldsDownOpts = {}): void {
 
   // 2. Determine and apply relaxed policy
   let policyFile: string;
+  let policyFileIsTemp = false;
   if (policyName === "permissive") {
-    policyFile = resolvePermissivePolicyPath(sandboxName);
+    const basePath = resolvePermissivePolicyPath(sandboxName);
+    // Union the live sandbox's filesystem_policy into the static permissive
+    // baseline. OpenShell rejects removal of read_only / read_write paths
+    // on a live sandbox, and runtime-injected entries (/proc on GPU,
+    // /opt/hermes on Hermes, /home/linuxbrew on post-#3913 OpenClaw, etc.)
+    // are not present in the static YAML. See #3942, #3957, #3168.
+    policyFile = buildRuntimePermissivePolicy(sandboxName, basePath, {
+      fetchLivePolicy: () => rawPolicy,
+      readBasePolicy: () => fs.readFileSync(basePath, "utf-8"),
+    });
+    policyFileIsTemp = policyFile !== basePath;
   } else if (fs.existsSync(policyName)) {
     policyFile = path.resolve(policyName);
   } else {
@@ -914,7 +929,13 @@ function shieldsDown(sandboxName: string, opts: ShieldsDownOpts = {}): void {
   }
 
   console.log(`  Applying ${policyName} policy...`);
-  run(buildPolicySetCommand(policyFile, sandboxName));
+  try {
+    run(buildPolicySetCommand(policyFile, sandboxName));
+  } finally {
+    if (policyFileIsTemp) {
+      cleanupTempDir(policyFile, "nemoclaw-permissive-runtime");
+    }
+  }
 
   // 2b. Return config to default mutable state.
   //     OpenClaw uses sandbox:sandbox 0660/2770 here so the gateway UID, which

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -909,13 +909,15 @@ function shieldsDown(sandboxName: string, opts: ShieldsDownOpts = {}): void {
   let policyFileIsTemp = false;
   if (policyName === "permissive") {
     const basePath = resolvePermissivePolicyPath(sandboxName);
-    // Union the live sandbox's filesystem_policy into the static permissive
-    // baseline. OpenShell rejects removal of read_only / read_write paths
-    // on a live sandbox, and runtime-injected entries (/proc on GPU,
-    // /opt/hermes on Hermes, /home/linuxbrew on post-#3913 OpenClaw, etc.)
-    // are not present in the static YAML. See #3942, #3957, #3168.
-    policyFile = buildRuntimePermissivePolicy(sandboxName, basePath, {
-      fetchLivePolicy: () => rawPolicy,
+    // Union the live sandbox's filesystem_policy.read_only/read_write into
+    // the static permissive baseline. OpenShell rejects removal of those
+    // paths on a live sandbox, and runtime-injected entries (/proc on
+    // GPU, /opt/hermes on Hermes, /home/linuxbrew on post-#3913 OpenClaw,
+    // etc.) are not present in the static YAML. See #3942, #3957, #3168.
+    // policyYaml is the pre-parsed body we already captured for the
+    // snapshot above — reuse it instead of re-fetching.
+    policyFile = buildRuntimePermissivePolicy(basePath, {
+      livePolicyYaml: policyYaml,
       readBasePolicy: () => fs.readFileSync(basePath, "utf-8"),
     });
     policyFileIsTemp = policyFile !== basePath;

--- a/src/lib/shields/permissive-runtime.ts
+++ b/src/lib/shields/permissive-runtime.ts
@@ -4,7 +4,9 @@
 import fs from "node:fs";
 import YAML from "yaml";
 
-import { secureTempFile } from "../onboard/temp-files";
+import { cleanupTempDir, secureTempFile } from "../onboard/temp-files";
+
+const TEMP_FILE_PREFIX = "nemoclaw-permissive-runtime";
 
 /**
  * Build a permissive policy YAML whose filesystem path lists
@@ -47,11 +49,17 @@ import { secureTempFile } from "../onboard/temp-files";
 export interface PermissiveRuntimeDeps {
   // Pre-parsed live policy YAML body (e.g. parseCurrentPolicy(rawPolicy)
   // from the caller, which already strips the OpenShell header). Passed
-  // in rather than fetched here so this helper stays a pure transform.
+  // in rather than fetched here so live-policy acquisition stays
+  // outside this helper — the helper itself still does I/O (base read,
+  // temp file write) but does not shell out to openshell.
   livePolicyYaml: string;
   // Lazy because callers may want to defer the read until the helper
   // actually needs it. The returned string is parsed by YAML.parse.
   readBasePolicy: () => string;
+  // Injectable temp-file writer. Defaults to fs.writeFileSync via
+  // secureTempFile when omitted. Exposed so tests can drive the
+  // write-failure fallback path without monkey-patching node:fs.
+  writeTempPolicy?: (yaml: string) => string;
 }
 
 export function buildRuntimePermissivePolicy(
@@ -100,11 +108,24 @@ export function buildRuntimePermissivePolicy(
   fsPolicy.read_write = [...baseRw];
   fsPolicy.read_only = [...baseRo];
 
+  const yaml = YAML.stringify(base);
+  if (deps.writeTempPolicy) {
+    try {
+      return deps.writeTempPolicy(yaml);
+    } catch {
+      return basePermissivePath;
+    }
+  }
+  let tmpPath: string | null = null;
   try {
-    const tmpPath = secureTempFile("nemoclaw-permissive-runtime", ".yaml");
-    fs.writeFileSync(tmpPath, YAML.stringify(base), { mode: 0o600 });
+    tmpPath = secureTempFile(TEMP_FILE_PREFIX, ".yaml");
+    fs.writeFileSync(tmpPath, yaml, { mode: 0o600 });
     return tmpPath;
   } catch {
+    // secureTempFile may have created an mkdtemp directory before
+    // writeFileSync failed. Clean it up so we do not leak a 0700 dir
+    // on /tmp every time the write path errors.
+    if (tmpPath) cleanupTempDir(tmpPath, TEMP_FILE_PREFIX);
     return basePermissivePath;
   }
 }

--- a/src/lib/shields/permissive-runtime.ts
+++ b/src/lib/shields/permissive-runtime.ts
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import YAML from "yaml";
+
+import { secureTempFile } from "../onboard/temp-files";
+
+/**
+ * Build a permissive policy YAML that is guaranteed to be a strict superset
+ * of the live sandbox's filesystem policy.
+ *
+ * Background (#3942, #3957, #3168): OpenShell refuses to remove a
+ * `filesystem_policy.read_only` or `filesystem_policy.read_write` entry on a
+ * live sandbox. The static `openclaw-sandbox-permissive.yaml` baseline does
+ * not see runtime-injected paths — `/proc` on GPU sandboxes, `/opt/hermes`
+ * on Hermes, `/home/linuxbrew` on post-#3913 OpenClaw, and any future
+ * agent- or feature-specific enrichment. Each of those past mismatches
+ * shipped its own permissive-YAML patch. This helper closes the loop by
+ * unioning whatever the live sandbox advertises into the permissive YAML
+ * before it is applied, so future runtime injections are absorbed
+ * automatically.
+ *
+ * Resolution rules when a path appears on both sides:
+ * - Live `read_write` is the more permissive of the two and takes priority:
+ *   if the live state writes a path, the permissive transition keeps it
+ *   writable, removing it from `read_only` first so we never emit a path
+ *   in both lists.
+ * - Live `read_only` is merged into base `read_only` only when the same
+ *   path is not already granted `read_write` (either by base or by live).
+ *
+ * Returns the path to a freshly created temp YAML file. Falls back to the
+ * base permissive path if the live policy can't be parsed or omits the
+ * filesystem section — degrading to the existing static behavior rather
+ * than failing closed.
+ */
+export interface PermissiveRuntimeDeps {
+  fetchLivePolicy: (sandboxName: string) => string;
+  readBasePolicy: () => string;
+}
+
+export function buildRuntimePermissivePolicy(
+  sandboxName: string,
+  basePermissivePath: string,
+  deps: PermissiveRuntimeDeps,
+): string {
+  const liveRaw = deps.fetchLivePolicy(sandboxName);
+  const liveYaml = parsePolicyBlock(liveRaw);
+  const live = liveYaml ? safeYamlObject(liveYaml) : null;
+  const liveRw = readStringList(live, "read_write");
+  const liveRo = readStringList(live, "read_only");
+
+  // No live filesystem section to merge — keep the static path so the
+  // caller's apply path is unchanged.
+  if (liveRw.length === 0 && liveRo.length === 0) {
+    return basePermissivePath;
+  }
+
+  const baseYaml = deps.readBasePolicy();
+  const base = safeYamlObject(baseYaml);
+  if (!base) {
+    return basePermissivePath;
+  }
+  const fsPolicy =
+    base.filesystem_policy && typeof base.filesystem_policy === "object"
+      ? (base.filesystem_policy as Record<string, unknown>)
+      : ((base.filesystem_policy = {} as Record<string, unknown>),
+        base.filesystem_policy as Record<string, unknown>);
+
+  const baseRw = new Set(readStringList(base, "read_write"));
+  const baseRo = new Set(readStringList(base, "read_only"));
+
+  // RW wins: a live write-path must stay writable in the new policy, and
+  // the same path cannot also live in read_only afterwards.
+  for (const p of liveRw) {
+    baseRo.delete(p);
+    baseRw.add(p);
+  }
+  for (const p of liveRo) {
+    if (!baseRw.has(p)) baseRo.add(p);
+  }
+
+  fsPolicy.read_write = [...baseRw];
+  fsPolicy.read_only = [...baseRo];
+
+  const tmpPath = secureTempFile("nemoclaw-permissive-runtime", ".yaml");
+  fs.writeFileSync(tmpPath, YAML.stringify(base), { mode: 0o600 });
+  return tmpPath;
+}
+
+function safeYamlObject(text: string): Record<string, unknown> | null {
+  try {
+    const parsed = YAML.parse(text);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function readStringList(
+  root: Record<string, unknown> | null,
+  key: "read_only" | "read_write",
+): string[] {
+  const fsPolicy = root?.filesystem_policy;
+  if (!fsPolicy || typeof fsPolicy !== "object") return [];
+  const value = (fsPolicy as Record<string, unknown>)[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+// Lightweight clone of policy/index.ts:parseCurrentPolicy that strips the
+// OpenShell header / error preamble before YAML.parse. Inlined to avoid a
+// runtime cycle with the policy module.
+function parsePolicyBlock(raw: string | null | undefined): string {
+  if (!raw) return "";
+  const sep = raw.indexOf("---");
+  const candidate = (sep === -1 ? raw : raw.slice(sep + 3)).trim();
+  if (!candidate) return "";
+  if (/^(error|failed|invalid|warning|status)\b/i.test(candidate)) return "";
+  if (!/^[a-z_][a-z0-9_]*\s*:/m.test(candidate)) return "";
+  try {
+    const parsed = YAML.parse(candidate);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "";
+  } catch {
+    return "";
+  }
+  return candidate;
+}

--- a/src/lib/shields/permissive-runtime.ts
+++ b/src/lib/shields/permissive-runtime.ts
@@ -7,46 +7,58 @@ import YAML from "yaml";
 import { secureTempFile } from "../onboard/temp-files";
 
 /**
- * Build a permissive policy YAML that is guaranteed to be a strict superset
- * of the live sandbox's filesystem policy.
+ * Build a permissive policy YAML whose filesystem path lists
+ * (`filesystem_policy.read_only` + `filesystem_policy.read_write`) are a
+ * superset of the live sandbox's, so OpenShell never has to remove a path
+ * on a live transition.
+ *
+ * Only the two path lists are unioned. Other `filesystem_policy` fields
+ * (e.g. `include_workdir`) are preserved verbatim from the static base —
+ * the bug class this helper exists for is path removal on a live sandbox,
+ * not policy shape changes.
  *
  * Background (#3942, #3957, #3168): OpenShell refuses to remove a
- * `filesystem_policy.read_only` or `filesystem_policy.read_write` entry on a
- * live sandbox. The static `openclaw-sandbox-permissive.yaml` baseline does
- * not see runtime-injected paths — `/proc` on GPU sandboxes, `/opt/hermes`
- * on Hermes, `/home/linuxbrew` on post-#3913 OpenClaw, and any future
- * agent- or feature-specific enrichment. Each of those past mismatches
- * shipped its own permissive-YAML patch. This helper closes the loop by
- * unioning whatever the live sandbox advertises into the permissive YAML
- * before it is applied, so future runtime injections are absorbed
- * automatically.
+ * `filesystem_policy.read_only` or `filesystem_policy.read_write` entry
+ * on a live sandbox. The static `openclaw-sandbox-permissive.yaml`
+ * baseline does not see runtime-injected paths — `/proc` on GPU
+ * sandboxes, `/opt/hermes` on Hermes, `/home/linuxbrew` on post-#3913
+ * OpenClaw, and any future agent- or feature-specific enrichment. Each
+ * past mismatch shipped its own permissive-YAML patch. This helper
+ * closes the loop by unioning whatever the live sandbox advertises into
+ * the permissive YAML before it is applied, so future runtime injections
+ * are absorbed automatically.
  *
- * Resolution rules when a path appears on both sides:
- * - Live `read_write` is the more permissive of the two and takes priority:
- *   if the live state writes a path, the permissive transition keeps it
- *   writable, removing it from `read_only` first so we never emit a path
- *   in both lists.
+ * Resolution rules when a path appears in both `read_only` and
+ * `read_write`:
+ * - Live `read_write` is the more permissive of the two and takes
+ *   priority: if the live state writes a path, the permissive transition
+ *   keeps it writable, removing it from `read_only` first so we never
+ *   emit a path in both lists.
  * - Live `read_only` is merged into base `read_only` only when the same
  *   path is not already granted `read_write` (either by base or by live).
  *
- * Returns the path to a freshly created temp YAML file. Falls back to the
- * base permissive path if the live policy can't be parsed or omits the
- * filesystem section — degrading to the existing static behavior rather
- * than failing closed.
+ * Returns the path to a freshly created temp YAML file when the live
+ * policy carries a filesystem section that needs merging. Falls back to
+ * the static base path when the live policy is empty / has no filesystem
+ * lists, when the base YAML cannot be parsed, or when temp-file I/O
+ * fails — degrading to the existing static apply path rather than
+ * aborting shields-down with an I/O error.
  */
 export interface PermissiveRuntimeDeps {
-  fetchLivePolicy: (sandboxName: string) => string;
+  // Pre-parsed live policy YAML body (e.g. parseCurrentPolicy(rawPolicy)
+  // from the caller, which already strips the OpenShell header). Passed
+  // in rather than fetched here so this helper stays a pure transform.
+  livePolicyYaml: string;
+  // Lazy because callers may want to defer the read until the helper
+  // actually needs it. The returned string is parsed by YAML.parse.
   readBasePolicy: () => string;
 }
 
 export function buildRuntimePermissivePolicy(
-  sandboxName: string,
   basePermissivePath: string,
   deps: PermissiveRuntimeDeps,
 ): string {
-  const liveRaw = deps.fetchLivePolicy(sandboxName);
-  const liveYaml = parsePolicyBlock(liveRaw);
-  const live = liveYaml ? safeYamlObject(liveYaml) : null;
+  const live = deps.livePolicyYaml ? safeYamlObject(deps.livePolicyYaml) : null;
   const liveRw = readStringList(live, "read_write");
   const liveRo = readStringList(live, "read_only");
 
@@ -56,7 +68,12 @@ export function buildRuntimePermissivePolicy(
     return basePermissivePath;
   }
 
-  const baseYaml = deps.readBasePolicy();
+  let baseYaml: string;
+  try {
+    baseYaml = deps.readBasePolicy();
+  } catch {
+    return basePermissivePath;
+  }
   const base = safeYamlObject(baseYaml);
   if (!base) {
     return basePermissivePath;
@@ -70,8 +87,8 @@ export function buildRuntimePermissivePolicy(
   const baseRw = new Set(readStringList(base, "read_write"));
   const baseRo = new Set(readStringList(base, "read_only"));
 
-  // RW wins: a live write-path must stay writable in the new policy, and
-  // the same path cannot also live in read_only afterwards.
+  // RW wins: a live write-path must stay writable in the new policy,
+  // and the same path cannot also live in read_only afterwards.
   for (const p of liveRw) {
     baseRo.delete(p);
     baseRw.add(p);
@@ -83,9 +100,13 @@ export function buildRuntimePermissivePolicy(
   fsPolicy.read_write = [...baseRw];
   fsPolicy.read_only = [...baseRo];
 
-  const tmpPath = secureTempFile("nemoclaw-permissive-runtime", ".yaml");
-  fs.writeFileSync(tmpPath, YAML.stringify(base), { mode: 0o600 });
-  return tmpPath;
+  try {
+    const tmpPath = secureTempFile("nemoclaw-permissive-runtime", ".yaml");
+    fs.writeFileSync(tmpPath, YAML.stringify(base), { mode: 0o600 });
+    return tmpPath;
+  } catch {
+    return basePermissivePath;
+  }
 }
 
 function safeYamlObject(text: string): Record<string, unknown> | null {
@@ -109,23 +130,4 @@ function readStringList(
   const value = (fsPolicy as Record<string, unknown>)[key];
   if (!Array.isArray(value)) return [];
   return value.filter((entry): entry is string => typeof entry === "string");
-}
-
-// Lightweight clone of policy/index.ts:parseCurrentPolicy that strips the
-// OpenShell header / error preamble before YAML.parse. Inlined to avoid a
-// runtime cycle with the policy module.
-function parsePolicyBlock(raw: string | null | undefined): string {
-  if (!raw) return "";
-  const sep = raw.indexOf("---");
-  const candidate = (sep === -1 ? raw : raw.slice(sep + 3)).trim();
-  if (!candidate) return "";
-  if (/^(error|failed|invalid|warning|status)\b/i.test(candidate)) return "";
-  if (!/^[a-z_][a-z0-9_]*\s*:/m.test(candidate)) return "";
-  try {
-    const parsed = YAML.parse(candidate);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "";
-  } catch {
-    return "";
-  }
-  return candidate;
 }

--- a/test/permissive-runtime.test.ts
+++ b/test/permissive-runtime.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, afterEach } from "vitest";
 import YAML from "yaml";
@@ -18,6 +19,19 @@ const BASE_PERMISSIVE = YAML.stringify({
 });
 
 const tempFilesToClean: string[] = [];
+
+function trackTempForCleanup(out: string, basePath: string): void {
+  // Defensive: if the helper degrades to the static base path we must
+  // never try to `rm -rf` its parent dir — that would target the
+  // user's checkout. Only enqueue paths that the helper actually
+  // produced via mkdtemp.
+  if (out === basePath) return;
+  const tempRoot = path.resolve(os.tmpdir());
+  const parent = path.resolve(path.dirname(out));
+  const rel = path.relative(tempRoot, parent);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return;
+  tempFilesToClean.push(out);
+}
 
 afterEach(() => {
   while (tempFilesToClean.length > 0) {
@@ -45,7 +59,8 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
       livePolicyYaml: liveYaml,
       readBasePolicy: () => BASE_PERMISSIVE,
     });
-    tempFilesToClean.push(out);
+    trackTempForCleanup(out, "/unused-base.yaml");
+    expect(out).not.toBe("/unused-base.yaml");
 
     const result = YAML.parse(fs.readFileSync(out, "utf-8"));
     expect(result.filesystem_policy.read_write).toEqual(
@@ -64,7 +79,8 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
       livePolicyYaml: liveYaml,
       readBasePolicy: () => BASE_PERMISSIVE,
     });
-    tempFilesToClean.push(out);
+    trackTempForCleanup(out, "/unused-base.yaml");
+    expect(out).not.toBe("/unused-base.yaml");
 
     const result = YAML.parse(fs.readFileSync(out, "utf-8"));
     expect(result.filesystem_policy.include_workdir).toBe(true);
@@ -83,7 +99,8 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
       livePolicyYaml: liveYaml,
       readBasePolicy: () => BASE_PERMISSIVE,
     });
-    tempFilesToClean.push(out);
+    trackTempForCleanup(out, "/unused-base.yaml");
+    expect(out).not.toBe("/unused-base.yaml");
 
     const result = YAML.parse(fs.readFileSync(out, "utf-8"));
     expect(result.filesystem_policy.read_write).toContain("/tmp");
@@ -103,7 +120,8 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
       livePolicyYaml: liveYaml,
       readBasePolicy: () => BASE_PERMISSIVE,
     });
-    tempFilesToClean.push(out);
+    trackTempForCleanup(out, "/unused-base.yaml");
+    expect(out).not.toBe("/unused-base.yaml");
 
     const result = YAML.parse(fs.readFileSync(out, "utf-8"));
     const rwCount = result.filesystem_policy.read_write.filter((p: string) => p === "/tmp").length;
@@ -159,5 +177,23 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
       readBasePolicy: () => "::: not yaml :::",
     });
     expect(out).toBe(basePath);
+  });
+
+  it("returns the static base path when temp-file write throws", () => {
+    const basePath = "/path/to/static.yaml";
+    const liveYaml = YAML.stringify({
+      filesystem_policy: { read_write: ["/proc"] },
+    });
+    let writeAttempts = 0;
+    const out = buildRuntimePermissivePolicy(basePath, {
+      livePolicyYaml: liveYaml,
+      readBasePolicy: () => BASE_PERMISSIVE,
+      writeTempPolicy: () => {
+        writeAttempts += 1;
+        throw new Error("ENOSPC: simulated /tmp full");
+      },
+    });
+    expect(out).toBe(basePath);
+    expect(writeAttempts).toBe(1);
   });
 });

--- a/test/permissive-runtime.test.ts
+++ b/test/permissive-runtime.test.ts
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect, afterEach } from "vitest";
+import YAML from "yaml";
+
+import { buildRuntimePermissivePolicy } from "../dist/lib/shields/permissive-runtime.js";
+
+const BASE_PERMISSIVE = YAML.stringify({
+  filesystem_policy: {
+    read_only: ["/proc", "/etc"],
+    read_write: ["/tmp", "/sandbox/.openclaw"],
+  },
+  landlock: { compatibility: "best_effort" },
+});
+
+const tempFilesToClean: string[] = [];
+
+afterEach(() => {
+  while (tempFilesToClean.length > 0) {
+    const p = tempFilesToClean.pop();
+    if (!p) continue;
+    try {
+      fs.rmSync(path.dirname(p), { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  }
+});
+
+function withWrapper(yaml: string): string {
+  // Mirror `openshell policy get --full` output shape: a header line, then
+  // `---`, then the YAML body. parsePolicyBlock should strip the prefix.
+  return `policy: openclaw-sandbox\n---\n${yaml}`;
+}
+
+describe("buildRuntimePermissivePolicy (#3942)", () => {
+  it("preserves /proc when the live GPU sandbox has it in read_write", () => {
+    const live = YAML.stringify({
+      filesystem_policy: {
+        read_only: ["/etc", "/usr"],
+        // GPU enrichment from src/lib/onboard/initial-policy.ts:57.
+        read_write: ["/tmp", "/proc", "/home/linuxbrew"],
+      },
+    });
+
+    const out = buildRuntimePermissivePolicy("alpha", "/unused-base.yaml", {
+      fetchLivePolicy: () => withWrapper(live),
+      readBasePolicy: () => BASE_PERMISSIVE,
+    });
+    tempFilesToClean.push(out);
+
+    const result = YAML.parse(fs.readFileSync(out, "utf-8"));
+    expect(result.filesystem_policy.read_write).toEqual(
+      expect.arrayContaining(["/tmp", "/sandbox/.openclaw", "/proc", "/home/linuxbrew"]),
+    );
+    // /proc must NOT also appear in read_only; rw wins.
+    expect(result.filesystem_policy.read_only).not.toContain("/proc");
+  });
+
+  it("merges live read_only paths into base read_only without clobbering rw", () => {
+    const live = YAML.stringify({
+      filesystem_policy: {
+        // /tmp is in base read_write — live ro should NOT downgrade it.
+        read_only: ["/usr", "/tmp"],
+        read_write: [],
+      },
+    });
+
+    const out = buildRuntimePermissivePolicy("alpha", "/unused-base.yaml", {
+      fetchLivePolicy: () => withWrapper(live),
+      readBasePolicy: () => BASE_PERMISSIVE,
+    });
+    tempFilesToClean.push(out);
+
+    const result = YAML.parse(fs.readFileSync(out, "utf-8"));
+    expect(result.filesystem_policy.read_write).toContain("/tmp");
+    expect(result.filesystem_policy.read_only).toContain("/usr");
+    expect(result.filesystem_policy.read_only).not.toContain("/tmp");
+  });
+
+  it("deduplicates entries within each list and across lists", () => {
+    const live = YAML.stringify({
+      filesystem_policy: {
+        read_only: ["/etc", "/etc"], // duplicate within live ro
+        read_write: ["/tmp", "/tmp", "/proc"], // duplicate within live rw
+      },
+    });
+
+    const out = buildRuntimePermissivePolicy("alpha", "/unused-base.yaml", {
+      fetchLivePolicy: () => withWrapper(live),
+      readBasePolicy: () => BASE_PERMISSIVE,
+    });
+    tempFilesToClean.push(out);
+
+    const result = YAML.parse(fs.readFileSync(out, "utf-8"));
+    const rwCount = result.filesystem_policy.read_write.filter((p: string) => p === "/tmp").length;
+    const roCount = result.filesystem_policy.read_only.filter((p: string) => p === "/etc").length;
+    expect(rwCount).toBe(1);
+    expect(roCount).toBe(1);
+    // No path appears in both lists.
+    const rwSet = new Set(result.filesystem_policy.read_write);
+    for (const p of result.filesystem_policy.read_only) {
+      expect(rwSet.has(p)).toBe(false);
+    }
+  });
+
+  it("returns the static base path when live policy is empty / unparseable", () => {
+    const basePath = "/path/to/static.yaml";
+    const out = buildRuntimePermissivePolicy("alpha", basePath, {
+      fetchLivePolicy: () => "",
+      readBasePolicy: () => BASE_PERMISSIVE,
+    });
+    expect(out).toBe(basePath);
+  });
+
+  it("returns the static base path when openshell policy get errored", () => {
+    const basePath = "/path/to/static.yaml";
+    const out = buildRuntimePermissivePolicy("alpha", basePath, {
+      fetchLivePolicy: () => "Error: sandbox not found",
+      readBasePolicy: () => BASE_PERMISSIVE,
+    });
+    expect(out).toBe(basePath);
+  });
+
+  it("returns the static base path when live policy has no filesystem_policy section", () => {
+    const basePath = "/path/to/static.yaml";
+    const live = YAML.stringify({ landlock: { compatibility: "best_effort" } });
+    const out = buildRuntimePermissivePolicy("alpha", basePath, {
+      fetchLivePolicy: () => withWrapper(live),
+      readBasePolicy: () => BASE_PERMISSIVE,
+    });
+    expect(out).toBe(basePath);
+  });
+});

--- a/test/permissive-runtime.test.ts
+++ b/test/permissive-runtime.test.ts
@@ -10,6 +10,7 @@ import { buildRuntimePermissivePolicy } from "../dist/lib/shields/permissive-run
 
 const BASE_PERMISSIVE = YAML.stringify({
   filesystem_policy: {
+    include_workdir: true,
     read_only: ["/proc", "/etc"],
     read_write: ["/tmp", "/sandbox/.openclaw"],
   },
@@ -30,15 +31,9 @@ afterEach(() => {
   }
 });
 
-function withWrapper(yaml: string): string {
-  // Mirror `openshell policy get --full` output shape: a header line, then
-  // `---`, then the YAML body. parsePolicyBlock should strip the prefix.
-  return `policy: openclaw-sandbox\n---\n${yaml}`;
-}
-
 describe("buildRuntimePermissivePolicy (#3942)", () => {
   it("preserves /proc when the live GPU sandbox has it in read_write", () => {
-    const live = YAML.stringify({
+    const liveYaml = YAML.stringify({
       filesystem_policy: {
         read_only: ["/etc", "/usr"],
         // GPU enrichment from src/lib/onboard/initial-policy.ts:57.
@@ -46,8 +41,8 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
       },
     });
 
-    const out = buildRuntimePermissivePolicy("alpha", "/unused-base.yaml", {
-      fetchLivePolicy: () => withWrapper(live),
+    const out = buildRuntimePermissivePolicy("/unused-base.yaml", {
+      livePolicyYaml: liveYaml,
       readBasePolicy: () => BASE_PERMISSIVE,
     });
     tempFilesToClean.push(out);
@@ -60,8 +55,23 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
     expect(result.filesystem_policy.read_only).not.toContain("/proc");
   });
 
+  it("preserves non-list filesystem_policy fields (e.g. include_workdir)", () => {
+    const liveYaml = YAML.stringify({
+      filesystem_policy: { read_write: ["/proc"], read_only: ["/usr"] },
+    });
+
+    const out = buildRuntimePermissivePolicy("/unused-base.yaml", {
+      livePolicyYaml: liveYaml,
+      readBasePolicy: () => BASE_PERMISSIVE,
+    });
+    tempFilesToClean.push(out);
+
+    const result = YAML.parse(fs.readFileSync(out, "utf-8"));
+    expect(result.filesystem_policy.include_workdir).toBe(true);
+  });
+
   it("merges live read_only paths into base read_only without clobbering rw", () => {
-    const live = YAML.stringify({
+    const liveYaml = YAML.stringify({
       filesystem_policy: {
         // /tmp is in base read_write — live ro should NOT downgrade it.
         read_only: ["/usr", "/tmp"],
@@ -69,8 +79,8 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
       },
     });
 
-    const out = buildRuntimePermissivePolicy("alpha", "/unused-base.yaml", {
-      fetchLivePolicy: () => withWrapper(live),
+    const out = buildRuntimePermissivePolicy("/unused-base.yaml", {
+      livePolicyYaml: liveYaml,
       readBasePolicy: () => BASE_PERMISSIVE,
     });
     tempFilesToClean.push(out);
@@ -82,15 +92,15 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
   });
 
   it("deduplicates entries within each list and across lists", () => {
-    const live = YAML.stringify({
+    const liveYaml = YAML.stringify({
       filesystem_policy: {
-        read_only: ["/etc", "/etc"], // duplicate within live ro
-        read_write: ["/tmp", "/tmp", "/proc"], // duplicate within live rw
+        read_only: ["/etc", "/etc"],
+        read_write: ["/tmp", "/tmp", "/proc"],
       },
     });
 
-    const out = buildRuntimePermissivePolicy("alpha", "/unused-base.yaml", {
-      fetchLivePolicy: () => withWrapper(live),
+    const out = buildRuntimePermissivePolicy("/unused-base.yaml", {
+      livePolicyYaml: liveYaml,
       readBasePolicy: () => BASE_PERMISSIVE,
     });
     tempFilesToClean.push(out);
@@ -100,26 +110,16 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
     const roCount = result.filesystem_policy.read_only.filter((p: string) => p === "/etc").length;
     expect(rwCount).toBe(1);
     expect(roCount).toBe(1);
-    // No path appears in both lists.
     const rwSet = new Set(result.filesystem_policy.read_write);
     for (const p of result.filesystem_policy.read_only) {
       expect(rwSet.has(p)).toBe(false);
     }
   });
 
-  it("returns the static base path when live policy is empty / unparseable", () => {
+  it("returns the static base path when live policy is empty", () => {
     const basePath = "/path/to/static.yaml";
-    const out = buildRuntimePermissivePolicy("alpha", basePath, {
-      fetchLivePolicy: () => "",
-      readBasePolicy: () => BASE_PERMISSIVE,
-    });
-    expect(out).toBe(basePath);
-  });
-
-  it("returns the static base path when openshell policy get errored", () => {
-    const basePath = "/path/to/static.yaml";
-    const out = buildRuntimePermissivePolicy("alpha", basePath, {
-      fetchLivePolicy: () => "Error: sandbox not found",
+    const out = buildRuntimePermissivePolicy(basePath, {
+      livePolicyYaml: "",
       readBasePolicy: () => BASE_PERMISSIVE,
     });
     expect(out).toBe(basePath);
@@ -127,10 +127,36 @@ describe("buildRuntimePermissivePolicy (#3942)", () => {
 
   it("returns the static base path when live policy has no filesystem_policy section", () => {
     const basePath = "/path/to/static.yaml";
-    const live = YAML.stringify({ landlock: { compatibility: "best_effort" } });
-    const out = buildRuntimePermissivePolicy("alpha", basePath, {
-      fetchLivePolicy: () => withWrapper(live),
+    const liveYaml = YAML.stringify({ landlock: { compatibility: "best_effort" } });
+    const out = buildRuntimePermissivePolicy(basePath, {
+      livePolicyYaml: liveYaml,
       readBasePolicy: () => BASE_PERMISSIVE,
+    });
+    expect(out).toBe(basePath);
+  });
+
+  it("returns the static base path when readBasePolicy throws (I/O failure)", () => {
+    const basePath = "/path/to/static.yaml";
+    const liveYaml = YAML.stringify({
+      filesystem_policy: { read_write: ["/proc"] },
+    });
+    const out = buildRuntimePermissivePolicy(basePath, {
+      livePolicyYaml: liveYaml,
+      readBasePolicy: () => {
+        throw new Error("ENOENT");
+      },
+    });
+    expect(out).toBe(basePath);
+  });
+
+  it("returns the static base path when base YAML is unparseable", () => {
+    const basePath = "/path/to/static.yaml";
+    const liveYaml = YAML.stringify({
+      filesystem_policy: { read_write: ["/proc"] },
+    });
+    const out = buildRuntimePermissivePolicy(basePath, {
+      livePolicyYaml: liveYaml,
+      readBasePolicy: () => "::: not yaml :::",
     });
     expect(out).toBe(basePath);
   });


### PR DESCRIPTION
## Summary

`nemoclaw <name> shields down` fails on GPU sandboxes with:

```
status: InvalidArgument, message: "filesystem read_write path '/proc' cannot be removed on a live sandbox"
```

OpenShell refuses to remove a `filesystem_policy.read_only` or `filesystem_policy.read_write` entry on a live sandbox. The static `openclaw-sandbox-permissive.yaml` baseline never sees the runtime enrichment that NemoClaw adds at create time, so applying it on top of a live sandbox triggers the rejection whenever a runtime-injected path is missing from the static YAML.

This has reappeared with each new runtime-injected path:

- #3168 — Hermes `/opt/hermes` (closed by per-agent permissive YAML)
- #3957 — OpenClaw `/home/linuxbrew` (closed by patching the static YAML in 60d3e5e)
- #3942 — GPU sandboxes `/proc` (this PR)

Close the loop with a generic helper. Before `shields down` applies the permissive policy, fetch the live sandbox's policy via the snapshot we already capture and union its `filesystem_policy.read_write` and `filesystem_policy.read_only` into the base permissive YAML. The result has filesystem path lists that are a superset of the live filesystem section, so OpenShell never sees a removal on the `shields down` transition. Future runtime-injected paths are absorbed automatically **on the `shields down` path**. Other permissive-apply surfaces (`applyPermissivePolicy` in `src/lib/policy/index.ts` — currently unused by any in-source caller — and the E2E scripts that read the static YAML directly) are unchanged and continue to rely on the static file being correct; the earlier whack-a-mole fixes for #3168 and #3957 are kept for those paths.

## Related Issue

Partially addresses #3942 - Part 2
Closes #3957

## Changes

- [src/lib/shields/permissive-runtime.ts](src/lib/shields/permissive-runtime.ts): new helper `buildRuntimePermissivePolicy(basePath, deps)`. Takes the already-parsed live policy YAML body (from the caller's `parseCurrentPolicy(rawPolicy)`) and a lazy base-policy reader as injected deps. Unions `filesystem_policy.read_only` + `filesystem_policy.read_write` into the static base. Other `filesystem_policy` fields (e.g. `include_workdir`) are preserved verbatim. RW wins on path overlap. Returns the static base path verbatim when (a) the live YAML has no filesystem path lists, (b) the base YAML cannot be parsed, or (c) base-read / temp-file I/O throws — so an I/O fault degrades to the existing static apply path rather than aborting shields-down. If `secureTempFile` already created its mkdtemp directory before the subsequent `writeFileSync` throws, the directory is cleaned up via `cleanupTempDir` so the failure path never leaks 0700 dirs under `/tmp`. A `writeTempPolicy` dep is exposed so tests can drive the write-failure branch without monkey-patching `node:fs`.
- [src/lib/shields/index.ts](src/lib/shields/index.ts): wire `buildRuntimePermissivePolicy` in. Reuse the already-captured `policyYaml` (parsed via `parseCurrentPolicy(rawPolicy)`) so there is no duplicate parser. Wrap the `openshell policy set` call in `try / finally` so the temp file's mkdtemp directory is cleaned up via `cleanupTempDir`.
- [test/permissive-runtime.test.ts](test/permissive-runtime.test.ts): 9 regression tests covering `/proc` preservation on GPU sandboxes, `include_workdir` passthrough, dedup across lists, the RW-wins rule on conflicts, and five degraded paths (empty live YAML, no filesystem section, `readBasePolicy` throws, base YAML unparseable, `writeTempPolicy` throws) returning the static base path. Cleanup helper rejects any output that is not under `os.tmpdir()` to avoid an accidental `rm -rf` on the user's checkout when the helper degrades to the static base path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic runtime generation of permissive network policies based on live system configurations, enabling more responsive policy enforcement aligned with current system state
  * Automatic cleanup of temporary policy artifacts to improve system resource management and hygiene

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->