### PR TITLE
fix(advisor): wait for required PR checks

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -53,7 +53,7 @@ jobs:
     name: PR review advisor
     if: ${{ github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'NVIDIA/NemoClaw') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     env:
       # Pin the Pi SDK to a known-good version. Updates should go through
       # normal dependency review so a compromised upstream release cannot run
@@ -61,6 +61,14 @@ jobs:
       PI_SDK_VERSION: "0.74.0"
       PR_REVIEW_ADVISOR_TIMEOUT_MS: "900000"
       PR_REVIEW_ADVISOR_HEARTBEAT_MS: "60000"
+      # This job is advisory and must not be configured as a required status
+      # check. It waits for required checks before model analysis so summaries
+      # are based on settled CI instead of an immediate pending snapshot.
+      PR_REVIEW_ADVISOR_WAIT_FOR_REQUIRED_CHECKS: "1"
+      PR_REVIEW_ADVISOR_WAIT_TIMEOUT_MS: "900000"
+      PR_REVIEW_ADVISOR_WAIT_POLL_MS: "30000"
+      PR_REVIEW_ADVISOR_WAIT_ADDITIONAL_CONTEXTS: "E2E recommendation"
+      PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS: "checks,commit-lint,dco-check,check-hash,changes"
       # Trusted implementation code is always checked out here. PR content is
       # only read as inert analysis data under ADVISOR_WORKDIR.
       ADVISOR_DIR: ${{ github.workspace }}/advisor

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -8,7 +8,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
 
 import { buildComment } from "../tools/pr-review-advisor/comment.mts";
-import { buildSystemPrompt, classifyMonolithDelta, classifyTestDepth, deriveGateStatus, normalizeReviewResult, readTrustedSecurityReviewSkill, renderSummary } from "../tools/pr-review-advisor/analyze.mts";
+import {
+  buildSystemPrompt,
+  classifyMonolithDelta,
+  classifyTestDepth,
+  deriveGateStatus,
+  extractRequiredStatusChecksFromRulesets,
+  extractStatusCheckSummaries,
+  normalizeReviewResult,
+  pendingRequiredContexts,
+  readTrustedSecurityReviewSkill,
+  renderSummary,
+} from "../tools/pr-review-advisor/analyze.mts";
 import { githubGraphql } from "../tools/advisors/github.mts";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
@@ -30,6 +41,8 @@ function metadata(overrides: Partial<ReviewMetadata> = {}): ReviewMetadata {
       reviewThreads: { status: "unknown", evidence: "No review thread state was available." },
       riskyCodeTested: { status: "pass", evidence: "No risky code areas detected by path heuristics." },
     },
+    requiredStatusCheckContexts: [],
+    additionalWaitContexts: [],
     workflowSignals: [],
     monolithDeltas: [],
     driftEvidence: [],
@@ -174,6 +187,88 @@ describe("PR review advisor", () => {
     expect(clean.mergeability.status).toBe("pass");
   });
 
+  it("extracts required checks from active branch rulesets", () => {
+    const rulesets = [
+      {
+        target: "branch",
+        enforcement: "active",
+        conditions: { ref_name: { include: ["refs/heads/main"], exclude: [] } },
+        rules: [
+          {
+            type: "required_status_checks",
+            parameters: {
+              required_status_checks: [
+                { context: "checks" },
+                { context: "commit-lint" },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        target: "branch",
+        enforcement: "active",
+        conditions: { ref_name: { include: ["refs/heads/release/*"], exclude: [] } },
+        rules: [{ type: "required_status_checks", parameters: { required_status_checks: [{ context: "release-only" }] } }],
+      },
+      {
+        target: "branch",
+        enforcement: "disabled",
+        conditions: { ref_name: { include: ["refs/heads/main"], exclude: [] } },
+        rules: [{ type: "required_status_checks", parameters: { required_status_checks: [{ context: "disabled" }] } }],
+      },
+    ];
+
+    expect(extractRequiredStatusChecksFromRulesets(rulesets, "main")).toEqual(["checks", "commit-lint"]);
+    expect(extractRequiredStatusChecksFromRulesets(rulesets, "release/1.0")).toEqual(["release-only"]);
+  });
+
+  it("bases the CI gate on required contexts when they are known", () => {
+    const gates = deriveGateStatus(
+      {
+        graphQl: {
+          data: {
+            repository: {
+              pullRequest: {
+                statusCheckRollup: {
+                  contexts: {
+                    nodes: [
+                      { __typename: "CheckRun", name: "checks", status: "COMPLETED", conclusion: "SUCCESS" },
+                      { __typename: "CheckRun", name: "commit-lint", status: "COMPLETED", conclusion: "SUCCESS" },
+                      { __typename: "CheckRun", name: "PR review advisor", status: "IN_PROGRESS", conclusion: null },
+                      { __typename: "CheckRun", name: "optional-gpu-e2e", status: "IN_PROGRESS", conclusion: null },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      [],
+      [],
+      ["checks", "commit-lint"],
+    );
+
+    expect(gates.ci.status).toBe("pass");
+    expect(gates.ci.evidence).toContain("2 required status context(s) completed");
+    expect(gates.ci.evidence).toContain("Non-required contexts still pending: 1");
+  });
+
+  it("wait logic treats missing or in-progress required contexts as pending", () => {
+    const statuses = extractStatusCheckSummaries([
+      { __typename: "CheckRun", name: "checks", status: "COMPLETED", conclusion: "SUCCESS" },
+      { __typename: "CheckRun", name: "commit-lint", status: "IN_PROGRESS", conclusion: null },
+      { __typename: "StatusContext", context: "dco-check", state: "SUCCESS" },
+      { __typename: "StatusContext", context: "check-hash", state: "FAILURE" },
+    ]);
+
+    expect(pendingRequiredContexts(["checks", "commit-lint", "dco-check", "check-hash", "changes"], statuses)).toEqual([
+      "commit-lint",
+      "changes",
+    ]);
+  });
+
   it("surfaces GitHub GraphQL errors even when the HTTP status is successful", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
       ok: true,
@@ -277,6 +372,9 @@ describe("PR review advisor", () => {
     expect(analyzeStep.env.PR_REVIEW_ADVISOR_API_KEY).toBe(
       "${{ secrets.PR_REVIEW_ADVISOR_API_KEY || secrets.PI_PR_REVIEW_ADVISOR_API_KEY }}",
     );
+    expect(workflow.jobs.review["timeout-minutes"]).toBe(40);
+    expect(workflow.jobs.review.env.PR_REVIEW_ADVISOR_WAIT_FOR_REQUIRED_CHECKS).toBe("1");
+    expect(workflow.jobs.review.env.PR_REVIEW_ADVISOR_WAIT_ADDITIONAL_CONTEXTS).toBe("E2E recommendation");
     expect(installStep.run.includes("--ignore-scripts")).toBe(true);
     expect(analyzeStep.run.includes("$ADVISOR_DIR/tools/pr-review-advisor/analyze.mts")).toBe(true);
     expect(analyzeStep.run).toContain("trusted main checkout does not yet contain analyze.mts");

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -13,6 +13,7 @@ import {
   classifyMonolithDelta,
   classifyTestDepth,
   deriveGateStatus,
+  discoverRequiredStatusCheckContexts,
   extractRequiredStatusChecksFromRulesets,
   extractStatusCheckSummaries,
   normalizeReviewResult,
@@ -56,6 +57,14 @@ function metadata(overrides: Partial<ReviewMetadata> = {}): ReviewMetadata {
     deterministic,
     ...overrides,
   } as ReviewMetadata;
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
 }
 
 function validResult(overrides = {}) {
@@ -223,6 +232,30 @@ describe("PR review advisor", () => {
     expect(extractRequiredStatusChecksFromRulesets(rulesets, "release/1.0")).toEqual(["release-only"]);
   });
 
+  it("falls back to configured required checks when rulesets cannot be read", async () => {
+    const previous = {
+      repo: process.env.GITHUB_REPOSITORY,
+      token: process.env.GH_TOKEN,
+      githubToken: process.env.GITHUB_TOKEN,
+      fallback: process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS,
+    };
+    process.env.GITHUB_REPOSITORY = "NVIDIA/NemoClaw";
+    process.env.GH_TOKEN = "token";
+    delete process.env.GITHUB_TOKEN;
+    process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS = "checks,commit-lint";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({ ok: false, text: async () => "rulesets unavailable" } as Response);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await expect(discoverRequiredStatusCheckContexts()).resolves.toEqual(["checks", "commit-lint"]);
+    } finally {
+      restoreEnv("GITHUB_REPOSITORY", previous.repo);
+      restoreEnv("GH_TOKEN", previous.token);
+      restoreEnv("GITHUB_TOKEN", previous.githubToken);
+      restoreEnv("PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS", previous.fallback);
+    }
+  });
+
   it("bases the CI gate on required contexts when they are known", () => {
     const gates = deriveGateStatus(
       {
@@ -253,6 +286,35 @@ describe("PR review advisor", () => {
     expect(gates.ci.status).toBe("pass");
     expect(gates.ci.evidence).toContain("2 required status context(s) completed");
     expect(gates.ci.evidence).toContain("Non-required contexts still pending: 1");
+  });
+
+  it("fails the CI gate when required contexts fail", () => {
+    const gates = deriveGateStatus(
+      {
+        graphQl: {
+          data: {
+            repository: {
+              pullRequest: {
+                statusCheckRollup: {
+                  contexts: {
+                    nodes: [
+                      { __typename: "CheckRun", name: "checks", status: "COMPLETED", conclusion: "FAILURE" },
+                      { __typename: "CheckRun", name: "commit-lint", status: "COMPLETED", conclusion: "SUCCESS" },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      [],
+      [],
+      ["checks", "commit-lint"],
+    );
+
+    expect(gates.ci.status).toBe("fail");
+    expect(gates.ci.evidence).toContain("Required status context(s) failed: checks");
   });
 
   it("wait logic treats missing or in-progress required contexts as pending", () => {

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -16,6 +16,7 @@ import {
   discoverRequiredStatusCheckContexts,
   extractRequiredStatusChecksFromRulesets,
   extractStatusCheckSummaries,
+  normalizeBaseBranch,
   normalizeReviewResult,
   pendingRequiredContexts,
   readTrustedSecurityReviewSkill,
@@ -230,6 +231,52 @@ describe("PR review advisor", () => {
 
     expect(extractRequiredStatusChecksFromRulesets(rulesets, "main")).toEqual(["checks", "commit-lint"]);
     expect(extractRequiredStatusChecksFromRulesets(rulesets, "release/1.0")).toEqual(["release-only"]);
+  });
+
+  it("normalizes analyzed base refs before ruleset lookup", () => {
+    expect(normalizeBaseBranch("origin/main")).toBe("main");
+    expect(normalizeBaseBranch("target/release/1.0")).toBe("release/1.0");
+    expect(normalizeBaseBranch("refs/heads/feature/x")).toBe("feature/x");
+    expect(normalizeBaseBranch("refs/remotes/upstream/main")).toBe("main");
+  });
+
+  it("uses the analyzed base ref for required-check ruleset discovery", async () => {
+    const previous = {
+      repo: process.env.GITHUB_REPOSITORY,
+      token: process.env.GH_TOKEN,
+      githubToken: process.env.GITHUB_TOKEN,
+      base: process.env.GITHUB_BASE_REF,
+      override: process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_BASE,
+      fallback: process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS,
+    };
+    process.env.GITHUB_REPOSITORY = "NVIDIA/NemoClaw";
+    process.env.GH_TOKEN = "token";
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_BASE_REF;
+    delete process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_BASE;
+    delete process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS;
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1, target: "branch", enforcement: "active" }] } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          target: "branch",
+          enforcement: "active",
+          conditions: { ref_name: { include: ["refs/heads/release/*"], exclude: [] } },
+          rules: [{ type: "required_status_checks", parameters: { required_status_checks: [{ context: "release-only" }] } }],
+        }),
+      } as Response);
+
+    try {
+      await expect(discoverRequiredStatusCheckContexts("origin/release/1.0")).resolves.toEqual(["release-only"]);
+    } finally {
+      restoreEnv("GITHUB_REPOSITORY", previous.repo);
+      restoreEnv("GH_TOKEN", previous.token);
+      restoreEnv("GITHUB_TOKEN", previous.githubToken);
+      restoreEnv("GITHUB_BASE_REF", previous.base);
+      restoreEnv("PR_REVIEW_ADVISOR_REQUIRED_CHECK_BASE", previous.override);
+      restoreEnv("PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS", previous.fallback);
+    }
   });
 
   it("falls back to configured required checks when rulesets cannot be read", async () => {

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -9,6 +9,7 @@ import YAML from "yaml";
 
 import { buildComment } from "../tools/pr-review-advisor/comment.mts";
 import {
+  assertPrHeadStillCurrent,
   buildSystemPrompt,
   classifyMonolithDelta,
   classifyTestDepth,
@@ -303,6 +304,13 @@ describe("PR review advisor", () => {
     }
   });
 
+  it("aborts when the PR head advances during required-check wait", () => {
+    expect(() => assertPrHeadStillCurrent("def456789012", "abc123456789")).toThrow(
+      "PR head advanced from abc123456789 to def456789012",
+    );
+    expect(() => assertPrHeadStillCurrent("abc123456789", "abc123456789")).not.toThrow();
+  });
+
   it("bases the CI gate on required contexts when they are known", () => {
     const gates = deriveGateStatus(
       {
@@ -333,6 +341,18 @@ describe("PR review advisor", () => {
     expect(gates.ci.status).toBe("pass");
     expect(gates.ci.evidence).toContain("2 required status context(s) completed");
     expect(gates.ci.evidence).toContain("Non-required contexts still pending: 1");
+  });
+
+  it("keeps empty required-check rollups pending instead of unknown", () => {
+    const gates = deriveGateStatus(
+      { graphQl: { data: { repository: { pullRequest: { statusCheckRollup: { contexts: { nodes: [] } } } } } } } as never,
+      [],
+      [],
+      ["checks", "commit-lint"],
+    );
+
+    expect(gates.ci.status).toBe("pending");
+    expect(gates.ci.evidence).toContain("Required status context(s) pending or missing: checks, commit-lint");
   });
 
   it("fails the CI gate when required contexts fail", () => {

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -23,9 +23,13 @@ It complements CodeRabbit and the E2E Advisor by encoding NemoClaw maintainer re
 2. Checks out advisor implementation code from trusted `main` into `advisor/`.
 3. Checks out PR content into `pr-workdir/` as inert read-only analysis data.
 4. Installs a pinned Pi SDK package with lifecycle scripts disabled.
-5. Runs `tools/pr-review-advisor/analyze.mts` from the trusted checkout.
-6. Writes artifacts under `artifacts/pr-review-advisor/`.
-7. Posts or updates a sticky PR comment marked by `<!-- nemoclaw-pr-review-advisor -->`.
+5. Waits for repository-required status checks, plus the E2E Advisor recommendation, to leave the pending/in-progress state.
+6. Runs `tools/pr-review-advisor/analyze.mts` from the trusted checkout.
+7. Writes artifacts under `artifacts/pr-review-advisor/`.
+8. Posts or updates a sticky PR comment marked by `<!-- nemoclaw-pr-review-advisor -->`.
+
+The workflow is advisory and must not be configured as a required status check. Making it required can
+create circular wait behavior and defeats the goal of letting it observe settled required-check state.
 
 ## Safety model
 
@@ -36,6 +40,7 @@ It complements CodeRabbit and the E2E Advisor by encoding NemoClaw maintainer re
 - Generated advisor credential config is written under `/tmp`, not uploaded artifacts.
 - The job is limited to upstream `NVIDIA/NemoClaw` PRs when model secrets are in scope.
 - The workflow posts advisory comments only; it does not approve, request changes, merge, push, label, or dispatch E2E.
+- Before model analysis, the workflow deterministically waits for required status checks from repository rulesets. If rulesets cannot be read, it falls back to the configured `PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS` list.
 
 ## Required secret
 

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -16,6 +16,9 @@ const root = process.cwd();
 const ADVISOR_PROVIDER = DEFAULT_ADVISOR_PROVIDER;
 const ADVISOR_MODEL = DEFAULT_ADVISOR_MODEL;
 const ADVISOR_CREDENTIAL_ENV = ["PR", "REVIEW", "ADVISOR", "API", "KEY"].join("_");
+const DEFAULT_WAIT_POLL_MS = 30000;
+const DEFAULT_REQUIRED_CHECK_WAIT_MS = 15 * 60 * 1000;
+const ADVISOR_CHECK_CONTEXT_PATTERNS = [/^PR review advisor(?:\b|$)/i, /^PR Review \/ Advisor$/i];
 const SECURITY_REVIEW_SKILL_PATH = ".agents/skills/nemoclaw-maintainer-security-code-review/SKILL.md";
 const TRUSTED_SECURITY_REVIEW_SKILL_PATH = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -153,6 +156,8 @@ type DeterministicReviewContext = {
   riskyAreas: string[];
   testDepth: ReviewAdvisorResult["testDepth"];
   gateStatus: ReviewAdvisorResult["gateStatus"];
+  requiredStatusCheckContexts: string[];
+  additionalWaitContexts: string[];
   workflowSignals: string[];
   monolithDeltas: MonolithDelta[];
   driftEvidence: DriftEvidence[];
@@ -205,6 +210,21 @@ type LinkedIssue = {
   fetchError?: string;
 };
 
+type CheckStatusSummary = {
+  name: string;
+  status: string | undefined;
+  conclusion: string | null;
+  state: string | undefined;
+  terminal: boolean;
+};
+
+type RequiredCheckWaitState = {
+  requiredContexts: string[];
+  pendingContexts: string[];
+  statuses: CheckStatusSummary[];
+  headRefOid?: string;
+};
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error: unknown) => {
     console.error(error instanceof Error ? error.message : String(error));
@@ -231,6 +251,7 @@ async function main(): Promise<void> {
   const schema = readJson<Record<string, unknown>>(schemaPath);
   const changedFiles = getChangedFiles(baseRef, headRef);
   const headSha = getHeadSha(headRef);
+  await waitForRequiredChecksBeforeAnalysis(headSha);
   const diff = getDiff(baseRef, headRef, 160000);
   const deterministic = await collectDeterministicContext({ baseRef, headRef, changedFiles, diff });
   const metadata = { baseRef, headRef, headSha, changedFiles, deterministic };
@@ -312,6 +333,213 @@ function logProgress(message: string): void {
   console.log(`[pr-review-advisor] ${new Date().toISOString()} ${message}`);
 }
 
+async function waitForRequiredChecksBeforeAnalysis(headSha: string): Promise<void> {
+  if (process.env.PR_REVIEW_ADVISOR_RUN_ANALYSIS === "0" || process.env.PR_REVIEW_ADVISOR_WAIT_FOR_REQUIRED_CHECKS === "0") return;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const prNumber = currentPrNumber();
+  if (!repo || !token || !prNumber) {
+    logProgress("Required-check wait skipped: GitHub repository, token, or PR number is unavailable.");
+    return;
+  }
+
+  const requiredContexts = uniqueStrings([
+    ...(await discoverRequiredStatusCheckContexts()),
+    ...parseContextList(process.env.PR_REVIEW_ADVISOR_WAIT_ADDITIONAL_CONTEXTS),
+  ]).filter((context) => !isAdvisorCheckContext(context));
+
+  if (requiredContexts.length === 0) {
+    logProgress("Required-check wait skipped: no required or additional check contexts were discovered.");
+    return;
+  }
+
+  const timeoutMs = parsePositiveInt(process.env.PR_REVIEW_ADVISOR_WAIT_TIMEOUT_MS, DEFAULT_REQUIRED_CHECK_WAIT_MS);
+  const pollMs = parsePositiveInt(process.env.PR_REVIEW_ADVISOR_WAIT_POLL_MS, DEFAULT_WAIT_POLL_MS);
+  const deadline = Date.now() + timeoutMs;
+  logProgress(
+    `Waiting up to ${Math.round(timeoutMs / 1000)}s for required check contexts before model analysis: ${requiredContexts.join(", ")}`,
+  );
+
+  let lastState: RequiredCheckWaitState | undefined;
+  while (true) {
+    try {
+      lastState = await fetchRequiredCheckWaitState({ repo, token, prNumber, requiredContexts });
+      const shaNote = lastState.headRefOid && lastState.headRefOid !== headSha
+        ? ` latest PR head is ${lastState.headRefOid.slice(0, 12)}, workflow head is ${headSha.slice(0, 12)}.`
+        : "";
+      if (lastState.pendingContexts.length === 0) {
+        logProgress(`Required-check wait complete.${shaNote}`);
+        return;
+      }
+      logProgress(`Required-check wait pending: ${lastState.pendingContexts.join(", ")}.${shaNote}`);
+    } catch (error: unknown) {
+      logProgress(`Required-check wait poll failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      const pending = lastState?.pendingContexts.length ? lastState.pendingContexts.join(", ") : "unknown";
+      logProgress(`Required-check wait timed out; continuing with advisor analysis. Pending contexts: ${pending}.`);
+      return;
+    }
+    await sleep(Math.min(pollMs, remainingMs));
+  }
+}
+
+function currentPrNumber(): number | undefined {
+  const value = process.env.PR_NUMBER || process.env.GITHUB_REF_NAME?.match(/^(\d+)\//)?.[1] || "";
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseContextList(value: string | undefined): string[] {
+  return uniqueStrings((value || "").split(/[\n,]/).map((item) => item.trim()).filter(Boolean));
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function isAdvisorCheckContext(context: string): boolean {
+  return ADVISOR_CHECK_CONTEXT_PATTERNS.some((pattern) => pattern.test(context));
+}
+
+async function discoverRequiredStatusCheckContexts(): Promise<string[]> {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const fallbackContexts = parseContextList(process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS);
+  if (!repo || !token) return fallbackContexts;
+
+  const baseBranch = process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_BASE || process.env.GITHUB_BASE_REF || "main";
+  try {
+    const rulesetContexts = await fetchRequiredStatusChecks(repo, token, baseBranch);
+    return rulesetContexts.length > 0 ? rulesetContexts : fallbackContexts;
+  } catch (error: unknown) {
+    logProgress(`Could not discover required checks from repository rulesets: ${error instanceof Error ? error.message : String(error)}`);
+    return fallbackContexts;
+  }
+}
+
+async function fetchRequiredStatusChecks(repo: string, token: string, baseBranch: string): Promise<string[]> {
+  const summaries = await githubRest<unknown[]>(`repos/${repo}/rulesets?includes_parents=true`, token);
+  const detailPromises = summaries
+    .filter((ruleset) => stringOrUndefined(getPath<unknown>(ruleset, ["target"])) === "branch")
+    .filter((ruleset) => stringOrUndefined(getPath<unknown>(ruleset, ["enforcement"])) === "active")
+    .map(async (ruleset) => {
+      const idValue = getPath<unknown>(ruleset, ["id"]);
+      const id = typeof idValue === "number" ? String(idValue) : stringOrUndefined(idValue);
+      return id ? await githubRest<unknown>(`repos/${repo}/rulesets/${id}`, token) : ruleset;
+    });
+  const details = await Promise.all(detailPromises);
+  return extractRequiredStatusChecksFromRulesets(details, baseBranch);
+}
+
+export function extractRequiredStatusChecksFromRulesets(rulesets: unknown[], baseBranch: string): string[] {
+  const contexts: string[] = [];
+  for (const ruleset of rulesets) {
+    if (!rulesetAppliesToBranch(ruleset, baseBranch)) continue;
+    const rules = getPath<unknown[]>(ruleset, ["rules"]) || [];
+    for (const rule of rules) {
+      if (stringOrUndefined(getPath<unknown>(rule, ["type"])) !== "required_status_checks") continue;
+      const requiredChecks = getPath<unknown[]>(rule, ["parameters", "required_status_checks"]) || [];
+      for (const check of requiredChecks) {
+        const context = stringOrUndefined(getPath<unknown>(check, ["context"]));
+        if (context) contexts.push(context);
+      }
+    }
+  }
+  return uniqueStrings(contexts);
+}
+
+function rulesetAppliesToBranch(ruleset: unknown, baseBranch: string): boolean {
+  if (stringOrUndefined(getPath<unknown>(ruleset, ["target"])) !== "branch") return false;
+  if (stringOrUndefined(getPath<unknown>(ruleset, ["enforcement"])) !== "active") return false;
+  const ref = `refs/heads/${baseBranch}`;
+  const include = stringArray(getPath<unknown>(ruleset, ["conditions", "ref_name", "include"]));
+  const exclude = stringArray(getPath<unknown>(ruleset, ["conditions", "ref_name", "exclude"]));
+  if (exclude.some((pattern) => refPatternMatches(pattern, ref, baseBranch))) return false;
+  return include.length === 0 || include.some((pattern) => refPatternMatches(pattern, ref, baseBranch));
+}
+
+function refPatternMatches(pattern: string, ref: string, baseBranch: string): boolean {
+  if (pattern === ref || pattern === baseBranch) return true;
+  if (pattern === "~DEFAULT_BRANCH" && baseBranch === "main") return true;
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`).test(ref);
+}
+
+async function fetchRequiredCheckWaitState(options: {
+  repo: string;
+  token: string;
+  prNumber: number;
+  requiredContexts: string[];
+}): Promise<RequiredCheckWaitState> {
+  const [owner, name] = options.repo.split("/");
+  const graphQl = await githubGraphql(options.token, buildRequiredCheckWaitQuery(), {
+    owner,
+    name,
+    number: options.prNumber,
+  });
+  const pr = getPath<Record<string, unknown>>(graphQl, ["data", "repository", "pullRequest"]);
+  const statuses = extractStatusCheckSummaries(getPath<unknown[]>(pr, ["statusCheckRollup", "contexts", "nodes"]) || []);
+  return {
+    requiredContexts: options.requiredContexts,
+    pendingContexts: pendingRequiredContexts(options.requiredContexts, statuses),
+    statuses,
+    headRefOid: stringOrUndefined(getPath<unknown>(pr, ["headRefOid"])),
+  };
+}
+
+export function extractStatusCheckSummaries(nodes: unknown[]): CheckStatusSummary[] {
+  return nodes
+    .map((node) => {
+      const name = stringOrUndefined(getPath<unknown>(node, ["name"])) || stringOrUndefined(getPath<unknown>(node, ["context"]));
+      if (!name) return undefined;
+      const status = stringOrUndefined(getPath<unknown>(node, ["status"]));
+      const conclusion = stringOrUndefined(getPath<unknown>(node, ["conclusion"])) || null;
+      const state = stringOrUndefined(getPath<unknown>(node, ["state"]));
+      return { name, status, conclusion, state, terminal: isTerminalStatus({ status, conclusion, state }) };
+    })
+    .filter((summary): summary is CheckStatusSummary => Boolean(summary));
+}
+
+export function pendingRequiredContexts(requiredContexts: string[], statuses: CheckStatusSummary[]): string[] {
+  return requiredContexts.filter((context) => {
+    const matches = statuses.filter((status) => status.name === context);
+    return matches.length === 0 || matches.some((status) => !status.terminal);
+  });
+}
+
+function isTerminalStatus(status: { status?: string; conclusion?: string | null; state?: string }): boolean {
+  if (status.state) return /SUCCESS|FAILURE|ERROR/i.test(status.state);
+  if (status.status) return /COMPLETED/i.test(status.status);
+  return Boolean(status.conclusion);
+}
+
+function buildRequiredCheckWaitQuery(): string {
+  return `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      headRefOid
+      statusCheckRollup {
+        contexts(first: 100) {
+          nodes {
+            __typename
+            ... on CheckRun { name status conclusion }
+            ... on StatusContext { context state }
+          }
+        }
+      }
+    }
+  }
+}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function collectDeterministicContext(options: {
   baseRef: string;
   headRef: string;
@@ -321,13 +549,17 @@ async function collectDeterministicContext(options: {
   const github = await collectGitHubContext();
   const riskyAreas = detectRiskyAreas(options.changedFiles);
   const testDepth = classifyTestDepth(options.changedFiles, options.diff);
-  const gateStatus = deriveGateStatus(github, options.changedFiles, riskyAreas);
+  const requiredStatusCheckContexts = await discoverRequiredStatusCheckContexts();
+  const additionalWaitContexts = parseContextList(process.env.PR_REVIEW_ADVISOR_WAIT_ADDITIONAL_CONTEXTS);
+  const gateStatus = deriveGateStatus(github, options.changedFiles, riskyAreas, requiredStatusCheckContexts);
   return {
     diffStat: getDiffStat(options.baseRef, options.headRef),
     commits: getCommits(options.baseRef, options.headRef),
     riskyAreas,
     testDepth,
     gateStatus,
+    requiredStatusCheckContexts,
+    additionalWaitContexts,
     workflowSignals: detectWorkflowSignals(options.changedFiles, options.diff),
     monolithDeltas: computeMonolithDeltas(options.baseRef, options.changedFiles),
     driftEvidence: collectDriftEvidence(options.baseRef, options.changedFiles),
@@ -473,22 +705,58 @@ function countLines(text: string): number {
   return text.endsWith("\n") ? text.split("\n").length - 1 : text.split("\n").length;
 }
 
+function deriveCiGateStatus(statuses: CheckStatusSummary[], requiredContexts: string[]): GateStatus {
+  if (statuses.length === 0) return { status: "unknown", evidence: "No statusCheckRollup data was available." };
+
+  if (requiredContexts.length > 0) {
+    const failedRequired = failedRequiredContexts(requiredContexts, statuses);
+    const pendingRequired = pendingRequiredContexts(requiredContexts, statuses);
+    const nonRequiredPending = statuses.filter(
+      (status) => !requiredContexts.includes(status.name) && !status.terminal,
+    ).length;
+    const nonRequiredFailed = statuses.filter(
+      (status) => !requiredContexts.includes(status.name) && isFailedStatus(status),
+    ).length;
+    const suffix = ` Non-required contexts still pending: ${nonRequiredPending}; failed: ${nonRequiredFailed}.`;
+    if (failedRequired.length > 0) {
+      return { status: "fail", evidence: `Required status context(s) failed: ${failedRequired.join(", ")}.${suffix}` };
+    }
+    if (pendingRequired.length > 0) {
+      return { status: "pending", evidence: `Required status context(s) pending or missing: ${pendingRequired.join(", ")}.${suffix}` };
+    }
+    return { status: "pass", evidence: `${requiredContexts.length} required status context(s) completed with no failures.${suffix}` };
+  }
+
+  const failed = statuses.filter(isFailedStatus);
+  const pending = statuses.filter((status) => !status.terminal);
+  return failed.length > 0
+    ? { status: "fail", evidence: `${failed.length} status context(s) appear failed.` }
+    : pending.length > 0
+      ? { status: "pending", evidence: `${pending.length} status context(s) appear pending.` }
+      : { status: "pass", evidence: `${statuses.length} status context(s) were present with no failures detected.` };
+}
+
+function failedRequiredContexts(requiredContexts: string[], statuses: CheckStatusSummary[]): string[] {
+  return requiredContexts.filter((context) => statuses.some((status) => status.name === context && isFailedStatus(status)));
+}
+
+function isFailedStatus(status: CheckStatusSummary): boolean {
+  return /FAILURE|ERROR|CANCELLED|TIMED_OUT|ACTION_REQUIRED|STARTUP_FAILURE|STALE/i.test(
+    [status.state, status.conclusion].filter(Boolean).join(" "),
+  );
+}
+
 export function deriveGateStatus(
   github: GitHubReviewContext | null,
   changedFiles: string[],
   riskyAreas: string[],
+  requiredStatusCheckContexts: string[] = [],
 ): ReviewAdvisorResult["gateStatus"] {
   const graphQlPr = getPath<Record<string, unknown>>(github?.graphQl, ["data", "repository", "pullRequest"]);
   const checkNodes = getPath<unknown[]>(graphQlPr, ["statusCheckRollup", "contexts", "nodes"]) || [];
-  const failed = checkNodes.filter((node) => /FAILURE|ERROR|CANCELLED|TIMED_OUT/i.test(JSON.stringify(node)));
-  const pending = checkNodes.filter((node) => /PENDING|IN_PROGRESS|QUEUED|EXPECTED/i.test(JSON.stringify(node)));
-  const ci: GateStatus = checkNodes.length === 0
-    ? { status: "unknown", evidence: "No statusCheckRollup data was available." }
-    : failed.length > 0
-      ? { status: "fail", evidence: `${failed.length} status context(s) appear failed.` }
-      : pending.length > 0
-        ? { status: "pending", evidence: `${pending.length} status context(s) appear pending.` }
-        : { status: "pass", evidence: `${checkNodes.length} status context(s) were present with no failures detected.` };
+  const checkSummaries = extractStatusCheckSummaries(checkNodes).filter((status) => !isAdvisorCheckContext(status.name));
+  const requiredContexts = uniqueStrings(requiredStatusCheckContexts).filter((context) => !isAdvisorCheckContext(context));
+  const ci = deriveCiGateStatus(checkSummaries, requiredContexts);
 
   const mergeState = stringOrUndefined(getPath<unknown>(graphQlPr, ["mergeStateStatus"])) ||
     stringOrUndefined(getPath<unknown>(github?.pullRequest, ["mergeable_state"]));

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -404,7 +404,7 @@ function isAdvisorCheckContext(context: string): boolean {
   return ADVISOR_CHECK_CONTEXT_PATTERNS.some((pattern) => pattern.test(context));
 }
 
-async function discoverRequiredStatusCheckContexts(): Promise<string[]> {
+export async function discoverRequiredStatusCheckContexts(): Promise<string[]> {
   const repo = process.env.GITHUB_REPOSITORY;
   const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
   const fallbackContexts = parseContextList(process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS);

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -251,7 +251,7 @@ async function main(): Promise<void> {
   const schema = readJson<Record<string, unknown>>(schemaPath);
   const changedFiles = getChangedFiles(baseRef, headRef);
   const headSha = getHeadSha(headRef);
-  await waitForRequiredChecksBeforeAnalysis(headSha);
+  await waitForRequiredChecksBeforeAnalysis(headSha, baseRef);
   const diff = getDiff(baseRef, headRef, 160000);
   const deterministic = await collectDeterministicContext({ baseRef, headRef, changedFiles, diff });
   const metadata = { baseRef, headRef, headSha, changedFiles, deterministic };
@@ -333,7 +333,7 @@ function logProgress(message: string): void {
   console.log(`[pr-review-advisor] ${new Date().toISOString()} ${message}`);
 }
 
-async function waitForRequiredChecksBeforeAnalysis(headSha: string): Promise<void> {
+async function waitForRequiredChecksBeforeAnalysis(headSha: string, baseRef: string): Promise<void> {
   if (process.env.PR_REVIEW_ADVISOR_RUN_ANALYSIS === "0" || process.env.PR_REVIEW_ADVISOR_WAIT_FOR_REQUIRED_CHECKS === "0") return;
   const repo = process.env.GITHUB_REPOSITORY;
   const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
@@ -344,7 +344,7 @@ async function waitForRequiredChecksBeforeAnalysis(headSha: string): Promise<voi
   }
 
   const requiredContexts = uniqueStrings([
-    ...(await discoverRequiredStatusCheckContexts()),
+    ...(await discoverRequiredStatusCheckContexts(baseRef)),
     ...parseContextList(process.env.PR_REVIEW_ADVISOR_WAIT_ADDITIONAL_CONTEXTS),
   ]).filter((context) => !isAdvisorCheckContext(context));
 
@@ -404,13 +404,15 @@ function isAdvisorCheckContext(context: string): boolean {
   return ADVISOR_CHECK_CONTEXT_PATTERNS.some((pattern) => pattern.test(context));
 }
 
-export async function discoverRequiredStatusCheckContexts(): Promise<string[]> {
+export async function discoverRequiredStatusCheckContexts(baseRef?: string): Promise<string[]> {
   const repo = process.env.GITHUB_REPOSITORY;
   const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
   const fallbackContexts = parseContextList(process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_FALLBACK_CONTEXTS);
   if (!repo || !token) return fallbackContexts;
 
-  const baseBranch = process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_BASE || process.env.GITHUB_BASE_REF || "main";
+  const baseBranch = normalizeBaseBranch(
+    process.env.PR_REVIEW_ADVISOR_REQUIRED_CHECK_BASE || baseRef || process.env.GITHUB_BASE_REF || "main",
+  );
   try {
     const rulesetContexts = await fetchRequiredStatusChecks(repo, token, baseBranch);
     return rulesetContexts.length > 0 ? rulesetContexts : fallbackContexts;
@@ -459,6 +461,13 @@ function rulesetAppliesToBranch(ruleset: unknown, baseBranch: string): boolean {
   const exclude = stringArray(getPath<unknown>(ruleset, ["conditions", "ref_name", "exclude"]));
   if (exclude.some((pattern) => refPatternMatches(pattern, ref, baseBranch))) return false;
   return include.length === 0 || include.some((pattern) => refPatternMatches(pattern, ref, baseBranch));
+}
+
+export function normalizeBaseBranch(ref: string): string {
+  return ref
+    .replace(/^refs\/heads\//, "")
+    .replace(/^refs\/remotes\/[^/]+\//, "")
+    .replace(/^(?:origin|target)\//, "");
 }
 
 function refPatternMatches(pattern: string, ref: string, baseBranch: string): boolean {
@@ -549,7 +558,7 @@ async function collectDeterministicContext(options: {
   const github = await collectGitHubContext();
   const riskyAreas = detectRiskyAreas(options.changedFiles);
   const testDepth = classifyTestDepth(options.changedFiles, options.diff);
-  const requiredStatusCheckContexts = await discoverRequiredStatusCheckContexts();
+  const requiredStatusCheckContexts = await discoverRequiredStatusCheckContexts(options.baseRef);
   const additionalWaitContexts = parseContextList(process.env.PR_REVIEW_ADVISOR_WAIT_ADDITIONAL_CONTEXTS);
   const gateStatus = deriveGateStatus(github, options.changedFiles, riskyAreas, requiredStatusCheckContexts);
   return {

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -364,15 +364,14 @@ async function waitForRequiredChecksBeforeAnalysis(headSha: string, baseRef: str
   while (true) {
     try {
       lastState = await fetchRequiredCheckWaitState({ repo, token, prNumber, requiredContexts });
-      const shaNote = lastState.headRefOid && lastState.headRefOid !== headSha
-        ? ` latest PR head is ${lastState.headRefOid.slice(0, 12)}, workflow head is ${headSha.slice(0, 12)}.`
-        : "";
+      assertPrHeadStillCurrent(lastState.headRefOid, headSha);
       if (lastState.pendingContexts.length === 0) {
-        logProgress(`Required-check wait complete.${shaNote}`);
+        logProgress("Required-check wait complete.");
         return;
       }
-      logProgress(`Required-check wait pending: ${lastState.pendingContexts.join(", ")}.${shaNote}`);
+      logProgress(`Required-check wait pending: ${lastState.pendingContexts.join(", ")}.`);
     } catch (error: unknown) {
+      if (isStaleAdvisorRunError(error)) throw error;
       logProgress(`Required-check wait poll failed: ${error instanceof Error ? error.message : String(error)}`);
     }
 
@@ -384,6 +383,24 @@ async function waitForRequiredChecksBeforeAnalysis(headSha: string, baseRef: str
     }
     await sleep(Math.min(pollMs, remainingMs));
   }
+}
+
+export function assertPrHeadStillCurrent(latestHeadSha: string | undefined, workflowHeadSha: string): void {
+  if (!latestHeadSha || latestHeadSha === workflowHeadSha) return;
+  throw new StaleAdvisorRunError(
+    `PR head advanced from ${workflowHeadSha.slice(0, 12)} to ${latestHeadSha.slice(0, 12)}; rerun advisor on the latest commit.`,
+  );
+}
+
+class StaleAdvisorRunError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StaleAdvisorRunError";
+  }
+}
+
+function isStaleAdvisorRunError(error: unknown): boolean {
+  return error instanceof StaleAdvisorRunError;
 }
 
 function currentPrNumber(): number | undefined {
@@ -715,7 +732,14 @@ function countLines(text: string): number {
 }
 
 function deriveCiGateStatus(statuses: CheckStatusSummary[], requiredContexts: string[]): GateStatus {
-  if (statuses.length === 0) return { status: "unknown", evidence: "No statusCheckRollup data was available." };
+  if (statuses.length === 0) {
+    return requiredContexts.length > 0
+      ? {
+        status: "pending",
+        evidence: `Required status context(s) pending or missing: ${requiredContexts.join(", ")}. Non-required contexts still pending: 0; failed: 0.`,
+      }
+      : { status: "unknown", evidence: "No statusCheckRollup data was available." };
+  }
 
   if (requiredContexts.length > 0) {
     const failedRequired = failedRequiredContexts(requiredContexts, statuses);


### PR DESCRIPTION
## Summary
Make the PR Review Advisor wait for required PR checks and the E2E recommendation before launching model analysis. This should reduce early, low-context reviews where the advisor reports blocked primarily because CI is still pending.

## Changes
- Add a deterministic required-check wait loop to `tools/pr-review-advisor/analyze.mts` that reads required contexts from repository rulesets, falls back to configured contexts, and excludes the advisor's own check to avoid self-deadlock.
- Update CI gate derivation to evaluate known required contexts separately from optional pending checks while still reporting non-required pending/failed counts.
- Configure `.github/workflows/pr-review-advisor.yaml` with wait timeout/poll settings, the E2E Advisor context, and documentation that the workflow must remain advisory/non-required.
- Add tests for ruleset extraction, pending required-check detection, and required-context CI gate behavior.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR Review Advisor now deterministically waits for repository-required status checks (with configurable fallback/additional contexts), polling until completion or timeout before analysis; CI gate logic respects required-check outcomes.

* **Documentation**
  * Clarified workflow policy and guidance to avoid making the advisor itself a required check.

* **Tests**
  * Expanded tests for required-check discovery, fallback behavior, wait/poll logic, head-staleness aborts, and CI gate outcomes.

* **Chores**
  * Increased workflow execution timeout and added related workflow environment settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->