### PR TITLE
fix(e2e): run full repo scenario cli build

### DIFF
--- a/test/e2e/nemoclaw_scenarios/install/repo-current.sh
+++ b/test/e2e/nemoclaw_scenarios/install/repo-current.sh
@@ -28,21 +28,16 @@ e2e_install_repo() {
   mkdir -p .e2e
   echo "repo-current: build cli"
   build_status=0
-  ./node_modules/.bin/tsc -p tsconfig.src.json >.e2e/build-cli.log 2>&1 || build_status=$?
+  npm run build:cli >.e2e/build-cli.log 2>&1 || build_status=$?
   if [ "${build_status}" -ne 0 ]; then
     cat .e2e/build-cli.log >&2
-    echo "CLI TypeScript build failed with status ${build_status}" >&2
+    echo "CLI build failed with status ${build_status}" >&2
     return "${build_status}"
   fi
-  if find nemoclaw-blueprint/scripts -name '*.ts' -print -quit | grep -q .; then
-    echo "repo-current: build blueprint"
-    build_status=0
-    ./node_modules/.bin/tsc -p nemoclaw-blueprint/tsconfig.json >.e2e/build-blueprint.log 2>&1 || build_status=$?
-    if [ "${build_status}" -ne 0 ]; then
-      cat .e2e/build-blueprint.log >&2
-      echo "Blueprint TypeScript build failed with status ${build_status}" >&2
-      return "${build_status}"
-    fi
+  if [ ! -s dist/lib/cli/oclif-command-metadata.generated.json ]; then
+    cat .e2e/build-cli.log >&2
+    echo "CLI build did not generate oclif command metadata" >&2
+    return 1
   fi
   echo "repo-current: link cli"
   chmod +x bin/nemoclaw.js

--- a/test/e2e/scenario-framework-tests/e2e-lib-helpers.test.ts
+++ b/test/e2e/scenario-framework-tests/e2e-lib-helpers.test.ts
@@ -812,6 +812,20 @@ describe("Phase 1.E install dispatcher splits", () => {
     expect(r.stdout + r.stderr).not.toMatch(/install-curl|install-ollama|install-launchable/);
   });
 
+  it("repo_current_install_should_use_full_cli_build_script", () => {
+    const script = fs.readFileSync(path.join(INSTALL_DIR, "repo-current.sh"), "utf8");
+    expect(script).toContain("npm run build:cli");
+    expect(script).not.toContain("./node_modules/.bin/tsc -p tsconfig.src.json");
+    expect(script).not.toContain("./node_modules/.bin/tsc -p nemoclaw-blueprint/tsconfig.json");
+  });
+
+  it("repo_current_install_should_verify_generated_oclif_metadata", () => {
+    const script = fs.readFileSync(path.join(INSTALL_DIR, "repo-current.sh"), "utf8");
+    const buildScript = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8")).scripts?.["build:cli"] ?? "";
+    expect(buildScript).toContain("generate-oclif-metadata-manifest.js");
+    expect(script).toContain("dist/lib/cli/oclif-command-metadata.generated.json");
+  });
+
   it("install_should_dispatch_to_install_curl_helper_for_public_installer_profile", () => {
     const r = dispatchDryRun("public-installer");
     expect(r.status, r.stderr).toBe(0);


### PR DESCRIPTION
## Summary
- Use `npm run build:cli` for repo-current scenario installs instead of raw `tsc`.
- Fail fast if the generated oclif metadata manifest is missing after the build.
- Add scenario-framework guard tests so repo-current installs keep using the full CLI build path.

## Context
The `E2E / Scenario Runner / All` run on main failed repo-based scenarios because `repo-current.sh` compiled TypeScript directly and skipped `generate-oclif-metadata-manifest.js`, leaving `dist/lib/cli/oclif-command-metadata.generated.json` absent at first CLI invocation.

## Verification
- `bash -n test/e2e/nemoclaw_scenarios/install/repo-current.sh`
- `npm run build:cli`
- `npm test -- --run test/e2e/scenario-framework-tests/e2e-lib-helpers.test.ts -t repo_current_install`
- `npm test -- --run test/e2e/scenario-framework-tests/e2e-scenario-first-migration.test.ts test/e2e/scenario-framework-tests/e2e-scenario-resolver.test.ts test/e2e/scenario-framework-tests/e2e-scenarios-workflow.test.ts`

Note: full `e2e-lib-helpers.test.ts` still has two pre-existing unrelated failures in this worktree (`security_policy_credentials_helper_should_fail_on_missing_policy_preset`, `scenario_dry_run_should_trace_helper_sequence_in_order`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for CLI build process to validate correct build command usage and metadata generation.

* **Chores**
  * Enhanced CLI build validation with improved error reporting for build failures and output verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4002?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->