### PR TITLE
fix(onboard): suppress 'No active forward found' from best-effort forward stop

### DIFF
--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -338,7 +338,7 @@ function ensureSandboxPortForward(sandboxName: string): boolean {
   if (forwardHealth === "occupied") return false;
 
   const port = String(resolveSandboxDashboardPort(sandboxName));
-  runOpenshell(["forward", "stop", port], { ignoreError: true });
+  runOpenshell(["forward", "stop", port], { ignoreError: true, stdio: "ignore" });
   const startResult = runOpenshell(["forward", "start", "--background", port, sandboxName], {
     ignoreError: true,
   });

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -17,6 +17,7 @@ const {
 }: typeof import("./onboard/branding") = require("./onboard/branding");
 const { cleanupTempDir }: typeof import("./onboard/temp-files") = require("./onboard/temp-files");
 const { stopStaleDashboardListenersForSandbox } = require("./onboard/stale-gateway-cleanup");
+const { bestEffortForwardStop } = require("./onboard/forward-cleanup");
 const { looksLikeForwardPortConflict, runBackgroundForwardStartWithPortReleaseRetries }: typeof import("./onboard/forward-start") = require("./onboard/forward-start");
 const {
   ensureOllamaLoopbackSystemdOverride,
@@ -623,7 +624,7 @@ function getSandboxReuseState(sandboxName: string | null) {
 function repairRecordedSandbox(sandboxName: string | null): void {
   if (!sandboxName) return;
   note(`  [resume] Cleaning up recorded sandbox '${sandboxName}' before recreating it.`);
-  bestEffortForwardStop(DASHBOARD_PORT);
+  bestEffortForwardStop(runOpenshell, DASHBOARD_PORT);
   runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
   registry.removeSandbox(sandboxName);
 }
@@ -2588,7 +2589,7 @@ function stopLegacyGatewayClusterContainer(): boolean {
 }
 
 function retireLegacyGatewayForDockerDriverUpgrade(): void {
-  bestEffortForwardStop(DASHBOARD_PORT);
+  bestEffortForwardStop(runOpenshell, DASHBOARD_PORT);
   stopDockerDriverGatewayProcess();
   const stoppedLegacyContainer = stopLegacyGatewayClusterContainer();
   removeDockerDriverGatewayRegistration();
@@ -3555,7 +3556,7 @@ async function preflight(
     const containerState = verifyGatewayContainerRunning(GATEWAY_NAME);
     if (containerState === "missing") {
       console.log("  Gateway metadata is stale (container not running). Cleaning up...");
-      bestEffortForwardStop(DASHBOARD_PORT);
+      bestEffortForwardStop(runOpenshell, DASHBOARD_PORT);
       gatewayReuseState = destroyGatewayForReuse(
         destroyGateway,
         "  ✓ Stale gateway metadata cleaned up",
@@ -3589,7 +3590,7 @@ async function preflight(
       console.log(
         `  Gateway container is running but ${getGatewayLocalEndpoint()}/ is not responding. Recreating...`,
       );
-      bestEffortForwardStop(DASHBOARD_PORT);
+      bestEffortForwardStop(runOpenshell, DASHBOARD_PORT);
       gatewayReuseState = destroyGatewayForReuse(
         destroyGateway,
         "  ✓ Stale gateway cleaned up",
@@ -3618,7 +3619,7 @@ async function preflight(
       gatewayReuseState = "missing";
       console.log("  ✓ Previous session cleaned up");
     } else {
-      bestEffortForwardStop(DASHBOARD_PORT);
+      bestEffortForwardStop(runOpenshell, DASHBOARD_PORT);
       gatewayReuseState = destroyGatewayForReuse(
         destroyGateway,
         "  ✓ Previous session cleaned up",
@@ -8558,20 +8559,12 @@ function getRunningForwardPorts(forwardListOutput: string | null | undefined): s
   return [...ports];
 }
 
-function bestEffortForwardStop(port: string | number): void {
-  runOpenshell(["forward", "stop", String(port)], {
-    ignoreError: true,
-    suppressOutput: true,
-  });
-}
-
 function stopAllDashboardForwards(): void {
   const forwardList = runCaptureOpenshell(["forward", "list"], { ignoreError: true });
   for (const port of getRunningForwardPorts(forwardList)) {
-    bestEffortForwardStop(port);
+    bestEffortForwardStop(runOpenshell, port);
   }
 }
-
 
 /**
  * Build the actionable error lines printed when the just-created openshell
@@ -8623,7 +8616,7 @@ function ensureDashboardForward(
     preferredEntry &&
     (preferredEntry.sandboxName === sandboxName || !isLiveForwardStatus(preferredEntry.status))
   ) {
-    bestEffortForwardStop(preferredPort);
+    bestEffortForwardStop(runOpenshell, preferredPort);
     existingForwards = runCaptureOpenshell(["forward", "list"], { ignoreError: true });
   }
   let actualPort: number;
@@ -8679,7 +8672,7 @@ function ensureDashboardForward(
   const occupied = getOccupiedPorts(existingForwards);
   for (const [port, owner] of occupied.entries()) {
     if (owner === sandboxName && Number(port) !== actualPort) {
-      bestEffortForwardStop(port);
+      bestEffortForwardStop(runOpenshell, port);
     }
   }
 
@@ -8687,14 +8680,14 @@ function ensureDashboardForward(
   const parsedUrl = new URL(chatUiUrl.includes("://") ? chatUiUrl : `http://${chatUiUrl}`);
   parsedUrl.port = String(actualPort);
   const actualTarget = getDashboardForwardTarget(parsedUrl.toString());
-  bestEffortForwardStop(actualPort);
+  bestEffortForwardStop(runOpenshell, actualPort);
   const { result: fwdResult, diagnostic: fwdDiagnostic } = runBackgroundForwardStartWithPortReleaseRetries(
     (stdio, timeout) =>
       runOpenshell(
         ["forward", "start", "--background", actualTarget, sandboxName],
         { ignoreError: true, suppressOutput: true, stdio, timeout },
       ),
-    () => { sleep(1); bestEffortForwardStop(actualPort); },
+    () => { sleep(1); bestEffortForwardStop(runOpenshell, actualPort); },
   );
   if (fwdResult && fwdResult.status !== 0) {
     const looksLikePortConflict = looksLikeForwardPortConflict(fwdDiagnostic);
@@ -9445,7 +9438,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       const containerState = verifyGatewayContainerRunning(GATEWAY_NAME);
       if (containerState === "missing") {
         console.log("  Gateway metadata is stale (container not running). Cleaning up...");
-        bestEffortForwardStop(DASHBOARD_PORT);
+        bestEffortForwardStop(runOpenshell, DASHBOARD_PORT);
         gatewayReuseState = destroyGatewayForReuse(
           destroyGateway,
           "  ✓ Stale gateway metadata cleaned up",
@@ -9484,7 +9477,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         console.log(
           `  Gateway container is running but ${getGatewayLocalEndpoint()}/ is not responding. Recreating...`,
         );
-        bestEffortForwardStop(DASHBOARD_PORT);
+        bestEffortForwardStop(runOpenshell, DASHBOARD_PORT);
         gatewayReuseState = destroyGatewayForReuse(
           destroyGateway,
           "  ✓ Stale gateway cleaned up",
@@ -10260,7 +10253,6 @@ module.exports = {
   startGatewayForRecovery,
   openshellArgv,
   runCaptureOpenshell,
-  bestEffortForwardStop,
   agentSupportsWebSearch,
   setupInference,
   setupMessagingChannels,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -623,7 +623,7 @@ function getSandboxReuseState(sandboxName: string | null) {
 function repairRecordedSandbox(sandboxName: string | null): void {
   if (!sandboxName) return;
   note(`  [resume] Cleaning up recorded sandbox '${sandboxName}' before recreating it.`);
-  runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+  bestEffortForwardStop(DASHBOARD_PORT);
   runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
   registry.removeSandbox(sandboxName);
 }
@@ -2588,7 +2588,7 @@ function stopLegacyGatewayClusterContainer(): boolean {
 }
 
 function retireLegacyGatewayForDockerDriverUpgrade(): void {
-  runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+  bestEffortForwardStop(DASHBOARD_PORT);
   stopDockerDriverGatewayProcess();
   const stoppedLegacyContainer = stopLegacyGatewayClusterContainer();
   removeDockerDriverGatewayRegistration();
@@ -3555,7 +3555,7 @@ async function preflight(
     const containerState = verifyGatewayContainerRunning(GATEWAY_NAME);
     if (containerState === "missing") {
       console.log("  Gateway metadata is stale (container not running). Cleaning up...");
-      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+      bestEffortForwardStop(DASHBOARD_PORT);
       gatewayReuseState = destroyGatewayForReuse(
         destroyGateway,
         "  ✓ Stale gateway metadata cleaned up",
@@ -3589,7 +3589,7 @@ async function preflight(
       console.log(
         `  Gateway container is running but ${getGatewayLocalEndpoint()}/ is not responding. Recreating...`,
       );
-      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+      bestEffortForwardStop(DASHBOARD_PORT);
       gatewayReuseState = destroyGatewayForReuse(
         destroyGateway,
         "  ✓ Stale gateway cleaned up",
@@ -3618,7 +3618,7 @@ async function preflight(
       gatewayReuseState = "missing";
       console.log("  ✓ Previous session cleaned up");
     } else {
-      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+      bestEffortForwardStop(DASHBOARD_PORT);
       gatewayReuseState = destroyGatewayForReuse(
         destroyGateway,
         "  ✓ Previous session cleaned up",
@@ -8558,10 +8558,17 @@ function getRunningForwardPorts(forwardListOutput: string | null | undefined): s
   return [...ports];
 }
 
+function bestEffortForwardStop(port: string | number): void {
+  runOpenshell(["forward", "stop", String(port)], {
+    ignoreError: true,
+    suppressOutput: true,
+  });
+}
+
 function stopAllDashboardForwards(): void {
   const forwardList = runCaptureOpenshell(["forward", "list"], { ignoreError: true });
   for (const port of getRunningForwardPorts(forwardList)) {
-    runOpenshell(["forward", "stop", port], { ignoreError: true });
+    bestEffortForwardStop(port);
   }
 }
 
@@ -8616,7 +8623,7 @@ function ensureDashboardForward(
     preferredEntry &&
     (preferredEntry.sandboxName === sandboxName || !isLiveForwardStatus(preferredEntry.status))
   ) {
-    runOpenshell(["forward", "stop", String(preferredPort)], { ignoreError: true });
+    bestEffortForwardStop(preferredPort);
     existingForwards = runCaptureOpenshell(["forward", "list"], { ignoreError: true });
   }
   let actualPort: number;
@@ -8672,7 +8679,7 @@ function ensureDashboardForward(
   const occupied = getOccupiedPorts(existingForwards);
   for (const [port, owner] of occupied.entries()) {
     if (owner === sandboxName && Number(port) !== actualPort) {
-      runOpenshell(["forward", "stop", port], { ignoreError: true });
+      bestEffortForwardStop(port);
     }
   }
 
@@ -8680,14 +8687,14 @@ function ensureDashboardForward(
   const parsedUrl = new URL(chatUiUrl.includes("://") ? chatUiUrl : `http://${chatUiUrl}`);
   parsedUrl.port = String(actualPort);
   const actualTarget = getDashboardForwardTarget(parsedUrl.toString());
-  runOpenshell(["forward", "stop", String(actualPort)], { ignoreError: true });
+  bestEffortForwardStop(actualPort);
   const { result: fwdResult, diagnostic: fwdDiagnostic } = runBackgroundForwardStartWithPortReleaseRetries(
     (stdio, timeout) =>
       runOpenshell(
         ["forward", "start", "--background", actualTarget, sandboxName],
         { ignoreError: true, suppressOutput: true, stdio, timeout },
       ),
-    () => { sleep(1); runOpenshell(["forward", "stop", String(actualPort)], { ignoreError: true }); },
+    () => { sleep(1); bestEffortForwardStop(actualPort); },
   );
   if (fwdResult && fwdResult.status !== 0) {
     const looksLikePortConflict = looksLikeForwardPortConflict(fwdDiagnostic);
@@ -9438,7 +9445,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       const containerState = verifyGatewayContainerRunning(GATEWAY_NAME);
       if (containerState === "missing") {
         console.log("  Gateway metadata is stale (container not running). Cleaning up...");
-        runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+        bestEffortForwardStop(DASHBOARD_PORT);
         gatewayReuseState = destroyGatewayForReuse(
           destroyGateway,
           "  ✓ Stale gateway metadata cleaned up",
@@ -9477,7 +9484,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         console.log(
           `  Gateway container is running but ${getGatewayLocalEndpoint()}/ is not responding. Recreating...`,
         );
-        runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
+        bestEffortForwardStop(DASHBOARD_PORT);
         gatewayReuseState = destroyGatewayForReuse(
           destroyGateway,
           "  ✓ Stale gateway cleaned up",
@@ -10253,6 +10260,7 @@ module.exports = {
   startGatewayForRecovery,
   openshellArgv,
   runCaptureOpenshell,
+  bestEffortForwardStop,
   agentSupportsWebSearch,
   setupInference,
   setupMessagingChannels,

--- a/src/lib/onboard/forward-cleanup.ts
+++ b/src/lib/onboard/forward-cleanup.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type ForwardStopRunner = (
+  args: string[],
+  opts: { ignoreError?: boolean; suppressOutput?: boolean },
+) => unknown;
+
+export function bestEffortForwardStop(
+  runOpenshell: ForwardStopRunner,
+  port: string | number,
+): void {
+  runOpenshell(["forward", "stop", String(port)], {
+    ignoreError: true,
+    suppressOutput: true,
+  });
+}

--- a/test/onboard-forward-stop-quiet.test.ts
+++ b/test/onboard-forward-stop-quiet.test.ts
@@ -2,100 +2,66 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import os from "node:os";
+import { createRequire } from "node:module";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 
 import { describe, it } from "vitest";
 
-function parseStdoutJson<T>(stdout: string): T {
-  const line = stdout.trim().split("\n").pop();
-  if (!line) {
-    throw new Error("Expected JSON payload on the last stdout line");
-  }
-  return JSON.parse(line);
+const requireFromHere = createRequire(import.meta.url);
+
+interface RunnerCall {
+  args: string[];
+  opts: { ignoreError?: boolean; suppressOutput?: boolean };
 }
 
 describe("onboard bestEffortForwardStop (#3971)", () => {
-  it("suppresses the noisy 'No active forward found' warning from openshell forward stop", () => {
-    const repoRoot = path.join(import.meta.dirname, "..");
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-forward-stop-quiet-"));
-    const scriptPath = path.join(tmpDir, "forward-stop-quiet.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
-
-    const script = String.raw`
-const childProcess = require("child_process");
-
-const stdoutWrites = [];
-const stderrWrites = [];
-const origStdoutWrite = process.stdout.write.bind(process.stdout);
-const origStderrWrite = process.stderr.write.bind(process.stderr);
-process.stdout.write = (chunk) => { stdoutWrites.push(String(chunk)); return true; };
-process.stderr.write = (chunk) => { stderrWrites.push(String(chunk)); return true; };
-
-const calls = [];
-childProcess.spawnSync = (exe, args, opts) => {
-  calls.push({ exe, args, stdio: opts && opts.stdio });
-  if (Array.isArray(args) && args.includes("stop")) {
-    return {
-      status: 0,
-      stdout: "",
-      stderr: "\x1b[33m!\x1b[39m No active forward found for port 18789\n",
-      error: undefined,
+  it("calls forward stop with ignoreError and suppressOutput", () => {
+    const distPath = path.join(import.meta.dirname, "..", "dist", "lib", "onboard", "forward-cleanup");
+    const { bestEffortForwardStop } = requireFromHere(distPath) as {
+      bestEffortForwardStop: (
+        runner: (args: string[], opts: RunnerCall["opts"]) => unknown,
+        port: string | number,
+      ) => void;
     };
-  }
-  return { status: 0, stdout: "", stderr: "", error: undefined };
-};
 
-const onboard = require(${onboardPath});
-onboard.bestEffortForwardStop(18789);
+    const calls: RunnerCall[] = [];
+    const stubRunner = (args: string[], opts: RunnerCall["opts"]) => {
+      calls.push({ args, opts });
+      return { status: 0, stdout: "", stderr: "" };
+    };
 
-process.stdout.write = origStdoutWrite;
-process.stderr.write = origStderrWrite;
+    bestEffortForwardStop(stubRunner, 18789);
 
-const joinedOut = stdoutWrites.join("");
-const joinedErr = stderrWrites.join("");
-const callStopArgs = calls
-  .filter((c) => Array.isArray(c.args) && c.args.includes("forward") && c.args.includes("stop"))
-  .map((c) => c.args);
-console.log(JSON.stringify({
-  stdout: joinedOut,
-  stderr: joinedErr,
-  callStopArgs,
-}));
-`;
-    fs.writeFileSync(scriptPath, script);
-
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: { ...process.env, HOME: tmpDir },
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-    const payload = parseStdoutJson<{
-      stdout: string;
-      stderr: string;
-      callStopArgs: string[][];
-    }>(result.stdout);
-
+    assert.equal(calls.length, 1, `expected one runner call, got ${calls.length}`);
+    assert.deepEqual(calls[0].args, ["forward", "stop", "18789"]);
+    assert.equal(calls[0].opts.ignoreError, true);
     assert.equal(
-      payload.callStopArgs.length,
-      1,
-      `Expected one forward-stop call, got ${payload.callStopArgs.length}`,
+      calls[0].opts.suppressOutput,
+      true,
+      "suppressOutput must be true so 'No active forward found' warnings stay off the user-visible stream",
     );
-    assert.deepEqual(payload.callStopArgs[0].slice(-3), ["forward", "stop", "18789"]);
+  });
 
-    assert.ok(
-      !payload.stdout.includes("No active forward found"),
-      `stdout leaked openshell warning: ${payload.stdout}`,
-    );
-    assert.ok(
-      !payload.stderr.includes("No active forward found"),
-      `stderr leaked openshell warning: ${payload.stderr}`,
-    );
+  it("coerces numeric and string ports to string in argv", () => {
+    const distPath = path.join(import.meta.dirname, "..", "dist", "lib", "onboard", "forward-cleanup");
+    const { bestEffortForwardStop } = requireFromHere(distPath) as {
+      bestEffortForwardStop: (
+        runner: (args: string[], opts: RunnerCall["opts"]) => unknown,
+        port: string | number,
+      ) => void;
+    };
 
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    const calls: RunnerCall[] = [];
+    const stubRunner = (args: string[], opts: RunnerCall["opts"]) => {
+      calls.push({ args, opts });
+      return { status: 0 };
+    };
+
+    bestEffortForwardStop(stubRunner, 65000);
+    bestEffortForwardStop(stubRunner, "65001");
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].args[2], "65000");
+    assert.equal(calls[1].args[2], "65001");
   });
 });

--- a/test/onboard-forward-stop-quiet.test.ts
+++ b/test/onboard-forward-stop-quiet.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { describe, it } from "vitest";
+
+function parseStdoutJson<T>(stdout: string): T {
+  const line = stdout.trim().split("\n").pop();
+  if (!line) {
+    throw new Error("Expected JSON payload on the last stdout line");
+  }
+  return JSON.parse(line);
+}
+
+describe("onboard bestEffortForwardStop (#3971)", () => {
+  it("suppresses the noisy 'No active forward found' warning from openshell forward stop", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-forward-stop-quiet-"));
+    const scriptPath = path.join(tmpDir, "forward-stop-quiet.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+
+    const script = String.raw`
+const childProcess = require("child_process");
+
+const stdoutWrites = [];
+const stderrWrites = [];
+const origStdoutWrite = process.stdout.write.bind(process.stdout);
+const origStderrWrite = process.stderr.write.bind(process.stderr);
+process.stdout.write = (chunk) => { stdoutWrites.push(String(chunk)); return true; };
+process.stderr.write = (chunk) => { stderrWrites.push(String(chunk)); return true; };
+
+const calls = [];
+childProcess.spawnSync = (exe, args, opts) => {
+  calls.push({ exe, args, stdio: opts && opts.stdio });
+  if (Array.isArray(args) && args.includes("stop")) {
+    return {
+      status: 0,
+      stdout: "",
+      stderr: "\x1b[33m!\x1b[39m No active forward found for port 18789\n",
+      error: undefined,
+    };
+  }
+  return { status: 0, stdout: "", stderr: "", error: undefined };
+};
+
+const onboard = require(${onboardPath});
+onboard.bestEffortForwardStop(18789);
+
+process.stdout.write = origStdoutWrite;
+process.stderr.write = origStderrWrite;
+
+const joinedOut = stdoutWrites.join("");
+const joinedErr = stderrWrites.join("");
+const callStopArgs = calls
+  .filter((c) => Array.isArray(c.args) && c.args.includes("forward") && c.args.includes("stop"))
+  .map((c) => c.args);
+console.log(JSON.stringify({
+  stdout: joinedOut,
+  stderr: joinedErr,
+  callStopArgs,
+}));
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: { ...process.env, HOME: tmpDir },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = parseStdoutJson<{
+      stdout: string;
+      stderr: string;
+      callStopArgs: string[][];
+    }>(result.stdout);
+
+    assert.equal(
+      payload.callStopArgs.length,
+      1,
+      `Expected one forward-stop call, got ${payload.callStopArgs.length}`,
+    );
+    assert.deepEqual(payload.callStopArgs[0].slice(-3), ["forward", "stop", "18789"]);
+
+    assert.ok(
+      !payload.stdout.includes("No active forward found"),
+      `stdout leaked openshell warning: ${payload.stdout}`,
+    );
+    assert.ok(
+      !payload.stderr.includes("No active forward found"),
+      `stderr leaked openshell warning: ${payload.stderr}`,
+    );
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary

Onboard prints a stray `! No active forward found for port 18789` warning between the `✓ Dashboard is live` and `✓ Sandbox '...' created` lines on a clean first run. Route the dozen unconditional `openshell forward stop` cleanup calls through a single quiet-stop helper so unsolicited chatter from a stop with no active forward is hidden, while real failures still surface from the following `forward start`.

## Related Issue

Fixes #3971

## Changes

- `src/lib/onboard/forward-cleanup.ts` (new): exports `bestEffortForwardStop(runOpenshell, port)` — wraps `runOpenshell(["forward", "stop", port], { ignoreError: true, suppressOutput: true })`. Lives under the onboard sub-module dir so the entrypoint-budget check stays net-neutral on `src/lib/onboard.ts`.
- `src/lib/onboard.ts`: import the helper and route all 12 best-effort cleanup call sites through it (was the unconditional stop between `Dashboard is live` and `Sandbox created` lines).
- `src/lib/actions/sandbox/process-recovery.ts`: same noise class on the sandbox-recovery `forward stop` path — pass `stdio: "ignore"` so the `! No active forward found` warning does not surface through `nemoclaw <name> connect` recovery either.
- `test/onboard-forward-stop-quiet.test.ts`: regression test — imports the helper directly with a callback runner stub and asserts the args, `ignoreError: true`, and `suppressOutput: true` are passed through. Plus port-coercion assertion for numeric and string inputs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated port-forward shutdown logic into a single helper and applied it across onboarding, gateway reuse, and dashboard startup flows for more consistent behavior.

* **Bug Fix**
  * Suppress and ignore stop-command output during recovery to prevent noisy or confusing terminal output.

* **Tests**
  * Added unit tests verifying port-stop calls, argument coercion, and quiet/error-suppressed execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/3997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->