### PR TITLE
fix(policy): scope Hermes messaging policies

### DIFF
--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -146,7 +146,11 @@ network_policies:
       - { path: /usr/bin/python3* }
       - { path: /opt/hermes/.venv/bin/python }
 
-  # ── Messaging — pre-allowed for agent notifications ───────────
+  # ── Messaging policy templates ─────────────────────────────────
+  # These entries are agent-specific channel templates. During sandbox
+  # creation, NemoClaw filters out entries for messaging channels that were not
+  # selected, so a Discord-only Hermes sandbox does not retain Telegram, Slack,
+  # or WeChat egress.
   telegram:
     name: telegram
     endpoints:

--- a/src/lib/onboard/initial-policy.test.ts
+++ b/src/lib/onboard/initial-policy.test.ts
@@ -154,6 +154,42 @@ network_policies:
     });
   });
 
+  it("records active channel policies already provided by an agent base policy", () => {
+    const basePolicyPath = tmpPolicy("version: 1\nnetwork_policies:\n  discord: {}\n");
+
+    expect(prepareInitialSandboxCreatePolicy(basePolicyPath, ["discord"])).toEqual({
+      policyPath: basePolicyPath,
+      appliedPresets: ["discord"],
+    });
+  });
+
+  it("filters inactive Hermes messaging policies from the create-time policy", () => {
+    const basePolicyPath = tmpPolicy(
+      [
+        "version: 1",
+        "network_policies:",
+        "  pypi: {}",
+        "  telegram: {}",
+        "  discord: {}",
+        "  slack: {}",
+        "  wechat_bridge: {}",
+        "",
+      ].join("\n"),
+    );
+
+    const prepared = prepareInitialSandboxCreatePolicy(basePolicyPath, ["discord"], {
+      agentName: "hermes",
+    });
+
+    expect(prepared.policyPath).not.toBe(basePolicyPath);
+    expect(prepared.appliedPresets).toEqual(["discord"]);
+    expect(getNetworkPolicyNames(fs.readFileSync(prepared.policyPath, "utf-8"))).toEqual(
+      new Set(["pypi", "discord"]),
+    );
+    expect(prepared.cleanup?.()).toBe(true);
+    expect(fs.existsSync(prepared.policyPath)).toBe(false);
+  });
+
   it("merges missing create-time presets into a temporary policy", () => {
     const basePolicyPath = tmpPolicy("version: 1\nnetwork_policies:\n  base: {}\n");
 

--- a/src/lib/onboard/initial-policy.test.ts
+++ b/src/lib/onboard/initial-policy.test.ts
@@ -190,6 +190,23 @@ network_policies:
     expect(fs.existsSync(prepared.policyPath)).toBe(false);
   });
 
