### PR TITLE
fix(bootstrap-windows): degrade gracefully when winget is missing

### DIFF
--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -52,6 +52,9 @@ $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 If the bootstrap script reports that Docker is not reachable from Ubuntu, open Docker Desktop Settings and confirm that WSL integration is enabled for Ubuntu (Settings > Resources > WSL integration), then rerun the script.
 
+If the bootstrap script reports that `winget.exe` is not available (common on Windows Server or stripped Windows installs), install **App Installer** from the Microsoft Store (which provides `winget`), or download and install Docker Desktop manually from [docker.com](https://www.docker.com/products/docker-desktop/).
+Rerun the bootstrap script after Docker Desktop is installed; the script skips the install step once it detects Docker Desktop is present.
+
 The manual steps below describe the same Windows preparation pieces and are useful when you need to verify or repair WSL, Ubuntu, or Docker Desktop by hand.
 
 ## Enable WSL 2

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -359,7 +359,13 @@ function Install-DockerDesktop {
 
     $winget = Resolve-WingetExe
     if (-not $winget) {
-        throw 'winget.exe not found. Install App Installer from the Microsoft Store and re-run.'
+        Write-Status -Level ERROR 'Cannot install Docker Desktop automatically: winget.exe is not available on this machine.'
+        Write-Status -Level ERROR 'This usually means the Windows App Installer package is missing (common on Windows Server or stripped images).'
+        Write-Status -Level INFO  'To finish setup, do one of the following, then re-run scripts\bootstrap-windows.ps1:'
+        Write-Status -Level INFO  '  1) Install "App Installer" from the Microsoft Store (provides winget), or'
+        Write-Status -Level INFO  '  2) Download Docker Desktop manually from https://www.docker.com/products/docker-desktop/ and install it.'
+        Write-Status -Level INFO  'After Docker Desktop is installed, the bootstrap script will skip the install step on the next run.'
+        exit 1
     }
 
     Write-Status 'Installing Docker Desktop with winget...'

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -359,9 +359,10 @@ function Install-DockerDesktop {
 
     $winget = Resolve-WingetExe
     if (-not $winget) {
+        $scriptHint = if ($PSCommandPath) { $PSCommandPath } else { 'this bootstrap script' }
         Write-Status -Level ERROR 'Cannot install Docker Desktop automatically: winget.exe is not available on this machine.'
         Write-Status -Level ERROR 'This usually means the Windows App Installer package is missing (common on Windows Server or stripped images).'
-        Write-Status -Level INFO  'To finish setup, do one of the following, then re-run scripts\bootstrap-windows.ps1:'
+        Write-Status -Level INFO  "To finish setup, do one of the following, then re-run ${scriptHint}:"
         Write-Status -Level INFO  '  1) Install "App Installer" from the Microsoft Store (provides winget), or'
         Write-Status -Level INFO  '  2) Download Docker Desktop manually from https://www.docker.com/products/docker-desktop/ and install it.'
         Write-Status -Level INFO  'After Docker Desktop is installed, the bootstrap script will skip the install step on the next run.'


### PR DESCRIPTION
## Summary

`scripts/bootstrap-windows.ps1` from #3744 raised an unhandled PowerShell exception when `winget.exe` was not on PATH — common on Windows Server images and stripped Windows installs without the App Installer Store package. The user saw a raw stack trace with no clear next step.

Replace the `throw` at line 362 with a friendly `Write-Status` error message that names the cause, offers the two viable recovery paths (install App Installer from the Microsoft Store, or download Docker Desktop manually from docker.com), notes that re-running the script will skip the install step once Docker Desktop is present, and exits with code 1 instead of throwing.

No automatic-download fallback is added: hardcoding a Docker Desktop installer URL without integrity verification would broaden the bootstrap script's trust surface for marginal gain, and the manual link path is the expected behaviour (option b) from the bug report.

## Related Issue

Fixes #3972

## Changes

- [scripts/bootstrap-windows.ps1](scripts/bootstrap-windows.ps1): replace `throw 'winget.exe not found...'` with `Write-Status -Level ERROR` + actionable recovery instructions + `exit 1`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Docker Desktop setup: when automatic install can't run, the process now shows clear, step-by-step status messages and a user-friendly error path instead of a generic failure.

* **Documentation**
  * Added Windows setup guidance advising users to install App Installer (to obtain winget) or install Docker Desktop manually and then retry the bootstrap.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->