+  it("filters inactive Hermes messaging policies from the relative Hermes policy path", () => {
+    const hermesPolicyPath = path.relative(
+      process.cwd(),
+      path.join(import.meta.dirname, "..", "..", "..", "agents", "hermes", "policy-additions.yaml"),
+    );
+
+    const prepared = prepareInitialSandboxCreatePolicy(hermesPolicyPath, ["discord"]);
+    const policyNames = getNetworkPolicyNames(fs.readFileSync(prepared.policyPath, "utf-8"));
+
+    expect(policyNames?.has("discord")).toBe(true);
+    expect(policyNames?.has("telegram")).toBe(false);
+    expect(policyNames?.has("slack")).toBe(false);
+    expect(policyNames?.has("wechat_bridge")).toBe(false);
+    expect(prepared.cleanup?.()).toBe(true);
+    expect(fs.existsSync(prepared.policyPath)).toBe(false);
+  });
+
   it("merges missing create-time presets into a temporary policy", () => {
     const basePolicyPath = tmpPolicy("version: 1\nnetwork_policies:\n  base: {}\n");
 

--- a/src/lib/onboard/initial-policy.ts
+++ b/src/lib/onboard/initial-policy.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import path from "node:path";
 import YAML from "yaml";
 
 import * as policies from "../policy";
@@ -15,6 +16,13 @@ export type InitialSandboxPolicy = {
 
 const CREATE_TIME_POLICY_PRESETS_BY_CHANNEL: Record<string, string[]> = {
   slack: ["slack"],
+};
+
+const HERMES_MESSAGING_POLICY_KEYS: Record<string, string[]> = {
+  discord: ["discord"],
+  slack: ["slack"],
+  telegram: ["telegram"],
+  wechat: ["wechat_bridge"],
 };
 
 const PROC_PATH = "/proc";
@@ -161,18 +169,63 @@ export function getNetworkPolicyNames(policyContent: string): Set<string> | null
   }
 }
 
+function isYamlObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function filterHermesInactiveMessagingPolicies(
+  policyContent: string,
+  activeMessagingChannels: string[],
+): { content: string; changed: boolean } {
+  const parsed = YAML.parse(policyContent);
+  if (!isYamlObject(parsed) || !isYamlObject(parsed.network_policies)) {
+    return { content: policyContent, changed: false };
+  }
+
+  const active = new Set(activeMessagingChannels);
+  let changed = false;
+  for (const [channel, policyKeys] of Object.entries(HERMES_MESSAGING_POLICY_KEYS)) {
+    if (active.has(channel)) continue;
+    for (const key of policyKeys) {
+      if (Object.prototype.hasOwnProperty.call(parsed.network_policies, key)) {
+        delete parsed.network_policies[key];
+        changed = true;
+      }
+    }
+  }
+
+  return {
+    content: changed ? YAML.stringify(parsed) : policyContent,
+    changed,
+  };
+}
+
+function isHermesPolicyPath(policyPath: string): boolean {
+  const normalized = policyPath.split(path.sep).join("/");
+  return normalized.endsWith("/agents/hermes/policy-additions.yaml");
+}
+
 export function prepareInitialSandboxCreatePolicy(
   basePolicyPath: string,
   activeMessagingChannels: string[],
-  options: { directGpu?: boolean; dockerGpuPatch?: boolean; additionalPresets?: string[] } = {},
+  options: {
+    directGpu?: boolean;
+    dockerGpuPatch?: boolean;
+    additionalPresets?: string[];
+    agentName?: string | null;
+  } = {},
 ): InitialSandboxPolicy {
   const directGpuPolicy = options.directGpu
     ? prepareDirectGpuSandboxPolicy(basePolicyPath, {
         procReadWrite: options.dockerGpuPatch === true,
       })
     : null;
-  const effectiveBasePolicyPath = directGpuPolicy?.policyPath || basePolicyPath;
+  let effectiveBasePolicyPath = directGpuPolicy?.policyPath || basePolicyPath;
   const cleanupFns = directGpuPolicy?.cleanup ? [directGpuPolicy.cleanup] : [];
+  const buildCleanup = () =>
+    cleanupFns.length > 0
+      ? () => cleanupFns.map((cleanup) => cleanup()).every(Boolean)
+      : undefined;
   const requestedCreateTimePresets = [
     ...new Set(
       [
@@ -183,26 +236,47 @@ export function prepareInitialSandboxCreatePolicy(
       ],
     ),
   ];
-  const combinedCleanup =
-    cleanupFns.length > 0 ? () => cleanupFns.map((cleanup) => cleanup()).every(Boolean) : undefined;
+  const dedupe = (values: string[]) => [...new Set(values.filter(Boolean))];
 
-  if (requestedCreateTimePresets.length === 0) {
-    return {
-      policyPath: effectiveBasePolicyPath,
-      appliedPresets: [],
-      cleanup: combinedCleanup,
-    };
+  let basePolicy = fs.readFileSync(effectiveBasePolicyPath, "utf-8");
+  if (options.agentName === "hermes" || isHermesPolicyPath(basePolicyPath)) {
+    const filtered = filterHermesInactiveMessagingPolicies(basePolicy, activeMessagingChannels);
+    if (filtered.changed) {
+      const policyPath = secureTempFile("nemoclaw-agent-policy", ".yaml");
+      fs.writeFileSync(policyPath, filtered.content, { encoding: "utf-8", mode: 0o600 });
+      cleanupFns.push(() => {
+        try {
+          cleanupTempDir(policyPath, "nemoclaw-agent-policy");
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      effectiveBasePolicyPath = policyPath;
+      basePolicy = filtered.content;
+    }
   }
 
-  const basePolicy = fs.readFileSync(effectiveBasePolicyPath, "utf-8");
   const basePolicyNames = getNetworkPolicyNames(basePolicy);
   if (basePolicyNames === null) {
     return {
       policyPath: effectiveBasePolicyPath,
       appliedPresets: [],
-      cleanup: combinedCleanup,
+      cleanup: buildCleanup(),
     };
   }
+  const existingChannelPresets = activeMessagingChannels.filter((channel) =>
+    basePolicyNames.has(channel),
+  );
+
+  if (requestedCreateTimePresets.length === 0) {
+    return {
+      policyPath: effectiveBasePolicyPath,
+      appliedPresets: dedupe(existingChannelPresets),
+      cleanup: buildCleanup(),
+    };
+  }
+
   const existingCreateTimePresets = requestedCreateTimePresets.filter((preset) =>
     basePolicyNames.has(preset),
   );
@@ -212,8 +286,8 @@ export function prepareInitialSandboxCreatePolicy(
   if (createTimePresets.length === 0) {
     return {
       policyPath: effectiveBasePolicyPath,
-      appliedPresets: existingCreateTimePresets,
-      cleanup: combinedCleanup,
+      appliedPresets: dedupe([...existingChannelPresets, ...existingCreateTimePresets]),
+      cleanup: buildCleanup(),
     };
   }
 
@@ -237,7 +311,11 @@ export function prepareInitialSandboxCreatePolicy(
 
   return {
     policyPath,
-    appliedPresets: [...existingCreateTimePresets, ...mergedPolicy.appliedPresets],
-    cleanup: () => cleanupFns.map((cleanup) => cleanup()).every(Boolean),
+    appliedPresets: dedupe([
+      ...existingChannelPresets,
+      ...existingCreateTimePresets,
+      ...mergedPolicy.appliedPresets,
+    ]),
+    cleanup: buildCleanup(),
   };
 }

--- a/src/lib/onboard/initial-policy.ts
+++ b/src/lib/onboard/initial-policy.ts
@@ -202,7 +202,7 @@ function filterHermesInactiveMessagingPolicies(
 
 function isHermesPolicyPath(policyPath: string): boolean {
   const normalized = policyPath.split(path.sep).join("/");
-  return normalized.endsWith("/agents/hermes/policy-additions.yaml");
+  return /(^|\/)agents\/hermes\/policy-additions\.yaml$/.test(normalized);
 }
 
 export function prepareInitialSandboxCreatePolicy(

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -84,6 +84,92 @@ function loadPreset(name: string): string | null {
   return fs.readFileSync(file, "utf-8");
 }
 
+function isPolicyObject(value: PolicyValue): value is PolicyObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseNetworkPolicies(content: string | null | undefined): PolicyObject | null {
+  if (!content) return null;
+  try {
+    const parsed = YAML.parse(content);
+    const networkPolicies = isPolicyDocument(parsed) ? parsed.network_policies : null;
+    return isPolicyObject(networkPolicies) ? networkPolicies : null;
+  } catch {
+    return null;
+  }
+}
+
+function parsePresetPolicyKeys(presetContent: string | null | undefined): string[] {
+  const presetEntries = extractPresetEntries(presetContent);
+  if (!presetEntries) return [];
+  return Object.keys(parseNetworkPolicies(`network_policies:\n${presetEntries}`) || {});
+}
+
+function selectAgentPolicyKeys(
+  agentPolicies: PolicyObject,
+  presetName: string,
+  builtinPresetContent: string,
+): string[] {
+  const builtinKeys = parsePresetPolicyKeys(builtinPresetContent);
+  if (
+    builtinKeys.length > 0 &&
+    builtinKeys.every((key) => Object.prototype.hasOwnProperty.call(agentPolicies, key))
+  ) {
+    return builtinKeys;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(agentPolicies, presetName)) {
+    return [presetName];
+  }
+
+  return Object.entries(agentPolicies)
+    .filter(([, value]) => isPolicyObject(value) && value.name === presetName)
+    .map(([key]) => key);
+}
+
+function loadAgentPresetContent(
+  sandboxName: string,
+  presetName: string,
+  builtinPresetContent: string,
+): string | null {
+  try {
+    const sandbox = registry.getSandbox(sandboxName);
+    if (!sandbox?.agent) return null;
+
+    const agent = loadAgent(sandbox.agent);
+    if (!agent?.policyAdditionsPath || !fs.existsSync(agent.policyAdditionsPath)) return null;
+
+    const agentPolicies = parseNetworkPolicies(
+      fs.readFileSync(agent.policyAdditionsPath, "utf-8"),
+    );
+    if (!agentPolicies) return null;
+
+    const keys = selectAgentPolicyKeys(agentPolicies, presetName, builtinPresetContent);
+    if (keys.length === 0) return null;
+
+    const selectedPolicies: PolicyObject = {};
+    for (const key of keys) selectedPolicies[key] = agentPolicies[key];
+
+    return YAML.stringify({
+      preset: {
+        name: presetName,
+        description: `${agent.displayName} ${presetName} policy`,
+      },
+      network_policies: selectedPolicies,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function loadPresetForSandbox(sandboxName: string, presetName: string): string | null {
+  const builtinPresetContent = loadPreset(presetName);
+  if (!builtinPresetContent) return null;
+  return (
+    loadAgentPresetContent(sandboxName, presetName, builtinPresetContent) || builtinPresetContent
+  );
+}
+
 /**
  * Extract the bare hostnames declared in a preset YAML (anything matched by
  * `host: <value>`), with surrounding quotes stripped. Used to show the
@@ -440,7 +526,7 @@ function removePreset(sandboxName: string, presetName: string): boolean {
   // Resolve preset content: built-in first, then custom presets persisted
   // in the registry. `isCustom` controls which registry bucket to prune on
   // success.
-  let presetContent: string | null = loadPreset(presetName);
+  let presetContent: string | null = loadPresetForSandbox(sandboxName, presetName);
   let isCustom = false;
   if (!presetContent) {
     const custom = registry
@@ -679,7 +765,7 @@ function applyPreset(
   presetName: string,
   options: Record<string, unknown> = {},
 ): boolean {
-  const presetContent = loadPreset(presetName);
+  const presetContent = loadPresetForSandbox(sandboxName, presetName);
   if (!presetContent) {
     console.error(`  Cannot load preset: ${presetName}`);
     return false;
@@ -716,7 +802,7 @@ function applyPresets(sandboxName: string, presetNames: string[]): boolean {
   const endpointLogs: string[][] = [];
 
   for (const presetName of uniquePresetNames) {
-    const presetContent = loadPreset(presetName);
+    const presetContent = loadPresetForSandbox(sandboxName, presetName);
     if (!presetContent) {
       console.error(`  Cannot load preset: ${presetName}`);
       return false;
@@ -947,7 +1033,7 @@ function getGatewayPresets(sandboxName: string): string[] | null {
   const matched = [];
 
   for (const preset of listPresets()) {
-    const content = loadPreset(preset.name);
+    const content = loadPresetForSandbox(sandboxName, preset.name);
     if (!content) continue;
     const entries = extractPresetEntries(content);
     if (!entries) continue;

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -105,6 +105,10 @@ function parsePresetPolicyKeys(presetContent: string | null | undefined): string
   return Object.keys(parseNetworkPolicies(`network_policies:\n${presetEntries}`) || {});
 }
 
+const AGENT_PRESET_KEY_ALIASES: Record<string, string[]> = {
+  wechat: ["wechat_bridge"],
+};
+
 function selectAgentPolicyKeys(
   agentPolicies: PolicyObject,
   presetName: string,
@@ -121,6 +125,12 @@ function selectAgentPolicyKeys(
   if (Object.prototype.hasOwnProperty.call(agentPolicies, presetName)) {
     return [presetName];
   }
+
+  const aliases = AGENT_PRESET_KEY_ALIASES[presetName] || [];
+  const aliasMatches = aliases.filter((key) =>
+    Object.prototype.hasOwnProperty.call(agentPolicies, key),
+  );
+  if (aliasMatches.length > 0) return aliasMatches;
 
   return Object.entries(agentPolicies)
     .filter(([, value]) => isPolicyObject(value) && value.name === presetName)

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -534,6 +534,89 @@ exit 1
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
+
+    it("uses agent-specific preset content for Hermes Discord", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-policy-hermes-"));
+      const fakeOpenshell = path.join(tmpDir, "openshell");
+      const policyOut = path.join(tmpDir, "policy.yaml");
+      const script = String.raw`
+const fs = require("node:fs");
+const registry = require(${REGISTRY_PATH});
+const policies = require(${POLICIES_PATH});
+registry.registerSandbox({ name: "hermes-sandbox", agent: "hermes", policies: [] });
+const result = policies.applyPresets("hermes-sandbox", ["discord"]);
+process.stdout.write("\n__RESULT__" + JSON.stringify({
+  result,
+  policy: fs.readFileSync(process.env.POLICY_OUT, "utf-8"),
+  registry: registry.getSandbox("hermes-sandbox"),
+}));
+`;
+      fs.writeFileSync(
+        fakeOpenshell,
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 $2" = "policy get" ]; then
+  printf 'Version: 1\nHash: test\n---\nversion: 1\n\nnetwork_policies: {}\n'
+  exit 0
+fi
+if [ "$1 $2" = "policy set" ]; then
+  policy_file=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--policy" ]; then
+      policy_file="$2"
+      break
+    fi
+    shift
+  done
+  cp "$policy_file" ${JSON.stringify(policyOut)}
+  printf 'Policy version 2 submitted\nPolicy version 2 loaded\n'
+  exit 0
+fi
+exit 1
+`,
+        { mode: 0o755 },
+      );
+
+      try {
+        const result = spawnSync(process.execPath, ["-e", script], {
+          cwd: REPO_ROOT,
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            HOME: tmpDir,
+            NEMOCLAW_OPENSHELL_BIN: fakeOpenshell,
+            POLICY_OUT: policyOut,
+          },
+        });
+
+        expect(result.status).toBe(0);
+        const marker = "__RESULT__";
+        const markerIndex = result.stdout.indexOf(marker);
+        expect(markerIndex).toBeGreaterThanOrEqual(0);
+        const payload = JSON.parse(result.stdout.slice(markerIndex + marker.length));
+        const parsed = YAML.parse(payload.policy);
+        const discordPolicy = parsed.network_policies.discord;
+        const binaries = discordPolicy.binaries.map((entry: { path: string }) => entry.path);
+        expect(binaries).toContain("/usr/bin/python3*");
+        expect(binaries).toContain("/opt/hermes/.venv/bin/python");
+        const discordCom = discordPolicy.endpoints.find(
+          (endpoint: { host?: string }) => endpoint.host === "discord.com",
+        );
+        const mutationRules = discordCom.rules
+          .map((rule: { allow?: { method?: string; path?: string } }) => rule.allow)
+          .filter((rule: { method?: string } | undefined) =>
+            ["PUT", "PATCH", "DELETE"].includes(rule?.method || ""),
+          );
+        expect(mutationRules).toContainEqual({
+          method: "PATCH",
+          path: "/api/v*/channels/*/messages/*",
+        });
+        expect(mutationRules).not.toContainEqual({ method: "PATCH", path: "/**" });
+        expect(payload.registry.policies).toEqual(["discord"]);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe("applyPreset disclosure logging", () => {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -617,6 +617,77 @@ exit 1
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
+
+    it("uses agent-specific preset aliases for Hermes WeChat", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-policy-hermes-wechat-"));
+      const fakeOpenshell = path.join(tmpDir, "openshell");
+      const policyOut = path.join(tmpDir, "policy.yaml");
+      const script = String.raw`
+const fs = require("node:fs");
+const registry = require(${REGISTRY_PATH});
+const policies = require(${POLICIES_PATH});
+registry.registerSandbox({ name: "hermes-sandbox", agent: "hermes", policies: [] });
+const result = policies.applyPresets("hermes-sandbox", ["wechat"]);
+process.stdout.write("\n__RESULT__" + JSON.stringify({
+  result,
+  policy: fs.readFileSync(process.env.POLICY_OUT, "utf-8"),
+  registry: registry.getSandbox("hermes-sandbox"),
+}));
+`;
+      fs.writeFileSync(
+        fakeOpenshell,
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 $2" = "policy get" ]; then
+  printf 'Version: 1\nHash: test\n---\nversion: 1\n\nnetwork_policies: {}\n'
+  exit 0
+fi
+if [ "$1 $2" = "policy set" ]; then
+  policy_file=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--policy" ]; then
+      policy_file="$2"
+      break
+    fi
+    shift
+  done
+  cp "$policy_file" ${JSON.stringify(policyOut)}
+  printf 'Policy version 2 submitted\nPolicy version 2 loaded\n'
+  exit 0
+fi
+exit 1
+`,
+        { mode: 0o755 },
+      );
+
+      try {
+        const result = spawnSync(process.execPath, ["-e", script], {
+          cwd: REPO_ROOT,
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            HOME: tmpDir,
+            NEMOCLAW_OPENSHELL_BIN: fakeOpenshell,
+            POLICY_OUT: policyOut,
+          },
+        });
+
+        expect(result.status).toBe(0);
+        const marker = "__RESULT__";
+        const markerIndex = result.stdout.indexOf(marker);
+        expect(markerIndex).toBeGreaterThanOrEqual(0);
+        const payload = JSON.parse(result.stdout.slice(markerIndex + marker.length));
+        const parsed = YAML.parse(payload.policy);
+        expect(parsed.network_policies.wechat).toBeUndefined();
+        const wechatPolicy = parsed.network_policies.wechat_bridge;
+        const binaries = wechatPolicy.binaries.map((entry: { path: string }) => entry.path);
+        expect(binaries).toContain("/usr/bin/python3*");
+        expect(binaries).toContain("/opt/hermes/.venv/bin/python");
+        expect(payload.registry.policies).toEqual(["wechat"]);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe("applyPreset disclosure logging", () => {


### PR DESCRIPTION
## Summary
This PR scopes Hermes messaging policy so selected channels are applied without pre-enabling every Hermes messaging provider. It also makes dynamic preset application use Hermes-specific policy content, preventing Discord from falling back to generic Node-oriented allowlists on Hermes sandboxes.
<img width="1399" height="496" alt="Screenshot 2026-05-21 at 16 27 44" src="https://github.com/user-attachments/assets/20dce4bf-cc8f-47fc-b01d-be8806bbe462" />
## Related Issue
Fixes #3981

## Changes
- Filter inactive Hermes messaging policy entries from the create-time sandbox policy.
- Resolve built-in policy presets against the sandbox agent so Hermes can use Hermes-specific messaging entries.
- Record selected channel policies already present in the prepared base policy as applied presets.
- Clarify Hermes messaging entries as policy templates and add regression coverage for Discord-only Hermes policy behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional checks run:
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run source-shape:check`
- `npx vitest run src/lib/onboard/initial-policy.test.ts test/policies.test.ts`
- Git pre-commit hooks passed during `git commit`
- Git pre-push hooks passed during `git push` (including TypeScript CLI, CLI tests, and source-shape budget)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for agent-specific policy variants so presets can resolve to agent-provided policy variants.
  * Messaging channels are filtered so sandboxes include only active/selected channels.

* **Refactor**
  * Preset application/loading is sandbox-aware and deduplicates applied preset names for clearer results.

* **Documentation**
  * Clarified messaging policy header to note channel-template behavior and sandbox filtering.

* **Tests**
  * Added tests covering agent-specific presets and messaging-channel filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->